### PR TITLE
support dynamic lookup of R symbols on macOS

### DIFF
--- a/extensions/positron-r/amalthea/.cargo/config.toml
+++ b/extensions/positron-r/amalthea/.cargo/config.toml
@@ -1,5 +1,0 @@
-[build]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]

--- a/extensions/positron-r/amalthea/Cargo.lock
+++ b/extensions/positron-r/amalthea/Cargo.lock
@@ -843,12 +843,10 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 [[package]]
 name = "libR-sys"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a97fd689379c62156b5c9b7b368d118ef660ad8c220a2f3e4c655529ad52384"
+source = "git+https://github.com/kevinushey/libR-sys?branch=feature/dynamic-lookup#3f022f21b9b09b583136fc51379cb80e66984036"
 dependencies = [
  "bindgen",
  "regex",
- "winapi",
 ]
 
 [[package]]

--- a/extensions/positron-r/amalthea/crates/ark/.cargo/config.toml
+++ b/extensions/positron-r/amalthea/crates/ark/.cargo/config.toml
@@ -1,6 +1,0 @@
-[build]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]
-

--- a/extensions/positron-r/amalthea/crates/ark/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/ark/Cargo.toml
@@ -16,7 +16,7 @@ ego-tree = "0.6.2"
 harp = { path = "../harp" }
 html5ever = "0.26.0"
 lazy_static = "1.4.0"
-libR-sys = "0.3"
+libR-sys = { git = "https://github.com/kevinushey/libR-sys", branch = "feature/dynamic-lookup" }
 libc = "0.2"
 log = "0.4.14"
 nix = { version = "0.24.1", features = ["signal"] }
@@ -44,4 +44,4 @@ rpath = true
 # Note that this typically requires the `llvm` and `clang` packages to be
 # installed on the build host.
 [target.'cfg(all(target_os="linux", target_arch="aarch64"))'.dependencies]
-libR-sys = { version = "0.3", features = ["use-bindgen"] }
+libR-sys = { git = "https://github.com/kevinushey/libR-sys", branch = "feature/dynamic-lookup", features = ["use-bindgen"] }

--- a/extensions/positron-r/amalthea/crates/ark/build.rs
+++ b/extensions/positron-r/amalthea/crates/ark/build.rs
@@ -1,0 +1,10 @@
+
+fn main() {
+
+	#[cfg(target_os = "macos")]
+	{
+		println!("cargo:rustc-link-arg=-undefined");
+		println!("cargo:rustc-link-arg=dynamic_lookup");
+	}
+
+}

--- a/extensions/positron-r/amalthea/crates/harp/.cargo/config.toml
+++ b/extensions/positron-r/amalthea/crates/harp/.cargo/config.toml
@@ -1,6 +1,0 @@
-[build]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]
-

--- a/extensions/positron-r/amalthea/crates/harp/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/harp/Cargo.toml
@@ -7,6 +7,6 @@ Tools for integrating R and Rust.
 """
 
 [dependencies]
-libR-sys = "0.3.0"
+libR-sys = { git = "https://github.com/kevinushey/libR-sys", branch = "feature/dynamic-lookup" }
 log = "0.4.17"
 stdext = { path = "../stdext" }

--- a/extensions/positron-r/amalthea/crates/harp/src/lib.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/lib.rs
@@ -18,7 +18,6 @@ pub mod vector;
 
 pub fn initialize() {
     lock::initialize();
-    routines::initialize();
 }
 
 #[macro_export]


### PR DESCRIPTION
```
kevin@MBP-P2MQ:~/myriac/extensions/positron-r/amalthea [feature/r-dynamic-lookup]
$ otool -L target/debug/ark
target/debug/ark:
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1300.32.0)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1953.1.0)
        /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)
        /usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)
        /usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
```

And the relevant commit on the libR-sys side:

https://github.com/kevinushey/libR-sys/commit/3f022f21b9b09b583136fc51379cb80e66984036