### PR TITLE
wire up ShowHelpUrl handling

### DIFF
--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -34,7 +34,8 @@ declare module 'positron' {
 
 	/** The set of possible language runtime events */
 	export enum LanguageRuntimeEventType {
-		ShowMessage = 'show_message'
+		ShowMessage = 'show_message',
+		ShowHelpUrl = 'show_help_url',
 	}
 
 	/**

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -73,7 +73,8 @@ export enum LanguageRuntimeMessageType {
 
 /** The set of possible language runtime events */
 export enum LanguageRuntimeEventType {
-	ShowMessage = 'show_message'
+	ShowMessage = 'show_message',
+	ShowHelpUrl = 'show_help_url',
 }
 
 

--- a/src/vs/workbench/contrib/repl/browser/replInstanceView.ts
+++ b/src/vs/workbench/contrib/repl/browser/replInstanceView.ts
@@ -9,10 +9,11 @@ import { DomScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableEle
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { ReplCell, ReplCellState } from 'vs/workbench/contrib/repl/browser/replCell';
 import { IReplInstance } from 'vs/workbench/contrib/repl/browser/repl';
-import { ILanguageRuntime, ILanguageRuntimeError, ILanguageRuntimeEvent, ILanguageRuntimeOutput, ILanguageRuntimePrompt, ILanguageRuntimeState, LanguageRuntimeEventType, LanguageRuntimeMessageType, RuntimeCodeExecutionMode, RuntimeErrorBehavior, RuntimeOnlineState, RuntimeState, ShowMessageEvent } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeError, ILanguageRuntimeEvent, ILanguageRuntimeOutput, ILanguageRuntimePrompt, ILanguageRuntimeState, LanguageRuntimeEventType, LanguageRuntimeMessageType, RuntimeCodeExecutionMode, RuntimeErrorBehavior, RuntimeOnlineState, RuntimeState, ShowHelpUrlEvent, ShowMessageEvent } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ReplStatusMessage } from 'vs/workbench/contrib/repl/browser/replStatusMessage';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import Severity from 'vs/base/common/severity';
+import { IPositronHelpService } from 'vs/workbench/services/positronHelp/common/positronHelp';
 
 export const REPL_NOTEBOOK_SCHEME = 'repl';
 
@@ -59,6 +60,7 @@ export class ReplInstanceView extends Disposable {
 
 	constructor(private readonly _instance: IReplInstance,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IPositronHelpService private readonly _positronHelpService: IPositronHelpService,
 		@ILogService private readonly _logService: ILogService,
 		@IDialogService private readonly _dialogService: IDialogService) {
 		super();
@@ -138,6 +140,12 @@ export class ReplInstanceView extends Disposable {
 					const msg = new ReplStatusMessage(
 						'info', `${data.message}`);
 					msg.render(this._cellContainer);
+				} else if (evt.name === LanguageRuntimeEventType.ShowHelpUrl) {
+					const data = evt.data as ShowHelpUrlEvent;
+					console.log(`Show Help URL: ${data.url}`);
+					this._positronHelpService.openHelpURL(data.url);
+				} else {
+					console.error(`Internal error: unhandled event '${JSON.stringify(evt)}'`);
 				}
 			} else if (msg.type === LanguageRuntimeMessageType.Prompt) {
 				this.showPrompt(msg as ILanguageRuntimePrompt);

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -144,7 +144,8 @@ export enum LanguageRuntimeMessageType {
 
 /** The set of possible language runtime events */
 export enum LanguageRuntimeEventType {
-	ShowMessage = 'show_message'
+	ShowMessage = 'show_message',
+	ShowHelpUrl = 'show_help_url',
 }
 
 export enum LanguageRuntimeStartupBehavior {
@@ -176,6 +177,11 @@ export interface LanguageRuntimeEventData { }
 export interface ShowMessageEvent extends LanguageRuntimeEventData {
 	/** The message to show */
 	message: string;
+}
+
+export interface ShowHelpUrlEvent extends LanguageRuntimeEventData {
+	/** The Help URL to display in the Help pane */
+	url: string;
 }
 
 export interface ILanguageRuntimeEvent extends ILanguageRuntimeMessage {


### PR DESCRIPTION
@jmcphers, is this the right place to wire up the handler for ShowHelpUrl events? Or is there some other place where I should be registering a LanguageRuntime handler?

I also wonder if we could auto-generate some of these event interfaces from a single source of truth (JSON?) similar to what we do in RStudio.