### PR TITLE
add editor action for inserting positron comment markers

### DIFF
--- a/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
+++ b/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
@@ -5,6 +5,8 @@
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorAction, registerEditorAction, ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { ISingleEditOperation } from 'vs/editor/common/core/editOperation';
+import { IPosition } from 'vs/editor/common/core/position';
+import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
 import { ICommand, ICursorStateComputerData, IEditOperationBuilder } from 'vs/editor/common/editorCommon';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
@@ -14,24 +16,42 @@ import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys'
 
 export function addPositronCommentMarkers(model: ITextModel, selection: Selection): ISingleEditOperation[] {
 
+	// Compute the start position.
+	const startPosition = <IPosition>{
+		lineNumber: selection.selectionStartLineNumber,
+		column: 0,
+	};
+
+	// Compute the end position.
+	// If the end selection ends before the start selection, assume that this is
+	// because the user had expands the selection and perhaps the end anchor of
+	// the selection lies at the start of the intended selection.
+	let endPosition;
+	if (selection.endColumn <= selection.selectionStartColumn) {
+		endPosition = <IPosition>{
+			lineNumber: selection.endLineNumber - 1,
+			column: Infinity,
+		};
+	} else {
+		endPosition = <IPosition>{
+			lineNumber: selection.endLineNumber,
+			column: Infinity,
+		};
+	}
+
+	// Inherit the indentation from the first line.
+	const startLine = model.getLineContent(startPosition.lineNumber);
+	const indent = /^\s*/.exec(startLine)?.[0];
+
+	// Return the actions to insert text around the selection.
 	return [
 		{
-			range: {
-				startLineNumber: selection.getStartPosition().lineNumber,
-				startColumn: 0,
-				endLineNumber: selection.getStartPosition().lineNumber,
-				endColumn: 0,
-			},
-			text: '// --- Begin Positron ---\n',
+			range: Range.fromPositions(startPosition, startPosition),
+			text: `${indent}// --- Begin Positron ---\n`,
 		},
 		{
-			range: {
-				startLineNumber: selection.getEndPosition().lineNumber,
-				startColumn: Infinity,
-				endLineNumber: selection.getEndPosition().lineNumber,
-				endColumn: Infinity,
-			},
-			text: '\n// --- End Positron ---\n',
+			range: Range.fromPositions(endPosition, endPosition),
+			text: `\n${indent}// --- End Positron ---\n`,
 		},
 	];
 

--- a/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
+++ b/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
@@ -69,21 +69,10 @@ function addPositronCommentMarkers(model: ITextModel, selection: Selection, mark
 	};
 
 	// Compute the end position.
-	// If the end selection ends before the start selection, assume that this is
-	// because the user has expanded the selection and perhaps the end anchor of
-	// the selection lies on the line after the intended end of the selection.
-	let endPosition;
-	if (selection.endColumn <= selection.selectionStartColumn) {
-		endPosition = <IPosition>{
-			lineNumber: selection.endLineNumber - 1,
-			column: Infinity,
-		};
-	} else {
-		endPosition = <IPosition>{
-			lineNumber: selection.endLineNumber,
-			column: Infinity,
-		};
-	}
+	const endPosition = <IPosition>{
+		lineNumber: selection.endLineNumber,
+		column: Infinity,
+	};
 
 	// Inherit the indentation from the first line.
 	const startLine = model.getLineContent(startPosition.lineNumber);
@@ -97,7 +86,7 @@ function addPositronCommentMarkers(model: ITextModel, selection: Selection, mark
 		},
 		{
 			range: Range.fromPositions(endPosition, endPosition),
-			text: `\n${indent}${markers.endText}\n`,
+			text: `\n${indent}${markers.endText}`,
 		},
 	];
 

--- a/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
+++ b/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
@@ -11,7 +11,6 @@ import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { ITextModel } from 'vs/editor/common/model';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
-import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 
 export function addPositronCommentMarkers(model: ITextModel, selection: Selection): ISingleEditOperation[] {
 

--- a/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
+++ b/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Posit, PBC.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
+import { EditorAction, registerEditorAction, ServicesAccessor } from 'vs/editor/browser/editorExtensions';
+import { ISingleEditOperation } from 'vs/editor/common/core/editOperation';
+import { Selection } from 'vs/editor/common/core/selection';
+import { ICommand, ICursorStateComputerData, IEditOperationBuilder } from 'vs/editor/common/editorCommon';
+import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
+import { ITextModel } from 'vs/editor/common/model';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
+import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
+import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
+
+export function addPositronCommentMarkers(model: ITextModel, selection: Selection): ISingleEditOperation[] {
+
+	return [
+		{
+			range: {
+				startLineNumber: selection.getStartPosition().lineNumber,
+				startColumn: 0,
+				endLineNumber: selection.getStartPosition().lineNumber,
+				endColumn: 0,
+			},
+			text: '// --- Begin Positron ---\n',
+		},
+		{
+			range: {
+				startLineNumber: selection.getEndPosition().lineNumber,
+				startColumn: Infinity,
+				endLineNumber: selection.getEndPosition().lineNumber,
+				endColumn: Infinity,
+			},
+			text: '\n// --- End Positron ---\n',
+		},
+	];
+
+}
+
+
+export class AddPositronCommentMarkersCommand implements ICommand {
+
+	private readonly _selection: Selection;
+	private _selectionId: string | null;
+
+	constructor(selection: Selection) {
+		this._selection = selection;
+		this._selectionId = null;
+	}
+
+	public getEditOperations(model: ITextModel, builder: IEditOperationBuilder): void {
+		const ops = addPositronCommentMarkers(model, this._selection);
+		for (const op of ops) {
+			builder.addTrackedEditOperation(op.range, op.text);
+		}
+		this._selectionId = builder.trackSelection(this._selection);
+	}
+
+	public computeCursorState(model: ITextModel, helper: ICursorStateComputerData): Selection {
+		return helper.getTrackedSelection(this._selectionId!);
+	}
+
+}
+
+export class AddPositronCommentMarkersAction extends EditorAction {
+
+	public static readonly ID = 'editor.action.addPositronCommentMarkers';
+
+	constructor() {
+		super({
+			id: AddPositronCommentMarkersAction.ID,
+			label: 'Positron: Add Positron Comment Markers',
+			alias: 'Positron: Add Positron Comment Markers',
+			precondition: ContextKeyExpr.and(IsDevelopmentContext, EditorContextKeys.writable),
+			kbOpts: {
+				kbExpr: EditorContextKeys.editorTextFocus,
+				weight: KeybindingWeight.EditorContrib
+			}
+		});
+	}
+
+	public run(_accessor: ServicesAccessor, editor: ICodeEditor, args: any): void {
+
+		const selection = editor.getSelection();
+		if (selection === null) {
+			return;
+		}
+
+		const command = new AddPositronCommentMarkersCommand(selection);
+
+		editor.pushUndoStop();
+		editor.executeCommands(this.id, [command]);
+		editor.pushUndoStop();
+	}
+}
+
+registerEditorAction(AddPositronCommentMarkersAction);

--- a/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
+++ b/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
@@ -73,10 +73,6 @@ export class AddPositronCommentMarkersAction extends EditorAction {
 			label: 'Positron: Add Positron Comment Markers',
 			alias: 'Positron: Add Positron Comment Markers',
 			precondition: ContextKeyExpr.and(IsDevelopmentContext, EditorContextKeys.writable),
-			kbOpts: {
-				kbExpr: EditorContextKeys.editorTextFocus,
-				weight: KeybindingWeight.EditorContrib
-			}
 		});
 	}
 

--- a/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
+++ b/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
@@ -70,8 +70,8 @@ function addPositronCommentMarkers(model: ITextModel, selection: Selection, mark
 
 	// Compute the end position.
 	// If the end selection ends before the start selection, assume that this is
-	// because the user had expands the selection and perhaps the end anchor of
-	// the selection lies at the start of the intended selection.
+	// because the user has expanded the selection and perhaps the end anchor of
+	// the selection lies on the line after the intended end of the selection.
 	let endPosition;
 	if (selection.endColumn <= selection.selectionStartColumn) {
 		endPosition = <IPosition>{

--- a/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
+++ b/src/vs/editor/contrib/positronEditorActions/browser/positronEditorActions.ts
@@ -10,11 +10,57 @@ import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
 import { ICommand, ICursorStateComputerData, IEditOperationBuilder } from 'vs/editor/common/editorCommon';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
+import { ILanguageConfigurationService } from 'vs/editor/common/languages/languageConfigurationRegistry';
 import { ITextModel } from 'vs/editor/common/model';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
 
-export function addPositronCommentMarkers(model: ITextModel, selection: Selection): ISingleEditOperation[] {
+interface IPositronCommentMarkers {
+	startText: string;
+	endText: string;
+}
+
+function inferCommentMarkers(accessor: ServicesAccessor, editor: ICodeEditor): IPositronCommentMarkers {
+
+	const defaultCommentMarkers = <IPositronCommentMarkers>{
+		startText: '// --- Start Positron ---',
+		endText: '// --- End Positron ---',
+	};
+
+	const languageId = editor.getModel()?.getLanguageId();
+	if (!languageId) {
+		return defaultCommentMarkers;
+	}
+
+	const languageConfigurationService = accessor.get(ILanguageConfigurationService);
+	const languageConfiguration = languageConfigurationService.getLanguageConfiguration(languageId);
+	const comments = languageConfiguration.comments;
+	if (!comments) {
+		return defaultCommentMarkers;
+	}
+
+	const lineCommentToken = comments.lineCommentToken;
+	if (lineCommentToken) {
+		return <IPositronCommentMarkers>{
+			startText: `${lineCommentToken} --- Start Positron ---`,
+			endText: `${lineCommentToken} --- End Positron ---`,
+		};
+	}
+
+	const startToken = comments.blockCommentStartToken;
+	const endToken = comments.blockCommentEndToken;
+	if (startToken && endToken) {
+		return <IPositronCommentMarkers>{
+			startText: `${startToken} --- Start Positron --- ${endToken}`,
+			endText: `${startToken} --- End Positron --- ${endToken}`,
+		};
+	}
+
+	return defaultCommentMarkers;
+
+}
+
+function addPositronCommentMarkers(model: ITextModel, selection: Selection, markers: IPositronCommentMarkers): ISingleEditOperation[] {
 
 	// Compute the start position.
 	const startPosition = <IPosition>{
@@ -47,11 +93,11 @@ export function addPositronCommentMarkers(model: ITextModel, selection: Selectio
 	return [
 		{
 			range: Range.fromPositions(startPosition, startPosition),
-			text: `${indent}// --- Begin Positron ---\n`,
+			text: `${indent}${markers.startText}\n`,
 		},
 		{
 			range: Range.fromPositions(endPosition, endPosition),
-			text: `\n${indent}// --- End Positron ---\n`,
+			text: `\n${indent}${markers.endText}\n`,
 		},
 	];
 
@@ -61,15 +107,17 @@ export function addPositronCommentMarkers(model: ITextModel, selection: Selectio
 export class AddPositronCommentMarkersCommand implements ICommand {
 
 	private readonly _selection: Selection;
+	private readonly _markers: IPositronCommentMarkers;
 	private _selectionId: string | null;
 
-	constructor(selection: Selection) {
+	constructor(selection: Selection, markers: IPositronCommentMarkers) {
 		this._selection = selection;
+		this._markers = markers;
 		this._selectionId = null;
 	}
 
 	public getEditOperations(model: ITextModel, builder: IEditOperationBuilder): void {
-		const ops = addPositronCommentMarkers(model, this._selection);
+		const ops = addPositronCommentMarkers(model, this._selection, this._markers);
 		for (const op of ops) {
 			builder.addTrackedEditOperation(op.range, op.text);
 		}
@@ -95,14 +143,15 @@ export class AddPositronCommentMarkersAction extends EditorAction {
 		});
 	}
 
-	public run(_accessor: ServicesAccessor, editor: ICodeEditor, args: any): void {
+	public run(accessor: ServicesAccessor, editor: ICodeEditor, args: any): void {
 
 		const selection = editor.getSelection();
 		if (selection === null) {
 			return;
 		}
 
-		const command = new AddPositronCommentMarkersCommand(selection);
+		const commentMarkers = inferCommentMarkers(accessor, editor);
+		const command = new AddPositronCommentMarkersCommand(selection, commentMarkers);
 
 		editor.pushUndoStop();
 		editor.executeCommands(this.id, [command]);

--- a/src/vs/editor/editor.all.ts
+++ b/src/vs/editor/editor.all.ts
@@ -57,6 +57,10 @@ import 'vs/editor/contrib/wordOperations/browser/wordOperations';
 import 'vs/editor/contrib/wordPartOperations/browser/wordPartOperations';
 import 'vs/editor/contrib/readOnlyMessage/browser/contribution';
 
+// --- Start Positron ---
+import 'vs/editor/contrib/positronEditorActions/browser/positronEditorActions';
+// --- End Positron ---
+
 // Load up these strings even in VSCode, even if they are not used
 // in order to get them translated
 import 'vs/editor/common/standaloneStrings';


### PR DESCRIPTION
This PR adds a simple command / editor action for surrounding the current selection with the Positron comment markers we use for identifying our own additions to the VSCode code base. Note that this command is only enabled and visible in development mode; it won't appear in packaged versions of Positron.

It was also a useful excuse to get familiar with the editor command infrastructure.

https://user-images.githubusercontent.com/1976582/206988867-8e6ae76e-b8e7-45d8-9892-08d6b0d293bf.mov


