### PR TITLE
enable code signing for Positron builds on macOS

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -126,12 +126,14 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      # Download arm64 and x64 binaries
+
+      # Download arm64 client
       - name: Download arm64 client
         uses: actions/download-artifact@v3
         with:
           name: positron-darwin-arm64-archive
 
+      # Download x64 client
       - name: Download x64 client
         uses: actions/download-artifact@v3
         with:
@@ -177,6 +179,15 @@ jobs:
         run: |
           export AGENT_BUILDDIRECTORY=$(pwd)
           node build/darwin/create-universal-app.js
+
+      # codesign the generated bundle
+      - name: Codesign client
+        run: |
+          export AGENT_BUILDDIRECTORY="$(pwd)"
+          export AGENT_TEMPDIRECTORY="${TMPDIR}"
+          export VSCODE_ARCH=universal
+          export CODESIGN_DEBUG=1
+          ts-node build/darwin/sign.ts
 
       # Compress universal client to a zip file
       - name: Create universal client archive

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -187,7 +187,7 @@ jobs:
           export AGENT_TEMPDIRECTORY="${TMPDIR}"
           export VSCODE_ARCH=universal
           export CODESIGN_DEBUG=1
-          ts-node build/darwin/sign.ts
+          npx ts-node build/darwin/sign.ts
 
       # Compress universal client to a zip file
       - name: Create universal client archive

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -186,7 +186,7 @@ jobs:
           export AGENT_BUILDDIRECTORY="$(pwd)"
           export AGENT_TEMPDIRECTORY="${TMPDIR}"
           export VSCODE_ARCH=universal
-          export CODESIGN_DEBUG=1
+          export DEBUG=electron-osx-sign
           npx ts-node build/darwin/sign.ts
 
       # Compress universal client to a zip file

--- a/build/darwin/sign.ts
+++ b/build/darwin/sign.ts
@@ -16,12 +16,6 @@ async function main(): Promise<void> {
 
 	// --- Start Positron ---
 
-	// enable codesign debug output
-	const debug = process.env['CODESIGN_DEBUG'];
-	if (debug) {
-		process.env['DEBUG'] = 'electron-osx-sign';
-	}
-
 	// set up codesign identity
 	let identity = process.env['CODESIGN_IDENTITY'];
 	let identityValidation = true;

--- a/build/darwin/sign.ts
+++ b/build/darwin/sign.ts
@@ -14,6 +14,25 @@ async function main(): Promise<void> {
 	const tempDir = process.env['AGENT_TEMPDIRECTORY'];
 	const arch = process.env['VSCODE_ARCH'];
 
+	// --- Start Positron ---
+
+	// enable codesign debug output
+	const debug = process.env['CODESIGN_DEBUG'];
+	if (debug) {
+		process.env['DEBUG'] = 'electron-osx-sign';
+	}
+
+	// set up codesign identity
+	let identity = process.env['CODESIGN_IDENTITY'];
+	let identityValidation = true;
+	if (!identity) {
+		console.log('- $CODESIGN_IDENTITY is not set; using ad-hoc signature');
+		identity = '-';
+		identityValidation = false;
+	}
+
+	// --- End Positron ---
+
 	if (!buildDir) {
 		throw new Error('$AGENT_BUILDDIRECTORY not set');
 	}
@@ -42,7 +61,10 @@ async function main(): Promise<void> {
 		'pre-embed-provisioning-profile': false,
 		keychain: path.join(tempDir, 'buildagent.keychain'),
 		version: util.getElectronVersion(),
-		identity: '99FM488X57',
+		// --- Begin Positron ---
+		identity: identity,
+		'identity-validation': identityValidation,
+		// --- End Positron ---
 		'gatekeeper-assess': false
 	};
 
@@ -80,6 +102,17 @@ async function main(): Promise<void> {
 	// Only overwrite plist entries for x64 and arm64 builds,
 	// universal will get its copy from the x64 build.
 	if (arch !== 'universal') {
+
+		// --- Begin Positron ---
+
+		// primarily for interactive debugging; this lets us re-run the script
+		// on a build tree that might have failed signing before
+		await spawn('plutil', ['-remove', 'NSAppleEventsUsageDescription', `${infoPlistPath}`]);
+		await spawn('plutil', ['-remove', 'NSMicrophoneUsageDescription', `${infoPlistPath}`]);
+		await spawn('plutil', ['-remove', 'NSCameraUsageDescription', `${infoPlistPath}`]);
+
+		// --- End Positron ---
+
 		await spawn('plutil', [
 			'-insert',
 			'NSAppleEventsUsageDescription',


### PR DESCRIPTION
This PR adds the changes necessary for us to be able to sign Positron with our own signing identity, and also makes it possible to sign Positron with an ad-hoc signature (which allows us to test the application with a hardened runtime locally).

With this PR, I can produce a hardened-runtime build of Positron locally, and so far everything Just Works:

```
$ codesign --display --verbose Positron.app
Executable=/Users/kevin/VSCode-darwin-arm64/Positron.app/Contents/MacOS/Electron
Identifier=com.rstudio.positron
Format=app bundle with Mach-O thin (arm64)
CodeDirectory v=20500 size=757 flags=0x10002(adhoc,runtime) hashes=13+7 location=embedded
Signature=adhoc
Info.plist entries=35
TeamIdentifier=not set
Runtime Version=12.3.0
Sealed Resources version=2 rules=13 files=9867
Internal requirements count=0 size=12
```

TODO:

- Import certificate to build host and use it; needs to be placed in `$TMPDIR/buildagent.keychain` IIUC.
- Validate application entitlements are compatible with our own requirements.