### PR TITLE
wire up runtime events in help service

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -13,6 +13,7 @@ import { IPositronHelpService } from 'vs/workbench/services/positronHelp/common/
 import { MarkdownRenderer } from 'vs/editor/contrib/markdownRenderer/browser/markdownRenderer';
 import { ILanguageRuntimeEvent, ILanguageRuntimeService, LanguageRuntimeMessageType } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { LanguageRuntimeEventType, ShowHelpUrlEvent } from 'vs/workbench/services/languageRuntime/common/languageRuntimeEvents';
+import { URI } from 'vs/base/common/uri';
 
 // The TrustedTypePolicy for rendering.
 const ttPolicyPositronHelp = window.trustedTypes?.createPolicy('positronHelp', {
@@ -30,9 +31,13 @@ export class PositronHelpService extends Disposable implements IPositronHelpServ
 	// The markdown renderer.
 	private _markdownRenderer: MarkdownRenderer;
 
-	// The onSizeChanged event.
+	// The onRenderHelp event.
 	private _onRenderHelp = this._register(new Emitter<TrustedHTML | undefined>());
 	readonly onRenderHelp: Event<TrustedHTML | undefined> = this._onRenderHelp.event;
+
+	// The onShowHelpUrl event.
+	private _onShowHelpUrl = this._register(new Emitter<URI>());
+	readonly onShowHelpUrl: Event<URI> = this._onShowHelpUrl.event;
 
 	/**
 	 * Constructor.
@@ -62,7 +67,7 @@ export class PositronHelpService extends Disposable implements IPositronHelpServ
 					const event = message as ILanguageRuntimeEvent;
 					if (event.name === LanguageRuntimeEventType.ShowHelpUrl) {
 						const data = event.data as ShowHelpUrlEvent;
-						this.openHelpURL(data.url);
+						this.openHelpUrl(data.url);
 					}
 				}
 			});
@@ -96,8 +101,9 @@ export class PositronHelpService extends Disposable implements IPositronHelpServ
 	 * Opens the specified help URL.
 	 * @param url The help URL.
 	 */
-	openHelpURL(url: string) {
-		console.log(`+++++++++++++++ PositronHelpService openHelpURL ${url}`);
+	openHelpUrl(url: string) {
+		const uri = URI.parse(url, true);
+		this._onShowHelpUrl.fire(uri);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -52,6 +52,10 @@ export class PositronHelpService extends Disposable implements IPositronHelpServ
 		// TODO (kevin): use a more explicit interface for listening to
 		// language runtime events, rather than connecting through the
 		// language runtime service.
+		//
+		// TODO (kevin): is it possible that the help service could be
+		// instantiated _after_ a runtime was started? do we need to do
+		// anything explicit to force sequencing of startup events here?
 		languageRuntimeService.onDidStartRuntime(runtime => {
 			runtime.onDidReceiveRuntimeMessage(message => {
 				if (message.type === LanguageRuntimeMessageType.Event) {

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
@@ -107,6 +107,10 @@ export class PositronHelpViewPane extends ViewPane implements IReactComponentCon
 			this._helpIFrame.contentWindow?.document.write(helpResult as unknown as string);
 			this._helpIFrame.contentWindow?.document.close();
 		}));
+
+		this._register(this.positronHelpService.onShowHelpUrl(uri => {
+			// TODO (kevin): how do we convince VSCode to iframe the R help server?
+		}));
 	}
 
 	/**

--- a/src/vs/workbench/contrib/repl/browser/replInstanceView.ts
+++ b/src/vs/workbench/contrib/repl/browser/replInstanceView.ts
@@ -9,11 +9,11 @@ import { DomScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableEle
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { ReplCell, ReplCellState } from 'vs/workbench/contrib/repl/browser/replCell';
 import { IReplInstance } from 'vs/workbench/contrib/repl/browser/repl';
-import { ILanguageRuntime, ILanguageRuntimeError, ILanguageRuntimeEvent, ILanguageRuntimeOutput, ILanguageRuntimePrompt, ILanguageRuntimeState, LanguageRuntimeEventType, LanguageRuntimeMessageType, RuntimeCodeExecutionMode, RuntimeErrorBehavior, RuntimeOnlineState, RuntimeState, ShowHelpUrlEvent, ShowMessageEvent } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeError, ILanguageRuntimeEvent, ILanguageRuntimeOutput, ILanguageRuntimePrompt, ILanguageRuntimeState, LanguageRuntimeMessageType, RuntimeCodeExecutionMode, RuntimeErrorBehavior, RuntimeOnlineState, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ReplStatusMessage } from 'vs/workbench/contrib/repl/browser/replStatusMessage';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import Severity from 'vs/base/common/severity';
-import { IPositronHelpService } from 'vs/workbench/services/positronHelp/common/positronHelp';
+import { LanguageRuntimeEventType, ShowMessageEvent } from 'vs/workbench/services/languageRuntime/common/languageRuntimeEvents';
 
 export const REPL_NOTEBOOK_SCHEME = 'repl';
 
@@ -60,7 +60,6 @@ export class ReplInstanceView extends Disposable {
 
 	constructor(private readonly _instance: IReplInstance,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IPositronHelpService private readonly _positronHelpService: IPositronHelpService,
 		@ILogService private readonly _logService: ILogService,
 		@IDialogService private readonly _dialogService: IDialogService) {
 		super();
@@ -137,15 +136,8 @@ export class ReplInstanceView extends Disposable {
 				const evt = msg as ILanguageRuntimeEvent;
 				if (evt.name === LanguageRuntimeEventType.ShowMessage) {
 					const data = evt.data as ShowMessageEvent;
-					const msg = new ReplStatusMessage(
-						'info', `${data.message}`);
+					const msg = new ReplStatusMessage('info', `${data.message}`);
 					msg.render(this._cellContainer);
-				} else if (evt.name === LanguageRuntimeEventType.ShowHelpUrl) {
-					const data = evt.data as ShowHelpUrlEvent;
-					console.log(`Show Help URL: ${data.url}`);
-					this._positronHelpService.openHelpURL(data.url);
-				} else {
-					console.error(`Internal error: unhandled event '${JSON.stringify(evt)}'`);
 				}
 			} else if (msg.type === LanguageRuntimeMessageType.Prompt) {
 				this.showPrompt(msg as ILanguageRuntimePrompt);

--- a/src/vs/workbench/services/positronHelp/common/positronHelp.ts
+++ b/src/vs/workbench/services/positronHelp/common/positronHelp.ts
@@ -5,6 +5,7 @@
 import { Event } from 'vs/base/common/event';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { MarkdownString } from 'vs/base/common/htmlContent';
+import { URI } from 'vs/base/common/uri';
 
 export const POSITRON_HELP_VIEW_ID = 'workbench.panel.positronHelp';
 
@@ -20,8 +21,8 @@ export interface IPositronHelpService {
 	readonly _serviceBrand: undefined;
 
 	readonly onRenderHelp: Event<TrustedHTML | undefined>;
+	readonly onShowHelpUrl: Event<URI>;
 
 	openHelpMarkdown(markdown: MarkdownString): void;
-
-	openHelpURL(url: string): void;
+	openHelpUrl(url: string): void;
 }


### PR DESCRIPTION
In the end, it felt more natural to put this in the Help service directly rather than threaded through from the REPL service.