### PR TITLE
Update the runtime registration API to allow startup behavior to be customized

### DIFF
--- a/extensions/jupyter-adapter/src/Api.ts
+++ b/extensions/jupyter-adapter/src/Api.ts
@@ -22,8 +22,9 @@ export class Api implements vscode.Disposable {
 	 */
 	adaptKernel(kernel: JupyterKernelSpec,
 		version: string,
-		lsp: () => Promise<number> | null): positron.LanguageRuntime {
-		return new LanguageRuntimeAdapter(kernel, version, lsp, this._channel);
+		lsp: () => Promise<number> | null,
+		startupBehavior: positron.LanguageRuntimeStartupBehavior = positron.LanguageRuntimeStartupBehavior.Implicit): positron.LanguageRuntime {
+		return new LanguageRuntimeAdapter(kernel, version, lsp, this._channel, startupBehavior);
 	}
 
 	dispose() {

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -49,7 +49,8 @@ export class LanguageRuntimeAdapter
 	constructor(private readonly _spec: JupyterKernelSpec,
 		version: string,
 		private readonly _lsp: () => Promise<number> | null,
-		private readonly _channel: vscode.OutputChannel) {
+		private readonly _channel: vscode.OutputChannel,
+		startupBehavior: positron.LanguageRuntimeStartupBehavior = positron.LanguageRuntimeStartupBehavior.Implicit) {
 		this._kernel = new JupyterKernel(this._spec, this._channel);
 
 		// Generate kernel metadata and ID
@@ -58,6 +59,7 @@ export class LanguageRuntimeAdapter
 			name: this._spec.display_name,
 			version: version,
 			id: uuidv4(),
+			startupBehavior: startupBehavior
 		};
 		this._channel.appendLine('Registered kernel: ' + JSON.stringify(this.metadata));
 

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -28,7 +28,8 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		id: '7282a3c7-c6b7-4652-b59d-a10506f2d21a',
 		language: 'Zed',
 		name: 'Zed',
-		version: '1.0.0'
+		version: '1.0.0',
+		startupBehavior: positron.LanguageRuntimeStartupBehavior.Implicit
 	};
 
 	/**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -226,6 +226,17 @@ declare module 'positron' {
 
 		/** The version of the runtime. */
 		version: string;
+
+		/** Whether the runtime should start up automatically or wait until explicitly requested */
+		startupBehavior: LanguageRuntimeStartupBehavior;
+	}
+
+	export enum LanguageRuntimeStartupBehavior {
+		/** The runtime should start automatically; usually used for runtimes that provide LSPs */
+		Implicit = 'implicit',
+
+		/** The runtime should start when the user explicitly requests it; usually used for runtimes that only provide REPLs */
+		Explicit = 'explicit',
 	}
 
 	/**

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -9,7 +9,7 @@ import {
 	ExtHostPositronContext
 } from '../../common/positron/extHost.positron.protocol';
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
-import { ILanguageRuntime, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMetadata, ILanguageRuntimeService, IRuntimeClientInstance, LanguageRuntimeStartupBehavior, RuntimeClientState, RuntimeClientType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMetadata, ILanguageRuntimeService, IRuntimeClientInstance, RuntimeClientState, RuntimeClientType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { Event, Emitter } from 'vs/base/common/event';
 
@@ -220,7 +220,7 @@ export class MainThreadLanguageRuntime implements MainThreadLanguageRuntimeShape
 		// Consider - do we need a flag (on the API side) to indicate whether
 		// the runtime should be started implicitly?
 		this._languageRuntimeService.registerRuntime(adapter,
-			LanguageRuntimeStartupBehavior.Implicit);
+			metadata.startupBehavior);
 	}
 
 	$unregisterLanguageRuntime(handle: number): void {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -49,6 +49,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			LanguageRuntimeEventType: extHostTypes.LanguageRuntimeEventType,
 			RuntimeCodeExecutionMode: extHostTypes.RuntimeCodeExecutionMode,
 			RuntimeErrorBehavior: extHostTypes.RuntimeErrorBehavior,
+			LanguageRuntimeStartupBehavior: extHostTypes.LanguageRuntimeStartupBehavior,
 			RuntimeOnlineState: extHostTypes.RuntimeOnlineState,
 			RuntimeState: extHostTypes.RuntimeState,
 			RuntimeCodeFragmentStatus: extHostTypes.RuntimeCodeFragmentStatus,

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -154,3 +154,11 @@ export enum RuntimeErrorBehavior {
 	/** The runtime should continue execution when an error is encountered */
 	Continue = 'continue',
 }
+
+export enum LanguageRuntimeStartupBehavior {
+	/** The runtime should start automatically; usually used for runtimes that provide LSPs */
+	Implicit = 'implicit',
+
+	/** The runtime should start when the user explicitly requests it; usually used for runtimes that only provide REPLs */
+	Explicit = 'explicit',
+}

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeNotebook.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeNotebook.ts
@@ -6,7 +6,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
 import { ILogService } from 'vs/platform/log/common/log';
-import { ILanguageRuntime, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMetadata, ILanguageRuntimeOutput, ILanguageRuntimeState, IRuntimeClientInstance, LanguageRuntimeMessageType, RuntimeClientType, RuntimeCodeFragmentStatus, RuntimeOnlineState, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMetadata, ILanguageRuntimeOutput, ILanguageRuntimeState, IRuntimeClientInstance, LanguageRuntimeMessageType, LanguageRuntimeStartupBehavior, RuntimeClientType, RuntimeCodeFragmentStatus, RuntimeOnlineState, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
 import { CellEditType, CellKind } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { INotebookExecutionStateService } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
@@ -59,7 +59,8 @@ export class NotebookLanguageRuntime extends Disposable implements ILanguageRunt
 			version: '1.0',
 			id: _kernel.id,
 			language: _kernel.supportedLanguages[0],
-			name: `${this._kernel.label} - ${this._kernel.description} [Notebook Bridge]`
+			name: `${this._kernel.label} - ${this._kernel.description} [Notebook Bridge]`,
+			startupBehavior: LanguageRuntimeStartupBehavior.Implicit
 		};
 
 		this._messages = this._register(new Emitter<ILanguageRuntimeMessage>());

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -226,6 +226,9 @@ export interface ILanguageRuntimeMetadata {
 
 	/** The version of the runtime. */
 	readonly version: string;
+
+	/** Whether the runtime should start up automatically or wait until explicitly requested */
+	startupBehavior: LanguageRuntimeStartupBehavior;
 }
 
 /**


### PR DESCRIPTION
We want to be able to register multiple python environments as potential runtimes, but we only want to mark those with ipykernel already installed as being suitable for implicit starting.

