### PR TITLE
For the container dev scenario, install cmake in Positron post-create.sh

### DIFF
--- a/.devcontainer/cache/post-create.sh
+++ b/.devcontainer/cache/post-create.sh
@@ -21,6 +21,10 @@ sudo apt --assume-yes install python3-pip
 echo "*** Installing key Python packages"
 pip3 install ipython ipykernel pandas numpy matplotlib
 
+# Install cmake which is used to build dependencies in our jupyter-adapter extension
+echo "*** Installing cmake"
+sudo apt --assume-yes install cmake
+
 # Install R base system
 echo "*** Installing R base system"
 sudo apt --assume-yes install r-base

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,9 @@
 	},
 
 	// Optionally loads a cached yarn install for the repo
-	"postCreateCommand": ".devcontainer/cache/restore-diff.sh",
+    // --- Start Positron ---
+	"postCreateCommand": ".devcontainer/cache/post-create.sh",
+    // --- End Positron ---
 
 	"remoteUser": "node",
 


### PR DESCRIPTION
When building Positron in a dev container in VS Code, we now need cmake installed to build the jupyter-adapter dependencies while running yarn.

