### PR TITLE
Part one of two parts to refactor onDidReceiveRuntimeMessage out of I…

### DIFF
--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -15,12 +15,12 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 	/**
 	 * The onDidReceiveRuntimeMessage event emitter.
 	 */
-	private readonly _onDidReceiveRuntimeMessage: vscode.EventEmitter<positron.LanguageRuntimeMessage> = new vscode.EventEmitter<positron.LanguageRuntimeMessage>();
+	private readonly _onDidReceiveRuntimeMessage = new vscode.EventEmitter<positron.LanguageRuntimeMessage>();
 
 	/**
 	 * The onDidChangeRuntimeState event emitter.
 	 */
-	private readonly _onDidChangeRuntimeState: vscode.EventEmitter<positron.RuntimeState> = new vscode.EventEmitter<positron.RuntimeState>();
+	private readonly _onDidChangeRuntimeState = new vscode.EventEmitter<positron.RuntimeState>();
 
 	/**
 	 * A history of executed commands
@@ -46,20 +46,6 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		};
 	}
 
-	getExecutionHistory(type: positron.LanguageRuntimeHistoryType, max: number): Thenable<string[][]> {
-		// Number of items to return: the lesser of the max and the number of items in the history
-		const n = Math.min(max, this._history.length);
-		const history = this._history.slice(n * -1);
-
-		if (type === positron.LanguageRuntimeHistoryType.InputAndOutput) {
-			// If the type is input and output, return the entire history
-			return Promise.resolve(history);
-		} else {
-			// If the type is input only, return only the input
-			return Promise.resolve(history.map(h => [h[0]]));
-		}
-	}
-
 	//#endregion Constructor
 
 	//#region LanguageRuntime Implementation
@@ -78,8 +64,6 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 	 * An object that emits he current state of the runtime.
 	 */
 	onDidChangeRuntimeState: vscode.Event<positron.RuntimeState> = this._onDidChangeRuntimeState.event;
-
-	//#region  Public Properties
 
 	/**
 	 * Execute code in the runtime.
@@ -147,6 +131,25 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 	}
 
 	/**
+	 * Gets the history of code executed in the runtime.
+	 * @param type The type of history to return
+	 * @param max The maximum number of entries to return.
+	 */
+	getExecutionHistory(type: positron.LanguageRuntimeHistoryType, max: number): Thenable<string[][]> {
+		// Number of items to return: the lesser of the max and the number of items in the history
+		const n = Math.min(max, this._history.length);
+		const history = this._history.slice(n * -1);
+
+		if (type === positron.LanguageRuntimeHistoryType.InputAndOutput) {
+			// If the type is input and output, return the entire history
+			return Promise.resolve(history);
+		} else {
+			// If the type is input only, return only the input
+			return Promise.resolve(history.map(h => [h[0]]));
+		}
+	}
+
+	/**
 	 * Create a new instance of a client.
 	 * @param type The runtime client type.
 	 */
@@ -184,7 +187,6 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 	 * @returns A Thenable that resolves with information about the runtime
 	 */
 	start(): Thenable<positron.LanguageRuntimeInfo> {
-
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Ready);
 		return Promise.resolve({
 			banner: `Zed ${this.metadata.version}`,

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IDisposable } from 'vs/base/common/lifecycle';
-import { ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMetadata, LanguageRuntimeHistoryType, RuntimeClientState, RuntimeClientType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMetadata, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, LanguageRuntimeHistoryType, RuntimeClientState, RuntimeClientType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { createProxyIdentifier, IRPCProtocol } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
 // This is the interface that the main process exposes to the extension host
@@ -14,6 +14,13 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$emitLanguageRuntimeState(handle: number, state: RuntimeState): void;
 	$emitRuntimeClientMessage(handle: number, id: string, message: ILanguageRuntimeMessage): void;
 	$emitRuntimeClientState(handle: number, id: string, state: RuntimeClientState): void;
+
+	$emitLanguageRuntimeMessageOutput(handle: number, message: ILanguageRuntimeMessageOutput): void;
+	$emitLanguageRuntimeMessageInput(handle: number): void; // TODO@softwarenerd - Add ILanguageRuntimeMessageInput.
+	$emitLanguageRuntimeMessageError(handle: number, message: ILanguageRuntimeMessageError): void;
+	$emitLanguageRuntimeMessagePrompt(handle: number, message: ILanguageRuntimeMessagePrompt): void;
+	$emitLanguageRuntimeMessageState(handle: number, message: ILanguageRuntimeMessageState): void;
+	$emitLanguageRuntimeMessageEvent(handle: number, message: ILanguageRuntimeMessageEvent): void;
 }
 
 // The interface to the main thread exposed by the extension host

--- a/src/vs/workbench/contrib/positronEnvironment/browser/classes/languageEnvironment.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/classes/languageEnvironment.tsx
@@ -213,22 +213,26 @@ export class LanguageEnvironment extends Disposable implements IListItemsProvide
 			console.log(`********************* onDidChangeRuntimeState ${runtimeState}`);
 		}));
 
+		this._register(this._runtime.onDidReceiveRuntimeMessageOutput(languageRuntimeMessageOutput => {
+		}));
+
+		// Add the did receive runtime message event handler.
+		this._register(this._runtime.onDidReceiveRuntimeMessage(languageRuntimeMessage => {
+			console.log(`********************* onDidReceiveRuntimeMessage ${languageRuntimeMessage.id} ${languageRuntimeMessage.type}`);
+			console.log(languageRuntimeMessage);
+		}));
+
 		// Add the did complete startup event handler.
 		this._register(this._runtime.onDidCompleteStartup(languageRuntimeInfo => {
 			console.log(`********************* onDidCompleteStartup ${this._runtime.metadata.language}`);
 		}));
 
-		// Add the did receive runtime message event handler.
-		this._register(this._runtime.onDidReceiveRuntimeMessage(languageRuntimeMessage => {
-			console.log(`********************* onDidReceiveRuntimeMessage ${languageRuntimeMessage.id}`);
-		}));
-
 		this.testInterval = setInterval(() => {
-			console.log(`testInterval fired. ${new Date().getTime()}`);
-			const date = new Date();
-			const name = `variable${date.getTime()}`;
-			this.setEnvironmentDataEntry(new EnvironmentValueEntry(name, new StringEnvironmentValue(date.toTimeString())));
-			this.setEnvironmentValueEntry(new EnvironmentValueEntry(name, new StringEnvironmentValue(date.toTimeString())));
+			// console.log(`testInterval fired. ${new Date().getTime()}`);
+			// const date = new Date();
+			// const name = `variable${date.getTime()}`;
+			// this.setEnvironmentDataEntry(new EnvironmentValueEntry(name, new StringEnvironmentValue(date.toTimeString())));
+			// this.setEnvironmentValueEntry(new EnvironmentValueEntry(name, new StringEnvironmentValue(date.toTimeString())));
 		}, 1000);
 	}
 
@@ -269,23 +273,23 @@ export class LanguageEnvironment extends Disposable implements IListItemsProvide
 
 	//#region Private Methods
 
-	/**
-	 * Sets an environment data entry.
-	 * @param environmenentEntry
-	 */
-	private setEnvironmentDataEntry(environmenentEntry: EnvironmentValueEntry) {
-		this.environmentDataEntries.set(environmenentEntry.name, environmenentEntry);
-		this.onDidChangeListItemsEmitter.fire();
-	}
+	// /**
+	//  * Sets an environment data entry.
+	//  * @param environmenentEntry
+	//  */
+	// private setEnvironmentDataEntry(environmenentEntry: EnvironmentValueEntry) {
+	// 	this.environmentDataEntries.set(environmenentEntry.name, environmenentEntry);
+	// 	this.onDidChangeListItemsEmitter.fire();
+	// }
 
-	/**
-	 * Sets an environment value entry.
-	 * @param environmenentEntry
-	 */
-	private setEnvironmentValueEntry(environmenentEntry: EnvironmentValueEntry) {
-		this.environmentValueEntries.set(environmenentEntry.name, environmenentEntry);
-		this.onDidChangeListItemsEmitter.fire();
-	}
+	// /**
+	//  * Sets an environment value entry.
+	//  * @param environmenentEntry
+	//  */
+	// private setEnvironmentValueEntry(environmenentEntry: EnvironmentValueEntry) {
+	// 	this.environmentValueEntries.set(environmenentEntry.name, environmenentEntry);
+	// 	this.onDidChangeListItemsEmitter.fire();
+	// }
 
 	//#endregion Private Methods
 }

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -11,7 +11,7 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { IPositronHelpService } from 'vs/workbench/services/positronHelp/common/positronHelp';
 import { MarkdownRenderer } from 'vs/editor/contrib/markdownRenderer/browser/markdownRenderer';
-import { ILanguageRuntimeEvent, ILanguageRuntimeService, LanguageRuntimeMessageType } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeMessageEvent, ILanguageRuntimeService, LanguageRuntimeMessageType } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { LanguageRuntimeEventType, ShowHelpEvent } from 'vs/workbench/services/languageRuntime/common/languageRuntimeEvents';
 
 // The TrustedTypePolicy for rendering.
@@ -51,7 +51,7 @@ export class PositronHelpService extends Disposable implements IPositronHelpServ
 		languageRuntimeService.onDidStartRuntime(runtime => {
 			runtime.onDidReceiveRuntimeMessage(message => {
 				if (message.type === LanguageRuntimeMessageType.Event) {
-					const event = message as ILanguageRuntimeEvent;
+					const event = message as ILanguageRuntimeMessageEvent;
 					if (event.name === LanguageRuntimeEventType.ShowHelp) {
 						const data = event.data as ShowHelpEvent;
 						if (data.kind === 'markdown') {

--- a/src/vs/workbench/contrib/repl/browser/replInstanceView.ts
+++ b/src/vs/workbench/contrib/repl/browser/replInstanceView.ts
@@ -9,7 +9,7 @@ import { DomScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableEle
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { ReplCell, ReplCellState } from 'vs/workbench/contrib/repl/browser/replCell';
 import { IReplInstance } from 'vs/workbench/contrib/repl/browser/repl';
-import { ILanguageRuntime, ILanguageRuntimeError, ILanguageRuntimeEvent, ILanguageRuntimeOutput, ILanguageRuntimePrompt, ILanguageRuntimeState, LanguageRuntimeHistoryType, LanguageRuntimeMessageType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeOnlineState, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, LanguageRuntimeHistoryType, LanguageRuntimeMessageType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeOnlineState, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ReplStatusMessage } from 'vs/workbench/contrib/repl/browser/replStatusMessage';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import Severity from 'vs/base/common/severity';
@@ -92,7 +92,7 @@ export class ReplInstanceView extends Disposable {
 		// Listen for execution state changes
 		this._runtime.onDidReceiveRuntimeMessage((msg) => {
 			if (msg.type === LanguageRuntimeMessageType.State) {
-				const stateMsg = msg as ILanguageRuntimeState;
+				const stateMsg = msg as ILanguageRuntimeMessageState;
 
 				// If the kernel is entering a busy state, ignore for now
 				if (stateMsg.state === RuntimeOnlineState.Busy) {
@@ -113,7 +113,7 @@ export class ReplInstanceView extends Disposable {
 					this.addCell(this._hadFocus);
 				}
 			} else if (msg.type === LanguageRuntimeMessageType.Output) {
-				const outputMsg = msg as ILanguageRuntimeOutput;
+				const outputMsg = msg as ILanguageRuntimeMessageOutput;
 
 				// Look up the cell with which this output is associated
 				const cell = this._executedCells.get(outputMsg.parent_id);
@@ -123,7 +123,7 @@ export class ReplInstanceView extends Disposable {
 					this._logService.warn(`Received output ${JSON.stringify(outputMsg)} for unknown code execution ${outputMsg.parent_id}`);
 				}
 			} else if (msg.type === LanguageRuntimeMessageType.Error) {
-				const errMsg = msg as ILanguageRuntimeError;
+				const errMsg = msg as ILanguageRuntimeMessageError;
 
 				// Look up the cell with which this error is associated
 				const cell = this._executedCells.get(errMsg.parent_id);
@@ -133,7 +133,7 @@ export class ReplInstanceView extends Disposable {
 					this._logService.warn(`Received error ${JSON.stringify(errMsg)} for unknown code execution ${errMsg.parent_id}`);
 				}
 			} else if (msg.type === LanguageRuntimeMessageType.Event) {
-				const evt = msg as ILanguageRuntimeEvent;
+				const evt = msg as ILanguageRuntimeMessageEvent;
 				if (evt.name === LanguageRuntimeEventType.ShowMessage) {
 					const data = evt.data as ShowMessageEvent;
 					const msg = new ReplStatusMessage(
@@ -141,7 +141,7 @@ export class ReplInstanceView extends Disposable {
 					msg.render(this._cellContainer);
 				}
 			} else if (msg.type === LanguageRuntimeMessageType.Prompt) {
-				this.showPrompt(msg as ILanguageRuntimePrompt);
+				this.showPrompt(msg as ILanguageRuntimeMessagePrompt);
 			}
 
 			this.scrollToBottom();
@@ -433,7 +433,7 @@ export class ReplInstanceView extends Disposable {
 	 *
 	 * @param prompt The prompt to display
 	 */
-	private showPrompt(prompt: ILanguageRuntimePrompt) {
+	private showPrompt(prompt: ILanguageRuntimeMessagePrompt) {
 		this._dialogService.input(
 			Severity.Info,
 			prompt.prompt,

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -8,7 +8,7 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
-import { formatLanguageRuntime, ILanguageRuntime, ILanguageRuntimeEvent, ILanguageRuntimeGlobalEvent, ILanguageRuntimeService, ILanguageRuntimeStateEvent, LanguageRuntimeMessageType, LanguageRuntimeStartupBehavior, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { formatLanguageRuntime, ILanguageRuntime, ILanguageRuntimeMessageEvent, ILanguageRuntimeGlobalEvent, ILanguageRuntimeService, ILanguageRuntimeStateEvent, LanguageRuntimeMessageType, LanguageRuntimeStartupBehavior, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 
 /**
  * The language runtime info class.
@@ -226,7 +226,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 		this._register(runtime.onDidReceiveRuntimeMessage((message) => {
 			// Rebroadcast runtime events globally
 			if (message.type === LanguageRuntimeMessageType.Event) {
-				const event = message as ILanguageRuntimeEvent;
+				const event = message as ILanguageRuntimeMessageEvent;
 				this._onDidReceiveRuntimeEvent.fire({
 					id: runtime.metadata.id,
 					event

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -33,13 +33,13 @@ export interface ILanguageRuntimeMessage {
 }
 
 /** LanguageRuntimeOutput is a LanguageRuntimeMessage representing output (text, plots, etc.) */
-export interface ILanguageRuntimeOutput extends ILanguageRuntimeMessage {
+export interface ILanguageRuntimeMessageOutput extends ILanguageRuntimeMessage {
 	/** A map of data MIME types to the associated data, e.g. `text/plain` => `'hello world'` */
 	data: Map<string, string>;
 }
 
 /** LanguageRuntimePrompt is a LanguageRuntimeMessage representing a prompt for input */
-export interface ILanguageRuntimePrompt extends ILanguageRuntimeMessage {
+export interface ILanguageRuntimeMessagePrompt extends ILanguageRuntimeMessage {
 	/** The prompt text */
 	prompt: string;
 
@@ -187,12 +187,12 @@ export enum LanguageRuntimeStartupBehavior {
 	Explicit = 'explicit',
 }
 
-export interface ILanguageRuntimeState extends ILanguageRuntimeMessage {
+export interface ILanguageRuntimeMessageState extends ILanguageRuntimeMessage {
 	/** The new state */
 	state: RuntimeOnlineState;
 }
 
-export interface ILanguageRuntimeError extends ILanguageRuntimeMessage {
+export interface ILanguageRuntimeMessageError extends ILanguageRuntimeMessage {
 	/** The error name */
 	name: string;
 
@@ -203,7 +203,7 @@ export interface ILanguageRuntimeError extends ILanguageRuntimeMessage {
 	traceback: Array<string>;
 }
 
-export interface ILanguageRuntimeEvent extends ILanguageRuntimeMessage {
+export interface ILanguageRuntimeMessageEvent extends ILanguageRuntimeMessage {
 	/** The event name */
 	name: LanguageRuntimeEventType;
 
@@ -216,7 +216,7 @@ export interface ILanguageRuntimeGlobalEvent {
 	id: string;
 
 	/** The event itself */
-	event: ILanguageRuntimeEvent;
+	event: ILanguageRuntimeMessageEvent;
 }
 
 export interface ILanguageRuntimeStateEvent {
@@ -313,6 +313,13 @@ export interface ILanguageRuntime {
 
 	/** An object that emits an event when the runtime completes startup */
 	onDidCompleteStartup: Event<ILanguageRuntimeInfo>;
+
+	onDidReceiveRuntimeMessageOutput: Event<ILanguageRuntimeMessageOutput>;
+	onDidReceiveRuntimeMessageInput: Event<void>;
+	onDidReceiveRuntimeMessageError: Event<ILanguageRuntimeMessageError>;
+	onDidReceiveRuntimeMessagePrompt: Event<ILanguageRuntimeMessagePrompt>;
+	onDidReceiveRuntimeMessageState: Event<ILanguageRuntimeMessageState>;
+	onDidReceiveRuntimeMessagesEvent: Event<ILanguageRuntimeMessageEvent>;
 
 	/** The current state of the runtime (tracks events above) */
 	getRuntimeState(): RuntimeState;


### PR DESCRIPTION
Part one of two parts to refactor `onDidReceiveRuntimeMessage` out of `ILanguageRuntime` in favor of new, discrete, and strongly-typed events called:

- `onDidReceiveRuntimeMessageOutput`
- `onDidReceiveRuntimeMessageInput`
- `onDidReceiveRuntimeMessageError`
- `onDidReceiveRuntimeMessagePrompt`
- `onDidReceiveRuntimeMessageState`
- `onDidReceiveRuntimeMessagesEvent`.

This will prevent us from having to implement a big `if` statement or `switch` statement in every implementation of `onDidReceiveRuntimeMessage` to determine what type of `ILanguageRuntimeMessage` was received.