### PR TITLE
Part two of the removal of onDidReceiveRuntimeMessage

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -18,7 +18,6 @@ import { Event, Emitter } from 'vs/base/common/event';
 class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 
 	private readonly _stateEmitter = new Emitter<RuntimeState>();
-	private readonly _messageEmitter = new Emitter<ILanguageRuntimeMessage>();
 	private readonly _startupEmitter = new Emitter<ILanguageRuntimeInfo>();
 
 	private readonly _onDidReceiveRuntimeMessageOutputEmitter = new Emitter<ILanguageRuntimeMessageOutput>();
@@ -37,7 +36,6 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 
 		// Bind events to emitters
 		this.onDidChangeRuntimeState = this._stateEmitter.event;
-		this.onDidReceiveRuntimeMessage = this._messageEmitter.event;
 		this.onDidCompleteStartup = this._startupEmitter.event;
 
 		// Listen to state changes and track the current state
@@ -45,8 +43,6 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 			this._currentState = state;
 		});
 	}
-
-	onDidReceiveRuntimeMessage: Event<ILanguageRuntimeMessage>;
 
 	onDidChangeRuntimeState: Event<RuntimeState>;
 
@@ -57,11 +53,7 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 	onDidReceiveRuntimeMessageError = this._onDidReceiveRuntimeMessageErrorEmitter.event;
 	onDidReceiveRuntimeMessagePrompt = this._onDidReceiveRuntimeMessagePromptEmitter.event;
 	onDidReceiveRuntimeMessageState = this._onDidReceiveRuntimeMessageStateEmitter.event;
-	onDidReceiveRuntimeMessagesEvent = this._onDidReceiveRuntimeMessageEventEmitter.event;
-
-	emitMessage(message: ILanguageRuntimeMessage): void {
-		this._messageEmitter.fire(message);
-	}
+	onDidReceiveRuntimeMessageEvent = this._onDidReceiveRuntimeMessageEventEmitter.event;
 
 	emitDidReceiveRuntimeMessageOutput(languageRuntimeMessageOutput: ILanguageRuntimeMessageOutput) {
 		this._onDidReceiveRuntimeMessageOutputEmitter.fire(languageRuntimeMessageOutput);
@@ -235,10 +227,6 @@ export class MainThreadLanguageRuntime implements MainThreadLanguageRuntimeShape
 
 	$emitRuntimeClientState(handle: number, id: string, state: RuntimeClientState): void {
 		throw new Error('Method not implemented.');
-	}
-
-	$emitLanguageRuntimeMessage(handle: number, message: ILanguageRuntimeMessage): void {
-		this.findRuntime(handle).emitMessage(message);
 	}
 
 	$emitLanguageRuntimeMessageOutput(handle: number, message: ILanguageRuntimeMessageOutput): void {

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -10,7 +10,6 @@ import { createProxyIdentifier, IRPCProtocol } from 'vs/workbench/services/exten
 export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$registerLanguageRuntime(handle: number, metadata: ILanguageRuntimeMetadata): void;
 	$unregisterLanguageRuntime(handle: number): void;
-	$emitLanguageRuntimeMessage(handle: number, message: ILanguageRuntimeMessage): void;
 	$emitLanguageRuntimeState(handle: number, state: RuntimeState): void;
 	$emitRuntimeClientMessage(handle: number, id: string, message: ILanguageRuntimeMessage): void;
 	$emitRuntimeClientState(handle: number, id: string, state: RuntimeClientState): void;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type * as positron from 'positron';
-import { ILanguageRuntimeInfo, ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, LanguageRuntimeHistoryType, RuntimeClientType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, LanguageRuntimeHistoryType, RuntimeClientType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import * as extHostProtocol from './extHost.positron.protocol';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { Disposable, LanguageRuntimeMessageType } from 'vs/workbench/api/common/extHostTypes';
@@ -112,34 +112,31 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		runtime.onDidChangeRuntimeState(state =>
 			this._proxy.$emitLanguageRuntimeState(handle, state));
 
-		// TODO@softwarenerd - This should broker the runtime message.
 		runtime.onDidReceiveRuntimeMessage(message => {
-			this._proxy.$emitLanguageRuntimeMessage(handle, message);
-
 			// Broker the message type to one of the discrete message events.
 			switch (message.type) {
 				case LanguageRuntimeMessageType.Output:
-					this._proxy.$emitLanguageRuntimeMessageOutput(handle, message as ILanguageRuntimeMessageOutput);
+					this._proxy.$emitLanguageRuntimeMessageOutput(handle, message as ILanguageRuntimeMessage as ILanguageRuntimeMessageOutput);
 					break;
 
 				case LanguageRuntimeMessageType.Input:
-					this._proxy.$emitLanguageRuntimeMessageInput(handle, message as ILanguageRuntimeMessageInput);
+					this._proxy.$emitLanguageRuntimeMessageInput(handle, message as ILanguageRuntimeMessage as ILanguageRuntimeMessageInput);
 					break;
 
 				case LanguageRuntimeMessageType.Error:
-					this._proxy.$emitLanguageRuntimeMessageError(handle, message as ILanguageRuntimeMessageError);
+					this._proxy.$emitLanguageRuntimeMessageError(handle, message as ILanguageRuntimeMessage as ILanguageRuntimeMessageError);
 					break;
 
 				case LanguageRuntimeMessageType.Prompt:
-					this._proxy.$emitLanguageRuntimeMessagePrompt(handle, message as ILanguageRuntimeMessagePrompt);
+					this._proxy.$emitLanguageRuntimeMessagePrompt(handle, message as ILanguageRuntimeMessage as ILanguageRuntimeMessagePrompt);
 					break;
 
 				case LanguageRuntimeMessageType.State:
-					this._proxy.$emitLanguageRuntimeMessageState(handle, message as ILanguageRuntimeMessageState);
+					this._proxy.$emitLanguageRuntimeMessageState(handle, message as ILanguageRuntimeMessage as ILanguageRuntimeMessageState);
 					break;
 
 				case LanguageRuntimeMessageType.Event:
-					this._proxy.$emitLanguageRuntimeMessageEvent(handle, message as ILanguageRuntimeMessageEvent);
+					this._proxy.$emitLanguageRuntimeMessageEvent(handle, message as ILanguageRuntimeMessage as ILanguageRuntimeMessageEvent);
 					break;
 			}
 		});

--- a/src/vs/workbench/contrib/positronEnvironment/browser/classes/languageEnvironment.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/classes/languageEnvironment.tsx
@@ -214,12 +214,32 @@ export class LanguageEnvironment extends Disposable implements IListItemsProvide
 		}));
 
 		this._register(this._runtime.onDidReceiveRuntimeMessageOutput(languageRuntimeMessageOutput => {
+			console.log('********************* onDidReceiveRuntimeMessageOutput');
+			console.log(languageRuntimeMessageOutput);
 		}));
 
-		// Add the did receive runtime message event handler.
-		this._register(this._runtime.onDidReceiveRuntimeMessage(languageRuntimeMessage => {
-			console.log(`********************* onDidReceiveRuntimeMessage ${languageRuntimeMessage.id} ${languageRuntimeMessage.type}`);
-			console.log(languageRuntimeMessage);
+		this._register(this._runtime.onDidReceiveRuntimeMessageInput(() => {
+			console.log('********************* onDidReceiveRuntimeMessageInput');
+		}));
+
+		this._register(this._runtime.onDidReceiveRuntimeMessageError(languageRuntimeMessageError => {
+			console.log('********************* languageRuntimeMessageError');
+			console.log(languageRuntimeMessageError);
+		}));
+
+		this._register(this._runtime.onDidReceiveRuntimeMessagePrompt(languageRuntimeMessagePrompt => {
+			console.log('********************* onDidReceiveRuntimeMessagePrompt');
+			console.log(languageRuntimeMessagePrompt);
+		}));
+
+		this._register(this._runtime.onDidReceiveRuntimeMessageState(languageRuntimeMessageState => {
+			console.log('********************* onDidReceiveRuntimeMessageState');
+			console.log(languageRuntimeMessageState);
+		}));
+
+		this._register(this._runtime.onDidReceiveRuntimeMessageEvent(languageRuntimeMessageEvent => {
+			console.log('********************* onDidReceiveRuntimeMessageEvent');
+			console.log(languageRuntimeMessageEvent);
 		}));
 
 		// Add the did complete startup event handler.

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -11,7 +11,7 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { IPositronHelpService } from 'vs/workbench/services/positronHelp/common/positronHelp';
 import { MarkdownRenderer } from 'vs/editor/contrib/markdownRenderer/browser/markdownRenderer';
-import { ILanguageRuntimeMessageEvent, ILanguageRuntimeService, LanguageRuntimeMessageType } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { LanguageRuntimeEventType, ShowHelpEvent } from 'vs/workbench/services/languageRuntime/common/languageRuntimeEvents';
 
 // The TrustedTypePolicy for rendering.
@@ -49,19 +49,18 @@ export class PositronHelpService extends Disposable implements IPositronHelpServ
 
 		// Listen for language runtime Help events.
 		languageRuntimeService.onDidStartRuntime(runtime => {
-			runtime.onDidReceiveRuntimeMessage(message => {
-				if (message.type === LanguageRuntimeMessageType.Event) {
-					const event = message as ILanguageRuntimeMessageEvent;
-					if (event.name === LanguageRuntimeEventType.ShowHelp) {
-						const data = event.data as ShowHelpEvent;
-						if (data.kind === 'markdown') {
-							const markdown = new MarkdownString(data.content, true);
-							this.openHelpMarkdown(markdown);
-						} else {
-							this.openHelpHtml(data.content);
-						}
+
+			runtime.onDidReceiveRuntimeMessageEvent(languageRuntimeMessageEvent => {
+				if (languageRuntimeMessageEvent.name === LanguageRuntimeEventType.ShowHelp) {
+					const data = languageRuntimeMessageEvent.data as ShowHelpEvent;
+					if (data.kind === 'markdown') {
+						const markdown = new MarkdownString(data.content, true);
+						this.openHelpMarkdown(markdown);
+					} else {
+						this.openHelpHtml(data.content);
 					}
 				}
+
 			});
 		});
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -8,7 +8,7 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
-import { formatLanguageRuntime, ILanguageRuntime, ILanguageRuntimeMessageEvent, ILanguageRuntimeGlobalEvent, ILanguageRuntimeService, ILanguageRuntimeStateEvent, LanguageRuntimeMessageType, LanguageRuntimeStartupBehavior, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { formatLanguageRuntime, ILanguageRuntime, ILanguageRuntimeGlobalEvent, ILanguageRuntimeService, ILanguageRuntimeStateEvent, LanguageRuntimeStartupBehavior, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 
 /**
  * The language runtime info class.
@@ -223,15 +223,12 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 			}
 		}));
 
-		this._register(runtime.onDidReceiveRuntimeMessage((message) => {
+		this._register(runtime.onDidReceiveRuntimeMessageEvent(languageRuntimeMessageEvent => {
 			// Rebroadcast runtime events globally
-			if (message.type === LanguageRuntimeMessageType.Event) {
-				const event = message as ILanguageRuntimeMessageEvent;
-				this._onDidReceiveRuntimeEvent.fire({
-					id: runtime.metadata.id,
-					event
-				});
-			}
+			this._onDidReceiveRuntimeEvent.fire({
+				id: runtime.metadata.id,
+				event: languageRuntimeMessageEvent
+			});
 		}));
 
 		return toDisposable(() => {

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -27,9 +27,6 @@ export interface ILanguageRuntimeMessage {
 
 	/** The ID of this event's parent (the event that caused it), if applicable */
 	parent_id: string;
-
-	/** The type of event */
-	type: LanguageRuntimeMessageType;
 }
 
 
@@ -315,9 +312,6 @@ export interface ILanguageRuntime {
 	/** The language runtime's static metadata */
 	readonly metadata: ILanguageRuntimeMetadata;
 
-	/** An object that emits language runtime events */
-	onDidReceiveRuntimeMessage: Event<ILanguageRuntimeMessage>;
-
 	/** An object that emits events when the runtime state changes */
 	onDidChangeRuntimeState: Event<RuntimeState>;
 
@@ -329,7 +323,7 @@ export interface ILanguageRuntime {
 	onDidReceiveRuntimeMessageError: Event<ILanguageRuntimeMessageError>;
 	onDidReceiveRuntimeMessagePrompt: Event<ILanguageRuntimeMessagePrompt>;
 	onDidReceiveRuntimeMessageState: Event<ILanguageRuntimeMessageState>;
-	onDidReceiveRuntimeMessagesEvent: Event<ILanguageRuntimeMessageEvent>;
+	onDidReceiveRuntimeMessageEvent: Event<ILanguageRuntimeMessageEvent>;
 
 	/** The current state of the runtime (tracks events above) */
 	getRuntimeState(): RuntimeState;


### PR DESCRIPTION
In this part, I've fully removed `onDidReceiveRuntimeMessage` and removed the type field from the `ILanguageRuntimeMessage` interface and refactored the event handling in `ReplInstanceView`.
