### PR TITLE
More protection care when initializing `PRECIOUS_LIST`

### DIFF
--- a/extensions/positron-r/amalthea/crates/harp/src/object.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/object.rs
@@ -43,10 +43,8 @@ unsafe fn protect(object: SEXP) -> SEXP {
 
     // Initialize the precious list.
     PRECIOUS_LIST_ONCE.call_once(|| {
-        let tail = Rf_protect(Rf_cons(R_NilValue, R_NilValue));
-        let precious_list = Rf_protect(Rf_cons(R_NilValue, tail));
+        let precious_list = Rf_cons(R_NilValue, Rf_cons(R_NilValue, R_NilValue));
         R_PreserveObject(precious_list);
-        Rf_unprotect(2);
         PRECIOUS_LIST = Some(precious_list);
     });
 

--- a/extensions/positron-r/amalthea/crates/harp/src/object.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/object.rs
@@ -33,6 +33,10 @@ static PRECIOUS_LIST_ONCE: Once = Once::new();
 static mut PRECIOUS_LIST : Option<SEXP> = None;
 
 unsafe fn protect(object: SEXP) -> SEXP {
+    // Nothing to do
+    if object == R_NilValue {
+        return R_NilValue;
+    }
 
     // Protect the incoming object, just in case.
     Rf_protect(object);
@@ -45,10 +49,6 @@ unsafe fn protect(object: SEXP) -> SEXP {
         Rf_unprotect(2);
         PRECIOUS_LIST = Some(precious_list);
     });
-
-    if object == R_NilValue {
-        return R_NilValue;
-    }
 
     let precious_list = PRECIOUS_LIST.unwrap_unchecked();
 

--- a/extensions/positron-r/amalthea/crates/harp/src/object.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/object.rs
@@ -39,8 +39,10 @@ unsafe fn protect(object: SEXP) -> SEXP {
 
     // Initialize the precious list.
     PRECIOUS_LIST_ONCE.call_once(|| {
-        let precious_list = Rf_cons(R_NilValue, Rf_cons(R_NilValue, R_NilValue));
+        let tail = Rf_protect(Rf_cons(R_NilValue, R_NilValue));
+        let precious_list = Rf_protect(Rf_cons(R_NilValue, tail));
         R_PreserveObject(precious_list);
+        Rf_unprotect(2);
         PRECIOUS_LIST = Some(precious_list);
     });
 


### PR DESCRIPTION
Because with the form: `Rf_cons(R_NilValue, Rf_cons(R_NilValue, R_NilValue))` the outer `Rf_cons` might gc the inner when it allocates. Also, I believe `R_PreserveObject()` allocates, so `precious_list` needs to be temporarily `Rf_protect()`'ed ?