### PR TITLE
Add initial keybindings for our Console

### DIFF
--- a/src/vs/workbench/contrib/repl/browser/replActions.ts
+++ b/src/vs/workbench/contrib/repl/browser/replActions.ts
@@ -13,6 +13,9 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { ILogService } from 'vs/platform/log/common/log';
 import { IEditor } from 'vs/editor/common/editorCommon';
 import { ITextModel } from 'vs/editor/common/model';
+import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
+import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 
 export function registerReplActions() {
 	const category: ILocalizedString = { value: REPL_ACTION_CATEGORY, original: 'REPL' };
@@ -60,6 +63,10 @@ export function registerReplActions() {
 				f1: true,
 				category,
 				icon: Codicon.plus,
+				keybinding: {
+					weight: KeybindingWeight.WorkbenchContrib,
+					primary: KeyMod.WinCtrl | KeyCode.KeyL
+				},
 				description: {
 					description: 'workbench.action.repl.clear',
 					args: []
@@ -86,6 +93,12 @@ export function registerReplActions() {
 				f1: true,
 				category,
 				icon: Codicon.plus,
+				keybinding: {
+					weight: KeybindingWeight.WorkbenchContrib,
+					primary: KeyMod.CtrlCmd | KeyCode.Enter,
+					win: { primary: KeyMod.WinCtrl | KeyCode.Enter },
+					when: EditorContextKeys.editorTextFocus
+				},
 				description: {
 					description: 'workbench.action.repl.send',
 					args: []

--- a/src/vs/workbench/contrib/repl/browser/replActions.ts
+++ b/src/vs/workbench/contrib/repl/browser/replActions.ts
@@ -16,6 +16,7 @@ import { ITextModel } from 'vs/editor/common/model';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 
 export function registerReplActions() {
 	const category: ILocalizedString = { value: REPL_ACTION_CATEGORY, original: 'REPL' };
@@ -65,7 +66,8 @@ export function registerReplActions() {
 				icon: Codicon.plus,
 				keybinding: {
 					weight: KeybindingWeight.WorkbenchContrib,
-					primary: KeyMod.WinCtrl | KeyCode.KeyL
+					primary: KeyMod.WinCtrl | KeyCode.KeyL,
+					when: ContextKeyExpr.not('notebookEditorFocused')
 				},
 				description: {
 					description: 'workbench.action.repl.clear',


### PR DESCRIPTION
To start we'll match RStudio for "Send to REPL" and Clear Console.

Keybindings:
```
Send to REPL  = Cmd+Enter (Ctrl+Enter on Windows)
Clear Console = Ctrl+L
```

For now, the only condition for Send to REPL is that the editor is focused. We may add additional criteria to limit this function to files that make sense for this action.
