### PR TITLE
Fix hover styles on Positron top and side bars.

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
@@ -37,10 +37,12 @@
 .action-bar-button-face:hover {
 	border-radius: 6px;
 	background: var(--positronActionBar-hoverBackground);
+	outline: 1px dashed var(--vscode-toolbar-hoverOutline);
 }
 
 .disabled .action-bar-button-face:hover {
 	background: transparent;
+	outline: none;
 }
 
 .action-bar-button-icon {

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -217,9 +217,10 @@ export function getColorRegistry(): IColorRegistry {
 //export const foreground = registerColor('foreground', { dark: '#CCCCCC', light: '#616161', hcDark: '#FFFFFF', hcLight: '#292929' }, nls.localize('foreground', "Overall foreground color. This color is only used if not overridden by a component."));
 export const foreground = registerColor('foreground', { dark: '#acbece', light: '#75828d', hcDark: '#ffffff', hcLight: '#000000' }, nls.localize('foreground', "Overall foreground color. This color is only used if not overridden by a component."));
 export const secondaryBackground = registerColor('secondaryBackground', { dark: '#292f32', light: '#dee1e5', hcDark: '#dee1e5', hcLight: '#dee1e5' }, nls.localize('foreground', "Overall foreground color. This color is only used if not overridden by a component."));
-// --- End Positron ---
 
-export const disabledForeground = registerColor('disabledForeground', { dark: '#CCCCCC80', light: '#61616180', hcDark: '#A5A5A5', hcLight: '#7F7F7F' }, nls.localize('disabledForeground', "Overall foreground for disabled elements. This color is only used if not overridden by a component."));
+//export const disabledForeground = registerColor('disabledForeground', { dark: '#CCCCCC80', light: '#61616180', hcDark: '#A5A5A5', hcLight: '#7F7F7F' }, nls.localize('disabledForeground', "Overall foreground for disabled elements. This color is only used if not overridden by a component."));
+export const disabledForeground = registerColor('disabledForeground', { dark: '#acbece80', light: '#75828d80', hcDark: '#A5A5A5', hcLight: '#7F7F7F' }, nls.localize('disabledForeground', "Overall foreground for disabled elements. This color is only used if not overridden by a component."));
+// --- End Positron ---
 export const errorForeground = registerColor('errorForeground', { dark: '#F48771', light: '#A1260D', hcDark: '#F48771', hcLight: '#B5200D' }, nls.localize('errorForeground', "Overall foreground color for error messages. This color is only used if not overridden by a component."));
 export const descriptionForeground = registerColor('descriptionForeground', { light: '#717171', dark: transparent(foreground, 0.7), hcDark: transparent(foreground, 0.7), hcLight: transparent(foreground, 0.7) }, nls.localize('descriptionForeground', "Foreground color for description text providing additional information, for example for a label."));
 // --- Start Positron ---

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -5,7 +5,7 @@
 
 import { localize } from 'vs/nls';
 // --- Start Positron ---
-import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground, treeIndentGuidesStroke, errorForeground, listActiveSelectionBackground, listActiveSelectionForeground, editorForeground, toolbarHoverBackground, inputBorder, widgetBorder, buttonForeground, buttonSecondaryForeground, buttonBackground, buttonSecondaryBackground, secondaryBackground, checkboxBorder, checkboxBackground, checkboxForeground, inputBackground, foreground } from 'vs/platform/theme/common/colorRegistry';
+import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground, treeIndentGuidesStroke, errorForeground, listActiveSelectionBackground, listActiveSelectionForeground, editorForeground, toolbarHoverBackground, inputBorder, widgetBorder, buttonForeground, buttonSecondaryForeground, buttonBackground, buttonSecondaryBackground, secondaryBackground, checkboxBorder, checkboxBackground, checkboxForeground, inputBackground, foreground, disabledForeground } from 'vs/platform/theme/common/colorRegistry';
 // --- End Positron ---
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
 import { Color } from 'vs/base/common/color';
@@ -992,18 +992,18 @@ export const POSITRON_TOP_ACTION_BAR_BACKGROUND = registerColor('positronTopActi
 
 // The Positron top action bar foreground color.
 export const POSITRON_TOP_ACTION_BAR_FOREGROUND = registerColor('positronTopActionBar.foreground', {
-	dark: '#acbece',
-	light: '#75828D',
-	hcDark: '#ffffff',
-	hcLight: '#000000'
+	dark: foreground,
+	light: foreground,
+	hcDark: foreground,
+	hcLight: foreground
 }, localize('positronTopActionBar.foreground', "Positron top action bar foreground color."));
 
 // The Positron top action bar disabled foreground color.
 export const POSITRON_TOP_ACTION_BAR_DISABLED_FOREGROUND = registerColor('positronTopActionBar.disabledForeground', {
-	dark: '#b9c0c6',
-	light: '#b9c0c6',
-	hcDark: '#00000088',
-	hcLight: '#00000088'
+	dark: disabledForeground,
+	light: disabledForeground,
+	hcDark: disabledForeground,
+	hcLight: disabledForeground
 }, localize('positronTopActionBar.disabledForeground', "Positron top action bar disabled foreground color."));
 
 // The Positron top action bar separator color.

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1032,10 +1032,10 @@ export const POSITRON_TOP_ACTION_BAR_SELECT_BOX_BACKGROUND = registerColor('posi
 
 // The Positron top action bar hover background color.
 export const POSITRON_TOP_ACTION_BAR_HOVER_BACKGROUND = registerColor('positronTopActionBar.hoverBackground', {
-	dark: '#dae1ea',
+	dark: '#000000',
 	light: '#dae1ea',
-	hcDark: '#dae1ea',
-	hcLight: '#dae1ea'
+	hcDark: null,
+	hcLight: null
 }, localize('positronTopActionBar.hoverBackground', "Positron top action bar hover background color."));
 
 // The Positron top action bar text input background color.
@@ -1114,10 +1114,10 @@ export const POSITRON_SIDE_ACTION_BAR_SEPARATOR = registerColor('positronSideAct
 
 // The Positron side action bar hover background color.
 export const POSITRON_SIDE_ACTION_BAR_HOVER_BACKGROUND = registerColor('positronSideActionBar.hoverBackground', {
-	dark: '#0c0c0d',
+	dark: '#3b4245',
 	light: '#dae1ea',
-	hcDark: '#0c0c0d',
-	hcLight: '#dae1ea'
+	hcDark: null,
+	hcLight: null
 }, localize('positronSideActionBar.hoverBackground', "Positron side action bar hover background color."));
 
 // The Positron side action bar text input background color.


### PR DESCRIPTION
Fix incorrect dark background for hover.
HC themes use outlines, not backgrounds, to show hover.
