### PR TITLE
Include timestamps on all language runtime messages

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -412,6 +412,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			message: msg.content,
 			msgId: msg.header.msg_id,
 			msgType: msg.header.msg_type,
+			when: msg.header.date,
 			originId: msg.parent_header ? msg.parent_header.msg_id : '',
 			socket: socket
 		};

--- a/extensions/jupyter-adapter/src/JupyterMessagePacket.ts
+++ b/extensions/jupyter-adapter/src/JupyterMessagePacket.ts
@@ -24,6 +24,9 @@ export interface JupyterMessagePacket {
 	/** The ID of the message that triggered this one */
 	originId: string;
 
+	/** The date and time the message was emitted, in ISO 8061 format */
+	when: string;
+
 	/** The message itself */
 	message: JupyterMessageSpec;
 

--- a/extensions/jupyter-adapter/src/JupyterRpc.ts
+++ b/extensions/jupyter-adapter/src/JupyterRpc.ts
@@ -36,6 +36,7 @@ export class JupyterRpc<T extends JupyterMessageSpec, U extends JupyterMessageSp
 			msgType: this.requestType,
 			originId: '',
 			message: this.request,
+			when: new Date().toISOString(),
 			socket: JupyterSockets.shell
 		};
 		k.sendMessage(packet);

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -399,6 +399,7 @@ export class LanguageRuntimeAdapter
 		this._messages.fire({
 			id: message.msgId,
 			parent_id: message.originId,
+			when: message.when,
 			type: positron.LanguageRuntimeMessageType.Prompt,
 			prompt: req.prompt,
 			password: req.password,
@@ -415,6 +416,7 @@ export class LanguageRuntimeAdapter
 		this._messages.fire({
 			id: message.msgId,
 			parent_id: message.originId,
+			when: message.when,
 			type: positron.LanguageRuntimeMessageType.Event,
 			name: event.name,
 			data: event.data
@@ -432,8 +434,9 @@ export class LanguageRuntimeAdapter
 		this._messages.fire({
 			id: message.msgId,
 			parent_id: message.originId,
+			when: message.when,
 			type: positron.LanguageRuntimeMessageType.Output,
-			data: data.data as any
+			data: data.data as any,
 		} as positron.LanguageRuntimeOutput);
 	}
 
@@ -448,6 +451,7 @@ export class LanguageRuntimeAdapter
 		this._messages.fire({
 			id: message.msgId,
 			parent_id: message.originId,
+			when: message.when,
 			type: positron.LanguageRuntimeMessageType.Error,
 			name: data.ename,
 			message: data.evalue,
@@ -466,6 +470,7 @@ export class LanguageRuntimeAdapter
 		this._messages.fire({
 			id: message.msgId,
 			parent_id: message.originId,
+			when: message.when,
 			type: positron.LanguageRuntimeMessageType.Output,
 			data: data.data as any
 		} as positron.LanguageRuntimeOutput);
@@ -482,6 +487,7 @@ export class LanguageRuntimeAdapter
 		this._messages.fire({
 			id: message.msgId,
 			parent_id: message.originId,
+			when: message.when,
 			type: data.name === 'stderr' ?
 				positron.LanguageRuntimeMessageType.Error :
 				positron.LanguageRuntimeMessageType.Output,
@@ -502,6 +508,7 @@ export class LanguageRuntimeAdapter
 		this._messages.fire({
 			id: message.msgId,
 			parent_id: message.originId,
+			when: message.when,
 			type: positron.LanguageRuntimeMessageType.Input,
 			code: data.code
 		} as positron.LanguageRuntimeInput);
@@ -518,6 +525,7 @@ export class LanguageRuntimeAdapter
 		this._messages.fire({
 			id: message.msgId,
 			parent_id: message.originId,
+			when: message.when,
 			type: positron.LanguageRuntimeMessageType.State,
 			state: data.execution_state
 		} as positron.LanguageRuntimeState);

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -76,6 +76,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		const busy: positron.LanguageRuntimeState = {
 			id: randomUUID(),
 			parent_id: id,
+			when: new Date().toISOString(),
 			type: positron.LanguageRuntimeMessageType.State,
 			state: positron.RuntimeOnlineState.Busy
 		};
@@ -100,6 +101,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		const output: positron.LanguageRuntimeOutput = {
 			id: randomUUID(),
 			parent_id: id,
+			when: new Date().toISOString(),
 			type: positron.LanguageRuntimeMessageType.Output,
 			data: {
 				'text/plain': result
@@ -113,6 +115,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		const idle: positron.LanguageRuntimeState = {
 			id: randomUUID(),
 			parent_id: id,
+			when: new Date().toISOString(),
 			type: positron.LanguageRuntimeMessageType.State,
 			state: positron.RuntimeOnlineState.Idle
 		};

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -139,6 +139,9 @@ declare module 'positron' {
 		/** The ID of this event's parent (the event that caused it), if applicable */
 		parent_id: string;
 
+		/** The message's date and time, in ISO 8601 format */
+		when: string;
+
 		/** The type of event */
 		type: LanguageRuntimeMessageType;
 	}

--- a/src/vs/workbench/contrib/executionHistory/common/languageInputHistory.ts
+++ b/src/vs/workbench/contrib/executionHistory/common/languageInputHistory.ts
@@ -64,7 +64,7 @@ export class LanguageInputHistory extends Disposable {
 		// When a runtime records an input, emit it to the history.
 		this._register(runtime.onDidReceiveRuntimeMessageInput(message => {
 			const entry: IInputHistoryEntry = {
-				when: Date.now(),
+				when: Date.parse(message.when),
 				input: message.code
 			};
 			this._pendingEntries.push(entry);

--- a/src/vs/workbench/contrib/executionHistory/common/runtimeExecutionHistory.ts
+++ b/src/vs/workbench/contrib/executionHistory/common/runtimeExecutionHistory.ts
@@ -66,7 +66,7 @@ export class RuntimeExecutionHistory extends Disposable {
 				// Create a new entry
 				const entry: IExecutionHistoryEntry<string> = {
 					id: message.parent_id,
-					when: Date.now(),
+					when: Date.parse(message.when),
 					input: message.code,
 					outputType: '',
 					output: '',
@@ -97,7 +97,7 @@ export class RuntimeExecutionHistory extends Disposable {
 					// a new entry.
 					const entry: IExecutionHistoryEntry<string> = {
 						id: message.parent_id,
-						when: Date.now(),
+						when: Date.parse(message.when),
 						input: '',
 						outputType: 'text',
 						output: outputText,

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeNotebook.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeNotebook.ts
@@ -146,6 +146,7 @@ export class NotebookLanguageRuntime extends Disposable implements ILanguageRunt
 					id: 'status-' + NotebookLanguageRuntime._msgCounter++,
 					parent_id: this._executingCellId,
 					state: RuntimeOnlineState.Idle,
+					when: new Date().toISOString()
 				});
 
 				// Clear the cell execution state
@@ -242,7 +243,8 @@ export class NotebookLanguageRuntime extends Disposable implements ILanguageRunt
 			this._onDidReceiveRuntimeMessageOutputEmitter.fire({
 				id: 'output-' + NotebookLanguageRuntime._msgCounter++,
 				parent_id: id,
-				data
+				data,
+				when: new Date().toISOString()
 			});
 		});
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -27,6 +27,9 @@ export interface ILanguageRuntimeMessage {
 
 	/** The ID of this event's parent (the event that caused it), if applicable */
 	parent_id: string;
+
+	/** The message's date and time, in ISO 8601 format */
+	when: string;
 }
 
 


### PR DESCRIPTION
This change adds ISO 8601 timestamps in a new `when` field on all language runtime messages. It's pretty small since this information was already being recorded; it was just being discarded before the message crossed the extension host boundary. 