### PR TITLE
Fix foreground in Positron dark default theme

### DIFF
--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -223,13 +223,13 @@ export const foreground = registerColor('foreground', { dark: '#acbece', light: 
 export const secondaryBackground = registerColor('secondaryBackground', { dark: '#292f32', light: '#dee1e5', hcDark: '#dee1e5', hcLight: '#dee1e5' }, nls.localize('foreground', "Overall foreground color. This color is only used if not overridden by a component."));
 
 //export const disabledForeground = registerColor('disabledForeground', { dark: '#CCCCCC80', light: '#61616180', hcDark: '#A5A5A5', hcLight: '#7F7F7F' }, nls.localize('disabledForeground', "Overall foreground for disabled elements. This color is only used if not overridden by a component."));
-export const disabledForeground = registerColor('disabledForeground', { dark: '#acbece80', light: '#75828d80', hcDark: '#A5A5A5', hcLight: '#7F7F7F' }, nls.localize('disabledForeground', "Overall foreground for disabled elements. This color is only used if not overridden by a component."));
+export const disabledForeground = registerColor('disabledForeground', { dark: transparent(foreground, 0.8), light: '#75828d80', hcDark: '#A5A5A5', hcLight: '#7F7F7F' }, nls.localize('disabledForeground', "Overall foreground for disabled elements. This color is only used if not overridden by a component."));
 // --- End Positron ---
 export const errorForeground = registerColor('errorForeground', { dark: '#F48771', light: '#A1260D', hcDark: '#F48771', hcLight: '#B5200D' }, nls.localize('errorForeground', "Overall foreground color for error messages. This color is only used if not overridden by a component."));
 export const descriptionForeground = registerColor('descriptionForeground', { light: '#717171', dark: transparent(foreground, 0.7), hcDark: transparent(foreground, 0.7), hcLight: transparent(foreground, 0.7) }, nls.localize('descriptionForeground', "Foreground color for description text providing additional information, for example for a label."));
 // --- Start Positron ---
 //export const iconForeground = registerColor('icon.foreground', { dark: '#C5C5C5', light: '#424242', hcDark: '#FFFFFF', hcLight: '#292929' }, nls.localize('iconForeground', "The default color for icons in the workbench."));
-export const iconForeground = registerColor('icon.foreground', { dark: '#acbece', light: '#75828d', hcDark: '#ffffff', hcLight: '#000000' }, nls.localize('iconForeground', "The default color for icons in the workbench."));
+export const iconForeground = registerColor('icon.foreground', { dark: foreground, light: '#75828d', hcDark: '#ffffff', hcLight: '#000000' }, nls.localize('iconForeground', "The default color for icons in the workbench."));
 // --- End Positron ---
 
 export const focusBorder = registerColor('focusBorder', { dark: '#007FD4', light: '#0090F1', hcDark: '#F38518', hcLight: '#006BBD' }, nls.localize('focusBorder', "Overall border color for focused elements. This color is only used if not overridden by a component."));
@@ -295,7 +295,7 @@ export const buttonBorder = registerColor('button.border', { dark: contrastBorde
 
 // --- Start Positron ---
 //export const buttonSecondaryForeground = registerColor('button.secondaryForeground', { dark: Color.white, light: Color.white, hcDark: Color.white, hcLight: foreground }, nls.localize('buttonSecondaryForeground', "Secondary button foreground color."));
-export const buttonSecondaryForeground = registerColor('button.secondaryForeground', { dark: '#acbece', light: '#000000', hcDark: '#000000', hcLight: '#000000' }, nls.localize('buttonSecondaryForeground', "Secondary button foreground color."));
+export const buttonSecondaryForeground = registerColor('button.secondaryForeground', { dark: foreground, light: '#000000', hcDark: '#000000', hcLight: '#000000' }, nls.localize('buttonSecondaryForeground', "Secondary button foreground color."));
 //export const buttonSecondaryBackground = registerColor('button.secondaryBackground', { dark: '#3A3D41', light: '#5F6A79', hcDark: null, hcLight: Color.white }, nls.localize('buttonSecondaryBackground', "Secondary button background color."));
 export const buttonSecondaryBackground = registerColor('button.secondaryBackground', { dark: secondaryBackground, light: secondaryBackground, hcDark: secondaryBackground, hcLight: secondaryBackground }, nls.localize('buttonSecondaryBackground', "Secondary button background color."));
 // --- End Positron ---

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -354,7 +354,7 @@ export const PANEL_BORDER = registerColor('panel.border', {
 
 export const PANEL_ACTIVE_TITLE_FOREGROUND = registerColor('panelTitle.activeForeground', {
 	// --- Start Positron ---
-	dark: '#556677',
+	dark: foreground,
 	light: '#556677',
 	// dark: '#E7E7E7',
 	// light: '#424242',
@@ -364,7 +364,9 @@ export const PANEL_ACTIVE_TITLE_FOREGROUND = registerColor('panelTitle.activeFor
 }, localize('panelActiveTitleForeground', "Title color for the active panel. Panels are shown below the editor area and contain views like output and integrated terminal."));
 
 export const PANEL_INACTIVE_TITLE_FOREGROUND = registerColor('panelTitle.inactiveForeground', {
-	dark: transparent(PANEL_ACTIVE_TITLE_FOREGROUND, 0.6),
+	// --- Start Positron ---
+	dark: transparent(PANEL_ACTIVE_TITLE_FOREGROUND, 0.7),
+	// --- End Positron ---
 	light: transparent(PANEL_ACTIVE_TITLE_FOREGROUND, 0.75),
 	hcDark: Color.white,
 	hcLight: editorForeground
@@ -460,7 +462,7 @@ export const BANNER_ICON_FOREGROUND = registerColor('banner.iconForeground', {
 
 export const STATUS_BAR_FOREGROUND = registerColor('statusBar.foreground', {
 	// --- Start Positron ---
-	dark: '#acbece',
+	dark: foreground,
 	light: '#75828d',
 	// dark: '#FFFFFF',
 	// light: '#FFFFFF',
@@ -610,7 +612,7 @@ export const ACTIVITY_BAR_BACKGROUND = registerColor('activityBar.background', {
 
 export const ACTIVITY_BAR_FOREGROUND = registerColor('activityBar.foreground', {
 	// --- Start Positron ---
-	dark: '#acbece',
+	dark: foreground,
 	light: '#ffffff',
 	// dark: Color.white,
 	// light: Color.white,
@@ -729,7 +731,7 @@ export const SIDE_BAR_BACKGROUND = registerColor('sideBar.background', {
 
 export const SIDE_BAR_FOREGROUND = registerColor('sideBar.foreground', {
 	// --- Start Positron ---
-	dark: '#acbece',
+	dark: foreground,
 	light: null,
 	// dark: null,
 	// light: null,
@@ -789,7 +791,7 @@ export const SIDE_BAR_SECTION_HEADER_BORDER = registerColor('sideBarSectionHeade
 
 export const TITLE_BAR_ACTIVE_FOREGROUND = registerColor('titleBar.activeForeground', {
 	// --- Start Positron ---
-	dark: '#acbece',
+	dark: foreground,
 	light: '#75828d',
 	hcDark: '#ffffff',
 	hcLight: '#000000'
@@ -1090,7 +1092,7 @@ export const POSITRON_SIDE_ACTION_BAR_BACKGROUND = registerColor('positronSideAc
 
 // The Positron side action bar foreground color.
 export const POSITRON_SIDE_ACTION_BAR_FOREGROUND = registerColor('positronSideActionBar.foreground', {
-	dark: '#acbece',
+	dark: foreground,
 	light: '#75828D',
 	hcDark: '#ffffff',
 	hcLight: editorForeground
@@ -1164,7 +1166,7 @@ export const MODAL_DIALOG_BACKGROUND = registerColor('modalDialog.background', {
 
 // Modal dialog foreground color.
 export const MODAL_DIALOG_FOREGROUND = registerColor('modalDialog.foreground', {
-	dark: '#acbece',
+	dark: foreground,
 	light: '#000000',
 	hcDark: foreground,
 	hcLight: foreground
@@ -1198,7 +1200,7 @@ export const MODAL_DIALOG_TITLE_BAR_BACKGROUND = registerColor('modalDialog.titl
 
 // Modal dialog title bar foreground color.
 export const MODAL_DIALOG_TITLE_BAR_FOREGROUND = registerColor('modalDialog.titleBarForeground', {
-	dark: '#acbece',
+	dark: foreground,
 	light: '#000000',
 	hcDark: foreground,
 	hcLight: foreground
@@ -1324,7 +1326,7 @@ export const MODAL_DIALOG_CHECKBOX_BACKGROUND = registerColor('modalDialog.check
 
 // Modal dialog checkbox foreground color.
 export const MODAL_DIALOG_CHECKBOX_FOREGROUND = registerColor('modalDialog.checkboxForeground', {
-	dark: '#acbece',
+	dark: foreground,
 	light: '#000000',
 	hcDark: checkboxForeground,
 	hcLight: checkboxForeground


### PR DESCRIPTION
Matching updated foreground colors from design.

Also opportunistically map these foregrounds to the common base foreground registered color.