### PR TITLE
Clarify and lightly refactor runtime metadata

### DIFF
--- a/extensions/jupyter-adapter/src/Api.ts
+++ b/extensions/jupyter-adapter/src/Api.ts
@@ -16,15 +16,17 @@ export class Api implements vscode.Disposable {
 	 * Create an adapter for a Jupyter-compatible kernel.
 	 *
 	 * @param kernel A Jupyter kernel spec containing the information needed to start the kernel.
-	 * @param version The version of the kernel.
+	 * @param languageVersion The version of the language interpreter.
+	 * @param kernelVersion The version of the kernel itself.
 	 * @param lsp An optional function that returns a client port number for the LSP server to connect to.
 	 * @returns A LanguageRuntimeAdapter that wraps the kernel.
 	 */
 	adaptKernel(kernel: JupyterKernelSpec,
-		version: string,
+		languageVersion: string,
+		kernelVersion: string,
 		lsp: () => Promise<number> | null,
 		startupBehavior: positron.LanguageRuntimeStartupBehavior = positron.LanguageRuntimeStartupBehavior.Implicit): positron.LanguageRuntime {
-		return new LanguageRuntimeAdapter(kernel, version, lsp, this._channel, startupBehavior);
+		return new LanguageRuntimeAdapter(kernel, languageVersion, kernelVersion, lsp, this._channel, startupBehavior);
 	}
 
 	dispose() {

--- a/extensions/jupyter-adapter/src/Api.ts
+++ b/extensions/jupyter-adapter/src/Api.ts
@@ -22,11 +22,12 @@ export class Api implements vscode.Disposable {
 	 * @returns A LanguageRuntimeAdapter that wraps the kernel.
 	 */
 	adaptKernel(kernel: JupyterKernelSpec,
+		languageId: string,
 		languageVersion: string,
 		kernelVersion: string,
 		lsp: () => Promise<number> | null,
 		startupBehavior: positron.LanguageRuntimeStartupBehavior = positron.LanguageRuntimeStartupBehavior.Implicit): positron.LanguageRuntime {
-		return new LanguageRuntimeAdapter(kernel, languageVersion, kernelVersion, lsp, this._channel, startupBehavior);
+		return new LanguageRuntimeAdapter(kernel, languageId, languageVersion, kernelVersion, lsp, this._channel, startupBehavior);
 	}
 
 	dispose() {

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -52,6 +52,7 @@ export class LanguageRuntimeAdapter
 	private readonly _comms: Map<string, RuntimeClientAdapter> = new Map();
 
 	constructor(private readonly _spec: JupyterKernelSpec,
+		languageId: string,
 		languageVersion: string,
 		runtimeVersion: string,
 		private readonly _lsp: () => Promise<number> | null,
@@ -64,6 +65,7 @@ export class LanguageRuntimeAdapter
 			runtimeId: uuidv4(),
 			runtimeName: this._spec.display_name,
 			runtimeVersion,
+			languageId,
 			languageName: this._spec.language,
 			languageVersion,
 			startupBehavior: startupBehavior

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -113,7 +113,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 				'--connection_file', '{connection_file}',
 				'--log', '{log_file}'],
 			'display_name': `R: ${rHome.rHome}`, // eslint-disable-line
-			'language': 'r',
+			'language': 'R',
 			'env': {
 				'RUST_LOG': 'trace', // eslint-disable-line
 				'R_HOME': rHome.rHome, // eslint-disable-line
@@ -129,7 +129,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 		const version = packageJson.version;
 
 		// Create an adapter for the kernel to fulfill the LanguageRuntime interface.
-		runtime = ext.exports.adaptKernel(kernelSpec, rHome.rVersion ?? '0.0.1', version, () => {
+		runtime = ext.exports.adaptKernel(kernelSpec, 'r', rHome.rVersion ?? '0.0.1', version, () => {
 			return activateLsp(context);
 		});
 

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -123,8 +123,13 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 			}
 		};
 
+		// Get the version of this extension from package.json so we can pass it
+		// to the adapter as the implementation version.
+		const packageJson = require('../package.json');
+		const version = packageJson.version;
+
 		// Create an adapter for the kernel to fulfill the LanguageRuntime interface.
-		runtime = ext.exports.adaptKernel(kernelSpec, rHome.rVersion ?? '0.0.1', () => {
+		runtime = ext.exports.adaptKernel(kernelSpec, rHome.rVersion ?? '0.0.1', version, () => {
 			return activateLsp(context);
 		});
 

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -33,15 +33,16 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 
 	/**
 	 * Constructor.
-	 * @param id The language ID.
+	 * @param runtimeId The ID for the new runtime
 	 * @param version The language version.
 	 */
-	constructor(id: string, version: string) {
+	constructor(runtimeId: string, version: string) {
 		this.metadata = {
-			id,
-			language: 'Zed',
-			name: 'Zed',
-			version,
+			runtimeId,
+			languageName: 'Zed',
+			runtimeName: 'Zed',
+			languageVersion: version,
+			runtimeVersion: '0.0.1',
 			startupBehavior: positron.LanguageRuntimeStartupBehavior.Implicit
 		};
 	}
@@ -88,7 +89,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		let result;
 		switch (code.toLowerCase()) {
 			case 'version':
-				result = `Zed v${this.metadata.version} (${this.metadata.id})`;
+				result = `Zed v${this.metadata.languageVersion} (${this.metadata.runtimeId})`;
 				break;
 			default:
 				result = `Error. '${code}' not recognized.`;
@@ -173,9 +174,9 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 	start(): Thenable<positron.LanguageRuntimeInfo> {
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Ready);
 		return Promise.resolve({
-			banner: `Zed ${this.metadata.version}`,
-			implementation_version: this.metadata.version,
-			language_version: this.metadata.version
+			banner: `Zed ${this.metadata.languageVersion} `,
+			implementation_version: this.metadata.runtimeVersion,
+			language_version: this.metadata.languageVersion,
 		} as positron.LanguageRuntimeInfo);
 	}
 

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -39,6 +39,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 	constructor(runtimeId: string, version: string) {
 		this.metadata = {
 			runtimeId,
+			languageId: 'zed',
 			languageName: 'Zed',
 			runtimeName: 'Zed',
 			languageVersion: version,

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -224,7 +224,7 @@ declare module 'positron' {
 		/** The name of the runtime displayed to the user; e.g. "R 4.2 (64-bit)" */
 		runtimeName: string;
 
-		/** The version of the runtime as a string; e.g. "4.2" */
+		/** The version of the runtime itself (e.g. kernel or extension version) as a string; e.g. "0.1" */
 		runtimeVersion: string;
 
 		/** The free-form, user-friendly name of the language this runtime can execute; e.g. "R" */
@@ -238,7 +238,7 @@ declare module 'positron' {
 		 */
 		languageId: string;
 
-		/** The version of the language. */
+		/** The version of the language; e.g. "4.2" */
 		languageVersion: string;
 
 		/** Whether the runtime should start up automatically or wait until explicitly requested */

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -221,17 +221,25 @@ declare module 'positron' {
 		/** A unique identifier for this runtime; takes the form of a GUID */
 		runtimeId: string;
 
-		/** The name of the language this runtime can execute */
+		/** The name of the runtime displayed to the user; e.g. "R 4.2 (64-bit)" */
+		runtimeName: string;
+
+		/** The version of the runtime as a string; e.g. "4.2" */
+		runtimeVersion: string;
+
+		/** The free-form, user-friendly name of the language this runtime can execute; e.g. "R" */
 		languageName: string;
+
+		/**
+		 * The Visual Studio Code Language ID of the language this runtime can execute; e.g. "r"
+		 *
+		 * See here for a list of known language IDs:
+		 * https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers
+		 */
+		languageId: string;
 
 		/** The version of the language. */
 		languageVersion: string;
-
-		/** The name of the runtime. */
-		runtimeName: string;
-
-		/** The version of the runtime. */
-		runtimeVersion: string;
 
 		/** Whether the runtime should start up automatically or wait until explicitly requested */
 		startupBehavior: LanguageRuntimeStartupBehavior;

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -218,17 +218,20 @@ declare module 'positron' {
 	 * before the runtime is started.
 	 */
 	export interface LanguageRuntimeMetadata {
-		/** A unique identifier for this runtime */
-		id: string;
+		/** A unique identifier for this runtime; takes the form of a GUID */
+		runtimeId: string;
 
-		/** The language identifier for this runtime. */
-		language: string;
+		/** The name of the language this runtime can execute */
+		languageName: string;
+
+		/** The version of the language. */
+		languageVersion: string;
 
 		/** The name of the runtime. */
-		name: string;
+		runtimeName: string;
 
 		/** The version of the runtime. */
-		version: string;
+		runtimeVersion: string;
 
 		/** Whether the runtime should start up automatically or wait until explicitly requested */
 		startupBehavior: LanguageRuntimeStartupBehavior;

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -13,8 +13,6 @@ import { ExtHostConfigProvider } from 'vs/workbench/api/common/extHostConfigurat
 import { ExtHostPositronContext } from 'vs/workbench/api/common/positron/extHost.positron.protocol';
 import * as extHostTypes from 'vs/workbench/api/common/positron/extHostTypes.positron';
 import { IExtHostInitDataService } from 'vs/workbench/api/common/extHostInitDataService';
-import { ILanguageService } from 'vs/editor/common/languages/language';
-import { ILogService } from 'vs/platform/log/common/log';
 
 /**
  * Factory interface for creating an instance of the Positron API.
@@ -30,9 +28,7 @@ export interface IExtensionPositronApiFactory {
 export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAccessor): IExtensionPositronApiFactory {
 	const rpcProtocol = accessor.get(IExtHostRpcService);
 	const initData = accessor.get(IExtHostInitDataService);
-	const languageService = accessor.get(ILanguageService);
-	const logService = accessor.get(ILogService);
-	const extHostLanguageRuntime = rpcProtocol.set(ExtHostPositronContext.ExtHostLanguageRuntime, new ExtHostLanguageRuntime(rpcProtocol, languageService, logService));
+	const extHostLanguageRuntime = rpcProtocol.set(ExtHostPositronContext.ExtHostLanguageRuntime, new ExtHostLanguageRuntime(rpcProtocol));
 
 	return function (extension: IExtensionDescription, extensionInfo: IExtensionRegistries, configProvider: ExtHostConfigProvider): typeof positron {
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -13,6 +13,8 @@ import { ExtHostConfigProvider } from 'vs/workbench/api/common/extHostConfigurat
 import { ExtHostPositronContext } from 'vs/workbench/api/common/positron/extHost.positron.protocol';
 import * as extHostTypes from 'vs/workbench/api/common/positron/extHostTypes.positron';
 import { IExtHostInitDataService } from 'vs/workbench/api/common/extHostInitDataService';
+import { ILanguageService } from 'vs/editor/common/languages/language';
+import { ILogService } from 'vs/platform/log/common/log';
 
 /**
  * Factory interface for creating an instance of the Positron API.
@@ -28,7 +30,9 @@ export interface IExtensionPositronApiFactory {
 export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAccessor): IExtensionPositronApiFactory {
 	const rpcProtocol = accessor.get(IExtHostRpcService);
 	const initData = accessor.get(IExtHostInitDataService);
-	const extHostLanguageRuntime = rpcProtocol.set(ExtHostPositronContext.ExtHostLanguageRuntime, new ExtHostLanguageRuntime(rpcProtocol));
+	const languageService = accessor.get(ILanguageService);
+	const logService = accessor.get(ILogService);
+	const extHostLanguageRuntime = rpcProtocol.set(ExtHostPositronContext.ExtHostLanguageRuntime, new ExtHostLanguageRuntime(rpcProtocol, languageService, logService));
 
 	return function (extension: IExtensionDescription, extensionInfo: IExtensionRegistries, configProvider: ExtHostConfigProvider): typeof positron {
 

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -7,6 +7,8 @@ import { ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageE
 import * as extHostProtocol from './extHost.positron.protocol';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { Disposable, LanguageRuntimeMessageType } from 'vs/workbench/api/common/extHostTypes';
+import { ILanguageService } from 'vs/editor/common/languages/language';
+import { ILogService } from 'vs/platform/log/common/log';
 
 export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRuntimeShape {
 
@@ -16,6 +18,8 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 
 	constructor(
 		mainContext: extHostProtocol.IMainPositronContext,
+		@ILanguageService private _languageService: ILanguageService,
+		@ILogService private _logService: ILogService
 	) {
 		// Trigger creation of the proxy
 		this._proxy = mainContext.getProxy(extHostProtocol.MainPositronContext.MainThreadLanguageRuntime);
@@ -137,7 +141,23 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		// Register the runtime
 		this._runtimes.push(runtime);
 
-		this._proxy.$registerLanguageRuntime(handle, runtime.metadata);
+		// Look up the langauge ID from the language name using the language service
+		let languageId = this._languageService.getLanguageIdByLanguageName(runtime.metadata.languageName);
+		if (!languageId) {
+			// Didn't get a language ID, so use the language name as the ID.
+			// This could cause downstream trouble if it's meant for a language
+			// the editor speaks, but more than likely it's a custom language
+			// that the editor doesn't know about, in which case this is the
+			// best we can do.
+			this._logService.warn(`Language runtime '${runtime.metadata.runtimeName}' registered for unknown language '${runtime.metadata.languageName}'`);
+			languageId = runtime.metadata.languageName;
+		}
+
+		// Register the runtime with the main thread
+		this._proxy.$registerLanguageRuntime(handle, {
+			...runtime.metadata,
+			languageId
+		});
 		return new Disposable(() => {
 			this._proxy.$unregisterLanguageRuntime(handle);
 		});

--- a/src/vs/workbench/contrib/executionHistory/common/executionHistory.ts
+++ b/src/vs/workbench/contrib/executionHistory/common/executionHistory.ts
@@ -68,15 +68,15 @@ export class ExecutionHistoryService extends Disposable implements IExecutionHis
 
 	private beginRecordingHistory(runtime: ILanguageRuntime): void {
 		// Create a new history for the runtime if we don't already have one
-		if (!this._executionHistories.has(runtime.metadata.id)) {
+		if (!this._executionHistories.has(runtime.metadata.runtimeId)) {
 			const history = new RuntimeExecutionHistory(runtime, this._storageService, this._logService);
-			this._executionHistories.set(runtime.metadata.id, history);
+			this._executionHistories.set(runtime.metadata.runtimeId, history);
 			this._register(history);
 		}
 
 		// Attach the runtime to an input history recorder for the language,
 		// creating one if necessary
-		this.getInputHistory(runtime.metadata.language).attachToRuntime(runtime);
+		this.getInputHistory(runtime.metadata.languageId).attachToRuntime(runtime);
 	}
 
 	getExecutionEntries(runtimeId: string): IExecutionHistoryEntry<any>[] {

--- a/src/vs/workbench/contrib/executionHistory/common/executionHistoryActions.ts
+++ b/src/vs/workbench/contrib/executionHistory/common/executionHistoryActions.ts
@@ -4,7 +4,6 @@
 
 import { Codicon } from 'vs/base/common/codicons';
 import Severity from 'vs/base/common/severity';
-import { ILanguageService } from 'vs/editor/common/languages/language';
 import { localize } from 'vs/nls';
 import { ILocalizedString } from 'vs/platform/action/common/action';
 import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
@@ -41,7 +40,6 @@ export function registerHistoryActions() {
 			const languageRuntimeService = accessor.get(ILanguageRuntimeService);
 			const dialogService = accessor.get(IDialogService);
 			const replService = accessor.get(IReplService);
-			const languageService = accessor.get(ILanguageService);
 
 			// If there's no active language runtime, then we can't clear the
 			// history, since we don't know which language to clear history for.
@@ -53,8 +51,7 @@ export function registerHistoryActions() {
 				return;
 			}
 
-			// Look up the user-friendly name for the language.
-			const languageName = languageService.getLanguageName(languageRuntime.metadata.language);
+			const languageName = languageRuntime.metadata.languageName;
 
 			// Ask the user if they want to clear the history; this is a
 			// destructive action and it can't be undone.
@@ -67,10 +64,10 @@ export function registerHistoryActions() {
 			}
 
 			// Clear the stored history from the history service.
-			historyService.clearInputEntries(languageRuntime.metadata.language);
+			historyService.clearInputEntries(languageRuntime.metadata.languageId);
 
 			// Clear the history from the REPL service.
-			replService.clearInputHistory(languageRuntime.metadata.language);
+			replService.clearInputHistory(languageRuntime.metadata.languageId);
 
 			// Let the user know that the history was cleared.
 			dialogService.show(Severity.Info, localize('clearedInputHistory', "The {0} input history has been cleared.", languageName));

--- a/src/vs/workbench/contrib/executionHistory/common/languageInputHistory.ts
+++ b/src/vs/workbench/contrib/executionHistory/common/languageInputHistory.ts
@@ -49,15 +49,15 @@ export class LanguageInputHistory extends Disposable {
 
 	public attachToRuntime(runtime: ILanguageRuntime): void {
 		// Don't attach to the same runtime twice.
-		if (this._attachedRuntimes.has(runtime.metadata.id)) {
-			this._logService.debug(`LanguageInputHistory (${this._languageId}): Already attached to runtime ${runtime.metadata.id}`);
+		if (this._attachedRuntimes.has(runtime.metadata.runtimeId)) {
+			this._logService.debug(`LanguageInputHistory (${this._languageId}): Already attached to runtime ${runtime.metadata.runtimeId}`);
 			return;
 		}
 
 		// Safety check: ensure that this runtime is associated with the
 		// language for this history recorder.
-		if (runtime.metadata.language !== this._languageId) {
-			this._logService.warn(`LanguageInputHistory (${this._languageId}): Language mismatch (expected ${this._languageId}, got ${runtime.metadata.language}))`);
+		if (runtime.metadata.languageId !== this._languageId) {
+			this._logService.warn(`LanguageInputHistory (${this._languageId}): Language mismatch (expected ${this._languageId}, got ${runtime.metadata.languageId}))`);
 			return;
 		}
 

--- a/src/vs/workbench/contrib/executionHistory/common/runtimeExecutionHistory.ts
+++ b/src/vs/workbench/contrib/executionHistory/common/runtimeExecutionHistory.ts
@@ -37,7 +37,7 @@ export class RuntimeExecutionHistory extends Disposable {
 		super();
 
 		// Create storage key for this runtime based on its ID
-		this._storageKey = `positron.executionHistory.${_runtime.metadata.id}`;
+		this._storageKey = `positron.executionHistory.${_runtime.metadata.runtimeId}`;
 
 		// Load existing history entries
 		const entries = this._storageService.get(this._storageKey, StorageScope.WORKSPACE, '[]');
@@ -46,7 +46,7 @@ export class RuntimeExecutionHistory extends Disposable {
 				this._entries.push(entry);
 			});
 		} catch (err) {
-			this._logService.warn(`Couldn't load history for ${this._runtime.metadata.name} ${this._runtime.metadata.id}: ${err}}`);
+			this._logService.warn(`Couldn't load history for ${this._runtime.metadata.runtimeName} ${this._runtime.metadata.runtimeVersion}: ${err}}`);
 		}
 
 		this._register(this._runtime.onDidReceiveRuntimeMessageInput(message => {

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
@@ -35,9 +35,9 @@ export const selectLanguageRuntime = async (
 
 	// Build the language runtime quick pick items.
 	const languageRuntimeQuickPickItems = languageRuntimes.map<LanguageRuntimeQuickPickItem>(languageRuntime => ({
-		id: languageRuntime.metadata.id,
-		label: languageRuntime.metadata.name,
-		description: languageRuntime.metadata.version,
+		id: languageRuntime.metadata.runtimeId,
+		label: languageRuntime.metadata.runtimeName,
+		description: languageRuntime.metadata.languageVersion,
 		languageRuntime
 	} satisfies LanguageRuntimeQuickPickItem));
 
@@ -136,7 +136,7 @@ export function registerLanguageRuntimeActions() {
 		// Ask the user to select the language runtime to start. If they selected one, start it.
 		const languageRuntime = await selectLanguageRuntime(quickInputService, registeredRuntimes, 'Select the language runtime to start');
 		if (languageRuntime) {
-			languageRuntimeService.startRuntime(languageRuntime.metadata.id);
+			languageRuntimeService.startRuntime(languageRuntime.metadata.runtimeId);
 		}
 	});
 
@@ -199,7 +199,7 @@ export function registerLanguageRuntimeActions() {
 			runtimeClientType: RuntimeClientType.Environment,
 		}], {
 			canPickMany: false,
-			placeHolder: `Select runtime client for ${languageRuntime.metadata.name}`
+			placeHolder: `Select runtime client for ${languageRuntime.metadata.runtimeName}`
 		});
 
 		// If the user selected a runtime client type, create the client for it.
@@ -236,7 +236,7 @@ export function registerLanguageRuntimeActions() {
 		// Prompt the user to select a runtime client instance.
 		const selection = await quickInputService.pick<RuntimeClientInstanceQuickPickItem>(runtimeClientInstanceQuickPickItems, {
 			canPickMany: false,
-			placeHolder: nls.localize('Client Close Selection Placeholder', 'Close Client for {0}', languageRuntime.metadata.name)
+			placeHolder: nls.localize('Client Close Selection Placeholder', 'Close Client for {0}', languageRuntime.metadata.runtimeName)
 		});
 
 		// If the user selected a runtime client instance, dispose it.

--- a/src/vs/workbench/contrib/positronConsole/browser/classes/consoleReplInstance.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/classes/consoleReplInstance.ts
@@ -19,12 +19,6 @@ export class ConsoleReplInstance {
 	 * Gets the display name.
 	 */
 	get displayName() {
-		// TODO@softwarenerd - Temporary code because R's metadata returns 'r' for the language and something like
-		// 'R: /Library/Frameworks/R.framework/Resources' for the name.
-		if (this.replInstance.runtime.metadata.name.startsWith('R')) {
-			return 'R';
-		} else {
-			return this.replInstance.runtime.metadata.name;
-		}
+		return this.replInstance.runtime.metadata.languageName;
 	}
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.tsx
@@ -36,7 +36,7 @@ export const ConsoleCore = (props: ConsoleCoreProps) => {
 			<div className='console-repls-container' style={{ height: props.height - 32 }}>
 				{positronConsoleContext.consoleReplInstances.map(consoleReplInstance =>
 					<ConsoleRepl
-						key={consoleReplInstance.replInstance.runtime.metadata.id}
+						key={consoleReplInstance.replInstance.runtime.metadata.languageId}
 						hidden={consoleReplInstance !== positronConsoleContext.currentConsoleReplInstance}
 						consoleReplInstance={consoleReplInstance} />
 				)}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleReplMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleReplMenuButton.tsx
@@ -22,7 +22,7 @@ export const ConsoleReplMenuButton = () => {
 		const actions: IAction[] = [];
 		positronConsoleContext.consoleReplInstances.map(consoleReplInstance => {
 			actions.push({
-				id: consoleReplInstance.replInstance.runtime.metadata.id,
+				id: consoleReplInstance.replInstance.runtime.metadata.runtimeId,
 				label: consoleReplInstance.displayName,
 				tooltip: '',
 				class: undefined,

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleService.ts
@@ -5,7 +5,6 @@
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { ILogService } from 'vs/platform/log/common/log';
-import { ILanguageService } from 'vs/editor/common/languages/language';
 import { formatLanguageRuntime, ILanguageRuntime, ILanguageRuntimeService, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { PositronConsoleInstance } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleInstance';
 import { IPositronConsoleInstance, IPositronConsoleOptions, IPositronConsoleService } from 'vs/workbench/services/positronConsole/common/positronConsole';
@@ -35,7 +34,6 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 	 */
 	constructor(
 		@ILanguageRuntimeService private _languageRuntimeService: ILanguageRuntimeService,
-		@ILanguageService private readonly _languageService: ILanguageService,
 		@ILogService private _logService: ILogService,
 	) {
 		// Call the disposable constrcutor.
@@ -48,7 +46,7 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 
 		// Get the active language runtime. If there is one, activate the REPL for it.
 		if (this._languageRuntimeService.activeRuntime) {
-			const instance = this._runningInstancesById.get(this._languageRuntimeService.activeRuntime.metadata.id);
+			const instance = this._runningInstancesById.get(this._languageRuntimeService.activeRuntime.metadata.runtimeId);
 			if (instance) {
 				this.setActiveRepl(instance);
 			} else {
@@ -68,7 +66,7 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 			if (!runtime) {
 				this.setActiveRepl();
 			} else {
-				const instance = this._runningInstancesById.get(runtime.metadata.id);
+				const instance = this._runningInstancesById.get(runtime.metadata.runtimeId);
 				if (instance) {
 					this.setActiveRepl(instance);
 				} else {
@@ -150,21 +148,15 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 	 * @returns The new REPL instance.
 	 */
 	private startConsole(runtime: ILanguageRuntime): IPositronConsoleInstance {
-		// Look up supported language ID for this runtime.
-		const languageId = this._languageService.getLanguageIdByLanguageName(runtime.metadata.language);
-		if (!languageId) {
-			throw new Error(`Language runtime ${formatLanguageRuntime(runtime)} was not found in the language service.`);
-		}
-
 		// Log.
 		this._logService.trace(`Starting REPL for language runtime ${formatLanguageRuntime(runtime)}.`);
 
 		// Create the new REPL instance.
-		const instance = new PositronConsoleInstance(languageId, runtime);
+		const instance = new PositronConsoleInstance(runtime.metadata.languageId, runtime);
 
 		// Add the REPL instance to the running instances.
-		this._runningInstancesById.set(runtime.metadata.id, instance);
-		this._runningInstancesByLanguageId.set(languageId, instance);
+		this._runningInstancesById.set(runtime.metadata.runtimeId, instance);
+		this._runningInstancesByLanguageId.set(runtime.metadata.languageId, instance);
 
 		// Fire the onDidStartRepl event.
 		this._onDidStartConsole.fire(instance);
@@ -172,8 +164,8 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 		// When the runtime exits, see if the user wants to restart it.
 		this._register(runtime.onDidChangeRuntimeState(state => {
 			if (state === RuntimeState.Exited) {
-				this._runningInstancesById.delete(runtime.metadata.id);
-				this._runningInstancesByLanguageId.delete(languageId);
+				this._runningInstancesById.delete(runtime.metadata.runtimeId);
+				this._runningInstancesByLanguageId.delete(runtime.metadata.languageId);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/positronEnvironment/browser/classes/languageEnvironment.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/classes/languageEnvironment.tsx
@@ -154,20 +154,14 @@ export class LanguageEnvironment extends Disposable implements IListItemsProvide
 	 */
 	get identifier() {
 		// TODO@softwarenerd - For the moment, just reuse the language runtime ID.
-		return this._runtime.metadata.id;
+		return this._runtime.metadata.runtimeId;
 	}
 
 	/**
 	 * Gets the display name.
 	 */
 	get displayName() {
-		// TODO@softwarenerd - Temporary code because R's metadata returns 'r' for the language and something like
-		// 'R: /Library/Frameworks/R.framework/Resources' for the name.
-		if (this._runtime.metadata.name.startsWith('R')) {
-			return 'R';
-		} else {
-			return this._runtime.metadata.name;
-		}
+		return this._runtime.metadata.languageName;
 	}
 
 	//#endregion Public Properties

--- a/src/vs/workbench/contrib/positronEnvironment/browser/positronEnvironmentState.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/positronEnvironmentState.tsx
@@ -52,7 +52,7 @@ export const usePositronEnvironmentState = (services: PositronEnvironmentService
 				setCurrentLanguageEnvironment(undefined);
 			} else {
 				const languageEnvironment = refLanguageEnvironments.current.find(languageEnvironment =>
-					languageEnvironment.runtime.metadata.id === runtime.metadata.id
+					languageEnvironment.runtime.metadata.runtimeId === runtime.metadata.runtimeId
 				);
 
 				if (languageEnvironment) {

--- a/src/vs/workbench/contrib/repl/browser/replCell.ts
+++ b/src/vs/workbench/contrib/repl/browser/replCell.ts
@@ -70,7 +70,7 @@ export class ReplCell extends Disposable {
 	private static _counter: number = 0;
 
 	constructor(
-		private readonly _language: string,
+		private readonly _languageId: string,
 		private _state: ReplCellState,
 		private readonly _history: HistoryNavigator2<string>,
 		private readonly _parentElement: HTMLElement,
@@ -99,7 +99,7 @@ export class ReplCell extends Disposable {
 		this._input = this._instantiationService.createInstance(
 			ReplInput,
 			this._handle,
-			this._language,
+			this._languageId,
 			this._history,
 			this._container);
 		this._register(this._input);

--- a/src/vs/workbench/contrib/repl/browser/replInput.ts
+++ b/src/vs/workbench/contrib/repl/browser/replInput.ts
@@ -59,7 +59,7 @@ export class ReplInput extends Disposable {
 
 	constructor(
 		private readonly _handle: number,
-		private readonly _language: string,
+		private readonly _languageId: string,
 		private readonly _history: HistoryNavigator2<string>,
 		private readonly _parentElement: HTMLElement,
 		@IModelService private readonly _modelService: IModelService,
@@ -105,12 +105,11 @@ export class ReplInput extends Disposable {
 		// Form URI for input control
 		this._uri = URI.from({
 			scheme: Schemas.inMemory,
-			path: `/repl-${this._language}-${this._handle}`
+			path: `/repl-${this._languageId}-${this._handle}`
 		});
 
 		// Create language selector
-		const languageId = this._languageService.getLanguageIdByLanguageName(this._language);
-		const languageSelection = this._languageService.createById(languageId);
+		const languageSelection = this._languageService.createById(this._languageId);
 
 		// Create text model; this is the backing store for the Monaco editor that receives
 		// the user's input

--- a/src/vs/workbench/contrib/repl/browser/replInstanceView.ts
+++ b/src/vs/workbench/contrib/repl/browser/replInstanceView.ts
@@ -23,8 +23,8 @@ export const REPL_NOTEBOOK_SCHEME = 'repl';
  */
 export class ReplInstanceView extends Disposable {
 
-	/** The language executed by this REPL */
-	private readonly _language: string;
+	/** The ID of the language executed by this REPL */
+	private readonly _languageId: string;
 
 	/** The scrolling element that hosts content */
 	private _scroller: DomScrollableElement;
@@ -67,7 +67,7 @@ export class ReplInstanceView extends Disposable {
 		super();
 		this._runtime = this._instance.runtime;
 
-		this._language = this._runtime.metadata.language;
+		this._languageId = this._runtime.metadata.languageId;
 
 		this._root = document.createElement('div');
 		this._root.classList.add('repl-root');
@@ -168,7 +168,7 @@ export class ReplInstanceView extends Disposable {
 		this._instance.onDidClearRepl(() => {
 			this.clear();
 			// Clear the stored execution history so it doesn't get replayed
-			this._executionHistoryService.clearExecutionEntries(this._instance.runtime.metadata.id);
+			this._executionHistoryService.clearExecutionEntries(this._instance.runtime.metadata.runtimeId);
 		});
 
 		// Execute code when the user requests it
@@ -178,10 +178,10 @@ export class ReplInstanceView extends Disposable {
 
 		// Populate with execution history
 		// (TODO: these entries, after being fetched here, should be appended to the UI)
-		this._executionHistoryService.getExecutionEntries(this._instance.runtime.metadata.id);
+		this._executionHistoryService.getExecutionEntries(this._instance.runtime.metadata.runtimeId);
 
 		// Populate with input history
-		const inputHistory = this._executionHistoryService.getInputEntries(this._instance.runtime.metadata.language);
+		const inputHistory = this._executionHistoryService.getInputEntries(this._instance.runtime.metadata.languageId);
 		for (const entry of inputHistory) {
 			this._instance.history.add(entry.input);
 		}
@@ -371,7 +371,7 @@ export class ReplInstanceView extends Disposable {
 	addCell(focus: boolean) {
 		// Create the new cell
 		const cell = this._instantiationService.createInstance(ReplCell,
-			this._language,
+			this._languageId,
 			ReplCellState.ReplCellInput,
 			this._instance.history,
 			this._cellContainer);
@@ -402,7 +402,7 @@ export class ReplInstanceView extends Disposable {
 	private addPendingCell(contents: string) {
 		// Create the new cell
 		const cell = this._instantiationService.createInstance(ReplCell,
-			this._language,
+			this._languageId,
 			ReplCellState.ReplCellPending,
 			this._instance.history,
 			this._cellContainer);
@@ -490,7 +490,7 @@ export class ReplInstanceView extends Disposable {
 					this._activeCell = undefined;
 				}
 				const msg = new ReplStatusMessage(
-					'refresh', `${this._runtime.metadata.name} restarting`);
+					'refresh', `${this._runtime.metadata.runtimeName} restarting`);
 				msg.render(this._cellContainer);
 			}
 		}
@@ -505,7 +505,7 @@ export class ReplInstanceView extends Disposable {
 			// message and a new cell to accept the first input in the new
 			// session.
 			const msg = new ReplStatusMessage(
-				'check-all', `${this._runtime.metadata.name} started`);
+				'check-all', `${this._runtime.metadata.runtimeName} started`);
 			msg.render(this._cellContainer);
 
 			this.addCell(this._hadFocus);
@@ -523,13 +523,13 @@ export class ReplInstanceView extends Disposable {
 
 			if (state === RuntimeState.Exited) {
 				const msg = new ReplStatusMessage(
-					'info', `${this._runtime.metadata.name} exited`);
+					'info', `${this._runtime.metadata.runtimeName} exited`);
 				msg.render(this._cellContainer);
 			}
 
 			if (state === RuntimeState.Offline) {
 				const msg = new ReplStatusMessage(
-					'debug-disconnect', `${this._runtime.metadata.name} is offline`);
+					'debug-disconnect', `${this._runtime.metadata.runtimeName} is offline`);
 				msg.render(this._cellContainer);
 			}
 		}

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -15,7 +15,7 @@ export const ILanguageRuntimeService = createDecorator<ILanguageRuntimeService>(
  * @returns A string suitable for logging the language runtime.
  */
 export const formatLanguageRuntime = (languageRuntime: ILanguageRuntime) =>
-	`${languageRuntime.metadata.id} (language: ${languageRuntime.metadata.language} name: ${languageRuntime.metadata.name} version: ${languageRuntime.metadata.version})`;
+	`${languageRuntime.metadata.runtimeId} (language: ${languageRuntime.metadata.languageName} name: ${languageRuntime.metadata.runtimeName} version: ${languageRuntime.metadata.languageVersion})`;
 
 /**
  * LanguageRuntimeMessage is an interface that defines an event occurring in a
@@ -212,7 +212,7 @@ export interface ILanguageRuntimeMessageEvent extends ILanguageRuntimeMessage {
 
 export interface ILanguageRuntimeGlobalEvent {
 	/** The ID of the runtime from which the event originated */
-	id: string;
+	runtime_id: string;
 
 	/** The event itself */
 	event: ILanguageRuntimeMessageEvent;
@@ -220,7 +220,7 @@ export interface ILanguageRuntimeGlobalEvent {
 
 export interface ILanguageRuntimeStateEvent {
 	/** The ID of the runtime that changed states */
-	id: string;
+	runtime_id: string;
 
 	/** The runtime's previous state */
 	old_state: RuntimeState;
@@ -233,17 +233,23 @@ export interface ILanguageRuntimeStateEvent {
  * before the runtime is started.
  */
 export interface ILanguageRuntimeMetadata {
-	/** A unique identifier for this runtime */
-	readonly id: string;
+	/** A unique identifier for this runtime; usually a GUID */
+	readonly runtimeId: string;
 
-	/** The language identifier for this runtime. */
-	readonly language: string;
+	/** The name of the language that this runtime can execute; e.g. "R" */
+	readonly languageName: string;
 
-	/** The name of the runtime. */
-	readonly name: string;
+	/** The internal ID of the language that this runtime can execute; e.g. "r" */
+	readonly languageId: string;
 
-	/** The version of the runtime. */
-	readonly version: string;
+	/** The version of the language in question; e.g. "4.3.3" */
+	readonly languageVersion: string;
+
+	/** The user-facing descriptive name of the runtime; e.g. "R 4.3.3" */
+	readonly runtimeName: string;
+
+	/** The internal version of the runtime that wraps the language; e.g. "1.0.3" */
+	readonly runtimeVersion: string;
 
 	/** Whether the runtime should start up automatically or wait until explicitly requested */
 	startupBehavior: LanguageRuntimeStartupBehavior;


### PR DESCRIPTION
The intent of this change is to clarify the meaning of the fields in the runtime metadata, and to make their use more consistent. Specifically:

- No more bare field names like `id` or `name` -- each field now has more verbose naming (`runtimeId`, `languageName`, etc.)
- The metadata has been augmented with additional fields to reduce confusion and cross-referencing.
- The language runtimes are now responsible for supplying both language ID and language name; this way we avoid confusion about what `language` is, and we also avoid having to guess name from ID or the other way around. IDs are publicly documented here so shouldn't be a huge burden:  https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers