### PR TITLE
Ensure kernels are shut down during deactivate

### DIFF
--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -625,6 +625,6 @@ export class LanguageRuntimeAdapter
 		}
 
 		// Tell the kernel to shut down
-		this.shutdown();
+		this._kernel.dispose();
 	}
 }


### PR DESCRIPTION
This fixes an issue in which the `ark` kernel does not get cleaned up when Positron exits. It turns out that the main reason for this problem is a simple ordering error: we tear down all of the sockets and then tell the kernel to shut down. However ... the shutdown request is sent over a socket, so it's never delivered! 

The fix is just to tell the kernel to shut down _before_ tearing down the ZeroMQ sockets.

(Note -- changes to spawn options are just to clarify intent.)