### PR TITLE
Stop release if tag already exists

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -38,8 +38,13 @@ jobs:
       # Call again to get just the build number. Example: 123
       - name: Determine Version (Build Number)
         id: build_number
-        run: echo "result=$(./versions/show-version.js --build)" >> $GITHUB_OUTPUT
-
+        run: |
+          result=`./versions/show-version.js --build`
+          echo "result=$result" >> $GITHUB_OUTPUT
+          # Stop if release tag already exists
+          git fetch --tags
+          tag_exists=`git tag -l ${result}`
+          if [ -n tag_exists ]; then exit 78; fi
 
   macos-arm64:
     name: Build macOS client (arm64)

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -36,12 +36,12 @@ jobs:
         run: echo "result=$(./versions/show-version.js --short)" >> $GITHUB_OUTPUT
 
       # Call again to get just the build number. Example: 123
+      # We stop if release tag already exists.
       - name: Determine Version (Build Number)
         id: build_number
         run: |
           result=`./versions/show-version.js --build`
           echo "result=$result" >> $GITHUB_OUTPUT
-          # Stop if release tag already exists
           git fetch --tags
           tag_exists=`git tag -l ${result}`
           if [ -n tag_exists ]; then exit 78; fi


### PR DESCRIPTION
If no changes have been made since the last release, the distance would be the same and the tag would already exist.

We stop the build to avoid rebuilding the release and failing on a tag conflict.
