### PR TITLE
Stop release if tag already exists

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -31,9 +31,16 @@ jobs:
       # artifact.
       #
       # Example: 2022.10.0-123
+      #
+      # We also use the short_version as a release tag, and stop if the tag already exists.
       - name: Determine Version (Short)
         id: short_version
-        run: echo "result=$(./versions/show-version.js --short)" >> $GITHUB_OUTPUT
+        run: |
+          result=`./versions/show-version.js --short`
+          echo "result=$result" >> $GITHUB_OUTPUT
+          git fetch --tags
+          tag_exists=`git tag -l ${result}`
+          if [ -n tag_exists ]; then exit 78; fi
 
       # Call again to get just the build number. Example: 123
       - name: Determine Version (Build Number)


### PR DESCRIPTION
If no changes have been made since the last release, the distance would be the same and the tag would already exist.

We stop the build to avoid rebuilding the release and failing on a tag conflict.
