### PR TITLE
Workflow for reviving macOS agent

### DIFF
--- a/.github/workflows/revive-macos-build-agent.yml
+++ b/.github/workflows/revive-macos-build-agent.yml
@@ -24,5 +24,5 @@ jobs:
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
-          ssh user229818@NY503.macincloud.com "if screen -list | grep -q 'No Sockets found'; then screen -dmS agent_session bash -c 'cd ./actions-runner && ./run.sh'; fi"
+          ssh user229818@NY503.macincloud.com "if screen -list | grep -q 'No Sockets found'; then screen -dmS agent_session zsh -c 'cd ./actions-runner && ./run.sh'; fi"
 

--- a/.github/workflows/revive-macos-build-agent.yml
+++ b/.github/workflows/revive-macos-build-agent.yml
@@ -1,0 +1,28 @@
+name: "Positron: Revive macOS build agent"
+
+# check every hour to see if the agent's online
+on:
+  schedule:
+  - cron: "0 * * * *"
+  workflow_dispatch:
+
+jobs:
+
+  revive_agent:
+    name: Revive build agent
+    runs-on: [self-hosted, linux]
+    steps:
+      - name: Setup SSH Keys and known_hosts
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add - <<< "${{ secrets.MACOS_PRIVATE_SSH_KEY }}"
+
+      - name: Revive Screen session
+        id: revive_agent
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          ssh user229818@NY503.macincloud.com "if screen -list | grep -q 'No Sockets found'; then screen -dmS agent_session bash -c 'cd ./actions-runner && ./run.sh'; fi"
+

--- a/.github/workflows/revive-macos-build-agent.yml
+++ b/.github/workflows/revive-macos-build-agent.yml
@@ -24,5 +24,6 @@ jobs:
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
-          ssh user229818@NY503.macincloud.com "if screen -list | grep -q 'No Sockets found'; then screen -dmS agent_session zsh -c 'cd ./actions-runner && ./run.sh'; fi"
+          ssh user229818@NY503.macincloud.com "/bin/zsh -li -c \"if screen -list | grep -q 'No Sockets found'; then screen -dmS agent_session /bin/zsh -li -c 'cd ./actions-runner && ./run.sh'; fi\""
+
 


### PR DESCRIPTION
Adds a new hourly workflow that attempts to revive the macOS build agent. The workflow checks to see if `screen` is running; if it isn't, it starts a new `screen` session, inside which it runs the Github Actions client.

You can see what's going on in the agent (its stdout/stderr logs) by connecting to the host directly and running `screen -r`. 