### PR TITLE
Add positron-python as a submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,5 @@ vscode.db
 
 # --- Start Positron ---
 .Rproj.user
-/extensions/positron-python/
 # --- End Positron ---
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "extensions/positron-python"]
+	path = extensions/positron-python
+	url = git@github.com:posit-dev/positron-python.git

--- a/build/hygiene.js
+++ b/build/hygiene.js
@@ -299,7 +299,9 @@ if (require.main === module) {
 		});
 	} else {
 		cp.exec(
-			'git diff --cached --name-only',
+			// --- Start Positron ---
+			'git diff --cached --name-only --ignore-submodules',
+			// --- End Positron ---
 			{ maxBuffer: 2000 * 1024 },
 			(err, out) => {
 				if (err) {

--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -153,14 +153,13 @@ function getHeaderInfo(rcFile) {
 
 
 // --- Start Positron ---
-// TOOD: make more robust against dirty working dir, etc.
-console.log(`Installing positron built-in extensions...`);
-if (process.env['POSITRON_GITHUB_PAT']) {
-	// For unattended builds: read-only clone with PAT
-	console.log(`Using POSITRON_GITHUB_PAT for authentication`);
-	cp.execSync(`git -C positron-python pull || git clone https://${process.env['POSITRON_GITHUB_PAT']}@github.com/posit-dev/positron-python.git positron-python`, { cwd: 'extensions' });
-} else {
-	// For dev environments: read-write clone with developer's default SSH key
-	cp.execSync('git -C positron-python pull || git clone git@github.com:posit-dev/positron-python.git positron-python', { cwd: 'extensions' });
+// TODO: Remove this once we have a standard set of scripts for our repositories
+console.log(`Updating positron built-in extensions...`);
+// For dev environments: if a local sync of extensions/positron-python already
+// exists, "absorb" it as if it were originally added via submodule
+if (fs.existsSync('extensions/positron-python/.git') &&
+	!fs.existsSync('.git/modules/extensions/positron-python')) {
+	cp.execSync('git submodule absorbgitdirs extensions/positron-python');
 }
+cp.execSync('git submodule update --init');
 // --- End Positron ---

--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -161,5 +161,14 @@ if (fs.existsSync('extensions/positron-python/.git') &&
 	!fs.existsSync('.git/modules/extensions/positron-python')) {
 	cp.execSync('git submodule absorbgitdirs extensions/positron-python');
 }
-cp.execSync('git submodule update --init');
+
+cp.execSync('git submodule init');
+
+// For unattended builds: config with PAT
+if (process.env['POSITRON_GITHUB_PAT']) {
+	cp.execSync(`git config submodule.extensions/positron-python.url https://${process.env['POSITRON_GITHUB_PAT']}@github.com/posit-dev/positron-python.git`);
+}
+
+cp.execSync('git submodule update');
+
 // --- End Positron ---


### PR DESCRIPTION
This allows us to test and track a specific commit of the positron-python extension.

