### PR TITLE
set cran mirror to cran.rstudio.com

### DIFF
--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/modules/options.R
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/modules/options.R
@@ -16,8 +16,19 @@ options(browser = function(url) {
 # Set cran mirror
 local({
     repos <- getOption("repos")
+    rstudio_cran <- "https://cran.rstudio.com/"
 
-    if (is.null(repos) || identical(repos, "@CRAN@")) {
-        options(repos = c(CRAN = "https://cran.rstudio.com/"))
+    if (is.null(repos) || !is.character(repos)) {
+        options(repos = c(CRAN = rstudio_cran))
+    } else {
+        if ("CRAN" %in% names(repos)) {
+            if (identical(repos[["CRAN"]], "@CRAN@")) {
+                repos[["CRAN"]] <- rstudio_cran
+                options(repos = repos)
+            }
+        } else {
+            repos <- c(CRAN = rstudio_cran, repos)
+            options(repos = repos)
+        }
     }
 })

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/modules/options.R
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/modules/options.R
@@ -15,7 +15,7 @@ options(browser = function(url) {
 
 # Set cran mirror
 local({
-    repos = getOption("repos")
+    repos <- getOption("repos")
 
     if (is.null(repos) || identical(repos, "@CRAN@")) {
         options(repos = c(CRAN = "https://cran.rstudio.com/"))

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/modules/options.R
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/modules/options.R
@@ -12,3 +12,11 @@ options(help_type = "html")
 options(browser = function(url) {
     .Call("ps_browse_url", as.character(url), PACKAGE = "(embedding)")
 })
+
+local({
+    repos = getOption("repos")
+
+    if (is.null(repos) || identical(repos, "@CRAN@")) {
+        options(repos = c(CRAN = "https://cran.rstudio.com/"))
+    }
+})

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/modules/options.R
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/modules/options.R
@@ -13,6 +13,7 @@ options(browser = function(url) {
     .Call("ps_browse_url", as.character(url), PACKAGE = "(embedding)")
 })
 
+# Set cran mirror
 local({
     repos = getOption("repos")
 


### PR DESCRIPTION
closes #138

rstudio has a more sophisticated way to get to this: https://github.com/rstudio/rstudio/blob/df7efaa7c605d91399201ad68eb607d5c16fda54/src/cpp/session/SessionMain.cpp#L2321

But at least this make `install.packages()` less surprising for MVP. 