### PR TITLE
move positron preinstall script to own file

### DIFF
--- a/build/npm/positron-preinstall.js
+++ b/build/npm/positron-preinstall.js
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Posit Software, PBC.
+ *--------------------------------------------------------------------------------------------*/
+
+const child_process = require('child_process');
+const fs = require('fs');
+const process = require('process');
+
+function executeCommandOrDie(command, options) {
+
+	console.log(`$ ${command}`);
+	const result = child_process.spawnSync(command, [], {
+		encoding: 'utf-8',
+		stdio: 'inherit',
+		shell: true,
+		...(options || {}),
+	});
+
+	if (result.error || result.status !== 0) {
+		console.error(`Error executing ${command} [exit status ${result.status}]`);
+		process.exit(1);
+	}
+
+}
+
+function githubUrlWithPat(url) {
+
+	const pat = process.env['POSITRON_GITHUB_PAT'] || '';
+	if (pat.length) {
+		url = url.replace('https://', `https://${pat}@`);
+	}
+
+	return url;
+
+}
+
+function updateBuiltinExtension(name, url) {
+
+	// If the positron-python folder already exists, try to update it.
+	if (fs.existsSync(name)) {
+		executeCommandOrDie(`git -C ${name} pull`);
+		return;
+	}
+
+	// Otherwise, clone the repository.
+	url = githubUrlWithPat(url);
+	executeCommandOrDie(`git clone ${url} positron-python`);
+
+}
+
+process.chdir('extensions');
+updateBuiltinExtension('positron-python', 'https://github.com/posit-dev/positron-python.git');
+process.chdir('..');

--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -153,14 +153,5 @@ function getHeaderInfo(rcFile) {
 
 
 // --- Start Positron ---
-// TOOD: make more robust against dirty working dir, etc.
-console.log(`Installing positron built-in extensions...`);
-if (process.env['POSITRON_GITHUB_PAT']) {
-	// For unattended builds: read-only clone with PAT
-	console.log(`Using POSITRON_GITHUB_PAT for authentication`);
-	cp.execSync(`git -C positron-python pull || git clone https://${process.env['POSITRON_GITHUB_PAT']}@github.com/posit-dev/positron-python.git positron-python`, { cwd: 'extensions' });
-} else {
-	// For dev environments: read-write clone with developer's default SSH key
-	cp.execSync('git -C positron-python pull || git clone git@github.com:posit-dev/positron-python.git positron-python', { cwd: 'extensions' });
-}
+require('./positron-preinstall');
 // --- End Positron ---


### PR DESCRIPTION
This PR:

- Moves the Positron-specific pre-install stuff to its own script;
- Moves some of the existing script execution to node-specific tools.