### PR TITLE
This PR combines arm64 and x64 builds into a single job...

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -86,7 +86,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     strategy:
-      parallel: 2
+      concurrency: ci-${{ matrix.arch[0] }}
       matrix:
         arch: [[arm64, aarch64-apple-darwin], [x64, x86_64-apple-darwin]]
 

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -76,88 +76,133 @@ jobs:
         id: build_number
         run: echo "result=$(./versions/show-version.js --build)" >> $GITHUB_OUTPUT
 
-
-  macos-arm64:
-    name: Build macOS client (arm64)
-    needs: [revive_agent, version_string]
-    runs-on: [self-hosted, macos, arm64]
-    timeout-minutes: 40
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      # Perform initial (arm64) dependency download/install
-      - name: Install dependencies (arm64)
-        run: yarn
-        env:
-          npm_config_arch: arm64
-          RUST_TARGET: aarch64-apple-darwin
-          POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
-
-      # Build client for arm64
-      - name: Build client (arm64)
-        run: yarn gulp vscode-darwin-arm64
-        env:
-          POSITRON_BUILD_NUMBER: ${{ needs.version_string.outputs.build_number }}
-
-      # Compress arm64 client to a zip file
-      - name: Create arm64 client archive
-        run: |
-          pushd ..
-          zip -Xry $GITHUB_WORKSPACE/positron-${{ needs.version_string.outputs.short_version }}-darwin-arm64.zip VSCode-darwin-arm64
-          popd
-
-      # Create build artifact
-      - name: Upload arm64 client archive
-        uses: actions/upload-artifact@v3
-        with:
-          name: positron-darwin-arm64-archive
-          path: positron-${{ needs.version_string.outputs.short_version }}-darwin-arm64.zip
-
-  macos-x64:
-    name: Build macOS client (x64)
+  build-archs:
+    name: Build macOS
     runs-on: [self-hosted, macos, arm64]
     needs: [revive_agent, version_string]
     timeout-minutes: 40
+
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    strategy:
+      matrix:
+        arch: [[arm64, aarch64-apple-darwin], [x64, x86_64-apple-darwin]]
+
     steps:
+      # Checkout sources
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      # Install node_modules binaries for x64
-      - name: Install dependencies (x64)
+      # Install node_modules binaries
+      - name: Install dependencies
         env:
-          npm_config_arch: x64
-          RUST_TARGET: x86_64-apple-darwin
+          npm_config_arch: ${{ matrix.arch[0] }}
+          RUST_TARGET: ${{ matrix.arch[1] }}
           POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
         run: yarn
 
-      # Build client for x64
-      - name: Build client (x64)
-        run: yarn gulp vscode-darwin-x64
+      # Build client
+      - name: Build client
         env:
           POSITRON_BUILD_NUMBER: ${{ needs.version_string.outputs.build_number }}
+        run: yarn gulp vscode-darwin-${{ matrix.arch[0] }}
 
-      # Compress x64 client to a zip file
-      - name: Create x64 client archive
+      # Compress client to a zip file
+      - name: Create client archive
         run: |
           pushd ..
-          zip -Xry $GITHUB_WORKSPACE/positron-${{ needs.version_string.outputs.short_version }}-darwin-x64.zip VSCode-darwin-x64
+          zip -Xry $GITHUB_WORKSPACE/positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch[0] }}.zip VSCode-darwin-${{ matrix.arch[0] }}
           popd
 
       # Create build artifact
-      - name: Upload x64 client archive
+      - name: Upload client archive
         uses: actions/upload-artifact@v3
         with:
-          name: positron-darwin-x64-archive
-          path: positron-${{ needs.version_string.outputs.short_version }}-darwin-x64.zip
+          name: positron-darwin-${{ matrix.arch[0] }}-archive
+          path: positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch[0] }}.zip
+
+  # macos-arm64:
+  #   name: Build macOS client (arm64)
+  #   runs-on: [self-hosted, macos, arm64]
+  #   needs: [revive_agent, version_string]
+  #   timeout-minutes: 40
+  #   env:
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
+
+  #     # Perform initial (arm64) dependency download/install
+  #     - name: Install dependencies (arm64)
+  #       run: yarn
+  #       env:
+  #         npm_config_arch: arm64
+  #         RUST_TARGET: aarch64-apple-darwin
+  #         POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+
+  #     # Build client for arm64
+  #     - name: Build client (arm64)
+  #       run: yarn gulp vscode-darwin-arm64
+  #       env:
+  #         POSITRON_BUILD_NUMBER: ${{ needs.version_string.outputs.build_number }}
+
+  #     # Compress arm64 client to a zip file
+  #     - name: Create arm64 client archive
+  #       run: |
+  #         pushd ..
+  #         zip -Xry $GITHUB_WORKSPACE/positron-${{ needs.version_string.outputs.short_version }}-darwin-arm64.zip VSCode-darwin-arm64
+  #         popd
+
+  #     # Create build artifact
+  #     - name: Upload arm64 client archive
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: positron-darwin-arm64-archive
+  #         path: positron-${{ needs.version_string.outputs.short_version }}-darwin-arm64.zip
+
+  # macos-x64:
+  #   name: Build macOS client (x64)
+  #   runs-on: [self-hosted, macos, arm64]
+  #   needs: [revive_agent, version_string]
+  #   timeout-minutes: 40
+  #   env:
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
+
+  #     # Install node_modules binaries for x64
+  #     - name: Install dependencies (x64)
+  #       run: yarn
+  #       env:
+  #         npm_config_arch: x64
+  #         RUST_TARGET: x86_64-apple-darwin
+  #         POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+
+  #     # Build client for x64
+  #     - name: Build client (x64)
+  #       run: yarn gulp vscode-darwin-x64
+  #       env:
+  #         POSITRON_BUILD_NUMBER: ${{ needs.version_string.outputs.build_number }}
+
+  #     # Compress x64 client to a zip file
+  #     - name: Create x64 client archive
+  #       run: |
+  #         pushd ..
+  #         zip -Xry $GITHUB_WORKSPACE/positron-${{ needs.version_string.outputs.short_version }}-darwin-x64.zip VSCode-darwin-x64
+  #         popd
+
+  #     # Create build artifact
+  #     - name: Upload x64 client archive
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: positron-darwin-x64-archive
+  #         path: positron-${{ needs.version_string.outputs.short_version }}-darwin-x64.zip
 
   macos-universal:
     name: Create macOS universal binary
-    needs: [version_string, macos-arm64, macos-x64]
+    needs: [version_string, build-archs]
     runs-on: [self-hosted, macos, arm64]
     timeout-minutes: 40
     env:

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         arch: [[arm64, aarch64-apple-darwin], [x64, x86_64-apple-darwin]]
-      parallel: 2
+      maxParallel: 2
 
     steps:
       # Checkout sources

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -88,7 +88,12 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        arch: [[arm64, aarch64-apple-darwin], [x64, x86_64-apple-darwin]]
+        arch: [arm64, x64]
+        include:
+          - arch: arm64
+          rust_target_prefix: aarch64
+          - arch: x64
+          rust_target_prefix: x86_64
 
     steps:
       # Checkout sources
@@ -98,8 +103,8 @@ jobs:
       # Install node_modules binaries
       - name: Install dependencies
         env:
-          npm_config_arch: ${{ matrix.arch[0] }}
-          RUST_TARGET: ${{ matrix.arch[1] }}
+          npm_config_arch: ${{ matrix.arch }}
+          RUST_TARGET: ${{ matrix.rust_target_prefix }}-apple-darwin
           POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
         run: yarn
 
@@ -107,21 +112,21 @@ jobs:
       - name: Build client
         env:
           POSITRON_BUILD_NUMBER: ${{ needs.version_string.outputs.build_number }}
-        run: yarn gulp vscode-darwin-${{ matrix.arch[0] }}
+        run: yarn gulp vscode-darwin-${{ matrix.arch }}
 
       # Compress client to a zip file
       - name: Create client archive
         run: |
           pushd ..
-          zip -Xry $GITHUB_WORKSPACE/positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch[0] }}.zip VSCode-darwin-${{ matrix.arch[0] }}
+          zip -Xry $GITHUB_WORKSPACE/positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch }}.zip VSCode-darwin-${{ matrix.arch }}
           popd
 
       # Create build artifact
       - name: Upload client archive
         uses: actions/upload-artifact@v3
         with:
-          name: positron-darwin-${{ matrix.arch[0] }}-archive
-          path: positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch[0] }}.zip
+          name: positron-darwin-${{ matrix.arch }}-archive
+          path: positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch }}.zip
 
   macos-universal:
     name: Create macOS universal binary

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -86,7 +86,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     strategy:
-      max-parallel: 2
+      parallel: 2
       matrix:
         arch: [[arm64, aarch64-apple-darwin], [x64, x86_64-apple-darwin]]
 

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -77,7 +77,7 @@ jobs:
         run: echo "result=$(./versions/show-version.js --build)" >> $GITHUB_OUTPUT
 
   build-archs:
-    name: Build macOS Archs
+    name: Build macOS
     runs-on: [self-hosted, macos, arm64]
     needs: [revive_agent, version_string]
     timeout-minutes: 40

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -77,7 +77,7 @@ jobs:
         run: echo "result=$(./versions/show-version.js --build)" >> $GITHUB_OUTPUT
 
   build-archs:
-    name: Build macOS
+    name: Build macOS Architectures
     runs-on: [self-hosted, macos, arm64]
     needs: [revive_agent, version_string]
     timeout-minutes: 40

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -77,7 +77,7 @@ jobs:
         run: echo "result=$(./versions/show-version.js --build)" >> $GITHUB_OUTPUT
 
   build-archs:
-    name: Build macOS Architectures
+    name: Build macOS Archs
     runs-on: [self-hosted, macos, arm64]
     needs: [revive_agent, version_string]
     timeout-minutes: 40

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -86,7 +86,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     strategy:
-      max-parallel: 8
+      max-parallel: 2
       matrix:
         arch: [[arm64, aarch64-apple-darwin], [x64, x86_64-apple-darwin]]
 
@@ -122,84 +122,6 @@ jobs:
         with:
           name: positron-darwin-${{ matrix.arch[0] }}-archive
           path: positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch[0] }}.zip
-
-  # macos-arm64:
-  #   name: Build macOS client (arm64)
-  #   runs-on: [self-hosted, macos, arm64]
-  #   needs: [revive_agent, version_string]
-  #   timeout-minutes: 40
-  #   env:
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   steps:
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
-
-  #     # Perform initial (arm64) dependency download/install
-  #     - name: Install dependencies (arm64)
-  #       run: yarn
-  #       env:
-  #         npm_config_arch: arm64
-  #         RUST_TARGET: aarch64-apple-darwin
-  #         POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
-
-  #     # Build client for arm64
-  #     - name: Build client (arm64)
-  #       run: yarn gulp vscode-darwin-arm64
-  #       env:
-  #         POSITRON_BUILD_NUMBER: ${{ needs.version_string.outputs.build_number }}
-
-  #     # Compress arm64 client to a zip file
-  #     - name: Create arm64 client archive
-  #       run: |
-  #         pushd ..
-  #         zip -Xry $GITHUB_WORKSPACE/positron-${{ needs.version_string.outputs.short_version }}-darwin-arm64.zip VSCode-darwin-arm64
-  #         popd
-
-  #     # Create build artifact
-  #     - name: Upload arm64 client archive
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: positron-darwin-arm64-archive
-  #         path: positron-${{ needs.version_string.outputs.short_version }}-darwin-arm64.zip
-
-  # macos-x64:
-  #   name: Build macOS client (x64)
-  #   runs-on: [self-hosted, macos, arm64]
-  #   needs: [revive_agent, version_string]
-  #   timeout-minutes: 40
-  #   env:
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   steps:
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
-
-  #     # Install node_modules binaries for x64
-  #     - name: Install dependencies (x64)
-  #       run: yarn
-  #       env:
-  #         npm_config_arch: x64
-  #         RUST_TARGET: x86_64-apple-darwin
-  #         POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
-
-  #     # Build client for x64
-  #     - name: Build client (x64)
-  #       run: yarn gulp vscode-darwin-x64
-  #       env:
-  #         POSITRON_BUILD_NUMBER: ${{ needs.version_string.outputs.build_number }}
-
-  #     # Compress x64 client to a zip file
-  #     - name: Create x64 client archive
-  #       run: |
-  #         pushd ..
-  #         zip -Xry $GITHUB_WORKSPACE/positron-${{ needs.version_string.outputs.short_version }}-darwin-x64.zip VSCode-darwin-x64
-  #         popd
-
-  #     # Create build artifact
-  #     - name: Upload x64 client archive
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: positron-darwin-x64-archive
-  #         path: positron-${{ needs.version_string.outputs.short_version }}-darwin-x64.zip
 
   macos-universal:
     name: Create macOS universal binary

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -86,7 +86,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     strategy:
-      concurrency: ci-${{ matrix.arch[0] }}
+      max-parallel: 8
       matrix:
         arch: [[arm64, aarch64-apple-darwin], [x64, x86_64-apple-darwin]]
 

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -86,9 +86,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     strategy:
+      max-parallel: 2
       matrix:
         arch: [[arm64, aarch64-apple-darwin], [x64, x86_64-apple-darwin]]
-      maxParallel: 2
 
     steps:
       # Checkout sources

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -88,12 +88,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        arch: [arm64, x64]
-        include:
-          - arch: arm64
-          rust_target_prefix: aarch64
-          - arch: x64
-          rust_target_prefix: x86_64
+        arch: [[arm64, aarch64-apple-darwin], [x64, x86_64-apple-darwin]]
 
     steps:
       # Checkout sources
@@ -103,8 +98,8 @@ jobs:
       # Install node_modules binaries
       - name: Install dependencies
         env:
-          npm_config_arch: ${{ matrix.arch }}
-          RUST_TARGET: ${{ matrix.rust_target_prefix }}-apple-darwin
+          npm_config_arch: ${{ matrix.arch[0] }}
+          RUST_TARGET: ${{ matrix.arch[1] }}
           POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
         run: yarn
 
@@ -112,21 +107,21 @@ jobs:
       - name: Build client
         env:
           POSITRON_BUILD_NUMBER: ${{ needs.version_string.outputs.build_number }}
-        run: yarn gulp vscode-darwin-${{ matrix.arch }}
+        run: yarn gulp vscode-darwin-${{ matrix.arch[0] }}
 
       # Compress client to a zip file
       - name: Create client archive
         run: |
           pushd ..
-          zip -Xry $GITHUB_WORKSPACE/positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch }}.zip VSCode-darwin-${{ matrix.arch }}
+          zip -Xry $GITHUB_WORKSPACE/positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch[0] }}.zip VSCode-darwin-${{ matrix.arch[0] }}
           popd
 
       # Create build artifact
       - name: Upload client archive
         uses: actions/upload-artifact@v3
         with:
-          name: positron-darwin-${{ matrix.arch }}-archive
-          path: positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch }}.zip
+          name: positron-darwin-${{ matrix.arch[0] }}-archive
+          path: positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch[0] }}.zip
 
   macos-universal:
     name: Create macOS universal binary

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -86,7 +86,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     strategy:
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         arch: [[arm64, aarch64-apple-darwin], [x64, x86_64-apple-darwin]]
 

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -88,6 +88,7 @@ jobs:
     strategy:
       matrix:
         arch: [[arm64, aarch64-apple-darwin], [x64, x86_64-apple-darwin]]
+      parallel: 2
 
     steps:
       # Checkout sources

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -88,7 +88,12 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        arch: [[arm64, aarch64-apple-darwin], [x64, x86_64-apple-darwin]]
+        arch: [arm64, x64]
+        include:
+          - arch: arm64
+            rust_target_prefix: aarch64
+          - arch: x64
+            rust_target_prefix: x86_64
 
     steps:
       # Checkout sources
@@ -98,8 +103,8 @@ jobs:
       # Install node_modules binaries
       - name: Install dependencies
         env:
-          npm_config_arch: ${{ matrix.arch[0] }}
-          RUST_TARGET: ${{ matrix.arch[1] }}
+          npm_config_arch: ${{ matrix.arch }}
+          RUST_TARGET: ${{ matrix.rust_target_prefix }}-apple-darwin
           POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
         run: yarn
 
@@ -107,21 +112,21 @@ jobs:
       - name: Build client
         env:
           POSITRON_BUILD_NUMBER: ${{ needs.version_string.outputs.build_number }}
-        run: yarn gulp vscode-darwin-${{ matrix.arch[0] }}
+        run: yarn gulp vscode-darwin-${{ matrix.arch }}
 
       # Compress client to a zip file
       - name: Create client archive
         run: |
           pushd ..
-          zip -Xry $GITHUB_WORKSPACE/positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch[0] }}.zip VSCode-darwin-${{ matrix.arch[0] }}
+          zip -Xry $GITHUB_WORKSPACE/positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch }}.zip VSCode-darwin-${{ matrix.arch }}
           popd
 
       # Create build artifact
       - name: Upload client archive
         uses: actions/upload-artifact@v3
         with:
-          name: positron-darwin-${{ matrix.arch[0] }}-archive
-          path: positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch[0] }}.zip
+          name: positron-darwin-${{ matrix.arch }}-archive
+          path: positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch }}.zip
 
   macos-universal:
     name: Create macOS universal binary


### PR DESCRIPTION
This PR combines the `arm64` and `x64` jobs into a single job called `build-archs` using a matrix strategy. The immediate benefit of this is that we won't have to maintain two jobs that are 99% identical. A future benefit is that this should allow us to run these builds in parallel once we figure out how to make this work. We're not going to do this right now, so I've set `max-parallel: 1` in the strategy.