### PR TITLE
use fork of zeromq for now

### DIFF
--- a/extensions/jupyter-adapter/package.json
+++ b/extensions/jupyter-adapter/package.json
@@ -45,7 +45,7 @@
     "tail": "^2.2.6",
     "uuid": "^9.0.0",
     "vscode-nls": "^5.2.0",
-    "zeromq": "6.0.0-beta.16"
+    "zeromq": "kevinushey/zeromq.js"
   },
   "repository": {
     "type": "git",

--- a/extensions/jupyter-adapter/yarn.lock
+++ b/extensions/jupyter-adapter/yarn.lock
@@ -1407,3 +1407,13 @@ zeromq@6.0.0-beta.16:
     node-addon-api "^5.0.0"
     shelljs "^0.8.5"
     shx "^0.3.4"
+
+zeromq@kevinushey/zeromq.js:
+  version "6.0.0-beta.16"
+  resolved "https://codeload.github.com/kevinushey/zeromq.js/tar.gz/dd0a4dce4f12f4b3230f3aaa14f72ca2a5c748b2"
+  dependencies:
+    "@aminya/node-gyp-build" "4.5.0-aminya.4"
+    cross-env "^7.0.3"
+    node-addon-api "^5.0.0"
+    shelljs "^0.8.5"
+    shx "^0.3.4"


### PR DESCRIPTION
This PR switches us to building against a fork of `zeromq`, while we wait for https://github.com/zeromq/zeromq.js/issues/557 to be sorted out upstream.

This works on my machine:

```
$ otool -L node_modules/zeromq/build/Release/zeromq.node
node_modules/zeromq/build/Release/zeromq.node:
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1300.36.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)
```

but we should check that builds from the lab work as well.

Closes https://github.com/rstudio/positron/issues/154.