### PR TITLE
keep 'Attach to VS Code' launch target around

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -216,6 +216,23 @@
 			],
 			"perScriptSourcemaps": "yes"
 		},
+		// NOTE: The VSCode internal extension for debugging of tests requires
+    	// a launch target called 'Attach to VS Code', so we keep this around.
+		// See: https://github.com/microsoft/vscode-selfhost-test-provider/blob/1e18eea05b47a9a8b0175d1ee0650386e6bcaae9/src/vscodeTestRunner.ts#L22
+		{
+			"type": "chrome",
+			"request": "attach",
+			"name": "Attach to VS Code",
+			"browserAttachLocation": "workspace",
+			"port": 9222,
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"resolveSourceMapLocations": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"perScriptSourcemaps": "yes"
+		},
 		{
 			"type": "chrome",
 			"request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -217,7 +217,7 @@
 			"perScriptSourcemaps": "yes"
 		},
 		// NOTE: The VSCode internal extension for debugging of tests requires
-    	// a launch target called 'Attach to VS Code', so we keep this around.
+		// a launch target called 'Attach to VS Code', so we keep this around.
 		// See: https://github.com/microsoft/vscode-selfhost-test-provider/blob/1e18eea05b47a9a8b0175d1ee0650386e6bcaae9/src/vscodeTestRunner.ts#L22
 		{
 			"type": "chrome",


### PR DESCRIPTION
Required for debugging of tests.