### PR TITLE
stop trying to use R_Is_Running

### DIFF
--- a/extensions/positron-r/amalthea/Cargo.lock
+++ b/extensions/positron-r/amalthea/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "amalthea-macros",
  "async-trait",
  "chrono",
+ "crossbeam",
  "crypto-common",
  "dirs",
  "env_logger 0.10.0",
@@ -97,6 +98,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "crossbeam",
  "ctor",
  "dashmap",
  "ego-tree",
@@ -346,6 +348,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "memoffset 0.7.1",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +583,7 @@ version = "0.1.0"
 dependencies = [
  "amalthea",
  "async-trait",
+ "crossbeam",
  "env_logger 0.9.3",
  "log",
  "serde_json",
@@ -1160,6 +1230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metadeps"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,7 +1285,7 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -1219,7 +1298,7 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
  "pin-utils",
 ]
 

--- a/extensions/positron-r/amalthea/Cargo.lock
+++ b/extensions/positron-r/amalthea/Cargo.lock
@@ -97,6 +97,7 @@ dependencies = [
  "amalthea",
  "anyhow",
  "async-trait",
+ "bus",
  "chrono",
  "crossbeam",
  "ctor",
@@ -226,6 +227,17 @@ name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
+name = "bus"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80cb4625f5b60155ff1018c9d4ce2e38bf5ae3e5780dfab9fa68bb44a6b751e2"
+dependencies = [
+ "crossbeam-channel",
+ "num_cpus",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "byteorder"

--- a/extensions/positron-r/amalthea/crates/amalthea/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/amalthea/Cargo.toml
@@ -22,6 +22,7 @@ uuid = { version = "0.8.2", features = ["v4"] }
 zmq = { version = "0.9.2", features = ["vendored"] }
 strum = "0.24"
 strum_macros = "0.24"
+crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/extensions/positron-r/amalthea/crates/amalthea/src/language/lsp_handler.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/src/language/lsp_handler.rs
@@ -15,5 +15,5 @@ use crate::error::Error;
 #[async_trait]
 pub trait LspHandler: Send {
     /// Starts the LSP server and binds it to the given TCP address.
-    fn start(&self, tcp_address: String) -> Result<(), Error>;
+    fn start(&mut self, tcp_address: String) -> Result<(), Error>;
 }

--- a/extensions/positron-r/amalthea/crates/amalthea/src/language/shell_handler.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/src/language/shell_handler.rs
@@ -21,9 +21,8 @@ use crate::wire::is_complete_request::IsCompleteRequest;
 use crate::wire::kernel_info_reply::KernelInfoReply;
 use crate::wire::kernel_info_request::KernelInfoRequest;
 
-use std::sync::mpsc::SyncSender;
-
 use async_trait::async_trait;
+use crossbeam::channel::Sender;
 
 #[async_trait]
 pub trait ShellHandler: Send {
@@ -89,5 +88,5 @@ pub trait ShellHandler: Send {
     /// input and deliver it via the `handle_input_reply` method.
     ///
     /// https://jupyter-client.readthedocs.io/en/stable/messaging.html#messages-on-the-stdin-router-dealer-channel
-    fn establish_input_handler(&mut self, handler: SyncSender<ShellInputRequest>);
+    fn establish_input_handler(&mut self, handler: Sender<ShellInputRequest>);
 }

--- a/extensions/positron-r/amalthea/crates/amalthea/src/socket/iopub.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/src/socket/iopub.rs
@@ -18,8 +18,8 @@ use crate::wire::jupyter_message::ProtocolMessage;
 use crate::wire::status::ExecutionState;
 use crate::wire::status::KernelStatus;
 use crate::wire::stream::StreamOutput;
+use crossbeam::channel::Receiver;
 use log::{trace, warn};
-use std::sync::mpsc::Receiver;
 
 pub struct IOPub {
     /// The underlying IOPub socket

--- a/extensions/positron-r/amalthea/crates/amalthea/src/socket/shell.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/src/socket/shell.rs
@@ -31,12 +31,13 @@ use crate::wire::kernel_info_reply::KernelInfoReply;
 use crate::wire::kernel_info_request::KernelInfoRequest;
 use crate::wire::status::ExecutionState;
 use crate::wire::status::KernelStatus;
+use crossbeam::channel::Sender;
 use futures::executor::block_on;
 use log::{debug, trace, warn};
 use std::collections::HashMap;
-use std::sync::mpsc::SyncSender;
-use std::sync::{Arc, Mutex};
 use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 /// Wrapper for the Shell socket; receives requests for execution, etc. from the
 /// front end and handles them or dispatches them to the execution thread.
@@ -45,7 +46,7 @@ pub struct Shell {
     socket: Socket,
 
     /// Sends messages to the IOPub socket (owned by another thread)
-    iopub_sender: SyncSender<IOPubMessage>,
+    iopub_sender: Sender<IOPubMessage>,
 
     /// Language-provided shell handler object
     handler: Arc<Mutex<dyn ShellHandler>>,
@@ -62,7 +63,7 @@ impl Shell {
     /// * `handler` - The language's shell channel handler
     pub fn new(
         socket: Socket,
-        iopub_sender: SyncSender<IOPubMessage>,
+        iopub_sender: Sender<IOPubMessage>,
         handler: Arc<Mutex<dyn ShellHandler>>,
     ) -> Self {
         Self {

--- a/extensions/positron-r/amalthea/crates/amalthea/src/socket/stdin.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/src/socket/stdin.rs
@@ -5,15 +5,17 @@
  *
  */
 
+use std::sync::Arc;
+use std::sync::Mutex;
+
 use crate::language::shell_handler::ShellHandler;
 use crate::socket::socket::Socket;
 use crate::wire::input_request::ShellInputRequest;
 use crate::wire::jupyter_message::JupyterMessage;
 use crate::wire::jupyter_message::Message;
+use crossbeam::channel::bounded;
 use futures::executor::block_on;
 use log::{trace, warn};
-use std::sync::mpsc::sync_channel;
-use std::sync::{Arc, Mutex};
 
 pub struct Stdin {
     /// The ZeroMQ stdin socket
@@ -40,7 +42,7 @@ impl Stdin {
     /// 1. Wait for
     pub fn listen(&self) {
         // Create the communication channel for the shell handler and inject it
-        let (sender, receiver) = sync_channel::<ShellInputRequest>(1);
+        let (sender, receiver) = bounded::<ShellInputRequest>(1);
         {
             let mut shell_handler = self.handler.lock().unwrap();
             shell_handler.establish_input_handler(sender);

--- a/extensions/positron-r/amalthea/crates/amalthea/tests/shell/mod.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/tests/shell/mod.rs
@@ -31,13 +31,13 @@ use amalthea::wire::kernel_info_reply::KernelInfoReply;
 use amalthea::wire::kernel_info_request::KernelInfoRequest;
 use amalthea::wire::language_info::LanguageInfo;
 use async_trait::async_trait;
+use crossbeam::channel::Sender;
 use log::warn;
 use serde_json::json;
-use std::sync::mpsc::SyncSender;
 
 pub struct Shell {
-    iopub: SyncSender<IOPubMessage>,
-    input_sender: Option<SyncSender<ShellInputRequest>>,
+    iopub: Sender<IOPubMessage>,
+    input_sender: Option<Sender<ShellInputRequest>>,
     execution_count: u32,
 }
 
@@ -60,7 +60,7 @@ impl CommChannel for TestComm {
 
 /// Stub implementation of the shell handler for test harness
 impl Shell {
-    pub fn new(iopub: SyncSender<IOPubMessage>) -> Self {
+    pub fn new(iopub: Sender<IOPubMessage>) -> Self {
         Self {
             iopub: iopub,
             execution_count: 0,
@@ -255,7 +255,7 @@ impl ShellHandler for Shell {
     }
 
 
-    fn establish_input_handler(&mut self, handler: SyncSender<ShellInputRequest>) {
+    fn establish_input_handler(&mut self, handler: Sender<ShellInputRequest>) {
         self.input_sender = Some(handler);
     }
 }

--- a/extensions/positron-r/amalthea/crates/ark/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/ark/Cargo.toml
@@ -37,6 +37,7 @@ tree-sitter = "0.20.6"
 tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", branch = "next" }
 walkdir = "2"
 yaml-rust = "0.4.5"
+crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
 
 [profile.dev]
 rpath = true

--- a/extensions/positron-r/amalthea/crates/ark/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/ark/Cargo.toml
@@ -38,6 +38,7 @@ tree-sitter-r = { git = "https://github.com/r-lib/tree-sitter-r", branch = "next
 walkdir = "2"
 yaml-rust = "0.4.5"
 crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }
+bus = "2.3.0"
 
 [profile.dev]
 rpath = true

--- a/extensions/positron-r/amalthea/crates/ark/src/control.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/control.rs
@@ -12,20 +12,20 @@ use amalthea::wire::jupyter_message::Status;
 use amalthea::wire::shutdown_reply::ShutdownReply;
 use amalthea::wire::shutdown_request::ShutdownRequest;
 use async_trait::async_trait;
+use crossbeam::channel::Sender;
 use log::*;
 use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
-use std::sync::mpsc::SyncSender;
 
 
 use crate::request::Request;
 
 pub struct Control {
-    req_sender: SyncSender<Request>,
+    req_sender: Sender<Request>,
 }
 
 impl Control {
-    pub fn new(sender: SyncSender<Request>) -> Self {
+    pub fn new(sender: Sender<Request>) -> Self {
         Self { req_sender: sender }
     }
 }

--- a/extensions/positron-r/amalthea/crates/ark/src/interface.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/interface.rs
@@ -9,6 +9,9 @@ use amalthea::events::BusyEvent;
 use amalthea::events::PositronEvent;
 use amalthea::events::ShowMessageEvent;
 use amalthea::socket::iopub::IOPubMessage;
+use crossbeam::channel::Receiver;
+use crossbeam::channel::RecvTimeoutError;
+use crossbeam::channel::Sender;
 use harp::lock::R_RUNTIME_LOCK;
 use harp::lock::R_RUNTIME_TASKS_PENDING;
 use harp::routines::r_register_routines;
@@ -19,10 +22,10 @@ use log::*;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_uchar;
 use std::os::raw::c_void;
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::MutexGuard;
-use std::sync::mpsc::channel;
-use std::sync::mpsc::{Receiver, Sender, SyncSender};
-use std::sync::{Arc, Mutex, Once};
+use std::sync::Once;
 use std::thread;
 use std::time::Duration;
 use std::time::SystemTime;
@@ -172,9 +175,9 @@ pub extern "C" fn r_read_console(
 
             Err(error) => {
 
-                use std::sync::mpsc::RecvTimeoutError::*;
                 unsafe { R_RUNTIME_LOCK_GUARD = Some(R_RUNTIME_LOCK.as_ref().unwrap_unchecked().lock().unwrap()) };
 
+                use RecvTimeoutError::*;
                 match error {
 
                     Timeout => {
@@ -278,9 +281,9 @@ pub unsafe extern "C" fn r_polled_events() {
 }
 
 pub fn start_r(
-    iopub: SyncSender<IOPubMessage>,
+    iopub: Sender<IOPubMessage>,
     receiver: Receiver<Request>,
-    initializer: Sender<KernelInfo>,
+    kernel_init_sender: Sender<KernelInfo>,
 ) {
     use std::borrow::BorrowMut;
 
@@ -289,10 +292,10 @@ pub fn start_r(
     unsafe { R_RUNTIME_LOCK_GUARD = Some(R_RUNTIME_LOCK.as_ref().unwrap_unchecked().lock().unwrap()) };
 
     // Start building the channels + kernel objects
-    let (console_send, console_recv) = channel::<Option<String>>();
-    let (rprompt_send, rprompt_recv) = channel::<String>();
+    let (console_send, console_recv) = crossbeam::channel::unbounded();
+    let (rprompt_send, rprompt_recv) = crossbeam::channel::unbounded();
     let console = console_send.clone();
-    let kernel = Kernel::new(iopub, console, initializer);
+    let kernel = Kernel::new(iopub, console, kernel_init_sender);
 
     // Initialize kernel (ensure we only do this once!)
     INIT.call_once(|| unsafe {

--- a/extensions/positron-r/amalthea/crates/ark/src/interface.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/interface.rs
@@ -9,6 +9,7 @@ use amalthea::events::BusyEvent;
 use amalthea::events::PositronEvent;
 use amalthea::events::ShowMessageEvent;
 use amalthea::socket::iopub::IOPubMessage;
+use bus::Bus;
 use crossbeam::channel::Receiver;
 use crossbeam::channel::RecvTimeoutError;
 use crossbeam::channel::Sender;
@@ -283,7 +284,7 @@ pub unsafe extern "C" fn r_polled_events() {
 pub fn start_r(
     iopub: Sender<IOPubMessage>,
     receiver: Receiver<Request>,
-    kernel_init_sender: Sender<KernelInfo>,
+    kernel_init_sender: Bus<KernelInfo>,
 ) {
     use std::borrow::BorrowMut;
 

--- a/extensions/positron-r/amalthea/crates/ark/src/kernel.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/kernel.rs
@@ -18,6 +18,7 @@ use amalthea::wire::input_request::InputRequest;
 use amalthea::wire::input_request::ShellInputRequest;
 use amalthea::wire::jupyter_message::Status;
 use anyhow::*;
+use crossbeam::channel::Sender;
 use harp::exec::RFunction;
 use harp::exec::RFunctionExt;
 use harp::object::RObject;
@@ -28,20 +29,19 @@ use log::*;
 use serde_json::json;
 use std::result::Result::Err;
 use std::result::Result::Ok;
-use std::sync::mpsc::{Sender, SyncSender};
 
 use crate::request::Request;
 
 /// Represents the Rust state of the R kernel
 pub struct Kernel {
     pub execution_count: u32,
-    iopub: SyncSender<IOPubMessage>,
+    iopub: Sender<IOPubMessage>,
     console: Sender<Option<String>>,
     initializer: Sender<KernelInfo>,
     output: String,
     error: String,
     response_sender: Option<Sender<ExecuteResponse>>,
-    input_requestor: Option<SyncSender<ShellInputRequest>>,
+    input_requestor: Option<Sender<ShellInputRequest>>,
     banner: String,
     initializing: bool,
 }
@@ -55,7 +55,7 @@ pub struct KernelInfo {
 impl Kernel {
     /// Create a new R kernel instance
     pub fn new(
-        iopub: SyncSender<IOPubMessage>,
+        iopub: Sender<IOPubMessage>,
         console: Sender<Option<String>>,
         initializer: Sender<KernelInfo>,
     ) -> Self {
@@ -311,7 +311,7 @@ impl Kernel {
 
     /// Establishes the input handler for the kernel to request input from the
     /// user
-    pub fn establish_input_handler(&mut self, sender: SyncSender<ShellInputRequest>) {
+    pub fn establish_input_handler(&mut self, sender: Sender<ShellInputRequest>) {
         self.input_requestor = Some(sender);
     }
 

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/backend.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/backend.rs
@@ -10,8 +10,8 @@
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::mpsc::SyncSender;
 
+use crossbeam::channel::Sender;
 use dashmap::DashMap;
 use harp::r_lock;
 use log::*;
@@ -75,7 +75,7 @@ pub struct Backend {
     pub documents: Arc<DashMap<Url, Document>>,
     pub workspace: Arc<Mutex<Workspace>>,
     #[allow(dead_code)]
-    pub shell_request_sender: SyncSender<Request>,
+    pub shell_request_sender: Sender<Request>,
 }
 
 impl Backend {
@@ -555,7 +555,7 @@ impl Backend {
 }
 
 #[tokio::main]
-pub async fn start_lsp(address: String, shell_request_sender: SyncSender<Request>) {
+pub async fn start_lsp(address: String, shell_request_sender: Sender<Request>) {
     #[cfg(feature = "runtime-agnostic")]
     use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/global.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/global.rs
@@ -5,15 +5,16 @@
 //
 //
 
-use std::sync::mpsc::SyncSender;
+use crossbeam::channel::Sender;
 use tower_lsp::Client;
-use crate::request::Request;
 use once_cell::sync::OnceCell;
+
+use crate::request::Request;
 
 #[derive(Debug, Clone)]
 pub struct ClientInstance {
     pub client: Client,
-    pub shell_request_sender: SyncSender<Request>
+    pub shell_request_sender: Sender<Request>
 }
 
 // This global instance of the LSP client and request channel is used for

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/global.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/global.rs
@@ -13,7 +13,7 @@ use once_cell::sync::OnceCell;
 #[derive(Debug, Clone)]
 pub struct ClientInstance {
     pub client: Client,
-    pub channel: SyncSender<Request>
+    pub shell_request_sender: SyncSender<Request>
 }
 
 // This global instance of the LSP client and request channel is used for

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/handler.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/handler.rs
@@ -5,29 +5,36 @@
 //
 //
 
-use std::sync::mpsc::SyncSender;
-
 use amalthea::language::lsp_handler::LspHandler;
-use async_trait::async_trait;
+use crossbeam::channel::Receiver;
+use crossbeam::channel::Sender;
 use std::thread;
+use std::time::Duration;
 
+use crate::kernel::KernelInfo;
 use crate::request::Request;
 
 use super::backend;
 
 pub struct Lsp {
-    shell_request_sender: SyncSender<Request>
+    shell_request_sender: Sender<Request>,
+    kernel_init_receiver: Receiver<KernelInfo>,
 }
 
 impl Lsp {
-    pub fn new(shell_request_sender: SyncSender<Request>) -> Self {
-        Self { shell_request_sender }
+    pub fn new(shell_request_sender: Sender<Request>, kernel_init_receiver: Receiver<KernelInfo>) -> Self {
+        Self { shell_request_sender, kernel_init_receiver }
     }
 }
 
-#[async_trait]
 impl LspHandler for Lsp {
     fn start(&self, tcp_address: String) -> Result<(), amalthea::error::Error> {
+
+        let status = self.kernel_init_receiver.recv_timeout(Duration::from_secs(10));
+        if let Err(error) = status {
+            log::error!("Error waiting for kernel to initialize: {}", error);
+        }
+
         let sender = self.shell_request_sender.clone();
         thread::spawn(move || backend::start_lsp(tcp_address, sender));
         return Ok(());

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/handler.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/handler.rs
@@ -5,7 +5,7 @@
 //
 //
 
-use std::{sync::mpsc::SyncSender, time::Duration};
+use std::sync::mpsc::SyncSender;
 
 use amalthea::language::lsp_handler::LspHandler;
 use async_trait::async_trait;
@@ -15,45 +15,21 @@ use crate::request::Request;
 
 use super::backend;
 
-extern "C" {
-static R_Is_Running: i32;
-}
-
 pub struct Lsp {
-    req_sender: SyncSender<Request>
+    shell_request_sender: SyncSender<Request>
 }
 
 impl Lsp {
-    pub fn new(req_sender: SyncSender<Request>) -> Self {
-        Self {
-            req_sender
-        }
+    pub fn new(shell_request_sender: SyncSender<Request>) -> Self {
+        Self { shell_request_sender }
     }
 }
 
 #[async_trait]
 impl LspHandler for Lsp {
     fn start(&self, tcp_address: String) -> Result<(), amalthea::error::Error> {
-        let sender = self.req_sender.clone();
-        thread::spawn(move || {
-
-            // Is there a better way? Perhaps we should initialize the LSP
-            // from one of the R callbacks; e.g. in R_ReadConsole. This
-            // is the strategy used by RStudio for detecting when the R
-            // session is "ready" for extension pieces to be loaded.
-            //
-            // Or perhaps we should be loading R extensions in the main
-            // thread, rather than asking the LSP to handle this during
-            // its own initialization.
-            unsafe {
-               while R_Is_Running != 2 {
-                   std::thread::sleep(Duration::from_millis(200));
-               }
-            }
-
-            // R appears to be ready; start the backend.
-            backend::start_lsp(tcp_address, sender);
-        });
+        let sender = self.shell_request_sender.clone();
+        thread::spawn(move || backend::start_lsp(tcp_address, sender));
         return Ok(());
     }
 }

--- a/extensions/positron-r/amalthea/crates/ark/src/main.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/main.rs
@@ -11,6 +11,7 @@ use amalthea::connection_file::ConnectionFile;
 use amalthea::kernel::Kernel;
 use amalthea::kernel_spec::KernelSpec;
 use bus::Bus;
+use crossbeam::channel::bounded;
 use log::*;
 use std::env;
 use std::io::stdin;
@@ -28,6 +29,7 @@ mod version;
 mod comm;
 
 use crate::control::Control;
+use crate::request::Request;
 use crate::shell::Shell;
 use crate::version::detect_r;
 
@@ -42,19 +44,36 @@ fn start_kernel(connection_file: ConnectionFile, capture_streams: bool) {
         }
     };
 
-    // Create the shell handler; this is the main entry point for the kernel
-    let shell_sender = kernel.create_iopub_sender();
-    let mut kernel_init_sender = Bus::new(1);
-    let r1 = kernel_init_sender.add_rx();
-    let r2 = kernel_init_sender.add_rx();
-    let shell = Shell::new(shell_sender, kernel_init_sender, r1);
+    // Create the channels used for communication. These are created here
+    // as they need to be shared across different components / threads.
+    let iopub = kernel.create_iopub_sender();
 
-    // Create the LSP client; not all Amalthea kernels provide one, but ARK
-    // does. It must be able to deliver messages to the shell channel directly.
+    // A broadcast channel (bus) used to notify clients when the kernel
+    // has finished initialization.
+    let mut kernel_init_sender = Bus::new(1);
+
+    // A channel pair used for shell requests.
+    // These events are used to manage the runtime state, and also to
+    // handle message delivery, among other things.
+    let (shell_request_sender, shell_request_receiver) = bounded::<Request>(1);
+
+    // Create the LSP client.
+    // Not all Amalthea kernels provide one, but ark does.
+    // It must be able to deliver messages to the shell channel directly.
     let lsp = Arc::new(Mutex::new(lsp::handler::Lsp::new(
-        shell.request_sender(),
-        r2,
+        shell_request_sender.clone(),
+        kernel_init_sender.add_rx(),
     )));
+
+    // Create the shell.
+    let kernel_init_receiver = kernel_init_sender.add_rx();
+    let shell = Shell::new(
+        iopub,
+        shell_request_sender,
+        shell_request_receiver,
+        kernel_init_sender,
+        kernel_init_receiver,
+    );
 
     // Create the control handler; this is used to handle shutdown/interrupt and
     // related requests
@@ -62,10 +81,9 @@ fn start_kernel(connection_file: ConnectionFile, capture_streams: bool) {
 
     // Create the stream behavior; this determines whether the kernel should
     // capture stdout/stderr and send them to the front end as IOPub messages
-    let stream_behavior = if capture_streams {
-        amalthea::kernel::StreamBehavior::Capture
-    } else {
-        amalthea::kernel::StreamBehavior::None
+    let stream_behavior = match capture_streams {
+        true  => amalthea::kernel::StreamBehavior::Capture,
+        false => amalthea::kernel::StreamBehavior::None,
     };
 
     // Create the kernel

--- a/extensions/positron-r/amalthea/crates/ark/src/request.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/request.rs
@@ -8,7 +8,7 @@
 use amalthea::{wire::execute_request::ExecuteRequest, events::PositronEvent};
 use amalthea::wire::execute_response::ExecuteResponse;
 use amalthea::wire::input_request::ShellInputRequest;
-use std::sync::mpsc::{Sender, SyncSender};
+use crossbeam::channel::Sender;
 
 /// Represents requests to the primary R execution thread.
 #[derive(Debug, Clone)]
@@ -18,7 +18,7 @@ pub enum Request {
     ExecuteCode(ExecuteRequest, Vec<u8>, Sender<ExecuteResponse>),
 
     /// Establish a channel to the front end to send input requests
-    EstablishInputChannel(SyncSender<ShellInputRequest>),
+    EstablishInputChannel(Sender<ShellInputRequest>),
 
     /// Deliver an event to the front end
     DeliverEvent(PositronEvent),

--- a/extensions/positron-r/amalthea/crates/ark/src/request.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/request.rs
@@ -11,6 +11,7 @@ use amalthea::wire::input_request::ShellInputRequest;
 use std::sync::mpsc::{Sender, SyncSender};
 
 /// Represents requests to the primary R execution thread.
+#[derive(Debug, Clone)]
 pub enum Request {
     /// Fulfill an execution request from the front end, producing either a
     /// Reply or an Exception

--- a/extensions/positron-r/amalthea/crates/ark/src/shell.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/shell.rs
@@ -28,6 +28,8 @@ use amalthea::wire::kernel_info_reply::KernelInfoReply;
 use amalthea::wire::kernel_info_request::KernelInfoRequest;
 use amalthea::wire::language_info::LanguageInfo;
 use async_trait::async_trait;
+use bus::Bus;
+use bus::BusReader;
 use crossbeam::channel::Receiver;
 use crossbeam::channel::Sender;
 use crossbeam::channel::bounded;
@@ -44,7 +46,7 @@ use crate::comm::environment::EnvironmentInstance;
 
 pub struct Shell {
     req_sender: Sender<Request>,
-    kernel_init_receiver: crossbeam::channel::Receiver<KernelInfo>,
+    kernel_init_receiver: BusReader<KernelInfo>,
     kernel_info: Option<KernelInfo>,
 }
 
@@ -52,8 +54,8 @@ impl Shell {
     /// Creates a new instance of the shell message handler.
     pub fn new(
         iopub: Sender<IOPubMessage>,
-        kernel_init_sender: crossbeam::channel::Sender<KernelInfo>,
-        kernel_init_receiver: crossbeam::channel::Receiver<KernelInfo>
+        kernel_init_sender: Bus<KernelInfo>,
+        kernel_init_receiver: BusReader<KernelInfo>,
     ) -> Self {
 
         let iopub_sender = iopub.clone();
@@ -74,7 +76,7 @@ impl Shell {
     pub fn execution_thread(
         sender: Sender<IOPubMessage>,
         receiver: Receiver<Request>,
-        kernel_init_sender: crossbeam::channel::Sender<KernelInfo>,
+        kernel_init_sender: Bus<KernelInfo>,
     ) {
         // Start kernel (does not return)
         crate::interface::start_r(sender, receiver, kernel_init_sender);

--- a/extensions/positron-r/amalthea/crates/echo/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/echo/Cargo.toml
@@ -9,3 +9,4 @@ log = "0.4.14"
 env_logger = "0.9.0"
 serde_json = "1.0.59"
 async-trait = "0.1.53"
+crossbeam = { version = "0.8.2", features = ["crossbeam-channel"] }

--- a/extensions/positron-r/amalthea/crates/echo/src/shell.rs
+++ b/extensions/positron-r/amalthea/crates/echo/src/shell.rs
@@ -30,18 +30,18 @@ use amalthea::wire::kernel_info_reply::KernelInfoReply;
 use amalthea::wire::kernel_info_request::KernelInfoRequest;
 use amalthea::wire::language_info::LanguageInfo;
 use async_trait::async_trait;
+use crossbeam::channel::Sender;
 use log::warn;
 use serde_json::json;
-use std::sync::mpsc::SyncSender;
 
 pub struct Shell {
-    iopub: SyncSender<IOPubMessage>,
-    input_sender: Option<SyncSender<ShellInputRequest>>,
+    iopub: Sender<IOPubMessage>,
+    input_sender: Option<Sender<ShellInputRequest>>,
     execution_count: u32,
 }
 
 impl Shell {
-    pub fn new(iopub: SyncSender<IOPubMessage>) -> Self {
+    pub fn new(iopub: Sender<IOPubMessage>) -> Self {
         Self {
             iopub: iopub,
             execution_count: 0,
@@ -209,7 +209,7 @@ impl ShellHandler for Shell {
         Ok(())
     }
 
-    fn establish_input_handler(&mut self, handler: SyncSender<ShellInputRequest>) {
+    fn establish_input_handler(&mut self, handler: Sender<ShellInputRequest>) {
         self.input_sender = Some(handler);
     }
 }


### PR DESCRIPTION
The most interesting part of this PR is here:

https://github.com/rstudio/positron/compare/bugfix/linux-compile?expand=1#diff-ff5706db2eed01587e3786b377b19b745bfc159ac589162862856c8bc45f50ddR35

Effectively, we now use a broadcast channel (a [bus](https://crates.io/crates/bus)) to broadcast that R has finished initialization to all consumers who may need to know.

This PR also moves from using `std` channels to `crossbeam` channels. See https://github.com/rstudio/positron/issues/173 for motivation.

Closes https://github.com/rstudio/positron/issues/171.
Closes https://github.com/rstudio/positron/issues/173.