### PR TITLE
use consistent naming for Rust channels

### DIFF
--- a/extensions/positron-r/amalthea/crates/amalthea/src/kernel.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/src/kernel.rs
@@ -39,10 +39,10 @@ pub struct Kernel {
     session: Session,
 
     /// Sends messages to the IOPub socket
-    iopub_sender: Sender<IOPubMessage>,
+    iopub_tx: Sender<IOPubMessage>,
 
     /// Receives message sent to the IOPub socket
-    iopub_receiver: Option<Receiver<IOPubMessage>>,
+    iopub_rx: Option<Receiver<IOPubMessage>>,
 }
 
 /// Possible behaviors for the stream capture thread. When set to `Capture`,
@@ -59,13 +59,13 @@ impl Kernel {
     pub fn new(file: ConnectionFile) -> Result<Kernel, Error> {
         let key = file.key.clone();
 
-        let (iopub_sender, iopub_receiver) = bounded::<IOPubMessage>(10);
+        let (iopub_tx, iopub_rx) = bounded::<IOPubMessage>(10);
 
         Ok(Self {
             connection: file,
             session: Session::create(key)?,
-            iopub_sender: iopub_sender,
-            iopub_receiver: Some(iopub_receiver),
+            iopub_tx: iopub_tx,
+            iopub_rx: Some(iopub_rx),
         })
     }
 
@@ -91,8 +91,8 @@ impl Kernel {
         )?;
 
         let shell_clone = shell_handler.clone();
-        let iopub_sender_clone = self.create_iopub_sender();
-        thread::spawn(move || Self::shell_thread(shell_socket, iopub_sender_clone, shell_clone));
+        let iopub_tx_clone = self.create_iopub_tx();
+        thread::spawn(move || Self::shell_thread(shell_socket, iopub_tx_clone, shell_clone));
 
         // Create the IOPub PUB/SUB socket and start a thread to broadcast to
         // the client. IOPub only broadcasts messages, so it listens to other
@@ -105,8 +105,8 @@ impl Kernel {
             None,
             self.connection.endpoint(self.connection.iopub_port),
         )?;
-        let iopub_receiver = self.iopub_receiver.take().unwrap();
-        thread::spawn(move || Self::iopub_thread(iopub_socket, iopub_receiver));
+        let iopub_rx = self.iopub_rx.take().unwrap();
+        thread::spawn(move || Self::iopub_thread(iopub_socket, iopub_rx));
 
         // Create the heartbeat socket and start a thread to listen for
         // heartbeat messages.
@@ -136,8 +136,8 @@ impl Kernel {
 
         // Create the thread that handles stdout and stderr, if requested
         if stream_behavior == StreamBehavior::Capture {
-            let iopub_sender = self.create_iopub_sender();
-            thread::spawn(move || Self::output_capture_thread(iopub_sender));
+            let iopub_tx = self.create_iopub_tx();
+            thread::spawn(move || Self::output_capture_thread(iopub_tx));
         }
 
         // Create the Control ROUTER/DEALER socket
@@ -168,8 +168,8 @@ impl Kernel {
     }
 
     /// Returns a copy of the IOPub sending channel.
-    pub fn create_iopub_sender(&self) -> Sender<IOPubMessage> {
-        self.iopub_sender.clone()
+    pub fn create_iopub_tx(&self) -> Sender<IOPubMessage> {
+        self.iopub_tx.clone()
     }
 
     /// Starts the control thread
@@ -181,10 +181,10 @@ impl Kernel {
     /// Starts the shell thread.
     fn shell_thread(
         socket: Socket,
-        iopub_sender: Sender<IOPubMessage>,
+        iopub_tx: Sender<IOPubMessage>,
         shell_handler: Arc<Mutex<dyn ShellHandler>>,
     ) -> Result<(), Error> {
-        let mut shell = Shell::new(socket, iopub_sender.clone(), shell_handler);
+        let mut shell = Shell::new(socket, iopub_tx.clone(), shell_handler);
         shell.listen();
         Ok(())
     }
@@ -214,8 +214,8 @@ impl Kernel {
     }
 
     /// Starts the output capture thread.
-    fn output_capture_thread(iopub_sender: Sender<IOPubMessage>) -> Result<(), Error> {
-        let output_capture = StreamCapture::new(iopub_sender);
+    fn output_capture_thread(iopub_tx: Sender<IOPubMessage>) -> Result<(), Error> {
+        let output_capture = StreamCapture::new(iopub_tx);
         output_capture.listen();
         Ok(())
     }

--- a/extensions/positron-r/amalthea/crates/amalthea/src/socket/shell.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/src/socket/shell.rs
@@ -46,7 +46,7 @@ pub struct Shell {
     socket: Socket,
 
     /// Sends messages to the IOPub socket (owned by another thread)
-    iopub_sender: Sender<IOPubMessage>,
+    iopub_tx: Sender<IOPubMessage>,
 
     /// Language-provided shell handler object
     handler: Arc<Mutex<dyn ShellHandler>>,
@@ -59,16 +59,16 @@ impl Shell {
     /// Create a new Shell socket.
     ///
     /// * `socket` - The underlying ZeroMQ Shell socket
-    /// * `iopub_sender` - A channel that delivers messages to the IOPub socket
+    /// * `iopub_tx` - A channel that delivers messages to the IOPub socket
     /// * `handler` - The language's shell channel handler
     pub fn new(
         socket: Socket,
-        iopub_sender: Sender<IOPubMessage>,
+        iopub_tx: Sender<IOPubMessage>,
         handler: Arc<Mutex<dyn ShellHandler>>,
     ) -> Self {
         Self {
             socket,
-            iopub_sender,
+            iopub_tx,
             handler,
             open_comms: HashMap::new(),
         }
@@ -174,7 +174,7 @@ impl Shell {
             execution_state: state,
         };
         if let Err(err) = self
-            .iopub_sender
+            .iopub_tx
             .send(IOPubMessage::Status(parent.header, reply))
         {
             return Err(Error::SendError(format!("{}", err)));

--- a/extensions/positron-r/amalthea/crates/amalthea/src/socket/stdin.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/src/socket/stdin.rs
@@ -42,16 +42,16 @@ impl Stdin {
     /// 1. Wait for
     pub fn listen(&self) {
         // Create the communication channel for the shell handler and inject it
-        let (sender, receiver) = bounded::<ShellInputRequest>(1);
+        let (tx, rx) = bounded::<ShellInputRequest>(1);
         {
             let mut shell_handler = self.handler.lock().unwrap();
-            shell_handler.establish_input_handler(sender);
+            shell_handler.establish_input_handler(tx);
         }
 
         // Listen for input requests from the back end
         loop {
             // Wait for a message (input request) from the back end
-            let req = receiver.recv().unwrap();
+            let req = rx.recv().unwrap();
 
             // Deliver the message to the front end
             let msg = JupyterMessage::create_with_identity(

--- a/extensions/positron-r/amalthea/crates/amalthea/src/stream_capture.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/src/stream_capture.rs
@@ -18,26 +18,26 @@ use crate::wire::stream::Stream;
 use crate::wire::stream::StreamOutput;
 
 pub struct StreamCapture {
-    iopub_sender: Sender<IOPubMessage>,
+    iopub_tx: Sender<IOPubMessage>,
 }
 
 /// StreamCapture captures the output of a stream and sends it to the IOPub
 /// socket.
 impl StreamCapture {
-    pub fn new(iopub_sender: Sender<IOPubMessage>) -> Self {
-        Self { iopub_sender }
+    pub fn new(iopub_tx: Sender<IOPubMessage>) -> Self {
+        Self { iopub_tx }
     }
 
     /// Listens to stdout and stderr and sends the output to the IOPub socket.
     /// Does not return.
     pub fn listen(&self) {
-        if let Err(err) = Self::output_capture(self.iopub_sender.clone()) {
+        if let Err(err) = Self::output_capture(self.iopub_tx.clone()) {
             warn!("Error capturing output; stdout/stderr won't be forwarded: {}", err);
         };
     }
 
     /// Captures stdout and stderr streams
-    fn output_capture(iopub_sender: Sender<IOPubMessage>) -> Result<(), Error> {
+    fn output_capture(iopub_tx: Sender<IOPubMessage>) -> Result<(), Error> {
         // Create redirected file descriptors for stdout and stderr. These are
         // pipes into which stdout/stderr are redirected.
         let stdout_fd = Self::redirect_fd(nix::libc::STDOUT_FILENO)?;
@@ -94,7 +94,7 @@ impl StreamCapture {
                     };
 
                     // Read the data from the stream and send it to iopub.
-                    Self::fd_to_iopub(fd, stream, iopub_sender.clone());
+                    Self::fd_to_iopub(fd, stream, iopub_tx.clone());
                 }
             }
         };
@@ -103,7 +103,7 @@ impl StreamCapture {
     }
 
     /// Reads data from a file descriptor and sends it to the IOPub socket.
-    fn fd_to_iopub(fd: RawFd, stream: Stream, iopub_sender: Sender<IOPubMessage>) {
+    fn fd_to_iopub(fd: RawFd, stream: Stream, iopub_tx: Sender<IOPubMessage>) {
         // Read up to 1024 bytes from the stream into `buf`
         let mut buf = [0u8; 1024];
         let count = match nix::unistd::read(fd, &mut buf) {
@@ -125,7 +125,7 @@ impl StreamCapture {
 
         // Create and send the IOPub
         let message = IOPubMessage::Stream(output);
-        if let Err(e) = iopub_sender.send(message) {
+        if let Err(e) = iopub_tx.send(message) {
             warn!("Error sending stream data to iopub: {}", e);
         }
     }

--- a/extensions/positron-r/amalthea/crates/amalthea/tests/client.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/tests/client.rs
@@ -31,8 +31,8 @@ fn test_kernel() {
     let frontend = frontend::Frontend::new();
     let connection_file = frontend.get_connection_file();
     let mut kernel = Kernel::new(connection_file).unwrap();
-    let shell_sender = kernel.create_iopub_sender();
-    let shell = Arc::new(Mutex::new(shell::Shell::new(shell_sender)));
+    let shell_tx = kernel.create_iopub_tx();
+    let shell = Arc::new(Mutex::new(shell::Shell::new(shell_tx)));
     let control = Arc::new(Mutex::new(control::Control {}));
 
     // Initialize logging

--- a/extensions/positron-r/amalthea/crates/amalthea/tests/shell/mod.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/tests/shell/mod.rs
@@ -37,7 +37,7 @@ use serde_json::json;
 
 pub struct Shell {
     iopub: Sender<IOPubMessage>,
-    input_sender: Option<Sender<ShellInputRequest>>,
+    input_tx: Option<Sender<ShellInputRequest>>,
     execution_count: u32,
 }
 
@@ -64,13 +64,13 @@ impl Shell {
         Self {
             iopub: iopub,
             execution_count: 0,
-            input_sender: None,
+            input_tx: None,
         }
     }
 
     // Simluates an input request
     fn prompt_for_input(&self, originator: &Vec<u8>) {
-        if let Some(sender) = &self.input_sender {
+        if let Some(sender) = &self.input_tx {
             if let Err(err) = sender.send(ShellInputRequest {
                 originator: originator.clone(),
                 request: InputRequest {
@@ -256,6 +256,6 @@ impl ShellHandler for Shell {
 
 
     fn establish_input_handler(&mut self, handler: Sender<ShellInputRequest>) {
-        self.input_sender = Some(handler);
+        self.input_tx = Some(handler);
     }
 }

--- a/extensions/positron-r/amalthea/crates/ark/src/control.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/control.rs
@@ -21,12 +21,12 @@ use nix::unistd::Pid;
 use crate::request::Request;
 
 pub struct Control {
-    req_sender: Sender<Request>,
+    req_tx: Sender<Request>,
 }
 
 impl Control {
     pub fn new(sender: Sender<Request>) -> Self {
-        Self { req_sender: sender }
+        Self { req_tx: sender }
     }
 }
 
@@ -37,7 +37,7 @@ impl ControlHandler for Control {
         msg: &ShutdownRequest,
     ) -> Result<ShutdownReply, Exception> {
         debug!("Received shutdown request: {:?}", msg);
-        if let Err(err) = self.req_sender.send(Request::Shutdown(msg.restart)) {
+        if let Err(err) = self.req_tx.send(Request::Shutdown(msg.restart)) {
             warn!(
                 "Could not deliver shutdown request to execution thread: {}",
                 err

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/backend.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/backend.rs
@@ -75,7 +75,7 @@ pub struct Backend {
     pub documents: Arc<DashMap<Url, Document>>,
     pub workspace: Arc<Mutex<Workspace>>,
     #[allow(dead_code)]
-    pub shell_request_sender: Sender<Request>,
+    pub shell_request_tx: Sender<Request>,
 }
 
 impl Backend {
@@ -555,7 +555,7 @@ impl Backend {
 }
 
 #[tokio::main]
-pub async fn start_lsp(address: String, shell_request_sender: Sender<Request>) {
+pub async fn start_lsp(address: String, shell_request_tx: Sender<Request>) {
     #[cfg(feature = "runtime-agnostic")]
     use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
@@ -583,7 +583,7 @@ pub async fn start_lsp(address: String, shell_request_sender: Sender<Request>) {
         // initialize global client (needs to be visible for R routines)
         INSTANCE.set(ClientInstance {
             client: client,
-            shell_request_sender: shell_request_sender.clone(),
+            shell_request_tx: shell_request_tx.clone(),
         }).unwrap();
 
         // create backend
@@ -591,7 +591,7 @@ pub async fn start_lsp(address: String, shell_request_sender: Sender<Request>) {
             client: get_instance().client,
             documents: DOCUMENT_INDEX.clone(),
             workspace: Arc::new(Mutex::new(Workspace::default())),
-            shell_request_sender: shell_request_sender.clone(),
+            shell_request_tx: shell_request_tx.clone(),
         };
 
         backend

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/global.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/global.rs
@@ -14,7 +14,7 @@ use crate::request::Request;
 #[derive(Debug, Clone)]
 pub struct ClientInstance {
     pub client: Client,
-    pub shell_request_sender: Sender<Request>
+    pub shell_request_tx: Sender<Request>
 }
 
 // This global instance of the LSP client and request channel is used for

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/show_message.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/show_message.rs
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn ps_show_message(message: SEXP) -> SEXP {
 
         let event = PositronEvent::ShowMessage(ShowMessageEvent { message });
         let event = Request::DeliverEvent(event);
-        let status = unwrap!(instance.shell_request_sender.send(event), Err(error) => {
+        let status = unwrap!(instance.shell_request_tx.send(event), Err(error) => {
             anyhow::bail!("Error sending request: {}", error);
         });
 

--- a/extensions/positron-r/amalthea/crates/ark/src/main.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/main.rs
@@ -46,38 +46,38 @@ fn start_kernel(connection_file: ConnectionFile, capture_streams: bool) {
 
     // Create the channels used for communication. These are created here
     // as they need to be shared across different components / threads.
-    let iopub = kernel.create_iopub_sender();
+    let iopub_tx = kernel.create_iopub_tx();
 
     // A broadcast channel (bus) used to notify clients when the kernel
     // has finished initialization.
-    let mut kernel_init_sender = Bus::new(1);
+    let mut kernel_init_tx = Bus::new(1);
 
     // A channel pair used for shell requests.
     // These events are used to manage the runtime state, and also to
     // handle message delivery, among other things.
-    let (shell_request_sender, shell_request_receiver) = bounded::<Request>(1);
+    let (shell_request_tx, shell_request_rx) = bounded::<Request>(1);
 
     // Create the LSP client.
     // Not all Amalthea kernels provide one, but ark does.
     // It must be able to deliver messages to the shell channel directly.
     let lsp = Arc::new(Mutex::new(lsp::handler::Lsp::new(
-        shell_request_sender.clone(),
-        kernel_init_sender.add_rx(),
+        shell_request_tx.clone(),
+        kernel_init_tx.add_rx(),
     )));
 
     // Create the shell.
-    let kernel_init_receiver = kernel_init_sender.add_rx();
+    let kernel_init_rx = kernel_init_tx.add_rx();
     let shell = Shell::new(
-        iopub,
-        shell_request_sender,
-        shell_request_receiver,
-        kernel_init_sender,
-        kernel_init_receiver,
+        iopub_tx,
+        shell_request_tx,
+        shell_request_rx,
+        kernel_init_tx,
+        kernel_init_rx,
     );
 
     // Create the control handler; this is used to handle shutdown/interrupt and
     // related requests
-    let control = Arc::new(Mutex::new(Control::new(shell.request_sender())));
+    let control = Arc::new(Mutex::new(Control::new(shell.request_tx())));
 
     // Create the stream behavior; this determines whether the kernel should
     // capture stdout/stderr and send them to the front end as IOPub messages

--- a/extensions/positron-r/amalthea/crates/echo/src/main.rs
+++ b/extensions/positron-r/amalthea/crates/echo/src/main.rs
@@ -27,8 +27,8 @@ fn start_kernel(connection_file: ConnectionFile) {
         }
     };
 
-    let shell_sender = kernel.create_iopub_sender();
-    let shell = Arc::new(Mutex::new(Shell::new(shell_sender)));
+    let shell_tx = kernel.create_iopub_tx();
+    let shell = Arc::new(Mutex::new(Shell::new(shell_tx)));
     let control = Arc::new(Mutex::new(Control {}));
 
     match kernel.connect(shell, control, None, StreamBehavior::None) {

--- a/extensions/positron-r/amalthea/crates/echo/src/shell.rs
+++ b/extensions/positron-r/amalthea/crates/echo/src/shell.rs
@@ -36,7 +36,7 @@ use serde_json::json;
 
 pub struct Shell {
     iopub: Sender<IOPubMessage>,
-    input_sender: Option<Sender<ShellInputRequest>>,
+    input_tx: Option<Sender<ShellInputRequest>>,
     execution_count: u32,
 }
 
@@ -45,7 +45,7 @@ impl Shell {
         Self {
             iopub: iopub,
             execution_count: 0,
-            input_sender: None,
+            input_tx: None,
         }
     }
 }
@@ -210,6 +210,6 @@ impl ShellHandler for Shell {
     }
 
     fn establish_input_handler(&mut self, handler: Sender<ShellInputRequest>) {
-        self.input_sender = Some(handler);
+        self.input_tx = Some(handler);
     }
 }


### PR DESCRIPTION
cc: @jmcphers; let me know if you feel this increases the overall code clarity.

Closes https://github.com/rstudio/positron/issues/175.