### PR TITLE
zeromq hack

### DIFF
--- a/build/npm/positron-postinstall.js
+++ b/build/npm/positron-postinstall.js
@@ -15,3 +15,8 @@ if (platform() === 'darwin') {
 	console.error(`Error: The ${platform()} platform is not currently supported.`);
 	process.exit(1);
 }
+
+// On Windows and Linux, we need to unslam the zeromq dependency.
+if (process.platform !== 'darwin') {
+	require('./positron-zeromq-hack').unslamZeromq();
+}

--- a/build/npm/positron-zeromq-hack.js
+++ b/build/npm/positron-zeromq-hack.js
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Posit Software, PBC.
+ *--------------------------------------------------------------------------------------------*/
+
+const cp = require('child_process');
+const fs = require('fs');
+
+// The Jupyter package file.
+const jupyterPackageFile = 'extensions/jupyter-adapter/package.json';
+
+// Slam the zeromq dependency of the jupyter-adapter extension.
+function slamZeromq() {
+	console.log(`---------------> SLAMMING ${jupyterPackageFile} zeromq version to beta.16`)
+	fs.writeFileSync(jupyterPackageFile, fs.readFileSync(jupyterPackageFile, 'utf8').replace(/"zeromq": "6.0.0-beta.6"/g, '"zeromq": "6.0.0-beta.16"'));
+}
+
+// Unslam the zeromq dependency of the jupyter-adapter extension.
+function unslamZeromq() {
+	console.log(`---------------> SLAMMING ${jupyterPackageFile} zeromq version back to beta.6`)
+	fs.writeFileSync(jupyterPackageFile, fs.readFileSync(jupyterPackageFile, 'utf8').replace(/"zeromq": "6.0.0-beta.16"/g, '"zeromq": "6.0.0-beta.6"'));
+	cp.execSync('git checkout yarn.lock', { cwd: 'extensions/jupyter-adapter' });
+}
+
+exports.slamZeromq = slamZeromq;
+exports.unslamZeromq = unslamZeromq;

--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -153,6 +153,11 @@ function getHeaderInfo(rcFile) {
 
 
 // --- Start Positron ---
+// On Windows and Linux, we need to slam the zeromq dependency.
+if (process.platform !== 'darwin') {
+	require('./positron-zeromq-hack').slamZeromq();
+}
+
 // TOOD: make more robust against dirty working dir, etc.
 console.log(`Installing positron built-in extensions...`);
 if (process.env['POSITRON_GITHUB_PAT']) {

--- a/extensions/jupyter-adapter/package.json
+++ b/extensions/jupyter-adapter/package.json
@@ -42,11 +42,11 @@
     "ts-node": "^10.9.1"
   },
   "dependencies": {
+    "portfinder": "^1.0.28",
     "tail": "^2.2.6",
     "uuid": "^9.0.0",
     "vscode-nls": "^5.2.0",
-    "portfinder": "^1.0.28",
-    "zeromq": "kevinushey/zeromq.js#d6486945247b059bc2c290d83d66064dd91edce5"
+    "zeromq": "6.0.0-beta.6"
   },
   "repository": {
     "type": "git",

--- a/extensions/jupyter-adapter/scripts/postinstall.ts
+++ b/extensions/jupyter-adapter/scripts/postinstall.ts
@@ -6,16 +6,10 @@ import { spawnSync } from 'child_process';
 import { arch, platform } from 'os';
 import { argv, env, exit } from 'process';
 
-// Don't do anything on Windows.
-if (platform() === 'win32') {
-	exit(0);
-}
-
-// Make sure that zmq produces x86 / arm64 builds where appropriate.
-// Note that the build pipeline sets 'npm_config_arch' to configure
-// the build architecture.
 if (platform() === 'darwin') {
-
+	// Make sure that zmq produces x86 / arm64 builds where appropriate.
+	// Note that the build pipeline sets 'npm_config_arch' to configure
+	// the build architecture.
 	let configArch = env['npm_config_arch'] ?? arch();
 	if (configArch === 'x64') {
 		configArch = 'x86_64';
@@ -24,16 +18,15 @@ if (platform() === 'darwin') {
 	env['ARCH'] = configArch;
 	env['CMAKE_OSX_ARCHITECTURES'] = configArch;
 
-}
+	// Ensure that zeromq is built against the right version of node.
+	const result = spawnSync('electron-rebuild', ['zeromq', ...argv.slice(2)], {
+		encoding: 'utf-8',
+		stdio: 'inherit',
+		shell: true,
+	});
 
-// Ensure that zeromq is built against the right version of node.
-const result = spawnSync('electron-rebuild', ['zeromq', ...argv.slice(2)], {
-	encoding: 'utf-8',
-	stdio: 'inherit',
-	shell: true,
-});
-
-if (result.error || result.status !== 0) {
-	console.error(`Error rebuilding zeromq ${result.error ?? ''} [error code ${result.status}]`);
-	exit(1);
+	if (result.error || result.status !== 0) {
+		console.error(`Error rebuilding zeromq ${result.error ?? ''} [error code ${result.status}]`);
+		exit(1);
+	}
 }

--- a/extensions/jupyter-adapter/yarn.lock
+++ b/extensions/jupyter-adapter/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@aminya/node-gyp-build@4.5.0-aminya.4":
-  version "4.5.0-aminya.4"
-  resolved "https://registry.yarnpkg.com/@aminya/node-gyp-build/-/node-gyp-build-4.5.0-aminya.4.tgz#35fc3970cc32aab0a117aea40a3ff209e07c0b4e"
-  integrity sha512-2c2+BqZOxfTz/m+1MNWncMyMgil2WOg8cHhKPf1qUo1t9ohOWOgSeb7TVVD4fnTxIcAcpWdmXBpFkjPRyBVS9g==
-
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -391,13 +386,6 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-env@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
-  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
-  dependencies:
-    cross-spawn "^7.0.1"
-
 cross-spawn@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -535,11 +523,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-function-bind@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
-  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
-
 gauge@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-4.0.4.tgz#52ff0652f2bbf607a989793d53b751bef2328dce"
@@ -566,7 +549,7 @@ get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
-glob@^7.0.0, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -620,13 +603,6 @@ has-unicode@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
-
-has@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
-  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
-  dependencies:
-    function-bind "^1.1.1"
 
 http-cache-semantics@^4.0.0, http-cache-semantics@^4.1.0:
   version "4.1.1"
@@ -705,22 +681,10 @@ inherits@2, inherits@^2.0.3, inherits@^2.0.4:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-interpret@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
-  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
-
 ip@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
   integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
-
-is-core-module@^2.9.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
-  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
-  dependencies:
-    has "^1.0.3"
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
@@ -863,11 +827,6 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.3:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
-  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
-
 minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
@@ -966,17 +925,17 @@ node-addon-api@^3.1.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
-node-addon-api@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
-  integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
-
 node-api-version@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/node-api-version/-/node-api-version-0.1.4.tgz#1ed46a485e462d55d66b5aa1fe2821720dedf080"
   integrity sha512-KGXihXdUChwJAOHO53bv9/vXcLmdUsZ6jIptbvYvkpKfth+r7jw44JkVxQFA3kX5nQjzjmGu1uAu/xNNLNlI5g==
   dependencies:
     semver "^7.3.5"
+
+node-gyp-build@^4.1.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.0.tgz#0c52e4cbf54bbd28b709820ef7b6a3c2d6209055"
+  integrity sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==
 
 node-gyp-build@^4.2.1:
   version "4.5.0"
@@ -1072,11 +1031,6 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
-  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
-
 portfinder@^1.0.28:
   version "1.0.32"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.32.tgz#2fe1b9e58389712429dc2bea5beb2146146c7f81"
@@ -1121,13 +1075,6 @@ readable-stream@^3.4.0, readable-stream@^3.6.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
-  dependencies:
-    resolve "^1.1.6"
-
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -1137,15 +1084,6 @@ resolve-alpn@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz#b7adbdac3546aaaec20b45e7d8265927072726f9"
   integrity sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==
-
-resolve@^1.1.6:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
-  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
-  dependencies:
-    is-core-module "^2.9.0"
-    path-parse "^1.0.7"
-    supports-preserve-symlinks-flag "^1.0.0"
 
 responselike@^2.0.0:
   version "2.0.1"
@@ -1207,23 +1145,6 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
-
-shelljs@^0.8.5:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
-  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
-shx@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.4.tgz#74289230b4b663979167f94e1935901406e40f02"
-  integrity sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==
-  dependencies:
-    minimist "^1.2.3"
-    shelljs "^0.8.5"
 
 signal-exit@^3.0.2, signal-exit@^3.0.7:
   version "3.0.7"
@@ -1288,11 +1209,6 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
-
-supports-preserve-symlinks-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
-  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 tail@^2.2.6:
   version "2.2.6"
@@ -1437,12 +1353,9 @@ yn@3.1.1:
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-zeromq@kevinushey/zeromq.js#d6486945247b059bc2c290d83d66064dd91edce5:
-  version "6.0.0-beta.16"
-  resolved "https://codeload.github.com/kevinushey/zeromq.js/tar.gz/d6486945247b059bc2c290d83d66064dd91edce5"
+zeromq@6.0.0-beta.6:
+  version "6.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/zeromq/-/zeromq-6.0.0-beta.6.tgz#2b8934cafce735ea9007fd3074ec8aca9bf11204"
+  integrity sha512-wLf6M7pBHijl+BRltUL2VoDpgbQcOZetiX8UzycHL8CcYFxYnRrpoG5fi3UX3+Umavz1lk4/dGaQez8qiDgr/Q==
   dependencies:
-    "@aminya/node-gyp-build" "4.5.0-aminya.4"
-    cross-env "^7.0.3"
-    node-addon-api "^5.0.0"
-    shelljs "^0.8.5"
-    shx "^0.3.4"
+    node-gyp-build "^4.1.0"


### PR DESCRIPTION
I've found a potential, temporary path forward with the zeromq 6.0.0-beta.6 vs 6.0.0-beta.16 problem.

Basically, this PR does three things:

1. It switches jupyter-adapter back to zeromq 6.0.0-beta.6. This is the only release of zeromq that builds out of the box on macOS. (There is a big issue related to this [here](https://github.com/zeromq/zeromq.js/issues/529) which they will have to fix at some point, and we should chime in there about the issues we're seeing.)
2. It alters the `jupyter-adapter/scripts/postinstall.ts` file to only do things on macOS.
3. On non-macOS platforms, it _temporarily changes_ the version of zeromq from 6.0.0-beta.6 to 6.0.0-beta.16 during yarn install. When yarn install is complete, it undoes this change.

There is output during yarn install on Windows and Linux that indicates what is happening. During preinstall, you will see:

```
---------------> SLAMMING extensions/jupyter-adapter/package.json zeromq version to beta.16
```

And during postinstall you will see:

```
---------------> SLAMMING extensions/jupyter-adapter/package.json zeromq version back to beta.6
```

The **Positron: Build macOS Release** action is happy with this PR:

<img width="978" alt="image" src="https://user-images.githubusercontent.com/853239/219865965-55f0efcb-2bd9-4fa0-bf0b-9adbd38877a3.png">
