### PR TITLE
Add initial CI for Positron unit tests on ubuntu

### DIFF
--- a/.github/workflows/positron-ci.yml
+++ b/.github/workflows/positron-ci.yml
@@ -1,0 +1,59 @@
+name: "Positron: CI"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+
+  linux:
+    name: Tests on Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      POSITRON_BUILD_NUMBER: 0 # CI skips building releases
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Build Environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y vim curl build-essential clang make cmake git r-base-dev python3-pip python-is-python3 libsodium-dev libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0 libgbm1 libnss3 libnspr4 libasound2
+          sudo cp build/azure-pipelines/linux/xvfb.init /etc/init.d/xvfb
+          sudo chmod +x /etc/init.d/xvfb
+          sudo update-rc.d xvfb defaults
+          sudo service xvfb start
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Execute yarn
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+          POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+        run: |
+          npm install -g yarn
+          yarn --immutable --network-timeout 120000
+      - name: Compile and Download
+        run: yarn npm-run-all --max_old_space_size=4095 -lp compile "electron x64" playwright-install download-builtin-extensions
+
+      - name: Run Unit Tests (node.js)
+        id: nodejs-unit-tests
+        run: yarn test-node
+
+      - name: Run ARK Unit Tests (Rust)
+        id: positron-ark-unit-tests
+        run: |
+          cd extensions/positron-r
+          yarn test-amalthea
+          cd ../..
+
+      - name: Run Unit Tests (Browser, Chromium)
+        id: browser-unit-tests
+        run: DISPLAY=:10 yarn test-browser-no-install --browser chromium

--- a/build/npm/positron-postinstall.js
+++ b/build/npm/positron-postinstall.js
@@ -9,9 +9,6 @@ const { platform } = require('os');
 console.log('Installing Positron post-install dependencies...');
 if (platform() === 'darwin') {
 	cp.execSync('./scripts/install-python-dependencies.sh', { cwd: 'extensions/positron-python' });
-} else if (platform() === 'win32') {
-	cp.execSync('yarn --ignore-engines gulp installPythonLibs', { cwd: 'extensions/positron-python' });
 } else {
-	console.error(`Error: The ${platform()} platform is not currently supported.`);
-	process.exit(1);
+	cp.execSync('yarn --ignore-engines gulp installPythonLibs', { cwd: 'extensions/positron-python' });
 }

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -81,7 +81,8 @@
 		"pretest": "yarn run compile && yarn run lint",
 		"postinstall": "ts-node scripts/post-install.ts",
 		"lint": "eslint src --ext ts",
-		"test": "node ./out/test/runTest.js"
+		"test": "node ./out/test/runTest.js",
+		"test-amalthea": "cd amalthea && cargo test"
 	},
 	"extensionDependencies": [
 		"vscode.jupyter-adapter"


### PR DESCRIPTION
For now we'll start with a ci process for unit testing on ubuntu x86.

This workflow does not build or publish releases.

We will add additional tests and platforms over time.