### PR TITLE
hack around `R_DirtyImage` to check if something has changed in global environment

### DIFF
--- a/extensions/positron-r/amalthea/crates/harp/src/exec.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/exec.rs
@@ -549,5 +549,21 @@ mod tests {
 
     }}
 
+    #[test]
+    fn test_dirty_image() { r_test! {
+        libR_sys::R_DirtyImage = 2;
+        let sym = r_symbol!("aaa");
+        Rf_defineVar(sym, Rf_ScalarInteger(42), R_GlobalEnv);
+        assert_eq!(libR_sys::R_DirtyImage, 1);
+
+        libR_sys::R_DirtyImage = 2;
+        Rf_setVar(sym, Rf_ScalarInteger(43), R_GlobalEnv);
+        assert_eq!(libR_sys::R_DirtyImage, 1);
+
+        libR_sys::R_DirtyImage = 2;
+        R_removeVarFromFrame(sym, R_GlobalEnv);
+        assert_eq!(libR_sys::R_DirtyImage, 1);
+    }}
+
 }
 


### PR DESCRIPTION
R uses `R_DirtyImage` to flag if the current session is dirty, meaning if something has been added/deleted/changed in the global environment. 

`R_DirtyImage` is initialized to 0 on startup: https://github.com/r-devel/r-svn/blob/b26ef50a789fa720ec1a91b620e9033e9a34ceea/src/include/Defn.h#L1499

and then set to 1 any time something happens to the global environment (and only the global environment). 

R only cares about whether it's not 0, in `Rstd_CleanUp()`
 - windows : https://github.com/r-devel/r-svn/blob/4f4112ddd64eaa81e5954583c455d97093141b6e/src/gnuwin32/system.c#L581 
 - unix: https://github.com/r-devel/r-svn/blob/71b0a497eb9dd3ef59a0738a979fa04be1986e69/src/unix/sys-std.c#L1215

I believe this can be used to cheaply check if anything has changed in the global environment since last time we checked. We can set `R_DirtyImage` to some value (e.g. 2) and then when we check again, if it's back to 1 it means that something has changed. 

Uses of `R_DirtyImage` in R: https://github.com/r-devel/r-svn/search?q=R_DirtyImage

I believe this could be used by e.g. the environment pane (only when viewing the global env though) to quickly check if anything has changed.

``` r
cpp11::cpp_function("int dirty(){ extern int R_DirtyImage; return R_DirtyImage; }")
cpp11::cpp_function("void set_dirty(int dirty){ extern int R_DirtyImage; R_DirtyImage = dirty; }")
dirty()
#> [1] 1
set_dirty(2)
1:10
#>  [1]  1  2  3  4  5  6  7  8  9 10
dirty()
#> [1] 2
x <- 2 # define a new variable in global env
dirty()
#> [1] 1
set_dirty(2)
dirty()
#> [1] 2
x <- 3 # change a variable in global env
dirty()
#> [1] 1
set_dirty(2)
rm(x)  # remove a variable from globalenv
dirty()
#> [1] 1
```

<sup>Created on 2023-02-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>