### PR TITLE
Skip serializing our internal language kernel terminal processes on shutdown

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -549,6 +549,7 @@
 				"Attach to Main Process",
 				"Attach to Extension Host",
 				"Attach to Shared Process",
+				"Attach to Pty Host Process"
 			],
 			"preLaunchTask": "Ensure Prelaunch Dependencies",
 			"presentation": {

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -409,7 +409,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		const command = args.join(' ');
 
 		// Create environment.
-		const env = { POSITRON_LANGUAGE: this._spec.language };
+		const env = { POSITRON_VERSION: positron.version };
 		Object.assign(env, process.env, this._spec.env);
 
 		// We are now starting the kernel

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -409,7 +409,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		const command = args.join(' ');
 
 		// Create environment.
-		const env = {};
+		const env = { POSITRON_LANGUAGE: this._spec.language };
 		Object.assign(env, process.env, this._spec.env);
 
 		// We are now starting the kernel

--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -134,6 +134,15 @@ export class PtyService extends Disposable implements IPtyService {
 	async serializeTerminalState(ids: number[]): Promise<string> {
 		const promises: Promise<ISerializedTerminalState>[] = [];
 		for (const [persistentProcessId, persistentProcess] of this._ptys.entries()) {
+
+			// --- Start Positron ---
+			// Skip serializing Positron language runtime kernel processes
+			const positronLanguage = persistentProcess.shellLaunchConfig.env?.POSITRON_LANGUAGE;
+			if (positronLanguage) {
+				continue;
+			}
+			// --- End Positron ---
+
 			// Only serialize persistent processes that have had data written or performed a replay
 			if (persistentProcess.hasWrittenData && ids.indexOf(persistentProcessId) !== -1) {
 				promises.push(Promises.withAsyncBody<ISerializedTerminalState>(async r => {

--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -137,7 +137,7 @@ export class PtyService extends Disposable implements IPtyService {
 
 			// --- Start Positron ---
 			// Skip serializing Positron language runtime kernel processes
-			const positronLanguage = persistentProcess.shellLaunchConfig.env?.POSITRON_LANGUAGE;
+			const positronLanguage = persistentProcess.shellLaunchConfig.env?.POSITRON_VERSION;
 			if (positronLanguage) {
 				continue;
 			}


### PR DESCRIPTION
When we quit Positron, we tear down any language runtime kernel processes (which are now managed by the terminal service host).

These internal terminal processes should not be serialized/replayed on restarting Positron.

This change attempts to detect those internal positron kernel terminal processes without changing the terminal service API.

Issue: #213 
