### PR TITLE
Set R environment R_CLI_NUM_COLORS to 256

### DIFF
--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -115,6 +115,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 			'display_name': `R: ${rHome.rHome}`, // eslint-disable-line
 			'language': 'R',
 			'env': {
+				'R_CLI_NUM_COLORS': '256',
 				'RUST_LOG': 'trace', // eslint-disable-line
 				'R_HOME': rHome.rHome, // eslint-disable-line
 				'DYLD_INSERT_LIBRARIES': `${rHome.rHome}/lib/libR.dylib`, // eslint-disable-line

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -115,12 +115,12 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 			'display_name': `R: ${rHome.rHome}`, // eslint-disable-line
 			'language': 'R',
 			'env': {
-				'R_CLI_NUM_COLORS': '256',
 				'RUST_LOG': 'trace', // eslint-disable-line
 				'R_HOME': rHome.rHome, // eslint-disable-line
 				'DYLD_INSERT_LIBRARIES': `${rHome.rHome}/lib/libR.dylib`, // eslint-disable-line
 				'DYLD_FALLBACK_LIBRARY_PATH': `${rHome.rHome}/lib:${dyldFallbackLibraryPath}`, // eslint-disable-line
-				'RUST_BACKTRACE': '1' // eslint-disable-line
+				'RUST_BACKTRACE': '1', // eslint-disable-line
+				'R_CLI_NUM_COLORS': '256' // eslint-disable-line
 			}
 		};
 


### PR DESCRIPTION
Now that our console handles ANSI SGR color escape sequences, we can let R know we support color output.


