### PR TITLE
Shut down R LSP when R exits

### DIFF
--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -7,9 +7,7 @@ import * as positron from 'positron';
 import * as fs from 'fs';
 
 import { withActiveExtension } from './util';
-
-import { activateLsp } from './lsp';
-import { Disposable } from 'vscode-languageclient';
+import { ArkLsp } from './lsp';
 
 // A global instance of the language runtime (and LSP language server) provided
 // by this language pack
@@ -105,8 +103,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 	const dyldFallbackLibraryPath = process.env['DYLD_FALLBACK_LIBRARY_PATH'];
 
 	// Loop over the R installations and create a language runtime for each one.
-	const disposables: vscode.Disposable[] = rInstallations.map(rHome => {
-
+	for (const rHome of rInstallations) {
 		// Create a kernel spec for this R installation
 		const kernelSpec = {
 			'argv': [kernelPath,
@@ -128,6 +125,9 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 		const packageJson = require('../package.json');
 		const version = packageJson.version;
 
+		// Create an LSP language server for this R installation
+		const lsp = new ArkLsp(rHome.rVersion);
+
 		// Create an adapter for the kernel to fulfill the LanguageRuntime interface.
 		runtime = ext.exports.adaptKernel(kernelSpec,
 			'r',      // Language ID
@@ -136,15 +136,18 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 			positron.LanguageRuntimeStartupBehavior.Implicit, // OK to start the kernel automatically
 			(port: number) => {
 				// Activate the LSP language server when the adapter is ready.
-				return activateLsp(port, context);
+				return lsp.activate(port, context);
 			});
 
-		// Register a language runtime provider for the ARK kernel.
-		return positron.runtime.registerLanguageRuntime(runtime);
-	});
+		// Associate the LSP client instance with the kernel adapter.
+		lsp.attachRuntime(runtime);
+		context.subscriptions.push(lsp);
 
-	// Ensure that the language runtime registrations are torn down when the
-	// extension is deactivated.
-	context.subscriptions.push(...disposables);
+		// Register a language runtime provider for the ARK kernel.
+		const disposable = positron.runtime.registerLanguageRuntime(runtime);
+
+		// Ensure that the kernel is disposed when the extension is deactivated.
+		context.subscriptions.push(disposable);
+	}
 }
 

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -3,126 +3,165 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import * as positron from 'positron';
 
 import {
 	LanguageClient,
 	LanguageClientOptions,
-	createClientSocketTransport,
 	StreamInfo,
 } from 'vscode-languageclient/node';
 
 import { trace, traceOutputChannel } from './logging';
 import { Socket } from 'net';
 
-// A global instance of the LSP language client provided by this language pack
-let client: LanguageClient;
-
 /**
- * Activate the language server; returns a promise that resolves when the LSP is
- * activated.
- *
- * @param port The port on which the language server is listening.
- * @param context The VSCode extension context.
+ * Wraps an instance of the client side of the ARK LSP.
  */
-export async function activateLsp(port: number,
-	context: vscode.ExtensionContext): Promise<void> {
+export class ArkLsp implements vscode.Disposable {
 
-	// Define server options for the language server; this is a callback
-	// that creates and returns the reader/writer stream for TCP
-	// communication. It will retry up to 20 times, with a back-off
-	// interval. We do this because the language server may not be
-	// ready to accept connections when we first try to connect.
-	const serverOptions = async (): Promise<StreamInfo> => {
+	/** The languge client instance, if it has been created */
+	private _client?: LanguageClient;
 
-		const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+	public constructor(private readonly _version: string) {
+	}
 
-		const maxAttempts = 20;
-		const baseDelay = 50;
-		const multiplier = 1.5;
+	/**
+	 * Activate the language server; returns a promise that resolves when the LSP is
+	 * activated.
+	 *
+	 * @param port The port on which the language server is listening.
+	 * @param context The VSCode extension context.
+	 */
+	public async activate(port: number,
+		context: vscode.ExtensionContext): Promise<void> {
 
-		const tryToConnect = async (port: number): Promise<Socket> => {
-			return new Promise((resolve, reject) => {
-				const socket = new Socket();
-				socket.on('ready', () => {
-					resolve(socket);
+		// Define server options for the language server; this is a callback
+		// that creates and returns the reader/writer stream for TCP
+		// communication. It will retry up to 20 times, with a back-off
+		// interval. We do this because the language server may not be
+		// ready to accept connections when we first try to connect.
+		const serverOptions = async (): Promise<StreamInfo> => {
+
+			const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+			const maxAttempts = 20;
+			const baseDelay = 50;
+			const multiplier = 1.5;
+
+			const tryToConnect = async (port: number): Promise<Socket> => {
+				return new Promise((resolve, reject) => {
+					const socket = new Socket();
+					socket.on('ready', () => {
+						resolve(socket);
+					});
+					socket.on('error', (error) => {
+						reject(error);
+					});
+					socket.connect(port);
 				});
-				socket.on('error', (error) => {
-					reject(error);
-				});
-				socket.connect(port);
-			});
+			};
+
+			for (let attempt = 0; attempt < maxAttempts; attempt++) {
+				// Retry up to five times then start to back-off
+				const interval = attempt < 6 ? baseDelay : baseDelay * multiplier * attempt;
+				if (attempt > 0) {
+					await delay(interval);
+				}
+
+				try {
+					// Try to connect to LSP port
+					const socket: Socket = await tryToConnect(port);
+					const streams: StreamInfo = {
+						reader: socket,
+						writer: socket
+					};
+					return streams;
+				} catch (error: any) {
+					if (error?.code === 'ECONNREFUSED') {
+						trace(`Error '${error.message}' on connection attempt '${attempt}' to Ark LSP (R ${this._version}) on port '${port}', will retry`);
+					} else {
+						throw error;
+					}
+				}
+			}
+			throw new Error(`Failed to create TCP connection to Ark LSP (R ${this._version}) on port ${port} after ${maxAttempts} attempts`);
 		};
 
-		for (let attempt = 0; attempt < maxAttempts; attempt++) {
-			// Retry up to five times then start to back-off
-			const interval = attempt < 6 ? baseDelay : baseDelay * multiplier * attempt;
-			if (attempt > 0) {
-				await delay(interval);
-			}
+		const clientOptions: LanguageClientOptions = {
+			documentSelector: [{ scheme: 'file', language: 'r' }],
+			synchronize: { fileEvents: vscode.workspace.createFileSystemWatcher('**/*.R') },
+			traceOutputChannel: traceOutputChannel(),
+		};
 
-			try {
-				// Try to connect to LSP port
-				const socket: Socket = await tryToConnect(port);
-				const streams: StreamInfo = {
-					reader: socket,
-					writer: socket
-				};
-				return streams;
-			} catch (error: any) {
-				if (error?.code === 'ECONNREFUSED') {
-					trace(`Error '${error.message}' on connection attempt '${attempt}' to Ark LSP on port '${port}', will retry`);
-				} else {
-					throw error;
-				}
-			}
-		}
-		throw new Error(`Failed to create TCP connection to Ark LSP on port ${port} after ${maxAttempts} attempts`);
-	};
+		trace(`Creating Positron R ${this._version} language client...`);
+		this._client = new LanguageClient('positron-r', `Positron R Language Server (${this._version})`, serverOptions, clientOptions);
 
-	const clientOptions: LanguageClientOptions = {
-		documentSelector: [{ scheme: 'file', language: 'r' }],
-		synchronize: { fileEvents: vscode.workspace.createFileSystemWatcher('**/*.R') },
-		traceOutputChannel: traceOutputChannel(),
-	};
-
-	trace('Creating Positron R language client...');
-	client = new LanguageClient('positron-r', 'Positron R Language Server', serverOptions, clientOptions);
-
-	client.onDidChangeState(event => {
-		trace(`ARK language client state changed ${event.oldState} => ${event.newState}`);
-	});
-
-	context.subscriptions.push(client.start());
-
-	return new Promise<void>((resolve, reject) => {
-		client.onReady().then(() => {
-			trace('Positron R language client is ready');
-			resolve();
-
-			// Placeholder for custom notification.
-			setTimeout(async () => {
-
-				trace('Sending a "positron/request" request.');
-				try {
-					const response = await client.sendRequest('positron/request', { value: 42 });
-					trace(`Got a response: ${response}`);
-				} catch (error) {
-					trace(`Error sending request: ${error}`);
-				}
-
-				trace('Sending a "positron/notification" notification.');
-				try {
-					client.sendNotification('positron/notification');
-				} catch (error) {
-					trace(`Error sending notification: ${error}`);
-				}
-
-
-			}, 5000);
+		this._client.onDidChangeState(event => {
+			trace(`ARK (R ${this._version}) language client state changed ${event.oldState} => ${event.newState}`);
 		});
-	});
-}
 
-export function deactivate(): Thenable<void> | undefined {
-	return client?.stop();
+		context.subscriptions.push(this._client.start());
+
+		return new Promise<void>((resolve, reject) => {
+			this._client?.onReady().then(() => {
+				trace(`Positron R (${this._version} language client is ready`);
+				resolve();
+
+				// Placeholder for custom notification.
+				setTimeout(async () => {
+
+					trace('Sending a "positron/request" request.');
+					try {
+						const response = await this._client?.sendRequest('positron/request', { value: 42 });
+						trace(`Got a response: ${response}`);
+					} catch (error) {
+						trace(`Error sending request: ${error}`);
+					}
+
+					trace('Sending a "positron/notification" notification.');
+					try {
+						this._client?.sendNotification('positron/notification');
+					} catch (error) {
+						trace(`Error sending notification: ${error}`);
+					}
+
+
+				}, 5000);
+			});
+		});
+	}
+
+	/**
+	 * Attaches the R language runtime to the client.
+	 *
+	 * @param runtime The R language runtime to attach
+	 */
+	public attachRuntime(runtime: positron.LanguageRuntime) {
+		// The client is already started when the runtime indicates it's ready
+		// (via a callback); attach to additional events in the runtime to
+		// deactivate the client when the runtime is stopped.
+		runtime.onDidChangeRuntimeState((state: positron.RuntimeState) => {
+			if (state === positron.RuntimeState.Exiting ||
+				state === positron.RuntimeState.Exited) {
+				trace(`Stopping Positron R ${this._version} language client since runtime is now state '${state}'...`);
+				this.deactivate();
+			}
+		});
+	}
+
+	/**
+	 * Stops the client instance.
+	 *
+	 * @returns A promise that resolves when the client has been stopped.
+	 */
+	public deactivate(): Thenable<void> | undefined {
+		return this._client?.stop();
+	}
+
+	/**
+	 * Dispose of the client instance.
+	 */
+	dispose() {
+		this.deactivate();
+	}
 }


### PR DESCRIPTION
This change adds code to the R LSP so that it shuts down when the language runtime does; it address the R side of https://github.com/rstudio/positron/issues/216.

It also makes some minor changes to the structure of the code; previously, we had a single global LSP client, but now we create a unique instance per runtime.