### PR TITLE
`RObject` -> `Vec<Option<String>>`

### DIFF
--- a/extensions/positron-r/amalthea/crates/harp/src/error.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/error.rs
@@ -22,7 +22,8 @@ pub enum Error {
     UnexpectedType(u32, Vec<u32>),
     InvalidUtf8(Utf8Error),
     TryCatchError { message: Vec<String>, classes : Vec<String> },
-    ParseSyntaxError { message: String, line: i32 }
+    ParseSyntaxError { message: String, line: i32 },
+    MissingValueError { index: isize }
 }
 
 // empty implementation required for 'anyhow'
@@ -82,6 +83,10 @@ impl fmt::Display for Error {
 
             Error::ParseSyntaxError { message, line } => {
                 write!(f, "Syntax error on line {} when parsing: {}", line, message)
+            }
+
+            Error::MissingValueError { index } => {
+                write!(f, "Missing value at index {}", index )
             }
 
         }

--- a/extensions/positron-r/amalthea/crates/harp/src/error.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/error.rs
@@ -23,7 +23,7 @@ pub enum Error {
     InvalidUtf8(Utf8Error),
     TryCatchError { message: Vec<String>, classes : Vec<String> },
     ParseSyntaxError { message: String, line: i32 },
-    MissingValueError { index: isize }
+    MissingValueError
 }
 
 // empty implementation required for 'anyhow'
@@ -85,8 +85,8 @@ impl fmt::Display for Error {
                 write!(f, "Syntax error on line {} when parsing: {}", line, message)
             }
 
-            Error::MissingValueError { index } => {
-                write!(f, "Missing value at index {}", index )
+            Error::MissingValueError => {
+                write!(f, "Missing value" )
             }
 
         }

--- a/extensions/positron-r/amalthea/crates/harp/src/lib.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/lib.rs
@@ -53,17 +53,27 @@ macro_rules! r_symbol {
 }
 
 #[macro_export]
-macro_rules! r_string {
+macro_rules! r_char {
 
     ($id:expr) => {{
         use std::os::raw::c_char;
         use libR_sys::*;
 
-        let mut protect = $crate::protect::RProtect::new();
         let value = &*$id;
+        Rf_mkCharLenCE(value.as_ptr() as *mut c_char, value.len() as i32, cetype_t_CE_UTF8)
+    }}
+
+}
+
+#[macro_export]
+macro_rules! r_string {
+
+    ($id:expr) => {{
+        use libR_sys::*;
+
+        let mut protect = $crate::protect::RProtect::new();
         let string_sexp = protect.add(Rf_allocVector(STRSXP, 1));
-        let char_sexp = Rf_mkCharLenCE(value.as_ptr() as *mut c_char, value.len() as i32, cetype_t_CE_UTF8);
-        SET_STRING_ELT(string_sexp, 0, char_sexp);
+        SET_STRING_ELT(string_sexp, 0, crate::r_char!($id));
         string_sexp
     }}
 

--- a/extensions/positron-r/amalthea/crates/harp/src/object.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/object.rs
@@ -357,7 +357,7 @@ impl TryFrom<RObject> for Option<String> {
             };
 
             if charsexp == R_NaString {
-                return Err(Error::MissingValueError);
+                return Ok(None);
             }
 
             let utf8text = Rf_translateCharUTF8(charsexp);
@@ -492,6 +492,46 @@ mod tests {
     use crate::{r_test, r_string, r_char, protect, utils::{CharSxpEq, r_typeof}};
 
     use super::*;
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_tryfrom_RObject_Option_String() { r_test! {
+        let s = RObject::from("abc");
+
+        assert_match!(
+            Option::<String>::try_from(s),
+            Ok(Some(x)) => {
+                assert_eq!(x, "abc");
+            }
+        );
+
+        let s = RObject::from("abc");
+        SET_STRING_ELT(*s, 0, R_NaString);
+        assert_match!(
+            Option::<String>::try_from(s),
+            Ok(None) => {}
+        );
+    }}
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_tryfrom_RObject_String() { r_test! {
+        let s = RObject::from("abc");
+
+        assert_match!(
+            String::try_from(s),
+            Ok(x) => {
+                assert_eq!(x, "abc");
+            }
+        );
+
+        let s = RObject::from("abc");
+        SET_STRING_ELT(*s, 0, R_NaString);
+        assert_match!(
+            String::try_from(s),
+            Err(Error::MissingValueError) => {}
+        );
+    }}
 
     #[test]
     #[allow(non_snake_case)]

--- a/extensions/positron-r/amalthea/crates/harp/src/object.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/object.rs
@@ -373,9 +373,7 @@ impl TryFrom<RObject> for Vec<String> {
             for i in 0..n {
                 let charsexp = STRING_ELT(*value, i);
                 if charsexp == R_NaString {
-                    return Err(Error::MissingValueError {
-                        index: i
-                    })
+                    return Err(Error::MissingValueError);
                 }
                 let cstr = Rf_translateCharUTF8(charsexp);
                 let string = CStr::from_ptr(cstr);


### PR DESCRIPTION
This adds and tests this impl: `impl TryFrom<RObject> for Vec<Option<String>>` so that we can try to convert an `RObject` to a `Vec<Option<String>>` where the `None` mean NA. 

This also adapts the original `TryFrom<RObject> for Vec<String>` so that it errors if there is a missing value, it used to panic. 