### PR TITLE
RStudio keybinding for clear console is Ctrl+L, even on Mac

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -60,7 +60,7 @@ export function registerPositronConsoleActions() {
 				//icon: Codicon.?
 				keybinding: {
 					weight: KeybindingWeight.WorkbenchContrib,
-					primary: KeyMod.CtrlCmd | KeyCode.KeyL
+					primary: KeyMod.WinCtrl | KeyCode.KeyL
 				},
 				description: {
 					description: 'workbench.action.positronConsole.clearConsole',


### PR DESCRIPTION
We should keep this keybinding from RStudio to match existing customer behavior.