### PR TITLE
Use lowercase for zed language id

### DIFF
--- a/extensions/positron-zed/package.json
+++ b/extensions/positron-zed/package.json
@@ -17,7 +17,7 @@
 	"contributes": {
 		"languages": [
 			{
-				"id": "Zed",
+				"id": "zed",
 				"extensions": [
 					".zed"
 				],


### PR DESCRIPTION
By convention, VS Code uses lowercase for language id, this will fix awareness of .zed files as targets for the Zed language.

The 'Zed' language name is separately set in the language runtime metadata and is not impacted by this change.

