### PR TITLE
Add tests for environment pane

### DIFF
--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -40,13 +40,13 @@ pub enum ValueKind {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EnvironmentVariable {
     /** The environment variable's name */
-    name: String,
+    pub name: String,
 
     /** The environment variable's value kind (string, number, etc.) */
-    kind: ValueKind,
+    pub kind: ValueKind,
 
     /** A formatted representation of the variable's value */
-    value: String,
+    pub value: String,
 }
 
 impl EnvironmentVariable {

--- a/extensions/positron-r/amalthea/crates/ark/src/lib.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/lib.rs
@@ -1,0 +1,17 @@
+//
+// lib.rs
+//
+// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+//
+//
+
+pub mod control;
+pub mod environment;
+pub mod interface;
+pub mod kernel;
+pub mod logger;
+pub mod lsp;
+pub mod plots;
+pub mod request;
+pub mod shell;
+pub mod version;

--- a/extensions/positron-r/amalthea/crates/ark/src/main.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/main.rs
@@ -10,6 +10,8 @@
 use amalthea::connection_file::ConnectionFile;
 use amalthea::kernel::Kernel;
 use amalthea::kernel_spec::KernelSpec;
+use ark::logger;
+use ark::lsp;
 use bus::Bus;
 use crossbeam::channel::bounded;
 use log::*;
@@ -18,21 +20,10 @@ use std::io::stdin;
 use std::sync::{Arc, Mutex};
 use stdext::unwrap;
 
-mod control;
-mod environment;
-mod interface;
-mod kernel;
-mod logger;
-mod lsp;
-mod plots;
-mod request;
-mod shell;
-mod version;
-
-use crate::control::Control;
-use crate::request::Request;
-use crate::shell::Shell;
-use crate::version::detect_r;
+use ark::control::Control;
+use ark::request::Request;
+use ark::shell::Shell;
+use ark::version::detect_r;
 
 fn start_kernel(connection_file: ConnectionFile, capture_streams: bool) {
     // Create a new kernel from the connection file

--- a/extensions/positron-r/amalthea/crates/ark/tests/environment.rs
+++ b/extensions/positron-r/amalthea/crates/ark/tests/environment.rs
@@ -9,6 +9,7 @@ use amalthea::comm::comm_channel::CommChannelMsg;
 use ark::environment::message::EnvironmentMessage;
 use ark::environment::message::EnvironmentMessageList;
 use ark::environment::r_environment::REnvironment;
+use harp::r_lock;
 use harp::r_symbol;
 use harp::test::start_r;
 use libR_sys::R_GlobalEnv;
@@ -52,7 +53,7 @@ fn test_environment_list() {
 
     // Now create a variable in the R environment and ensure we get a list of
     // variables with the new variable in it.
-    unsafe {
+    r_lock! {
         let sym = r_symbol!("everything");
         Rf_defineVar(sym, Rf_ScalarInteger(42), R_GlobalEnv);
     }

--- a/extensions/positron-r/amalthea/crates/ark/tests/environment.rs
+++ b/extensions/positron-r/amalthea/crates/ark/tests/environment.rs
@@ -1,0 +1,77 @@
+//
+// environment.rs
+//
+// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+//
+//
+
+use amalthea::comm::comm_channel::CommChannelMsg;
+use ark::environment::message::EnvironmentMessage;
+use ark::environment::message::EnvironmentMessageList;
+use ark::environment::r_environment::REnvironment;
+use harp::r_symbol;
+use harp::test::start_r;
+use libR_sys::R_GlobalEnv;
+use libR_sys::Rf_ScalarInteger;
+use libR_sys::Rf_defineVar;
+
+/**
+ * Basic test for the R environment list. This test:
+ *
+ * 1. Starts the R interpreter
+ * 2. Creates a new REnvironment
+ * 3. Ensures that the environment list is empty
+ * 4. Creates a variable in the R environment
+ * 5. Ensures that the environment list contains the new variable
+ */
+#[test]
+fn test_environment_list() {
+    // Start the R interpreter so we have a live environment for the test to run
+    // against.
+    start_r();
+
+    // Create a sender/receiver pair for the comm channel.
+    let (frontend_message_tx, frontend_message_rx) =
+        crossbeam::channel::unbounded::<CommChannelMsg>();
+
+    // Create a new environment
+    let r_env = REnvironment::new(frontend_message_tx.clone());
+    let backend_msg_sender = r_env.channel_msg_tx.clone();
+
+    // Ensure we get a list of variables after initialization
+    let msg = frontend_message_rx.recv().unwrap();
+    let data = match msg {
+        CommChannelMsg::Data(data) => data,
+        _ => panic!("Expected data message"),
+    };
+
+    // Ensure we got a list of variables by unmarshalling the JSON. The list
+    // should be empty since we don't have any variables in the R environment.
+    let list: EnvironmentMessageList = serde_json::from_value(data).unwrap();
+    assert!(list.variables.len() == 0);
+
+    // Now create a variable in the R environment and ensure we get a list of
+    // variables with the new variable in it.
+    unsafe {
+        let sym = r_symbol!("everything");
+        Rf_defineVar(sym, Rf_ScalarInteger(42), R_GlobalEnv);
+    }
+
+    // Request that the environment be refreshed
+    let refresh = EnvironmentMessage::Refresh;
+    let data = serde_json::to_value(refresh).unwrap();
+    backend_msg_sender.send(CommChannelMsg::Data(data)).unwrap();
+
+    // Wait for the new list of variables to be delivered
+    let msg = frontend_message_rx.recv().unwrap();
+    let data = match msg {
+        CommChannelMsg::Data(data) => data,
+        _ => panic!("Expected data message, got {:?}", msg),
+    };
+
+    // Unmarshal the list and check for the variable we created
+    let list: EnvironmentMessageList = serde_json::from_value(data).unwrap();
+    assert!(list.variables.len() == 1);
+    let var = &list.variables[0];
+    assert_eq!(var.name, "everything");
+}


### PR DESCRIPTION
This change adds integration tests for the new environment pane. The test starts R, verifies that an initially empty environment is delivered, adds a variable, refreshes the environment, and verifies that the variable shows up. It uses a `Sender`/`Receiver` pair to simulate those operations being performed by the front end. 

Note that because the environment pane is an independent module, the tests can run outside the context of the R kernel and Amalthea. 

Also note that since tests don't get access to `main` modules (only `lib` modules) I've split `ark` into main/lib pieces. 