### PR TITLE
Coding standards: 100 width lines

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -119,5 +119,8 @@
 	"githubPullRequests.assignCreated": "${user}",
 	"githubPullRequests.defaultMergeMethod": "squash",
 	"application.experimental.rendererProfiling": true,
-	"cmake.configureOnOpen": false
+	"cmake.configureOnOpen": false,
+	"editor.rulers": [
+		100
+	]
 }

--- a/extensions/positron-r/amalthea/.editorconfig
+++ b/extensions/positron-r/amalthea/.editorconfig
@@ -5,4 +5,6 @@
 indent_style = space
 trim_trailing_whitespace = true
 indent_size = 4
+max_line_length = 100
+
 

--- a/extensions/positron-r/amalthea/.rustfmt.toml
+++ b/extensions/positron-r/amalthea/.rustfmt.toml
@@ -9,3 +9,5 @@
 match_block_trailing_comma = true
 # normalize_comments = true
 # overflow_delimited_expr = true
+max_width = 100
+


### PR DESCRIPTION
This change provides soft enforcement of a team coding standard of 100 columns for Rust and Typescript code.

Only the Rust code gets a 100 column enforcement at the formatter level, since we don't want to trigger reformatting of Microsoft's code. 

On the Typescript side, we just use a ruler so that everyone can see the guideline. 