### PR TITLE
Add a new message type to separate runtime output from stderr/stdout output

### DIFF
--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -539,6 +539,7 @@ export class LanguageRuntimeAdapter
 			id: message.msgId,
 			parent_id: message.originId,
 			when: message.when,
+			type: positron.LanguageRuntimeMessageType.Stream,
 			name: data.name,
 			text: data.text
 		} as positron.LanguageRuntimeStream);

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -539,13 +539,9 @@ export class LanguageRuntimeAdapter
 			id: message.msgId,
 			parent_id: message.originId,
 			when: message.when,
-			type: data.name === 'stderr' ?
-				positron.LanguageRuntimeMessageType.Error :
-				positron.LanguageRuntimeMessageType.Output,
-			data: {
-				'text/plain': data.text
-			} as any
-		} as positron.LanguageRuntimeOutput);
+			name: data.name,
+			text: data.text
+		} as positron.LanguageRuntimeStream);
 	}
 
 	/**

--- a/extensions/positron-r/amalthea/crates/amalthea/src/stream_capture.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/src/stream_capture.rs
@@ -1,4 +1,3 @@
-
 /*
  * stream_capture.rs
  *
@@ -32,7 +31,10 @@ impl StreamCapture {
     /// Does not return.
     pub fn listen(&self) {
         if let Err(err) = Self::output_capture(self.iopub_tx.clone()) {
-            warn!("Error capturing output; stdout/stderr won't be forwarded: {}", err);
+            warn!(
+                "Error capturing output; stdout/stderr won't be forwarded: {}",
+                err
+            );
         };
     }
 
@@ -62,7 +64,7 @@ impl StreamCapture {
                     }
                     warn!("Error polling for stream data: {}", e);
                     continue;
-                }
+                },
             };
 
             // No data available; likely timed out waiting for data. Try again.
@@ -72,7 +74,6 @@ impl StreamCapture {
 
             // See which stream has data available.
             for poll_fd in poll_fds.iter() {
-
                 // Skip this fd if it doesn't have any new events.
                 let revents = match poll_fd.revents() {
                     Some(r) => r,
@@ -97,7 +98,7 @@ impl StreamCapture {
                     Self::fd_to_iopub(fd, stream, iopub_tx.clone());
                 }
             }
-        };
+        }
         warn!("Stream capture thread exiting after interrupt");
         Ok(())
     }
@@ -111,7 +112,7 @@ impl StreamCapture {
             Err(e) => {
                 warn!("Error reading stream data: {}", e);
                 return;
-            }
+            },
         };
 
         // No bytes read? Nothing to send.
@@ -121,7 +122,10 @@ impl StreamCapture {
 
         // Convert the UTF-8 bytes to a string.
         let data = String::from_utf8_lossy(&buf[..count]).to_string();
-        let output = StreamOutput{stream, text: data };
+        let output = StreamOutput {
+            name: stream,
+            text: data,
+        };
 
         // Create and send the IOPub
         let message = IOPubMessage::Stream(output);
@@ -138,7 +142,7 @@ impl StreamCapture {
             Ok((read, write)) => (read, write),
             Err(e) => {
                 return Err(Error::SysError(format!("create socket for {}", fd), e));
-            }
+            },
         };
 
         // Redirect the stream into the write end of the pipe
@@ -149,7 +153,8 @@ impl StreamCapture {
         // Make reads non-blocking on the read end of the pipe
         if let Err(e) = nix::fcntl::fcntl(
             read,
-            nix::fcntl::FcntlArg::F_SETFL(nix::fcntl::OFlag::O_NONBLOCK)) {
+            nix::fcntl::FcntlArg::F_SETFL(nix::fcntl::OFlag::O_NONBLOCK),
+        ) {
             return Err(Error::SysError(format!("set non-blocking for {}", fd), e));
         }
 

--- a/extensions/positron-r/amalthea/crates/amalthea/src/wire/stream.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/src/wire/stream.rs
@@ -11,8 +11,8 @@ use serde::{Deserialize, Serialize};
 /// Represents a message from the front end to indicate stream output
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct StreamOutput {
-    /// The stream for which output is being emitted
-    pub stream: Stream,
+    /// The name of the stream for which output is being emitted
+    pub name: Stream,
 
     /// The output emitted on the stream
     pub text: String,

--- a/extensions/positron-r/amalthea/crates/ark/src/interface.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/interface.rs
@@ -76,7 +76,6 @@ static mut CONSOLE_RECV: Option<Mutex<Receiver<Option<String>>>> = None;
 static INIT: Once = Once::new();
 
 pub unsafe fn process_events() {
-
     // Process regular R events.
     R_ProcessEvents();
 
@@ -97,11 +96,9 @@ pub unsafe fn process_events() {
 
     // Render pending plots.
     graphics_device::on_process_events();
-
 }
 
 fn on_console_input(buf: *mut c_uchar, buflen: c_int, mut input: String) {
-
     // TODO: What if the input is too large for the buffer?
     input.push_str("\n");
     if input.len() > buflen as usize {
@@ -113,7 +110,6 @@ fn on_console_input(buf: *mut c_uchar, buflen: c_int, mut input: String) {
     unsafe {
         libc::strcpy(buf as *mut c_char, src.as_ptr());
     }
-
 }
 
 /// Invoked by R to read console input from the user.
@@ -159,14 +155,11 @@ pub extern "C" fn r_read_console(
     // descriptors that R has open and select() on those for
     // available data?
     loop {
-
         // Release the R runtime lock while we're waiting for input.
         unsafe { R_RUNTIME_LOCK_GUARD = None };
 
         match receiver.recv_timeout(Duration::from_millis(200)) {
-
             Ok(response) => {
-
                 // Take back the lock after we've received some console input.
                 unsafe { R_RUNTIME_LOCK_GUARD = Some(R_RUNTIME_LOCK.lock()) };
 
@@ -178,37 +171,28 @@ pub extern "C" fn r_read_console(
                 }
 
                 return 1;
-
-            }
+            },
 
             Err(error) => {
-
                 unsafe { R_RUNTIME_LOCK_GUARD = Some(R_RUNTIME_LOCK.lock()) };
 
                 use RecvTimeoutError::*;
                 match error {
-
                     Timeout => {
-
                         // Process events.
                         unsafe { process_events() };
 
                         // Keep waiting for console input.
                         continue;
-
-                    }
+                    },
 
                     Disconnected => {
-
                         return 1;
-
-                    }
+                    },
                 }
-            }
+            },
         }
-
     }
-
 }
 
 /**
@@ -218,7 +202,11 @@ pub extern "C" fn r_read_console(
 pub extern "C" fn r_write_console(buf: *const c_char, _buflen: i32, otype: i32) {
     let content = unsafe { CStr::from_ptr(buf) };
     let mutex = unsafe { KERNEL.as_ref().unwrap() };
-    let stream = if otype == 1 { Stream::Stdout } else { Stream::Stderr };
+    let stream = if otype == 0 {
+        Stream::Stdout
+    } else {
+        Stream::Stderr
+    };
     let mut kernel = mutex.lock().unwrap();
     kernel.write_console(content.to_str().unwrap(), stream);
 }
@@ -236,7 +224,7 @@ pub extern "C" fn r_show_message(buf: *const c_char) {
     let kernel = mutex.lock().unwrap();
 
     // Create an event representing the message
-    let event = PositronEvent::ShowMessage(ShowMessageEvent{
+    let event = PositronEvent::ShowMessage(ShowMessageEvent {
         message: message.to_str().unwrap().to_string(),
     });
 
@@ -255,9 +243,7 @@ pub extern "C" fn r_busy(which: i32) {
     let kernel = mutex.lock().unwrap();
 
     // Create an event representing the new busy state
-    let event = PositronEvent::Busy(BusyEvent{
-        busy: which != 0,
-    });
+    let event = PositronEvent::Busy(BusyEvent { busy: which != 0 });
 
     // Have the kernel deliver the event to the front end
     kernel.send_event(event);
@@ -265,14 +251,16 @@ pub extern "C" fn r_busy(which: i32) {
 
 #[no_mangle]
 pub unsafe extern "C" fn r_polled_events() {
-
     // Check for pending tasks.
     let count = R_RUNTIME_LOCK_COUNT.load(std::sync::atomic::Ordering::Acquire);
     if count == 0 {
         return;
     }
 
-    info!("{} thread(s) are waiting; the main thread is releasing the R runtime lock.", count);
+    info!(
+        "{} thread(s) are waiting; the main thread is releasing the R runtime lock.",
+        count
+    );
     let now = SystemTime::now();
 
     // Release the lock. This drops the lock, and gives other threads
@@ -282,8 +270,10 @@ pub unsafe extern "C" fn r_polled_events() {
     // Take the lock back.
     R_RUNTIME_LOCK_GUARD = Some(R_RUNTIME_LOCK.lock());
 
-    info!("The main thread re-acquired the R runtime lock after {} milliseconds.", now.elapsed().unwrap().as_millis());
-
+    info!(
+        "The main thread re-acquired the R runtime lock after {} milliseconds.",
+        now.elapsed().unwrap().as_millis()
+    );
 }
 
 pub fn start_r(
@@ -313,7 +303,6 @@ pub fn start_r(
     thread::spawn(move || listen(shell_request_rx, rprompt_rx));
 
     unsafe {
-
         let mut args = cargs!["ark", "--interactive"];
         R_running_as_main_program = 1;
         R_SignalHandlers = 0;
@@ -407,7 +396,6 @@ fn complete_execute_request(req: &Request, prompt_recv: &Receiver<String>) {
     // If the current prompt doesn't match the default prompt, assume that
     // we're reading use input, e.g. via 'readline()'.
     if prompt != default_prompt {
-
         trace!("Got R prompt '{}', asking user for input", prompt);
         if let Request::ExecuteCode(_, originator, _) = req {
             kernel.request_input(originator, &prompt);
@@ -424,7 +412,6 @@ fn complete_execute_request(req: &Request, prompt_recv: &Receiver<String>) {
     // Default prompt, finishing request
     trace!("Got R prompt '{}', completing execution", prompt);
     return kernel.finish_request();
-
 }
 
 pub fn listen(exec_recv: Receiver<Request>, prompt_recv: Receiver<String>) {

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -16,6 +16,9 @@ declare module 'positron' {
 		/** A message representing output (text, plots, etc.) */
 		Output = 'output',
 
+		/** A message representing output from one of the standard streams (stdout or stderr) */
+		Stream = 'stream',
+
 		/** A message representing echoed user input */
 		Input = 'input',
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -175,6 +175,27 @@ declare module 'positron' {
 		data: Record<string, string>;
 	}
 
+
+	/**
+	 * The set of standard stream names supported for streaming textual output.
+	 */
+	export enum LanguageRuntimeStreamName {
+		Stdout = 'stdout',
+		Stderr = 'stderr'
+	}
+
+	/**
+	 * LanguageRuntimeStream is a LanguageRuntimeMessage representing output from a standard stream
+	 * (stdout or stderr).
+	 */
+	export interface LanguageRuntimeStream extends LanguageRuntimeMessage {
+		/** The stream name */
+		name: LanguageRuntimeStreamName;
+
+		/** The stream's text */
+		text: string;
+	}
+
 	/** LanguageRuntimeInput is a LanguageRuntimeMessage representing echoed user input */
 	export interface LanguageRuntimeInput extends LanguageRuntimeMessage {
 		/** The code that was input */

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -9,7 +9,7 @@ import {
 	ExtHostPositronContext
 } from '../../common/positron/extHost.positron.protocol';
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
-import { ILanguageRuntime, ILanguageRuntimeInfo, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMetadata, ILanguageRuntimeService, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeInfo, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeService, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { Event, Emitter } from 'vs/base/common/event';
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
@@ -24,6 +24,7 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 	private readonly _startupEmitter = new Emitter<ILanguageRuntimeInfo>();
 
 	private readonly _onDidReceiveRuntimeMessageOutputEmitter = new Emitter<ILanguageRuntimeMessageOutput>();
+	private readonly _onDidReceiveRuntimeMessageStreamEmitter = new Emitter<ILanguageRuntimeMessageStream>();
 	private readonly _onDidReceiveRuntimeMessageInputEmitter = new Emitter<ILanguageRuntimeMessageInput>();
 	private readonly _onDidReceiveRuntimeMessageErrorEmitter = new Emitter<ILanguageRuntimeMessageError>();
 	private readonly _onDidReceiveRuntimeMessagePromptEmitter = new Emitter<ILanguageRuntimeMessagePrompt>();
@@ -53,6 +54,7 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 	onDidCompleteStartup: Event<ILanguageRuntimeInfo>;
 
 	onDidReceiveRuntimeMessageOutput = this._onDidReceiveRuntimeMessageOutputEmitter.event;
+	onDidReceiveRuntimeMessageStream = this._onDidReceiveRuntimeMessageStreamEmitter.event;
 	onDidReceiveRuntimeMessageInput = this._onDidReceiveRuntimeMessageInputEmitter.event;
 	onDidReceiveRuntimeMessageError = this._onDidReceiveRuntimeMessageErrorEmitter.event;
 	onDidReceiveRuntimeMessagePrompt = this._onDidReceiveRuntimeMessagePromptEmitter.event;
@@ -61,6 +63,10 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 
 	emitDidReceiveRuntimeMessageOutput(languageRuntimeMessageOutput: ILanguageRuntimeMessageOutput) {
 		this._onDidReceiveRuntimeMessageOutputEmitter.fire(languageRuntimeMessageOutput);
+	}
+
+	emitDidReceiveRuntimeMessageStream(languageRuntimeMessageStream: ILanguageRuntimeMessageStream) {
+		this._onDidReceiveRuntimeMessageStreamEmitter.fire(languageRuntimeMessageStream);
 	}
 
 	emitDidReceiveRuntimeMessageInput(languageRuntimeMessageInput: ILanguageRuntimeMessageInput) {
@@ -287,6 +293,10 @@ export class MainThreadLanguageRuntime implements MainThreadLanguageRuntimeShape
 
 	$emitLanguageRuntimeMessageOutput(handle: number, message: ILanguageRuntimeMessageOutput): void {
 		this.findRuntime(handle).emitDidReceiveRuntimeMessageOutput(message);
+	}
+
+	$emitLanguageRuntimeMessageStream(handle: number, message: ILanguageRuntimeMessageStream): void {
+		this.findRuntime(handle).emitDidReceiveRuntimeMessageStream(message);
 	}
 
 	$emitLanguageRuntimeMessageInput(handle: number, message: ILanguageRuntimeMessageInput): void {

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4012,6 +4012,9 @@ export enum LanguageRuntimeMessageType {
 	/** A message representing output (text, plots, etc.) */
 	Output = 'output',
 
+	/** A message representing output from one of the standard streams (stdout or stderr) */
+	Stream = 'stream',
+
 	/** A message representing echoed user input */
 	Input = 'input',
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -47,6 +47,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			RuntimeClientState: extHostTypes.RuntimeClientState,
 			LanguageRuntimeMessageType: extHostTypes.LanguageRuntimeMessageType,
 			LanguageRuntimeEventType: extHostTypes.LanguageRuntimeEventType,
+			LanguageRuntimeStreamName: extHostTypes.LanguageRuntimeStreamName,
 			RuntimeCodeExecutionMode: extHostTypes.RuntimeCodeExecutionMode,
 			RuntimeErrorBehavior: extHostTypes.RuntimeErrorBehavior,
 			LanguageRuntimeStartupBehavior: extHostTypes.LanguageRuntimeStartupBehavior,

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IDisposable } from 'vs/base/common/lifecycle';
-import { ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeInfo, ILanguageRuntimeMetadata, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, RuntimeClientType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageCommClosed } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeInfo, ILanguageRuntimeMetadata, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, RuntimeClientType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageStream } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { createProxyIdentifier, IRPCProtocol } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
 // This is the interface that the main process exposes to the extension host
@@ -15,6 +15,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$emitRuntimeClientClosed(handle: number, message: ILanguageRuntimeMessageCommClosed): void;
 
 	$emitLanguageRuntimeMessageOutput(handle: number, message: ILanguageRuntimeMessageOutput): void;
+	$emitLanguageRuntimeMessageStream(handle: number, message: ILanguageRuntimeMessageStream): void;
 	$emitLanguageRuntimeMessageInput(handle: number, message: ILanguageRuntimeMessageInput): void;
 	$emitLanguageRuntimeMessageError(handle: number, message: ILanguageRuntimeMessageError): void;
 	$emitLanguageRuntimeMessagePrompt(handle: number, message: ILanguageRuntimeMessagePrompt): void;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type * as positron from 'positron';
-import { ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import * as extHostProtocol from './extHost.positron.protocol';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { Disposable, LanguageRuntimeMessageType } from 'vs/workbench/api/common/extHostTypes';
@@ -109,6 +109,10 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		runtime.onDidReceiveRuntimeMessage(message => {
 			// Broker the message type to one of the discrete message events.
 			switch (message.type) {
+				case LanguageRuntimeMessageType.Stream:
+					this._proxy.$emitLanguageRuntimeMessageStream(handle, message as ILanguageRuntimeMessage as ILanguageRuntimeMessageStream);
+					break;
+
 				case LanguageRuntimeMessageType.Output:
 					this._proxy.$emitLanguageRuntimeMessageOutput(handle, message as ILanguageRuntimeMessage as ILanguageRuntimeMessageOutput);
 					break;

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -55,6 +55,9 @@ export enum LanguageRuntimeMessageType {
 	/** A message representing output (text, plots, etc.) */
 	Output = 'output',
 
+	/** A message representing output from one of the standard streams (stdout or stderr) */
+	Stream = 'stream',
+
 	/** A message representing echoed user input */
 	Input = 'input',
 

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -81,6 +81,14 @@ export enum LanguageRuntimeMessageType {
 }
 
 /**
+ * The set of stand stream names supported for streaming textual output.
+ */
+export enum LanguageRuntimeStreamName {
+	Stdout = 'stdout',
+	Stderr = 'stderr'
+}
+
+/**
  * Results of analyzing code fragment for completeness
  */
 export enum RuntimeCodeFragmentStatus {

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeNotebook.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeNotebook.ts
@@ -6,7 +6,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
 import { ILogService } from 'vs/platform/log/common/log';
-import { ILanguageRuntime, ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeInfo, ILanguageRuntimeMetadata, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, IRuntimeClientInstance, LanguageRuntimeStartupBehavior, RuntimeClientType, RuntimeCodeFragmentStatus, RuntimeOnlineState, RuntimeState, ILanguageRuntimeMessageInput } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeInfo, ILanguageRuntimeMetadata, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, IRuntimeClientInstance, LanguageRuntimeStartupBehavior, RuntimeClientType, RuntimeCodeFragmentStatus, RuntimeOnlineState, RuntimeState, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageStream } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
 import { CellEditType, CellKind } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { INotebookExecutionStateService } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
@@ -41,6 +41,7 @@ export class NotebookLanguageRuntime extends Disposable implements ILanguageRunt
 	private readonly _startup: Emitter<ILanguageRuntimeInfo>;
 
 	private readonly _onDidReceiveRuntimeMessageOutputEmitter = new Emitter<ILanguageRuntimeMessageOutput>();
+	private readonly _onDidReceiveRuntimeMessageStreamEmitter = new Emitter<ILanguageRuntimeMessageStream>();
 	private readonly _onDidReceiveRuntimeMessageInputEmitter = new Emitter<ILanguageRuntimeMessageInput>();
 	private readonly _onDidReceiveRuntimeMessageErrorEmitter = new Emitter<ILanguageRuntimeMessageError>();
 	private readonly _onDidReceiveRuntimeMessagePromptEmitter = new Emitter<ILanguageRuntimeMessagePrompt>();
@@ -181,6 +182,7 @@ export class NotebookLanguageRuntime extends Disposable implements ILanguageRunt
 	onDidChangeRuntimeState: Event<RuntimeState>;
 
 	onDidReceiveRuntimeMessageOutput = this._onDidReceiveRuntimeMessageOutputEmitter.event;
+	onDidReceiveRuntimeMessageStream = this._onDidReceiveRuntimeMessageStreamEmitter.event;
 	onDidReceiveRuntimeMessageInput = this._onDidReceiveRuntimeMessageInputEmitter.event;
 	onDidReceiveRuntimeMessageError = this._onDidReceiveRuntimeMessageErrorEmitter.event;
 	onDidReceiveRuntimeMessagePrompt = this._onDidReceiveRuntimeMessagePromptEmitter.event;

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -40,6 +40,18 @@ export interface ILanguageRuntimeMessageOutput extends ILanguageRuntimeMessage {
 	readonly data: Record<string, string>;
 }
 
+/**
+ * ILanguageRuntimeMessageStream is a LanguageRuntimeMessage representing text
+ * emitted on one of the standard streams (stdout or stderr)
+ */
+export interface ILanguageRuntimeMessageStream extends ILanguageRuntimeMessage {
+	/** The stream name */
+	name: 'stdout' | 'stderr';
+
+	/** The text emitted from the stream */
+	text: string;
+}
+
 /** ILanguageRuntimeInput is a ILanguageRuntimeMessage representing echoed user input */
 export interface ILanguageRuntimeMessageInput extends ILanguageRuntimeMessage {
 	/** The code that was input */
@@ -297,6 +309,7 @@ export interface ILanguageRuntime {
 	onDidCompleteStartup: Event<ILanguageRuntimeInfo>;
 
 	onDidReceiveRuntimeMessageOutput: Event<ILanguageRuntimeMessageOutput>;
+	onDidReceiveRuntimeMessageStream: Event<ILanguageRuntimeMessageStream>;
 	onDidReceiveRuntimeMessageInput: Event<ILanguageRuntimeMessageInput>;
 	onDidReceiveRuntimeMessageError: Event<ILanguageRuntimeMessageError>;
 	onDidReceiveRuntimeMessagePrompt: Event<ILanguageRuntimeMessagePrompt>;

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -184,6 +184,9 @@ export enum LanguageRuntimeMessageType {
 	/** A message representing output (text, plots, etc.) */
 	Output = 'output',
 
+	/** A message representing output from one of the standard streams (stdout or stderr) */
+	Stream = 'stream',
+
 	/** A message representing echoed user input */
 	Input = 'input',
 


### PR DESCRIPTION
Prior to this change, all output from the language runtime was sent in `Output` messages. This made it impossible to differentiate text generated from standard output, text generated from standard error, and actual output from the language runtime. 

After it, there is a new `Stream` message type that contains stdout/stderr output.

Also, this change fixes an inadvertent deviance from the Jupyter spec; the field containing the name of the output stream is `name`, not `stream`. A few `rustfmt` changes result.