### PR TITLE
add boost::signals-like Signal class

### DIFF
--- a/extensions/positron-r/amalthea/crates/stdext/src/lib.rs
+++ b/extensions/positron-r/amalthea/crates/stdext/src/lib.rs
@@ -11,6 +11,7 @@ pub mod case;
 pub mod local;
 pub mod join;
 pub mod push;
+pub mod signals;
 pub mod unwrap;
 
 #[macro_export]

--- a/extensions/positron-r/amalthea/crates/stdext/src/signals.rs
+++ b/extensions/positron-r/amalthea/crates/stdext/src/signals.rs
@@ -1,0 +1,83 @@
+//
+// signals.rs
+//
+// Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+//
+//
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicI32;
+
+static ID: AtomicI32 = AtomicI32::new(0);
+
+#[derive(Default)]
+pub struct Signal<T> {
+    listeners: Mutex<HashMap<i32, Box<dyn Fn(&T)>>>,
+}
+
+impl<T> Signal<T> {
+
+    pub fn emit(&mut self, data: impl Into<T>) {
+        let data = data.into();
+        let mut listeners = self.listeners.lock().unwrap();
+        for listener in listeners.iter_mut() {
+            listener.1(&data);
+        }
+    }
+
+    pub fn listen(&mut self, callback: impl Fn(&T) + 'static) -> i32 {
+        let mut listeners = self.listeners.lock().unwrap();
+        let id = ID.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        listeners.insert(id, Box::new(callback));
+        return id;
+    }
+
+    pub fn remove(&mut self, id: i32) {
+        let mut listeners = self.listeners.lock().unwrap();
+        listeners.remove(&id);
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_signals() {
+
+        #[derive(Default)]
+        pub struct Signals {
+            number: Signal<i32>,
+            string: Signal<String>,
+        }
+
+        let mut signals = Signals::default();
+
+        // call with a number
+        signals.number.listen(|number| {
+            assert!(*number == 42);
+        });
+
+        signals.number.emit(42);
+
+        // call with a string
+        signals.string.listen(|string| {
+            assert!(*string == "hello");
+        });
+
+        signals.string.emit("hello");
+
+        // add and remove a signal
+        let id = signals.string.listen(|string| {
+            assert!(*string == "goodbye");
+        });
+
+        signals.string.remove(id);
+        signals.string.emit("hello");
+
+    }
+
+}
+


### PR DESCRIPTION
See tests for example usage. The general idea is you can declare a struct full of signals, e.g. something like:

```
struct Signals {
    console_prompt: Signal<String>
}

static SIGNALS: Signals = Signals::new();  // or the 'Lazy::new()' equivalent
```

and then use `SIGNALS.listen()` to attach a handler, and `SIGNALS.emit()` to emit data.

We might want to iterate on the interface depending on how this actually feels with e..g Rust object lifetimes but I think this is a nice start, and it felt better having our own implementation that serves our own needs.