### PR TITLE
Add simple environment client for Zed

### DIFF
--- a/extensions/positron-zed/src/positronZedEnvironment.ts
+++ b/extensions/positron-zed/src/positronZedEnvironment.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * ZedEnvironment is a synthetic environment backend for the Zed language.
+ */
+class ZedEnvironment {
+	constructor() {
+	}
+
+	public handleMessage(message: object) {
+		// TODO
+	}
+}

--- a/extensions/positron-zed/src/positronZedEnvironment.ts
+++ b/extensions/positron-zed/src/positronZedEnvironment.ts
@@ -79,7 +79,7 @@ export class ZedEnvironment {
 		const kindToUse = kind || 'string';
 
 		// Get the starting index for the new variables
-		const start = this._vars.size;
+		const start = this._vars.size + 1;
 
 		// Ensure we don't collide with existing variables
 		for (let i = 0; i < count; i++) {
@@ -101,6 +101,17 @@ export class ZedEnvironment {
 		}
 
 		// Emit the new variables to the front end
+		this.emitFullList();
+	}
+
+	/**
+	 * Clears all variables from the environment
+	 */
+	public clearAllVars() {
+		// Clear the variables
+		this._vars.clear();
+
+		// Refresh the client view
 		this.emitFullList();
 	}
 

--- a/extensions/positron-zed/src/positronZedEnvironment.ts
+++ b/extensions/positron-zed/src/positronZedEnvironment.ts
@@ -2,11 +2,21 @@
  *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+
 /**
  * ZedEnvironment is a synthetic environment backend for the Zed language.
  */
-class ZedEnvironment {
-	constructor() {
+export class ZedEnvironment {
+
+	/**
+	 * Emitter that handles outgoing messages to the front end
+	 */
+	private readonly _onDidEmitData = new vscode.EventEmitter<object>();
+	onDidEmitData: vscode.Event<object> = this._onDidEmitData.event;
+
+	constructor(readonly id: string) {
 	}
 
 	public handleMessage(message: object) {

--- a/extensions/positron-zed/src/positronZedEnvironment.ts
+++ b/extensions/positron-zed/src/positronZedEnvironment.ts
@@ -6,7 +6,18 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 
 /**
- * ZedEnvironment is a synthetic environment backend for the Zed language.
+ * ZedVar is a simple Zed variable.
+ */
+class ZedVariable {
+	constructor(
+		readonly name: string,
+		readonly value: string,
+		readonly kind: string
+	) { }
+}
+
+/**
+ * ZedEnvironment is a synthetic environment backend for the Zed language containing a set of ZedVariables.
  */
 export class ZedEnvironment {
 
@@ -16,10 +27,57 @@ export class ZedEnvironment {
 	private readonly _onDidEmitData = new vscode.EventEmitter<object>();
 	onDidEmitData: vscode.Event<object> = this._onDidEmitData.event;
 
+	/**
+	 * A map of variable names to their respective metadata
+	 */
+	private readonly _vars = new Map<string, ZedVariable>();
+
+	/**
+	 * Creates a new ZedEnvironment backend
+	 *
+	 * @param id The ID of the environment client instance
+	 */
 	constructor(readonly id: string) {
+		// Create a few variables to start with
+		this._vars.set('z', new ZedVariable('Z', 'zed1', 'string'));
+		this._vars.set('e', new ZedVariable('Z', 'zed2', 'string'));
+		this._vars.set('d', new ZedVariable('Z', 'zed3', 'string'));
+
+		setTimeout(() => {
+			// List the environment on the first tick after startup. There's no
+			// reason we couldn't do this immediately, but waiting a tick simulates the
+			// behavior of a "real" language more accuratley.
+
+			this.emitFullList();
+		});
 	}
 
-	public handleMessage(message: object) {
-		// TODO
+	/**
+	 * Handles an incoming message from the Positron front end
+	 *
+	 * @param message The message to handle
+	 */
+	public handleMessage(message: any) {
+		switch (message.msg_type) {
+
+			// A request to refresh the environment by sending a full list to the front end
+			case 'refresh':
+				this.emitFullList();
+				break;
+		}
+	}
+
+	/**
+	 * Emits a full list of variables to the front end
+	 */
+	private emitFullList() {
+		// Create a list of all the variables in the environment
+		const vars = Array.from(this._vars.values());
+
+		// Emit the data to the front end
+		this._onDidEmitData.fire({
+			msg_type: 'list',
+			vars: vars
+		});
 	}
 }

--- a/extensions/positron-zed/src/positronZedEnvironment.ts
+++ b/extensions/positron-zed/src/positronZedEnvironment.ts
@@ -38,11 +38,15 @@ export class ZedEnvironment {
 	 *
 	 * @param id The ID of the environment client instance
 	 */
-	constructor(readonly id: string) {
+	constructor(readonly id: string,
+		private readonly zedVersion: string) {
 		// Create a few variables to start with
 		this._vars.set('z', new ZedVariable('z', 'zed1', 'string'));
 		this._vars.set('e', new ZedVariable('e', 'zed2', 'string'));
 		this._vars.set('d', new ZedVariable('d', 'zed3', 'string'));
+
+		// Create a Zed Version variable
+		this._vars.set('ZED_VERSION', new ZedVariable('ZED_VERSION', this.zedVersion, 'string'));
 
 		setTimeout(() => {
 			// List the environment on the first tick after startup. There's no

--- a/extensions/positron-zed/src/positronZedEnvironment.ts
+++ b/extensions/positron-zed/src/positronZedEnvironment.ts
@@ -4,6 +4,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
+import { randomUUID } from 'crypto';
 
 /**
  * ZedVar is a simple Zed variable.
@@ -39,9 +40,9 @@ export class ZedEnvironment {
 	 */
 	constructor(readonly id: string) {
 		// Create a few variables to start with
-		this._vars.set('z', new ZedVariable('Z', 'zed1', 'string'));
-		this._vars.set('e', new ZedVariable('Z', 'zed2', 'string'));
-		this._vars.set('d', new ZedVariable('Z', 'zed3', 'string'));
+		this._vars.set('z', new ZedVariable('z', 'zed1', 'string'));
+		this._vars.set('e', new ZedVariable('e', 'zed2', 'string'));
+		this._vars.set('d', new ZedVariable('d', 'zed3', 'string'));
 
 		setTimeout(() => {
 			// List the environment on the first tick after startup. There's no
@@ -68,6 +69,42 @@ export class ZedEnvironment {
 	}
 
 	/**
+	 * Defines a number of variables at once.
+	 *
+	 * @param count The number of variables to define
+	 * @param kind The kind of variable to define; defaults to 'string'
+	 */
+	public defineVars(count: number, kind: string) {
+		// Select the kind of variable to define
+		const kindToUse = kind || 'string';
+
+		// Get the starting index for the new variables
+		const start = this._vars.size;
+
+		// Ensure we don't collide with existing variables
+		for (let i = 0; i < count; i++) {
+			const name = `zed${start + i}`;
+			let value = '';
+
+			// Create a random value for the variable
+			if (kindToUse === 'string') {
+				// Strings: use a random UUID
+				value = randomUUID();
+			} else if (kindToUse === 'number') {
+				// Numbers: use a random number
+				value = Math.random().toString();
+			} else {
+				// Everything else: use the counter
+				value = `value{start + i}`;
+			}
+			this._vars.set(name, new ZedVariable(name, value, kindToUse));
+		}
+
+		// Emit the new variables to the front end
+		this.emitFullList();
+	}
+
+	/**
 	 * Emits a full list of variables to the front end
 	 */
 	private emitFullList() {
@@ -77,7 +114,7 @@ export class ZedEnvironment {
 		// Emit the data to the front end
 		this._onDidEmitData.fire({
 			msg_type: 'list',
-			vars: vars
+			variables: vars
 		});
 	}
 }

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -679,7 +679,12 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 	 * Removes an instance of a client.
 	 */
 	removeClient(id: string): void {
-		throw new Error('Method not implemented.');
+		// Right now, the only client instances are environments.
+		if (this._environments.has(id)) {
+			this._environments.delete(id);
+		} else {
+			throw new Error(`Can't remove client; unknown client id ${id}`);
+		}
 	}
 
 	/**

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -47,6 +47,7 @@ const HelpLines = [
 	'code X Y    - Simulates a successful X line input with Y lines of output (where X >= 1 and Y >= 0)',
 	'def X       - Defines X variables',
 	'def X Y     - Defines X variables of type Y',
+	'env clear   - Clears all variables from the environment',
 	'error X Y Z - Simulates an unsuccessful X line input with Y lines of error message and Z lines of traceback (where X >= 1 and Y >= 1 and Z >= 0)',
 	'help        - Shows this help',
 	'offline     - Simulates going offline for two seconds',
@@ -597,6 +598,15 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 					`${makeSGR(SGR.SetBackground, 2, 0x00, 0x00, 0x83)}${TEN_SPACES}${makeSGR()} Indigo Background\n` +
 					`${makeSGR(SGR.SetBackground, 2, 0x30, 0x00, 0x9b)}${TEN_SPACES}${makeSGR()} Violet Background\n`
 				);
+				break;
+			}
+
+			case 'env clear': {
+				// Clear each environment in turn
+				for (const env of this._environments.values()) {
+					env.clearAllVars();
+				}
+				this.simulateSuccessfulCodeExecution(id, code, 'Environment cleared.');
 				break;
 			}
 

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -661,7 +661,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 	createClient(type: positron.RuntimeClientType): Promise<string> {
 		if (type === positron.RuntimeClientType.Environment) {
 			// Allocate a new ID and ZedEnvironment object for this environment backend
-			const env = new ZedEnvironment(randomUUID());
+			const env = new ZedEnvironment(randomUUID(), this.metadata.languageVersion);
 
 			// Connect it and save the instance to coordinate future communication
 			this.connectEnvironmentEmitter(env);


### PR DESCRIPTION
This change adds a very simple environment client implementation for Zed to make it easier to iterate on the environment pane UI. 

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/470418/225447694-2ace0e6a-cd7d-4009-80c2-597caee51355.png">

New commands:

- `def X` - define X environment variables
- `def X Y` - define X environment variables of type Y, e.g. `def 2 number` creates two numeric variables.
- `env clear` - clear the environment