### PR TITLE
Add support for language-supplied interpreter prompt

### DIFF
--- a/extensions/jupyter-adapter/src/Api.ts
+++ b/extensions/jupyter-adapter/src/Api.ts
@@ -17,8 +17,12 @@ export class Api implements vscode.Disposable {
 	 * Create an adapter for a Jupyter-compatible kernel.
 	 *
 	 * @param kernel A Jupyter kernel spec containing the information needed to start the kernel.
+	 * @param languageId The language ID for the language this adapter supports; must be one of
+	 *    VS Code's built-in language IDs or a language ID registered by another extension.
 	 * @param languageVersion The version of the language interpreter.
 	 * @param kernelVersion The version of the kernel itself.
+	 * @param inputPrompt The input prompt to use for the kernel, such as ">"
+	 * @param startupBehavior Whether the runtime should be started automatically
 	 * @param lsp An optional function that starts an LSP server, given the port
 	 *   on which the kernel is listening, and returns a promise that resolves
 	 *   when the server is ready.
@@ -28,11 +32,13 @@ export class Api implements vscode.Disposable {
 		languageId: string,
 		languageVersion: string,
 		kernelVersion: string,
+		inputPrompt: string,
 		startupBehavior: positron.LanguageRuntimeStartupBehavior = positron.LanguageRuntimeStartupBehavior.Implicit,
 		lsp?: (port: number) => Promise<void>): positron.LanguageRuntime {
 
 		return new LanguageRuntimeAdapter(
-			this._context, kernel, languageId, languageVersion, kernelVersion, this._channel, startupBehavior, lsp);
+			this._context, kernel, languageId, languageVersion, kernelVersion, inputPrompt,
+			this._channel, startupBehavior, lsp);
 	}
 
 	dispose() {

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -60,11 +60,28 @@ export class LanguageRuntimeAdapter
 	 */
 	private readonly _comms: Map<string, RuntimeClientAdapter> = new Map();
 
+	/**
+	 * Create a new LanguageRuntimeAdapter to wrap a Jupyter kernel instance in
+	 * a LanguageRuntime interface.
+	 *
+	 * @param _context The extension context for the extension that owns this adapter
+	 * @param _spec The Jupyter kernel spec for the kernel to wrap
+	 * @param languageId  The language ID for the language this adapter supports; must be one of
+	 *    VS Code's built-in language IDs or a language ID registered by another extension.
+	 * @param languageVersion The specific version of the interpreter bound to this adapter
+	 * @param runtimeVersion The version of the language runtime wrapper around
+	 *    the interpreter, often the extension version
+	 * @param inputPrompt The input prompt to use for the kernel, such as ">"
+	 * @param _channel The channel on which to emit logging messages
+	 * @param startupBehavior Whether the runtime should be started automatically
+	 * @param _lsp A callback to invoke to start the client side of the LSP
+	 */
 	constructor(private readonly _context: vscode.ExtensionContext,
 		private readonly _spec: JupyterKernelSpec,
 		languageId: string,
 		languageVersion: string,
 		runtimeVersion: string,
+		inputPrompt: string,
 		private readonly _channel: vscode.OutputChannel,
 		startupBehavior: positron.LanguageRuntimeStartupBehavior = positron.LanguageRuntimeStartupBehavior.Implicit,
 		private readonly _lsp?: (port: number) => Promise<void>) {
@@ -89,6 +106,7 @@ export class LanguageRuntimeAdapter
 			languageId,
 			languageName: this._spec.language,
 			languageVersion,
+			inputPrompt,
 			startupBehavior: startupBehavior
 		};
 		this._channel.appendLine('Registered kernel: ' + JSON.stringify(this.metadata));

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -135,6 +135,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 			'r',      // Language ID
 			rHome.rVersion ?? '0.0.1',   // Version of R, if we know it
 			version,  // Version of this extension
+			'>', 	// Input prompt
 			positron.LanguageRuntimeStartupBehavior.Implicit, // OK to start the kernel automatically
 			(port: number) => {
 				// Activate the LSP language server when the adapter is ready.

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -123,6 +123,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 			languageName: 'Zed',
 			runtimeName: 'Zed',
 			languageVersion: version,
+			inputPrompt: `Z>`,
 			runtimeVersion: '0.0.1',
 			startupBehavior: positron.LanguageRuntimeStartupBehavior.Implicit
 		};

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -265,7 +265,8 @@ declare module 'positron' {
 		data: object;
 	}
 
-	/** LanguageRuntimeMetadata contains information about a language runtime that is known
+	/**
+	 * LanguageRuntimeMetadata contains information about a language runtime that is known
 	 * before the runtime is started.
 	 */
 	export interface LanguageRuntimeMetadata {
@@ -291,6 +292,9 @@ declare module 'positron' {
 
 		/** The version of the language; e.g. "4.2" */
 		languageVersion: string;
+
+		/** The text the language's interpreter uses to prompt the user for input, e.g. ">" */
+		inputPrompt: string;
 
 		/** Whether the runtime should start up automatically or wait until explicitly requested */
 		startupBehavior: LanguageRuntimeStartupBehavior;

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeNotebook.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeNotebook.ts
@@ -75,6 +75,7 @@ export class NotebookLanguageRuntime extends Disposable implements ILanguageRunt
 			languageId: _kernel.supportedLanguages[0],
 			languageName: languageName,
 			languageVersion: '1.0',
+			inputPrompt: 'NB>',
 			runtimeName: `${this._kernel.label} - ${this._kernel.description} [Notebook Bridge]`,
 			runtimeVersion: '0.0.1',
 			startupBehavior: LanguageRuntimeStartupBehavior.Implicit

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
@@ -21,7 +21,7 @@ export const ActivityInput = (props: ActivityInputProps) => {
 	// Render.
 	return (
 		<div className='activity-input'>
-			<div className='prompt'>&gt;</div>
+			<div className='prompt'>{props.activityItemInput.prompt}</div>
 			<div className='code'>
 				<OutputLines outputLines={props.activityItemInput.codeOutputLines} />
 			</div>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/liveInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/liveInput.tsx
@@ -315,10 +315,10 @@ export const LiveInput = forwardRef<HTMLDivElement, LiveInputProps>((props: Live
 		// Turn off most editor chrome.
 		const editorOptions: IEditorOptions = {
 			lineNumbers: (n: number) => {
-				// Render the prompt as > for the first line; do not render
+				// Render the input prompt for the first line; do not render
 				// anything in the margin for following lines
 				if (n < 2) {
-					return '>';
+					return props.positronConsoleInstance.runtime.metadata.inputPrompt;
 				}
 				return '';
 			},

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -288,6 +288,9 @@ export interface ILanguageRuntimeMetadata {
 	/** The version of the language in question; e.g. "4.3.3" */
 	readonly languageVersion: string;
 
+	/** The text the langauge's interpreter uses to prompt the user for input, e.g. ">" */
+	readonly inputPrompt: string;
+
 	/** The user-facing descriptive name of the runtime; e.g. "R 4.3.3" */
 	readonly runtimeName: string;
 

--- a/src/vs/workbench/services/positronConsole/common/classes/activityItemInput.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/activityItemInput.ts
@@ -24,12 +24,14 @@ export class ActivityItemInput {
 	 * @param id The identifier.
 	 * @param parentId The parent identifier.
 	 * @param when The date.
+	 * @param prompt The input prompt.
 	 * @param code The code.
 	 */
 	constructor(
 		readonly id: string,
 		readonly parentId: string,
 		readonly when: Date,
+		readonly prompt: string,
 		readonly code: string
 	) {
 		// Process the code directly into ANSI output lines suitable for rendering.

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -690,6 +690,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				languageRuntimeMessageInput.id,
 				languageRuntimeMessageInput.parent_id,
 				new Date(languageRuntimeMessageInput.when),
+				this._runtime.metadata.inputPrompt,
 				languageRuntimeMessageInput.code
 			));
 		}));


### PR DESCRIPTION
This is a small change that makes it possible for a language runtime to specify what input prompt should be used in the Console.

There's a lot it does not do, such as supporting prompt customizations or reacting to changes users make to their prompt strings, but for MVP I think all we need is to look more like a native interpreter by using the same prompt text.

Note that we still need some work to align the prompt text with the input control, and account for the arbitrarily longer prompts which we'll have in the future when we support customization. 