### PR TITLE
Update protocol messages for environment pane

### DIFF
--- a/extensions/positron-r/amalthea/crates/ark/src/environment/message.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/message.rs
@@ -46,6 +46,7 @@ pub enum EnvironmentMessage {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EnvironmentMessageList {
     pub variables: Vec<EnvironmentVariable>,
+    pub length: usize,
 }
 
 /**

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
@@ -198,7 +198,15 @@ impl REnvironment {
             }
 
         }
-        let env_list = EnvironmentMessage::List(EnvironmentMessageList { variables });
+
+        // TODO: Avoid serializing the full list of variables if it exceeds a
+        // certain threshold
+        let env_size = variables.len();
+        let env_list = EnvironmentMessage::List(EnvironmentMessageList {
+            variables,
+            length: env_size,
+        });
+
         let data = serde_json::to_value(env_list);
         match data {
             Ok(data) => {

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -13,27 +13,35 @@ use serde::Serialize;
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ValueKind {
-    /// A character vector (string) or value that can be converted to a string
-    String,
+    /// A length-1 logical vector
+    Boolean,
 
-    /// A numeric value
-    Number,
+    /// A raw byte array
+    Bytes,
 
-    /// A vector (VECSXP)
-    Vector,
+    /// A collection of unnamed values; usually a vector
+    Collection,
 
-    /// A list (LISTSXP)
-    List,
+    /// Empty/missing values such as NULL, NA, or missing
+    Empty,
 
-    /// A function value
+    /// A function, method, closure, or other callable object
     Function,
 
-    /// Data frame (data.frame, tibble, etc.)
-    Dataframe,
-    // TODO: Add other types of values. These don't have to map 1-1 to R object
-    // types; they represent the kinds of values that have unique UI
-    // representations. Note that these value kinds are shared across all
-    // languages so they need to be somewhat generic.
+    /// Named lists of values, such as lists and (hashed) environments
+    Map,
+
+    /// A number, such as an integer or floating-point value
+    Number,
+
+    /// A value of an unknown or unspecified type
+    Other,
+
+    /// A character string
+    String,
+
+    /// A table, dataframe, 2D matrix, or other two-dimensional data structure
+    Table,
 }
 
 /// Represents the serialized form of an environment variable.
@@ -61,8 +69,6 @@ impl EnvironmentVariable {
         let value = name.clone();
         let kind = ValueKind::String;
 
-        Self {
-            name, kind, value
-        }
+        Self { name, kind, value }
     }
 }

--- a/extensions/positron-zed/src/positronZedEnvironment.ts
+++ b/extensions/positron-zed/src/positronZedEnvironment.ts
@@ -11,7 +11,7 @@ import { randomUUID } from 'crypto';
  */
 class ZedVariable {
 	// Zed variables do not currently support truncation.
-	public readonly truncated: boolean = false;
+	public readonly is_truncated: boolean = false;
 	public readonly type_name;
 	public readonly has_children;
 

--- a/extensions/positron-zed/src/positronZedEnvironment.ts
+++ b/extensions/positron-zed/src/positronZedEnvironment.ts
@@ -258,7 +258,8 @@ export class ZedEnvironment {
 		// Emit the data to the front end
 		this._onDidEmitData.fire({
 			msg_type: 'list',
-			variables: vars
+			variables: vars,
+			length: vars.length
 		});
 	}
 
@@ -281,7 +282,8 @@ export class ZedEnvironment {
 					// We've reached the end of the path, so emit the variable
 					this._onDidEmitData.fire({
 						msg_type: 'details',
-						children: v.children
+						children: v.children,
+						length: v.children.length
 					});
 				} else {
 					// This is not the end of the path, so consume this path element and

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -48,6 +48,7 @@ const HelpLines = [
 	'env clear    - Clears all variables from the environment',
 	'env def X    - Defines X variables (randomly typed)',
 	'env def X Y  - Defines X variables of type Y, where Y is one of: string, number, vector, list, or blob',
+	'env max X    - Set the maximum number of displayed variables to X',
 	'env rm X     - Removes X variables',
 	'env update X - Updates X variables',
 	'error X Y Z  - Simulates an unsuccessful X line input with Y lines of error message and Z lines of traceback (where X >= 1 and Y >= 1 and Z >= 0)',
@@ -245,6 +246,15 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 			}
 			return this.simulateSuccessfulCodeExecution(id, code,
 				`Removed ${count} variables.`);
+		} else if (match = code.match(/^env max ([1-9]{1}[\d]*)/)) {
+			const max = +match[1];
+			if (this._environments.size > 0) {
+				for (const environment of this._environments.values()) {
+					environment.setMaxVarDisplay(max);
+				}
+			}
+			return this.simulateSuccessfulCodeExecution(id, code,
+				`Now displaying a maximum of ${max} variables.`);
 		}
 
 		// Process the "code".

--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentInstance.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentInstance.tsx
@@ -141,7 +141,7 @@ export const EnvironmentInstance = (props: EnvironmentInstanceProps) => {
 		const valueItems: EnvironmentVariableItem[] = [];
 		const functionItems: EnvironmentVariableItem[] = [];
 		props.positronEnvironmentInstance.environmentVariableItems.forEach(item => {
-			if (item.environmentVariable.data.kind === EnvironmentVariableValueKind.Dataframe) {
+			if (item.environmentVariable.data.kind === EnvironmentVariableValueKind.Table) {
 				dataItems.push(item);
 			} else if (item.environmentVariable.data.kind === EnvironmentVariableValueKind.Function) {
 				functionItems.push(item);

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeEnvironmentClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeEnvironmentClient.ts
@@ -118,7 +118,7 @@ export interface IEnvironmentVariable {
 	has_children: boolean;
 
 	/// True if the 'value' field was truncated to fit in the message
-	truncated: boolean;
+	is_truncated: boolean;
 }
 
 /**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeEnvironmentClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeEnvironmentClient.ts
@@ -205,14 +205,24 @@ export interface IEnvironmentClientMessageOutput {
  * A list of all the variables and their values.
  */
 export interface IEnvironmentClientMessageList extends IEnvironmentClientMessageOutput {
+	/// The list of variables
 	variables: Array<IEnvironmentVariable>;
+
+	/// The total number of variables known to the runtime. This may be greater
+	/// than the number of variables in the list if the list was truncated.
+	length: number;
 }
 
 /**
  * The details (children) of a specific variable.
  */
 export interface IEnvironmentClientMessageDetails extends IEnvironmentClientMessageOutput {
+	/// The list of child variables
 	children: Array<IEnvironmentVariable>;
+
+	/// The total number of child variables. This may be greater than the number
+	/// of variables in the list if the list was truncated.
+	length: number;
 }
 
 /**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeEnvironmentClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeEnvironmentClient.ts
@@ -61,12 +61,35 @@ export enum EnvironmentClientMessageTypeOutput {
  * Represents the possible kinds of values in an environment.
  */
 export enum EnvironmentVariableValueKind {
-	String = 'string',
-	Number = 'number',
-	Vector = 'vector',
-	List = 'list',
+	/// A boolean value
+	Boolean = 'boolean',
+
+	/// A sequence of bytes or raw binary data
+	Bytes = 'bytes',
+
+	/// A iterable collection of unnamed values, such as a list or array
+	Collection = 'collection',
+
+	/// An empty, missing, null, or invalid value
+	Empty = 'empty',
+
+	/// A function, method, closure, or other callable object
 	Function = 'function',
-	Dataframe = 'dataframe',
+
+	/// A map, dictionary, named list, or associative array
+	Map = 'map',
+
+	/// A number, such as an integer or floating-point value
+	Number = 'number',
+
+	/// A value of an unknown or unspecified type
+	Other = 'other',
+
+	/// A character string
+	String = 'string',
+
+	/// A table, dataframe, 2D matrix, or other two-dimensional data structure
+	Table = 'table',
 }
 
 /**


### PR DESCRIPTION
Adds new types and metadata to environment messages. 

Also adds a new Zed command to make it easier to test the UI for truncated environment limits, `env max 100` tells Zed to only show 100 variables in the environment (while still telling the UI the total number available). 