### PR TITLE
Implement remainder of environment pane messages in Zed

### DIFF
--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariable.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariable.tsx
@@ -37,6 +37,12 @@ export const EnvironmentVariable = (props: EnvironmentVariableProps) => {
 			props.environmentVariableItem.environmentVariable.getChildren().then(children => {
 				console.info(`children: ${JSON.stringify(children.data)}`);
 			});
+		} else {
+			// For items without children, fetch the formatted clipboard value. Totally a
+			// placeholder; this just exists to exercise the API.
+			props.environmentVariableItem.environmentVariable.formatForClipboard('text/plain').then(val => {
+				console.info(`formatted value: ${val}`);
+			});
 		}
 	};
 


### PR DESCRIPTION
This change implements `delete` and `clipboard_format` and the associated replies in Zed. 

To help exercise the latter, clicking on a variable that has no children will cause the front end to ask the variable for its formatted value. 