### PR TITLE
Try using chevrons for env pane nav expand / collapse icons

### DIFF
--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariable.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariable.tsx
@@ -52,8 +52,8 @@ export const EnvironmentVariable = (props: EnvironmentVariableProps) => {
 								<button className='expand-collapse-button' onClick={handleExpandCollapse}>
 									<div className='expand-collapse-button-face'>
 										{!expanded ?
-											<div className={`expand-collapse-button-icon codicon codicon-positron-expand`}></div> :
-											<div className={`expand-collapse-button-icon codicon codicon-positron-collapse`}></div>
+											<div className={`expand-collapse-button-icon codicon codicon-chevron-right`}></div> :
+											<div className={`expand-collapse-button-icon codicon codicon-chevron-down`}></div>
 										}
 									</div>
 								</button>


### PR DESCRIPTION
This matches expand / collapse icons used in other views, such as the workspace explorer view, search view, etc.


