### PR TITLE
handle CharacterVector::create(Vec<String>)

### DIFF
--- a/extensions/positron-r/amalthea/crates/harp/src/exec.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/exec.rs
@@ -329,7 +329,7 @@ where
     F: FnMut() -> R,
     RObject: From<R>
 {
-    let vector = CharacterVector::create(["error"]);
+    let vector = CharacterVector::create(&["error"]);
     r_try_catch_finally(fun, vector, || {})
 }
 
@@ -491,7 +491,7 @@ mod tests {
 
         // ok something else, Vec<&str>
         let value = r_try_catch_error(|| {
-            CharacterVector::create(["hello", "world"]).cast()
+            CharacterVector::create(&["hello", "world"]).cast()
         });
 
         assert_match!(value, Ok(value) => {


### PR DESCRIPTION
allow `CharacterVector::create(Vec<String>)` by bringing back some traits and implementation from before #305, so that we don't have to first convert a `Vec<String>` into a `Vec<&str>` as I'm struggling with in #310. 