### PR TITLE
End-to-end handling of runtime startup failures

### DIFF
--- a/extensions/jupyter-adapter/positron.json
+++ b/extensions/jupyter-adapter/positron.json
@@ -3,6 +3,10 @@
 		{
 			"from": "node_modules/zeromq/build/Release/zeromq.node",
 			"to": "build/Release"
+		},
+		{
+			"from": "resources/kernel-wrapper.*",
+			"to": "resources"
 		}
 	]
 }

--- a/extensions/jupyter-adapter/resources/kernel-wrapper.bat
+++ b/extensions/jupyter-adapter/resources/kernel-wrapper.bat
@@ -1,0 +1,30 @@
+REM ---------------------------------------------------------------------------------------------
+REM Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+REM ---------------------------------------------------------------------------------------------
+
+REM This script is used to run a program and capture its output to a file. It is
+REM used to capture the output of the kernel process so that it can be displayed
+REM in the UI in the case of a startup failure; it may also be used in the future
+REM to perform Positron-specific kernel startup routines, such as setting up
+REM environment variables.
+
+@echo off
+
+REM Check that the user provided at least two arguments; the first is the output
+REM file and the second is the program to run and any arguments. If not, print a
+REM usage message and exit with an error code.
+
+if "%~2"=="" (
+  echo Usage: %0 ^<output-file^> ^<program^> [program-args...] >&2
+  exit /b 1
+)
+
+REM The first argument is the output file; consume it.
+set output_file=%1
+shift
+
+REM Run the program with its arguments, redirecting stdout and stderr to the output file
+"%*" > "%output_file%" 2>&1
+
+REM Exit with the same code as the program so that the caller can correctly report errors
+exit /b %ERRORLEVEL%

--- a/extensions/jupyter-adapter/resources/kernel-wrapper.sh
+++ b/extensions/jupyter-adapter/resources/kernel-wrapper.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# ---------------------------------------------------------------------------------------------
+# Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+# ---------------------------------------------------------------------------------------------
+
+# This script is used to run a program and capture its output to a file. It is
+# used to capture the output of the kernel process so that it can be displayed
+# in the UI in the case of a startup failure; it may also be used in the future
+# to perform Positron-specific kernel startup routines, such as setting up
+# environment variables.
+
+# Check that the user provided at least two arguments; the first is the output
+# file and the second is the program to run and any arguments. If not, print a
+# usage message and exit with an error code.
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <output-file> <program> [program-args...]" >&2
+  exit 1
+fi
+
+# The first argument is the output file; consume it.
+output_file="$1"
+shift
+
+# Run the program with its arguments, redirecting stdout and stderr to the output file
+"$@" > "$output_file" 2>&1
+
+# Save the exit code of the program
+exit_code=$?
+
+# Exit with the same code as the program so that the caller can correctly report errors
+exit $exit_code

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -29,6 +29,7 @@ import { JupyterInputReply } from './JupyterInputReply';
 import { Tail } from 'tail';
 import { JupyterCommMsg } from './JupyterCommMsg';
 import { createJupyterSession, JupyterSession, JupyterSessionState } from './JupyterSession';
+import path = require('path');
 
 export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 	private readonly _spec: JupyterKernelSpec;
@@ -478,13 +479,20 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		const showTerminal = vscode.workspace.getConfiguration('positron.jupyterAdapter')
 			.get('showTerminal', false);
 
+		const kernelWrapperPath = path.join(this._context.extensionPath,
+			'resources',
+			process.platform === 'win32' ?
+				'kernel-wrapper.bat' :
+				'kernel-wrapper.sh');
+		const logArg = [logFile];
+
 		// Use the VS Code terminal API to create a terminal for the kernel
 		vscode.window.createTerminal(<vscode.TerminalOptions>{
 			name: this._spec.display_name,
-			shellPath: args[0],
-			shellArgs: args.slice(1),
+			shellPath: kernelWrapperPath,
+			shellArgs: logArg.concat(args),
 			env,
-			message: `** ${this._spec.display_name} **`,
+			message: '',
 			hideFromUser: !showTerminal,
 			isTransient: false
 		});

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -145,10 +145,10 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 						`${this._spec.display_name} failed to start; exit code: ${closedTerminal.exitStatus?.code}`);
 				} else {
 					// Otherwise, we exited normally (but print the exit code anyway)
-					this.setStatus(positron.RuntimeState.Exited);
 					this.log(
 						`${this._spec.display_name} exited with code ${closedTerminal.exitStatus?.code}`);
 				}
+				this.setStatus(positron.RuntimeState.Exited);
 			}
 		});
 	}

--- a/extensions/jupyter-adapter/src/JupyterSession.ts
+++ b/extensions/jupyter-adapter/src/JupyterSession.ts
@@ -40,13 +40,12 @@ export class JupyterSession implements vscode.Disposable {
 	}
 
 	dispose() {
-		// Remove the connection and log files if they exist
+		// Remove the connection file
 		if (fs.existsSync(this.state.connectionFile)) {
 			fs.unlinkSync(this.state.connectionFile);
 		}
-		if (fs.existsSync(this.state.logFile)) {
-			fs.unlinkSync(this.state.logFile);
-		}
+		// Note that we don't remove the log file, so we can still see what
+		// happened if the kernel crashed or failed to start.
 	}
 
 	get key(): string {

--- a/extensions/jupyter-adapter/src/StartupFailure.ts
+++ b/extensions/jupyter-adapter/src/StartupFailure.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Represents a failure that occured during kernel startup; thrown as an error
+ * from all code paths that can fail during startup.
+ */
+export class StartupFailure {
+	constructor(
+		public readonly message: string,
+		public readonly details: string,
+	) { }
+}

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -752,15 +752,18 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 	 * @returns A Thenable that resolves with information about the runtime
 	 */
 	start(): Promise<positron.LanguageRuntimeInfo> {
-		// Zed 0.98.0 always fails to start.
+		// Zed 0.98.0 always fails to start. Simulate this by going directly
+		// from Starting to Exited and rejecting the promise with a multi-line
+		// error message.
 		if (this.metadata.runtimeId === '00000000-0000-0000-0000-000000000098') {
 			this._onDidChangeRuntimeState.fire(positron.RuntimeState.Uninitialized);
 			this._onDidChangeRuntimeState.fire(positron.RuntimeState.Initializing);
 			this._onDidChangeRuntimeState.fire(positron.RuntimeState.Starting);
-			this.simulateErrorMessage(randomUUID(), 'StartupFailed', 'Startup failed');
-			this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exiting);
 			this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
-			return Promise.reject('Failure');
+			return Promise.reject({
+				message: 'Zed Startup failed',
+				details: `Zed 0.98.0 always fails to start.\nFailure occured at ${new Date().toLocaleString()}.`
+			});
 		}
 
 		return new Promise<positron.LanguageRuntimeInfo>((resolve, reject) => {

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -427,7 +427,12 @@ declare module 'positron' {
 		/** Reply to a prompt issued by the runtime */
 		replyToPrompt(id: string, reply: string): void;
 
-		/** Start the runtime; returns a Thenable that resolves with information about the runtime. */
+		/**
+		 * Start the runtime; returns a Thenable that resolves with information about the runtime.
+		 * If the runtime fails to start for any reason, the Thenable should reject with an error
+		 * object containing a `message` field with a human-readable error message and an optional
+		 * `details` field with additional information.
+		 */
 		start(): Thenable<LanguageRuntimeInfo>;
 
 		/** Interrupt the runtime */

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -206,6 +206,7 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 				this._startupEmitter.fire(info);
 				resolve(info);
 			}).catch((err) => {
+				this._startupFailureEmitter.fire(err);
 				reject(err);
 			});
 		});

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -9,7 +9,7 @@ import {
 	ExtHostPositronContext
 } from '../../common/positron/extHost.positron.protocol';
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
-import { ILanguageRuntime, ILanguageRuntimeInfo, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeService, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeInfo, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeService, ILanguageRuntimeStartupFailure, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { Event, Emitter } from 'vs/base/common/event';
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
@@ -25,6 +25,7 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 
 	private readonly _stateEmitter = new Emitter<RuntimeState>();
 	private readonly _startupEmitter = new Emitter<ILanguageRuntimeInfo>();
+	private readonly _startupFailureEmitter = new Emitter<ILanguageRuntimeStartupFailure>();
 
 	private readonly _onDidReceiveRuntimeMessageOutputEmitter = new Emitter<ILanguageRuntimeMessageOutput>();
 	private readonly _onDidReceiveRuntimeMessageStreamEmitter = new Emitter<ILanguageRuntimeMessageStream>();
@@ -46,6 +47,7 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 		// Bind events to emitters
 		this.onDidChangeRuntimeState = this._stateEmitter.event;
 		this.onDidCompleteStartup = this._startupEmitter.event;
+		this.onDidEncounterStartupFailure = this._startupFailureEmitter.event;
 
 		// Listen to state changes and track the current state
 		this.onDidChangeRuntimeState((state) => {
@@ -56,6 +58,8 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 	onDidChangeRuntimeState: Event<RuntimeState>;
 
 	onDidCompleteStartup: Event<ILanguageRuntimeInfo>;
+
+	onDidEncounterStartupFailure: Event<ILanguageRuntimeStartupFailure>;
 
 	onDidReceiveRuntimeMessageOutput = this._onDidReceiveRuntimeMessageOutputEmitter.event;
 	onDidReceiveRuntimeMessageStream = this._onDidReceiveRuntimeMessageStreamEmitter.event;

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -206,9 +206,26 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 				this._startupEmitter.fire(info);
 				resolve(info);
 			}).catch((err) => {
-				this._startupFailureEmitter.fire(
-					{ message: err, details: '' } satisfies ILanguageRuntimeStartupFailure);
-				reject(err);
+				// Examine the error object to see what kind of failure it is
+				if (err.message && err.details) {
+					// We have an error message and details; use both
+					this._startupFailureEmitter.fire(err satisfies ILanguageRuntimeStartupFailure);
+					reject(err.message);
+				} else if (err.message) {
+					// We only have a message.
+					this._startupFailureEmitter.fire({
+						message: err.message,
+						details: ''
+					} satisfies ILanguageRuntimeStartupFailure);
+					reject(err.message);
+				} else {
+					// Not an error object, or it doesn't have a message; just use the string
+					this._startupFailureEmitter.fire({
+						message: err.toString(),
+						details: ''
+					} satisfies ILanguageRuntimeStartupFailure);
+					reject(err);
+				}
 			});
 		});
 	}

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -206,7 +206,8 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 				this._startupEmitter.fire(info);
 				resolve(info);
 			}).catch((err) => {
-				this._startupFailureEmitter.fire(err);
+				this._startupFailureEmitter.fire(
+					{ message: err, details: '' } satisfies ILanguageRuntimeStartupFailure);
 				reject(err);
 			});
 		});

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -29,6 +29,8 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 			}
 			this._runtimes[handle].start().then(info => {
 				resolve(info);
+			}, err => {
+				reject(err);
 			});
 		});
 	}

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeNotebook.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeNotebook.ts
@@ -6,7 +6,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
 import { ILogService } from 'vs/platform/log/common/log';
-import { ILanguageRuntime, ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeInfo, ILanguageRuntimeMetadata, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, IRuntimeClientInstance, LanguageRuntimeStartupBehavior, RuntimeClientType, RuntimeCodeFragmentStatus, RuntimeOnlineState, RuntimeState, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageStream } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeMessageError, ILanguageRuntimeMessageEvent, ILanguageRuntimeInfo, ILanguageRuntimeMetadata, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, IRuntimeClientInstance, LanguageRuntimeStartupBehavior, RuntimeClientType, RuntimeCodeFragmentStatus, RuntimeOnlineState, RuntimeState, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageStream, ILanguageRuntimeStartupFailure } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
 import { CellEditType, CellKind } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { INotebookExecutionStateService } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
@@ -39,6 +39,9 @@ export class NotebookLanguageRuntime extends Disposable implements ILanguageRunt
 
 	/** Emitter for runtime startup event */
 	private readonly _startup: Emitter<ILanguageRuntimeInfo>;
+
+	/** Emitter for runtime startup failure event */
+	private readonly _failure: Emitter<ILanguageRuntimeStartupFailure>;
 
 	private readonly _onDidReceiveRuntimeMessageOutputEmitter = new Emitter<ILanguageRuntimeMessageOutput>();
 	private readonly _onDidReceiveRuntimeMessageStreamEmitter = new Emitter<ILanguageRuntimeMessageStream>();
@@ -86,6 +89,9 @@ export class NotebookLanguageRuntime extends Disposable implements ILanguageRunt
 
 		this._startup = this._register(new Emitter<ILanguageRuntimeInfo>());
 		this.onDidCompleteStartup = this._startup.event;
+
+		this._failure = this._register(new Emitter<ILanguageRuntimeStartupFailure>());
+		this.onDidEncounterStartupFailure = this._failure.event;
 
 		// Listen to our own messages and track current state
 		this.onDidChangeRuntimeState((state) => {
@@ -179,6 +185,7 @@ export class NotebookLanguageRuntime extends Disposable implements ILanguageRunt
 	}
 
 	onDidCompleteStartup: Event<ILanguageRuntimeInfo>;
+	onDidEncounterStartupFailure: Event<ILanguageRuntimeStartupFailure>;
 
 	onDidChangeRuntimeState: Event<RuntimeState>;
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -29,6 +29,8 @@ import { RuntimeReconnected } from 'vs/workbench/contrib/positronConsole/browser
 import { RuntimeItemReconnected } from 'vs/workbench/services/positronConsole/common/classes/runtimeItemReconnected';
 import { RuntimeCodeExecutionMode, RuntimeErrorBehavior } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IPositronConsoleInstance, PositronConsoleState } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
+import { RuntimeItemStartupFailure } from 'vs/workbench/services/positronConsole/common/classes/runtimeItemStartupFailure';
+import { RuntimeStartupFailure } from 'vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure';
 
 // ConsoleInstanceProps interface.
 interface ConsoleInstanceProps {
@@ -124,6 +126,8 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			return <RuntimeOffline key={runtimeItem.id} runtimeItemOffline={runtimeItem} />;
 		} else if (runtimeItem instanceof RuntimeItemExited) {
 			return <RuntimeExited key={runtimeItem.id} runtimeItemExited={runtimeItem} />;
+		} else if (runtimeItem instanceof RuntimeItemStartupFailure) {
+			return <RuntimeStartupFailure key={runtimeItem.id} runtimeItemStartupFailure={runtimeItem} />;
 		} else if (runtimeItem instanceof RuntimeItemTrace) {
 			return trace && <RuntimeTrace key={runtimeItem.id} runtimeItemTrace={runtimeItem} />;
 		} else {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure.css
@@ -8,3 +8,7 @@
 	padding-top: 1em;
 	padding-bottom: 1em;
 }
+
+.runtime-startup-failure .message {
+	font-weight: bold;
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure.css
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+.runtime-startup-failure {
+	color: red;
+	padding-left: 14px;
+	padding-top: 1em;
+	padding-bottom: 1em;
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure.tsx
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'vs/css!./runtimeStartupFailure';
+import * as React from 'react';
+import { OutputLines } from 'vs/workbench/contrib/positronConsole/browser/components/outputLines';
+import { RuntimeItemStartupFailure } from 'vs/workbench/services/positronConsole/common/classes/runtimeItemStartupFailure';
+
+// RuntimeStartupFailureProps interface.
+export interface RuntimeStartupFailureProps {
+	runtimeItemStartupFailure: RuntimeItemStartupFailure;
+}
+
+/**
+ * RuntimeStartupFailure component.
+ * @param props A RuntimeStartupFailureProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const RuntimeStartupFailure = ({ runtimeItemStartupFailure }: RuntimeStartupFailureProps) => {
+	// Render.
+	return (
+		<div className='runtime-startup-failure'>
+			<OutputLines outputLines={runtimeItemStartupFailure.outputLines} />
+		</div>
+	);
+};

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure.tsx
@@ -21,6 +21,7 @@ export const RuntimeStartupFailure = ({ runtimeItemStartupFailure }: RuntimeStar
 	// Render.
 	return (
 		<div className='runtime-startup-failure'>
+			<div className='message'>{runtimeItemStartupFailure.message}</div>
 			<OutputLines outputLines={runtimeItemStartupFailure.outputLines} />
 		</div>
 	);

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -152,6 +152,15 @@ export interface ILanguageRuntimeInfo {
 	language_version: string;
 }
 
+/** LanguageRuntimeInfo contains metadata about the runtime after it has started. */
+export interface ILanguageRuntimeStartupFailure {
+	/** The error message to show to the user; at most one line of text */
+	message: string;
+
+	/** Error details, logs, etc. as a multi-line string */
+	details: string;
+}
+
 /**
  * Possible error dispositions for a language runtime
  */
@@ -310,6 +319,9 @@ export interface ILanguageRuntime {
 
 	/** An object that emits an event when the runtime completes startup */
 	onDidCompleteStartup: Event<ILanguageRuntimeInfo>;
+
+	/** An object that emits an event when runtime startup fails */
+	onDidEncounterStartupFailure: Event<ILanguageRuntimeStartupFailure>;
 
 	onDidReceiveRuntimeMessageOutput: Event<ILanguageRuntimeMessageOutput>;
 	onDidReceiveRuntimeMessageStream: Event<ILanguageRuntimeMessageStream>;

--- a/src/vs/workbench/services/positronConsole/common/classes/runtimeItemStartupFailure.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/runtimeItemStartupFailure.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ANSIOutput, ANSIOutputLine } from 'vs/base/common/ansi/ansiOutput';
+import { RuntimeItem } from 'vs/workbench/services/positronConsole/common/classes/runtimeItem';
+
+/**
+ * RuntimeItemStartup class.
+ */
+export class RuntimeItemStartupFailure extends RuntimeItem {
+	//#region Public Properties
+
+	/**
+	 * Gets the output lines.
+	 */
+	readonly outputLines: readonly ANSIOutputLine[];
+
+	//#endregion Public Properties
+
+	//#region Constructor
+
+	/**
+	 * Constructor.
+	 * @param id The identifier.
+	 * @param message The failure message.
+	 * @param details The failure details or logs.
+	 */
+	constructor(
+		id: string,
+		message: string,
+		details: string,
+	) {
+		// Call the base class's constructor.
+		super(id);
+
+		// Process the message and details directly into ANSI output lines. In the future, we
+		// may want to do something more sophisticated here.
+		this.outputLines = [
+			...ANSIOutput.processOutput(message),
+			...ANSIOutput.processOutput(details),
+		];
+	}
+
+	//#endregion Constructor
+}

--- a/src/vs/workbench/services/positronConsole/common/classes/runtimeItemStartupFailure.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/runtimeItemStartupFailure.ts
@@ -16,6 +16,11 @@ export class RuntimeItemStartupFailure extends RuntimeItem {
 	 */
 	readonly outputLines: readonly ANSIOutputLine[];
 
+	/**
+	 * Gets the failure message.
+	 */
+	readonly message: string;
+
 	//#endregion Public Properties
 
 	//#region Constructor
@@ -29,14 +34,15 @@ export class RuntimeItemStartupFailure extends RuntimeItem {
 	constructor(
 		id: string,
 		message: string,
-		_details: string,
+		details: string,
 	) {
 		// Call the base class's constructor.
 		super(id);
 
 		// Process the message directly into ANSI output lines. In the future, we
 		// may want to do something more sophisticated here.
-		this.outputLines = ANSIOutput.processOutput(message);
+		this.message = message;
+		this.outputLines = ANSIOutput.processOutput(details);
 	}
 
 	//#endregion Constructor

--- a/src/vs/workbench/services/positronConsole/common/classes/runtimeItemStartupFailure.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/runtimeItemStartupFailure.ts
@@ -6,7 +6,7 @@ import { ANSIOutput, ANSIOutputLine } from 'vs/base/common/ansi/ansiOutput';
 import { RuntimeItem } from 'vs/workbench/services/positronConsole/common/classes/runtimeItem';
 
 /**
- * RuntimeItemStartup class.
+ * RuntimeItemStartupFailure class.
  */
 export class RuntimeItemStartupFailure extends RuntimeItem {
 	//#region Public Properties
@@ -29,17 +29,14 @@ export class RuntimeItemStartupFailure extends RuntimeItem {
 	constructor(
 		id: string,
 		message: string,
-		details: string,
+		_details: string,
 	) {
 		// Call the base class's constructor.
 		super(id);
 
-		// Process the message and details directly into ANSI output lines. In the future, we
+		// Process the message directly into ANSI output lines. In the future, we
 		// may want to do something more sophisticated here.
-		this.outputLines = [
-			...ANSIOutput.processOutput(message),
-			...ANSIOutput.processOutput(details),
-		];
+		this.outputLines = ANSIOutput.processOutput(message);
 	}
 
 	//#endregion Constructor

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -344,6 +344,16 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	private _runtimeDisposableStore = new DisposableStore();
 
 	/**
+	 * Gets or sets the runtime state.
+	 */
+	private _runtimeState: RuntimeState = RuntimeState.Uninitialized;
+
+	/**
+	 * Whether or not we are currently attached to the runtime.
+	 */
+	private _runtimeAttached = false;
+
+	/**
 	 * Gets or sets the state.
 	 */
 	private _state = PositronConsoleState.Uninitialized;
@@ -596,6 +606,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * @param starting A value which indicates whether the runtime is starting.
 	 */
 	private attachRuntime(starting: boolean) {
+		// Mark the runtime as attached.
+		this._runtimeAttached = true;
+
 		// Set the state and add the appropriate runtime item to indicate whether the Positron
 		// console instance is is starting or is reconnected.
 		if (starting) {
@@ -616,8 +629,37 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		this._runtimeDisposableStore.add(this._runtime.onDidChangeRuntimeState(runtimeState => {
 			this.addRuntimeItemTrace(`onDidChangeRuntimeState (${runtimeState})`);
 			if (runtimeState === RuntimeState.Exited) {
-				this.detachRuntime();
+				if (this._runtimeState === RuntimeState.Starting ||
+					this._runtimeState === RuntimeState.Initializing) {
+					// If we moved directly from Starting or Initializing to
+					// Exited, then we probably encountered a startup
+					// failure, and will be receiving a
+					// `onDidEncounterStartupFailure` event shortly.  In this
+					// case, we don't want to detach the runtime, because we
+					// want to keep the onDidEncounterStartupFailure event
+					// handler attached.
+					//
+					// We don't want to wait forever, though, so we'll set a
+					// timeout to detach the runtime if we don't receive a
+					// onDidEncounterStartupFailure event within a reasonable
+					// amount of time.
+					setTimeout(() => {
+						// If we're still in the Exited state and haven't
+						// disposed, then do it now.
+						if (this._runtimeState === RuntimeState.Exited && this._runtimeAttached) {
+							this.detachRuntime();
+						}
+					}, 1000);
+				} else if (this._runtimeAttached) {
+					// We exited from a state other than Starting or Initializing, so this is a
+					// "normal" exit, or at least not a startup failure. Detach the runtime.
+					this.detachRuntime();
+				}
 			}
+
+			// Remember this runtime state so we know which state we are
+			// transitioning from when the next state change occurs.
+			this._runtimeState = runtimeState;
 		}));
 
 		// Add the onDidCompleteStartup event handler.
@@ -634,7 +676,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			));
 		}));
 
-		// Add the onDidEncounterStartupFailure event handler.
+		// Add the onDidEncounterStartupFailure event handler. This can arrive before or after
+		// the state change to Exited, so we need to handle it in both places.
 		this._runtimeDisposableStore.add(this._runtime.onDidEncounterStartupFailure(startupFailure => {
 			// Add item trace.
 			this.addRuntimeItemTrace(`onDidEncounterStartupFailure`);
@@ -645,6 +688,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				startupFailure.message,
 				startupFailure.details,
 			));
+
+			// If we haven't already detached the runtime, do it now.
+			if (this._runtimeState === RuntimeState.Exited && this._runtimeAttached) {
+				this.detachRuntime();
+			}
 		}));
 
 		// Add the onDidReceiveRuntimeMessageOutput event handler.
@@ -781,13 +829,22 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * Detaches from a runtime.
 	 */
 	private detachRuntime() {
-		this._runtimeDisposableStore.dispose();
-		this._runtimeDisposableStore = new DisposableStore();
+		if (this._runtimeAttached) {
+			// We are currently attached; detach.
+			this._runtimeAttached = false;
 
-		this.addRuntimeItem(new RuntimeItemExited(
-			generateUuid(),
-			`${this._runtime.metadata.runtimeName} ${this._runtime.metadata.languageVersion} has exited.`
-		));
+			// Dispose of the runtime event handlers.
+			this._runtimeDisposableStore.dispose();
+			this._runtimeDisposableStore = new DisposableStore();
+
+			this.addRuntimeItem(new RuntimeItemExited(
+				generateUuid(),
+				`${this._runtime.metadata.runtimeName} ${this._runtime.metadata.languageVersion} has exited.`
+			));
+		} else {
+			// We are not currently attached; warn.
+			console.warn(`Attempt to detach already detached runtime ${this._runtime.metadata.runtimeName}.`);
+		}
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -24,6 +24,7 @@ import { ActivityItemErrorMessage } from 'vs/workbench/services/positronConsole/
 import { ActivityItemOutputMessage } from 'vs/workbench/services/positronConsole/common/classes/activityItemOutputMessage';
 import { IPositronConsoleInstance, IPositronConsoleService, PositronConsoleState } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
 import { formatLanguageRuntime, ILanguageRuntime, ILanguageRuntimeMessage, ILanguageRuntimeService, RuntimeOnlineState, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { RuntimeItemStartupFailure } from 'vs/workbench/services/positronConsole/common/classes/runtimeItemStartupFailure';
 
 //#region Helper Functions
 
@@ -630,6 +631,19 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				languageRuntimeInfo.banner,
 				languageRuntimeInfo.implementation_version,
 				languageRuntimeInfo.language_version
+			));
+		}));
+
+		// Add the onDidEncounterStartupFailure event handler.
+		this._runtimeDisposableStore.add(this._runtime.onDidEncounterStartupFailure(startupFailure => {
+			// Add item trace.
+			this.addRuntimeItemTrace(`onDidEncounterStartupFailure`);
+
+			// Add the item startup.
+			this.addRuntimeItem(new RuntimeItemStartupFailure(
+				generateUuid(),
+				startupFailure.message,
+				startupFailure.details,
 			));
 		}));
 


### PR DESCRIPTION
This change improves the handling of runtime startup failures. Previously, a runtime that failed to start would appear (to the UI) to just get stuck in the `starting` state, never completing startup. No output or errors were visible to the user.

After the change, an explanation of the startup failure appears in the UI.

<img width="690" alt="image" src="https://user-images.githubusercontent.com/470418/227590532-50ec479c-c7b7-4336-8ec8-65fbde318a39.png">

Here's how it is done:

- A wrapper script captures all the output of the Jupyter Kernels as they start up. 
- Inside the Jupyter Kernel adapter, all codepaths that could fail during startup emit a rich error object when they fail. This object includes the output of the kernel during startup as captured by the wrapper.
- Various codepaths that didn't propagate errors correctly have been fixed up, and timeouts have been added to ensure that no part of startup is capable of waiting forever. 
- There is a new event emitter on the Positron side for language runtimes that, `onDidEncounterStartupFailure`. This event fires when a runtime fails to start up. It is fired after the runtime exits to let the UI know that the runtime exited due a startup failure. 

Fixes https://github.com/rstudio/positron/issues/307. 