### PR TITLE
Add plumbing for comm_open (for backend -> frontend)

### DIFF
--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -27,6 +27,7 @@ import { JupyterHistoryRequest } from './JupyterHistoryRequest';
 import { findAvailablePort } from './PortFinder';
 import { JupyterCommMsg } from './JupyterCommMsg';
 import { JupyterCommClose } from './JupyterCommClose';
+import { JupyterCommOpen } from './JupyterCommOpen';
 
 /**
  * LangaugeRuntimeAdapter wraps a JupyterKernel in a LanguageRuntime compatible interface.
@@ -422,6 +423,9 @@ export class LanguageRuntimeAdapter
 			case 'input_request':
 				this.onInputRequest(msg, message as JupyterInputRequest);
 				break;
+			case 'comm_open':
+				this.onCommOpen(msg, message as JupyterCommOpen);
+				break;
 			case 'comm_msg':
 				this.onCommMessage(msg, message as JupyterCommMsg);
 				break;
@@ -447,6 +451,26 @@ export class LanguageRuntimeAdapter
 			prompt: req.prompt,
 			password: req.password,
 		} as positron.LanguageRuntimePrompt);
+	}
+
+	/**
+	 * Delivers a comm_open message from the kernel to the front end. Typically
+	 * this is used to create a front-end representation of a back-end
+	 * object, such as an interactive plot or Jupyter widget.
+	 *
+	 * @param message The outer message packet
+	 * @param msg The inner comm_open message
+	 */
+	private onCommOpen(message: JupyterMessagePacket, msg: JupyterCommOpen): void {
+		this._messages.fire({
+			id: message.msgId,
+			parent_id: message.originId,
+			when: message.when,
+			type: positron.LanguageRuntimeMessageType.CommOpen,
+			comm_id: msg.comm_id,
+			target_name: msg.target_name,
+			data: msg.data,
+		} as positron.LanguageRuntimeCommOpen);
 	}
 
 	/**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -34,6 +34,9 @@ declare module 'positron' {
 		/** A message representing a runtime event */
 		Event = 'event',
 
+		/** A message representing a new comm (client instance) being opened from the rutime side */
+		CommOpen = 'comm_open',
+
 		/** A message representing data received via a comm (to a client instance) */
 		CommData = 'comm_data',
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -247,6 +247,21 @@ declare module 'positron' {
 		traceback: Array<string>;
 	}
 
+	/**
+	 * LanguageRuntimeCommOpen is a LanguageRuntimeMessage that indicates a
+	 * comm (client instance) was opened from the server side
+	 */
+	export interface LanguageRuntimeCommOpen extends LanguageRuntimeMessage {
+		/** The unique ID of the comm being opened */
+		comm_id: string;
+
+		/** The name (type) of the comm being opened, e.g. 'jupyter.widget' */
+		target_name: string;
+
+		/** The data from the back-end */
+		data: object;
+	}
+
 	/** LanguageRuntimeCommMessage is a LanguageRuntimeMessage that represents data for a comm (client instance) */
 	export interface LanguageRuntimeCommMessage extends LanguageRuntimeMessage {
 		/** The unique ID of the client comm ID for which the message is intended */

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4030,6 +4030,9 @@ export enum LanguageRuntimeMessageType {
 	/** A message representing a runtime event */
 	Event = 'event',
 
+	/** A message representing a new comm (client instance) being opened from the rutime side */
+	CommOpen = 'comm_open',
+
 	/** A message representing data received via a comm */
 	CommData = 'comm_data',
 

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -73,6 +73,9 @@ export enum LanguageRuntimeMessageType {
 	/** A message representing a runtime event */
 	Event = 'event',
 
+	/** A message representing a new comm (client instance) being opened from the rutime side */
+	CommOpen = 'comm_open',
+
 	/** A message representing data received via a comm */
 	CommData = 'comm_data',
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -70,6 +70,18 @@ export interface ILanguageRuntimeMessagePrompt extends ILanguageRuntimeMessage {
 	password: boolean;
 }
 
+/** ILanguageRuntimeMessageCommOpen is a LanguageRuntimeMessage representing a comm open request */
+export interface ILanguageRuntimeMessageCommOpen extends ILanguageRuntimeMessage {
+	/** The comm ID */
+	comm_id: string;
+
+	/** The target name of the comm to open, e.g. 'jupyter.widget' */
+	target_name: string;
+
+	/** Data associated with the request (e.g. parameters to client-side comm constructor) */
+	data: object;
+}
+
 /** ILanguageRuntimeMessageCommData is a LanguageRuntimeMessage representing data received from a comm */
 export interface ILanguageRuntimeMessageCommData extends ILanguageRuntimeMessage {
 	/** The comm ID */

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -214,6 +214,9 @@ export enum LanguageRuntimeMessageType {
 	/** A message representing a runtime event */
 	Event = 'event',
 
+	/** A message representing a new comm (client instance) being opened from the runtime side */
+	CommOpen = 'comm_open',
+
 	/** A message representing data received via a comm */
 	CommData = 'comm_data',
 


### PR DESCRIPTION
We already support `comm_open` from the frontend to backend, but not the other way around. This other path is important as an underpinning for showing interactive content in the Plots pane (it's how all Jupyter widgets work), so this PR enables it. 