### PR TITLE
Add 'type' to EnvironmentVariable

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeEnvironmentClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeEnvironmentClient.ts
@@ -114,6 +114,9 @@ export interface IEnvironmentVariable {
 	/// The size of the variable's value, in bytes
 	size: number;
 
+	/// A compact representation of the variable's type (and length, if applicable) for display
+	type: string;
+
 	/// True if the variable contains other variables
 	has_children: boolean;
 

--- a/src/vs/workbench/services/positronEnvironment/common/classes/environmentVariableItem.ts
+++ b/src/vs/workbench/services/positronEnvironment/common/classes/environmentVariableItem.ts
@@ -66,6 +66,13 @@ export class EnvironmentVariableItem {
 	}
 
 	/**
+	 * Gets the type summary of value for display.
+	 */
+	get type() {
+		return this._environmentVariable.data.type;
+	}
+
+	/**
 	 * Gets a value which indicates whether the variable contains child variables.
 	 */
 	get hasChildren() {


### PR DESCRIPTION
Runtimes can add a type summary for display with environment variables, which is intended to be an informative but compact representation. The runtime may choose to leave the type unqualified if the context is understood, and decorate the type with length information if it represents a collection.

We may allow a runtime to describe a fully qualified type name in a separate property if a different UI treatment is required.


