### PR TITLE
Bump python to pick up env pane display_type summaries

### DIFF
--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariable.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariable.tsx
@@ -64,7 +64,7 @@ export const EnvironmentVariable = (props: EnvironmentVariableProps) => {
 			</div>
 			{props.typeColumnVisible && (
 				<div className='type' style={{ width: props.typeColumnWidth }}>
-					{props.environmentVariableItem.kind}
+					{props.environmentVariableItem.type}
 				</div>
 			)}
 			<div className='value' style={{ width: props.valueColumnWidth }}>

--- a/src/vs/workbench/services/positronEnvironment/common/classes/environmentVariableItem.ts
+++ b/src/vs/workbench/services/positronEnvironment/common/classes/environmentVariableItem.ts
@@ -66,6 +66,13 @@ export class EnvironmentVariableItem {
 	}
 
 	/**
+	 * Gets the type of the variable's value to display.
+	 */
+	get type() {
+		return this._environmentVariable.data.display_type;
+	}
+
+	/**
 	 * Gets a value which indicates whether the variable contains child variables.
 	 */
 	get hasChildren() {


### PR DESCRIPTION
Types with values with a 'length', such as collections, will include the length in the display_type, e.g. list [5]


