### PR TITLE
Use DYLD_FALLBACK_LIBRARY_PATH workaround for SIP

### DIFF
--- a/extensions/jupyter-adapter/resources/kernel-wrapper.sh
+++ b/extensions/jupyter-adapter/resources/kernel-wrapper.sh
@@ -22,6 +22,14 @@ fi
 output_file="$1"
 shift
 
+# If the POSITRON_DYLD_FALLBACK_LIBRARY_PATH environment variable is set, then
+# set it as the DYLD_FALLBACK_LIBRARY_PATH environment variable for the program
+# we are about to run. This is a workaround for behavior on macOS wherein SIP
+# prevents DYLD_FALLBACK_LIBRARY_PATH from being inherited.
+if [ -n "$POSITRON_DYLD_FALLBACK_LIBRARY_PATH" ]; then
+	export DYLD_FALLBACK_LIBRARY_PATH="$POSITRON_DYLD_FALLBACK_LIBRARY_PATH"
+fi
+
 # Run the program with its arguments, redirecting stdout and stderr to the output file
 "$@" > "$output_file" 2>&1
 

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -133,7 +133,13 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 				dyldFallbackLibraryPaths.push(defaultDyldFallbackLibraryPath);
 			}
 
-			env['DYLD_FALLBACK_LIBRARY_PATH'] = dyldFallbackLibraryPaths.join(':');
+			// Set the DYLD_FALLBACK_LIBRARY_PATH to include the R installation.
+			// This specific environment variable can be blocked from being
+			// inherited by child processes on macOS with SIP enabled, so we
+			// prefix it with 'POSITRON_' here. The script that starts the
+			// kernel will check for this variable and set it as
+			// DYLD_FALLBACK_LIBRARY_PATH if it's present.
+			env['POSITRON_DYLD_FALLBACK_LIBRARY_PATH'] = dyldFallbackLibraryPaths.join(':');
 
 		}
 


### PR DESCRIPTION
Uses an alternate variable name to workaround macOS SIP policy that prevents this value from being inherited as we need it to for R.