### PR TITLE
Speculative fix for intermittent comm_id unit test failure

### DIFF
--- a/extensions/positron-r/amalthea/crates/amalthea/tests/client.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/tests/client.rs
@@ -304,6 +304,11 @@ fn test_kernel() {
         data: serde_json::Value::Null,
     });
 
+    // Absorb the IOPub messages that the kernel sends back during the
+    // processing of the above `CommOpen` request
+    frontend.receive_iopub(); // Busy
+    frontend.receive_iopub(); // Idle
+
     info!("Requesting comm info from the kernel (to test opening from the front end)");
     frontend.send_shell(CommInfoRequest {
         target_name: "environment".to_string(),


### PR DESCRIPTION
This change is a speculative fix for the intermittent following unit test failure:

```
---- test_kernel stdout ----
thread 'test_kernel' panicked at 'assertion failed: comms.contains_key(comm_id)', crates/amalthea/tests/client.rs:317:13
```

This fix is to implement busy/idle wrappers around the shell messages that handle comm open/comm message handling. This is what they are supposed to do anyway (as per the kernel spec), and emitting these/handling them gives the system time to reconcile the state. 