### PR TITLE
name threads spawned in amalthea

### DIFF
--- a/extensions/positron-r/amalthea/Cargo.lock
+++ b/extensions/positron-r/amalthea/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "stdext",
  "strum",
  "strum_macros",
  "uuid",

--- a/extensions/positron-r/amalthea/crates/amalthea/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/amalthea/Cargo.toml
@@ -18,6 +18,7 @@ nix = "0.26.2"
 serde = { version = "1.0.154", features = ["derive"] }
 serde_json = "1.0.94"
 sha2 = "0.10.6"
+stdext = { path = "../stdext" }
 uuid = { version = "1.3.0", features = ["v4"] }
 zmq = "0.10.0"
 strum = "0.24"

--- a/extensions/positron-r/amalthea/crates/amalthea/src/comm/comm_manager.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/src/comm/comm_manager.rs
@@ -13,6 +13,7 @@ use crossbeam::channel::Select;
 use crossbeam::channel::Sender;
 use log::info;
 use log::warn;
+use stdext::spawn;
 
 use crate::comm::comm_channel::CommChannelMsg;
 use crate::comm::event::CommChanged;
@@ -47,7 +48,7 @@ impl CommManager {
         comm_event_rx: Receiver<CommEvent>,
     ) -> Receiver<CommChanged> {
         let (comm_changed_tx, comm_changed_rx) = crossbeam::channel::unbounded();
-        thread::spawn(move || {
+        spawn!("comm-manager", move || {
             let mut comm_manager = CommManager::new(iopub_tx, comm_event_rx, comm_changed_tx);
             loop {
                 comm_manager.execution_thread();

--- a/extensions/positron-r/amalthea/crates/amalthea/src/comm/comm_manager.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/src/comm/comm_manager.rs
@@ -6,7 +6,6 @@
  */
 
 use std::collections::HashMap;
-use std::thread;
 
 use crossbeam::channel::Receiver;
 use crossbeam::channel::Select;

--- a/extensions/positron-r/amalthea/crates/amalthea/tests/client.rs
+++ b/extensions/positron-r/amalthea/crates/amalthea/tests/client.rs
@@ -35,7 +35,7 @@ mod shell;
 fn test_kernel() {
     let frontend = frontend::Frontend::new();
     let connection_file = frontend.get_connection_file();
-    let mut kernel = Kernel::new(connection_file).unwrap();
+    let mut kernel = Kernel::new("amalthea", connection_file).unwrap();
     let shell_tx = kernel.create_iopub_tx();
     let comm_manager_tx = kernel.create_comm_manager_tx();
     let shell = Arc::new(Mutex::new(shell::Shell::new(shell_tx)));

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
@@ -4,8 +4,6 @@
 // Copyright (C) 2023 by Posit Software, PBC
 //
 //
-use std::thread;
-
 use amalthea::comm::comm_channel::CommChannelMsg;
 use amalthea::socket::comm::CommSocket;
 use crossbeam::channel::select;
@@ -23,6 +21,7 @@ use libR_sys::*;
 use log::debug;
 use log::error;
 use log::warn;
+use stdext::spawn;
 
 use crate::environment::message::EnvironmentMessage;
 use crate::environment::message::EnvironmentMessageClear;
@@ -61,7 +60,7 @@ impl REnvironment {
         }
 
         // Start the execution thread and wait for requests from the front end
-        thread::spawn(move || {
+        spawn!("ark-environment", move || {
             let environment = Self {
                 comm,
                 env,

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/handler.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/handler.rs
@@ -9,7 +9,7 @@ use amalthea::comm::event::CommEvent;
 use amalthea::language::lsp_handler::LspHandler;
 use bus::BusReader;
 use crossbeam::channel::Sender;
-use std::thread;
+use stdext::spawn;
 
 use crate::kernel::KernelInfo;
 use crate::request::Request;
@@ -52,7 +52,9 @@ impl LspHandler for Lsp {
 
         let shell_request_tx = self.shell_request_tx.clone();
         let comm_manager_tx = self.comm_manager_tx.clone();
-        thread::spawn(move || backend::start_lsp(tcp_address, shell_request_tx, comm_manager_tx, lsp_initialized));
+        spawn!("ark-lsp", move || {
+            backend::start_lsp(tcp_address, shell_request_tx, comm_manager_tx, lsp_initialized)
+        });
         return Ok(());
     }
 }

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/help_proxy.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/help_proxy.rs
@@ -13,6 +13,7 @@ use hyper::Body;
 use hyper::client::conn::handshake;
 use hyper::server::conn::Http;
 use hyper::service::service_fn;
+use stdext::spawn;
 use tokio::net::TcpListener;
 use tokio::net::TcpStream;
 
@@ -73,7 +74,7 @@ async fn task(port: i32) -> anyhow::Result<()> {
 }
 
 pub fn start(port: i32) {
-    std::thread::spawn(move || {
+    spawn!("ark-help-proxy", move || {
         match task(port) {
             Ok(value) => log::info!("Help proxy server exited with value {:?}", value),
             Err(error) => log::error!("Help proxy server exited unexpectedly: {}", error),

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/modules.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/modules.rs
@@ -13,6 +13,7 @@ use harp::r_string;
 use harp::r_symbol;
 use libR_sys::*;
 use stdext::local;
+use stdext::spawn;
 use stdext::unwrap::IntoResult;
 use std::collections::HashMap;
 use std::env;
@@ -185,7 +186,7 @@ pub unsafe fn initialize() -> anyhow::Result<RModuleInfo> {
     }
 
     // Create a directory watcher that reloads module files as they are changed.
-    std::thread::spawn({
+    spawn!("ark-watcher", {
         let root = root.clone();
         move || {
             let mut watcher = RModuleWatcher::new(root);

--- a/extensions/positron-r/amalthea/crates/ark/src/main.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/main.rs
@@ -27,7 +27,7 @@ use ark::version::detect_r;
 
 fn start_kernel(connection_file: ConnectionFile, capture_streams: bool) {
     // Create a new kernel from the connection file
-    let mut kernel = match Kernel::new(connection_file) {
+    let mut kernel = match Kernel::new("ark", connection_file) {
         Ok(k) => k,
         Err(e) => {
             error!("Failed to create kernel: {}", e);

--- a/extensions/positron-r/amalthea/crates/ark/src/shell.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/shell.rs
@@ -40,6 +40,7 @@ use harp::r_lock;
 use libR_sys::R_GlobalEnv;
 use log::*;
 use serde_json::json;
+use stdext::spawn;
 
 use crate::environment::r_environment::REnvironment;
 use crate::kernel::KernelInfo;
@@ -66,7 +67,7 @@ impl Shell {
         kernel_init_rx: BusReader<KernelInfo>,
     ) -> Self {
         let iopub_tx = iopub_tx.clone();
-        std::thread::spawn(move || {
+        spawn!("ark-shell", move || {
             Self::execution_thread(iopub_tx, kernel_init_tx, shell_request_rx);
         });
 

--- a/extensions/positron-r/amalthea/crates/echo/src/main.rs
+++ b/extensions/positron-r/amalthea/crates/echo/src/main.rs
@@ -19,7 +19,7 @@ use std::io::stdin;
 use std::sync::{Arc, Mutex};
 
 fn start_kernel(connection_file: ConnectionFile) {
-    let mut kernel = match Kernel::new(connection_file) {
+    let mut kernel = match Kernel::new("echo", connection_file) {
         Ok(k) => k,
         Err(e) => {
             error!("Failed to create kernel: {}", e);

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -291,7 +291,6 @@ pub fn env_bindings(env: SEXP) -> Vec<Binding> {
 unsafe fn frame_bindings(mut frame: SEXP, bindings: &mut Vec<Binding> ) {
     while frame != R_NilValue {
         bindings.push(Binding::new(frame));
-
         frame = CDR(frame);
     }
 }

--- a/extensions/positron-r/amalthea/crates/stdext/src/lib.rs
+++ b/extensions/positron-r/amalthea/crates/stdext/src/lib.rs
@@ -12,6 +12,7 @@ pub mod local;
 pub mod join;
 pub mod push;
 pub mod signals;
+pub mod spawn;
 pub mod unwrap;
 
 #[macro_export]

--- a/extensions/positron-r/amalthea/crates/stdext/src/spawn.rs
+++ b/extensions/positron-r/amalthea/crates/stdext/src/spawn.rs
@@ -1,0 +1,16 @@
+//
+// spawn.rs
+//
+// Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+//
+//
+
+#[macro_export]
+macro_rules! spawn {
+    ($name:expr, $body:expr) => {
+        std::thread::Builder::new()
+            .name($name.to_string())
+            .spawn($body)
+            .unwrap()
+    };
+}


### PR DESCRIPTION
This PR makes life easier when debugging crashes in Ark, as the debugger can now show thread names. For example, the one I'm investigating now:

<img width="2032" alt="Screenshot 2023-04-03 at 9 37 50 PM" src="https://user-images.githubusercontent.com/1976582/229688308-6523d424-35be-44fc-9576-3554f274d2fc.png">

With this PR, we can clearly see the faulting thread is 'ark-shell'.