### PR TITLE
r environment pane expanding of pairlist, aka `LISTSXP`

### DIFF
--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -106,7 +106,7 @@ impl EnvironmentVariable {
             type_info,
         } = binding.get_type();
 
-        let kind = ValueKind::String;
+        let kind = ValueKind::Other;
         let has_children = binding.has_children();
 
         Self {

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -8,6 +8,7 @@
 use harp::environment::Binding;
 use harp::environment::BindingType;
 use harp::environment::BindingValue;
+use harp::environment::env_bindings;
 use harp::exec::RFunction;
 use harp::exec::RFunctionExt;
 use harp::object::RObject;
@@ -150,6 +151,7 @@ impl EnvironmentVariable {
         match r_typeof(*object) {
             VECSXP  => Self::inspect_list(object),
             LISTSXP => Self::inspect_pairlist(object),
+            ENVSXP  => Self::inspect_environment(object),
             _       => Ok(vec![])
         }
     }
@@ -248,4 +250,20 @@ impl EnvironmentVariable {
 
         Ok(out)
     }
+
+    fn inspect_environment(value: RObject) -> Result<Vec<Self>, harp::error::Error> {
+        let mut out : Vec<Self> = vec![];
+
+        for binding in &env_bindings(*value) {
+            out.push(Self::new(binding));
+        }
+
+        // TODO: figure out how to avoid .clone() ?
+        out.sort_by_key(|v| {
+            v.display_name.clone()
+        });
+
+        Ok(out)
+    }
+
 }

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -281,9 +281,8 @@ impl EnvironmentVariable {
             out.push(Self::new(binding));
         }
 
-        // TODO: figure out how to avoid .clone() ?
-        out.sort_by_key(|v| {
-            v.display_name.clone()
+        out.sort_by(|a, b| {
+            a.display_name.cmp(&b.display_name)
         });
 
         Ok(out)

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/modules/public/environment.R
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/modules/public/environment.R
@@ -14,22 +14,3 @@
     }
     names
 }
-
-.ps.environment.resolveObjectFromPath <- function(env, path) {
-    rx_unnamed <- "^[[][[]([[:digit:]])[]][]]"
-
-    # start with environment
-    object <- env
-
-    # and then move down the path
-    for (p in path) {
-        if (grepl(rx_unnamed, p)) {
-            index <- as.integer(sub(rx_unnamed, "\\1", p))
-            object <- object[[index]]
-        } else {
-            object <- object[[p]]
-        }
-    }
-
-    object
-}

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -180,6 +180,7 @@ pub fn has_children(value: SEXP) -> bool {
     match r_typeof(value) {
         VECSXP  => !unsafe{ r_inherits(value, "POSIXlt") },
         LISTSXP => true,
+        ENVSXP => true,
 
         _       => false
     }
@@ -311,6 +312,8 @@ fn regular_binding_type(value: SEXP) -> BindingType {
         BindingType::new(String::from("symbol"), String::from("symbol"))
     } else if rtype == CLOSXP {
         BindingType::new(String::from("function"), String::from("function"))
+    } else if rtype == ENVSXP {
+        BindingType::new(String::from("environment"), String::from("environment"))
     } else {
         let class = first_class(value);
         match class {

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -305,11 +305,12 @@ fn regular_binding_type(value: SEXP) -> BindingType {
                 }
                 // TODO: should type_info be different ?
                 // TODO: deal with record types, e.g. POSIXlt
-
             }
         }
     } else if rtype == SYMSXP {
         BindingType::new(String::from("symbol"), String::from("symbol"))
+    } else if rtype == CLOSXP {
+        BindingType::new(String::from("function"), String::from("function"))
     } else {
         let class = first_class(value);
         match class {


### PR DESCRIPTION
i.e. with 

```r
pl <- pairlist(a = 1, b = list(c = 2, d = 3), 3)
```

we get this: 

<img width="561" alt="image" src="https://user-images.githubusercontent.com/2625526/229816314-ee9fec37-6cc3-48b4-9996-5682ea6f2fb3.png">

This somewhat drifts from what rstudio does, i.e. flatten the pairlist so that it can show it as a `VECSXP` list: 

<img width="351" alt="image" src="https://user-images.githubusercontent.com/2625526/229816892-ba6ffdae-ac54-4658-9beb-e0dc2c9cb587.png">

<img width="576" alt="image" src="https://user-images.githubusercontent.com/2625526/229816992-2a8e3a42-0f36-4705-8158-c905f0a567e2.png">

But the thing is this assumes that the `CDR` of a pairlist is always either another pairlist or `NULL` (to mark the end), but the `CDR` can actually be anything else, so this expands the pairlist into (at most 3 things): tag (a symbol or NULL), car and cdr. 
