### PR TITLE
Require Rust 1.64 (for std::ffi)

### DIFF
--- a/extensions/positron-r/amalthea/crates/amalthea/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/amalthea/Cargo.toml
@@ -2,6 +2,7 @@
 name = "amalthea"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.64.0"
 
 [dependencies]
 amalthea-macros = { path = "./amalthea-macros" }

--- a/extensions/positron-r/amalthea/crates/ark/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/ark/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ark"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.64.0"
 description = """
 The Amalthea R Kernel.
 """

--- a/extensions/positron-r/amalthea/crates/echo/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/echo/Cargo.toml
@@ -2,6 +2,7 @@
 name = "echo"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.64.0"
 
 [dependencies]
 amalthea = { path = "../amalthea" }

--- a/extensions/positron-r/amalthea/crates/harp/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/harp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "harp"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.64.0"
 description = """
 Tools for integrating R and Rust.
 """

--- a/extensions/positron-r/amalthea/crates/stdext/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/stdext/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stdext"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.64.0"
 description = """
 Useful extensions to the Rust standard library.
 """


### PR DESCRIPTION
I was hitting this compile error:

```
error[E0412]: cannot find type `c_char` in this scope
   --> crates/ark/src/interface.rs:212:47
    |
212 |   pub extern "C" fn r_write_console(buf: *const c_char, _buflen: i32, otype: i32) {
    |                                                 ^^^^^^
    |
```

It turned out to be caused by my toolchain; I was using Rust 1.63, but `std::ffi` was introduced in Rust 1.64, and we depend on `c_char` being in `std::ffi` as of this change: https://github.com/rstudio/positron/commit/9345da2c6819b7880bb1c819e8a147f5039643d1

This change makes our dependency on Rust 1.64 formal by adding `rust-version` to our Cargo packages as documented here:

https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field

