### PR TITLE
ensure interrupt handler is reset appropriately

### DIFF
--- a/extensions/positron-r/amalthea/crates/ark/src/interface.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/interface.rs
@@ -97,8 +97,6 @@ static INIT: Once = Once::new();
 
 pub unsafe fn process_events() {
 
-    eprintln!("process_events()");
-
     // Don't process interrupts in this scope.
     let _interrupts_suspended = RInterruptsSuspendedScope::new();
 
@@ -189,6 +187,12 @@ pub extern "C" fn r_read_console(
             Ok(response) => {
                 // Take back the lock after we've received some console input.
                 unsafe { R_RUNTIME_LOCK_GUARD = Some(R_RUNTIME_LOCK.lock()) };
+
+                // If we received an interrupt while the user was typing input,
+                // we can assume the interrupt was 'handled' and so reset the flag.
+                unsafe {
+                    R_interrupts_pending = 0;
+                }
 
                 // Process events.
                 unsafe { process_events() };

--- a/extensions/positron-r/amalthea/crates/ark/src/interface.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/interface.rs
@@ -57,6 +57,24 @@ extern "C" {
 fn initialize_signal_handlers() {
 
     // Reset the signal block.
+    //
+    // This appears to be necessary on macOS; 'sigprocmask()' specifically
+    // blocks the signals in _all_ threads associated with the process, even
+    // when called from a spawned child thread. See:
+    //
+    // https://github.com/opensource-apple/xnu/blob/0a798f6738bc1db01281fc08ae024145e84df927/bsd/kern/kern_sig.c#L1238-L1285
+    // https://github.com/opensource-apple/xnu/blob/0a798f6738bc1db01281fc08ae024145e84df927/bsd/kern/kern_sig.c#L796-L839
+    //
+    // and note that 'sigprocmask()' uses 'block_procsigmask()' to apply the
+    // requested block to all threads in the process:
+    //
+    // https://github.com/opensource-apple/xnu/blob/0a798f6738bc1db01281fc08ae024145e84df927/bsd/kern/kern_sig.c#L571-L599
+    //
+    // We may need to re-visit this on Linux later on, since 'sigprocmask()' and
+    // 'pthread_sigmask()' may only target the executing thread there.
+    //
+    // The behavior of 'sigprocmask()' is unspecified after all, so we're really
+    // just relying on what the implementation happens to do.
     let mut sigset = SigSet::empty();
     sigset.add(SIGINT);
     sigprocmask(SigmaskHow::SIG_BLOCK, Some(&sigset), None).unwrap();
@@ -65,7 +83,9 @@ fn initialize_signal_handlers() {
     pthread_sigmask(SigmaskHow::SIG_UNBLOCK, Some(&sigset), None).unwrap();
 
     // Install an interrupt handler.
-    unsafe { signal(SIGINT, SigHandler::Handler(handle_interrupt)).unwrap(); }
+    unsafe {
+        signal(SIGINT, SigHandler::Handler(handle_interrupt)).unwrap();
+    }
 
 }
 
@@ -276,9 +296,9 @@ pub extern "C" fn r_busy(which: i32) {
     //
     // https://github.com/wch/r-source/blob/e7a21904029917a63b4717b53a173b01eeabcc7b/src/unix/sys-std.c#L171-L178
     //
-    // However, it seems like this can cause the old interrupt handler
-    // to be 'moved' to a separate thread, such that interrupts end
-    // up being handled on a thread different from the R execution thread.
+    // However, it seems like this can cause the old interrupt handler to be
+    // 'moved' to a separate thread, such that interrupts end up being handled
+    // on a thread different from the R execution thread. At least, on macOS.
     initialize_signal_handlers();
 
     // Wait for a lock on the kernel

--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/modules/public/utils.R
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/modules/public/utils.R
@@ -1,0 +1,10 @@
+#
+# utils.R
+#
+# Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+#
+#
+
+.ps.inspect <- function(item) {
+    .Internal(inspect(item))
+}

--- a/extensions/positron-r/amalthea/crates/ark/src/main.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/main.rs
@@ -15,6 +15,7 @@ use ark::lsp;
 use bus::Bus;
 use crossbeam::channel::bounded;
 use log::*;
+use nix::sys::signal::*;
 use std::env;
 use std::io::stdin;
 use std::sync::{Arc, Mutex};
@@ -183,11 +184,17 @@ Available options:
 }
 
 fn main() {
+
     #[cfg(target_os = "macos")]
     {
         // Unset DYLD_INSERT_LIBRARIES if it was passed down
         std::env::remove_var("DYLD_INSERT_LIBRARIES");
     }
+
+    // Block signals in this (and any child) threads.
+    let mut sigset = SigSet::empty();
+    sigset.add(SIGINT);
+    sigprocmask(SigmaskHow::SIG_BLOCK, Some(&sigset), None).unwrap();
 
     // Get an iterator over all the command-line arguments
     let mut argv = std::env::args();

--- a/extensions/positron-r/amalthea/crates/ark/src/main.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/main.rs
@@ -191,7 +191,11 @@ fn main() {
         std::env::remove_var("DYLD_INSERT_LIBRARIES");
     }
 
-    // Block signals in this (and any child) threads.
+    // Block signals in this thread (and any child threads).
+    //
+    // Any threads that would like to handle signals should explicitly
+    // unblock the signals they want to handle. This allows us to ensure
+    // that interrupts are consistently handled on the same thread.
     let mut sigset = SigSet::empty();
     sigset.add(SIGINT);
     sigprocmask(SigmaskHow::SIG_BLOCK, Some(&sigset), None).unwrap();

--- a/extensions/positron-r/amalthea/crates/ark/src/shell.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/shell.rs
@@ -67,7 +67,7 @@ impl Shell {
         kernel_init_rx: BusReader<KernelInfo>,
     ) -> Self {
         let iopub_tx = iopub_tx.clone();
-        spawn!("ark-shell", move || {
+        spawn!("ark-r-main-thread", move || {
             Self::execution_thread(iopub_tx, kernel_init_tx, shell_request_rx);
         });
 

--- a/extensions/positron-r/amalthea/crates/harp/src/utils.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/utils.rs
@@ -17,6 +17,7 @@ use crate::exec::RArgument;
 use crate::exec::RFunction;
 use crate::exec::RFunctionExt;
 use crate::object::RObject;
+use crate::protect::RProtect;
 use crate::r_symbol;
 use crate::vector::CharacterVector;
 use crate::vector::Vector;
@@ -180,4 +181,11 @@ pub unsafe fn r_stringify(object: SEXP, delimiter: &str) -> Result<String> {
 
     Ok(object)
 
+}
+
+pub unsafe fn r_inspect(object: SEXP) {
+    let mut protect = RProtect::new();
+    let inspect = protect.add(Rf_lang2(r_symbol!("inspect"), object));
+    let internal = protect.add(Rf_lang2(r_symbol!(".Internal"), inspect));
+    Rf_eval(internal, R_BaseEnv);
 }


### PR DESCRIPTION
As learned with @jmcphers, R tries to temporarily install its own interrupt signal handler when select is invoked, e.g. here:

https://github.com/wch/r-source/blob/e7a21904029917a63b4717b53a173b01eeabcc7b/src/unix/sys-std.c#L171-L179

However, something about the way that R tries to save and restore the signal handler seems to cause issues -- when the interrupt is handled, it can get executed on the wrong thread (e.g. the "main" thread instead of the thread actually hosting R).

This PR tries to side-step the issue by making sure to reinstall the interrupt handler whenever R_Busy is invoked (which it seemingly is after an interrupt is handled).

Closes https://github.com/rstudio/positron/issues/291.