### PR TITLE
`with_vector!()` macro

### DIFF
--- a/extensions/positron-r/amalthea/crates/harp/src/error.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/error.rs
@@ -23,8 +23,7 @@ pub enum Error {
     InvalidUtf8(Utf8Error),
     TryCatchError { message: Vec<String>, classes : Vec<String> },
     ParseSyntaxError { message: String, line: i32 },
-    MissingValueError,
-    NotSimpleVectorError,
+    MissingValueError
 }
 
 // empty implementation required for 'anyhow'
@@ -88,12 +87,7 @@ impl fmt::Display for Error {
 
             Error::MissingValueError => {
                 write!(f, "Missing value")
-            },
-
-            Error::NotSimpleVectorError => {
-                write!(f, "Not a simple vector")
             }
-
         }
     }
 }

--- a/extensions/positron-r/amalthea/crates/harp/src/error.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/error.rs
@@ -23,7 +23,8 @@ pub enum Error {
     InvalidUtf8(Utf8Error),
     TryCatchError { message: Vec<String>, classes : Vec<String> },
     ParseSyntaxError { message: String, line: i32 },
-    MissingValueError
+    MissingValueError,
+    NotSimpleVectorError,
 }
 
 // empty implementation required for 'anyhow'
@@ -86,7 +87,11 @@ impl fmt::Display for Error {
             }
 
             Error::MissingValueError => {
-                write!(f, "Missing value" )
+                write!(f, "Missing value")
+            },
+
+            Error::NotSimpleVectorError => {
+                write!(f, "Not a simple vector")
             }
 
         }

--- a/extensions/positron-r/amalthea/crates/harp/src/lib.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/lib.rs
@@ -40,6 +40,42 @@ macro_rules! r_lock {
 }
 
 #[macro_export]
+macro_rules! with_vector_impl {
+    ($x:expr, $class:ident, $variable:ident, $($code:tt)*) => {{
+        let fun = |$variable: $class| {
+            $($code)*
+        };
+        Ok(fun($class::new_unchecked($x)))
+    }};
+}
+
+#[macro_export]
+macro_rules! with_vector {
+    ($sexp:expr, |$variable:ident| { $($code:tt)* }) => {
+        unsafe {
+            let sexp = $sexp;
+
+            match r_typeof(sexp) {
+                LGLSXP => crate::with_vector_impl!(sexp, LogicalVector, $variable, $($code)*),
+                INTSXP => {
+                    if r_inherits(sexp, "factor") {
+                        crate::with_vector_impl!(sexp, Factor, $variable, $($code)*)
+                    } else {
+                        crate::with_vector_impl!(sexp, IntegerVector, $variable, $($code)*)
+                    }
+                },
+                REALSXP => crate::with_vector_impl!(sexp, NumericVector, $variable, $($code)*),
+                RAWSXP => crate::with_vector_impl!(sexp, RawVector, $variable, $($code)*),
+                STRSXP => crate::with_vector_impl!(sexp, CharacterVector, $variable, $($code)*),
+
+                _ => Err(crate::error::Error::NotSimpleVectorError)
+            }
+        }
+
+    };
+}
+
+#[macro_export]
 macro_rules! r_symbol {
 
     ($id:literal) => {{

--- a/extensions/positron-r/amalthea/crates/harp/src/lib.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/lib.rs
@@ -55,7 +55,8 @@ macro_rules! with_vector {
         unsafe {
             let sexp = $sexp;
 
-            match r_typeof(sexp) {
+            let rtype = r_typeof(sexp);
+            match rtype {
                 LGLSXP => crate::with_vector_impl!(sexp, LogicalVector, $variable, $($code)*),
                 INTSXP => {
                     if r_inherits(sexp, "factor") {
@@ -68,7 +69,7 @@ macro_rules! with_vector {
                 RAWSXP => crate::with_vector_impl!(sexp, RawVector, $variable, $($code)*),
                 STRSXP => crate::with_vector_impl!(sexp, CharacterVector, $variable, $($code)*),
 
-                _ => Err(crate::error::Error::NotSimpleVectorError)
+                _ => Err(crate::error::Error::UnexpectedType(rtype, vec![LGLSXP, INTSXP, REALSXP, RAWSXP, STRSXP]))
             }
         }
 


### PR DESCRIPTION
The idea is to be call a lambda on a specific `*Vector* class, e.g. 

```rust
with_vector!(value, |v| {
            let formatted = v.format(" ", 100);
            BindingValue::new(formatted.1, formatted.0)
}).unwrap()
```

the macro does the dispatch, so `v` gets to be either a `IntegerVector`, a `NumericVector`,  a `Factor` etc ... 

You get either: 
  - `Ok(<whatever the lambda returns>)`
  - `Err(NotSimpleVectorError)` (part of the `Error` enum) 