### PR TITLE
Make plots removable from plot history

### DIFF
--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -316,10 +316,14 @@ export class LanguageRuntimeAdapter
 	removeClient(id: string): void {
 		const comm = this._comms.get(id);
 		if (comm) {
+			// This is one of the clients we created, so we need to dispose of it
 			this._kernel.log(`Removing "${comm.getClientType()}" client ${comm.getClientId()} for ${this.metadata.languageName}`);
 			comm.dispose();
 		} else {
-			this._kernel.log(`Error: can't remove client ${id} (not found)`);
+			// This is a client created on the back end, so we just need to send a
+			// comm_close message
+			this._kernel.log(`Closing client ${id} for ${this.metadata.languageName}`);
+			this._kernel.closeComm(id);
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotThumbnail.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotThumbnail.tsx
@@ -43,6 +43,10 @@ export const DynamicPlotThumbnail = (props: DynamicPlotThumbnailProps) => {
 		props.plotService.positronPlotsService.selectPlot(props.plotClient.id);
 	};
 
+	const removePlot = () => {
+		props.plotService.positronPlotsService.removePlot(props.plotClient.id);
+	};
+
 	// If the plot is not yet rendered yet (no URI), show a placeholder;
 	// otherwise, show the rendered plot.
 	//
@@ -55,6 +59,7 @@ export const DynamicPlotThumbnail = (props: DynamicPlotThumbnailProps) => {
 					onClick={selectPlot} />
 			</div>}
 			{!uri && <div className='plot-thumbnail-placeholder'></div>}
+			<div className='plot-close codicon codicon-close' onClick={removePlot}></div>
 		</div>
 	);
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotThumbnail.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotThumbnail.tsx
@@ -26,12 +26,17 @@ export const StaticPlotThumbnail = (props: StaticPlotThumbnailProps) => {
 		props.plotService.positronPlotsService.selectPlot(props.plotClient.id);
 	};
 
+	const removePlot = () => {
+		props.plotService.positronPlotsService.removePlot(props.plotClient.id);
+	};
+
 	return (
 		<div className='plot-thumbnail'>
 			<div className='image-wrapper'>
 				<img src={props.plotClient.uri} alt={'Plot ' + props.plotClient.id}
 					onClick={selectPlot} />
 			</div>
+			<div className='plot-close codicon codicon-close' onClick={removePlot}></div>
 		</div>
 	);
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
@@ -42,6 +42,11 @@
 	transition: opacity 0.2s ease-in-out;
 }
 
+.plot-thumbnail:hover .plot-close {
+	opacity: 1;
+	transition: opacity 0.2s ease-in-out;
+}
+
 .plot-thumbnail,
 .static-plot-instance {
 	display: flex;
@@ -65,4 +70,13 @@
 .static-plot-instance {
 	height: 100%;
 	width: 100%;
+}
+
+.plot-close {
+	position: absolute;
+	top: 0;
+	right: 0;
+	padding: 2px;
+	cursor: pointer;
+	opacity: 0;
 }

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -28,6 +28,9 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	/** The emitter for the onDidSelectPlot event */
 	private readonly _onDidSelectPlot = new Emitter<string>();
 
+	/** The emitter for the onDidRemovePlot event */
+	private readonly _onDidRemovePlot = new Emitter<string>();
+
 	/**
 	 * A map of recently executed code; the map is from the parent ID to the
 	 * code executed. We keep around the last 10 executions so that when a plot
@@ -139,6 +142,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 
 	onDidEmitPlot: Event<PositronPlotClient> = this._onDidEmitPlot.event;
 	onDidSelectPlot: Event<string> = this._onDidSelectPlot.event;
+	onDidRemovePlot: Event<string> = this._onDidRemovePlot.event;
 
 	// Gets the individual plot instances.
 	get positronPlotInstances(): PositronPlotClient[] {
@@ -152,6 +156,24 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	 */
 	selectPlot(id: string): void {
 		this._onDidSelectPlot.fire(id);
+	}
+
+	/**
+	 * Remove a plot by ID
+	 *
+	 * @param id The ID of the plot to remove
+	 */
+	removePlot(id: string): void {
+		// Find the plot with the given ID and remove it from the list
+		this._plots.forEach((plot, index) => {
+			if (plot.id === id) {
+				plot.dispose();
+				this._plots.splice(index, 1);
+			}
+		});
+
+		// Fire the event notifying subscribers
+		this._onDidRemovePlot.fire(id);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -31,6 +31,9 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	/** The emitter for the onDidRemovePlot event */
 	private readonly _onDidRemovePlot = new Emitter<string>();
 
+	/** The ID Of the currently selected plot, if any */
+	private _selectedPlotId: string | undefined;
+
 	/**
 	 * A map of recently executed code; the map is from the parent ID to the
 	 * code executed. We keep around the last 10 executions so that when a plot
@@ -90,6 +93,11 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 				if (imageKey) {
 					this.registerStaticPlot(message, code);
 				}
+			}));
+
+			// Listen for plots being selected and update the selected plot ID
+			this._register(this._onDidSelectPlot.event((id) => {
+				this._selectedPlotId = id;
 			}));
 		}));
 	}
@@ -171,6 +179,18 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 				this._plots.splice(index, 1);
 			}
 		});
+
+		// If this plot was selected, select the first plot in the list
+		if (this._selectedPlotId === id) {
+			if (this._plots.length > 0) {
+				// There are still some plots; select the first one
+				this._onDidSelectPlot.fire(this._plots[0].id);
+			}
+			else {
+				// There are no plots; clear the selected plot ID
+				this._selectedPlotId = undefined;
+			}
+		}
 
 		// Fire the event notifying subscribers
 		this._onDidRemovePlot.fire(id);

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsState.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsState.tsx
@@ -59,6 +59,11 @@ export const usePositronPlotsState = (services: PositronPlotsServices): Positron
 			setSelectedInstanceId(id);
 		}));
 
+		// Listen for plot removal.
+		disposableStore.add(services.positronPlotsService.onDidRemovePlot(id => {
+			setPositronPlotInstances(positronPlotInstances => positronPlotInstances.filter(p => p.id !== id));
+		}));
+
 		// Return the clean up for our event handlers.
 		return () => disposableStore.dispose();
 	}, []);

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -38,11 +38,24 @@ export interface IPositronPlotsService {
 	readonly onDidSelectPlot: Event<string>;
 
 	/**
-	 * Selects the plot at the specified index.
+	 * Notifies subscribers when a Positron plot instance is removed. The ID
+	 * of the removed plot is the event payload.
+	 */
+	readonly onDidRemovePlot: Event<string>;
+
+	/**
+	 * Selects the plot with the specified ID.
 	 *
-	 * @param index The ID of the plot to select.
+	 * @param id The ID of the plot to select.
 	 */
 	selectPlot(id: string): void;
+
+	/**
+	 * Removes the plot with the specified ID.
+	 *
+	 * @param id The ID of the plot to remove.
+	 */
+	removePlot(id: string): void;
 
 	/**
 	 * Placeholder for service initialization.


### PR DESCRIPTION
Small change to make it possible to delete plots from the history.

<img width="277" alt="image" src="https://user-images.githubusercontent.com/470418/230201752-497cde26-208c-458a-9c6b-e8ad6310f792.png">

The "X", when clicked, will remove the plot from the history, and will also notify the kernel to dispose its end of the widget. 