### PR TITLE
Inspecting functions (`CLOSXP`) 

### DIFF
--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -192,20 +192,31 @@ impl EnvironmentVariable {
             VECSXP  => Self::inspect_list(object),
             LISTSXP => Self::inspect_pairlist(object),
             ENVSXP  => Self::inspect_environment(object),
+            CLOSXP  => Self::inspect_function(object),
+
             _       => Ok(vec![])
         }
     }
 
     unsafe fn resolve_object_from_path(mut object: RObject, path: &Vec<String>) -> Result<RObject, harp::error::Error> {
         for path_element in path {
+            // TODO: handle attributes before doing any dispatch
+
             let rtype = r_typeof(*object);
             object = match rtype {
-                ENVSXP => {
-                    // TODO: active bindings and promises can't be inspected at the moment,
+                ENVSXP => unsafe {
+                    let symbol = r_symbol!(path_element);
+
+                    // TODO: active bindings can't be inspected at the moment,
                     //       so we can safely assume we can call Rf_findVarInFrame()
-                    //       without forcing them, but it might be something we want to relax in the future
-                    //       e.g. if we want to be able to expand a promise to show its code and/or env
-                    RObject::view(unsafe { Rf_findVarInFrame(*object, r_symbol!(path_element)) } )
+                    let mut value = Rf_findVarInFrame(*object, symbol);
+
+                    // we might get a forced promise, in that case, just use its value
+                    if r_typeof(value) == PROMSXP {
+                        value = PRVALUE(value);
+                    }
+
+                    RObject::view(value)
                 },
                 VECSXP => {
                     let index = path_element.parse::<isize>().unwrap();
@@ -219,6 +230,14 @@ impl EnvironmentVariable {
                         pairlist = CDR(pairlist);
                     }
                     RObject::view(CAR(pairlist))
+                },
+
+                CLOSXP => {
+                    if path_element == "formals" {
+                        RObject::view(FORMALS(*object))
+                    } else {
+                        RObject::view(CLOENV(*object))
+                    }
                 }
 
                 _ => return Err( harp::error::Error::UnexpectedType(rtype, vec![ENVSXP, VECSXP, LISTSXP]))
@@ -285,6 +304,22 @@ impl EnvironmentVariable {
             a.display_name.cmp(&b.display_name)
         });
 
+        Ok(out)
+    }
+
+    fn inspect_function(value: RObject) -> Result<Vec<Self>, harp::error::Error> {
+        let mut out : Vec<Self> = vec![];
+
+        unsafe {
+            let formals = FORMALS(*value);
+            if formals != R_NilValue {
+                out.push(Self::from(String::from("formals"), String::from("formals(.)"), formals));
+            }
+
+            let env = CLOENV(*value);
+            out.push(Self::from(String::from("env"), String::from("env(.)"), env));
+
+        }
         Ok(out)
     }
 

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -192,7 +192,6 @@ impl EnvironmentVariable {
             VECSXP  => Self::inspect_list(object),
             LISTSXP => Self::inspect_pairlist(object),
             ENVSXP  => Self::inspect_environment(object),
-            CLOSXP  => Self::inspect_function(object),
 
             _       => Ok(vec![])
         }
@@ -304,22 +303,6 @@ impl EnvironmentVariable {
             a.display_name.cmp(&b.display_name)
         });
 
-        Ok(out)
-    }
-
-    fn inspect_function(value: RObject) -> Result<Vec<Self>, harp::error::Error> {
-        let mut out : Vec<Self> = vec![];
-
-        unsafe {
-            let formals = FORMALS(*value);
-            if formals != R_NilValue {
-                out.push(Self::from(String::from("formals"), String::from("formals(.)"), formals));
-            }
-
-            let env = CLOENV(*value);
-            out.push(Self::from(String::from("env"), String::from("env(.)"), env));
-
-        }
         Ok(out)
     }
 

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -315,6 +315,8 @@ fn regular_binding_display_value(value: SEXP) -> BindingValue {
         BindingValue::empty()
     } else if rtype == LISTSXP {
         BindingValue::empty()
+    } else if rtype == SYMSXP && value == unsafe{ R_MissingArg } {
+        BindingValue::new(String::from("<missing>"), false)
     } else {
         format_display_value(value)
     }


### PR DESCRIPTION
Showing formals and environment (not body, not yet at least), i.e. `summarise <- dplyr::summarise` gives: 

<img width="791" alt="image" src="https://user-images.githubusercontent.com/2625526/230611982-dffab015-7407-462f-b842-06a1f20b145f.png">

I'm not sure this is useful. This is modelled after what rstudio does with e.g. `.rs.explorer.viewObject(dplyr::summarise, title = "dplyr::summarise", envir = globalenv())`: 

<img width="1119" alt="image" src="https://user-images.githubusercontent.com/2625526/230612457-c9a65bd3-bcbd-49e2-9de4-e2297b848b83.png">

Although the canonical `View()` for function actually does show the function: 

<img width="558" alt="image" src="https://user-images.githubusercontent.com/2625526/230612611-13bd275a-2c64-4d31-af0c-74f656d492bf.png">