### PR TITLE
Read initial state of plots pane from service

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -278,6 +278,11 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		return this._plots;
 	}
 
+	// Gets the ID of the currently selected plot.
+	get selectedPlotId(): string | undefined {
+		return this._selectedPlotId;
+	}
+
 	/**
 	 * Select a plot by ID
 	 *

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsState.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsState.tsx
@@ -32,9 +32,19 @@ export interface PositronPlotsState extends PositronPlotsServices {
 export const usePositronPlotsState = (services: PositronPlotsServices): PositronPlotsState => {
 
 	// Hooks.
-	const [positronPlotInstances, setPositronPlotInstances] = useState<PositronPlotClient[]>([]);
-	const [selectedInstanceId, setSelectedInstanceId] = useState<string>('');
-	const [selectedInstanceIndex, setSelectedInstanceIndex] = useState<number>(-1);
+
+	// Initial set of plot instances.
+	const [positronPlotInstances, setPositronPlotInstances] = useState<PositronPlotClient[]>(
+		services.positronPlotsService.positronPlotInstances);
+
+	// Initial selected plot instance.
+	const initialSelectedId = services.positronPlotsService.selectedPlotId;
+	const [selectedInstanceId, setSelectedInstanceId] = useState<string>(initialSelectedId ?? '');
+
+	// Index of the selected plot instance.
+	const initialSelectedIndex = services.positronPlotsService.positronPlotInstances.findIndex
+		(p => p.id === initialSelectedId);
+	const [selectedInstanceIndex, setSelectedInstanceIndex] = useState<number>(initialSelectedIndex);
 
 	// Add event handlers.
 	useEffect(() => {

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -27,6 +27,11 @@ export interface IPositronPlotsService {
 	readonly positronPlotInstances: PositronPlotClient[];
 
 	/**
+	 * Gets the currently selected Positron plot instance.
+	 */
+	readonly selectedPlotId: string | undefined;
+
+	/**
 	 * Notifies subscribers when a new Positron plot instance is created.
 	 */
 	readonly onDidEmitPlot: Event<PositronPlotClient>;


### PR DESCRIPTION
Reads the initial state of the Plots pane from the Plots headless service. This allows the pane to show plots that were emitted before the pane was open, and repopulates the pane correctly when it is moved/reattached to different locations in the UI.