### PR TITLE
hide the hidden environment objects, handle R6

### DIFF
--- a/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
@@ -421,7 +421,11 @@ impl REnvironment {
     }
 
     fn bindings(&self) -> Vec<Binding> {
-        let mut bindings = env_bindings(self.env.sexp, false);
+        // TODO: it might be too restritive to drop all objects
+        //       whose name start with "."
+        let mut bindings = env_bindings(self.env.sexp, |binding| {
+            !String::from(binding.name).starts_with(".")
+        });
         bindings.sort();
         bindings
     }

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
@@ -421,7 +421,7 @@ impl REnvironment {
     }
 
     fn bindings(&self) -> Vec<Binding> {
-        let mut bindings = env_bindings(self.env.sexp);
+        let mut bindings = env_bindings(self.env.sexp, false);
         bindings.sort();
         bindings
     }

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -301,7 +301,7 @@ impl EnvironmentVariable {
     fn inspect_environment(value: SEXP) -> Result<Vec<Self>, harp::error::Error> {
         let mut out : Vec<Self> = vec![];
 
-        for binding in &env_bindings(value) {
+        for binding in &env_bindings(value, false) {
             out.push(Self::new(binding));
         }
 

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -301,7 +301,15 @@ impl EnvironmentVariable {
     fn inspect_environment(value: SEXP) -> Result<Vec<Self>, harp::error::Error> {
         let mut out : Vec<Self> = vec![];
 
-        for binding in &env_bindings(value, false) {
+        // TODO: it might be too restritive to drop all objects
+        //       whose name start with "."
+        //       in that case, reconsider the case where `value` is an R6 object
+        //       because we'd want to filter .__enclos_env__ out
+        let bindings = env_bindings(value, |binding| {
+            !String::from(binding.name).starts_with(".")
+        });
+
+        for binding in &bindings {
             out.push(Self::new(binding));
         }
 


### PR DESCRIPTION
This hides objects in environments whose name start with a ".". Maybe this could be more fine grained and make a difference between things like `.x` and things like `.__C__track` ?

This probably should be governed by some ui thing perhaps related to the Filter textbox ?

Alternatively, `EnvironmentVariable` could have a `hidden: bool` so that the ui can decide what to do with them ? grey them, hide them, whatever ?