### PR TITLE
handle EXPRSXP in r env pane

### DIFF
--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -194,6 +194,7 @@ impl EnvironmentVariable {
         } else {
             match r_typeof(*object) {
                 VECSXP  => Self::inspect_list(*object),
+                EXPRSXP => Self::inspect_list(*object),
                 LISTSXP => Self::inspect_pairlist(*object),
                 ENVSXP  => Self::inspect_environment(*object),
                 _       => Ok(vec![])
@@ -229,7 +230,7 @@ impl EnvironmentVariable {
                         }
                     },
 
-                    VECSXP => {
+                    VECSXP | EXPRSXP => {
                         let index = path_element.parse::<isize>().unwrap();
                         RObject::view(VECTOR_ELT(*object, index))
                     },


### PR DESCRIPTION
```r
exprs <- parse(text = "x <- 2; y <- 3")
```

`EXPRSXP` are essentially the same as `VECSXP` but they typically host only calls (`LANGSXP`) and symbols (`SYMSXP`), but it's not mandatory.

<img width="341" alt="image" src="https://user-images.githubusercontent.com/2625526/232476135-1e6cfb10-fcd3-4f0e-bf32-a36905a41745.png">

The `structure(...)` bit is a bit much, but this is what `format()` gives: 

```r
> exprs <- parse(text = "x <- 1; y <- 2")
> format(exprs)
[1] "structure(expression(x <- 1, y <- 2), srcfile = <environment>, wholeSrcref = structure(c(1L, "
[2] "0L, 2L, 0L, 0L, 0L, 1L, 2L), srcfile = <environment>, class = \"srcref\"))"                   
```

Is this a case where dropping the attributes would make sense: 

```r
> format(`attributes<-`(exprs, NULL))
[1] "expression(x <- 1, y <- 2)"
> attributes(exprs)
$srcref
$srcref[[1]]
x <- 1

$srcref[[2]]
y <- 2


$srcfile
<text> 

$wholeSrcref
x <- 1; y <- 2
```