### PR TITLE
Environment.iter()

### DIFF
--- a/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
@@ -8,7 +8,7 @@ use amalthea::comm::comm_channel::CommChannelMsg;
 use amalthea::socket::comm::CommSocket;
 use crossbeam::channel::select;
 use crossbeam::channel::unbounded;
-use harp::environment::env_bindings;
+use harp::environment::Environment;
 use harp::environment::Binding;
 use harp::exec::RFunction;
 use harp::exec::RFunctionExt;
@@ -423,9 +423,11 @@ impl REnvironment {
     fn bindings(&self) -> Vec<Binding> {
         // TODO: it might be too restritive to drop all objects
         //       whose name start with "."
-        let mut bindings = env_bindings(self.env.sexp, |binding| {
+        let env = Environment::new(self.env.sexp);
+        let mut bindings: Vec<Binding> = env.iter().filter(|binding| {
             !String::from(binding.name).starts_with(".")
-        });
+        }).collect();
+
         bindings.sort();
         bindings
     }

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -9,7 +9,7 @@ use harp::environment::Binding;
 use harp::environment::BindingKind;
 use harp::environment::BindingType;
 use harp::environment::BindingValue;
-use harp::environment::env_bindings;
+use harp::environment::Environment;
 use harp::exec::RFunction;
 use harp::exec::RFunctionExt;
 use harp::exec::r_try_catch_error;
@@ -301,16 +301,11 @@ impl EnvironmentVariable {
     fn inspect_environment(value: SEXP) -> Result<Vec<Self>, harp::error::Error> {
         let mut out : Vec<Self> = vec![];
 
-        // TODO: it might be too restritive to drop all objects
-        //       whose name start with "."
-        //       in that case, reconsider the case where `value` is an R6 object
-        //       because we'd want to filter .__enclos_env__ out
-        let bindings = env_bindings(value, |binding| {
-            !String::from(binding.name).starts_with(".")
-        });
-
-        for binding in &bindings {
-            out.push(Self::new(binding));
+        let env = Environment::new(value);
+        for binding in env.iter() {
+            if !String::from(binding.name).starts_with(".") {
+                out.push(Self::new(&binding));
+            }
         }
 
         out.sort_by(|a, b| {

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -6,6 +6,7 @@
 //
 
 use std::cmp::Ordering;
+use std::ops::Deref;
 
 use c2rust_bitfields::BitfieldStruct;
 use itertools::Itertools;
@@ -449,38 +450,210 @@ fn altrep_class(object: SEXP) -> String {
     format!("{}::{}", pkg, klass)
 }
 
-pub fn env_bindings<Retain>(env: SEXP, retain: Retain) -> Vec<Binding>
-where
-    Retain: Fn(&Binding) -> bool
-{
-    unsafe {
-        let hash  = HASHTAB(env);
-        if hash == R_NilValue {
-            frame_bindings(env, FRAME(env), retain)
-        } else {
-            let mut bindings : Vec<Binding> = vec![];
+pub struct Environment {
+    env: RObject,
+}
 
-            let n = XLENGTH(hash);
-            for i in 0..n {
-                bindings.append(&mut frame_bindings(env, VECTOR_ELT(hash, i), &retain));
+impl Deref for Environment {
+    type Target = SEXP;
+    fn deref(&self) -> &Self::Target {
+        &self.env.sexp
+    }
+}
+
+pub struct HashedEnvironmentIter<'a> {
+    env: &'a Environment,
+
+    hashtab: SEXP,
+    hashtab_index: R_xlen_t,
+    frame: SEXP
+}
+
+impl<'a> HashedEnvironmentIter<'a> {
+    pub fn new(env: &'a Environment) -> Self {
+        unsafe {
+            let hashtab = HASHTAB(**env);
+            let hashtab_len = XLENGTH(hashtab);
+            let mut hashtab_index = 0;
+            let mut frame = R_NilValue;
+
+            // look for the first non null frame
+            loop {
+                let f = VECTOR_ELT(hashtab, hashtab_index);
+                if f != R_NilValue {
+                    frame = f;
+                    break;
+                }
+
+                hashtab_index = hashtab_index + 1;
+                if hashtab_index == hashtab_len {
+                    break;
+                }
             }
-            bindings
+
+            Self {
+                env,
+                hashtab,
+                hashtab_index,
+                frame
+            }
+
         }
     }
 }
 
-unsafe fn frame_bindings<Retain>(env: SEXP, mut frame: SEXP, retain: Retain) -> Vec<Binding>
-where
-    Retain: Fn(&Binding) -> bool
-{
-    let mut bindings: Vec<Binding> = vec![];
-    while frame != R_NilValue {
-        let binding = Binding::new(env, frame);
-        if retain(&binding) {
-            bindings.push(binding);
-        }
+impl<'a> Iterator for HashedEnvironmentIter<'a> {
+    type Item = Binding;
 
-        frame = CDR(frame);
+    fn next(&mut self) -> Option<Self::Item> {
+
+        unsafe {
+            if self.frame == R_NilValue {
+                return None;
+            }
+
+            // grab the next Binding
+            let binding = Binding::new(*self.env.env, self.frame);
+
+            // and advance to next binding
+            self.frame = CDR(self.frame);
+
+            if self.frame == R_NilValue {
+                // end of frame: move to the next non empty frame
+                let hashtab_len = XLENGTH(self.hashtab);
+                loop {
+                    // move to the next frame
+                    self.hashtab_index = self.hashtab_index + 1;
+
+                    // end of iteration
+                    if self.hashtab_index == hashtab_len {
+                        self.frame = R_NilValue;
+                        break;
+                    }
+
+                    // skip empty frames
+                    self.frame = VECTOR_ELT(self.hashtab, self.hashtab_index);
+                    if self.frame != R_NilValue {
+                        break;
+                    }
+                }
+            }
+
+            Some(binding)
+
+        }
     }
-    bindings
+}
+
+pub struct NonHashedEnvironmentIter<'a> {
+    env: &'a Environment,
+
+    frame: SEXP
+}
+
+impl<'a> NonHashedEnvironmentIter<'a> {
+    pub fn new(env: &'a Environment) -> Self {
+        unsafe {
+            Self {
+                env,
+                frame: FRAME(**env),
+            }
+        }
+    }
+}
+
+impl<'a> Iterator for NonHashedEnvironmentIter<'a> {
+    type Item = Binding;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unsafe {
+            if self.frame == R_NilValue {
+                None
+            } else {
+                let binding = Binding::new(*self.env.env, self.frame);
+                self.frame = CDR(self.frame);
+                Some(binding)
+            }
+        }
+    }
+}
+
+pub enum EnvironmentIter<'a> {
+    Hashed(HashedEnvironmentIter<'a>),
+    NonHashed(NonHashedEnvironmentIter<'a>)
+}
+
+impl<'a> EnvironmentIter<'a> {
+    pub fn new(env: &'a Environment) -> Self {
+
+        unsafe {
+            let hashtab = HASHTAB(**env);
+            if hashtab == R_NilValue {
+                EnvironmentIter::NonHashed(NonHashedEnvironmentIter::new(env))
+            } else {
+                EnvironmentIter::Hashed(HashedEnvironmentIter::new(env))
+            }
+        }
+    }
+}
+
+impl<'a> Iterator for EnvironmentIter<'a> {
+    type Item = Binding;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            EnvironmentIter::Hashed(iter) => iter.next(),
+            EnvironmentIter::NonHashed(iter) => iter.next()
+        }
+    }
+}
+
+impl Environment {
+    pub fn new(value: SEXP) -> Self {
+        Self {
+            env: unsafe{ RObject::new(value) }
+        }
+    }
+
+    pub fn iter(&self) -> EnvironmentIter {
+        EnvironmentIter::new(&self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libR_sys::*;
+
+    use crate::r_symbol;
+    use crate::r_test;
+
+    use super::*;
+
+    unsafe fn test_environment_iter_impl(hash: bool) {
+        let test_env = RFunction::new("base", "new.env")
+            .param("parent", R_EmptyEnv)
+            .param("hash", RObject::from(hash))
+            .call()
+            .unwrap();
+
+        let sym = r_symbol!("a");
+        Rf_defineVar(sym, Rf_ScalarInteger(42), test_env.sexp);
+
+        let sym = r_symbol!("b");
+        Rf_defineVar(sym, Rf_ScalarInteger(43), test_env.sexp);
+
+        let sym = r_symbol!("c");
+        Rf_defineVar(sym, Rf_ScalarInteger(44), test_env.sexp);
+
+        let env = Environment::new(*test_env);
+        assert_eq!(env.iter().count(), 3);
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_environment_iter() { r_test! {
+        test_environment_iter_impl(true);
+        test_environment_iter_impl(false);
+    }}
+
 }


### PR DESCRIPTION
Added class `harp::environment::Environment` that has an `iter()` method to iterate over the `Binding`s of an environment. 

To account for hashed and non hashed environments, the iterator class is one of these two variants: 

```rust
pub enum EnvironmentIter<'a> {
    Hashed(HashedEnvironmentIter<'a>),
    NonHashed(NonHashedEnvironmentIter<'a>)
}
```

and the `next()` method dispatches.  

```rust
impl<'a> Iterator for EnvironmentIter<'a> {
    type Item = Binding;

    fn next(&mut self) -> Option<Self::Item> {
        match self {
            EnvironmentIter::Hashed(iter) => iter.next(),
            EnvironmentIter::NonHashed(iter) => iter.next()
        }
    }
}
```

We might want to call it `REnvironment` instead, but we already have `ark::environment::r_environment::REnvironment` but maybe this is the one that should be renamed ?
