### PR TITLE
call `object.size()` to populate EnvironmentVariable::size

### DIFF
--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -18,6 +18,7 @@ use harp::r_symbol;
 use harp::symbol::RSymbol;
 use harp::utils::r_assert_type;
 use harp::utils::r_inherits;
+use harp::utils::r_is_null;
 use harp::utils::r_typeof;
 use harp::vector::CharacterVector;
 use harp::vector::Vector;
@@ -95,6 +96,9 @@ pub struct EnvironmentVariable {
 }
 
 fn variable_size(x: SEXP) -> usize {
+    if r_is_null(x) {
+        return 0;
+    }
     if RObject::view(x).is_altrep() {
         return unsafe {
             variable_size(R_altrep_data1(x)) + variable_size(R_altrep_data2(x))
@@ -188,7 +192,7 @@ impl EnvironmentVariable {
                 } else {
                     unsafe {
                         let names = Rf_getAttrib(x, R_NamesSymbol) ;
-                        if names == R_NilValue {
+                        if r_is_null(names) {
                             ValueKind::Collection
                         } else {
                             ValueKind::Map
@@ -306,7 +310,7 @@ impl EnvironmentVariable {
                 r_assert_type(pairlist, &[LISTSXP])?;
 
                 let tag = TAG(pairlist);
-                let display_name = if tag == R_NilValue {
+                let display_name = if r_is_null(tag) {
                     format!("[[{}]]", i + 1)
                 } else {
                     String::from(RSymbol::new(tag))

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -94,6 +94,27 @@ pub struct EnvironmentVariable {
     pub is_truncated: bool,
 }
 
+fn variable_size(x: SEXP) -> usize {
+    if RObject::view(x).is_altrep() {
+        return unsafe {
+            variable_size(R_altrep_data1(x)) + variable_size(R_altrep_data2(x))
+        };
+    }
+    let size = unsafe {
+        RFunction::new("utils", "object.size")
+            .add(x)
+            .call()
+    };
+
+    match size {
+        Err(_) => 0,
+        Ok(size) => {
+            let value = unsafe { REAL_ELT(*size, 0) };
+            value as usize
+        }
+    }
+}
+
 impl EnvironmentVariable {
     /**
      * Create a new EnvironmentVariable from a Binding
@@ -115,9 +136,9 @@ impl EnvironmentVariable {
             BindingKind::Promise(false) => (ValueKind::Other, 0),
             BindingKind::Promise(true) => {
                 let value = unsafe { PRVALUE(binding.value) };
-                (Self::variable_kind(value), Self::variable_size(value))
+                (Self::variable_kind(value), variable_size(value))
             },
-            BindingKind::Regular => (Self::variable_kind(binding.value), Self::variable_size(binding.value)),
+            BindingKind::Regular => (Self::variable_kind(binding.value), variable_size(binding.value)),
         };
         let has_children = binding.has_children();
 
@@ -151,7 +172,7 @@ impl EnvironmentVariable {
             type_info,
             kind: Self::variable_kind(x),
             length: 0,
-            size: Self::variable_size(x),
+            size: variable_size(x),
             has_children,
             is_truncated
         }
@@ -184,22 +205,6 @@ impl EnvironmentVariable {
             RAWSXP  => ValueKind::Collection,
 
             _       => ValueKind::Other
-        }
-    }
-
-    fn variable_size(x: SEXP) -> usize {
-        let size = unsafe {
-            RFunction::new("utils", "object.size")
-                .add(x)
-                .call()
-        };
-
-        match size {
-            Err(_) => 0,
-            Ok(size) => {
-                let value = unsafe { REAL_ELT(*size, 0) };
-                value as usize
-            }
         }
     }
 

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -68,6 +68,10 @@ impl Sxpinfo {
     pub fn is_s4(&self) -> bool {
         self.gp() & unsafe {S4_OBJECT_MASK} != 0
     }
+
+    pub fn is_altrep(&self) -> bool {
+        self.alt() != 0
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -17,6 +17,7 @@ use crate::object::RObject;
 use crate::symbol::RSymbol;
 use crate::utils::r_assert_type;
 use crate::utils::r_inherits;
+use crate::utils::r_is_null;
 use crate::utils::r_typeof;
 use crate::vector::CharacterVector;
 use crate::vector::Factor;
@@ -300,12 +301,8 @@ fn is_simple_vector(value: SEXP) -> bool {
         let class = Rf_getAttrib(value, R_ClassSymbol);
 
         match r_typeof(value) {
-            LGLSXP  => class == R_NilValue,
-            INTSXP  => class == R_NilValue || r_inherits(value, "factor"),
-            REALSXP => class == R_NilValue,
-            CPLXSXP => class == R_NilValue,
-            STRSXP  => class == R_NilValue,
-            RAWSXP  => class == R_NilValue,
+            LGLSXP | REALSXP | CPLXSXP | STRSXP | RAWSXP => r_is_null(class),
+            INTSXP  => r_is_null(class) || r_inherits(value, "factor"),
 
             _       => false
         }
@@ -315,7 +312,7 @@ fn is_simple_vector(value: SEXP) -> bool {
 fn first_class(value: SEXP) -> Option<String> {
     unsafe {
         let classes = Rf_getAttrib(value, R_ClassSymbol);
-        if classes == R_NilValue {
+        if r_is_null(classes) {
             None
         } else {
             let classes = CharacterVector::new_unchecked(classes);
@@ -433,7 +430,7 @@ fn vec_shape(value: SEXP) -> String {
     unsafe {
         let dim = RObject::new(Rf_getAttrib(value, R_DimSymbol));
 
-        if *dim == R_NilValue {
+        if r_is_null(*dim) {
             format!("{}", Rf_xlength(value))
         } else {
             let dim = IntegerVector::new(dim).unwrap();
@@ -459,7 +456,7 @@ where
 {
     unsafe {
         let hash  = HASHTAB(env);
-        if hash == R_NilValue {
+        if r_is_null(hash) {
             frame_bindings(env, FRAME(env), retain)
         } else {
             let mut bindings : Vec<Binding> = vec![];

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -7,7 +7,6 @@
 
 use std::cmp::Ordering;
 
-use c2rust_bitfields::BitfieldStruct;
 use itertools::Itertools;
 use libR_sys::*;
 
@@ -15,6 +14,7 @@ use crate::exec::RFunction;
 use crate::exec::RFunctionExt;
 use crate::object::RObject;
 use crate::symbol::RSymbol;
+use crate::utils::Sxpinfo;
 use crate::utils::r_assert_type;
 use crate::utils::r_inherits;
 use crate::utils::r_is_null;
@@ -27,57 +27,6 @@ use crate::vector::NumericVector;
 use crate::vector::RawVector;
 use crate::vector::Vector;
 use crate::with_vector;
-
-#[derive(Copy, Clone, BitfieldStruct)]
-#[repr(C)]
-pub struct Sxpinfo {
-    #[bitfield(name = "rtype", ty = "libc::c_uint", bits = "0..=4")]
-    #[bitfield(name = "scalar", ty = "libc::c_uint", bits = "5..=5")]
-    #[bitfield(name = "obj", ty = "libc::c_uint", bits = "6..=6")]
-    #[bitfield(name = "alt", ty = "libc::c_uint", bits = "7..=7")]
-    #[bitfield(name = "gp", ty = "libc::c_uint", bits = "8..=23")]
-    #[bitfield(name = "mark", ty = "libc::c_uint", bits = "24..=24")]
-    #[bitfield(name = "debug", ty = "libc::c_uint", bits = "25..=25")]
-    #[bitfield(name = "trace", ty = "libc::c_uint", bits = "26..=26")]
-    #[bitfield(name = "spare", ty = "libc::c_uint", bits = "27..=27")]
-    #[bitfield(name = "gcgen", ty = "libc::c_uint", bits = "28..=28")]
-    #[bitfield(name = "gccls", ty = "libc::c_uint", bits = "29..=31")]
-    #[bitfield(name = "named", ty = "libc::c_uint", bits = "32..=47")]
-    #[bitfield(name = "extra", ty = "libc::c_uint", bits = "48..=63")]
-    pub rtype_scalar_obj_alt_gp_mark_debug_trace_spare_gcgen_gccls_named_extra: [u8; 8],
-}
-
-pub static mut ACTIVE_BINDING_MASK: libc::c_uint = 1 << 15;
-pub static mut S4_OBJECT_MASK: libc::c_uint = 1 << 4;
-
-impl Sxpinfo {
-
-    pub fn interpret(x: &SEXP) -> &Self {
-        unsafe {
-            (*x as *mut Sxpinfo).as_ref().unwrap()
-        }
-    }
-
-    pub fn is_active(&self) -> bool {
-        self.gp() & unsafe {ACTIVE_BINDING_MASK} != 0
-    }
-
-    pub fn is_immediate(&self) -> bool {
-        self.extra() != 0
-    }
-
-    pub fn is_s4(&self) -> bool {
-        self.gp() & unsafe {S4_OBJECT_MASK} != 0
-    }
-
-    pub fn is_altrep(&self) -> bool {
-        self.alt() != 0
-    }
-    
-    pub fn is_object(&self) -> bool {
-        self.obj() != 0
-    }
-}
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum BindingKind {

--- a/extensions/positron-r/amalthea/crates/harp/src/lib.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/lib.rs
@@ -209,6 +209,7 @@ mod tests {
     use libR_sys::*;
     use crate::object::RObject;
     use crate::protect::RProtect;
+    use crate::utils::r_is_null;
     use crate::utils::r_typeof;
 
     use super::*;
@@ -267,7 +268,7 @@ mod tests {
 
         let value = RObject::new(r_lang!("hello", A = 1, B = 2));
         assert!(r_typeof(CAR(*value)) == STRSXP);
-        assert!(TAG(*value) == R_NilValue);
+        assert!(r_is_null(TAG(*value)));
 
     }
 

--- a/extensions/positron-r/amalthea/crates/harp/src/object.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/object.rs
@@ -127,7 +127,7 @@ fn sexp_size(x: SEXP) -> usize {
     if r_is_null(x) {
         return 0;
     }
-    if RObject::view(x).is_altrep() {
+    if Sxpinfo::interpret(&x).is_altrep() {
         return unsafe {
             sexp_size(R_altrep_data1(x)) + sexp_size(R_altrep_data2(x))
         };

--- a/extensions/positron-r/amalthea/crates/harp/src/object.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/object.rs
@@ -17,14 +17,16 @@ use std::sync::Once;
 use libR_sys::*;
 use log::trace;
 
-use crate::environment::Sxpinfo;
 use crate::error::Error;
 use crate::exec::RFunction;
 use crate::exec::RFunctionExt;
 use crate::protect::RProtect;
 use crate::utils::r_assert_length;
 use crate::utils::r_assert_type;
+use crate::utils::r_is_altrep;
 use crate::utils::r_is_null;
+use crate::utils::r_is_object;
+use crate::utils::r_is_s4;
 use crate::utils::r_typeof;
 
 // Objects are protected using a doubly-linked list,
@@ -123,13 +125,13 @@ impl<T: Into<RObject>> RObjectExt<T> for RObject {
 
 // TODO: borrow implementation from lobstr instead
 //       of calling object.size()
-fn sexp_size(x: SEXP) -> usize {
+fn r_size(x: SEXP) -> usize {
     if r_is_null(x) {
         return 0;
     }
-    if Sxpinfo::interpret(&x).is_altrep() {
+    if r_is_altrep(x) {
         return unsafe {
-            sexp_size(R_altrep_data1(x)) + sexp_size(R_altrep_data2(x))
+            r_size(R_altrep_data1(x)) + r_size(R_altrep_data2(x))
         };
     }
     let size = unsafe {
@@ -170,19 +172,19 @@ impl RObject {
     }
 
     pub fn is_s4(&self) -> bool {
-        Sxpinfo::interpret(&self.sexp).is_s4()
+        r_is_s4(self.sexp)
     }
 
     pub fn is_altrep(&self) -> bool {
-        Sxpinfo::interpret(&self.sexp).is_altrep()
+        r_is_altrep(self.sexp)
     }
 
     pub fn is_object(&self) -> bool {
-        Sxpinfo::interpret(&self.sexp).is_object()
+        r_is_object(self.sexp)
     }
 
     pub fn size(&self) -> usize {
-        sexp_size(self.sexp)
+        r_size(self.sexp)
     }
 
 }

--- a/extensions/positron-r/amalthea/crates/harp/src/object.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/object.rs
@@ -146,6 +146,10 @@ impl RObject {
         Sxpinfo::interpret(&self.sexp).is_s4()
     }
 
+    pub fn is_altrep(&self) -> bool {
+        Sxpinfo::interpret(&self.sexp).is_altrep()
+    }
+
 }
 
 impl Drop for RObject {

--- a/extensions/positron-r/amalthea/crates/harp/src/object.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/object.rs
@@ -121,6 +121,8 @@ impl<T: Into<RObject>> RObjectExt<T> for RObject {
     }
 }
 
+// TODO: borrow implementation from lobstr instead
+//       of calling object.size()
 fn sexp_size(x: SEXP) -> usize {
     if r_is_null(x) {
         return 0;

--- a/extensions/positron-r/amalthea/crates/harp/src/object.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/object.rs
@@ -24,6 +24,7 @@ use crate::exec::RFunctionExt;
 use crate::protect::RProtect;
 use crate::utils::r_assert_length;
 use crate::utils::r_assert_type;
+use crate::utils::r_is_null;
 use crate::utils::r_typeof;
 
 // Objects are protected using a doubly-linked list,
@@ -33,7 +34,7 @@ static mut PRECIOUS_LIST : Option<SEXP> = None;
 
 unsafe fn protect(object: SEXP) -> SEXP {
     // Nothing to do
-    if object == R_NilValue {
+    if r_is_null(object) {
         return R_NilValue;
     }
 
@@ -76,7 +77,7 @@ unsafe fn protect(object: SEXP) -> SEXP {
 
 unsafe fn unprotect(cell: SEXP) {
 
-    if cell == R_NilValue {
+    if r_is_null(cell) {
         return;
     }
 

--- a/extensions/positron-r/amalthea/crates/harp/src/utils.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/utils.rs
@@ -5,6 +5,8 @@
 //
 //
 
+use c2rust_bitfields::BitfieldStruct;
+
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::os::raw::c_void;
@@ -34,6 +36,57 @@ extern "C" {
         symbol: SEXP,
         envir: SEXP,
     ) -> c_void;
+}
+
+#[derive(Copy, Clone, BitfieldStruct)]
+#[repr(C)]
+pub struct Sxpinfo {
+    #[bitfield(name = "rtype", ty = "libc::c_uint", bits = "0..=4")]
+    #[bitfield(name = "scalar", ty = "libc::c_uint", bits = "5..=5")]
+    #[bitfield(name = "obj", ty = "libc::c_uint", bits = "6..=6")]
+    #[bitfield(name = "alt", ty = "libc::c_uint", bits = "7..=7")]
+    #[bitfield(name = "gp", ty = "libc::c_uint", bits = "8..=23")]
+    #[bitfield(name = "mark", ty = "libc::c_uint", bits = "24..=24")]
+    #[bitfield(name = "debug", ty = "libc::c_uint", bits = "25..=25")]
+    #[bitfield(name = "trace", ty = "libc::c_uint", bits = "26..=26")]
+    #[bitfield(name = "spare", ty = "libc::c_uint", bits = "27..=27")]
+    #[bitfield(name = "gcgen", ty = "libc::c_uint", bits = "28..=28")]
+    #[bitfield(name = "gccls", ty = "libc::c_uint", bits = "29..=31")]
+    #[bitfield(name = "named", ty = "libc::c_uint", bits = "32..=47")]
+    #[bitfield(name = "extra", ty = "libc::c_uint", bits = "48..=63")]
+    pub rtype_scalar_obj_alt_gp_mark_debug_trace_spare_gcgen_gccls_named_extra: [u8; 8],
+}
+
+pub static mut ACTIVE_BINDING_MASK: libc::c_uint = 1 << 15;
+pub static mut S4_OBJECT_MASK: libc::c_uint = 1 << 4;
+
+impl Sxpinfo {
+
+    pub fn interpret(x: &SEXP) -> &Self {
+        unsafe {
+            (*x as *mut Sxpinfo).as_ref().unwrap()
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.gp() & unsafe {ACTIVE_BINDING_MASK} != 0
+    }
+
+    pub fn is_immediate(&self) -> bool {
+        self.extra() != 0
+    }
+
+    pub fn is_s4(&self) -> bool {
+        self.gp() & unsafe {S4_OBJECT_MASK} != 0
+    }
+
+    pub fn is_altrep(&self) -> bool {
+        self.alt() != 0
+    }
+
+    pub fn is_object(&self) -> bool {
+        self.obj() != 0
+    }
 }
 
 pub fn r_assert_type(
@@ -75,6 +128,18 @@ pub unsafe fn r_assert_length(
 
 pub fn r_is_null(object: SEXP) -> bool {
     unsafe { object == R_NilValue }
+}
+
+pub fn r_is_altrep(object: SEXP) -> bool {
+    Sxpinfo::interpret(&object).is_altrep()
+}
+
+pub fn r_is_object(object: SEXP) -> bool {
+    Sxpinfo::interpret(&object).is_object()
+}
+
+pub fn r_is_s4(object: SEXP) -> bool {
+    Sxpinfo::interpret(&object).is_s4()
 }
 
 pub fn r_typeof(object: SEXP) -> u32 {


### PR DESCRIPTION
active bindings and promise report size 0 which IMO is fair game. 

This calls an R function `object.size()` each time, so do we want to make it optional to retrieve the sizes ?