### PR TITLE
Moving `Vector::format()` to a `collapse()` function

### DIFF
--- a/extensions/positron-r/amalthea/crates/harp/harp-macros/src/lib.rs
+++ b/extensions/positron-r/amalthea/crates/harp/harp-macros/src/lib.rs
@@ -114,36 +114,6 @@ pub fn vector(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     size: size,
                 }
             }
-
-            pub fn format(&self, sep: &str, max: usize) -> (bool, String)
-            {
-                let mut out = String::from("");
-                let mut truncated = false;
-                let mut first = true;
-                let mut iter = self.iter();
-
-                while let Some(x) = iter.next() {
-                    if max > 0 && out.len() > max {
-                        truncated = true;
-                        break;
-                    }
-
-                    if first {
-                        first = false;
-                    } else {
-                        out.push_str(sep);
-                    }
-
-                    match x {
-                        Some(value) => {
-                            out.push_str(self.format_one(value).as_str());
-                        },
-                        None => out.push_str("NA")
-                    }
-                }
-
-                (truncated, out)
-            }
         }
 
         impl<T> std::cmp::PartialEq<T> for #ident

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -21,14 +21,8 @@ use crate::utils::r_is_altrep;
 use crate::utils::r_is_null;
 use crate::utils::r_typeof;
 use crate::vector::CharacterVector;
-use crate::vector::Factor;
-use crate::vector::IntegerVector;
-use crate::vector::LogicalVector;
-use crate::vector::NumericVector;
-use crate::vector::RawVector;
-use crate::vector::ComplexVector;
 use crate::vector::Vector;
-use crate::with_vector;
+use crate::vector::collapse;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum BindingKind {
@@ -127,9 +121,7 @@ impl BindingType {
                         .add(value)
                         .call()
                         .unwrap();
-
-                    let dim = IntegerVector::new(dim).unwrap();
-                    let shape = dim.format(",", 0).1;
+                    let shape = collapse(*dim, ",", 0, "").unwrap().result;
 
                     Self::simple(
                         format!("{} [{}]", dfclass, shape)
@@ -279,18 +271,15 @@ fn first_class(value: SEXP) -> Option<String> {
 fn all_classes(value: SEXP) -> String {
     unsafe {
         let classes = Rf_getAttrib(value, R_ClassSymbol);
-        let classes = CharacterVector::new_unchecked(classes);
-        classes.format("/", 0).1
+        collapse(classes, "/", 0, "").unwrap().result
     }
 }
 
 fn regular_binding_display_value(value: SEXP) -> BindingValue {
     let rtype = r_typeof(value);
     if is_simple_vector(value) {
-        with_vector!(value, |v| {
-            let formatted = v.format(" ", 100);
-            BindingValue::new(formatted.1, formatted.0)
-        }).unwrap()
+        let formatted = collapse(value, " ", 100, if rtype == STRSXP { "\"" } else { "" }).unwrap();
+        BindingValue::new(formatted.result, formatted.truncated)
     } else if rtype == VECSXP && ! unsafe{r_inherits(value, "POSIXlt")}{
         // This includes data frames
         BindingValue::empty()
@@ -321,10 +310,8 @@ fn format_display_value(value: SEXP) -> BindingValue {
         match formatted {
             Ok(fmt) => {
                 if r_typeof(*fmt) == STRSXP {
-                    let fmt = CharacterVector::unquoted(*fmt);
-                    let fmt = fmt.format(" ", 100);
-
-                    BindingValue::new(fmt.1, fmt.0)
+                    let fmt = collapse(*fmt, " ", 100, "").unwrap();
+                    BindingValue::new(fmt.result, fmt.truncated)
                 } else {
                     BindingValue::new(String::from("???"), false)
                 }
@@ -392,8 +379,7 @@ fn vec_shape(value: SEXP) -> String {
                 format!(" [{}]", Rf_xlength(value))
             }
         } else {
-            let dim = IntegerVector::new(dim).unwrap();
-            format!(" [{}]", dim.format(",", 0).1)
+            format!(" [{}]", collapse(*dim, ",", 0, "").unwrap().result)
         }
     }
 }

--- a/extensions/positron-r/amalthea/crates/harp/src/lib.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/lib.rs
@@ -55,11 +55,11 @@ macro_rules! with_vector {
         unsafe {
             let sexp = $sexp;
 
-            let rtype = r_typeof(sexp);
+            let rtype = crate::utils::r_typeof(sexp);
             match rtype {
                 LGLSXP  => crate::with_vector_impl!(sexp, LogicalVector, $variable, $($code)*),
                 INTSXP  => {
-                    if r_inherits(sexp, "factor") {
+                    if crate::utils::r_inherits(sexp, "factor") {
                         crate::with_vector_impl!(sexp, Factor, $variable, $($code)*)
                     } else {
                         crate::with_vector_impl!(sexp, IntegerVector, $variable, $($code)*)

--- a/extensions/positron-r/amalthea/crates/harp/src/vector/character_vector.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/vector/character_vector.rs
@@ -14,18 +14,7 @@ use crate::vector::Vector;
 
 #[harp_macros::vector]
 pub struct CharacterVector {
-    object: RObject,
-    quotes: bool
-}
-
-impl CharacterVector {
-    pub unsafe fn unquoted(object: impl Into<SEXP>) -> Self {
-        let object = object.into();
-        Self {
-            object: RObject::new(object),
-            quotes: false
-        }
-    }
+    object: RObject
 }
 
 impl Vector for CharacterVector {
@@ -40,10 +29,8 @@ impl Vector for CharacterVector {
     }
 
     unsafe fn new_unchecked(object: impl Into<SEXP>) -> Self {
-        let object = object.into();
         Self {
-            object: RObject::new(object),
-            quotes: true
+            object: RObject::new(object.into())
         }
     }
 
@@ -90,11 +77,7 @@ impl Vector for CharacterVector {
     }
 
     fn format_one(&self, x: Self::Type) -> String {
-        if self.quotes {
-            format!("\"{}\"", x)
-        } else {
-            x
-        }
+        x
     }
 
 }

--- a/extensions/positron-r/amalthea/crates/harp/src/vector/mod.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/vector/mod.rs
@@ -5,11 +5,14 @@
 //
 //
 
+use itertools::Itertools;
+use itertools::FoldWhile::{Continue, Done};
 use libR_sys::*;
 
 use crate::error::Result;
 use crate::utils::r_assert_capacity;
 use crate::utils::r_assert_type;
+use crate::with_vector;
 
 pub mod character_vector;
 pub use character_vector::CharacterVector;
@@ -83,4 +86,41 @@ pub trait Vector {
 
     fn format_one(&self, x: Self::Type) -> String;
 
+}
+
+pub struct Collapse {
+    pub result: String,
+    pub truncated: bool,
+}
+
+pub fn collapse(vector: SEXP, sep: &str, max: usize, quote: &str) -> Result<Collapse> {
+    with_vector!(vector, |v| {
+        let mut first = true;
+        let formatted = v.iter().fold_while(String::from(""), |mut acc, x| {
+            let added = format!("{}{}{}{}",
+                if first {
+                    first = false;
+                    ""
+                } else {
+                    sep
+                },
+                quote,
+                match x {
+                    Some(x) => v.format_one(x),
+                    None    => String::from("NA")
+                },
+                quote
+            );
+            acc.push_str(&added);
+            if max > 0 && acc.len() > max {
+                Done(acc)
+            } else {
+                Continue(acc)
+            }
+        });
+        match formatted {
+            Done(result) => Collapse{result, truncated: false},
+            Continue(result) => Collapse{result, truncated: true}
+        }
+    })
 }


### PR DESCRIPTION
This removes some complexity from the `vector()` macro and the `CharacterVector` classes. 