### PR TITLE
update reacts to changes in altrep data1 or data2

### DIFF
--- a/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
@@ -444,7 +444,7 @@ impl REnvironment {
         //       whose name start with "."
         let env = Environment::new(self.env.sexp);
         let mut bindings: Vec<Binding> = env.iter().filter(|binding| {
-            !String::from(binding.name).starts_with(".")
+            !binding.is_hidden()
         }).collect();
 
         bindings.sort();

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
@@ -381,31 +381,11 @@ impl REnvironment {
 
                     (Some(old), Some(new)) => {
                         if old.name == new.name {
-                            let mut updated = false;
-                            if old.value != new.value {
-                                updated = true;
-                            } else {
-                                if old.watch_list.len() != new.watch_list.len() {
-                                    // watch lists have difference sizes, that should not happen
-                                    // but that means the binding has changed for sure
-                                    updated = true;
-                                } else {
-                                    // consider the object updated if any of the watched SEXP has changed
-                                    for (x, y) in std::iter::zip(old.watch_list.iter(), new.watch_list.iter()) {
-                                        if x != y {
-                                            updated = true;
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-
-                            if updated {
+                            if old != new {
                                 assigned.push(
                                     EnvironmentVariable::new(&new)
                                 );
                             }
-
                             old_next = old_iter.next();
                             new_next = new_iter.next();
                         } else if old.name < new.name {
@@ -447,7 +427,9 @@ impl REnvironment {
             !binding.is_hidden()
         }).collect();
 
-        bindings.sort();
+        bindings.sort_by(|a, b| {
+            a.name.cmp(&b.name)
+        });
         bindings
     }
 }

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
@@ -381,7 +381,26 @@ impl REnvironment {
 
                     (Some(old), Some(new)) => {
                         if old.name == new.name {
+                            let mut updated = false;
                             if old.value != new.value {
+                                updated = true;
+                            } else {
+                                if old.watch_list.len() != new.watch_list.len() {
+                                    // watch lists have difference sizes, that should not happen
+                                    // but that means the binding has changed for sure
+                                    updated = true;
+                                } else {
+                                    // consider the object updated if any of the watched SEXP has changed
+                                    for (x, y) in std::iter::zip(old.watch_list.iter(), new.watch_list.iter()) {
+                                        if x != y {
+                                            updated = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+
+                            if updated {
                                 assigned.push(
                                     EnvironmentVariable::new(&new)
                                 );

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/r_environment.rs
@@ -381,7 +381,7 @@ impl REnvironment {
 
                     (Some(old), Some(new)) => {
                         if old.name == new.name {
-                            if old != new {
+                            if old.value != new.value {
                                 assigned.push(
                                     EnvironmentVariable::new(&new)
                                 );

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -11,12 +11,12 @@ use harp::environment::first_class;
 use harp::environment::vec_shape;
 use harp::environment::vec_type;
 use harp::utils::r_is_altrep;
+use harp::utils::r_is_simple_vector;
 use itertools::Itertools;
 
 use harp::environment::Binding;
 use harp::environment::BindingKind;
 use harp::environment::Environment;
-use harp::environment::is_simple_vector;
 use harp::environment::pairlist_size;
 use harp::exec::RFunction;
 use harp::exec::RFunctionExt;
@@ -123,7 +123,7 @@ impl WorkspaceVariableDisplayValue {
 
     pub fn from(value: SEXP) -> Self {
         let rtype = r_typeof(value);
-        if is_simple_vector(value) {
+        if r_is_simple_vector(value) {
             let formatted = collapse(value, " ", 100, if rtype == STRSXP { "\"" } else { "" }).unwrap();
             Self::new(formatted.result, formatted.truncated)
         } else if rtype == VECSXP && ! unsafe{r_inherits(value, "POSIXlt")}{
@@ -183,7 +183,7 @@ impl WorkspaceVariableDisplayType {
             return Self::from_class(value, String::from("S4"));
         }
 
-        if is_simple_vector(value) {
+        if r_is_simple_vector(value) {
             let display_type = format!("{}{}", vec_type(value), vec_shape(value));
 
             let mut type_info = display_type.clone();

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 
 use harp::environment::Binding;
 use harp::environment::BindingKind;
-use harp::environment::BindingType;
+use harp::environment::WorkspaceVariableDisplayType;
 use harp::environment::Environment;
 use harp::environment::is_simple_vector;
 use harp::environment::pairlist_size;
@@ -182,7 +182,7 @@ impl EnvironmentVariable {
      */
     fn from(access_key: String, display_name: String, x: SEXP) -> Self {
         let WorkspaceVariableDisplayValue{display_value, is_truncated} = WorkspaceVariableDisplayValue::from(x);
-        let BindingType{display_type, type_info} = BindingType::from(x);
+        let WorkspaceVariableDisplayType{display_type, type_info} = WorkspaceVariableDisplayType::from(x);
         let has_children = harp::environment::has_children(x);
 
         Self {

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -422,7 +422,7 @@ impl EnvironmentVariable {
 
         let env = Environment::new(value);
         for binding in env.iter() {
-            if !String::from(binding.name).starts_with(".") {
+            if !binding.is_hidden() {
                 out.push(Self::new(&binding));
             }
         }

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -291,9 +291,9 @@ impl EnvironmentVariable {
         let display_name = binding.name.to_string();
 
         match binding.value {
-            BindingValue::Active{fun: _} => Self::from_lazy(display_name, String::from("active binding")),
-            BindingValue::Promise{promise: _} => Self::from_lazy(display_name, String::from("promise")),
-            BindingValue::Altrep{object, ..} | BindingValue::Standard { object, .. } => Self::from(display_name.clone(), display_name, object)
+            BindingValue::Active{..} => Self::from_lazy(display_name, String::from("active binding")),
+            BindingValue::Promise{..} => Self::from_lazy(display_name, String::from("promise")),
+            BindingValue::Altrep{object, ..} | BindingValue::Standard {object, ..} => Self::from(display_name.clone(), display_name, object)
         }
     }
 

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -293,7 +293,7 @@ impl EnvironmentVariable {
         match binding.value {
             BindingValue::Active{fun: _} => Self::from_lazy(display_name, String::from("active binding")),
             BindingValue::Promise{promise: _} => Self::from_lazy(display_name, String::from("promise")),
-            BindingValue::Altrep{object, data1: _, data2: _} | BindingValue::Standard { object } => Self::from(display_name.clone(), display_name, object)
+            BindingValue::Altrep{object, ..} | BindingValue::Standard { object, .. } => Self::from(display_name.clone(), display_name, object)
         }
     }
 

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -5,6 +5,7 @@
 //
 //
 
+use harp::environment::BindingValue;
 use harp::utils::r_altrep_class;
 use harp::utils::r_vec_shape;
 use harp::utils::r_vec_type;
@@ -15,7 +16,6 @@ use harp::utils::r_is_simple_vector;
 use itertools::Itertools;
 
 use harp::environment::Binding;
-use harp::environment::BindingKind;
 use harp::environment::Environment;
 use harp::exec::RFunction;
 use harp::exec::RFunctionExt;
@@ -290,11 +290,10 @@ impl EnvironmentVariable {
     pub fn new(binding: &Binding) -> Self {
         let display_name = binding.name.to_string();
 
-        match binding.kind {
-            BindingKind::Active => Self::from_lazy(display_name, String::from("active binding")),
-            BindingKind::Promise(false) => Self::from_lazy(display_name, String::from("promise")),
-            BindingKind::Promise(true) => Self::from(display_name.clone(), display_name, unsafe { PRVALUE(binding.value) }),
-            BindingKind::Regular => Self::from(display_name.clone(), display_name, binding.value)
+        match binding.value {
+            BindingValue::Active{fun: _} => Self::from_lazy(display_name, String::from("active binding")),
+            BindingValue::Promise{promise: _} => Self::from_lazy(display_name, String::from("promise")),
+            BindingValue::Altrep{object, data1: _, data2: _} | BindingValue::Standard { object } => Self::from(display_name.clone(), display_name, object)
         }
     }
 

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -491,11 +491,10 @@ impl EnvironmentVariable {
             Self::inspect_s4(*object)
         } else {
             match r_typeof(*object) {
-                VECSXP  => Self::inspect_list(*object),
-                EXPRSXP => Self::inspect_list(*object),
-                LISTSXP => Self::inspect_pairlist(*object),
-                ENVSXP  => Self::inspect_environment(*object),
-                _       => Ok(vec![])
+                VECSXP | EXPRSXP  => Self::inspect_list(*object),
+                LISTSXP           => Self::inspect_pairlist(*object),
+                ENVSXP            => Self::inspect_environment(*object),
+                _                 => Ok(vec![])
             }
         }
     }

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -7,6 +7,7 @@
 
 use harp::environment::BindingValue;
 use harp::utils::r_altrep_class;
+use harp::utils::r_is_s4;
 use harp::utils::r_vec_shape;
 use harp::utils::r_vec_type;
 use harp::utils::pairlist_size;
@@ -174,11 +175,11 @@ pub struct WorkspaceVariableDisplayType {
 impl WorkspaceVariableDisplayType {
 
     pub fn from(value: SEXP) -> Self {
-        if value == unsafe { R_NilValue } {
+        if r_is_null(value) {
             return Self::simple(String::from("NULL"))
         }
 
-        if RObject::view(value).is_s4() {
+        if r_is_s4(value) {
             return Self::from_class(value, String::from("S4"));
         }
 
@@ -248,9 +249,11 @@ impl WorkspaceVariableDisplayType {
         match r_classes(value) {
             None => Self::simple(default),
             Some(classes) => {
+                unsafe {Rf_PrintValue(*classes)};
+
                 Self::new(
                     classes.get_unchecked(0).unwrap(),
-                    unsafe { classes.unsafe_iter() }.join("/")
+                    classes.iter().map(|s| s.unwrap()).join("/")
                 )
             }
         }

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -8,7 +8,7 @@
 use harp::environment::Binding;
 use harp::environment::BindingKind;
 use harp::environment::BindingType;
-use harp::environment::BindingValue;
+use harp::environment::WorkspaceVariableDisplayValue;
 use harp::environment::Environment;
 use harp::environment::pairlist_size;
 use harp::exec::RFunction;
@@ -104,30 +104,8 @@ impl EnvironmentVariable {
         let display_name = binding.name.to_string();
 
         match binding.kind {
-            BindingKind::Active => Self {
-                access_key: display_name.clone(),
-                display_name,
-                display_value: String::from(""),
-                display_type: String::from("active binding"),
-                type_info: String::from("active binding"),
-                kind: ValueKind::Other,
-                length: 0,
-                size: 0,
-                has_children: false,
-                is_truncated: false
-            },
-            BindingKind::Promise(false) => Self {
-                access_key: display_name.clone(),
-                display_name,
-                display_value: String::from(""),
-                display_type: String::from("promise"),
-                type_info: String::from("promise"),
-                kind: ValueKind::Other,
-                length: 0,
-                size: 0,
-                has_children: false,
-                is_truncated: false
-            },
+            BindingKind::Active => Self::from_lazy(display_name, String::from("active binding")),
+            BindingKind::Promise(false) => Self::from_lazy(display_name, String::from("promise")),
             BindingKind::Promise(true) => Self::from(display_name.clone(), display_name, unsafe { PRVALUE(binding.value) }),
             BindingKind::Regular => Self::from(display_name.clone(), display_name, binding.value)
         }
@@ -137,7 +115,7 @@ impl EnvironmentVariable {
      * Create a new EnvironmentVariable from an R object
      */
     fn from(access_key: String, display_name: String, x: SEXP) -> Self {
-        let BindingValue{display_value, is_truncated} = BindingValue::from(x);
+        let WorkspaceVariableDisplayValue{display_value, is_truncated} = WorkspaceVariableDisplayValue::from(x);
         let BindingType{display_type, type_info} = BindingType::from(x);
         let has_children = harp::environment::has_children(x);
 
@@ -152,6 +130,21 @@ impl EnvironmentVariable {
             size: RObject::view(x).size(),
             has_children,
             is_truncated
+        }
+    }
+
+    fn from_lazy(display_name: String, lazy_type: String) -> Self {
+        Self {
+            access_key: display_name.clone(),
+            display_name,
+            display_value: String::from(""),
+            display_type: lazy_type.clone(),
+            type_info: lazy_type,
+            kind: ValueKind::Other,
+            length: 0,
+            size: 0,
+            has_children: false,
+            is_truncated: false
         }
     }
 

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -5,9 +5,9 @@
 //
 //
 
-use harp::environment::altrep_class;
-use harp::environment::vec_shape;
-use harp::environment::vec_type;
+use harp::utils::r_altrep_class;
+use harp::utils::r_vec_shape;
+use harp::utils::r_vec_type;
 use harp::utils::pairlist_size;
 use harp::utils::r_classes;
 use harp::utils::r_is_altrep;
@@ -183,11 +183,11 @@ impl WorkspaceVariableDisplayType {
         }
 
         if r_is_simple_vector(value) {
-            let display_type = format!("{}{}", vec_type(value), vec_shape(value));
+            let display_type = format!("{}{}", r_vec_type(value), r_vec_shape(value));
 
             let mut type_info = display_type.clone();
             if r_is_altrep(value) {
-                type_info.push_str(altrep_class(value).as_str())
+                type_info.push_str(r_altrep_class(value).as_str())
             }
 
             return Self::new(display_type, type_info);
@@ -200,7 +200,7 @@ impl WorkspaceVariableDisplayType {
             CLOSXP  => Self::from_class(value, String::from("function")),
             ENVSXP  => Self::from_class(value, String::from("environment")),
             SYMSXP  => {
-                if value == unsafe { R_MissingArg } {
+                if r_is_null(value) {
                     Self::simple(String::from("missing"))
                 } else {
                     Self::simple(String::from("symbol"))
@@ -250,7 +250,7 @@ impl WorkspaceVariableDisplayType {
             Some(classes) => {
                 Self::new(
                     classes.get_unchecked(0).unwrap(),
-                    classes.unsafe_iter().join("/")
+                    unsafe { classes.unsafe_iter() }.join("/")
                 )
             }
         }

--- a/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/environment/variable.rs
@@ -249,8 +249,6 @@ impl WorkspaceVariableDisplayType {
         match r_classes(value) {
             None => Self::simple(default),
             Some(classes) => {
-                unsafe {Rf_PrintValue(*classes)};
-
                 Self::new(
                     classes.get_unchecked(0).unwrap(),
                     classes.iter().map(|s| s.unwrap()).join("/")

--- a/extensions/positron-r/amalthea/crates/harp/harp-macros/src/lib.rs
+++ b/extensions/positron-r/amalthea/crates/harp/harp-macros/src/lib.rs
@@ -105,10 +105,37 @@ pub fn vector(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         }
 
+        pub struct UnsafeVectorIter<'a> {
+            data: &'a #ident,
+            index: isize,
+            size: isize,
+        }
+
+        impl<'a> std::iter::Iterator for UnsafeVectorIter<'a> {
+            type Item = <#ident as Vector>::Type;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                if self.index == self.size {
+                    return None;
+                }
+
+                unsafe { self.data.get_unchecked(self.index) }
+            }
+        }
+
         impl #ident {
             pub fn iter(&self) -> VectorIter<'_> {
                 let size = unsafe { self.len() as isize };
                 VectorIter {
+                    data: self,
+                    index: 0,
+                    size: size,
+                }
+            }
+
+            pub fn unsafe_iter(&self) -> UnsafeVectorIter<'_> {
+                let size = unsafe { self.len() as isize };
+                UnsafeVectorIter {
                     data: self,
                     index: 0,
                     size: size,

--- a/extensions/positron-r/amalthea/crates/harp/harp-macros/src/lib.rs
+++ b/extensions/positron-r/amalthea/crates/harp/harp-macros/src/lib.rs
@@ -133,7 +133,9 @@ pub fn vector(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
             }
 
-            pub fn unsafe_iter(&self) -> UnsafeVectorIter<'_> {
+            // !!! safety: this should only be used when it is known that
+            //             there are no missing values
+            pub fn unsafe unsafe_iter(&self) -> UnsafeVectorIter<'_> {
                 let size = unsafe { self.len() as isize };
                 UnsafeVectorIter {
                     data: self,

--- a/extensions/positron-r/amalthea/crates/harp/harp-macros/src/lib.rs
+++ b/extensions/positron-r/amalthea/crates/harp/harp-macros/src/lib.rs
@@ -105,39 +105,10 @@ pub fn vector(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         }
 
-        pub struct UnsafeVectorIter<'a> {
-            data: &'a #ident,
-            index: isize,
-            size: isize,
-        }
-
-        impl<'a> std::iter::Iterator for UnsafeVectorIter<'a> {
-            type Item = <#ident as Vector>::Type;
-
-            fn next(&mut self) -> Option<Self::Item> {
-                if self.index == self.size {
-                    return None;
-                }
-
-                unsafe { self.data.get_unchecked(self.index) }
-            }
-        }
-
         impl #ident {
             pub fn iter(&self) -> VectorIter<'_> {
                 let size = unsafe { self.len() as isize };
                 VectorIter {
-                    data: self,
-                    index: 0,
-                    size: size,
-                }
-            }
-
-            // !!! safety: this should only be used when it is known that
-            //             there are no missing values
-            pub unsafe fn unsafe_iter(&self) -> UnsafeVectorIter<'_> {
-                let size = unsafe { self.len() as isize };
-                UnsafeVectorIter {
                     data: self,
                     index: 0,
                     size: size,

--- a/extensions/positron-r/amalthea/crates/harp/harp-macros/src/lib.rs
+++ b/extensions/positron-r/amalthea/crates/harp/harp-macros/src/lib.rs
@@ -135,7 +135,7 @@ pub fn vector(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
             // !!! safety: this should only be used when it is known that
             //             there are no missing values
-            pub fn unsafe unsafe_iter(&self) -> UnsafeVectorIter<'_> {
+            pub unsafe fn unsafe_iter(&self) -> UnsafeVectorIter<'_> {
                 let size = unsafe { self.len() as isize };
                 UnsafeVectorIter {
                     data: self,

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -16,12 +16,23 @@ use crate::utils::r_is_altrep;
 use crate::utils::r_is_null;
 use crate::utils::r_typeof;
 
+#[derive(Eq)]
+pub struct BindingReference {
+    pub reference: bool
+}
+
+impl PartialEq for BindingReference {
+    fn eq(&self, other: &Self) -> bool {
+        !(self.reference || other.reference)
+    }
+}
+
 #[derive(Eq, PartialEq)]
 pub enum BindingValue {
     Active{fun: SEXP},
     Promise{promise: SEXP},
     Altrep{object: SEXP, data1: SEXP, data2: SEXP},
-    Standard{object: SEXP}
+    Standard{object: SEXP, reference: BindingReference}
 }
 
 #[derive(Eq, PartialEq)]
@@ -69,9 +80,9 @@ impl Binding {
                 return Self {name, value};
             }
 
-            let value = BindingValue::Standard { object: value };
+            let reference = BindingReference{ reference: r_typeof(value) == ENVSXP};
+            let value = BindingValue::Standard { object: value, reference };
             Self { name, value}
-
         }
 
     }

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -53,25 +53,65 @@ pub struct Binding {
     pub extra: BindingExtra,
 }
 
-pub struct BindingValue {
+pub struct WorkspaceVariableDisplayValue {
     pub display_value: String,
     pub is_truncated: bool
 }
 
-impl BindingValue {
-    pub fn new(display_value: String, is_truncated: bool) -> Self {
-        BindingValue {
+impl WorkspaceVariableDisplayValue {
+    fn new(display_value: String, is_truncated: bool) -> Self {
+        WorkspaceVariableDisplayValue {
             display_value,
             is_truncated
         }
     }
 
-    pub fn empty() -> Self {
+    fn empty() -> Self {
         Self::new(String::from(""), false)
     }
 
-    pub fn from(x: SEXP) -> Self {
-        regular_binding_display_value(x)
+    pub fn from(value: SEXP) -> Self {
+        let rtype = r_typeof(value);
+        if is_simple_vector(value) {
+            let formatted = collapse(value, " ", 100, if rtype == STRSXP { "\"" } else { "" }).unwrap();
+            Self::new(formatted.result, formatted.truncated)
+        } else if rtype == VECSXP && ! unsafe{r_inherits(value, "POSIXlt")}{
+            // This includes data frames
+            Self::empty()
+        } else if rtype == LISTSXP {
+            Self::empty()
+        } else if rtype == SYMSXP && value == unsafe{ R_MissingArg } {
+            Self::new(String::from("<missing>"), false)
+        } else if rtype == CLOSXP {
+            unsafe {
+                let args      = RFunction::from("args").add(value).call().unwrap();
+                let formatted = RFunction::from("format").add(*args).call().unwrap();
+                let formatted = CharacterVector::new_unchecked(formatted);
+                let out = formatted.iter().take(formatted.len() -1).map(|o|{ o.unwrap() }).join("");
+                Self::new(out, false)
+            }
+        } else {
+            unsafe {
+                // try to call format() on the object
+                let formatted = RFunction::new("base", "format")
+                    .add(value)
+                    .call();
+
+                match formatted {
+                    Ok(fmt) => {
+                        if r_typeof(*fmt) == STRSXP {
+                            let fmt = collapse(*fmt, " ", 100, "").unwrap();
+                            Self::new(fmt.result, fmt.truncated)
+                        } else {
+                            Self::new(String::from("???"), false)
+                        }
+                    },
+                    Err(_) => {
+                        Self::new(String::from("???"), false)
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -255,54 +295,6 @@ fn all_classes(value: SEXP) -> String {
     unsafe {
         let classes = Rf_getAttrib(value, R_ClassSymbol);
         collapse(classes, "/", 0, "").unwrap().result
-    }
-}
-
-fn regular_binding_display_value(value: SEXP) -> BindingValue {
-    let rtype = r_typeof(value);
-    if is_simple_vector(value) {
-        let formatted = collapse(value, " ", 100, if rtype == STRSXP { "\"" } else { "" }).unwrap();
-        BindingValue::new(formatted.result, formatted.truncated)
-    } else if rtype == VECSXP && ! unsafe{r_inherits(value, "POSIXlt")}{
-        // This includes data frames
-        BindingValue::empty()
-    } else if rtype == LISTSXP {
-        BindingValue::empty()
-    } else if rtype == SYMSXP && value == unsafe{ R_MissingArg } {
-        BindingValue::new(String::from("<missing>"), false)
-    } else if rtype == CLOSXP {
-        unsafe {
-            let args      = RFunction::from("args").add(value).call().unwrap();
-            let formatted = RFunction::from("format").add(*args).call().unwrap();
-            let formatted = CharacterVector::new_unchecked(formatted);
-            let out = formatted.iter().take(formatted.len() -1).map(|o|{ o.unwrap() }).join("");
-            BindingValue::new(out, false)
-        }
-    } else {
-        format_display_value(value)
-    }
-}
-
-fn format_display_value(value: SEXP) -> BindingValue {
-    unsafe {
-        // try to call format() on the object
-        let formatted = RFunction::new("base", "format")
-            .add(value)
-            .call();
-
-        match formatted {
-            Ok(fmt) => {
-                if r_typeof(*fmt) == STRSXP {
-                    let fmt = collapse(*fmt, " ", 100, "").unwrap();
-                    BindingValue::new(fmt.result, fmt.truncated)
-                } else {
-                    BindingValue::new(String::from("???"), false)
-                }
-            },
-            Err(_) => {
-                BindingValue::new(String::from("???"), false)
-            }
-        }
     }
 }
 

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -36,7 +36,8 @@ pub enum BindingKind {
 pub struct Binding {
     pub name: RSymbol,
     pub value: SEXP,
-    pub kind: BindingKind
+    pub kind: BindingKind,
+    pub watch_list: Vec<SEXP>
 }
 
 impl Ord for Binding {
@@ -182,7 +183,10 @@ impl Binding {
             };
 
             Self {
-                name, value, kind
+                name,
+                value,
+                kind,
+                watch_list: vec![]
             }
         }
 

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -50,12 +50,12 @@ pub struct Binding {
     pub extra: BindingExtra,
 }
 
-pub struct BindingType {
+pub struct WorkspaceVariableDisplayType {
     pub display_type: String,
     pub type_info: String
 }
 
-impl BindingType {
+impl WorkspaceVariableDisplayType {
 
     pub fn from(value: SEXP) -> Self {
         if value == unsafe { R_NilValue } {
@@ -267,7 +267,7 @@ fn vec_type(value: SEXP) -> String {
     }
 }
 
-fn vec_type_info(value: SEXP) -> BindingType {
+fn vec_type_info(value: SEXP) -> WorkspaceVariableDisplayType {
     let display_type = format!("{}{}", vec_type(value), vec_shape(value));
 
     let mut type_info = display_type.clone();
@@ -275,7 +275,7 @@ fn vec_type_info(value: SEXP) -> BindingType {
         type_info.push_str(altrep_class(value).as_str())
     }
 
-    BindingType::new(display_type, type_info)
+    WorkspaceVariableDisplayType::new(display_type, type_info)
 }
 
 fn vec_shape(value: SEXP) -> String {

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -33,18 +33,22 @@ fn has_reference(value: SEXP) -> bool {
         }
     }
 
-    // for now
-    if r_is_s4(value) {
-        return true;
+    unsafe {
+        // S4 slots are attributes and might be expandable
+        // so we need to check if they have reference objects
+        if r_is_s4(value) && has_reference(ATTRIB(value)) {
+            return true;
+        }
     }
 
     let rtype = r_typeof(value);
     match rtype {
-
         ENVSXP  => true,
+
         LISTSXP | LANGSXP => unsafe {
             has_reference(CAR(value)) || has_reference(CDR(value))
         },
+
         VECSXP | EXPRSXP  => unsafe {
             let n = XLENGTH(value);
             let mut has_ref = false;

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -95,19 +95,6 @@ impl Binding {
 
 }
 
-pub fn is_simple_vector(value: SEXP) -> bool {
-    unsafe {
-        let class = Rf_getAttrib(value, R_ClassSymbol);
-
-        match r_typeof(value) {
-            LGLSXP | REALSXP | CPLXSXP | STRSXP | RAWSXP => r_is_null(class),
-            INTSXP  => r_is_null(class) || r_inherits(value, "factor"),
-
-            _       => false
-        }
-    }
-}
-
 pub fn first_class(value: SEXP) -> Option<String> {
     unsafe {
         let classes = Rf_getAttrib(value, R_ClassSymbol);

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -12,13 +12,10 @@ use libR_sys::*;
 use crate::object::RObject;
 use crate::symbol::RSymbol;
 use crate::utils::Sxpinfo;
-use crate::utils::r_assert_type;
 use crate::utils::r_inherits;
 use crate::utils::r_is_altrep;
 use crate::utils::r_is_null;
 use crate::utils::r_typeof;
-use crate::vector::CharacterVector;
-use crate::vector::Vector;
 use crate::vector::collapse;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -93,38 +90,6 @@ impl Binding {
         String::from(self.name).starts_with(".")
     }
 
-}
-
-pub fn first_class(value: SEXP) -> Option<String> {
-    unsafe {
-        let classes = Rf_getAttrib(value, R_ClassSymbol);
-        if r_is_null(classes) {
-            None
-        } else {
-            let classes = CharacterVector::new_unchecked(classes);
-            Some(classes.get_unchecked(0).unwrap())
-        }
-    }
-}
-
-pub fn all_classes(value: SEXP) -> String {
-    unsafe {
-        let classes = Rf_getAttrib(value, R_ClassSymbol);
-        collapse(classes, "/", 0, "").unwrap().result
-    }
-}
-
-pub fn pairlist_size(mut pairlist: SEXP) -> Result<isize, crate::error::Error> {
-    let mut n = 0;
-    unsafe {
-        while pairlist != R_NilValue {
-            r_assert_type(pairlist, &[LISTSXP])?;
-
-            pairlist = CDR(pairlist);
-            n = n + 1;
-        }
-    }
-    Ok(n)
 }
 
 pub fn vec_type(value: SEXP) -> String {

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -198,28 +198,6 @@ impl Binding {
 
     }
 
-    pub fn get_type(&self) -> BindingType {
-        match self.kind {
-            BindingKind::Active => BindingType::simple(String::from("active binding")),
-            BindingKind::Promise(false) => BindingType::simple(String::from("promise")),
-
-            BindingKind::Regular => BindingType::from(self.value),
-            BindingKind::Promise(true) => BindingType::from(unsafe{PRVALUE(self.value)})
-        }
-    }
-
-    pub fn has_children(&self) -> bool {
-        match self.kind {
-            BindingKind::Regular => has_children(self.value),
-            BindingKind::Promise(true) => has_children(unsafe{PRVALUE(self.value)}),
-
-            // TODO:
-            //   - BindingKind::Promise(false) could have code and env as their children
-            //   - BindingKind::Active could have their function
-            _ => false
-        }
-    }
-
     pub fn is_hidden(&self) -> bool {
         String::from(self.name).starts_with(".")
     }

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -14,6 +14,7 @@ use crate::symbol::RSymbol;
 use crate::utils::Sxpinfo;
 use crate::utils::r_is_altrep;
 use crate::utils::r_is_null;
+use crate::utils::r_is_s4;
 use crate::utils::r_typeof;
 
 #[derive(Eq)]
@@ -32,11 +33,10 @@ fn has_reference(value: SEXP) -> bool {
         }
     }
 
-    /*
-    if has_reference(unsafe { ATTRIB(value) }) {
+    // for now
+    if r_is_s4(value) {
         return true;
     }
-    */
 
     let rtype = r_typeof(value);
     match rtype {

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -182,11 +182,17 @@ impl Binding {
                 }
             };
 
+            let watch_list = if r_is_altrep(value) {
+                vec![R_altrep_data1(value), R_altrep_data2(value)]
+            } else {
+                vec![]
+            };
+
             Self {
                 name,
                 value,
                 kind,
-                watch_list: vec![]
+                watch_list
             }
         }
 

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -9,8 +9,6 @@ use std::ops::Deref;
 
 use libR_sys::*;
 
-use crate::exec::RFunction;
-use crate::exec::RFunctionExt;
 use crate::object::RObject;
 use crate::symbol::RSymbol;
 use crate::utils::Sxpinfo;
@@ -95,24 +93,6 @@ impl Binding {
         String::from(self.name).starts_with(".")
     }
 
-}
-
-pub fn has_children(value: SEXP) -> bool {
-    if RObject::view(value).is_s4() {
-        unsafe {
-            let names = RFunction::new("methods", ".slotNames").add(value).call().unwrap();
-            let names = CharacterVector::new_unchecked(names);
-            names.len() > 0
-        }
-    } else {
-        match r_typeof(value) {
-            VECSXP   => unsafe { XLENGTH(value) != 0 },
-            EXPRSXP  => unsafe { XLENGTH(value) != 0 },
-            LISTSXP  => true,
-            ENVSXP   => true,
-            _        => false
-        }
-    }
 }
 
 pub fn is_simple_vector(value: SEXP) -> bool {

--- a/extensions/positron-r/amalthea/crates/harp/src/utils.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/utils.rs
@@ -23,8 +23,10 @@ use crate::exec::RFunctionExt;
 use crate::object::RObject;
 use crate::protect::RProtect;
 use crate::r_symbol;
+use crate::symbol::RSymbol;
 use crate::vector::CharacterVector;
 use crate::vector::Vector;
+use crate::vector::collapse;
 
 // NOTE: Regex::new() is quite slow to compile, so it's much better to keep
 // a single singleton pattern and use that repeatedly for matches.
@@ -178,6 +180,54 @@ pub fn pairlist_size(mut pairlist: SEXP) -> Result<isize> {
         }
     }
     Ok(n)
+}
+
+pub fn r_vec_type(value: SEXP) -> String {
+    match r_typeof(value) {
+        INTSXP  => unsafe {
+            if r_inherits(value, "factor") {
+                let levels = Rf_getAttrib(value, R_LevelsSymbol);
+                format!("fct({})", XLENGTH(levels))
+            } else {
+                String::from("int")
+            }
+        },
+        REALSXP => String::from("dbl"),
+        LGLSXP  => String::from("lgl"),
+        STRSXP  => String::from("str"),
+        RAWSXP  => String::from("raw"),
+        CPLXSXP => String::from("cplx"),
+
+        // TODO: this should not happen
+        _       => String::from("???")
+    }
+}
+
+pub fn r_vec_shape(value: SEXP) -> String {
+    unsafe {
+        let dim = RObject::new(Rf_getAttrib(value, R_DimSymbol));
+
+        if r_is_null(*dim) {
+            if XLENGTH(value) == 1 {
+                String::from("")
+            } else {
+                format!(" [{}]", Rf_xlength(value))
+            }
+        } else {
+            format!(" [{}]", collapse(*dim, ",", 0, "").unwrap().result)
+        }
+    }
+}
+
+pub fn r_altrep_class(object: SEXP) -> String {
+    let serialized_klass = unsafe{
+        ATTRIB(ALTREP_CLASS(object))
+    };
+
+    let klass = RSymbol::new(unsafe{CAR(serialized_klass)});
+    let pkg = RSymbol::new(unsafe{CADR(serialized_klass)});
+
+    format!("{}::{}", pkg, klass)
 }
 
 pub fn r_typeof(object: SEXP) -> u32 {

--- a/extensions/positron-r/amalthea/crates/harp/src/utils.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/utils.rs
@@ -155,6 +155,31 @@ pub fn r_is_simple_vector(value: SEXP) -> bool {
     }
 }
 
+pub fn r_classes(value: SEXP) -> Option<CharacterVector> {
+    unsafe {
+        let classes = RObject::from(Rf_getAttrib(value, R_ClassSymbol));
+
+        if *classes == R_NilValue {
+            None
+        } else {
+            Some(CharacterVector::new_unchecked(classes))
+        }
+    }
+}
+
+pub fn pairlist_size(mut pairlist: SEXP) -> Result<isize> {
+    let mut n = 0;
+    unsafe {
+        while pairlist != R_NilValue {
+            r_assert_type(pairlist, &[LISTSXP])?;
+
+            pairlist = CDR(pairlist);
+            n = n + 1;
+        }
+    }
+    Ok(n)
+}
+
 pub fn r_typeof(object: SEXP) -> u32 {
     // SAFETY: The type of an R object is typically considered constant,
     // and TYPEOF merely queries the R type directly from the SEXPREC struct.

--- a/extensions/positron-r/amalthea/crates/harp/src/utils.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/utils.rs
@@ -142,6 +142,19 @@ pub fn r_is_s4(object: SEXP) -> bool {
     Sxpinfo::interpret(&object).is_s4()
 }
 
+pub fn r_is_simple_vector(value: SEXP) -> bool {
+    unsafe {
+        let class = Rf_getAttrib(value, R_ClassSymbol);
+
+        match r_typeof(value) {
+            LGLSXP | REALSXP | CPLXSXP | STRSXP | RAWSXP => r_is_null(class),
+            INTSXP  => r_is_null(class) || r_inherits(value, "factor"),
+
+            _       => false
+        }
+    }
+}
+
 pub fn r_typeof(object: SEXP) -> u32 {
     // SAFETY: The type of an R object is typically considered constant,
     // and TYPEOF merely queries the R type directly from the SEXPREC struct.


### PR DESCRIPTION
closes #486 : 

This simplified the `Binding` struct so that bindings that are altrep also store their data1 and data2. This way, we can test if binding changed, when data1 or data2 has changed. 

This is not perfect, i.e. what if `data1` is a reference object like an environment, then we won't detect the change, but that's a good compromise IMO. 

closes #488 : 

Standard bindings (things that are not active bindings or promises) track whether they have references. For now this includes environments and lists that have one element that has reference. 

Starting with: 

```r
rm(list = ls())
e1 <- new.env()
e2 <- new.env()
a <- list(e1 = e1, e2 = e2)
e1$a <- 1
e2$b <- 2
```

and expanding a to: 

<img width="276" alt="image" src="https://user-images.githubusercontent.com/2625526/233603640-ccdba944-8a12-4416-a2af-0da0b28e2db5.png">

If we then do `e1$c <- 3` then `a` is updated so we get refreshed to: 

<img width="546" alt="image" src="https://user-images.githubusercontent.com/2625526/233603871-2826363d-672e-4269-a8f2-0129dddde79a.png">

Similarly, if we delete something, e.g. `rm(list = "b", envir = e2)`: 

<img width="548" alt="image" src="https://user-images.githubusercontent.com/2625526/233604416-647dbd6b-1390-4d68-a0f7-935f937c9910.png">
