### PR TITLE
R6 fields, methods and private

### DIFF
--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -147,6 +147,14 @@ impl Binding {
         String::from(self.name).starts_with(".")
     }
 
+    pub fn is_active(&self) -> bool {
+        if let BindingValue::Active { .. } = self.value {
+            true
+        } else {
+            false
+        }
+    }
+
 }
 
 pub struct Environment {

--- a/extensions/positron-r/amalthea/crates/harp/src/environment.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/environment.rs
@@ -317,6 +317,18 @@ impl Environment {
     pub fn iter(&self) -> EnvironmentIter {
         EnvironmentIter::new(&self)
     }
+
+    pub fn exists(&self, name: impl Into<RSymbol>) -> bool {
+        unsafe {
+            R_existsVarInFrame(self.env.sexp, *name.into()) == Rboolean_TRUE
+        }
+    }
+
+    pub fn find(&self, name: impl Into<RSymbol>) -> SEXP {
+        let name = name.into();
+        unsafe { Rf_findVarInFrame(self.env.sexp, *name) }
+    }
+
 }
 
 #[cfg(test)]

--- a/extensions/positron-r/amalthea/crates/harp/src/error.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/error.rs
@@ -23,7 +23,8 @@ pub enum Error {
     InvalidUtf8(Utf8Error),
     TryCatchError { message: Vec<String>, classes : Vec<String> },
     ParseSyntaxError { message: String, line: i32 },
-    MissingValueError
+    MissingValueError,
+    InspectError { path : Vec<String> }
 }
 
 // empty implementation required for 'anyhow'
@@ -87,6 +88,10 @@ impl fmt::Display for Error {
 
             Error::MissingValueError => {
                 write!(f, "Missing value")
+            }
+
+            Error::InspectError { path } => {
+                write!(f, "Error inspecting path {}", path.join(" / "))
             }
         }
     }

--- a/extensions/positron-r/amalthea/crates/harp/src/symbol.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/symbol.rs
@@ -10,6 +10,8 @@ use std::ffi::CStr;
 
 use std::ops::Deref;
 
+use crate::r_symbol;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RSymbol {
     pub sexp: SEXP
@@ -37,8 +39,25 @@ impl From<RSymbol> for String {
     }
 }
 
+impl From<&str> for RSymbol {
+    fn from(value: &str) -> Self {
+        RSymbol {
+            sexp: unsafe { r_symbol!(value) }
+        }
+    }
+}
+
 impl std::fmt::Display for RSymbol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", String::from(*self))
+    }
+}
+
+impl PartialEq<&str> for RSymbol {
+    fn eq(&self, other: &&str) -> bool {
+        unsafe {
+            let utf8text = Rf_translateCharUTF8(PRINTNAME(self.sexp));
+            CStr::from_ptr(utf8text).to_str().unwrap() == *other
+        }
     }
 }

--- a/extensions/positron-r/amalthea/crates/harp/src/symbol.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/symbol.rs
@@ -47,6 +47,12 @@ impl From<&str> for RSymbol {
     }
 }
 
+impl From<&String> for RSymbol {
+    fn from(value: &String) -> Self {
+        RSymbol::from(value.as_str())
+    }
+}
+
 impl std::fmt::Display for RSymbol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", String::from(*self))

--- a/extensions/positron-r/amalthea/crates/harp/src/utils.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/utils.rs
@@ -144,6 +144,10 @@ pub fn r_is_s4(object: SEXP) -> bool {
     Sxpinfo::interpret(&object).is_s4()
 }
 
+pub fn r_is_unbound(object: SEXP) -> bool {
+    object == unsafe { R_UnboundValue }
+}
+
 pub fn r_is_simple_vector(value: SEXP) -> bool {
     unsafe {
         let class = Rf_getAttrib(value, R_ClassSymbol);


### PR DESCRIPTION
closes #489 

This structures the tree for R6 objects so that fields (incl active fields) are direct children, methods are under a artificial "methods" node and private fields are under "private" node. 

For example with the objects in `?R6` : 

<img width="277" alt="image" src="https://user-images.githubusercontent.com/2625526/234287194-b6e5f5dd-2de8-4f31-a669-1a038fbb61a2.png">

<img width="284" alt="image" src="https://user-images.githubusercontent.com/2625526/234287362-14af826d-3bf0-49be-8518-4441c8155dc3.png">

<img width="277" alt="image" src="https://user-images.githubusercontent.com/2625526/234287489-df3cb76c-9592-4086-8b0c-22dc62d8c51d.png">

For now the class generators are displayed as regular environments: 

<img width="274" alt="image" src="https://user-images.githubusercontent.com/2625526/234287628-6403270d-1fd8-44b5-9b11-a21c2e13178f.png">

