### PR TITLE
Bump python to avoid sending env pane updates on empty statements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -558,6 +558,7 @@
 				"host": "localhost",
 				"port": 5678
 			},
+			"subProcess": false,
 			"pathMappings": [
 				{
 					"localRoot": "${workspaceFolder}",


### PR DESCRIPTION
Also update debug python launch profile to not include subprocesses by default.

