### PR TITLE
Fix build breaks on amd64 and older R

### DIFF
--- a/extensions/positron-r/amalthea/crates/ark/src/lsp/util.rs
+++ b/extensions/positron-r/amalthea/crates/ark/src/lsp/util.rs
@@ -7,6 +7,7 @@
 
 use harp::object::RObject;
 use libR_sys::*;
+use std::os::raw::c_char;
 
 /// Shows a message in the Positron frontend
 #[harp::register]
@@ -22,5 +23,5 @@ pub unsafe extern "C" fn ps_log_error(message: SEXP) -> SEXP {
 #[harp::register]
 pub unsafe extern "C" fn ps_object_id(object: SEXP) -> SEXP {
     let value = format!("{:p}", object);
-    return Rf_mkString(value.as_ptr() as *const i8);
+    return Rf_mkString(value.as_ptr() as *const c_char);
 }

--- a/extensions/positron-r/amalthea/crates/harp/src/vector/character_vector.rs
+++ b/extensions/positron-r/amalthea/crates/harp/src/vector/character_vector.rs
@@ -6,6 +6,7 @@
 //
 
 use std::ffi::CStr;
+use std::os::raw::c_char;
 
 use libR_sys::*;
 
@@ -14,7 +15,7 @@ use crate::vector::Vector;
 
 #[harp_macros::vector]
 pub struct CharacterVector {
-    object: RObject
+    object: RObject,
 }
 
 impl Vector for CharacterVector {
@@ -30,7 +31,7 @@ impl Vector for CharacterVector {
 
     unsafe fn new_unchecked(object: impl Into<SEXP>) -> Self {
         Self {
-            object: RObject::new(object.into())
+            object: RObject::new(object.into()),
         }
     }
 
@@ -50,7 +51,7 @@ impl Vector for CharacterVector {
             let value = data.next().unwrap_unchecked();
             let value = value.as_ref();
             let charsexp = Rf_mkCharLenCE(
-                value.as_ptr() as *const i8,
+                value.as_ptr() as *const c_char,
                 value.len() as i32,
                 cetype_t_CE_UTF8,
             );
@@ -64,7 +65,10 @@ impl Vector for CharacterVector {
         unsafe { *x == R_NaString }
     }
 
-    fn get_unchecked_elt(&self, index: isize) -> Self::UnderlyingType {
+    fn get_unchecked_elt(
+        &self,
+        index: isize,
+    ) -> Self::UnderlyingType {
         unsafe { STRING_ELT(self.data(), index as R_xlen_t) }
     }
 
@@ -76,10 +80,12 @@ impl Vector for CharacterVector {
         }
     }
 
-    fn format_one(&self, x: Self::Type) -> String {
+    fn format_one(
+        &self,
+        x: Self::Type,
+    ) -> String {
         x
     }
-
 }
 
 #[cfg(test)]
@@ -87,7 +93,6 @@ mod test {
     use crate::r_test;
     use crate::utils::r_typeof;
     use crate::vector::*;
-
 
     #[test]
     fn test_character_vector() {
@@ -145,6 +150,4 @@ mod test {
 
         }
     }
-
-
 }


### PR DESCRIPTION
Addresses to build breaks when building Amalthea against amd64 on Linux with older R:

- use system character type instead of `u8` / `i8`
- don't use `R_existsVarInFrame` (it's too new)

Also has a rustfmt pass. 