### PR TITLE
Install libr-sys from source

### DIFF
--- a/extensions/positron-r/amalthea/Cargo.lock
+++ b/extensions/positron-r/amalthea/Cargo.lock
@@ -175,9 +175,9 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bindgen"
-version = "0.64.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -1125,10 +1125,11 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 [[package]]
 name = "libR-sys"
 version = "0.4.0"
-source = "git+https://github.com/extendr/libR-sys#6a0d96a7061dc2af4c8a841470a8976e16b68100"
+source = "git+https://github.com/jmcphers/libR-sys#4feea1d0a91885902cadd26b3d23f925d0be2cbb"
 dependencies = [
  "bindgen",
  "clang",
+ "regex",
 ]
 
 [[package]]

--- a/extensions/positron-r/amalthea/Cargo.lock
+++ b/extensions/positron-r/amalthea/Cargo.lock
@@ -175,9 +175,9 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bindgen"
-version = "0.63.0"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -1125,12 +1125,10 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 [[package]]
 name = "libR-sys"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd728a97b9b0975f546bc865a7413e0ce6f98a8f6cea52e77dc5ee0bcea00adf"
+source = "git+https://github.com/extendr/libR-sys#6a0d96a7061dc2af4c8a841470a8976e16b68100"
 dependencies = [
  "bindgen",
  "clang",
- "regex",
 ]
 
 [[package]]

--- a/extensions/positron-r/amalthea/crates/ark/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/ark/Cargo.toml
@@ -24,7 +24,9 @@ http = "0.2.9"
 hyper = { version = "0.14.24", features = ["full"] }
 itertools = "0.10.5"
 lazy_static = "1.4.0"
-libR-sys = "0.4.0"
+# Install libR-sys from Github since 0.4.0 doesn't work against R-devel.
+# See https://github.com/extendr/libR-sys/pull/150 for more info.
+libR-sys = { git = "https://github.com/extendr/libR-sys" }
 libc = "0.2"
 log = "0.4.17"
 nix = { version = "0.26.2", features = ["signal"] }
@@ -54,4 +56,4 @@ rpath = true
 # Note that this typically requires the `llvm` and `clang` packages to be
 # installed on the build host.
 [target.'cfg(all(target_os="linux", target_arch="aarch64"))'.dependencies]
-libR-sys = { version = "0.4.0", features = ["use-bindgen"] }
+libR-sys = { git = "https://github.com/extendr/libR-sys", features = ["use-bindgen"] }

--- a/extensions/positron-r/amalthea/crates/ark/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/ark/Cargo.toml
@@ -26,7 +26,7 @@ itertools = "0.10.5"
 lazy_static = "1.4.0"
 # Install libR-sys from Github since 0.4.0 doesn't work against R-devel.
 # See https://github.com/extendr/libR-sys/pull/150 for more info.
-libR-sys = { git = "https://github.com/extendr/libR-sys" }
+libR-sys = { git = "https://github.com/jmcphers/libR-sys" }
 libc = "0.2"
 log = "0.4.17"
 nix = { version = "0.26.2", features = ["signal"] }
@@ -56,4 +56,4 @@ rpath = true
 # Note that this typically requires the `llvm` and `clang` packages to be
 # installed on the build host.
 [target.'cfg(all(target_os="linux", target_arch="aarch64"))'.dependencies]
-libR-sys = { git = "https://github.com/extendr/libR-sys", features = ["use-bindgen"] }
+libR-sys = { git = "https://github.com/jmcphers/libR-sys", features = ["use-bindgen"] }

--- a/extensions/positron-r/amalthea/crates/harp/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/harp/Cargo.toml
@@ -15,7 +15,7 @@ itertools = "0.10.5"
 lazy_static = "1.4.0"
 # Install libR-sys from Github since 0.4.0 doesn't work against R-devel.
 # See https://github.com/extendr/libR-sys/pull/150 for more info.
-libR-sys = { git = "https://github.com/extendr/libR-sys" }
+libR-sys = { git = "https://github.com/jmcphers/libR-sys" }
 libc = "0.2.140"
 log = "0.4.17"
 once_cell = "1.17.1"
@@ -24,5 +24,5 @@ regex = "1.7.3"
 stdext = { path = "../stdext" }
 
 [target.'cfg(all(target_os="linux", target_arch="aarch64"))'.dependencies]
-libR-sys = { git = "https://github.com/extendr/libR-sys", features = ["use-bindgen"] }
+libR-sys = { git = "https://github.com/jmcphers/libR-sys", features = ["use-bindgen"] }
 

--- a/extensions/positron-r/amalthea/crates/harp/Cargo.toml
+++ b/extensions/positron-r/amalthea/crates/harp/Cargo.toml
@@ -13,7 +13,9 @@ ctor = "0.1.26"
 harp-macros = { path = "./harp-macros" }
 itertools = "0.10.5"
 lazy_static = "1.4.0"
-libR-sys = "0.4.0"
+# Install libR-sys from Github since 0.4.0 doesn't work against R-devel.
+# See https://github.com/extendr/libR-sys/pull/150 for more info.
+libR-sys = { git = "https://github.com/extendr/libR-sys" }
 libc = "0.2.140"
 log = "0.4.17"
 once_cell = "1.17.1"
@@ -22,5 +24,5 @@ regex = "1.7.3"
 stdext = { path = "../stdext" }
 
 [target.'cfg(all(target_os="linux", target_arch="aarch64"))'.dependencies]
-libR-sys = { version = "0.4.0", features = ["use-bindgen"] }
+libR-sys = { git = "https://github.com/extendr/libR-sys", features = ["use-bindgen"] }
 


### PR DESCRIPTION
Speculative fix for incompatibility between libR-sys and R-devel.

See https://github.com/extendr/libR-sys/pull/150