### PR TITLE
Updates for displaying a continuation prompt for runtimes

### DIFF
--- a/extensions/jupyter-adapter/src/Api.ts
+++ b/extensions/jupyter-adapter/src/Api.ts
@@ -21,7 +21,8 @@ export class Api implements vscode.Disposable {
 	 *    VS Code's built-in language IDs or a language ID registered by another extension.
 	 * @param languageVersion The version of the language interpreter.
 	 * @param kernelVersion The version of the kernel itself.
-	 * @param inputPrompt The input prompt to use for the kernel, such as ">"
+	 * @param inputPrompt The input prompt to use for the kernel, e.g. ">" or ">>>"
+	 * @param continuationPrompt The continuation prompt to use for the kernel, e.g. "+" or "..."
 	 * @param startupBehavior Whether the runtime should be started automatically
 	 * @param lsp An optional function that starts an LSP server, given the port
 	 *   on which the kernel is listening, and returns a promise that resolves
@@ -33,12 +34,23 @@ export class Api implements vscode.Disposable {
 		languageVersion: string,
 		kernelVersion: string,
 		inputPrompt: string,
+		continuationPrompt: string,
 		startupBehavior: positron.LanguageRuntimeStartupBehavior = positron.LanguageRuntimeStartupBehavior.Implicit,
-		lsp?: (port: number) => Promise<void>): positron.LanguageRuntime {
+		lsp?: (port: number) => Promise<void>
+	): positron.LanguageRuntime {
 
 		return new LanguageRuntimeAdapter(
-			this._context, kernel, languageId, languageVersion, kernelVersion, inputPrompt,
-			this._channel, startupBehavior, lsp);
+			this._context,
+			kernel,
+			languageId,
+			languageVersion,
+			kernelVersion,
+			inputPrompt,
+			continuationPrompt,
+			this._channel,
+			startupBehavior,
+			lsp
+		);
 	}
 
 	dispose() {

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -74,7 +74,8 @@ export class LanguageRuntimeAdapter
 	 * @param languageVersion The specific version of the interpreter bound to this adapter
 	 * @param runtimeVersion The version of the language runtime wrapper around
 	 *    the interpreter, often the extension version
-	 * @param inputPrompt The input prompt to use for the kernel, such as ">"
+	 * @param inputPrompt The input prompt to use for the kernel, e.g. ">" or ">>>"
+	 * @param continuationPrompt The continuation prompt to use for the kernel, e.g. "+" or "..."
 	 * @param _channel The channel on which to emit logging messages
 	 * @param startupBehavior Whether the runtime should be started automatically
 	 * @param _lsp A callback to invoke to start the client side of the LSP
@@ -85,9 +86,11 @@ export class LanguageRuntimeAdapter
 		languageVersion: string,
 		runtimeVersion: string,
 		inputPrompt: string,
+		continuationPrompt: string,
 		private readonly _channel: vscode.OutputChannel,
 		startupBehavior: positron.LanguageRuntimeStartupBehavior = positron.LanguageRuntimeStartupBehavior.Implicit,
-		private readonly _lsp?: (port: number) => Promise<void>) {
+		private readonly _lsp?: (port: number) => Promise<void>
+	) {
 
 		// Hash all the metadata together
 		const digest = crypto.createHash('sha256');
@@ -110,6 +113,7 @@ export class LanguageRuntimeAdapter
 			languageName: this._spec.language,
 			languageVersion,
 			inputPrompt,
+			continuationPrompt,
 			startupBehavior: startupBehavior
 		};
 		this._channel.appendLine('Registered kernel: ' + JSON.stringify(this.metadata));

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -170,6 +170,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 			rHome.rVersion ?? '0.0.1',   // Version of R, if we know it
 			version,  // Version of this extension
 			'>', 	// Input prompt
+			'+',	// Continuation prompt
 			positron.LanguageRuntimeStartupBehavior.Implicit, // OK to start the kernel automatically
 			(port: number) => {
 				// Activate the LSP language server when the adapter is ready.

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -168,6 +168,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 			runtimeName: 'Zed',
 			languageVersion: version,
 			inputPrompt: `Z>`,
+			continuationPrompt: 'Z+',
 			runtimeVersion: '0.0.1',
 			startupBehavior: positron.LanguageRuntimeStartupBehavior.Implicit
 		};

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -311,8 +311,11 @@ declare module 'positron' {
 		/** The version of the language; e.g. "4.2" */
 		languageVersion: string;
 
-		/** The text the language's interpreter uses to prompt the user for input, e.g. ">" */
+		/** The text the language's interpreter uses to prompt the user for input, e.g. ">" or ">>>" */
 		inputPrompt: string;
+
+		/** The text the language's interpreter uses to prompt the user for continued input, e.g. "+" or "..." */
+		continuationPrompt: string;
 
 		/** Whether the runtime should start up automatically or wait until explicitly requested */
 		startupBehavior: LanguageRuntimeStartupBehavior;

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeNotebook.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeNotebook.ts
@@ -80,6 +80,7 @@ export class NotebookLanguageRuntime extends Disposable implements ILanguageRunt
 			languageName: languageName,
 			languageVersion: '1.0',
 			inputPrompt: 'NB>',
+			continuationPrompt: 'NB+',
 			runtimeName: `${this._kernel.label} - ${this._kernel.description} [Notebook Bridge]`,
 			runtimeVersion: '0.0.1',
 			startupBehavior: LanguageRuntimeStartupBehavior.Implicit

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -335,8 +335,9 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 			// anything in the margin for following lines
 			if (n < 2) {
 				return props.positronConsoleInstance.runtime.metadata.inputPrompt;
+			} else {
+				return props.positronConsoleInstance.runtime.metadata.continuationPrompt;
 			}
-			return '';
 		};
 
 		// The editor options we override.

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -324,8 +324,11 @@ export interface ILanguageRuntimeMetadata {
 	/** The version of the language in question; e.g. "4.3.3" */
 	readonly languageVersion: string;
 
-	/** The text the langauge's interpreter uses to prompt the user for input, e.g. ">" */
+	/** The text the language's interpreter uses to prompt the user for input, e.g. ">" or ">>>" */
 	readonly inputPrompt: string;
+
+	/** The text the language's interpreter uses to prompt the user for continued input, e.g. "+" or "..." */
+	readonly continuationPrompt: string;
 
 	/** The user-facing descriptive name of the runtime; e.g. "R 4.3.3" */
 	readonly runtimeName: string;


### PR DESCRIPTION
This PR contains updates for displaying a continuation prompt in the various runtimes.

Examples:

R:
![image](https://user-images.githubusercontent.com/853239/236595716-95ebe353-9b95-4136-b1ea-743f6fd2fa25.png)

Python:
![image](https://user-images.githubusercontent.com/853239/236595722-3c8020fa-3be0-42f5-ace3-f40a91d534e3.png)

Zed:
<img width="1465" alt="image" src="https://user-images.githubusercontent.com/853239/236595761-e6f68b2f-b381-407c-bff0-d64a45982b64.png">
