### PR TITLE
Fix outdated URL in `package.json`

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -106,6 +106,6 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/rstudio/amalthea"
+		"url": "https://github.com/posit-dev/amalthea"
 	}
 }


### PR DESCRIPTION
Do these urls actually do anything? Nevertheless, probably good to update? There is also one on the amalthea side that I'll do