### PR TITLE
Remove unused positron-plots-view-icon

### DIFF
--- a/src/vs/base/common/codicons.ts
+++ b/src/vs/base/common/codicons.ts
@@ -600,7 +600,6 @@ export const Codicon = {
 	positronWorkspace: register('positron-workspace', 0xf24f),
 	positronEnvironmentGrouping: register('positron-environment-grouping', 0xf250),
 	positronPlots: register('positron-plots', 0xf251),
-	positronPlotsView: register('positron-plots-view', 0xf252),
 	positronEnvironmentSorting: register('positron-environment-sorting', 0xf253),
 	positronInterrupt: register('positron-interrupt', 0xf254),
 	positronWordWrap: register('positron-word-wrap', 0xf255),

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -24,7 +24,7 @@ import { VIEW_CONTAINER } from 'vs/workbench/contrib/positronEnvironment/browser
 registerSingleton(IPositronPlotsService, PositronPlotsService, InstantiationType.Delayed);
 
 // The Positron plots view icon.
-const positronPlotsViewIcon = registerIcon('positron-plots-view-icon', Codicon.positronPlotsView, nls.localize('positronPlotsViewIcon', 'View icon of the Positron plots view.'));
+const positronPlotViewIcon = registerIcon('positron-plot-view-icon', Codicon.positronPlotView, nls.localize('positronPlotViewIcon', 'View icon of the Positron plot view.'));
 
 // Register the Positron plots view.
 Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews(
@@ -36,7 +36,7 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 			collapsed: true,
 			canToggleVisibility: false,
 			canMoveView: true,
-			containerIcon: positronPlotsViewIcon,
+			containerIcon: positronPlotViewIcon,
 			openCommandActionDescriptor: {
 				id: 'workbench.action.positron.togglePlots',
 				mnemonicTitle: nls.localize({ key: 'miTogglePlots', comment: ['&& denotes a mnemonic'] }, "&&Plots"),


### PR DESCRIPTION
It looks like issue https://github.com/rstudio/positron/issues/455 was caused by a typo; there exists both `positron-plots-view-icon` and `positron-plot-view-icon`. Only the latter is actually an icon, but the former is what the Plots pane refers to.

This change removes the pluralized version, and switches the Plots pane to use the other version, which does actually have an icon.

<img width="1166" alt="image" src="https://github.com/rstudio/positron/assets/470418/8644b0ce-fee9-410b-bab8-d68d0be3021d">
