### PR TITLE
This fix addresses #602 by using pseudo-class selectors to style the …

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.css
@@ -17,8 +17,14 @@
 .console-core .console-instance::-webkit-scrollbar {
 	width: 14px;
 	height: 14px;
-	border-top: 1px solid var(--vscode-positronScrollBar-border);
-	border-left: 1px solid var(--vscode-positronScrollBar-border);
+}
+
+.console-core .console-instance::-webkit-scrollbar:vertical {
+	border-left: 0.5px solid var(--vscode-positronScrollBar-border);
+}
+
+.console-core .console-instance::-webkit-scrollbar:horizontal {
+	border-top: 0.5px solid var(--vscode-positronScrollBar-border);
 }
 
 .console-core .console-instance::-webkit-scrollbar-track {


### PR DESCRIPTION
<img width="306" alt="ExtraLine" src="https://github.com/rstudio/positron/assets/853239/6fd5d68c-b091-4b1d-a5d2-56cd6e300937">

This fix addresses #602 by using pseudo-class selectors to style the horizontal and vertical scrollbars independently. Also, the size of the border has been reduced so that it matches the editor. I just noticed that the borders on the scrollbars were too thick.