### PR TITLE
Load R icon from resources/branding. Also, fix loading of react-windo…

### DIFF
--- a/extensions/positron-r/positron.json
+++ b/extensions/positron-r/positron.json
@@ -1,6 +1,10 @@
 {
 	"binaries": [
 		{
+			"from": "resources/branding/r-icon.svg",
+			"to": "resources/branding"
+		},
+		{
 			"from": "./amalthea/target/release/ark",
 			"to": "./dist/bin"
 		},

--- a/extensions/positron-r/resources/branding/r-icon.svg
+++ b/extensions/positron-r/resources/branding/r-icon.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="linear-gradient" x1="-48.93" y1="150.88" x2="-48.8" y2="150.74" gradientTransform="translate(35285.51 72877.49) scale(721.09 -482.94)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ccced0"/>
+      <stop offset="1" stop-color="#85848c"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="-49.53" y1="151.17" x2="-49.39" y2="151.03" gradientTransform="translate(19751 61428.67) scale(398 -406.12)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#336db6"/>
+      <stop offset="1" stop-color="#1c5eaa"/>
+    </linearGradient>
+  </defs>
+  <path d="m50,77.95C22.84,77.95.81,63.21.81,45.01S22.84,12.07,50,12.07s49.19,14.75,49.19,32.94-22.02,32.94-49.19,32.94Zm7.53-53c-20.65,0-37.39,10.08-37.39,22.52s16.74,22.52,37.39,22.52,35.88-6.89,35.88-22.52-15.24-22.52-35.88-22.52Z" style="fill: url(#linear-gradient); fill-rule: evenodd;"/>
+  <path d="m75.72,63.09s2.98.9,4.71,1.77c.6.3,1.64.91,2.39,1.71.73.78,1.09,1.57,1.09,1.57l11.73,19.78h-18.96s-8.87-16.64-8.87-16.64c0,0-1.82-3.12-2.93-4.02-.93-.75-1.33-1.02-2.25-1.02h-4.51v21.69s-16.78,0-16.78,0v-55.4h33.7s15.35.28,15.35,14.88-14.67,15.69-14.67,15.69Zm-7.3-18.55h-10.16s0,9.41,0,9.41h10.16s4.71-.02,4.71-4.8-4.71-4.62-4.71-4.62Z" style="fill: url(#linear-gradient-2); fill-rule: evenodd;"/>
+</svg>

--- a/extensions/positron-r/src/constants.ts
+++ b/extensions/positron-r/src/constants.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+
+// The extension root directory.
+export const EXTENSION_ROOT_DIR = path.join(__dirname, '..');

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -4,26 +4,15 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
+import * as path from 'path';
 import * as fs from 'fs';
 
 import { withActiveExtension } from './util';
 import { ArkLsp } from './lsp';
+import { EXTENSION_ROOT_DIR } from './constants';
 
-// TODO@softwarenerd - I would like to load this from a file, but I am not smart enough to do it.
-const iconSVG = `
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
-	<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="-48.9322" y1="150.8798" x2="-48.7958" y2="150.7433" gradientTransform="matrix(721.094 0 0 -482.937 35285.5117 72877.4922)">
-		<stop  offset="0" style="stop-color:#CCCED0"/>
-		<stop  offset="1" style="stop-color:#85848C"/>
-	</linearGradient>
-	<path fill-rule="evenodd" clip-rule="evenodd" fill="url(#SVGID_1_)" d="M50,78C22.8,78,0.8,63.2,0.8,45c0-18.2,22-32.9,49.2-32.9c27.2,0,49.2,14.7,49.2,32.9C99.2,63.2,77.2,78,50,78z M57.5,24.9c-20.6,0-37.4,10.1-37.4,22.5S36.9,70,57.5,70c20.6,0,35.9-6.9,35.9-22.5C93.4,31.8,78.2,24.9,57.5,24.9z"/>
-	<linearGradient id="SVGID_00000075146920461689179980000013175888087647547526_" gradientUnits="userSpaceOnUse" x1="-49.5303" y1="151.1673" x2="-49.3939" y2="151.0309" gradientTransform="matrix(398 0 0 -406.124 19751 61428.6641)">
-		<stop  offset="0" style="stop-color:#336DB6"/>
-		<stop  offset="1" style="stop-color:#1C5EAA"/>
-	</linearGradient>
-	<path fill-rule="evenodd" clip-rule="evenodd" fill="url(#SVGID_00000075146920461689179980000013175888087647547526_)" d="M75.7,63.1c0,0,3,0.9,4.7,1.8c0.6,0.3,1.6,0.9,2.4,1.7c0.7,0.8,1.1,1.6,1.1,1.6l11.7,19.8l-19,0l-8.9-16.7c0,0-1.8-3.1-2.9-4c-0.9-0.8-1.3-1-2.3-1c-0.6,0-4.5,0-4.5,0l0,21.7l-16.8,0V32.5H75c0,0,15.3,0.3,15.3,14.9S75.7,63.1,75.7,63.1z M68.4,44.5l-10.2,0l0,9.4l10.2,0c0,0,4.7,0,4.7-4.8C73.1,44.3,68.4,44.5,68.4,44.5z"/>
-</svg>`;
-const base64EncodedIconSvg = Buffer.from(iconSVG).toString('base64');
+// Load the R icon.
+const base64EncodedIconSvg = fs.readFileSync(path.join(EXTENSION_ROOT_DIR, 'resources', 'branding', 'r-icon.svg')).toString('base64');
 
 // A global instance of the language runtime (and LSP language server) provided
 // by this language pack

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -10,6 +10,7 @@
 		"jschardet": "3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-window": "^1.8.8",
 		"tas-client-umd": "0.1.8",
 		"vscode-oniguruma": "1.7.0",
 		"vscode-textmate": "9.0.0",

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@^7.0.0":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.5.tgz#8492dddda9644ae3bda3b45eabe87382caee7200"
+  integrity sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@microsoft/1ds-core-js@3.2.3", "@microsoft/1ds-core-js@^3.2.2":
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/@microsoft/1ds-core-js/-/1ds-core-js-3.2.3.tgz#2217d92ec8b073caa4577a13f40ea3a5c4c4d4e7"
@@ -65,6 +72,11 @@ loose-envify@^1.1.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+"memoize-one@>=3.1.1 <6":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 react-dom@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
@@ -73,12 +85,25 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-window@^1.8.8:
+  version "1.8.9"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.9.tgz#24bc346be73d0468cdf91998aac94e32bc7fa6a8"
+  integrity sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
+
 react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 scheduler@^0.23.0:
   version "0.23.0"


### PR DESCRIPTION
This PR addresses two issues:

1) We should load the R icon from a resource file within the positron-r extension.
2) There was an issue running the web Positron app because react-window was not loading properly. The image below shows this working now.

<img width="1436" alt="image" src="https://github.com/rstudio/positron/assets/853239/2382cc6e-ee24-4fab-b378-e624f08d88de">
