### PR TITLE
Update code editor if input is incomplete

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -116,6 +116,7 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 				const updatedCodeFragment = codeFragment + '\n';
 				setCurrentCodeFragment(updatedCodeFragment);
 				codeEditorWidgetRef.current.setValue(updatedCodeFragment);
+				updateCodeEditorWidgetPositionToEnd();
 				return;
 			}
 


### PR DESCRIPTION
Addresses #614.

Use same approach as in Shift+Enter to deal with incomplete inputs on Enter.