### PR TITLE
add more info and links about extensions to the readme

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -4,9 +4,9 @@ This repository hosts the source code for the Positron IDE, a fork of [Visual St
 
 You can read more about Positron IDE development on the [Positron Wiki](https://connect.rstudioservices.com/positron-wiki).
 
-## About
+## Extensions
 
-VSCode is a highly extensible IDE. Its foundation is implemented in [`src`](../src), however, much of the core functionality is provided through [`extensions`](../extensions).
+Positron is a highly extensible IDE. Its foundation is implemented in [`src`](../src), however, much of the core functionality is provided through [`extensions`](../extensions).
 
 Positron provides the following built-in extensions:
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,14 +1,24 @@
-
-## The Positron IDE
+# The Positron IDE
 
 This repository hosts the source code for the Positron IDE, a fork of [Visual Studio Code](https://github.com/microsoft/vscode) that provides a batteries-included, opinionated environment for data science and scientific authoring.
 
 You can read more about Positron IDE development on the [Positron Wiki](https://connect.rstudioservices.com/positron-wiki).
 
+## About
+
+VSCode is a highly extensible IDE. Its foundation is implemented in [`src`](../src), however, much of the core functionality is provided through [`extensions`](../extensions).
+
+Positron provides the following built-in extensions:
+
+- [**Jupyter Adapter**](../extensions/jupyter-adapter), the interface between the front end and language extensions described below
+- [**Positron R**](../extensions/positron-r), the Positron extension for the R programming language powered by [ARK](https://github.com/posit-dev/amalthea/tree/main/crates/ark) (the Amalthea R kernel -- our Rust-based kernel for R) which is built on top of our [Amalthea](https://github.com/posit-dev/amalthea) Jupyter kernel framework and the open source [tower-lsp](https://github.com/ebkalderon/tower-lsp) LSP framework
+- [**Positron Python**](https://github.com/posit-dev/positron-python), the Positron extension for the Python programming language, a fork of [Microsoft's Python VSCode extension](https://github.com/microsoft/vscode-python) built on top of the open source Python-based kernel [IPyKernel](https://github.com/ipython/ipykernel) and [Jedi Language Server](https://github.com/pappasam/jedi-language-server)
+- [**Positron Zed**](https://github.com/rstudio/positron/tree/main/extensions/positron-zed), the Positron extension for a test-bed language, intended for fast simulations primarily to aid UI development
+- [**Positron Data Viewer**](https://github.com/rstudio/positron/tree/main/extensions/positron-data-viewer)
+
 ## Related Repositories
 
 - [VSCode - OSS](https://github.com/microsoft/vscode), the upstream VS Code OSS repository
 - [OpenVSCode Server](https://github.com/gitpod-io/openvscode-server), another fork of VS Code focused on running in the browser
-- [Positron Python](https://github.com/posit-dev/positron-python), a fork of the MS Python Extension repository
 - [Positron Codicons](https://github.com/posit-dev/positron-codicons), a fork of the MS Codicons repository
-- [Positron WIki](https://github.com/posit-dev/positron-wiki), the Quarto-based source for Positron's development wiki
+- [Positron Wiki](https://github.com/posit-dev/positron-wiki), the Quarto-based source for Positron's development wiki


### PR DESCRIPTION
I think an overview would be helpful.

I'm not sure how much info we want to put in the readme vs wiki vs respective repos. Happy to close this or put it elsewhere if you feel it's too much info and/or might become stale quickly, since it was helpful to write in any case 😄.

You can preview it here: https://github.com/rstudio/positron/tree/readme-extensions.