### PR TITLE
Add 'source' field to runtime metadata

### DIFF
--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -7,6 +7,7 @@ import * as positron from 'positron';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
+import * as os from 'os';
 
 import { withActiveExtension } from './util';
 import { RRuntime } from './runtime';
@@ -146,6 +147,17 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 
 		}
 
+		// Is the runtime path within the user's home directory?
+		const isUserInstallation = rHome.rHome.startsWith(os.homedir());
+
+		// Does the runtime path have 'homebrew' as a component? (we assume that
+		// it's a Homebrew installation if it does)
+		const isHomebrewInstallation = rHome.rHome.includes('/homebrew/');
+
+		const runtimeSource = isHomebrewInstallation ? 'Homebrew' :
+			isUserInstallation ?
+				'User' : 'System';
+
 		// Create a kernel spec for this R installation
 		const kernelSpec: JupyterKernelSpec = {
 			'argv': [
@@ -153,7 +165,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 				'--connection_file', '{connection_file}',
 				'--log', '{log_file}'
 			],
-			'display_name': `R: ${rHome.rHome}`, // eslint-disable-line
+			'display_name': `R (${runtimeSource})`, // eslint-disable-line
 			'language': 'R',
 			'env': env,
 		};
@@ -174,6 +186,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 			runtimeName: kernelSpec.display_name,
 			runtimePath: rHome.rHome,
 			runtimeVersion: packageJson.version,
+			runtimeSource,
 			languageId: 'r',
 			languageName: kernelSpec.language,
 			languageVersion: rVersion,

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -174,6 +174,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 			languageId: 'zed',
 			languageName: 'Zed',
 			runtimeName: 'Zed',
+			runtimeSource: 'Test',
 			languageVersion: version,
 			base64EncodedIconSvg: fs.readFileSync(iconSvgPath).toString('base64'),
 			inputPrompt: `Z>`,

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -303,6 +303,9 @@ declare module 'positron' {
 		/** The version of the runtime itself (e.g. kernel or extension version) as a string; e.g. "0.1" */
 		runtimeVersion: string;
 
+		/** The runtime's source or origin; e.g. PyEnv, System, Homebrew, Conda, etc. */
+		runtimeSource: string;
+
 		/** The free-form, user-friendly name of the language this runtime can execute; e.g. "R" */
 		languageName: string;
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -345,6 +345,9 @@ export interface ILanguageRuntimeMetadata {
 	/** The internal version of the runtime that wraps the language; e.g. "1.0.3" */
 	readonly runtimeVersion: string;
 
+	/** The runtime's source or origin; e.g. PyEnv, System, Homebrew, Conda, etc. */
+	readonly runtimeSource: string;
+
 	/** Whether the runtime should start up automatically or wait until explicitly requested */
 	readonly startupBehavior: LanguageRuntimeStartupBehavior;
 }


### PR DESCRIPTION
Adds a `source` field to the runtime metadata to help group and label runtimes. It isn't displayed in the UI yet, but I added it to the R runtime names to show what value is coming through; here I have a Homebrew R installation and a system installation.

<img width="622" alt="image" src="https://github.com/rstudio/positron/assets/470418/6e6663a3-8795-4c54-b128-f41fd7ed012e">


Addresses https://github.com/rstudio/positron/issues/632. 
