### PR TITLE
Only push an `OutputLine` if the buffer isn't empty

### DIFF
--- a/src/vs/base/common/ansi/ansiOutput.ts
+++ b/src/vs/base/common/ansi/ansiOutput.ts
@@ -292,13 +292,13 @@ export class ANSIOutput {
 	 * Flushes the buffer to the output line.
 	 */
 	private flushBuffer() {
-		// Ensure that we have sufficient output lines in the output lines array.
-		for (let i = this._outputLines.length; i < this._outputLine + 1; i++) {
-			this._outputLines.push(new OutputLine());
-		}
-
 		// If the buffer isn't empty, flush it.
 		if (this._buffer) {
+			// Ensure that we have sufficient output lines in the output lines array.
+			for (let i = this._outputLines.length; i < this._outputLine + 1; i++) {
+				this._outputLines.push(new OutputLine());
+			}
+
 			// Get the output line.
 			const outputLine = this._outputLines[this._outputLine];
 


### PR DESCRIPTION
Addresses #673 

It looks like we were pushing `OutputLine`s even if there was an empty buffer. This image below tries to show that. Note:
- `Processing output: ""`
- `_outputLine: 0`
- `_outputLines: (0)` (empty, 0 length)
- The loop runs up to `_outputLine + 1`, so even in this empty case we get a `push()`, and I don't think we should.

<img width="1499" alt="Screen Shot 2023-06-05 at 4 40 09 PM" src="https://github.com/rstudio/positron/assets/19150088/e9416048-4fd9-449a-a33b-1693c0080f9b">


I now see this with `error 1 1 0`, as expected

<img width="336" alt="Screen Shot 2023-06-05 at 5 26 20 PM" src="https://github.com/rstudio/positron/assets/19150088/8d788500-8d5f-4a1a-b45e-143ccec9429d">

And this when sending over an R exception with no traceback (ignore the first line of red starting with `Error`, that is output by R itself, still working on turning that off. The second line is the `evalue` error message, and now we correctly don't see a red horizontal line accompanying it since there is no traceback here) 

<img width="456" alt="Screen Shot 2023-06-05 at 5 29 17 PM" src="https://github.com/rstudio/positron/assets/19150088/e5c93640-a5ee-4e3d-bbd9-56c0ba34765e">


