### PR TITLE
Fix potential race condition in terminal startup

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -528,7 +528,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		const logArg = [logFile];
 
 		// Use the VS Code terminal API to create a terminal for the kernel
-		vscode.window.createTerminal(<vscode.TerminalOptions>{
+		this._terminal = vscode.window.createTerminal(<vscode.TerminalOptions>{
 			name: this._spec.display_name,
 			shellPath: kernelWrapperPath,
 			shellArgs: logArg.concat(args),
@@ -541,7 +541,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		// Wait for the terminal to open
 		return new Promise<void>((resolve, reject) => {
 			const disposable = vscode.window.onDidOpenTerminal((openedTerminal) => {
-				if (openedTerminal.name === this._spec.display_name) {
+				if (openedTerminal === this._terminal) {
 					// Read the process ID and connect to the kernel when it's ready
 					openedTerminal.processId.then((pid) => {
 						if (pid) {
@@ -556,9 +556,6 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 							// Clean up event listener now that we've located the
 							// correct terminal
 							disposable.dispose();
-
-							// Save a reference to the terminal so we can close it later if needed
-							this._terminal = openedTerminal;
 
 							// Connect to the kernel running in the terminal
 							this.connectToSession(session).then(() => {


### PR DESCRIPTION
I noticed that the Jupyter Adapter matches terminal startup events based on name rather than object identity. Since the name is generic this potentially exposes us to a race if terminals are launching concurrently? It felt safer to match on object identity instead.