### PR TITLE
Register `CMD + SHIFT + T` as the "test" keybinding

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -1537,10 +1537,12 @@ export class ReopenClosedEditorAction extends Action2 {
 			id: ReopenClosedEditorAction.ID,
 			title: { value: localize('reopenClosedEditor', "Reopen Closed Editor"), original: 'Reopen Closed Editor' },
 			f1: true,
-			keybinding: {
-				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyT
-			},
+			// --- Start Positron ---
+			// keybinding: {
+			// 	weight: KeybindingWeight.WorkbenchContrib,
+			// 	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyT
+			// },
+			// --- End Positron ---
 			category: Categories.View
 		});
 	}

--- a/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
+++ b/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
@@ -361,6 +361,15 @@ KeybindingsRegistry.registerKeybindingRule({
 	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyB
 });
 
+// --- Start Positron ---
+KeybindingsRegistry.registerKeybindingRule({
+	id: 'workbench.action.tasks.test',
+	weight: KeybindingWeight.WorkbenchContrib,
+	when: TaskCommandsRegistered,
+	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyT
+});
+// --- End Positron ---
+
 // Tasks Output channel. Register it before using it in Task Service.
 const outputChannelRegistry = Registry.as<IOutputChannelRegistry>(OutputExt.OutputChannels);
 outputChannelRegistry.registerChannel({ id: AbstractTaskService.OutputChannelId, label: AbstractTaskService.OutputChannelLabel, log: false });


### PR DESCRIPTION
Addresses the rest of https://github.com/rstudio/positron/issues/578

https://github.com/posit-dev/amalthea/pull/17 wired up `cargo test` as the default "test task" for when you are working within Amalthea. But, unlike `Run Build Task` and `CMD+SHIFT+B`, `Run Test Task` isn't hooked up to a keybinding in VS Code so you have to add one manually (as I mentioned in that PR).

As @kevinushey mentioned here https://github.com/rstudio/positron/issues/578#issuecomment-1574343551, I think we could make a case for `CMD+SHIFT+T` being the primary way of running the test task for your project (or pulling up a menu to choose from multiple if there are >1 test tasks and no default is set). This currently could have two use cases:
- In Amalthea it runs `cargo test` for Rust tests
- In R packages it runs `devtools::test()` for R tests (and is the same as RStudio)

And of course users could set whatever they wanted as their default "test task" for their specific project.

`CMD+SHIFT+T` currently defaults to `View: Reopen Closed Editor`. I don't know how often that is used, but wiring this command up to "run tests" feels better to me?

Any thoughts? This is either a great idea or a horrible idea 😆 