### PR TITLE
Discard ready messages when exiting or exited

### DIFF
--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -19,6 +19,7 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 	/** The Jupyter kernel-based implementation of the Language Runtime API */
 	private _kernel: JupyterLanguageRuntime;
 
+	/** Whether we've received an "exiting" or "exited" message from the backend */
 	private _stale: boolean;
 
 	constructor(


### PR DESCRIPTION
Addresses #718.

Fixes a race condition where the LSP server and client would be started up while the backend is exiting, if a ready event is processed in the mean time. Then we fail to stop the duplicate LSP client since the exiting event has already be emitted at this point.

To fix this, we mark ourselves as stale when the backend sends an exiting/exited message, and check that flag before starting up the LSP server.

Perhaps we could also solve this on the backend side by ignoring the request to start an LSP server once we are in the exiting state. See also discussion in https://github.com/rstudio/positron/issues/667. However we'd need to communicate that failure back to the frontend and act accordingly (not start a client), which seems more complicated. Also I thought it's safer to avoid any further interactions with a service that is shutting down.