### PR TITLE
Ctrl+C and ESC now interrupts the runtime and resets the console input

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -179,6 +179,18 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 			e.stopPropagation();
 		};
 
+		/**
+		 * Interrupts the runtime and resets the console input state.
+		 */
+		const interruptRuntimeAndResetConsoleInput = () => {
+			// Interrupt the runtime.
+			props.positronConsoleInstance.runtime.interrupt();
+
+			// Reset the code input state.
+			setCurrentCodeFragment(undefined);
+			codeEditorWidgetRef.current.setValue('');
+		};
+
 		// Check for a suggest widget in the DOM. If one exists, then don't
 		// handle the key.
 		//
@@ -200,8 +212,8 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 				// Consume the event.
 				consumeEvent();
 
-				// Interrupt the runtime.
-				props.positronConsoleInstance.runtime.interrupt();
+				// Interrupt the runtime and reset the console input.
+				interruptRuntimeAndResetConsoleInput();
 				break;
 			}
 
@@ -249,8 +261,8 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 					// Consume the event.
 					consumeEvent();
 
-					// Interrupt the runtime.
-					props.positronConsoleInstance.runtime.interrupt();
+					// Interrupt the runtime and reset the console input.
+					interruptRuntimeAndResetConsoleInput();
 				}
 				break;
 			}


### PR DESCRIPTION
This PR fixes #548 by having Ctrl+C and ESC interrupt the runtime and reset the console input.