### PR TITLE
positron-r: Fix some race conditions in LSP handling

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -118,7 +118,8 @@
     "vsce": "^2.11.0"
   },
   "dependencies": {
-    "vscode-languageclient": "^7.0.0"
+    "vscode-languageclient": "^7.0.0",
+    "p-queue": "^6.6.2"
   },
   "repository": {
     "type": "git",

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -4,6 +4,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
+import { promiseHandles } from './util'
 
 import {
 	LanguageClient,
@@ -34,6 +35,9 @@ export class ArkLsp implements vscode.Disposable {
 	private _client?: LanguageClient;
 
 	private _state: LspState = LspState.uninitialized;
+
+	/** Promise that resolves after initialization is complete */
+	private _initializing?: Promise<void>;
 
 	public constructor(private readonly _version: string) {
 	}
@@ -113,6 +117,9 @@ export class ArkLsp implements vscode.Disposable {
 		trace(`Creating Positron R ${this._version} language client...`);
 		this._client = new LanguageClient('positron-r', `Positron R Language Server (${this._version})`, serverOptions, clientOptions);
 
+		const out = promiseHandles();
+		this._initializing = out.promise as Promise<void>;
+
 		this._client.onDidChangeState(event => {
 			const oldState = this._state;
 			// Convert the state to our own enum
@@ -121,9 +128,18 @@ export class ArkLsp implements vscode.Disposable {
 					this._state = LspState.starting;
 					break;
 				case State.Running:
+					if (this._initializing) {
+						trace(`ARK (R ${this._version}) language client init successful`);
+						this._initializing = undefined;
+						out.resolve();
+					}
 					this._state = LspState.running;
 					break;
 				case State.Stopped:
+					if (this._initializing) {
+						trace(`ARK (R ${this._version}) language client init failed`);
+						out.reject("Ark LSP client stopped before initialization");
+					}
 					this._state = LspState.stopped;
 					break;
 			}
@@ -131,6 +147,8 @@ export class ArkLsp implements vscode.Disposable {
 		});
 
 		context.subscriptions.push(this._client.start());
+
+		await out.promise;
 	}
 
 	/**
@@ -138,14 +156,19 @@ export class ArkLsp implements vscode.Disposable {
 	 *
 	 * @returns A promise that resolves when the client has been stopped.
 	 */
-	public deactivate(): Thenable<void> {
-		if (this._client) {
-			// Stop the client if it's running
-			return this._client.stop();
-		} else {
-			// Otherwise, no client to stop, so just resolve
-			return Promise.resolve();
+	public async deactivate() {
+		if (!this._client) {
+			// No client to stop, so just resolve
+			return;
 		}
+
+		// First wait for initialization to complete.
+		// `stop()` should not be called on a
+		// partially initialized client.
+		await this._initializing;
+
+		// Stop the client if it's running
+		await this._client.stop();
 	}
 
 	/**

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -4,7 +4,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { promiseHandles } from './util'
+import { PromiseHandles } from './util'
 
 import {
 	LanguageClient,
@@ -117,8 +117,8 @@ export class ArkLsp implements vscode.Disposable {
 		trace(`Creating Positron R ${this._version} language client...`);
 		this._client = new LanguageClient('positron-r', `Positron R Language Server (${this._version})`, serverOptions, clientOptions);
 
-		const out = promiseHandles();
-		this._initializing = out.promise as Promise<void>;
+		const out = new PromiseHandles<void>();
+		this._initializing = out.promise;
 
 		this._client.onDidChangeState(event => {
 			const oldState = this._state;

--- a/extensions/positron-r/src/util.ts
+++ b/extensions/positron-r/src/util.ts
@@ -14,18 +14,15 @@ export function withActiveExtension(ext: vscode.Extension<any>, callback: () => 
 
 }
 
-export function promiseHandles() {
-	const out = {
-		resolve: (_value?: unknown) => { },
-		reject: (_reason?: any) => { },
-		promise: null as unknown as Promise<unknown>,
-	};
+export class PromiseHandles<T> {
+	resolve!: (value: T | Promise<T>) => void;
+	reject!: (error: unknown) => void;
+	promise: Promise<T>;
 
-	const promise = new Promise((resolve, reject) => {
-		out.resolve = resolve;
-		out.reject = reject;
-	});
-	out.promise = promise;
-
-	return out;
+	constructor() {
+		this.promise = new Promise((resolve, reject) => {
+			this.resolve = resolve;
+			this.reject = reject;
+		})
+	}
 }

--- a/extensions/positron-r/src/util.ts
+++ b/extensions/positron-r/src/util.ts
@@ -13,3 +13,19 @@ export function withActiveExtension(ext: vscode.Extension<any>, callback: () => 
 	}
 
 }
+
+export function promiseHandles() {
+	const out = {
+		resolve: (_value?: unknown) => { },
+		reject: (_reason?: any) => { },
+		promise: null as unknown as Promise<unknown>,
+	};
+
+	const promise = new Promise((resolve, reject) => {
+		out.resolve = resolve;
+		out.reject = reject;
+	});
+	out.promise = promise;
+
+	return out;
+}

--- a/extensions/positron-r/yarn.lock
+++ b/extensions/positron-r/yarn.lock
@@ -818,6 +818,11 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eventemitter3@^4.0.4:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 expand-template@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz"
@@ -1423,6 +1428,11 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
+
 p-limit@^3.0.2:
   version "3.1.0"
   resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
@@ -1436,6 +1446,21 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
+
+p-queue@^6.6.2:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
+p-timeout@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+  dependencies:
+    p-finally "^1.0.0"
 
 parent-module@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Follow-up to #719 which was closed in favour of #667. I believe #718 is a different issue than #667. While reading the languageclient code I noticed that the `stop()` method is not supposed to be called during initialization. Waiting for complete initialization before stopping addresses #718.

- The first commit is mostly unrelated but fixes potential race conditions in our event handling. The handlers are now put on an async queue to prevent them from running concurrently. We now `await` for completion of the `lsp.activate()` method (though at this stage it does not return an actionable promise, see second commit). I opted for the "p-queue" module which seemed rather popular and featureful. The version is pinned to v6 because newer v7 versions require ESM modules.

- The second commit changes `lsp.activate()` to create and return a promise that resolves when initialization is complete. The promise is also waited on in the `deactivate()` method to avoid calling `stop()` on a partially initialized client. This addresses #718.
