### PR TITLE
R package build / check / etc as tasks provided by extension

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -11,8 +11,7 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "onStartupFinished",
-    "onCommand:workbench.action.tasks.runTask"
+    "onStartupFinished"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -11,7 +11,8 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "onStartupFinished"
+    "onStartupFinished",
+    "onCommand:workbench.action.tasks.runTask"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -86,7 +87,12 @@
           "when": "!virtualWorkspace"
         }
       ]
-    }
+    },
+    "taskDefinitions": [
+      {
+        "type": "rPackageBuild"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "yarn run compile",

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -90,16 +90,20 @@
     },
     "taskDefinitions": [
       {
-        "type": "rPackageBuild"
+        "type": "rPackageBuild",
+        "when": "isRPackage"
       },
       {
-        "type": "rPackageLoad"
+        "type": "rPackageLoad",
+        "when": "isRPackage"
       },
       {
-        "type": "rPackageTest"
+        "type": "rPackageTest",
+        "when": "isRPackage"
       },
       {
-        "type": "rPackageCheck"
+        "type": "rPackageCheck",
+        "when": "isRPackage"
       }
     ]
   },

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -91,6 +91,15 @@
     "taskDefinitions": [
       {
         "type": "rPackageBuild"
+      },
+      {
+        "type": "rPackageLoad"
+      },
+      {
+        "type": "rPackageTest"
+      },
+      {
+        "type": "rPackageCheck"
       }
     ]
   },

--- a/extensions/positron-r/src/extension.ts
+++ b/extensions/positron-r/src/extension.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { registerCommands } from './commands';
 import { adaptJupyterKernel } from './kernel';
 import { initializeLogging, trace, traceOutputChannel } from './logging';
+import { providePackageTasks } from './tasks';
 
 function activateKernel(context: vscode.ExtensionContext) {
 
@@ -58,6 +59,9 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Register commands.
 	registerCommands(context);
+
+	// Provide tasks.
+	providePackageTasks(context);
 
 }
 

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export function providePackageTasks(_context: vscode.ExtensionContext): void {
+	vscode.tasks.registerTaskProvider('rPackageBuild', new RPackageTaskProvider());
+}
+
+export class RPackageTaskProvider implements vscode.TaskProvider {
+
+	public provideTasks() {
+		return [
+			new vscode.Task(
+				{ type: 'rPackageBuild' },
+				vscode.TaskScope.Workspace,
+				'Build package',
+				'R',
+				new vscode.ShellExecution('R CMD INSTALL --preclean .')
+			)
+		];
+	}
+
+	public resolveTask(_task: vscode.Task): vscode.Task | undefined {
+		return undefined;
+	}
+}

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -29,7 +29,11 @@ async function detectRPackage(): Promise<boolean> {
 		try {
 			const bytes = await vscode.workspace.fs.readFile(fileUri);
 			const descriptionText = Buffer.from(bytes).toString('utf8');
-			return descriptionText.startsWith('Package:');
+			const descriptionLines = descriptionText.split(/(\r?\n)/);
+			const startsWithDescription = descriptionLines[0].startsWith('Package:');
+			const typeLines = descriptionLines.filter(line => line.startsWith('Type:'));
+			const typeIsDescription = typeLines.length === 0 || typeLines[0].includes('Package');
+			return startsWithDescription && typeIsDescription;
 		} catch { }
 	}
 	return false;

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -38,7 +38,8 @@ function rPackageTask(packageTask: PackageTask): vscode.Task {
 		vscode.TaskScope.Workspace,
 		packageTask.name,
 		'R',
-		new vscode.ShellExecution(packageTask.shellExecution)
+		new vscode.ShellExecution(packageTask.shellExecution),
+		[]
 	);
 }
 

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -5,15 +5,23 @@
 import * as vscode from 'vscode';
 
 export function providePackageTasks(_context: vscode.ExtensionContext): void {
-	registerRPackageTaskProvider('rPackageLoad', 'Load package', 'R -e "devtools::load_all()"');
-	registerRPackageTaskProvider('rPackageBuild', 'Build package', 'R -e "devtools::build()"');
-	registerRPackageTaskProvider('rPackageTest', 'Test package', 'R -e "devtools::test()"');
-	registerRPackageTaskProvider('rPackageCheck', 'Check package', 'R -e "devtools::check()"');
+
+	const allPackageTasks: PackageTask[] = [
+		{ 'type': 'rPackageLoad', 'name': 'Load package', 'shellExecution': 'R -e "devtools::load_all()"' },
+		{ 'type': 'rPackageBuild', 'name': 'Build package', 'shellExecution': 'R -e "devtools::build()"' },
+		{ 'type': 'rPackageTest', 'name': 'Test package', 'shellExecution': 'R -e "devtools::test()"' },
+		{ 'type': 'rPackageCheck', 'name': 'Check package', 'shellExecution': 'R -e "devtools::check()"' },
+	];
+
+	for (const packageTask of allPackageTasks) {
+		registerRPackageTaskProvider(packageTask);
+	}
+
 }
 
-function registerRPackageTaskProvider(type: string, name: string, shellExecution: string): vscode.Disposable {
-	const task = rPackageTask(type, name, shellExecution);
-	const taskProvider = vscode.tasks.registerTaskProvider(type, {
+function registerRPackageTaskProvider(packageTask: PackageTask): vscode.Disposable {
+	const task = rPackageTask(packageTask);
+	const taskProvider = vscode.tasks.registerTaskProvider(packageTask.type, {
 		provideTasks: () => {
 			return [task];
 		},
@@ -24,12 +32,18 @@ function registerRPackageTaskProvider(type: string, name: string, shellExecution
 	return (taskProvider);
 }
 
-function rPackageTask(type: string, name: string, shellExecution: string): vscode.Task {
+function rPackageTask(packageTask: PackageTask): vscode.Task {
 	return new vscode.Task(
-		{ type: type },
+		{ type: packageTask.type },
 		vscode.TaskScope.Workspace,
-		name,
+		packageTask.name,
 		'R',
-		new vscode.ShellExecution(shellExecution)
+		new vscode.ShellExecution(packageTask.shellExecution)
 	);
 }
+
+type PackageTask = {
+	type: string;
+	name: string;
+	shellExecution: string;
+};

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -6,6 +6,8 @@ import * as vscode from 'vscode';
 
 export function providePackageTasks(_context: vscode.ExtensionContext): void {
 
+	vscode.commands.executeCommand('setContext', 'isRPackage', true);
+
 	const allPackageTasks: PackageTask[] = [
 		{ 'type': 'rPackageLoad', 'name': 'Load package', 'shellExecution': 'R -e "devtools::load_all()"' },
 		{ 'type': 'rPackageBuild', 'name': 'Build package', 'shellExecution': 'R -e "devtools::build()"' },

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -30,10 +30,10 @@ async function detectRPackage(): Promise<boolean> {
 			const bytes = await vscode.workspace.fs.readFile(fileUri);
 			const descriptionText = Buffer.from(bytes).toString('utf8');
 			const descriptionLines = descriptionText.split(/(\r?\n)/);
-			const startsWithDescription = descriptionLines[0].startsWith('Package:');
+			const descStartsWithPackage = descriptionLines[0].startsWith('Package:');
 			const typeLines = descriptionLines.filter(line => line.startsWith('Type:'));
-			const typeIsDescription = typeLines.length === 0 || typeLines[0].includes('Package');
-			return startsWithDescription && typeIsDescription;
+			const typeIsPackage = typeLines.length === 0 || typeLines[0].includes('Package');
+			return descStartsWithPackage && typeIsPackage;
 		} catch { }
 	}
 	return false;


### PR DESCRIPTION
Addresses #28 and #122

The biggest question is whether implementing this as a [task](https://code.visualstudio.com/docs/editor/tasks) is the right call. I believe the main alternative is a [command](https://code.visualstudio.com/api/extension-guides/command). 

This is currently an initial POC and still needs:

- additional tasks added for `devtools::load_all()`, checking, and probably simple testing as well
- to detect if we are in an R package
- ~~implement optional `resolveTask()` for a better command palette experience~~ (only need when there is no execution but all our tasks have `execution`)
