### PR TITLE
positron-r: Couple of memory leak fixes

### DIFF
--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -243,6 +243,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 
 		// Create an adapter for the kernel to fulfill the LanguageRuntime interface.
 		runtime = new RRuntime(context, kernelSpec, metadata, ext.exports, extra);
+		context.subscriptions.push(runtime);
 
 		// Register the language runtime with Positron.
 		const disposable = positron.runtime.registerLanguageRuntime(runtime);

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -180,7 +180,7 @@ export class ArkLsp implements vscode.Disposable {
 	/**
 	 * Dispose of the client instance.
 	 */
-	dispose() {
-		this.deactivate();
+	async dispose() {
+		await this.deactivate();
 	}
 }

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -146,8 +146,7 @@ export class ArkLsp implements vscode.Disposable {
 			trace(`ARK (R ${this._version}) language client state changed ${oldState} => ${this._state}`);
 		});
 
-		context.subscriptions.push(this._client.start());
-
+		this._client.start();
 		await out.promise;
 	}
 

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -96,8 +96,9 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 		return this._kernel.shutdown();
 	}
 
-	dispose() {
-		this._lsp.dispose();
+	async dispose() {
+		await this._lsp.dispose();
+		this._kernel.dispose();
 	}
 
 	private onStateChange(state: positron.RuntimeState): void {

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1023,6 +1023,8 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
 	}
 
+	dispose(): void { };
+
 	//#endregion LanguageRuntime Implementation
 
 	//#region Private Methods

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -469,6 +469,11 @@ declare module 'positron' {
 		 * sequence has been successfully started (not necessarily when it has completed).
 		 */
 		shutdown(): Thenable<void>;
+
+		/**
+		 * Dispose of the resources held onto by the runtime.
+		 */
+		dispose(): void;
 	}
 
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -390,7 +390,7 @@ declare module 'positron' {
 	 * set of common tools for interacting with a language runtime, such as code
 	 * execution, LSP implementation, and plotting.
 	 */
-	export interface LanguageRuntime {
+	export interface LanguageRuntime extends vscode.Disposable {
 		/** An object supplying metadata about the runtime */
 		readonly metadata: LanguageRuntimeMetadata;
 
@@ -469,11 +469,6 @@ declare module 'positron' {
 		 * sequence has been successfully started (not necessarily when it has completed).
 		 */
 		shutdown(): Thenable<void>;
-
-		/**
-		 * Dispose of the resources held onto by the runtime.
-		 */
-		dispose(): void;
 	}
 
 


### PR DESCRIPTION
1. I noticed that the `stop()` method of LSP clients disposes of its resources. We call it via our `deactivate()` and `dispose()`methods (the latter calls the former). However we also subscribe the disposable returned by `start()` to the extension context.

   If I understand correctly, this means we are piling up references to old clients as we restart them, and they can never be garbage collected until the extension is unloaded. To fix this, the first commit simply removes the subscription. It's already taken care of by our runtime's `dispose()` method.

2. I think the runtime's `dispose()` method is never actually called when the extension is unloaded. We subscribe the result of registering the runtime (this dispose method simply removes the runtime from a `Map`) but we never subscribe the runtime itself. To fix this, the second commit adds a `dispose()` method to the runtime interface and subscribes newly created runtimes to the context.