### PR TITLE
Delay Ark startup until debugger is attached

### DIFF
--- a/extensions/jupyter-adapter/package.json
+++ b/extensions/jupyter-adapter/package.json
@@ -30,6 +30,12 @@
           "type": "boolean",
           "default": false,
           "description": "Show the terminal window when running a Jupyter kernel"
+        },
+        "positron.jupyterAdapter.attachOnStartup": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "description": "Run <f5> before starting up Jupyter kernel (when supported)"
         }
       }
     }

--- a/extensions/jupyter-adapter/package.json
+++ b/extensions/jupyter-adapter/package.json
@@ -40,7 +40,7 @@
         "positron.jupyterAdapter.delayStartup": {
           "scope": "window",
           "type": "number",
-          "description": "Sleep for n milliseconds before starting up Jupyter kernel (when supported)"
+          "description": "Sleep for n seconds before starting up Jupyter kernel (when supported)"
         }
       }
     }

--- a/extensions/jupyter-adapter/package.json
+++ b/extensions/jupyter-adapter/package.json
@@ -36,6 +36,11 @@
           "type": "boolean",
           "default": false,
           "description": "Run <f5> before starting up Jupyter kernel (when supported)"
+        },
+        "positron.jupyterAdapter.delayStartup": {
+          "scope": "window",
+          "type": "number",
+          "description": "Sleep for n milliseconds before starting up Jupyter kernel (when supported)"
         }
       }
     }

--- a/extensions/jupyter-adapter/package.json
+++ b/extensions/jupyter-adapter/package.json
@@ -37,7 +37,7 @@
           "default": false,
           "description": "Run <f5> before starting up Jupyter kernel (when supported)"
         },
-        "positron.jupyterAdapter.delayStartup": {
+        "positron.jupyterAdapter.sleepOnStartup": {
           "scope": "window",
           "type": "number",
           "description": "Sleep for n seconds before starting up Jupyter kernel (when supported)"

--- a/extensions/jupyter-adapter/src/Api.ts
+++ b/extensions/jupyter-adapter/src/Api.ts
@@ -4,7 +4,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { JupyterAdapterApi, JupyterKernelSpec, JupyterLanguageRuntime } from './jupyter-adapter';
+import { JupyterAdapterApi, JupyterKernelSpec, JupyterLanguageRuntime, JupyterKernelExtra } from './jupyter-adapter';
 
 import { LanguageRuntimeAdapter } from './LanguageRuntimeAdapter';
 import { findAvailablePort } from './PortFinder';
@@ -17,17 +17,25 @@ export class JupyterAdapterApiImpl implements JupyterAdapterApi {
 	/**
 	 * Create an adapter for a Jupyter-compatible kernel.
 	 *
-	 * @param kernel A Jupyter kernel spec containing the information needed to start the kernel.
+	 * @param kernel A Jupyter kernel spec containing the information needed to
+	 *   start the kernel.
+	 * @param metadata The metadata for the language runtime to be wrapped by the
+	 *   adapter.
+	 * @param extra Optional implementations for extra functionality.
 	 * @returns A LanguageRuntimeAdapter that wraps the kernel.
 	 */
-	adaptKernel(kernel: JupyterKernelSpec,
+	adaptKernel(
+		kernel: JupyterKernelSpec,
 		metadata: positron.LanguageRuntimeMetadata,
+		extra: JupyterKernelExtra,
 	): JupyterLanguageRuntime {
 		return new LanguageRuntimeAdapter(
 			this._context,
 			this._channel,
 			kernel,
-			metadata);
+			metadata,
+			extra
+		);
 	}
 
 	/**

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -506,9 +506,14 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 
 		const config = vscode.workspace.getConfiguration('positron.jupyterAdapter');
 		const attachOnStartup = config.get('attachOnStartup', false) && this._extra?.attachOnStartup;
+		const delayStartup = config.get('delayStartup', undefined) && this._extra?.delayStartup;
 
 		if (attachOnStartup) {
 			this._extra!.attachOnStartup!.init(args);
+		}
+		if (delayStartup) {
+			const delay = config.get('delayStartup', 0);
+			this._extra!.delayStartup!.init(args, delay);
 		}
 
 		const command = args.join(' ');

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -506,14 +506,14 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 
 		const config = vscode.workspace.getConfiguration('positron.jupyterAdapter');
 		const attachOnStartup = config.get('attachOnStartup', false) && this._extra?.attachOnStartup;
-		const delayStartup = config.get('delayStartup', undefined) && this._extra?.delayStartup;
+		const sleepOnStartup = config.get('sleepOnStartup', undefined) && this._extra?.sleepOnStartup;
 
 		if (attachOnStartup) {
 			this._extra!.attachOnStartup!.init(args);
 		}
-		if (delayStartup) {
-			const delay = config.get('delayStartup', 0);
-			this._extra!.delayStartup!.init(args, delay);
+		if (sleepOnStartup) {
+			const delay = config.get('sleepOnStartup', 0);
+			this._extra!.sleepOnStartup!.init(args, delay);
 		}
 
 		const command = args.join(' ');

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -499,6 +499,10 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			return arg;
 		}) as Array<string>;
 
+		const delay_dir = fs.mkdtempSync(`${os.tmpdir()}-JupyterDelayStartup`);
+		const delay_file = path.join(delay_dir, 'file')
+		args.push(`--delay-startup ${delay_file}`);
+
 		const command = args.join(' ');
 
 		// Create environment.
@@ -549,6 +553,14 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			// Ignore terminals that don't have a process ID
 			if (!pid) {
 				return;
+			}
+
+			try {
+				await vscode.commands.executeCommand('workbench.action.debug.start');
+				fs.writeFileSync(delay_file, "go\n");
+				fs.rmSync(delay_dir, { recursive: true, force: true });
+			} catch (err) {
+				this.log(`Can't execute debug action: ${err}`)
 			}
 
 			// Save the process ID in the session state

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -5,7 +5,7 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { JupyterKernel } from './JupyterKernel';
-import { JupyterKernelSpec } from './jupyter-adapter';
+import { JupyterKernelSpec, JupyterKernelExtra } from './jupyter-adapter';
 import { JupyterMessagePacket } from './JupyterMessagePacket';
 import { JupyterDisplayData } from './JupyterDisplayData';
 import { JupyterExecuteResult } from './JupyterExecuteResult';
@@ -69,15 +69,20 @@ export class LanguageRuntimeAdapter
 	 * @param _spec The Jupyter kernel spec for the kernel to wrap
 	 * @param metadata The metadata for the language runtime to wrap
 	 */
-	constructor(private readonly _context: vscode.ExtensionContext,
+	constructor(
+		private readonly _context: vscode.ExtensionContext,
 		private readonly _channel: vscode.OutputChannel,
 		private readonly _spec: JupyterKernelSpec,
 		readonly metadata: positron.LanguageRuntimeMetadata,
+		extra?: JupyterKernelExtra,
 	) {
-		this._kernel = new JupyterKernel(this._context,
+		this._kernel = new JupyterKernel(
+			this._context,
 			this._spec,
 			metadata.runtimeId,
-			this._channel);
+			this._channel,
+			extra
+		);
 		this._channel.appendLine('Registered kernel: ' + JSON.stringify(this.metadata));
 
 		// Create emitter for LanguageRuntime messages and state changes

--- a/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
+++ b/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
@@ -94,4 +94,7 @@ export interface JupyterKernelExtra {
 		init: (args: Array<String>) => void;
 		attach: () => Promise<void>;
 	};
+	delayStartup?: {
+		init: (args: Array<String>, delay: number) => void;
+	};
 }

--- a/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
+++ b/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
@@ -69,10 +69,14 @@ export interface JupyterAdapterApi extends vscode.Disposable {
 	 *   start the kernel.
 	 * @param metadata The metadata for the language runtime to be wrapped by the
 	 *   adapter.
+	 * @param extra Optional implementations for extra functionality.
 	 * @returns A LanguageRuntimeAdapter that wraps the kernel.
 	 */
-	adaptKernel(kernel: JupyterKernelSpec,
-		metadata: positron.LanguageRuntimeMetadata): JupyterLanguageRuntime;
+	adaptKernel(
+		kernel: JupyterKernelSpec,
+		metadata: positron.LanguageRuntimeMetadata,
+		extra?: JupyterKernelExtra,
+	): JupyterLanguageRuntime;
 
 	/**
 	 * Finds an available TCP port for a server
@@ -82,4 +86,12 @@ export interface JupyterAdapterApi extends vscode.Disposable {
 	 * @returns An available TCP port
 	 */
 	findAvailablePort(excluding: Array<number>, maxTries: number): Promise<number>;
+}
+
+/** Specific functionality implemented by runtimes */
+export interface JupyterKernelExtra {
+	attachOnStartup?: {
+		init: (args: Array<String>) => void;
+		attach: () => Promise<void>;
+	};
 }

--- a/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
+++ b/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
@@ -94,7 +94,7 @@ export interface JupyterKernelExtra {
 		init: (args: Array<String>) => void;
 		attach: () => Promise<void>;
 	};
-	delayStartup?: {
+	sleepOnStartup?: {
 		init: (args: Array<String>, delay: number) => void;
 	};
 }

--- a/extensions/positron-r/src/jupyter-adapter.d.ts
+++ b/extensions/positron-r/src/jupyter-adapter.d.ts
@@ -94,4 +94,7 @@ export interface JupyterKernelExtra {
 		init: (args: Array<String>) => void;
 		attach: () => Promise<void>;
 	};
+	delayStartup?: {
+		init: (args: Array<String>, delay: number) => void;
+	};
 }

--- a/extensions/positron-r/src/jupyter-adapter.d.ts
+++ b/extensions/positron-r/src/jupyter-adapter.d.ts
@@ -69,10 +69,14 @@ export interface JupyterAdapterApi extends vscode.Disposable {
 	 *   start the kernel.
 	 * @param metadata The metadata for the language runtime to be wrapped by the
 	 *   adapter.
+	 * @param extra Optional implementations for extra functionality.
 	 * @returns A LanguageRuntimeAdapter that wraps the kernel.
 	 */
-	adaptKernel(kernel: JupyterKernelSpec,
-		metadata: positron.LanguageRuntimeMetadata): JupyterLanguageRuntime;
+	adaptKernel(
+		kernel: JupyterKernelSpec,
+		metadata: positron.LanguageRuntimeMetadata,
+		extra?: JupyterKernelExtra,
+	): JupyterLanguageRuntime;
 
 	/**
 	 * Finds an available TCP port for a server
@@ -82,4 +86,12 @@ export interface JupyterAdapterApi extends vscode.Disposable {
 	 * @returns An available TCP port
 	 */
 	findAvailablePort(excluding: Array<number>, maxTries: number): Promise<number>;
+}
+
+/** Specific functionality implemented by runtimes */
+export interface JupyterKernelExtra {
+	attachOnStartup?: {
+		init: (args: Array<String>) => void;
+		attach: () => Promise<void>;
+	};
 }

--- a/extensions/positron-r/src/jupyter-adapter.d.ts
+++ b/extensions/positron-r/src/jupyter-adapter.d.ts
@@ -94,7 +94,7 @@ export interface JupyterKernelExtra {
 		init: (args: Array<String>) => void;
 		attach: () => Promise<void>;
 	};
-	delayStartup?: {
+	sleepOnStartup?: {
 		init: (args: Array<String>, delay: number) => void;
 	};
 }

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -233,7 +233,8 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 		};
 
 		const extra: JupyterKernelExtra = {
-			attachOnStartup: new ArkAttachOnStartup()
+			attachOnStartup: new ArkAttachOnStartup(),
+			delayStartup: new ArkDelayStartup(),
 		};
 
 		// Create an adapter for the kernel to fulfill the LanguageRuntime interface.
@@ -273,5 +274,14 @@ class ArkAttachOnStartup {
 		delay(100).then(() => {
 			fs.rmSync(this._delay_dir!, { recursive: true, force: true });
 		});
+	}
+}
+
+class ArkDelayStartup {
+	// Add `--startup-delay` argument to pass a delay in
+	// milliseconds before starting up the kernel
+	init(args: Array<String>, delay: number) {
+		args.push("--startup-delay");
+		args.push(delay.toString());
 	}
 }

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -255,7 +255,10 @@ class ArkAttachOnStartup {
 		this._delay_dir = fs.mkdtempSync(`${os.tmpdir()}-JupyterDelayStartup`);
 		this._delay_file = path.join(this._delay_dir, 'file')
 
-		args.push(`--delay-startup ${this._delay_file}`);
+		fs.writeFileSync(this._delay_file!, "create\n");
+
+		args.push("--delay-startup");
+		args.push(this._delay_file);
 	}
 
 	// This is paired with `init()` and disposes of created resources

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -249,7 +249,7 @@ class ArkAttachOnStartup {
 	_delay_dir?: string;
 	_delay_file?: string;
 
-	// Add `--delay-startup` argument to pass a notification file
+	// Add `--startup-notifier-file` argument to pass a notification file
 	// that triggers the actual startup of the kernel
 	init(args: Array<String>) {
 		this._delay_dir = fs.mkdtempSync(`${os.tmpdir()}-JupyterDelayStartup`);
@@ -257,7 +257,7 @@ class ArkAttachOnStartup {
 
 		fs.writeFileSync(this._delay_file!, "create\n");
 
-		args.push("--delay-startup");
+		args.push("--startup-notifier-file");
 		args.push(this._delay_file);
 	}
 

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -279,7 +279,7 @@ class ArkAttachOnStartup {
 
 class ArkDelayStartup {
 	// Add `--startup-delay` argument to pass a delay in
-	// milliseconds before starting up the kernel
+	// seconds before starting up the kernel
 	init(args: Array<String>, delay: number) {
 		args.push("--startup-delay");
 		args.push(delay.toString());

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 import * as crypto from 'crypto';
 import * as os from 'os';
 
-import { withActiveExtension } from './util';
+import { withActiveExtension, delay } from './util';
 import { RRuntime } from './runtime';
 import { JupyterKernelSpec, JupyterKernelExtra } from './jupyter-adapter';
 
@@ -269,14 +269,9 @@ class ArkAttachOnStartup {
 		// Notify the kernel it can now start up
 		fs.writeFileSync(this._delay_file!, "go\n");
 
-		function delay(ms: number) {
-			return new Promise( resolve => setTimeout(resolve, ms) );
-		}
-
-		// Give some time before removing the file
-		await delay(50);
-
-		// Remove notification file
-		fs.rmSync(this._delay_dir!, { recursive: true, force: true });
+		// Give some time before removing the file, no need to await
+		delay(100).then(() => {
+			fs.rmSync(this._delay_dir!, { recursive: true, force: true });
+		});
 	}
 }

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -234,7 +234,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 
 		const extra: JupyterKernelExtra = {
 			attachOnStartup: new ArkAttachOnStartup(),
-			delayStartup: new ArkDelayStartup(),
+			sleepOnStartup: new ArkDelayStartup(),
 		};
 
 		// Create an adapter for the kernel to fulfill the LanguageRuntime interface.

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -269,6 +269,13 @@ class ArkAttachOnStartup {
 		// Notify the kernel it can now start up
 		fs.writeFileSync(this._delay_file!, "go\n");
 
+		function delay(ms: number) {
+			return new Promise( resolve => setTimeout(resolve, ms) );
+		}
+
+		// Give some time before removing the file
+		await delay(50);
+
 		// Remove notification file
 		fs.rmSync(this._delay_dir!, { recursive: true, force: true });
 	}

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -6,7 +6,7 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 import PQueue from 'p-queue';
 
-import { JupyterAdapterApi, JupyterKernelSpec, JupyterLanguageRuntime } from './jupyter-adapter';
+import { JupyterAdapterApi, JupyterKernelSpec, JupyterLanguageRuntime, JupyterKernelExtra } from './jupyter-adapter';
 import { ArkLsp, LspState } from './lsp';
 
 /**
@@ -29,8 +29,9 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 		readonly kernelSpec: JupyterKernelSpec,
 		readonly metadata: positron.LanguageRuntimeMetadata,
 		readonly adapterApi: JupyterAdapterApi,
+		readonly extra?: JupyterKernelExtra,
 	) {
-		this._kernel = adapterApi.adaptKernel(kernelSpec, metadata);
+		this._kernel = adapterApi.adaptKernel(kernelSpec, metadata, extra);
 		this._lsp = new ArkLsp(metadata.languageVersion);
 
 		this.onDidChangeRuntimeState = this._kernel.onDidChangeRuntimeState;

--- a/extensions/positron-r/src/util.ts
+++ b/extensions/positron-r/src/util.ts
@@ -26,3 +26,7 @@ export class PromiseHandles<T> {
 		})
 	}
 }
+
+export function delay(ms: number) {
+	return new Promise( resolve => setTimeout(resolve, ms) );
+}


### PR DESCRIPTION
Branched from #741
Addresses #740

This PR makes it possible to automatically delay the startup of Ark until the debugger is attached to the process:

- This is controlled by a new `positron.jupyterAdapter.attachOnStartup` setting. Set it to `true` in your settings.json to enable attach on startup.

  Edit: There is now also `positron.jupyterAdapter.sleepOnStartup` which can be combined with the above. Useful to attach the debugger and give some time to hit the pause button to enter some commands before resuming startup.

- Attach on startup is supported via a new undocumented argument `--startup-notifier-file` passed to Ark. It takes the path to a notification file to which the frontend writes when the debugger has been attached. Ark blocks until a change to the file is detected. After that, startup continues as normal. Implemented in posit-dev/amalthea#35.

- The actions of adding this argument and attaching the debugger need to be performed in the `start()` method of the Jupyter kernel. To support this, Jupyter kernels now optionally accept a new `JupyterKernelExtra` object containing custom implementations for this sort of extra functionality. This extra object is created and passed in by the Ark registration routine.
