### PR TITLE
Add simple API for executing code in Positron

### DIFF
--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -57,6 +57,7 @@ const HelpLines = [
 	'env rm X     - Removes X variables',
 	'env update X - Updates X variables',
 	'error X Y Z  - Simulates an unsuccessful X line input with Y lines of error message and Z lines of traceback (where X >= 1 and Y >= 1 and Z >= 0)',
+	'exec X Y     - Executes a code snippet Y in the language X',
 	'help         - Shows this help',
 	'offline      - Simulates going offline for two seconds',
 	'plot X       - Renders a dynamic (auto-sizing) plot of the letter X',
@@ -326,6 +327,12 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 			// Simulate a data viewer
 			const title = (match.length > 1 && match[1]) ? match[1].trim() : 'Data';
 			this.simulateDataView(id, code, `Zed: ${title}`);
+			return;
+		} else if (match = code.match(/^exec ([a-zA-Z]+) (.+)/)) {
+			// Execute code in another language.
+			const languageId = match[1];
+			const codeToExecute = match[2];
+			this.simulateCodeExecution(id, code, languageId, codeToExecute);
 			return;
 		}
 
@@ -1083,6 +1090,35 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 				'text/plain': `<ZedData view>`
 			} as Record<string, string>
 		} as positron.LanguageRuntimeOutput);
+		// Return to idle state.
+		this.simulateIdleState(parentId);
+	}
+
+	/**
+	 * Simulates execution of code in another language.
+	 *
+	 * @param parentId The parent identifier.
+	 * @param code The Zed code the user entered.
+	 * @param languageId The language identifier
+	 * @param codeToExecute The code to execute.
+	 */
+	private async simulateCodeExecution(parentId: string,
+		code: string,
+		languageId: string,
+		codeToExecute: string) {
+		// Enter busy state and output the code.
+		this.simulateBusyState(parentId);
+		this.simulateInputMessage(parentId, code);
+
+		// Let the user know what we're about to do
+		this.simulateOutputMessage(parentId, `Executing ${languageId} snippet: ${code}`);
+
+		// Perform the execution
+		const success = await positron.runtime.executeCode(languageId, codeToExecute, true);
+		if (!success) {
+			this.simulateOutputMessage(parentId, `Failed; is there an active console for ${languageId}?`);
+		}
+
 		// Return to idle state.
 		this.simulateIdleState(parentId);
 	}

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1111,7 +1111,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		this.simulateInputMessage(parentId, code);
 
 		// Let the user know what we're about to do
-		this.simulateOutputMessage(parentId, `Executing ${languageId} snippet: ${code}`);
+		this.simulateOutputMessage(parentId, `Executing ${languageId} snippet: ${codeToExecute}`);
 
 		// Perform the execution
 		const success = await positron.runtime.executeCode(languageId, codeToExecute, true);

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -500,6 +500,19 @@ declare module 'positron' {
 	}
 
 	namespace runtime {
+
+		/**
+		 * Executes code in a language runtime's console, as though it were typed
+		 * interactively by the user.
+		 *
+		 * @param languageId The language ID of the code snippet
+		 * @param code The code snippet to execute
+		 * @param focus Whether to raise and focus the runtime's console
+		 */
+		export function executeCode(languageId: string,
+			code: string,
+			focus: boolean): Thenable<void>;
+
 		/**
 		 * Register a language runtime with Positron.
 		 *

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -508,10 +508,12 @@ declare module 'positron' {
 		 * @param languageId The language ID of the code snippet
 		 * @param code The code snippet to execute
 		 * @param focus Whether to raise and focus the runtime's console
+		 * @returns A Thenable that resolves with true if the code was sent to a
+		 *   runtime successfully, false otherwise.
 		 */
 		export function executeCode(languageId: string,
 			code: string,
-			focus: boolean): Thenable<void>;
+			focus: boolean): Thenable<boolean>;
 
 		/**
 		 * Register a language runtime with Positron.

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -750,6 +750,10 @@ export class MainThreadLanguageRuntime implements MainThreadLanguageRuntimeShape
 		this._runtimes.delete(handle);
 	}
 
+	$executeCode(languageId: string, code: string, focus: boolean): Promise<void> {
+		return Promise.resolve();
+	}
+
 	public dispose(): void {
 		this._disposables.dispose();
 	}

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -750,8 +750,8 @@ export class MainThreadLanguageRuntime implements MainThreadLanguageRuntimeShape
 		this._runtimes.delete(handle);
 	}
 
-	$executeCode(languageId: string, code: string, focus: boolean): Promise<void> {
-		return Promise.resolve();
+	$executeCode(languageId: string, code: string, focus: boolean): Promise<boolean> {
+		return this._positronConsoleService.executeCode(languageId, code, focus);
 	}
 
 	public dispose(): void {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -34,6 +34,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 		// --- Start Positron ---
 		const runtime: typeof positron.runtime = {
+			executeCode(langaugeId, code, focus): Thenable<void> {
+				return extHostLanguageRuntime.executeCode(langaugeId, code, focus);
+			},
 			registerLanguageRuntime(runtime: positron.LanguageRuntime): vscode.Disposable {
 				return extHostLanguageRuntime.registerLanguageRuntime(runtime);
 			},

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -34,7 +34,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 		// --- Start Positron ---
 		const runtime: typeof positron.runtime = {
-			executeCode(langaugeId, code, focus): Thenable<void> {
+			executeCode(langaugeId, code, focus): Thenable<boolean> {
 				return extHostLanguageRuntime.executeCode(langaugeId, code, focus);
 			},
 			registerLanguageRuntime(runtime: positron.LanguageRuntime): vscode.Disposable {

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -10,6 +10,7 @@ import { createProxyIdentifier, IRPCProtocol } from 'vs/workbench/services/exten
 export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$registerLanguageRuntime(handle: number, metadata: ILanguageRuntimeMetadata): void;
 	$unregisterLanguageRuntime(handle: number): void;
+	$executeCode(languageId: string, code: string, focus: boolean): Promise<void>;
 
 	$emitLanguageRuntimeMessage(handle: number, message: ILanguageRuntimeMessage): void;
 	$emitLanguageRuntimeState(handle: number, clock: number, state: RuntimeState): void;

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -10,7 +10,7 @@ import { createProxyIdentifier, IRPCProtocol } from 'vs/workbench/services/exten
 export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$registerLanguageRuntime(handle: number, metadata: ILanguageRuntimeMetadata): void;
 	$unregisterLanguageRuntime(handle: number): void;
-	$executeCode(languageId: string, code: string, focus: boolean): Promise<void>;
+	$executeCode(languageId: string, code: string, focus: boolean): Promise<boolean>;
 
 	$emitLanguageRuntimeMessage(handle: number, message: ILanguageRuntimeMessage): void;
 	$emitLanguageRuntimeState(handle: number, clock: number, state: RuntimeState): void;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -126,6 +126,10 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		});
 	}
 
+	public executeCode(languageId: string, code: string, focus: boolean): Promise<void> {
+		return this._proxy.$executeCode(languageId, code, focus);
+	}
+
 	public registerLanguageRuntime(
 		runtime: positron.LanguageRuntime): IDisposable {
 

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -126,7 +126,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		});
 	}
 
-	public executeCode(languageId: string, code: string, focus: boolean): Promise<void> {
+	public executeCode(languageId: string, code: string, focus: boolean): Promise<boolean> {
 		return this._proxy.$executeCode(languageId, code, focus);
 	}
 

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -294,7 +294,7 @@ export function registerPositronConsoleActions() {
 			await viewsService.openView<PositronConsoleViewPane>(POSITRON_CONSOLE_VIEW_ID, false);
 
 			// Ask the Positron console service to execute the code.
-			if (!positronConsoleService.executeCode(languageId, code)) {
+			if (!positronConsoleService.executeCode(languageId, code, true)) {
 				const languageName = languageService.getLanguageName(languageId);
 				notificationService.notify({
 					severity: Severity.Info,

--- a/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
@@ -59,9 +59,11 @@ export interface IPositronConsoleService {
 	 * Executes code in a PositronConsoleInstance.
 	 * @param languageId The language ID.
 	 * @param code The code.
+	 * @param activate A value which indicates whether to activate the Positron console instance
+	 *   if it is not already active.
 	 * @returns A value which indicates whether the code could be executed.
 	 */
-	executeCode(languageId: string, code: string): boolean;
+	executeCode(languageId: string, code: string, activate: boolean): Promise<boolean>;
 }
 
 /**

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -274,19 +274,22 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 	 * Executes code in a PositronConsoleInstance.
 	 * @param languageId The language ID.
 	 * @param code The code.
+	 * @param activate A value which indicates whether the REPL should be activated.
 	 * @returns A value which indicates whether the code could be executed.
 	 */
-	executeCode(languageId: string, code: string): boolean {
+	executeCode(languageId: string, code: string, activate: boolean): Promise<boolean> {
 		// Get the Positron console instance for the language.
 		const positronConsoleInstance = this._positronConsoleInstancesByLanguageId.get(languageId);
 		if (!positronConsoleInstance) {
 			// TODO@softwarenerd - In an ideal world, we should start a new runtime for the language
-			// and queue this code up to be executed, once it starts.
-			return false;
+			// and queue this code up to be executed, once it starts. In this case we'd
+			// keep the promise around around and resolve it when the runtime starts
+			// and begins executing the code.
+			return Promise.resolve(false);
 		}
 
 		// Activate the Positron console instance, if it isn't active.
-		if (positronConsoleInstance !== this._activePositronConsoleInstance) {
+		if (activate && positronConsoleInstance !== this._activePositronConsoleInstance) {
 			this.setActivePositronConsoleInstance(positronConsoleInstance);
 		}
 
@@ -294,7 +297,7 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 		positronConsoleInstance.executeCode(code);
 
 		// Success.
-		return true;
+		return Promise.resolve(true);
 	}
 
 	//#endregion IPositronConsoleService Implementation


### PR DESCRIPTION
Adds an API that executes code in a fire-and-forget manner, designed to be used by extensions that need to generate and run code on the user's behalf.

The new API is also callable from Zed; the new command `exec foo bar` executes the code `bar` in the `foo` language. For example, try `exec r 1+1` to run `1+1` in the R console.

Addresses https://github.com/rstudio/positron/issues/723.