### PR TITLE
Set R kernel log level from configuration

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -38,6 +38,26 @@
           "default": "",
           "description": "%r.configuration.kernelPath.description%"
         },
+        "positron.r.kernel.logLevel": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "enumDescriptions": [
+            "%r.configuration.logLevel.error.description%",
+            "%r.configuration.logLevel.warn.description%",
+            "%r.configuration.logLevel.info.description%",
+            "%r.configuration.logLevel.debug.description%",
+            "%r.configuration.logLevel.trace.description%"
+          ],
+          "default": "warn",
+          "description": "%r.configuration.logLevel.description%"
+        },
         "positron.r.trace.server": {
           "scope": "window",
           "type": "string",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -15,5 +15,5 @@
 	"r.configuration.logLevel.info.description": "Informational messages",
 	"r.configuration.logLevel.debug.description": "Debug messages",
 	"r.configuration.logLevel.trace.description": "Verbose tracing messages",
-	"r.configuration.logLevel.description": "Log level for the R Kernel"
+	"r.configuration.logLevel.description": "Log level for the R Kernel (requires restart to take effect)"
 }

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -9,5 +9,11 @@
 	"r.configuration.tracing.description": "Traces the communication between VS Code and the language server",
 	"r.configuration.tracing.off.description": "No tracing.",
 	"r.configuration.tracing.messages.description": "Log messages from the server to the output panel.",
-	"r.configuration.tracing.verbose.description": "Log messages from the server as well as verbose output."
+	"r.configuration.tracing.verbose.description": "Log messages from the server as well as verbose output.",
+	"r.configuration.logLevel.error.description": "Errors only",
+	"r.configuration.logLevel.warn.description": "Errors and warnings",
+	"r.configuration.logLevel.info.description": "Informational messages",
+	"r.configuration.logLevel.debug.description": "Debug messages",
+	"r.configuration.logLevel.trace.description": "Verbose tracing messages",
+	"r.configuration.logLevel.description": "Log level for the R Kernel"
 }

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -89,6 +89,10 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 
 	const { execSync } = require('child_process');
 
+	// Check the R kernel log level setting
+	const config = vscode.workspace.getConfiguration('positron.r');
+	const logLevel = config.get<string>('kernel.logLevel') ?? 'warn';
+
 	// Discover R installations.
 	// TODO: Needs to handle Linux and Windows
 	// TODO: Needs to handle other installation locations (like RSwitch)
@@ -154,7 +158,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 		/* eslint-disable */
 		const env = <Record<string, string>>{
 			'RUST_BACKTRACE': '1',
-			'RUST_LOG': 'trace',
+			'RUST_LOG': logLevel,
 			'R_HOME': rHome.rHome,
 			'R_CLI_NUM_COLORS': '256',
 		};


### PR DESCRIPTION
@DavisVaughan pointed out that you can't change ARK's log level; as it's always `TRACE`, the output can get pretty overwhelming.

https://positpbc.slack.com/archives/C04FPQK3H9C/p1686858660577239?thread_ts=1686784736.329279&cid=C04FPQK3H9C

This change:
- defaults to WARN level logs, which is probably the correct setting for anyone not actually working on ARK (now the majority of the Positron team)
- adds a new configuration option that lets you set the log level you want in the Settings UI

<img width="352" alt="image" src="https://github.com/rstudio/positron/assets/470418/eb080d8b-3078-4290-b987-ed7e4821351c">
