### PR TITLE
Respect the `heartbeat` config variable everywhere

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -398,7 +398,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 					this.setStatus(positron.RuntimeState.Ready);
 					resolve();
 
-					const seconds = vscode.workspace.getConfiguration('positron').get('heartbeat', 30) as number;
+					const seconds = vscode.workspace.getConfiguration('positron.jupyterAdapter').get('heartbeat', 30) as number;
 					this.log(`Starting heartbeat check at ${seconds} second intervals...`);
 					this.heartbeat();
 					this._heartbeat?.socket().on('message', (msg: string) => {
@@ -1036,7 +1036,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 
 		// Schedule the next heartbeat at the configured interval. Re-read the configuration
 		// in case it changed.
-		const seconds = vscode.workspace.getConfiguration('positron').get('heartbeat', 30) as number;
+		const seconds = vscode.workspace.getConfiguration('positron.jupyterAdapter').get('heartbeat', 30) as number;
 		if (seconds > 0) {
 			this._nextHeartbeat = setTimeout(() => {
 				this.heartbeat();


### PR DESCRIPTION
I noticed that the `heartbeat` config variable isn't actually being respected holistically due to a probable typo.

It is respected here:
https://github.com/rstudio/positron/blob/9c118e56b05bd4dc0b480330f873e3f6159bc31e/extensions/jupyter-adapter/src/JupyterKernel.ts#L966

But not in the two places changed in this PR