### PR TITLE
Add command to source the current R script

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -26,6 +26,11 @@
         "category": "R",
         "title": "%r.command.createNewFile.title%",
         "shortTitle": "%r.menu.createNewFile.title%"
+      },
+      {
+        "command": "r.sourceCurrentFile",
+        "category": "R",
+        "title": "%r.command.sourceCurrentFile.title%"
       }
     ],
     "configuration": {
@@ -104,6 +109,14 @@
           "command": "r.createNewFile",
           "group": "file",
           "when": "!virtualWorkspace"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "r.sourceCurrentFile",
+          "group": "R",
+          "title": "%r.command.sourceCurrentFile.title%",
+          "when": "editorLangId == r && !virtualWorkspace"
         }
       ]
     },

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -30,7 +30,8 @@
       {
         "command": "r.sourceCurrentFile",
         "category": "R",
-        "title": "%r.command.sourceCurrentFile.title%"
+        "title": "%r.command.sourceCurrentFile.title%",
+        "icon": "$(play)"
       }
     ],
     "configuration": {
@@ -104,6 +105,15 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "category": "R",
+          "command": "r.sourceCurrentFile",
+          "icon": "$(play)",
+          "title": "%r.command.sourceCurrentFile.title%",
+          "when": "editorLangId == r"
+        }
+      ],
       "file/newFile": [
         {
           "command": "r.createNewFile",
@@ -116,7 +126,16 @@
           "command": "r.sourceCurrentFile",
           "group": "R",
           "title": "%r.command.sourceCurrentFile.title%",
-          "when": "editorLangId == r && !virtualWorkspace"
+          "when": "editorLangId == r"
+        }
+      ],
+      "editor/title/run": [
+        {
+          "command": "r.sourceCurrentFile",
+          "group": "navigation@0",
+          "icon": "$(play)",
+          "title": "%r.command.sourceCurrentFile.title%",
+          "when": "resourceLangId == r && !isInDiffEditor"
         }
       ]
     },

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -1,6 +1,7 @@
 {
 	"displayName": "R",
 	"description": "R Language Pack for Positron",
+	"r.command.sourceCurrentFile.title": "Source File",
 	"r.command.setKernelPath.title": "Set Kernel Path",
 	"r.command.createNewFile.title": "New R File",
 	"r.menu.createNewFile.title": "R File",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -1,7 +1,7 @@
 {
 	"displayName": "R",
 	"description": "R Language Pack for Positron",
-	"r.command.sourceCurrentFile.title": "Source File",
+	"r.command.sourceCurrentFile.title": "Source R File",
 	"r.command.setKernelPath.title": "Set Kernel Path",
 	"r.command.createNewFile.title": "New R File",
 	"r.menu.createNewFile.title": "R File",

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import * as positron from 'positron';
 
 import { adaptJupyterKernel } from './kernel';
 
@@ -40,6 +41,31 @@ export function registerCommands(context: vscode.ExtensionContext) {
 			vscode.workspace.openTextDocument({ language: 'r' }).then((newFile) => {
 				vscode.window.showTextDocument(newFile);
 			});
-		})
+		}),
+
+		// Command used to source the current file
+		vscode.commands.registerCommand('r.sourceCurrentFile', () => {
+			// Get the active text editor
+			const editor = vscode.window.activeTextEditor;
+			if (!editor) {
+				// No editor; nothing to do
+				return;
+			}
+
+			const filePath = editor.document.uri.fsPath;
+			if (!filePath) {
+				// File is unsaved; show a warning
+				vscode.window.showWarningMessage('Cannot source unsaved file.');
+				return;
+			}
+
+			// In the future, we will want to shorten the path by making it
+			// relative to the current directory; doing so, however, will
+			// require the kernel to alert us to the current working directory,
+			// or provide a method for asking it to create the `source()`
+			// command. For now, just use the full path.
+			const command = `source('${filePath}')`;
+			positron.runtime.executeCode('r', command, true);
+		}),
 	);
 }

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -44,7 +44,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
 		}),
 
 		// Command used to source the current file
-		vscode.commands.registerCommand('r.sourceCurrentFile', () => {
+		vscode.commands.registerCommand('r.sourceCurrentFile', async () => {
 			// Get the active text editor
 			const editor = vscode.window.activeTextEditor;
 			if (!editor) {
@@ -59,13 +59,28 @@ export function registerCommands(context: vscode.ExtensionContext) {
 				return;
 			}
 
-			// In the future, we will want to shorten the path by making it
-			// relative to the current directory; doing so, however, will
-			// require the kernel to alert us to the current working directory,
-			// or provide a method for asking it to create the `source()`
-			// command. For now, just use the full path.
-			const command = `source('${filePath}')`;
-			positron.runtime.executeCode('r', command, true);
+			try {
+				// Check to see if the fsPath is an actual path to a file using
+				// the VS Code file system API.
+				const fsStat = await vscode.workspace.fs.stat(vscode.Uri.file(filePath));
+
+				// In the future, we will want to shorten the path by making it
+				// relative to the current directory; doing so, however, will
+				// require the kernel to alert us to the current working directory,
+				// or provide a method for asking it to create the `source()`
+				// command. For now, just use the full path.
+				if (fsStat) {
+					const command = `source('${filePath}')`;
+					positron.runtime.executeCode('r', command, true);
+				}
+			} catch (e) {
+				// This is not a valid file path, which isn't an error; it just
+				// means the active editor has something loaded into it that
+				// isn't a file on disk.  In Positron, there is currently a bug
+				// which causes the REPL to act like an active editor. See:
+				//
+				// https://github.com/rstudio/positron/issues/780
+			}
 		}),
 	);
 }


### PR DESCRIPTION
This change adds a very simple command to `source()` the current R script. 

<img width="509" alt="image" src="https://github.com/rstudio/positron/assets/470418/ada50a1b-a835-4ab1-bf27-41916f6f31c2">

It's mainly a stopgap for Alpha. In a later version of Positron, we will have the `source()` command generated from the backend. 

Addresses https://github.com/rstudio/positron/issues/396 (at the Alpha level)