### PR TITLE
Save before sourcing; add ergonomic keybinding

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -140,7 +140,7 @@
         "path": "./syntaxes/r.tmGrammar.gen.json"
       }
     ],
-    "keybindings" : [
+    "keybindings": [
       {
         "command": "r.packageLoad",
         "key": "ctrl+shift+l",
@@ -170,6 +170,12 @@
         "key": "ctrl+shift+d",
         "mac": "cmd+shift+d",
         "when": "isRPackage"
+      },
+      {
+        "command": "r.sourceCurrentFile",
+        "key": "ctrl+shift+enter",
+        "mac": "cmd+shift+enter",
+        "when": "editorLangId == r"
       }
     ],
     "menus": {

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -101,9 +101,12 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 				// relative to the current directory; doing so, however, will
 				// require the kernel to alert us to the current working directory,
 				// or provide a method for asking it to create the `source()`
-				// command. For now, just use the full path.
+				// command.
+				//
+				// For now, just use the full path, passed through JSON encoding
+				// to ensure that it is properly escaped.
 				if (fsStat) {
-					const command = `source('${filePath}')`;
+					const command = `source(${JSON.stringify(filePath)})`;
 					positron.runtime.executeCode('r', command, true);
 				}
 			} catch (e) {

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -88,6 +88,10 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 				return;
 			}
 
+			// Save the file before sourcing it to ensure that the contents are
+			// up to date with editor buffer.
+			await vscode.commands.executeCommand('workbench.action.files.save');
+
 			try {
 				// Check to see if the fsPath is an actual path to a file using
 				// the VS Code file system API.


### PR DESCRIPTION
Adds a couple of small ergonomic improvements to the new `Source` command for R scripts:

- There's now a `Cmd+Shift+Enter` keybinding (when inside an R script)
- We now save the file before sourcing it

(both suggested by @jjallaire)

Also, we now properly escape the file path (h/t @kevinushey)