### PR TITLE
Force x64 `pkg-config` and run `cargo clean`

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -118,6 +118,8 @@ jobs:
           R_VERSION=$(ls ${R_FOLDER} | head -1)
           # Form the path to the R binary, e.g. /Users/user229818/homebrew/Cellar/r/4.2.2/bin/R
           R_EXECUTABLE="${R_FOLDER}/${R_VERSION}/bin/R"
+          R_SCRIPT="${R_FOLDER}/${R_VERSION}/bin/Rscript"
+          echo $(${R_SCRIPT} -e R.version)
           # Invoke the R binary to determine its RHOME directory (usually lib/R)
           R_HOME=$(${R_EXECUTABLE} RHOME)
           # Output the result for consumption in later steps

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -110,6 +110,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
+      # These are already installed for both architectures, but would be required if we switch off
+      # a self-hosted runner, so we may as well leave them in
       - name: Install zeromq dependencies
         id: install_zeromq_dependencies
         run: |

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -118,8 +118,6 @@ jobs:
           R_VERSION=$(ls ${R_FOLDER} | head -1)
           # Form the path to the R binary, e.g. /Users/user229818/homebrew/Cellar/r/4.2.2/bin/R
           R_EXECUTABLE="${R_FOLDER}/${R_VERSION}/bin/R"
-          R_SCRIPT="${R_FOLDER}/${R_VERSION}/bin/Rscript"
-          echo $(${R_SCRIPT} -e R.version)
           # Invoke the R binary to determine its RHOME directory (usually lib/R)
           R_HOME=$(${R_EXECUTABLE} RHOME)
           # Output the result for consumption in later steps

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        arch: [x64, arm64]
+        arch: [arm64, x64]
         include:
           - arch: arm64
             arch_terminal: arm64

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -97,9 +97,11 @@ jobs:
         arch: [arm64, x64]
         include:
           - arch: arm64
+            arch_terminal: arm64
             homebrew_folder: homebrew
             rust_target_prefix: aarch64
           - arch: x64
+            arch_terminal: x86_64
             homebrew_folder: homebrew-x86_64
             rust_target_prefix: x86_64
 
@@ -107,6 +109,20 @@ jobs:
       # Checkout sources
       - name: Checkout sources
         uses: actions/checkout@v3
+
+      - name: Install zeromq dependencies
+        id: install_zeromq_dependencies
+        run: |
+          arch -${{matrix.arch_terminal}} /bin/bash -c "~/${{matrix.homebrew_folder}}/bin/brew install pkg-config"
+          arch -${{matrix.arch_terminal}} /bin/bash -c "~/${{matrix.homebrew_folder}}/bin/brew install libsodium"
+
+      # Zeromq calls whatever pkg-config is findable on the PATH, so we have to ensure the x86_64
+      # version is first on the PATH when compiling for that architecture
+      - name: Update PATH to pkg-config for zeromq
+        id: update_path_for_zeromq
+        if: matrix.arch == 'x64'
+        run: |
+          export PATH=~/${{matrix.homebrew_folder}}/bin:$PATH
 
       # Determine R_HOME (for building ark)
       - name: Find Homebrew R installation

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -116,8 +116,9 @@ jobs:
           arch -${{matrix.arch_terminal}} /bin/bash -c "~/${{matrix.homebrew_folder}}/bin/brew install pkg-config"
           arch -${{matrix.arch_terminal}} /bin/bash -c "~/${{matrix.homebrew_folder}}/bin/brew install libsodium"
 
-      # Zeromq calls whatever pkg-config is findable on the PATH, so we have to ensure the x86_64
-      # version is first on the PATH when compiling for that architecture
+      # Zeromq calls whatever pkg-config version is findable on the PATH to be able to locate
+      # libsodium, so we have to ensure the x86_64 version is first on the PATH when compiling for
+      # that architecture, so that it finds the x86_64 version of libsodium for zeromq to link against.
       - name: Update PATH to pkg-config for zeromq
         id: update_path_for_zeromq
         if: matrix.arch == 'x64'

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        arch: [arm64, x64]
+        arch: [x64, arm64]
         include:
           - arch: arm64
             arch_terminal: arm64
@@ -122,7 +122,7 @@ jobs:
         id: update_path_for_zeromq
         if: matrix.arch == 'x64'
         run: |
-          export PATH=~/${{matrix.homebrew_folder}}/bin:$PATH
+          echo "~/${{matrix.homebrew_folder}}/bin" >> $GITHUB_PATH
 
       # Determine R_HOME (for building ark)
       - name: Find Homebrew R installation

--- a/extensions/positron-r/scripts/compile-kernel.ts
+++ b/extensions/positron-r/scripts/compile-kernel.ts
@@ -16,6 +16,17 @@ if (whichCargoResult.status !== 0 || whichCargoResult.error) {
 // Enter the kernel directory
 chdir(`${__dirname}/../amalthea`);
 
+// `cargo clean` if on CI, because old builds are likely persistent due to using a hosted runner.
+// Locally we `cargo clean` manually as needed, to save time.
+const ci = env['CI'];
+if (ci) {
+	const cargoCleanResult = spawnSync('cargo', ['clean'], { encoding: 'utf-8', stdio: 'inherit' });
+	if (cargoCleanResult.status !== 0 || cargoCleanResult.error) {
+		console.log(`ERROR: cargo clean failed [exit status ${cargoCleanResult.status}]`);
+		exit(1);
+	}
+}
+
 // Start building the arguments to cargo build.
 const cargoBuildArgs = ['build'];
 
@@ -30,13 +41,6 @@ const rustTarget = env['RUST_TARGET'];
 if (rustTarget) {
 	env['PKG_CONFIG_ALLOW_CROSS'] = '1';
 	cargoBuildArgs.push('--target', rustTarget);
-}
-
-// Clean it!
-const cargoCleanResult = spawnSync('cargo', ['clean'], { encoding: 'utf-8', stdio: 'inherit' });
-if (cargoCleanResult.status !== 0 || cargoCleanResult.error) {
-	console.log(`ERROR: cargo clean failed [exit status ${cargoCleanResult.status}]`);
-	exit(1);
 }
 
 // Build it!

--- a/extensions/positron-r/scripts/compile-kernel.ts
+++ b/extensions/positron-r/scripts/compile-kernel.ts
@@ -32,6 +32,13 @@ if (rustTarget) {
 	cargoBuildArgs.push('--target', rustTarget);
 }
 
+// Clean it!
+const cargoCleanResult = spawnSync('cargo', ['clean'], { encoding: 'utf-8', stdio: 'inherit' });
+if (cargoCleanResult.status !== 0 || cargoCleanResult.error) {
+	console.log(`ERROR: cargo clean failed [exit status ${cargoCleanResult.status}]`);
+	exit(1);
+}
+
 // Build it!
 const cargoBuildResult = spawnSync('cargo', cargoBuildArgs, { encoding: 'utf-8', stdio: 'inherit' });
 if (cargoBuildResult.status !== 0 || cargoBuildResult.error) {

--- a/extensions/positron-r/scripts/compile-kernel.ts
+++ b/extensions/positron-r/scripts/compile-kernel.ts
@@ -16,7 +16,7 @@ if (whichCargoResult.status !== 0 || whichCargoResult.error) {
 // Enter the kernel directory
 chdir(`${__dirname}/../amalthea`);
 
-// `cargo clean` if on CI, because old builds are likely persistent due to using a hosted runner.
+// `cargo clean` if on CI, because old builds are likely persistent due to using a self-hosted runner.
 // Locally we `cargo clean` manually as needed, to save time.
 const ci = env['CI'];
 if (ci) {


### PR DESCRIPTION
Addresses https://github.com/rstudio/positron/issues/580

See https://github.com/rstudio/positron/issues/580#issuecomment-1630888579 for details on tracking down that `pkg-config` (used to find libsodium) was one of the issues. If we use an x64 version of `pkg-config`, it will find the x64 version of libsodium, which is required when building x64 zeromq!

The other thing this PR does is force `cargo clean` to run on CI. This is required to clean out the old results of `cargo build` since we use a self hosted runner, meaning our builds are persistent (and we don't want that). The persistent builds were causing issues with the addition of the `R_HOME` environment variable, because libR-sys wasn't being rebuilt due to the persistence, so it looked like the addition of `R_HOME` didn't do anything.