### PR TITLE
Align with new `modules` location

### DIFF
--- a/extensions/positron-r/positron.json
+++ b/extensions/positron-r/positron.json
@@ -9,7 +9,7 @@
 			"to": "./dist/bin"
 		},
 		{
-			"from": "./amalthea/crates/ark/src/lsp/modules/*.R",
+			"from": "./amalthea/crates/ark/src/modules/*.R",
 			"to": "./dist/bin/modules"
 		}
 	]

--- a/extensions/positron-r/positron.json
+++ b/extensions/positron-r/positron.json
@@ -9,8 +9,12 @@
 			"to": "./dist/bin"
 		},
 		{
-			"from": "./amalthea/crates/ark/src/modules/*.R",
-			"to": "./dist/bin/modules"
+			"from": "./amalthea/crates/ark/src/modules/public/*.R",
+			"to": "./dist/bin/modules/public"
+		},
+		{
+			"from": "./amalthea/crates/ark/src/modules/private/*.R",
+			"to": "./dist/bin/modules/private"
 		}
 	]
 }


### PR DESCRIPTION
Addresses https://github.com/rstudio/positron/issues/796
Follow up to https://github.com/posit-dev/amalthea/pull/50

I didn't realize that positron-r referenced / copied these R files over into the release build, sorry about that!