### PR TITLE
Start missing runtime for `executeCode` API

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -487,7 +487,7 @@ export interface ILanguageRuntimeService {
 	 * Starts a runtime.
 	 * @param runtimeId The runtime identifier of the runtime to start.
 	 */
-	startRuntime(runtimeId: string): void;
+	startRuntime(runtimeId: string): Promise<void>;
 }
 export { RuntimeClientType, IRuntimeClientInstance };
 

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -91,6 +91,11 @@ const formatTraceback = (traceback: string[]) => {
 	return result;
 };
 
+const isImplicitStartupLanguage = (runtime: ILanguageRuntime, languageId: string) => {
+	return (runtime.metadata.languageId === languageId &&
+		runtime.metadata.startupBehavior === LanguageRuntimeStartupBehavior.Implicit);
+};
+
 //#endregion Helper Functions
 
 /**
@@ -277,19 +282,15 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 	 * @param activate A value which indicates whether the REPL should be activated.
 	 * @returns A value which indicates whether the code could be executed.
 	 */
-	executeCode(languageId: string, code: string, activate: boolean): Promise<boolean> {
+	async executeCode(languageId: string, code: string, activate: boolean): Promise<boolean> {
 		// Get the running runtimes for the language.
 		const runningLanguageRuntimes = this._languageRuntimeService.runningRuntimes.filter(
-			languageRuntime =>
-				languageRuntime.metadata.languageId === languageId &&
-				languageRuntime.metadata.startupBehavior === LanguageRuntimeStartupBehavior.Implicit);
+			runtime => isImplicitStartupLanguage(runtime, languageId));
 
 		if (!runningLanguageRuntimes.length) {
 			// Get the registered runtimes for the language.
 			const languageRuntimes = this._languageRuntimeService.registeredRuntimes.filter(
-				languageRuntime =>
-					languageRuntime.metadata.languageId === languageId &&
-					languageRuntime.metadata.startupBehavior === LanguageRuntimeStartupBehavior.Implicit);
+				runtime => isImplicitStartupLanguage(runtime, languageId));
 			if (!languageRuntimes.length) {
 				return Promise.resolve(false);
 			}

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -91,6 +91,12 @@ const formatTraceback = (traceback: string[]) => {
 	return result;
 };
 
+/**
+ * Tests whether a runtime is a specific language, and has implicit startup behavior.
+ * @param runtime A runtime.
+ * @param languageId A string like 'r' or 'python'.
+ * @returns A logical.
+ */
 const isImplicitStartupLanguage = (runtime: ILanguageRuntime, languageId: string) => {
 	return (runtime.metadata.languageId === languageId &&
 		runtime.metadata.startupBehavior === LanguageRuntimeStartupBehavior.Implicit);

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -298,7 +298,7 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 			// Start the first runtime that was found.
 			const languageRuntime = languageRuntimes[0];
 			this._logService.trace(`Language runtime ${formatLanguageRuntime(languageRuntime)} automatically starting`);
-			this._languageRuntimeService.startRuntime(languageRuntime.metadata.runtimeId);
+			await this._languageRuntimeService.startRuntime(languageRuntime.metadata.runtimeId);
 		}
 
 		const positronConsoleInstance = this._positronConsoleInstancesByLanguageId.get(languageId);

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -298,7 +298,7 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 			const languageRuntimes = this._languageRuntimeService.registeredRuntimes.filter(
 				runtime => isImplicitStartupLanguage(runtime, languageId));
 			if (!languageRuntimes.length) {
-				return Promise.resolve(false);
+				return false;
 			}
 
 			// Start the first runtime that was found.

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -310,7 +310,7 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 		const positronConsoleInstance = this._positronConsoleInstancesByLanguageId.get(languageId);
 
 		if (!positronConsoleInstance) {
-			return Promise.resolve(false);
+			return false;
 		}
 
 		// Activate the Positron console instance, if it isn't active.


### PR DESCRIPTION
Addresses #806 

As of right now, this starts the missing runtime but I don't have it wired up to wait yet, so the code doesn't get executed.
