### PR TITLE
Always move the cursor to the end of the line on history navigation

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -59,7 +59,6 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 	/**
 	 * Updates the code editor widget position such that the cursor appers on the first line and the
 	 * first column.
-	 */
 	const updateCodeEditorWidgetPositionToBeginning = () => {
 		// Set the code editor widget position.
 		codeEditorWidgetRef.current.setPosition({
@@ -70,6 +69,7 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 		// Ensure that the code editor widget is scrolled into view.
 		codeEditorWidgetContainerRef.current?.scrollIntoView({ behavior: 'auto' });
 	};
+	 */
 
 	/**
 	 * Updates the code editor widget position such that the cursor appers on the last line and the
@@ -297,7 +297,7 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 						codeEditorWidgetRef.current.setValue(inputHistoryEntry.input);
 
 						// Position the code editor widget.
-						updateCodeEditorWidgetPositionToBeginning();
+						updateCodeEditorWidgetPositionToEnd();
 					}
 				}
 				break;

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -57,21 +57,6 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 		useStateRef<string | undefined>(undefined);
 
 	/**
-	 * Updates the code editor widget position such that the cursor appers on the first line and the
-	 * first column.
-	const updateCodeEditorWidgetPositionToBeginning = () => {
-		// Set the code editor widget position.
-		codeEditorWidgetRef.current.setPosition({
-			lineNumber: 1,
-			column: 1
-		});
-
-		// Ensure that the code editor widget is scrolled into view.
-		codeEditorWidgetContainerRef.current?.scrollIntoView({ behavior: 'auto' });
-	};
-	 */
-
-	/**
 	 * Updates the code editor widget position such that the cursor appers on the last line and the
 	 * last column.
 	 */


### PR DESCRIPTION
This basically reverts https://github.com/rstudio/positron/commit/fe1bddbb48c9ae53e01b495c1899ddb51b3500f3 to address #597, although I left the function commented in case we need it. I'm happy to remove it completely if that's preferred.

I noted Pete's [comment](https://github.com/rstudio/positron/issues/597#issuecomment-1554710298) re fixing multiline navigation, and testing that seems to work fine:

https://github.com/rstudio/positron/assets/559360/e1f94ead-ca4c-4ca4-aca1-8ca1ccd77e91
