### PR TITLE
More carefully check pending input during send-to-console

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -586,8 +586,9 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 					// and if so, append the new code fragment on a new line.
 					codeFragment = `${currentCodeFragment}${codeFragment}`;
 					// Empty the current value, since we used it.
-					currentCodeFragment = '';
+
 				}
+				currentCodeFragment = '';
 			}
 
 			// Update the current code fragment.
@@ -596,12 +597,6 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 
 			// Try to execute the code.
 			await executeCodeEditorWidgetCodeIfPossible();
-
-			// If anything is still pending, set back to current.
-			if (currentCodeFragment.length) {
-				setCurrentCodeFragment(currentCodeFragment);
-				codeEditorWidgetRef.current.setValue(currentCodeFragment);
-			}
 		}));
 
 		// Focus the console.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -585,9 +585,8 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 				if (currentCodeFragmentStatus === RuntimeCodeFragmentStatus.Incomplete) {
 					// and if so, append the new code fragment on a new line.
 					codeFragment = `${currentCodeFragment}${codeFragment}`;
-					// Empty the current value, since we used it.
-
 				}
+				// Empty the current value, since we either used it or need to discard it.
 				currentCodeFragment = '';
 			}
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -575,11 +575,19 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 		// Add the onDidExecuteCode event handler.
 		disposableStore.add(props.positronConsoleInstance.onDidExecuteCode(async codeFragment => {
 			// Get the current code fragment.
-			const currentCodeFragment = codeEditorWidgetRef.current.getValue();
+			let currentCodeFragment = codeEditorWidgetRef.current.getValue();
 
-			// If there is a current code fragment, append the new code fragment on a new line.
+			// If there is a current code fragment,
 			if (currentCodeFragment.length) {
-				codeFragment = `${currentCodeFragment}${codeFragment}`;
+				// check whether the current code fragment is incomplete,
+				const currentCodeFragmentStatus = await props.positronConsoleInstance.runtime.
+					isCodeFragmentComplete(currentCodeFragment);
+				if (currentCodeFragmentStatus === RuntimeCodeFragmentStatus.Incomplete) {
+					// and if so, append the new code fragment on a new line.
+					codeFragment = `${currentCodeFragment}${codeFragment}`;
+					// Empty the current value, since we used it.
+					currentCodeFragment = '';
+				}
 			}
 
 			// Update the current code fragment.
@@ -588,6 +596,12 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 
 			// Try to execute the code.
 			await executeCodeEditorWidgetCodeIfPossible();
+
+			// If anything is still pending, set back to current.
+			if (currentCodeFragment.length) {
+				setCurrentCodeFragment(currentCodeFragment);
+				codeEditorWidgetRef.current.setValue(currentCodeFragment);
+			}
 		}));
 
 		// Focus the console.


### PR DESCRIPTION
Addresses #552 

With this change, we more carefully check the current code fragment and only paste it together with the new one if it is incomplete. I think we still need to check `runtimeCodeFragmentStatus` in `executeCodeEditorWidgetCodeIfPossible`; this is an extra check just for whether we should keep building up this little buffer.

Two situations now work as I think we want them to.

### Situation 1 😃 

- Type `some stuff` in the console, but don't submit it
- Open a source file and put the cursor on a line containing valid code
- Press Cmd+Enter to run the line

In this situation, `some stuff` is _not_ pasted together with the code sent via cmd + enter. It is again the current value after the code sent via cmd + enter is executed.

### Situation 2 😃

We still handle the situation of #387 as before, but more carefully check before pasting it together.

### Situation 3 😩 

Sadly, if you type `some stuff` in the console but don't submit it and then try to step through a multi-line expression via cmd + enter (i.e. submitted code is not complete), it does not work at all. As @jmcphers says in #552:

> This can get a little weird if the submitted code is not complete, but that shouldn't happen much in practice unless you are actively trying

I definitely agree this shouldn't happen much, but I'm open to further ideas on how to distinguish between these code fragments!
