### PR TITLE
Refactor R installation discovery

### DIFF
--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -73,7 +73,7 @@ function getRHOME(rHome: string): string {
 }
 
 // input: '4.3-arm64'
-// output: '/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/bin/R'
+// output: '/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/bin/R'
 function getRBinary(version: string): string {
 	return path.join(R_ROOT, R_BINPATH.replace('{}', version));
 }

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -140,7 +140,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 		});
 	// TODO: see Google Doc about multiple R versions for things we could do in the future
 	// re: non-orthogonal R installations
-	rInstallations.filter(inst => inst.is_orthogonal());
+	rInstallations.filter(inst => inst.isOrthogonal());
 
 	// Sort the R installations by version number, descending. If we don't find an R
 	// installation on the PATH, this produces reasonable default behaviour, which is to

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -100,7 +100,10 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 			// e.g. distinguish between 4.3-arm64 vs. 4.3-x86_64
 		}
 
-		is_orthogonal() {
+		// https://github.com/r-lib/rig/blob/793663844638127abbb51e3b696e1068b200a5ab/src/macos.rs#L575-L584
+		// "orthogonal" basically means the R installation knows its own concrete home directory,
+		// as opposed to reporting the abstract home directory for the "current version of R"
+		isOrthogonal() {
 			return fs.realpathSync(this.rHomeRHOME) === this.rHome;
 		}
 	}


### PR DESCRIPTION
Addresses #702 (was actually addressed by #831, but it's more obvious why this PR closes it).
(Presumably) addresses #839.

This refactoring has a couple motivations:

* Helped me to dig in to this bit of code and gain more practice with typescript. If I've done gross things, I'm happy to reverse them!
* Lay the groundwork for eventually discovering R installations on Windows and linux
* Don't offer to launch non-Current, non-orthogonal R installations, i.e. installations that are only well-formed when they are the current default version of R

I created a Google Doc on "multiple R versions" while working on this. I will clean that up before this gets merged: https://docs.google.com/document/d/1RZQ4yejA6EsRDZODtEjeW6OIdyPJeRQCqWlhNDxXTHw/edit?pli=1