### PR TITLE
Improve Cmd+Enter behavior

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -279,18 +279,32 @@ export function registerPositronConsoleActions() {
 				editor.revealPositionInCenterIfOutsideViewport(newPosition);
 			}
 
-			// If there is no code to execute, inform the user.
-			if (code.length === 0) {
-				notificationService.notify({
-					severity: Severity.Info,
-					message: localize('positron.executeCode.noCode', "No code is selected or available to execute."),
-					sticky: false
-				});
-				return;
+			// If we're at the very end of the document, insert a newline so that
+			// the user can continue typing.
+			if (position?.lineNumber === model.getLineCount()) {
+				// Create an edit operation that will append a new line to the end
+				// of the document.
+				const editOperation = {
+					range: {
+						startLineNumber: model.getLineCount(),
+						startColumn: model.getLineMaxColumn(model.getLineCount()),
+						endLineNumber: model.getLineCount(),
+						endColumn: model.getLineMaxColumn(model.getLineCount())
+					},
+					text: '\n'
+				};
+				model.pushEditOperations([], [editOperation], () => []);
+
+				// If we didn't actually execute any code, move the cursor back
+				// up a line so that we don't wind up adding a bunch of empty
+				// lines to the end of the document if the command is run
+				// multiple times.
+				if (!code.length) {
+					editor.setPosition(position.with(position.lineNumber, position.column));
+				}
 			}
 
-			// Now that we've gotten this far, and there's "code" to execute, ensure we have a
-			// target language.
+			// Now that we've gotten this far, ensure we have a target language.
 			const languageId = editorService.activeTextEditorLanguageId;
 			if (!languageId) {
 				notificationService.notify({

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -257,10 +257,21 @@ export function registerPositronConsoleActions() {
 			if (code.length && position && ++lineNumber <= model.getLineCount()) {
 				// Continue to move past empty lines so that the cursor lands on
 				// the first non-empty line
-				while (this.trimNewlines(model.getLineContent(lineNumber)).length === 0 &&
-					lineNumber < model.getLineCount()) {
-					lineNumber++;
+				let nextLineNumber = lineNumber;
+				while (this.trimNewlines(model.getLineContent(nextLineNumber)).length === 0 &&
+					nextLineNumber < model.getLineCount()) {
+					nextLineNumber++;
 				}
+
+				if (nextLineNumber < model.getLineCount()) {
+					// If we found a non-empty line, move the cursor to it.
+					lineNumber = nextLineNumber;
+				} else {
+					// If we didn't, just move the cursor to the line after the
+					// one we executed, even if it's empty.
+					lineNumber = position.lineNumber + 1;
+				}
+
 				// This is the cursor's new position; move the cursor and scroll
 				// the editor to it if necessary.
 				const newPosition = position.with(lineNumber, 0);


### PR DESCRIPTION
This change aligns Positron's Cmd+Enter behavior to be more like RStudio's in edge cases at the end of the file. In particular:

- If you Cmd+Enter on the last line of the file, a new line will be created at the end of the file. This is the most important part of the change; it lets you treat the editor surface more like a REPL.
- When you Cmd+Enter on a line of code and the rest of the file is empty, the cursor will be placed at the line after the code instead of at the end of the file.
- You no longer get an pop-up error if you Cmd+Enter and we can't find any code to run. Instead we "run" a blank line and don't advance the cursor.

Addresses https://github.com/rstudio/positron/issues/695, including adding RStudio's subtle behavior change when you Cmd+Enter on the last line of the file and that line is empty (we add a new line beneath the cursor when you do this, but don't navigate to it)

Addresses https://github.com/rstudio/positron/issues/876
