### PR TITLE
Raise console before executing code, when focusing

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
@@ -9,8 +9,9 @@ import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { ViewPaneContainer } from 'vs/workbench/browser/parts/views/viewPaneContainer';
 import { PositronConsoleViewPane } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleView';
-import { POSITRON_CONSOLE_VIEW_ID, registerPositronConsoleActions } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleActions';
+import { registerPositronConsoleActions } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleActions';
 import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
+import { POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
 
 // The Positron console view icon.
 const positronConsoleViewIcon = registerIcon('positron-console-view-icon', Codicon.positronConsoleView, nls.localize('positronConsoleViewIcon', 'View icon of the Positron console view.'));

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -17,7 +17,7 @@ import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/la
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { confirmationModalDialog } from 'vs/workbench/browser/positronModalDialogs/confirmationModalDialog';
 import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/common/executionHistoryService';
-import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
+import { IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
 import { IViewsService } from 'vs/workbench/common/views';
 import { PositronConsoleViewPane } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleView';
 
@@ -34,11 +34,6 @@ const enum PositronConsoleCommandId {
  * Positron console action category.
  */
 const POSITRON_CONSOLE_ACTION_CATEGORY = localize('positronConsoleCategory', "Console");
-
-/**
- * The Positron console view ID.
- */
-export const POSITRON_CONSOLE_VIEW_ID = 'workbench.panel.positronConsole';
 
 /**
  * Registers Positron console actions.

--- a/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
@@ -11,6 +11,11 @@ import { ILanguageRuntime } from 'vs/workbench/services/languageRuntime/common/l
 export const IPositronConsoleService = createDecorator<IPositronConsoleService>('positronConsoleService');
 
 /**
+ * The Positron console view ID.
+ */
+export const POSITRON_CONSOLE_VIEW_ID = 'workbench.panel.positronConsole';
+
+/**
  * PositronConsoleState enumeration.
  */
 export const enum PositronConsoleState {


### PR DESCRIPTION
Ensures that the Console view is raised when executing code.

