### PR TITLE
Bundle the Quarto extension with Positron

### DIFF
--- a/product.json
+++ b/product.json
@@ -79,6 +79,21 @@
 				},
 				"publisherDisplayName": "Microsoft"
 			}
+		},
+		{
+			"name": "quarto.quarto",
+			"version": "1.89.0",
+			"repo": "https://github.com/quarto-dev/quarto/tree/main/apps/vscode",
+			"metadata": {
+				"id": "0c8ba31b-5771-4fa9-bc20-a9f2e69a77ad",
+				"publisherId": {
+					"publisherId": "4c107a56-c3e3-4f93-b127-071cae1c6c52",
+					"publisherName": "quarto",
+					"displayName": "Quarto",
+					"flags": "verified"
+				},
+				"publisherDisplayName": "Quarto"
+			}
 		}
 	],
 	"extensionsGallery": {


### PR DESCRIPTION
This change adds the Quarto extension to Positron as a built-in (preinstalled) extension.

Addresses the first part of https://github.com/rstudio/positron/issues/808.