### PR TITLE
fix: executing indented Python statements

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -227,7 +227,7 @@ export function registerPositronConsoleActions() {
 			if (selection) {
 				// If there is an active selection, use the contents of the selection to drive
 				// execution.
-				code = this.trimNewlines(model.getValueInRange(selection));
+				code = model.getValueInRange(selection);
 				lineNumber = selection.endLineNumber;
 			}
 


### PR DESCRIPTION
If there's a selection, don't trim newlines. Ipykernel checks if the code ends in a non-indented newline to determine whether the code is complete.

For example: it considers this as complete `for i in range(25):\n    pass\n` but this as incomplete `for i in range(25):\n    pass`.

I figured it would be reasonable to execute a user's selection as is, with any newlines included. Let me know if I'm missing an edge case or if there's a better solution.

Addresses https://github.com/rstudio/positron/issues/892.