### PR TITLE
Add basic workspace/runtime affiliation

### DIFF
--- a/src/vs/workbench/browser/parts/positronTopActionBar/modalPopups/interpreterGroups.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/modalPopups/interpreterGroups.tsx
@@ -85,7 +85,7 @@ export const InterpreterGroups = (props: InterpreterGroupsProps) => {
 
 		// Add our onDidChangeRegisteredRuntimes event handler. This allows the set of runtimes to
 		// be dynamic at app startup.
-		disposableStore.add(props.languageRuntimeService.onDidChangeRegisteredRuntimes(() => {
+		disposableStore.add(props.languageRuntimeService.onDidRegisterRuntime(() => {
 			setInterpreterGroups(createInterpreterGroups(props.languageRuntimeService));
 		}));
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -62,8 +62,8 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	// The active runtime.
 	private _activeRuntime?: ILanguageRuntime;
 
-	// The event emitter for the onDidChangeRegisteredRuntimes event.
-	private readonly _onDidChangeRegisteredRuntimesEmitter = this._register(new Emitter<void>);
+	// The event emitter for the onDidRegisterRuntime event.
+	private readonly _onDidRegisterRuntimeEmitter = this._register(new Emitter<ILanguageRuntime>);
 
 	// The event emitter for the onWillStartRuntime event.
 	private readonly _onWillStartRuntimeEmitter = this._register(new Emitter<ILanguageRuntime>);
@@ -140,7 +140,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	declare readonly _serviceBrand: undefined;
 
 	// An event that fires when a runtime is about to start.
-	readonly onDidChangeRegisteredRuntimes = this._onDidChangeRegisteredRuntimesEmitter.event;
+	readonly onDidRegisterRuntime = this._onDidRegisterRuntimeEmitter.event;
 
 	// An event that fires when a runtime is about to start.
 	readonly onWillStartRuntime = this._onWillStartRuntimeEmitter.event;
@@ -237,7 +237,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 		this._registeredRuntimesByRuntimeId.set(runtime.metadata.runtimeId, languageRuntimeInfo);
 
 		// Signal that the set of registered runtimes has changed.
-		this._onDidChangeRegisteredRuntimesEmitter.fire();
+		this._onDidRegisterRuntimeEmitter.fire(runtime);
 
 		// Runtimes are usually registered in the Uninitialized state. If the
 		// runtime is already running when it is registered, we are

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -107,7 +107,8 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 		super();
 
 		// Create the object that tracks the affiliation of runtimes to workspaces.
-		new LanguageRuntimeWorkspaceAffiliation(this, this._storageService, this._logService);
+		this._register(new LanguageRuntimeWorkspaceAffiliation(
+			this, this._storageService, this._logService));
 
 		// Add the onDidEncounterLanguage event handler.
 		this._register(this._languageService.onDidRequestRichLanguageFeatures(languageId => {

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -9,6 +9,8 @@ import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle'
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { formatLanguageRuntime, ILanguageRuntime, ILanguageRuntimeGlobalEvent, ILanguageRuntimeService, ILanguageRuntimeStateEvent, LanguageRuntimeStartupBehavior, RuntimeClientType, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { FrontEndClientInstance, IFrontEndClientMessageInput, IFrontEndClientMessageOutput } from 'vs/workbench/services/languageRuntime/common/languageRuntimeFrontEndClient';
+import { LanguageRuntimeWorkspaceAffiliation } from 'vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation';
+import { IStorageService } from 'vs/platform/storage/common/storage';
 
 /**
  * LanguageRuntimeInfo class.
@@ -94,13 +96,18 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	 * Constructor.
 	 * @param _languageService The language service.
 	 * @param _logService The log service.
+	 * @param _storageService The storage service.
 	 */
 	constructor(
 		@ILanguageService private readonly _languageService: ILanguageService,
-		@ILogService private readonly _logService: ILogService
+		@ILogService private readonly _logService: ILogService,
+		@IStorageService private readonly _storageService: IStorageService
 	) {
 		// Call the base class's constructor.
 		super();
+
+		// Create the object that tracks the affiliation of runtimes to workspaces.
+		new LanguageRuntimeWorkspaceAffiliation(this, this._storageService, this._logService);
 
 		// Add the onDidEncounterLanguage event handler.
 		this._register(this._languageService.onDidRequestRichLanguageFeatures(languageId => {

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -428,8 +428,8 @@ export interface ILanguageRuntimeService {
 	// Needed for service branding in dependency injector.
 	readonly _serviceBrand: undefined;
 
-	// An event that fires when the registered runtimes changes.
-	readonly onDidChangeRegisteredRuntimes: Event<void>;
+	// An event that fires when a new runtime is registered.
+	readonly onDidRegisterRuntime: Event<ILanguageRuntime>;
 
 	// An event that fires when a runtime is about to start.
 	readonly onWillStartRuntime: Event<ILanguageRuntime>;

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation.ts
@@ -101,6 +101,17 @@ export class LanguageRuntimeWorkspaceAffiliation extends Disposable {
 	}
 
 	/**
+	 * Get the runtime ID affiliated with the given language ID.
+	 *
+	 * @param languageId The ID of the language for which to get the affiliated runtime.
+	 *
+	 * @returns The runtime ID.
+	 */
+	public getAffiliatedRuntimeId(languageId: string): string | undefined {
+		return this._storageService.get(`${this.storageKey}.${languageId}`, StorageScope.WORKSPACE);
+	}
+
+	/**
 	 * Convenience method for creating a storage key for a given runtime.
 	 *
 	 * @param runtime The runtime for which to get the storage key.

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation.ts
@@ -2,21 +2,44 @@
  *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
+import { Disposable } from 'vs/base/common/lifecycle';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
-import { ILanguageRuntime, ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeService, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 
-export class LanguageRuntimeWorkspaceAffiliation {
+/**
+ * The LanguageRuntimeWorkspaceAffiliation class is responsible for managing the
+ * affiliation between language runtimes and workspaces, in the service of
+ * ensuring that the correct runtime is started when opening each workspace.
+ *
+ * It works by storing the runtime ID of the affiliated runtime in the workspace
+ * storage. When a new runtime is registered, it checks to see if the runtime is
+ * affiliated with the current workspace, and if so, starts the runtime.
+ *
+ * When runtimes become active, they are affiliated with the current workspace;
+ * manually shutting down a runtime removes the affiliation.
+ */
+export class LanguageRuntimeWorkspaceAffiliation extends Disposable {
 	private readonly storageKey = 'positron.affiliatedRuntimeId';
 
 	constructor(
 		@ILanguageRuntimeService private readonly _runtimeService: ILanguageRuntimeService,
 		@IStorageService private readonly _storageService: IStorageService,
 		@ILogService private readonly _logService: ILogService) {
-		this._runtimeService.onDidChangeActiveRuntime(this.onDidChangeActiveRuntime, this);
-		this._runtimeService.onDidRegisterRuntime(this.onDidRegisterRuntime, this);
+
+		super();
+
+		this._register(
+			this._runtimeService.onDidChangeActiveRuntime(this.onDidChangeActiveRuntime, this));
+		this._register(
+			this._runtimeService.onDidRegisterRuntime(this.onDidRegisterRuntime, this));
 	}
 
+	/**
+	 * Runs as an event handler when the active runtime changes.
+	 *
+	 * @param runtime The newly active runtime, or undefined if no runtime is active.
+	 */
 	private onDidChangeActiveRuntime(runtime: ILanguageRuntime | undefined): void {
 		// Ignore if we are entering a state in which no runtime is active.
 		if (!runtime) {
@@ -28,11 +51,40 @@ export class LanguageRuntimeWorkspaceAffiliation {
 			runtime.metadata.runtimeId,
 			StorageScope.WORKSPACE,
 			StorageTarget.MACHINE);
+
+		// If the runtime is exiting, remove the affiliation if it enters the
+		// `Exiting` state. This state only occurs when the runtime is manually
+		// shut down, so may represent a user's intent to stop using the runtime
+		// for this workspace.
+		this._register(runtime.onDidChangeRuntimeState((newState) => {
+			if (newState === RuntimeState.Exiting) {
+				// Just to be safe, check that the runtime is still affiliated
+				// before removing the affiliation
+				const affiliatedRuntimeId = this._storageService.get(
+					this.storageKeyForRuntime(runtime), StorageScope.WORKSPACE);
+				if (runtime.metadata.runtimeId === affiliatedRuntimeId) {
+					// Remove the affiliation
+					this._storageService.remove(this.storageKeyForRuntime(runtime),
+						StorageScope.WORKSPACE);
+				}
+			}
+		}));
 	}
 
+	/**
+	 * Runs as an event handler when a new runtime is registered; checks to see
+	 * if the runtime is affiliated with this workspace, and if so, starts the
+	 * runtime.
+	 *
+	 * @param runtime The newly registered runtime.
+	 */
 	private onDidRegisterRuntime(runtime: ILanguageRuntime): void {
+
+		// Get the runtime ID that is affiliated with this workspace, if any.
 		const affiliatedRuntimeId = this._storageService.get(
 			this.storageKeyForRuntime(runtime), StorageScope.WORKSPACE);
+
+		// If the runtime is affiliated with this workspace, start it.
 		if (runtime.metadata.runtimeId === affiliatedRuntimeId) {
 			this._logService.debug(`Starting affiliated runtime ${runtime.metadata.runtimeName} ` +
 				` (${runtime.metadata.runtimeId}) for this workspace.`);
@@ -40,6 +92,13 @@ export class LanguageRuntimeWorkspaceAffiliation {
 		}
 	}
 
+	/**
+	 * Convenience method for creating a storage key for a given runtime.
+	 *
+	 * @param runtime The runtime for which to get the storage key.
+	 *
+	 * @returns A string used to store the affiliated runtime ID for the given runtime.
+	 */
 	private storageKeyForRuntime(runtime: ILanguageRuntime): string {
 		return `${this.storageKey}.${runtime.metadata.languageId}`;
 	}

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation.ts
@@ -88,7 +88,15 @@ export class LanguageRuntimeWorkspaceAffiliation extends Disposable {
 		if (runtime.metadata.runtimeId === affiliatedRuntimeId) {
 			this._logService.debug(`Starting affiliated runtime ${runtime.metadata.runtimeName} ` +
 				` (${runtime.metadata.runtimeId}) for this workspace.`);
-			this._runtimeService.startRuntime(runtime.metadata.runtimeId);
+			try {
+				this._runtimeService.startRuntime(runtime.metadata.runtimeId);
+			} catch (e) {
+				// This isn't necessarily an error; if another runtime took precedence and has
+				// already started for this workspace, we don't want to start this one.
+				this._logService.debug(`Did not start affiliated runtime ` +
+					`${runtime.metadata.runtimeName} for this workspace: ` +
+					`${e.message}`);
+			}
 		}
 	}
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
+import { ILanguageRuntime, ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+
+export class LanguageRuntimeWorkspaceAffiliation {
+	private readonly storageKey = 'positron.affiliatedRuntimeId';
+
+	constructor(
+		@ILanguageRuntimeService private readonly _runtimeService: ILanguageRuntimeService,
+		@IStorageService private readonly _storageService: IStorageService) {
+		this._runtimeService.onDidChangeActiveRuntime(this.onDidChangeActiveRuntime, this);
+		this._runtimeService.onDidRegisterRuntime(this.onDidRegisterRuntime, this);
+	}
+
+	private onDidChangeActiveRuntime(runtime: ILanguageRuntime | undefined): void {
+		// Ignore if we are entering a state in which no runtime is active.
+		if (!runtime) {
+			return;
+		}
+
+		// Save this runtime as the affiliated runtime for the current workspace.
+		this._storageService.store(this.storageKeyForRuntime(runtime),
+			runtime.metadata.runtimeId,
+			StorageScope.WORKSPACE,
+			StorageTarget.MACHINE);
+	}
+
+	private onDidRegisterRuntime(runtime: ILanguageRuntime): void {
+	}
+
+	private storageKeyForRuntime(runtime: ILanguageRuntime): string {
+		return `${this.storageKey}.${runtime.metadata.languageId}`;
+	}
+}


### PR DESCRIPTION
This change adds a basic form of workspace/runtime affiliation, such that runtimes stick to workspaces: if you start a runtime in a workspace, it will be started for you automatically the next time you open that workspace. 

There's more work to do here; this change is intended to address the minimal set of changes needed for Private Alpha. In this form, it primarily just remembers what you had running and brings it back online. An affiliation can be removed by *manually* shutting down a runtime (using the power button in the toolbar). 

A known issue with this approach is that it doesn't address the case where the affiliated runtime never gets registered (e.g. your project wants R 4.3, but you uninstalled it); the desirable behavior is likely that we should start a different R interpreter, but the behavior in this PR is that we don't start anything. That'll have to wait until after Alpha. 

Addresses https://github.com/rstudio/positron/issues/650.