### PR TITLE
Fixes for 828

### DIFF
--- a/src/vs/platform/positronActionBar/browser/positronActionBar.css
+++ b/src/vs/platform/positronActionBar/browser/positronActionBar.css
@@ -31,9 +31,9 @@
 }
 
 .positron-action-bar.border-top {
-	border-top: 1px solid var(--positronActionBar-border);
+	border-top: 0.5px solid var(--positronActionBar-border);
 }
 
 .positron-action-bar.border-bottom {
-	border-bottom: 1px solid var(--positronActionBar-border);
+	border-bottom: 0.5px solid var(--positronActionBar-border);
 }

--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -21,7 +21,10 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { PanelActivityAction, TogglePanelAction, PlaceHolderPanelActivityAction, PlaceHolderToggleCompositePinnedAction } from 'vs/workbench/browser/parts/panel/panelActions';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { ThemeIcon } from 'vs/base/common/themables';
-import { PANEL_BACKGROUND, PANEL_BORDER, PANEL_ACTIVE_TITLE_FOREGROUND, PANEL_INACTIVE_TITLE_FOREGROUND, PANEL_ACTIVE_TITLE_BORDER, EDITOR_DRAG_AND_DROP_BACKGROUND, PANEL_DRAG_AND_DROP_BORDER } from 'vs/workbench/common/theme';
+// --- Start Positron ---
+// Added new import for PANEL_HEADER_BACKGROUND that replaces PANEL_BACKGROUND.
+import { PANEL_HEADER_BACKGROUND /*PANEL_BACKGROUND*/, PANEL_BORDER, PANEL_ACTIVE_TITLE_FOREGROUND, PANEL_INACTIVE_TITLE_FOREGROUND, PANEL_ACTIVE_TITLE_BORDER, EDITOR_DRAG_AND_DROP_BACKGROUND, PANEL_DRAG_AND_DROP_BORDER } from 'vs/workbench/common/theme';
+// --- End Positron ---
 import { contrastBorder, badgeBackground, badgeForeground } from 'vs/platform/theme/common/colorRegistry';
 import { CompositeBar, ICompositeBarItem, CompositeDragAndDrop } from 'vs/workbench/browser/parts/compositeBar';
 import { IActivityHoverOptions, ToggleCompositeBadgeAction, ToggleCompositePinnedAction } from 'vs/workbench/browser/parts/compositeBarActions';
@@ -960,7 +963,10 @@ export class PanelPart extends BasePanelPart {
 			'workbench.panel.pinnedPanels',
 			'workbench.panel.placeholderPanels',
 			PaneCompositeExtensions.Panels,
-			PANEL_BACKGROUND,
+			// --- Start Positron ---
+			// Replace PANEL_BACKGROUND with PANEL_HEADER_BACKGROUND.
+			PANEL_HEADER_BACKGROUND,
+			// --- End Positron ---
 			ViewContainerLocation.Panel,
 			ActivePanelContext.bindTo(contextKeyService),
 			PanelFocusContext.bindTo(contextKeyService),

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -337,6 +337,16 @@ export const SIDE_BY_SIDE_EDITOR_VERTICAL_BORDER = registerColor('sideBySideEdit
 
 // < --- Panels --- >
 
+// --- Start Positron ---
+// Added panel header background that matches the sidebar background.
+export const PANEL_HEADER_BACKGROUND = registerColor('panel.headerBackground', {
+	dark: 'sideBar.background',
+	light: 'sideBar.background',
+	hcDark: 'sideBar.background',
+	hcLight: 'sideBar.background'
+}, localize('panel.headerBackground', "Panel header background color. Panels are shown below the editor area and contain views like output and integrated terminal."));
+// --- End Positron ---
+
 export const PANEL_BACKGROUND = registerColor('panel.background', {
 	dark: editorBackground,
 	light: editorBackground,
@@ -960,10 +970,10 @@ export const POSITRON_TOP_ACTION_BAR_BORDER = registerColor('positronTopActionBa
 
 // The Positron top action bar background color.
 export const POSITRON_TOP_ACTION_BAR_BACKGROUND = registerColor('positronTopActionBar.background', {
-	dark: 'terminal.background',
-	light: 'terminal.background',
-	hcDark: 'terminal.background',
-	hcLight: 'terminal.background'
+	dark: 'titleBar.activeBackground',
+	light: 'titleBar.activeBackground',
+	hcDark: 'titleBar.activeBackground',
+	hcLight: 'titleBar.activeBackground'
 }, localize('positronTopActionBar.background', "Positron top action bar background color."));
 
 // The Positron top action bar foreground color.

--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/actionBars.tsx
@@ -104,7 +104,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	return (
 		<PositronActionBarContextProvider {...props}>
 			<div className='action-bars'>
-				<PositronActionBar size='small' borderBottom={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
+				<PositronActionBar size='small' borderTop={true} borderBottom={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
 					<ActionBarRegion location='left'>
 						<GroupingMenuButton />
 						<SortingMenuButton />
@@ -116,7 +116,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						<ActionBarButton align='right' iconId='positron-refresh' tooltip={localize('positronRefreshObjects', "Refresh objects")} onClick={refreshObjectsHandler} />
 					</ActionBarRegion>
 				</PositronActionBar>
-				<PositronActionBar size='small' gap={kSecondaryActionBarGap} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
+				<PositronActionBar size='small' borderBottom={true} gap={kSecondaryActionBarGap} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
 					<ActionBarRegion location='left'>
 						<EnvironmentInstanceMenuButton />
 						{/* Disabled for Private Alpha <ActionBarButton iconId='positron-environment' text='Global Environment' dropDown={true} tooltip={localize('positronSelectEnvironment', "Select environment")} /> */}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.css
@@ -4,5 +4,4 @@
 
 .positron-plots-container .action-bars {
 	height: min-content;
-	border-bottom: 1px solid var(--vscode-statusBar-border);
 }

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -88,7 +88,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	return (
 		<PositronActionBarContextProvider {...props}>
 			<div className='action-bars'>
-				<PositronActionBar size='small' paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
+				<PositronActionBar size='small' borderTop={true} borderBottom={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
 					<ActionBarRegion location='left'>
 						<ActionBarButton iconId='positron-left-arrow' disabled={disableLeft} tooltip={localize('positronShowPreviousPlot', "Show previous plot")} onClick={showPreviousPlotHandler} />
 						<ActionBarButton iconId='positron-right-arrow' disabled={disableRight} tooltip={localize('positronShowNextPlot', "Show next plot")} onClick={showNextPlotHandler} />


### PR DESCRIPTION
After feedback from @jjallaire, more updates to colors and UI for #828. Here's what things look like with this update:

<img width="1516" alt="image" src="https://github.com/rstudio/positron/assets/853239/631e8d83-2722-4528-868a-193ec224f151">