### PR TITLE
Fixes for 828

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -2583,16 +2583,12 @@ class LayoutStateModel extends Disposable {
 		// --- Start Positron ---
 		// LayoutStateKeys.SIDEBAR_SIZE.defaultValue = Math.min(300, workbenchDimensions.width / 4);
 		// LayoutStateKeys.AUXILIARYBAR_SIZE.defaultValue = Math.min(300, workbenchDimensions.width / 4);
-		// Positron side bar is 250px and secondary side bar is 380px.
 		LayoutStateKeys.SIDEBAR_SIZE.defaultValue = Math.min(250, workbenchDimensions.width / 4);
 		LayoutStateKeys.AUXILIARYBAR_SIZE.defaultValue = Math.max(380, workbenchDimensions.width / 3);
 		// --- End Positron ---
 		LayoutStateKeys.PANEL_SIZE.defaultValue = (this.stateCache.get(LayoutStateKeys.PANEL_POSITION.name) ?? LayoutStateKeys.PANEL_POSITION.defaultValue) === 'bottom' ? workbenchDimensions.height / 3 : workbenchDimensions.width / 4;
+		LayoutStateKeys.SIDEBAR_HIDDEN.defaultValue = this.contextService.getWorkbenchState() === WorkbenchState.EMPTY;
 		// --- Start Positron ---
-		// LayoutStateKeys.SIDEBAR_HIDDEN.defaultValue = this.contextService.getWorkbenchState() === WorkbenchState.EMPTY;
-		// Positron shows the side bar and secondary side bar by default.
-		this.contextService.getWorkbenchState(); // Dummy call so we don't change the constructor signature.
-		LayoutStateKeys.SIDEBAR_HIDDEN.defaultValue = false;
 		LayoutStateKeys.AUXILIARYBAR_HIDDEN.defaultValue = false;
 		LayoutStateKeys.PANEL_HIDDEN.defaultValue = false;
 		// --- End Positron ---


### PR DESCRIPTION
This PR gets us one step closer to resolving #828. With this change, `LayoutStateKeys.SIDEBAR_HIDDEN.defaultValue` gets set to `true` when the workspace is empty, which leads to no sidebar being visible for the out of box experience.

Note that this change _reverts_ a previous change we made to _always_ set `LayoutStateKeys.SIDEBAR_HIDDEN.defaultValue` to `false`.

<img width="1507" alt="image" src="https://github.com/rstudio/positron/assets/853239/6d1a5249-970c-43c9-aac3-7133ca4c18c1">

I am trying to figure out how to maximize the panel for the out of box experience, but so far, I haven't found the right way to do it yet.
