### PR TITLE
Fixes for 828

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -2591,6 +2591,9 @@ class LayoutStateModel extends Disposable {
 		// --- Start Positron ---
 		LayoutStateKeys.AUXILIARYBAR_HIDDEN.defaultValue = false;
 		LayoutStateKeys.PANEL_HIDDEN.defaultValue = false;
+		// For Private Alpha, hide the editor by default. This will cause the panel to become
+		// maximized.
+		LayoutStateKeys.EDITOR_HIDDEN.defaultValue = true;
 		// --- End Positron ---
 
 		// Apply all defaults

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -324,7 +324,11 @@ import 'vs/workbench/contrib/surveys/browser/ces.contribution';
 import 'vs/workbench/contrib/surveys/browser/languageSurveys.contribution';
 
 // Welcome
-import 'vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution';
+// --- Start Positron ---
+// For Private Alpha, disable the getting started contribution. This allows us to hide the editor by
+// default in layout.ts.
+// import 'vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution';
+// --- End Positron ---
 import 'vs/workbench/contrib/welcomeWalkthrough/browser/walkThrough.contribution';
 import 'vs/workbench/contrib/welcomeViews/common/viewsWelcome.contribution';
 import 'vs/workbench/contrib/welcomeViews/common/newFile.contribution';


### PR DESCRIPTION
This final PR disables the getting started contribution and hides the editor by default, resulting in an out of box experience that looks more like a calculator (and RStudio) than a programmer's editor:

<img width="1507" alt="image" src="https://github.com/rstudio/positron/assets/853239/420f5c6a-845f-44ef-914f-d1e7fd98bd64">

What's next is to figure out which "interpreter" to start, but that isn't a part of #828.