### PR TITLE
Re-factor R installation discovery

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -253,6 +253,7 @@
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.1.0",
     "@types/node": "14.x",
+    "@types/which": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",
     "@vscode/test-electron": "^2.1.2",
@@ -264,8 +265,8 @@
     "vsce": "^2.11.0"
   },
   "dependencies": {
-    "vscode-languageclient": "^7.0.0",
-    "p-queue": "^6.6.2"
+    "p-queue": "^6.6.2",
+    "vscode-languageclient": "^7.0.0"
   },
   "repository": {
     "type": "git",

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -8,6 +8,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
 import * as os from 'os';
+import * as semver from 'semver';
+import * as which from 'which';
 
 import { withActiveExtension, delay } from './util';
 import { RRuntime } from './runtime';

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -40,110 +40,176 @@ export function adaptJupyterKernel(context: vscode.ExtensionContext, kernelPath:
 	});
 }
 
-function getRVersion(rHome: string): string {
-	// Get the version of the R installation
-	const { execSync } = require('child_process');
-	let rVersion = '';
-	try {
-		rVersion = execSync(
-			`${rHome}/bin/R --vanilla -s -e 'cat(R.Version()$major,R.Version()$minor, sep=".")'`,
-			{ shell: '/bin/bash', encoding: 'utf8' })
-			.trim();
-	} catch (e) {
-		console.error(`Error getting R version: ${e}`);
+// directory where this OS is known to keep its R installations
+function rHeadquarters(): string {
+	switch (process.platform) {
+		case 'darwin':
+			return '/Library/Frameworks/R.framework/Versions';
+		case 'linux':
+			return '/opt/R';
+		default:
+			// TODO: handle Windows
+			throw new Error('Unsupported platform');
 	}
-	return rVersion;
+}
+
+function binFragment(version: string): string {
+	switch (process.platform) {
+		case 'darwin':
+			return `${version}/Resources/bin/R`;
+		case 'linux':
+			return `${version}/bin/R`;
+		default:
+			// TODO: handle Windows
+			throw new Error('Unsupported platform');
+	}
+}
+
+function readLines(pth: string): Array<string> {
+	const bigString = fs.readFileSync(pth, 'utf8');
+	return bigString.split(/\r?\n/);
+}
+
+// extractValue('KEY=VALUE', 'KEY')      --> 'VALUE'
+// extractValue('KEY:VALUE', 'KEY', ':') --> 'VALUE'
+// extractValue('KEE:VALUE', 'KEY')      --> ''
+function extractValue(str: string, key: string, delim: string = '='): string {
+	const re = `${key}${delim}(.*)`;
+	if (!str.startsWith(key)) {
+		return '';
+	}
+	const m = str.match(re);
+	return m?.[1] ?? '';
 }
 
 export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.ExtensionContext, kernelPath: string): void {
 
 	class RInstallation {
-		public readonly rHome: string;
-		public readonly rVersion: string;
+		public readonly binpath: string;
+		public readonly homepath: string;
+		public readonly version: string;
+		public readonly arch: string;
+		public readonly current: boolean;
+		public readonly orthogonal: boolean;
 
 		/**
 		 * Represents an installation of R on the user's system.
 		 *
-		 * @param rHome The path to the R installation's home folder
-		 * @param resolved Whether the path has been resolved to a canonical path
+		 * @param pth Filepath for an R "binary" (on macOS and linux, this is actually a
+		 * shell script)
 		 */
-		constructor(rHome: string, resolved: boolean) {
-			// Form the canonical path to the R installation by asking R itself
-			// for its home directory. This may differ from the path that was
-			// passed since the discovered home path may contain symlinks.
-			if (resolved) {
-				this.rHome = rHome;
-			} else {
-				try {
-					this.rHome = execSync(
-						`${rHome}/R RHOME`, { encoding: 'utf8' })
-						.trim();
-				} catch (e) {
-					console.error(`Error running RHOME command for ${rHome}: ${e}`);
-					this.rHome = rHome;
-				}
-			}
-			this.rVersion = getRVersion(rHome);
+		constructor(pth: string, current: boolean = false) {
+			this.binpath = pth;
+			this.current = current;
+
+			const binLines = readLines(this.binpath);
+			const targetLine = binLines.filter(line => line.match('R_HOME_DIR'))[0];
+			// macOS: R_HOME_DIR=/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
+			// macOS non-orthogonal: R_HOME_DIR=/Library/Frameworks/R.framework/Resources
+			// linux: R_HOME_DIR=/opt/R/4.2.3/lib/R
+			const R_HOME_DIR = extractValue(targetLine, 'R_HOME_DIR');
+			this.homepath = R_HOME_DIR;
+
+			// orthogonality is a concern specific to macOS
+			// a non-orthogonal R "binary" is hard-wired to launch the current version of R,
+			// so it only works when it actually is the current version of R
+			// learn more in https://github.com/r-lib/rig/blob/main/src/macos.rs
+			// see is_orthogonal(), make_orthogonal_()
+			const re = new RegExp('R[.]framework/Resources');
+			this.orthogonal = !re.test(this.homepath);
+
+			// make sure to target a base package that contains compiled code, so the
+			// 'Built' field contains the platform info
+			const descPath = path.join(this.homepath, 'library', 'utils', 'DESCRIPTION');
+			const descLines = readLines(descPath);
+			const targetLine2 = descLines.filter(line => line.match('Built'))[0];
+			// macOS arm64: Built: R 4.3.1; aarch64-apple-darwin20; 2023-06-16 21:52:54 UTC; unix
+			// macOS intel: Built: R 4.3.1; x86_64-apple-darwin20; 2023-06-16 21:51:34 UTC; unix
+			// linux: Built: R 4.2.3; x86_64-pc-linux-gnu; 2023-03-15 09:03:13 UTC; unix
+			const builtField = extractValue(targetLine2, 'Built', ':');
+
+			const builtParts = builtField.split(new RegExp(';\\s+'));
+			const versionPart = builtParts[0];
+			const version = semver.coerce(versionPart) ?? '0.0.1';
+			this.version = `${semver.major(version)}.${semver.minor(version)}`;
+
+			const platformPart = builtParts[1];
+			const architecture = platformPart.match('^(aarch64|x86_64)');
+			this.arch = architecture ? architecture[1] : '';
 		}
 	}
-
-	const rInstallations: Array<RInstallation> = [];
-
-	const { execSync } = require('child_process');
 
 	// Check the R kernel log level setting
 	const config = vscode.workspace.getConfiguration('positron.r');
 	const logLevel = config.get<string>('kernel.logLevel') ?? 'warn';
 
-	// Discover R installations.
-	// TODO: Needs to handle Linux and Windows. See e.g. how Quarto handles this:
-	// https://github.com/quarto-dev/quarto-cli/blob/main/src/core/resources.ts#L77
-	//
-	// TODO: Needs to handle other installation locations (like RSwitch)
+	const binaries = new Set<string>();
+	let rInstallations: Array<RInstallation> = [];
 
-	// Check the R Versions folder on macOS. Typically, this only contains one
-	// version of R, but it's possible to have multiple versions installed in
-	// cases where a third-party utility such as `rig` is used to manage R
-	// installations.
-	const rVersionsFolder = '/Library/Frameworks/R.framework/Versions';
-	if (fs.existsSync(rVersionsFolder)) {
-		fs.readdirSync(rVersionsFolder).forEach((version: string) => {
-			const rHome = path.join(rVersionsFolder, version, 'Resources');
-			if (fs.existsSync(rHome)) {
-				// Ensure the R binary actually exists at this path; it's possible that
-				// the user has deleted the R installation but left the folder behind.
-				const rBin = path.join(rHome, 'bin', 'R');
-				if (fs.existsSync(rBin)) {
-					rInstallations.push(new RInstallation(rHome, false));
-				}
-			}
-		});
+	// look in the well-known place for R installations on this OS
+	const rHq = rHeadquarters();
+	if (fs.existsSync(rHq)) {
+		const versionBinaries = fs.readdirSync(rHq)
+			// 'Current', if it exists, is a symlink to an actual version. Skip it here to avoid
+			// redundant entries. This is a macOS phenomenon.
+			.filter(v => v !== 'Current')
+			.map(v => path.join(rHq, binFragment(v)))
+			// By default, macOS CRAN installer deletes previous R installations, but sometimes
+			// it doesn't do a thorough job of it and a nearly-empty version directory lingers on.
+			.filter(b => fs.existsSync(b));
+		for (const b of versionBinaries) {
+			binaries.add(b);
+		}
 	}
 
-	// Sort the R installations by version number, descending. If we don't find an R
-	// installation on the $PATH (see below), we get reasonable default behaviour, which
-	// is to use the most recent version of R available.
-	rInstallations.sort((a, b) => {
-		return b.rVersion.localeCompare(a.rVersion);
+	// other places we might find an R binary
+	const possibleBinaries = [
+		'/usr/bin/R',
+		'/usr/local/bin/R',
+		'/opt/local/bin/R',
+		'/opt/homebrew/bin/R'
+	];
+	const moreBinaries = possibleBinaries
+		.filter(b => fs.existsSync(b))
+		.map(b => fs.realpathSync(b));
+	for (const b of moreBinaries) {
+		binaries.add(b);
+	}
+
+	// make sure we include R executable found on the PATH
+	// we've probably already discovered it, but we still need to single it out, so that we mark
+	// that particular R installation as the current one
+	const whichR = which.sync('R', { nothrow: true }) as string;
+	if (whichR) {
+		const whichRCanonical = fs.realpathSync(whichR);
+		rInstallations.push(new RInstallation(whichRCanonical, true));
+		binaries.delete(whichRCanonical);
+	}
+
+	binaries.forEach((b: string) => {
+		rInstallations.push(new RInstallation(b));
 	});
 
-	// Look for an R installation on the $PATH (e.g. installed via Homebrew). If found,
-	// add or move it to the front of the list.
-	try {
-		// Try R RHOME to get the installation path; run under bash so we get $PATH
-		// set as the user would expect.
-		const rHome = execSync('R RHOME', { shell: '/bin/bash', encoding: 'utf8' }).trim();
-		if (fs.existsSync(rHome)) {
-			const loc = rInstallations.findIndex(r => r.rHome === rHome);
-			if (loc < 0) {
-				rInstallations.unshift(new RInstallation(rHome, true));
-			} else {
-				rInstallations.splice(0, 0, rInstallations.splice(loc, 1)[0]);
-			}
+	// TODO: possible future intervention re: non-orthogonal R installations
+	// * Alert the user they have R more installations?
+	// * Offer to make installations orthogonal?
+	// * Offer to switch the current version of R?
+	// for now, we drop non-orthogonal, not-current R installations
+	rInstallations = rInstallations.filter(r => r.current || r.orthogonal);
+
+	// FIXME? should I explicitly check that there is <= 1 R installation
+	// marked as 'current'?
+
+	rInstallations.sort((a, b) => {
+		if (a.current || b.current) {
+			// always put the current R version first
+			return Number(b.current) - Number(a.current);
 		}
-	} catch (err) {
-		// Just swallow this; it's okay if there's no R on the $PATH
-	}
+		// otherwise, sort by version number, descending
+		// break ties by architecture
+		// (currently taking advantage of the fact that 'aarch64' > 'x86_64')
+		return b.version.localeCompare(a.version) || a.arch.localeCompare(b.arch);
+	});
 
 	// Loop over the R installations and create a language runtime for each one.
 	//
@@ -166,7 +232,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 		const env = <Record<string, string>>{
 			'RUST_BACKTRACE': '1',
 			'RUST_LOG': logLevel,
-			'R_HOME': rHome.rHome,
+			'R_HOME': rHome.homepath,
 			'R_CLI_NUM_COLORS': '256',
 		};
 		/* eslint-enable */
@@ -174,7 +240,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 		if (process.platform === 'darwin') {
 
 			const dyldFallbackLibraryPaths: string[] = [];
-			dyldFallbackLibraryPaths.push(`${rHome.rHome}/lib`);
+			dyldFallbackLibraryPaths.push(`${rHome.homepath}/lib`);
 
 			const defaultDyldFallbackLibraryPath = process.env['DYLD_FALLBACK_LIBRARY_PATH'];
 			if (defaultDyldFallbackLibraryPath) {
@@ -193,17 +259,17 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 
 		// Is the runtime path within the user's home directory?
 		const homedir = os.homedir();
-		const isUserInstallation = rHome.rHome.startsWith(homedir);
+		const isUserInstallation = rHome.homepath.startsWith(homedir);
 
 		// Create the runtime path.
 		// TODO@softwarenerd - We will need to update this for Windows.
 		const runtimePath = os.platform() !== 'win32' && isUserInstallation ?
-			path.join('~', rHome.rHome.substring(homedir.length)) :
-			rHome.rHome;
+			path.join('~', rHome.homepath.substring(homedir.length)) :
+			rHome.homepath;
 
 		// Does the runtime path have 'homebrew' as a component? (we assume that
 		// it's a Homebrew installation if it does)
-		const isHomebrewInstallation = rHome.rHome.includes('/homebrew/');
+		const isHomebrewInstallation = rHome.homepath.includes('/homebrew/');
 
 		const runtimeSource = isHomebrewInstallation ? 'Homebrew' :
 			isUserInstallation ?
@@ -224,7 +290,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 		// Get the version of this extension from package.json so we can pass it
 		// to the adapter as the implementation version.
 		const packageJson = require('../package.json');
-		const rVersion = rHome.rVersion ?? '0.0.1';
+		const rVersion = rHome.version;
 
 		// Create a stable ID for the runtime based on the interpreter path and version.
 		const digest = crypto.createHash('sha256');

--- a/extensions/positron-r/yarn.lock
+++ b/extensions/positron-r/yarn.lock
@@ -130,6 +130,11 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz"
   integrity sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==
 
+"@types/which@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-3.0.0.tgz#849afdd9fdcb0b67339b9cfc80fa6ea4e0253fc5"
+  integrity sha512-ASCxdbsrwNfSMXALlC3Decif9rwDMu+80KGp5zI2RLRotfMsTv7fHL8W8VDp24wymzDyIFudhUeSCugrgRFfHQ==
+
 "@typescript-eslint/eslint-plugin@^5.12.1":
   version "5.16.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.16.0.tgz"


### PR DESCRIPTION
*Successor to #870. Different enough to be a new PR.*

Addresses https://github.com/rstudio/positron/issues/702 (was actually addressed by https://github.com/rstudio/positron/pull/831, but it's more obvious why this PR closes it).

(Presumably) addresses https://github.com/rstudio/positron/issues/839. Logically, it sure seems like it should and I do _not_ see any errors about registering R runtimes in the debug console when launching positron from this PR.

This refactoring has a couple motivations:

* Helped me to dig in to this bit of code and gain more practice with typescript. If I've done gross things, I'm happy to reverse them!
* Lay the groundwork for eventually discovering R installations on Windows and linux. This code (in a standalone form, i.e. outside of positron) has been tested on linux (Workbench on Colorado).
* Don't offer to launch non-Current, non-orthogonal R installations, i.e. installations that are only well-formed when they are the current default version of R.
* Obtain the (alleged) R home directory, the version, and the architecture from files within the R installation. We no longer launch R (twice) for each R installation.

I have tested this code, in standalone `.ts`/`.js` form on:

* my M2 MacBook Pro, with 3 orthogonal R installations, all managed by rig
* my 2015 intel MacBook Pro, with 3 R installations, installed like so:
  - A development version of R from https://mac.r-project.org/ (non-orthogonal installation)
  - The current release from CRAN (after forgetting R installations; non-orthogonal installation; is Current installation)
  - `oldrel` installed with rig (orthogonal installation)
* my 2020 intel MacBook Pro, which has been taken over by a kid and now it has zero R installations
* Workbench on Colorado

and it discovers/discards the R installations in the way that I believe is correct.

I also produced a universal binary (https://github.com/rstudio/positron/actions/runs/5662600006) and verified all seems well on the 2015 MBP described above.

I created a Google Doc on "multiple R versions" while working on this: https://docs.google.com/document/d/1RZQ4yejA6EsRDZODtEjeW6OIdyPJeRQCqWlhNDxXTHw/edit?pli=1