### PR TITLE
Updates to move the console interrupt button to the right and to make it red…

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -4,7 +4,7 @@
 
 import 'vs/css!./actionBarButton';
 import * as React from 'react';
-import { forwardRef } from 'react'; // eslint-disable-line no-duplicate-imports
+import { forwardRef, PropsWithChildren } from 'react'; // eslint-disable-line no-duplicate-imports
 import { PositronButton } from 'vs/base/browser/ui/positronComponents/positronButton';
 import { ActionBarTooltip } from 'vs/platform/positronActionBar/browser/components/actionBarTooltip';
 import { optionalBoolean, optionalValue, positronClassNames } from 'vs/base/common/positronUtilities';
@@ -29,10 +29,10 @@ export interface ActionBarButtonProps {
 
 /**
  * ActionBarButton component.
- * @param props An ActionBarButtonProps that contains the component properties.
+ * @param props A PropsWithChildren<ActionBarButtonProps> that contains the component properties.
  * @returns The rendered component.
  */
-export const ActionBarButton = forwardRef<HTMLDivElement, ActionBarButtonProps>((props, ref) => {
+export const ActionBarButton = forwardRef<HTMLDivElement, PropsWithChildren<ActionBarButtonProps>>((props, ref) => {
 	// Create the class names.
 	const buttonClassNames = positronClassNames(
 		'action-bar-button',
@@ -55,6 +55,7 @@ export const ActionBarButton = forwardRef<HTMLDivElement, ActionBarButtonProps>(
 					{props.iconId && <div className={`action-bar-button-icon codicon codicon-${props.iconId}`} style={iconStyle} />}
 					{props.text && <div className='action-bar-button-text' style={{ maxWidth: optionalValue(props.maxTextWidth, 'none') }}>{props.text}</div>}
 					{props.dropDown && <div className='action-bar-button-drop-down-arrow codicon codicon-positron-drop-down-arrow' />}
+					{props.children}
 				</div>
 			</PositronButton>
 		</ActionBarTooltip>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.css
@@ -5,3 +5,7 @@
 .positron-console .action-bar {
 	height: 32px;
 }
+
+.action-bar-button-icon.interrupt::before {
+	color: var(--vscode-errorForeground);
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -114,18 +114,19 @@ export const ActionBar = (props: ActionBarProps) => {
 				<PositronActionBar size='small' borderTop={true} borderBottom={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
 					<ActionBarRegion location='left'>
 						<ConsoleInstanceMenuButton {...props} />
+					</ActionBarRegion>
+					<ActionBarRegion location='right'>
 						{interruptible &&
 							<ActionBarButton
 								fadeIn={true}
 								disabled={interrupting}
-								iconId='positron-interrupt-runtime'
-								align='left'
+								align='right'
 								tooltip={localize('positronInterruptExeuction', "Interrupt execution")}
 								onClick={interruptHandler}
-							/>
+							>
+								<div className={`action-bar-button-icon interrupt codicon codicon-positron-interrupt-runtime`} />
+							</ActionBarButton>
 						}
-					</ActionBarRegion>
-					<ActionBarRegion location='right'>
 						<ActionBarButton iconId='positron-list' align='right' tooltip={localize('positronToggleTrace', "Toggle trace")} onClick={toggleTraceHandler} />
 						<ActionBarButton iconId='word-wrap' align='right' tooltip={localize('positronWordWrap', "Toggle word wrap")} onClick={toggleWordWrapHandler} />
 						<ActionBarSeparator />


### PR DESCRIPTION
This PR moves the console interrupt button to the right and makes it red to address #874.

Note: Instead of introducing a generalized way to set the color of action bar buttons - a feature that we don't really need right now except for this button -  I've allowed one to set the children of an action bar button and used this to display a red `codicon-positron-interrupt-runtime` icon.

Here's a movie of the button in action:

https://github.com/rstudio/positron/assets/853239/6557ebef-2282-4e7f-bd65-7df785d0990c
