### PR TITLE
Updates to address #705

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -124,7 +124,7 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 				);
 				break;
 
-			// If the code gragment status is unknown, log a warning but execute it anyway (so the
+			// If the code fragment status is unknown, log a warning but execute it anyway (so the
 			// user can see an error from the interpreter).
 			case RuntimeCodeFragmentStatus.Unknown:
 				positronConsoleContext.logService.warn(
@@ -153,10 +153,16 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 			}
 		}
 
+		// Create the ID for the code fragment that will be executed.
+		const id = `fragment-${generateUuid()}`;
+
+		// Begin executing the code fragment.
+		props.positronConsoleInstance.beginExecuteCode(id, codeFragment);
+
 		// Ask the runtime to execute the code fragment. This is an asynchronous and unwaitable.
 		props.positronConsoleInstance.runtime.execute(
 			codeFragment,
-			`fragment-${generateUuid()}`,
+			id,
 			RuntimeCodeExecutionMode.Interactive,
 			RuntimeErrorBehavior.Continue);
 

--- a/src/vs/workbench/services/positronConsole/common/classes/activityItemInput.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/activityItemInput.ts
@@ -21,6 +21,7 @@ export class ActivityItemInput {
 
 	/**
 	 * Constructor.
+	 * @param provisional A value which indicates whether this is a provisional ActivityItemInput.
 	 * @param id The identifier.
 	 * @param parentId The parent identifier.
 	 * @param when The date.
@@ -29,6 +30,7 @@ export class ActivityItemInput {
 	 * @param code The code.
 	 */
 	constructor(
+		readonly provisional: boolean,
 		readonly id: string,
 		readonly parentId: string,
 		readonly when: Date,

--- a/src/vs/workbench/services/positronConsole/common/classes/runtimeItemActivity.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/runtimeItemActivity.ts
@@ -60,8 +60,22 @@ export class RuntimeItemActivity extends RuntimeItem {
 	 * @param activityItem The activity item to add.
 	 */
 	addActivityItem(activityItem: ActivityItem) {
-		// Group ActivityItemOutputStreams with the same parent identifier.
-		if (activityItem instanceof ActivityItemOutputStream) {
+		if (activityItem instanceof ActivityItemInput && !activityItem.provisional) {
+			// When a non-provisional ActivityItemInput is being added, see if there's a provisional
+			// ActivityItemInput for it in the activity items. If there is, replace the provisional
+			// ActivityItemInput with the actual ActivityItemInput.
+			for (let i = this.activityItems.length - 1; i >= 0; --i) {
+				const activityItemToCheck = this.activityItems[i];
+				if (activityItemToCheck instanceof ActivityItemInput) {
+					if (activityItemToCheck.provisional &&
+						activityItemToCheck.parentId === activityItem.parentId) {
+						this.activityItems[i] = activityItem;
+						return;
+					}
+					break;
+				}
+			}
+		} else if (activityItem instanceof ActivityItemOutputStream) {
 			// If the last activity item is an ActivityItemOutputStream, and it's for the same
 			// parent as this ActivityItemOutputStream, add this ActivityItemOutputStream to it.
 			if (this.activityItems.length) {

--- a/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
@@ -141,14 +141,14 @@ export interface IPositronConsoleInstance {
 	readonly onDidExecuteCode: Event<string>;
 
 	/**
-	 * Toggles word wrap.
-	 */
-	toggleWordWrap(): void;
-
-	/**
 	 * Toggles trace.
 	 */
 	toggleTrace(): void;
+
+	/**
+	 * Toggles word wrap.
+	 */
+	toggleWordWrap(): void;
 
 	/**
 	 * Clears the console.
@@ -159,6 +159,13 @@ export interface IPositronConsoleInstance {
 	 * Clears the input hstory.
 	 */
 	clearInputHistory(): void;
+
+	/**
+	 * Begins executing code.
+	 * @param id The identifier.
+	 * @param code The code.
+	 */
+	beginExecuteCode(id: string, code: string): void;
 
 	/**
 	 * Executes code in the Positron console instance.

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -5,6 +5,7 @@
 import { generateUuid } from 'vs/base/common/uuid';
 import { Emitter, Event } from 'vs/base/common/event';
 import { ILogService } from 'vs/platform/log/common/log';
+import { IViewsService } from 'vs/workbench/common/views';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { RuntimeItem } from 'vs/workbench/services/positronConsole/common/classes/runtimeItem';
@@ -27,7 +28,6 @@ import { RuntimeItemStartupFailure } from 'vs/workbench/services/positronConsole
 import { ActivityItem, RuntimeItemActivity } from 'vs/workbench/services/positronConsole/common/classes/runtimeItemActivity';
 import { IPositronConsoleInstance, IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID, PositronConsoleState } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
 import { formatLanguageRuntime, ILanguageRuntime, ILanguageRuntimeMessage, ILanguageRuntimeService, LanguageRuntimeStartupBehavior, RuntimeOnlineState, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
-import { IViewsService } from 'vs/workbench/common/views';
 
 //#region Helper Functions
 
@@ -617,6 +617,29 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	}
 
 	/**
+	 * Begins executing code.
+	 * @param id The identifier.
+	 * @param code The code.
+	 */
+	beginExecuteCode(id: string, code: string): void {
+		// Add a provisional ActivityItemInput for the code that will be executed. This provisional
+		// ActivityItemInput will be replaced with the real ActivityItemInput when the runtime sends
+		// it (which can take a moment or two to happen).
+		this.addOrUpdateUpdateRuntimeItemActivity(
+			id,
+			new ActivityItemInput(
+				true,
+				id,
+				id,
+				new Date(),
+				this._runtime.metadata.inputPrompt,
+				this._runtime.metadata.continuationPrompt,
+				code
+			)
+		);
+	}
+
+	/**
 	 * Executes code.
 	 * @param codeFragment The code fragment to execute.
 	 */
@@ -839,6 +862,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			this.addOrUpdateUpdateRuntimeItemActivity(
 				languageRuntimeMessageInput.parent_id,
 				new ActivityItemInput(
+					false,
 					languageRuntimeMessageInput.id,
 					languageRuntimeMessageInput.parent_id,
 					new Date(languageRuntimeMessageInput.when),


### PR DESCRIPTION
This PR addresses #705.

Before code is executed from the Console, a provisional `ActivityItemInput` is added to the console activity items for the code. This provisional `ActivityItemInput` is replaced with the _actual_ `ActivityItemInput` when it arrives.