### PR TITLE
Updates to address #920

### DIFF
--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.css
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.css
@@ -1,34 +1,3 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (C) 2022 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
-
-.top-action-bar-container {
-	width: 100%;
-	display: grid;
-	grid-template-columns: 48px 1fr;
-}
-
-.logo-button {
-	display: flex;
-	cursor: pointer;
-	align-items: center;
-	justify-content: center;
-	background: var(--vscode-activityBar-background);
-}
-
-.logo-button:focus {
-	outline: none !important;
-}
-
-.logo-button .logo-icon {
-	font-size: 28px !important;
-	color: var(--vscode-activityBar-inactiveForeground);
-}
-
-.logo-button .logo-icon:hover {
-	color: var(--vscode-activityBar-foreground);
-}
-
-.logo-button:focus-visible .logo-icon {
-	color: var(--vscode-activityBar-foreground);
-}

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
@@ -13,7 +13,6 @@ import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
-import { PositronButton } from 'vs/base/browser/ui/positronComponents/positronButton';
 import { PositronActionBar } from 'vs/platform/positronActionBar/browser/positronActionBar';
 import { ActionBarRegion } from 'vs/platform/positronActionBar/browser/components/actionBarRegion';
 import { ActionBarSeparator } from 'vs/platform/positronActionBar/browser/components/actionBarSeparator';
@@ -56,12 +55,12 @@ export interface IPositronTopActionBarContainer {
 export interface PositronTopActionBarServices extends PositronActionBarServices {
 	hostService: IHostService;
 	labelService: ILabelService;
+	languageRuntimeService: ILanguageRuntimeService;
 	layoutService: ILayoutService;
+	positronTopActionBarService: IPositronTopActionBarService;
 	quickInputService: IQuickInputService;
 	workspaceContextService: IWorkspaceContextService;
 	workspacesService: IWorkspacesService;
-	languageRuntimeService: ILanguageRuntimeService;
-	positronTopActionBarService: IPositronTopActionBarService;
 }
 
 /**
@@ -198,73 +197,54 @@ export const PositronTopActionBar = (props: PositronTopActionBarProps) => {
 		}
 	};
 
-	/**
-	 * The logo click handler.
-	 */
-	const logoClickHandler = () => {
-		// For now, open the Welcome user experience.
-		props.commandService.executeCommand('workbench.action.openWalkthrough');
-	};
-
 	// Render.
 	return (
 		<PositronTopActionBarContextProvider {...props}>
 			<PositronActionBarContextProvider {...props}>
 
-				<div className='top-action-bar-container'>
-					<PositronButton className='logo-button' onClick={logoClickHandler}>
-						<span className='logo-icon codicon codicon-positron-posit-logo' />
-					</PositronButton>
+				<PositronActionBar size='large' borderBottom={true} paddingLeft={kHorizontalPadding} paddingRight={kHorizontalPadding}>
 
+					<ActionBarRegion location='left'>
+						<TopActionBarNewMenu />
+						<ActionBarSeparator />
+						<TopActionBarOpenMenu />
+						<ActionBarSeparator />
+						<ActionBarCommandButton iconId='positron-save' commandId={'workbench.action.files.save'} />
+						<ActionBarCommandButton iconId='positron-save-all' commandId={'workbench.action.files.saveFiles'} />
+					</ActionBarRegion>
 
-					<PositronActionBar size='large' borderBottom={true} paddingLeft={kHorizontalPadding} paddingRight={kHorizontalPadding}>
+					{showCenterUI && (
+						<ActionBarRegion location='center'>
 
-						<ActionBarRegion location='left'>
-							<TopActionBarNewMenu />
-							<ActionBarSeparator />
-							<TopActionBarOpenMenu />
-							<ActionBarSeparator />
-							<ActionBarCommandButton iconId='positron-save' commandId={'workbench.action.files.save'} />
-							<ActionBarCommandButton iconId='positron-save-all' commandId={'workbench.action.files.saveFiles'} />
-						</ActionBarRegion>
-
-						{showCenterUI && (
-							<ActionBarRegion location='center'>
-
-								<PositronActionBar size='large' nestedActionBar={true}>
-									{showFullCenterUI && (
-										<ActionBarRegion width={60} location='left' justify='right'>
-											<ActionBarCommandButton iconId='chevron-left' commandId={NavigateBackwardsAction.ID} />
-											<ActionBarCommandButton iconId='chevron-right' commandId={NavigateForwardAction.ID} />
-										</ActionBarRegion>
-									)}
-									<ActionBarRegion location='center'>
-										<TopActionBarCommandCenter />
+							<PositronActionBar size='large' nestedActionBar={true}>
+								{showFullCenterUI && (
+									<ActionBarRegion width={60} location='left' justify='right'>
+										<ActionBarCommandButton iconId='chevron-left' commandId={NavigateBackwardsAction.ID} />
+										<ActionBarCommandButton iconId='chevron-right' commandId={NavigateForwardAction.ID} />
 									</ActionBarRegion>
-									{showFullCenterUI && (
-										<ActionBarRegion width={60} location='right' justify='left' />
-									)}
-								</PositronActionBar>
+								)}
+								<ActionBarRegion location='center'>
+									<TopActionBarCommandCenter />
+								</ActionBarRegion>
+								{showFullCenterUI && (
+									<ActionBarRegion width={60} location='right' justify='left' />
+								)}
+							</PositronActionBar>
 
-								{/* This balances the logo button. */}
-								<div className='centering-spacer' />
-
-							</ActionBarRegion>
-
-						)}
-
-						<ActionBarRegion location='right'>
-							<TopActionBarInterpretersManager
-								onStartRuntime={startRuntimeHandler}
-								onActivateRuntime={activateRuntimeHandler}
-							/>
-							{showCenterUI && (
-								<TopActionBarFolderMenu />
-							)}
 						</ActionBarRegion>
+					)}
 
-					</PositronActionBar>
-				</div>
+					<ActionBarRegion location='right'>
+						<TopActionBarInterpretersManager
+							onStartRuntime={startRuntimeHandler}
+							onActivateRuntime={activateRuntimeHandler}
+						/>
+						{showCenterUI && (
+							<TopActionBarFolderMenu />
+						)}
+					</ActionBarRegion>
+
+				</PositronActionBar>
 
 			</PositronActionBarContextProvider>
 		</PositronTopActionBarContextProvider>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarPart.css
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarPart.css
@@ -30,7 +30,3 @@
 .monaco-workbench .part.positron-top-action-bar:focus {
 	outline: none !important;
 }
-
-.centering-spacer {
-	min-width: 48px;
-}


### PR DESCRIPTION
This PR removes the Positron "logo button" on the top left of the top action bar. This addresses #920.