### PR TITLE
Fix the colors of the activity prompt for #653

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -758,7 +758,9 @@
 		"--vscode-positronConsole-ansiBrightMagenta",
 		"--vscode-positronConsole-ansiBrightCyan",
 		"--vscode-positronConsole-ansiBrightWhite",
-		"--vscode-positronPlots-background"
+		"--vscode-positronPlots-background",
+		"--vscode-positronConsole-foreground",
+		"--vscode-positronConsole-background"
 	],
 	"others": [
 		"--background-dark",

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.css
@@ -12,4 +12,6 @@
 	flex-grow: 1;
 	border: none;
 	outline: 0 !important;
+	color: var(--vscode-positronConsole-foreground);
+	background: var(--vscode-positronConsole-background);
 }


### PR DESCRIPTION
This PR addresses #653. Here's a screen recording of the fix:

https://github.com/rstudio/positron/assets/853239/36f00b21-3602-422c-b2a1-e3a2a157bd82
