### PR TITLE
Fix reconnect regression

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -173,10 +173,10 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 				// Save the exit code for error reporting if we know it
 				if (closedTerminal.exitStatus && closedTerminal.exitStatus.code) {
 					this._exitCode = closedTerminal.exitStatus.code;
-				}
 
-				// The kernel's status is now exited
-				this.setStatus(positron.RuntimeState.Exited);
+					// The kernel's status is now exited
+					this.setStatus(positron.RuntimeState.Exited);
+				}
 			}
 		});
 	}


### PR DESCRIPTION
This small change addresses https://github.com/rstudio/positron/issues/901.

The issue turned out to be that we mark the kernel as `Exited` when the terminal in which it is running closes. Marking it as Exited causes the session to be cleaned up, so we can't connect to it again even though it's still running.

However, it turns out that VS Code's infrastructure fires close events for terminals when Positron is reloaded, so closing the terminal does not imply the kernel has exited. The kernel is still running and attached to the ptyhost.

The fix is to only mark the kernel `Exited` if there's an actual exit code/status, indicating that the process ended.