### PR TITLE
Make comms waitable

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterCommMsg.ts
+++ b/extensions/jupyter-adapter/src/JupyterCommMsg.ts
@@ -12,5 +12,5 @@ export interface JupyterCommMsg {
 	comm_id: string;  // eslint-disable-line
 
 	/** The message payload */
-	data: object;
+	data: { [key: string]: any };
 }

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -317,7 +317,12 @@ export class LanguageRuntimeAdapter
 			});
 
 			// Open the client (this will send the comm_open message; wait for it to complete)
-			await adapter.open();
+			try {
+				await adapter.open();
+			} catch (err) {
+				this._kernel.log(`Info: error while creating ${type} client for ${this.metadata.languageName}: ${err}`);
+				this.removeClient(id);
+			}
 		} else {
 			this._kernel.log(`Info: can't create ${type} client for ${this.metadata.languageName} (not supported)`);
 		}

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -294,8 +294,13 @@ export class LanguageRuntimeAdapter
 			type === positron.RuntimeClientType.FrontEnd) {
 			this._kernel.log(`Creating '${type}' client for ${this.metadata.languageName}`);
 
+			// Does the comm wrap a server? In that case the
+			// promise should only resolve when the server is
+			// ready to accept connections
+			const server_comm = type === positron.RuntimeClientType.Lsp;
+
 			// Create a new client adapter to wrap the comm channel
-			const adapter = new RuntimeClientAdapter(id, type, params, this._kernel);
+			const adapter = new RuntimeClientAdapter(id, type, params, this._kernel, server_comm);
 
 			// Add the client to the map. Note that we have to do this before opening
 			// the instance, because we may need to process messages from the client

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -282,9 +282,11 @@ export class LanguageRuntimeAdapter
 	 * @param params The parameters for the client; the format of this object is
 	 *   specific to the client type
 	 */
-	public async createClient(id: string,
+	public async createClient(
+		id: string,
 		type: positron.RuntimeClientType,
-		params: object) {
+		params: object
+	) {
 
 		// Ensure the type of client we're being asked to create is one we know ark supports
 		if (type === positron.RuntimeClientType.Environment ||
@@ -732,7 +734,7 @@ export class LanguageRuntimeAdapter
 	 *
 	 * @param clientAddress The client's TCP address, e.g. '127.0.0.1:1234'
 	 */
-	startPositronLsp(clientAddress: string) {
+	async startPositronLsp(clientAddress: string) {
 		// TODO: Should we query the kernel to see if it can create an LSP
 		// (QueryInterface style) instead of just demanding it?
 		//
@@ -744,9 +746,11 @@ export class LanguageRuntimeAdapter
 		const clientId = `positron-lsp-${this.metadata.languageId}-${LanguageRuntimeAdapter._clientCounter++}-${uniqueId}}`;
 		this._kernel.log(`Starting LSP server ${clientId} for ${clientAddress}`);
 
-		this.createClient(clientId,
+		await this.createClient(
+			clientId,
 			positron.RuntimeClientType.Lsp,
-			{ client_address: clientAddress });
+			{ client_address: clientAddress }
+		);
 	}
 
 	/**

--- a/extensions/jupyter-adapter/src/RuntimeClientAdapter.ts
+++ b/extensions/jupyter-adapter/src/RuntimeClientAdapter.ts
@@ -84,6 +84,9 @@ export class RuntimeClientAdapter {
 		]);
 
 		if (!connected) {
+			// Send 'comm_close' event and update state to Closed
+			this.close();
+
 			const err = `Timeout while connecting to comm ${this._id}`;
 			this._kernel.log(err);
 			out.reject(new Error(err));
@@ -124,6 +127,7 @@ export class RuntimeClientAdapter {
 	 * Closes the communications channel between the client and the runtime.
 	 */
 	public close() {
+		// FIXME: Should we set ourselves to Closed here?
 		this._state.fire(positron.RuntimeClientState.Closing);
 		this._kernel.closeComm(this._id);
 	}

--- a/extensions/jupyter-adapter/src/RuntimeClientAdapter.ts
+++ b/extensions/jupyter-adapter/src/RuntimeClientAdapter.ts
@@ -59,10 +59,22 @@ export class RuntimeClientAdapter {
 		let connected = false;
 
 		const handler = this.onDidChangeClientState(state => {
-			if (state === positron.RuntimeClientState.Connected) {
-				out.resolve();
-				handler.dispose();
-				connected = true;
+			switch (state) {
+				case positron.RuntimeClientState.Connected: {
+					out.resolve();
+					connected = true;
+					handler.dispose();
+					break;
+				}
+				case positron.RuntimeClientState.Closing:
+				case positron.RuntimeClientState.Closed: {
+					out.reject(new Error( `Comm ${this._id} closed before connecting`));
+					handler.dispose();
+					break;
+				}
+				default: {
+					return;
+				}
 			}
 		});
 

--- a/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
+++ b/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
@@ -46,7 +46,7 @@ export interface JupyterLanguageRuntime extends positron.LanguageRuntime {
 	 * @param clientAddress The address of the client that will connect to the
 	 *  language server.
 	 */
-	startPositronLsp(clientAddress: string): void;
+	startPositronLsp(clientAddress: string): Thenable<void>;
 
 	/**
 	 * Method for emitting a message to the language server's Jupyter output

--- a/extensions/jupyter-adapter/src/utils.ts
+++ b/extensions/jupyter-adapter/src/utils.ts
@@ -25,3 +25,7 @@ export class PromiseHandles<T> {
 		});
 	}
 }
+
+export function delay(ms: number) {
+	return new Promise( resolve => setTimeout(resolve, ms) );
+}

--- a/extensions/positron-r/src/jupyter-adapter.d.ts
+++ b/extensions/positron-r/src/jupyter-adapter.d.ts
@@ -46,7 +46,7 @@ export interface JupyterLanguageRuntime extends positron.LanguageRuntime {
 	 * @param clientAddress The address of the client that will connect to the
 	 *  language server.
 	 */
-	startPositronLsp(clientAddress: string): void;
+	startPositronLsp(clientAddress: string): Thenable<void>;
 
 	/**
 	 * Method for emitting a message to the language server's Jupyter output

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -185,7 +185,7 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 				const port = await this.adapterApi!.findAvailablePort([], 25);
 				if (this._kernel) {
 					this._kernel.emitJupyterLog(`Starting Positron LSP server on port ${port}`);
-					this._kernel.startPositronLsp(`127.0.0.1:${port}`);
+					await this._kernel.startPositronLsp(`127.0.0.1:${port}`);
 				}
 				await this._lsp.activate(port, this.context);
 			});


### PR DESCRIPTION
Progress towards #408.

Two changes in the runtime client adapter allow the `createClient()` promise to resolve only when the comm is ready to use:

1. Regular comms now set themselves to "Connected" after receiving a `comm_open` response. Edit: No longer the case as this is not how the Jupyter protocol is defined.

2. Server comms (LSP or DAP) now wait for a `server_started` notification message before setting themselves to "Connected".

With these changes we can now wait for `startPositronLsp()` which resolves when the server comm is operational before attempting to connect. This requires https://github.com/posit-dev/amalthea/pull/71 to be merged.
