### PR TITLE
Don't restore .RData workspaces; add option for command-line arguments

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -121,6 +121,15 @@
           "type": "boolean",
           "default": false,
           "description": "%r.configuration.restoreWorkspace.description%"
+        },
+        "positron.r.extraArguments": {
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "%r.configuration.extraArguments.description%"
         }
       }
     },

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -115,6 +115,12 @@
           ],
           "default": "off",
           "description": "%r.configuration.tracing.description%"
+        },
+        "positron.r.restoreWorkspace": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "description": "%r.configuration.restoreWorkspace.description%"
         }
       }
     },

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -29,5 +29,6 @@
 	"r.configuration.logLevel.debug.description": "Debug messages",
 	"r.configuration.logLevel.trace.description": "Verbose tracing messages",
 	"r.configuration.logLevel.description": "Log level for the R Kernel (requires restart to take effect)",
-	"r.configuration.restoreWorkspace.description": "Restore the workspace from .Rdata on startup"
+	"r.configuration.restoreWorkspace.description": "Restore the workspace from .Rdata on startup",
+	"r.configuration.extraArguments.description": "Extra command-line arguments for R intialization"
 }

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -28,5 +28,6 @@
 	"r.configuration.logLevel.info.description": "Informational messages",
 	"r.configuration.logLevel.debug.description": "Debug messages",
 	"r.configuration.logLevel.trace.description": "Verbose tracing messages",
-	"r.configuration.logLevel.description": "Log level for the R Kernel (requires restart to take effect)"
+	"r.configuration.logLevel.description": "Log level for the R Kernel (requires restart to take effect)",
+	"r.configuration.restoreWorkspace.description": "Restore the workspace from .Rdata on startup"
 }

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -298,12 +298,21 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 			'argv': [
 				kernelPath,
 				'--connection_file', '{connection_file}',
-				'--log', '{log_file}'
+				'--log', '{log_file}',
+				// The arguments after `--` are passed verbatim to R
+				'--',
+				'--interactive',
 			],
 			'display_name': `R (${runtimeSource})`, // eslint-disable-line
 			'language': 'R',
 			'env': env,
 		};
+
+		// Unless the user has chosen to restore the workspace, pass the
+		// `--no-restore-data` flag to R.
+		if (!config.get<boolean>('restoreWorkspace')) {
+			kernelSpec.argv.push('--no-restore-data');
+		}
 
 		// Get the version of this extension from package.json so we can pass it
 		// to the adapter as the implementation version.
@@ -312,7 +321,7 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 
 		// Create a stable ID for the runtime based on the interpreter path and version.
 		const digest = crypto.createHash('sha256');
-		digest.update(JSON.stringify(kernelSpec));
+		digest.update(rHome.homepath);
 		digest.update(rVersion);
 		const runtimeId = digest.digest('hex').substring(0, 32);
 

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -314,6 +314,12 @@ export function registerArkKernel(ext: vscode.Extension<any>, context: vscode.Ex
 			kernelSpec.argv.push('--no-restore-data');
 		}
 
+		// If the user has supplied extra arguments to R, pass them along.
+		const extraArgs = config.get<Array<string>>('extraArguments');
+		if (extraArgs) {
+			kernelSpec.argv.push(...extraArgs);
+		}
+
 		// Get the version of this extension from package.json so we can pass it
 		// to the adapter as the implementation version.
 		const packageJson = require('../package.json');


### PR DESCRIPTION
This change adds a couple of new settings.

The first causes Positron to default to _not_ loading `.Rdata` by default, by passing `--no-restore-data` to R in the default argument list.

The second provides a way to pass arbitrary command line arguments to R. It's not likely to be used by average R users, but can be helpful for developers. For example, you can make R emit a lot of verbose output by adding `--verbose` as an extra argument.

<img width="767" alt="image" src="https://github.com/rstudio/positron/assets/470418/a336f7df-eed6-434f-bab0-9c9d8c91bbc3">

Note that this PR also bumps the Amalthea submodule to pick up the required kernel changes to support this work (see https://github.com/posit-dev/amalthea/pull/70). 

Addresses https://github.com/rstudio/positron/issues/930.
