### PR TITLE
Start an R runtime during extension startup

### DIFF
--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -398,7 +398,7 @@ class ArkDelayStartup {
 
 function isRStudioUser(): boolean {
 	try {
-		const filenames = fs.readdirSync(localShareRStudioPath(''));
+		const filenames = fs.readdirSync(localShareRStudioPath());
 		const today = new Date();
 		const thirtyDaysAgo = new Date(new Date().setDate(today.getDate() - 30));
 		const recentlyModified = new Array<boolean>();
@@ -411,7 +411,7 @@ function isRStudioUser(): boolean {
 	return false;
 }
 
-function localShareRStudioPath(pathToAppend: string): string {
+function localShareRStudioPath(pathToAppend = ''): string {
 	const newPath = path.join(process.env.HOME!, '.local/share/rstudio', pathToAppend);
 	return newPath;
 }


### PR DESCRIPTION
Addresses #792 

This PR takes a [Kool-Aid man busting through a wall](https://youtu.be/_fjEViOF4JE) approach to starting an R runtime while the R extension is activating (specifically, alongside registering the runtimes). In the longer run, we want to think through the proposal @jmcphers made about only starting runtimes from Positron, not from any extensions, but for alpha we don't want folks to have to think about starting what they may think of as default runtimes. This change will start an R runtime even when we have no `.R` files open, no workspace open, no nothing.

To check out the experience:

- stop all your runtimes
- `rm -rf ./.profile-oss`
- start Positron in a factory fresh state

This PR does not address starting any Python runtimes. Perhaps we can add some similar functionality? Or maybe not important for alpha.