### PR TITLE
Reconcile plot history navigation

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
@@ -36,6 +36,7 @@ export const HistoryPx = 100;
 export const PlotsContainer = (props: PlotContainerProps) => {
 
 	const positronPlotsContext = usePositronPlotsContext();
+	const plotHistoryRef = React.createRef<HTMLDivElement>();
 
 	// Show the plot history gallery along the shortest edge of the container.
 	// This gives the plot rendering area the most space and a gentler aspect
@@ -50,7 +51,23 @@ export const PlotsContainer = (props: PlotContainerProps) => {
 	const plotWidth = historyBottom ? props.width : props.width - historyPx;
 
 	useEffect(() => {
-		// Empty for now.
+		// Ensure the selected plot is visible. We do this so that the history
+		// filmstrip automatically scrolls to new plots as they are emitted, or
+		// when the user selects a plot.
+		const plotHistory = plotHistoryRef.current;
+		if (plotHistory) {
+			// Find the selected plot in the history
+			const selectedPlot = plotHistoryRef.current.querySelector('.selected');
+			if (selectedPlot) {
+				// If a plot is selected, scroll it into view.
+				selectedPlot.scrollIntoView();
+			} else {
+				// If no plot is selected, scroll the history to the end, which
+				// will show the most recently generated plot.
+				plotHistory.scrollLeft = plotHistory.scrollWidth;
+				plotHistory.scrollTop = plotHistory.scrollHeight;
+			}
+		}
 	});
 
 	/**
@@ -104,7 +121,7 @@ export const PlotsContainer = (props: PlotContainerProps) => {
 
 	// Render the plot history gallery.
 	const renderHistory = () => {
-		return <div className='plot-history-scroller'>
+		return <div className='plot-history-scroller' ref={plotHistoryRef}>
 			<div className='plot-history'>
 				{positronPlotsContext.positronPlotInstances.map((plotInstance) => (
 					renderThumbnail(plotInstance,

--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
@@ -57,7 +57,7 @@ export const PlotsContainer = (props: PlotContainerProps) => {
 		const plotHistory = plotHistoryRef.current;
 		if (plotHistory) {
 			// Find the selected plot in the history
-			const selectedPlot = plotHistoryRef.current.querySelector('.selected');
+			const selectedPlot = plotHistory.querySelector('.selected');
 			if (selectedPlot) {
 				// If a plot is selected, scroll it into view.
 				selectedPlot.scrollIntoView();

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
@@ -3,9 +3,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 .plots-container {
-	height: 100%;
 	display: flex;
 	background: var(--vscode-positronPlots-background);
+	flex: 1;
+	overflow: hidden;
 }
 
 .plots-container.history-right {
@@ -43,10 +44,13 @@
 .history-right .plot-history {
 	flex-direction: column;
 	height: fit-content;
+	margin-top: 10px;
+	margin-bottom: 10px;
 }
 
 .history-right .plot-thumbnail {
-	margin-top: 10px;
+	margin-top: 5px;
+	margin-bottom: 5px;
 }
 
 /*
@@ -66,10 +70,13 @@
 .history-bottom .plot-history {
 	flex-direction: row;
 	width: fit-content;
+	margin-right: 10px;
+	margin-left: 10px;
 }
 
 .history-bottom .plot-thumbnail {
-	margin-left: 10px;
+	margin-left: 5px;
+	margin-right: 5px;
 }
 
 .selected-plot {

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -134,7 +134,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 
 			// Re-sort the plots by creation time since we may have added new ones that are
 			// out of order.
-			this._plots.sort((a, b) => b.metadata.created - a.metadata.created);
+			this._plots.sort((a, b) => a.metadata.created - b.metadata.created);
 
 			// Fire the onDidReplacePlots event
 			this._onDidReplacePlots.fire(this._plots);
@@ -225,7 +225,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	private registerPlotClient(plotClient: PlotClientInstance, fireEvents: boolean) {
 
 		// Add to our list of plots
-		this._plots.unshift(plotClient);
+		this._plots.push(plotClient);
 
 		// Fire events for this plot if requested
 		if (fireEvents) {

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsState.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsState.tsx
@@ -59,7 +59,7 @@ export const usePositronPlotsState = (services: PositronPlotsServices): Positron
 				if (positronPlotInstances.some(p => p.id === plotInstance.id)) {
 					return positronPlotInstances;
 				}
-				return [plotInstance, ...positronPlotInstances];
+				return [...positronPlotInstances, plotInstance];
 			});
 
 			// When the plot closes, remove it from the list of plot instances.


### PR DESCRIPTION
This change addresses https://github.com/rstudio/positron/issues/416 by making plot history navigation work the way more people expect. 

Specifically, the filmstrip now shows plots from oldest -> newest (top to bottom / left to right). 

While more people expect this behavior, it does mean that we need to fiddle with the scroll position as new plots are emitted, so that the newest (or at least most recently selected) plot is always visible in the filmstrip.