### PR TITLE
Create universal build artifacts from the main branch

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -265,12 +265,10 @@ jobs:
           asset_name: Positron-${{ needs.version_string.outputs.short_version }}-darwin-universal.zip
           asset_content_type: application/zip
 
-      # On the other hand, if  we *aren't* running against the main branch,
-      # just create a regular build artifact for the universal archive, to be
+      # Create a regular build artifact for the universal archive, to be
       # downloaded from the actions page for testing purposes.
       - name: Upload
         uses: actions/upload-artifact@v3
-        if: github.ref != 'refs/heads/main'
         with:
           name: positron-darwin-universal-archive
           path: Positron-${{ needs.version_string.outputs.short_version }}-darwin-universal.zip


### PR DESCRIPTION
On the `main` branch, the macOS universal binary currently is published as a release instead of (not in addition to) a build artifact. This has proven somewhat confusing, as some builds have universal build artifacts and some don't. This change causes all builds, even those from `main`, to produce a build artifact with a universal binary.