### PR TITLE
Improve description of "Restore the workspace" option for R

### DIFF
--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -29,6 +29,6 @@
 	"r.configuration.logLevel.debug.description": "Debug messages",
 	"r.configuration.logLevel.trace.description": "Verbose tracing messages",
 	"r.configuration.logLevel.description": "Log level for the R Kernel (requires restart to take effect)",
-	"r.configuration.restoreWorkspace.description": "Restore the workspace from .Rdata on startup",
+	"r.configuration.restoreWorkspace.description": "Restore the workspace from .RData on startup (requires restart to take effect)",
 	"r.configuration.extraArguments.description": "Extra command-line arguments for R intialization"
 }


### PR DESCRIPTION
A couple of tweaks to the language of the "Restore the workspace" option for R, based on discussion with @jennybc.