### PR TITLE
Do not disconnect background terminals on reload

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -667,9 +667,17 @@ export class TerminalService implements ITerminalService {
 			}
 		}
 
-		// If not persisting terminals, dispose of all backgrounded terminals.
-		if (!shouldPersistTerminals) {
-			for (const instance of this._backgroundedTerminalInstances) {
+		// For backgrounded terminal instances, dispose them if either (a) they
+		// are marked as transient, or (b) we are not persisting terminals.
+		for (const instance of this._backgroundedTerminalInstances) {
+			if (shouldPersistTerminals) {
+				// Dipsose transient terminals even if we are persisting terminals.
+				if (!instance.shouldPersist) {
+					instance.dispose(TerminalExitReason.Shutdown);
+				}
+			} else {
+				// We aren't persisting terminals, so all backgrounded instances
+				// should be disposed.
 				instance.dispose(TerminalExitReason.Shutdown);
 			}
 		}

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -651,13 +651,29 @@ export class TerminalService implements ITerminalService {
 		// Don't touch processes if the shutdown was a result of reload as they will be reattached
 		const shouldPersistTerminals = this._configHelper.config.enablePersistentSessions && e.reason === ShutdownReason.RELOAD;
 
-		for (const instance of [...this._terminalGroupService.instances, ...this._backgroundedTerminalInstances]) {
+		// --- Begin Positron ---
+		// In upstream VS Code, both the terminal group service's instances as
+		// well as the background instances are detached here during a reload.
+		// However, because the background instances are never reattached, they
+		// wind up getting killed by the PtyHost. We use these background
+		// instances to run kernel processes, so we need them to stay alive.
+		//
+		// https://github.com/rstudio/positron/issues/939
+		for (const instance of this._terminalGroupService.instances) {
 			if (shouldPersistTerminals && instance.shouldPersist) {
 				instance.detachProcessAndDispose(TerminalExitReason.Shutdown);
 			} else {
 				instance.dispose(TerminalExitReason.Shutdown);
 			}
 		}
+
+		// If not persisting terminals, dispose of all backgrounded terminals.
+		if (!shouldPersistTerminals) {
+			for (const instance of this._backgroundedTerminalInstances) {
+				instance.dispose(TerminalExitReason.Shutdown);
+			}
+		}
+		// --- End Positron ---
 
 		// Clear terminal layout info only when not persisting
 		if (!shouldPersistTerminals && !this._shouldReviveProcesses(e.reason)) {

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -671,7 +671,7 @@ export class TerminalService implements ITerminalService {
 		// are marked as transient, or (b) we are not persisting terminals.
 		for (const instance of this._backgroundedTerminalInstances) {
 			if (shouldPersistTerminals) {
-				// Dipsose transient terminals even if we are persisting terminals.
+				// Dispose transient terminals even if we are persisting terminals.
 				if (!instance.shouldPersist) {
 					instance.dispose(TerminalExitReason.Shutdown);
 				}


### PR DESCRIPTION
Positron uses background (hidden) terminals to run the R and Python kernels. Unfortunately, a recent upstream change to VS Code causes background terminals to be destroyed 1 minute after a window reload, so reloading Positron now effectively kills all your R and Python sessions. 

It is my view that the upstream behavior is a bug, but we probably don't want to wait for Microsoft to address it, so I'm adding this small patch to address our use case so we stay unblocked. 

The fix here is to avoid calling `detachProcessAndDispose` on background terminal instances when reloading the window. That call is meant to _temporarily_ detach a terminal, but for a background terminal instance, it has the effect of _permanently_ detaching the terminal, since background terminals aren't saved to the `TerminalGroupService`. The `PtyHost` times out waiting for the terminal to reattach and, after a minute of waiting, sends it a `SIGHUP`, killing it. 

Addresses https://github.com/rstudio/positron/issues/939. 