### PR TITLE
New UI adding viewer icon to address #945

### DIFF
--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentInstance.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentInstance.tsx
@@ -24,7 +24,7 @@ import { EnvironmentEntry, IPositronEnvironmentInstance, isEnvironmentVariableGr
 const LINE_HEIGHT = 26;
 const DEFAULT_NAME_COLUMN_WIDTH = 130;
 const MINIMUM_NAME_COLUMN_WIDTH = 100;
-const TYPE_SIZE_VISIBILITY_THRESHOLD = 250;
+const RIGHT_COLUMN_VISIBILITY_THRESHOLD = 250;
 
 /**
  * EnvironmentInstanceProps interface.
@@ -55,8 +55,8 @@ export const EnvironmentInstance = (props: EnvironmentInstanceProps) => {
 	const [nameColumnWidth, setNameColumnWidth] = useState(DEFAULT_NAME_COLUMN_WIDTH);
 	const [detailsColumnWidth, setDetailsColumnWidth] =
 		useState(props.width - DEFAULT_NAME_COLUMN_WIDTH);
-	const [typeSizeVisible, setTypeSizeVisible] =
-		useState(props.width - DEFAULT_NAME_COLUMN_WIDTH > TYPE_SIZE_VISIBILITY_THRESHOLD);
+	const [rightColumnVisible, setRightColumnVisible] =
+		useState(props.width - DEFAULT_NAME_COLUMN_WIDTH > RIGHT_COLUMN_VISIBILITY_THRESHOLD);
 	const [initializing, setInitializing] = useState(true);
 	const [entries, setEntries] = useState<EnvironmentEntry[]>([]);
 	const [resizingColumn, setResizingColumn] = useState(false);
@@ -119,8 +119,8 @@ export const EnvironmentInstance = (props: EnvironmentInstanceProps) => {
 		setNameColumnWidth(props.width - newDetailsColumnWidth);
 		setDetailsColumnWidth(newDetailsColumnWidth);
 
-		// Set the type / size visibility.
-		setTypeSizeVisible(newDetailsColumnWidth > TYPE_SIZE_VISIBILITY_THRESHOLD);
+		// Set the right column visibility.
+		setRightColumnVisible(newDetailsColumnWidth > RIGHT_COLUMN_VISIBILITY_THRESHOLD);
 	}, [props.width]);
 
 	// Entries useEffect hook.
@@ -381,8 +381,8 @@ export const EnvironmentInstance = (props: EnvironmentInstanceProps) => {
 		setNameColumnWidth(newNameColumnWidth);
 		setDetailsColumnWidth(newDetailsColumnWidth);
 
-		// Set the type /size visibility.
-		setTypeSizeVisible(newDetailsColumnWidth > TYPE_SIZE_VISIBILITY_THRESHOLD);
+		// Set the right column visibility.
+		setRightColumnVisible(newDetailsColumnWidth > RIGHT_COLUMN_VISIBILITY_THRESHOLD);
 	};
 
 	/**
@@ -415,7 +415,7 @@ export const EnvironmentInstance = (props: EnvironmentInstanceProps) => {
 					key={entry.id}
 					nameColumnWidth={nameColumnWidth}
 					detailsColumnWidth={detailsColumnWidth}
-					typeSizeVisible={typeSizeVisible}
+					rightColumnVisible={rightColumnVisible}
 					environmentVariableItem={entry}
 					style={style}
 					focused={focused}

--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariableItem.css
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariableItem.css
@@ -69,8 +69,13 @@
 	text-overflow: ellipsis;
 }
 
-.environment-variable .details-column .type-size {
+.environment-variable .details-column .right-column {
 	opacity: 0.75;
 	flex: 0 0 auto;
 	margin: 0 10px 0 0;
 }
+
+.environment-variable .details-column .right-column .viewer-icon {
+	display: flex;
+}
+

--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariableItem.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariableItem.tsx
@@ -68,7 +68,7 @@ const formatSize = (size: number) => {
 export interface EnvironmentVariableItemProps {
 	nameColumnWidth: number;
 	detailsColumnWidth: number;
-	typeSizeVisible: boolean;
+	rightColumnVisible: boolean;
 	environmentVariableItem: IEnvironmentVariableItem;
 	selected: boolean;
 	focused: boolean;
@@ -152,6 +152,18 @@ export const EnvironmentVariableItem = (props: EnvironmentVariableItemProps) => 
 	};
 
 	/**
+	 * MouseDown handler for the viewer icon.
+	 * @param e A MouseEvent<HTMLElement> that describes a user interaction with the mouse.
+	 */
+	const viewerMouseDownHandler = (e: MouseEvent<HTMLElement>) => {
+		// Consume the event.
+		e.preventDefault();
+		e.stopPropagation();
+
+		props.environmentVariableItem.view();
+	};
+
+	/**
 	 * Shows the context menu.
 	 */
 	const showContextMenu = (x: number, y: number) => {
@@ -172,6 +184,12 @@ export const EnvironmentVariableItem = (props: EnvironmentVariableItemProps) => 
 
 		// If the environment variable has children, add the toggle expand / collapse action.
 		if (props.environmentVariableItem.hasChildren) {
+			// Push a separator, if there are actions above this action.
+			if (actions.length) {
+				actions.push(new Separator());
+			}
+
+			// Push the expand or collapse action.
 			if (props.environmentVariableItem.expanded) {
 				actions.push({
 					id: POSITRON_ENVIRONMENT_COLLAPSE,
@@ -257,6 +275,22 @@ export const EnvironmentVariableItem = (props: EnvironmentVariableItemProps) => 
 		}
 	);
 
+	/**
+	 * RightColumn component.
+	 * @returns The rendered component.
+	 */
+	const RightColumnContent = () => {
+		// If the environment variable item has a viewer, render the viewer icon and event handler.
+		// Otherwise, render the display type or size, based on sorting.
+		if (props.environmentVariableItem.hasViewer) {
+			return <div className='viewer-icon codicon codicon-table' onMouseDown={viewerMouseDownHandler}></div>;
+		} else if (props.positronEnvironmentInstance.sorting === PositronEnvironmentSorting.Name) {
+			return <span>{props.environmentVariableItem.displayType}</span>;
+		} else {
+			return <span>{formatSize(props.environmentVariableItem.size)}</span>;
+		}
+	};
+
 	// Render.
 	return (
 		<div className={classNames} onMouseDown={mouseDownHandler} style={props.style}>
@@ -269,7 +303,6 @@ export const EnvironmentVariableItem = (props: EnvironmentVariableItemProps) => 
 									<div className={`expand-collapse-icon codicon codicon-chevron-down`} /> :
 									<div className={`expand-collapse-icon codicon codicon-chevron-right`} />
 							)}
-
 						</div>
 					</div>
 					<div className='name-value'>
@@ -285,13 +318,11 @@ export const EnvironmentVariableItem = (props: EnvironmentVariableItemProps) => 
 				<div className='value'>
 					{props.environmentVariableItem.displayValue}
 				</div>
-				{props.typeSizeVisible && (
-					<div className='type-size'>
-						{props.positronEnvironmentInstance.sorting === PositronEnvironmentSorting.Name ?
-							props.environmentVariableItem.displayType :
-							formatSize(props.environmentVariableItem.size)}
+				{props.rightColumnVisible &&
+					<div className='right-column'>
+						<RightColumnContent />
 					</div>
-				)}
+				}
 			</div>
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariableItem.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariableItem.tsx
@@ -160,6 +160,7 @@ export const EnvironmentVariableItem = (props: EnvironmentVariableItemProps) => 
 		e.preventDefault();
 		e.stopPropagation();
 
+		// Launch the viewer.
 		props.environmentVariableItem.view();
 	};
 


### PR DESCRIPTION
This PR addresses #945 by replacing the display type or size in the right column with a viewer icon when `environmentVariableItem.hasViewer` is true.

Look at the right column of the `dat` environment variable item:

<img width="1381" alt="image" src="https://github.com/rstudio/positron/assets/853239/65445613-446d-4c8d-9eeb-d690460af1d0">

Here's a movie of it being clicked:

https://github.com/rstudio/positron/assets/853239/3d972788-1372-4123-9e61-e2c5122be761
