### PR TITLE
Add 10px of bottom padding to console instance

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.css
@@ -5,9 +5,10 @@
 .console-core .console-instance {
 	top: 0;
 	cursor: default;
-	padding-left: 10px;
 	position: absolute;
 	overflow-y: overlay;
+	padding: 0 0 10px 10px;
+	background: var(--vscode-positronConsole-background);
 
 	/* Selection */
 	user-select: text;


### PR DESCRIPTION
This PR adds 10px of bottom spacing to the console instance component.

<img width="1528" alt="image" src="https://github.com/rstudio/positron/assets/853239/931c354c-1e31-4390-ba40-57513fd6ad68">