### PR TITLE
Handle generated svg plots as static images

### DIFF
--- a/src/vs/workbench/services/positronConsole/common/classes/activityItemOutputPlot.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/activityItemOutputPlot.ts
@@ -51,7 +51,12 @@ export class ActivityItemOutputPlot {
 
 		// Get the MIME type and data.
 		this.mimeType = imageKey!;
-		this.plotUri = `data:${this.mimeType};base64,${data[imageKey!]}`;
+		if (this.mimeType === 'image/svg+xml') {
+			const svgData = encodeURIComponent(data[imageKey!]);
+			this.plotUri = `data:${this.mimeType};utf8,${svgData}`;
+		} else {
+			this.plotUri = `data:${this.mimeType};base64,${data[imageKey!]}`;
+		}
 
 		// If the output is empty, don't render any output lines; otherwise, process the output into
 		// output lines.

--- a/src/vs/workbench/services/positronPlots/common/staticPlotClient.ts
+++ b/src/vs/workbench/services/positronPlots/common/staticPlotClient.ts
@@ -41,6 +41,10 @@ export class StaticPlotClient extends Disposable {
 	}
 
 	get uri() {
+		if (this.mimeType === 'image/svg+xml') {
+			const svgData = encodeURIComponent(this.data);
+			return `data:${this.mimeType};utf8,${svgData}`;
+		}
 		return `data:${this.mimeType};base64,${this.data}`;
 	}
 


### PR DESCRIPTION
While binary image formats such as PNG are returned in base64 encoded messages, svg images are XML encoded. The data uri format is typically:

```
<img src='data:image/svg+xml;utf8,<svg ... > ... </svg>'>
```

However, some characters need to be URI escaped. While the number of characters that need to be escaped is technically less than encodeURIComponent(), this is a simple way to encode the svg data in the data uri.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
