### PR TITLE
Updates to Envrionment right column

### DIFF
--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariableItem.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariableItem.tsx
@@ -280,15 +280,29 @@ export const EnvironmentVariableItem = (props: EnvironmentVariableItemProps) => 
 	 * RightColumn component.
 	 * @returns The rendered component.
 	 */
-	const RightColumnContent = () => {
-		// If the environment variable item has a viewer, render the viewer icon and event handler.
-		// Otherwise, render the display type or size, based on sorting.
+	const RightColumn = () => {
 		if (props.environmentVariableItem.hasViewer) {
-			return <div className='viewer-icon codicon codicon-table' onMouseDown={viewerMouseDownHandler}></div>;
-		} else if (props.positronEnvironmentInstance.sorting === PositronEnvironmentSorting.Name) {
-			return <span>{props.environmentVariableItem.displayType}</span>;
+			return (
+				<div className='right-column'>
+					<div className='viewer-icon codicon codicon-table' onMouseDown={viewerMouseDownHandler}></div>
+				</div>
+			);
+		} else if (props.rightColumnVisible) {
+			if (props.positronEnvironmentInstance.sorting === PositronEnvironmentSorting.Name) {
+				return (
+					<div className='right-column'>
+						<span>{props.environmentVariableItem.displayType}</span>
+					</div>
+				);
+			} else {
+				return (
+					<div className='right-column'>
+						<span>{formatSize(props.environmentVariableItem.size)}</span>
+					</div>
+				);
+			}
 		} else {
-			return <span>{formatSize(props.environmentVariableItem.size)}</span>;
+			return null;
 		}
 	};
 
@@ -319,11 +333,7 @@ export const EnvironmentVariableItem = (props: EnvironmentVariableItemProps) => 
 				<div className='value'>
 					{props.environmentVariableItem.displayValue}
 				</div>
-				{props.rightColumnVisible &&
-					<div className='right-column'>
-						<RightColumnContent />
-					</div>
-				}
+				<RightColumn />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
This PR addresses #972. When the Environment pane is wide enough, three columns of information are displayed: name, display value, and type / size / viewer:

<img width="433" alt="image" src="https://github.com/rstudio/positron/assets/853239/2ba379c0-219d-4249-abb6-97f7d935e13a">

When the Environment pane is narrow, the type / size / viewer column changes to only display the viewer, if one is available for the row:

<img width="342" alt="image" src="https://github.com/rstudio/positron/assets/853239/e5e06d36-5e84-4590-ad58-500730b0158f">
