### PR TITLE
Updates to the TopActionBarFolderMenu

### DIFF
--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -140,9 +140,9 @@ export class PositronNewFolderFromGitAction extends Action2 {
 }
 
 /**
- * The PositronOpenWorkspaceInNewWindowAction.
+ * The PositronOpenFolderInNewWindowAction.
  */
-export class PositronOpenWorkspaceInNewWindowAction extends Action2 {
+export class PositronOpenFolderInNewWindowAction extends Action2 {
 	/**
 	 * The action ID.
 	 */
@@ -153,10 +153,10 @@ export class PositronOpenWorkspaceInNewWindowAction extends Action2 {
 	 */
 	constructor() {
 		super({
-			id: PositronOpenWorkspaceInNewWindowAction.ID,
+			id: PositronOpenFolderInNewWindowAction.ID,
 			title: {
-				value: localize('positronOpenWorkspaceInNewWindow', "Open Workspace in New Window..."),
-				original: 'Open Workspace in New Window...'
+				value: localize('positronOpenFolderInNewWindow', "Open Folder in New Window..."),
+				original: 'Open Folder in New Window...'
 			},
 			category: workspacesCategory,
 			f1: true,
@@ -178,4 +178,4 @@ export class PositronOpenWorkspaceInNewWindowAction extends Action2 {
 // Register the actions defined above.
 registerAction2(PositronNewFolderAction);
 registerAction2(PositronNewFolderFromGitAction);
-registerAction2(PositronOpenWorkspaceInNewWindowAction);
+registerAction2(PositronOpenFolderInNewWindowAction);

--- a/src/vs/workbench/browser/actions/workspaceActions.ts
+++ b/src/vs/workbench/browser/actions/workspaceActions.ts
@@ -141,10 +141,7 @@ export class OpenFileFolderAction extends Action2 {
 	}
 }
 
-// --- Start Positron ---
-// Export this.
-export class OpenWorkspaceAction extends Action2 {
-	// --- End Positron ---
+class OpenWorkspaceAction extends Action2 {
 
 	static readonly ID = 'workbench.action.openWorkspace';
 

--- a/src/vs/workbench/browser/actions/workspaceActions.ts
+++ b/src/vs/workbench/browser/actions/workspaceActions.ts
@@ -141,7 +141,10 @@ export class OpenFileFolderAction extends Action2 {
 	}
 }
 
-class OpenWorkspaceAction extends Action2 {
+// --- Start Positron ---
+// Export this.
+export class OpenWorkspaceAction extends Action2 {
+	// --- End Positron ---
 
 	static readonly ID = 'workbench.action.openWorkspace';
 

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarFolderMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarFolderMenu.tsx
@@ -6,13 +6,17 @@ import 'vs/css!./topActionBarFolderMenu';
 import * as React from 'react';
 import { localize } from 'vs/nls';
 import { IAction, Separator } from 'vs/base/common/actions';
-import { ClearRecentFilesAction } from 'vs/workbench/browser/parts/editor/editorActions';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
+import { OpenFolderAction, OpenWorkspaceAction } from 'vs/workbench/browser/actions/workspaceActions';
+import { EmptyWorkspaceSupportContext, WorkbenchStateContext } from 'vs/workbench/common/contextkeys';
 import { ActionBarMenuButton } from 'vs/platform/positronActionBar/browser/components/actionBarMenuButton';
 import { usePositronActionBarContext } from 'vs/platform/positronActionBar/browser/positronActionBarContext';
 import { recentMenuActions } from 'vs/workbench/browser/parts/positronTopActionBar/components/topActionBarOpenMenu';
 import { usePositronTopActionBarContext } from 'vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarContext';
+import { PositronNewFolderAction, PositronNewFolderFromGitAction, PositronOpenFolderInNewWindowAction } from 'vs/workbench/browser/actions/positronActions';
 
 // Constants.
+const kCloseFolder = 'workbench.action.closeFolder';
 const kWorkbenchSettings = 'workbench.action.openWorkspaceSettings';
 const kDuplicateWorkspace = 'workbench.action.duplicateWorkspaceInNewWindow';
 
@@ -28,16 +32,73 @@ export const TopActionBarFolderMenu = () => {
 	// fetch actions when menu is shown
 	const actions = async () => {
 		const actions: IAction[] = [];
-		positronActionBarContext.appendCommandAction(actions, kDuplicateWorkspace, localize('positronDuplicateWorkspace', "Duplicate Workspace"));
+		positronActionBarContext.appendCommandAction(actions, {
+			id: PositronNewFolderAction.ID
+		});
+		positronActionBarContext.appendCommandAction(actions, {
+			id: PositronNewFolderFromGitAction.ID
+		});
+		actions.push(new Separator());
+		positronActionBarContext.appendCommandAction(actions, {
+			id: OpenFolderAction.ID,
+			label: localize('positronOpenFolder', "Open Folder...")
+		});
+
+		positronActionBarContext.appendCommandAction(actions, {
+			id: PositronOpenFolderInNewWindowAction.ID
+		});
+
+		// actions.push(new Separator());
+
+		positronActionBarContext.appendCommandAction(actions, {
+			id: OpenWorkspaceAction.ID
+		});
+
+		actions.push(new Separator());
+
+		positronActionBarContext.appendCommandAction(actions, {
+			id: kDuplicateWorkspace,
+			label: localize('positronDuplicateWorkspace', "Duplicate Workspace")
+		});
+
+		// When a folder is open, the action is called "Close Folder...".
+		positronActionBarContext.appendCommandAction(actions, {
+			id: kCloseFolder,
+			label: localize('positronCloseFolder', "Close Folder..."),
+			separator: true,
+			when: ContextKeyExpr.and(
+				WorkbenchStateContext.isEqualTo('folder'),
+				EmptyWorkspaceSupportContext
+			)
+		});
+
+		// When a workspace is open, the action is called "Close Workspace...".
+		positronActionBarContext.appendCommandAction(actions, {
+			id: kCloseFolder,
+			label: localize('positronCloseWorkspace', "Close Workspace..."),
+			separator: true,
+			when: ContextKeyExpr.and(
+				WorkbenchStateContext.isEqualTo('workspace'),
+				EmptyWorkspaceSupportContext
+			)
+		});
+
 		const recent = await positronTopActionBarContext.workspacesService.getRecentlyOpened();
 		if (positronTopActionBarContext && recent?.workspaces?.length) {
 			actions.push(new Separator());
 			actions.push(...recentMenuActions(recent.workspaces, positronTopActionBarContext));
-			actions.push(new Separator());
-			positronActionBarContext.appendCommandAction(actions, ClearRecentFilesAction.ID);
+
+			// For now, do not add this command action because it clars files and folders. It would
+			// be better to have an action that just clears folders / workspaces.
+			// actions.push(new Separator());
+			// positronActionBarContext.appendCommandAction(actions, {
+			// 	commandId: ClearRecentFilesAction.ID
+			// });
 		}
 		actions.push(new Separator());
-		positronActionBarContext.appendCommandAction(actions, kWorkbenchSettings);
+		positronActionBarContext.appendCommandAction(actions, {
+			id: kWorkbenchSettings
+		});
 		return actions;
 	};
 

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarFolderMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarFolderMenu.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { localize } from 'vs/nls';
 import { IAction, Separator } from 'vs/base/common/actions';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
-import { OpenFolderAction, OpenWorkspaceAction } from 'vs/workbench/browser/actions/workspaceActions';
+import { OpenFolderAction } from 'vs/workbench/browser/actions/workspaceActions';
 import { EmptyWorkspaceSupportContext, WorkbenchStateContext } from 'vs/workbench/common/contextkeys';
 import { ActionBarMenuButton } from 'vs/platform/positronActionBar/browser/components/actionBarMenuButton';
 import { usePositronActionBarContext } from 'vs/platform/positronActionBar/browser/positronActionBarContext';
@@ -17,8 +17,6 @@ import { PositronNewFolderAction, PositronNewFolderFromGitAction, PositronOpenFo
 
 // Constants.
 const kCloseFolder = 'workbench.action.closeFolder';
-const kWorkbenchSettings = 'workbench.action.openWorkspaceSettings';
-const kDuplicateWorkspace = 'workbench.action.duplicateWorkspaceInNewWindow';
 
 /**
  * TopActionBarFolderMenu component.
@@ -48,18 +46,20 @@ export const TopActionBarFolderMenu = () => {
 			id: PositronOpenFolderInNewWindowAction.ID
 		});
 
-		// actions.push(new Separator());
-
-		positronActionBarContext.appendCommandAction(actions, {
-			id: OpenWorkspaceAction.ID
-		});
+		// As of Private Alpha (August, 20223), we are not exposing the user to the concept of a
+		// "Workspace" in this user experience.
+		// positronActionBarContext.appendCommandAction(actions, {
+		// 	id: OpenWorkspaceAction.ID
+		// });
 
 		actions.push(new Separator());
 
-		positronActionBarContext.appendCommandAction(actions, {
-			id: kDuplicateWorkspace,
-			label: localize('positronDuplicateWorkspace', "Duplicate Workspace")
-		});
+		// As of Private Alpha (August, 20223), we are not exposing the user to the concept of a
+		// "Workspace" in this user experience.
+		// positronActionBarContext.appendCommandAction(actions, {
+		// 	id: kDuplicateWorkspace,
+		// 	label: localize('positronDuplicateWorkspace', "Duplicate Workspace")
+		// });
 
 		// When a folder is open, the action is called "Close Folder...".
 		positronActionBarContext.appendCommandAction(actions, {
@@ -88,17 +88,22 @@ export const TopActionBarFolderMenu = () => {
 			actions.push(new Separator());
 			actions.push(...recentMenuActions(recent.workspaces, positronTopActionBarContext));
 
-			// For now, do not add this command action because it clars files and folders. It would
+			// For now, do not add this command action because it clears files and folders. It would
 			// be better to have an action that just clears folders / workspaces.
 			// actions.push(new Separator());
 			// positronActionBarContext.appendCommandAction(actions, {
 			// 	commandId: ClearRecentFilesAction.ID
 			// });
 		}
-		actions.push(new Separator());
-		positronActionBarContext.appendCommandAction(actions, {
-			id: kWorkbenchSettings
-		});
+
+
+		// As of Private Alpha (August, 20223), we are not exposing the user to the concept of a
+		// "Workspace" in this user experience.
+		// actions.push(new Separator());
+		// positronActionBarContext.appendCommandAction(actions, {
+		// 	id: kWorkbenchSettings
+		// });
+
 		return actions;
 	};
 

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarFolderMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarFolderMenu.tsx
@@ -46,7 +46,7 @@ export const TopActionBarFolderMenu = () => {
 			id: PositronOpenFolderInNewWindowAction.ID
 		});
 
-		// As of Private Alpha (August, 20223), we are not exposing the user to the concept of a
+		// As of Private Alpha (August, 2023), we are not exposing the user to the concept of a
 		// "Workspace" in this user experience.
 		// positronActionBarContext.appendCommandAction(actions, {
 		// 	id: OpenWorkspaceAction.ID
@@ -54,7 +54,7 @@ export const TopActionBarFolderMenu = () => {
 
 		actions.push(new Separator());
 
-		// As of Private Alpha (August, 20223), we are not exposing the user to the concept of a
+		// As of Private Alpha (August, 2023), we are not exposing the user to the concept of a
 		// "Workspace" in this user experience.
 		// positronActionBarContext.appendCommandAction(actions, {
 		// 	id: kDuplicateWorkspace,
@@ -97,7 +97,7 @@ export const TopActionBarFolderMenu = () => {
 		}
 
 
-		// As of Private Alpha (August, 20223), we are not exposing the user to the concept of a
+		// As of Private Alpha (August, 2023), we are not exposing the user to the concept of a
 		// "Workspace" in this user experience.
 		// actions.push(new Separator());
 		// positronActionBarContext.appendCommandAction(actions, {

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
@@ -21,12 +21,21 @@ export const TopActionBarNewMenu = () => {
 	// fetch actions when menu is shown
 	const actions = () => {
 		const actions: IAction[] = [];
-		positronActionBarContext.appendCommandAction(actions, 'welcome.showNewFileEntries', localize('positronNewFile', "New File..."));
+		positronActionBarContext.appendCommandAction(actions, {
+			id: 'welcome.showNewFileEntries',
+			label: localize('positronNewFile', "New File...")
+		});
 		actions.push(new Separator());
-		positronActionBarContext.appendCommandAction(actions, PositronNewFolderAction.ID);
-		positronActionBarContext.appendCommandAction(actions, PositronNewFolderFromGitAction.ID);
+		positronActionBarContext.appendCommandAction(actions, {
+			id: PositronNewFolderAction.ID
+		});
+		positronActionBarContext.appendCommandAction(actions, {
+			id: PositronNewFolderFromGitAction.ID
+		});
 		actions.push(new Separator());
-		positronActionBarContext.appendCommandAction(actions, 'workbench.action.newWindow');
+		positronActionBarContext.appendCommandAction(actions, {
+			id: 'workbench.action.newWindow'
+		});
 		return actions;
 	};
 

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarOpenMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarOpenMenu.tsx
@@ -38,12 +38,19 @@ export const TopActionBarOpenMenu = () => {
 		// core open actions
 		const actions: IAction[] = [];
 		if (IsMacNativeContext.getValue(positronActionBarContext.contextKeyService)) {
-			positronActionBarContext.appendCommandAction(actions, OpenFileFolderAction.ID, localize('positronOpenFile', "Open File..."));
+			positronActionBarContext.appendCommandAction(actions, {
+				id: OpenFileFolderAction.ID,
+				label: localize('positronOpenFile', "Open File...")
+			});
 		} else {
-			positronActionBarContext.appendCommandAction(actions, OpenFileAction.ID);
+			positronActionBarContext.appendCommandAction(actions, {
+				id: OpenFileAction.ID
+			});
 		}
-
-		positronActionBarContext.appendCommandAction(actions, OpenFolderAction.ID, localize('positronOpenFolder', "Open Folder..."));
+		positronActionBarContext.appendCommandAction(actions, {
+			id: OpenFolderAction.ID,
+			label: localize('positronOpenFolder', "Open Folder...")
+		});
 		actions.push(new Separator());
 
 		// recent files/workspaces actions
@@ -56,9 +63,13 @@ export const TopActionBarOpenMenu = () => {
 			if (recentActions.length > 0) {
 				actions.push(...recentActions);
 				actions.push(new Separator());
-				positronActionBarContext.appendCommandAction(actions, OpenRecentAction.ID);
+				positronActionBarContext.appendCommandAction(actions, {
+					id: OpenRecentAction.ID
+				});
 				actions.push(new Separator());
-				positronActionBarContext.appendCommandAction(actions, ClearRecentFilesAction.ID);
+				positronActionBarContext.appendCommandAction(actions, {
+					id: ClearRecentFilesAction.ID
+				});
 			}
 		}
 		return actions;


### PR DESCRIPTION
This PR makes several updates to the `TopActionBarFolderMenu` component to address #976.

When Positron is running without a folder or workspace open, the `TopActionBarFolderMenu` looks like this:

<img width="450" alt="image" src="https://github.com/rstudio/positron/assets/853239/d1e8b329-5f2d-442a-903b-d2ff91201228">

This provides options to:

- Create a new folder or create a new folder from Git (eventually, these will be combined into a wizard dialog similar to what RStudio does today).
- Open a folder, open a folder in a new window, and open a workspace from a file (a .code-workspace file). (We need to rename .code-workspace files to .positron-workspace files.)
- Duplicate Workspace. (This is a standard Visual Studio Code feature that we are just using for the moment. We need to do more thinking about this user experience. It's pretty terrible.)
- Open MRU folders and workspaces.
- Open Workspace Settings. (Not sure I love this for Positron users...)

Note that in prior Positron builds, we had a **Close Folder** or **Close Workspace** menu item that was always available. This has been fixed. If a folder or workspace isn't open, this option isn't available.

When Positron is running with a folder open, the `TopActionBarFolderMenu` looks like this:

<img width="391" alt="image" src="https://github.com/rstudio/positron/assets/853239/652918ea-d2b3-4d31-b8e9-db6bba477f25">

And when Positron is running with a workspace open, the `TopActionBarFolderMenu` looks like this:

<img width="403" alt="image" src="https://github.com/rstudio/positron/assets/853239/36957a74-8697-465d-9bbd-6b4ef99aff41">

Note that the Close [Folder | Workspace] option now matches the File menu, which displays:

<img width="309" alt="image" src="https://github.com/rstudio/positron/assets/853239/c4667607-003a-4304-8ce7-2d96cd6eea5e">

when there isn't a folder or workspace open, or:

<img width="305" alt="image" src="https://github.com/rstudio/positron/assets/853239/99a4580f-462c-4a0a-8373-a2abd43a9a8b">

when there's a folder open, or:

<img width="300" alt="image" src="https://github.com/rstudio/positron/assets/853239/cb2ebc54-bb26-495e-b253-4ce4f61cafdc">

when there's a workspace open.

(The shortcut is always ⌘K F or Cmd+K F, for file, even when it's Close Workspace, from Visual Studio Code.)

Depending on whether a folder or a workspace is open.