### PR TITLE
Set the default sidebar width to the minimum sidebar width

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -10,7 +10,7 @@ import { onDidChangeFullscreen, isFullscreen, isWCOEnabled } from 'vs/base/brows
 import { IWorkingCopyBackupService } from 'vs/workbench/services/workingCopy/common/workingCopyBackup';
 import { isWindows, isLinux, isMacintosh, isWeb, isNative, isIOS } from 'vs/base/common/platform';
 import { EditorInputCapabilities, GroupIdentifier, isResourceEditorInput, IUntypedEditorInput, pathsToEditors } from 'vs/workbench/common/editor';
-import { SidebarPart } from 'vs/workbench/browser/parts/sidebar/sidebarPart';
+import { SIDEBAR_PART_MINIMUM_WIDTH, SidebarPart } from 'vs/workbench/browser/parts/sidebar/sidebarPart';
 import { PanelPart } from 'vs/workbench/browser/parts/panel/panelPart';
 import { Position, Parts, PanelOpensMaximizedOptions, IWorkbenchLayoutService, positionFromString, positionToString, panelOpensMaximizedFromString, PanelAlignment } from 'vs/workbench/services/layout/browser/layoutService';
 import { isTemporaryWorkspace, IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
@@ -2583,7 +2583,7 @@ class LayoutStateModel extends Disposable {
 		// --- Start Positron ---
 		// LayoutStateKeys.SIDEBAR_SIZE.defaultValue = Math.min(300, workbenchDimensions.width / 4);
 		// LayoutStateKeys.AUXILIARYBAR_SIZE.defaultValue = Math.min(300, workbenchDimensions.width / 4);
-		LayoutStateKeys.SIDEBAR_SIZE.defaultValue = Math.min(250, Math.round(workbenchDimensions.width / 4));
+		LayoutStateKeys.SIDEBAR_SIZE.defaultValue = Math.min(SIDEBAR_PART_MINIMUM_WIDTH, Math.round(workbenchDimensions.width / 4)); // 170 mirrors minimumWidth in sidebarPart.ts.
 		LayoutStateKeys.AUXILIARYBAR_SIZE.defaultValue = Math.round(workbenchDimensions.width * 0.45);
 		// --- End Positron ---
 		LayoutStateKeys.PANEL_SIZE.defaultValue = (this.stateCache.get(LayoutStateKeys.PANEL_POSITION.name) ?? LayoutStateKeys.PANEL_POSITION.defaultValue) === 'bottom' ? workbenchDimensions.height / 3 : workbenchDimensions.width / 4;

--- a/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
+++ b/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
@@ -33,6 +33,13 @@ import { Gesture, EventType as GestureEventType } from 'vs/base/browser/touch';
 import { IPaneComposite } from 'vs/workbench/common/panecomposite';
 import { IPaneCompositePart } from 'vs/workbench/browser/parts/paneCompositePart';
 
+// --- Start Positron ---
+// The minimum sidebar part width is 170. Export this as a constant so that we can use this same
+// width in layout.ts where we set the default size (see LayoutStateKeys.SIDEBAR_SIZE.defaultValue
+// in layout.ts).
+export const SIDEBAR_PART_MINIMUM_WIDTH = 170;
+// --- End Positron ---
+
 export class SidebarPart extends CompositePart<PaneComposite> implements IPaneCompositePart {
 
 	declare readonly _serviceBrand: undefined;
@@ -41,7 +48,9 @@ export class SidebarPart extends CompositePart<PaneComposite> implements IPaneCo
 
 	//#region IView
 
-	readonly minimumWidth: number = 170;
+	// --- Start Positron ---
+	readonly minimumWidth: number = /*170*/ SIDEBAR_PART_MINIMUM_WIDTH;
+	// --- End Positron ---
 	readonly maximumWidth: number = Number.POSITIVE_INFINITY;
 	readonly minimumHeight: number = 0;
 	readonly maximumHeight: number = Number.POSITIVE_INFINITY;


### PR DESCRIPTION
This PR addresses #982 by setting the default sidebar width to the minimum sidebar width.

Top layer is @jjallaire's bug report. Bottom layer is the default sidebar width with this PR.

![image](https://github.com/rstudio/positron/assets/853239/6c096ae7-88a8-42ef-92d2-abe86ed2789b)

I've made @jjallaire, @petetronic, @juliasilge, and @DavisVaughan reviewers just to close the loop on what was done with the issue.
