### PR TITLE
Disable preview editors by default

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -34,7 +34,10 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 	focusRecentEditorAfterClose: true,
 	showIcons: true,
 	hasIcons: true, // 'vs-seti' is our default icon theme
-	enablePreview: true,
+	// --- Start Positron ---
+	// enablePreview: true,
+	enablePreview: false,
+	// --- End Positron ---
 	openPositioning: 'right',
 	openSideBySideDirection: 'right',
 	closeEmptyGroups: true,

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -195,7 +195,10 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.editor.enablePreview': {
 				'type': 'boolean',
 				'description': localize('enablePreview', "Controls whether opened editors show as preview editors. Preview editors do not stay open, are reused until explicitly set to be kept open (via double-click or editing), and show file names in italics."),
-				'default': true
+				// --- Start Positron ---
+				// 'default': true
+				'default': false
+				// --- End Positron ---
 			},
 			'workbench.editor.enablePreviewFromQuickOpen': {
 				'type': 'boolean',

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -395,6 +395,13 @@ suite('EditorGroupsService', () => {
 		assert.strictEqual(oldOptions, currentOptions);
 	});
 
+	// --- Start Positron ---
+	test('enablePreview default', async function () {
+		const [part] = await createPart();
+		assert.strictEqual(part.partOptions.enablePreview, false);
+	});
+	// --- End Positron ---
+
 	test('editor basics', async function () {
 		const [part] = await createPart();
 		// --- Start Positron ---

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -395,17 +395,11 @@ suite('EditorGroupsService', () => {
 		assert.strictEqual(oldOptions, currentOptions);
 	});
 
-	// --- Start Positron ---
-	test('enablePreview default', async function () {
-		const [part] = await createPart();
-		assert.strictEqual(part.partOptions.enablePreview, false);
-	});
-	// --- End Positron ---
-
 	test('editor basics', async function () {
 		const [part] = await createPart();
 		// --- Start Positron ---
 		// We default this to `false`, but this test expects it to be `true`
+		assert.strictEqual(part.partOptions.enablePreview, false);
 		part.enforcePartOptions({ enablePreview: true });
 		// --- End Positron ---
 		const group = part.activeGroup;

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -397,6 +397,10 @@ suite('EditorGroupsService', () => {
 
 	test('editor basics', async function () {
 		const [part] = await createPart();
+		// --- Start Positron ---
+		// We default this to `false`, but this test expects it to be `true`
+		part.enforcePartOptions({ enablePreview: true });
+		// --- End Positron ---
 		const group = part.activeGroup;
 		assert.strictEqual(group.isEmpty, true);
 


### PR DESCRIPTION
Addresses https://github.com/rstudio/positron/issues/858

With no user setting specified:

<img width="439" alt="Screenshot 2023-08-10 at 3 23 50 PM" src="https://github.com/rstudio/positron/assets/19150088/b2262f30-b916-496c-925d-923679bc12ec">

Enable preview is now turned off by default

<img width="466" alt="Screenshot 2023-08-10 at 3 23 40 PM" src="https://github.com/rstudio/positron/assets/19150088/4679296a-5830-4f70-9c9a-5ff9ebbe6b51">


https://github.com/rstudio/positron/assets/19150088/a4abf8ab-97bb-4730-a866-54f56145797e

