### PR TITLE
Add `extensionEnabledApiProposals` to Positron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@ product.overrides.json
 
 # --- Start Positron ---
 .Rproj.user
+VSCode*
 # --- End Positron ---
 

--- a/build/update_api_proposals.sh
+++ b/build/update_api_proposals.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+export VSCODE_QUALITY="stable"
+
+while getopts ":i" opt; do
+  case "$opt" in
+    i)
+      export VSCODE_QUALITY="insider"
+      ;;
+    *)
+      ;;
+  esac
+done
+
+
+URL=$( curl -s "https://update.code.visualstudio.com/api/update/win32-x64-archive/${VSCODE_QUALITY}/0000000000000000000000000000000000000000" | jq -c '.url' | sed -E 's/.*"([^"]+)".*/\1/' )
+# echo "url: ${URL}"
+FILE="${URL##*/}"
+# echo "file: ${FILE}"
+DIRECTORY="${FILE%.zip}"
+# echo "directory: ${DIRECTORY}"
+
+if [[ ! -f "${FILE}" ]]; then
+  wget "${URL}"
+fi
+
+if [[ ! -d "${DIRECTORY}" ]]; then
+  unzip "${FILE}" -d "${DIRECTORY}"
+fi
+
+APIS=$( jq --tab -r '.extensionEnabledApiProposals' "${DIRECTORY}/resources/app/product.json" )
+
+APIS=$( echo "${APIS}" | jq '. += {"jeanp413.open-remote-ssh": ["resolvers", "tunnels", "terminalDataWriteEvent", "contribRemoteHelp", "contribViewsRemote"]}' )
+
+jsonTmp=$( jq --tab --argjson v "${APIS}" 'setpath(["extensionEnabledApiProposals"]; $v)' product.json )
+echo "${jsonTmp}" > product.json && unset jsonTmp

--- a/product.json
+++ b/product.json
@@ -107,5 +107,241 @@
 	},
 	"linkProtectionTrustedDomains": [
 		"https://open-vsx.org"
-	]
+	],
+	"extensionEnabledApiProposals": {
+		"ms-vscode.vscode-selfhost-test-provider": [
+			"testObserver"
+		],
+		"VisualStudioExptTeam.vscodeintellicode-completions": [
+			"inlineCompletionsAdditions"
+		],
+		"ms-vsliveshare.vsliveshare": [
+			"contribMenuBarHome",
+			"contribShareMenu",
+			"contribStatusBarItems",
+			"diffCommand",
+			"documentFiltersExclusive",
+			"fileSearchProvider",
+			"findTextInFiles",
+			"notebookCellExecutionState",
+			"notebookLiveShare",
+			"terminalDimensions",
+			"terminalDataWriteEvent",
+			"textSearchProvider"
+		],
+		"ms-vscode.js-debug": [
+			"portsAttributes",
+			"findTextInFiles",
+			"workspaceTrust",
+			"tunnels"
+		],
+		"ms-toolsai.vscode-ai-remote": [
+			"resolvers"
+		],
+		"ms-python.python": [
+			"contribEditorContentMenu",
+			"quickPickSortByLabel",
+			"portsAttributes",
+			"testObserver",
+			"envShellEvent",
+			"quickPickItemTooltip",
+			"terminalDataWriteEvent",
+			"envCollectionWorkspace",
+			"saveEditor",
+			"envCollectionOptions"
+		],
+		"ms-dotnettools.dotnet-interactive-vscode": [
+			"notebookMessaging",
+			"languageConfigurationAutoClosingPairs"
+		],
+		"GitHub.codespaces": [
+			"contribEditSessions",
+			"contribMenuBarHome",
+			"contribRemoteHelp",
+			"contribViewsRemote",
+			"resolvers",
+			"tunnels",
+			"terminalDataWriteEvent",
+			"treeViewReveal",
+			"notebookKernelSource"
+		],
+		"ms-vscode.azure-repos": [
+			"extensionRuntime",
+			"fileSearchProvider",
+			"textSearchProvider"
+		],
+		"ms-vscode.remote-repositories": [
+			"canonicalUriProvider",
+			"contribEditSessions",
+			"contribRemoteHelp",
+			"contribMenuBarHome",
+			"contribViewsRemote",
+			"contribViewsWelcome",
+			"contribShareMenu",
+			"documentFiltersExclusive",
+			"editSessionIdentityProvider",
+			"extensionRuntime",
+			"fileSearchProvider",
+			"quickPickSortByLabel",
+			"workspaceTrust",
+			"shareProvider",
+			"scmActionButton",
+			"scmSelectedProvider",
+			"scmValidation",
+			"textSearchProvider",
+			"timeline"
+		],
+		"ms-vscode-remote.remote-wsl": [
+			"resolvers",
+			"contribRemoteHelp",
+			"contribViewsRemote",
+			"telemetry"
+		],
+		"ms-vscode-remote.remote-ssh": [
+			"resolvers",
+			"tunnels",
+			"terminalDataWriteEvent",
+			"contribRemoteHelp",
+			"contribViewsRemote",
+			"telemetry"
+		],
+		"ms-vscode.remote-server": [
+			"resolvers",
+			"tunnels",
+			"tunnelFactory",
+			"contribViewsWelcome"
+		],
+		"ms-vscode.remote-explorer": [
+			"contribRemoteHelp",
+			"contribViewsRemote",
+			"extensionsAny"
+		],
+		"ms-vscode-remote.remote-containers": [
+			"contribEditSessions",
+			"resolvers",
+			"tunnels",
+			"workspaceTrust",
+			"terminalDimensions",
+			"contribRemoteHelp",
+			"contribViewsRemote"
+		],
+		"ms-vscode.js-debug-nightly": [
+			"portsAttributes",
+			"findTextInFiles",
+			"workspaceTrust",
+			"tunnels"
+		],
+		"ms-vscode.lsif-browser": [
+			"documentFiltersExclusive"
+		],
+		"GitHub.vscode-pull-request-github": [
+			"contribCommentThreadAdditionalMenu",
+			"tokenInformation",
+			"contribShareMenu",
+			"fileComments",
+			"contribCommentPeekContext",
+			"codiconDecoration",
+			"diffCommand",
+			"contribCommentEditorActionsMenu",
+			"readonlyMessage",
+			"treeViewMarkdownMessage",
+			"shareProvider",
+			"quickDiffProvider"
+		],
+		"GitHub.copilot": [
+			"inlineCompletionsAdditions"
+		],
+		"GitHub.copilot-nightly": [
+			"inlineCompletionsAdditions"
+		],
+		"GitHub.copilot-chat": [
+			"handleIssueUri",
+			"interactive",
+			"interactiveUserActions",
+			"semanticSimilarity",
+			"terminalDataWriteEvent",
+			"terminalSelection",
+			"terminalQuickFixProvider"
+		],
+		"GitHub.remotehub": [
+			"contribRemoteHelp",
+			"contribMenuBarHome",
+			"contribViewsRemote",
+			"contribViewsWelcome",
+			"documentFiltersExclusive",
+			"extensionRuntime",
+			"fileSearchProvider",
+			"quickPickSortByLabel",
+			"workspaceTrust",
+			"scmSelectedProvider",
+			"scmValidation",
+			"textSearchProvider",
+			"timeline"
+		],
+		"ms-python.gather": [
+			"notebookCellExecutionState"
+		],
+		"ms-python.vscode-pylance": [
+			"notebookCellExecutionState"
+		],
+		"ms-toolsai.jupyter-renderers": [
+			"contribNotebookStaticPreloads"
+		],
+		"ms-toolsai.jupyter": [
+			"notebookDeprecated",
+			"notebookMessaging",
+			"notebookMime",
+			"notebookCellExecutionState",
+			"portsAttributes",
+			"quickPickSortByLabel",
+			"notebookKernelSource",
+			"interactiveWindow",
+			"notebookControllerAffinityHidden",
+			"contribNotebookStaticPreloads",
+			"quickPickItemTooltip",
+			"notebookExecution"
+		],
+		"dbaeumer.vscode-eslint": [
+			"notebookCellExecutionState"
+		],
+		"ms-vscode.azure-sphere-tools-ui": [
+			"tunnels"
+		],
+		"ms-azuretools.vscode-azureappservice": [
+			"terminalDataWriteEvent"
+		],
+		"ms-azuretools.vscode-azureresourcegroups": [
+			"authGetSessions"
+		],
+		"ms-vscode.anycode": [
+			"extensionsAny"
+		],
+		"ms-vscode.cpptools": [
+			"terminalDataWriteEvent"
+		],
+		"redhat.java": [
+			"documentPaste"
+		],
+		"ms-dotnettools.csdevkit": [
+			"inlineCompletionsAdditions"
+		],
+		"ms-dotnettools.vscodeintellicode-csharp": [
+			"inlineCompletionsAdditions"
+		],
+		"microsoft-IsvExpTools.powerplatform-vscode": [
+			"fileSearchProvider",
+			"textSearchProvider"
+		],
+		"microsoft-IsvExpTools.powerplatform-vscode-preview": [
+			"fileSearchProvider",
+			"textSearchProvider"
+		],
+		"jeanp413.open-remote-ssh": [
+			"resolvers",
+			"tunnels",
+			"terminalDataWriteEvent",
+			"contribRemoteHelp",
+			"contribViewsRemote"
+		]
+	}
 }


### PR DESCRIPTION
Addresses #911 

This PR adds the `extensionEnabledApiProposals` to Positron's `product.json`. After this change, the Jupyter extension works:

![Screenshot 2023-08-11 at 6 06 04 PM](https://github.com/rstudio/positron/assets/12505835/d66a12aa-93d5-4057-a53e-6a0c82f4d73e)


(Notice 👀 that variables defined in the notebook cells do not show up in the Environment pane.)

This PR [takes a page from vscodium's book](https://github.com/VSCodium/vscodium/pull/1187/files) and adds a shell script to automate this moving forward. I made this change by running the shell script manually, but eventually we'll want to do this on some cadence in an automated way. I'll open a follow-up issue to track that.