### PR TITLE
Ensure all inputs are idle after an exit

### DIFF
--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -1086,6 +1086,18 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			// We are currently attached; detach.
 			this._runtimeAttached = false;
 
+			// Ensure all inputs are marked as idle. When a runtime exits, it
+			// may not send an Idle message corresponding to the command that
+			// caused it to exit (for instance if the command causes the runtime
+			// to crash).
+			for (const activity of this._runtimeItemActivities.values()) {
+				for (const item of activity.activityItems) {
+					if (item instanceof ActivityItemInput) {
+						item.setBusyState(false);
+					}
+				}
+			}
+
 			// Dispose of the runtime event handlers.
 			this._runtimeDisposableStore.dispose();
 			this._runtimeDisposableStore = new DisposableStore();


### PR DESCRIPTION
This change addresses a portion of https://github.com/rstudio/positron/issues/1038, in which a command that causes the runtime to crash can cause the last executed input to get stuck in a busy state. 

The fix is to ensure that when a runtime exits, all inputs are set to the idle state. 
