### PR TITLE
Add error type in red if defined (only for Python)

### DIFF
--- a/src/vs/workbench/services/positronConsole/common/classes/activityItemErrorMessage.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/activityItemErrorMessage.ts
@@ -42,7 +42,12 @@ export class ActivityItemErrorMessage {
 		readonly traceback: string[]
 	) {
 		// Process the message and traceback directly into ANSI output lines suitable for rendering.
-		this.messageOutputLines = ANSIOutput.processOutput(message);
+		let detailedMessage = message;
+		if (name) {
+			// name provides additional context about the error; display in red if defined
+			detailedMessage = `\x1b[31m${name}\x1b[0m: ${message}`;
+		}
+		this.messageOutputLines = ANSIOutput.processOutput(detailedMessage);
 		this.tracebackOutputLines = !traceback.length ?
 			[] :
 			ANSIOutput.processOutput(traceback.join('\n'));


### PR DESCRIPTION
Thanks to @petetronic for doing the legwork on this. Addresses #993 

Adds error type to console output in red, if it exists.

In Python:
![image (10)](https://github.com/rstudio/positron/assets/7817881/345cf363-de3e-4b61-a868-a4420c808d08)

In R (no error types defined):
![image (11)](https://github.com/rstudio/positron/assets/7817881/e7ba18dc-250d-4030-9f8d-8df401451a9b)
