### PR TITLE
Add API for runtime selection 

### DIFF
--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -707,6 +707,14 @@ declare module 'positron' {
 		export function registerLanguageRuntime(runtime: LanguageRuntime): vscode.Disposable;
 
 		/**
+		 * Select and start a runtime previously registered with Positron. Any
+		 * previously active runtimes for the language will be shut down.
+		 *
+		 * @param runtimeId The ID of the runtime to select and start.
+		 */
+		export function selectLanguageRuntime(runtimeId: string): Thenable<void>;
+
+		/**
 		 * Register a handler for runtime client instances. This handler will be called
 		 * whenever a new client instance is created by a language runtime of the given
 		 * type.

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -839,7 +839,8 @@ export class MainThreadLanguageRuntime implements MainThreadLanguageRuntimeShape
 	// Called by the extension host to select a previously registered language runtime
 	$selectLanguageRuntime(handle: number): Promise<void> {
 		return this._languageRuntimeService.selectRuntime(
-			this.findRuntime(handle).metadata.runtimeId);
+			this.findRuntime(handle).metadata.runtimeId,
+			'Extension-requested runtime selection via Positron API');
 	}
 
 	// Signals that language runtime discovery is complete.

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -836,6 +836,12 @@ export class MainThreadLanguageRuntime implements MainThreadLanguageRuntimeShape
 		this._languageRuntimeService.registerRuntime(adapter, metadata.startupBehavior);
 	}
 
+	// Called by the extension host to select a previously registered language runtime
+	$selectLanguageRuntime(handle: number): Promise<void> {
+		return this._languageRuntimeService.selectRuntime(
+			this.findRuntime(handle).metadata.runtimeId);
+	}
+
 	// Signals that language runtime discovery is complete.
 	$completeLanguageRuntimeDiscovery(): void {
 		this._languageRuntimeService.completeDiscovery();

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -65,6 +65,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			registerLanguageRuntimeProvider(languageId: string, provider: positron.LanguageRuntimeProvider): void {
 				return extHostLanguageRuntime.registerLanguageRuntimeProvider(languageId, provider);
 			},
+			selectLanguageRuntime(runtimeId: string): Thenable<void> {
+				return extHostLanguageRuntime.selectLanguageRuntime(runtimeId);
+			},
 			registerClientHandler(handler: positron.RuntimeClientHandler): vscode.Disposable {
 				return extHostLanguageRuntime.registerClientHandler(handler);
 			}

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -11,6 +11,7 @@ import { UriComponents } from 'vs/base/common/uri';
 // This is the interface that the main process exposes to the extension host
 export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$registerLanguageRuntime(handle: number, metadata: ILanguageRuntimeMetadata, dynState: ILanguageRuntimeDynState): void;
+	$selectLanguageRuntime(handle: number): Promise<void>;
 	$isLanguageRuntimeDiscoveryComplete(): Promise<boolean>;
 	$completeLanguageRuntimeDiscovery(): void;
 	$unregisterLanguageRuntime(handle: number): void;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -251,6 +251,23 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 	}
 
 	/**
+	 * Selects and starts a language runtime.
+	 *
+	 * @param runtimeId The runtime ID to select and start.
+	 */
+	public selectLanguageRuntime(runtimeId: string): Promise<void> {
+		// Look for the runtime with the given ID
+		for (let i = 0; i < this._runtimes.length; i++) {
+			if (this._runtimes[i].metadata.runtimeId === runtimeId) {
+				return this._proxy.$selectLanguageRuntime(i);
+			}
+		}
+		return Promise.reject(
+			new Error(`Runtime with ID '${runtimeId}' must be registered before ` +
+				`it can be selected.`));
+	}
+
+	/**
 	 * Handles a comm open message from the language runtime by either creating
 	 * a client instance for it or passing it to a registered client handler.
 	 *

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
@@ -96,86 +96,12 @@ export const PositronTopActionBar = (props: PositronTopActionBarProps) => {
 	}, []);
 
 	/**
-	 * Shuts down runtimes for the specified language. Note that there should only ever be one
-	 * running runtime per language.
-	 * @param languageId The language identifier.
-	 * @returns A promise that resolves when runtimes for the specified language identifier are shut
-	 * down.
-	 */
-	const shutdownRuntimes = async (languageId: string): Promise<void> => {
-		/**
-		 * Gets the running runtimes for the language identifier.
-		 * @returns The running runtimes for the language identifier.
-		 */
-		const runningRuntimes = () => props.languageRuntimeService.runningRuntimes.filter(runtime =>
-			runtime.metadata.languageId === languageId
-		);
-
-		// Get the running runtimes for the language identifier.
-		const runtimes = runningRuntimes();
-
-		// If there are no running runtimes for the language identifier, return.
-		if (!runtimes.length) {
-			return;
-		}
-
-		// Return a promise that resolves when the running runtimes for the language identifier are
-		// shutdown.
-		return new Promise<void>((resolve, reject) => {
-			// Shutdown the running runtimes.
-			runtimes.forEach(runtime => runtime.shutdown());
-
-			// Wait for the running runtimes to be shutdown.
-			let tries = 0;
-			const interval = setInterval(() => {
-				if (!runningRuntimes().length) {
-					clearInterval(interval);
-					resolve();
-				} else {
-					if (++tries > 10) {
-						clearInterval(interval);
-						reject();
-					}
-				}
-			}, 500);
-		});
-	};
-
-	/**
 	 * startRuntime event handler.
 	 * @param runtimeToStart An ILanguageRuntime representing the runtime to start.
 	 */
 	const startRuntimeHandler = async (runtimeToStart: ILanguageRuntime): Promise<void> => {
-		// Shutdown runtimes for the runtime language identifier
-		await shutdownRuntimes(runtimeToStart.metadata.languageId);
-
-		// Start the runtime.
-		props.languageRuntimeService.startRuntime(runtimeToStart.metadata.runtimeId,
+		return props.languageRuntimeService.selectRuntime(runtimeToStart.metadata.runtimeId,
 			`User-requested startup from the Positron top action bar`);
-
-		// Return a promise that resolves when the runtime is started.
-		return new Promise<void>((resolve, reject) => {
-			// Wait for the running runtimes to be shutdown.
-			let tries = 0;
-			const interval = setInterval(() => {
-				// See if the runtime is running.
-				const runningRuntime = props.languageRuntimeService.runningRuntimes.find(
-					runtime => runtime.metadata.runtimeId === runtimeToStart.metadata.runtimeId
-				);
-
-				// If the runtime is running, resolve the promise; otherwise, if we have waited too
-				// long, reject the promise.
-				if (runningRuntime) {
-					clearInterval(interval);
-					resolve();
-				} else {
-					if (++tries > 10) {
-						clearInterval(interval);
-						reject();
-					}
-				}
-			}, 500);
-		});
 	};
 
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -261,6 +261,15 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	}
 
 	/**
+	 * Selects and starts a runtime.
+	 *
+	 * @param runtimeId The ID of the runtime to select
+	 */
+	selectRuntime(runtimeId: string): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+
+	/**
 	 * Register a new runtime
 	 *
 	 * @param runtime The runtime to register

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -472,7 +472,7 @@ export interface ILanguageRuntime {
 	restart(): void;
 
 	/** Shut down the runtime */
-	shutdown(): void;
+	shutdown(): Thenable<void>;
 }
 
 export interface ILanguageRuntimeService {
@@ -531,8 +531,11 @@ export interface ILanguageRuntimeService {
 
 	/**
 	 * Selects a previously registered runtime as the active runtime.
+	 *
+	 * @param runtimeId The identifier of the runtime to select.
+	 * @param source The source of the request to select the runtime, for debugging purposes.
 	 */
-	selectRuntime(runtimeId: string): Promise<void>;
+	selectRuntime(runtimeId: string, source: string): Promise<void>;
 
 	/**
 	 * Signal that discovery of language runtimes is complete.

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -530,6 +530,11 @@ export interface ILanguageRuntimeService {
 	registerRuntime(runtime: ILanguageRuntime, startupBehavior: LanguageRuntimeStartupBehavior): IDisposable;
 
 	/**
+	 * Selects a previously registered runtime as the active runtime.
+	 */
+	selectRuntime(runtimeId: string): Promise<void>;
+
+	/**
 	 * Signal that discovery of language runtimes is complete.
 	 */
 	completeDiscovery(): void;


### PR DESCRIPTION
This change adds a new Positron API for selecting an active language runtime. It also moves the logic for runtime selection (the task that involves ending a previous runtime for the language, then starting the selected runtime) from the top bar into the language runtime service, so that the top bar and the API use the same logic.

A prerequisite for (but not a fix for) https://github.com/rstudio/positron/issues/1046.