### PR TITLE
Hook `onErrorResult()` to `'error'` messages

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterErrorReply.ts
+++ b/extensions/jupyter-adapter/src/JupyterErrorReply.ts
@@ -7,12 +7,9 @@ import { JupyterMessageSpec } from './JupyterMessageSpec';
 /**
  * Returned by many Jupyter methods when they fail.
  *
- * @link https://jupyter-client.readthedocs.io/en/stable/messaging.html#request-reply
+ * @link https://jupyter-client.readthedocs.io/en/stable/messaging.html#execution-errors
  */
 export interface JupyterErrorReply extends JupyterMessageSpec {
-	/** The status, always 'error' */
-	status: 'error';
-
 	/** The name of the exception that caused the error, if any */
 	ename: string;
 


### PR DESCRIPTION
Addresses https://github.com/rstudio/positron/issues/1053
See https://github.com/rstudio/positron/issues/1053#issuecomment-1682759270 in particular for the rationale for this change

I'm a little uncertain about the full implications of this one

On one hand, it does fix the issue from #1053 as expected, as we now emit errors when things like `raise Exception` are run interactively AND through a script:

https://github.com/rstudio/positron/assets/19150088/d32250e5-9000-4f35-bb59-891d808c85bd

R errors also still work (because we were already emitting IOPub `error`s)

https://github.com/rstudio/positron/assets/19150088/6e86f898-3609-4696-ac35-67b90afe104a

The thing that I am unsure about is the fact that previously we routed _any_ messages to `onErrorResult()` if they had a `status = "error"` field. _In theory_ this could include messages like `InspectReply` and `CompleteReply` since those have a `status` field, but at least in ark it doesn't seem like we ever send those messages with a potential for `status = "error"` (either because we only have a dummy stub in for the message type right now, or because it literally just can't error).

If those kinds of messages were sent now, they would be dropped completely because our `switch` doesn't handle them and we no longer have this catch all on `status = "error"`. I actually think this might not be a bad thing, because if we were to forward the errors related to those non-execution errors through `onErrorResult()` then they would show up in the console to the user, which would probably be very confusing?

Regardless, I did want to show that we now explicitly ignore `execute_reply` messages (and have thought about doing so, i.e. it wasn't an oversight) so I left in a dummy case in the switch statement that "handles" them.