### PR TITLE
Make sure help UI is visible

### DIFF
--- a/src/vs/workbench/services/positronHelp/common/positronHelpService.ts
+++ b/src/vs/workbench/services/positronHelp/common/positronHelpService.ts
@@ -198,6 +198,10 @@ export class PositronHelpService extends Disposable implements IPositronHelpServ
 					targetUrl: targetUrl.toString()
 				};
 
+				// Ensure that the auxiliary bar is showing and open the help view.
+				await this.commandService.executeCommand('workbench.action.showAuxiliaryBar');
+				await this.commandService.executeCommand('workbench.action.positron.openHelp');
+
 				// Add the help entry.
 				this.addHelpEntry(helpEntry);
 


### PR DESCRIPTION
When a show help event arrives from the language runtime service, make sure the auxiliary bar is showing and the help view is open before rendering the help.

