### PR TITLE
Fix runtime state after an R crash.

### DIFF
--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import * as positron from 'positron';
 import { PromiseHandles } from './util';
 
 import {
@@ -114,7 +113,7 @@ export class ArkLsp implements vscode.Disposable {
 			traceOutputChannel: traceOutputChannel(),
 		};
 
-		trace(`Creating Positron R ${this._version} language client...`);
+		trace(`Creating Positron R ${this._version} language client (port ${port})...`);
 		this._client = new LanguageClient('positron-r', `Positron R Language Server (${this._version})`, serverOptions, clientOptions);
 
 		const out = new PromiseHandles<void>();
@@ -138,7 +137,7 @@ export class ArkLsp implements vscode.Disposable {
 				case State.Stopped:
 					if (this._initializing) {
 						trace(`ARK (R ${this._version}) language client init failed`);
-						out.reject("Ark LSP client stopped before initialization");
+						out.reject('Ark LSP client stopped before initialization');
 					}
 					this._state = LspState.stopped;
 					break;
@@ -161,13 +160,38 @@ export class ArkLsp implements vscode.Disposable {
 			return;
 		}
 
+		// If we don't need to stop the client, just resolve
+		if (!this._client.needsStop()) {
+			return;
+		}
+
 		// First wait for initialization to complete.
 		// `stop()` should not be called on a
 		// partially initialized client.
 		await this._initializing;
 
-		// Stop the client if it's running
-		await this._client.stop();
+		// The promise returned by `stop()` never resolves if the server side is
+		// disconnected, so rather than awaiting it, we wait for the client to
+		// change state to `stopped`, which does happen reliably.
+		const promise = new Promise<void>((resolve) => {
+			const disposable = this._client!.onDidChangeState((event) => {
+				if (event.newState === State.Stopped) {
+					resolve();
+					disposable.dispose();
+				}
+			});
+			this._client!.stop();
+		});
+
+		// Don't wait more than a couple of seconds for the client to stop.
+		const timeout = new Promise<void>((_, reject) => {
+			setTimeout(() => {
+				reject(`Timed out after 2 seconds waiting for client to stop.`);
+			}, 2000);
+		});
+
+		// Wait for the client to enter the stopped state, or for the timeout
+		await Promise.race([promise, timeout]);
 	}
 
 	/**


### PR DESCRIPTION
After an R crash and startup, the newly started instance of R doesn't work correctly (see #1038 for details).

This happens because when R crashes, the LSP client on the Positron side enters a broken state in which calling `stop()` returns a promise that never resolves. Since we use a `PQueue` for activation and deactivation, this unresolved promise blocks the queue forever and no further LSP activation or deactivation can be done.

The fix is as follows:
- Since `stop()`'s promise never resolves in this case, we listen for the `Stopped` state to arrive instead.
- A two-second timeout ensures that we never wait forever for the LSP to stop.
- Some cleanup to ensure event handlers are cleaned up after each activation and when the client is disposed.
 
Addresses https://github.com/rstudio/positron/issues/1038.

