### PR TITLE
Show runtime version in console

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceMenuButton.tsx
@@ -49,9 +49,14 @@ export const ConsoleInstanceMenuButton = (props: ConsoleInstanceMenuButtonProps)
 	};
 
 	// Render.
+	let runtimeLabel = 'None';
+	const runtime = positronConsoleContext.activePositronConsoleInstance?.runtime;
+	if (runtime) {
+		runtimeLabel = `${runtime.metadata.languageName} ${runtime.metadata.languageVersion}`;
+	}
 	return (
 		<ActionBarMenuButton
-			text={positronConsoleContext.activePositronConsoleInstance?.runtime.metadata.languageName ?? 'None'}
+			text={runtimeLabel}
 			actions={actions}
 		/>
 	);


### PR DESCRIPTION
Like this:

<img width="601" alt="image" src="https://github.com/rstudio/positron/assets/470418/55c2ba45-fe87-4173-973f-67e5a6bdc384">


Addresses https://github.com/rstudio/positron/issues/983.