### PR TITLE
Potential changes to address 979 and 1051

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -456,6 +456,10 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 			overviewRulerLanes: 0,
 			scrollBeyondLastLine: false,
 			lineNumbersMinChars: inputPrompt.length,
+			// This appears to disable validations to address:
+			// https://github.com/rstudio/positron/issues/979
+			// https://github.com/rstudio/positron/issues/1051
+			renderValidationDecorations: 'off',
 		} satisfies IEditorOptions;
 
 		// Create the code editor widget.


### PR DESCRIPTION
I need someone to verify that this does indeed stop syntax errors from appearing when you do something like:

```
flhewerlj =
```

in R and and

```
pip install
```

in Python.