### PR TITLE
Avoid driving focus to console on interpreter restart

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -406,8 +406,16 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 					break;
 
 				case RuntimeState.Ready:
+					if (runtime !== this._activeRuntime) {
+						// If this runtime isn't already active, activate it. We
+						// avoid re-activation if already active since the
+						// resulting events can cause Positron behave as though
+						// a new runtime were started (e.g. focusing the
+						// console)
+						this.activeRuntime = runtime;
+					}
+
 					// @TODO@softwarenerd - Talk with the team about this.
-					this.activeRuntime = runtime;
 					// // If the runtime is ready, and we have no active runtime,
 					// // set the active runtime to the new runtime.
 					// if (!this._activeRuntime || this._activeRuntime.metadata.languageId === runtime.metadata.languageId) {


### PR DESCRIPTION
This fixes an issue in which restarting an interpreter drives focus to the console.

It turned out that focus was being driven to the console because the interpreter, after becoming ready again, is re-selected as the active interpreter. That's the moral equivalent of clicking the interpreter in the top bar interpreter dropdown (which _does_ drive focus to the console, even if it is the current interpreter). 

The fix is pretty simple: we don't fire runtime activation events when the runtime becomes ready but is already the active runtime.

Addresses https://github.com/rstudio/positron/issues/927.