### PR TITLE
Fixes for 598

### DIFF
--- a/src/vs/workbench/common/contextkeys.ts
+++ b/src/vs/workbench/common/contextkeys.ts
@@ -97,6 +97,7 @@ export const StatusBarFocused = new RawContextKey<boolean>('statusBarFocused', f
 // --- Start Positron ---
 export const PositronTopActionBarFocused = new RawContextKey<boolean>('positronTopActionBarFocused', false, localize('positronTopActionBarFocused', "Whether the Positron top action bar has keyboard focus"));
 export const PositronTopActionBarVisibleContext = new RawContextKey<boolean>('positronTopActionBarVisible', true, localize('positronTopActionBarVisible', "Whether the Positron top action bar is visible"));
+export const PositronConsoleFocused = new RawContextKey<boolean>('positronConsoleFocused', false, localize('positronConsoleFocused', "Whether the Positron Console has keyboard focus"));
 export const PositronEnvironmentFocused = new RawContextKey<boolean>('positronEnvironmentFocused', false, localize('positronEnvironmentFocused', "Whether the Positron Environment has keyboard focus"));
 // --- End Positron ---
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -582,7 +582,7 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 
 		// Add the onDidClearConsole event handler.
 		disposableStore.add(props.positronConsoleInstance.onDidClearConsole(() => {
-			// Re-focus the console.
+			// Focus the code editor widget.
 			codeEditorWidget.focus();
 		}));
 
@@ -591,7 +591,7 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 			// Discard the history navigator.
 			setHistoryNavigator(undefined);
 
-			// Re-focus the console.
+			// Focus the code editor widget.
 			codeEditorWidget.focus();
 		}));
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -39,7 +39,7 @@ const enum Position {
 export interface ConsoleInputProps {
 	readonly width: number;
 	readonly positronConsoleInstance: IPositronConsoleInstance;
-	selectAll: () => void;
+	readonly selectAll: () => void;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -4,7 +4,7 @@
 
 import 'vs/css!./consoleInput';
 import * as React from 'react';
-import { FocusEvent, forwardRef, useEffect, useRef } from 'react'; // eslint-disable-line no-duplicate-imports
+import { FocusEvent, useEffect, useRef } from 'react'; // eslint-disable-line no-duplicate-imports
 import { URI } from 'vs/base/common/uri';
 import { Schemas } from 'vs/base/common/network';
 import { KeyCode } from 'vs/base/common/keyCodes';
@@ -47,7 +47,7 @@ export interface ConsoleInputProps {
  * @param props A ConsoleInputProps that contains the component properties.
  * @returns The rendered component.
  */
-export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props, consoleInputRef) => {
+export const ConsoleInput = (props: ConsoleInputProps) => {
 	// Context hooks.
 	const positronConsoleContext = usePositronConsoleContext();
 
@@ -542,6 +542,20 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 				})
 		);
 
+		// Add the onActivateInput event handler.
+		disposableStore.add(props.positronConsoleInstance.onActivateInput(() => {
+			codeEditorWidgetContainerRef.current?.scrollIntoView({ behavior: 'auto' });
+			codeEditorWidget.focus();
+		}));
+
+		// Add the onDidPasteText event handler.
+		disposableStore.add(props.positronConsoleInstance.onDidPasteText(text => {
+			const codeFragment = codeEditorWidgetRef.current.getValue();
+			codeEditorWidgetRef.current.setValue(codeFragment + text);
+			updateCodeEditorWidgetPosition(Position.Last, Position.Last);
+			codeEditorWidget.focus();
+		}));
+
 		// Add the onDidChangeState event handler.
 		disposableStore.add(props.positronConsoleInstance.onDidChangeState(state => {
 			// Set up editor options based on state.
@@ -663,8 +677,8 @@ export const ConsoleInput = forwardRef<HTMLDivElement, ConsoleInputProps>((props
 
 	// Render.
 	return (
-		<div ref={consoleInputRef} className='console-input' tabIndex={0} onFocus={focusHandler}>
+		<div className='console-input' tabIndex={0} onFocus={focusHandler}>
 			<div ref={codeEditorWidgetContainerRef} />
 		</div>
 	);
-});
+};

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -3,9 +3,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./consoleInstance';
-import * as nls from 'vs/nls';
 import * as React from 'react';
 import { KeyboardEvent, MouseEvent, UIEvent, useEffect, useRef, useState } from 'react'; // eslint-disable-line no-duplicate-imports
+import * as nls from 'vs/nls';
 import { generateUuid } from 'vs/base/common/uuid';
 import { PixelRatio } from 'vs/base/browser/browser';
 import { isMacintosh } from 'vs/base/common/platform';
@@ -40,7 +40,7 @@ import { RuntimeItemReconnected } from 'vs/workbench/services/positronConsole/co
 import { RuntimeStartupFailure } from 'vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure';
 import { IPositronConsoleInstance } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
 import { RuntimeItemStartupFailure } from 'vs/workbench/services/positronConsole/common/classes/runtimeItemStartupFailure';
-import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
+import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_CUT, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
 
 // ConsoleInstanceProps interface.
 interface ConsoleInstanceProps {
@@ -116,8 +116,20 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 		// Get the selection.
 		const selection = getSelection();
 
-		// Add the copy action.
+		// The actions that are built below.
 		const actions: IAction[] = [];
+
+		// Add the cut action.
+		actions.push({
+			id: POSITRON_CONSOLE_CUT,
+			label: nls.localize('positron.console.cut', "Cut"),
+			tooltip: '',
+			class: undefined,
+			enabled: false,
+			run: () => { }
+		});
+
+		// Add the copy action.
 		actions.push({
 			id: POSITRON_CONSOLE_COPY,
 			label: nls.localize('positron.console.copy', "Copy"),
@@ -132,8 +144,8 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			}
 		});
 
-		// Get the clipboard text.
-		const clipboardText = await positronConsoleContext.clipboardService.readText();
+		// // Get the clipboard text.
+		// const clipboardText = await positronConsoleContext.clipboardService.readText();
 
 		// Add the paste action.
 		actions.push({
@@ -141,10 +153,8 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			label: nls.localize('positron.console.paste', "Paste"),
 			tooltip: '',
 			class: undefined,
-			enabled: clipboardText !== '',
-			run: () => {
-				consoleInputRef.current?.focus();
-			}
+			enabled: false,
+			run: () => { }
 		});
 
 		// Push a separator.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -119,7 +119,9 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 		// The actions that are built below.
 		const actions: IAction[] = [];
 
-		// Add the cut action.
+		// Add the cut action. This action is never enabled here. It exists here so that the user
+		// will see a consistent set of Cut, Copy, Paste actions in this context menu and the code
+		// editor widget's context menu.
 		actions.push({
 			id: POSITRON_CONSOLE_CUT,
 			label: nls.localize('positron.console.cut', "Cut"),

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -3,12 +3,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./consoleInstance';
+import * as nls from 'vs/nls';
 import * as React from 'react';
 import { KeyboardEvent, MouseEvent, UIEvent, useEffect, useRef, useState } from 'react'; // eslint-disable-line no-duplicate-imports
 import { generateUuid } from 'vs/base/common/uuid';
 import { PixelRatio } from 'vs/base/browser/browser';
 import { isMacintosh } from 'vs/base/common/platform';
 import { DisposableStore } from 'vs/base/common/lifecycle';
+import { IAction, Separator } from 'vs/base/common/actions';
 import { useStateRef } from 'vs/base/browser/ui/react/useStateRef';
 import { applyFontInfo } from 'vs/editor/browser/config/domFontInfo';
 import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
@@ -16,6 +18,7 @@ import { BareFontInfo, FontInfo } from 'vs/editor/common/config/fontInfo';
 import { FontMeasurements } from 'vs/editor/browser/config/fontMeasurements';
 import { IReactComponentContainer } from 'vs/base/browser/positronReactRenderer';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { AnchorAlignment, AnchorAxisAlignment } from 'vs/base/browser/ui/contextview/contextview';
 import { ConsoleInput } from 'vs/workbench/contrib/positronConsole/browser/components/consoleInput';
 import { RuntimeTrace } from 'vs/workbench/contrib/positronConsole/browser/components/runtimeTrace';
 import { RuntimeExited } from 'vs/workbench/contrib/positronConsole/browser/components/runtimeExited';
@@ -37,6 +40,7 @@ import { RuntimeItemReconnected } from 'vs/workbench/services/positronConsole/co
 import { RuntimeStartupFailure } from 'vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure';
 import { IPositronConsoleInstance } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
 import { RuntimeItemStartupFailure } from 'vs/workbench/services/positronConsole/common/classes/runtimeItemStartupFailure';
+import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
 
 // ConsoleInstanceProps interface.
 interface ConsoleInstanceProps {
@@ -101,6 +105,68 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 
 		// Return the selection.
 		return selection;
+	};
+
+	/**
+	 * Shows the context menu.
+	 * @param x The x coordinate.
+	 * @param y The y coordinate.
+	 */
+	const showContextMenu = async (x: number, y: number): Promise<void> => {
+		// Get the selection.
+		const selection = getSelection();
+
+		// Add the copy action.
+		const actions: IAction[] = [];
+		actions.push({
+			id: POSITRON_CONSOLE_COPY,
+			label: nls.localize('positron.console.copy', "Copy"),
+			tooltip: '',
+			class: undefined,
+			enabled: selection?.type === 'Range',
+			run: () => {
+				// Copy the selection to the clipboard.
+				if (selection) {
+					positronConsoleContext.clipboardService.writeText(selection.toString());
+				}
+			}
+		});
+
+		// Get the clipboard text.
+		const clipboardText = await positronConsoleContext.clipboardService.readText();
+
+		// Add the paste action.
+		actions.push({
+			id: POSITRON_CONSOLE_PASTE,
+			label: nls.localize('positron.console.paste', "Paste"),
+			tooltip: '',
+			class: undefined,
+			enabled: clipboardText !== '',
+			run: () => {
+				consoleInputRef.current?.focus();
+			}
+		});
+
+		// Push a separator.
+		actions.push(new Separator());
+
+		// Add the select all action.
+		actions.push({
+			id: POSITRON_CONSOLE_SELECT_ALL,
+			label: nls.localize('positron.console.selectAll', "Select All"),
+			tooltip: '',
+			class: undefined,
+			enabled: true,
+			run: () => selectAllRuntimeItems()
+		});
+
+		// Show the context menu.
+		positronConsoleContext.contextMenuService.showContextMenu({
+			getActions: () => actions,
+			getAnchor: () => ({ x, y }),
+			anchorAlignment: AnchorAlignment.LEFT,
+			anchorAxisAlignment: AnchorAxisAlignment.VERTICAL
+		});
 	};
 
 	/**
@@ -190,21 +256,6 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	}, [marker]);
 
 	/**
-	 * onClick event handler.
-	 * @param e A MouseEvent<HTMLElement> that describes a user interaction with the mouse.
-	 */
-	const clickHandler = (e: MouseEvent<HTMLDivElement>) => {
-		// Get the document selection.
-		const selection = getSelection();
-
-		// If there is a selection, and its type is Caret (as opposed to Range), drive focus into
-		// the console input.
-		if (!selection || selection.type === 'Caret') {
-			consoleInputRef.current?.focus();
-		}
-	};
-
-	/**
 	 * onKeyDown event handler.
 	 * @param e A KeyboardEvent<HTMLDivElement> that describes a user interaction with the keyboard.
 	 */
@@ -280,6 +331,13 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	 * @param e A MouseEvent<HTMLElement> that describes a user interaction with the mouse.
 	 */
 	const mouseDownHandler = (e: MouseEvent<HTMLDivElement>) => {
+		// Show the context menu.
+		if ((e.button === 0 && isMacintosh && e.ctrlKey) || e.button === 2) {
+			// Do this on the next tick. Otherwise, the document selection won't be up to date.
+			setTimeout(async () => await showContextMenu(e.clientX, e.clientY), 0);
+			return;
+		}
+
 		// Get the selection.
 		const selection = getSelection();
 
@@ -318,10 +376,8 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			// If the click was inside the selection, copy the selection to the clipboard.
 			if (insideSelection) {
 				positronConsoleContext.clipboardService.writeText(selection.toString());
+				return;
 			}
-
-			// Drive focus into the console input.
-			consoleInputRef.current?.focus();
 		}
 	};
 
@@ -343,9 +399,13 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 		<div
 			ref={consoleInstanceRef}
 			className='console-instance'
-			style={{ width: adjustedWidth, height: props.height, whiteSpace: wordWrap ? 'pre-wrap' : 'pre', zIndex: props.active ? 'auto' : -1 }}
+			style={{
+				width: adjustedWidth,
+				height: props.height,
+				whiteSpace: wordWrap ? 'pre-wrap' : 'pre',
+				zIndex: props.active ? 'auto' : -1
+			}}
 			tabIndex={0}
-			onClick={clickHandler}
 			onKeyDown={keyDownHandler}
 			onMouseDown={mouseDownHandler}
 			onScroll={scrollHandler}>

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
@@ -15,7 +15,7 @@ import { registerPositronConsoleActions } from 'vs/workbench/contrib/positronCon
 import { POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
 import { ICommandAndKeybindingRule, KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
-import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
+import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_CUT, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
 
 // The Positron console view icon.
 const positronConsoleViewIcon = registerIcon(
@@ -56,6 +56,15 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 		order: 3,
 	}
 }], VIEW_CONTAINER);
+
+// Register keybinding rule for copy.
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: POSITRON_CONSOLE_CUT,
+	weight: KeybindingWeight.WorkbenchContrib,
+	primary: KeyMod.CtrlCmd | KeyCode.KeyV,
+	when: PositronConsoleFocused,
+	handler: accessor => { }
+} satisfies ICommandAndKeybindingRule);
 
 // Register keybinding rule for copy.
 KeybindingsRegistry.registerCommandAndKeybindingRule({

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
@@ -57,7 +57,7 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 	}
 }], VIEW_CONTAINER);
 
-// Register keybinding rule for copy.
+// Register keybinding rule for cut.
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: POSITRON_CONSOLE_CUT,
 	weight: KeybindingWeight.WorkbenchContrib,
@@ -84,7 +84,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	handler: accessor => { }
 } satisfies ICommandAndKeybindingRule);
 
-// Register keybinding rule for paste.
+// Register keybinding rule for select all.
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: POSITRON_CONSOLE_SELECT_ALL,
 	weight: KeybindingWeight.WorkbenchContrib,

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
@@ -61,7 +61,7 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: POSITRON_CONSOLE_CUT,
 	weight: KeybindingWeight.WorkbenchContrib,
-	primary: KeyMod.CtrlCmd | KeyCode.KeyV,
+	primary: KeyMod.CtrlCmd | KeyCode.KeyX,
 	when: PositronConsoleFocused,
 	handler: accessor => { }
 } satisfies ICommandAndKeybindingRule);

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
@@ -4,17 +4,25 @@
 
 import * as nls from 'vs/nls';
 import { Codicon } from 'vs/base/common/codicons';
+import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
+import { PositronConsoleFocused } from 'vs/workbench/common/contextkeys';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { ViewPaneContainer } from 'vs/workbench/browser/parts/views/viewPaneContainer';
 import { PositronConsoleViewPane } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleView';
 import { registerPositronConsoleActions } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleActions';
-import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
 import { POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
+import { ICommandAndKeybindingRule, KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
+import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
 
 // The Positron console view icon.
-const positronConsoleViewIcon = registerIcon('positron-console-view-icon', Codicon.positronConsoleView, nls.localize('positronConsoleViewIcon', 'View icon of the Positron console view.'));
+const positronConsoleViewIcon = registerIcon(
+	'positron-console-view-icon',
+	Codicon.positronConsoleView,
+	nls.localize('positronConsoleViewIcon', 'View icon of the Positron console view.')
+);
 
 // Register the Positron console view container.
 const VIEW_CONTAINER: ViewContainer = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry).registerViewContainer({
@@ -48,6 +56,33 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 		order: 3,
 	}
 }], VIEW_CONTAINER);
+
+// Register keybinding rule for copy.
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: POSITRON_CONSOLE_COPY,
+	weight: KeybindingWeight.WorkbenchContrib,
+	primary: KeyMod.CtrlCmd | KeyCode.KeyC,
+	when: PositronConsoleFocused,
+	handler: accessor => { }
+} satisfies ICommandAndKeybindingRule);
+
+// Register keybinding rule for paste.
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: POSITRON_CONSOLE_PASTE,
+	weight: KeybindingWeight.WorkbenchContrib,
+	primary: KeyMod.CtrlCmd | KeyCode.KeyV,
+	when: PositronConsoleFocused,
+	handler: accessor => { }
+} satisfies ICommandAndKeybindingRule);
+
+// Register keybinding rule for paste.
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: POSITRON_CONSOLE_SELECT_ALL,
+	weight: KeybindingWeight.WorkbenchContrib,
+	primary: KeyMod.CtrlCmd | KeyCode.KeyA,
+	when: PositronConsoleFocused,
+	handler: accessor => { }
+} satisfies ICommandAndKeybindingRule);
 
 // Register all the Positron console actions.
 registerPositronConsoleActions();

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // Identifiers.
-export const POSITRON_CONSOLE_CUT = 'positron.console.copy';
+export const POSITRON_CONSOLE_CUT = 'positron.console.cut';
 export const POSITRON_CONSOLE_COPY = 'positron.console.copy';
 export const POSITRON_CONSOLE_PASTE = 'positron.console.paste';
 export const POSITRON_CONSOLE_SELECT_ALL = 'positron.console.selectAll';

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// Identifiers.
+export const POSITRON_CONSOLE_COPY = 'positron.console.copy';
+export const POSITRON_CONSOLE_PASTE = 'positron.console.paste';
+export const POSITRON_CONSOLE_SELECT_ALL = 'positron.console.selectAll';

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers.ts
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // Identifiers.
+export const POSITRON_CONSOLE_CUT = 'positron.console.copy';
 export const POSITRON_CONSOLE_COPY = 'positron.console.copy';
 export const POSITRON_CONSOLE_PASTE = 'positron.console.paste';
 export const POSITRON_CONSOLE_SELECT_ALL = 'positron.console.selectAll';

--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariableGroup.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariableGroup.tsx
@@ -94,6 +94,8 @@ export const EnvironmentVariableGroup = (props: EnvironmentVariableGroupProps) =
 
 	/**
 	 * Shows the context menu.
+	 * @param x The x coordinate.
+	 * @param y The y coordinate.
 	 */
 	const showContextMenu = (x: number, y: number) => {
 		// Build the actions.

--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariableItem.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentVariableItem.tsx
@@ -166,6 +166,8 @@ export const EnvironmentVariableItem = (props: EnvironmentVariableItemProps) => 
 
 	/**
 	 * Shows the context menu.
+	 * @param x The x coordinate.
+	 * @param y The y coordinate.
 	 */
 	const showContextMenu = (x: number, y: number) => {
 		// Build the actions.

--- a/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
@@ -106,6 +106,11 @@ export interface IPositronConsoleInstance {
 	readonly promptActive: boolean;
 
 	/**
+	 * The onActivateInput event.
+	 */
+	readonly onActivateInput: Event<void>;
+
+	/**
 	 * The onDidChangeState event.
 	 */
 	readonly onDidChangeState: Event<PositronConsoleState>;
@@ -126,6 +131,11 @@ export interface IPositronConsoleInstance {
 	readonly onDidChangeRuntimeItems: Event<RuntimeItem[]>;
 
 	/**
+	 * The onDidPasteText event.
+	 */
+	readonly onDidPasteText: Event<string>;
+
+	/**
 	 * The onDidClearConsole event.
 	 */
 	readonly onDidClearConsole: Event<void>;
@@ -141,6 +151,11 @@ export interface IPositronConsoleInstance {
 	readonly onDidExecuteCode: Event<string>;
 
 	/**
+	 * Activates the input for the console.
+	 */
+	activateInput(): void;
+
+	/**
 	 * Toggles trace.
 	 */
 	toggleTrace(): void;
@@ -149,6 +164,11 @@ export interface IPositronConsoleInstance {
 	 * Toggles word wrap.
 	 */
 	toggleWordWrap(): void;
+
+	/**
+	 * Pastes text into the console.
+	 */
+	pasteText(text: string): void;
 
 	/**
 	 * Clears the console.

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -20,6 +20,7 @@ import { ActivityItemPrompt } from 'vs/workbench/services/positronConsole/common
 import { RuntimeItemStarting } from 'vs/workbench/services/positronConsole/common/classes/runtimeItemStarting';
 import { ActivityItemOutputPlot } from 'vs/workbench/services/positronConsole/common/classes/activityItemOutputPlot';
 import { RuntimeItemReconnected } from 'vs/workbench/services/positronConsole/common/classes/runtimeItemReconnected';
+import { ActivityItemOutputHtml } from 'vs/workbench/services/positronConsole/common/classes/activityItemOutputHtml';
 import { ActivityItemErrorStream } from 'vs/workbench/services/positronConsole/common/classes/activityItemErrorStream';
 import { ActivityItemOutputStream } from 'vs/workbench/services/positronConsole/common/classes/activityItemOutputStream';
 import { ActivityItemErrorMessage } from 'vs/workbench/services/positronConsole/common/classes/activityItemErrorMessage';
@@ -28,7 +29,6 @@ import { RuntimeItemStartupFailure } from 'vs/workbench/services/positronConsole
 import { ActivityItem, RuntimeItemActivity } from 'vs/workbench/services/positronConsole/common/classes/runtimeItemActivity';
 import { IPositronConsoleInstance, IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID, PositronConsoleState } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
 import { formatLanguageRuntime, ILanguageRuntime, ILanguageRuntimeMessage, ILanguageRuntimeService, LanguageRuntimeStartupBehavior, RuntimeOnlineState, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
-import { ActivityItemOutputHtml } from 'vs/workbench/services/positronConsole/common/classes/activityItemOutputHtml';
 
 //#region Helper Functions
 

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -441,6 +441,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	private _promptActive = false;
 
 	/**
+	 * The onActivateInput event emitter.
+	 */
+	private readonly _onActivateInputEmitter = this._register(new Emitter<void>);
+
+	/**
 	 * The onDidChangeState event emitter.
 	 */
 	private readonly _onDidChangeStateEmitter = this._register(new Emitter<PositronConsoleState>);
@@ -459,6 +464,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * The onDidChangeRuntimeItems event emitter.
 	 */
 	private readonly _onDidChangeRuntimeItemsEmitter = this._register(new Emitter<RuntimeItem[]>);
+
+	/**
+	 * The onDidPasteText event emitter.
+	 */
+	private readonly _onDidPasteTextEmitter = this._register(new Emitter<string>);
 
 	/**
 	 * The onDidClearConsole event emitter.
@@ -553,6 +563,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	}
 
 	/**
+	 * onActivateInput event.
+	 */
+	readonly onActivateInput: Event<void> = this._onActivateInputEmitter.event;
+
+	/**
 	 * onDidChangeState event.
 	 */
 	readonly onDidChangeState: Event<PositronConsoleState> = this._onDidChangeStateEmitter.event;
@@ -573,6 +588,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	readonly onDidChangeRuntimeItems: Event<RuntimeItem[]> = this._onDidChangeRuntimeItemsEmitter.event;
 
 	/**
+	 * onDidPasteText event.
+	 */
+	readonly onDidPasteText: Event<string> = this._onDidPasteTextEmitter.event;
+
+	/**
 	 * onDidClearConsole event.
 	 */
 	readonly onDidClearConsole: Event<void> = this._onDidClearConsoleEmitter.event;
@@ -588,6 +608,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	readonly onDidExecuteCode: Event<string> = this._onDidExecuteCodeEmitter.event;
 
 	/**
+	 * Activates the input for the console.
+	 */
+	activateInput(): void {
+		this._onActivateInputEmitter.fire();
+	}
+
+	/**
 	 * Toggles trace.
 	 */
 	toggleTrace(): void {
@@ -601,6 +628,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	toggleWordWrap(): void {
 		this._wordWrap = !this._wordWrap;
 		this._onDidChangeWordWrapEmitter.fire(this._wordWrap);
+	}
+
+	/**
+	 * Pastes text into the console.
+	 */
+	pasteText(text: string): void {
+		this._onDidPasteTextEmitter.fire(text);
 	}
 
 	/**


### PR DESCRIPTION
This PR addresses #598. In addition to fixing the "jumpy behavior" described in the bug, it also introduces a context menu for the console, something that has been missing for months:

<img width="506" alt="image" src="https://github.com/rstudio/positron/assets/853239/52827a83-b9e3-4de5-8bf4-68cd2164ed16">


The console context menu is made to match up well to the code editor widget context menu:

<img width="397" alt="image" src="https://github.com/rstudio/positron/assets/853239/937ff880-483c-456f-b853-8268dc47e954">

So it contains Cut, Copy, Paste, and Select All. Cut is always disabled in the console context menu because one cannot cut text from the console output. (This matches up to what RStudio's context menu feels like.)

When the user scrolls the console to some area, they can click away to their heart's content - selecting words, selecting ranges, deselecting, reselecting, and so on. Clicking in console output _never_ drives focus to the code editor widget or scrolls the window. This is how Terminals behave. This is how RStudio behaves. I believe what we're doing now very closely matches what people expect.

Here's a little movie showing some of this:

https://github.com/rstudio/positron/assets/853239/d7676dd8-b222-4245-9c05-4696da88695d

It's hard to record every interaction.

One final note is that I took this opportunity to get rid of the `forwardRef` in `ConsoleInput`. Instead of using this `forwardRef`, I am using a set of events in the IPositronConsoleInstance.
