### PR TITLE
This appears to address #1109

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -199,6 +199,8 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 
 				// Raise the Plots pane so the plot is visible
 				this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+
+				//shit
 			}
 		}));
 
@@ -217,6 +219,9 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 			if (imageKey) {
 				this.registerStaticPlot(runtime.metadata.runtimeId, message, code);
 			}
+
+			// Raise the Plots pane so the plot is visible
+			this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
 		}));
 	}
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -199,8 +199,6 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 
 				// Raise the Plots pane so the plot is visible
 				this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
-
-				//shit
 			}
 		}));
 


### PR DESCRIPTION
This fix addresses #1109.

I was only able to reproduce this issue by forcing the auxiliary bar to be hidden by default in `layout.ts`. I verified then that showing dynamic and static plots resulted in the auxiliary bar and plots view being shown.

To verify this yourself, find:

```
		// --- Start Positron ---
		LayoutStateKeys.AUXILIARYBAR_HIDDEN.defaultValue = false;
```

And set it to true for testing.
