### PR TITLE
Only await LSP stop when kernel is online

### DIFF
--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -129,7 +129,7 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 	async restart(): Promise<void> {
 		if (this._kernel) {
 			// Stop the LSP client before restarting the kernel
-			await this._lsp.deactivate();
+			await this._lsp.deactivate(true);
 			return this._kernel.restart();
 		} else {
 			throw new Error('Cannot restart; kernel not started');
@@ -139,7 +139,7 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 	async shutdown(): Promise<void> {
 		if (this._kernel) {
 			// Stop the LSP client before shutting down the kernel
-			await this._lsp.deactivate();
+			await this._lsp.deactivate(true);
 			return this._kernel.shutdown();
 		} else {
 			throw new Error('Cannot shutdown; kernel not started');
@@ -195,7 +195,7 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 					if (this._kernel) {
 						this._kernel.emitJupyterLog(`Stopping Positron LSP server`);
 					}
-					await this._lsp.deactivate();
+					await this._lsp.deactivate(false);
 				});
 			}
 		}


### PR DESCRIPTION
Addresses an issue noted by @lionel- in https://github.com/rstudio/positron/issues/1038. 

In the cases of repeated, aggressive restarts, it is important to wait for the LSP to fully stop before attempting to start it again. It turns out that the only way to do this reliably is to wait for the `stop()` method to resolve (as it was before).

Therefore, we now need two codepaths -- one that we use it's safe to wait for `stop()` to return, and another that we use to shut down the LSP when the kernel has already exited. In both cases, we keep the new 2s timeout to keep the queue from getting blocked indefinitely.