### PR TITLE
Another try at detecting whether we are in an R package

### DIFF
--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -103,7 +103,9 @@ async function detectRPackage(): Promise<boolean> {
 			const descriptionLines = descriptionText.split(/(\r?\n)/);
 			const packageLines = descriptionLines.filter(line => line.startsWith('Package:'));
 			const typeLines = descriptionLines.filter(line => line.startsWith('Type:'));
-			const typeIsPackage = typeLines[0].toLowerCase().includes('package');
+			const typeIsPackage = (typeLines.length > 0
+				? typeLines[0].toLowerCase().includes('package')
+				: false);
 			const typeIsPackageOrMissing = typeLines.length === 0 || typeIsPackage;
 			return packageLines.length > 0 && typeIsPackageOrMissing;
 		} catch { }


### PR DESCRIPTION
Addresses #1138 

I will be honest that I could not reproduce what you saw @DavisVaughan (really did work as expected for me) but this change here will hopefully fix the detection in a more robust way.

Do you mind checking it out in the same way you did before, Davis?
