### PR TITLE
Follow more conventions; treat `Roxygen:` field as R code

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -172,8 +172,8 @@
       },
       {
         "language": "debian-control-file",
-        "scopeName": "debian-control-file",
-        "path": "./syntaxes/dcf.tmGrammar.json",
+        "scopeName": "source.dcf",
+        "path": "./syntaxes/dcf.tmLanguage.json",
         "embeddedLanguages": {
           "meta.embedded.block.r": "r"
         }

--- a/extensions/positron-r/syntaxes/dcf.tmLanguage.json
+++ b/extensions/positron-r/syntaxes/dcf.tmLanguage.json
@@ -1,5 +1,5 @@
 {
-	"scopeName": "debian-control-file",
+	"scopeName": "source.dcf",
 	"patterns": [
 		{
 			"include": "#keyword"
@@ -22,7 +22,7 @@
 			"patterns": [
 				{
 					"comment": "keyword",
-					"match": "^(?!(Authors@R:|linters:|exclusions:)).*?:",
+					"match": "^(?!(Authors@R:|linters:|exclusions:|Roxygen:)).*?:",
 					"name": "keyword.control"
 				}
 			]
@@ -62,7 +62,7 @@
 			],
 			"repository": {
 				"code-block-r": {
-					"begin": "^(Authors@R:|linters:|exclusions:)",
+					"begin": "^(Authors@R:|linters:|exclusions:|Roxygen:)",
 					"beginCaptures": {
 						"1": {
 							"name": "keyword.control"


### PR DESCRIPTION
Some picky little changes in the Debian Control language configuration, mostly motivated by reading more about Textmate grammar conventions.