### PR TITLE
"Preview" pane => "Viewer" pane

### DIFF
--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreview.contribution.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreview.contribution.ts
@@ -28,7 +28,7 @@ const positronPreviewViewIcon = registerIcon('positron-preview-view-icon', Codic
 // Register the Positron preview container.
 const VIEW_CONTAINER: ViewContainer = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry).registerViewContainer({
 	id: POSITRON_PREVIEW_VIEW_ID,
-	title: nls.localize('positron.preview', "Preview"),
+	title: nls.localize('positron.viewer', "Viewer"),
 	icon: positronPreviewViewIcon,
 	order: 3,
 	ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [POSITRON_PREVIEW_VIEW_ID, { mergeViewWithContainerWhenSingleView: true }]),


### PR DESCRIPTION
Makes the user-facing name of the "Preview" pane the "Viewer" pane. Doesn't change anything else.

Addresses https://github.com/rstudio/positron/issues/1149.