### PR TITLE
Include the `patch` version in the R version

### DIFF
--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -76,7 +76,7 @@ export class RInstallation {
 
 		const versionPart = builtParts[0];
 		this.semVersion = semver.coerce(versionPart) ?? new semver.SemVer('0.0.1');
-		this.version = `${semver.major(this.semVersion)}.${semver.minor(this.semVersion)}`;
+		this.version = `${semver.major(this.semVersion)}.${semver.minor(this.semVersion)}.${semver.patch(this.semVersion)}`;
 
 		const platformPart = builtParts[1];
 		const architecture = platformPart.match('^(aarch64|x86_64)');


### PR DESCRIPTION
Follow up to https://github.com/posit-dev/positron/issues/983#issuecomment-1693573070

Here are a few places we now show the patch version:

<img width="239" alt="Screenshot 2023-08-25 at 12 41 30 PM" src="https://github.com/posit-dev/positron/assets/19150088/d3c2ba62-9e31-439d-b165-96c27b64ab8e">

<img width="320" alt="Screenshot 2023-08-25 at 12 41 39 PM" src="https://github.com/posit-dev/positron/assets/19150088/20d98d18-63db-4ac7-8fd7-5bc2b139debf">

<img width="221" alt="Screenshot 2023-08-25 at 12 41 58 PM" src="https://github.com/posit-dev/positron/assets/19150088/c36b4047-526c-4aff-b329-aaaa8f449607">

I think this is useful for a few reasons:
- We now align with what R shows in its startup message, for consistency (see the 3rd image)
- We align with what we show for Python
- As package devs, we often request users report their full R version when debugging an issue, and this makes that easily accessible

I swear I thought rig would allow you to have 2 of the same minor (but different patch) versions of R installed, but that doesn't seem to be the case. Regardless I still think this is worth it.