### PR TITLE
Fixes for 1058

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.css
@@ -28,7 +28,7 @@
 	}
 }
 
-.activity-input.busy .progress-bar {
+.activity-input.executing .progress-bar {
 	background-color: var(--vscode-positronConsole-ansiGreen);
 	animation-name: pulseAnimation;
 	animation-duration: 1s;

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
@@ -4,10 +4,12 @@
 
 import 'vs/css!./activityInput';
 import * as React from 'react';
+import { useState } from 'react'; // eslint-disable-line no-duplicate-imports
+import { DisposableStore } from 'vs/base/common/lifecycle';
 import { FontInfo } from 'vs/editor/common/config/fontInfo';
+import { positronClassNames } from 'vs/base/common/positronUtilities';
 import { OutputRun } from 'vs/workbench/contrib/positronConsole/browser/components/outputRun';
 import { ActivityItemInput } from 'vs/workbench/services/positronConsole/common/classes/activityItemInput';
-import { DisposableStore } from 'vs/base/common/lifecycle';
 
 // ActivityInputProps interface.
 export interface ActivityInputProps {
@@ -21,37 +23,42 @@ export interface ActivityInputProps {
  * @returns The rendered component.
  */
 export const ActivityInput = (props: ActivityInputProps) => {
+	// Hooks.
+	const [busyState, setBusyState] = useState(props.activityItemInput.busyState);
+	const [codeOutputLines, setCodeOutputLines] = useState(props.activityItemInput.codeOutputLines);
+
+	// Main useEffect.
+	React.useEffect(() => {
+		// Create the disposable store for cleanup.
+		const disposableStore = new DisposableStore();
+
+		// Listen for the changes to the activity item input.
+		disposableStore.add(props.activityItemInput.onChanged(() => {
+			setBusyState(props.activityItemInput.busyState);
+			setCodeOutputLines(props.activityItemInput.codeOutputLines);
+		}));
+
+		// Return the cleanup function that will dispose of the disposables.
+		return () => disposableStore.dispose();
+	}, []);
+
 	// Calculate the prompt width.
 	const promptWidth = Math.ceil(
 		(props.activityItemInput.inputPrompt.length + 1) *
 		props.fontInfo.typicalHalfwidthCharacterWidth
 	);
 
-	const activityRef = React.useRef<HTMLDivElement>(undefined!);
-
-	React.useEffect(() => {
-		const disposables = new DisposableStore();
-		// Listen for the busy state to change on the activity item; when it
-		// does, update the `busy` class on the activity input.
-		disposables.add(props.activityItemInput.onBusyStateChanged((busy: boolean) => {
-			if (busy) {
-				activityRef.current?.classList.add('busy');
-			} else {
-				activityRef.current?.classList.remove('busy');
-			}
-		}));
-		return () => disposables.dispose();
-	}, [props.activityItemInput]);
+	// Generate the class names.
+	const classNames = positronClassNames(
+		'activity-input',
+		{ 'busy': busyState }
+	);
 
 	// Render.
 	return (
-		<div ref={activityRef}
-			className={
-				'activity-input' +
-				(props.activityItemInput.busyState ?
-					' busy' : '')}>
-			<div className='progress-bar'></div>
-			{props.activityItemInput.codeOutputLines.map((outputLine, index) =>
+		<div className={classNames}>
+			{busyState && <div className='progress-bar' />}
+			{codeOutputLines.map((outputLine, index) =>
 				<div key={outputLine.id}>
 					<span style={{ width: promptWidth }}>
 						{(index === 0 ?

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
@@ -32,7 +32,7 @@ export const ActivityInput = (props: ActivityInputProps) => {
 		// Create the disposable store for cleanup.
 		const disposableStore = new DisposableStore();
 
-		// Listen for the changes to the activity item input.
+		// Listen for the changes to the item.
 		disposableStore.add(props.activityItemInput.onChanged(() => {
 			setExecuting(props.activityItemInput.executing);
 			setCodeOutputLines(props.activityItemInput.codeOutputLines);

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
@@ -24,7 +24,7 @@ export interface ActivityInputProps {
  */
 export const ActivityInput = (props: ActivityInputProps) => {
 	// Hooks.
-	const [busyState, setBusyState] = useState(props.activityItemInput.busyState);
+	const [executing, setExecuting] = useState(props.activityItemInput.executing);
 	const [codeOutputLines, setCodeOutputLines] = useState(props.activityItemInput.codeOutputLines);
 
 	// Main useEffect.
@@ -34,7 +34,7 @@ export const ActivityInput = (props: ActivityInputProps) => {
 
 		// Listen for the changes to the activity item input.
 		disposableStore.add(props.activityItemInput.onChanged(() => {
-			setBusyState(props.activityItemInput.busyState);
+			setExecuting(props.activityItemInput.executing);
 			setCodeOutputLines(props.activityItemInput.codeOutputLines);
 		}));
 
@@ -51,13 +51,13 @@ export const ActivityInput = (props: ActivityInputProps) => {
 	// Generate the class names.
 	const classNames = positronClassNames(
 		'activity-input',
-		{ 'busy': busyState }
+		{ 'executing': executing }
 	);
 
 	// Render.
 	return (
 		<div className={classNames}>
-			{busyState && <div className='progress-bar' />}
+			{executing && <div className='progress-bar' />}
 			{codeOutputLines.map((outputLine, index) =>
 				<div key={outputLine.id}>
 					<span style={{ width: promptWidth }}>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -152,7 +152,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			}
 		}
 
-		props.positronConsoleInstance.executeCodex11mnt(code);
+		props.positronConsoleInstance.executeCode(code);
 
 		// Reset the code input state.
 		setCurrentCodeFragment(undefined);

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -24,13 +24,13 @@ import { MarkerController } from 'vs/editor/contrib/gotoError/browser/gotoError'
 import { SuggestController } from 'vs/editor/contrib/suggest/browser/suggestController';
 import { SnippetController2 } from 'vs/editor/contrib/snippet/browser/snippetController2';
 import { ContextMenuController } from 'vs/editor/contrib/contextmenu/browser/contextmenu';
+import { EditOperation, ISingleEditOperation } from 'vs/editor/common/core/editOperation';
 import { TabCompletionController } from 'vs/workbench/contrib/snippets/browser/tabCompletion';
 import { IInputHistoryEntry } from 'vs/workbench/contrib/executionHistory/common/executionHistoryService';
 import { SelectionClipboardContributionID } from 'vs/workbench/contrib/codeEditor/browser/selectionClipboard';
 import { usePositronConsoleContext } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleContext';
+import { RuntimeCodeFragmentStatus } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IPositronConsoleInstance, PositronConsoleState } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
-import { RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
-import { EditOperation, ISingleEditOperation } from 'vs/editor/common/core/editOperation';
 
 // Position enumeration.
 const enum Position {
@@ -94,15 +94,11 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 	 * Executes the code editor widget's code, if possible.
 	 */
 	const executeCodeEditorWidgetCodeIfPossible = async () => {
-		// Get the code fragment from the code editor widget.
-		const codeFragment = codeEditorWidgetRef.current.getValue();
+		// Get the code from the code editor widget.
+		const code = codeEditorWidgetRef.current.getValue();
 
-		// Check on whether the code fragment is complete and can be executed.
-		const runtimeCodeFragmentStatus = await props.positronConsoleInstance.runtime.
-			isCodeFragmentComplete(codeFragment);
-
-		// Handle the runtime code fragment status.
-		switch (runtimeCodeFragmentStatus) {
+		// Check on whether the code is complete and can be executed.
+		switch (await props.positronConsoleInstance.runtime.isCodeFragmentComplete(code)) {
 			// If the code fragment is complete, execute it.
 			case RuntimeCodeFragmentStatus.Complete:
 				break;
@@ -112,7 +108,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			case RuntimeCodeFragmentStatus.Incomplete: {
 				// For the moment, this works. Ideally, we'd like to have the current code fragment
 				// prettied up by the runtime and updated.
-				const updatedCodeFragment = codeFragment + '\n';
+				const updatedCodeFragment = code + '\n';
 				setCurrentCodeFragment(updatedCodeFragment);
 				codeEditorWidgetRef.current.setValue(updatedCodeFragment);
 				updateCodeEditorWidgetPosition(Position.Last, Position.Last);
@@ -123,7 +119,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			// it anyway (so the user can see a syntax error from the interpreter).
 			case RuntimeCodeFragmentStatus.Invalid:
 				positronConsoleContext.logService.warn(
-					`Executing invalid code fragment: '${codeFragment}'`
+					`Executing invalid code fragment: '${code}'`
 				);
 				break;
 
@@ -131,17 +127,17 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			// user can see an error from the interpreter).
 			case RuntimeCodeFragmentStatus.Unknown:
 				positronConsoleContext.logService.warn(
-					`Could not determine whether code fragment: '${codeFragment}' is complete.`
+					`Could not determine whether code fragment: '${code}' is complete.`
 				);
 				break;
 		}
 
 		// If the code fragment isn't just whitespace characters, add it to the history navigator.
-		if (codeFragment.trim().length) {
+		if (code.trim().length) {
 			// Create the input history entry.
 			const inputHistoryEntry = {
 				when: new Date().getTime(),
-				input: codeFragment,
+				input: code,
 			} satisfies IInputHistoryEntry;
 
 			// Add the input history entry.
@@ -156,18 +152,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			}
 		}
 
-		// Create the ID for the code fragment that will be executed.
-		const id = `fragment-${generateUuid()}`;
-
-		// Begin executing the code fragment.
-		props.positronConsoleInstance.beginExecuteCode(id, codeFragment);
-
-		// Ask the runtime to execute the code fragment. This is an asynchronous and unwaitable.
-		props.positronConsoleInstance.runtime.execute(
-			codeFragment,
-			id,
-			RuntimeCodeExecutionMode.Interactive,
-			RuntimeErrorBehavior.Continue);
+		props.positronConsoleInstance.executeCodex11mnt(code);
 
 		// Reset the code input state.
 		setCurrentCodeFragment(undefined);
@@ -416,27 +401,14 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 		// Line numbers functions.
 		const notReadyLineNumbers = (n: number) => '';
 		const readyLineNumbers = (n: number) => {
-			// FIXME: Temporary compats during switch to dynamic config
-			const inputPrompt =
-				props.positronConsoleInstance.runtime.dynState?.inputPrompt ||
-				props.positronConsoleInstance.runtime.metadata.inputPrompt as string;
-			const continuationPrompt =
-				props.positronConsoleInstance.runtime.dynState?.continuationPrompt ||
-				props.positronConsoleInstance.runtime.metadata.continuationPrompt as string;
-
 			// Render the input prompt for the first line; do not render
 			// anything in the margin for following lines
 			if (n < 2) {
-				return inputPrompt;
+				return props.positronConsoleInstance.runtime.dynState.inputPrompt;
 			} else {
-				return continuationPrompt;
+				return props.positronConsoleInstance.runtime.dynState.continuationPrompt;
 			}
 		};
-
-		// FIXME: Temporary compat during switch to dynamic config
-		const inputPrompt =
-			props.positronConsoleInstance.runtime.dynState?.inputPrompt ||
-			props.positronConsoleInstance.runtime.metadata.inputPrompt as string;
 
 		// The editor options we override.
 		const editorOptions = {
@@ -458,7 +430,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			},
 			overviewRulerLanes: 0,
 			scrollBeyondLastLine: false,
-			lineNumbersMinChars: inputPrompt.length,
+			lineNumbersMinChars: props.positronConsoleInstance.runtime.dynState.inputPrompt.length,
 			// This appears to disable validations to address:
 			// https://github.com/rstudio/positron/issues/979
 			// https://github.com/rstudio/positron/issues/1051
@@ -645,32 +617,6 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			// custom prompts on initialization. FIXME: Is there a better way?
 			const currentCodeFragment = codeEditorWidgetRef.current.getValue();
 			codeEditorWidgetRef.current.setValue(currentCodeFragment);
-		}));
-
-		// Add the onDidExecuteCode event handler.
-		disposableStore.add(props.positronConsoleInstance.onDidExecuteCode(async codeFragment => {
-			// Get the current code fragment.
-			let currentCodeFragment = codeEditorWidgetRef.current.getValue();
-
-			// If there is a current code fragment,
-			if (currentCodeFragment.length) {
-				// check whether the current code fragment is incomplete,
-				const currentCodeFragmentStatus = await props.positronConsoleInstance.runtime.
-					isCodeFragmentComplete(currentCodeFragment);
-				if (currentCodeFragmentStatus === RuntimeCodeFragmentStatus.Incomplete) {
-					// and if so, append the new code fragment on a new line.
-					codeFragment = `${currentCodeFragment}${codeFragment}`;
-				}
-				// Empty the current value, since we either used it or need to discard it.
-				currentCodeFragment = '';
-			}
-
-			// Update the current code fragment.
-			setCurrentCodeFragment(codeFragment);
-			codeEditorWidgetRef.current.setValue(codeFragment);
-
-			// Try to execute the code.
-			await executeCodeEditorWidgetCodeIfPossible();
 		}));
 
 		// Focus the console.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -265,7 +265,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 		}));
 
 		// Add the onDidExecuteCode event handler.
-		disposableStore.add(props.positronConsoleInstance.onDidExecuteCode(code => {
+		disposableStore.add(props.positronConsoleInstance.onDidExecuteCode(() => {
 			consoleInstanceRef.current.scrollTo(consoleInstanceRef.current.scrollLeft, consoleInstanceRef.current.scrollHeight);
 		}));
 

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -37,6 +37,13 @@ const enum PositronConsoleCommandId {
 const POSITRON_CONSOLE_ACTION_CATEGORY = localize('positronConsoleCategory', "Console");
 
 /**
+ * trimNewLines helper.
+ * @param str The string to trim newlines for.
+ * @returns The string with newlines trimmed.
+ */
+const trimNewlines = (str: string) => str.replace(/^\n+|\n+$/g, '');
+
+/**
  * Registers Positron console actions.
  */
 export function registerPositronConsoleActions() {
@@ -247,7 +254,7 @@ export function registerPositronConsoleActions() {
 					// Find the first non-empty line after the cursor position and read the
 					// contents of that line.
 					for (let number = lineNumber; number <= model.getLineCount(); ++number) {
-						code = this.trimNewlines(model.getLineContent(number));
+						code = trimNewlines(model.getLineContent(number));
 
 						if (code.length > 0) {
 							lineNumber = number;
@@ -262,7 +269,7 @@ export function registerPositronConsoleActions() {
 					let onlyEmptyLines = true;
 
 					for (let number = lineNumber + 1; number <= model.getLineCount(); ++number) {
-						if (this.trimNewlines(model.getLineContent(number)).length !== 0) {
+						if (trimNewlines(model.getLineContent(number)).length !== 0) {
 							// We found a non-empty line, move the cursor to it.
 							onlyEmptyLines = false;
 							lineNumber = number;
@@ -345,10 +352,6 @@ export function registerPositronConsoleActions() {
 					sticky: false
 				});
 			}
-		}
-
-		trimNewlines(str: string): string {
-			return str.replace(/^\n+/, '').replace(/\n+$/, '');
 		}
 	});
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -8,6 +8,7 @@ import { ITextModel } from 'vs/editor/common/model';
 import { IEditor } from 'vs/editor/common/editorCommon';
 import { Position } from 'vs/editor/common/core/position';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
+import { IViewsService } from 'vs/workbench/common/views';
 import { ILocalizedString } from 'vs/platform/action/common/action';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
@@ -16,11 +17,10 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { PositronConsoleViewPane } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleView';
 import { confirmationModalDialog } from 'vs/workbench/browser/positronModalDialogs/confirmationModalDialog';
 import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/common/executionHistoryService';
 import { IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
-import { IViewsService } from 'vs/workbench/common/views';
-import { PositronConsoleViewPane } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleView';
 
 /**
  * Positron console command ID's.

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -337,7 +337,7 @@ export function registerPositronConsoleActions() {
 			await viewsService.openView<PositronConsoleViewPane>(POSITRON_CONSOLE_VIEW_ID, false);
 
 			// Ask the Positron console service to execute the code.
-			if (!positronConsoleService.executeCode(languageId, code, true)) {
+			if (!await positronConsoleService.executeCode(languageId, code, true)) {
 				const languageName = languageService.getLanguageName(languageId);
 				notificationService.notify({
 					severity: Severity.Info,

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -383,11 +383,11 @@ export interface ILanguageRuntimeMetadata {
 	/** Whether the runtime should start up automatically or wait until explicitly requested */
 	readonly startupBehavior: LanguageRuntimeStartupBehavior;
 
-	/** FIXME
-	 * These are for compatibility until runtimes have added
-		 * support for the dynamic state struct */
-	readonly inputPrompt?: string;
-	readonly continuationPrompt?: string;
+	// /** FIXME
+	//  * These are for compatibility until runtimes have added
+	// 	 * support for the dynamic state struct */
+	// readonly inputPrompt?: string;
+	// readonly continuationPrompt?: string;
 }
 
 /* ILanguageRuntimeConfig contains information about a language runtime that is known

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -382,12 +382,6 @@ export interface ILanguageRuntimeMetadata {
 
 	/** Whether the runtime should start up automatically or wait until explicitly requested */
 	readonly startupBehavior: LanguageRuntimeStartupBehavior;
-
-	// /** FIXME
-	//  * These are for compatibility until runtimes have added
-	// 	 * support for the dynamic state struct */
-	// readonly inputPrompt?: string;
-	// readonly continuationPrompt?: string;
 }
 
 /* ILanguageRuntimeConfig contains information about a language runtime that is known

--- a/src/vs/workbench/services/positronConsole/common/classes/activityItemInput.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/activityItemInput.ts
@@ -17,9 +17,9 @@ export class ActivityItemInput {
 	private _code: string;
 
 	/**
-	 * The busy state.
+	 * A value which indicates whether the ActivityItemInput is executing.
 	 */
-	private _busyState = false;
+	private _executing = false;
 
 	/**
 	 * The code output lines.
@@ -53,18 +53,18 @@ export class ActivityItemInput {
 	}
 
 	/**
-	 * Gets the busy state.
+	 * Gets a value which indicates whether the ActivityItemInput is executing.
 	 */
-	get busyState() {
-		return this._busyState;
+	get executing() {
+		return this._executing;
 	}
 
 	/**
-	 * Sets the busy state.
-	 * @param busyState The busy state.
+	 * Sets a value which indicates whether the ActivityItemInput is executing.
+	 * @param executing A value which indicates whether the ActivityItemInput is executing
 	 */
-	set busyState(busyState: boolean) {
-		this._busyState = busyState;
+	set executing(executing: boolean) {
+		this._executing = executing;
 		this._onChangedEmitter.fire();
 	}
 
@@ -107,8 +107,8 @@ export class ActivityItemInput {
 		this._code = code;
 		this._codeOutputLines = ANSIOutput.processOutput(this._code);
 
-		// Non-provisional ActivityItemInputs are busy by default.
-		this._busyState = !this.provisional;
+		// Non-provisional ActivityItemInputs are executing by default.
+		this._executing = !this.provisional;
 	}
 
 	//#endregion Constructor

--- a/src/vs/workbench/services/positronConsole/common/classes/activityItemInput.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/activityItemInput.ts
@@ -2,35 +2,85 @@
  *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
-import { Emitter, Event } from 'vs/base/common/event';
+import { Emitter } from 'vs/base/common/event';
 import { ANSIOutput, ANSIOutputLine } from 'ansi-output';
 
 /**
  * ActivityItemInput class.
  */
 export class ActivityItemInput {
+	//#region Private Properties
+
+	/**
+	 * The code.
+	 */
+	private _code: string;
+
+	/**
+	 * The busy state.
+	 */
+	private _busyState = false;
+
+	/**
+	 * The code output lines.
+	 */
+	private _codeOutputLines: ANSIOutputLine[];
+
+	/**
+	 * onChanged event emitter.
+	 */
+	private _onChangedEmitter = new Emitter<void>();
+
+	//#endregion Private Properties
+
 	//#region Public Properties
+
+	/**
+	 * Gets the code.
+	 */
+	get code() {
+		return this._code;
+	}
+
+	/**
+	 * Sets the code.
+	 * @param code The code.
+	 */
+	set code(code: string) {
+		this._code = code;
+		this._codeOutputLines = ANSIOutput.processOutput(this._code);
+		this._onChangedEmitter.fire();
+	}
+
+	/**
+	 * Gets the busy state.
+	 */
+	get busyState() {
+		return this._busyState;
+	}
+
+	/**
+	 * Sets the busy state.
+	 * @param busyState The busy state.
+	 */
+	set busyState(busyState: boolean) {
+		this._busyState = busyState;
+		this._onChangedEmitter.fire();
+	}
 
 	/**
 	 * Gets the code output lines.
 	 */
-	readonly codeOutputLines: readonly ANSIOutputLine[];
+	get codeOutputLines() {
+		return this._codeOutputLines;
+	}
 
 	/**
-	 * The current busy state; defaults to true since we receive input items
-	 * when they are already in the process of being executed.
+	 * An event that fires when the ActivityItemInput changes.
 	 */
-	public busyState: boolean = true;
-
-	/**
-	 * An event that fires when the busy state changes; the event value is the
-	 * new busy state.
-	 */
-	public onBusyStateChanged: Event<boolean>;
+	public onChanged = this._onChangedEmitter.event;
 
 	//#endregion Public Properties
-
-	private _onBusyStateChangedEmitter: Emitter<boolean> = new Emitter<boolean>();
 
 	//#region Constructor
 
@@ -51,23 +101,15 @@ export class ActivityItemInput {
 		readonly when: Date,
 		readonly inputPrompt: string,
 		readonly continuationPrompt: string,
-		readonly code: string
+		code: string
 	) {
-		// Process the code directly into ANSI output lines suitable for rendering.
-		this.codeOutputLines = ANSIOutput.processOutput(code);
+		// Process the code into ANSI output lines suitable for rendering.
+		this._code = code;
+		this._codeOutputLines = ANSIOutput.processOutput(this._code);
 
-		this.onBusyStateChanged = this._onBusyStateChangedEmitter.event;
+		// Non-provisional ActivityItemInputs are busy by default.
+		this._busyState = !this.provisional;
 	}
 
 	//#endregion Constructor
-
-	/**
-	 * Sets the busy state.
-	 *
-	 * @param busyState The new busy state
-	 */
-	public setBusyState(busyState: boolean): void {
-		this.busyState = busyState;
-		this._onBusyStateChangedEmitter.fire(busyState);
-	}
 }

--- a/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
@@ -64,8 +64,7 @@ export interface IPositronConsoleService {
 	 * Executes code in a PositronConsoleInstance.
 	 * @param languageId The language ID.
 	 * @param code The code.
-	 * @param activate A value which indicates whether to activate the Positron console instance
-	 *   if it is not already active.
+	 * @param activate A value which indicates whether to activate the Positron console instance.
 	 * @returns A value which indicates whether the code could be executed.
 	 */
 	executeCode(languageId: string, code: string, activate: boolean): Promise<boolean>;
@@ -148,7 +147,7 @@ export interface IPositronConsoleInstance {
 	/**
 	 * The onDidExecuteCode event.
 	 */
-	readonly onDidExecuteCode: Event<string>;
+	readonly onDidExecuteCode: Event<void>;
 
 	/**
 	 * Focuses the input for the console.
@@ -181,17 +180,10 @@ export interface IPositronConsoleInstance {
 	clearInputHistory(): void;
 
 	/**
-	 * Begins executing code.
-	 * @param id The identifier.
-	 * @param code The code.
-	 */
-	beginExecuteCode(id: string, code: string): void;
-
-	/**
 	 * Executes code in the Positron console instance.
 	 * @param code The code to execute.
 	 */
-	executeCode(code: string): void;
+	executeCodex11mnt(code: string): void;
 
 	/**
 	 * Replies to a prompt.

--- a/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
@@ -183,7 +183,7 @@ export interface IPositronConsoleInstance {
 	 * Executes code in the Positron console instance.
 	 * @param code The code to execute.
 	 */
-	executeCodex11mnt(code: string): void;
+	executeCode(code: string): void;
 
 	/**
 	 * Replies to a prompt.

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -688,6 +688,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * @param codeFragment The code fragment to execute.
 	 */
 	executeCode(codeFragment: string): void {
+		// Queue code...
 		this._onDidExecuteCodeEmitter.fire(codeFragment);
 	}
 

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -305,6 +305,7 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 		const runningLanguageRuntimes = this._languageRuntimeService.runningRuntimes.filter(
 			runtime => isImplicitStartupLanguage(runtime, languageId));
 
+		// If there isn't a running runtime for the language, start one.
 		if (!runningLanguageRuntimes.length) {
 			// Get the registered runtimes for the language.
 			const languageRuntimes = this._languageRuntimeService.registeredRuntimes.filter(
@@ -321,13 +322,13 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 				`for the language.`);
 		}
 
+		// Get the Positron console instance for the language ID.
 		const positronConsoleInstance = this._positronConsoleInstancesByLanguageId.get(languageId);
-
 		if (!positronConsoleInstance) {
 			return false;
 		}
 
-		// Activate the Positron console instance, if it isn't active.
+		// If we're supposed to, activate the Positron console instance, if it isn't active.
 		if (activate && positronConsoleInstance !== this._activePositronConsoleInstance) {
 			this.setActivePositronConsoleInstance(positronConsoleInstance);
 		}

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -334,7 +334,7 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 		}
 
 		// Execute the code in the Positron console instance.
-		positronConsoleInstance.executeCodex11mnt(code);
+		positronConsoleInstance.executeCode(code);
 
 		// Success.
 		return Promise.resolve(true);
@@ -665,7 +665,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * Executes code.
 	 * @param code The code to execute.
 	 */
-	executeCodex11mnt(code: string): void {
+	executeCode(code: string): void {
 		if (this.runtime.getRuntimeState() !== RuntimeState.Idle && this._pendingActivityItemInput) {
 			this._pendingActivityItemInput.code += `\n${code}`;
 			this._onDidChangeRuntimeItemsEmitter.fire(this._runtimeItems);

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -765,7 +765,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			if (item instanceof ActivityItemInput) {
 				// This is the input activity; update its busy state.
 				const input = item as ActivityItemInput;
-				input.busyState = busy;
+				input.executing = busy;
 
 				// Found the input, so we're done.
 				break;
@@ -1184,7 +1184,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			for (const activity of this._runtimeItemActivities.values()) {
 				for (const item of activity.activityItems) {
 					if (item instanceof ActivityItemInput) {
-						item.busyState = false;
+						item.executing = false;
 					}
 				}
 			}

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -1177,10 +1177,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			// We are currently attached; detach.
 			this._runtimeAttached = false;
 
-			// Ensure all inputs are marked as idle. When a runtime exits, it
-			// may not send an Idle message corresponding to the command that
-			// caused it to exit (for instance if the command causes the runtime
-			// to crash).
+			// Clear the executing state of all ActivityItemInputs inputs. When a runtime exits, it
+			// may not send an Idle message corresponding to the command that caused it to exit (for
+			// instance if the command causes the runtime to crash).
 			for (const activity of this._runtimeItemActivities.values()) {
 				for (const item of activity.activityItems) {
 					if (item instanceof ActivityItemInput) {


### PR DESCRIPTION
This PR addresses https://github.com/posit-dev/positron/issues/1058 by adding a new capability that gathers execute code requests together in a pending ActivityItemInput while a piece of code is being executed in a runtime. When the runtime becomes idle, the pending ActivityItemInput is then executed.

It also contains refactoring of a number of things, where necessary.

This is not a final or ideal implementation of things. It's essentially a hack to improve things for Private Alpha. In an ideal world, we would be able to use `isCodeFragmentComplete` _while a runtime is busy executing code_  to intelligently queue up complete code blocks for subsequent execution.

I will be adding further improvements to this in the coming days. (For example, I will be improving Ctrl-C handling in the console so that it will discard the pending ActivityItemInput.)

Here's a movie of this in action:

https://github.com/posit-dev/positron/assets/853239/9b62b003-e21d-4002-ad29-bdd14ee77125

