### PR TITLE
Add jupyter and its 4 bundled extensions as built-in extensions

### DIFF
--- a/product.json
+++ b/product.json
@@ -94,6 +94,81 @@
 				},
 				"publisherDisplayName": "Quarto"
 			}
+		},
+		{
+			"name": "ms-toolsai.jupyter-keymap",
+			"version": "1.1.2",
+			"repo": "https://github.com/Microsoft/vscode-jupyter-keymap",
+			"metadata": {
+				"id": "9f6dc8db-620c-4844-b8c5-e74914f1be27",
+				"publisherId": {
+					"publisherId": "ac8eb7c9-3e59-4b39-8040-f0484d8170ce",
+					"publisherName": "ms-toolsai",
+					"displayName": "Jupyter Keymap",
+					"flags": "verified"
+				},
+				"publisherDisplayName": "ms-toolsai"
+			}
+		},
+		{
+			"name": "ms-toolsai.vscode-jupyter-cell-tags",
+			"version": "0.1.8",
+			"repo": "https://github.com/Microsoft/vscode-jupyter-cell-tags",
+			"metadata": {
+				"id": "ab4fb32a-befb-4102-adf9-1652d0cd6a5e",
+				"publisherId": {
+					"publisherId": "ac8eb7c9-3e59-4b39-8040-f0484d8170ce",
+					"publisherName": "ms-toolsai",
+					"displayName": "Jupyter Cell Tags",
+					"flags": "verified"
+				},
+				"publisherDisplayName": "ms-toolsai"
+			}
+		},
+		{
+			"name": "ms-toolsai.vscode-jupyter-slideshow",
+			"version": "0.1.5",
+			"repo": "https://github.com/Microsoft/vscode-jupyter-slideshow",
+			"metadata": {
+				"id": "e153ca70-b543-4865-b4c5-b31d34185948",
+				"publisherId": {
+					"publisherId": "ac8eb7c9-3e59-4b39-8040-f0484d8170ce",
+					"publisherName": "ms-toolsai",
+					"displayName": "Jupyter Slide Show",
+					"flags": "verified"
+				},
+				"publisherDisplayName": "ms-toolsai"
+			}
+		},
+		{
+			"name": "ms-toolsai.jupyter-renderers",
+			"version": "1.0.15",
+			"repo": "https://github.com/Microsoft/vscode-notebook-renderers",
+			"metadata": {
+				"id": "b15c72f8-d5fe-421a-a4f7-27ed9f6addbf",
+				"publisherId": {
+					"publisherId": "ac8eb7c9-3e59-4b39-8040-f0484d8170ce",
+					"publisherName": "ms-toolsai",
+					"displayName": "Jupyter Notebook Renderers",
+					"flags": "verified"
+				},
+				"publisherDisplayName": "ms-toolsai"
+			}
+		},
+		{
+			"name": "ms-toolsai.jupyter",
+			"version": "2023.3.100",
+			"repo": "https://github.com/Microsoft/vscode-jupyter",
+			"metadata": {
+				"id": "6c2f1801-1e7f-45b2-9b5c-7782f1e076e8",
+				"publisherId": {
+					"publisherId": "ac8eb7c9-3e59-4b39-8040-f0484d8170ce",
+					"publisherName": "ms-toolsai",
+					"displayName": "Jupyter",
+					"flags": "verified"
+				},
+				"publisherDisplayName": "ms-toolsai"
+			}
 		}
 	],
 	"extensionsGallery": {


### PR DESCRIPTION
Addresses #1163 

Includes:
- Jupyter 2023.3.100
- Jupyter Keymap 1.1.2
- Jupyter Cell Tags 0.1.8
- Jupyter Slide Show 0.1.5
- Jupyter Notebook Renderers 1.0.15