### PR TITLE
Set Viewer view name to match the view container title

### DIFF
--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreview.contribution.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreview.contribution.ts
@@ -38,7 +38,7 @@ const VIEW_CONTAINER: ViewContainer = Registry.as<IViewContainersRegistry>(ViewC
 
 Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews([{
 	id: POSITRON_PREVIEW_VIEW_ID,
-	name: nls.localize('positron.preview', "Preview"),
+	name: nls.localize('positron.viewer', "Viewer"),
 	containerIcon: positronPreviewViewIcon,
 	canMoveView: true,
 	canToggleVisibility: false,


### PR DESCRIPTION
This avoids seeing Viewer: Preview in the tab when the Viewer is selected.

Also tested that a Quarto render of a .qmd still shows up in the Viewer pane.

