### PR TITLE
Add useEffect to automatically scroll traceback into view

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx
@@ -4,7 +4,7 @@
 
 import 'vs/css!./activityErrorMessage';
 import * as React from 'react';
-import { useState } from 'react'; // eslint-disable-line no-duplicate-imports
+import { useEffect, useRef, useState } from 'react'; // eslint-disable-line no-duplicate-imports
 import { localize } from 'vs/nls';
 import { PositronButton } from 'vs/base/browser/ui/positronComponents/positronButton';
 import { OutputLines } from 'vs/workbench/contrib/positronConsole/browser/components/outputLines';
@@ -21,8 +21,17 @@ export interface ActivityErrorMessageProps {
  * @returns The rendered component.
  */
 export const ActivityErrorMessage = (props: ActivityErrorMessageProps) => {
+	// Reference hooks.
+	const activityErrorMessageRef = useRef<HTMLDivElement>(undefined!);
+
 	// State hooks.
 	const [showTraceback, setShowTraceback] = useState(false);
+
+	// Traceback useEffect.
+	useEffect(() => {
+		// Ensure that the component is scrolled into view.
+		activityErrorMessageRef.current?.scrollIntoView({ behavior: 'auto' });
+	}, [showTraceback]);
 
 	/**
 	 * Traceback component.
@@ -33,6 +42,7 @@ export const ActivityErrorMessage = (props: ActivityErrorMessageProps) => {
 		 * onClick handler.
 		 */
 		const clickHandler = () => {
+			// Toggle show traceback.
 			setShowTraceback(!showTraceback);
 		};
 
@@ -66,7 +76,7 @@ export const ActivityErrorMessage = (props: ActivityErrorMessageProps) => {
 
 	// Render.
 	return (
-		<div className='activity-error-message'>
+		<div ref={activityErrorMessageRef} className='activity-error-message'>
 			<div className='error-bar'></div>
 			<div className='error-information'>
 				{props.activityItemErrorMessage.messageOutputLines.length > 0 &&

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx
@@ -29,8 +29,10 @@ export const ActivityErrorMessage = (props: ActivityErrorMessageProps) => {
 
 	// Traceback useEffect.
 	useEffect(() => {
-		// Ensure that the component is scrolled into view.
-		activityErrorMessageRef.current?.scrollIntoView({ behavior: 'auto' });
+		// Ensure that the component is scrolled into view when traceback is showing.
+		if (showTraceback) {
+			activityErrorMessageRef.current?.scrollIntoView({ behavior: 'auto' });
+		}
 	}, [showTraceback]);
 
 	/**


### PR DESCRIPTION
To address #755 and #1116, this PR adds a useEffect to automatically scroll traceback into view when it is toggled to true. This works both ways, so the `activityErrorMessage` component is always optimally positioned after traceback is shown or hidden.

Here's a little movie showing how this works:

https://github.com/posit-dev/positron/assets/853239/681dea28-9dc3-4127-ae64-220bfa166467

