### PR TITLE
Updates to drive focus to the input

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -394,8 +394,20 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			// If the click was inside the selection, copy the selection to the clipboard.
 			if (insideSelection) {
 				positronConsoleContext.clipboardService.writeText(selection.toString());
+				props.positronConsoleInstance.focusInput();
 				return;
 			}
+		}
+	};
+
+	/**
+	 * onClick event handler.
+	 * @param e A MouseEvent<HTMLElement> that describes a user interaction with the mouse.
+	 */
+	const clickHandler = (e: MouseEvent<HTMLDivElement>) => {
+		const selection = getSelection();
+		if (!selection || selection.type !== 'Range') {
+			props.positronConsoleInstance.focusInput();
 		}
 	};
 
@@ -432,9 +444,9 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 				whiteSpace: wordWrap ? 'pre-wrap' : 'pre',
 				zIndex: props.active ? 'auto' : -1
 			}}
-			tabIndex={0}
 			onKeyDown={keyDownHandler}
 			onMouseDown={mouseDownHandler}
+			onClick={clickHandler}
 			onScroll={scrollHandler}>
 			<div ref={runtimeItemsRef} className='runtime-items'>
 				<div className='top-spacer' />


### PR DESCRIPTION
This PR addresses #1147 by driving focus to the input in three situations:

- The user clicks and there is no selection (this can't really happen).
- The user clicks and there is a caret selection.
- The user clicks on a selected range to copy it to the clipboard.

Here's a little movie:

https://github.com/posit-dev/positron/assets/853239/b823e660-0fe9-4a92-8d1a-d2e53c3758db

Note that we _do not scroll the input into view_ because this would defeat the scroll lock feature.