### PR TITLE
Move calls to localize out of React rendering code

### DIFF
--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
@@ -11,6 +11,13 @@ import { usePositronActionBarContext } from 'vs/platform/positronActionBar/brows
 import { PositronNewFolderAction, PositronNewFolderFromGitAction } from 'vs/workbench/browser/actions/positronActions';
 
 /**
+ * Localized strings.
+ */
+const positronNew = localize('positronNew', "New");
+const positronNewFile = localize('positronNewFile', "New File...");
+const positronNewFileFolder = localize('positronNewFileFolder', "New File/Folder");
+
+/**
  * TopActionBarNewMenu component.
  * @returns The component.
  */
@@ -23,7 +30,7 @@ export const TopActionBarNewMenu = () => {
 		const actions: IAction[] = [];
 		positronActionBarContext.appendCommandAction(actions, {
 			id: 'welcome.showNewFileEntries',
-			label: localize('positronNewFile', "New File...")
+			label: positronNewFile
 		});
 		actions.push(new Separator());
 		positronActionBarContext.appendCommandAction(actions, {
@@ -43,9 +50,9 @@ export const TopActionBarNewMenu = () => {
 	return (
 		<ActionBarMenuButton
 			iconId='positron-new'
-			text={localize('positronNew', "New")}
+			text={positronNew}
 			actions={actions}
-			tooltip={localize('positronNewFileFolder', "New File/Folder")}
+			tooltip={positronNewFileFolder}
 		/>
 	);
 };

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarOpenMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarOpenMenu.tsx
@@ -22,7 +22,18 @@ import { PositronTopActionBarState } from 'vs/workbench/browser/parts/positronTo
 import { OpenFileAction, OpenFileFolderAction, OpenFolderAction } from 'vs/workbench/browser/actions/workspaceActions';
 import { usePositronTopActionBarContext } from 'vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarContext';
 
+/**
+ * Constants.
+ */
 const MAX_MENU_RECENT_ENTRIES = 10;
+
+/**
+ * Localized strings.
+ */
+const positronOpen = localize('positronOpen', "Open");
+const positronOpenFile = localize('positronOpenFile', "Open File...");
+const positronOpenFolder = localize('positronOpenFolder', "Open Folder...");
+const positronOpenFileFolder = localize('positronOpenFileFolder', "Open File/Folder");
 
 /**
  * TopActionBarOpenMenu component.
@@ -40,7 +51,7 @@ export const TopActionBarOpenMenu = () => {
 		if (IsMacNativeContext.getValue(positronActionBarContext.contextKeyService)) {
 			positronActionBarContext.appendCommandAction(actions, {
 				id: OpenFileFolderAction.ID,
-				label: localize('positronOpenFile', "Open File...")
+				label: positronOpenFile
 			});
 		} else {
 			positronActionBarContext.appendCommandAction(actions, {
@@ -49,7 +60,7 @@ export const TopActionBarOpenMenu = () => {
 		}
 		positronActionBarContext.appendCommandAction(actions, {
 			id: OpenFolderAction.ID,
-			label: localize('positronOpenFolder', "Open Folder...")
+			label: positronOpenFolder
 		});
 		actions.push(new Separator());
 
@@ -79,10 +90,10 @@ export const TopActionBarOpenMenu = () => {
 	return (
 		<ActionBarMenuButton
 			iconId='folder-opened'
-			text={localize('positronOpen', "Open")}
+			text={positronOpen}
 			iconFontSize={18}
 			actions={actions}
-			tooltip={localize('positronOpenFileFolder', "Open File/Folder")}
+			tooltip={positronOpenFileFolder}
 		/>
 	);
 };


### PR DESCRIPTION
This PR fixes the New and Open buttons in the top action bar not having text in release builds. Here's a screenshot of the top action bar in a release build:

<img width="433" alt="image" src="https://github.com/posit-dev/positron/assets/853239/aad80d46-8d24-4c45-85fa-e6102b7799f1">