### PR TITLE
Tweak that hides the letterpress instead of the shortcuts

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -1914,6 +1914,11 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		this.lastLayout = { width, height, top, left };
 		this.element.classList.toggle('max-height-478px', height <= 478);
 
+		// --- Start Positron ---
+		// In Positron, we add an additional class that hides the letterpress below 400px.
+		this.element.classList.toggle('max-height-400px', height <= 400);
+		// --- End Positron ---
+
 		// Layout the title area first to receive the size it occupies
 		const titleAreaSize = this.titleAreaControl.layout({
 			container: new Dimension(width, height),

--- a/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
@@ -72,8 +72,19 @@
 
 .monaco-workbench .part.editor > .content:not(.empty) .editor-group-container > .editor-group-watermark > .shortcuts,
 .monaco-workbench .part.editor > .content .editor-group-container.max-height-478px > .editor-group-watermark > .shortcuts {
+	/* Start Positron */
+	/* In Positron, we do not hide the shortcuts. */
+	/* display: none; */
+	/* End Positron */
+}
+
+/* Start Positron */
+/* In Positron, we hide the letterpress below 400px. */
+.monaco-workbench .part.editor > .content:not(.empty) .editor-group-container > .editor-group-watermark > .letterpress,
+.monaco-workbench .part.editor > .content .editor-group-container.max-height-400px > .editor-group-watermark > .letterpress {
 	display: none;
 }
+/* End Positron */
 
 .monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark > .shortcuts > .watermark-box {
 	display: inline-table;


### PR DESCRIPTION
This tweak hides the letterpress instead of the shortcuts when the empty editor group is shown. Here's a movie of this in action (and shows the OOB experience):

https://github.com/posit-dev/positron/assets/853239/f9ece77c-2aee-4d91-8c64-68be0e6f59f1
