### PR TITLE
Add `restartLanguageRuntime` to Positron API

### DIFF
--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -712,7 +712,7 @@ declare module 'positron' {
 		 * @param languageId The language ID for running runtimes
 		 */
 		export function getRunningRuntimes(languageId: string): Thenable<LanguageRuntimeMetadata[]>;
-    
+
 		/**
 		 * Select and start a runtime previously registered with Positron. Any
 		 * previously active runtimes for the language will be shut down.
@@ -720,6 +720,13 @@ declare module 'positron' {
 		 * @param runtimeId The ID of the runtime to select and start.
 		 */
 		export function selectLanguageRuntime(runtimeId: string): Thenable<void>;
+
+		/**
+		 * Restart a running runtime.
+		 *
+		 * @param runtimeId The ID of the running runtime to restart.
+		 */
+		export function restartLanguageRuntime(runtimeId: string): Thenable<void>;
 
 		/**
 		 * Register a handler for runtime client instances. This handler will be called

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -841,13 +841,20 @@ export class MainThreadLanguageRuntime implements MainThreadLanguageRuntimeShape
 			runtime.metadata.languageId === languageId
 		);
 		return Promise.resolve(runningRuntimes().map(runtime => runtime.metadata));
-  }
+	}
 
 	// Called by the extension host to select a previously registered language runtime
 	$selectLanguageRuntime(handle: number): Promise<void> {
 		return this._languageRuntimeService.selectRuntime(
 			this.findRuntime(handle).metadata.runtimeId,
 			'Extension-requested runtime selection via Positron API');
+	}
+
+	// Called by the extension host to restart a running language runtime
+	$restartLanguageRuntime(handle: number): Promise<void> {
+		return this._languageRuntimeService.restartRuntime(
+			this.findRuntime(handle).metadata.runtimeId,
+			'Extension-requested runtime restart via Positron API');
 	}
 
 	// Signals that language runtime discovery is complete.

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -67,9 +67,12 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			},
 			getRunningRuntimes(languageId: string): Thenable<positron.LanguageRuntimeMetadata[]> {
 				return extHostLanguageRuntime.getRunningRuntimes(languageId);
-      },
+			},
 			selectLanguageRuntime(runtimeId: string): Thenable<void> {
 				return extHostLanguageRuntime.selectLanguageRuntime(runtimeId);
+			},
+			restartLanguageRuntime(runtimeId: string): Thenable<void> {
+				return extHostLanguageRuntime.restartLanguageRuntime(runtimeId);
 			},
 			registerClientHandler(handler: positron.RuntimeClientHandler): vscode.Disposable {
 				return extHostLanguageRuntime.registerClientHandler(handler);

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -12,6 +12,7 @@ import { UriComponents } from 'vs/base/common/uri';
 export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$registerLanguageRuntime(handle: number, metadata: ILanguageRuntimeMetadata, dynState: ILanguageRuntimeDynState): void;
 	$selectLanguageRuntime(handle: number): Promise<void>;
+	$restartLanguageRuntime(handle: number): Promise<void>;
 	$isLanguageRuntimeDiscoveryComplete(): Promise<boolean>;
 	$completeLanguageRuntimeDiscovery(): void;
 	$unregisterLanguageRuntime(handle: number): void;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -272,6 +272,23 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 	}
 
 	/**
+	 * Restarts a running language runtime.
+	 *
+	 * @param runtimeId The runtime ID to restart.
+	 */
+	public restartLanguageRuntime(runtimeId: string): Promise<void> {
+		// Look for the runtime with the given ID
+		for (let i = 0; i < this._runtimes.length; i++) {
+			if (this._runtimes[i].metadata.runtimeId === runtimeId) {
+				return this._proxy.$restartLanguageRuntime(i);
+			}
+		}
+		return Promise.reject(
+			new Error(`Runtime with ID '${runtimeId}' must be registered before ` +
+				`it can be restarted.`));
+	}
+
+	/**
 	 * Handles a comm open message from the language runtime by either creating
 	 * a client instance for it or passing it to a registered client handler.
 	 *

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
@@ -11,11 +11,10 @@ import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { LANGUAGE_RUNTIME_ACTION_CATEGORY } from 'vs/workbench/contrib/languageRuntime/common/languageRuntime';
-import { ILanguageRuntime, ILanguageRuntimeService, IRuntimeClientInstance, RuntimeClientType, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeService, IRuntimeClientInstance, RuntimeClientType } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IKeybindingRule, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
-import { INotificationService } from 'vs/platform/notification/common/notification';
 
 // The category for language runtime actions.
 const category: ILocalizedString = { value: LANGUAGE_RUNTIME_ACTION_CATEGORY, original: 'Language Runtime' };
@@ -184,6 +183,7 @@ export function registerLanguageRuntimeActions() {
 	// Registers the restart language runtime action.
 	registerLanguageRuntimeAction('workbench.action.languageRuntime.restart', 'Restart Language Runtime', async accessor => {
 		const consoleService = accessor.get(IPositronConsoleService);
+		const languageRuntimeService = accessor.get(ILanguageRuntimeService);
 
 		// The runtime we'll try to restart.
 		let runtime: ILanguageRuntime | undefined = undefined;
@@ -212,30 +212,8 @@ export function registerLanguageRuntimeActions() {
 			}
 		}
 
-		const state = runtime.getRuntimeState();
-		if (state === RuntimeState.Busy ||
-			state === RuntimeState.Idle ||
-			state === RuntimeState.Ready) {
-			// The runtime looks like it could handle a restart request, so send
-			// one over.
-			runtime.restart();
-		} else if (state === RuntimeState.Uninitialized ||
-			state === RuntimeState.Exited) {
-			// The runtime has never been started, or is no longer running. Just
-			// tell it to start.
-			accessor.get(ILanguageRuntimeService).startRuntime(runtime.metadata.runtimeId,
-				`'Restart Language Runtime' command invoked`);
-		} else if (state === RuntimeState.Starting ||
-			state === RuntimeState.Restarting) {
-			// The runtime is already starting or restarting. We could show an
-			// error, but this is probably just the result of a user mashing the
-			// restart when we already have one in flight.
-			return;
-		} else {
-			// The runtime is not in a state where it can be restarted.
-			accessor.get(INotificationService).error(
-				nls.localize('positronCannotRestart', "The {0} language runtime is '{1}' and cannot be restarted.", runtime.metadata.languageName, state));
-		}
+		languageRuntimeService.restartRuntime(runtime.metadata.runtimeId,
+			`'Restart Language Runtime' command invoked`);
 	},
 		[
 			{

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
@@ -183,7 +183,6 @@ export function registerLanguageRuntimeActions() {
 	// Registers the restart language runtime action.
 	registerLanguageRuntimeAction('workbench.action.languageRuntime.restart', 'Restart Language Runtime', async accessor => {
 		// Access services.
-		const commandService = accessor.get(ICommandService);
 		const consoleService = accessor.get(IPositronConsoleService);
 		const languageRuntimeService = accessor.get(ILanguageRuntimeService);
 
@@ -217,8 +216,6 @@ export function registerLanguageRuntimeActions() {
 		// Restart the language runtime.
 		languageRuntimeService.restartRuntime(runtime.metadata.runtimeId,
 			`'Restart Language Runtime' command invoked`);
-		// Drive focus into the Positron console.
-		commandService.executeCommand('workbench.panel.positronConsole.focus');
 	},
 		[
 			{

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
@@ -182,6 +182,8 @@ export function registerLanguageRuntimeActions() {
 
 	// Registers the restart language runtime action.
 	registerLanguageRuntimeAction('workbench.action.languageRuntime.restart', 'Restart Language Runtime', async accessor => {
+		// Access services.
+		const commandService = accessor.get(ICommandService);
 		const consoleService = accessor.get(IPositronConsoleService);
 		const languageRuntimeService = accessor.get(ILanguageRuntimeService);
 
@@ -212,8 +214,11 @@ export function registerLanguageRuntimeActions() {
 			}
 		}
 
+		// Restart the language runtime.
 		languageRuntimeService.restartRuntime(runtime.metadata.runtimeId,
 			`'Restart Language Runtime' command invoked`);
+		// Drive focus into the Positron console.
+		commandService.executeCommand('workbench.panel.positronConsole.focus');
 	},
 		[
 			{

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -536,7 +536,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	 * @param runtimeId The runtime identifier of the runtime to shut down.
 	 * @param source The source of the request to shut down the runtime.
 		 */
-	private async shutdownRuntime(runtimeId: string, source: string): Promise<void> {
+	async shutdownRuntime(runtimeId: string, source: string): Promise<void> {
 		const languageRuntimeInfo = this._registeredRuntimesByRuntimeId.get(runtimeId);
 		if (!languageRuntimeInfo) {
 			throw new Error(`No language runtime with id '${runtimeId}' was found.`);

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -285,7 +285,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 			}
 
 			// Ask the runtime to shut down.
-			await this.shutdownRuntime(runtime.metadata.runtimeId, source);
+			await this.shutdownRuntime(runningRuntime.metadata.runtimeId, source);
 		}
 
 		// Start the selected runtime.

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -574,8 +574,8 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 
 	/**
 	 * Restarts a runtime.
-	 * @param runtimeId The ID of the runtime to select
-	 * @param source The source of the selection
+	 * @param runtimeId The ID of the runtime to restart
+	 * @param source The source of the request to restart the runtime.
 	 */
 	async restartRuntime(runtimeId: string, source: string): Promise<void> {
 		const runtimeInfo = this._registeredRuntimesByRuntimeId.get(runtimeId);
@@ -583,17 +583,6 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 			throw new Error(`No language runtime with id '${runtimeId}' was found.`);
 		}
 		const runtime = runtimeInfo.runtime;
-		const runningRuntime = this._runningRuntimesByLanguageId.get(runtime.metadata.languageId);
-		if (!runningRuntime) {
-			return Promise.reject(
-				new Error(`There is no running runtime for the language that matches language ` +
-					`runtime ID '${runtimeId}'.`));
-		}
-		if (runningRuntime.metadata.runtimeId !== runtimeId) {
-			return Promise.reject(
-				new Error(`${formatLanguageRuntime(runtime)} is not currently running.`));
-		}
-
 		this._logService.info(`Restarting language runtime ${formatLanguageRuntime(runtime)} (Source: ${source})`);
 		await this.doRestartRuntime(runtime);
 	}
@@ -721,8 +710,8 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	}
 
 	/**
-	 * Starts a runtime.
-	 * @param runtime The runtime to start.
+	 * Restarts a runtime.
+	 * @param runtime The runtime to restart.
 	 */
 	private async doRestartRuntime(runtime: ILanguageRuntime): Promise<void> {
 		const state = runtime.getRuntimeState();

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -317,6 +317,34 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	}
 
 	/**
+	 * Restarts a runtime.
+	 *
+	 * @param runtimeId The ID of the runtime to select
+	 * @param source The source of the selection
+	 */
+	async restartRuntime(runtimeId: string, source: string): Promise<void> {
+		const runtimeInfo = this._registeredRuntimesByRuntimeId.get(runtimeId);
+		if (!runtimeInfo) {
+			return Promise.reject(new Error(`Language runtime ID '${runtimeId}' ` +
+				`is not registered.`));
+		}
+		const runtime = runtimeInfo.runtime;
+		const runningRuntime = this._runningRuntimesByLanguageId.get(runtime.metadata.languageId);
+		if (!runningRuntime) {
+			return Promise.reject(
+				new Error(`There is no running runtime for the language that matches language ` +
+					`runtime ID '${runtimeId}'.`));
+		}
+		if (runningRuntime.metadata.runtimeId !== runtimeId) {
+			return Promise.reject(
+				new Error(`${formatLanguageRuntime(runningRuntime)} is not currently running.`));
+		}
+
+		// Restart the selected runtime.
+		return this.restartRuntime(runtime.metadata.runtimeId, source);
+	}
+
+	/**
 	 * Register a new runtime
 	 *
 	 * @param runtime The runtime to register

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -703,12 +703,12 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 			state === RuntimeState.Ready) {
 			// The runtime looks like it could handle a restart request, so send
 			// one over.
-			runtime.restart();
+			return runtime.restart();
 		} else if (state === RuntimeState.Uninitialized ||
 			state === RuntimeState.Exited) {
 			// The runtime has never been started, or is no longer running. Just
 			// tell it to start.
-			this.startRuntime(runtime.metadata.runtimeId, `'Restart Language Runtime' command invoked`);
+			return this.startRuntime(runtime.metadata.runtimeId, `'Restart Language Runtime' command invoked`);
 		} else if (state === RuntimeState.Starting ||
 			state === RuntimeState.Restarting) {
 			// The runtime is already starting or restarting. We could show an
@@ -717,7 +717,9 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 			return;
 		} else {
 			// The runtime is not in a state where it can be restarted.
-			this._logService.error(`The ${runtime.metadata.languageName} language runtime is '${state}' and cannot be restarted.`);
+			return Promise.reject(
+				new Error(`The ${runtime.metadata.languageName} language runtime is '${state}' and cannot be restarted.`)
+			);
 		}
 	}
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -553,14 +553,6 @@ export interface ILanguageRuntimeService {
 	startRuntime(runtimeId: string, source: string): Promise<void>;
 
 	/**
-	 * Shuts down a runtime.
-	 * @param runtimeId The runtime identifier of the runtime to shut down.
-	 * @param source The source of the request to shut down the runtime, for debugging purposes
-	 *  (not displayed to the user)
-	 */
-	shutdownRuntime(runtimeId: string, source: string): Promise<void>;
-
-	/**
 	 * Restart a running runtime.
 	 * @param runtimeId The identifier of the runtime to restart.
 	 * @param source The source of the request to restart the runtime, for debugging purposes.

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -532,14 +532,6 @@ export interface ILanguageRuntimeService {
 	selectRuntime(runtimeId: string, source: string): Promise<void>;
 
 	/**
-	 * Restart a running runtime.
-	 *
-	 * @param runtimeId The identifier of the runtime to restart.
-	 * @param source The source of the request to restart the runtime, for debugging purposes.
-	 */
-	restartRuntime(runtimeId: string, source: string): Promise<void>;
-
-	/**
 	 * Signal that discovery of language runtimes is complete.
 	 */
 	completeDiscovery(): void;
@@ -559,5 +551,21 @@ export interface ILanguageRuntimeService {
 	 *  (not displayed to the user)
 	 */
 	startRuntime(runtimeId: string, source: string): Promise<void>;
+
+	/**
+	 * Shuts down a runtime.
+	 * @param runtimeId The runtime identifier of the runtime to shut down.
+	 * @param source The source of the request to shut down the runtime, for debugging purposes
+	 *  (not displayed to the user)
+	 */
+	shutdownRuntime(runtimeId: string, source: string): Promise<void>;
+
+	/**
+	 * Restart a running runtime.
+	 * @param runtimeId The identifier of the runtime to restart.
+	 * @param source The source of the request to restart the runtime, for debugging purposes.
+	 */
+	restartRuntime(runtimeId: string, source: string): Promise<void>;
+
 }
 export { RuntimeClientType, IRuntimeClientInstance };

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -463,7 +463,7 @@ export interface ILanguageRuntime {
 	interrupt(): void;
 
 	/** Restart the runtime */
-	restart(): void;
+	restart(): Thenable<void>;
 
 	/** Shut down the runtime */
 	shutdown(): Thenable<void>;

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -532,6 +532,14 @@ export interface ILanguageRuntimeService {
 	selectRuntime(runtimeId: string, source: string): Promise<void>;
 
 	/**
+	 * Restart a running runtime.
+	 *
+	 * @param runtimeId The identifier of the runtime to restart.
+	 * @param source The source of the request to restart the runtime, for debugging purposes.
+	 */
+	restartRuntime(runtimeId: string, source: string): Promise<void>;
+
+	/**
 	 * Signal that discovery of language runtimes is complete.
 	 */
 	completeDiscovery(): void;


### PR DESCRIPTION
Related to #1099 again, with a new addition to the Positron API to restart a runtime.

For now, we are having Positron be in charge of restarting the runtime (as well as saying what runtimes are running, selecting a new runtime, etc) because there is so much state to keep track of, as outlined in #634. If the API here gets unwieldy, we'll want to reevaluate this approach so that the extensions can take runtime actions without components getting in the wrong state.
