### PR TITLE
Standardize on `runtimeName`

### DIFF
--- a/extensions/positron-javascript/src/runtime.ts
+++ b/extensions/positron-javascript/src/runtime.ts
@@ -32,7 +32,8 @@ export class JavascriptLanguageRuntime implements positron.LanguageRuntime {
 
 		const iconSvgPath = path.join(this.context.extensionPath, 'resources', 'nodejs-icon.svg');
 
-		const runtimeName = `Node.js ${version}`;
+		const runtimeShortName = version;
+		const runtimeName = `Node.js ${runtimeShortName}`;
 
 		this.metadata = {
 			runtimePath: process.execPath,
@@ -40,6 +41,7 @@ export class JavascriptLanguageRuntime implements positron.LanguageRuntime {
 			languageId: 'javascript',
 			languageName: 'Node.js',
 			runtimeName,
+			runtimeShortName,
 			runtimeSource: 'Node.js',
 			languageVersion: version,
 			base64EncodedIconSvg: fs.readFileSync(iconSvgPath).toString('base64'),

--- a/extensions/positron-javascript/src/runtime.ts
+++ b/extensions/positron-javascript/src/runtime.ts
@@ -32,12 +32,14 @@ export class JavascriptLanguageRuntime implements positron.LanguageRuntime {
 
 		const iconSvgPath = path.join(this.context.extensionPath, 'resources', 'nodejs-icon.svg');
 
+		const runtimeName = `Node.js ${version}`;
+
 		this.metadata = {
 			runtimePath: process.execPath,
 			runtimeId: '13C365D6-099A-43EC-934D-353ADEFD798F',
 			languageId: 'javascript',
 			languageName: 'Node.js',
-			runtimeName: 'Node.js',
+			runtimeName,
 			runtimeSource: 'Node.js',
 			languageVersion: version,
 			base64EncodedIconSvg: fs.readFileSync(iconSvgPath).toString('base64'),

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -171,18 +171,21 @@ export async function* rRuntimeProvider(context: vscode.ExtensionContext): Async
 			isUserInstallation ?
 				'User' : 'System';
 
-		// Display name shown to users
-		let runtimeName = `R ${rHome.version}`;
+		// Short name shown to users (when disambiguating within a language)
+		let runtimeShortName = rHome.version;
 
 		// If there is another R installation with the same version but different architecture,
 		// then disambiguate by appending the architecture to the runtime name.
 		// For example, if x86_64 and arm64 versions of R 4.4.0 exist simultaneously.
 		for (const otherRHome of rInstallations) {
 			if (rHome.version === otherRHome.version && rHome.arch !== otherRHome.arch) {
-				runtimeName = `${runtimeName} (${rHome.arch})`;
+				runtimeShortName = `${runtimeShortName} (${rHome.arch})`;
 				break;
 			}
 		}
+
+		// Full name shown to users
+		const runtimeName = `R ${runtimeShortName}`;
 
 		// R script to run on session startup
 		const startupFile = path.join(context.extensionPath, 'resources', 'scripts', 'startup.R');
@@ -238,6 +241,7 @@ export async function* rRuntimeProvider(context: vscode.ExtensionContext): Async
 		const metadata: positron.LanguageRuntimeMetadata = {
 			runtimeId,
 			runtimeName,
+			runtimeShortName,
 			runtimePath,
 			runtimeVersion: packageJson.version,
 			runtimeSource,

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -174,9 +174,14 @@ export async function* rRuntimeProvider(context: vscode.ExtensionContext): Async
 		// Display name shown to users
 		let runtimeName = `R ${rHome.version}`;
 
-		if (process.arch !== rHome.arch) {
-			// Display nonstandard arch information (like an x64 version of R on an arm64 Mac)
-			runtimeName = `${runtimeName} (${rHome.arch})`;
+		// If there is another R installation with the same version but different architecture,
+		// then disambiguate by appending the architecture to the runtime name.
+		// For example, if x86_64 and arm64 versions of R 4.4.0 exist simultaneously.
+		for (const otherRHome of rInstallations) {
+			if (rHome.version === otherRHome.version && rHome.arch !== otherRHome.arch) {
+				runtimeName = `${runtimeName} (${rHome.arch})`;
+				break;
+			}
 		}
 
 		// R script to run on session startup

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -171,6 +171,14 @@ export async function* rRuntimeProvider(context: vscode.ExtensionContext): Async
 			isUserInstallation ?
 				'User' : 'System';
 
+		// Display name shown to users
+		let runtimeName = `R ${rHome.version}`;
+
+		if (process.arch !== rHome.arch) {
+			// Display nonstandard arch information (like an x64 version of R on an arm64 Mac)
+			runtimeName = `${runtimeName} (${rHome.arch})`;
+		}
+
 		// R script to run on session startup
 		const startupFile = path.join(context.extensionPath, 'resources', 'scripts', 'startup.R');
 
@@ -185,7 +193,7 @@ export async function* rRuntimeProvider(context: vscode.ExtensionContext): Async
 				'--',
 				'--interactive',
 			],
-			'display_name': `R (${runtimeSource})`, // eslint-disable-line
+			'display_name': runtimeName,
 			'language': 'R',
 			'env': env,
 		};
@@ -224,7 +232,7 @@ export async function* rRuntimeProvider(context: vscode.ExtensionContext): Async
 
 		const metadata: positron.LanguageRuntimeMetadata = {
 			runtimeId,
-			runtimeName: kernelSpec.display_name,
+			runtimeName,
 			runtimePath,
 			runtimeVersion: packageJson.version,
 			runtimeSource,

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -76,7 +76,7 @@ export class RInstallation {
 
 		const versionPart = builtParts[0];
 		this.semVersion = semver.coerce(versionPart) ?? new semver.SemVer('0.0.1');
-		this.version = `${semver.major(this.semVersion)}.${semver.minor(this.semVersion)}.${semver.patch(this.semVersion)}`;
+		this.version = this.semVersion.format();
 
 		const platformPart = builtParts[1];
 		const architecture = platformPart.match('^(aarch64|x86_64)');

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -80,6 +80,20 @@ export class RInstallation {
 
 		const platformPart = builtParts[1];
 		const architecture = platformPart.match('^(aarch64|x86_64)');
-		this.arch = architecture ? architecture[1] : '';
+
+		if (architecture) {
+			// Remap known architectures to equivalent `process.arch` values
+			if (architecture[1] === 'aarch64') {
+				this.arch = 'arm64';
+			} else if (architecture[1] === 'x86_64') {
+				this.arch = 'x64';
+			} else {
+				// Should never happen
+				this.arch = architecture[1];
+			}
+		} else {
+			// Unknown architecture
+			this.arch = '';
+		}
 	}
 }

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -82,14 +82,17 @@ export class RInstallation {
 		const architecture = platformPart.match('^(aarch64|x86_64)');
 
 		if (architecture) {
-			// Remap known architectures to equivalent `process.arch` values
-			if (architecture[1] === 'aarch64') {
+			const arch = architecture[1];
+
+			// Remap known architectures to equivalent values used by Rig,
+			// just for overall consistency and familiarity
+			if (arch === 'aarch64') {
 				this.arch = 'arm64';
-			} else if (architecture[1] === 'x86_64') {
-				this.arch = 'x64';
+			} else if (arch === 'x86_64') {
+				this.arch = 'x86_64';
 			} else {
-				// Should never happen
-				this.arch = architecture[1];
+				// Should never happen because of how our `match()` works
+				this.arch = arch;
 			}
 		} else {
 			// Unknown architecture

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -92,6 +92,7 @@ export class RInstallation {
 				this.arch = 'x86_64';
 			} else {
 				// Should never happen because of how our `match()` works
+				console.warn(`Matched an unknown architecture '${arch}' for R '${this.version}'.`);
 				this.arch = arch;
 			}
 		} else {

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -180,13 +180,17 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		// Create the icon SVG path.
 		const iconSvgPath = path.join(this.context.extensionPath, 'resources', 'zed-icon.svg');
 
+		const runtimeShortName = version;
+		const runtimeName = `Zed ${runtimeShortName}`;
+
 		// Set the metadata for Zed.
 		this.metadata = {
 			runtimePath: '/zed',
 			runtimeId,
 			languageId: 'zed',
 			languageName: 'Zed',
-			runtimeName: `Zed ${version}`,
+			runtimeName,
+			runtimeShortName,
 			runtimeSource: 'Test',
 			languageVersion: version,
 			base64EncodedIconSvg: fs.readFileSync(iconSvgPath).toString('base64'),

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -186,7 +186,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 			runtimeId,
 			languageId: 'zed',
 			languageName: 'Zed',
-			runtimeName: 'Zed',
+			runtimeName: `Zed ${version}`,
 			runtimeSource: 'Test',
 			languageVersion: version,
 			base64EncodedIconSvg: fs.readFileSync(iconSvgPath).toString('base64'),

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -273,8 +273,17 @@ declare module 'positron' {
 		/** A unique identifier for this runtime; takes the form of a GUID */
 		runtimeId: string;
 
-		/** The name of the runtime displayed to the user; e.g. "R 4.2 (64-bit)" */
+		/**
+		 * The fully qualified name of the runtime displayed to the user; e.g. "R 4.2 (64-bit)".
+		 * Should be unique across languages.
+		 */
 		runtimeName: string;
+
+		/**
+		 * A language specific runtime name displayed to the user; e.g. "4.2 (64-bit)".
+		 * Should be unique within a single language.
+		 */
+		runtimeShortName: string;
 
 		/** The version of the runtime itself (e.g. kernel or extension version) as a string; e.g. "0.1" */
 		runtimeVersion: string;
@@ -712,7 +721,7 @@ declare module 'positron' {
 		 * @param languageId The language ID for running runtimes
 		 */
 		export function getRunningRuntimes(languageId: string): Thenable<LanguageRuntimeMetadata[]>;
-    
+
 		/**
 		 * Select and start a runtime previously registered with Positron. Any
 		 * previously active runtimes for the language will be shut down.

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarInterpretersManager.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarInterpretersManager.tsx
@@ -96,7 +96,7 @@ export const TopActionBarInterpretersManager = (props: TopActionBarInterpretersM
 					<div className='label'>Start Interpreter</div> :
 					<div className='label'>
 						<img className='icon' src={`data:image/svg+xml;base64,${activeRuntime.metadata.base64EncodedIconSvg}`} />
-						<span>{activeRuntime.metadata.languageName} {activeRuntime.metadata.languageVersion}</span>
+						<span>{activeRuntime.metadata.runtimeName}</span>
 					</div>
 				}
 			</div>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/modalPopups/primaryInterpreter.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/modalPopups/primaryInterpreter.tsx
@@ -57,7 +57,7 @@ export const PrimaryInterpreter = (props: PrimaryInterpreterProps) => {
 			<img className='icon' src={`data:image/svg+xml;base64,${props.runtime.metadata.base64EncodedIconSvg}`} />
 			<div className='info'>
 				<div className='container'>
-					<div className='line'>{props.runtime.metadata.languageName} {props.runtime.metadata.languageVersion}</div>
+					<div className='line'>{props.runtime.metadata.runtimeName}</div>
 					<div className='line light' title={props.runtime.metadata.runtimePath}>{props.runtime.metadata.runtimePath}</div>
 				</div>
 			</div>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/modalPopups/secondaryInterpreter.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/modalPopups/secondaryInterpreter.tsx
@@ -55,7 +55,7 @@ export const SecondaryInterpreter = (props: SecondaryInterpreterProps) => {
 			<img className='icon' src={`data:image/svg+xml;base64,${props.runtime.metadata.base64EncodedIconSvg}`} />
 			<div className='info'>
 				<div className='container'>
-					<div className='line'>{props.runtime.metadata.runtimeName}</div>
+					<div className='line'>{props.runtime.metadata.runtimeShortName}</div>
 					<div className='line light' title={props.runtime.metadata.runtimePath}>{props.runtime.metadata.runtimePath}</div>
 				</div>
 			</div>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/modalPopups/secondaryInterpreter.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/modalPopups/secondaryInterpreter.tsx
@@ -55,7 +55,7 @@ export const SecondaryInterpreter = (props: SecondaryInterpreterProps) => {
 			<img className='icon' src={`data:image/svg+xml;base64,${props.runtime.metadata.base64EncodedIconSvg}`} />
 			<div className='info'>
 				<div className='container'>
-					<div className='line'>{props.runtime.metadata.languageVersion}</div>
+					<div className='line'>{props.runtime.metadata.runtimeName}</div>
 					<div className='line light' title={props.runtime.metadata.runtimePath}>{props.runtime.metadata.runtimePath}</div>
 				</div>
 			</div>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceMenuButton.tsx
@@ -28,7 +28,7 @@ export const ConsoleInstanceMenuButton = (props: ConsoleInstanceMenuButtonProps)
 	// Helper method to calculate the label for a runtime.
 	const labelForRuntime = (runtime?: ILanguageRuntime): string => {
 		if (runtime) {
-			return `${runtime.metadata.languageName} ${runtime.metadata.languageVersion}`;
+			return runtime.metadata.runtimeName;
 		}
 		return 'None';
 	};
@@ -55,7 +55,7 @@ export const ConsoleInstanceMenuButton = (props: ConsoleInstanceMenuButtonProps)
 		positronConsoleContext.positronConsoleInstances.map(positronConsoleInstance => {
 			actions.push({
 				id: positronConsoleInstance.runtime.metadata.runtimeId,
-				label: `${positronConsoleInstance.runtime.metadata.runtimeName} ${positronConsoleInstance.runtime.metadata.languageVersion}`,
+				label: positronConsoleInstance.runtime.metadata.runtimeName,
 				tooltip: '',
 				class: undefined,
 				enabled: true,

--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentInstanceMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/environmentInstanceMenuButton.tsx
@@ -21,7 +21,7 @@ export const EnvironmentInstanceMenuButton = () => {
 	// Helper method to calculate the label for a runtime.
 	const labelForRuntime = (runtime?: ILanguageRuntime): string => {
 		if (runtime) {
-			return `${runtime.metadata.languageName} ${runtime.metadata.languageVersion}`;
+			return runtime.metadata.runtimeName;
 		}
 		return 'None';
 	};
@@ -48,7 +48,7 @@ export const EnvironmentInstanceMenuButton = () => {
 		positronEnvironmentContext.positronEnvironmentInstances.map(positronEnvironmentInstance => {
 			actions.push({
 				id: positronEnvironmentInstance.runtime.metadata.runtimeId,
-				label: `${positronEnvironmentInstance.runtime.metadata.runtimeName} ${positronEnvironmentInstance.runtime.metadata.languageVersion}`,
+				label: positronEnvironmentInstance.runtime.metadata.runtimeName,
 				tooltip: '',
 				class: undefined,
 				enabled: true,

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -323,7 +323,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	 * @returns A disposable that unregisters the runtime
 	 */
 	registerRuntime(runtime: ILanguageRuntime, startupBehavior: LanguageRuntimeStartupBehavior): IDisposable {
-		console.log(`registerRuntime for ${runtime.metadata.languageName} ${runtime.metadata.languageVersion}`);
+		console.log(`registerRuntime for ${runtime.metadata.runtimeName}`);
 		// If the runtime has already been registered, throw an error.
 		if (this._registeredRuntimesByRuntimeId.has(runtime.metadata.runtimeId)) {
 			throw new Error(`Language runtime ${formatLanguageRuntime(runtime)} has already been registered.`);

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -323,7 +323,6 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	 * @returns A disposable that unregisters the runtime
 	 */
 	registerRuntime(runtime: ILanguageRuntime, startupBehavior: LanguageRuntimeStartupBehavior): IDisposable {
-		console.log(`registerRuntime for ${runtime.metadata.runtimeName}`);
 		// If the runtime has already been registered, throw an error.
 		if (this._registeredRuntimesByRuntimeId.has(runtime.metadata.runtimeId)) {
 			throw new Error(`Language runtime ${formatLanguageRuntime(runtime)} has already been registered.`);

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -371,8 +371,17 @@ export interface ILanguageRuntimeMetadata {
 	/** The Base64-encoded icon SVG for the language. */
 	readonly base64EncodedIconSvg: string | undefined;
 
-	/** The user-facing descriptive name of the runtime; e.g. "R 4.3.3" */
+	/**
+	 * The fully qualified name of the runtime displayed to the user; e.g. "R 4.2 (64-bit)".
+	 * Should be unique across languages.
+	 */
 	readonly runtimeName: string;
+
+	/**
+	 * A language specific runtime name displayed to the user; e.g. "4.2 (64-bit)".
+	 * Should be unique within a single language.
+	 */
+	readonly runtimeShortName: string;
 
 	/** The internal version of the runtime that wraps the language; e.g. "1.0.3" */
 	readonly runtimeVersion: string;

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -813,7 +813,6 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 								this._runtimeItems[i] = new RuntimeItemStarted(
 									generateUuid(),
 									`${this._runtime.metadata.runtimeName} ` +
-									`${this._runtime.metadata.languageVersion} ` +
 									`${runtimeItem.isRestart ? 'restarted' : 'started'}.`
 								);
 								this._onDidChangeRuntimeItemsEmitter.fire(this._runtimeItems);
@@ -825,7 +824,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 						this.addRuntimeItem(
 							new RuntimeItemReconnected(
 								generateUuid(),
-								`${this._runtime.metadata.runtimeName} ${this._runtime.metadata.languageVersion} reconnected.`
+								`${this._runtime.metadata.runtimeName} reconnected.`
 							)
 						);
 						break;
@@ -836,7 +835,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				this.addRuntimeItem(
 					new RuntimeItemOffline(
 						generateUuid(),
-						`${this._runtime.metadata.runtimeName} ${this._runtime.metadata.languageVersion} offline. Waiting to reconnect.`
+						`${this._runtime.metadata.runtimeName} offline. Waiting to reconnect.`
 					)
 				);
 				break;
@@ -866,7 +865,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			this.setState(PositronConsoleState.Starting);
 			this.addRuntimeItem(new RuntimeItemStarting(
 				generateUuid(),
-				`${this._runtime.metadata.runtimeName} ${this._runtime.metadata.languageVersion} ` +
+				`${this._runtime.metadata.runtimeName} ` +
 				`${restart ? 'restarting' : 'starting'}.`,
 				restart
 			));
@@ -874,7 +873,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			this.setState(PositronConsoleState.Ready);
 			this.addRuntimeItem(new RuntimeItemReconnected(
 				generateUuid(),
-				`${this._runtime.metadata.runtimeName} ${this._runtime.metadata.languageVersion} reconnected.`
+				`${this._runtime.metadata.runtimeName} reconnected.`
 			));
 		}
 
@@ -1207,7 +1206,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 			this.addRuntimeItem(new RuntimeItemExited(
 				generateUuid(),
-				`${this._runtime.metadata.runtimeName} ${this._runtime.metadata.languageVersion} has exited.`
+				`${this._runtime.metadata.runtimeName} has exited.`
 			));
 		} else {
 			// We are not currently attached; warn.


### PR DESCRIPTION
Addresses most of https://github.com/posit-dev/positron/issues/692

- [x] @seeM said he'd update the Python `runtimeName` to reflect what they want to show here

---

- Fixed up R's `runtimeName` to show `R {version} ({optional-arch})` where the arch is only shown if it doesn't match `process.arch` (i.e. the 1% case is more verbose and shows more information)
- Tweaked the Zed `runtimeName` to show the version
- Tweaked the JS `runtimeName` to show the version
- Use `runtimeName` in all user facing places we show runtime name information, including
  - The primary interpreter selector
  - The secondary interpreter selector
  - The env pane switcher, and its corresponding drop down
  - The Console switcher, and its corresponding drop down
  - Console output, like `R 4.2.1 started`

---

The one note here is that the _secondary_ interpreter selection menu previously displayed a short name like `4.4.0` rather than the full name of `R 4.4.0` to reduce a little duplication. I don't think the full name looks too bad, but we can try and get back to this by doing something like:

> "If we wanted to get rid of that we could have runtimeName omit the language name by convention and let the UI concatenate the two where a fully qualified name is needed" -Jonathan

Or by introducing `runtimeShortName` with descriptions of:

```
runtimeName: Fully qualified user friendly name which uniquely identifies a runtime across languages, e.g. R 4.4.0
runtimeShortName: User friendly name which uniquely identifies a runtime within a language, e.g. 4.4.0 or 4.4.0 (x64)
```

Which might be useful if we have future places where we need to display _within language_ runtime versions

<img width="396" alt="Screenshot 2023-08-29 at 4 54 24 PM" src="https://github.com/posit-dev/positron/assets/19150088/637a814e-1595-4fd0-8d54-8d9969bbf352">
<img width="234" alt="Screenshot 2023-08-29 at 4 54 34 PM" src="https://github.com/posit-dev/positron/assets/19150088/6f88c971-23c1-4ce1-b5f6-1ac181d12cdd">
<img width="371" alt="Screenshot 2023-08-29 at 4 55 17 PM" src="https://github.com/posit-dev/positron/assets/19150088/01fab3c0-8229-4d6d-adbe-59a27ceaf071">
<img width="465" alt="Screenshot 2023-08-29 at 4 55 25 PM" src="https://github.com/posit-dev/positron/assets/19150088/fa012ae7-8c98-42cf-9a17-0f7ea0ba9275">

