### PR TITLE
Updates suggest-widget hack to only fire when cmdOrCtrlKey is false

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -182,6 +182,9 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			codeEditorWidgetRef.current.setValue('');
 		};
 
+		// Determine whether the cmd or ctrl key is pressed.
+		const cmdOrCtrlKey = isMacintosh ? e.metaKey : e.ctrlKey;
+
 		// Check for a suggest widget in the DOM. If one exists, then don't
 		// handle the key.
 		//
@@ -189,10 +192,12 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 		// 'suggestWidgetVisible' context key, but the way VSCode handles
 		// 'scoped' contexts makes that challenging to access here, and I
 		// haven't figured out the 'right' way to get access to those contexts.
-		const suggestWidgets = document.getElementsByClassName('suggest-widget');
-		for (const suggestWidget of suggestWidgets) {
-			if (suggestWidget.classList.contains('visible')) {
-				return;
+		if (!cmdOrCtrlKey) {
+			const suggestWidgets = document.getElementsByClassName('suggest-widget');
+			for (const suggestWidget of suggestWidgets) {
+				if (suggestWidget.classList.contains('visible')) {
+					return;
+				}
 			}
 		}
 
@@ -210,9 +215,6 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 
 			// Ctrl-A handling.
 			case KeyCode.KeyA: {
-				// Determine whether the cmd or ctrl key is pressed.
-				const cmdOrCtrlKey = isMacintosh ? e.metaKey : e.ctrlKey;
-
 				// If the cmd or ctrl key is pressed, see if the user wants to select all.
 				if (cmdOrCtrlKey) {
 					// Get the code fragment from the code editor widget.


### PR DESCRIPTION
This PR changes how the `suggest-widget` hack in `consoleInput.ts` works. With this PR, ⌘ (macOS) or Ctrl key combinations are allowed to be processed by `ConsoleInput` component.

This addresses the specific issue of #596.

https://github.com/posit-dev/positron/assets/853239/4f659781-8682-4261-9a97-b8741a2acb32

```TypeScript
		// Check for a suggest widget in the DOM. If one exists, then don't
		// handle the key.
		//
		// TODO(Kevin): Ideally, we'd do this by checking the
		// 'suggestWidgetVisible' context key, but the way VSCode handles
		// 'scoped' contexts makes that challenging to access here, and I
		// haven't figured out the 'right' way to get access to those contexts.
		if (!cmdOrCtrlKey) {
			const suggestWidgets = document.getElementsByClassName('suggest-widget');
			for (const suggestWidget of suggestWidgets) {
				if (suggestWidget.classList.contains('visible')) {
					return;
				}
			}
		}
```

The overall validity of the `suggest-widget` hack remains questionable. I will continue to evaluate it for correctness.