### PR TITLE
Allow Ctrl+Enter to also execute code

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -194,8 +194,9 @@ export function registerPositronConsoleActions() {
 				keybinding: {
 					weight: KeybindingWeight.WorkbenchContrib,
 					primary: KeyMod.CtrlCmd | KeyCode.Enter,
-					win: {
-						primary: KeyMod.WinCtrl | KeyCode.Enter
+					mac: {
+						primary: KeyMod.CtrlCmd | KeyCode.Enter,
+						secondary: [KeyMod.WinCtrl | KeyCode.Enter]
 					}
 				},
 				description: {


### PR DESCRIPTION
Addresses #1192

This implements the simplest thing I could figure out, based on the @jmcphers hint I recorded in #1192. This PR allows me to execute R code with both Ctrl+Enter and Cmd+Enter, on macOS.

But I'm concerned that this might have additional ramifications that are undesirable in contexts I know less about, so hopefully others can evaluate that.