### PR TITLE
Make the console input's code editor widget a "simple" widget

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -452,7 +452,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				// Make the console input's code editor widget a "simple" widget. This prevents the
 				// console input's code editor widget from being the active editor (i.e. being the
 				// vscode.window.activeTextEditor).
-				isSimpleWidget: false,
+				isSimpleWidget: true,
 				contributions: EditorExtensionsRegistry.getSomeEditorContributions([
 					SelectionClipboardContributionID,
 					ContextMenuController.ID,

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -449,6 +449,9 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				...editorOptions
 			},
 			{
+				// Make the console input's code editor widget a "simple" widget. This prevents the
+				// console input's code editor widget from being the active editor (i.e. being the
+				// vscode.window.activeTextEditor).
 				isSimpleWidget: false,
 				contributions: EditorExtensionsRegistry.getSomeEditorContributions([
 					SelectionClipboardContributionID,

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -450,7 +450,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			},
 			{
 				// Make the console input's code editor widget a "simple" widget. This prevents the
-				// console input's code editor widget from being the active editor (i.e. being the
+				// console input's code editor widget from being the active text editor (i.e. being
 				// vscode.window.activeTextEditor).
 				isSimpleWidget: true,
 				contributions: EditorExtensionsRegistry.getSomeEditorContributions([


### PR DESCRIPTION
This PR appears to address #1184 by making the console input's code editor widget a "simple" widget. This means that the console input's code editor widget will not be returned as the active editor through `vscode.window.activeTextEditor`.

Here's a movie:

https://github.com/posit-dev/positron/assets/853239/36dcc491-363b-4c78-954c-4a23dcce7ebe

