### PR TITLE
Add new "Statement Range Provider" to power "Execute Current Statement"

### DIFF
--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -664,7 +664,8 @@ declare module 'positron' {
 	export interface StatementRangeProvider {
 		/**
 		 * Given a cursor position, return the range of the statement that the
-		 * cursor is within.
+		 * cursor is within. If the cursor is not within a statement, return the
+		 * range of the next statement, if one exists.
 		 *
 		 * @param document The document in which the command was invoked.
 		 * @param position The position at which the command was invoked.

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -673,7 +673,7 @@ declare module 'positron' {
 		 */
 		provideStatementRange(document: vscode.TextDocument,
 			position: vscode.Position,
-			token: vscode.CancellationToken): vscode.ProviderResult<Range>;
+			token: vscode.CancellationToken): vscode.ProviderResult<vscode.Range>;
 	}
 
 	namespace languages {

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -661,6 +661,34 @@ declare module 'positron' {
 		readonly previewPanel: PreviewPanel;
 	}
 
+	export interface StatementRangeProvider {
+		/**
+		 * Given a cursor position, return the range of the statement that the
+		 * cursor is within.
+		 *
+		 * @param document The document in which the command was invoked.
+		 * @param position The position at which the command was invoked.
+		 * @param token A cancellation token.
+		 * @return The range of the statement at the given position.
+		 */
+		provideStatementRange(document: vscode.TextDocument,
+			position: vscode.Position,
+			token: vscode.CancellationToken): vscode.ProviderResult<Range>;
+	}
+
+	namespace languages {
+		/**
+		 * Register a statement range provider.
+		 *
+		 * @param selector A selector that defines the documents this provider is applicable to.
+		 * @param provider A statement range provider.
+		 * @return A {@link Disposable} that unregisters this provider when being disposed.
+		 */
+		export function registerStatementRangeProvider(
+			selector: vscode.DocumentSelector,
+			provider: StatementRangeProvider): vscode.Disposable;
+	}
+
 	namespace window {
 		/**
 		 * Create and show a new preview panel.
@@ -712,7 +740,7 @@ declare module 'positron' {
 		 * @param languageId The language ID for running runtimes
 		 */
 		export function getRunningRuntimes(languageId: string): Thenable<LanguageRuntimeMetadata[]>;
-    
+
 		/**
 		 * Select and start a runtime previously registered with Positron. Any
 		 * previously active runtimes for the language will be shut down.

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1484,6 +1484,15 @@ export class FoldingRangeKind {
 	}
 }
 
+// --- Start Positron ---
+export interface StatementRangeProvider {
+	/**
+	 * Provide the statement that contains the given position.
+	 */
+	provideStatementRange(model: model.ITextModel, position: Position, token: CancellationToken):
+		ProviderResult<Range>;
+}
+// --- End Positron ---
 
 export interface WorkspaceEditMetadata {
 	needsConfirmation: boolean;

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1490,7 +1490,7 @@ export interface StatementRangeProvider {
 	 * Provide the statement that contains the given position.
 	 */
 	provideStatementRange(model: model.ITextModel, position: Position, token: CancellationToken):
-		ProviderResult<Range>;
+		ProviderResult<IRange>;
 }
 // --- End Positron ---
 

--- a/src/vs/editor/common/services/languageFeatures.ts
+++ b/src/vs/editor/common/services/languageFeatures.ts
@@ -7,6 +7,12 @@ import { LanguageFeatureRegistry, NotebookInfoResolver } from 'vs/editor/common/
 import { CodeActionProvider, CodeLensProvider, CompletionItemProvider, DeclarationProvider, DefinitionProvider, DocumentColorProvider, DocumentFormattingEditProvider, DocumentHighlightProvider, DocumentOnDropEditProvider, DocumentPasteEditProvider, DocumentRangeFormattingEditProvider, DocumentRangeSemanticTokensProvider, DocumentSemanticTokensProvider, DocumentSymbolProvider, EvaluatableExpressionProvider, FoldingRangeProvider, HoverProvider, ImplementationProvider, InlayHintsProvider, InlineCompletionsProvider, InlineValuesProvider, LinkedEditingRangeProvider, LinkProvider, OnTypeFormattingEditProvider, ReferenceProvider, RenameProvider, SelectionRangeProvider, SignatureHelpProvider, TypeDefinitionProvider } from 'vs/editor/common/languages';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 
+// --- Start Positron ---
+// Disable warning about multiple import from same source
+// eslint-disable-next-line no-duplicate-imports
+import { StatementRangeProvider } from 'vs/editor/common/languages';
+// --- End Positron ---
+
 export const ILanguageFeaturesService = createDecorator<ILanguageFeaturesService>('ILanguageFeaturesService');
 
 export interface ILanguageFeaturesService {
@@ -56,6 +62,12 @@ export interface ILanguageFeaturesService {
 	readonly selectionRangeProvider: LanguageFeatureRegistry<SelectionRangeProvider>;
 
 	readonly foldingRangeProvider: LanguageFeatureRegistry<FoldingRangeProvider>;
+
+	// --- Start Positron ---
+
+	readonly statementRangeProvider: LanguageFeatureRegistry<StatementRangeProvider>;
+
+	// --- End Positron ---
 
 	readonly linkProvider: LanguageFeatureRegistry<LinkProvider>;
 

--- a/src/vs/editor/common/services/languageFeatures.ts
+++ b/src/vs/editor/common/services/languageFeatures.ts
@@ -8,7 +8,7 @@ import { CodeActionProvider, CodeLensProvider, CompletionItemProvider, Declarati
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 
 // --- Start Positron ---
-// Disable warning about multiple import from same source
+// This import is on its own line to avoid unnecessary merge conflicts.
 // eslint-disable-next-line no-duplicate-imports
 import { StatementRangeProvider } from 'vs/editor/common/languages';
 // --- End Positron ---

--- a/src/vs/editor/common/services/languageFeaturesService.ts
+++ b/src/vs/editor/common/services/languageFeaturesService.ts
@@ -10,7 +10,7 @@ import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeat
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 
 // --- Start Positron ---
-// Disable warning about multiple import from same source
+// This import is on its own line to avoid unnecessary merge conflicts.
 // eslint-disable-next-line no-duplicate-imports
 import { StatementRangeProvider } from 'vs/editor/common/languages';
 // --- End Positron ---

--- a/src/vs/editor/common/services/languageFeaturesService.ts
+++ b/src/vs/editor/common/services/languageFeaturesService.ts
@@ -9,6 +9,12 @@ import { CodeActionProvider, CodeLensProvider, CompletionItemProvider, DocumentP
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 
+// --- Start Positron ---
+// Disable warning about multiple import from same source
+// eslint-disable-next-line no-duplicate-imports
+import { StatementRangeProvider } from 'vs/editor/common/languages';
+// --- End Positron ---
+
 export class LanguageFeaturesService implements ILanguageFeaturesService {
 
 	declare _serviceBrand: undefined;
@@ -42,6 +48,10 @@ export class LanguageFeaturesService implements ILanguageFeaturesService {
 	readonly documentSemanticTokensProvider = new LanguageFeatureRegistry<DocumentSemanticTokensProvider>(this._score.bind(this));
 	readonly documentOnDropEditProvider = new LanguageFeatureRegistry<DocumentOnDropEditProvider>(this._score.bind(this));
 	readonly documentPasteEditProvider = new LanguageFeatureRegistry<DocumentPasteEditProvider>(this._score.bind(this));
+
+	// --- Start Positron ---
+	readonly statementRangeProvider = new LanguageFeatureRegistry<StatementRangeProvider>(this._score.bind(this));
+	// --- End Positron ---
 
 	private _notebookTypeResolver?: NotebookInfoResolver;
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7589,6 +7589,13 @@ declare namespace monaco.languages {
 		constructor(value: string);
 	}
 
+	export interface StatementRangeProvider {
+		/**
+		 * Provide the statement that contains the given position.
+		 */
+		provideStatementRange(model: editor.ITextModel, position: Position, token: CancellationToken): ProviderResult<IRange>;
+	}
+
 	export interface WorkspaceEditMetadata {
 		needsConfirmation: boolean;
 		label: string;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7589,12 +7589,14 @@ declare namespace monaco.languages {
 		constructor(value: string);
 	}
 
+	// --- Start Positron ---
 	export interface StatementRangeProvider {
 		/**
 		 * Provide the statement that contains the given position.
 		 */
 		provideStatementRange(model: editor.ITextModel, position: Position, token: CancellationToken): ProviderResult<IRange>;
 	}
+	// --- End Positron ---
 
 	export interface WorkspaceEditMetadata {
 		needsConfirmation: boolean;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7589,14 +7589,12 @@ declare namespace monaco.languages {
 		constructor(value: string);
 	}
 
-	// --- Start Positron ---
 	export interface StatementRangeProvider {
 		/**
 		 * Provide the statement that contains the given position.
 		 */
 		provideStatementRange(model: editor.ITextModel, position: Position, token: CancellationToken): ProviderResult<IRange>;
 	}
-	// --- End Positron ---
 
 	export interface WorkspaceEditMetadata {
 		needsConfirmation: boolean;

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -761,6 +761,16 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 		}));
 	}
 
+	// --- Start Positron ---
+	$registerStatementRangeProvider(handle: number, selector: IDocumentFilterDto[]): void {
+		this._registrations.set(handle, this._languageFeaturesService.statementRangeProvider.register(selector, {
+			provideStatementRange: (model, positions, token) => {
+				return this._proxy.$provideStatementRange(handle, model.uri, positions, token);
+			}
+		}));
+	}
+	// --- End Positron ---
+
 	// --- call hierarchy
 
 	$registerCallHierarchyProvider(handle: number, selector: IDocumentFilterDto[]): void {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -416,7 +416,9 @@ export interface MainThreadLanguageFeaturesShape extends IDisposable {
 	$registerFoldingRangeProvider(handle: number, selector: IDocumentFilterDto[], extensionId: ExtensionIdentifier, eventHandle: number | undefined): void;
 	$emitFoldingRangeEvent(eventHandle: number, event?: any): void;
 	$registerSelectionRangeProvider(handle: number, selector: IDocumentFilterDto[]): void;
+	// --- Start Positron ---
 	$registerStatementRangeProvider(handle: number, selector: IDocumentFilterDto[]): void;
+	// --- End Positron ---
 	$registerCallHierarchyProvider(handle: number, selector: IDocumentFilterDto[]): void;
 	$registerTypeHierarchyProvider(handle: number, selector: IDocumentFilterDto[]): void;
 	$registerDocumentOnDropEditProvider(handle: number, selector: IDocumentFilterDto[], metadata?: IDocumentDropEditProviderMetadata): void;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -416,6 +416,7 @@ export interface MainThreadLanguageFeaturesShape extends IDisposable {
 	$registerFoldingRangeProvider(handle: number, selector: IDocumentFilterDto[], extensionId: ExtensionIdentifier, eventHandle: number | undefined): void;
 	$emitFoldingRangeEvent(eventHandle: number, event?: any): void;
 	$registerSelectionRangeProvider(handle: number, selector: IDocumentFilterDto[]): void;
+	$registerStatementRangeProvider(handle: number, selector: IDocumentFilterDto[]): void;
 	$registerCallHierarchyProvider(handle: number, selector: IDocumentFilterDto[]): void;
 	$registerTypeHierarchyProvider(handle: number, selector: IDocumentFilterDto[]): void;
 	$registerDocumentOnDropEditProvider(handle: number, selector: IDocumentFilterDto[], metadata?: IDocumentDropEditProviderMetadata): void;
@@ -1948,6 +1949,9 @@ export interface ExtHostLanguageFeaturesShape {
 	$provideColorPresentations(handle: number, resource: UriComponents, colorInfo: IRawColorInfo, token: CancellationToken): Promise<languages.IColorPresentation[] | undefined>;
 	$provideFoldingRanges(handle: number, resource: UriComponents, context: languages.FoldingContext, token: CancellationToken): Promise<languages.FoldingRange[] | undefined>;
 	$provideSelectionRanges(handle: number, resource: UriComponents, positions: IPosition[], token: CancellationToken): Promise<languages.SelectionRange[][]>;
+	// --- Start Positron ---
+	$provideStatementRange(handle: number, resource: UriComponents, position: IPosition, token: CancellationToken): Promise<IRange | undefined>;
+	// --- End Positron ---
 	$prepareCallHierarchy(handle: number, resource: UriComponents, position: IPosition, token: CancellationToken): Promise<ICallHierarchyItemDto[] | undefined>;
 	$provideCallHierarchyIncomingCalls(handle: number, sessionId: string, itemId: string, token: CancellationToken): Promise<IIncomingCallDto[] | undefined>;
 	$provideCallHierarchyOutgoingCalls(handle: number, sessionId: string, itemId: string, token: CancellationToken): Promise<IOutgoingCallDto[] | undefined>;

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -464,11 +464,14 @@ const newCommands: ApiCommand[] = [
 		[ApiCommandArgument.Uri,
 		new ApiCommandArgument<types.Position, IPosition>('position',
 			'A position in a text document',
+			// validator: check for a valid position
 			v => types.Position.isPosition(v),
+			// converter: convert from vscode.Position to IPosition (API type)
 			v => {
 				return typeConverters.Position.from(v);
 			})],
 		new ApiCommandResult<IRange, types.Range>('A promise that resolves to a range.', result => {
+			// converter: convert from IRange (API type) to vscode.Range
 			return typeConverters.Range.to(result);
 		})
 	),

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -456,6 +456,24 @@ const newCommands: ApiCommand[] = [
 		[ApiCommandArgument.Uri.with('workspaceUri', 'The target workspace to continue the current edit session in')],
 		ApiCommandResult.Void
 	),
+
+	// --- Start Positron ---
+	// -- statement range
+	new ApiCommand(
+		'vscode.executeStatementRangeProvider', '_executeStatementRangeProvider', 'Execute statement range provider.',
+		[ApiCommandArgument.Uri,
+		new ApiCommandArgument<types.Position, IPosition>('position',
+			'A position in a text document',
+			v => types.Position.isPosition(v),
+			v => {
+				return typeConverters.Position.from(v);
+			})],
+		new ApiCommandResult<IRange, types.Range>('A promise that resolves to a range.', result => {
+			return typeConverters.Range.to(result);
+		})
+	),
+	// --- End Positron
+
 	// --- context keys
 	new ApiCommand(
 		'setContext', '_setContext', 'Set a custom context key value that can be used in when clauses.',

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1560,6 +1560,10 @@ class FoldingProviderAdapter {
 
 // --- Start Positron ---
 
+/**
+ * Adapter for the `StatementRangeProvider` API; serves as a bridge to convert
+ * API types to and from internal VS Code types.
+ */
 class StatementRangeAdapter {
 
 	constructor(
@@ -1568,6 +1572,14 @@ class StatementRangeAdapter {
 		private readonly _logService: ILogService
 	) { }
 
+	/**
+	 * Provide the range of the statement at the given position.
+	 *
+	 * @param resource The URI of the document to search
+	 * @param pos The position to search at
+	 * @param token The cancellation token (currently unused)
+	 * @returns A promise that resolves to the statement range
+	 */
 	async provideStatementRange(resource: URI, pos: IPosition, token: CancellationToken): Promise<IRange> {
 		const document = this._documents.getDocument(resource);
 		const position = typeConvert.Position.to(pos);
@@ -1576,7 +1588,8 @@ class StatementRangeAdapter {
 		if (!providerRange) {
 			this._logService.debug(`No statement range from provider ` +
 				`for position ${position} in ${resource}`);
-			throw new Error('INVALID statement range, must return a range');
+			throw new Error(`Invalid statement range returned from provider ` +
+				`for ${position} in ${resource}`);
 		}
 		return typeConvert.Range.from(providerRange);
 	}

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1568,7 +1568,7 @@ class StatementRangeAdapter {
 		private readonly _logService: ILogService
 	) { }
 
-	async provideStatementRange(resource: URI, pos: IPosition, token: CancellationToken): Promise<Range> {
+	async provideStatementRange(resource: URI, pos: IPosition, token: CancellationToken): Promise<IRange> {
 		const document = this._documents.getDocument(resource);
 		const position = typeConvert.Position.to(pos);
 
@@ -2401,6 +2401,10 @@ export class ExtHostLanguageFeatures implements extHostProtocol.ExtHostLanguageF
 		const handle = this._addNewAdapter(new StatementRangeAdapter(this._documents, provider, this._logService), extension);
 		this._proxy.$registerStatementRangeProvider(handle, this._transformDocumentSelector(selector, extension));
 		return this._createDisposable(handle);
+	}
+
+	$provideStatementRange(handle: number, resource: UriComponents, position: IPosition, token: CancellationToken): Promise<IRange | undefined> {
+		return this._withAdapter(handle, StatementRangeAdapter, adapter => adapter.provideStatementRange(URI.revive(resource), position, token), undefined, token);
 	}
 	// --- End Positron ---
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -17,6 +17,7 @@ import { ExtHostPreviewPanels } from 'vs/workbench/api/common/positron/extHostPr
 import { ExtHostContext } from 'vs/workbench/api/common/extHost.protocol';
 import { IExtHostWorkspace } from 'vs/workbench/api/common/extHostWorkspace';
 import { ExtHostWebviews } from 'vs/workbench/api/common/extHostWebview';
+import { ExtHostLanguageFeatures } from 'vs/workbench/api/common/extHostLanguageFeatures';
 
 /**
  * Factory interface for creating an instance of the Positron API.
@@ -48,6 +49,10 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 		throw new Error('Could not retrieve ExtHostWebviews from the RPC protocol. ' +
 			' The VS Code API must be created before the Positron API.');
 	}
+
+	// Same deal for the `ExtHostLanguageFeatures` object
+	const extHostLanguageFeatures: ExtHostLanguageFeatures =
+		rpcProtocol.getRaw(ExtHostContext.ExtHostLanguageFeatures);
 
 	const extHostLanguageRuntime = rpcProtocol.set(ExtHostPositronContext.ExtHostLanguageRuntime, new ExtHostLanguageRuntime(rpcProtocol));
 	const extHostPreviewPanels = rpcProtocol.set(ExtHostPositronContext.ExtHostPreviewPanel, new ExtHostPreviewPanels(rpcProtocol, extHostWebviews, extHostWorkspace));
@@ -86,11 +91,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			registerStatementRangeProvider(
 				selector: vscode.DocumentSelector,
 				provider: positron.StatementRangeProvider): vscode.Disposable {
-				// TODO: Implement
-				// Return empty disposable for now
-				return {
-					dispose() { }
-				};
+				return extHostLanguageFeatures.registerSelectionRangeProvider(extension, selector, provider);
 			},
 		};
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -67,7 +67,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			},
 			getRunningRuntimes(languageId: string): Thenable<positron.LanguageRuntimeMetadata[]> {
 				return extHostLanguageRuntime.getRunningRuntimes(languageId);
-      },
+			},
 			selectLanguageRuntime(runtimeId: string): Thenable<void> {
 				return extHostLanguageRuntime.selectLanguageRuntime(runtimeId);
 			},
@@ -81,12 +81,26 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 				return extHostPreviewPanels.createPreviewPanel(extension, viewType, title, preserveFocus, options);
 			}
 		};
+
+		const languages: typeof positron.languages = {
+			registerStatementRangeProvider(
+				selector: vscode.DocumentSelector,
+				provider: positron.StatementRangeProvider): vscode.Disposable {
+				// TODO: Implement
+				// Return empty disposable for now
+				return {
+					dispose() { }
+				};
+			},
+		};
+
 		// --- End Positron ---
 
 		return <typeof positron>{
 			version: initData.positronVersion,
 			runtime,
 			window,
+			languages,
 			RuntimeClientType: extHostTypes.RuntimeClientType,
 			RuntimeClientState: extHostTypes.RuntimeClientState,
 			LanguageRuntimeMessageType: extHostTypes.LanguageRuntimeMessageType,

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -22,6 +22,9 @@ import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/
 import { IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { CancellationToken } from 'vs/base/common/cancellation';
+import { Position } from 'vs/editor/common/core/position';
+import { IRange } from 'vs/editor/common/core/range';
+import { ILogService } from 'vs/platform/log/common/log';
 
 /**
  * Positron console command ID's.
@@ -220,6 +223,7 @@ export function registerPositronConsoleActions() {
 			const positronConsoleService = accessor.get(IPositronConsoleService);
 			const viewsService = accessor.get(IViewsService);
 			const languageFeaturesService = accessor.get(ILanguageFeaturesService);
+			const logService = accessor.get(ILogService);
 
 			// The code to execute.
 			let code = '';
@@ -240,21 +244,103 @@ export function registerPositronConsoleActions() {
 				code = model.getValueInRange(selection);
 			}
 
-			// If the user doesn't have an explicit selection, see if the active language
-			// in the editor has a statement range provider, which can be used to get the
-			// code to execute.
-			if (code.length === 0) {
-				const statementRangeProviders =
-					languageFeaturesService.statementRangeProvider.all(model);
+			// Get the position of the cursor. If we don't have a selection, we'll use this to
+			// determine the code to execute.
+			const position = editor.getPosition();
+			if (!position) {
+				return;
+			}
 
-				if (statementRangeProviders.length > 0) {
-					const statementRange = await statementRangeProviders[0].provideStatementRange(
+			// Get all the statement range providers for the active document.
+			const statementRangeProviders =
+				languageFeaturesService.statementRangeProvider.all(model);
+
+			// If the user doesn't have an explicit selection (and we aren't at
+			// the end of the document), consult a statement range provider,
+			// which can be used to get the code to execute.
+			if (code.length === 0 &&
+				statementRangeProviders.length > 0 &&
+				position.lineNumber < model.getLineCount()) {
+
+				let statementRange: IRange | null | undefined = undefined;
+				try {
+					// Just consult the first statement range provider if several are registered
+					statementRange = await statementRangeProviders[0].provideStatementRange(
 						model,
-						editor.getPosition()!,
+						position,
 						CancellationToken.None);
-					if (statementRange) {
-						code = model.getValueInRange(statementRange);
+				} catch (err) {
+					// If the statement range provider throws an exception, log it and continue
+					logService.warn(`Failed to get statement range at ${position}: ${err}`);
+				}
+
+				if (statementRange) {
+					// If a statement was found, get the code to execute.
+					code = model.getValueInRange(statementRange);
+
+					if (code.length > 0) {
+						// If code was returned, move the cursor to the next
+						// statement by creating a position on the line
+						// following the statement and then invoking the
+						// statement range provider again to find the start
+						// boundary of the next statement.
+						let newPosition = new Position(
+							statementRange.endLineNumber + 1,
+							1
+						);
+						if (newPosition.lineNumber > model.getLineCount()) {
+							// If the new position is past the end of the
+							// document, add a newline to the end of the
+							// document, unless it already ends with an empty
+							// line.
+							if (model.getLineContent(model.getLineCount()).trim().length > 0) {
+								// The document doesn't end with an empty line;
+								// add one
+								this.amendNewlineToEnd(editor);
+							} else {
+								// If the document already ends with an empty
+								// line, move the cursor to that line.
+								newPosition = new Position(
+									model.getLineCount(),
+									1
+								);
+								editor.setPosition(newPosition);
+								editor.revealPositionInCenterIfOutsideViewport(newPosition);
+							}
+						} else {
+							// Invoke the statement range provider again to
+							// find the start boundary of the next statement.
+
+							let nextStatement: IRange | null | undefined = undefined;
+							try {
+								nextStatement = await statementRangeProviders[0].provideStatementRange(
+									model,
+									newPosition,
+									CancellationToken.None);
+							} catch (err) {
+								logService.warn(`Failed to get statement range for next statement ` +
+									`at position ${newPosition}: ${err}`);
+							}
+
+							// If it found a statement, move the cursor to the
+							// start of that statement.
+							if (nextStatement) {
+								newPosition = new Position(
+									nextStatement.startLineNumber,
+									nextStatement.startColumn
+								);
+							}
+							editor.setPosition(newPosition);
+							editor.revealPositionInCenterIfOutsideViewport(newPosition);
+						}
+					} else {
+						// The statement range provider returned a range that
+						// didn't contain any code. This is okay; we'll fall
+						// back to line-based execution below.
 					}
+				} else {
+					// The statement range provider didn't return a range. This
+					// is okay; we'll fall back to line-based execution below.
 				}
 			}
 
@@ -330,28 +416,9 @@ export function registerPositronConsoleActions() {
 				}
 
 				if (!code.length && position && lineNumber === model.getLineCount()) {
-					// Typically we don't do anything when we don't have code to execute,
-					// but when we are at the end of a document we add a new line. However,
-					// we don't move to that new line to avoid adding a bunch of empty
-					// lines to the end.
-
-					// Create an edit operation that will append a new line to the end
-					// of the document. It also moves us to that line.
-					const editOperation = {
-						range: {
-							startLineNumber: model.getLineCount(),
-							startColumn: model.getLineMaxColumn(model.getLineCount()),
-							endLineNumber: model.getLineCount(),
-							endColumn: model.getLineMaxColumn(model.getLineCount())
-						},
-						text: '\n'
-					};
-					model.pushEditOperations([], [editOperation], () => []);
-
-					// Undo the fact that the edit operation moved the cursor.
-					const newPosition = position.with(lineNumber, position.column);
-					editor.setPosition(newPosition);
-					editor.revealPositionInCenterIfOutsideViewport(newPosition);
+					// If we still don't have code and we are at the end of the document, add a
+					// newline to the end of the document.
+					this.amendNewlineToEnd(editor);
 				}
 			}
 
@@ -378,6 +445,33 @@ export function registerPositronConsoleActions() {
 					sticky: false
 				});
 			}
+		}
+
+		// Typically we don't do anything when we don't have code to execute,
+		// but when we are at the end of a document we add a new line. However,
+		// we don't move to that new line to avoid adding a bunch of empty
+		// lines to the end.
+
+		// Create an edit operation that will append a new line to the end
+		// of the document. It also moves us to that line.
+		amendNewlineToEnd(editor: IEditor) {
+			const model = editor.getModel() as ITextModel;
+			const lineNumber = model.getLineCount();
+			const editOperation = {
+				range: {
+					startLineNumber: model.getLineCount(),
+					startColumn: model.getLineMaxColumn(model.getLineCount()),
+					endLineNumber: model.getLineCount(),
+					endColumn: model.getLineMaxColumn(model.getLineCount())
+				},
+				text: '\n'
+			};
+			model.pushEditOperations([], [editOperation], () => []);
+
+			// Undo the fact that the edit operation moved the cursor.
+			const newPosition = new Position(lineNumber, 1);
+			editor.setPosition(newPosition);
+			editor.revealPositionInCenterIfOutsideViewport(newPosition);
 		}
 	});
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -447,14 +447,14 @@ export function registerPositronConsoleActions() {
 			}
 		}
 
-		// Typically we don't do anything when we don't have code to execute,
-		// but when we are at the end of a document we add a new line. However,
-		// we don't move to that new line to avoid adding a bunch of empty
-		// lines to the end.
-
-		// Create an edit operation that will append a new line to the end
-		// of the document. It also moves us to that line.
 		amendNewlineToEnd(editor: IEditor) {
+			// Typically we don't do anything when we don't have code to execute,
+			// but when we are at the end of a document we add a new line. However,
+			// we don't move to that new line to avoid adding a bunch of empty
+			// lines to the end.
+
+			// Create an edit operation that will append a new line to the end
+			// of the document. It also moves us to that line.
 			const model = editor.getModel() as ITextModel;
 			const lineNumber = model.getLineCount();
 			const editOperation = {

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -242,6 +242,17 @@ export function registerPositronConsoleActions() {
 			// only contains whitespace or comments) and also retain the user's selection location.
 			if (selection && !selection.isEmpty()) {
 				code = model.getValueInRange(selection);
+				// HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK
+				// This attempts to address https://github.com/posit-dev/positron/issues/1177
+				// by tacking a newline onto multiline, indented Python code fragments. This allows
+				// such code fragments to be complete.
+				if (editorService.activeTextEditorLanguageId === 'python') {
+					const lines = code.split('\n');
+					if (lines.length > 1 && /^[ \t]/.test(lines[lines.length - 1])) {
+						code += '\n';
+					}
+				}
+				// HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK
 			}
 
 			// Get the position of the cursor. If we don't have a selection, we'll use this to


### PR DESCRIPTION
This change adds a whole bunch of plumbing that makes it possible for language packs to provide intelligent statement range detection -- that is, finding the current statement around the cursor point. These are subsequently used by the Execute Statement command (Cmd+Enter). Here's a video of the feature in action:

https://github.com/posit-dev/positron/assets/470418/0463d3de-a91e-4e82-979f-016b702b8f5f

The API is modeled after VS Code's [programmatic language features](https://code.visualstudio.com/api/language-extensions/programmatic-language-features) system. Any extension can supply a `StatementRangeProvider`, which is just a function that accepts a `Position`, indicating the user's cursor point, and returns a `Range`, indicating the statement to execute. 

When the user presses Cmd+Enter, we use a `StatementRangeProvider` (if one is registered) to determine the boundary of the current statement, then use it again to find the boundary of the next statement. This makes it possible to Cmd+Enter your way through a file, statement by statement.

Note that this PR does not have any effect on its own since it doesn't contain any range providers. I have implemented a simple range provider for Python as a proof of concept (it's demo'ed above and I'll submit a PR for it on the Python repository). 

Part of https://github.com/posit-dev/positron/issues/394.