### PR TITLE
Handle empty elements and text-only elements in React HTML renderer

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputHtml.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputHtml.tsx
@@ -38,10 +38,24 @@ const renderHtml = (html: string): React.ReactElement => {
 			// currently ignored.
 			return undefined;
 		} else if (node.type === 'tag' && node.children) {
-			// Call the renderer recursively to render the children, if any.
-			const children = node.children.map(renderNode);
-			// Create a React element for the tag and its children.
-			return React.createElement(node.name!, node.attrs, children);
+			if (node.children.length === 1 && node.children[0].type === 'text') {
+				// If this is a tag with a single text child, create a React element
+				// for the tag and its text content.
+				return React.createElement(node.name!, node.attrs, node.children[0].content);
+			} else {
+				if (node.children.length === 0) {
+					// If the node has no children, create a React element for
+					// the tag. For tags that cannot have children (such as
+					// <br>), React will throw an exception if an array if
+					// childen is supplied, even if the array is empty.
+					return React.createElement(node.name!, node.attrs);
+				} else {
+					// Call the renderer recursively to render the children;
+					// create a React element for the tag and its children.
+					const children = node.children.map(renderNode);
+					return React.createElement(node.name!, node.attrs, children);
+				}
+			}
 		} else if (node.type === 'tag') {
 			// Create a React element for the tag.
 			return React.createElement(node.name!, node.attrs);


### PR DESCRIPTION
This issue fixes a React error by handling some new cases in the HTML renderer:

- Elements with a single `text` node now get rendered with text contents directly, instead of rendering the text inside its own `<span>`.
- Elements with no children, such as `<br>`, are now created without any children. It turns out that React throws a render exception if you create a `<br>` element with a child array, even if that child array is empty! This was the root cause of the reported issue. 

Addresses https://github.com/posit-dev/positron/issues/1195. Note, however, that because the HTML renderer is stripping scripts for safety, the rendered item we display isn't very helpful -- it looks expandable but can't be expanded.

<img width="191" alt="image" src="https://github.com/posit-dev/positron/assets/470418/998a2c8a-db51-4219-bbda-bdddeb94307a">

A better fix for this would be showing the element in a sandboxed frame so it could run scripts, but for Private Alpha, I think the best we can do is make it not blow up.  