### PR TITLE
Only bind to localhost when testing available ports

### DIFF
--- a/extensions/jupyter-adapter/src/PortFinder.ts
+++ b/extensions/jupyter-adapter/src/PortFinder.ts
@@ -49,7 +49,9 @@ export async function findAvailablePort(excluding: Array<number>, maxTries: numb
 			test.close();
 		});
 
-		// Begin attempting to listen on the candidate port
-		test.listen(candidate);
+		// Begin attempting to listen on the candidate port. Use 'localhost' by
+		// name; otherwise the server attempts to listen on 0.0.0.0, which may
+		// be restricted by the OS.
+		test.listen(candidate, 'localhost');
 	});
 }


### PR DESCRIPTION
This is a speculative change that attempts to address https://github.com/posit-dev/positron/issues/1211. 

As macOS's heuristics for deciding when to prompt the user about network connections are opaque, I can't tell for sure if the issue is fixed or not, but I did run a full rebuild (which often results in getting prompted again) and didn't get prompted afterwards. 