### PR TITLE
Implement `RStatementRangeProvider`

### DIFF
--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -112,6 +112,11 @@ export class ArkLsp implements vscode.Disposable {
 					if (this._initializing) {
 						trace(`ARK (R ${this._version}) language client init successful`);
 						this._initializing = undefined;
+						if (this._client) {
+							// Register a statement range provider to detect R statements
+							const disposable = positron.languages.registerStatementRangeProvider('r', new RStatementRangeProvider(this._client));
+							this.activationDisposables.push(disposable);
+						}
 						out.resolve();
 					}
 					this._state = LspState.running;
@@ -129,12 +134,6 @@ export class ArkLsp implements vscode.Disposable {
 
 		this._client.start();
 		await out.promise;
-
-		if (this._state === LspState.running) {
-			// Register a statement range provider to detect R statements
-			const disposable = positron.languages.registerStatementRangeProvider('r', new RStatementRangeProvider(this._client));
-			this.activationDisposables.push(disposable);
-		}
 	}
 
 	/**

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -5,6 +5,7 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { PromiseHandles } from './util';
+import { RStatementRangeProvider } from './statement-range';
 
 import {
 	LanguageClient,
@@ -128,6 +129,12 @@ export class ArkLsp implements vscode.Disposable {
 
 		this._client.start();
 		await out.promise;
+
+		if (this._state === LspState.running) {
+			// Register a statement range provider to detect R statements
+			const disposable = positron.languages.registerStatementRangeProvider('r', new RStatementRangeProvider(this._client));
+			this.activationDisposables.push(disposable);
+		}
 	}
 
 	/**

--- a/extensions/positron-r/src/statement-range.ts
+++ b/extensions/positron-r/src/statement-range.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+import { CancellationToken, LanguageClient, Position, Range, RequestType, VersionedTextDocumentIdentifier } from 'vscode-languageclient/node';
+
+interface StatementRangeParams {
+	textDocument: VersionedTextDocumentIdentifier;
+	position: Position;
+}
+
+interface StatementRangeResponse {
+	range: Range;
+}
+
+export namespace StatementRangeRequest {
+	export const type: RequestType<StatementRangeParams, StatementRangeResponse, any> = new RequestType('positron/textDocument/statementRange');
+}
+
+/**
+ * A StatementRangeProvider implementation for R
+ */
+export class RStatementRangeProvider implements positron.StatementRangeProvider {
+
+	/** The language client instance */
+	private readonly _client: LanguageClient;
+
+	constructor(
+		readonly client: LanguageClient,
+	) {
+		this._client = client;
+	}
+
+	async provideStatementRange(
+		document: vscode.TextDocument,
+		position: vscode.Position,
+		_token: vscode.CancellationToken): Promise<vscode.Range | undefined> {
+
+		const params: StatementRangeParams = {
+			textDocument: this._client.code2ProtocolConverter.asVersionedTextDocumentIdentifier(document),
+			position: this._client.code2ProtocolConverter.asPosition(position)
+		};
+
+		const response = this._client.sendRequest(StatementRangeRequest.type, params, CancellationToken.None);
+
+		return response.then(data => {
+			return this._client.protocol2CodeConverter.asRange(data.range);
+		});
+	}
+}

--- a/extensions/positron-r/src/statement-range.ts
+++ b/extensions/positron-r/src/statement-range.ts
@@ -36,14 +36,14 @@ export class RStatementRangeProvider implements positron.StatementRangeProvider 
 	async provideStatementRange(
 		document: vscode.TextDocument,
 		position: vscode.Position,
-		_token: vscode.CancellationToken): Promise<vscode.Range | undefined> {
+		token: vscode.CancellationToken): Promise<vscode.Range | undefined> {
 
 		const params: StatementRangeParams = {
 			textDocument: this._client.code2ProtocolConverter.asVersionedTextDocumentIdentifier(document),
 			position: this._client.code2ProtocolConverter.asPosition(position)
 		};
 
-		const response = this._client.sendRequest(StatementRangeRequest.type, params, CancellationToken.None);
+		const response = this._client.sendRequest(StatementRangeRequest.type, params, token);
 
 		return response.then(data => {
 			return this._client.protocol2CodeConverter.asRange(data?.range);

--- a/extensions/positron-r/src/statement-range.ts
+++ b/extensions/positron-r/src/statement-range.ts
@@ -16,7 +16,7 @@ interface StatementRangeResponse {
 }
 
 export namespace StatementRangeRequest {
-	export const type: RequestType<StatementRangeParams, StatementRangeResponse, any> = new RequestType('positron/textDocument/statementRange');
+	export const type: RequestType<StatementRangeParams, StatementRangeResponse | undefined, any> = new RequestType('positron/textDocument/statementRange');
 }
 
 /**
@@ -46,7 +46,7 @@ export class RStatementRangeProvider implements positron.StatementRangeProvider 
 		const response = this._client.sendRequest(StatementRangeRequest.type, params, CancellationToken.None);
 
 		return response.then(data => {
-			return this._client.protocol2CodeConverter.asRange(data.range);
+			return this._client.protocol2CodeConverter.asRange(data?.range);
 		});
 	}
 }


### PR DESCRIPTION
Joint with https://github.com/posit-dev/amalthea/pull/85
Part of https://github.com/posit-dev/positron/pull/1213
Part of #394 

This currently has the behavior where if you hit `CMD+Enter` _within_ a function definition (like on line `1 + 2` in the video) then it will send the _entire function_ to the console rather than the current line (similar behavior occurs within a function call). RStudio does the opposite, but I actually don't mind this new behavior all that much, and the implementation is _very_ simple for now. You can always opt out of this by doing a manual selection of `1 + 2` and sending just that to the console

https://github.com/posit-dev/positron/assets/19150088/6f663dec-7c0e-4195-9761-13d5a3d9293e



After this PR (both of which I'll look at):
- Small bug related to https://github.com/posit-dev/positron/issues/1231
- Tweak `provideStatementRange()` to allow `| undefined` all the way through, rather than catching and erroring on it here https://github.com/posit-dev/positron/blob/07925f0fd1b5b7c27e92db5d2b27fa2d9cce7b5b/src/vs/workbench/api/common/extHostLanguageFeatures.ts#L1587-L1593