### PR TITLE
Re-add "disable line" lint

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -201,7 +201,7 @@ export async function* rRuntimeProvider(context: vscode.ExtensionContext): Async
 				'--',
 				'--interactive',
 			],
-			'display_name': runtimeName,
+			'display_name': runtimeName, // eslint-disable-line
 			'language': 'R',
 			'env': env,
 		};


### PR DESCRIPTION
Removed in https://github.com/posit-dev/positron/pull/1201 because I didn't think it mattered anymore and didn't see the warning myself, but @lionel- saw:

```
/Users/lionel/Sync/Projects/Positron/positron/extensions/positron-r/src/provider.ts
  204:4  warning  Object Literal Property name `display_name` must match one of the following formats: camelCase  @typescript-eslint/naming-convention
```

so I guess it does depending on how your typescript checks are set up