### PR TITLE
Use `positron.r` as language client id

### DIFF
--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -91,8 +91,11 @@ export class ArkLsp implements vscode.Disposable {
 			traceOutputChannel: traceOutputChannel(),
 		};
 
+		// With a `.` rather than a `-` so vscode-languageserver can look up related options correctly
+		const id = 'positron.r';
+
 		trace(`Creating Positron R ${this._version} language client (port ${port})...`);
-		this._client = new LanguageClient('positron-r', `Positron R Language Server (${this._version})`, serverOptions, clientOptions);
+		this._client = new LanguageClient(id, `Positron R Language Server (${this._version})`, serverOptions, clientOptions);
 
 		const out = new PromiseHandles<void>();
 		this._initializing = out.promise;


### PR DESCRIPTION
Fixes the issue where language client/server details weren't being logged even with `positron.r.trace.server` set to `verbose`

The languageserver was trying to look up the option using the id as the prefix, but it was looking for `positron-r.trace.server`, which didn't correspond to anything