### PR TITLE
Updates to console interrupt handling to address 1221 and 1239

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
@@ -9,7 +9,7 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 import { FontInfo } from 'vs/editor/common/config/fontInfo';
 import { positronClassNames } from 'vs/base/common/positronUtilities';
 import { OutputRun } from 'vs/workbench/contrib/positronConsole/browser/components/outputRun';
-import { ActivityItemInput } from 'vs/workbench/services/positronConsole/common/classes/activityItemInput';
+import { ActivityItemInput, ActivityItemInputState } from 'vs/workbench/services/positronConsole/common/classes/activityItemInput';
 
 // ActivityInputProps interface.
 export interface ActivityInputProps {
@@ -24,16 +24,16 @@ export interface ActivityInputProps {
  */
 export const ActivityInput = (props: ActivityInputProps) => {
 	// Hooks.
-	const [executing, setExecuting] = useState(props.activityItemInput.executing);
+	const [state, setState] = useState(props.activityItemInput.state);
 
 	// Main useEffect.
 	React.useEffect(() => {
 		// Create the disposable store for cleanup.
 		const disposableStore = new DisposableStore();
 
-		// Listen for the changes to the item.
-		disposableStore.add(props.activityItemInput.onChanged(() => {
-			setExecuting(props.activityItemInput.executing);
+		// Listen for state changes to the item.
+		disposableStore.add(props.activityItemInput.onStateChanged(() => {
+			setState(props.activityItemInput.state);
 		}));
 
 		// Return the cleanup function that will dispose of the disposables.
@@ -49,13 +49,13 @@ export const ActivityInput = (props: ActivityInputProps) => {
 	// Generate the class names.
 	const classNames = positronClassNames(
 		'activity-input',
-		{ 'executing': executing }
+		{ 'executing': state === ActivityItemInputState.Executing }
 	);
 
 	// Render.
 	return (
 		<div className={classNames}>
-			{executing && <div className='progress-bar' />}
+			{state === ActivityItemInputState.Executing && <div className='progress-bar' />}
 			{props.activityItemInput.codeOutputLines.map((outputLine, index) =>
 				<div key={outputLine.id}>
 					<span style={{ width: promptWidth }}>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -170,18 +170,6 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			e.stopPropagation();
 		};
 
-		/**
-		 * Interrupts the runtime and resets the console input state.
-		 */
-		const interruptRuntimeAndResetConsoleInput = () => {
-			// Interrupt the runtime.
-			props.positronConsoleInstance.runtime.interrupt();
-
-			// Reset the code input state.
-			setCurrentCodeFragment(undefined);
-			codeEditorWidgetRef.current.setValue('');
-		};
-
 		// Determine whether the cmd or ctrl key is pressed.
 		const cmdOrCtrlKey = isMacintosh ? e.metaKey : e.ctrlKey;
 
@@ -208,8 +196,8 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				// Consume the event.
 				consumeEvent();
 
-				// Interrupt the runtime and reset the console input.
-				interruptRuntimeAndResetConsoleInput();
+				// Interrupt the console.
+				props.positronConsoleInstance.interrupt();
 				break;
 			}
 
@@ -254,8 +242,8 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 					// Consume the event.
 					consumeEvent();
 
-					// Interrupt the runtime and reset the console input.
-					interruptRuntimeAndResetConsoleInput();
+					// Interrupt the console.
+					props.positronConsoleInstance.interrupt();
 				}
 				break;
 			}

--- a/src/vs/workbench/services/positronConsole/common/classes/activityItemInput.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/activityItemInput.ts
@@ -6,39 +6,50 @@ import { Emitter } from 'vs/base/common/event';
 import { ANSIOutput, ANSIOutputLine } from 'ansi-output';
 
 /**
+ * ActivityItemInputState enumeration.
+ */
+export const enum ActivityItemInputState {
+	Provisional = 'provisional',
+	Executing = 'executing',
+	Completed = 'completed'
+}
+
+/**
  * ActivityItemInput class.
  */
 export class ActivityItemInput {
 	//#region Private Properties
 
 	/**
-	 * A value which indicates whether the ActivityItemInput is executing.
+	 * The state.
 	 */
-	private executingValue = false;
+	private _state: ActivityItemInputState;
 
 	/**
-	 * onChanged event emitter.
+	 * onStateChanged event emitter.
 	 */
-	private onChangedEmitter = new Emitter<void>();
+	private onStateChangedEmitter = new Emitter<void>();
 
 	//#endregion Private Properties
 
 	//#region Public Properties
 
 	/**
-	 * Gets a value which indicates whether the ActivityItemInput is executing.
+	 * Gets the state.
 	 */
-	get executing() {
-		return this.executingValue;
+	get state() {
+		return this._state;
 	}
 
 	/**
-	 * Sets a value which indicates whether the ActivityItemInput is executing.
-	 * @param executing A value which indicates whether the ActivityItemInput is executing
+	 * Sets the state.
+	 * @param state The state to set.
 	 */
-	set executing(executing: boolean) {
-		this.executingValue = executing;
-		this.onChangedEmitter.fire();
+	set state(state: ActivityItemInputState) {
+		if (state !== this._state) {
+			this._state = state;
+			this.onStateChangedEmitter.fire();
+		}
 	}
 
 	/**
@@ -49,15 +60,15 @@ export class ActivityItemInput {
 	//#endregion Public Properties
 
 	/**
-	 * An event that fires when the ActivityItemInput changes.
+	 * An event that fires when the state changes.
 	 */
-	public onChanged = this.onChangedEmitter.event;
+	public onStateChanged = this.onStateChangedEmitter.event;
 
 	//#region Constructor
 
 	/**
 	 * Constructor.
-	 * @param provisional A value which indicates whether this is a provisional ActivityItemInput.
+	 * @param state The initial state.
 	 * @param id The identifier.
 	 * @param parentId The parent identifier.
 	 * @param when The date.
@@ -66,7 +77,7 @@ export class ActivityItemInput {
 	 * @param code The code.
 	 */
 	constructor(
-		readonly provisional: boolean,
+		state: ActivityItemInputState,
 		readonly id: string,
 		readonly parentId: string,
 		readonly when: Date,
@@ -74,11 +85,8 @@ export class ActivityItemInput {
 		readonly continuationPrompt: string,
 		readonly code: string
 	) {
-		// Process the code into ANSI output lines suitable for rendering.
+		this._state = state;
 		this.codeOutputLines = ANSIOutput.processOutput(code);
-
-		// A non-provisional ActivityItemInput is executing by default.
-		this.executing = !this.provisional;
 	}
 
 	//#endregion Constructor

--- a/src/vs/workbench/services/positronConsole/common/classes/runtimeItemActivity.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/runtimeItemActivity.ts
@@ -3,14 +3,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { RuntimeItem } from 'vs/workbench/services/positronConsole/common/classes/runtimeItem';
-import { ActivityItemInput } from 'vs/workbench/services/positronConsole/common/classes/activityItemInput';
 import { ActivityItemPrompt } from 'vs/workbench/services/positronConsole/common/classes/activityItemPrompt';
+import { ActivityItemOutputHtml } from 'vs/workbench/services/positronConsole/common/classes/activityItemOutputHtml';
 import { ActivityItemOutputPlot } from 'vs/workbench/services/positronConsole/common/classes/activityItemOutputPlot';
 import { ActivityItemErrorStream } from 'vs/workbench/services/positronConsole/common/classes/activityItemErrorStream';
 import { ActivityItemErrorMessage } from 'vs/workbench/services/positronConsole/common/classes/activityItemErrorMessage';
 import { ActivityItemOutputStream } from 'vs/workbench/services/positronConsole/common/classes/activityItemOutputStream';
 import { ActivityItemOutputMessage } from 'vs/workbench/services/positronConsole/common/classes/activityItemOutputMessage';
-import { ActivityItemOutputHtml } from 'vs/workbench/services/positronConsole/common/classes/activityItemOutputHtml';
+import { ActivityItemInput, ActivityItemInputState } from 'vs/workbench/services/positronConsole/common/classes/activityItemInput';
 
 /**
  * The ActivityItem type alias.
@@ -62,14 +62,15 @@ export class RuntimeItemActivity extends RuntimeItem {
 	 * @param activityItem The activity item to add.
 	 */
 	addActivityItem(activityItem: ActivityItem) {
-		if (activityItem instanceof ActivityItemInput && !activityItem.provisional) {
+		if (activityItem instanceof ActivityItemInput &&
+			activityItem.state !== ActivityItemInputState.Provisional) {
 			// When a non-provisional ActivityItemInput is being added, see if there's a provisional
 			// ActivityItemInput for it in the activity items. If there is, replace the provisional
 			// ActivityItemInput with the actual ActivityItemInput.
 			for (let i = this.activityItems.length - 1; i >= 0; --i) {
 				const activityItemToCheck = this.activityItems[i];
 				if (activityItemToCheck instanceof ActivityItemInput) {
-					if (activityItemToCheck.provisional &&
+					if (activityItemToCheck.state === ActivityItemInputState.Provisional &&
 						activityItemToCheck.parentId === activityItem.parentId) {
 						this.activityItems[i] = activityItem;
 						return;

--- a/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
@@ -180,9 +180,14 @@ export interface IPositronConsoleInstance {
 	clearConsole(): void;
 
 	/**
-	 * Clears the input hstory.
+	 * Clears the input history.
 	 */
 	clearInputHistory(): void;
+
+	/**
+	 * Interrupts the console.
+	 */
+	interrupt(): void;
 
 	/**
 	 * Enqueues code to be executed.


### PR DESCRIPTION
This PR address #1221 and #1239 by improving console interrupt handling.

When pressing Ctrl-C or escape, all pending input and pending code is removed and the user is provided with feedback that something has happened.

This screen recording shows Ctrl-C or escape when the console is busy:

https://github.com/posit-dev/positron/assets/853239/8e18b1ee-8015-46a3-ad22-6a5ca75ee145

This screen recording shows Ctrl-C or escape when the console is idle:

https://github.com/posit-dev/positron/assets/853239/e44c3824-3187-4194-9e65-d235fff4167a


