### PR TITLE
Fix CSS issue that caused the wrong cursor to be shown over interpreter actions

### DIFF
--- a/src/vs/workbench/browser/parts/positronTopActionBar/modalPopups/interpreterActions.css
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/modalPopups/interpreterActions.css
@@ -10,16 +10,15 @@
 }
 
 .interpreter-actions .action-button {
-	cursor: default !important;
 	height: 24px;
 	width: 24px;
 	border: none;
 	display: flex;
-	cursor: pointer;
 	overflow: visible;
 	align-items: center;
 	background: transparent;
 	justify-content: center;
+	cursor: pointer !important;
 }
 
 .interpreter-actions .action-button.disabled {


### PR DESCRIPTION
The correct cursor is now shown:

https://github.com/posit-dev/positron/assets/853239/d8ea7686-995f-438d-b54f-ab8bd9cf1730

There as a CSS bug that caused this not to work.