### PR TITLE
Use threshold to determine scroll lock

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -420,7 +420,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	const scrollHandler = (e: UIEvent<HTMLDivElement>) => {
 		// Determine whether the console instance is scroll locked.
 		if (Math.abs(consoleInstanceRef.current.scrollHeight -
-			consoleInstanceRef.current.offsetHeight -
+			consoleInstanceRef.current.clientHeight -
 			consoleInstanceRef.current.scrollTop) < 1) {
 			setScrollLocked(false);
 		} else {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -419,8 +419,9 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	 */
 	const scrollHandler = (e: UIEvent<HTMLDivElement>) => {
 		// Determine whether the console instance is scroll locked.
-		if (consoleInstanceRef.current.offsetHeight + consoleInstanceRef.current.scrollTop ===
-			consoleInstanceRef.current.scrollHeight) {
+		if (Math.abs(consoleInstanceRef.current.scrollHeight -
+			consoleInstanceRef.current.offsetHeight -
+			consoleInstanceRef.current.scrollTop) < 1) {
 			setScrollLocked(false);
 		} else {
 			setScrollLocked(true);


### PR DESCRIPTION
As documented in https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#determine_if_an_element_has_been_totally_scrolled. I've used the threshold suggested on that page but I have no sense of what a reasonable threshold would be.

This fixes the scroll-locking issues with my increased font size (addresses #1246). Hopefully this will also fix @DavisVaughan's issues.

Context: https://github.com/posit-dev/positron/pull/1134


https://github.com/posit-dev/positron/assets/4465050/f7d2fd51-9e4a-4048-ab14-26e009bd102b

