### PR TITLE
Allow up and down arrow for history navigation when console is busy

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -260,11 +260,6 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 					// Consume the event.
 					consumeEvent();
 
-					// If the console instance isn't ready, do not navigate.
-					if (props.positronConsoleInstance.state !== PositronConsoleState.Ready) {
-						return;
-					}
-
 					// If there are history entries, process the event.
 					if (historyNavigatorRef.current) {
 						// When the user moves up from the end, and we don't have a current code editor
@@ -297,11 +292,6 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				if (position?.lineNumber === textModel?.getLineCount()) {
 					// Consume the event.
 					consumeEvent();
-
-					// If the console instance isn't ready, do not navigate.
-					if (props.positronConsoleInstance.state !== PositronConsoleState.Ready) {
-						return;
-					}
 
 					// If there are history entries, process the event.
 					if (historyNavigatorRef.current) {


### PR DESCRIPTION
In prior builds, we didn't allow history navigation when the console was busy. This was on purpose and was a decision we made at some point in the past. This PR undoes that decision. You can now navigate through history while the console is busy. The fix was code removal.

Here's a little movie.

https://github.com/posit-dev/positron/assets/853239/0f03c96d-1929-4c79-b627-55a6eaf610b9