### PR TITLE
Fixes for 1157 1196

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -27,6 +27,7 @@ import { PositronConsoleViewPane } from 'vs/workbench/contrib/positronConsole/br
 import { confirmationModalDialog } from 'vs/workbench/browser/positronModalDialogs/confirmationModalDialog';
 import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/common/executionHistoryService';
 import { IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
+import { NOTEBOOK_EDITOR_FOCUSED } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
 
 /**
  * Positron console command ID's.
@@ -197,7 +198,10 @@ export function registerPositronConsoleActions() {
 				},
 				f1: true,
 				category,
-				precondition: EditorContextKeys.editorTextFocus,
+				precondition: ContextKeyExpr.and(
+					EditorContextKeys.editorTextFocus,
+					NOTEBOOK_EDITOR_FOCUSED.toNegated()
+				),
 				keybinding: {
 					weight: KeybindingWeight.WorkbenchContrib,
 					primary: KeyMod.CtrlCmd | KeyCode.Enter,

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -5,26 +5,28 @@
 import { localize } from 'vs/nls';
 import { Codicon } from 'vs/base/common/codicons';
 import { ITextModel } from 'vs/editor/common/model';
+import { IRange } from 'vs/editor/common/core/range';
 import { IEditor } from 'vs/editor/common/editorCommon';
+import { ILogService } from 'vs/platform/log/common/log';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
+import { Position } from 'vs/editor/common/core/position';
 import { IViewsService } from 'vs/workbench/common/views';
+import { CancellationToken } from 'vs/base/common/cancellation';
 import { ILocalizedString } from 'vs/platform/action/common/action';
+import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { ILanguageService } from 'vs/editor/common/languages/language';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { PositronConsoleViewPane } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleView';
 import { confirmationModalDialog } from 'vs/workbench/browser/positronModalDialogs/confirmationModalDialog';
 import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/common/executionHistoryService';
 import { IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
-import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
-import { CancellationToken } from 'vs/base/common/cancellation';
-import { Position } from 'vs/editor/common/core/position';
-import { IRange } from 'vs/editor/common/core/range';
-import { ILogService } from 'vs/platform/log/common/log';
 
 /**
  * Positron console command ID's.
@@ -195,7 +197,7 @@ export function registerPositronConsoleActions() {
 				},
 				f1: true,
 				category,
-				//icon: Codicon.?,
+				precondition: EditorContextKeys.editorTextFocus,
 				keybinding: {
 					weight: KeybindingWeight.WorkbenchContrib,
 					primary: KeyMod.CtrlCmd | KeyCode.Enter,


### PR DESCRIPTION
This PR addresses #1157 and #1196 by adding a precondition to the `workbench.action.positronConsole.executeCode` action. The action will only be available when a non-notebook editor has focus.