### PR TITLE
Store discovery phase completion status in extension host

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -779,9 +779,6 @@ export class MainThreadLanguageRuntime implements MainThreadLanguageRuntimeShape
 
 	private readonly _runtimes: Map<number, ExtHostLanguageRuntimeAdapter> = new Map();
 
-	private _discoveryPhase: LanguageRuntimeDiscoveryPhase =
-		LanguageRuntimeDiscoveryPhase.AwaitingExtensions;
-
 	constructor(
 		extHostContext: IExtHostContext,
 		@ILanguageRuntimeService private readonly _languageRuntimeService: ILanguageRuntimeService,
@@ -801,16 +798,10 @@ export class MainThreadLanguageRuntime implements MainThreadLanguageRuntimeShape
 		this._proxy = extHostContext.getProxy(ExtHostPositronContext.ExtHostLanguageRuntime);
 
 		this._languageRuntimeService.onDidChangeDiscoveryPhase((phase) => {
-			this._discoveryPhase = phase;
 			if (phase === LanguageRuntimeDiscoveryPhase.Discovering) {
 				this._proxy.$discoverLanguageRuntimes();
 			}
 		});
-	}
-
-	$isLanguageRuntimeDiscoveryComplete(): Promise<boolean> {
-		return Promise.resolve(
-			this._discoveryPhase === LanguageRuntimeDiscoveryPhase.Complete);
 	}
 
 	$emitLanguageRuntimeMessage(handle: number, message: ILanguageRuntimeMessage): void {

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -13,7 +13,6 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$registerLanguageRuntime(handle: number, metadata: ILanguageRuntimeMetadata, dynState: ILanguageRuntimeDynState): void;
 	$selectLanguageRuntime(handle: number): Promise<void>;
 	$restartLanguageRuntime(handle: number): Promise<void>;
-	$isLanguageRuntimeDiscoveryComplete(): Promise<boolean>;
 	$completeLanguageRuntimeDiscovery(): void;
 	$unregisterLanguageRuntime(handle: number): void;
 	$executeCode(languageId: string, code: string, focus: boolean): Promise<boolean>;


### PR DESCRIPTION
This change addresses another timing issue that contributes to #1003. In particular, using the main thread as the source of truth about whether discovery is complete was causing a race condition in which we were getting a stale value back. 

The fix is to track whether or not discovery is complete inside the extension host so we don't need an asynchronous trip to the main thread to check it. 
