### PR TITLE
Add bottom padding to activity prompt

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.css
@@ -9,6 +9,7 @@
 }
 
 .activity-prompt .prompt-line .input-field {
+	padding-bottom: 10px;
 	flex-grow: 1;
 	border: none;
 	outline: 0 !important;


### PR DESCRIPTION
Same as for console input.

Before:

https://github.com/posit-dev/positron/assets/4465050/8705a13d-0a48-45ca-9463-10f766a716b4

After:

https://github.com/posit-dev/positron/assets/4465050/955a62f6-4d87-47d0-812d-776303145958


