### PR TITLE
Change Positron modal dialog top border radius to 5px

### DIFF
--- a/src/vs/base/browser/ui/positronModalDialog/positronModalDialog.css
+++ b/src/vs/base/browser/ui/positronModalDialog/positronModalDialog.css
@@ -42,7 +42,7 @@
 	display: flex;
 	overflow: hidden;
 	position: absolute;
-	border-radius: 15px 15px 5px 5px;
+	border-radius: 5px;
 	color: var(--vscode-positronModalDialog-foreground);
 	background: var(--vscode-positronModalDialog-background);
 	box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1), 0 6px 20px 0 rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
This PR changes Positron modal dialog top border radius to 5px.

<img width="430" alt="Screenshot 2023-09-08 at 2 09 05 PM" src="https://github.com/posit-dev/positron/assets/853239/240da663-efc4-4167-9e24-6dc796686b4c">
