### PR TITLE
Updates to fix Help view display issues

### DIFF
--- a/extensions/positron-proxy/src/positronProxy.ts
+++ b/extensions/positron-proxy/src/positronProxy.ts
@@ -220,9 +220,10 @@ export class PositronProxy implements Disposable {
 					target: targetOrigin,
 					changeOrigin: true,
 					selfHandleResponse: true,
-					onProxyReq: (proxyReq, req, res, options) => {
-						console.log(`Proxy request ${serverOrigin}${req.url} -> ${targetOrigin}${req.url}`);
-					},
+					// Logging for development work.
+					// onProxyReq: (proxyReq, req, res, options) => {
+					// 	console.log(`Proxy request ${serverOrigin}${req.url} -> ${targetOrigin}${req.url}`);
+					// },
 					onProxyRes: responseInterceptor(async (responseBuffer, proxyRes, req, res) => {
 						// Get the URL and the content type. These must be present to call the
 						// content rewriter. Also, the scripts must be loaded.

--- a/src/vs/base/browser/positronReactRenderer.ts
+++ b/src/vs/base/browser/positronReactRenderer.ts
@@ -4,6 +4,7 @@
 
 import { Event } from 'vs/base/common/event';
 import { createRoot, Root } from 'react-dom/client';
+import { Disposable } from 'vs/base/common/lifecycle';
 
 /**
  * ISize interface.
@@ -77,37 +78,68 @@ export interface IReactComponentContainer {
  * PositronReactRenderer class.
  * Manages rendering a React component in the specified container HTMLElement.
  */
-export class PositronReactRenderer {
+export class PositronReactRenderer extends Disposable {
+	//#region Private Properties
+
 	/**
 	 * The root where the React element will be rendered.
 	 */
-	private _root?: Root;
+	private root?: Root;
+
+	//#endregion Private Properties
+
+	//#region Constructor & Dispose
 
 	/**
 	 * Initializes a new instance of the ReactRenderer class.
 	 * @param container The container HTMLElement where the React component will be rendered.
 	 */
 	constructor(container: HTMLElement) {
-		this._root = createRoot(container);
+		// Call the base class's constructor.
+		super();
+
+		// Create the root.
+		this.root = createRoot(container);
 	}
+
+	/**
+	 * dispose override method.
+	 */
+	public override dispose(): void {
+		// Unmount and dispose of the root.
+		if (this.root) {
+			this.root.unmount();
+			this.root = undefined;
+		}
+
+		// Call the base class's dispose method.
+		super.dispose();
+	}
+
+	//#endregion Constructor & Dispose
+
+	//#region Public Methods
 
 	/**
 	 * Renders the React component that was supplied.
 	 * @param reactElement The ReactElement to render.
 	 */
 	public render(reactElement: React.ReactElement) {
-		if (this._root) {
-			this._root.render(reactElement);
+		if (this.root) {
+			this.root.render(reactElement);
 		}
 	}
 
 	/**
 	 * Destroys the ReactRenderer.
+	 * @deprecated Use Disposable instead.
 	 */
 	public destroy() {
-		if (this._root) {
-			this._root.unmount();
-			this._root = undefined;
+		if (this.root) {
+			this.root.unmount();
+			this.root = undefined;
 		}
 	}
+
+	//#endregion Public Methods
 }

--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/emptyEnvironment.css
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/emptyEnvironment.css
@@ -8,7 +8,6 @@
 	position: absolute;
 	box-sizing: border-box;
 	background: var(--vscode-positronEnvironment-background);
-	border-top: 1px solid var(--vscode-positronSideActionBar-border);
 }
 
 .empty-environment .title {

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.css
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.css
@@ -5,6 +5,7 @@
 .positron-help-container {
 	height: 100%;
 	display: flex;
+	position: relative;
 	flex-direction: column;
 }
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -197,7 +197,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 				const plotClient = new PlotClientInstance(event.client, metadata);
 				this.registerPlotClient(plotClient, true);
 
-				// Raise the Plots pane so the plot is visible
+				// Raise the Plots pane so the plot is visible.
 				this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
 			}
 		}));
@@ -215,11 +215,12 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 				this._recentExecutions.get(message.parent_id) : '';
 			const imageKey = Object.keys(message.data).find(key => key.startsWith('image/'));
 			if (imageKey) {
+				// Create a new static plot client instance and register it with the service.
 				this.registerStaticPlot(runtime.metadata.runtimeId, message, code);
-			}
 
-			// Raise the Plots pane so the plot is visible
-			this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+				// Raise the Plots pane so the plot is visible.
+				this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+			}
 		}));
 	}
 

--- a/src/vs/workbench/services/positronHelp/common/interfaces/positronHelpService.ts
+++ b/src/vs/workbench/services/positronHelp/common/interfaces/positronHelpService.ts
@@ -45,6 +45,11 @@ export interface IPositronHelpService {
 	readonly onHelpLoaded: Event<HelpEntry>;
 
 	/**
+	 * Gets the current help entry.
+	 */
+	readonly currentHelpEntry?: HelpEntry;
+
+	/**
 	 * Gets a value which indicates whether help can navigate backward.
 	 */
 	readonly canNavigateBackward: boolean;

--- a/src/vs/workbench/services/positronHelp/common/positronHelpService.ts
+++ b/src/vs/workbench/services/positronHelp/common/positronHelpService.ts
@@ -238,6 +238,13 @@ export class PositronHelpService extends Disposable implements IPositronHelpServ
 	readonly onHelpLoaded = this.onHelpLoadedEmitter.event;
 
 	/**
+	 * Gets the current help entry.
+	 */
+	get currentHelpEntry() {
+		return this.helpEntryIndex > -1 ? this.helpEntries[this.helpEntryIndex] : undefined;
+	}
+
+	/**
 	 * Gets a value which indicates whether help can navigate back.
 	 */
 	get canNavigateBackward() {


### PR DESCRIPTION
This PR addresses #1284. There were a number of issues with the lifecycle of the `PositronHelpView` and its `OverlayWebview`. This PR addresses them.

Additionally, I made a few other changes to fix things that were broken:

1. Turned off request logging in the `PositronProxy` extension. It was too chatty.
2. Updated the `PositronReactRenderer` to be `Disposable` and deprecated its `destroy` method. I will switch over other uses of the `PositronReactRenderer` to the disposable pattern after Private Alpha.
3. Removed the `border-top` for the `EmptyEnvironment` React component. It was causing a double line to be painted.
4. Updated the `positron-help-container`'s `position` to be `relative` to fix layout issues.
5. Fixed a bug I created that was causing the Plots view to become visible every time the `onDidReceiveRuntimeMessageOutput` even was fired.

Here's a movie of how Help works now:

https://github.com/posit-dev/positron/assets/853239/cd8aff08-da0c-47c7-9daf-459b3bf7aba2
