### PR TITLE
update R startup heuristic

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -313,20 +313,6 @@ async function shouldRecommendForWorkspace(): Promise<boolean> {
 		return true;
 	}
 
-	// Check if the workspace contains .qmd files with R code blocks.
-	// Limit to 1000 files (unordered) - the assumption is that it's unlikely that none will contain
-	// an R code block in an R workspace.
-	const qmdFiles = await findFiles('**/*.qmd', 1000);
-	if (qmdFiles) {
-		for (const qmdFile of qmdFiles) {
-			const fileContents = (await vscode.workspace.fs.readFile(qmdFile)).toString();
-			// Check if the file contains an R code block.
-			if (fileContents.match(/^```(\{\.?r.*\}|\.?r)/m)) {
-				return true;
-			}
-		}
-	}
-
 	// Check if the workspace is empty and the user is an RStudio user.
 	if (!(await hasFiles('**/*')) && isRStudioUser()) {
 		return true;
@@ -335,15 +321,10 @@ async function shouldRecommendForWorkspace(): Promise<boolean> {
 	return false;
 }
 
-// Find files in the current workspace matching a glob pattern.
-async function findFiles(glob: string, maxResult: number): Promise<vscode.Uri[]> {
-	// Exclude node_modules for performance reasons
-	return vscode.workspace.findFiles(glob, '**/node_modules/**', maxResult);
-}
-
 // Check if the current workspace contains files matching a glob pattern.
 async function hasFiles(glob: string): Promise<boolean> {
-	return (await findFiles(glob, 1)).length > 0;
+	// Exclude node_modules for performance reasons
+	return (await vscode.workspace.findFiles(glob, '**/node_modules/**', 1)).length > 0;
 }
 
 /**

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -107,7 +107,7 @@ export async function* rRuntimeProvider(context: vscode.ExtensionContext): Async
 	// or if it's empty and the user is an RStudio user.
 	// In the future, we will use more sophisticated heuristics, such as
 	// checking an renv lockfile for a match against a system version of R.
-	const hasRFiles = async () => hasFiles('**/*.r');
+	const hasRFiles = async () => hasFiles('**/*.R');
 	const isEmpty = async () => !(await hasFiles('**/*'));
 	let recommendedForWorkspace = await hasRFiles() || (await isEmpty() && isRStudioUser());
 

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -305,6 +305,7 @@ async function shouldRecommendForWorkspace(): Promise<boolean> {
 		'**/.Rprofile',
 		'**/renv.lock',
 		'**/.Rbuildignore',
+		'**/.Renviron',
 		'**/*.Rproj'
 	];
 	// Convert to the glob format used by vscode.workspace.findFiles.


### PR DESCRIPTION
Only start an R runtime immediately if the workspace contains R files, or if it's empty but the user has installed RStudio. This is less likely to incorrectly start R in Python projects for users that happen to have RStudio installed.

See https://github.com/posit-dev/positron/issues/1282#issuecomment-1714179194 for more detail.