### PR TITLE
Keep map of `RRuntime` objects in extension, use in `r.packageInstall` command

### DIFF
--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -5,8 +5,10 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { delay } from './util';
+import { RRuntime } from './runtime';
+import { randomUUID } from 'crypto';
 
-export async function registerCommands(context: vscode.ExtensionContext) {
+export async function registerCommands(context: vscode.ExtensionContext, runtimes: Map<string, RRuntime>) {
 
 	const isRPackage = await detectRPackage();
 	vscode.commands.executeCommand('setContext', 'isRPackage', isRPackage);
@@ -46,14 +48,27 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 				vscode.window.showWarningMessage('Cannot install package as there is no R interpreter running.');
 				return;
 			}
-
 			// For now, there will be only one running R runtime:
-			const runtimePath = runningRuntimes[0].runtimePath;
-			const originalTimeStamp = getPackageDescriptionTimestamp(runtimePath, packageName);
-			positron.runtime.executeCode('r', 'devtools::install()', true);
-			await pollForNewTimestamp(runtimePath, packageName, originalTimeStamp);
-			positron.runtime.restartLanguageRuntime(runningRuntimes[0].runtimeId);
-			positron.runtime.executeCode('r', `library(${packageName})`, true);
+			const runtime = runtimes.get(runningRuntimes[0].runtimeId);
+			if (runtime) {
+				runtime.execute('devtools::install()',
+					randomUUID(),
+					positron.RuntimeCodeExecutionMode.Interactive,
+					positron.RuntimeErrorBehavior.Continue);
+				await positron.runtime.restartLanguageRuntime(runtime.metadata.runtimeId);
+				runtime.onDidChangeRuntimeState(async runtimeState => {
+					if (runtimeState === positron.RuntimeState.Starting) {
+						await delay(500);
+						//positron.runtime.executeCode('r', `library(${packageName})`, true);
+						runtime.execute(`library(${packageName})`,
+							randomUUID(),
+							positron.RuntimeCodeExecutionMode.Interactive,
+							positron.RuntimeErrorBehavior.Continue);
+					}
+				});
+			} else {
+				throw new Error(`R runtime '${runningRuntimes[0].runtimeId}' is not registered in the extension host`);
+			}
 		}),
 
 		vscode.commands.registerCommand('r.packageTest', () => {
@@ -147,34 +162,4 @@ async function parseRPackageDescription(): Promise<string[]> {
 		} catch { }
 	}
 	return [''];
-}
-
-function getPackageDescriptionTimestamp(runtimePath: string, packageName: string): number | null {
-	const path = require('path');
-	const fs = require('fs');
-	const libraryPath = path.join(runtimePath, 'library', packageName, 'DESCRIPTION');
-	try {
-		const stats = fs.statSync(libraryPath);
-		return stats.mtimeMs;
-	} catch { }
-	return null;
-}
-
-async function pollForNewTimestamp(runtimePath: string, packageName: string, oldTimestamp: number | null) {
-	const path = require('path');
-	const fs = require('fs');
-	const timeout = Date.now() + 3e5;
-
-	if (oldTimestamp === null) {
-		const libraryPath = path.join(runtimePath, 'library', packageName, 'DESCRIPTION');
-		while (!fs.existsSync(libraryPath) && Date.now() < timeout) {
-			await delay(1000);
-		}
-	} else {
-		let newTimeStamp = getPackageDescriptionTimestamp(runtimePath, packageName);
-		while (newTimeStamp !== null && !(newTimeStamp > oldTimestamp) && Date.now() < timeout) {
-			await delay(1000);
-			newTimeStamp = getPackageDescriptionTimestamp(runtimePath, packageName);
-		}
-	}
 }

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -56,22 +56,24 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 					id,
 					positron.RuntimeCodeExecutionMode.Interactive,
 					positron.RuntimeErrorBehavior.Continue);
-				runtime.onDidReceiveRuntimeMessage(runtimeMessage => {
+				const disp1 = runtime.onDidReceiveRuntimeMessage(runtimeMessage => {
 					if (runtimeMessage.parent_id === id &&
 						runtimeMessage.type === positron.LanguageRuntimeMessageType.State) {
 						const runtimeMessageState = runtimeMessage as positron.LanguageRuntimeState;
 						if (runtimeMessageState.state === positron.RuntimeOnlineState.Idle) {
 							positron.runtime.restartLanguageRuntime(runtime.metadata.runtimeId);
+							disp1.dispose();
 						}
 					}
 				});
-				runtime.onDidChangeRuntimeState(async runtimeState => {
+				const disp2 = runtime.onDidChangeRuntimeState(async runtimeState => {
 					if (runtimeState === positron.RuntimeState.Starting) {
 						await delay(500);
 						runtime.execute(`library(${packageName})`,
 							randomUUID(),
 							positron.RuntimeCodeExecutionMode.Interactive,
 							positron.RuntimeErrorBehavior.Continue);
+						disp2.dispose();
 					}
 				});
 			} else {

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -59,7 +59,6 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 				runtime.onDidChangeRuntimeState(async runtimeState => {
 					if (runtimeState === positron.RuntimeState.Starting) {
 						await delay(500);
-						//positron.runtime.executeCode('r', `library(${packageName})`, true);
 						runtime.execute(`library(${packageName})`,
 							randomUUID(),
 							positron.RuntimeCodeExecutionMode.Interactive,

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -55,7 +55,7 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 					randomUUID(),
 					positron.RuntimeCodeExecutionMode.Interactive,
 					positron.RuntimeErrorBehavior.Continue);
-				await positron.runtime.restartLanguageRuntime(runtime.metadata.runtimeId);
+				positron.runtime.restartLanguageRuntime(runtime.metadata.runtimeId);
 				runtime.onDidChangeRuntimeState(async runtimeState => {
 					if (runtimeState === positron.RuntimeState.Starting) {
 						await delay(500);

--- a/extensions/positron-r/src/extension.ts
+++ b/extensions/positron-r/src/extension.ts
@@ -8,18 +8,20 @@ import * as positron from 'positron';
 import { registerCommands } from './commands';
 import { initializeLogging } from './logging';
 import { rRuntimeProvider } from './provider';
+import { RRuntime } from './runtime';
 
 
 export function activate(context: vscode.ExtensionContext) {
 
+	const runtimes = new Map<string, RRuntime>();
 	positron.runtime.registerLanguageRuntimeProvider(
-		'r', rRuntimeProvider(context));
+		'r', rRuntimeProvider(context, runtimes));
 
 	// Initialize logging tools.
 	initializeLogging(context);
 
 	// Register commands.
-	registerCommands(context);
+	registerCommands(context, runtimes);
 
 }
 

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -23,7 +23,10 @@ import { getArkKernelPath } from './kernel';
  *
  * @param context The extension context.
  */
-export async function* rRuntimeProvider(context: vscode.ExtensionContext): AsyncGenerator<positron.LanguageRuntime> {
+export async function* rRuntimeProvider(
+	context: vscode.ExtensionContext,
+	runtimes: Map<string, RRuntime>
+): AsyncGenerator<positron.LanguageRuntime> {
 	let rInstallations: Array<RInstallation> = [];
 
 	// Path to the kernel executable
@@ -266,7 +269,9 @@ export async function* rRuntimeProvider(context: vscode.ExtensionContext): Async
 		};
 
 		// Create an adapter for the kernel to fulfill the LanguageRuntime interface.
-		yield new RRuntime(context, kernelSpec, metadata, dynState, extra);
+		const runtime = new RRuntime(context, kernelSpec, metadata, dynState, extra);
+		yield runtime;
+		runtimes.set(runtimeId, runtime);
 	}
 }
 


### PR DESCRIPTION
Addresses #1091 by ripping out the "watch for DESCRIPTION file change" piece and replace it with keeping a map of `RRuntime` objects in the R extension that we can `execute` and watch for events with. This is basically like this option I outlined in #1279:

> If we could check the status of an R runtime (busy/idle), we could find out when `devtools::install()` was no longer running.

However, this probably isn't a final version because we would like to know if the installation failed or not, to early return and not restart and `library(package_name)`.