### PR TITLE
Fix to hide tooltip when mouse pressed

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarTooltip.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarTooltip.tsx
@@ -21,13 +21,15 @@ interface ActionBarTooltipProps {
  * @returns The rendered component.
  */
 export const ActionBarTooltip = (props: PropsWithChildren<ActionBarTooltipProps>) => {
-	// Hooks.
+	// Context hooks.
 	const positronActionBarContext = usePositronActionBarContext();
+
+	// State hooks.
 	const [mouseInside, setMouseInside] = useState(false);
 	const [tooltip, setTooltip] = useState<string | undefined>(undefined);
 	const [showTooltip, setShowTooltip] = useState(false);
 
-	// Tooltip.
+	// Tooltip effect.
 	useEffect(() => {
 		// If we cannot show the tooltip, do nothing.
 		if (!mouseInside || !props.tooltip) {
@@ -63,34 +65,29 @@ export const ActionBarTooltip = (props: PropsWithChildren<ActionBarTooltipProps>
 				setShowTooltip(true);
 			}
 		}, showTooltipDelay);
+
+		// Return the cleanup funciton.
 		return () => clearTimeout(timeout);
-	}, [positronActionBarContext, mouseInside]);
-
-	// Mouse enter handler.
-	const mouseEnterHandler = () => {
-		setMouseInside(true);
-	};
-
-	// Mouse leave handler.
-	const mouseLeaveHandler = () => {
-		setMouseInside(false);
-		if (showTooltip) {
-			// Hide the toolip and refresh the tooltip keep alive so that the next tooltip will be shown immediately.
-			setShowTooltip(false);
-			positronActionBarContext.refreshTooltipKeepAlive();
-		}
-	};
-
-	// Click handler.
-	const clickHandler = () => {
-		// When the mouse is clicked, hide the tooltip but do not refresh the tooltip keep alive. A click resets the tooltip delay.
-		setShowTooltip(false);
-	};
+	}, [mouseInside]);
 
 	// Render.
 	return (
 		<div className='action-bar-tool-tip-container'>
-			<div className='action-bar-tool-tip-wrapper' onMouseEnter={mouseEnterHandler} onMouseLeave={mouseLeaveHandler} onClick={clickHandler}>
+			<div
+				className='action-bar-tool-tip-wrapper'
+				onMouseEnter={() => setMouseInside(true)}
+				onMouseLeave={() => {
+					setMouseInside(false);
+					if (showTooltip) {
+						setShowTooltip(false);
+						positronActionBarContext.updateTooltipLastHiddenAt();
+					}
+				}}
+				onMouseDown={() => {
+					setShowTooltip(false);
+					positronActionBarContext.resetTooltipLastHiddenAt();
+				}}
+			>
 				{props.children}
 			</div>
 			{showTooltip &&

--- a/src/vs/platform/positronActionBar/browser/positronActionBarState.tsx
+++ b/src/vs/platform/positronActionBar/browser/positronActionBarState.tsx
@@ -45,7 +45,8 @@ export interface PositronActionBarState extends PositronActionBarServices {
 	appendCommandAction(actions: IAction[], commandAction: CommandAction): void;
 	isCommandEnabled(commandId: string): boolean;
 	showTooltipDelay(): number;
-	refreshTooltipKeepAlive(): void;
+	updateTooltipLastHiddenAt(): void;
+	resetTooltipLastHiddenAt(): void;
 	menuShowing: boolean;
 	setMenuShowing(menuShowing: boolean): void;
 }
@@ -114,8 +115,11 @@ export const usePositronActionBarState = (services: PositronActionBarServices): 
 		...services,
 		appendCommandAction,
 		isCommandEnabled,
-		showTooltipDelay: () => new Date().getTime() - lastTooltipHiddenAt < kTooltipReset ? 0 : services.configurationService.getValue<number>('workbench.hover.delay'),
-		refreshTooltipKeepAlive: () => setLastTooltipHiddenAt(new Date().getTime()),
+		showTooltipDelay: () => new Date().getTime() - lastTooltipHiddenAt < kTooltipReset ?
+			0 :
+			services.configurationService.getValue<number>('workbench.hover.delay'),
+		updateTooltipLastHiddenAt: () => setLastTooltipHiddenAt(new Date().getTime()),
+		resetTooltipLastHiddenAt: () => setLastTooltipHiddenAt(0),
 		menuShowing,
 		setMenuShowing
 	};


### PR DESCRIPTION
This PR hides the action bar button tooltip when the user presses the mouse button.

https://github.com/posit-dev/positron/assets/853239/7feba1b5-49c1-4485-b4b4-92b44895a463

