### PR TITLE
only search the workspace root for R config files

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -307,11 +307,11 @@ async function shouldRecommendForWorkspace(): Promise<boolean> {
 	const globs = [
 		'**/*.R',
 		'**/*.Rmd',
-		'**/.Rprofile',
-		'**/renv.lock',
-		'**/.Rbuildignore',
-		'**/.Renviron',
-		'**/*.Rproj'
+		'.Rprofile',
+		'renv.lock',
+		'.Rbuildignore',
+		'.Renviron',
+		'*.Rproj'
 	];
 	// Convert to the glob format used by vscode.workspace.findFiles.
 	const glob = `{${globs.join(',')}}`;


### PR DESCRIPTION
See the discussion here: https://github.com/posit-dev/positron/pull/1289#discussion_r1323446393.

Relates to https://github.com/posit-dev/positron/issues/1282.
