### PR TITLE
Update the pull request template to point to Positron guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,8 @@
 <!-- Thank you for submitting a Pull Request. Please:
 * Read our Pull Request guidelines:
-  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
+  https://connect.posit.it/positron-wiki/pull-requests.html
 * Associate an issue with the Pull Request.
 * Ensure that the code is up-to-date with the `main` branch.
-* Include a description of the proposed changes and how to test them.
+* Include a description of why we are making the proposed changes and
+* how best to test them.
 -->


### PR DESCRIPTION
Removing a stale reference to Microsoft's pull request guide, and replace with a link to Positron's guide on the wiki.