### PR TITLE
Exit early if no DESCRIPTION found for utils package

### DIFF
--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -4,6 +4,7 @@
 
 import * as semver from 'semver';
 import * as path from 'path';
+import * as fs from 'fs';
 import { extractValue, readLines } from './util';
 
 /**
@@ -63,6 +64,11 @@ export class RInstallation {
 		// make sure to target a base package that contains compiled code, so the
 		// 'Built' field contains the platform info
 		const descPath = path.join(this.homepath, 'library', 'utils', 'DESCRIPTION');
+		// We have actually seen an R "installation" that doesn't have the base packages!
+		// https://github.com/posit-dev/positron/issues/1314
+		if (!fs.existsSync(descPath)) {
+			return;
+		}
 		const descLines = readLines(descPath);
 		const targetLine2 = descLines.filter(line => line.match('Built'))[0];
 		if (!targetLine2) {


### PR DESCRIPTION
Fix for #1314 

I have "tested" this locally by temporarily consulting the DESCRIPTION for a non-existent base package ("blarg" instead of "utils"), replicating the error seen in the dev tools log from #1314, adding the new guard, and verifying that the error goes away.