### PR TITLE
Fixes help find by adding the message listener when the `document.readyState` is  `complete`

### DIFF
--- a/extensions/positron-proxy/resources/scripts.html
+++ b/extensions/positron-proxy/resources/scripts.html
@@ -18,9 +18,6 @@
 			switch (document.readyState) {
 				// Interactive.
 				case "interactive":
-					// Add message listener.
-					addMessageListener();
-
 					// Indicate that help is interactive.
 					window.parent.postMessage({
 						id: "positron-help-interactive",
@@ -31,6 +28,9 @@
 
 				// Complete.
 				case "complete":
+					// Add message listener.
+					addMessageListener();
+
 					// Hijack links.
 					hijackLinks();
 
@@ -47,7 +47,7 @@
 			}
 		});
 
-		// Add message listener.
+		// Adds message listener.
 		const addMessageListener = () => {
 			// Add the event listener.
 			window.addEventListener("message", message => {

--- a/src/vs/workbench/contrib/positronHelp/browser/resources/help.html
+++ b/src/vs/workbench/contrib/positronHelp/browser/resources/help.html
@@ -36,7 +36,7 @@
 
 				// When the help iframe content window is interactive, scroll it, if there is a
 				// scroll position to restore.
-				if (message.data.id === "positron-help-interactive") {
+				if (message.data.id === "positron-help-complete") {
 					const scrollX = __scrollX__;
 					const scrollY = __scrollY__;
 					if (scrollX || scrollY) {


### PR DESCRIPTION
It turns out that we need to add our message listener when the `document.readyState` is  `complete` for find in help to work reliably. The `<pre>...</pre>` thing was a red herring.