### PR TITLE
Make it possible to clear recently opened workspaces

### DIFF
--- a/src/vs/workbench/browser/parts/editor/workspaceActions.ts
+++ b/src/vs/workbench/browser/parts/editor/workspaceActions.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Categories } from 'vs/platform/action/common/actionCommonCategories';
+import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
+import { localize } from 'vs/nls';
+import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
+import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
+
+
+/**
+ * Command to clear recent workspaces. This is an adaptation of the
+ * ClearRecentFilesAction that only clears workspaces; Positron uses it to offer
+ * a convenient "clear recently opened" option for workspaces in the workspace
+ * picker.
+ */
+export class ClearRecentWorkspacesAction extends Action2 {
+
+	static readonly ID = 'workbench.action.clearRecentWorkspaces';
+
+	constructor() {
+		super({
+			id: ClearRecentWorkspacesAction.ID,
+			title: { value: localize('clearRecentWorkspaces', "Clear Recently Opened"), original: 'Clear Recently Opened' },
+			// Don't show this in the Command Palette; it would be confused with
+			// workbench.action.clearRecentFiles
+			f1: false,
+			category: Categories.File
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const dialogService = accessor.get(IDialogService);
+		const workspacesService = accessor.get(IWorkspacesService);
+
+		// Ask for confirmation
+		const { confirmed } = await dialogService.confirm({
+			type: 'warning',
+			message: localize('confirmClearWorkspacesMessage', "Do you want to clear all recently opened workspaces?"),
+			detail: localize('confirmClearDetail', "This action is irreversible!"),
+			primaryButton: localize({ key: 'clearButtonLabel', comment: ['&& denotes a mnemonic'] }, "&&Clear")
+		});
+
+		if (!confirmed) {
+			return;
+		}
+
+		// Clear global recently opened
+		workspacesService.clearRecentlyOpened();
+	}
+}
+
+registerAction2(ClearRecentWorkspacesAction);

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarFolderMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarFolderMenu.tsx
@@ -14,6 +14,7 @@ import { usePositronActionBarContext } from 'vs/platform/positronActionBar/brows
 import { recentMenuActions } from 'vs/workbench/browser/parts/positronTopActionBar/components/topActionBarOpenMenu';
 import { usePositronTopActionBarContext } from 'vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarContext';
 import { PositronNewFolderAction, PositronNewFolderFromGitAction, PositronOpenFolderInNewWindowAction } from 'vs/workbench/browser/actions/positronActions';
+import { ClearRecentWorkspacesAction } from 'vs/workbench/browser/parts/editor/workspaceActions';
 
 // Constants.
 const kCloseFolder = 'workbench.action.closeFolder';
@@ -87,13 +88,10 @@ export const TopActionBarFolderMenu = () => {
 		if (positronTopActionBarContext && recent?.workspaces?.length) {
 			actions.push(new Separator());
 			actions.push(...recentMenuActions(recent.workspaces, positronTopActionBarContext));
-
-			// For now, do not add this command action because it clears files and folders. It would
-			// be better to have an action that just clears folders / workspaces.
-			// actions.push(new Separator());
-			// positronActionBarContext.appendCommandAction(actions, {
-			// 	commandId: ClearRecentFilesAction.ID
-			// });
+			actions.push(new Separator());
+			positronActionBarContext.appendCommandAction(actions, {
+				id: ClearRecentWorkspacesAction.ID
+			});
 		}
 
 


### PR DESCRIPTION
This quick change makes it possible to clear all the recent workspaces from a convenient location on the folder/workspace picker in the top bar.

Addresses https://github.com/posit-dev/positron/issues/1323.
