### PR TITLE
Stop help proxy servers that are no longer needed.

### DIFF
--- a/extensions/positron-proxy/resources/scripts.html
+++ b/extensions/positron-proxy/resources/scripts.html
@@ -5,6 +5,28 @@
 <head>
 	<!-- The help header style. -->
 	<style id="help-header-style">
+		::-webkit-scrollbar {
+			background: transparent;
+			width: 8px;
+			height: 8px;
+			cursor: default !important;
+		}
+
+		::-webkit-scrollbar-track {
+			opacity: 0;
+		}
+
+		::-webkit-scrollbar-thumb {
+			min-height: 20px;
+			background-color: var(--vscode-scrollbarSlider-background) !important;
+			background-color: #6e768133 !important;
+		}
+
+		::-webkit-scrollbar-thumb:hover {
+			cursor: pointer !important;
+			background-color: var(--vscode-scrollbarSlider-hoverBackground) !important;
+			background-color: #6e768133 !important;
+		}
 	</style>
 
 	<!-- The help header script. -->

--- a/extensions/positron-proxy/src/extension.ts
+++ b/extensions/positron-proxy/src/extension.ts
@@ -14,9 +14,24 @@ export function activate(context: vscode.ExtensionContext) {
 	const positronProxy = new PositronProxy(context);
 
 	// Register the positronProxy.startHelpProxyServer command and add its disposable.
-	context.subscriptions.push(vscode.commands.registerCommand('positronProxy.startHelpProxyServer', async (targetOrigin: string) => {
-		return await positronProxy.startHelpProxyServer(targetOrigin);
-	}));
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'positronProxy.startHelpProxyServer',
+			async (targetOrigin: string) => {
+				return await positronProxy.startHelpProxyServer(targetOrigin);
+			}
+		)
+	);
+
+	// Register the positronProxy.stopHelpProxyServer command and add its disposable.
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'positronProxy.stopHelpProxyServer',
+			(targetOrigin: string) => {
+				return positronProxy.stopHelpProxyServer(targetOrigin);
+			}
+		)
+	);
 
 	// Add the PositronProxy object disposable.
 	context.subscriptions.push(positronProxy);

--- a/extensions/positron-proxy/src/positronProxy.ts
+++ b/extensions/positron-proxy/src/positronProxy.ts
@@ -180,6 +180,7 @@ export class PositronProxy implements Disposable {
 		// See if we have a proxy server for the target origin. If we do, stop it.
 		const proxyServer = this.proxyServers.get(targetOrigin);
 		if (proxyServer) {
+			// Remove and stop the proxy server.
 			this.proxyServers.delete(targetOrigin);
 			proxyServer.dispose();
 

--- a/extensions/positron-proxy/src/positronProxy.ts
+++ b/extensions/positron-proxy/src/positronProxy.ts
@@ -173,7 +173,8 @@ export class PositronProxy implements Disposable {
 	/**
 	 * Stops a help proxy server
 	 * @param targetOrigin The target origin.
-	 * @returns The server origin.
+	 * @returns A value which indicates whether the proxy server for the target origin was found and
+	 * stopped.
 	 */
 	stopHelpProxyServer(targetOrigin: string): boolean {
 		// See if we have a proxy server for the target origin. If we do, stop it.

--- a/extensions/positron-proxy/src/positronProxy.ts
+++ b/extensions/positron-proxy/src/positronProxy.ts
@@ -170,6 +170,26 @@ export class PositronProxy implements Disposable {
 			});
 	}
 
+	/**
+	 * Stops a help proxy server
+	 * @param targetOrigin The target origin.
+	 * @returns The server origin.
+	 */
+	stopHelpProxyServer(targetOrigin: string): boolean {
+		// See if we have a proxy server for the target origin. If we do, stop it.
+		const proxyServer = this.proxyServers.get(targetOrigin);
+		if (proxyServer) {
+			this.proxyServers.delete(targetOrigin);
+			proxyServer.dispose();
+
+			// A proxy server for the target origin was found and stopped.
+			return true;
+		}
+
+		// A proxy server for the target origin was not found.
+		return false;
+	}
+
 	//#endregion Public Methods
 
 	//#region Private Methods

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -500,7 +500,7 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 		);
 
 		// If there are no help entries to delete, there's nothing more to do.
-		if (!helpEntriesToDelete) {
+		if (!helpEntriesToDelete.length) {
 			return;
 		}
 
@@ -524,6 +524,26 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 
 		// Dispose of the deleted help entries.
 		helpEntriesToDelete.forEach(deletedHelpEntry => deletedHelpEntry.dispose());
+
+		// Get the set of target origins that we may want to clean up.
+		const cleanupTargetOrigins = helpEntriesToDelete.map(helpEntry =>
+			new URL(helpEntry.targetUrl).origin
+		);
+
+		// Get the set of active target origins so we don't accidentally clean one of them up.
+		const activeTargetOrigins = this._helpEntries.map(helpEntry =>
+			new URL(helpEntry.targetUrl).origin
+		);
+
+		// Stop proxy servers that can be stopped.
+		cleanupTargetOrigins.forEach(targetOrigin => {
+			if (!activeTargetOrigins.includes(targetOrigin)) {
+				this._commandService.executeCommand<string>(
+					'positronProxy.stopHelpProxyServer',
+					targetOrigin
+				);
+			}
+		});
 	}
 
 	//#endregion Private Methods


### PR DESCRIPTION
This PR has two improvements.

First, just as a stopgap, it sets the help scrollbar style to match Positron's light scrollbar style. This is temporary and will come from vscode vars, soon.

Second, I've added a new command to the PositronProxy called `positronProxy.stopHelpProxyServer` and updated the PositronHelpService such that it stops help proxy servers that are no longer in use.