### PR TITLE
Update ark to 0.1.5

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -368,7 +368,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.3"
+      "ark": "0.1.5"
     }
   }
 }


### PR DESCRIPTION
Updates ark to 0.1.5 to pick up the new `.ps.ark.version()` feature. 