### PR TITLE
Injects `--vscode-x` vars into help through the Positron Proxy

### DIFF
--- a/extensions/positron-proxy/package.json
+++ b/extensions/positron-proxy/package.json
@@ -12,6 +12,7 @@
 	],
 	"activationEvents": [
     "onCommand:positronProxy.startHelpProxyServer",
+    "onCommand:positronProxy.setHelpProxyServerStyles",
 		"onStartupFinished"
 	],
 	"main": "./out/extension.js",

--- a/extensions/positron-proxy/resources/scripts.html
+++ b/extensions/positron-proxy/resources/scripts.html
@@ -18,14 +18,12 @@
 
 		::-webkit-scrollbar-thumb {
 			min-height: 20px;
-			background-color: var(--vscode-scrollbarSlider-background) !important;
-			background-color: #6e768133 !important;
+			background-color: var(--vscode-scrollbarSlider-background);
 		}
 
 		::-webkit-scrollbar-thumb:hover {
 			cursor: pointer !important;
-			background-color: var(--vscode-scrollbarSlider-hoverBackground) !important;
-			background-color: #6e768133 !important;
+			background-color: var(--vscode-scrollbarSlider-hoverBackground);
 		}
 	</style>
 

--- a/extensions/positron-proxy/src/extension.ts
+++ b/extensions/positron-proxy/src/extension.ts
@@ -6,6 +6,11 @@ import * as vscode from 'vscode';
 import { PositronProxy } from './positronProxy';
 
 /**
+ * ProxyServerStyles type.
+ */
+export type ProxyServerStyles = { readonly [key: string]: string | number };
+
+/**
  * Activates the extension.
  * @param context An ExtensionContext that contains the extention context.
  */
@@ -17,9 +22,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'positronProxy.startHelpProxyServer',
-			async (targetOrigin: string) => {
-				return await positronProxy.startHelpProxyServer(targetOrigin);
-			}
+			async (targetOrigin: string) => await positronProxy.startHelpProxyServer(targetOrigin)
 		)
 	);
 
@@ -27,9 +30,15 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'positronProxy.stopHelpProxyServer',
-			(targetOrigin: string) => {
-				return positronProxy.stopHelpProxyServer(targetOrigin);
-			}
+			(targetOrigin: string) => positronProxy.stopHelpProxyServer(targetOrigin)
+		)
+	);
+
+	// Register the positronProxy.stopHelpProxyServer command and add its disposable.
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'positronProxy.setHelpProxyServerStyles',
+			(styles: ProxyServerStyles) => positronProxy.setHelpProxyServerStyles(styles)
 		)
 	);
 


### PR DESCRIPTION
Seeing is believing:

<img width="1841" alt="image" src="https://github.com/posit-dev/positron/assets/853239/5a30a5e7-fb5e-4450-8b77-7d73d4c596a4">
