### PR TITLE
Direct keyboard events from help overlay webview to the element hosti…

### DIFF
--- a/extensions/positron-proxy/resources/scripts.html
+++ b/extensions/positron-proxy/resources/scripts.html
@@ -51,6 +51,7 @@
 					// Add our listeners.
 					addScrollListener();
 					addMessageListener();
+					addKeyboardListeners();
 					addContextMenuListener();
 
 					// Hijack links.
@@ -171,6 +172,41 @@
 						break;
 
 				}
+			});
+		};
+
+		// Add keyboard listeners.
+		const addKeyboardListeners = () => {
+			// Add the keydown event handler.
+			window.addEventListener('keydown', e => {
+				// Post the positron-help-keydown message.
+				window.parent.postMessage({
+					id: "positron-help-keydown",
+					key: e.key,
+					keyCode: e.keyCode,
+					code: e.code,
+					shiftKey: e.shiftKey,
+					altKey: e.altKey,
+					ctrlKey: e.ctrlKey,
+					metaKey: e.metaKey,
+					repeat: e.repeat
+				}, "*");
+			});
+
+			// Add the keyup event handler.
+			window.addEventListener('keyup', e => {
+				// Post the positron-help-keyup message.
+				window.parent.postMessage({
+					id: "positron-help-key-up",
+					key: e.key,
+					keyCode: e.keyCode,
+					code: e.code,
+					shiftKey: e.shiftKey,
+					altKey: e.altKey,
+					ctrlKey: e.ctrlKey,
+					metaKey: e.metaKey,
+					repeat: e.repeat
+				}, "*");
 			});
 		};
 

--- a/extensions/positron-proxy/resources/scripts.html
+++ b/extensions/positron-proxy/resources/scripts.html
@@ -187,6 +187,19 @@
 		const addKeyboardListeners = () => {
 			// Add the keydown event handler.
 			window.addEventListener('keydown', e => {
+				/**
+				 * Determines whether the KeyboardEvent is ctrl or meta.
+				 * @param e The keyboard event.
+				 * @return A value which indicates whether the KeyboardEvent is ctrl or meta.
+				 */
+				const isAltCtrlOrMeta = (e) => e.altKey || e.ctrlKey || e.metaKey;
+
+				// Rope off select all (65: keyCode of "A").
+				if (isAltCtrlOrMeta && e.keyCode === 65) {
+					e.preventDefault();
+					return;
+				}
+
 				// Post the positron-help-keydown message.
 				window.parent.postMessage({
 					id: "positron-help-keydown",

--- a/extensions/positron-proxy/resources/scripts.html
+++ b/extensions/positron-proxy/resources/scripts.html
@@ -171,6 +171,14 @@
 						window.focus();
 						break;
 
+					// positron-help-copy-selection message. Sent to copy the selection.
+					case "positron-help-copy-selection":
+						// Post the positron-help-selection message.
+						window.parent.postMessage({
+							id: "positron-help-copy-selection",
+							selection: window.getSelection().toString()
+						}, "*");
+						break;
 				}
 			});
 		};

--- a/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
@@ -456,11 +456,6 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 								id: 'positron-help-copy-selection'
 							});
 						} else {
-							// Rope off select all.
-							if (cmdOrCtrlKey && message.code === 'KeyA') {
-								return;
-							}
-
 							// Emulate the key event.
 							this.emulateKeyEvent('keydown', { ...message });
 						}

--- a/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
@@ -4,7 +4,7 @@
 
 import { localize } from 'vs/nls';
 import { IAction } from 'vs/base/common/actions';
-import * as platform from 'vs/base/common/platform';
+import { isMacintosh } from 'vs/base/common/platform';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Emitter, Event } from 'vs/base/common/event';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
@@ -446,16 +446,26 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 						break;
 
 					// positron-help-keydown message.
-					case 'positron-help-keydown':
-						if ((platform.isMacintosh ? message.metaKey : message.ctrlKey) &&
-							message.code === 'KeyC') {
+					case 'positron-help-keydown': {
+						// Determine whether the cmd or ctrl key is pressed.
+						const cmdOrCtrlKey = isMacintosh ? message.metaKey : message.ctrlKey;
+
+						// Copy.
+						if (cmdOrCtrlKey && message.code === 'KeyC') {
 							this._helpOverlayWebview?.postMessage({
 								id: 'positron-help-copy-selection'
 							});
 						} else {
+							// Rope off select all.
+							if (cmdOrCtrlKey && message.code === 'KeyA') {
+								return;
+							}
+
+							// Emulate the key event.
 							this.emulateKeyEvent('keydown', { ...message });
 						}
 						break;
+					}
 
 					// positron-help-keyup message.
 					case 'positron-help-keyup':


### PR DESCRIPTION
This PR addresses the issue where the help overlay webview, when it has focus, eats keyboard events, preventing things like ⇧⌘ P and ⌘ R from working properly.

Also, Ctrl+C / Cmd+C keyboard shortcut now copies the selection in the help overlay webview to the clipboard.