### PR TITLE
Ensure zeromq is properly configured for jupyter-adapter

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -110,6 +110,25 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
+      # These are already installed for both architectures, but would be
+      # required if we switch off a self-hosted runner, so we may as well leave
+      # them in
+      - name: Install zeromq dependencies
+        id: install_zeromq_dependencies
+        run: |
+          arch -${{matrix.arch_terminal}} /bin/bash -c "~/${{matrix.homebrew_folder}}/bin/brew install pkg-config"
+          arch -${{matrix.arch_terminal}} /bin/bash -c "~/${{matrix.homebrew_folder}}/bin/brew install libsodium"
+
+      # Zeromq calls whatever pkg-config version is findable on the PATH to be
+      # able to locate libsodium, so we have to ensure the x86_64 version is
+      # first on the PATH when compiling for that architecture, so that it finds
+      # the x86_64 version of libsodium for zeromq to link against.
+      - name: Update PATH to pkg-config for zeromq
+        id: update_path_for_zeromq
+        if: matrix.arch == 'x64'
+        run: |
+          echo "~/${{matrix.homebrew_folder}}/bin" >> $GITHUB_PATH
+
       # Install node_modules binaries and compile the R kernel
       - name: Install dependencies
         env:


### PR DESCRIPTION
In PR #1321, I removed the zeromq configuration from our build script, since the zeromq Rust crate builds as part of Amalthea instead. However, I theorize that this is what broke the extension host on Intel; the jupyter-adapter extension _also_ uses zeromq. It is possible that the jupyter-adapter loading an incorrectly compiled zeromq binary is what is crashing the extension host. 

This speculative change restores the zeromq configuration to the macOS build script, just as it was before #1321. 
