### PR TITLE
Skip looking for ARK on windows until we support that platform

### DIFF
--- a/extensions/positron-r/scripts/install-kernel.ts
+++ b/extensions/positron-r/scripts/install-kernel.ts
@@ -96,11 +96,6 @@ async function downloadAndReplaceArk(version: string,
 	githubPat: string,
 	gitCredential: boolean): Promise<void> {
 
-	if (platform() === 'win32') {
-		console.warn('ARK is not yet supported on Windows. Skipping download.');
-		return;
-	}
-
 	try {
 		const requestOptions: https.RequestOptions = {
 			headers: {
@@ -233,6 +228,12 @@ async function downloadAndReplaceArk(version: string,
 }
 
 async function main() {
+
+	// Temporarily skip downloading ARK on Windows until we have a Windows build.
+	if (platform() === 'win32') {
+		console.warn('ARK is not yet supported on Windows. Skipping download.');
+		return;
+	}
 
 	// Before we do any work, check to see if there is a locally built copy of Amalthea in the
 	// `amalthea / target` directory. If so, we'll assume that the user is a kernel developer

--- a/extensions/positron-r/scripts/install-kernel.ts
+++ b/extensions/positron-r/scripts/install-kernel.ts
@@ -5,6 +5,7 @@
 import * as fs from 'fs';
 import { IncomingMessage } from 'http';
 import * as https from 'https';
+import { platform } from 'os';
 import * as path from 'path';
 import { promisify } from 'util';
 
@@ -94,6 +95,11 @@ async function executeCommand(command: string, stdin?: string):
 async function downloadAndReplaceArk(version: string,
 	githubPat: string,
 	gitCredential: boolean): Promise<void> {
+
+	if (platform() === 'win32') {
+		console.warn('ARK is not yet supported on Windows. Skipping download.');
+		return;
+	}
 
 	try {
 		const requestOptions: https.RequestOptions = {
@@ -202,9 +208,9 @@ async function downloadAndReplaceArk(version: string,
 
 				// Unzip the binary.
 				const { stdout, stderr } =
-					await executeCommand(`unzip -o ` +
+					await executeCommand(`tar -xf ` +
 						`${path.join('resources', 'ark', 'ark.zip')}` +
-						` -d ` +
+						` -C ` +
 						`${path.join('resources', 'ark')}`);
 				console.log(stdout);
 				if (stderr) {

--- a/extensions/positron-r/scripts/install-kernel.ts
+++ b/extensions/positron-r/scripts/install-kernel.ts
@@ -203,9 +203,9 @@ async function downloadAndReplaceArk(version: string,
 
 				// Unzip the binary.
 				const { stdout, stderr } =
-					await executeCommand(`tar -xf ` +
+					await executeCommand(`unzip -o ` +
 						`${path.join('resources', 'ark', 'ark.zip')}` +
-						` -C ` +
+						` -d ` +
 						`${path.join('resources', 'ark')}`);
 				console.log(stdout);
 				if (stderr) {


### PR DESCRIPTION
We need to address #159 before we can support R on Windows, so skip trying to download ARK on Windows.

Also we can use a cross-platform approach for expanding a compressed file using tar -xf instead of unzip.