### PR TITLE
Use "interpreter" rather than "runtime" in user facing text

### DIFF
--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntime.ts
@@ -13,4 +13,4 @@ export interface INotebookBridgeService {
 
 export const INotebookBridgeService = createDecorator<INotebookBridgeService>('notebookBridgeService');
 
-export const LANGUAGE_RUNTIME_ACTION_CATEGORY = nls.localize('languageRuntimeCategory', "Language Runtime");
+export const LANGUAGE_RUNTIME_ACTION_CATEGORY = nls.localize('languageRuntimeCategory', "Interpreter");

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
@@ -134,7 +134,7 @@ export function registerLanguageRuntimeActions() {
 	};
 
 	// Registers the start language runtime action.
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.start', 'Start Language Runtime', async accessor => {
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.start', 'Start Interpreter', async accessor => {
 		// Access services.
 		const commandService = accessor.get(ICommandService);
 		const extensionService = accessor.get(IExtensionService);
@@ -147,16 +147,16 @@ export function registerLanguageRuntimeActions() {
 		// Get the registered language runtimes.
 		const registeredRuntimes = languageRuntimeService.registeredRuntimes;
 		if (!registeredRuntimes.length) {
-			alert(nls.localize('positronNoInstalledRuntimes', "No language runtimes are currently installed."));
+			alert(nls.localize('positronNoInstalledRuntimes', "No interpreters are currently installed."));
 			return;
 		}
 
 		// Ask the user to select the language runtime to start. If they selected one, start it.
-		const languageRuntime = await selectLanguageRuntime(quickInputService, registeredRuntimes, 'Select the language runtime to start');
+		const languageRuntime = await selectLanguageRuntime(quickInputService, registeredRuntimes, 'Select the interpreter to start');
 		if (languageRuntime) {
 			// Start the language runtime.
 			languageRuntimeService.startRuntime(languageRuntime.metadata.runtimeId,
-				`'Start Language Runtime' command invoked`);
+				`'Start Interpreter' command invoked`);
 
 			// Drive focus into the Positron console.
 			commandService.executeCommand('workbench.panel.positronConsole.focus');
@@ -164,7 +164,7 @@ export function registerLanguageRuntimeActions() {
 	});
 
 	// Registers the set active  language runtime action.
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.setActive', 'Set Active Language Runtime', async accessor => {
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.setActive', 'Set Active Interpreter', async accessor => {
 		// Get the language runtime service.
 		const languageRuntimeService = accessor.get(ILanguageRuntimeService);
 
@@ -181,7 +181,7 @@ export function registerLanguageRuntimeActions() {
 	});
 
 	// Registers the restart language runtime action.
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.restart', 'Restart Language Runtime', async accessor => {
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.restart', 'Restart Interpreter', async accessor => {
 		// Access services.
 		const consoleService = accessor.get(IPositronConsoleService);
 		const languageRuntimeService = accessor.get(ILanguageRuntimeService);
@@ -207,15 +207,15 @@ export function registerLanguageRuntimeActions() {
 			runtime = await selectRunningLanguageRuntime(
 				accessor.get(ILanguageRuntimeService),
 				accessor.get(IQuickInputService),
-				'Select the language runtime to restart');
+				'Select the interpreter to restart');
 			if (!runtime) {
-				throw new Error('No language runtime selected');
+				throw new Error('No interpreter selected');
 			}
 		}
 
 		// Restart the language runtime.
 		languageRuntimeService.restartRuntime(runtime.metadata.runtimeId,
-			`'Restart Language Runtime' command invoked`);
+			`'Restart Interpreter' command invoked`);
 	},
 		[
 			{
@@ -230,22 +230,22 @@ export function registerLanguageRuntimeActions() {
 	);
 
 	// Registers the interrupt language runtime action.
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.interrupt', 'Interrupt Language Runtime', async accessor => {
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.interrupt', 'Interrupt Interpreter', async accessor => {
 		(await selectRunningLanguageRuntime(
 			accessor.get(ILanguageRuntimeService),
 			accessor.get(IQuickInputService),
-			'Select the language runtime to interrupt'))?.interrupt();
+			'Select the interpreter to interrupt'))?.interrupt();
 	});
 
 	// Registers the shutdown language runtime action.
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.shutdown', 'Shutdown Language Runtime', async accessor => {
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.shutdown', 'Shutdown Interpreter', async accessor => {
 		(await selectRunningLanguageRuntime(
 			accessor.get(ILanguageRuntimeService),
 			accessor.get(IQuickInputService),
-			'Select the language runtime to shutdown'))?.shutdown();
+			'Select the interpreter to shutdown'))?.shutdown();
 	});
 
-	registerLanguageRuntimeAction('workbench.action.language.runtime.openClient', 'Create New Runtime Client Widget', async accessor => {
+	registerLanguageRuntimeAction('workbench.action.language.runtime.openClient', 'Create Runtime Client Widget', async accessor => {
 		// Access services.
 		const languageRuntimeService = accessor.get(ILanguageRuntimeService);
 		const quickInputService = accessor.get(IQuickInputService);

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -711,7 +711,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 			state === RuntimeState.Exited) {
 			// The runtime has never been started, or is no longer running. Just
 			// tell it to start.
-			return this.startRuntime(runtime.metadata.runtimeId, `'Restart Language Runtime' command invoked`);
+			return this.startRuntime(runtime.metadata.runtimeId, `'Restart Interpreter' command invoked`);
 		} else if (state === RuntimeState.Starting ||
 			state === RuntimeState.Restarting) {
 			// The runtime is already starting or restarting. We could show an


### PR DESCRIPTION
Addresses #1308

![Screenshot 2023-09-25 at 1 48 46 PM](https://github.com/posit-dev/positron/assets/12505835/8cd9cbb0-fb94-4f05-ae5b-b3c291bc8ad8)


In this PR, I changed to use "interpreter" in text I know is user facing, like the names of commands, strings that are localized, etc. I did _not_ change to "interpreter" in logs or, for example, the text about "runtime client widget":

![Screenshot 2023-09-25 at 1 49 01 PM](https://github.com/posit-dev/positron/assets/12505835/199ae460-8ae2-4a20-8a25-f90a04214042)
