### PR TITLE
Default SCM view to 'tree'

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -226,7 +226,10 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 				localize('scm.defaultViewMode.list', "Show the repository changes as a list.")
 			],
 			description: localize('scm.defaultViewMode', "Controls the default Source Control repository view mode."),
-			default: 'list'
+			// --- Start Positron ---
+			// default: 'list'
+			default: 'tree'
+			// --- End Positron ---
 		},
 		'scm.defaultViewSortKey': {
 			type: 'string',


### PR DESCRIPTION
Addresses #1374 at least in some capacity

Here I opened up an older Quarto project and rendered it afresh, causing a lot of changes in the directory for rendered files:

![Screenshot 2023-09-25 at 5 22 34 PM](https://github.com/posit-dev/positron/assets/12505835/b0055792-de40-4b44-bb32-8429ac1721ed)

When you are in tree mode like this, you can add whole subtrees of changes at once. I do think this is an improvement, and better for more data science workflows. This is probably _less_ true for package development and _more_ true for analysis projects.