### PR TITLE
Fixes/1388

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.css
@@ -7,7 +7,8 @@
 	cursor: default;
 	padding-left: 10px;
 	position: absolute;
-	overflow-y: overlay;
+	/* As of Chrome 114, overflow: overlay is no longer an option. So, use auto. */
+	overflow-y: auto;
 
 	/* Selection */
 	user-select: text;

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -436,6 +436,13 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	// Calculate the adjusted width (to account for indentation of the entire console instance).
 	const adjustedWidth = props.width - 10;
 
+	// Compute the console input width. If the vertical scrollbar is visible, subtract its width,
+	// which is set to 14px in consoleInstance.css, from the adjusted width.
+	let consoleInputWidth = adjustedWidth;
+	if (consoleInstanceRef.current?.scrollHeight > consoleInstanceRef.current?.clientHeight) {
+		consoleInputWidth -= 14;
+	}
+
 	// Render.
 	return (
 		<div
@@ -482,7 +489,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			</div>
 			{!props.positronConsoleInstance.promptActive &&
 				<ConsoleInput
-					width={adjustedWidth}
+					width={consoleInputWidth}
 					positronConsoleInstance={props.positronConsoleInstance}
 					selectAll={() => selectAllRuntimeItems()}
 				/>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -439,7 +439,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	// Compute the console input width. If the vertical scrollbar is visible, subtract its width,
 	// which is set to 14px in consoleInstance.css, from the adjusted width.
 	let consoleInputWidth = adjustedWidth;
-	if (consoleInstanceRef.current?.scrollHeight > consoleInstanceRef.current?.clientHeight) {
+	if (consoleInstanceRef.current?.scrollHeight >= consoleInstanceRef.current?.clientHeight) {
 		consoleInputWidth -= 14;
 	}
 


### PR DESCRIPTION
As of Chrome 114, `overflow: overlay` is no longer an option for scrollbars. (See https://developer.chrome.com/blog/chrome-114-beta/#alias-overflow-overlay-to-overflow-auto)

We were relying on this feature in Console to display the vertical scrollbar _over_ the console output and the `CodeEditorWidget`.

This fix addresses #1388 by adjusting the width of the `CodeEditorWidget` to account for the vertical scrollbar, when it is visible.

https://github.com/posit-dev/positron/assets/853239/935f9127-8599-465d-9e2b-860b8cafea49

