### PR TITLE
Improve plots thumbnail experience in Console

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.css
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .activity-output-plot img {
-	max-height: 30px;
-	max-width: 30px;
+	max-height: 50px;
+	max-width: 100%;
+	cursor: pointer;
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.css
@@ -4,6 +4,7 @@
 
 .activity-output-plot {
 	position: relative;
+	display: inline-block;
 	overflow: hidden;
 }
 
@@ -11,15 +12,15 @@
 	max-height: 50px;
 	max-width: 100%;
 	border: 2px solid transparent;
-	border-radius: 2px;
+	border-radius: 4px;
 	cursor: pointer;
 }
 
-.inspect {
+.activity-output-plot .inspect {
 	display: none;
 	position: absolute;
-	top: 0;
-	right: 0;
+	top: 3px;
+	right: 3px;
 }
 
 .activity-output-plot:hover .inspect {
@@ -27,5 +28,5 @@
 }
 
 .activity-output-plot:hover img {
-	border: 2px solid --vscode-tab-border;
+	border: 2px solid var(--vscode-tab-border);
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.css
@@ -11,9 +11,10 @@
 .activity-output-plot img {
 	max-height: 50px;
 	max-width: 100%;
-	border: 2px solid transparent;
+	border: 1px solid transparent;
 	border-radius: 4px;
 	cursor: pointer;
+	padding: 5px;
 }
 
 .activity-output-plot .inspect {
@@ -28,5 +29,5 @@
 }
 
 .activity-output-plot:hover img {
-	border: 2px solid var(--vscode-tab-border);
+	border: 1px solid var(--vscode-tab-border);
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.css
@@ -2,8 +2,30 @@
  *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
+.activity-output-plot {
+	position: relative;
+	overflow: hidden;
+}
+
 .activity-output-plot img {
 	max-height: 50px;
 	max-width: 100%;
+	border: 2px solid transparent;
+	border-radius: 2px;
 	cursor: pointer;
+}
+
+.inspect {
+	display: none;
+	position: absolute;
+	top: 0;
+	right: 0;
+}
+
+.activity-output-plot:hover .inspect {
+	display: block;
+}
+
+.activity-output-plot:hover img {
+	border: 2px solid --vscode-tab-border;
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.tsx
@@ -18,11 +18,16 @@ export interface ActivityOutputPlotProps {
  * @returns The rendered component.
  */
 export const ActivityOutputPlot = (props: ActivityOutputPlotProps) => {
+	// Click handler.
+	const handleClick = (event: React.MouseEvent<HTMLImageElement, MouseEvent>) => {
+		props.activityItemOutputPlot.onSelected();
+	};
+
 	// Render.
 	return (
 		<div className='activity-output-plot'>
 			<OutputLines outputLines={props.activityItemOutputPlot.outputLines} />
-			<img src={props.activityItemOutputPlot.plotUri} />
+			<img src={props.activityItemOutputPlot.plotUri} onClick={handleClick} />
 		</div>
 	);
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.tsx
@@ -21,7 +21,8 @@ const linkTitle = nls.localize('activityOutputPlotLinkTitle', "Select this plot 
  * @returns The rendered component.
  */
 export const ActivityOutputPlot = (props: ActivityOutputPlotProps) => {
-	// Click handler.
+	// Handles clicks on the plot. This raises a selection event that eventually
+	// selects the plot (by its ID) in the Plots pane.
 	const handleClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
 		props.activityItemOutputPlot.onSelected();
 	};

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.tsx
@@ -4,6 +4,7 @@
 
 import 'vs/css!./activityOutputPlot';
 import * as React from 'react';
+import * as nls from 'vs/nls';
 import { OutputLines } from 'vs/workbench/contrib/positronConsole/browser/components/outputLines';
 import { ActivityItemOutputPlot } from 'vs/workbench/services/positronConsole/common/classes/activityItemOutputPlot';
 
@@ -12,6 +13,8 @@ export interface ActivityOutputPlotProps {
 	activityItemOutputPlot: ActivityItemOutputPlot;
 }
 
+const linkTitle = nls.localize('activityOutputPlotLinkTitle', "Select this plot in the Plots pane.");
+
 /**
  * ActivityOutputPlot component.
  * @param props An ActivityErrorMessageProps that contains the component properties.
@@ -19,7 +22,7 @@ export interface ActivityOutputPlotProps {
  */
 export const ActivityOutputPlot = (props: ActivityOutputPlotProps) => {
 	// Click handler.
-	const handleClick = (event: React.MouseEvent<HTMLImageElement, MouseEvent>) => {
+	const handleClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
 		props.activityItemOutputPlot.onSelected();
 	};
 
@@ -27,10 +30,12 @@ export const ActivityOutputPlot = (props: ActivityOutputPlotProps) => {
 	return (
 		<>
 			<OutputLines outputLines={props.activityItemOutputPlot.outputLines} />
-			<div className='activity-output-plot'>
-				<img src={props.activityItemOutputPlot.plotUri} onClick={handleClick} />
+			<a className='activity-output-plot'
+				onClick={handleClick}
+				title={linkTitle}>
+				<img src={props.activityItemOutputPlot.plotUri} />
 				<span className='inspect codicon codicon-positron-search' />
-			</div>
+			</a>
 		</>
 	);
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.tsx
@@ -25,9 +25,12 @@ export const ActivityOutputPlot = (props: ActivityOutputPlotProps) => {
 
 	// Render.
 	return (
-		<div className='activity-output-plot'>
+		<>
 			<OutputLines outputLines={props.activityItemOutputPlot.outputLines} />
-			<img src={props.activityItemOutputPlot.plotUri} onClick={handleClick} />
-		</div>
+			<div className='activity-output-plot'>
+				<img src={props.activityItemOutputPlot.plotUri} onClick={handleClick} />
+				<span className='inspect codicon codicon-positron-search' />
+			</div>
+		</>
 	);
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -43,6 +43,7 @@ import { RuntimeItemPendingInput } from 'vs/workbench/services/positronConsole/c
 import { IPositronConsoleInstance } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
 import { RuntimeItemStartupFailure } from 'vs/workbench/services/positronConsole/common/classes/runtimeItemStartupFailure';
 import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_CUT, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
+import { POSITRON_PLOTS_VIEW_ID } from 'vs/workbench/services/positronPlots/common/positronPlots';
 
 // ConsoleInstanceProps interface.
 interface ConsoleInstanceProps {
@@ -273,6 +274,10 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 
 		// Add the onDidSelectPlot event handler.
 		disposableStore.add(props.positronConsoleInstance.onDidSelectPlot(plotId => {
+			// Ensure that the Plots pane is visible.
+			positronConsoleContext.viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+
+			// Select the plot in the Plots pane.
 			positronConsoleContext.positronPlotsService.selectPlot(plotId);
 		}));
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -271,6 +271,11 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			consoleInstanceRef.current.scrollTo(consoleInstanceRef.current.scrollLeft, consoleInstanceRef.current.scrollHeight);
 		}));
 
+		// Add the onDidSelectPlot event handler.
+		disposableStore.add(props.positronConsoleInstance.onDidSelectPlot(plotId => {
+			positronConsoleContext.positronPlotsService.selectPlot(plotId);
+		}));
+
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
 	}, []);

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.ts
@@ -15,6 +15,7 @@ import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
+import { IPositronPlotsService } from 'vs/workbench/services/positronPlots/common/positronPlots';
 import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/common/executionHistoryService';
 import { IPositronConsoleInstance, IPositronConsoleService } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
@@ -37,6 +38,7 @@ export interface PositronConsoleServices {
 	readonly modelService: IModelService;
 	readonly positronConsoleService: IPositronConsoleService;
 	readonly workbenchLayoutService: IWorkbenchLayoutService;
+	readonly positronPlotsService: IPositronPlotsService;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.ts
@@ -19,6 +19,7 @@ import { IPositronPlotsService } from 'vs/workbench/services/positronPlots/commo
 import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/common/executionHistoryService';
 import { IPositronConsoleInstance, IPositronConsoleService } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
+import { IViewsService } from 'vs/workbench/common/views';
 
 /**
  * PositronConsoleServices interface. Defines the set of services that are required by the Positron console.
@@ -37,8 +38,9 @@ export interface PositronConsoleServices {
 	readonly logService: ILogService;
 	readonly modelService: IModelService;
 	readonly positronConsoleService: IPositronConsoleService;
-	readonly workbenchLayoutService: IWorkbenchLayoutService;
 	readonly positronPlotsService: IPositronPlotsService;
+	readonly viewsService: IViewsService;
+	readonly workbenchLayoutService: IWorkbenchLayoutService;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -9,7 +9,7 @@ import { Event, Emitter } from 'vs/base/common/event';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IModelService } from 'vs/editor/common/services/model';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
-import { IViewDescriptorService } from 'vs/workbench/common/views';
+import { IViewDescriptorService, IViewsService } from 'vs/workbench/common/views';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { ICommandService } from 'vs/platform/commands/common/commands';
@@ -166,11 +166,12 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 	 * @param modelService The model service.
 	 * @param openerService The opener service.
 	 * @param positronConsoleService The Positron console service.
+	 * @param positronPlotsService The Positron plots service.
 	 * @param telemetryService The telemetry service.
 	 * @param themeService The theme service.
 	 * @param viewDescriptorService The view descriptor service.
+	 * @param viewsService The views service.
 	 * @param workbenchLayoutService The workbench layout service.
-	 * @param positronPlotsService The Positron plots service.
 	 */
 	constructor(
 		options: IViewPaneOptions,
@@ -188,11 +189,12 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 		@IModelService private readonly modelService: IModelService,
 		@IOpenerService openerService: IOpenerService,
 		@IPositronConsoleService private readonly positronConsoleService: IPositronConsoleService,
+		@IPositronPlotsService private readonly positronPlotsService: IPositronPlotsService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IThemeService themeService: IThemeService,
 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
-		@IWorkbenchLayoutService private readonly workbenchLayoutService: IWorkbenchLayoutService,
-		@IPositronPlotsService private readonly positronPlotsService: IPositronPlotsService
+		@IViewsService private readonly viewsService: IViewsService,
+		@IWorkbenchLayoutService private readonly workbenchLayoutService: IWorkbenchLayoutService
 	) {
 		super(
 			options,
@@ -269,8 +271,9 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 				logService={this.logService}
 				modelService={this.modelService}
 				positronConsoleService={this.positronConsoleService}
-				workbenchLayoutService={this.workbenchLayoutService}
 				positronPlotsService={this.positronPlotsService}
+				viewsService={this.viewsService}
+				workbenchLayoutService={this.workbenchLayoutService}
 				reactComponentContainer={this}
 			/>
 		);

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -28,6 +28,7 @@ import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/c
 import { IReactComponentContainer, ISize, PositronReactRenderer } from 'vs/base/browser/positronReactRenderer';
 import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/common/executionHistoryService';
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
+import { IPositronPlotsService } from 'vs/workbench/services/positronPlots/common/positronPlots';
 
 /**
  * PositronConsoleViewPane class.
@@ -169,6 +170,7 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 	 * @param themeService The theme service.
 	 * @param viewDescriptorService The view descriptor service.
 	 * @param workbenchLayoutService The workbench layout service.
+	 * @param positronPlotsService The Positron plots service.
 	 */
 	constructor(
 		options: IViewPaneOptions,
@@ -189,7 +191,8 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IThemeService themeService: IThemeService,
 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
-		@IWorkbenchLayoutService private readonly workbenchLayoutService: IWorkbenchLayoutService
+		@IWorkbenchLayoutService private readonly workbenchLayoutService: IWorkbenchLayoutService,
+		@IPositronPlotsService private readonly positronPlotsService: IPositronPlotsService
 	) {
 		super(
 			options,
@@ -267,6 +270,7 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 				modelService={this.modelService}
 				positronConsoleService={this.positronConsoleService}
 				workbenchLayoutService={this.workbenchLayoutService}
+				positronPlotsService={this.positronPlotsService}
 				reactComponentContainer={this}
 			/>
 		);

--- a/src/vs/workbench/services/positronConsole/common/classes/activityItemOutputPlot.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/activityItemOutputPlot.ts
@@ -64,4 +64,10 @@ export class ActivityItemOutputPlot {
 	}
 
 	//#endregion Constructor
+
+	//#region Public Methods
+	onSelected(): void {
+	}
+
+	//#endregion Public Methods
 }

--- a/src/vs/workbench/services/positronConsole/common/classes/activityItemOutputPlot.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/activityItemOutputPlot.ts
@@ -35,12 +35,14 @@ export class ActivityItemOutputPlot {
 	 * @param parentId The parent identifier.
 	 * @param when The date.
 	 * @param data The data.
+	 * @param onSelected A callback that is invoked when the item is selected.
 	 */
 	constructor(
 		readonly id: string,
 		readonly parentId: string,
 		readonly when: Date,
-		readonly data: Record<string, string>
+		readonly data: Record<string, string>,
+		readonly onSelected: () => void
 	) {
 		// Get the output; this will serve as the figure caption.
 		const output = data['text/plain'];
@@ -62,12 +64,4 @@ export class ActivityItemOutputPlot {
 		// output lines.
 		this.outputLines = !output ? [] : ANSIOutput.processOutput(output);
 	}
-
-	//#endregion Constructor
-
-	//#region Public Methods
-	onSelected(): void {
-	}
-
-	//#endregion Public Methods
 }

--- a/src/vs/workbench/services/positronConsole/common/classes/activityItemOutputPlot.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/activityItemOutputPlot.ts
@@ -64,4 +64,6 @@ export class ActivityItemOutputPlot {
 		// output lines.
 		this.outputLines = !output ? [] : ANSIOutput.processOutput(output);
 	}
+
+	//#endregion Constructor
 }

--- a/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
@@ -155,6 +155,11 @@ export interface IPositronConsoleInstance {
 	readonly onDidExecuteCode: Event<void>;
 
 	/**
+	 * The onDidSelectPlot event.
+	 */
+	readonly onDidSelectPlot: Event<string>;
+
+	/**
 	 * Focuses the input for the console.
 	 */
 	focusInput(): void;

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -1094,6 +1094,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 						languageRuntimeMessageOutput.parent_id,
 						new Date(languageRuntimeMessageOutput.when),
 						languageRuntimeMessageOutput.data, () => {
+							// This callback runs when the user clicks on the
+							// plot; when they do this, we'll select it in the
+							// Plots pane.
 							this._onDidSelectPlotEmitter.fire(languageRuntimeMessageOutput.id);
 						}
 					)

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -492,6 +492,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 */
 	private readonly _onDidExecuteCodeEmitter = this._register(new Emitter<void>);
 
+	/**
+	 * The onDidSelectPlot event emitter.
+	 */
+	private readonly _onDidSelectPlotEmitter = this._register(new Emitter<string>);
+
 	//#endregion Private Properties
 
 	//#region Constructor & Dispose
@@ -618,6 +623,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * onDidExecuteCode event.
 	 */
 	readonly onDidExecuteCode = this._onDidExecuteCodeEmitter.event;
+
+	/**
+	 * onDidSelectPlot event.
+	 */
+	readonly onDidSelectPlot = this._onDidSelectPlotEmitter.event;
 
 	/**
 	 * Focuses the input for the console.
@@ -1083,7 +1093,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 						languageRuntimeMessageOutput.id,
 						languageRuntimeMessageOutput.parent_id,
 						new Date(languageRuntimeMessageOutput.when),
-						languageRuntimeMessageOutput.data
+						languageRuntimeMessageOutput.data, () => {
+							this._onDidSelectPlotEmitter.fire(languageRuntimeMessageOutput.id);
+						}
 					)
 				);
 			} else if (html) {


### PR DESCRIPTION
This change improves the plots thumbnail experience in the Console. In particular:

- Thumbnails are now a little larger.
- Thumbnails are no longer width-constrained (except by the width of the console), so filmstrip-shaped plot thumbnails are possible (see #1399 for an example)
- Hovering over a thumbnail will reveal it to be a click target (with a border, pointer cursor, and inspect icon). Clicking it will reveal the plot in the Plots pane.

I would still like to do more here; in particular I think that it would be nice to have a better experience if the plot is already selected in the pane since in this case it looks like nothing is happening. Maybe we could show a kind of 100% zoom version of the plot with options to copy to clipboard or save to disk. 

Addresses https://github.com/posit-dev/positron/issues/1399.
