### PR TITLE
Prefetch node-gyp to address CI failures

### DIFF
--- a/.github/workflows/positron-ci.yml
+++ b/.github/workflows/positron-ci.yml
@@ -38,8 +38,17 @@ jobs:
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
           POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
         run: |
+          # Install Yarn
           npm install -g yarn
+
+          # Install node-gyp; this is required by some packages, and yarn
+          # sometimes fails to automatically install it.
+          yarn global add node-gyp
+
+          # Perform the main yarn command; this installs all Node packages and
+          # dependencies
           yarn --immutable --network-timeout 120000
+
       - name: Compile and Download
         run: yarn npm-run-all --max_old_space_size=4095 -lp compile "electron x64" playwright-install download-builtin-extensions
 


### PR DESCRIPTION
This change is intended to address an intermittent CI failure of the form:

```
info This package requires node-gyp, which is not currently installed. Yarn will attempt to automatically install it. If this fails, you can run "yarn global add node-gyp" to manually install it.
[1/4] Resolving packages...
error /home/runner/work/positron/positron/node_modules/@parcel/watcher: Command failed.
Exit code: 1
Command: node-gyp-build
Arguments: 
Directory: /home/runner/work/positron/positron/node_modules/@parcel/watcher
Output:
node:events:495
      throw er; // Unhandled 'error' event
      ^
```
