### PR TITLE
Add a force-quit command

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -847,8 +847,8 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			// the timeout fires. (This should be the normal case.)
 			this.once('status', (status) => {
 				if (status === positron.RuntimeState.Exited) {
-					resolve();
 					clearTimeout(timeout);
+					resolve();
 				} else {
 					this.log(`Kernel status changed to '${status}'; expected Exited`);
 					reject(`Kernel status changed '${status}'; expected Exited`);

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -824,6 +824,43 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 	}
 
 	/**
+	 * Forcefully terminates the kernel process.
+	 */
+	public forceQuit(): Promise<void> {
+		// Perform the termination. This should result in all of the sockets
+		// getting disconnected (since the connection to the process is
+		// severed), which will result in the kernel entering the `Exited`
+		// state.
+		return new Promise((resolve, reject) => {
+			if (!this._session) {
+				reject(`No session found to quit.`);
+			}
+
+			// Guarantee that we will enter the Exited state within 1 second.
+			const timeout = setTimeout(() => {
+				this.log(`Timed out waiting for kernel to exit; marking as exited`);
+				this.setStatus(positron.RuntimeState.Exited);
+				resolve();
+			});
+
+			// Cancel the timeout if the kernel changes state all by itself before
+			// the timeout fires. (This should be the normal case.)
+			this.once('status', (status) => {
+				if (status === positron.RuntimeState.Exited) {
+					resolve();
+					clearTimeout(timeout);
+				} else {
+					this.log(`Kernel status changed to '${status}'; expected Exited`);
+					reject(`Kernel status changed '${status}'; expected Exited`);
+				}
+			});
+
+			this.log(`Forcefully terminating kernel process ${this._session!.state.processId}...`);
+			process.kill(this._session!.state.processId, 9);
+		});
+	}
+
+	/**
 	 * Send a message to the kernel
 	 *
 	 * @param packet The message package

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -264,6 +264,13 @@ export class LanguageRuntimeAdapter
 		return this.shutdownKernel(false);
 	}
 
+	/**
+	 * Forcibly terminates the kernel.
+	 */
+	forceQuit(): Promise<void> {
+		return this._kernel.forceQuit();
+	}
+
 	private shutdownKernel(restart: boolean): Promise<void> {
 		// Ensure the kernel is in a running state before allowing the shutdown
 		if (this._kernelState !== positron.RuntimeState.Idle &&

--- a/extensions/positron-javascript/src/runtime.ts
+++ b/extensions/positron-javascript/src/runtime.ts
@@ -195,6 +195,11 @@ export class JavascriptLanguageRuntime implements positron.LanguageRuntime {
 		return Promise.resolve();
 	}
 
+	forceQuit(): Thenable<void> {
+		// See notes on `interrupt()`
+		return Promise.resolve();
+	}
+
 	dispose() { }
 
 	private emitOutput(parentId: string, output: string) {

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -8,6 +8,7 @@ import PQueue from 'p-queue';
 
 import { JupyterAdapterApi, JupyterKernelSpec, JupyterLanguageRuntime, JupyterKernelExtra } from './jupyter-adapter';
 import { ArkLsp, LspState } from './lsp';
+import { delay } from './util';
 
 /**
  * A Positron language runtime that wraps a Jupyter kernel and a Language Server

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -156,7 +156,7 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 			// warning.
 			await Promise.race([
 				this._lsp.deactivate(true),
-				new Promise((resolve) => setTimeout(resolve, 250))
+				delay(250)
 			]);
 			return this._kernel.forceQuit();
 		} else {

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -208,7 +208,6 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 			this._state = state;
 		});
 	}
-
 	//#endregion Constructor
 
 	//#region LanguageRuntime Implementation
@@ -1065,6 +1064,12 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		// Simulate state changes on exit.
 		this.simulateOutputMessage(parentId, 'Zed Kernel exiting.');
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
+	}
+
+	forceQuit(): Promise<void> {
+		// Simulate a force quit by immediately "exiting"
+		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
+		return Promise.resolve();
 	}
 
 	dispose(): void { }

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -512,9 +512,6 @@ declare module 'positron' {
 		 * Shut down the runtime; returns a Thenable that resolves when the
 		 * runtime shutdown sequence has been successfully started (not
 		 * necessarily when it has completed).
-		 *
-		 * The runtime will emit an `Exiting` state after a shutdown is
-		 * requested, then enter the `Exited` state when shutdown is complete.
 		 */
 		shutdown(): Thenable<void>;
 
@@ -523,9 +520,6 @@ declare module 'positron' {
 		 * runtime has been terminated. This may be called by Positron if the
 		 * runtime fails to respond to an interrupt and/or shutdown call, and
 		 * should forcibly terminate any underlying processes.
-		 *
-		 * The runtime will emit an `Exited` state immediately after this is
-		 * called, without going through the `Exiting` state.
 		 */
 		forceQuit(): Thenable<void>;
 	}

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -509,10 +509,25 @@ declare module 'positron' {
 		restart(): Thenable<void>;
 
 		/**
-		 * Shut down the runtime; returns a Thenable that resolves when the runtime shutdown
-		 * sequence has been successfully started (not necessarily when it has completed).
+		 * Shut down the runtime; returns a Thenable that resolves when the
+		 * runtime shutdown sequence has been successfully started (not
+		 * necessarily when it has completed).
+		 *
+		 * The runtime will emit an `Exiting` state after a shutdown is
+		 * requested, then enter the `Exited` state when shutdown is complete.
 		 */
 		shutdown(): Thenable<void>;
+
+		/**
+		 * Forcibly quits the runtime; returns a Thenable that resolves when the
+		 * runtime has been terminated. This may be called by Positron if the
+		 * runtime fails to respond to an interrupt and/or shutdown call, and
+		 * should forcibly terminate any underlying processes.
+		 *
+		 * The runtime will emit an `Exited` state immediately after this is
+		 * called, without going through the `Exiting` state.
+		 */
+		forceQuit(): Thenable<void>;
 	}
 
 

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -396,6 +396,11 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 		return this._proxy.$shutdownLanguageRuntime(this.handle);
 	}
 
+	async forceQuit(): Promise<void> {
+		// No check for state here; we can force quit the runtime at any time.
+		return this._proxy.$forceQuitLanguageRuntime(this.handle);
+	}
+
 	/**
 	 * Checks to see whether the runtime can be shut down or restarted.
 	 *

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -34,6 +34,7 @@ export interface ExtHostLanguageRuntimeShape {
 	$interruptLanguageRuntime(handle: number): Promise<void>;
 	$restartLanguageRuntime(handle: number): Promise<void>;
 	$shutdownLanguageRuntime(handle: number): Promise<void>;
+	$forceQuitLanguageRuntime(handle: number): Promise<void>;
 	$discoverLanguageRuntimes(): void;
 }
 

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -67,6 +67,13 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		return this._runtimes[handle].shutdown();
 	}
 
+	async $forceQuitLanguageRuntime(handle: number): Promise<void> {
+		if (handle >= this._runtimes.length) {
+			throw new Error(`Cannot force quit runtime: language runtime handle '${handle}' not found or no longer valid.`);
+		}
+		return this._runtimes[handle].forceQuit();
+	}
+
 	async $restartLanguageRuntime(handle: number): Promise<void> {
 		if (handle >= this._runtimes.length) {
 			throw new Error(`Cannot restart runtime: language runtime handle '${handle}' not found or no longer valid.`);

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
@@ -245,6 +245,14 @@ export function registerLanguageRuntimeActions() {
 			'Select the interpreter to shutdown'))?.shutdown();
 	});
 
+	// Registers the force quit language runtime action.
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.forceQuit', 'Force Quit Interpreter', async accessor => {
+		(await selectRunningLanguageRuntime(
+			accessor.get(ILanguageRuntimeService),
+			accessor.get(IQuickInputService),
+			'Select the interpreter to force-quit'))?.forceQuit();
+	});
+
 	registerLanguageRuntimeAction('workbench.action.language.runtime.openClient', 'Create Runtime Client Widget', async accessor => {
 		// Access services.
 		const languageRuntimeService = accessor.get(ILanguageRuntimeService);

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -476,6 +476,9 @@ export interface ILanguageRuntime {
 
 	/** Shut down the runtime */
 	shutdown(): Thenable<void>;
+
+	/** Force quit the runtime */
+	forceQuit(): Thenable<void>;
 }
 
 export interface ILanguageRuntimeService {


### PR DESCRIPTION
This change adds the internal plumbing necessary to support forcefully terminating a misbehaving runtime, as well as a "Force Quit" command available from the palette. Once this is in place, we can build UI around the feature.

The PR implements Force Quit for everything but Python; the Python implementation is in https://github.com/posit-dev/positron-python/pull/218. There's no compile-time dependency so the PRs can be merged in any order. 

Part of https://github.com/posit-dev/positron/issues/1422.