### PR TITLE
Use ark 0.1.9

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -368,7 +368,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.8"
+      "ark": "0.1.9"
     }
   }
 }


### PR DESCRIPTION
For https://github.com/posit-dev/amalthea/pull/95 which fixes various `CMD+Enter` statement range related quirks in R

- https://github.com/posit-dev/positron/issues/1259
- https://github.com/posit-dev/positron/issues/1268
- https://github.com/posit-dev/positron/issues/1416