### PR TITLE
Add `showOutput()` runtime command

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -1222,6 +1222,13 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 	}
 
 	/**
+	 * Show kernel log in output panel.
+	 */
+	public showOutput() {
+		this._logChannel?.show();
+	}
+
+	/**
 	 * Creates a detailed error object to emit to the client when the kernel fails
 	 * to start.
 	 *

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -284,6 +284,13 @@ export class LanguageRuntimeAdapter
 	}
 
 	/**
+	 * Show runtime log in output panel.
+	 */
+	public showOutput() {
+		this._kernel.showOutput();
+	}
+
+	/**
 	 * Creates a new client instance.
 	 *
 	 * @param id The client-supplied ID of the client to create

--- a/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
+++ b/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
@@ -69,6 +69,12 @@ export interface JupyterLanguageRuntime extends positron.LanguageRuntime {
 	 * @param message A message to emit to the Jupyter log.
 	 */
 	emitJupyterLog(message: string): void;
+
+	/**
+	 * A Jupyter kernel is guaranteed to have a `showOutput()`
+	 * method, so we declare it non-optional.
+	 */
+	showOutput(): void;
 }
 
 /**

--- a/extensions/positron-r/src/jupyter-adapter.d.ts
+++ b/extensions/positron-r/src/jupyter-adapter.d.ts
@@ -69,6 +69,12 @@ export interface JupyterLanguageRuntime extends positron.LanguageRuntime {
 	 * @param message A message to emit to the Jupyter log.
 	 */
 	emitJupyterLog(message: string): void;
+
+	/**
+	 * A Jupyter kernel is guaranteed to have a `showOutput()`
+	 * method, so we declare it non-optional.
+	 */
+	showOutput(): void;
 }
 
 /**

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -172,6 +172,13 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 		}
 	}
 
+	/**
+	 * Show runtime log in output panel.
+	 */
+	showOutput() {
+		this._kernel?.showOutput();
+	}
+
 	private async createKernel(): Promise<JupyterLanguageRuntime> {
 		const ext = vscode.extensions.getExtension('vscode.jupyter-adapter');
 		if (!ext) {

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -522,6 +522,11 @@ declare module 'positron' {
 		 * should forcibly terminate any underlying processes.
 		 */
 		forceQuit(): Thenable<void>;
+
+		/**
+		 * Show runtime log in output panel.
+		 */
+		showOutput?(): void;
 	}
 
 

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -401,6 +401,10 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 		return this._proxy.$forceQuitLanguageRuntime(this.handle);
 	}
 
+	async showOutput(): Promise<void> {
+		return this._proxy.$showOutputLanguageRuntime(this.handle);
+	}
+
 	/**
 	 * Checks to see whether the runtime can be shut down or restarted.
 	 *

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -35,6 +35,7 @@ export interface ExtHostLanguageRuntimeShape {
 	$restartLanguageRuntime(handle: number): Promise<void>;
 	$shutdownLanguageRuntime(handle: number): Promise<void>;
 	$forceQuitLanguageRuntime(handle: number): Promise<void>;
+	$showOutputLanguageRuntime(handle: number): void;
 	$discoverLanguageRuntimes(): void;
 }
 

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -81,6 +81,16 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		return this._runtimes[handle].restart();
 	}
 
+	$showOutputLanguageRuntime(handle: number): void {
+		if (handle >= this._runtimes.length) {
+			throw new Error(`Cannot show output for runtime: language runtime handle '${handle}' not found or no longer valid.`);
+		}
+		if (!this._runtimes[handle].showOutput) {
+			throw new Error(`Cannot show output for runtime: language runtime handle '${handle}' does not implement logging.`);
+		}
+		return this._runtimes[handle].showOutput!();
+	}
+
 	$executeCode(handle: number, code: string, id: string, mode: RuntimeCodeExecutionMode, errorBehavior: RuntimeErrorBehavior): void {
 		if (handle >= this._runtimes.length) {
 			throw new Error(`Cannot execute code: language runtime handle '${handle}' not found or no longer valid.`);

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
@@ -253,6 +253,14 @@ export function registerLanguageRuntimeActions() {
 			'Select the interpreter to force-quit'))?.forceQuit();
 	});
 
+	// Registers the show output language runtime action.
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.showOutput', 'Show runtime output', async accessor => {
+		(await selectRunningLanguageRuntime(
+			accessor.get(ILanguageRuntimeService),
+			accessor.get(IQuickInputService),
+			'Select the interpreter for which to show output'))?.showOutput();
+	});
+
 	registerLanguageRuntimeAction('workbench.action.language.runtime.openClient', 'Create Runtime Client Widget', async accessor => {
 		// Access services.
 		const languageRuntimeService = accessor.get(ILanguageRuntimeService);

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -479,6 +479,9 @@ export interface ILanguageRuntime {
 
 	/** Force quit the runtime */
 	forceQuit(): Thenable<void>;
+
+	/** Show output log of the runtime */
+	showOutput(): void;
 }
 
 export interface ILanguageRuntimeService {


### PR DESCRIPTION
- Add `showOutput()` as an optional `languageRuntime` method.
- Add `workbench.action.languageRuntime.showOutput` command.

With these you can now set a shortcut to quickly jump to the log of the currently selected runtime. This will also be useful for interacting with users facing an issue and make it easier for them to find their runtime log.