### PR TITLE
Lean in to translation of magrittr pipe token

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -154,9 +154,9 @@
         },
         "positron.r.pipe": {
           "type": "string",
-          "default": "|>",
+          "default": "%r.configuration.pipe.native.token%",
           "enum": [
-            "|>",
+            "%r.configuration.pipe.native.token%",
             "%r.configuration.pipe.magrittr.token%"
           ],
           "enumDescriptions": [

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -157,7 +157,7 @@
           "default": "|>",
           "enum": [
             "|>",
-            "%>%"
+            "%r.configuration.pipe.magrittr.token%"
           ],
           "enumDescriptions": [
             "%r.configuration.pipe.native.description%",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -38,6 +38,6 @@
 	"r.configuration.quietMode.description": "Run R in quiet mode, to suppress initial copyright and welcome messages (requires restart to take effect)",
 	"r.configuration.pipe": "String to insert as the pipe operator",
 	"r.configuration.pipe.magrittr.token": "%>%",
-	"r.configuration.pipe.native.description": "Native pipe available in R = 4.1",
+	"r.configuration.pipe.native.description": "Native pipe available in R >= 4.1",
 	"r.configuration.pipe.magrittr.description": "Pipe operator from the magrittr package, re-exported by many other packages"
 }

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -37,6 +37,7 @@
 	"r.configuration.extraArguments.description": "Extra command-line arguments for R intialization",
 	"r.configuration.quietMode.description": "Run R in quiet mode, to suppress initial copyright and welcome messages (requires restart to take effect)",
 	"r.configuration.pipe": "String to insert as the pipe operator",
-	"r.configuration.pipe.native.description": "Native pipe available in R >= 4.1",
+	"r.configuration.pipe.magrittr.token": "%>%",
+	"r.configuration.pipe.native.description": "Native pipe available in R = 4.1",
 	"r.configuration.pipe.magrittr.description": "Pipe operator from the magrittr package, re-exported by many other packages"
 }

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -37,6 +37,7 @@
 	"r.configuration.extraArguments.description": "Extra command-line arguments for R intialization",
 	"r.configuration.quietMode.description": "Run R in quiet mode, to suppress initial copyright and welcome messages (requires restart to take effect)",
 	"r.configuration.pipe": "String to insert as the pipe operator",
+	"r.configuration.pipe.native.token": "|>",
 	"r.configuration.pipe.magrittr.token": "%>%",
 	"r.configuration.pipe.native.description": "Native pipe available in R >= 4.1",
 	"r.configuration.pipe.magrittr.description": "Pipe operator from the magrittr package, re-exported by many other packages"


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/1465

I don't see any way to escape a `%` so the easiest solution seems to be to let it translate something, and ensure that the English translation is the magrittr pipe

I no longer see any Developer Tools warnings about this