### PR TITLE
Ensure we always "step" down the page when advancing the statement range cursor position

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -309,7 +309,7 @@ export function registerPositronConsoleActions() {
 							// line, then move to that empty line at the end.
 							if (model.getLineContent(model.getLineCount()).trim().length > 0) {
 								// The document doesn't end with an empty line; add one
-								this.amendNewlineToEnd(editor);
+								this.amendNewlineToEnd(model);
 							}
 							newPosition = new Position(
 								model.getLineCount(),
@@ -424,16 +424,7 @@ export function registerPositronConsoleActions() {
 						if (lineNumber === model.getLineCount() + 1) {
 							// If this puts us past the end of the document, insert a newline for us
 							// to move to
-							const editOperation = {
-								range: {
-									startLineNumber: model.getLineCount(),
-									startColumn: model.getLineMaxColumn(model.getLineCount()),
-									endLineNumber: model.getLineCount(),
-									endColumn: model.getLineMaxColumn(model.getLineCount())
-								},
-								text: '\n'
-							};
-							model.pushEditOperations([], [editOperation], () => []);
+							this.amendNewlineToEnd(model);
 						}
 					}
 
@@ -445,7 +436,7 @@ export function registerPositronConsoleActions() {
 				if (!code.length && position && lineNumber === model.getLineCount()) {
 					// If we still don't have code and we are at the end of the document, add a
 					// newline to the end of the document.
-					this.amendNewlineToEnd(editor);
+					this.amendNewlineToEnd(model);
 
 					// We don't move to that new line to avoid adding a bunch of empty
 					// lines to the end. The edit operation typically moves us to the new line,
@@ -481,13 +472,12 @@ export function registerPositronConsoleActions() {
 			}
 		}
 
-		amendNewlineToEnd(editor: IEditor) {
+		amendNewlineToEnd(model: ITextModel) {
 			// Typically we don't do anything when we don't have code to execute,
 			// but when we are at the end of a document we add a new line.
 			// This edit operation also moves the cursor to the new line if the cursor
 			// was already at the end of the document. This may or may not be desirable
 			// depending on the context.
-			const model = editor.getModel() as ITextModel;
 			const editOperation = {
 				range: {
 					startLineNumber: model.getLineCount(),


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/1463

This PR fixes 2 issues with the statement range provider, and I think it is best to look at the commits individually:

---

f4e8891 addresses https://github.com/posit-dev/positron/issues/1463 by tweaking our behavior when we find our `nextStatement`. Rather than simply accepting it and always moving to its starting row, we are now careful to never move "up" the page, as that results in a jumpy experience for the user.

If the starting row of the "next" statement is _after_ the current statement, then this is the typical "stepping through the code" case that occurs at the top level.

Otherwise, we are probably exiting a nested scope of some kind (like executing the last line of a function or testthat block, as shown in the video of https://github.com/posit-dev/positron/issues/1463), so instead we attempt to move to the _ending_ row of the "next" statement if it is after the current statement.

Otherwise if both of those fail then we are probably (?) in some really broken scenario (i can't think of any examples) so I think the best thing to do is to throw out the `nextStatement` altogether and just move to the next line.

I don't think the Python range provider can currently look "up", so this doesn't really affect it right now.

https://github.com/posit-dev/positron/assets/19150088/2eccbf07-fd20-495e-a482-a16bcd597e1c

---

32aa254 addresses an issue where executing a statement at the end of the document would add a new line, but would not move to it, so you end up executing the statement two times in a row. I've tweaked `amendNewlineToEnd()` so that it _just_ does the edit operation (rather than also doing the "undo" of the move) - now anyone who calls this function is in charge of positioning the cursor appropriately after the fact. ab2693f does a little extra clean up on top of this.

Before:

https://github.com/posit-dev/positron/assets/19150088/50eef27e-7ea0-4b71-9f4f-89bf0905ffa8

After:

https://github.com/posit-dev/positron/assets/19150088/f422a672-9f7b-44b1-b1ae-3ae18781d1f4