### PR TITLE
Add snippets for R

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -327,6 +327,12 @@
         }
       ]
     },
+    "snippets": [
+      {
+        "language": "r",
+        "path": "./snippets/r.code-snippets"
+      }
+    ],
     "debuggers": [
       {
         "type": "ark",

--- a/extensions/positron-r/snippets/r.code-snippets
+++ b/extensions/positron-r/snippets/r.code-snippets
@@ -4,11 +4,6 @@
         "body": "library(${1:package})",
 		"description": "Attach an R package"
 	},
-	"req": {
-        "prefix": "req",
-        "body": "require(${1:package})",
-		"description": "Load an R package"
-	},
 	"src": {
         "prefix": "src",
         "body": "source(\"${1:file.R}\")",

--- a/extensions/positron-r/snippets/r.code-snippets
+++ b/extensions/positron-r/snippets/r.code-snippets
@@ -2,7 +2,7 @@
 	"lib": {
         "prefix": "lib",
         "body": "library(${1:package})",
-		"description": "Load an R package"
+		"description": "Attach an R package"
 	},
 	"req": {
         "prefix": "req",
@@ -17,7 +17,7 @@
 	"ret": {
         "prefix": "ret",
         "body": "return(${1:code})",
-		"description": "Function return"
+		"description": "Return a value from a function"
 	},
 	"mat": {
         "prefix": "mat",

--- a/extensions/positron-r/snippets/r.code-snippets
+++ b/extensions/positron-r/snippets/r.code-snippets
@@ -1,23 +1,28 @@
 {
 	"lib": {
         "prefix": "lib",
-        "body": "library(${1:package})"
+        "body": "library(${1:package})",
+		"description": "Load an R package"
 	},
 	"req": {
         "prefix": "req",
-        "body": "require(${1:package})"
+        "body": "require(${1:package})",
+		"description": "Load an R package"
 	},
 	"src": {
         "prefix": "src",
-        "body": "source(\"${1:file.R}\")"
+        "body": "source(\"${1:file.R}\")",
+		"description": "Source an R file"
 	},
 	"ret": {
         "prefix": "ret",
-        "body": "return(${1:code})"
+        "body": "return(${1:code})",
+		"description": "Function return"
 	},
 	"mat": {
         "prefix": "mat",
-        "body": "matrix(${1:data}, nrow = ${2:rows}, ncol = ${3:cols})"
+        "body": "matrix(${1:data}, nrow = ${2:rows}, ncol = ${3:cols})",
+		"description": "Define a matrix"
 	},
 	"sg": {
         "prefix": "sg",
@@ -25,7 +30,8 @@
 		"setGeneric(\"${1:generic}\", function(${2:x, ...}) {",
 		"\tstandardGeneric(\"${1:generic}\")",
 		"})"
-        ]
+        ],
+		"description": "Define a generic"
 	},
 	"sm": {
         "prefix": "sm",
@@ -33,11 +39,13 @@
 		"setMethod(\"${1:generic}\", ${2:class}, function(${2:x, ...}) {",
 		"\t${0}",
 		"})"
-        ]
+        ],
+		"description": "Define a method for a generic function"
 	},
 	"sc": {
         "prefix": "sc",
-        "body": "setClass(\"${1:Class}\", slots = c(${2:name = \"type\"}))"
+        "body": "setClass(\"${1:Class}\", slots = c(${2:name = \"type\"}))",
+		"description": "Define a class definition"
 	},
 	"if": {
         "prefix": "if",
@@ -45,7 +53,8 @@
 		"if (${1:condition}) {",
 		"\t${0}",
 		"}"
-        ]
+        ],
+		"description": "Conditional expression"
 	},
 	"el": {
         "prefix": "el",
@@ -53,7 +62,8 @@
 		"else {",
 		"\t${0}",
 		"}"
-        ]
+        ],
+		"description": "Conditional expression"
 	},
 	"ei": {
         "prefix": "ei",
@@ -61,7 +71,8 @@
 		"else if (${1:condition}) {",
 		"\t${0}",
 		"}"
-        ]
+        ],
+		"description": "Conditional expression"
 	},
 	"fun": {
         "prefix": "fun",
@@ -69,7 +80,8 @@
 		"${1:name} <- function(${2:variables}) {",
 		"\t${0}",
 		"}"
-        ]
+        ],
+		"description": "Function skeleton"
 	},
 	"for": {
         "prefix": "for",
@@ -77,7 +89,8 @@
 		"for (${1:variable} in ${2:vector}) {",
 		"\t${0}",
 		"}"
-        ]
+        ],
+		"description": "Define a loop"
 	},
 	"while": {
         "prefix": "while",
@@ -85,7 +98,8 @@
 		"while (${1:condition}) {",
 		"\t${0}",
 		"}"
-        ]
+        ],
+		"description": "Define a loop"
 	},
 	"switch": {
         "prefix": "switch",
@@ -93,39 +107,48 @@
 		"switch (${1:object},",
 		"\t${2:case} = ${3:action}",
 		")"
-        ]
+        ],
+		"description": "Define a switch statement"
 	},
 	"apply": {
         "prefix": "apply",
-        "body": "apply(${1:array}, ${2:margin}, ${3:...})"
+        "body": "apply(${1:array}, ${2:margin}, ${3:...})",
+		"description": "Use the apply family"
 	},
 	"lapply": {
         "prefix": "lapply",
-        "body": "lapply(${1:list}, ${2:function})"
+        "body": "lapply(${1:list}, ${2:function})",
+		"description": "Use the apply family"
 	},
 	"sapply": {
         "prefix": "sapply",
-        "body": "sapply(${1:list}, ${2:function})"
+        "body": "sapply(${1:list}, ${2:function})",
+		"description": "Use the apply family"
 	},
 	"mapply": {
         "prefix": "mapply",
-        "body": "mapply(${1:function}, ${2:...})"
+        "body": "mapply(${1:function}, ${2:...})",
+		"description": "Use the apply family"
 	},
 	"tapply": {
         "prefix": "tapply",
-        "body": "tapply(${1:vector}, ${2:index}, ${3:function})"
+        "body": "tapply(${1:vector}, ${2:index}, ${3:function})",
+		"description": "Use the apply family"
 	},
 	"vapply": {
         "prefix": "vapply",
-        "body": "vapply(${1:list}, ${2:function}, FUN.VALUE = ${3:type}, ${4:...})"
+        "body": "vapply(${1:list}, ${2:function}, FUN.VALUE = ${3:type}, ${4:...})",
+		"description": "Use the apply family"
 	},
 	"rapply": {
         "prefix": "rapply",
-        "body": "rapply(${1:list}, ${2:function})"
+        "body": "rapply(${1:list}, ${2:function})",
+		"description": "Use the apply family"
 	},
 	"ts": {
         "prefix": "ts",
-        "body": "`r paste(\"#\", date(), \"------------------------------\\n\")`"
+        "body": "`r paste(\"#\", date(), \"------------------------------\\n\")`",
+		"description": "Insert a datetime"
 	},
 	"shinyapp": {
         "prefix": "shinyapp",
@@ -141,7 +164,8 @@
 		"}",
 		"",
 		"shinyApp(ui, server)"
-        ]
+        ],
+		"description": "Define a Shiny app"
 	},
 	"shinymod": {
         "prefix": "shinymod",
@@ -156,6 +180,7 @@
 		"${1:name} <- function(input, output, session) {",
 		"  ",
 		"}"
-        ]
+        ],
+		"description": "Define a Shiny module"
 	}
 }

--- a/extensions/positron-r/snippets/r.code-snippets
+++ b/extensions/positron-r/snippets/r.code-snippets
@@ -157,32 +157,5 @@
 		"  ",
 		"}"
         ]
-	},
-	"decade": {
-        "prefix": "decade",
-        "body": "decade = 10 * (lubridate::year(REPLACE_DATE) %/% 10)"
-	},
-	"target": {
-        "prefix": "target",
-        "body": "{target=\"_blank\"}"
-	},
-	"db_con": {
-        "prefix": "db_con",
-        "body": "con <- DBI::dbConnect(RSQLite::SQLite(), \"data/pbp_db\")"
-	},
-	"bench": {
-        "prefix": "bench",
-        "body": [
-		"bench_results <- bench::mark(",
-		"\tmin_iterations = ${1:10},",
-		"\tmax_iterations = ${2:10},",
-		"\t${3:expr1},",
-		"\t${4:expr2}",
-		"\t)",
-		"",
-		"bench_results",
-		"\t",
-		"autoplot(bench_results)"
-        ]
 	}
 }

--- a/extensions/positron-r/snippets/r.code-snippets
+++ b/extensions/positron-r/snippets/r.code-snippets
@@ -1,0 +1,188 @@
+{
+	"lib": {
+        "prefix": "lib",
+        "body": "library(${1:package})"
+	},
+	"req": {
+        "prefix": "req",
+        "body": "require(${1:package})"
+	},
+	"src": {
+        "prefix": "src",
+        "body": "source(\"${1:file.R}\")"
+	},
+	"ret": {
+        "prefix": "ret",
+        "body": "return(${1:code})"
+	},
+	"mat": {
+        "prefix": "mat",
+        "body": "matrix(${1:data}, nrow = ${2:rows}, ncol = ${3:cols})"
+	},
+	"sg": {
+        "prefix": "sg",
+        "body": [
+		"setGeneric(\"${1:generic}\", function(${2:x, ...}) {",
+		"\tstandardGeneric(\"${1:generic}\")",
+		"})"
+        ]
+	},
+	"sm": {
+        "prefix": "sm",
+        "body": [
+		"setMethod(\"${1:generic}\", ${2:class}, function(${2:x, ...}) {",
+		"\t${0}",
+		"})"
+        ]
+	},
+	"sc": {
+        "prefix": "sc",
+        "body": "setClass(\"${1:Class}\", slots = c(${2:name = \"type\"}))"
+	},
+	"if": {
+        "prefix": "if",
+        "body": [
+		"if (${1:condition}) {",
+		"\t${0}",
+		"}"
+        ]
+	},
+	"el": {
+        "prefix": "el",
+        "body": [
+		"else {",
+		"\t${0}",
+		"}"
+        ]
+	},
+	"ei": {
+        "prefix": "ei",
+        "body": [
+		"else if (${1:condition}) {",
+		"\t${0}",
+		"}"
+        ]
+	},
+	"fun": {
+        "prefix": "fun",
+        "body": [
+		"${1:name} <- function(${2:variables}) {",
+		"\t${0}",
+		"}"
+        ]
+	},
+	"for": {
+        "prefix": "for",
+        "body": [
+		"for (${1:variable} in ${2:vector}) {",
+		"\t${0}",
+		"}"
+        ]
+	},
+	"while": {
+        "prefix": "while",
+        "body": [
+		"while (${1:condition}) {",
+		"\t${0}",
+		"}"
+        ]
+	},
+	"switch": {
+        "prefix": "switch",
+        "body": [
+		"switch (${1:object},",
+		"\t${2:case} = ${3:action}",
+		")"
+        ]
+	},
+	"apply": {
+        "prefix": "apply",
+        "body": "apply(${1:array}, ${2:margin}, ${3:...})"
+	},
+	"lapply": {
+        "prefix": "lapply",
+        "body": "lapply(${1:list}, ${2:function})"
+	},
+	"sapply": {
+        "prefix": "sapply",
+        "body": "sapply(${1:list}, ${2:function})"
+	},
+	"mapply": {
+        "prefix": "mapply",
+        "body": "mapply(${1:function}, ${2:...})"
+	},
+	"tapply": {
+        "prefix": "tapply",
+        "body": "tapply(${1:vector}, ${2:index}, ${3:function})"
+	},
+	"vapply": {
+        "prefix": "vapply",
+        "body": "vapply(${1:list}, ${2:function}, FUN.VALUE = ${3:type}, ${4:...})"
+	},
+	"rapply": {
+        "prefix": "rapply",
+        "body": "rapply(${1:list}, ${2:function})"
+	},
+	"ts": {
+        "prefix": "ts",
+        "body": "`r paste(\"#\", date(), \"------------------------------\\n\")`"
+	},
+	"shinyapp": {
+        "prefix": "shinyapp",
+        "body": [
+		"library(shiny)",
+		"",
+		"ui <- fluidPage(",
+		"  ${0}",
+		")",
+		"",
+		"server <- function(input, output, session) {",
+		"  ",
+		"}",
+		"",
+		"shinyApp(ui, server)"
+        ]
+	},
+	"shinymod": {
+        "prefix": "shinymod",
+        "body": [
+		"${1:name}_UI <- function(id) {",
+		"  ns <- NS(id)",
+		"  tagList(",
+		"\t${0}",
+		"  )",
+		"}",
+		"",
+		"${1:name} <- function(input, output, session) {",
+		"  ",
+		"}"
+        ]
+	},
+	"decade": {
+        "prefix": "decade",
+        "body": "decade = 10 * (lubridate::year(REPLACE_DATE) %/% 10)"
+	},
+	"target": {
+        "prefix": "target",
+        "body": "{target=\"_blank\"}"
+	},
+	"db_con": {
+        "prefix": "db_con",
+        "body": "con <- DBI::dbConnect(RSQLite::SQLite(), \"data/pbp_db\")"
+	},
+	"bench": {
+        "prefix": "bench",
+        "body": [
+		"bench_results <- bench::mark(",
+		"\tmin_iterations = ${1:10},",
+		"\tmax_iterations = ${2:10},",
+		"\t${3:expr1},",
+		"\t${4:expr2}",
+		"\t)",
+		"",
+		"bench_results",
+		"\t",
+		"autoplot(bench_results)"
+        ]
+	}
+}


### PR DESCRIPTION
Addresses #1438 (as well as posit-dev/positron-python#217 for Python)

I was especially missing this function one!

https://github.com/posit-dev/positron/assets/12505835/663889e1-6c74-47b7-8a3a-b8c1f75fb205

I added the current RStudio snippets as @jthomasmock outlined them because I expect we at least want to keep these.

- Are there any of these snippets that have proved problematic and we should _not_ add?
- Are there any additional ones we know we want to add right now?