### PR TITLE
Switch to Console when last terminal is killed

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -410,6 +410,9 @@ export interface ITerminalGroupService extends ITerminalInstanceHost {
 	setContainer(container: HTMLElement): void;
 
 	showPanel(focus?: boolean): Promise<void>;
+	// --- Start Positron ---
+	showPositronConsole?: () => Promise<void>;
+	// --- End Positron ---
 	hidePanel(): void;
 	focusTabs(): void;
 	focusHover(): void;

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -411,7 +411,7 @@ export interface ITerminalGroupService extends ITerminalInstanceHost {
 
 	showPanel(focus?: boolean): Promise<void>;
 	// --- Start Positron ---
-	showPositronConsole?: () => Promise<void>;
+	switchToPositronConsole?: () => Promise<void>;
 	// --- End Positron ---
 	hidePanel(): void;
 	focusTabs(): void;

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -1246,6 +1246,13 @@ export function registerTerminalActions() {
 		if (c.groupService.instances.length > 0) {
 			await c.groupService.showPanel(true);
 		}
+		// --- Start Positron ---
+		// Switch to Console if last terminal is killed
+		// https://github.com/posit-dev/positron/issues/1458
+		else {
+			await c.groupService.showPositronConsole!();
+		}
+		// --- End Positron ---
 	}
 	registerTerminalAction({
 		id: TerminalCommandId.Kill,

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -1250,7 +1250,7 @@ export function registerTerminalActions() {
 		// Switch to Console if last terminal is killed
 		// https://github.com/posit-dev/positron/issues/1458
 		else {
-			await c.groupService.showPositronConsole!();
+			await c.groupService.switchToPositronConsole!();
 		}
 		// --- End Positron ---
 	}

--- a/src/vs/workbench/contrib/terminal/browser/terminalGroupService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalGroupService.ts
@@ -3,6 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// --- Start Positron ---
+import { POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
+// --- End Positron ---
+
 import { Orientation } from 'vs/base/browser/ui/sash/sash';
 import { timeout } from 'vs/base/common/async';
 import { Emitter, Event } from 'vs/base/common/event';
@@ -82,6 +86,12 @@ export class TerminalGroupService extends Disposable implements ITerminalGroupSe
 			TerminalContextKeys.tabsMouse.bindTo(this._contextKeyService).set(false);
 		}
 	}
+
+	// --- Start Positron ---
+	async showPositronConsole(): Promise<void> {
+		await this._viewsService.openView(POSITRON_CONSOLE_VIEW_ID, false);
+	}
+	// --- End Positron ---
 
 	get activeGroup(): ITerminalGroup | undefined {
 		if (this.activeGroupIndex < 0 || this.activeGroupIndex >= this.groups.length) {

--- a/src/vs/workbench/contrib/terminal/browser/terminalGroupService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalGroupService.ts
@@ -88,8 +88,21 @@ export class TerminalGroupService extends Disposable implements ITerminalGroupSe
 	}
 
 	// --- Start Positron ---
-	async showPositronConsole(): Promise<void> {
-		await this._viewsService.openView(POSITRON_CONSOLE_VIEW_ID, false);
+	// Switch to Console pane but only if in the same viewpane
+	async switchToPositronConsole(): Promise<void> {
+		const consoleViewContainer = this._viewDescriptorService.getViewContainerByViewId(POSITRON_CONSOLE_VIEW_ID);
+		const terminalViewContainer = this._viewDescriptorService.getViewContainerByViewId(TERMINAL_VIEW_ID);
+
+		if (!consoleViewContainer || !terminalViewContainer) {
+			return;
+		}
+
+		const consoleViewLocation = this._viewDescriptorService.getViewContainerLocation(consoleViewContainer);
+		const terminalViewLocation = this._viewDescriptorService.getViewContainerLocation(terminalViewContainer);
+
+		if (consoleViewLocation === terminalViewLocation) {
+			await this._viewsService.openView(POSITRON_CONSOLE_VIEW_ID, false);
+		}
 	}
 	// --- End Positron ---
 


### PR DESCRIPTION
Proposed fix to address #1458. This switches focus from the terminal pane to the console pane when the last terminal is killed:

https://github.com/posit-dev/positron/assets/4465050/0dcd4464-d9b5-4525-9d0a-2aac8e85bf33

