### PR TITLE
Improve language runtime exit and crash handling

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -83,6 +83,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/services/languageRuntime",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/services/voiceRecognition",
 			"project": "vscode-workbench"
 		},

--- a/extensions/jupyter-adapter/resources/kernel-wrapper.sh
+++ b/extensions/jupyter-adapter/resources/kernel-wrapper.sh
@@ -30,8 +30,22 @@ if [ -n "$POSITRON_DYLD_FALLBACK_LIBRARY_PATH" ]; then
 	export DYLD_FALLBACK_LIBRARY_PATH="$POSITRON_DYLD_FALLBACK_LIBRARY_PATH"
 fi
 
+# Start log file with current date
+echo "*** Log started at $(date)" > "$output_file"
+
+# Print the command line to the log file
+echo "*** Command line:" >> "$output_file"
+echo "$@" >> "$output_file"
+
 # Run the program with its arguments, redirecting stdout and stderr to the output file
-"$@" > "$output_file" 2>&1
+"$@" >> "$output_file" 2>&1
+
+# Emit the exit code of the program to the log file. Note that there is a log
+# file parser in the Jupyter Adapter that specifically looks for the string
+# "exit code XX" on the last line of the log, so don't change this without
+# updating the parser!
+echo "*** Log ended at $(date)" >> "$output_file"
+echo "Process exit code $?" >> "$output_file"
 
 # Save the exit code of the program
 exit_code=$?

--- a/extensions/jupyter-adapter/resources/kernel-wrapper.sh
+++ b/extensions/jupyter-adapter/resources/kernel-wrapper.sh
@@ -40,15 +40,15 @@ echo "$@" >> "$output_file"
 # Run the program with its arguments, redirecting stdout and stderr to the output file
 "$@" >> "$output_file" 2>&1
 
+# Save the exit code of the program
+exit_code=$?
+
 # Emit the exit code of the program to the log file. Note that there is a log
 # file parser in the Jupyter Adapter that specifically looks for the string
 # "exit code XX" on the last line of the log, so don't change this without
 # updating the parser!
 echo "*** Log ended at $(date)" >> "$output_file"
-echo "Process exit code $?" >> "$output_file"
-
-# Save the exit code of the program
-exit_code=$?
+echo "Process exit code ${exit_code}?" >> "$output_file"
 
 # Exit with the same code as the program so that the caller can correctly report errors
 exit $exit_code

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -1192,10 +1192,20 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 				const lastLine = lines[lines.length - 2];
 				if (lastLine) {
 					try {
-						exitCode = parseInt(lastLine);
+						const match = lastLine.match(/exit code (\d+)/);
+						if (match) {
+							exitCode = parseInt(match![1]);
+						} else {
+							this.log(`Last line of log file ${state.logFile} ` +
+								`does't name an exit code: ${lastLine}`);
+						}
+						if (isNaN(exitCode)) {
+							this.log(`Could not parse exit code in last line of log file ` +
+								`${state.logFile}: ${lastLine}`);
+						}
 					} catch (e) {
 						this.log(`Could not find exit code in last line of log file ` +
-							`${state.logFile}: ${lastLine}`);
+							`${state.logFile}: ${lastLine} (${e}))`);
 					}
 				}
 			} else {

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -31,7 +31,7 @@ import path = require('path');
 import { StartupFailure } from './StartupFailure';
 import { JupyterKernelStatus } from './JupyterKernelStatus';
 import { JupyterKernelSpec, JupyterKernelExtra } from './jupyter-adapter';
-import { PromiseHandles } from './utils';
+import { delay, PromiseHandles } from './utils';
 
 /** The message sent to the Heartbeat socket on a regular interval to test connectivity */
 const HEARTBEAT_MESSAGE = 'heartbeat';
@@ -96,6 +96,9 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 
 	/** The exit code, if any */
 	private _exitCode: number;
+
+	/** If the kernel is currently exiting, this promise resolves when it is complete. */
+	private _exitPromise?: PromiseHandles<void>;
 
 	constructor(
 		private readonly _context: vscode.ExtensionContext,
@@ -453,6 +456,13 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			this._status !== positron.RuntimeState.Exited) {
 			this.log(`Attempt to start ${this._spec.display_name} kernel but it's already '${this._status}'; ignoring.`);
 			return;
+		}
+
+		// If the previous session is cleaning up for exit, wait until it's
+		// done. This prevents the exit event from being fired when a new
+		// instance is already starting.
+		if (this._exitPromise) {
+			await this._exitPromise.promise;
 		}
 
 		// Mark the kernel as initializing so we don't try to start it again
@@ -1138,6 +1148,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			// Clean up the session files (logs, connection files, etc.)
 			if (this._session) {
 				this._session.dispose();
+				this.emitExitEvent(this._session.state);
 			}
 
 			// If the terminal's still open, close it.
@@ -1151,6 +1162,55 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			// Dispose the remainder of the connection state
 			await this.dispose();
 		}
+	}
+
+	/**
+	 * Emits the exit event, which indicates that the user's session has ended.
+	 * The main goal of this routine is to discover the exit code of the
+	 * underlying process.
+	 *
+	 * @param state The session state of the session that ended.
+	 */
+	private async emitExitEvent(state: JupyterSessionState) {
+		// We detect that the kernel has exited when all its sockets have
+		// disconnected. This usually, but not always, means that the process is
+		// gone, too.
+		//
+		// Since we want to include the exit code in the exit event, we need to
+		// wait for the process to actually exit.
+		this._exitPromise = new PromiseHandles<void>();
+		let count = 1;
+		while (this.isRunning(state.processId) && count++ < 10) {
+			await delay(100);
+		}
+
+		// Read the last line of the log file to get the exit code
+		let exitCode = 0;
+		try {
+			if (fs.existsSync(state.logFile)) {
+				const lines = fs.readFileSync(state.logFile, 'utf8').split('\n');
+				const lastLine = lines[lines.length - 2];
+				if (lastLine) {
+					try {
+						exitCode = parseInt(lastLine);
+					} catch (e) {
+						this.log(`Could not find exit code in last line of log file ` +
+							`${state.logFile}: ${lastLine}`);
+					}
+				}
+			} else {
+				this.log(`Not reading exit code from process ${state.processId}; ` +
+					`log file ${state.logFile} does not exist`);
+			}
+		} catch (e) {
+			this.log(`Error reading exit code from log file ${state.logFile}: ${e}`);
+		}
+
+		// Fire the actual exit event
+		this.emit('exit', exitCode);
+
+		// Resolve the exit promise (this allows us to start a new instance of the kernel)
+		this._exitPromise.resolve();
 	}
 
 	/**
@@ -1245,6 +1305,12 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 				logFileContent = fs.readFileSync(state.logFile, 'utf8');
 			}
 		}
+
+		// Filter out lines beginning with *** (these are metadata lines from
+		// the kernel-wrapper script)
+		logFileContent = logFileContent.split('\n')
+			.filter(line => !line.startsWith('***'))
+			.join('\n');
 
 		// Create a startup failure message
 		return new StartupFailure(message, logFileContent);

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -232,11 +232,16 @@ export class LanguageRuntimeAdapter
 	}
 
 	private async startKernel(): Promise<positron.LanguageRuntimeInfo> {
-		// Before starting, initialize the exit reason to Unknown so that if an
+		// Initialize the exit reason to Startup Failed, in case the kernel
+		// exits during startup
+		this._exitReason = positron.RuntimeExitReason.StartupFailed;
+
+		// Wait for the kernel to start
+		await this._kernel.start();
+
+		// We are now online; initialize the exit reason to Unknown so that if an
 		// unexpected exit occurs at any point, it will be marked appropriately.
 		this._exitReason = positron.RuntimeExitReason.Unknown;
-
-		await this._kernel.start();
 		return this.getKernelInfo();
 	}
 
@@ -284,6 +289,8 @@ export class LanguageRuntimeAdapter
 	 * Forcibly terminates the kernel.
 	 */
 	forceQuit(): Promise<void> {
+		// Ensure we mark this as a forced exit when the kernel exits
+		this._exitReason = positron.RuntimeExitReason.ForcedQuit;
 		return this._kernel.forceQuit();
 	}
 

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -109,10 +109,7 @@ export class LanguageRuntimeAdapter
 
 		// Bind to the kernel's exit event
 		this.onKernelExited = this.onKernelExited.bind(this);
-		this._kernel.addListener('exited', this.onKernelExited);
-
-		// Bind to the kernel's exit event
-		this._exit = new vscode.EventEmitter<positron.LanguageRuntimeExit>();
+		this._kernel.addListener('exit', this.onKernelExited);
 	}
 
 	onDidReceiveRuntimeMessage: vscode.Event<positron.LanguageRuntimeMessage>;

--- a/extensions/positron-javascript/src/runtime.ts
+++ b/extensions/positron-javascript/src/runtime.ts
@@ -19,6 +19,8 @@ export class JavascriptLanguageRuntime implements positron.LanguageRuntime {
 
 	private readonly _onDidChangeRuntimeState = new vscode.EventEmitter<positron.RuntimeState>();
 
+	private readonly _onDidEndSession = new vscode.EventEmitter<positron.LanguageRuntimeExit>();
+
 	private _env?: JavascriptEnvironment;
 
 	/**
@@ -63,6 +65,9 @@ export class JavascriptLanguageRuntime implements positron.LanguageRuntime {
 
 	readonly onDidChangeRuntimeState: vscode.Event<positron.RuntimeState>
 		= this._onDidChangeRuntimeState.event;
+
+	readonly onDidEndSession: vscode.Event<positron.LanguageRuntimeExit>
+		= this._onDidEndSession.event;
 
 	execute(code: string, id: string, mode: positron.RuntimeCodeExecutionMode, errorBehavior: positron.RuntimeErrorBehavior): void {
 		// Echo the input code

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -33,6 +33,10 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 	private _stateEmitter =
 		new vscode.EventEmitter<positron.RuntimeState>();
 
+	/** The emitter for runtime exits */
+	private _exitEmitter =
+		new vscode.EventEmitter<positron.LanguageRuntimeExit>();
+
 	/** The Jupyter Adapter extension API */
 	private adapterApi?: JupyterAdapterApi;
 
@@ -47,12 +51,14 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 		this._queue = new PQueue({ concurrency: 1 });
 		this.onDidReceiveRuntimeMessage = this._messageEmitter.event;
 		this.onDidChangeRuntimeState = this._stateEmitter.event;
+		this.onDidEndSession = this._exitEmitter.event;
 
 		this.onDidChangeRuntimeState((state) => {
 			this.onStateChange(state);
 		});
 	}
 
+	onDidEndSession: vscode.Event<positron.LanguageRuntimeExit>;
 	onDidReceiveRuntimeMessage: vscode.Event<positron.LanguageRuntimeMessage>;
 	onDidChangeRuntimeState: vscode.Event<positron.RuntimeState>;
 
@@ -193,6 +199,10 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 		kernel.onDidReceiveRuntimeMessage((message) => {
 			this._messageEmitter.fire(message);
 		});
+		kernel.onDidEndSession((exit) => {
+			this._exitEmitter.fire(exit);
+		});
+
 		return kernel;
 	}
 

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -116,6 +116,11 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 	private readonly _onDidChangeRuntimeState = new vscode.EventEmitter<positron.RuntimeState>();
 
 	/**
+	 * The onDidEndSession event emitter.
+	 */
+	private readonly _onDidEndSession = new vscode.EventEmitter<positron.LanguageRuntimeExit>();
+
+	/**
 	 * A history of executed commands
 	 */
 	private readonly _history: string[][] = [];
@@ -228,9 +233,14 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 	onDidReceiveRuntimeMessage: vscode.Event<positron.LanguageRuntimeMessage> = this._onDidReceiveRuntimeMessage.event;
 
 	/**
-	 * An object that emits he current state of the runtime.
+	 * An object that emits the current state of the runtime.
 	 */
 	onDidChangeRuntimeState: vscode.Event<positron.RuntimeState> = this._onDidChangeRuntimeState.event;
+
+	/**
+	 * An object that emits exit events.
+	 */
+	onDidEndSession: vscode.Event<positron.LanguageRuntimeExit> = this._onDidEndSession.event;
 
 	/**
 	 * Execute code in the runtime.
@@ -1023,6 +1033,11 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		const parentId = randomUUID();
 		this.simulateOutputMessage(parentId, 'Restarting.');
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
+		this._onDidEndSession.fire({
+			exit_code: 0,
+			reason: positron.RuntimeExitReason.Restart,
+			message: ''
+		});
 
 		// Wait for a second before starting again.
 		await new Promise(resolve => setTimeout(resolve, 500));
@@ -1064,6 +1079,11 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		// Simulate state changes on exit.
 		this.simulateOutputMessage(parentId, 'Zed Kernel exiting.');
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
+		this._onDidEndSession.fire({
+			exit_code: 0,
+			reason: positron.RuntimeExitReason.Shutdown,
+			message: ''
+		});
 	}
 
 	forceQuit(): Promise<void> {

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -49,6 +49,7 @@ const HelpLines = [
 	'ansi rgb       - Displays RGB ANSI colors as foreground and background colors',
 	'busy X         - Simulates an interuptible busy state for X seconds, or 5 seconds if X is not specified',
 	'code X Y       - Simulates a successful X line input with Y lines of output (where X >= 1 and Y >= 0)',
+	'crash          - Simulates a crash',
 	'env clear      - Clears all variables from the environment',
 	'env def X      - Defines X variables (randomly typed)',
 	'env def X Y    - Defines X variables of type Y, where Y is one of: string, number, vector, list, or blob',
@@ -756,6 +757,11 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 					`${makeSGR(SGR.SetBackground, 2, 0x00, 0x00, 0x83)}${TEN_SPACES}${makeSGR()} Indigo Background\n` +
 					`${makeSGR(SGR.SetBackground, 2, 0x30, 0x00, 0x9b)}${TEN_SPACES}${makeSGR()} Violet Background\n`
 				);
+				break;
+			}
+
+			case 'crash': {
+				this.simulateCrash(id, code);
 				break;
 			}
 
@@ -1643,5 +1649,22 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		}, durationSeconds * 1000);
 	}
 
+	/**
+	 * Simulates a crash.
+	 *
+	 * @param parentId The parent ID.
+	 * @param code The code.
+	 * @param output The optional output from the code.
+	 */
+	private simulateCrash(parentId: string, code: string, output: string | undefined = undefined) {
+		this.simulateBusyState(parentId);
+		this.simulateInputMessage(parentId, code);
+		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
+		this._onDidEndSession.fire({
+			exit_code: 137,
+			reason: positron.RuntimeExitReason.Error,
+			message: `I'm terribly sorry, but a segmentation fault has occurred.`
+		});
+	}
 	//#endregion Private Methods
 }

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1095,6 +1095,11 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 	forceQuit(): Promise<void> {
 		// Simulate a force quit by immediately "exiting"
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
+		this._onDidEndSession.fire({
+			exit_code: 0,
+			reason: positron.RuntimeExitReason.ForcedQuit,
+			message: ''
+		});
 		return Promise.resolve();
 	}
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -127,6 +127,47 @@ declare module 'positron' {
 	}
 
 	/**
+	 * Possible reasons a language runtime could exit.
+	 */
+	export enum RuntimeExitReason {
+		/** The runtime is shutting down at the request of the user. */
+		Shutdown = 'shutdown',
+
+		/** The runtime is exiting in order to restart. */
+		Restart = 'restart',
+
+		/** The runtime exited because of an error, most often a crash. */
+		Error = 'error',
+
+		/**
+		 * The runtime exited for an unknown reason. This typically means that
+		 * it exited unexpectedly but with a normal exit code (0).
+		 */
+		Unknown = 'unknown',
+	}
+
+	/**
+	 * LanguageRuntimeExit is an interface that defines an event occurring when a
+	 * language runtime exits.
+	 */
+	export interface LanguageRuntimeExit {
+		/**
+		 * The process exit code, if the runtime is backed by a process. If the
+		 * runtime is not backed by a process, this should just be 0 for a
+		 * succcessful exit and 1 for an error.
+		 */
+		exit_code: number;
+
+		/**
+		 * The reason the runtime exited.
+		 */
+		reason: RuntimeExitReason;
+
+		/** The exit message, if any. */
+		message: string;
+	}
+
+	/**
 	 * LanguageRuntimeMessage is an interface that defines an event occurring in a
 	 * language runtime, such as outputting text or plots.
 	 */
@@ -443,6 +484,9 @@ declare module 'positron' {
 
 		/** An object that emits the current state of the runtime */
 		onDidChangeRuntimeState: vscode.Event<RuntimeState>;
+
+		/** An object that emits an event when the user's session ends and the runtime exits */
+		onDidEndSession: vscode.Event<LanguageRuntimeExit>;
 
 		/** Execute code in the runtime */
 		execute(code: string,

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -130,8 +130,14 @@ declare module 'positron' {
 	 * Possible reasons a language runtime could exit.
 	 */
 	export enum RuntimeExitReason {
+		/** The runtime exited because it could not start correctly. */
+		StartupFailed = 'startupFailed',
+
 		/** The runtime is shutting down at the request of the user. */
 		Shutdown = 'shutdown',
+
+		/** The runtime exited because it was forced to quit. */
+		ForcedQuit = 'forcedQuit',
 
 		/** The runtime is exiting in order to restart. */
 		Restart = 'restart',

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -9,7 +9,7 @@ import {
 	ExtHostPositronContext
 } from '../../common/positron/extHost.positron.protocol';
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
-import { ILanguageRuntime, ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageCommOpen, ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeDynState as ILanguageRuntimeDynState, ILanguageRuntimeService, ILanguageRuntimeStartupFailure, LanguageRuntimeMessageType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, LanguageRuntimeDiscoveryPhase } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageCommOpen, ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeDynState as ILanguageRuntimeDynState, ILanguageRuntimeService, ILanguageRuntimeStartupFailure, LanguageRuntimeMessageType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, LanguageRuntimeDiscoveryPhase, ILanguageRuntimeExit } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { Event, Emitter } from 'vs/base/common/event';
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
@@ -68,6 +68,7 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 	private readonly _stateEmitter = new Emitter<RuntimeState>();
 	private readonly _startupEmitter = new Emitter<ILanguageRuntimeInfo>();
 	private readonly _startupFailureEmitter = new Emitter<ILanguageRuntimeStartupFailure>();
+	private readonly _exitEmitter = new Emitter<ILanguageRuntimeExit>();
 
 	private readonly _onDidReceiveRuntimeMessageOutputEmitter = new Emitter<ILanguageRuntimeMessageOutput>();
 	private readonly _onDidReceiveRuntimeMessageStreamEmitter = new Emitter<ILanguageRuntimeMessageStream>();
@@ -103,6 +104,7 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 		this.onDidChangeRuntimeState = this._stateEmitter.event;
 		this.onDidCompleteStartup = this._startupEmitter.event;
 		this.onDidEncounterStartupFailure = this._startupFailureEmitter.event;
+		this.onDidEndSession = this._exitEmitter.event;
 
 		// Listen to state changes and track the current state
 		this.onDidChangeRuntimeState((state) => {
@@ -162,6 +164,8 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 
 	onDidEncounterStartupFailure: Event<ILanguageRuntimeStartupFailure>;
 
+	onDidEndSession: Event<ILanguageRuntimeExit>;
+
 	onDidReceiveRuntimeMessageOutput = this._onDidReceiveRuntimeMessageOutputEmitter.event;
 	onDidReceiveRuntimeMessageStream = this._onDidReceiveRuntimeMessageStreamEmitter.event;
 	onDidReceiveRuntimeMessageInput = this._onDidReceiveRuntimeMessageInputEmitter.event;
@@ -209,6 +213,10 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 		// Add the state change to the event queue
 		const event = new QueuedRuntimeStateEvent(clock, state);
 		this.addToEventQueue(event);
+	}
+
+	emitExit(exit: ILanguageRuntimeExit): void {
+		this._exitEmitter.fire(exit);
 	}
 
 	/**
@@ -815,6 +823,10 @@ export class MainThreadLanguageRuntime implements MainThreadLanguageRuntimeShape
 
 	$emitLanguageRuntimeState(handle: number, clock: number, state: RuntimeState): void {
 		this.findRuntime(handle).emitState(clock, state);
+	}
+
+	$emitLanguageRuntimeExit(handle: number, exit: ILanguageRuntimeExit): void {
+		this.findRuntime(handle).emitExit(exit);
 	}
 
 	// Called by the extension host to register a language runtime

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -107,6 +107,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			languages,
 			RuntimeClientType: extHostTypes.RuntimeClientType,
 			RuntimeClientState: extHostTypes.RuntimeClientState,
+			RuntimeExitReason: extHostTypes.RuntimeExitReason,
 			LanguageRuntimeMessageType: extHostTypes.LanguageRuntimeMessageType,
 			LanguageRuntimeStreamName: extHostTypes.LanguageRuntimeStreamName,
 			RuntimeCodeExecutionMode: extHostTypes.RuntimeCodeExecutionMode,

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IDisposable } from 'vs/base/common/lifecycle';
-import { ILanguageRuntimeInfo, ILanguageRuntimeMetadata, RuntimeClientType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, ILanguageRuntimeMessage, ILanguageRuntimeDynState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeInfo, ILanguageRuntimeMetadata, RuntimeClientType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, ILanguageRuntimeMessage, ILanguageRuntimeDynState, ILanguageRuntimeExit } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { createProxyIdentifier, IRPCProtocol } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { IWebviewPortMapping, WebviewExtensionDescription } from 'vs/workbench/api/common/extHost.protocol';
 import { UriComponents } from 'vs/base/common/uri';
@@ -19,6 +19,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$getRunningRuntimes(languageId: string): Promise<ILanguageRuntimeMetadata[]>;
 	$emitLanguageRuntimeMessage(handle: number, message: ILanguageRuntimeMessage): void;
 	$emitLanguageRuntimeState(handle: number, clock: number, state: RuntimeState): void;
+	$emitLanguageRuntimeExit(handle: number, exit: ILanguageRuntimeExit): void;
 }
 
 // The interface to the main thread exposed by the extension host

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -299,6 +299,11 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 			}
 		});
 
+		// Hook up the session end (exit) handler
+		runtime.onDidEndSession(exit => {
+			this._proxy.$emitLanguageRuntimeExit(handle, exit);
+		});
+
 		// Register the runtime
 		this._runtimes.push(runtime);
 		this._eventClocks.push(0);

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -182,8 +182,14 @@ export enum RuntimeErrorBehavior {
  * Possible reasons a language runtime could exit.
  */
 export enum RuntimeExitReason {
+	/** The runtime exited because it could not start correctly. */
+	StartupFailed = 'startupFailed',
+
 	/** The runtime is shutting down at the request of the user. */
 	Shutdown = 'shutdown',
+
+	/** The runtime exited because it was forced to quit. */
+	ForcedQuit = 'forcedQuit',
 
 	/** The runtime is exiting in order to restart. */
 	Restart = 'restart',

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -178,6 +178,26 @@ export enum RuntimeErrorBehavior {
 	Continue = 'continue',
 }
 
+/**
+ * Possible reasons a language runtime could exit.
+ */
+export enum RuntimeExitReason {
+	/** The runtime is shutting down at the request of the user. */
+	Shutdown = 'shutdown',
+
+	/** The runtime is exiting in order to restart. */
+	Restart = 'restart',
+
+	/** The runtime exited because of an error, most often a crash. */
+	Error = 'error',
+
+	/**
+	 * The runtime exited for an unknown reason. This typically means that
+	 * it exited unexpectedly but with a normal exit code (0).
+	 */
+	Unknown = 'unknown',
+}
+
 export enum LanguageRuntimeStartupBehavior {
 	/**
 	 * The runtime should be started immediately after registration; usually used for runtimes

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -281,6 +281,16 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			positronConsoleContext.positronPlotsService.selectPlot(plotId);
 		}));
 
+		// Add the onDidRequestRestart event handler.
+		disposableStore.add(props.positronConsoleInstance.onDidRequestRestart(() => {
+			const runtime = positronConsoleContext.activePositronConsoleInstance?.runtime;
+			if (runtime) {
+				positronConsoleContext.languageRuntimeService.restartRuntime(
+					runtime.metadata.runtimeId,
+					'Restart requested from activity in the the Console tab');
+			}
+		}));
+
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
 	}, []);

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -287,7 +287,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			if (runtime) {
 				positronConsoleContext.languageRuntimeService.restartRuntime(
 					runtime.metadata.runtimeId,
-					'Restart requested from activity in the the Console tab');
+					'Restart requested from activity in the Console tab');
 			}
 		}));
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeExited.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeExited.css
@@ -6,3 +6,12 @@
 	margin-bottom: 2px;
 	border-bottom: 1px solid #758286;
 }
+
+.runtime-restart-button {
+	margin-top: 10px;
+	margin-bottom: 10px;
+	cursor: pointer;
+	width: fit-content;
+	padding-left: 10px;
+	padding-right: 10px;
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeExited.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeExited.tsx
@@ -3,9 +3,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./runtimeExited';
+import * as nls from 'vs/nls';
 import * as React from 'react';
 import { OutputLines } from 'vs/workbench/contrib/positronConsole/browser/components/outputLines';
 import { RuntimeItemExited } from 'vs/workbench/services/positronConsole/common/classes/runtimeItemExited';
+import { RuntimeExitReason } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 
 // RuntimeExitedProps interface.
 export interface RuntimeExitedProps {
@@ -18,10 +20,24 @@ export interface RuntimeExitedProps {
  * @returns The rendered component.
  */
 export const RuntimeExited = (props: RuntimeExitedProps) => {
+	// The set of exit reasons for which we will provide a way to manually restart.
+	const reason = props.runtimeItemExited.reason;
+	const offerRestart = reason === RuntimeExitReason.Shutdown || reason ===
+		RuntimeExitReason.ForcedQuit;
+
+	const restartLabel = nls.localize('positron.restartLabel', "Restart {0}", props.runtimeItemExited.languageName);
+
 	// Render.
 	return (
-		<div className='runtime-exited'>
-			<OutputLines outputLines={props.runtimeItemExited.outputLines} />
-		</div>
+		<>
+			<div className='runtime-exited'>
+				<OutputLines outputLines={props.runtimeItemExited.outputLines} />
+			</div>
+			{offerRestart &&
+				<button className='monaco-text-button runtime-restart-button'>
+					<span className='codicon codicon-debug-restart'></span>
+					<span className='label'>{restartLabel}</span>
+				</button>}
+		</>
 	);
 };

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -208,8 +208,14 @@ export interface ILanguageRuntimeStartupFailure {
  * Possible reasons a language runtime could exit.
  */
 export enum RuntimeExitReason {
+	/** The runtime exited because it could not start correctly. */
+	StartupFailed = 'startupFailed',
+
 	/** The runtime is shutting down at the request of the user. */
 	Shutdown = 'shutdown',
+
+	/** The runtime exited because it was forced to quit. */
+	ForcedQuit = 'forcedQuit',
 
 	/** The runtime is exiting in order to restart. */
 	Restart = 'restart',

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -205,6 +205,47 @@ export interface ILanguageRuntimeStartupFailure {
 }
 
 /**
+ * Possible reasons a language runtime could exit.
+ */
+export enum RuntimeExitReason {
+	/** The runtime is shutting down at the request of the user. */
+	Shutdown = 'shutdown',
+
+	/** The runtime is exiting in order to restart. */
+	Restart = 'restart',
+
+	/** The runtime exited because of an error, most often a crash. */
+	Error = 'error',
+
+	/**
+	 * The runtime exited for an unknown reason. This typically means that
+	 * it exited unexpectedly but with a normal exit code (0).
+	 */
+	Unknown = 'unknown',
+}
+
+/**
+ * LanguageRuntimeExit is an interface that defines an event occurring when a
+ * language runtime exits.
+ */
+export interface ILanguageRuntimeExit {
+	/**
+	 * The process exit code, if the runtime is backed by a process. If the
+	 * runtime is not backed by a process, this should just be 0 for a
+	 * succcessful exit and 1 for an error.
+	 */
+	exit_code: number;
+
+	/**
+	 * The reason the runtime exited.
+	 */
+	reason: RuntimeExitReason;
+
+	/** The exit message, if any. */
+	message: string;
+}
+
+/**
  * Possible error dispositions for a language runtime
  */
 export enum RuntimeErrorBehavior {
@@ -419,6 +460,9 @@ export interface ILanguageRuntime {
 
 	/** An object that emits an event when runtime startup fails */
 	onDidEncounterStartupFailure: Event<ILanguageRuntimeStartupFailure>;
+
+	/** An object that emits an event when the runtime exits */
+	onDidEndSession: Event<ILanguageRuntimeExit>;
 
 	/**
 	 * An object that emits an event when a client instance (comm) is created

--- a/src/vs/workbench/services/positronConsole/common/classes/runtimeItemExited.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/runtimeItemExited.ts
@@ -26,12 +26,14 @@ export class RuntimeItemExited extends RuntimeItem {
 	 * @param id The identifier.
 	 * @param reason The exit reason.
 	 * @param languageName The name of the language that exited.
-	 * @param message The banner.
+	 * @param message A message to display.
+	 * @param onRestartRequested A optional callback to invoke when a restart is requested.
 	 */
 	constructor(id: string,
 		readonly reason: RuntimeExitReason,
 		readonly languageName: string,
-		message: string) {
+		message: string,
+		readonly onRestartRequested?: () => void) {
 		// Call the base class's constructor.
 		super(id);
 

--- a/src/vs/workbench/services/positronConsole/common/classes/runtimeItemExited.ts
+++ b/src/vs/workbench/services/positronConsole/common/classes/runtimeItemExited.ts
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ANSIOutput, ANSIOutputLine } from 'ansi-output';
+import { RuntimeExitReason } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { RuntimeItem } from 'vs/workbench/services/positronConsole/common/classes/runtimeItem';
 
 /**
@@ -23,9 +24,14 @@ export class RuntimeItemExited extends RuntimeItem {
 	/**
 	 * Constructor.
 	 * @param id The identifier.
+	 * @param reason The exit reason.
+	 * @param languageName The name of the language that exited.
 	 * @param message The banner.
 	 */
-	constructor(id: string, message: string) {
+	constructor(id: string,
+		readonly reason: RuntimeExitReason,
+		readonly languageName: string,
+		message: string) {
 		// Call the base class's constructor.
 		super(id);
 

--- a/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
@@ -160,6 +160,11 @@ export interface IPositronConsoleInstance {
 	readonly onDidSelectPlot: Event<string>;
 
 	/**
+	 * The onDidRequestRestart event.
+	 */
+	readonly onDidRequestRestart: Event<void>;
+
+	/**
 	 * Focuses the input for the console.
 	 */
 	focusInput(): void;

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -1270,7 +1270,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				return nls.localize('positronConsole.exit.shutdown', "{0} shut down successfully.", this._runtime.metadata.runtimeName);
 
 			case RuntimeExitReason.Error:
-				return nls.localize('positronConsole.exit.error', "{0} crashed or exited unexpectedly (exit code {1})", this._runtime.metadata.runtimeName, exit.exit_code);
+				return nls.localize('positronConsole.exit.error', "{0} exited unexpectedly: {1}", this._runtime.metadata.runtimeName, this.formatExitCode(exit.exit_code));
 
 			case RuntimeExitReason.StartupFailed:
 				return nls.localize('positronConsole.exit.startupFailed', "{0} failed to start up (exit code {1})", this._runtime.metadata.runtimeName, exit.exit_code);
@@ -1279,6 +1279,68 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			case RuntimeExitReason.Unknown:
 				return nls.localize('positronConsole.exit.unknown', "{0} exited (exit code {1})", this._runtime.metadata.runtimeName, exit.exit_code);
 		}
+	}
+
+	private formatExitCode(exitCode: number): string {
+		if (exitCode === 1) {
+			return nls.localize('positronConsole.exitCode.error', "exit code 1 (error)");
+		} else if (exitCode === 126) {
+			return nls.localize('positronConsole.exitCode.cannotExit', "exit code 126 (not an executable or no permissions)");
+		} else if (exitCode === 127) {
+			return nls.localize('positronConsole.exitCode.notFound', "exit code 127 (command not found)");
+		} else if (exitCode === 130) {
+			return nls.localize('positronConsole.exitCode.interrupted', "exit code 130 (interrupted)");
+		} else if (exitCode > 128 && exitCode < 160) {
+			// Extract the signal from the exit code
+			const signal = exitCode - 128;
+
+			// Provide a human-readable signal name
+			let formattedSignal = this.formatSignal(signal);
+			if (formattedSignal.length > 0) {
+				formattedSignal = ` (${formattedSignal})`;
+			}
+
+			return nls.localize('positronConsole.exitCode.killed', "killed with signal {0}{1}", signal, formattedSignal);
+		}
+		return nls.localize('positronConsole.exitCode.genericError', "exit code {0}", exitCode);
+	}
+
+	/**
+	 * Formats a signal code for display. These signal codes are intentionally
+	 * not localized, and not every signal is listed here (only those commonly
+	 * associated with error conditions).
+	 *
+	 * @param signal The signal code
+	 * @returns A string representing the signal, or an empty string if the signal is unknown.
+	 */
+	private formatSignal(signal: number): string {
+		let name: string = '';
+		if (signal === 1) {
+			name = 'SIGHUP';
+		} else if (signal === 2) {
+			name = 'SIGINT';
+		} else if (signal === 3) {
+			name = 'SIGQUIT';
+		} else if (signal === 4) {
+			name = 'SIGILL';
+		} else if (signal === 5) {
+			name = 'SIGTRAP';
+		} else if (signal === 6) {
+			name = 'SIGABRT';
+		} else if (signal === 7) {
+			name = 'SIGBUS';
+		} else if (signal === 9) {
+			name = 'SIGKILL';
+		} else if (signal === 11) {
+			name = 'SIGSEGV';
+		} else if (signal === 13) {
+			name = 'SIGPIPE';
+		} else if (signal === 15) {
+			name = 'SIGTERM';
+		} else if (signal === 19) {
+			name = 'SIGSTOP';
+		}
+		return name;
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -498,6 +498,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 */
 	private readonly _onDidSelectPlotEmitter = this._register(new Emitter<string>);
 
+	/**
+	 * The onDidRequestRestart event emitter.
+	 */
+	private readonly _onDidRequestRestart = this._register(new Emitter<void>);
+
 	//#endregion Private Properties
 
 	//#region Constructor & Dispose
@@ -629,6 +634,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * onDidSelectPlot event.
 	 */
 	readonly onDidSelectPlot = this._onDidSelectPlotEmitter.event;
+
+	/**
+	 * onDidRequestRestart event.
+	 */
+	readonly onDidRequestRestart = this._onDidRequestRestart.event;
 
 	/**
 	 * Focuses the input for the console.
@@ -1240,7 +1250,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			const exited = new RuntimeItemExited(generateUuid(),
 				exit.reason,
 				this._runtime.metadata.languageName,
-				this.formatExit(exit));
+				this.formatExit(exit), () => {
+					this._onDidRequestRestart.fire();
+				});
 			this.addRuntimeItem(exited);
 			this.detachRuntime();
 		}));

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -957,6 +957,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 							this.addRuntimeItem(new RuntimeItemExited(
 								generateUuid(),
+								RuntimeExitReason.StartupFailed,
+								this._runtime.metadata.languageName,
 								`${this._runtime.metadata.runtimeName} failed to start.`
 							));
 						}
@@ -1235,7 +1237,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 		this._runtimeDisposableStore.add(this._runtime.onDidEndSession((exit) => {
 			this.addRuntimeItemTrace(`onDidEndSession (code ${exit.exit_code}, reason '${exit.reason}')`);
-			this.addRuntimeItem(new RuntimeItemExited(generateUuid(), this.formatExit(exit)));
+			const exited = new RuntimeItemExited(generateUuid(),
+				exit.reason,
+				this._runtime.metadata.languageName,
+				this.formatExit(exit));
+			this.addRuntimeItem(exited);
 			this.detachRuntime();
 		}));
 	}

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -1234,7 +1234,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		}));
 
 		this._runtimeDisposableStore.add(this._runtime.onDidEndSession((exit) => {
+			this.addRuntimeItemTrace(`onDidEndSession (code ${exit.exit_code}, reason '${exit.reason}')`);
 			this.addRuntimeItem(new RuntimeItemExited(generateUuid(), this.formatExit(exit)));
+			this.detachRuntime();
 		}));
 	}
 


### PR DESCRIPTION
This change tags language runtime exits with some useful metadata, and uses that metadata to add some new UI and behaviors around exits. The goal of these changes is to:

- reduce the time spent with no runtime online (Positron is mostly dead in this state)
- automatically recover from most crashes
- make it clearer why a runtime exited
- make it easier to get a runtime back online after it has exited

After the change, the Console will tell you why a runtime has exited, not just if it has done so. If you shut down the runtime manually, it won't restart automatically, but you'll get a nice button for doing so.

<img width="517" alt="image" src="https://github.com/posit-dev/positron/assets/470418/989cc2fa-e11a-4039-8498-ddd274720b63">

If the runtime shuts down all by itself (i.e. crashes), we will automatically try to restart it for you.

<img width="481" alt="image" src="https://github.com/posit-dev/positron/assets/470418/5d85e31b-a6af-419c-8c3e-a3f52b34531d">

Addresses https://github.com/posit-dev/positron/issues/647. 

Requires https://github.com/posit-dev/positron-python/pull/221. These PRs each require the other, so I won't merge until both are approved, and will orchestrate the merges. 