### PR TITLE
Don't focus editor on debugger breaks by default

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -533,7 +533,13 @@ configurationRegistry.registerConfiguration({
 		'debug.focusEditorOnBreak': {
 			type: 'boolean',
 			description: nls.localize('debug.focusEditorOnBreak', "Controls whether the editor should be focused when the debugger breaks."),
-			default: true
+			// --- Start Positron ---
+			// Avoid stealing focus from the Console where user is
+			// likely to type debugging statements. More rarely,
+			// the user might be typing debug commands like `next`.
+			// See https://github.com/posit-dev/positron/issues/1440
+			default: false
+			// --- End Positron ---
 		},
 		'debug.onTaskErrors': {
 			enum: ['debugAnyway', 'showErrors', 'prompt', 'abort'],


### PR DESCRIPTION
By default VS Code moves the focus to the editor when a debugger break is hit (either a breakpoint starting a new session or a step command pausing immediately to the next execution step). This is problematic in Positron for two reasons:

- In R, users might interact with the debugger (step over, step in, etc) via the console (sending `n`, `s`, etc) instead of a keybinding or the debug toolbar. In that case moving the focus away really gets in the way of the user workflow.

- When debugging REPL programs, interacting with the runtime by evaluating expressions in the console is very common. This can be done equivalently from the editor or from the console and whichever location the user has chosen to interact with the runtime shouldn't have focus stolen away on break.

To fix this, the PR changes the default of the editor focus setting to `false`. Addresses #1440.