### PR TITLE
Dataviewer/add loader state

### DIFF
--- a/extensions/positron-data-viewer/ui/src/DataPanel.css
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.css
@@ -60,3 +60,8 @@ body,
 	position: relative;
 	overflow: auto;
 }
+
+td.processing {
+	text-align: center;
+	font-weight: bold;
+}

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -41,7 +41,7 @@ export const DataPanel = (props: DataPanelProps) => {
 	const scrollThresholdPx = 300;
 
 	// The height of a single row of data
-	const rowHeightPx = 30;
+	const rowHeightPx = 10;
 
 	// The number of rows to render above and below the visible area of the table.
 	const scrollOverscan = 50;
@@ -263,7 +263,12 @@ export const DataPanel = (props: DataPanelProps) => {
 						</tr>
 					))}
 				</thead>
-				<tbody>
+				<tbody
+					style={{
+						height: `${totalSize+paddingTop+paddingBottom}px`,
+						position: 'relative'
+					}}
+				>
 					{paddingTop > 0 && (
 						<tr>
 							<td style={{ height: `${paddingTop}px` }} />

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -41,7 +41,7 @@ export const DataPanel = (props: DataPanelProps) => {
 	const scrollThresholdPx = 300;
 
 	// The height of a single row of data
-	const rowHeightPx = 10;
+	const rowHeightPx = 30;
 
 	// The number of rows to render above and below the visible area of the table.
 	const scrollOverscan = 50;
@@ -112,7 +112,6 @@ export const DataPanel = (props: DataPanelProps) => {
 	const {
 		data,
 		isLoading,
-		//isFetching,
 		isFetchingNextPage,
 		fetchNextPage,
 		hasNextPage
@@ -263,7 +262,7 @@ export const DataPanel = (props: DataPanelProps) => {
 						</tr>
 					))}
 				</thead>
-				<tbody style={{ height: `${totalSize}px` }} >
+				<tbody>
 					{paddingTop > 0 && (
 						<tr>
 							<td style={{ height: `${paddingTop}px` }} />
@@ -275,16 +274,14 @@ export const DataPanel = (props: DataPanelProps) => {
 
 						return (
 							<tr
-								key={isLoaderRow ? `loading-row-${virtualRow.index}` : row.id}
+								key={isLoaderRow ? `loading-row` : row.id}
 							>
 							{
-								isLoaderRow ?
-									hasNextPage ?
+								isLoaderRow && hasNextPage ?
 									// TODO: replace with a grouped column footer as in
 									// https://tanstack.com/table/v8/docs/examples/react/column-groups
 									// for the loading indicator
-										<td className='processing'>Loading more...</td> :
-										<td className='processing'>Nothing more to load</td> :
+									<td className='processing'>Loading more...</td> :
 									row.getVisibleCells().map(cell => {
 										return (
 											<td key={cell.id}>

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -12,7 +12,7 @@ import * as ReactTable from '@tanstack/react-table';
 
 // Local modules.
 import { DataFragment, DataModel } from './DataModel';
-import { DataViewerMessageRowRequest, DataSet } from './positron-data-viewer';
+import { DataSet } from './positron-data-viewer';
 
 interface DataPanelProps {
 	/**
@@ -55,6 +55,10 @@ export const DataPanel = (props: DataPanelProps) => {
 		new DataModel(initialData)
 	);
 
+	// Count total rows against those we have fetched.
+	const totalRows = dataModel.rowCount;
+	const maxPages = Math.ceil(totalRows / fetchSize);
+
 	React.useEffect(() => {
 		const handleMessage = ((event: any) => {
 			updateDataModel((prevDataModel) => {
@@ -86,19 +90,38 @@ export const DataPanel = (props: DataPanelProps) => {
 		,
 		[dataModel]);
 
+	async function fetchNextDataFragment(pageParam: number, fetchSize: number): Promise<DataFragment> {
+		// Fetches a single page of data from the data model.
+		const startRow = pageParam * fetchSize;
+
+		// Let the server know we are requesting more rows
+		if (startRow > 0) {
+			vscode.postMessage({
+				msg_type: 'request_rows',
+				start_row: startRow,
+				fetch_size: fetchSize
+			});
+		}
+
+		const fragment = dataModel.loadDataFragment(startRow, fetchSize);
+		return fragment;
+	}
+
 	// Use a React Query infinite query to fetch data from the data model,
 	// with the dataModel id as cache key so we re-query when new data comes in.
-	const { data, fetchNextPage, isFetching, isLoading } =
-		ReactQuery.useInfiniteQuery<DataFragment>(
+	const {
+		data,
+		isLoading,
+		//isFetching,
+		isFetchingNextPage,
+		fetchNextPage,
+		hasNextPage
+	} = ReactQuery.useInfiniteQuery<DataFragment>(
 			['table-data', dataModel.id],
-			async ({ pageParam = 0 }) => {
-				// Fetches a single page of data from the data model.
-				const start = pageParam * fetchSize;
-				const fragment = dataModel.loadDataFragment(start, fetchSize);
-				return fragment;
-			},
+			({pageParam = 0}) => fetchNextDataFragment(pageParam, fetchSize),
 			{
-				getNextPageParam: (_lastGroup, groups) => groups.length,
+				// undefined if we are on the final page of data
+				getNextPageParam: (_lastGroup, groups) => groups.length !== maxPages ? groups.length : undefined,
 				keepPreviousData: true,
 				refetchOnWindowFocus: false,
 			}
@@ -130,47 +153,7 @@ export const DataPanel = (props: DataPanelProps) => {
 		},
 		[data]);
 
-	// Count total rows against those we have fetched.
-	const totalRows = dataModel.rowCount;
-
-	// Find the maximum rowEnd value in the data; this is the
-	// total number of rows we have fetched.
-	const totalFetched = React.useMemo(
-		() => {
-			return data?.pages?.reduce((max, row) => Math.max(max, row.rowEnd + 1), 0) ?? 0;
-		},
-		[flatData]
-	);
-
-	// Callback, invoked on scroll, that will fetch more data from the backend if we have reached
-	// the bottom of the table container by sending a new MessageRequest.
-	const fetchMoreOnBottomReached = React.useCallback(
-		(containerRefElement?: HTMLDivElement | null) => {
-			if (containerRefElement) {
-				const { scrollHeight, scrollTop, clientHeight } = containerRefElement;
-				const distance = scrollHeight - scrollTop - clientHeight;
-				if (distance < scrollThresholdPx &&
-					!isFetching &&
-					totalFetched < totalRows
-				) {
-					fetchNextPage();
-					const msg: DataViewerMessageRowRequest = {
-						msg_type: 'request_rows',
-						start_row: totalFetched,
-						fetch_size: fetchSize
-					};
-					vscode.postMessage(msg);
-				}
-			}
-		},
-		[fetchNextPage, isFetching, totalFetched, totalRows]);
-
-	// Use an effect to fetch more data when the table container is scrolled.
-	React.useEffect(() => {
-		fetchMoreOnBottomReached(tableContainerRef.current);
-	}, [fetchMoreOnBottomReached]);
-
-	// Define the main ReactTable instance.
+		// Define the main ReactTable instance.
 	const table = ReactTable.useReactTable({
 		data: flatData,
 		columns,
@@ -179,11 +162,11 @@ export const DataPanel = (props: DataPanelProps) => {
 		enableSorting: false,
 	});
 
-	const { rows } = table.getRowModel();
+	const {rows} = table.getRowModel();
 
 	// Use a virtualizer to render only the rows that are visible.
 	const rowVirtualizer = ReactVirtual.useVirtualizer({
-		count: rows.length,
+		count: hasNextPage ? rows.length + 1 : rows.length, // add a row for the loader row
 		getScrollElement: () => tableContainerRef.current,
 		estimateSize: () => rowHeightPx,
 		overscan: scrollOverscan
@@ -198,6 +181,42 @@ export const DataPanel = (props: DataPanelProps) => {
 			? totalSize - (virtualRows?.[virtualRows.length - 1]?.end || 0)
 			: 0;
 
+	// Callback, invoked on scroll, that will fetch more data from the backend if we have reached
+	// the bottom of the table container by sending a new MessageRequest.
+	const fetchMoreOnBottomReached = React.useCallback(
+		(containerRefElement?: HTMLDivElement | null) => {
+			if (containerRefElement) {
+				const { scrollHeight, scrollTop, clientHeight } = containerRefElement;
+				const distance = scrollHeight - scrollTop - clientHeight;
+				if (distance < scrollThresholdPx &&
+					!isFetchingNextPage &&
+					hasNextPage
+				) {
+					fetchNextPage();
+				}
+			}
+		},
+		[fetchNextPage, isFetchingNextPage, hasNextPage]);
+
+	// Use an effect to fetch more data when the table container is scrolled.
+	React.useEffect(() => {
+		const [lastItem] = [...virtualRows].reverse();
+
+		if (!lastItem) {
+			return;
+		}
+
+		// user has scrolled to the last row of the loaded virtual rows
+		// so fetch more from the backend if there are more pages
+		if (lastItem.index >= rows.length - 1 &&
+			hasNextPage &&
+			!isFetchingNextPage
+		) {
+			fetchMoreOnBottomReached(tableContainerRef.current);
+		}
+
+	}, [fetchNextPage, isFetchingNextPage, hasNextPage, rows.length, virtualRows]);
+
 	if (isLoading) {
 		return <>Loading...</>;
 	}
@@ -208,7 +227,7 @@ export const DataPanel = (props: DataPanelProps) => {
 			onScroll={e => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
 			ref={tableContainerRef}
 		>
-			<table>
+			<table width='100%'>
 				<thead>
 					{table.getHeaderGroups().map(headerGroup => (
 						<tr key={headerGroup.id}>
@@ -233,8 +252,8 @@ export const DataPanel = (props: DataPanelProps) => {
 													header.getContext()
 												)}
 												{{
-													asc: '^',
-													desc: 'V',
+													asc: '🔼', // allow-any-unicode-next-line
+													desc: '🔽', // allow-any-unicode-next-line
 												}[header.column.getIsSorted() as string] ?? null}
 											</div>
 										)}
@@ -251,19 +270,27 @@ export const DataPanel = (props: DataPanelProps) => {
 						</tr>
 					)}
 					{virtualRows.map(virtualRow => {
+						const isLoaderRow = virtualRow.index > rows.length - 1;
 						const row = rows[virtualRow.index] as ReactTable.Row<any>;
+
 						return (
-							<tr key={row.id}>
-								{row.getVisibleCells().map(cell => {
-									return (
-										<td key={cell.id}>
-											{ReactTable.flexRender(
-												cell.column.columnDef.cell,
-												cell.getContext()
-											)}
-										</td>
-									);
-								})}
+							<tr key={isLoaderRow ? `loading-row-${virtualRow.index}` : row.id}>
+							{
+								isLoaderRow ?
+									hasNextPage ?
+										<td width='100%'>Loading more...</td> :
+										<td width='100%'>'Nothing more to load'</td> :
+									row.getVisibleCells().map(cell => {
+										return (
+											<td key={cell.id}>
+												{ReactTable.flexRender(
+													cell.column.columnDef.cell,
+													cell.getContext()
+												)}
+											</td>
+										);
+									})
+							}
 							</tr>
 						);
 					})}

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -227,7 +227,7 @@ export const DataPanel = (props: DataPanelProps) => {
 			onScroll={e => fetchMoreOnBottomReached(e.target as HTMLDivElement)}
 			ref={tableContainerRef}
 		>
-			<table width='100%'>
+			<table>
 				<thead>
 					{table.getHeaderGroups().map(headerGroup => (
 						<tr key={headerGroup.id}>
@@ -263,12 +263,7 @@ export const DataPanel = (props: DataPanelProps) => {
 						</tr>
 					))}
 				</thead>
-				<tbody
-					style={{
-						height: `${totalSize+paddingTop+paddingBottom}px`,
-						position: 'relative'
-					}}
-				>
+				<tbody style={{ height: `${totalSize}px` }} >
 					{paddingTop > 0 && (
 						<tr>
 							<td style={{ height: `${paddingTop}px` }} />
@@ -279,12 +274,17 @@ export const DataPanel = (props: DataPanelProps) => {
 						const row = rows[virtualRow.index] as ReactTable.Row<any>;
 
 						return (
-							<tr key={isLoaderRow ? `loading-row-${virtualRow.index}` : row.id}>
+							<tr
+								key={isLoaderRow ? `loading-row-${virtualRow.index}` : row.id}
+							>
 							{
 								isLoaderRow ?
 									hasNextPage ?
-										<td width='100%'>Loading more...</td> :
-										<td width='100%'>'Nothing more to load'</td> :
+									// TODO: replace with a grouped column footer as in
+									// https://tanstack.com/table/v8/docs/examples/react/column-groups
+									// for the loading indicator
+										<td className='processing'>Loading more...</td> :
+										<td className='processing'>Nothing more to load</td> :
 									row.getVisibleCells().map(cell => {
 										return (
 											<td key={cell.id}>

--- a/extensions/positron-zed/src/positronZedData.ts
+++ b/extensions/positron-zed/src/positronZedData.ts
@@ -18,8 +18,8 @@ class ZedColumn implements DataColumn {
 		this.name = name;
 		this.type = type;
 		// Create an array of random numbers of the requested length
-		//this.data = Array.from({ length }, () => Math.floor(Math.random() * 100));
-		this.data = Array.from({ length }, (_, i) => i);
+		this.data = Array.from({ length }, () => Math.floor(Math.random() * 100));
+		//this.data = Array.from({ length }, (_, i) => i);
 	}
 }
 
@@ -95,10 +95,6 @@ export class ZedData implements DataSet {
 				rowCount: this.rowCount
 			} as ZedData,
 		};
-		console.log(`Zed: Received a message: ${JSON.stringify(message)}`);
-		const { data, ...response_header } = response;
-		// adding a delay for testing purposes
-		console.log(`Zed: Sending a response: ${JSON.stringify(response_header)}`);
 		// Emit to the front end.
 		this._onDidEmitData.fire(response);
 	}

--- a/extensions/positron-zed/src/positronZedData.ts
+++ b/extensions/positron-zed/src/positronZedData.ts
@@ -18,8 +18,8 @@ class ZedColumn implements DataColumn {
 		this.name = name;
 		this.type = type;
 		// Create an array of random numbers of the requested length
-		this.data = Array.from({ length }, () => Math.floor(Math.random() * 100));
-		//this.data = Array.from({ length }, (_, i) => i);
+		//this.data = Array.from({ length }, () => Math.floor(Math.random() * 100));
+		this.data = Array.from({ length }, (_, i) => i);
 	}
 }
 
@@ -95,6 +95,10 @@ export class ZedData implements DataSet {
 				rowCount: this.rowCount
 			} as ZedData,
 		};
+		console.log(`Zed: Received a message: ${JSON.stringify(message)}`);
+		const { data, ...response_header } = response;
+		// adding a delay for testing purposes
+		console.log(`Zed: Sending a response: ${JSON.stringify(response_header)}`);
 		// Emit to the front end.
 		this._onDidEmitData.fire(response);
 	}

--- a/extensions/positron-zed/src/positronZedEnvironment.ts
+++ b/extensions/positron-zed/src/positronZedEnvironment.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import * as positron from 'positron';
 import { randomUUID } from 'crypto';
 import { PositronZedLanguageRuntime } from './positronZedLanguageRuntime';
 
@@ -92,7 +91,7 @@ export class ZedEnvironment {
 		this._vars.set('z', new ZedVariable('z', 'zed1', 'string', 4, 4));
 		this._vars.set('e', new ZedVariable('e', 'zed2', 'string', 4, 4));
 		this._vars.set('d', new ZedVariable('d', 'zed3', 'string', 4, 4));
-		this._vars.set('dat', new ZedVariable('dat', 'table(10 columns, 100 rows)', 'table', 100, 1000));
+		this._vars.set('dat', new ZedVariable('dat', 'table(10 columns, 1000 rows)', 'table', 1000, 10_000));
 
 		// Create a Zed Version variable
 		this._vars.set('ZED_VERSION', new ZedVariable('ZED_VERSION',


### PR DESCRIPTION
Adds a bare-bones **Loading **more...** indicator at the bottom of the table to indicate when more data is being fetched from the backend. This is usually only visible in larger datasets.

(I typically use the following for testing)
```
import numpy as np
import pandas as pd
df = pd.DataFrame(np.random.randn(412_698, 53))
%view df
```

https://github.com/posit-dev/positron/assets/7817881/3ed5f09e-b861-4a80-9ea3-126f5dc4a53f
(We haven't fixed the scrolling issues yet, but this screen recording shows the loading indicator)

It works and displays as expected, but I don't love its appearance -- I will follow up with some React Table magic to make the loader row a more visible footer that spans the full width of the table, but this PR sets up all the plumbing to get the loading state properly calculated in the JSX, and then we can adjust the actual appearance of the loading indicator shortly