### PR TITLE
Enable color decorators by default

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -5946,7 +5946,14 @@ export const EditorOptions = {
 	// Leave these at the end (because they have dependencies!)
 	editorClassName: register(new EditorClassName()),
 	defaultColorDecorators: register(new EditorBooleanOption(
-		EditorOption.defaultColorDecorators, 'defaultColorDecorators', false,
+		// --- Start Positron ---
+		// We enable default color decorators by default in Positron, so that
+		// files containing hex color codes will be rendered with a color
+		// swatch.
+		//
+		// EditorOption.defaultColorDecorators, 'defaultColorDecorators', false,
+		EditorOption.defaultColorDecorators, 'defaultColorDecorators', true,
+		// --- End Positron ---
 		{ markdownDescription: nls.localize('defaultColorDecorators', "Controls whether inline color decorations should be shown using the default document color provider") }
 	)),
 	pixelRatio: register(new EditorPixelRatio()),


### PR DESCRIPTION
This change enables "default color decorators" by default. This is a VS Code option that causes hex strings to be rendered with a small color swatch in all file types (including R and Python). When it's off (VS Code's default), hex colors are only rendered with a swatch in CSS/HTML files. 

In the future, we may want R and/or Python to provide their own color decorators so that named colors (e.g. `aliceblue`) are rendered with a swatch, too.
