### PR TITLE
Update top action bar select color

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -559,7 +559,7 @@
 		"--vscode-positronTopActionBar-hoverBackground",
 		"--vscode-positronTopActionBar-logoBackground",
 		"--vscode-positronTopActionBar-selectBoxBackground",
-		"--vscode-positronTopActionBar-selectBoxBorder",
+		"--vscode-positronTopActionBar-selectBorder",
 		"--vscode-positronTopActionBar-separator",
 		"--vscode-positronTopActionBar-textInputBackground",
 		"--vscode-positronTopActionBar-textInputBorder",

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
@@ -30,7 +30,7 @@
 }
 
 .action-bar-button.border {
-	border: 1px solid var(--vscode-positronTopActionBar-selectBoxBorder);
+	border: 1px solid var(--vscode-positronTopActionBar-selectBorder);
 }
 
 .action-bar-button.fade-in {

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCommandCenter.css
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCommandCenter.css
@@ -11,7 +11,7 @@
 	box-sizing: border-box;
 	grid-template-columns: 1fr min-content 1fr;
 	color: var(--positronActionBar-foreground);
-	border: 1px solid var(--vscode-positronTopActionBar-selectBoxBorder);
+	border: 1px solid var(--vscode-positronTopActionBar-selectBorder);
 	background-color: var(--vscode-positronTopActionBar-selectBoxBackground);
 }
 

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCustomFolderMenu.css
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCustomFolderMenu.css
@@ -14,7 +14,7 @@
 	box-sizing: border-box;
 	grid-template-columns: 1fr 1fr;
 	color: var(--positronActionBar-foreground);
-	border: 1px solid var(--vscode-positronTopActionBar-selectBoxBorder);
+	border: 1px solid var(--vscode-positronTopActionBar-selectBorder);
 	background-color: var(--vscode-positronTopActionBar-selectBoxBackground);
 }
 

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarInterpretersManager.css
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarInterpretersManager.css
@@ -14,7 +14,7 @@
 	box-sizing: border-box;
 	grid-template-columns: 1fr 1fr;
 	color: var(--positronActionBar-foreground);
-	border: 1px solid var(--vscode-positronTopActionBar-selectBoxBorder);
+	border: 1px solid var(--vscode-positronTopActionBar-selectBorder);
 	background-color: var(--vscode-positronTopActionBar-selectBoxBackground);
 }
 

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1138,13 +1138,13 @@ export const POSITRON_TOP_ACTION_BAR_SEPARATOR = registerColor('positronTopActio
 	hcLight: '#dfe3e6'
 }, localize('positronTopActionBar.separator', "Positron top action bar separator color."));
 
-// The Positron top action bar select box border color.
-export const POSITRON_TOP_ACTION_BAR_SELECT_BOX_BORDER = registerColor('positronTopActionBar.selectBoxBorder', {
-	dark: '#000000',
-	light: '#cad0d6',
-	hcDark: contrastBorder,
-	hcLight: contrastBorder
-}, localize('positronTopActionBar.selectBoxBorder', "Positron top action bar select box border color."));
+// The Positron top action bar select border color.
+export const POSITRON_TOP_ACTION_BAR_SELECT_BORDER = registerColor('positronTopActionBar.selectBorder', {
+	dark: selectBorder,
+	light: selectBorder,
+	hcDark: selectBorder,
+	hcLight: selectBorder
+}, localize('positronTopActionBar.selectBorder', "Positron top action bar select border color."));
 
 // The Positron top action bar select box background color.
 export const POSITRON_TOP_ACTION_BAR_SELECT_BOX_BACKGROUND = registerColor('positronTopActionBar.selectBoxBackground', {


### PR DESCRIPTION
This PR fixes a border theming problem with the `TopActionBarCommandCenter`, `TopActionBarInterpretersManager`, and `TopActionBarCustonFolderMenu` components. Before this PR, the border on these buttons was black and indistinct. With this PR, the border on these buttons now matches "selectBorder" theme color.

Before:

![image](https://github.com/posit-dev/positron/assets/853239/9990c89c-f509-453f-90e8-3057024d3c18)

After:

![image](https://github.com/posit-dev/positron/assets/853239/0565f2e9-6cfd-481e-bde2-c2cc14023f9a)

<img width="1318" alt="image" src="https://github.com/posit-dev/positron/assets/853239/ac793246-b5f0-4db4-b861-cfbe17805901">

