### PR TITLE
Dataviewer/continue loader state

### DIFF
--- a/extensions/positron-data-viewer/ui/src/DataPanel.css
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.css
@@ -15,7 +15,7 @@ table {
 	table-layout: fixed;
 }
 
-thead {
+thead, tfoot {
 	position: sticky;
 	background-color: var(--vscode-panel-background);
 	margin: 0;
@@ -61,7 +61,7 @@ body,
 	overflow: auto;
 }
 
-td.processing {
+.processing {
 	text-align: center;
 	font-weight: bold;
 }

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -77,7 +77,7 @@ export const DataPanel = (props: DataPanelProps) => {
 	// model is generic.
 	const columns = React.useMemo<ReactTable.ColumnDef<any>[]>(
 		() => {
-			const dataColumns = dataModel.columns.map((column, idx) => {
+			return dataModel.columns.map((column, idx) => {
 				return {
 					id: '' + idx,
 					accessorKey: idx,
@@ -87,11 +87,6 @@ export const DataPanel = (props: DataPanelProps) => {
 					header: column.name
 				};
 			});
-			return [{ // Create a column group with all columns
-				id: 'loading',
-				footer: () => <span className='processing'>Loading more rows...</span>,
-				columns: dataColumns
-			}];
 		},
 		[dataModel]);
 
@@ -301,18 +296,11 @@ export const DataPanel = (props: DataPanelProps) => {
 				</tbody>
 			{ isFetchingNextPage ?
 				<tfoot>
-				{table.getFooterGroups().map(footerGroup => (
-					<tr key={footerGroup.id}>
-						{footerGroup.headers.map(header => (
-							<th key={header.id} colSpan={header.colSpan}>
-								{ReactTable.flexRender(
-									header.column.columnDef.footer,
-									header.getContext()
-								)}
-							</th>
-						))}
+					<tr>
+						<th className='processing' colSpan={columns.length}>
+							Loading more rows...
+						</th>
 					</tr>
-				))}
 				</tfoot> :
 				null
 			}

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -76,8 +76,7 @@ export const DataPanel = (props: DataPanelProps) => {
 	// Create the columns for the table. These use the 'any' type since the data
 	// model is generic.
 	const columns = React.useMemo<ReactTable.ColumnDef<any>[]>(
-		() => {
-			return dataModel.columns.map((column, idx) => {
+		() => dataModel.columns.map((column, idx) => {
 				return {
 					id: '' + idx,
 					accessorKey: idx,
@@ -86,8 +85,7 @@ export const DataPanel = (props: DataPanelProps) => {
 					},
 					header: column.name
 				};
-			});
-		},
+			}),
 		[dataModel]);
 
 	async function fetchNextDataFragment(pageParam: number, fetchSize: number): Promise<DataFragment> {

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -89,7 +89,7 @@ export const DataPanel = (props: DataPanelProps) => {
 			});
 			return [{ // Create a column group with all columns
 				id: 'loading',
-				footer: () => <span className='processing'>Loading more...</span>,
+				footer: () => <span className='processing'>Loading more rows...</span>,
 				columns: dataColumns
 			}];
 		},
@@ -170,7 +170,7 @@ export const DataPanel = (props: DataPanelProps) => {
 
 	// Use a virtualizer to render only the rows that are visible.
 	const rowVirtualizer = ReactVirtual.useVirtualizer({
-		count: hasNextPage ? rows.length + 1 : rows.length, // add a row for the Loading... row
+		count: rows.length,
 		getScrollElement: () => tableContainerRef.current,
 		estimateSize: () => rowHeightPx,
 		overscan: scrollOverscan
@@ -274,38 +274,21 @@ export const DataPanel = (props: DataPanelProps) => {
 						</tr>
 					)}
 					{virtualRows.map(virtualRow => {
-						const isLoaderRow = virtualRow.index > rows.length - 1;
 						const row = rows[virtualRow.index] as ReactTable.Row<any>;
 
 						return (
-							<tr
-								key={isLoaderRow ? `loading-row` : row.id}
-							>
+							<tr key={row.id}>
 							{
-								isLoaderRow && hasNextPage ?
-									// We only have one footer, and it's the loading row
-									// We treat it as a regular row because we want it at the
-									// bottom of the visible area, not the bottom of the table
-									table.getFooterGroups().map(footerGroup => (
-										footerGroup.headers.map(header => (
-											<td key={header.id} colSpan={header.colSpan}>
-												{ReactTable.flexRender(
-													header.column.columnDef.footer,
-													header.getContext()
-												)}
-											</td>
-										))
-									)) :
-									row.getVisibleCells().map(cell => {
-										return (
-											<td key={cell.id}>
-												{ReactTable.flexRender(
-													cell.column.columnDef.cell,
-													cell.getContext()
-												)}
-											</td>
-										);
-									})
+								row.getVisibleCells().map(cell => {
+									return (
+										<td key={cell.id}>
+											{ReactTable.flexRender(
+												cell.column.columnDef.cell,
+												cell.getContext()
+											)}
+										</td>
+									);
+								})
 							}
 							</tr>
 						);
@@ -316,6 +299,23 @@ export const DataPanel = (props: DataPanelProps) => {
 						</tr>
 					)}
 				</tbody>
+			{ isFetchingNextPage ?
+				<tfoot>
+				{table.getFooterGroups().map(footerGroup => (
+					<tr key={footerGroup.id}>
+						{footerGroup.headers.map(header => (
+							<th key={header.id} colSpan={header.colSpan}>
+								{ReactTable.flexRender(
+									header.column.columnDef.footer,
+									header.getContext()
+								)}
+							</th>
+						))}
+					</tr>
+				))}
+				</tfoot> :
+				null
+			}
 			</table>
 		</div>
 	);


### PR DESCRIPTION
Continuation of #1517 with a simpler, nicer-looking solution for the loader row, which is now just a conditional footer