### PR TITLE
R: Executing code with Windows line endings

### DIFF
--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -66,7 +66,7 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 
 	execute(code: string, id: string, mode: positron.RuntimeCodeExecutionMode, errorBehavior: positron.RuntimeErrorBehavior): void {
 		if (this._kernel) {
-			this._kernel.execute(code, id, mode, errorBehavior);
+			this._kernel.execute(code.replace(/\r\n/g, '\n'), id, mode, errorBehavior);
 		} else {
 			throw new Error(`Cannot execute '${code}'; kernel not started`);
 		}
@@ -74,7 +74,7 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 
 	isCodeFragmentComplete(code: string): Thenable<positron.RuntimeCodeFragmentStatus> {
 		if (this._kernel) {
-			return this._kernel.isCodeFragmentComplete(code);
+			return this._kernel.isCodeFragmentComplete(code.replace(/\r\n/g, '\n'));
 		} else {
 			throw new Error(`Cannot check code fragment '${code}'; kernel not started`);
 		}

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -463,7 +463,6 @@ export function registerPositronConsoleActions() {
 			await viewsService.openView<PositronConsoleViewPane>(POSITRON_CONSOLE_VIEW_ID, false);
 
 			// Ask the Positron console service to execute the code.
-			code = code.replace(/\r\n/mg, '\n');
 			if (!await positronConsoleService.executeCode(languageId, code, true)) {
 				const languageName = languageService.getLanguageName(languageId);
 				notificationService.notify({

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -463,6 +463,7 @@ export function registerPositronConsoleActions() {
 			await viewsService.openView<PositronConsoleViewPane>(POSITRON_CONSOLE_VIEW_ID, false);
 
 			// Ask the Positron console service to execute the code.
+			code = code.replace(/\r\n/mg, '\n');
 			if (!await positronConsoleService.executeCode(languageId, code, true)) {
 				const languageName = languageService.getLanguageName(languageId);
 				notificationService.notify({


### PR DESCRIPTION
This is no longer just an exploration but is a proposed solution for #1520. Relative to the initial exploratory PR, this:

* Moves all "replace CRLF with LF" into the R runtime, because AFAICT we are only suffering from Windows line endings with R code right now.
* Applies the fix in two places:
  - `isCodeFragmentComplete()`: this parses code, in the form of a string, to determine if we have submitted a complete expression.
  - `execute()`: this executes code, also provided as a string. And executing means parsing.

I went through a phase of thinking the only solution was to expose the user's code to R's parser via a connection. Why? Because, unlike text input, a connection is guaranteed to cope with both CRLF and LF line endings. But this would require a fairly significant change in how we prepare code for the R kernel.

I was worried that simply replacing CRLF with LF would mangle literal `\r\n` in R code. But in the process of trying to prove that the simple approach could not work, I concluded that it does work.

*I'm still working on this.*