### PR TITLE
Updates to allow for dynamic width of right-aligned popups

### DIFF
--- a/src/vs/base/browser/ui/positronModalDialog/positronModalDialogReactRenderer.ts
+++ b/src/vs/base/browser/ui/positronModalDialog/positronModalDialogReactRenderer.ts
@@ -9,13 +9,13 @@ import { createRoot, Root } from 'react-dom/client';
 
 /**
  * PositronModalDialogReactRenderer class.
- * Manages rendering a React component as a modal dialog.
+ * Manages rendering a React element as a modal dialog.
  */
 export class PositronModalDialogReactRenderer {
 	/**
-	 * The container element where the React element will be rendered.
+	 * The overlay element where the modal dialog will be presented.
 	 */
-	private _container?: HTMLElement;
+	private _overlayElement?: HTMLElement;
 
 	/**
 	 * The root where the React element will be rendered.
@@ -24,11 +24,12 @@ export class PositronModalDialogReactRenderer {
 
 	/**
 	 * Initializes a new instance of the PositronModalDialogReactRenderer class.
-	 * @param container The container HTMLElement where the modal dialog will be presented.
+	 * @param containerElement The container element.
 	 */
-	constructor(container: HTMLElement) {
-		this._container = container.appendChild(DOM.$('.positron-modal-dialog-overlay'));
-		this._root = createRoot(this._container);
+	constructor(containerElement: HTMLElement) {
+		this._overlayElement = containerElement.
+			appendChild(DOM.$('.positron-modal-dialog-overlay'));
+		this._root = createRoot(this._overlayElement);
 	}
 
 	/**
@@ -51,10 +52,10 @@ export class PositronModalDialogReactRenderer {
 			this._root = undefined;
 		}
 
-		// Remove the container element.
-		if (this._container) {
-			this._container.remove();
-			this._container = undefined;
+		// Remove the overlay element.
+		if (this._overlayElement) {
+			this._overlayElement.remove();
+			this._overlayElement = undefined;
 		}
 	}
 }

--- a/src/vs/base/browser/ui/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/base/browser/ui/positronModalPopup/positronModalPopup.tsx
@@ -11,10 +11,17 @@ import { positronClassNames } from 'vs/base/common/positronUtilities';
 /**
  * Event aliases.
  */
-type Position = DOM.IDomPosition;
 type UIEvent = globalThis.UIEvent;
 type MouseEvent = globalThis.MouseEvent;
 type KeyboardEvent = globalThis.KeyboardEvent;
+
+// Position interface.
+interface Position {
+	top: number | 'auto';
+	right: number | 'auto';
+	bottom: number | 'auto';
+	left: number | 'auto';
+}
 
 /**
  * PopupPosition type.
@@ -30,10 +37,12 @@ export type PopupAlignment = 'left' | 'right';
  * PositronModalPopupProps interface.
  */
 export interface PositronModalPopupProps {
+	containerElement: HTMLElement;
 	anchorElement: HTMLElement;
 	popupPosition: PopupPosition;
 	popupAlignment: PopupAlignment;
-	width: number;
+	minWidth?: number;
+	width: number | 'max-content';
 	height: number | 'min-content';
 	onDismiss: () => void;
 }
@@ -52,11 +61,15 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 		const topLeftOffset = DOM.getTopLeftOffset(props.anchorElement);
 		return {
 			top: props.popupPosition === 'top' ?
-				topLeftOffset.top - popupRef.current.offsetHeight - 1 :
+				'auto' :
 				topLeftOffset.top + props.anchorElement.offsetHeight + 1,
+			right: props.popupAlignment === 'right' ?
+				props.containerElement.offsetWidth - (topLeftOffset.left + props.anchorElement.offsetWidth) :
+				'auto',
+			bottom: 'auto',
 			left: props.popupAlignment === 'left' ?
 				topLeftOffset.left :
-				topLeftOffset.left + props.anchorElement.offsetWidth - props.width
+				'auto'
 		};
 	};
 
@@ -155,7 +168,16 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 	return (
 		<div className='positron-modal-popup-shadow-container'>
 			<div ref={popupContainerRef} className='positron-modal-popup-container' role='dialog' tabIndex={-1}>
-				<div ref={popupRef} className={classNames} style={{ top: position.top, left: position.left, width: props.width, height: props.height }}>
+				<div
+					ref={popupRef}
+					className={classNames}
+					style={{
+						...position,
+						minWidth: props.minWidth,
+						width: props.width,
+						height: props.height
+					}}
+				>
 					{props.children}
 				</div>
 			</div>

--- a/src/vs/base/browser/ui/positronModalPopup/positronModalPopupReactRenderer.ts
+++ b/src/vs/base/browser/ui/positronModalPopup/positronModalPopupReactRenderer.ts
@@ -9,13 +9,13 @@ import { createRoot, Root } from 'react-dom/client';
 
 /**
  * PositronModalPopupReactRenderer class.
- * Manages rendering a React component as a modal popup.
+ * Manages rendering a React element as a modal popup.
  */
 export class PositronModalPopupReactRenderer {
 	/**
-	 * The container element where the React element will be rendered.
+	 * The overlay element where the modal popup will be presented.
 	 */
-	private _container?: HTMLElement;
+	private _overlayElement?: HTMLElement;
 
 	/**
 	 * The root where the React element will be rendered.
@@ -24,11 +24,12 @@ export class PositronModalPopupReactRenderer {
 
 	/**
 	 * Initializes a new instance of the PositronModalPopupReactRenderer class.
-	 * @param container The container HTMLElement where the modal popup will be presented.
+	 * @param containerElement The container element.
 	 */
-	constructor(container: HTMLElement) {
-		this._container = container.appendChild(DOM.$('.positron-modal-popup-overlay'));
-		this._root = createRoot(this._container);
+	constructor(containerElement: HTMLElement) {
+		this._overlayElement = containerElement.
+			appendChild(DOM.$('.positron-modal-popup-overlay'));
+		this._root = createRoot(this._overlayElement);
 	}
 
 	/**
@@ -51,10 +52,10 @@ export class PositronModalPopupReactRenderer {
 			this._root = undefined;
 		}
 
-		// Remove the container element.
-		if (this._container) {
-			this._container.remove();
-			this._container = undefined;
+		// Remove the overlay element.
+		if (this._overlayElement) {
+			this._overlayElement.remove();
+			this._overlayElement = undefined;
 		}
 	}
 }

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderModalPopup.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderModalPopup.tsx
@@ -20,7 +20,7 @@ import { CustomFolderMenuItems } from 'vs/workbench/browser/parts/positronTopAct
  * @param hostService The IHostService.
  * @param labelService The ILabelService.
  * @param workspacesService The IWorkspacesService.
- * @param container The container of the application.
+ * @param containerElement The container element.
  * @param anchorElement The anchor element for the modal popup.
  * @returns A promise that resolves when the popup is dismissed.
  */
@@ -30,7 +30,7 @@ export const showCustomFolderModalPopup = async (
 	hostService: IHostService,
 	labelService: ILabelService,
 	workspacesService: IWorkspacesService,
-	container: HTMLElement,
+	containerElement: HTMLElement,
 	anchorElement: HTMLElement
 ): Promise<void> => {
 	// Gets the workspaces recently opened.
@@ -39,7 +39,7 @@ export const showCustomFolderModalPopup = async (
 	// Return a promise that resolves when the popup is done.
 	return new Promise<void>(resolve => {
 		// Create the modal popup React renderer.
-		const positronModalPopupReactRenderer = new PositronModalPopupReactRenderer(container);
+		const positronModalPopupReactRenderer = new PositronModalPopupReactRenderer(containerElement);
 
 		// The modal popup component.
 		const ModalPopup = () => {
@@ -54,10 +54,12 @@ export const showCustomFolderModalPopup = async (
 			// Render.
 			return (
 				<PositronModalPopup
+					containerElement={containerElement}
 					anchorElement={anchorElement}
 					popupPosition='bottom'
 					popupAlignment='right'
-					width={275}
+					minWidth={275}
+					width={'max-content'}
 					height={'min-content'}
 					onDismiss={() => dismiss()}
 				>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderRecentlyUsedMenuItem.css
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderRecentlyUsedMenuItem.css
@@ -32,8 +32,13 @@
 }
 
 .custom-folder-recently-used-menu-item .title {
-	display: flex;
-	padding: 10px;
+	display: block;
+	max-width: 100%;
+	max-width: 600px;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	padding: 10px 5px 10px 10px;
 }
 
 .custom-folder-recently-used-menu-item .open-in-new-window {

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderRecentlyUsedMenuItem.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderRecentlyUsedMenuItem.tsx
@@ -25,11 +25,11 @@ export const CustomFolderRecentlyUsedMenuItem = (props: CustomFolderRecentlyUsed
 	// Render.
 	return (
 		<PositronButton className='custom-folder-recently-used-menu-item' onClick={props.onOpen}>
-			<div className='title'>
+			<div className='title' title={props.label}>
 				{props.label}
 			</div>
 			<PositronButton className='open-in-new-window' onClick={props.onOpenInNewWindow}>
-				<div className='codicon codicon-positron-open-in-new-window' />
+				<div className='codicon codicon-positron-open-in-new-window' title={props.label} />
 			</PositronButton>
 		</PositronButton>
 	);

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpretersManagerModalPopup.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpretersManagerModalPopup.tsx
@@ -12,7 +12,7 @@ import { ILanguageRuntime, ILanguageRuntimeService } from 'vs/workbench/services
 /**
  * Shows the interpreters manager modal popup.
  * @param languageRuntimeService The language runtime service.
- * @param container The container of the application.
+ * @param containerElement The container element.
  * @param anchorElement The anchor element for the modal popup.
  * @param onStartRuntime The start runtime event handler.
  * @param onActivateRuntime The activate runtime event handler.
@@ -20,7 +20,7 @@ import { ILanguageRuntime, ILanguageRuntimeService } from 'vs/workbench/services
  */
 export const showInterpretersManagerModalPopup = async (
 	languageRuntimeService: ILanguageRuntimeService,
-	container: HTMLElement,
+	containerElement: HTMLElement,
 	anchorElement: HTMLElement,
 	onStartRuntime: (runtime: ILanguageRuntime) => Promise<void>,
 	onActivateRuntime: (runtime: ILanguageRuntime) => Promise<void>
@@ -28,7 +28,7 @@ export const showInterpretersManagerModalPopup = async (
 	// Return a promise that resolves when the popup is done.
 	return new Promise<void>(resolve => {
 		// Create the modal popup React renderer.
-		const positronModalPopupReactRenderer = new PositronModalPopupReactRenderer(container);
+		const positronModalPopupReactRenderer = new PositronModalPopupReactRenderer(containerElement);
 
 		// The modal popup component.
 		const ModalPopup = () => {
@@ -55,6 +55,7 @@ export const showInterpretersManagerModalPopup = async (
 			// Render.
 			return (
 				<PositronModalPopup
+					containerElement={containerElement}
 					anchorElement={anchorElement}
 					popupPosition='bottom'
 					popupAlignment='right'


### PR DESCRIPTION
This PR allows modal popups to have a dynamic width and be anchored on the right. It also updates the custom folder modal popup to have a dynamic width.

The normal (minimum) width of the custom folder modal popup:

![image](https://github.com/posit-dev/positron/assets/853239/e0e3cd0f-f3d5-40e6-9cd5-1e7905499378)

![image](https://github.com/posit-dev/positron/assets/853239/5eb5e8b6-7cb0-42c4-b182-d2282c28ee96)

A wider dynamic width of the custom folder modal popup:

![image](https://github.com/posit-dev/positron/assets/853239/0f00021f-0a60-4a76-8706-a6ba6dc12c66)

A still wider dynamic width of the custom folder modal popup:

![image](https://github.com/posit-dev/positron/assets/853239/4eda92de-6d87-4dd7-b49d-5eb81f498f60)

The maximum dynamic width of the custom folder modal popup:

![image](https://github.com/posit-dev/positron/assets/853239/9025215c-1dc3-4b57-a593-6151d67971e9)

(Note the ellipsis on the top folder name.)