### PR TITLE
Revert back to list view for SCM by default

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -238,10 +238,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 				localize('scm.defaultViewMode.list', "Show the repository changes as a list.")
 			],
 			description: localize('scm.defaultViewMode', "Controls the default Source Control repository view mode."),
-			// --- Start Positron ---
-			// default: 'list'
-			default: 'tree'
-			// --- End Positron ---
+			default: 'list'
 		},
 		'scm.defaultViewSortKey': {
 			type: 'string',


### PR DESCRIPTION
Feedback requests that we go back to the original default as 'list' view for SCM changes.

It is simple for users to toggle to tree view if they wish.

This reverts the change requested in #1374 

