### PR TITLE
Remove ruler display from ConsoleInput component

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -415,6 +415,9 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 					useShadows: false
 				},
 				overviewRulerLanes: 0,
+				// This appears to disable the ruler.
+				// https://github.com/posit-dev/positron/issues/1080
+				rulers: [],
 				scrollBeyondLastLine: false,
 				// This appears to disable validations to address:
 				// https://github.com/posit-dev/positron/issues/979


### PR DESCRIPTION
Does what it says on the tin!

<img width="1482" alt="image" src="https://github.com/posit-dev/positron/assets/853239/0f7aa32a-d29e-49dd-b5f2-285d82f54c20">
