### PR TITLE
Push ark developer options before the `--`

### DIFF
--- a/extensions/positron-r/src/startup.ts
+++ b/extensions/positron-r/src/startup.ts
@@ -24,8 +24,15 @@ export class ArkAttachOnStartup {
 
 		fs.writeFileSync(this._delayFile!, 'create\n');
 
-		args.push('--startup-notifier-file');
-		args.push(this._delayFile);
+		// Push before the `--`, if there is one, because that is a catch all that forwards
+		// everything after it straight to R
+		let loc = args.findIndex((elt) => elt === '--');
+
+		if (loc === -1) {
+			loc = args.length;
+		}
+
+		args.splice(loc, 0, '--startup-notifier-file', this._delayFile);
 	}
 
 	// This is paired with `init()` and disposes of created resources
@@ -51,7 +58,14 @@ export class ArkDelayStartup {
 	// Add `--startup-delay` argument to pass a delay in
 	// seconds before starting up the kernel
 	init(args: Array<String>, delay: number) {
-		args.push('--startup-delay');
-		args.push(delay.toString());
+		// Push before the `--`, if there is one, because that is a catch all that forwards
+		// everything after it straight to R
+		let loc = args.findIndex((elt) => elt === '--');
+
+		if (loc === -1) {
+			loc = args.length;
+		}
+
+		args.splice(loc, 0, '--startup-delay', delay.toString());
 	}
 }


### PR DESCRIPTION
When we added support for the `--` catch all that passed all args after it on to R, we accidentally nuked our ark debug features that allowed us to start the debugger on attach / pause for a delay. This is because we ended up pushing those debug command line options _after_ the `--`, so they got swallowed up and passed on to R, who silently (?) ignored them.

https://github.com/posit-dev/positron/assets/19150088/60f5034b-d97c-4a48-9d47-74870ee47305

