### PR TITLE
`rawLog` option for `OutputChannel` to colourise the Ark log

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -299,7 +299,8 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			// Establish a log channel for the kernel we're connecting to, if we
 			// don't already have one (we will if we're restarting)
 			if (!this._logChannel) {
-				this._logChannel = vscode.window.createOutputChannel(`Runtime: ${this._spec.display_name}`);
+				// @ts-ignore - Hidden API entry
+				this._logChannel = vscode.window.createRawLogOutputChannel(`Runtime: ${this._spec.display_name}`);
 			}
 
 			// Bind to the Jupyter session
@@ -322,7 +323,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			// file.
 			const logFilePath = this._session!.state.logFile;
 			if (fs.existsSync(logFilePath)) {
-				this.streamLogFileToChannel(logFilePath, this._spec.language, this._logChannel);
+				this.streamLogFileToChannel(logFilePath, this._spec.language, this._logChannel!);
 			}
 
 			// Connect to the kernel's sockets; wait for all sockets to connect before continuing

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -299,8 +299,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			// Establish a log channel for the kernel we're connecting to, if we
 			// don't already have one (we will if we're restarting)
 			if (!this._logChannel) {
-				// @ts-ignore - Hidden API entry
-				this._logChannel = vscode.window.createRawLogOutputChannel(`Runtime: ${this._spec.display_name}`);
+				this._logChannel = positron.window.createRawLogOutputChannel(`Runtime: ${this._spec.display_name}`);
 			}
 
 			// Bind to the Jupyter session
@@ -323,7 +322,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			// file.
 			const logFilePath = this._session!.state.logFile;
 			if (fs.existsSync(logFilePath)) {
-				this.streamLogFileToChannel(logFilePath, this._spec.language, this._logChannel!);
+				this.streamLogFileToChannel(logFilePath, this._spec.language, this._logChannel);
 			}
 
 			// Connect to the kernel's sockets; wait for all sockets to connect before continuing

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -775,6 +775,20 @@ declare module 'positron' {
 		 * @return New preview panel.
 		 */
 		export function createPreviewPanel(viewType: string, title: string, preserveFocus?: boolean, options?: PreviewOptions): PreviewPanel;
+
+		/**
+		 * Create a log output channel from raw data.
+		 *
+		 * Variant of `createOutputChannel()` that creates a "raw log" output channel.
+		 * Compared to a normal `LogOutputChannel`, this doesn't add timestamps or info
+		 * level. It's meant for extensions that create fully formed log lines but still
+		 * want to benefit from the colourised rendering of log output channels.
+		 *
+		 * @param name Human-readable string which will be used to represent the channel in the UI.
+		 *
+		 * @return New log output channel.
+		 */
+		export function createRawLogOutputChannel(name: string): vscode.OutputChannel;
 	}
 
 	namespace runtime {

--- a/src/vs/platform/log/node/spdlogLog.ts
+++ b/src/vs/platform/log/node/spdlogLog.ts
@@ -101,6 +101,15 @@ export class SpdLogLogger extends AbstractMessageLogger implements ILogger {
 		}
 	}
 
+	// --- Start Positron ---
+	// Override pattern to avoid adding timestamps etc
+	public setRawLogger() {
+		this._loggerCreationPromise.then(() => {
+			this._logger!.setPattern('%v');
+		});
+	}
+	// --- End Positron ---
+
 	protected log(level: LogLevel, message: string): void {
 		if (this._logger) {
 			log(this._logger, level, message);

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -762,6 +762,13 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			createOutputChannel(name: string, options: string | { log: true } | undefined): any {
 				return extHostOutputService.createOutputChannel(name, options, extension);
 			},
+			// --- Start Positron ---
+			// This is a hidden API entry, don't expect it in the public `vscode.window`
+			// @ts-ignore
+			createRawLogOutputChannel(name: string): any {
+				return extHostOutputService.createRawLogOutputChannel(name, extension);
+			},
+			// --- End Positron ---
 			createWebviewPanel(viewType: string, title: string, showOptions: vscode.ViewColumn | { viewColumn: vscode.ViewColumn; preserveFocus?: boolean }, options?: vscode.WebviewPanelOptions & vscode.WebviewOptions): vscode.WebviewPanel {
 				return extHostWebviewPanels.createWebviewPanel(extension, viewType, title, showOptions, options);
 			},

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -762,13 +762,6 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			createOutputChannel(name: string, options: string | { log: true } | undefined): any {
 				return extHostOutputService.createOutputChannel(name, options, extension);
 			},
-			// --- Start Positron ---
-			// This is a hidden API entry, don't expect it in the public `vscode.window`
-			// @ts-ignore
-			createRawLogOutputChannel(name: string): any {
-				return extHostOutputService.createRawLogOutputChannel(name, extension);
-			},
-			// --- End Positron ---
 			createWebviewPanel(viewType: string, title: string, showOptions: vscode.ViewColumn | { viewColumn: vscode.ViewColumn; preserveFocus?: boolean }, options?: vscode.WebviewPanelOptions & vscode.WebviewOptions): vscode.WebviewPanel {
 				return extHostWebviewPanels.createWebviewPanel(extension, viewType, title, showOptions, options);
 			},

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -18,6 +18,7 @@ import { ExtHostContext } from 'vs/workbench/api/common/extHost.protocol';
 import { IExtHostWorkspace } from 'vs/workbench/api/common/extHostWorkspace';
 import { ExtHostWebviews } from 'vs/workbench/api/common/extHostWebview';
 import { ExtHostLanguageFeatures } from 'vs/workbench/api/common/extHostLanguageFeatures';
+import { ExtHostOutputService } from 'vs/workbench/api/common/extHostOutput';
 
 /**
  * Factory interface for creating an instance of the Positron API.
@@ -45,10 +46,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 	// VS Code API can share a single instance of `ExtHostWebViews`, which is
 	// necessary since the instance effectively needs to be a singleton.
 	const extHostWebviews: ExtHostWebviews = rpcProtocol.getRaw(ExtHostContext.ExtHostWebviews);
-	if (!extHostWebviews) {
-		throw new Error('Could not retrieve ExtHostWebviews from the RPC protocol. ' +
-			' The VS Code API must be created before the Positron API.');
-	}
+	const extHostOutputService: ExtHostOutputService = rpcProtocol.getRaw(ExtHostContext.ExtHostOutputService);
 
 	// Same deal for the `ExtHostLanguageFeatures` object
 	const extHostLanguageFeatures: ExtHostLanguageFeatures =
@@ -87,6 +85,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 		const window: typeof positron.window = {
 			createPreviewPanel(viewType: string, title: string, preserveFocus?: boolean, options?: vscode.WebviewPanelOptions & vscode.WebviewOptions) {
 				return extHostPreviewPanels.createPreviewPanel(extension, viewType, title, preserveFocus, options);
+			},
+			createRawLogOutputChannel(name: string): vscode.OutputChannel {
+				return extHostOutputService.createRawLogOutputChannel(name, extension);
 			}
 		};
 

--- a/src/vs/workbench/services/extensions/common/rpcProtocol.ts
+++ b/src/vs/workbench/services/extensions/common/rpcProtocol.ts
@@ -256,7 +256,8 @@ export class RPCProtocol extends Disposable implements IRPCProtocol {
 	 */
 	public getRaw<T, R extends T>(identifier: ProxyIdentifier<T>): R {
 		if (!this._locals[identifier.nid]) {
-			throw new Error(`Missing actor ${identifier.sid}`);
+			throw new Error(`Missing actor ${identifier.sid}.` +
+				' The VS Code API must be created before the Positron API.');
 		}
 		return this._locals[identifier.nid];
 	}


### PR DESCRIPTION
I would like to have colourised output in our Ark log because it is currently hard to read. VS Code doesn't support ansi escapes in output channels (see wontfix issue https://github.com/microsoft/vscode/issues/571) but it does colourise output channels that are created with `log: true`.

We can't do the latter option however because that automatically adds timestamps (which we already add elsewhere) and misleading `[info]` tags. I found a way to prevent VS Code from adding these with a new option. Using this, the Ark output becomes much more readable:

https://github.com/posit-dev/positron/assets/4465050/7bf4dfde-929b-41bc-a2c0-3c378bc5ca89


However this requires changing a bunch of VS Code signatures to thread the option in. Is this too much @jmcphers?
