### PR TITLE
Handle capping of fetchSize before sending row requests

### DIFF
--- a/extensions/positron-data-viewer/ui/src/DataModel.ts
+++ b/extensions/positron-data-viewer/ui/src/DataModel.ts
@@ -57,7 +57,7 @@ export class DataModel {
 		});
 		return {
 			rowStart: start,
-			rowEnd: Math.min(start + size - 1, this.rowCount - 1),
+			rowEnd: start + size - 1,
 			columns: columns
 		};
 	}

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -91,6 +91,8 @@ export const DataPanel = (props: DataPanelProps) => {
 	async function fetchNextDataFragment(pageParam: number, fetchSize: number): Promise<DataFragment> {
 		// Fetches a single page of data from the data model.
 		const startRow = pageParam * fetchSize;
+		// Overwrite fetchSize so that we never request rows past the end of the dataset
+		fetchSize = Math.min(fetchSize, totalRows - startRow);
 
 		// Let the server know we are requesting more rows
 		if (startRow > 0) {


### PR DESCRIPTION
Addresses #1585  

Javascript and Python gracefully handle slices where the end index exceeds the actual length of the data. Rust however panics and throws an error in the console. This means if we try to fetch 100 rows when there are only 50 left, the frontend is fine with it, Python is fine with it, but R is not. Rather than relying on this language behavior or adding a language specific fix in ark, we can just handle this on the frontend, before sending a request to the backend and before calling `loadDataFragment`.

One thing to note, because we're handling this in `fetchNextDataFragment`, this only is relevant for subsequent batches of data where the rows remaining is less than fetch size (e.g. rows 100-149 where fetch size = 100). This doesn't help if the initial batch of data is already smaller than fetch size (e.g. a 50 row dataset where fetch size = 100). However, this case is already being handled in [Zed](https://github.com/posit-dev/positron/blob/27110c9f193aa0e1cd744824a717ec3027686a8a/extensions/positron-zed/src/positronZedData.ts#L61-L63), [Python](https://github.com/posit-dev/positron-python/blob/f5f5084482a23713689f27c4ed822ca827299536/pythonFiles/positron/dataviewer.py#L50-L52), and [R](https://github.com/posit-dev/amalthea/blob/e4e8601ff78e9e72e0cf67e51278ee8acd313dc2/crates/ark/src/data_viewer/r_data_viewer.rs#L230-L232) by returning early, so we're already covered in that case