### PR TITLE
Don't hide panel when last terminal is killed

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -410,9 +410,6 @@ export interface ITerminalGroupService extends ITerminalInstanceHost {
 	setContainer(container: HTMLElement): void;
 
 	showPanel(focus?: boolean): Promise<void>;
-	// --- Start Positron ---
-	switchToPositronConsole?: () => Promise<void>;
-	// --- End Positron ---
 	hidePanel(): void;
 	focusTabs(): void;
 	focusHover(): void;

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -1246,13 +1246,6 @@ export function registerTerminalActions() {
 		if (c.groupService.instances.length > 0) {
 			await c.groupService.showPanel(true);
 		}
-		// --- Start Positron ---
-		// Switch to Console if last terminal is killed
-		// https://github.com/posit-dev/positron/issues/1458
-		else {
-			await c.groupService.switchToPositronConsole!();
-		}
-		// --- End Positron ---
 	}
 	registerTerminalAction({
 		id: TerminalCommandId.Kill,

--- a/src/vs/workbench/contrib/terminal/browser/terminalGroupService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalGroupService.ts
@@ -3,10 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// --- Start Positron ---
-import { POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
-// --- End Positron ---
-
 import { Orientation } from 'vs/base/browser/ui/sash/sash';
 import { timeout } from 'vs/base/common/async';
 import { Emitter, Event } from 'vs/base/common/event';
@@ -86,25 +82,6 @@ export class TerminalGroupService extends Disposable implements ITerminalGroupSe
 			TerminalContextKeys.tabsMouse.bindTo(this._contextKeyService).set(false);
 		}
 	}
-
-	// --- Start Positron ---
-	// Switch to Console pane but only if in the same viewpane
-	async switchToPositronConsole(): Promise<void> {
-		const consoleViewContainer = this._viewDescriptorService.getViewContainerByViewId(POSITRON_CONSOLE_VIEW_ID);
-		const terminalViewContainer = this._viewDescriptorService.getViewContainerByViewId(TERMINAL_VIEW_ID);
-
-		if (!consoleViewContainer || !terminalViewContainer) {
-			return;
-		}
-
-		const consoleViewLocation = this._viewDescriptorService.getViewContainerLocation(consoleViewContainer);
-		const terminalViewLocation = this._viewDescriptorService.getViewContainerLocation(terminalViewContainer);
-
-		if (consoleViewLocation === terminalViewLocation) {
-			await this._viewsService.openView(POSITRON_CONSOLE_VIEW_ID, false);
-		}
-	}
-	// --- End Positron ---
 
 	get activeGroup(): ITerminalGroup | undefined {
 		if (this.activeGroupIndex < 0 || this.activeGroupIndex >= this.groups.length) {

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -212,6 +212,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 			// This prevents hiding the panel along with the Console, which would
 			// confuse users.
 			if (!instance) {
+				this._terminalShellTypeContextKey.reset();
 				return;
 			}
 			// --- End Positron ---

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -207,6 +207,14 @@ export class TerminalService extends Disposable implements ITerminalService {
 		// down. When shutting down the panel is locked in place so that it is restored upon next
 		// launch.
 		this._terminalGroupService.onDidChangeActiveInstance(instance => {
+			// --- Start Positron ---
+			// Don't hide panel or reset context key when last terminal is hidden.
+			// This prevents hiding the panel along with the Console, which would
+			// confuse users.
+			if (!instance) {
+				return;
+			}
+			// --- End Positron ---
 			if (!instance && !this._isShuttingDown) {
 				this._terminalGroupService.hidePanel();
 			}


### PR DESCRIPTION
Addresses #1458.

Reverts #1475 because @DavisVaughan found edge cases (see linked issue) where it doesn't work as it should. Instead we just don't hide the panel when the last terminal is killed.