### PR TITLE
Handle `""` separately from `undefined` in `StatementRangeProvider`

### DIFF
--- a/extensions/positron-r/src/statement-range.ts
+++ b/extensions/positron-r/src/statement-range.ts
@@ -51,7 +51,9 @@ export class RStatementRangeProvider implements positron.StatementRangeProvider 
 				return undefined;
 			}
 			const range = this._client.protocol2CodeConverter.asRange(data.range);
-			return { range: range, code: data.code } as positron.StatementRange;
+			// Explicitly normalize non-strings to `undefined` (i.e. a possible `null`)
+			const code = typeof data.code === 'string' ? data.code : undefined;
+			return { range: range, code: code } as positron.StatementRange;
 		});
 	}
 }


### PR DESCRIPTION
Merges into https://github.com/posit-dev/positron/pull/1627

The diff looks more annoying than it is. The 3rd commit removes 1 layer of nesting that is no longer needed since we know `code` is _definitely_ a string at that point, so you could just look at the 2nd commit and mostly ignore that.

---

When working on https://github.com/posit-dev/amalthea/pull/126 I learned that if the statement range provider returns `""` back then it basically gets ignored on the Positron side and we try and execute the current line instead. This is problematic for stepping through roxygen2 lines. Because it steps through the roxygen2 lines one at a time you are bound to hit empty `#'` lines where the leading `#'` gets stripped, leaving you with `""` which we send back as `code`, but we _do_ want this to be respected, as otherwise Positron tries to run the current line containing the full `#'`. This makes executing something like:

```r
#' function() {
#'    x <- 1
#'    
#'    x
#' }  
```

particularly annoying because it will send a `#'` when you are in the middle of executing the function one line at a time.

I've changed the execute statement code so that it defaults the `code` to `undefined` rather than `""` and now respects _anything_ the range provider returns, even `""`.