### PR TITLE
1644 help focus lost when help is shown

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
@@ -618,7 +618,7 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 	readonly onDidStopFind = this._onDidStopFindEmitter.event;
 
 	/**
-	 * Finds the valye.
+	 * Finds the value.
 	 * @param value The value to find.
 	 * @param previous A value which indicates whether to find previous.
 	 */

--- a/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
@@ -674,11 +674,7 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 	 * Focus.
 	 */
 	public focus() {
-		if (this._helpOverlayWebview) {
-			this._helpOverlayWebview.postMessage({
-				id: 'positron-help-focus'
-			});
-		}
+		// NOOP to fix https://github.com/posit-dev/positron/issues/1644.
 	}
 
 	//#endregion WebviewFindDelegate Implementation


### PR DESCRIPTION
This PR addresses #1644.

In the initial implementation of the `WebviewFindDelegate` in `HelpEntry`, we were shifting focus into the help overlay webview when the `focus` method of the delegate was called. This was causing focus to get ripped away from whatever view caused the help topic to be displayed. It turns out that this was unnecessary because this method is only called when the `WebviewFindWidget` is hidden and we don't need to / want to shift focus anywhere in this case. This was the best fix.