### PR TITLE
Add history entry on every code execution

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -135,28 +135,6 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				break;
 		}
 
-		// If the code fragment isn't just whitespace characters, and it's not a duplicate, add it
-		// to the history navigator.
-		if (code.trim().length) {
-			// Creates an IInputHistoryEntry.
-			const createInputHistoryEntry = (): IInputHistoryEntry => ({
-				when: new Date().getTime(),
-				input: code,
-			});
-
-			// Add the history entry, if it's not a duplicate.
-			if (!historyNavigatorRef.current) {
-				setHistoryNavigator(new HistoryNavigator2<IInputHistoryEntry>(
-					[createInputHistoryEntry()],
-					1000
-				));
-			} else {
-				if (historyNavigatorRef.current.last().input !== code) {
-					historyNavigatorRef.current.add(createInputHistoryEntry());
-				}
-			}
-		}
-
 		// Execute the code.
 		props.positronConsoleInstance.executeCode(code);
 
@@ -580,20 +558,48 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			codeEditorWidget.focus();
 		}));
 
-		// Add the onDidSetCode event handler.
+		// Add the onDidSetPendingCode event handler.
 		disposableStore.add(props.positronConsoleInstance.onDidSetPendingCode(pendingCode => {
 			codeEditorWidget.setValue(pendingCode || '');
 			updateCodeEditorWidgetPosition(Position.Last, Position.Last);
 		}));
 
-		// Add the onDidReceiveRuntimeMessagePromptConfig event handler.
-		disposableStore.add(props.positronConsoleInstance.runtime.onDidReceiveRuntimeMessagePromptConfig(() => {
-			// Update just the line number options.
-			codeEditorWidget.updateOptions(createLineNumbersOptions());
+		// Add the onDidExecuteCode event handler.
+		disposableStore.add(props.positronConsoleInstance.onDidExecuteCode(code => {
+			// Trim the code. If it isn't empty, or a duplicate of the last history entry, add it to
+			// the history.
+			const trimmedCode = code.trim();
+			if (trimmedCode.length) {
+				// Creates an IInputHistoryEntry.
+				const createInputHistoryEntry = (): IInputHistoryEntry => ({
+					when: new Date().getTime(),
+					input: trimmedCode,
+				});
 
-			// Render the code editor widget.
-			codeEditorWidget.render(true);
+				// Add the history entry, if it's not a duplicate.
+				if (!historyNavigatorRef.current) {
+					setHistoryNavigator(new HistoryNavigator2<IInputHistoryEntry>(
+						[createInputHistoryEntry()],
+						1000
+					));
+				} else {
+					if (historyNavigatorRef.current.last().input !== code) {
+						historyNavigatorRef.current.add(createInputHistoryEntry());
+					}
+				}
+			}
 		}));
+
+		// Add the onDidReceiveRuntimeMessagePromptConfig event handler.
+		disposableStore.add(
+			props.positronConsoleInstance.runtime.onDidReceiveRuntimeMessagePromptConfig(() => {
+				// Update just the line number options.
+				codeEditorWidget.updateOptions(createLineNumbersOptions());
+
+				// Render the code editor widget.
+				codeEditorWidget.render(true);
+			})
+		);
 
 		// Focus the console.
 		codeEditorWidget.focus();

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -274,7 +274,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 		}));
 
 		// Add the onDidExecuteCode event handler.
-		disposableStore.add(props.positronConsoleInstance.onDidExecuteCode(() => {
+		disposableStore.add(props.positronConsoleInstance.onDidExecuteCode(_code => {
 			scrollVertically(consoleInstanceRef.current.scrollHeight);
 		}));
 

--- a/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
@@ -159,7 +159,7 @@ export interface IPositronConsoleInstance {
 	/**
 	 * The onDidExecuteCode event.
 	 */
-	readonly onDidExecuteCode: Event<void>;
+	readonly onDidExecuteCode: Event<string>;
 
 	/**
 	 * The onDidSelectPlot event.

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -540,7 +540,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	/**
 	 * The onDidExecuteCode event emitter.
 	 */
-	private readonly _onDidExecuteCodeEmitter = this._register(new Emitter<void>);
+	private readonly _onDidExecuteCodeEmitter = this._register(new Emitter<string>);
 
 	/**
 	 * The onDidSelectPlot event emitter.
@@ -1701,14 +1701,14 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					RuntimeErrorBehavior.Continue);
 
 				// Fire the onDidExecuteCode event.
-				this._onDidExecuteCodeEmitter.fire();
+				this._onDidExecuteCodeEmitter.fire(codeFragment);
 
 				// Return.
 				return;
 			}
 		}
 
-		// Fire the onDidExecuteCode event because we removed the pending input runtime item.
+		// Fire the onDidChangeRuntimeItems event because we removed the pending input runtime item.
 		this._onDidChangeRuntimeItemsEmitter.fire();
 
 		// The pending input line(s) now become the pending code.
@@ -1747,7 +1747,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			RuntimeErrorBehavior.Continue);
 
 		// Fire the onDidExecuteCode event.
-		this._onDidExecuteCodeEmitter.fire();
+		this._onDidExecuteCodeEmitter.fire(code);
 	}
 
 	/**


### PR DESCRIPTION
This PR updates how history entries are added in the `ConsoleInput` component. Now, every code execution, regardless of where it originated, gets added to `ConsoleInput`'s history navigator.