### PR TITLE
Implement quick suggest on `Tab`

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -559,6 +559,13 @@ export interface IEditorOptions {
 	 * Enable tab completion.
 	 */
 	tabCompletion?: 'on' | 'off' | 'onlySnippets';
+	// --- Start Positron ---
+	/**
+	 * Controls whether tab triggers quick suggestions.
+	 * Ignored if `tabCompletion` or `tabFocusMode` are enabled.
+	 */
+	tabSuggest?: 'on' | 'off';
+	// --- End Positron ---
 	/**
 	 * Enable selection highlight.
 	 * Defaults to true.
@@ -5182,7 +5189,8 @@ export const enum EditorOption {
 	inlineCompletionsAccessibilityVerbose,
 	// --- Start Positron ---
 	// Placed at the end to limit merge conflicts in the generated files
-	quickSuggestionsMinimumLength
+	quickSuggestionsMinimumLength,
+	tabSuggest
 	// --- End Positron ---
 }
 
@@ -5837,6 +5845,20 @@ export const EditorOptions = {
 			description: nls.localize('tabCompletion', "Enables tab completions.")
 		}
 	)),
+	// --- Start Positron ---
+	tabSuggest: register(new EditorStringEnumOption(
+		EditorOption.tabSuggest, 'tabSuggest',
+		'on' as 'on' | 'off',
+		['on', 'off'] as const,
+		{
+			enumDescriptions: [
+				nls.localize('tabSuggest.on', "Tab will trigger quick suggestions."),
+				nls.localize('tabSuggest.off', "Tab will not trigger quick suggestions.")
+			],
+			description: nls.localize('tabSuggest', "Controls whether tab triggers quick suggestions. Ignored if tab completions or tab focus mode are enabled.")
+		}
+	)),
+	// --- End Positron ---
 	tabIndex: register(new EditorIntOption(
 		EditorOption.tabIndex, 'tabIndex',
 		0, -1, Constants.MAX_SAFE_SMALL_INTEGER

--- a/src/vs/editor/common/standalone/standaloneEnums.ts
+++ b/src/vs/editor/common/standalone/standaloneEnums.ts
@@ -321,7 +321,8 @@ export enum EditorOption {
 	defaultColorDecorators = 145,
 	colorDecoratorsActivatedOn = 146,
 	inlineCompletionsAccessibilityVerbose = 147,
-	quickSuggestionsMinimumLength = 148
+	quickSuggestionsMinimumLength = 148,
+	tabSuggest = 149
 }
 
 /**

--- a/src/vs/editor/contrib/suggest/browser/tabSuggestContextKey.ts
+++ b/src/vs/editor/contrib/suggest/browser/tabSuggestContextKey.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable } from 'vs/base/common/lifecycle';
+import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
+import { EditorOption } from 'vs/editor/common/config/editorOptions';
+import { IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+
+export class TabSuggestContextKey {
+
+	static readonly InTabSuggestContext = new RawContextKey<boolean>('inTabSuggestContext', false);
+
+	private readonly _ckInTabSuggestContext: IContextKey<boolean>;
+	private readonly _configListener: IDisposable;
+
+	private _enabled: boolean = false;
+	private _selectionListener?: IDisposable;
+
+	constructor(
+		private readonly _editor: ICodeEditor,
+		@IContextKeyService contextKeyService: IContextKeyService,
+	) {
+
+		this._ckInTabSuggestContext = TabSuggestContextKey.InTabSuggestContext.bindTo(contextKeyService);
+		this._configListener = this._editor.onDidChangeConfiguration(e => e.hasChanged(EditorOption.tabSuggest) && this._update());
+		this._update();
+	}
+
+	dispose(): void {
+		this._configListener.dispose();
+		this._selectionListener?.dispose();
+		this._ckInTabSuggestContext.reset();
+	}
+
+	private _update(): void {
+		// only update this when suggest on tab is enabled
+		const enabled = this._editor.getOption(EditorOption.tabSuggest) === 'on';
+		if (this._enabled === enabled) {
+			return;
+		}
+		this._enabled = enabled;
+
+		if (this._enabled) {
+			const checkForInTabSuggestContext = () => {
+				if (!this._editor.hasModel()) {
+					this._ckInTabSuggestContext.set(false);
+					return;
+				}
+
+				const model = this._editor.getModel();
+				const selection = this._editor.getSelection();
+
+				if (!selection.isEmpty()) {
+					// User selected some text, probably wants an actual tab
+					this._ckInTabSuggestContext.set(false);
+					return;
+				}
+
+				const position = selection.getStartPosition();
+				const leadingText = model.getLineContent(position.lineNumber).substring(0, position.column - 1);
+
+				if (leadingText.trim().length === 0) {
+					// Leading text is all whitespace characters,
+					// user likely wants to insert one or more tabs
+					this._ckInTabSuggestContext.set(false);
+					return;
+				}
+
+				this._ckInTabSuggestContext.set(true);
+			};
+			this._selectionListener = this._editor.onDidChangeCursorSelection(checkForInTabSuggestContext);
+			checkForInTabSuggestContext();
+		} else if (this._selectionListener) {
+			this._ckInTabSuggestContext.reset();
+			this._selectionListener.dispose();
+			this._selectionListener = undefined;
+		}
+	}
+}

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3527,6 +3527,11 @@ declare namespace monaco.editor {
 		 */
 		tabCompletion?: 'on' | 'off' | 'onlySnippets';
 		/**
+		 * Controls whether tab triggers quick suggestions.
+		 * Ignored if `tabCompletion` or `tabFocusMode` are enabled.
+		 */
+		tabSuggest?: 'on' | 'off';
+		/**
 		 * Enable selection highlight.
 		 * Defaults to true.
 		 */
@@ -4853,7 +4858,8 @@ declare namespace monaco.editor {
 		defaultColorDecorators = 145,
 		colorDecoratorsActivatedOn = 146,
 		inlineCompletionsAccessibilityVerbose = 147,
-		quickSuggestionsMinimumLength = 148
+		quickSuggestionsMinimumLength = 148,
+		tabSuggest = 149
 	}
 
 	export const EditorOptions: {
@@ -4985,6 +4991,7 @@ declare namespace monaco.editor {
 		suggestOnTriggerCharacters: IEditorOption<EditorOption.suggestOnTriggerCharacters, boolean>;
 		suggestSelection: IEditorOption<EditorOption.suggestSelection, 'first' | 'recentlyUsed' | 'recentlyUsedByPrefix'>;
 		tabCompletion: IEditorOption<EditorOption.tabCompletion, 'on' | 'off' | 'onlySnippets'>;
+		tabSuggest: IEditorOption<EditorOption.tabSuggest, 'on' | 'off'>;
 		tabIndex: IEditorOption<EditorOption.tabIndex, number>;
 		unicodeHighlight: IEditorOption<EditorOption.unicodeHighlighting, any>;
 		unusualLineTerminators: IEditorOption<EditorOption.unusualLineTerminators, 'auto' | 'off' | 'prompt'>;


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/1166

New `tabSuggest` editor option that allows `"on"` or `"off"` (using an enum like `tabCompletion` now does, it was a boolean but they got a 3rd option of `onlySnippets` and I want to avoid any backwards compat weirdness if we also get more options in the future).

Defaults to `"on"` because I think we pretty much all want this. I think it is starting to feel _really_ good.

- Respects `Tab Completions`, a new ish VS Code feature that actually inserts the top quick suggest suggestion and then lets you tab your way through the remaining suggestions. We defer to `Tab Completions` if it is turned on by the user, it is off by default. These two features are at odds with each other.
- Respects `Tab Focus Mode`, an accessibility feature that allows the workbench to get `Tab` presses for navigation purposes. It is off by default.
- Respects tab in snippets, allowing you to bounce between snippet placeholders
- Respects selections, i.e. if you highlight part of a word and hit tab, you want an actual tab
- Respects the case of "no leading text", i.e. when there is no non-whitespace text on the line or if the line is `|foo()` with the cursor at the `|`, in which case we insert an actual tab

This ends up respecting most of the same cases that RStudio does, at least from some testing that I've been doing.

---

`tabSuggestContextKey.ts` is modeled after `wordContextKey.ts`, which is used to determine whether `tabCompletion` should be considered active or not. I also borrowed most of the `precondition`s from `insertBestCompletion` (i.e. tab completion) as well, since it has many of the same quirks about exactly when it should be active.
https://github.com/posit-dev/positron/blob/feature/tab-quick-suggest/src/vs/editor/contrib/suggest/browser/wordContextKey.ts
https://github.com/posit-dev/positron/blob/c70751092c5110c9d9665ea4d720dae433143e94/src/vs/editor/contrib/suggest/browser/suggestController.ts#L1049-L1067

---

Does _not_ currently handle the fact that `Tab` in the Console will move you _out_ of the Console when there is no text in the console. I think this should just work like RStudio and insert an actual tab character. It seems like a separate issue though.
https://github.com/posit-dev/positron/issues/1166#issuecomment-1731883180

---

Something I learned while tinkering is that VS Code actually does not respect Tab Focus Mode when Tab Completions is also set. It will prioritize Tab Completions instead. Based on the description of Tab Focus Mode, I think this is a bug. I think Tab Focus Mode should always have highest priority because it is an accessibility feature that seems to be quite important.