### PR TITLE
Fixes for console in the auxiliary bar

### DIFF
--- a/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
+++ b/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
@@ -19,7 +19,7 @@
 .monaco-workbench .part.auxiliarybar > .content .console-instance .console-input .monaco-editor,
 .monaco-workbench .part.auxiliarybar > .content .console-instance .console-input .monaco-editor .margin,
 .monaco-workbench .part.auxiliarybar > .content .console-instance .console-input .monaco-editor .monaco-editor-background {
-	background-color: var(--vscode-editor-background);
+	background-color: unset;
 }
 /* End Positron */
 

--- a/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
+++ b/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
@@ -14,6 +14,15 @@
 	background-color: var(--vscode-sideBar-background);
 }
 
+/* Start Positron */
+/* When the Console is in the auxiliary bar, set the background color to the editor background. */
+.monaco-workbench .part.auxiliarybar > .content .console-instance .console-input .monaco-editor,
+.monaco-workbench .part.auxiliarybar > .content .console-instance .console-input .monaco-editor .margin,
+.monaco-workbench .part.auxiliarybar > .content .console-instance .console-input .monaco-editor .monaco-editor-background {
+	background-color: var(--vscode-editor-background);
+}
+/* End Positron */
+
 .monaco-workbench .part.auxiliarybar > .title > .panel-switcher-container > .monaco-action-bar .action-item:hover .action-label,
 .monaco-workbench .part.auxiliarybar > .title > .panel-switcher-container > .monaco-action-bar .action-item:focus .action-label {
 	color: var(--vscode-sideBarTitle-foreground) !important;

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.css
@@ -8,7 +8,5 @@
 }
 
 .positron-console .console-core .console-instances-container {
-	left: 0;
-	top: 32px;
-	position: absolute;
+	position: relative;
 }


### PR DESCRIPTION
This PR fixes Console so that it will display properly in the auxiliary bar (Secondary Side Bar).

Here's how it looks with this PR:


<img width="2013" alt="image" src="https://github.com/posit-dev/positron/assets/853239/649f4513-8749-4073-9cae-ae7e3e112a26">


<img width="2013" alt="image" src="https://github.com/posit-dev/positron/assets/853239/df599002-3aea-4ccf-8c13-88030aa8bb02">


While fixing this issue, I found that Console's `CodeEditorWidget` had the wrong background color:

<img width="637" alt="image" src="https://github.com/posit-dev/positron/assets/853239/771e8732-7dbe-42ac-89db-980236ebb8e3">

To fix this, I added additional CSS to `src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css` so that it would have the right background color.