### PR TITLE
Make our Console aware of parameter hints

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -31,6 +31,7 @@ import { SelectionClipboardContributionID } from 'vs/workbench/contrib/codeEdito
 import { usePositronConsoleContext } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleContext';
 import { RuntimeCodeFragmentStatus } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IPositronConsoleInstance, PositronConsoleState } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
+import { ParameterHintsController } from 'vs/editor/contrib/parameterHints/browser/parameterHints';
 
 // Position enumeration.
 const enum Position {
@@ -446,6 +447,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 					TabCompletionController.ID,
 					ModesHoverController.ID,
 					MarkerController.ID,
+					ParameterHintsController.ID
 				])
 			}
 		);


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/582

I think we need to include this editor contribution in our Console, as parameter hints are pretty helpful when working there! I have certainly missed them.


https://github.com/posit-dev/positron/assets/19150088/dce1cf4b-72a6-4f19-ba44-0a4e0c65d03c

