### PR TITLE
Bump ark to 0.1.17 (pull in View hook)

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -456,7 +456,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.16"
+      "ark": "0.1.17"
     }
   }
 }


### PR DESCRIPTION
Bumping ark, this pulls in the change to register a `View()` hook in R for the Positron data viewer