### PR TITLE
Dev mode bundler in watch mode for data viewer

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -50,10 +50,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Set up Node 16; needed since the show-version.js script runs under Node
+      # Set up Node; needed since the show-version.js script runs under Node
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       # Call version script to determine short version. This is the version
       # string that we will use later to form the file name of the release

--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -230,7 +230,6 @@ const tasks = compilations.map(function (tsconfigFile) {
 		// Add '!**/*.tsx'.
 		const nonts = gulp.src(src, srcOpts).pipe(filter(['**', '!**/*.ts', '!**/*.tsx']));
 		// --- End Positron ---
-
 		const input = es.merge(nonts, pipeline.tsProjectSrc());
 		const watchInput = watcher(src, { ...srcOpts, ...{ readDelay: 200 } });
 

--- a/extensions/positron-data-viewer/extension.webpack.config.js
+++ b/extensions/positron-data-viewer/extension.webpack.config.js
@@ -7,7 +7,6 @@
 'use strict';
 
 const withDefaults = require('../shared.webpack.config');
-const path = require('path');
 
 module.exports = withDefaults({
 	context: __dirname,

--- a/extensions/positron-data-viewer/package.json
+++ b/extensions/positron-data-viewer/package.json
@@ -20,7 +20,7 @@
     "bundle-dev": "npx webpack-cli watch --mode development --config ./extension.webpack.config.js"
 	},
 	"devDependencies": {
-		"@types/node": "16.x",
+		"@types/node": "18.x",
 		"typescript": "^4.5.5"
 	},
 	"repository": {

--- a/extensions/positron-data-viewer/package.json
+++ b/extensions/positron-data-viewer/package.json
@@ -16,7 +16,8 @@
 	"main": "./out/extension.js",
 	"scripts": {
 		"compile": "npx gulp compile-extension:positron-data-viewer compile-extension:positron-data-viewer-ui",
-		"watch": "npx gulp watch-extension:positron-data-viewer watch-extension:positron-data-viewer-ui"
+		"watch": "npx gulp watch-extension:positron-data-viewer watch-extension:positron-data-viewer-ui",
+    "bundle-dev": "npx webpack-cli watch --mode development --config ./extension.webpack.config.js"
 	},
 	"devDependencies": {
 		"@types/node": "16.x",

--- a/extensions/positron-data-viewer/package.json
+++ b/extensions/positron-data-viewer/package.json
@@ -17,7 +17,7 @@
 	"scripts": {
 		"compile": "npx gulp compile-extension:positron-data-viewer compile-extension:positron-data-viewer-ui",
 		"watch": "npx gulp watch-extension:positron-data-viewer watch-extension:positron-data-viewer-ui",
-    "bundle-dev": "npx webpack-cli watch --mode development --config ./extension.webpack.config.js"
+    "bundle-dev": "npx webpack-cli watch --mode development --config ./extension.webpack.config.js --output-path ./out"
 	},
 	"devDependencies": {
 		"@types/node": "18.x",

--- a/extensions/positron-data-viewer/src/dataPanel.ts
+++ b/extensions/positron-data-viewer/src/dataPanel.ts
@@ -30,7 +30,6 @@ export async function createDataPanel(context: vscode.ExtensionContext,
 	const indexJs = path.join(context.extensionPath, 'ui', 'dist', 'index.js');
 	const fs = require('fs');
 	const productionMode = fs.existsSync(indexJs);
-	console.log(`productionMode: ${productionMode}`);
 
 	// Get a list of all the script files in the extension's ui/out or ui/dist folder and
 	// add them to the list of scripts to load in the webview

--- a/extensions/positron-data-viewer/src/dataPanel.ts
+++ b/extensions/positron-data-viewer/src/dataPanel.ts
@@ -27,41 +27,11 @@ export async function createDataPanel(context: vscode.ExtensionContext,
 		}
 	);
 
-	// Check for the 'index.js' file in the extension directory; this only exists in
-	// production mode.
-	const indexJs = path.join(context.extensionPath, 'ui', 'dist', 'index.js');
-	const fs = require('fs');
-	const productionMode = fs.existsSync(indexJs);
-
-	const scriptPaths = [];
-
-	if (!productionMode) {
-		const nodeFolder = path.join(context.extensionPath, 'ui', 'node_modules');
-		// In development mode, we use the React libraries from the extension
-		// folder directly. In production mode, webpack bundles these libraries
-		// into the index.js file.
-		scriptPaths.push(path.join(nodeFolder,
-			'react', 'umd', 'react.development.js'));
-		scriptPaths.push(path.join(nodeFolder,
-			'react-dom', 'umd', 'react-dom.development.js'));
-
-		// In development mode, we use the TanStack libraries from the extension
-		// folder directly as well.
-		const tanstackLibraries = [
-			'query-core',
-			'react-query',
-			'react-table',
-			'react-virtual',
-			'table-core'];
-		tanstackLibraries.forEach((library) => {
-			scriptPaths.push(path.join(nodeFolder,
-				'@tanstack', library, 'build', 'umd', `index.development.js`));
-		});
-	}
+	const scriptPaths: string[] = [];
 
 	// Get a list of all the script files in the extension's ui/out folder and
 	// add them to the list of scripts to load in the webview
-	const outFolder = path.join(context.extensionPath, 'ui', productionMode ? 'dist' : 'out');
+	const outFolder = path.join(context.extensionPath, 'ui', 'dist');
 	const files = await vscode.workspace.fs.readDirectory(vscode.Uri.file(outFolder));
 	files.forEach((file) => {
 		// If this file is a JavaScript file, add it to the list of scripts
@@ -93,20 +63,11 @@ export async function createDataPanel(context: vscode.ExtensionContext,
 
 	panel.title = data.title;
 
-	// In development mode, load the CSS file directly from the extension folder
-	let cssTag = '';
-	if (!productionMode) {
-		const cssUri = vscode.Uri.file(path.join(context.extensionPath, 'ui', 'src', 'DataPanel.css'));
-		const cssWebviewUri = panel.webview.asWebviewUri(cssUri);
-		cssTag = `<link rel="stylesheet" href="${cssWebviewUri}">`;
-	}
-
 	// Set the HTML content of the webview
 	panel.webview.html = `
 		<head>
 			<meta charset="UTF-8">
 			<title>${data.title}</title>
-			${cssTag}
 		</head>
 		<body>
 			<div id="root"></div>

--- a/extensions/positron-data-viewer/src/dataPanel.ts
+++ b/extensions/positron-data-viewer/src/dataPanel.ts
@@ -27,11 +27,15 @@ export async function createDataPanel(context: vscode.ExtensionContext,
 		}
 	);
 
-	const scriptPaths: string[] = [];
+	const indexJs = path.join(context.extensionPath, 'ui', 'dist', 'index.js');
+	const fs = require('fs');
+	const productionMode = fs.existsSync(indexJs);
+	console.log(`productionMode: ${productionMode}`);
 
-	// Get a list of all the script files in the extension's ui/out folder and
+	// Get a list of all the script files in the extension's ui/out or ui/dist folder and
 	// add them to the list of scripts to load in the webview
-	const outFolder = path.join(context.extensionPath, 'ui', 'dist');
+	const scriptPaths: string[] = [];
+	const outFolder = path.join(context.extensionPath, 'ui', productionMode ? 'dist' : 'out');
 	const files = await vscode.workspace.fs.readDirectory(vscode.Uri.file(outFolder));
 	files.forEach((file) => {
 		// If this file is a JavaScript file, add it to the list of scripts

--- a/extensions/positron-data-viewer/src/dataPanel.ts
+++ b/extensions/positron-data-viewer/src/dataPanel.ts
@@ -27,6 +27,8 @@ export async function createDataPanel(context: vscode.ExtensionContext,
 		}
 	);
 
+	// Check for the 'ui/dist/index.js' file in the extension directory;
+	// In dev mode this is written to 'ui/out/index.js' instead of 'ui/dist'
 	const indexJs = path.join(context.extensionPath, 'ui', 'dist', 'index.js');
 	const fs = require('fs');
 	const productionMode = fs.existsSync(indexJs);

--- a/extensions/positron-data-viewer/ui/package.json
+++ b/extensions/positron-data-viewer/ui/package.json
@@ -8,12 +8,12 @@
     "@tanstack/react-query": "^4.29.5",
     "@tanstack/react-table": "^8.8.5",
     "@tanstack/react-virtual": "^3.0.0-beta.54",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/react": "^17.0.33",
-    "@types/react-dom": "^17.0.10",
+    "@types/react": "^18.0.20",
+    "@types/react-dom": "^18.0.6",
     "css-loader": "^6.7.3",
     "style-loader": "^3.3.2"
   },

--- a/extensions/positron-data-viewer/ui/package.json
+++ b/extensions/positron-data-viewer/ui/package.json
@@ -20,6 +20,6 @@
   "scripts": {
     "compile": "gulp compile-extension:positron-data-viewer-ui",
     "watch": "gulp watch-extension:positron-data-viewer-ui",
-    "bundle-dev": "npx webpack-cli watch --mode development --config ./extension.webpack.config.js"
+    "bundle-dev": "npx webpack-cli watch --mode development --config ./extension.webpack.config.js --output-path ./out"
   }
 }

--- a/extensions/positron-data-viewer/ui/package.json
+++ b/extensions/positron-data-viewer/ui/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "compile": "gulp compile-extension:positron-data-viewer-ui",
-    "watch": "gulp watch-extension:positron-data-viewer-ui"
+    "watch": "gulp watch-extension:positron-data-viewer-ui",
+    "bundle-dev": "npx webpack-cli watch --mode development --config ./extension.webpack.config.js"
   }
 }

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -35,7 +35,6 @@ interface DataPanelProps {
  * @param props The properties for the component.
  */
 export const DataPanel = (props: DataPanelProps) => {
-
 	// The distance from the bottom of the table container at which we will
 	// trigger a fetch of more data.
 	const scrollThresholdPx = 300;

--- a/extensions/positron-data-viewer/ui/src/app.tsx
+++ b/extensions/positron-data-viewer/ui/src/app.tsx
@@ -3,7 +3,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 // External libraries.
-//import * as ReactDOM from 'react-dom';
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 

--- a/extensions/positron-data-viewer/ui/src/app.tsx
+++ b/extensions/positron-data-viewer/ui/src/app.tsx
@@ -36,10 +36,6 @@ window.addEventListener('message', (event: any) => {
 	const message = event.data as DataViewerMessage;
 
 	if (message.msg_type === 'initial_data') {
-		console.log('+++ WE ARE GOING TO CHECK ON createRoot');
-		console.log(createRoot);
-		console.log('--- WE ARE GOING TO CHECK ON createRoot');
-
 		const dataMessage = message as DataViewerMessageRowResponse;
 		const queryClient = new ReactQuery.QueryClient();
 		const container = document.getElementById('root');

--- a/extensions/positron-data-viewer/ui/src/app.tsx
+++ b/extensions/positron-data-viewer/ui/src/app.tsx
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // External libraries.
-import * as ReactDOM from 'react-dom';
+//import * as ReactDOM from 'react-dom';
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 
@@ -42,13 +42,14 @@ window.addEventListener('message', (event: any) => {
 
 		const dataMessage = message as DataViewerMessageRowResponse;
 		const queryClient = new ReactQuery.QueryClient();
-		ReactDOM.render(
+		const container = document.getElementById('root');
+		const root = createRoot(container!!);
+		root.render(
 			<React.StrictMode>
 				<ReactQuery.QueryClientProvider client={queryClient}>
 					<DataPanel initialData={dataMessage.data} fetchSize={fetchSize} vscode={vscode} />
 				</ReactQuery.QueryClientProvider>
-			</React.StrictMode>,
-			document.getElementById('root')
+			</React.StrictMode>
 		);
-	} // Other message types are handled in the DataPanel component.
+	} // Other message types are handled in the DataPanel component after app initialization.
 });

--- a/extensions/positron-data-viewer/ui/src/app.tsx
+++ b/extensions/positron-data-viewer/ui/src/app.tsx
@@ -5,6 +5,7 @@
 // External libraries.
 import * as ReactDOM from 'react-dom';
 import * as React from 'react';
+import { createRoot } from 'react-dom/client';
 
 // External modules.
 import * as ReactQuery from '@tanstack/react-query';
@@ -35,6 +36,10 @@ window.addEventListener('message', (event: any) => {
 	const message = event.data as DataViewerMessage;
 
 	if (message.msg_type === 'initial_data') {
+		console.log('+++ WE ARE GOING TO CHECK ON createRoot');
+		console.log(createRoot);
+		console.log('--- WE ARE GOING TO CHECK ON createRoot');
+
 		const dataMessage = message as DataViewerMessageRowResponse;
 		const queryClient = new ReactQuery.QueryClient();
 		ReactDOM.render(

--- a/extensions/positron-data-viewer/ui/src/app.tsx
+++ b/extensions/positron-data-viewer/ui/src/app.tsx
@@ -39,7 +39,7 @@ window.addEventListener('message', (event: any) => {
 		const dataMessage = message as DataViewerMessageRowResponse;
 		const queryClient = new ReactQuery.QueryClient();
 		const container = document.getElementById('root');
-		const root = createRoot(container!!);
+		const root = createRoot(container!);
 		root.render(
 			<React.StrictMode>
 				<ReactQuery.QueryClientProvider client={queryClient}>

--- a/extensions/positron-data-viewer/ui/yarn.lock
+++ b/extensions/positron-data-viewer/ui/yarn.lock
@@ -44,17 +44,17 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
-"@types/react-dom@^17.0.10":
-  version "17.0.19"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.19.tgz#36feef3aa35d045cacd5ed60fe0eef5272f19492"
-  integrity sha512-PiYG40pnQRdPHnlf7tZnp0aQ6q9tspYr72vD61saO6zFCybLfMqwUCN0va1/P+86DXn18ZWeW30Bk7xlC5eEAQ==
+"@types/react-dom@^18.0.6":
+  version "18.2.14"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.14.tgz#c01ba40e5bb57fc1dc41569bb3ccdb19eab1c539"
+  integrity sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==
   dependencies:
-    "@types/react" "^17"
+    "@types/react" "*"
 
-"@types/react@^17", "@types/react@^17.0.33":
-  version "17.0.58"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.58.tgz#c8bbc82114e5c29001548ebe8ed6c4ba4d3c9fb0"
-  integrity sha512-c1GzVY97P0fGxwGxhYq989j4XwlcHQoto6wQISOC2v6wm3h0PORRWJFHlkRjfGsiG3y1609WdQ+J+tKxvrEd6A==
+"@types/react@*", "@types/react@^18.0.20":
+  version "18.2.31"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.31.tgz#74ae2630e4aa9af599584157abd3b95d96fb9b40"
+  integrity sha512-c2UnPv548q+5DFh03y8lEDeMfDwBn9G3dRwfkrxQMo/dOtRHUUO57k6pHvBIfH/VF4Nh+98mZ5aaSe+2echD5g==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -118,11 +118,6 @@ nanoid@^3.3.6:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
-object-assign@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
-
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -178,30 +173,27 @@ postcss@^8.4.19:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-react-dom@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+react-dom@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    scheduler "^0.23.0"
 
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 semver@^7.3.8:
   version "7.5.3"

--- a/extensions/positron-data-viewer/yarn.lock
+++ b/extensions/positron-data-viewer/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@types/node@16.x":
-  version "16.18.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.23.tgz#b6e934fe427eb7081d0015aad070acb3373c3c90"
-  integrity sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g==
+"@types/node@18.x":
+  version "18.18.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.18.6.tgz#26da694f75cdb057750f49d099da5e3f3824cb3e"
+  integrity sha512-wf3Vz+jCmOQ2HV1YUJuCWdL64adYxumkrxtc+H1VUQlnQI04+5HtH+qZCOE21lBE7gIrt+CwX2Wv8Acrw5Ak6w==
 
 typescript@^4.5.5:
   version "4.9.5"


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/1662

If I run `yarn run bundle-dev` from both `extensions/positron-data-viewer` and `extensions/positron-data-viewer/ui`, this seems to work, and I can run the data viewer in Positron in development mode with all the old dev mode code removed. This still needs to get added to a task that actually runs with Positron though