### PR TITLE
fix role for top toolbar

### DIFF
--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -344,7 +344,7 @@ export class Workbench extends Layout {
 		for (const { id, role, classes, options } of [
 			{ id: Parts.TITLEBAR_PART, role: 'none', classes: ['titlebar'] },
 			// --- Start Positron ---
-			{ id: Parts.POSITRON_TOP_ACTION_BAR_PART, role: 'appbar', classes: ['positron-top-action-bar'] },
+			{ id: Parts.POSITRON_TOP_ACTION_BAR_PART, role: 'toolbar', classes: ['positron-top-action-bar'] },
 			// --- End Positron ---
 			{ id: Parts.BANNER_PART, role: 'banner', classes: ['banner'] },
 			{ id: Parts.ACTIVITYBAR_PART, role: 'none', classes: ['activitybar', this.getSideBarPosition() === Position.LEFT ? 'left' : 'right'] }, // Use role 'none' for some parts to make screen readers less chatty #114892


### PR DESCRIPTION
Addresses #1668

The top toolbar has `role="appbar"` which isn't a [valid aria role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles). Fixed by changing to `role="toolbar"`.

<img width="802" alt="Screenshot of Positron with the top toolbar outlined in red" src="https://github.com/posit-dev/positron/assets/10569626/9451a77d-bfb1-447e-bbfd-5e99de47a0db">

This has a significant impact on the behaviour of assistive tech when navigating to and in the toolbar. In fact, changing the role (or any aria attribute) ONLY impacts the accessibility tree (used by screen readers); so when aria is invalid, it is not noticeable except via screen reader usage and/or tools like Axe and Lighthouse.

With this change in place, #1671 becomes a factor; that fix will follow.

There are other accessibility problems with this toolbar, and the widgets inside it, which will come in separate fixes.