### PR TITLE
remove action bar separators from a11y tree

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarSeparator.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarSeparator.tsx
@@ -12,7 +12,7 @@ import * as React from 'react';
 export const ActionBarSeparator = () => {
 	// Render.
 	return (
-		<div className='action-bar-separator'>
+		<div className='action-bar-separator' aria-hidden='true' >
 			<div className='action-bar-separator-icon codicon codicon-positron-separator' />
 		</div>
 	);


### PR DESCRIPTION
Addresses #1671

Note: I should have done this as part of fixing #1668 since you can't repro this issue without that fix in place. Oh well.

<img width="267" alt="Screenshot of Positron toolbar with separators highlighted" src="https://github.com/posit-dev/positron/assets/10569626/7d9a0737-e991-4570-b057-e1efd4d38db4">

In a toolbar, separators between buttons can be navigated to via a screen reader. These separators currently have no role, and VoiceOver navigates to them and says absolutely nothing (a Very Bad Thing for a screen reader user).

I don't see any value in exposing these separators to a screen reader, so am marking them with `aria-hidden="true"` which removes them from the accessibility tree.

The alternative would have been to add `role="separator" aria-orientation="vertical"` to the element, per https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role.