### PR TITLE
981 add minimize button to console

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1827,21 +1827,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		if (!isMaximized) {
 			if (this.isVisible(Parts.PANEL_PART)) {
 				if (panelPosition === Position.BOTTOM) {
-					// --- Start Positron ---
-					// When the panel is at its minimum height, instead of maximizing the panel from
-					// this height, set the panel height to its preferred height.
-					if (size.height === this.panelPartView.minimumHeight) {
-						this.workbenchGrid.resizeView(
-							this.panelPartView,
-							{
-								width: size.width,
-								height: this.panelPartView.preferredHeight || this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT)
-							});
-						return;
-					} else {
-						this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT, size.height);
-					}
-					// --- End Positron ---
+					this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT, size.height);
 				} else {
 					this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_WIDTH, size.width);
 				}
@@ -1857,6 +1843,89 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		}
 		this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_WAS_LAST_MAXIMIZED, !isMaximized);
 	}
+
+	// --- Start Positron ---
+	/**
+	 * Maximizes the panel.
+	 */
+	maximizePanel(): void {
+		// This method works when the panel position is bottom and the panel alignment is center. It
+		// should not be called, and is not called, otherwise. This is a safety check.
+		if (this.getPanelPosition() === Position.BOTTOM && this.getPanelAlignment() === 'center') {
+			// Get the panel size.
+			const size = this.workbenchGrid.getViewSize(this.panelPartView);
+
+			// If the panel is not maximized, and it's visible, and its height is greater than its
+			// minimum height, save its last non-mazimized height.
+			if (!this.isPanelMaximized() &&
+				this.isVisible(Parts.PANEL_PART) &&
+				size.height > this.panelPartView.minimumHeight) {
+				this.stateModel.setRuntimeValue(
+					LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT,
+					size.height
+				);
+			}
+
+			// Hide the editor. This as the effect of maximizing the panel.
+			this.setEditorHidden(true);
+		}
+	}
+
+	/**
+	 * Minimizes the panel.
+	 */
+	minimizePanel(): void {
+		// This method works when the panel position is bottom and the panel alignment is center. It
+		// should not be called, and is not called, otherwise. This is a safety check.
+		if (this.getPanelPosition() === Position.BOTTOM && this.getPanelAlignment() === 'center') {
+			// Get the panel size.
+			const size = this.workbenchGrid.getViewSize(this.panelPartView);
+
+			// If the panel is not maximized, and it's visible, and its height is greater than its
+			// minimum height, save its last non-mazimized height.
+			if (!this.isPanelMaximized() &&
+				this.isVisible(Parts.PANEL_PART) &&
+				size.height > this.panelPartView.minimumHeight) {
+				this.stateModel.setRuntimeValue(
+					LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT,
+					size.height
+				);
+			}
+
+			// Show the editor.
+			this.setEditorHidden(false);
+
+			// Resize the panel to its current width and its minimum height.
+			this.workbenchGrid.resizeView(this.panelPartView, {
+				width: size.width,
+				height: this.panelPartView.minimumHeight
+			});
+		}
+	}
+
+	/**
+	 * Restores the panel.
+	 */
+	restorePanel(): void {
+		// This method works when the panel position is bottom and the panel alignment is center. It
+		// should not be called, and is not called, otherwise. This is a safety check.
+		if (this.getPanelPosition() === Position.BOTTOM && this.getPanelAlignment() === 'center') {
+			// Get the panel size.
+			const size = this.workbenchGrid.getViewSize(this.panelPartView);
+
+			// Show the editor.
+			this.setEditorHidden(false);
+
+			// Resize the panel to its current width and its last non-maximized height.
+			this.workbenchGrid.resizeView(this.panelPartView, {
+				width: size.width,
+				height: this.stateModel.getRuntimeValue(
+					LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT
+				)
+			});
+		}
+	}
+	// --- End Positron ---
 
 	/**
 	 * Returns whether or not the panel opens maximized
@@ -2026,7 +2095,16 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			if (position === Position.BOTTOM) {
 				this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_WIDTH, size.width);
 			} else if (positionFromString(oldPositionValue) === Position.BOTTOM) {
-				this.stateModel.setRuntimeValue(LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT, size.height);
+				// --- Start Positron ---
+				// Only set the last non-maximized height for the panel when its height is
+				// greater than minimum height.
+				if (size.height > this.panelPartView.minimumHeight) {
+					this.stateModel.setRuntimeValue(
+						LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT,
+						size.height
+					);
+				}
+				// --- End Positron ---
 			}
 		}
 

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -2097,7 +2097,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			} else if (positionFromString(oldPositionValue) === Position.BOTTOM) {
 				// --- Start Positron ---
 				// Only set the last non-maximized height for the panel when its height is
-				// greater than minimum height.
+				// greater than its minimum height.
 				if (size.height > this.panelPartView.minimumHeight) {
 					this.stateModel.setRuntimeValue(
 						LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT,

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -22,11 +22,19 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 import { ICommandActionTitle } from 'vs/platform/action/common/action';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 
+// --- Start Positron ---
 const maximizeIcon = registerIcon('panel-maximize', Codicon.chevronUp, localize('maximizeIcon', 'Icon to maximize a panel.'));
 const restoreIcon = registerIcon('panel-restore', Codicon.chevronDown, localize('restoreIcon', 'Icon to restore a panel.'));
+// --- End Positron ---
 const closeIcon = registerIcon('panel-close', Codicon.close, localize('closeIcon', 'Icon to close a panel.'));
 const panelIcon = registerIcon('panel-layout-icon', Codicon.layoutPanel, localize('togglePanelOffIcon', 'Icon to toggle the panel off when it is on.'));
 const panelOffIcon = registerIcon('panel-layout-icon-off', Codicon.layoutPanelOff, localize('togglePanelOnIcon', 'Icon to toggle the panel on when it is off.'));
+
+// --- Start Positron ---
+const positronMaximizePanelIcon = registerIcon('panel-maximize2', Codicon.chromeMaximize, localize('maximizeIcon', 'Icon to maximize a panel.'));
+const positronMinimizePanelIcon = registerIcon('panel-minimize2', Codicon.chromeMinimize, localize('minimizeIcon', 'Icon to minimize a panel.'));
+const positronRestorePanelIcon = registerIcon('panel-restore2', Codicon.chromeRestore, localize('restoreIcon', 'Icon to restore a panel.'));
+// --- End Positron ---
 
 export class TogglePanelAction extends Action2 {
 
@@ -332,14 +340,16 @@ registerAction2(class extends Action2 {
 			icon: maximizeIcon,
 			// the workbench grid currently prevents us from supporting panel maximization with non-center panel alignment
 			precondition: ContextKeyExpr.or(PanelAlignmentContext.isEqualTo('center'), PanelPositionContext.notEqualsTo('bottom')),
-			toggled: { condition: PanelMaximizedContext, icon: restoreIcon, tooltip: localize('minimizePanel', "Restore Panel Size") },
+			// --- Start Positron ---
+			toggled: { condition: PanelMaximizedContext, icon: restoreIcon, tooltip: localize('restoresPanel', "Restores Panel Size") },
 			menu: [{
 				id: MenuId.PanelTitle,
 				group: 'navigation',
-				order: 1,
+				order: 100,
 				// the workbench grid currently prevents us from supporting panel maximization with non-center panel alignment
-				when: ContextKeyExpr.or(PanelAlignmentContext.isEqualTo('center'), PanelPositionContext.notEqualsTo('bottom'))
+				when: PanelPositionContext.notEqualsTo('bottom') //ContextKeyExpr.or(PanelAlignmentContext.isEqualTo('center'), PanelPositionContext.notEqualsTo('bottom'))
 			}]
+			// --- End Positron ---
 		});
 	}
 	run(accessor: ServicesAccessor) {
@@ -362,6 +372,131 @@ registerAction2(class extends Action2 {
 		}
 	}
 });
+
+// --- Start Positron ---
+/**
+ * Positron minimize panel action.
+ */
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.minimizePanel',
+			title: { value: localize('minimizePanel', "Minimize Panel"), original: 'Minimizes Panel' },
+			tooltip: localize('minimizesPanel', "Minimizes Panel Size"),
+			category: Categories.View,
+			f1: true,
+			icon: positronMinimizePanelIcon,
+			// This action is only enabled when the panel position is bottom and the panel alignment
+			// is center.
+			precondition: ContextKeyExpr.and(PanelPositionContext.isEqualTo('bottom'), PanelAlignmentContext.isEqualTo('center')),
+			menu: [{
+				id: MenuId.PanelTitle,
+				group: 'navigation',
+				order: 1,
+				// This navigation icon is only enabled when the panel position is bottom and the
+				// panel alignment is center.
+				when: ContextKeyExpr.and(PanelPositionContext.isEqualTo('bottom'), PanelAlignmentContext.isEqualTo('center'))
+			}]
+		});
+	}
+
+	run(accessor: ServicesAccessor) {
+		// Access services.
+		const layoutService = accessor.get(IWorkbenchLayoutService);
+
+		// If the panel part isn't visible, unhide it.
+		if (!layoutService.isVisible(Parts.PANEL_PART)) {
+			// Unhide the panel part.
+			layoutService.setPartHidden(false, Parts.PANEL_PART);
+		}
+
+		// Have the layout service minimize the panel.
+		layoutService.minimizePanel();
+	}
+});
+
+/**
+ * Positron maximize panel action.
+ */
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.maximizePanel',
+			title: { value: localize('mazimizePanel', "Maximize Panel"), original: 'Maximize Panel' },
+			tooltip: localize('maximizesPanel', "Maximizes Panel Size"),
+			category: Categories.View,
+			f1: true,
+			icon: positronMaximizePanelIcon,
+			// This action is only enabled when the panel position is bottom and the panel alignment
+			// is center.
+			precondition: ContextKeyExpr.and(PanelPositionContext.isEqualTo('bottom'), PanelAlignmentContext.isEqualTo('center')),
+			menu: [{
+				id: MenuId.PanelTitle,
+				group: 'navigation',
+				order: 2,
+				// This navigation icon is only enabled when the panel position is bottom and the
+				// panel alignment is center.
+				when: ContextKeyExpr.and(PanelPositionContext.isEqualTo('bottom'), PanelAlignmentContext.isEqualTo('center'))
+			}]
+		});
+	}
+
+	run(accessor: ServicesAccessor) {
+		// Access services.
+		const layoutService = accessor.get(IWorkbenchLayoutService);
+
+		// If the panel part isn't visible, unhide it.
+		if (!layoutService.isVisible(Parts.PANEL_PART)) {
+			// Unhide the panel part.
+			layoutService.setPartHidden(false, Parts.PANEL_PART);
+		}
+
+		// Have the layout service maximize the panel.
+		layoutService.maximizePanel();
+	}
+});
+
+/**
+ * Positron restore panel action.
+ */
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.restorePanel',
+			title: { value: localize('restorePanel', "Restore Panel"), original: 'Restore Panel' },
+			tooltip: localize('restoresPanel', "Restores Panel Size"),
+			category: Categories.View,
+			f1: true,
+			icon: positronRestorePanelIcon,
+			// This action is only enabled when the panel position is bottom and the panel alignment
+			// is center.
+			precondition: ContextKeyExpr.and(PanelPositionContext.isEqualTo('bottom'), PanelAlignmentContext.isEqualTo('center')),
+			menu: [{
+				id: MenuId.PanelTitle,
+				group: 'navigation',
+				order: 3,
+				// This navigation icon is only enabled when the panel position is bottom and the
+				// panel alignment is center.
+				when: ContextKeyExpr.and(PanelPositionContext.isEqualTo('bottom'), PanelAlignmentContext.isEqualTo('center'))
+			}]
+		});
+	}
+
+	run(accessor: ServicesAccessor) {
+		// Access services.
+		const layoutService = accessor.get(IWorkbenchLayoutService);
+
+		// If the panel part isn't visible, unhide it.
+		if (!layoutService.isVisible(Parts.PANEL_PART)) {
+			// Unhide the panel part.
+			layoutService.setPartHidden(false, Parts.PANEL_PART);
+		}
+
+		// Have the layout service restore the panel.
+		layoutService.restorePanel();
+	}
+});
+// --- End Positron ---
 
 registerAction2(class extends Action2 {
 	constructor() {

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -22,18 +22,16 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 import { ICommandActionTitle } from 'vs/platform/action/common/action';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 
-// --- Start Positron ---
 const maximizeIcon = registerIcon('panel-maximize', Codicon.chevronUp, localize('maximizeIcon', 'Icon to maximize a panel.'));
 const restoreIcon = registerIcon('panel-restore', Codicon.chevronDown, localize('restoreIcon', 'Icon to restore a panel.'));
-// --- End Positron ---
 const closeIcon = registerIcon('panel-close', Codicon.close, localize('closeIcon', 'Icon to close a panel.'));
 const panelIcon = registerIcon('panel-layout-icon', Codicon.layoutPanel, localize('togglePanelOffIcon', 'Icon to toggle the panel off when it is on.'));
 const panelOffIcon = registerIcon('panel-layout-icon-off', Codicon.layoutPanelOff, localize('togglePanelOnIcon', 'Icon to toggle the panel on when it is off.'));
 
 // --- Start Positron ---
-const positronMaximizePanelIcon = registerIcon('panel-maximize2', Codicon.chromeMaximize, localize('maximizeIcon', 'Icon to maximize a panel.'));
-const positronMinimizePanelIcon = registerIcon('panel-minimize2', Codicon.chromeMinimize, localize('minimizeIcon', 'Icon to minimize a panel.'));
-const positronRestorePanelIcon = registerIcon('panel-restore2', Codicon.chromeRestore, localize('restoreIcon', 'Icon to restore a panel.'));
+const positronMaximizePanelIcon = registerIcon('positron-maximize-panel', Codicon.chromeMaximize, localize('maximizeIcon', 'Icon to maximize a panel.'));
+const positronMinimizePanelIcon = registerIcon('positron-minimize-panel', Codicon.chromeMinimize, localize('minimizeIcon', 'Icon to minimize a panel.'));
+const positronRestorePanelIcon = registerIcon('positron-restore-panel', Codicon.chromeRestore, localize('restoreIcon', 'Icon to restore a panel.'));
 // --- End Positron ---
 
 export class TogglePanelAction extends Action2 {

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -179,6 +179,23 @@ export interface IWorkbenchLayoutService extends ILayoutService {
 	 */
 	toggleMaximizedPanel(): void;
 
+	// --- Start Positron ---
+	/**
+	 * Maximizes the panel height.
+	 */
+	maximizePanel(): void;
+
+	/**
+	 * Minimizes the panel height.
+	 */
+	minimizePanel(): void;
+
+	/**
+	 * Restores the panel height.
+	 */
+	restorePanel(): void;
+	// --- End Positron ---
+
 	/**
 	 * Returns true if the window has a border.
 	 */

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -626,6 +626,11 @@ export class TestLayoutService implements IWorkbenchLayoutService {
 	isPanelHidden(): boolean { return false; }
 	async setPanelHidden(_hidden: boolean): Promise<void> { }
 	toggleMaximizedPanel(): void { }
+	// --- Start Positron ---
+	maximizePanel(): void { }
+	minimizePanel(): void { }
+	restorePanel(): void { }
+	// --- End Positron ---
 	isPanelMaximized(): boolean { return false; }
 	getMenubarVisibility(): MenuBarVisibility { throw new Error('not implemented'); }
 	toggleMenuBar(): void { }


### PR DESCRIPTION
This PR updates the panel part to have minimize, maximize, and restore buttons when it is positioned on the bottom and aligned center (which is the default positioning and alignment).

It was very difficult to sort out how we could "add minimize button to console" and support all the positioning and alignment scenarios. After a lot of experimentation, I found that it felt best to add explicit actions for minimize, maximize, and restore, and to enable those actions only when the panel was positioned on the bottom and aligned center. Instead of conditionalizing these actions and having their icons appear and disappear, I felt it was better to leave the icons always visible and discoverable in the panel:

<img width="120" alt="image" src="https://github.com/posit-dev/positron/assets/853239/fa319f46-eb46-4a51-b84d-21956a94e5a8">


Here's a movie of these action in motion:

https://github.com/posit-dev/positron/assets/853239/d35d1009-e97f-447b-ac67-c22d592630aa

When the panel is positioned left or right, it retains the standard Visual Studio Code "toggle maximized panel" behavior. 

Left:

<img width="1535" alt="image" src="https://github.com/posit-dev/positron/assets/853239/d92d627b-35da-4663-8129-2e4187180b48">

Left maximized:

<img width="1535" alt="image" src="https://github.com/posit-dev/positron/assets/853239/d9766a38-4772-4e53-b353-40cf7ded1e2d">

Right:

<img width="1535" alt="image" src="https://github.com/posit-dev/positron/assets/853239/8d25d4a4-ced8-4ed0-9d6e-be7833bb5b56">

Right maximized:

<img width="1535" alt="image" src="https://github.com/posit-dev/positron/assets/853239/c4d79595-23c8-4409-ad65-d94ca1714e3c">

When the panel is not aligned center, the new minimize, maximize, and restore actions are unavailable, as is "toggle maximized panel". This is a limitation of Workbench, as documented in `the workbench grid currently prevents us from supporting panel maximization with non-center panel alignment` comment in `panelActions.ts`.