### PR TITLE
add accessible labels to top toolbar buttons and set aria-disabled when needed

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/positronButton.tsx
+++ b/src/vs/base/browser/ui/positronComponents/positronButton.tsx
@@ -22,6 +22,7 @@ export interface KeyboardModifiers {
 interface PositronButtonProps {
 	className?: string;
 	disabled?: boolean;
+	ariaLabel?: string;
 	onClick?: (e: KeyboardModifiers) => void;
 }
 
@@ -79,6 +80,7 @@ export const PositronButton = forwardRef<HTMLDivElement, PropsWithChildren<Posit
 			className={classNames}
 			tabIndex={0}
 			role='button'
+			aria-label={props.ariaLabel}
 			onKeyDown={keyDownHandler}
 			onClick={clickHandler}>
 			{props.children}

--- a/src/vs/base/browser/ui/positronComponents/positronButton.tsx
+++ b/src/vs/base/browser/ui/positronComponents/positronButton.tsx
@@ -81,6 +81,7 @@ export const PositronButton = forwardRef<HTMLDivElement, PropsWithChildren<Posit
 			tabIndex={0}
 			role='button'
 			aria-label={props.ariaLabel}
+			aria-disabled={props.disabled ? 'true' : undefined}
 			onKeyDown={keyDownHandler}
 			onClick={clickHandler}>
 			{props.children}

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -24,6 +24,7 @@ export interface ActionBarButtonProps {
 	layout?: 'loose' | 'tight';
 	tooltip?: string | (() => string | undefined);
 	disabled?: boolean;
+	ariaLabel?: string;
 	onClick?: () => void;
 }
 
@@ -50,7 +51,7 @@ export const ActionBarButton = forwardRef<HTMLDivElement, PropsWithChildren<Acti
 	// Render.
 	return (
 		<ActionBarTooltip {...props}>
-			<PositronButton ref={ref} className={buttonClassNames} onClick={props.onClick}>
+			<PositronButton ref={ref} className={buttonClassNames} onClick={props.onClick} ariaLabel={props.ariaLabel}>
 				<div className='action-bar-button-face' style={{ padding: props.layout === 'tight' ? '0' : '0 2px' }}>
 					{props.iconId && <div className={`action-bar-button-icon codicon codicon-${props.iconId}`} style={iconStyle} />}
 					{props.text && <div className='action-bar-button-text' style={{ maxWidth: optionalValue(props.maxTextWidth, 'none') }}>{props.text}</div>}

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -38,8 +38,7 @@ export const ActionBarButton = forwardRef<HTMLDivElement, PropsWithChildren<Acti
 	const buttonClassNames = positronClassNames(
 		'action-bar-button',
 		{ 'border': optionalBoolean(props.border) },
-		{ 'fade-in': optionalBoolean(props.fadeIn) },
-		{ 'disabled': optionalBoolean(props.disabled) }
+		{ 'fade-in': optionalBoolean(props.fadeIn) }
 	);
 
 	// Create the icon style.
@@ -51,7 +50,7 @@ export const ActionBarButton = forwardRef<HTMLDivElement, PropsWithChildren<Acti
 	// Render.
 	return (
 		<ActionBarTooltip {...props}>
-			<PositronButton ref={ref} className={buttonClassNames} onClick={props.onClick} ariaLabel={props.ariaLabel}>
+			<PositronButton ref={ref} className={buttonClassNames} onClick={props.onClick} ariaLabel={props.ariaLabel} disabled={props.disabled}>
 				<div className='action-bar-button-face' style={{ padding: props.layout === 'tight' ? '0' : '0 2px' }}>
 					{props.iconId && <div className={`action-bar-button-icon codicon codicon-${props.iconId}`} style={iconStyle} />}
 					{props.text && <div className='action-bar-button-text' style={{ maxWidth: optionalValue(props.maxTextWidth, 'none') }}>{props.text}</div>}

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCommandCenter.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCommandCenter.tsx
@@ -4,9 +4,15 @@
 
 import 'vs/css!./topActionBarCommandCenter';
 import * as React from 'react';
+import { localize } from 'vs/nls';
 import { MouseEvent } from 'react'; // eslint-disable-line no-duplicate-imports
 import { AnythingQuickAccessProviderRunOptions } from 'vs/platform/quickinput/common/quickAccess';
 import { usePositronTopActionBarContext } from 'vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarContext';
+
+/**
+ * Localized strings.
+ */
+const positronShowQuickAccess = localize('positronShowQuickAccess', "Show Quick Access");
 
 /**
  * TopActionBarCommandCenter component.
@@ -30,7 +36,7 @@ export const TopActionBarCommandCenter = () => {
 		});
 	};
 
-	// DropDownCkick handler.
+	// DropDownClick handler.
 	const dropDownClickHandler = (e: MouseEvent<HTMLButtonElement>) => {
 		// Consume the event.
 		e.preventDefault();
@@ -44,7 +50,7 @@ export const TopActionBarCommandCenter = () => {
 	return (
 		<div className='top-action-bar-command-center' onClick={(e) => clickHandler(e)}>
 			<div className='left'>
-				<div className='codicon codicon-positron-search' />
+				<div className='codicon codicon-positron-search' aria-hidden='true' />
 			</div>
 			<div className='center'>
 				<button className='search' onClick={(e) => clickHandler(e)}>
@@ -52,7 +58,7 @@ export const TopActionBarCommandCenter = () => {
 				</button>
 			</div>
 			<div className='right'>
-				<button className='drop-down' onClick={(e) => dropDownClickHandler(e)}>
+				<button className='drop-down' onClick={(e) => dropDownClickHandler(e)} aria-label={positronShowQuickAccess} >
 					<div className='icon codicon codicon-chevron-down' />
 				</button>
 			</div>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCustomFolderMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCustomFolderMenu.tsx
@@ -4,9 +4,15 @@
 
 import 'vs/css!./topActionBarCustomFolderMenu';
 import * as React from 'react';
+import { localize } from 'vs/nls';
 import { KeyboardEvent, useRef } from 'react'; // eslint-disable-line no-duplicate-imports
 import { usePositronTopActionBarContext } from 'vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarContext';
 import { showCustomFolderModalPopup } from 'vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderModalPopup';
+
+/**
+ * Localized strings.
+ */
+const positronFolderMenu = localize('positronFolderMenu', "Folder Commands");
 
 /**
  * TopActionBarCustonFolderMenu component.
@@ -55,7 +61,7 @@ export const TopActionBarCustonFolderMenu = () => {
 
 	// Render.
 	return (
-		<div ref={ref} className='top-action-bar-custom-folder-menu' role='button' tabIndex={0} onKeyDown={keyDownHandler} onClick={clickHandler}>
+		<div ref={ref} className='top-action-bar-custom-folder-menu' role='button' tabIndex={0} onKeyDown={keyDownHandler} onClick={clickHandler} aria-label={positronFolderMenu}>
 			<div className='left'>
 				<div className='label'>
 					<div className={'action-bar-button-icon codicon codicon-folder'} />

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
@@ -12,6 +12,7 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
+import { CommandCenter } from 'vs/platform/commandCenter/common/commandCenter';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { PositronActionBar } from 'vs/platform/positronActionBar/browser/positronActionBar';
 import { ActionBarRegion } from 'vs/platform/positronActionBar/browser/components/actionBarRegion';
@@ -33,6 +34,10 @@ import { ILanguageRuntime, ILanguageRuntimeService, RuntimeState } from 'vs/work
 const kHorizontalPadding = 4;
 const kCenterUIBreak = 600;
 const kFulllCenterUIBreak = 765;
+const SAVE = 'workbench.action.files.save';
+const SAVE_FILES = 'workbench.action.files.saveFiles';
+const NAV_BACK = NavigateBackwardsAction.ID;
+const NAV_FORWARD = NavigateForwardAction.ID;
 
 /**
  * IPositronTopActionBarContainer interface.
@@ -136,8 +141,8 @@ export const PositronTopActionBar = (props: PositronTopActionBarProps) => {
 						<ActionBarSeparator />
 						<TopActionBarOpenMenu />
 						<ActionBarSeparator />
-						<ActionBarCommandButton iconId='positron-save' commandId={'workbench.action.files.save'} />
-						<ActionBarCommandButton iconId='positron-save-all' commandId={'workbench.action.files.saveFiles'} />
+						<ActionBarCommandButton iconId='positron-save' commandId={SAVE} ariaLabel={CommandCenter.title(SAVE)} />
+						<ActionBarCommandButton iconId='positron-save-all' commandId={SAVE_FILES} ariaLabel={CommandCenter.title(SAVE_FILES)} />
 					</ActionBarRegion>
 
 					{showCenterUI && (
@@ -146,8 +151,8 @@ export const PositronTopActionBar = (props: PositronTopActionBarProps) => {
 							<PositronActionBar size='large' nestedActionBar={true}>
 								{showFullCenterUI && (
 									<ActionBarRegion width={60} location='left' justify='right'>
-										<ActionBarCommandButton iconId='chevron-left' commandId={NavigateBackwardsAction.ID} />
-										<ActionBarCommandButton iconId='chevron-right' commandId={NavigateForwardAction.ID} />
+										<ActionBarCommandButton iconId='chevron-left' commandId={NAV_BACK} ariaLabel={CommandCenter.title(NAV_BACK)} />
+										<ActionBarCommandButton iconId='chevron-right' commandId={NAV_FORWARD} ariaLabel={CommandCenter.title(NAV_FORWARD)} />
 									</ActionBarRegion>
 								)}
 								<ActionBarRegion location='center'>


### PR DESCRIPTION
Addresses #1670 and #1693

The Save, Save All Files, Go Back, Go Forward, Show Quick Access, and Folder Commands buttons now have labels.

I made up the labels for "Show Quick Access" and "Folder Commands" whereas the others use the labels of the associated commands.

Also hid the magnifying glass icon from screen readers; it was browsable via VoiceOver and said nothing (and is redundant given it doesn't do anything different than the adjacent Search button).

For the disabled case, set `aria-disabled="true"` when buttons are disabled. This gets announced as "dimmed" by VoiceOver.