### PR TITLE
Upgrade ReactQuery and make fetchNextDataFragment actually wait for promises to be resolved

### DIFF
--- a/extensions/positron-data-viewer/ui/package.json
+++ b/extensions/positron-data-viewer/ui/package.json
@@ -5,7 +5,7 @@
   "author": "Posit Software",
   "main": "./out/main.js",
   "dependencies": {
-    "@tanstack/react-query": "^4.36.1",
+    "@tanstack/react-query": "^5.0.5",
     "@tanstack/react-table": "^8.8.5",
     "@tanstack/react-virtual": "^3.0.0-beta.54",
     "react": "^18.2.0",

--- a/extensions/positron-data-viewer/ui/package.json
+++ b/extensions/positron-data-viewer/ui/package.json
@@ -6,6 +6,7 @@
   "main": "./out/main.js",
   "dependencies": {
     "@tanstack/react-query": "^5.0.5",
+    "@tanstack/react-query-devtools": "^5.1.0",
     "@tanstack/react-table": "^8.8.5",
     "@tanstack/react-virtual": "^3.0.0-beta.54",
     "react": "^18.2.0",

--- a/extensions/positron-data-viewer/ui/src/DataModel.ts
+++ b/extensions/positron-data-viewer/ui/src/DataModel.ts
@@ -2,7 +2,7 @@
  *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
-import { DataColumn, DataSet, DataViewerMessage, DataViewerMessageRowResponse } from './positron-data-viewer';
+import { DataColumn, DataSet, DataViewerMessageRowResponse } from './positron-data-viewer';
 
 /**
  * A fragment of data, arranged by column.
@@ -102,17 +102,17 @@ export class DataModel {
 	/**
 	 *
 	 * @param event The message event received from the runtime
-	 * @returns Either the original data model, or a new data model that includes the message's data
+	 * @returns A new data model that includes the message's data, or the original data model
 	 */
-	handleDataMessage(event: any): DataModel {
-		const message = event.data as DataViewerMessage;
-		if (message.msg_type === 'receive_rows' && !this.renderedRows.includes(message.start_row)) {
-			const dataMessage = message as DataViewerMessageRowResponse;
-
+	handleDataMessage(message: DataViewerMessageRowResponse): DataModel {
+		// Check if we actually need to handle this message
+		if (message.msg_type === 'receive_rows' &&
+			!this.renderedRows.includes(message.start_row)
+		) {
 			const incrementalData: DataFragment = {
-				rowStart: dataMessage.start_row,
-				rowEnd: dataMessage.start_row + dataMessage.fetch_size - 1,
-				columns: dataMessage.data.columns
+				rowStart: message.start_row,
+				rowEnd: message.start_row + message.fetch_size - 1,
+				columns: message.data.columns
 			};
 			return this.appendFragment(incrementalData);
 		}

--- a/extensions/positron-data-viewer/ui/src/DataModel.ts
+++ b/extensions/positron-data-viewer/ui/src/DataModel.ts
@@ -107,6 +107,7 @@ export class DataModel {
 	handleDataMessage(event: any): DataModel {
 		const message = event.data as DataViewerMessage;
 		if (message.msg_type === 'receive_rows' && !this.renderedRows.includes(message.start_row)) {
+			console.log(`Message received: ${message.start_row}`);
 			const dataMessage = message as DataViewerMessageRowResponse;
 
 			const incrementalData: DataFragment = {

--- a/extensions/positron-data-viewer/ui/src/DataModel.ts
+++ b/extensions/positron-data-viewer/ui/src/DataModel.ts
@@ -102,7 +102,7 @@ export class DataModel {
 	/**
 	 *
 	 * @param event The message event received from the runtime
-	 * @returns A DataFragment to be appended to this dataModel
+	 * @returns A DataFragment representing the data in the message, or undefined
 	 */
 	handleDataMessage(event: any): DataFragment | undefined {
 		const message = event.data as DataViewerMessage;

--- a/extensions/positron-data-viewer/ui/src/DataModel.ts
+++ b/extensions/positron-data-viewer/ui/src/DataModel.ts
@@ -102,22 +102,22 @@ export class DataModel {
 	/**
 	 *
 	 * @param event The message event received from the runtime
-	 * @returns Either the original data model, or a new data model that includes the message's data
+	 * @returns A DataFragment to be appended to this dataModel
 	 */
-	handleDataMessage(event: any): DataModel {
+	handleDataMessage(event: any): DataFragment | undefined {
 		const message = event.data as DataViewerMessage;
 		if (message.msg_type === 'receive_rows' && !this.renderedRows.includes(message.start_row)) {
 			console.log(`Message received: ${message.start_row}`);
 			const dataMessage = message as DataViewerMessageRowResponse;
 
-			const incrementalData: DataFragment = {
+			const incrementalData = {
 				rowStart: dataMessage.start_row,
 				rowEnd: dataMessage.start_row + dataMessage.fetch_size - 1,
 				columns: dataMessage.data.columns
 			};
-			return this.appendFragment(incrementalData);
+			return incrementalData;
 		}
-		return this;
+		return undefined;
 	}
 
 	/**

--- a/extensions/positron-data-viewer/ui/src/DataModel.ts
+++ b/extensions/positron-data-viewer/ui/src/DataModel.ts
@@ -2,7 +2,7 @@
  *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
-import { DataColumn, DataSet, DataViewerMessageRowResponse } from './positron-data-viewer';
+import { DataColumn, DataSet, DataViewerMessage, DataViewerMessageRowResponse } from './positron-data-viewer';
 
 /**
  * A fragment of data, arranged by column.
@@ -102,17 +102,17 @@ export class DataModel {
 	/**
 	 *
 	 * @param event The message event received from the runtime
-	 * @returns A new data model that includes the message's data, or the original data model
+	 * @returns Either the original data model, or a new data model that includes the message's data
 	 */
-	handleDataMessage(message: DataViewerMessageRowResponse): DataModel {
-		// Check if we actually need to handle this message
-		if (message.msg_type === 'receive_rows' &&
-			!this.renderedRows.includes(message.start_row)
-		) {
+	handleDataMessage(event: any): DataModel {
+		const message = event.data as DataViewerMessage;
+		if (message.msg_type === 'receive_rows' && !this.renderedRows.includes(message.start_row)) {
+			const dataMessage = message as DataViewerMessageRowResponse;
+
 			const incrementalData: DataFragment = {
-				rowStart: message.start_row,
-				rowEnd: message.start_row + message.fetch_size - 1,
-				columns: message.data.columns
+				rowStart: dataMessage.start_row,
+				rowEnd: dataMessage.start_row + dataMessage.fetch_size - 1,
+				columns: dataMessage.data.columns
 			};
 			return this.appendFragment(incrementalData);
 		}

--- a/extensions/positron-data-viewer/ui/src/DataModel.ts
+++ b/extensions/positron-data-viewer/ui/src/DataModel.ts
@@ -121,13 +121,10 @@ export class DataModel {
 	}
 
 	/**
-	 * A unique identifier for the data model, used to cache the data query.
+	 * A stable unique identifier for the data model (doesn't change as new rows are loaded)
 	 */
 	get id(): String {
-		return `
-		Rendered rows: ${this.renderedRows}
-		Dataset: ${this.dataSet.id}
-		`;
+		return this.dataSet.id;
 	}
 
 	/**

--- a/extensions/positron-data-viewer/ui/src/DataModel.ts
+++ b/extensions/positron-data-viewer/ui/src/DataModel.ts
@@ -107,7 +107,6 @@ export class DataModel {
 	handleDataMessage(event: any): DataFragment | undefined {
 		const message = event.data as DataViewerMessage;
 		if (message.msg_type === 'receive_rows' && !this.renderedRows.includes(message.start_row)) {
-			console.log(`Message received: ${message.start_row}`);
 			const dataMessage = message as DataViewerMessageRowResponse;
 
 			const incrementalData = {

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -122,7 +122,6 @@ export const DataPanel = (props: DataPanelProps) => {
 		if (startRow > 0 && !dataModel.renderedRows.includes(startRow)) {
 			// Don't send duplicate requests
 			if (!requestQueue.current.includes(startRow)) {
-				console.log(`Sending request for ${startRow}`);
 				vscode.postMessage({
 					msg_type: 'request_rows',
 					start_row: startRow,
@@ -136,10 +135,7 @@ export const DataPanel = (props: DataPanelProps) => {
 				// This promise will be resolved in the event handler
 				requestResolvers.current[startRow] = {resolve, reject};
 			});
-			return promisedFragment.then((fragment) => {
-				console.log(`Fulfilled request: ${fragment.rowStart}`);
-				return fragment;
-			});
+			return await promisedFragment;
 		} else {
 			// No need to wait for a response, return the fragment immediately
 			return dataModel.loadDataFragment(startRow, fetchSize);

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -228,7 +228,8 @@ export const DataPanel = (props: DataPanelProps) => {
 
 	// Compute the padding for the table container.
 	const virtualRows = rowVirtualizer.getVirtualItems();
-	const totalSize = rowHeightPx * totalRows;
+	// Assume unfetched rows are all of height rowHeightPx
+	const totalSize = (totalRows - rows.length) * rowHeightPx + rowVirtualizer.getTotalSize();
 	const paddingTop = virtualRows?.[0]?.start || 0;
 	const paddingBottom = totalSize - (virtualRows?.[virtualRows.length - 1]?.end || 0);
 

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -35,6 +35,7 @@ interface DataPanelProps {
  * @param props The properties for the component.
  */
 export const DataPanel = (props: DataPanelProps) => {
+
 	// The distance from the bottom of the table container at which we will
 	// trigger a fetch of more data.
 	const scrollThresholdPx = 300;
@@ -89,7 +90,7 @@ export const DataPanel = (props: DataPanelProps) => {
 			}),
 		[dataModel]);
 
-	async function fetchNextDataFragment(pageParam: any, fetchSize: number): Promise<DataFragment> {
+	async function fetchNextDataFragment(pageParam: number, fetchSize: number): Promise<DataFragment> {
 		// Fetches a single page of data from the data model.
 		const startRow = pageParam * fetchSize;
 		// Overwrite fetchSize so that we never request rows past the end of the dataset
@@ -118,7 +119,7 @@ export const DataPanel = (props: DataPanelProps) => {
 		hasNextPage
 	} = ReactQuery.useInfiniteQuery<DataFragment>({
 			queryKey: ['table-data', dataModel.id],
-			queryFn: ({pageParam = 0}) => fetchNextDataFragment(pageParam, fetchSize),
+			queryFn: ({pageParam = 0}) => fetchNextDataFragment(pageParam as number, fetchSize),
 			initialPageParam: 0,
 			// undefined if we are on the final page of data
 			getNextPageParam: (_lastGroup, groups) => groups.length !== maxPages ? groups.length : undefined,

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -122,8 +122,9 @@ export const DataPanel = (props: DataPanelProps) => {
 			queryFn: ({pageParam = 0}) => fetchNextDataFragment(pageParam as number, fetchSize),
 			initialPageParam: 0,
 			// undefined if we are on the final page of data
-			getNextPageParam: (_lastGroup, groups) => groups.length !== maxPages ? groups.length : undefined,
+			getNextPageParam: (_lastPage, allPages) => allPages.length !== maxPages ? allPages.length : undefined,
 			refetchOnWindowFocus: false,
+			placeholderData: (previousData) => previousData
 		});
 
 

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -29,8 +29,8 @@ interface DataPanelProps {
 	vscode: any;
 }
 
-// A dict-like object to store functions used to resolve/reject a Promise with a DataFragment.
-// Resolver functions are indexed by the request ID (i.e. the start row number)
+// A dict-like object to store functions used to resolve a Promise with a DataFragment (or reject it).
+// Resolve functions are indexed by the request ID (i.e. the start row number)
 // and resolved when that request is fulfilled in the message event handler.
 type ResolverLookup = {
 	[requestId: number]: {

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -183,7 +183,8 @@ export const DataPanel = (props: DataPanelProps) => {
 		// Loop over each page of data and transpose the data for that page.
 		// Then flatten all the transposed data pages together
 
-		// data and pages will never be null because we declared initialData
+		// data and pages should never be null because we declared initialData
+		// and placeholderData in the infinite query
 		return data?.pages?.flatMap(page => {
 			// Get the number of rows for the current page
 			if (page.columns.length) {

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -42,6 +42,8 @@ export const DataPanel = (props: DataPanelProps) => {
 	// The number of rows to render above and below the visible area of the table.
 	const scrollOverscan = 30;
 
+	// The number of rows away from the bottom (not including scrollOverscan) when we should
+	// trigger a fetch for more data.
 	const scrollThresholdRows = 10;
 
 	// A reference to the table container element.
@@ -239,14 +241,12 @@ export const DataPanel = (props: DataPanelProps) => {
 		}
 
 		// don't trigger fetchNextPage if the data has already been requested
-		if (requestQueue.current.includes(nextStartRow)
-		) {
+		if (requestQueue.current.includes(nextStartRow)) {
 			return;
 		}
 
 		const virtualRowsRemaining = lastFetchedRow.index - lastVirtualRow.index;
-		if (( virtualRowsRemaining < scrollThresholdRows)
-		) {
+		if (virtualRowsRemaining < scrollThresholdRows) {
 			fetchNextPage();
 		}
 	}, [fetchNextPage, isFetchingNextPage, hasNextPage, rows, virtualRows]);

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -216,14 +216,19 @@ export const DataPanel = (props: DataPanelProps) => {
 	{
 		count: rows.length,
 		getScrollElement: () => tableContainerRef.current,
+		// For now, we assume all rows are of constant height
+		// TODO: account for variable height rows, here and below in the totalSize variable
 		estimateSize: () => rowHeightPx,
 		overscan: scrollOverscan
 	});
 
 	// Compute the padding for the table container.
 	const virtualRows = rowVirtualizer.getVirtualItems();
-	const totalSize = rowVirtualizer.getTotalSize();
-	const paddingTop = virtualRows.length > 0 ? virtualRows?.[0]?.start || 0 : 0;
+	const totalSize = rowHeightPx * totalRows;
+	const paddingTop =
+		virtualRows.length > 0
+			? virtualRows?.[0]?.start || 0
+			: 0;
 	const paddingBottom =
 		virtualRows.length > 0
 			? totalSize - (virtualRows?.[virtualRows.length - 1]?.end || 0)

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -89,7 +89,7 @@ export const DataPanel = (props: DataPanelProps) => {
 			}),
 		[dataModel]);
 
-	async function fetchNextDataFragment(pageParam: number, fetchSize: number): Promise<DataFragment> {
+	async function fetchNextDataFragment(pageParam: any, fetchSize: number): Promise<DataFragment> {
 		// Fetches a single page of data from the data model.
 		const startRow = pageParam * fetchSize;
 		// Overwrite fetchSize so that we never request rows past the end of the dataset
@@ -119,6 +119,7 @@ export const DataPanel = (props: DataPanelProps) => {
 	} = ReactQuery.useInfiniteQuery<DataFragment>({
 			queryKey: ['table-data', dataModel.id],
 			queryFn: ({pageParam = 0}) => fetchNextDataFragment(pageParam, fetchSize),
+			initialPageParam: 0,
 			// undefined if we are on the final page of data
 			getNextPageParam: (_lastGroup, groups) => groups.length !== maxPages ? groups.length : undefined,
 			refetchOnWindowFocus: false,

--- a/extensions/positron-data-viewer/ui/src/app.tsx
+++ b/extensions/positron-data-viewer/ui/src/app.tsx
@@ -8,6 +8,7 @@ import { createRoot } from 'react-dom/client';
 
 // External modules.
 import * as ReactQuery from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 // Local modules.
 import { DataPanel } from './DataPanel';
@@ -43,6 +44,7 @@ window.addEventListener('message', (event: any) => {
 			<React.StrictMode>
 				<ReactQuery.QueryClientProvider client={queryClient}>
 					<DataPanel initialData={dataMessage.data} fetchSize={fetchSize} vscode={vscode} />
+					<ReactQueryDevtools initialIsOpen={false} />
 				</ReactQuery.QueryClientProvider>
 			</React.StrictMode>
 		);

--- a/extensions/positron-data-viewer/ui/yarn.lock
+++ b/extensions/positron-data-viewer/ui/yarn.lock
@@ -7,7 +7,19 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.0.5.tgz#db02d648398f75a04cc536dacd640265f3614b14"
   integrity sha512-MThCETMkHDHTnFZHp71L+SqTtD5d6XHftFCVR1xRJdWM3qGrlQ2VCXaj0SKVcyJej2e1Opa2c7iknu1llxCDNQ==
 
-"@tanstack/react-query@^5.1.0":
+"@tanstack/query-devtools@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.1.0.tgz#ad7e88a4e7e0813bc00a25f0a9284d22990fe204"
+  integrity sha512-EZhYS6clf4yyzFwE3b+7P2J46zgiweIwatc80MhfuzScz/Z4m1kPsKvNK0j54v4y1WvG4pN14qfOXjp4ac7f/Q==
+
+"@tanstack/react-query-devtools@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.1.0.tgz#1e75b4c0d5d8da657b8da97a61a229bf125935ef"
+  integrity sha512-Ms/GMccsrTBZQ+0v2pyIlaU0NlZXjhutPyhiQCviBqBbvYwsp/N/mT66YFaphzK/bhXzx5+NHbq8GI6V7KMY1Q==
+  dependencies:
+    "@tanstack/query-devtools" "5.1.0"
+
+"@tanstack/react-query@^5.0.5":
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.0.5.tgz#f26e05290f4b6bc9014704a65d05cf0cf47afe6e"
   integrity sha512-ZG0Q4HZ0iuI8mWiZ2/MdVYPHbrmAVhMn7+gLOkxJh6zLIgCL4luSZlohzN5Xt4MjxfxxWioO1nemwpudaTsmQg==

--- a/extensions/positron-data-viewer/ui/yarn.lock
+++ b/extensions/positron-data-viewer/ui/yarn.lock
@@ -2,18 +2,17 @@
 # yarn lockfile v1
 
 
-"@tanstack/query-core@4.36.1":
-  version "4.36.1"
-  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.36.1.tgz#79f8c1a539d47c83104210be2388813a7af2e524"
-  integrity sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==
+"@tanstack/query-core@5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.0.5.tgz#db02d648398f75a04cc536dacd640265f3614b14"
+  integrity sha512-MThCETMkHDHTnFZHp71L+SqTtD5d6XHftFCVR1xRJdWM3qGrlQ2VCXaj0SKVcyJej2e1Opa2c7iknu1llxCDNQ==
 
-"@tanstack/react-query@^4.36.1":
-  version "4.36.1"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.36.1.tgz#acb589fab4085060e2e78013164868c9c785e5d2"
-  integrity sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==
+"@tanstack/react-query@^5.1.0":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.0.5.tgz#f26e05290f4b6bc9014704a65d05cf0cf47afe6e"
+  integrity sha512-ZG0Q4HZ0iuI8mWiZ2/MdVYPHbrmAVhMn7+gLOkxJh6zLIgCL4luSZlohzN5Xt4MjxfxxWioO1nemwpudaTsmQg==
   dependencies:
-    "@tanstack/query-core" "4.36.1"
-    use-sync-external-store "^1.2.0"
+    "@tanstack/query-core" "5.0.5"
 
 "@tanstack/react-table@^8.8.5":
   version "8.8.5"
@@ -211,11 +210,6 @@ style-loader@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.2.tgz#eaebca714d9e462c19aa1e3599057bc363924899"
   integrity sha512-RHs/vcrKdQK8wZliteNK4NKzxvLBzpuHMqYmUVWeKa6MkaIQ97ZTOS0b+zapZhy6GcrgWnvWYCMHRirC3FsUmw==
-
-use-sync-external-store@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
-  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 util-deprecate@^1.0.2:
   version "1.0.2"

--- a/extensions/positron-data-viewer/yarn.lock
+++ b/extensions/positron-data-viewer/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@types/node@16.x":
-  version "16.18.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.23.tgz#b6e934fe427eb7081d0015aad070acb3373c3c90"
-  integrity sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g==
+"@types/node@18.x":
+  version "18.18.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.18.6.tgz#26da694f75cdb057750f49d099da5e3f3824cb3e"
+  integrity sha512-wf3Vz+jCmOQ2HV1YUJuCWdL64adYxumkrxtc+H1VUQlnQI04+5HtH+qZCOE21lBE7gIrt+CwX2Wv8Acrw5Ak6w==
 
 typescript@^4.5.5:
   version "4.9.5"


### PR DESCRIPTION
There are still a few more changes I'd like to make, but in the interest of keeping things digestible I think this is a reviewable chunk of changes (and probably a massive improvement over what's currently in main). 

Changes (4 and 7 are probably the most impactful):
1. Upgrade to React Query v5. This also involved some API changes to how we call the useInfiniteQuery hook.
2. Add React Query Dev Tools, which only show up when the data viewer extension is run in development mode, to help debugging some of the infinite query issues.
3. Add a request queue that we add new in-flight requests to, and remove when the response has been fulfilled. For the most part this isn't really being used much in the code yet, but it's functional and will be useful in subsequent PRs. Whenever the dataModel state gets updated, we check the request queue and filter out any newly fulfilled requests.
4. Make the async `fetchNextDataFragment` actually async. In this function, when we make a new request, in addition to adding the request to the request queue, We create a promise and add the resolve function to a dictionary of sorts. Then, when the response is received in the event handler, we can actually resolve the promise from the event handler. (see DataPanel.tsx L59-L82 and L134-L138)
5. Refactor the flatData callback (L180-L198)
6. Update the fetchMoreOnBottomReached so that it no longer depends on scrollHeight and clientHeight, but looks at the actual virtualized rows and fetched rows to determine when to trigger the `fetchNextPage` function. Removing these dependencies allows us to add extra padding in the rendered container, so that clientHeight never changes and we can avoid some of the scrollbar resizing and jumping (see next point). Instead of a scrollThreshold based on the number of pixels distance from bottom of the container, the scrollThreshold is based on the number of fetched rows remaining in the table.
7. Eliminate scrollbar jumping, at least for constant height rows (will handle variable height rows later). This is fixed by setting the height of paddingBottom based on the total number of rows in the dataset, as opposed to the currently fetched number of rows in the ReactTable object.

