### PR TITLE
add aria-labels to assorted toolbar buttons

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
@@ -18,6 +18,7 @@ interface ActionBarMenuButtonProps {
 	iconId?: string;
 	iconFontSize?: number;
 	text?: string;
+	ariaLabel?: string;
 	maxTextWidth?: number;
 	align?: 'left' | 'right';
 	tooltip?: string | (() => string | undefined);

--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/actionBars.tsx
@@ -32,6 +32,12 @@ const kPaddingRight = 8;
 const kFilterTimeout = 800;
 
 /**
+ * Localized strings.
+ */
+const positronRefreshObjects = localize('positronRefreshObjects', "Refresh objects");
+const positronDeleteAllObjects = localize('positronDeleteAllObjects', "Delete all objects");
+
+/**
  * ActionBarsProps interface.
  */
 export interface ActionBarsProps extends PositronEnvironmentServices {
@@ -111,9 +117,9 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						{/* Disabled for Private Alpha <ActionBarButton iconId='positron-import-data' text='Import Dataset' dropDown={true} /> */}
 					</ActionBarRegion>
 					<ActionBarRegion location='right'>
-						<ActionBarButton align='right' iconId='positron-refresh' tooltip={localize('positronRefreshObjects', "Refresh objects")} onClick={refreshObjectsHandler} />
+						<ActionBarButton align='right' iconId='positron-refresh' tooltip={positronRefreshObjects} ariaLabel={positronRefreshObjects} onClick={refreshObjectsHandler} />
 						<ActionBarSeparator />
-						<ActionBarButton align='right' iconId='positron-clear-pane' tooltip={localize('positronDeleteAllObjects', "Delete all objects")} onClick={deleteAllObjectsHandler} />
+						<ActionBarButton align='right' iconId='positron-clear-pane' tooltip={positronDeleteAllObjects} ariaLabel={positronDeleteAllObjects} onClick={deleteAllObjectsHandler} />
 					</ActionBarRegion>
 				</PositronActionBar>
 				<PositronActionBar size='small' borderBottom={true} gap={kSecondaryActionBarGap} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>

--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/groupingMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/groupingMenuButton.tsx
@@ -11,6 +11,11 @@ import { usePositronEnvironmentContext } from 'vs/workbench/contrib/positronEnvi
 import { PositronEnvironmentGrouping } from 'vs/workbench/services/positronEnvironment/common/interfaces/positronEnvironmentInstance';
 
 /**
+ * Localized strings.
+ */
+const positronChangeHowObjectsAreGrouped = localize('positronChangeHowObjectsAreGrouped', "Change how objects are grouped");
+
+/**
  * GroupingMenuButton component.
  * @returns The rendered component.
  */
@@ -102,7 +107,8 @@ export const GroupingMenuButton = () => {
 	return (
 		<ActionBarMenuButton
 			iconId='positron-environment-grouping'
-			tooltip={localize('positronChangeHowObjectsAreGrouped', "Change how objects are grouped")}
+			tooltip={positronChangeHowObjectsAreGrouped}
+			ariaLabel={positronChangeHowObjectsAreGrouped}
 			actions={actions}
 		/>
 	);

--- a/src/vs/workbench/contrib/positronEnvironment/browser/components/sortingMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronEnvironment/browser/components/sortingMenuButton.tsx
@@ -11,6 +11,11 @@ import { usePositronEnvironmentContext } from 'vs/workbench/contrib/positronEnvi
 import { PositronEnvironmentSorting } from 'vs/workbench/services/positronEnvironment/common/interfaces/positronEnvironmentInstance';
 
 /**
+ * Localized strings.
+ */
+const positronChangeHowObjectsAreSorted = localize('positronChangeHowObjectsAreSorted', "Change how objects are sorted");
+
+/**
  * SortingMenuButton component.
  * @returns The rendered component.
  */
@@ -81,7 +86,8 @@ export const SortingMenuButton = () => {
 	return (
 		<ActionBarMenuButton
 			iconId='positron-environment-sorting'
-			tooltip={localize('positronChangeHowObjectsAreSorted', "Change how objects are sorted")}
+			tooltip={positronChangeHowObjectsAreSorted}
+			ariaLabel={positronChangeHowObjectsAreSorted}
 			actions={actions}
 		/>
 	);

--- a/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
@@ -158,12 +158,14 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						disabled={!canNavigateBackward}
 						iconId='positron-left-arrow'
 						tooltip={tooltipPreviousTopic}
+						ariaLabel={tooltipPreviousTopic}
 						onClick={() => props.positronHelpService.navigateBackward()}
 					/>
 					<ActionBarButton
 						disabled={!canNavigateForward}
 						iconId='positron-right-arrow'
 						tooltip={tooltipNextTopic}
+						ariaLabel={tooltipNextTopic}
 						onClick={() => props.positronHelpService.navigateForward()}
 					/>
 
@@ -172,6 +174,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 					<ActionBarButton
 						iconId='positron-home'
 						tooltip={tooltipShowPositronHelp}
+						ariaLabel={tooltipShowPositronHelp}
 						disabled={true}
 						onClick={() => props.onHome()}
 					/>
@@ -203,6 +206,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						<ActionBarButton
 							iconId='positron-search'
 							tooltip={tooltipShowPositronHelp}
+							ariaLabel={tooltipShowPositronHelp}
 							align='right'
 							disabled={currentHelpEntry === undefined}
 							onClick={() => currentHelpEntry?.showFind()}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -28,6 +28,13 @@ const kPaddingLeft = 14;
 const kPaddingRight = 8;
 
 /**
+ * Localized strings.
+ */
+const positronShowPreviousPlot = localize('positronShowPreviousPlot', "Show previous plot");
+const positronShowNextPlot = localize('positronShowNextPlot', "Show next plot");
+const positronClearAllPlots = localize('positronClearAllPlots', "Clear all plots");
+
+/**
  * ActionBarsProps interface.
  */
 export interface ActionBarsProps {
@@ -94,8 +101,8 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 			<div className='action-bars'>
 				<PositronActionBar size='small' borderTop={true} borderBottom={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
 					<ActionBarRegion location='left'>
-						<ActionBarButton iconId='positron-left-arrow' disabled={disableLeft} tooltip={localize('positronShowPreviousPlot', "Show previous plot")} onClick={showPreviousPlotHandler} />
-						<ActionBarButton iconId='positron-right-arrow' disabled={disableRight} tooltip={localize('positronShowNextPlot', "Show next plot")} onClick={showNextPlotHandler} />
+						<ActionBarButton iconId='positron-left-arrow' disabled={disableLeft} tooltip={positronShowPreviousPlot} ariaLabel={positronShowPreviousPlot} onClick={showPreviousPlotHandler} />
+						<ActionBarButton iconId='positron-right-arrow' disabled={disableRight} tooltip={positronShowNextPlot} ariaLabel={positronShowNextPlot} onClick={showNextPlotHandler} />
 						{enableSizingPolicy && <ActionBarSeparator />}
 						{enableSizingPolicy && <SizingPolicyMenuButton
 							layoutService={props.layoutService}
@@ -106,7 +113,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 					<ActionBarRegion location='right'>
 						<HistoryPolicyMenuButton plotsService={positronPlotsContext.positronPlotsService} />
 						<ActionBarSeparator />
-						<ActionBarButton iconId='positron-clear-pane' align='right' disabled={noPlots} tooltip={localize('positronClearAllPlots', "Clear all plots")} onClick={clearAllPlotsHandler} />
+						<ActionBarButton iconId='positron-clear-pane' align='right' disabled={noPlots} tooltip={positronClearAllPlots} ariaLabel={positronClearAllPlots} onClick={clearAllPlotsHandler} />
 					</ActionBarRegion>
 				</PositronActionBar>
 			</div>

--- a/src/vs/workbench/contrib/positronPlots/browser/components/historyPolicyMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/historyPolicyMenuButton.tsx
@@ -63,6 +63,7 @@ export const HistoryPolicyMenuButton = (props: HistoryPolicyMenuButtonProps) => 
 		<ActionBarMenuButton
 			iconId='layout'
 			tooltip={historyPolicyTooltip}
+			ariaLabel={historyPolicyTooltip}
 			align='right'
 			actions={actions}
 		/>


### PR DESCRIPTION
Addresses #1702 by setting aria-labels equivalent to the tooltips.

I could, conceivably, make this more automatic and have buttons that don't display text, and don't have an explicitly set aria-label, defaulting to using the tooltip as the aria-label. That's for future me.