### PR TITLE
Revert "Trigger quick suggest on backspace too"

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestModel.ts
@@ -13,9 +13,7 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { CursorChangeReason, ICursorSelectionChangedEvent } from 'vs/editor/common/cursorEvents';
 import { IPosition, Position } from 'vs/editor/common/core/position';
-// --- Start Positron ---
-// import { Selection } from 'vs/editor/common/core/selection';
-// --- End Positron ---
+import { Selection } from 'vs/editor/common/core/selection';
 import { ITextModel } from 'vs/editor/common/model';
 import { CompletionContext, CompletionItemKind, CompletionItemProvider, CompletionTriggerKind } from 'vs/editor/common/languages';
 import { IEditorWorkerService } from 'vs/editor/common/services/editorWorker';
@@ -140,9 +138,7 @@ export class SuggestModel implements IDisposable {
 	private _triggerState: SuggestTriggerOptions | undefined = undefined;
 	private _requestToken?: CancellationTokenSource;
 	private _context?: LineContext;
-	// --- Start Positron ---
-	// private _currentSelection: Selection;
-	// --- End Positron ---
+	private _currentSelection: Selection;
 
 	private _completionModel: CompletionModel | undefined;
 	private readonly _completionDisposables = new DisposableStore();
@@ -165,9 +161,7 @@ export class SuggestModel implements IDisposable {
 		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
 		@IEnvironmentService private readonly _envService: IEnvironmentService,
 	) {
-		// --- Start Positron ---
-		// this._currentSelection = this._editor.getSelection() || new Selection(1, 1, 1, 1);
-		// --- End Positron ---
+		this._currentSelection = this._editor.getSelection() || new Selection(1, 1, 1, 1);
 
 		// wire up various listeners
 		this._toDispose.add(this._editor.onDidChangeModel(() => {
@@ -344,10 +338,8 @@ export class SuggestModel implements IDisposable {
 			return;
 		}
 
-		// --- Start Positron ---
-		// const prevSelection = this._currentSelection;
-		// this._currentSelection = this._editor.getSelection();
-		// --- End Positron ---
+		const prevSelection = this._currentSelection;
+		this._currentSelection = this._editor.getSelection();
 
 		if (!e.selection.isEmpty()
 			|| (e.reason !== CursorChangeReason.NotSet && e.reason !== CursorChangeReason.Explicit)
@@ -361,18 +353,10 @@ export class SuggestModel implements IDisposable {
 
 
 		if (this._triggerState === undefined && e.reason === CursorChangeReason.NotSet) {
-			// --- Start Positron ---
-			// We believe it is appropriate to trigger quick suggest after a left cursor movement
-			// too. This can easily occur when you hit backspace a few times after a typo. The typo
-			// can kill the active IntelliSense session, but you should be able to get a session
-			// back without having to manually trigger quick suggest or type another character.
-			// https://github.com/posit-dev/positron/issues/1413
-			// if (prevSelection.containsRange(this._currentSelection) || prevSelection.getEndPosition().isBeforeOrEqual(this._currentSelection.getPosition())) {
-			// 	// cursor did move RIGHT due to typing -> trigger quick suggest
-			// 	this._doTriggerQuickSuggest();
-			// }
-			this._doTriggerQuickSuggest();
-			// --- End Positron ---
+			if (prevSelection.containsRange(this._currentSelection) || prevSelection.getEndPosition().isBeforeOrEqual(this._currentSelection.getPosition())) {
+				// cursor did move RIGHT due to typing -> trigger quick suggest
+				this._doTriggerQuickSuggest();
+			}
 
 		} else if (this._triggerState !== undefined && e.reason === CursorChangeReason.Explicit) {
 			// suggest is active and something like cursor keys are used to move


### PR DESCRIPTION
Reverts https://github.com/posit-dev/positron/pull/1502
Addresses https://github.com/posit-dev/positron/issues/1563

As seen by https://github.com/posit-dev/positron/issues/1563, it has turned out to be much more annoying to have backspace trigger quick suggestions when you don't want them to than it is for a typo to cause your current quick suggestions session to disappear. Not being able to print out the source of an R function due to this is highly annoying.

So this rolls back https://github.com/posit-dev/positron/pull/1502.

In the original report, the complaint was that typing `testthat::expect_c` gave completions, but then adding `ab` caused the completion session to "die", so when you backspaced back to `testthat::expect_c` you no longer got completions. With the new addition of `Tab` as a way to re-trigger quick suggestions, I think this is much less annoying than it was before, so I don't think rolling this back hurts much.

In the future, one alternative to look into is why the completions session is dying in the first place, if we kept it alive even though there are 0 suggestions, then backspace would pull the existing session back up without needing to retrigger a new one. - although honestly the new behavior with this PR + Tab doesn't feel bad to me anymore