### PR TITLE
#233 console should support hyperlinks in output

### DIFF
--- a/extensions/positron-r/resources/scripts/startup.R
+++ b/extensions/positron-r/resources/scripts/startup.R
@@ -11,5 +11,4 @@ options(cli.default_num_colors = 256L)
 options(cli.dynamic = TRUE)
 
 # Tell cli that Positron's console supports hyperlinks
-# TODO: This would be better as `cli.default_dynamic`, but that doesn't exist yet
 options(cli.hyperlink = TRUE)

--- a/extensions/positron-r/resources/scripts/startup.R
+++ b/extensions/positron-r/resources/scripts/startup.R
@@ -9,3 +9,7 @@ options(cli.default_num_colors = 256L)
 # Tell cli that Positron's console supports dynamic updates
 # TODO: This would be better as `cli.default_dynamic`, but that doesn't exist yet
 options(cli.dynamic = TRUE)
+
+# Tell cli that Positron's console supports hyperlinks
+# TODO: This would be better as `cli.default_dynamic`, but that doesn't exist yet
+options(cli.hyperlink = TRUE)

--- a/src/vs/base/common/ansi-output.ts
+++ b/src/vs/base/common/ansi-output.ts
@@ -2033,6 +2033,11 @@ class OutputRun implements ANSIOutputRun {
 	private _id = generateId();
 
 	/**
+	 * Gets the hyperlink.
+	 */
+	private readonly _hyperlink?: Hyperlink;
+
+	/**
 	 * Gets or sets the text.
 	 */
 	private _text: string;
@@ -2041,11 +2046,6 @@ class OutputRun implements ANSIOutputRun {
 	 * Gets the SGR state.
 	 */
 	private readonly _sgrState?: SGRState;
-
-	/**
-	 * Gets the hyperlink.
-	 */
-	private readonly _hyperlink?: Hyperlink;
 
 	//#endregion Private Properties
 
@@ -2056,13 +2056,6 @@ class OutputRun implements ANSIOutputRun {
 	 */
 	get sgrState() {
 		return this._sgrState;
-	}
-
-	/**
-	 * Gets the hyperlink.
-	 */
-	get hyperlink() {
-		return this._hyperlink;
 	}
 
 	//#endregion Public Properties
@@ -2130,6 +2123,13 @@ class OutputRun implements ANSIOutputRun {
 	 */
 	public get id() {
 		return this._id;
+	}
+
+	/**
+	 * Gets the hyperlink.
+	 */
+	get hyperlink() {
+		return this._hyperlink;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.css
@@ -7,3 +7,9 @@
 		opacity: 0;
 	}
 }
+
+a.output-run-hyperlink {
+	cursor: pointer;
+	text-decoration: underline dotted;
+	color: var(--vscode-textLink-foreground);
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.tsx
@@ -5,7 +5,9 @@
 import 'vs/css!./outputRun';
 import * as React from 'react';
 import { CSSProperties } from 'react'; // eslint-disable-line no-duplicate-imports
+import * as nls from 'vs/nls';
 import { ANSIColor, ANSIOutputRun, ANSIStyle } from 'vs/base/common/ansi-output';
+import { usePositronConsoleContext } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleContext';
 
 // OutputRunProps interface.
 export interface OutputRunProps {
@@ -18,6 +20,9 @@ export interface OutputRunProps {
  * @returns The rendered component.
  */
 export const OutputRun = (props: OutputRunProps) => {
+	// Context hooks.
+	const positronConsoleContext = usePositronConsoleContext();
+
 	/**
 	 * ColorType enumeration.
 	 */
@@ -27,8 +32,23 @@ export const OutputRun = (props: OutputRunProps) => {
 	}
 
 	/**
+	 * Hyperlink click handler.
+	 */
+	const clickHandler = () => {
+		// Open the hyperlink.
+		if (props.outputRun.hyperlink) {
+			positronConsoleContext.openerService.open(props.outputRun.hyperlink.url);
+		} else {
+			// Can't happen.
+			positronConsoleContext.notificationService.error(
+				nls.localize('positron.unableToOpenHyperlink', "The hyperlink could not be opened.")
+			);
+		}
+	};
+
+	/**
 	 * Computes the styles.
-	 * @param styles The styles to compute.
+	 * @param styles The ANSIStyle array to compute.
 	 * @returns A CSSProperties that represents the styles.
 	 */
 	const computeStyles = (styles?: ANSIStyle[]): CSSProperties => {
@@ -38,51 +58,108 @@ export const OutputRun = (props: OutputRunProps) => {
 			styles.forEach(style => {
 				switch (style) {
 					// Bold.
-					case ANSIStyle.Bold:
-						cssProperties = { ...cssProperties, ...{ fontWeight: 'bold' } };
+					case ANSIStyle.Bold: {
+						cssProperties = {
+							...cssProperties,
+							...{
+								fontWeight: 'bold'
+							}
+						};
 						break;
+					}
 
 					// Dim.
-					case ANSIStyle.Dim:
-						cssProperties = { ...cssProperties, ...{ fontWeight: 'lighter' } };
+					case ANSIStyle.Dim: {
+						cssProperties = {
+							...cssProperties,
+							...{
+								fontWeight: 'lighter'
+							}
+						};
 						break;
+					}
 
 					// Italic.
-					case ANSIStyle.Italic:
-						cssProperties = { ...cssProperties, ...{ fontStyle: 'italic' } };
+					case ANSIStyle.Italic: {
+						cssProperties = {
+							...cssProperties,
+							...{
+								fontStyle: 'italic'
+							}
+						};
 						break;
+					}
 
 					// Underlined.
-					case ANSIStyle.Underlined:
-						cssProperties = { ...cssProperties, ...{ textDecorationLine: 'underline', textDecorationStyle: 'solid' } };
+					case ANSIStyle.Underlined: {
+						cssProperties = {
+							...cssProperties,
+							...{
+								textDecorationLine: 'underline',
+								textDecorationStyle: 'solid'
+							}
+						};
 						break;
+					}
 
 					// Slow blink.
-					case ANSIStyle.SlowBlink:
-						cssProperties = { ...cssProperties, ...{ animation: 'output-run-blink 1s linear infinite' } };
+					case ANSIStyle.SlowBlink: {
+						cssProperties = {
+							...cssProperties,
+							...{
+								animation: 'output-run-blink 1s linear infinite'
+							}
+						};
 						break;
+					}
 
 					// Rapid blink.
-					case ANSIStyle.RapidBlink:
-						cssProperties = { ...cssProperties, ...{ animation: 'output-run-blink 0.5s linear infinite' } };
+					case ANSIStyle.RapidBlink: {
+						cssProperties = {
+							...cssProperties,
+							...{
+								animation: 'output-run-blink 0.5s linear infinite'
+							}
+						};
 						break;
+					}
 
 					// Hidden.
-					case ANSIStyle.Hidden:
-						cssProperties = { ...cssProperties, ...{ visibility: 'hidden' } };
+					case ANSIStyle.Hidden: {
+						cssProperties = {
+							...cssProperties,
+							...{
+								visibility: 'hidden'
+							}
+						};
 						break;
+					}
 
 					// CrossedOut.
-					case ANSIStyle.CrossedOut:
-						cssProperties = { ...cssProperties, ...{ textDecorationLine: 'line-through', textDecorationStyle: 'solid' } };
+					case ANSIStyle.CrossedOut: {
+						cssProperties = {
+							...cssProperties,
+							...{
+								textDecorationLine: 'line-through',
+								textDecorationStyle: 'solid'
+							}
+						};
 						break;
+					}
 
 					// TODO Fraktur
 
 					// DoubleUnderlined.
-					case ANSIStyle.DoubleUnderlined:
-						cssProperties = { ...cssProperties, ...{ textDecorationLine: 'underline', textDecorationStyle: 'double' } };
+					case ANSIStyle.DoubleUnderlined: {
+						cssProperties = {
+							...cssProperties,
+							...{
+								textDecorationLine: 'underline',
+								textDecorationStyle: 'double'
+							}
+						};
 						break;
+					}
 
 					// TODO Framed
 					// TODO Encircled
@@ -100,16 +177,19 @@ export const OutputRun = (props: OutputRunProps) => {
 	/**
 	 * Computes the foreground or background color.
 	 * @param colorType The color type (foreground or background).
-	 * @param color The color. This can be one of the standard ANSI colors from
-	 * the ANSIColor enumeration or
-	 * @returns A CSSProperties that represents the foreground or background
-	 * color.
+	 * @param color The color. This can be one of the standard ANSI colors from the ANSIColor
+	 * enumeration or a string with an RGB color.
+	 * @returns A CSSProperties that represents the foreground or background color.
 	 */
-	const computeForegroundBackgroundColor = (colorType: ColorType, color?: ANSIColor | string): CSSProperties => {
+	const computeForegroundBackgroundColor = (
+		colorType: ColorType,
+		color?: ANSIColor | string
+	): CSSProperties => {
 		switch (color) {
 			// Undefined.
-			case undefined:
+			case undefined: {
 				return {};
+			}
 
 			// One of the standard colors.
 			case ANSIColor.Black:
@@ -127,20 +207,22 @@ export const OutputRun = (props: OutputRunProps) => {
 			case ANSIColor.BrightBlue:
 			case ANSIColor.BrightMagenta:
 			case ANSIColor.BrightCyan:
-			case ANSIColor.BrightWhite:
+			case ANSIColor.BrightWhite: {
 				if (colorType === ColorType.Foreground) {
 					return { color: `var(--vscode-positronConsole-${color})` };
 				} else {
 					return { background: `var(--vscode-positronConsole-${color})` };
 				}
+			}
 
 			// TODO@softwarenerd - This isn't hooked up.
-			default:
+			default: {
 				if (colorType === ColorType.Foreground) {
 					return { color: color };
 				} else {
 					return { background: color };
 				}
+			}
 		}
 	};
 
@@ -150,22 +232,27 @@ export const OutputRun = (props: OutputRunProps) => {
 			{} :
 			{
 				...computeStyles(outputRun.format.styles),
-				...computeForegroundBackgroundColor(ColorType.Foreground, outputRun.format.foregroundColor),
-				...computeForegroundBackgroundColor(ColorType.Background, outputRun.format.backgroundColor),
+				...computeForegroundBackgroundColor(
+					ColorType.Foreground,
+					outputRun.format.foregroundColor
+				),
+				...computeForegroundBackgroundColor(
+					ColorType.Background,
+					outputRun.format.backgroundColor
+				),
 			};
 	};
 
-	if (props.outputRun.hyperlink) {
-		// Render.
-		return (
-			<span style={computeCSSProperties(props.outputRun)}>
-				<a href={props.outputRun.hyperlink.url} style={{ textDecoration: 'underline' }}>{props.outputRun.text}</a>
-			</span>
-		);
-	} else {
-		// Render.
+	// Render.
+	if (!props.outputRun.hyperlink) {
 		return (
 			<span style={computeCSSProperties(props.outputRun)}>{props.outputRun.text}</span>
+		);
+	} else {
+		return (
+			<a className='output-run-hyperlink' href='#' onClick={clickHandler}>
+				<span style={computeCSSProperties(props.outputRun)}>{props.outputRun.text}</span>
+			</a>
 		);
 	}
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.tsx
@@ -155,8 +155,17 @@ export const OutputRun = (props: OutputRunProps) => {
 			};
 	};
 
-	// Render.
-	return (
-		<span style={computeCSSProperties(props.outputRun)}>{props.outputRun.text}</span>
-	);
+	if (props.outputRun.hyperlink) {
+		// Render.
+		return (
+			<span style={computeCSSProperties(props.outputRun)}>
+				<a href={props.outputRun.hyperlink.url} style={{ textDecoration: 'underline' }}>{props.outputRun.text}</a>
+			</span>
+		);
+	} else {
+		// Render.
+		return (
+			<span style={computeCSSProperties(props.outputRun)}>{props.outputRun.text}</span>
+		);
+	}
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
@@ -4,14 +4,17 @@
 
 import { useEffect, useState } from 'react';  // eslint-disable-line no-duplicate-imports
 import { ILogService } from 'vs/platform/log/common/log';
+import { IViewsService } from 'vs/workbench/common/views';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { IModelService } from 'vs/editor/common/services/model';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
@@ -19,7 +22,6 @@ import { IPositronPlotsService } from 'vs/workbench/services/positronPlots/commo
 import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/common/executionHistoryService';
 import { IPositronConsoleInstance, IPositronConsoleService } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
-import { IViewsService } from 'vs/workbench/common/views';
 
 /**
  * PositronConsoleServices interface. Defines the set of services that are required by the Positron console.
@@ -37,6 +39,8 @@ export interface PositronConsoleServices {
 	readonly languageService: ILanguageService;
 	readonly logService: ILogService;
 	readonly modelService: IModelService;
+	readonly notificationService: INotificationService;
+	readonly openerService: IOpenerService;
 	readonly positronConsoleService: IPositronConsoleService;
 	readonly positronPlotsService: IPositronPlotsService;
 	readonly viewsService: IViewsService;

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -18,6 +18,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { IViewDescriptorService, IViewsService } from 'vs/workbench/common/views';
+import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ViewPane, IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
@@ -164,6 +165,7 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 	 * @param languageService The language service.
 	 * @param logService The log service.
 	 * @param modelService The model service.
+	 * @param notificationService The notification service.
 	 * @param openerService The opener service.
 	 * @param positronConsoleService The Positron console service.
 	 * @param positronPlotsService The Positron plots service.
@@ -187,6 +189,7 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 		@ILanguageService private readonly languageService: ILanguageService,
 		@ILogService private readonly logService: ILogService,
 		@IModelService private readonly modelService: IModelService,
+		@INotificationService private readonly notificationService: INotificationService,
 		@IOpenerService openerService: IOpenerService,
 		@IPositronConsoleService private readonly positronConsoleService: IPositronConsoleService,
 		@IPositronPlotsService private readonly positronPlotsService: IPositronPlotsService,
@@ -268,6 +271,8 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 				languageService={this.languageService}
 				logService={this.logService}
 				modelService={this.modelService}
+				notificationService={this.notificationService}
+				openerService={this.openerService}
 				positronConsoleService={this.positronConsoleService}
 				positronPlotsService={this.positronPlotsService}
 				viewsService={this.viewsService}


### PR DESCRIPTION
This PR updates ANSIOutput - adding support for parsing Operating System Command escape sequences and OSC 8 (Anchor).

You can read more about OSC 8 here: https://iterm2.com/3.2/documentation-escape-codes.html

In R, you can test this by executing these commands:

```R
library(cli)
cat("This is a", style_hyperlink("Google", "https://google.com"), "link.\n")
style_hyperlink("Google", "https://google.com")
cli::cli_text("Google! {.url https://google.com}.")
cat("\x1b]8;;http://www.google.com\x1b\x5cThis is a Google Link\x1b]8;;\x1b\x5c")
```

When you do, you'll see:

<img width="1854" alt="image" src="https://github.com/posit-dev/positron/assets/853239/55c10974-fff8-4452-bbe8-83e91c69c5c1">

Each of the Google links can be opened using ⌘+Click on macOS. (Ctrl+Click on Windows).

Much work remains! We still have to sort out all the different OSC 8 scenarios we'll support.