### PR TITLE
fix ActionBarButtons being seen as groups by VoiceOver

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -46,12 +46,16 @@ export const ActionBarButton = forwardRef<HTMLDivElement, PropsWithChildren<Acti
 	if (props.iconId && props.iconFontSize) {
 		iconStyle = { ...iconStyle, fontSize: props.iconFontSize };
 	}
+	// Aria-hide the inner elements and promote the button text to an aria-label in order to
+	// avoid VoiceOver treating buttons as groups. See VSCode issue for more:
+	// https://github.com/microsoft/vscode/issues/181739#issuecomment-1779701917
+	const ariaLabel = props.ariaLabel ? props.ariaLabel : props.text;
 
 	// Render.
 	return (
 		<ActionBarTooltip {...props}>
-			<PositronButton ref={ref} className={buttonClassNames} onClick={props.onClick} ariaLabel={props.ariaLabel} disabled={props.disabled}>
-				<div className='action-bar-button-face' style={{ padding: props.layout === 'tight' ? '0' : '0 2px' }}>
+			<PositronButton ref={ref} className={buttonClassNames} onClick={props.onClick} ariaLabel={ariaLabel} disabled={props.disabled}>
+				<div className='action-bar-button-face' style={{ padding: props.layout === 'tight' ? '0' : '0 2px' }} aria-hidden='true' >
 					{props.iconId && <div className={`action-bar-button-icon codicon codicon-${props.iconId}`} style={iconStyle} />}
 					{props.text && <div className='action-bar-button-text' style={{ maxWidth: optionalValue(props.maxTextWidth, 'none') }}>{props.text}</div>}
 					{props.dropDown && <div className='action-bar-button-drop-down-arrow codicon codicon-positron-drop-down-arrow' />}


### PR DESCRIPTION
Addresses #1710

Clean up how ActionBarButtons appear to VoiceOver by removing the child elements of the button (from the accessibility tree) and ensuring there's an aria-label matching the embedded text (if any).