### PR TITLE
Address problems with `selectRuntime` shutdown/start timing

### DIFF
--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -246,14 +246,14 @@ export class LanguageRuntimeAdapter
 	 * Restarts the kernel.
 	 */
 	public async restart(): Promise<void> {
-		return this.shutdownKernel(true);
+		return this.shutdownKernel(positron.RuntimeExitReason.Restart);
 	}
 
 	/**
 	 * Shuts down the kernel permanently.
 	 */
-	public async shutdown(): Promise<void> {
-		return this.shutdownKernel(false);
+	public async shutdown(exitReason: positron.RuntimeExitReason): Promise<void> {
+		return this.shutdownKernel(exitReason);
 	}
 
 	/**
@@ -271,7 +271,7 @@ export class LanguageRuntimeAdapter
 	 * @returns A promise that resolves when the kernel has been instructed to
 	 *   shut down (not necessarily when it has exited)
 	 */
-	private async shutdownKernel(restart: boolean): Promise<void> {
+	private async shutdownKernel(exitReason: positron.RuntimeExitReason): Promise<void> {
 		// Ensure the kernel is in a running state before allowing the shutdown
 		if (this._kernelState !== positron.RuntimeState.Idle &&
 			this._kernelState !== positron.RuntimeState.Busy &&
@@ -279,13 +279,10 @@ export class LanguageRuntimeAdapter
 			return Promise.reject(new Error('Cannot shut down kernel; it is not (yet) running.' +
 				` (state = ${this._kernelState})`));
 		}
-		this._restarting = restart;
 
-		// Set up the exit reason for replay when we receive the Exited state
-		// after shutdown is complete
-		this._exitReason = restart ?
-			positron.RuntimeExitReason.Restart :
-			positron.RuntimeExitReason.Shutdown;
+		const restart = exitReason === positron.RuntimeExitReason.Restart;
+		this._restarting = restart;
+		this._exitReason = exitReason;
 
 		try {
 			await this._kernel.shutdown(restart);

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -730,6 +730,7 @@ export class LanguageRuntimeAdapter
 
 		// Create and fire the exit event.
 		const event: positron.LanguageRuntimeExit = {
+			runtime_name: this.metadata.runtimeName,
 			exit_code: exitCode,
 			reason: this._exitReason,
 			message: ''

--- a/extensions/positron-notebook-controllers/src/notebookRuntime.ts
+++ b/extensions/positron-notebook-controllers/src/notebookRuntime.ts
@@ -49,8 +49,8 @@ export class NotebookRuntime implements vscode.Disposable {
 		return this.runtime.start();
 	}
 
-	async shutdown(): Promise<void> {
-		return this.runtime.shutdown();
+	async shutdown(exitReason = positron.RuntimeExitReason.Shutdown): Promise<void> {
+		return this.runtime.shutdown(exitReason);
 	}
 
 	execute(code: string, id: string, mode: positron.RuntimeCodeExecutionMode, errorBehavior: positron.RuntimeErrorBehavior) {

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -148,11 +148,11 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 		}
 	}
 
-	async shutdown(): Promise<void> {
+	async shutdown(exitReason = positron.RuntimeExitReason.Shutdown): Promise<void> {
 		if (this._kernel) {
 			// Stop the LSP client before shutting down the kernel
 			await this._lsp.deactivate(true);
-			return this._kernel.shutdown();
+			return this._kernel.shutdown(exitReason);
 		} else {
 			throw new Error('Cannot shutdown; kernel not started');
 		}

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1130,7 +1130,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 	/**
 	 * Shuts down the runtime.
 	 */
-	async shutdown(): Promise<void> {
+	async shutdown(exitReason = positron.RuntimeExitReason.Shutdown): Promise<void> {
 		const parentId = randomUUID();
 
 		// Enter busy state to do shutdown processing.
@@ -1169,7 +1169,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		this._onDidEndSession.fire({
 			runtime_name: this.metadata.runtimeName,
 			exit_code: 0,
-			reason: positron.RuntimeExitReason.Shutdown,
+			reason: exitReason,
 			message: ''
 		});
 	}

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1112,6 +1112,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		this.simulateOutputMessage(parentId, 'Restarting.');
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
 		this._onDidEndSession.fire({
+			runtime_name: this.metadata.runtimeName,
 			exit_code: 0,
 			reason: positron.RuntimeExitReason.Restart,
 			message: ''
@@ -1166,6 +1167,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		this.simulateOutputMessage(parentId, 'Zed Kernel exiting.');
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
 		this._onDidEndSession.fire({
+			runtime_name: this.metadata.runtimeName,
 			exit_code: 0,
 			reason: positron.RuntimeExitReason.Shutdown,
 			message: ''
@@ -1177,6 +1179,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		// Simulate a force quit by immediately "exiting"
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
 		this._onDidEndSession.fire({
+			runtime_name: this.metadata.runtimeName,
 			exit_code: 0,
 			reason: positron.RuntimeExitReason.ForcedQuit,
 			message: ''
@@ -1843,6 +1846,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		this.simulateInputMessage(parentId, code);
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Exited);
 		this._onDidEndSession.fire({
+			runtime_name: this.metadata.runtimeName,
 			exit_code: 137,
 			reason: positron.RuntimeExitReason.Error,
 			message: `I'm terribly sorry, but a segmentation fault has occurred.`

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -570,7 +570,7 @@ declare module 'positron' {
 		 * runtime shutdown sequence has been successfully started (not
 		 * necessarily when it has completed).
 		 */
-		shutdown(): Thenable<void>;
+		shutdown(exitReason: RuntimeExitReason): Thenable<void>;
 
 		/**
 		 * Forcibly quits the runtime; returns a Thenable that resolves when the

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -142,6 +142,9 @@ declare module 'positron' {
 		/** The runtime is exiting in order to restart. */
 		Restart = 'restart',
 
+		/** The runtime is exiting in order to switch to a new runtime. */
+		SwitchRuntime = 'switchRuntime',
+
 		/** The runtime exited because of an error, most often a crash. */
 		Error = 'error',
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -160,7 +160,7 @@ declare module 'positron' {
 	 * language runtime exits.
 	 */
 	export interface LanguageRuntimeExit {
-		/** Runtime's name */
+		/** Runtime name */
 		runtime_name: string;
 
 		/**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -157,6 +157,9 @@ declare module 'positron' {
 	 * language runtime exits.
 	 */
 	export interface LanguageRuntimeExit {
+		/** Runtime's name */
+		runtime_name: string;
+
 		/**
 		 * The process exit code, if the runtime is backed by a process. If the
 		 * runtime is not backed by a process, this should just be 0 for a

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -9,7 +9,7 @@ import {
 	ExtHostPositronContext
 } from '../../common/positron/extHost.positron.protocol';
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
-import { ILanguageRuntime, ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageCommOpen, ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeDynState as ILanguageRuntimeDynState, ILanguageRuntimeService, ILanguageRuntimeStartupFailure, LanguageRuntimeMessageType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, LanguageRuntimeDiscoveryPhase, ILanguageRuntimeExit, RuntimeOutputKind } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageCommOpen, ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeDynState as ILanguageRuntimeDynState, ILanguageRuntimeService, ILanguageRuntimeStartupFailure, LanguageRuntimeMessageType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, LanguageRuntimeDiscoveryPhase, ILanguageRuntimeExit, RuntimeOutputKind, RuntimeExitReason } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { Event, Emitter } from 'vs/base/common/event';
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
@@ -398,13 +398,13 @@ class ExtHostLanguageRuntimeAdapter implements ILanguageRuntime {
 		return this._proxy.$restartLanguageRuntime(this.handle);
 	}
 
-	async shutdown(): Promise<void> {
+	async shutdown(exitReason = RuntimeExitReason.Shutdown): Promise<void> {
 		if (!this.canShutdown()) {
 			throw new Error(`Cannot shut down runtime '${this.metadata.runtimeName}': ` +
 				`runtime is in state '${this._currentState}'`);
 		}
 		this._stateEmitter.fire(RuntimeState.Exiting);
-		return this._proxy.$shutdownLanguageRuntime(this.handle);
+		return this._proxy.$shutdownLanguageRuntime(this.handle, exitReason);
 	}
 
 	async forceQuit(): Promise<void> {

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IDisposable } from 'vs/base/common/lifecycle';
-import { ILanguageRuntimeInfo, ILanguageRuntimeMetadata, RuntimeClientType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, ILanguageRuntimeMessage, ILanguageRuntimeDynState, ILanguageRuntimeExit } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeInfo, ILanguageRuntimeMetadata, RuntimeClientType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, ILanguageRuntimeMessage, ILanguageRuntimeDynState, ILanguageRuntimeExit, RuntimeExitReason } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { createProxyIdentifier, IRPCProtocol } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { IWebviewPortMapping, WebviewExtensionDescription } from 'vs/workbench/api/common/extHost.protocol';
 import { UriComponents } from 'vs/base/common/uri';
@@ -35,7 +35,7 @@ export interface ExtHostLanguageRuntimeShape {
 	$replyToPrompt(handle: number, id: string, response: string): void;
 	$interruptLanguageRuntime(handle: number): Promise<void>;
 	$restartLanguageRuntime(handle: number): Promise<void>;
-	$shutdownLanguageRuntime(handle: number): Promise<void>;
+	$shutdownLanguageRuntime(handle: number, exitReason: RuntimeExitReason): Promise<void>;
 	$forceQuitLanguageRuntime(handle: number): Promise<void>;
 	$showOutputLanguageRuntime(handle: number): void;
 	$discoverLanguageRuntimes(): void;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -77,11 +77,11 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		return this._runtimes[handle].interrupt();
 	}
 
-	async $shutdownLanguageRuntime(handle: number): Promise<void> {
+	async $shutdownLanguageRuntime(handle: number, exitReason: positron.RuntimeExitReason): Promise<void> {
 		if (handle >= this._runtimes.length) {
 			throw new Error(`Cannot shut down runtime: language runtime handle '${handle}' not found or no longer valid.`);
 		}
-		return this._runtimes[handle].shutdown();
+		return this._runtimes[handle].shutdown(exitReason);
 	}
 
 	async $forceQuitLanguageRuntime(handle: number): Promise<void> {

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -195,6 +195,9 @@ export enum RuntimeExitReason {
 	/** The runtime is exiting in order to restart. */
 	Restart = 'restart',
 
+	/** The runtime is exiting in order to switch to a new runtime. */
+	SwitchRuntime = 'switchRuntime',
+
 	/** The runtime exited because of an error, most often a crash. */
 	Error = 'error',
 

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterActions.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterActions.tsx
@@ -8,7 +8,7 @@ import { PropsWithChildren, useEffect, useState } from 'react'; // eslint-disabl
 import { localize } from 'vs/nls';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { PositronButton } from 'vs/base/browser/ui/positronComponents/positronButton';
-import { ILanguageRuntime, RuntimeExitReason, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 
 /**
  * InterpreterActionsProps interface.
@@ -95,7 +95,7 @@ export const InterpreterActions = (props: PropsWithChildren<InterpreterActionsPr
 				runtimeState === RuntimeState.Offline ||
 				runtimeState === RuntimeState.Interrupting
 			) &&
-				<PositronButton className='action-button' onClick={() => props.runtime.shutdown(RuntimeExitReason.Shutdown)}>
+				<PositronButton className='action-button' onClick={() => props.runtime.shutdown()}>
 					<span
 						className='codicon codicon-positron-power-button'
 						title={localize('positronStopTheInterpreter', "Stop the interpreter")}

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterActions.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterActions.tsx
@@ -8,7 +8,7 @@ import { PropsWithChildren, useEffect, useState } from 'react'; // eslint-disabl
 import { localize } from 'vs/nls';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { PositronButton } from 'vs/base/browser/ui/positronComponents/positronButton';
-import { ILanguageRuntime, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, RuntimeExitReason, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 
 /**
  * InterpreterActionsProps interface.
@@ -95,7 +95,7 @@ export const InterpreterActions = (props: PropsWithChildren<InterpreterActionsPr
 				runtimeState === RuntimeState.Offline ||
 				runtimeState === RuntimeState.Interrupting
 			) &&
-				<PositronButton className='action-button' onClick={() => props.runtime.shutdown()}>
+				<PositronButton className='action-button' onClick={() => props.runtime.shutdown(RuntimeExitReason.Shutdown)}>
 					<span
 						className='codicon codicon-positron-power-button'
 						title={localize('positronStopTheInterpreter', "Stop the interpreter")}

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
@@ -11,7 +11,7 @@ import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { LANGUAGE_RUNTIME_ACTION_CATEGORY } from 'vs/workbench/contrib/languageRuntime/common/languageRuntime';
-import { ILanguageRuntime, ILanguageRuntimeService, IRuntimeClientInstance, RuntimeClientType, RuntimeExitReason } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeService, IRuntimeClientInstance, RuntimeClientType } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IKeybindingRule, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
@@ -242,7 +242,7 @@ export function registerLanguageRuntimeActions() {
 		(await selectRunningLanguageRuntime(
 			accessor.get(ILanguageRuntimeService),
 			accessor.get(IQuickInputService),
-			'Select the interpreter to shutdown'))?.shutdown(RuntimeExitReason.Shutdown);
+			'Select the interpreter to shutdown'))?.shutdown();
 	});
 
 	// Registers the force quit language runtime action.

--- a/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/common/languageRuntimeActions.ts
@@ -11,7 +11,7 @@ import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { LANGUAGE_RUNTIME_ACTION_CATEGORY } from 'vs/workbench/contrib/languageRuntime/common/languageRuntime';
-import { ILanguageRuntime, ILanguageRuntimeService, IRuntimeClientInstance, RuntimeClientType } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeService, IRuntimeClientInstance, RuntimeClientType, RuntimeExitReason } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IKeybindingRule, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
@@ -242,7 +242,7 @@ export function registerLanguageRuntimeActions() {
 		(await selectRunningLanguageRuntime(
 			accessor.get(ILanguageRuntimeService),
 			accessor.get(IQuickInputService),
-			'Select the interpreter to shutdown'))?.shutdown();
+			'Select the interpreter to shutdown'))?.shutdown(RuntimeExitReason.Shutdown);
 	});
 
 	// Registers the force quit language runtime action.

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -301,7 +301,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 			// Ask the runtime to shut down.
 			await runningRuntime.shutdown(RuntimeExitReason.SwitchRuntime);
 
-			// Wait for the runtime onDidEndSession to solve, or for the timeout to expire
+			// Wait for the runtime onDidEndSession to resolve, or for the timeout to expire
 			// (whichever comes first)
 			await Promise.race([promise, timeout]);
 		}

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -460,7 +460,8 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 			// are currently processing have been called (i.e. everyone knows it has exited)
 			setTimeout(() => {
 				if (languageRuntimeInfo.state === RuntimeState.Exited &&
-					exit.reason === RuntimeExitReason.Restart) {
+					(exit.reason === RuntimeExitReason.Restart ||
+						exit.reason === RuntimeExitReason.SwitchRuntime)) {
 					this._onWillStartRuntimeEmitter.fire(runtime);
 				}
 			}, 0);

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -299,7 +299,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 			});
 
 			// Ask the runtime to shut down.
-			await runningRuntime.shutdown();
+			await runningRuntime.shutdown(RuntimeExitReason.SwitchRuntime);
 
 			// Wait for the runtime onDidEndSession to solve, or for the timeout to expire
 			// (whichever comes first)
@@ -460,8 +460,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 			// are currently processing have been called (i.e. everyone knows it has exited)
 			setTimeout(() => {
 				if (languageRuntimeInfo.state === RuntimeState.Exited &&
-					(exit.reason === RuntimeExitReason.Restart ||
-						exit.reason === RuntimeExitReason.SwitchRuntime)) {
+					exit.reason === RuntimeExitReason.Restart) {
 					this._onWillStartRuntimeEmitter.fire(runtime);
 				}
 			}, 0);

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -285,6 +285,8 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 					new Error(`${formatLanguageRuntime(runningRuntime)} is already running.`));
 			}
 
+			// We wait for `onDidEndSession()` rather than `RuntimeState.Exited`, because the former
+			// generates some Console output that must finish before starting up a new runtime:
 			const promise = new Promise<void>(resolve => {
 				const disposable = runningRuntime.onDidEndSession((exit) => {
 					resolve();

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -285,13 +285,26 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 					new Error(`${formatLanguageRuntime(runningRuntime)} is already running.`));
 			}
 
+			const promiseDidEndSession = new Promise<void>(resolve => {
+				const disposable = runningRuntime.onDidEndSession((exit) => {
+					resolve();
+					disposable.dispose();
+				});
+			});
+
+			const timeout1 = new Promise<void>((_, reject) => {
+				setTimeout(() => {
+					reject(new Error(`Timed out waiting for runtime ${formatLanguageRuntime(runningRuntime)} to exit.`));
+				}, 5000);
+			});
+
 			// Ask the runtime to shut down.
 			await runningRuntime.shutdown();
 
 			// If the runtime doesn't exit immediately, wait for it to exit.
 			if (runningRuntime.getRuntimeState() !== RuntimeState.Exited) {
 				// Create a promise that resolves when the runtime exits.
-				const promise = new Promise<void>(resolve => {
+				const promiseRuntimeExit = new Promise<void>(resolve => {
 					const disposable = runningRuntime.onDidChangeRuntimeState(state => {
 						if (state === RuntimeState.Exited) {
 							resolve();
@@ -301,7 +314,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 				});
 
 				// Create a promise that rejects after a timeout.
-				const timeout = new Promise<void>((_, reject) => {
+				const timeout2 = new Promise<void>((_, reject) => {
 					setTimeout(() => {
 						reject(new Error(`Timed out waiting for runtime ${formatLanguageRuntime(runningRuntime)} to exit.`));
 					}, 5000);
@@ -309,8 +322,10 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 
 				// Wait for the runtime to exit, or for the timeout to expire
 				// (whichever comes first)
-				await Promise.race([promise, timeout]);
+				await Promise.race([promiseRuntimeExit, timeout2]);
 			}
+
+			await Promise.race([promiseDidEndSession, timeout1]);
 		}
 
 		// Start the selected runtime.

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -587,7 +587,7 @@ export interface ILanguageRuntime {
 	restart(): Thenable<void>;
 
 	/** Shut down the runtime */
-	shutdown(): Thenable<void>;
+	shutdown(exitReason: RuntimeExitReason): Thenable<void>;
 
 	/** Force quit the runtime */
 	forceQuit(): Thenable<void>;

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -587,7 +587,7 @@ export interface ILanguageRuntime {
 	restart(): Thenable<void>;
 
 	/** Shut down the runtime */
-	shutdown(exitReason: RuntimeExitReason): Thenable<void>;
+	shutdown(exitReason?: RuntimeExitReason): Thenable<void>;
 
 	/** Force quit the runtime */
 	forceQuit(): Thenable<void>;

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -273,6 +273,9 @@ export enum RuntimeExitReason {
 	/** The runtime is exiting in order to restart. */
 	Restart = 'restart',
 
+	/** The runtime is exiting in order to switch to a new runtime. */
+	SwitchRuntime = 'switchRuntime',
+
 	/** The runtime exited because of an error, most often a crash. */
 	Error = 'error',
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -288,6 +288,9 @@ export enum RuntimeExitReason {
  * language runtime exits.
  */
 export interface ILanguageRuntimeExit {
+	/** Runtime name */
+	runtime_name: string;
+
 	/**
 	 * The process exit code, if the runtime is backed by a process. If the
 	 * runtime is not backed by a process, this should just be 0 for a

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -1438,6 +1438,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				return nls.localize('positronConsole.exit.restart', "{0} exited (preparing for restart)", exit.runtime_name);
 
 			case RuntimeExitReason.Shutdown:
+			case RuntimeExitReason.SwitchRuntime:
 				return nls.localize('positronConsole.exit.shutdown', "{0} shut down successfully.", exit.runtime_name);
 
 			case RuntimeExitReason.Error:

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -1031,7 +1031,14 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		// Set the state and add the appropriate runtime item to indicate whether the Positron
 		// console instance is is starting or is reconnected.
 		if (starting) {
-			const restart = this._state === PositronConsoleState.Exited;
+			let switchingRuntime = false;
+			for (let i = 0; i < this._runtimeItems.length; i++) {
+				if (this._runtimeItems[i] instanceof RuntimeItemExited) {
+					const runtimeItem = this._runtimeItems[i] as RuntimeItemExited;
+					switchingRuntime = runtimeItem.reason === RuntimeExitReason.SwitchRuntime;
+				}
+			}
+			const restart = this._state === PositronConsoleState.Exited && !switchingRuntime;
 			this.setState(PositronConsoleState.Starting);
 			this.addRuntimeItem(new RuntimeItemStarting(
 				generateUuid(),

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -1621,7 +1621,6 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * has become ready, since at that point the restart is complete.
 	 */
 	private clearRestartItems() {
-
 		const itemCount = this._runtimeItems.length;
 
 		// Remove all restart buttons from the console.

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -1621,9 +1621,6 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * has become ready, since at that point the restart is complete.
 	 */
 	private clearRestartItems() {
-		if (this._trace) {
-			this.addRuntimeItemTrace(`clearRestartItems`);
-		}
 
 		const itemCount = this._runtimeItems.length;
 
@@ -1633,10 +1630,6 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 		// If we removed buttons, fire the runtime items changed event.
 		if (this._runtimeItems.length !== itemCount) {
-			if (this._trace) {
-				this.addRuntimeItemTrace(`Removed RuntimeItemRestartButton`);
-			}
-
 			this._onDidChangeRuntimeItemsEmitter.fire();
 		}
 	}

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -1432,23 +1432,23 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	private formatExit(exit: ILanguageRuntimeExit): string {
 		switch (exit.reason) {
 			case RuntimeExitReason.ForcedQuit:
-				return nls.localize('positronConsole.exit.forcedQuit', "{0} was forced to quit.", this._runtime.metadata.runtimeName);
+				return nls.localize('positronConsole.exit.forcedQuit', "{0} was forced to quit.", exit.runtime_name);
 
 			case RuntimeExitReason.Restart:
-				return nls.localize('positronConsole.exit.restart', "{0} exited (preparing for restart)", this._runtime.metadata.runtimeName);
+				return nls.localize('positronConsole.exit.restart', "{0} exited (preparing for restart)", exit.runtime_name);
 
 			case RuntimeExitReason.Shutdown:
-				return nls.localize('positronConsole.exit.shutdown', "{0} shut down successfully.", this._runtime.metadata.runtimeName);
+				return nls.localize('positronConsole.exit.shutdown', "{0} shut down successfully.", exit.runtime_name);
 
 			case RuntimeExitReason.Error:
-				return nls.localize('positronConsole.exit.error', "{0} exited unexpectedly: {1}", this._runtime.metadata.runtimeName, this.formatExitCode(exit.exit_code));
+				return nls.localize('positronConsole.exit.error', "{0} exited unexpectedly: {1}", exit.runtime_name, this.formatExitCode(exit.exit_code));
 
 			case RuntimeExitReason.StartupFailed:
-				return nls.localize('positronConsole.exit.startupFailed', "{0} failed to start up (exit code {1})", this._runtime.metadata.runtimeName, exit.exit_code);
+				return nls.localize('positronConsole.exit.startupFailed', "{0} failed to start up (exit code {1})", exit.runtime_name, exit.exit_code);
 
 			default:
 			case RuntimeExitReason.Unknown:
-				return nls.localize('positronConsole.exit.unknown', "{0} exited (exit code {1})", this._runtime.metadata.runtimeName, exit.exit_code);
+				return nls.localize('positronConsole.exit.unknown', "{0} exited (exit code {1})", exit.runtime_name, exit.exit_code);
 		}
 	}
 
@@ -1613,6 +1613,10 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * has become ready, since at that point the restart is complete.
 	 */
 	private clearRestartItems() {
+		if (this._trace) {
+			this.addRuntimeItemTrace(`clearRestartItems`);
+		}
+
 		const itemCount = this._runtimeItems.length;
 
 		// Remove all restart buttons from the console.
@@ -1621,6 +1625,10 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 		// If we removed buttons, fire the runtime items changed event.
 		if (this._runtimeItems.length !== itemCount) {
+			if (this._trace) {
+				this.addRuntimeItemTrace(`Removed RuntimeItemRestartButton`);
+			}
+
 			this._onDidChangeRuntimeItemsEmitter.fire();
 		}
 	}


### PR DESCRIPTION
Joint work with @DavisVaughan 

Addresses #1573 

The main problem causing the bad behavior we observe in that issue ⤴️ is that we commonly end up with this sequence:

- Old runtime starts shutting down
- It get to `Exited` before all the stuff in `onDidEndSession` is finished happening
- New runtime starts because old runtime gets to `Exited`
- Messages about new runtime say "restarting" / "restarted" because the console knows about the previous exit but doesn't know that exit was for a different runtime
- The *new* runtime is running when some things in `onDidEndSession` happen, so the button never gets cleaned up, the message about shutting down uses the wrong runtime, etc

This PR as of right now makes two changes:

- Pass the runtime name as part of the `exit` object so we emit the right message (no longer looking up the current runtime)
- Add another listener plus `Promise.race()` for `onDidEndSession`, to wait until those things are done before starting the new runtime

As of right now, the restart button still gets added (because the old runtime does in fact shutdown) but it is now cleaned up, and the messages are better but not ideal. I can work on these further issues but I wanted to raise a question here first:

#### How confident are we that the right runtime state for _during_ `onDidEndSession` is `Exited`? i.e. are we sure about it firing _after_ the exit is done?