### PR TITLE
change devtool mode in development bundling step only

### DIFF
--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -175,7 +175,8 @@ const tasks = compilations.map(function (tsconfigFile) {
 				.pipe(needsBundling
 					? webpack({
 						...require(webpackConfigPath),
-						mode: 'development'
+						mode: 'development',
+						devtool: 'eval-cheap-source-map',
 					}, compiler, function (_err, stats) {
 						// output some info about the compiled assets
 						console.log(stats.toString({ preset: 'minimal', colors: true }));


### PR DESCRIPTION
When we use webpack to bundle in development mode, we have a choice of how source maps are generated. Our [production builds](https://github.com/posit-dev/positron/blob/3afa0ee5485e6e920b76379ee99f651bf14d6cba/extensions/shared.webpack.config.js#L173) specify to use `source-map`, which is the "recommended choice for production builds with high quality SourceMaps" ([source](https://webpack.js.org/configuration/devtool/)). In development mode, if `devtool` option is not explicitly set, it uses `eval` by default. `eval` is the "recommended choice for development builds with maximum performance" but potentially low quality source maps. 

It also leads to all these warnings in the devtools console, which I find very annoying.
<img width="669" alt="image" src="https://github.com/posit-dev/positron/assets/7817881/f7051bc4-7026-41fc-8a97-20882b2f2ceb">

If we change the `devtool` option to `eval-source-map` or `eval-cheap-source-map`, the warnings go away, and it seems like this gives us better quality source maps too. `eval-source-map` is the "recommended choice for development builds with high quality SourceMaps" and `eval-cheap-source-map` appears to be a tradeoff between the maximum performance of `eval` and the maximum quality source maps of `eval-source-map`. These improved source maps eliminate all of those warnings in the console, so that's a win for me.

Putting it in the gulpfile instead of the webpack config js file so we use this setting only in development mode and only in the extensions that get bundled with webpack