### PR TITLE
Add Positron-level busy/idle messages to Zed frontend comm

### DIFF
--- a/extensions/positron-zed/src/positronZedFrontend.ts
+++ b/extensions/positron-zed/src/positronZedFrontend.ts
@@ -39,6 +39,21 @@ export class ZedFrontend {
 		});
 	}
 
+	/**
+	 * Mark Zed as busy or idle.
+	 *
+	 * @param busy Whether to mark Zed as busy (true) or idle (false)
+	 */
+	public markBusy(busy: boolean) {
+		this._onDidEmitData.fire({
+			msg_type: 'event',
+			name: 'busy',
+			data: {
+				busy: busy,
+			}
+		});
+	}
+
 	get directory(): string {
 		return this._directory;
 	}


### PR DESCRIPTION
Quick change to the Zed test platform so that it emits busy/idle messages for Zed's "computation" engine (for operations that don't return immediately). 