### PR TITLE
Updates/improve console url handling

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.tsx
@@ -5,9 +5,15 @@
 import 'vs/css!./outputRun';
 import * as React from 'react';
 import { CSSProperties } from 'react'; // eslint-disable-line no-duplicate-imports
-import * as nls from 'vs/nls';
+// import * as nls from 'vs/nls';
 import { ANSIColor, ANSIOutputRun, ANSIStyle } from 'vs/base/common/ansiOutput';
 import { usePositronConsoleContext } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleContext';
+import { Schemas } from 'vs/base/common/network';
+
+/**
+ * Constants.
+ */
+const numberRegex = /^\d+$/;
 
 // OutputRunProps interface.
 export interface OutputRunProps {
@@ -32,17 +38,62 @@ export const OutputRun = (props: OutputRunProps) => {
 	}
 
 	/**
+	 * Builds the hyperlink URL for the output run.
+	 * @returns The hyperlink URL for the output run. Returns undefined if the output run's
+	 * hyperlink is undefined.
+	 */
+	const buildHyperlinkURL = () => {
+		// If the hyperlink is undefined, return undefined.
+		if (!props.outputRun.hyperlink) {
+			return undefined;
+		}
+
+		// Get the URL. If it's not a file URL, return it.
+		let url = props.outputRun.hyperlink.url;
+		if (!url.startsWith(`${Schemas.file}:`)) {
+			return url;
+		}
+
+		// Get the line parameter. If it's not present, return the URL.
+		const line = props.outputRun.hyperlink.params?.get('line') || undefined;
+		if (!line) {
+			return url;
+		}
+		const lineMatch = line.match(numberRegex);
+		if (!lineMatch) {
+			return url;
+		}
+
+		// Append the line number to the URL.
+		url += `#${lineMatch[0]}`;
+
+		// Get the column parameter. If it's not present, return the URL.
+		const col = props.outputRun.hyperlink.params?.get('col') || undefined;
+		if (!col) {
+			return url;
+		}
+		const colMatch = col.match(numberRegex);
+		if (!colMatch) {
+			return url;
+		}
+
+		// Append the column number to the URL.
+		url += `,${colMatch[0]}`;
+
+		// Return the URL.
+		return url;
+	};
+
+	/**
 	 * Hyperlink click handler.
 	 */
-	const clickHandler = () => {
-		// Open the hyperlink.
-		if (props.outputRun.hyperlink) {
-			positronConsoleContext.openerService.open(props.outputRun.hyperlink.url);
+	const hyperlinkClickHandler = () => {
+		const url = buildHyperlinkURL();
+		if (url) {
+			positronConsoleContext.openerService.open(url);
 		} else {
 			// Can't happen.
-			positronConsoleContext.notificationService.error(
-				nls.localize('positron.unableToOpenHyperlink', "The hyperlink could not be opened.")
-			);
+			positronConsoleContext.notificationService.error('The hyperlink could not be opened.');
 		}
 	};
 
@@ -250,7 +301,7 @@ export const OutputRun = (props: OutputRunProps) => {
 		);
 	} else {
 		return (
-			<a className='output-run-hyperlink' href='#' onClick={clickHandler}>
+			<a className='output-run-hyperlink' href='#' onClick={hyperlinkClickHandler}>
 				<span style={computeCSSProperties(props.outputRun)}>{props.outputRun.text}</span>
 			</a>
 		);

--- a/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.tsx
@@ -5,7 +5,7 @@
 import 'vs/css!./outputRun';
 import * as React from 'react';
 import { CSSProperties } from 'react'; // eslint-disable-line no-duplicate-imports
-// import * as nls from 'vs/nls';
+import { localize } from 'vs/nls';
 import { ANSIColor, ANSIOutputRun, ANSIStyle } from 'vs/base/common/ansiOutput';
 import { usePositronConsoleContext } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleContext';
 import { Schemas } from 'vs/base/common/network';
@@ -93,7 +93,10 @@ export const OutputRun = (props: OutputRunProps) => {
 			positronConsoleContext.openerService.open(url);
 		} else {
 			// Can't happen.
-			positronConsoleContext.notificationService.error('The hyperlink could not be opened.');
+			positronConsoleContext.notificationService.error(localize(
+				'positron.unableToOpenHyperlink',
+				"The hyperlink could not be opened."
+			));
 		}
 	};
 


### PR DESCRIPTION
This PR updates file-scheme URL handling. 

You can test this out using:

```R
library(cli)

# Files
cli_text("Click {.file ~/.zshrc} to edit your .zshrc file.")
cli_text("Click {.file ~/.zshrc:7:8} to edit line 7 column 5 of your .zshrc file.")
cli_text("Click {.file ~/.zshrc:10:5} to edit line 10 column 5 of your .zshrc file.")
```

And:

```R
library(cli)

# Files
cli_text("Please visit {.href [.zshrc](file:///Users/brian/.zshrc)} to Brian's .zshrc file.")
cli_text("Please visit {.href [.zshrc](file:///Users/brian/.zshrc#17,5)} to Brian's .zshrc file.")
```

After picking suitable URLs that will open on your machine.

Note: I plan to add an href URL conversion feature in another PR that will map file URLs in this format:

```R
file:///Users/brian/.zshrc:17:5
```

into this format:

```R
file:///Users/brian/.zshrc#17,5
```

Because I believe users will generate URLs like this.
