### PR TITLE
Support file URLS in file:line:col and file:line format

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.tsx
@@ -14,6 +14,8 @@ import { Schemas } from 'vs/base/common/network';
  * Constants.
  */
 const numberRegex = /^\d+$/;
+const fileURLWithLine = /^(file:\/\/\/.+):(\d+)$/;
+const fileURLWithLineAndColumn = /^(file:\/\/\/.+):(\d+):(\d+)$/;
 
 // OutputRunProps interface.
 export interface OutputRunProps {
@@ -57,6 +59,23 @@ export const OutputRun = (props: OutputRunProps) => {
 		// Get the line parameter. If it's not present, return the URL.
 		const line = props.outputRun.hyperlink.params?.get('line') || undefined;
 		if (!line) {
+			// See if the URL has line / column information in :line:col format.
+			{
+				const match = url.match(fileURLWithLineAndColumn);
+				if (match && match.length === 4) {
+					return `${match[1]}#${match[2]},${match[3]}`;
+				}
+			}
+
+			// See if the URL has line information in :line format.
+			{
+				const match = url.match(fileURLWithLine);
+				if (match && match.length === 3) {
+					return `${match[1]}#${match[2]},1`;
+				}
+			}
+
+			// Just return the URL without line / column information.
 			return url;
 		}
 		const lineMatch = line.match(numberRegex);


### PR DESCRIPTION
This PR updates OSC 8 file URL handling so that URLs in the form:

```
file:///Users/brian/.zshrc:17:5
file:///Users/brian/.zshrc:5
```

Are supported and properly navigate to the `:line:col` or `:line` specified.

To test this, execute the following R code replacing the file URL with something that's valid on your machine.

```R
cli_text("Please visit {.href [.zshrc](file:///Users/brian/.zshrc:17:5)} to Brian's .zshrc file.")
cli_text("Please visit {.href [.zshrc](file:///Users/brian/.zshrc:5)} to Brian's .zshrc file.")
```

Here's a long list of file URLs that should work:

```R
# Files
cli_text("Click {.file ~/.zshrc} to edit your .zshrc file.")
cli_text("Click {.file ~/.zshrc:7:5} to edit line 7 column 5 of your .zshrc file.")
cli_text("Click {.file ~/.zshrc:10:5} to edit line 10 column 5 of your .zshrc file.")
cli_text("Please visit {.href [.zshrc](file:///Users/brian/.zshrc)} to Brian's .zshrc file.")
cli_text("Please visit {.href [.zshrc](file:///Users/brian/.zshrc#17,5)} to Brian's .zshrc file.")
cli_text("Please visit {.href [.zshrc](file:///Users/brian/.zshrc#5)} to Brian's .zshrc file.")
cli_text("Please visit {.href [.zshrc](file:///Users/brian/.zshrc:17:5)} to Brian's .zshrc file.")
cli_text("Please visit {.href [.zshrc](file:///Users/brian/.zshrc:5)} to Brian's .zshrc file.")
```


