### PR TITLE
Initialise number of log lines seen to support refresh

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -1358,6 +1358,15 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			output.appendLine(`[${prefix}] ${error}`);
 		});
 
+		// Initialise number of lines seen, which might not be zero as the
+		// kernel might have already started outputing lines, or we might be
+		// refreshing with an existing log file. This is used for flushing
+		// the tail of the log on disposal. There is a race condition here so
+		// this might be slightly off, causing duplicate lines in the tail of
+		// the log.
+		const lines = fs.readFileSync(this._session!.state.logFile, 'utf8').split('\n');
+		this._logNLines = lines.length;
+
 		// Start watching the log file. This streams output until the kernel is
 		// disposed.
 		this._logTail.watch();

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -1354,6 +1354,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			output.appendLine(`[${prefix}] ${data}`);
 		});
 		this._logTail.on('error', function (error: string) {
+			ses._logNLines += 1;
 			output.appendLine(`[${prefix}] ${error}`);
 		});
 


### PR DESCRIPTION
Follow-up to https://github.com/posit-dev/positron/pull/708 which adds a mechanism to flush the tail of the log on restart. I noticed some missing log lines in case of refresh. This PR fixes this by initialising the number of lines seen from the existing file.

There is a race condition here since the kernel is concurrently writing to the log file. If this happens there will be duplicate lines in the tail of the log when the runtime restarts, but no missing lines.

In addition:

- Rewrite implementation to use a synchronous file access API instead of asynchronous.
- Keep track of error lines seen.