### PR TITLE
Extend Mac build timeouts to 90 mins

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -86,7 +86,7 @@ jobs:
     name: Build macOS
     runs-on: [self-hosted, macos, arm64]
     needs: [revive_agent, version_string]
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -171,7 +171,7 @@ jobs:
     name: Create macOS universal binary
     needs: [version_string, build-archs]
     runs-on: [self-hosted, macos, arm64]
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
Sometimes the build can be a little slow, and we were timing out at 60 minutes. Increasing this to 90 minutes for now.