### PR TITLE
Add option to raise but not focus the console for `executeCode()`

### DIFF
--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -46,11 +46,11 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 
 		// Commands for package development tooling
 		vscode.commands.registerCommand('r.packageLoad', () => {
-			positron.runtime.executeCode('r', 'devtools::load_all()', true);
+			positron.runtime.executeCode('r', 'devtools::load_all()', positron.RuntimeConsoleFocus.Focus);
 		}),
 
 		vscode.commands.registerCommand('r.packageBuild', () => {
-			positron.runtime.executeCode('r', 'devtools::build()', true);
+			positron.runtime.executeCode('r', 'devtools::build()', positron.RuntimeConsoleFocus.Focus);
 		}),
 
 		vscode.commands.registerCommand('r.packageInstall', async () => {
@@ -94,7 +94,7 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 		}),
 
 		vscode.commands.registerCommand('r.packageTest', () => {
-			positron.runtime.executeCode('r', 'devtools::test()', true);
+			positron.runtime.executeCode('r', 'devtools::test()', positron.RuntimeConsoleFocus.Focus);
 		}),
 
 		vscode.commands.registerCommand('r.packageCheck', async () => {
@@ -104,7 +104,7 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 		}),
 
 		vscode.commands.registerCommand('r.packageDocument', () => {
-			positron.runtime.executeCode('r', 'devtools::document()', true);
+			positron.runtime.executeCode('r', 'devtools::document()', positron.RuntimeConsoleFocus.Focus);
 		}),
 
 		// Command used to source the current file
@@ -142,7 +142,7 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 				// to ensure that it is properly escaped.
 				if (fsStat) {
 					const command = `source(${JSON.stringify(filePath)})`;
-					positron.runtime.executeCode('r', command, true);
+					positron.runtime.executeCode('r', command, positron.RuntimeConsoleFocus.Focus);
 				}
 			} catch (e) {
 				// This is not a valid file path, which isn't an error; it just

--- a/extensions/positron-r/src/testing.ts
+++ b/extensions/positron-r/src/testing.ts
@@ -152,7 +152,7 @@ async function runTest(run: vscode.TestRun, test: vscode.TestItem): Promise<vsco
 		const testSource = source.slice(startIndex, endIndex);
 		const start = Date.now();
 		try {
-			positron.runtime.executeCode('r', testSource, true);
+			positron.runtime.executeCode('r', testSource, positron.RuntimeConsoleFocus.Focus);
 			run.passed(test, Date.now() - start);
 		} catch (error) {
 			run.failed(test, new vscode.TestMessage(String(error)), Date.now() - start);

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1606,7 +1606,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		this.simulateOutputMessage(parentId, `Executing ${languageId} snippet: ${codeToExecute}`);
 
 		// Perform the execution
-		const success = await positron.runtime.executeCode(languageId, codeToExecute, true);
+		const success = await positron.runtime.executeCode(languageId, codeToExecute, positron.RuntimeConsoleFocus.Focus);
 		if (!success) {
 			this.simulateOutputMessage(parentId, `Failed; is there an active console for ${languageId}?`);
 		}

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -102,6 +102,20 @@ declare module 'positron' {
 	}
 
 	/**
+	 * Possible console focus options for when code is executed in a language runtime
+	 */
+	export enum RuntimeConsoleFocus {
+		/** The console is raised AND focused. */
+		Focus = 'focus',
+
+		/** The console is raised but NOT focused. */
+		Raise = 'raise',
+
+		/** The code execution is run in the console in the background; the console is not raised or focused. */
+		Background = 'background'
+	}
+
+	/**
 	 * Possible code execution modes for a language runtime
 	 */
 	export enum RuntimeCodeExecutionMode {
@@ -865,13 +879,14 @@ declare module 'positron' {
 		 *
 		 * @param languageId The language ID of the code snippet
 		 * @param code The code snippet to execute
-		 * @param focus Whether to raise and focus the runtime's console
+		 * @param focus Whether to raise *and* focus the runtime's console, only raise, or neither
+		 *   focus nor raise
 		 * @returns A Thenable that resolves with true if the code was sent to a
 		 *   runtime successfully, false otherwise.
 		 */
 		export function executeCode(languageId: string,
 			code: string,
-			focus: boolean): Thenable<boolean>;
+			focus: RuntimeConsoleFocus): Thenable<boolean>;
 
 		/**
 		 * Register a language runtime provider with Positron.

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -9,7 +9,7 @@ import {
 	ExtHostPositronContext
 } from '../../common/positron/extHost.positron.protocol';
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
-import { ILanguageRuntime, ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageCommOpen, ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeDynState as ILanguageRuntimeDynState, ILanguageRuntimeService, ILanguageRuntimeStartupFailure, LanguageRuntimeMessageType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, LanguageRuntimeDiscoveryPhase, ILanguageRuntimeExit, RuntimeOutputKind, RuntimeExitReason } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageCommOpen, ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeDynState as ILanguageRuntimeDynState, ILanguageRuntimeService, ILanguageRuntimeStartupFailure, LanguageRuntimeMessageType, RuntimeConsoleFocus, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, LanguageRuntimeDiscoveryPhase, ILanguageRuntimeExit, RuntimeOutputKind, RuntimeExitReason } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { Event, Emitter } from 'vs/base/common/event';
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
@@ -993,7 +993,7 @@ export class MainThreadLanguageRuntime implements MainThreadLanguageRuntimeShape
 		this._runtimes.delete(handle);
 	}
 
-	$executeCode(languageId: string, code: string, focus: boolean): Promise<boolean> {
+	$executeCode(languageId: string, code: string, focus: RuntimeConsoleFocus): Promise<boolean> {
 		return this._positronConsoleService.executeCode(languageId, code, focus);
 	}
 

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4163,6 +4163,20 @@ export enum LanguageRuntimeMessageType {
 }
 
 /**
+ * Possible console focus options for when code is executed in a language runtime
+ */
+export enum RuntimeConsoleFocus {
+	/** The console is raised AND focused. */
+	Focus = 'focus',
+
+	/** The console is raised but NOT focused. */
+	Raise = 'raise',
+
+	/** The code execution is run in the console in the background; the console is not raised or focused. */
+	Background = 'background'
+}
+
+/**
  * Possible code execution modes for a language runtime
  */
 export enum RuntimeCodeExecutionMode {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -59,8 +59,8 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 		// --- Start Positron ---
 		const runtime: typeof positron.runtime = {
-			executeCode(langaugeId, code, focus): Thenable<boolean> {
-				return extHostLanguageRuntime.executeCode(langaugeId, code, focus);
+			executeCode(languageId, code, focus): Thenable<boolean> {
+				return extHostLanguageRuntime.executeCode(languageId, code, focus);
 			},
 			registerLanguageRuntime(runtime: positron.LanguageRuntime): vscode.Disposable {
 				return extHostLanguageRuntime.registerLanguageRuntime(extension, runtime);
@@ -125,6 +125,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			RuntimeExitReason: extHostTypes.RuntimeExitReason,
 			LanguageRuntimeMessageType: extHostTypes.LanguageRuntimeMessageType,
 			LanguageRuntimeStreamName: extHostTypes.LanguageRuntimeStreamName,
+			RuntimeConsoleFocus: extHostTypes.RuntimeConsoleFocus,
 			RuntimeCodeExecutionMode: extHostTypes.RuntimeCodeExecutionMode,
 			RuntimeErrorBehavior: extHostTypes.RuntimeErrorBehavior,
 			LanguageRuntimeStartupBehavior: extHostTypes.LanguageRuntimeStartupBehavior,

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IDisposable } from 'vs/base/common/lifecycle';
-import { ILanguageRuntimeInfo, ILanguageRuntimeMetadata, RuntimeClientType, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, ILanguageRuntimeMessage, ILanguageRuntimeDynState, ILanguageRuntimeExit, RuntimeExitReason } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeInfo, ILanguageRuntimeMetadata, RuntimeClientType, RuntimeConsoleFocus, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, ILanguageRuntimeMessage, ILanguageRuntimeDynState, ILanguageRuntimeExit, RuntimeExitReason } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { createProxyIdentifier, IRPCProtocol } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { IWebviewPortMapping, WebviewExtensionDescription } from 'vs/workbench/api/common/extHost.protocol';
 import { UriComponents } from 'vs/base/common/uri';
@@ -15,7 +15,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$restartLanguageRuntime(handle: number): Promise<void>;
 	$completeLanguageRuntimeDiscovery(): void;
 	$unregisterLanguageRuntime(handle: number): void;
-	$executeCode(languageId: string, code: string, focus: boolean): Promise<boolean>;
+	$executeCode(languageId: string, code: string, focus: RuntimeConsoleFocus): Promise<boolean>;
 	$getPreferredRuntime(languageId: string): Promise<ILanguageRuntimeMetadata>;
 	$getRunningRuntimes(languageId: string): Promise<ILanguageRuntimeMetadata[]>;
 	$emitLanguageRuntimeMessage(handle: number, message: ILanguageRuntimeMessage): void;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type * as positron from 'positron';
-import { ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageCommOpen, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageCommOpen, RuntimeConsoleFocus, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import * as extHostProtocol from './extHost.positron.protocol';
 import { Emitter } from 'vs/base/common/event';
 import { IDisposable } from 'vs/base/common/lifecycle';
@@ -370,7 +370,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		});
 	}
 
-	public executeCode(languageId: string, code: string, focus: boolean): Promise<boolean> {
+	public executeCode(languageId: string, code: string, focus: RuntimeConsoleFocus): Promise<boolean> {
 		return this._proxy.$executeCode(languageId, code, focus);
 	}
 

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -155,6 +155,20 @@ export enum RuntimeClientState {
 }
 
 /**
+ * Possible console focus options for when code is executed in a language runtime
+ */
+export enum RuntimeConsoleFocus {
+	/** The console is raised AND focused. */
+	Focus = 'focus',
+
+	/** The console is raised but NOT focused. */
+	Raise = 'raise',
+
+	/** The code execution is run in the console in the background; the console is not raised or focused. */
+	Background = 'background'
+}
+
+/**
  * Possible code execution modes for a language runtime
  */
 export enum RuntimeCodeExecutionMode {

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -25,6 +25,7 @@ import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeat
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { NOTEBOOK_EDITOR_FOCUSED } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
+import { RuntimeConsoleFocus } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { PositronConsoleViewPane } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleView';
 import { confirmationModalDialog } from 'vs/workbench/browser/positronModalDialogs/confirmationModalDialog';
 import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/common/executionHistoryService';
@@ -456,7 +457,7 @@ export function registerPositronConsoleActions() {
 			await viewsService.openView<PositronConsoleViewPane>(POSITRON_CONSOLE_VIEW_ID, false);
 
 			// Ask the Positron console service to execute the code.
-			if (!await positronConsoleService.executeCode(languageId, code, true)) {
+			if (!await positronConsoleService.executeCode(languageId, code, RuntimeConsoleFocus.Focus)) {
 				const languageName = languageService.getLanguageName(languageId);
 				notificationService.notify({
 					severity: Severity.Info,

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -217,6 +217,20 @@ export enum RuntimeState {
 }
 
 /**
+ * Possible console focus options for when code is executed in a language runtime
+ */
+export enum RuntimeConsoleFocus {
+	/** The console is raised AND focused. */
+	Focus = 'focus',
+
+	/** The console is raised but NOT focused. */
+	Raise = 'raise',
+
+	/** The code execution is run in the console in the background; the console is not raised or focused. */
+	Background = 'background'
+}
+
+/**
  * Possible code execution modes for a language runtime
  */
 export enum RuntimeCodeExecutionMode {

--- a/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/interfaces/positronConsoleService.ts
@@ -5,7 +5,7 @@
 import { Event } from 'vs/base/common/event';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { RuntimeItem } from 'vs/workbench/services/positronConsole/common/classes/runtimeItem';
-import { ILanguageRuntime } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, RuntimeConsoleFocus } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IEditor } from 'vs/editor/common/editorCommon';
 
 // Create the decorator for the Positron console service (used in dependency injection).
@@ -71,10 +71,11 @@ export interface IPositronConsoleService {
 	 * Executes code in a PositronConsoleInstance.
 	 * @param languageId The language ID.
 	 * @param code The code.
-	 * @param activate A value which indicates whether to activate the Positron console instance.
+	 * @param activate Whether to raise *and* focus the runtime's console, only raise, or neither
+	 *   focus nor raise
 	 * @returns A value which indicates whether the code could be executed.
 	 */
-	executeCode(languageId: string, code: string, activate: boolean): Promise<boolean>;
+	executeCode(languageId: string, code: string, activate: RuntimeConsoleFocus): Promise<boolean>;
 }
 
 /**

--- a/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/common/positronConsoleService.ts
@@ -32,7 +32,7 @@ import { ActivityItem, RuntimeItemActivity } from 'vs/workbench/services/positro
 import { ActivityItemInput, ActivityItemInputState } from 'vs/workbench/services/positronConsole/common/classes/activityItemInput';
 import { ActivityItemErrorStream, ActivityItemOutputStream } from 'vs/workbench/services/positronConsole/common/classes/activityItemStream';
 import { IPositronConsoleInstance, IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID, PositronConsoleState } from 'vs/workbench/services/positronConsole/common/interfaces/positronConsoleService';
-import { formatLanguageRuntime, ILanguageRuntime, ILanguageRuntimeExit, ILanguageRuntimeMessage, ILanguageRuntimeService, LanguageRuntimeStartupBehavior, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { formatLanguageRuntime, ILanguageRuntime, ILanguageRuntimeExit, ILanguageRuntimeMessage, ILanguageRuntimeService, LanguageRuntimeStartupBehavior, RuntimeConsoleFocus, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 
 /**
  * The onDidChangeRuntimeItems throttle threshold and throttle interval. The throttle threshold
@@ -320,15 +320,16 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 	 * Executes code in a PositronConsoleInstance.
 	 * @param languageId The language ID.
 	 * @param code The code.
-	 * @param activate A value which indicates whether the REPL should be activated.
+	 * @param activate Whether to raise *and* focus the runtime's console, only raise, or neither
+	 *   focus nor raise
 	 * @returns A value which indicates whether the code could be executed.
 	 */
-	async executeCode(languageId: string, code: string, activate: boolean) {
+	async executeCode(languageId: string, code: string, activate: RuntimeConsoleFocus) {
 		// If the console is to be activated, make sure we raise the console pane before we
 		// start attempting to run the code. We do this before we attempt to run anything so the
 		// user can see what's going on in the console (e.g. a language runtime starting up
 		// in order to handle the code that's about to be executed)
-		if (activate) {
+		if (activate === RuntimeConsoleFocus.Focus) {
 			await this._viewsService.openView(POSITRON_CONSOLE_VIEW_ID, false);
 		}
 
@@ -362,7 +363,7 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 		}
 
 		// If we're supposed to, activate the Positron console instance, if it isn't active.
-		if (activate && positronConsoleInstance !== this._activePositronConsoleInstance) {
+		if (activate === RuntimeConsoleFocus.Focus && positronConsoleInstance !== this._activePositronConsoleInstance) {
 			this.setActivePositronConsoleInstance(positronConsoleInstance);
 		}
 


### PR DESCRIPTION
Addresses #807 sort of, but I have realized that I don't think this is working how we want before the PR, or perhaps I have a misunderstanding here.

With the current code on main or a release build, I can't get the console to raise/focus in any of the circumstances I expect it to. If I have my console minimized and then do something like send code via <kbd>cmd</kbd> + <kbd>enter</kbd> or use one of the R package commands, the code is executed but the console is not raised.

With that being the situation, this PR switched out the boolean `focus` for a three-option enum but as far as I can tell, neither the current boolean or of course this new enum do anything at all. I haven't been able to dig into a solution for that focus/raise functionality yet.