### PR TITLE
Bump ark to 0.1.23

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -456,7 +456,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.22"
+      "ark": "0.1.23"
     }
   }
 }


### PR DESCRIPTION
This PR bumps `ark` version to `0.1.23` for https://github.com/posit-dev/amalthea/pull/139.
