### PR TITLE
Discontinuous scrolling continued: Better support for variable height rows, avoid ugly scroll pixel math assumptions

### DIFF
--- a/extensions/positron-data-viewer/ui/src/DataPanel.css
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.css
@@ -56,6 +56,10 @@ body,
 	height: 100%;
 }
 
+tr {
+	position: relative;
+}
+
 .container {
 	overflow: auto;
 	overflow-anchor: none;

--- a/extensions/positron-data-viewer/ui/src/DataPanel.css
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.css
@@ -56,10 +56,6 @@ body,
 	height: 100%;
 }
 
-tr {
-	position: relative;
-}
-
 .container {
 	overflow: auto;
 	overflow-anchor: none;

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -218,13 +218,13 @@ export const DataPanel = (props: DataPanelProps) => {
 	}, [positionOverlay]);
 
 	const fetchMorePages = React.useCallback(() => {
-		if (hasPreviousPage) {
-			fetchPreviousPage({cancelRefetch: false});
+		if (hasPreviousPage && !isFetching) {
+			fetchPreviousPage();
 		}
 		// We use else here to avoid fetching both pages simultaneously
 		// The callback will be invoked again after the previous page is fetched
-		else if (hasNextPage) {
-			fetchNextPage({cancelRefetch: false});
+		else if (hasNextPage && !isFetching) {
+			fetchNextPage();
 		}
 	}, [fetchNextPage, fetchPreviousPage, isFetching, hasPreviousPage, hasNextPage]);
 
@@ -239,7 +239,6 @@ export const DataPanel = (props: DataPanelProps) => {
 		const scrollPageBottom = Math.floor(lastVirtualRow / fetchSize);
 		dimensionsRef.current.scrollPageBottom = Math.min(scrollPageBottom, maxPage);
 
-		// Fetch more pages only if necessary
 		fetchMorePages();
 	}, [virtualRows, fetchMorePages]);
 
@@ -310,6 +309,7 @@ export const DataPanel = (props: DataPanelProps) => {
 								//ref={rowVirtualizer.measureElement}
 							>
 							{
+								!hasNextPage && !hasPreviousPage && !isFetching ?
 								row.getVisibleCells().map(cell => {
 									return (
 										<td key={cell.id}>
@@ -319,7 +319,8 @@ export const DataPanel = (props: DataPanelProps) => {
 											)}
 										</td>
 									);
-								})
+								}) :
+								null
 							}
 							</tr>
 						);

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -182,6 +182,14 @@ export const DataPanel = (props: DataPanelProps) => {
 
 	const virtualRows = rowVirtualizer.getVirtualItems();
 
+	const {paddingTop, paddingBottom} = React.useMemo(() => {
+		// Compute the padding for the table container.
+		const paddingTop = virtualRows?.[0]?.start || 0;
+		const totalSize = rowVirtualizer.getTotalSize();
+		const paddingBottom = totalSize - (virtualRows?.[virtualRows.length - 1]?.end || 0);
+		return {paddingTop, paddingBottom};
+	}, [virtualRows]);
+
 	const positionOverlay = React.useCallback((container: HTMLDivElement | null) => {
 		const emptyElement = {
 			clientHeight: 0,
@@ -249,7 +257,6 @@ export const DataPanel = (props: DataPanelProps) => {
 			onResize={e => positionOverlay(e.target as HTMLDivElement)}
 			ref={tableContainerRef}
 		>
-			<div style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
 			<table>
 				<thead ref={headerRef}>
 					{table.getHeaderGroups().map(headerGroup => (
@@ -287,18 +294,19 @@ export const DataPanel = (props: DataPanelProps) => {
 					))}
 				</thead>
 				<tbody>
-					{virtualRows.map((virtualRow, index) => {
+					{paddingTop > 0 && (
+						<tr>
+							<td style={{ height: `${paddingTop}px` }} />
+						</tr>
+					)}
+					{virtualRows.map(virtualRow => {
 						const row = rows[virtualRow.index] as ReactTable.Row<any>;
-						const translateY = virtualRow.start - index * virtualRow.size;
 
 						return (
 							<tr
 								key={virtualRow.key}
 								data-index={virtualRow.index}
-								style={{
-									transform: `translateY(${translateY}px)`,
-									height: `${virtualRow.size}px`
-								}}
+								//ref={rowVirtualizer.measureElement}
 							>
 							{
 								!hasNextPage && !hasPreviousPage && !isFetching ?
@@ -317,6 +325,11 @@ export const DataPanel = (props: DataPanelProps) => {
 							</tr>
 						);
 					})}
+					{paddingBottom > 0 && (
+						<tr>
+							<td style={{ height: `${paddingBottom}px` }} />
+						</tr>
+					)}
 				</tbody>
 			</table>
 			{
@@ -335,7 +348,6 @@ export const DataPanel = (props: DataPanelProps) => {
 				</div> :
 				null
 			}
-			</div>
 		</div>
 	);
 };

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -182,14 +182,6 @@ export const DataPanel = (props: DataPanelProps) => {
 
 	const virtualRows = rowVirtualizer.getVirtualItems();
 
-	const {paddingTop, paddingBottom} = React.useMemo(() => {
-		// Compute the padding for the table container.
-		const paddingTop = virtualRows?.[0]?.start || 0;
-		const totalSize = rowVirtualizer.getTotalSize();
-		const paddingBottom = totalSize - (virtualRows?.[virtualRows.length - 1]?.end || 0);
-		return {paddingTop, paddingBottom};
-	}, [virtualRows]);
-
 	const positionOverlay = React.useCallback((container: HTMLDivElement | null) => {
 		const emptyElement = {
 			clientHeight: 0,
@@ -257,6 +249,7 @@ export const DataPanel = (props: DataPanelProps) => {
 			onResize={e => positionOverlay(e.target as HTMLDivElement)}
 			ref={tableContainerRef}
 		>
+			<div style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
 			<table>
 				<thead ref={headerRef}>
 					{table.getHeaderGroups().map(headerGroup => (
@@ -294,19 +287,18 @@ export const DataPanel = (props: DataPanelProps) => {
 					))}
 				</thead>
 				<tbody>
-					{paddingTop > 0 && (
-						<tr>
-							<td style={{ height: `${paddingTop}px` }} />
-						</tr>
-					)}
-					{virtualRows.map(virtualRow => {
+					{virtualRows.map((virtualRow, index) => {
 						const row = rows[virtualRow.index] as ReactTable.Row<any>;
+						const translateY = virtualRow.start - index * virtualRow.size;
 
 						return (
 							<tr
 								key={virtualRow.key}
 								data-index={virtualRow.index}
-								//ref={rowVirtualizer.measureElement}
+								style={{
+									transform: `translateY(${translateY}px)`,
+									height: `${virtualRow.size}px`
+								}}
 							>
 							{
 								!hasNextPage && !hasPreviousPage && !isFetching ?
@@ -325,11 +317,6 @@ export const DataPanel = (props: DataPanelProps) => {
 							</tr>
 						);
 					})}
-					{paddingBottom > 0 && (
-						<tr>
-							<td style={{ height: `${paddingBottom}px` }} />
-						</tr>
-					)}
 				</tbody>
 			</table>
 			{
@@ -348,6 +335,7 @@ export const DataPanel = (props: DataPanelProps) => {
 				</div> :
 				null
 			}
+			</div>
 		</div>
 	);
 };

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -240,10 +240,7 @@ export const DataPanel = (props: DataPanelProps) => {
 		// Also ensures that we fetch both the previous and next page if both are needed
 		// (i.e. the viewport crosses a page boundary)
 		updateScroll(virtualRows?.[0], virtualRows?.[virtualRows.length - 1]);
-
-		if (!rowVirtualizer.isScrolling) {
-			fetchMorePages();
-		}
+		fetchMorePages();
 	}, [virtualRows, fetchMorePages, rowVirtualizer.isScrolling]);
 
 	return (

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -240,7 +240,10 @@ export const DataPanel = (props: DataPanelProps) => {
 		// Also ensures that we fetch both the previous and next page if both are needed
 		// (i.e. the viewport crosses a page boundary)
 		updateScroll(virtualRows?.[0], virtualRows?.[virtualRows.length - 1]);
-		fetchMorePages();
+
+		if (!rowVirtualizer.isScrolling) {
+			fetchMorePages();
+		}
 	}, [virtualRows, fetchMorePages, rowVirtualizer.isScrolling]);
 
 	return (

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -180,7 +180,6 @@ export const DataPanel = (props: DataPanelProps) => {
 		count: rows.length,
 		getScrollElement: () => tableContainerRef.current,
 		// This is just an initial estimate of row height
-		// The height of each row will be measured dynamically as it is rendered
 		estimateSize: () => rowHeightPx,
 		overscan: scrollOverscan
 	});
@@ -241,8 +240,7 @@ export const DataPanel = (props: DataPanelProps) => {
 		const lastVirtualRow = virtualRows?.[virtualRows.length - 1]?.index ?? 0;
 		const bottom = Math.min(Math.floor(lastVirtualRow / fetchSize), maxPage);
 		setScrollPages({top, bottom});
-		fetchMorePages();
-	}, [virtualRows, fetchMorePages]);
+	}, [virtualRows]);
 
 	React.useEffect(() => {
 		// Make sure we've caught up with the latest scroll position
@@ -250,7 +248,8 @@ export const DataPanel = (props: DataPanelProps) => {
 		// Also ensures that we fetch both the previous and next page if both are needed
 		// (i.e. the viewport crosses a page boundary)
 		updateScroll();
-	}, [updateScroll]);
+		fetchMorePages();
+	}, [updateScroll, fetchMorePages]);
 
 	return (
 		<div
@@ -308,9 +307,7 @@ export const DataPanel = (props: DataPanelProps) => {
 							<tr
 								key={virtualRow.key}
 								data-index={virtualRow.index}
-								style={{
-									height: `${virtualRow.size}px`
-								}}
+								style={{height: `${virtualRow.size}px`}}
 								//ref={rowVirtualizer.measureElement}
 							>
 							{

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -101,8 +101,7 @@ export const DataPanel = (props: DataPanelProps) => {
 	const initialDataFragment: DataFragment = new DataFragment(initialData.columns, 0, Math.min(fetchSize, totalRows));
 
 	// Use a React Query infinite query to fetch data from the data model
-	const {data, fetchNextPage, fetchPreviousPage, isFetching
-		, hasNextPage, hasPreviousPage
+	const {data, fetchNextPage, fetchPreviousPage, isFetching, hasNextPage, hasPreviousPage
 	} = ReactQuery.useInfiniteQuery(
 	{
 		queryKey: ['table-data'],
@@ -143,7 +142,7 @@ export const DataPanel = (props: DataPanelProps) => {
 		const flatData = Array(totalRows).fill(emptyRow);
 
 		// We don't expect pages to be in order, but we do expect that there aren't duplicates
-		// That shouldn't be possible based on our current implementation of getNext/PrevPageParams,
+		// That shouldn't be possible based on our implementation of getNext/PrevPageParams,
 		// but we check anyway to future-proof against changes to the query logic
 		const allPages = new Set(data.pageParams);
 		if (allPages.size !== data.pageParams.length) {

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -146,11 +146,12 @@ export const DataPanel = (props: DataPanelProps) => {
 			const page = data.pages[index];
 			if (page && page.columns.length) {
 				const {rowStart, rowEnd} = page;
-				flatData.splice(rowStart, rowEnd - rowStart, ...page.transpose());
+				flatData.splice(rowStart, rowEnd - rowStart + 1, ...page.transpose());
 			}
 		});
 		return flatData;
 	}, [data]);
+	console.log(`flatData: ${flatData.length} rows`);
 
 	// Define the main ReactTable instance.
 	const table = ReactTable.useReactTable(

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -143,9 +143,10 @@ export const DataPanel = (props: DataPanelProps) => {
 		const highestPage = Math.max(...data.pageParams as number[]);
 		const allPages = Array.from({ length: highestPage + 1 }, (_, pageParam) => pageParam);
 		const numColumns = data.pages[0].columns.length ?? 0;
-		const emptyPage = Array(fetchSize).fill(Array(numColumns).fill(null));
+		const emptyRow = Array(numColumns).fill(null);
+		const emptyPage = Array(fetchSize).fill(emptyRow);
 
-		return allPages.flatMap(pageParam => {
+		const flatData = allPages.flatMap(pageParam => {
 			const index = data.pageParams.indexOf(pageParam);
 			const page = data.pages[index];
 
@@ -156,7 +157,20 @@ export const DataPanel = (props: DataPanelProps) => {
 				return page.transpose();
 			}
 		});
+		const remainingRows = totalRows - flatData.length;
+		if (remainingRows > 0)
+		{
+			flatData.push(...Array(remainingRows).fill(emptyRow));
+		}
+		return flatData;
 	}, [data]);
+
+	React.useEffect(() => {
+		console.log(`flatData length: ${flatData.length}}`);
+		console.log(`totalRows: ${totalRows}}`);
+		const actualRows = flatData.filter(row => row.some((cell:any) => cell !== null));
+		console.log(`flatData actual data: ${actualRows.length}`);
+	}, [flatData]);
 
 	// Define the main ReactTable instance.
 	const table = ReactTable.useReactTable(


### PR DESCRIPTION
Follow-up to #1807, addresses #1706 more thoroughly

We can use the virtual row indices to properly calculate scroll top and bottom pages, without having to make assumptions/guesses about the height of each row. In order for this to work though, we need to make sure we fully pad the data with sparse rows, so that virtual row and row indices are always correct and the right shape, and update some of the effect dependencies to make sure they truly get re-run when scrolling is finished. React Query tends to ignore overlapping requests, so we need to be careful to re-trigger our hooks as the data comes in. Also some updates to flatData for better performance with very large and sparse data (sparse as in, we've only fetched ~500 rows of a 1 million row data frame, for example, and those 500 rows may not be contiguous).

This still has some performance issues with very large data frames that could be improved further, probably in a subsequent PR. Those performance issues are no longer due to the quantity of requests being made, but rather front-end issues -- we re-render the page several times per scroll. It's a little difficult to untangle, as we're using the virtual row index (possibly containing placeholder data) to determine the scroll position and what pages we need to fetch, and then fetching the data, which updates flatData -> table -> rows. So basically there are a lot of renders. But when I try to remove or refactor some of the dependencies, it either gets even slower or breaks. What's worse is it seems to worsen based on the size of the dataframe, i.e. fetching rows 100-199 on a 100,000 row data frame is significantly slower than on a 10,000 row data frame. I'm guessing this has to do with `flatData` -- we pad it to the size of the full dataset, creating a sparse dataframe, this makes a lot of the scrolling math and logic easier. But we're re-creating flatData from scratch every time we get a new page of data. I played around with storing flatData in a piece of state (since we need to re-render whenever flatData regenerates anyway), but using the previous state value of flatData to prepopulate the new flatData still requires a lot of copying and worse performance depending on the size of the full dataset. We could potentially store this in a ref instead, so we don't have to do any copying, and see if that helps performance at all

But also, we currently have the fetch size set to 100 (set in `app.tsx`) -- so only batches of 100 rows at a time will be sent over the comm. That's probably well below the threshold that would really strain the limits of the comm (although we could possibly make this dependent on number of columns too, smaller batch sizes for extra wide datasets), and sending such small batches might also have a deleterious effect on performance. There's a trade-off here between number of pages and size of each page, and 100 rows per page might not be optimal.

I experimented with using `useQueries` rather than `useInfiniteQuery` (see #1836). This allows us to run a dynamically defined number of queries, some or all of which are initially disabled, with each page having a separate entry in the cache, rather than infinite query where all pages share a single cache entry. I thought this might better allow us to run queries in parallel, since we don't have to worry about overwriting the single cache entry (which infinite query is particularly strict about), and the implementation works, but performance seems to be far worse, even scrolling within an already fetched page.

Also it looks like the scroll position gets reset when the component re-mounts, for example if you tab away to the editor and then back to the data viewer, your scroll position has been reset to the beginning of the dataset, which seems annoying. I can file an issue and address that separately as well