### PR TITLE
Fix tooltip tense and minimize, maximize, restore button order

### DIFF
--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -335,8 +335,8 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.minimizePanel',
-			title: { value: localize('minimizePanel', "Minimize Panel"), original: 'Minimizes Panel' },
-			tooltip: localize('minimizesPanel', "Minimizes Panel Size"),
+			title: { value: localize('positron.minimizePanel', "Minimize Panel"), original: 'Minimizes Panel' },
+			tooltip: localize('positron.minimizePanel', "Minimize Panel"),
 			category: Categories.View,
 			f1: true,
 			icon: positronMinimizePanelIcon,
@@ -370,17 +370,17 @@ registerAction2(class extends Action2 {
 });
 
 /**
- * Positron maximize panel action.
+ * Positron restore panel action.
  */
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: 'workbench.action.maximizePanel',
-			title: { value: localize('mazimizePanel', "Maximize Panel"), original: 'Maximize Panel' },
-			tooltip: localize('maximizesPanel', "Maximizes Panel Size"),
+			id: 'workbench.action.restorePanel',
+			title: { value: localize('positron.restorePanel', "Restore Panel"), original: 'Restore Panel' },
+			tooltip: localize('positron.restorePanel', "Restore Panel"),
 			category: Categories.View,
 			f1: true,
-			icon: positronMaximizePanelIcon,
+			icon: positronRestorePanelIcon,
 			// This action is only enabled when the panel position is bottom and the panel alignment
 			// is center.
 			precondition: ContextKeyExpr.and(PanelPositionContext.isEqualTo('bottom'), PanelAlignmentContext.isEqualTo('center')),
@@ -405,23 +405,23 @@ registerAction2(class extends Action2 {
 			layoutService.setPartHidden(false, Parts.PANEL_PART);
 		}
 
-		// Have the layout service maximize the panel.
-		layoutService.maximizePanel();
+		// Have the layout service restore the panel.
+		layoutService.restorePanel();
 	}
 });
 
 /**
- * Positron restore panel action.
+ * Positron maximize panel action.
  */
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: 'workbench.action.restorePanel',
-			title: { value: localize('restorePanel', "Restore Panel"), original: 'Restore Panel' },
-			tooltip: localize('restoresPanel', "Restores Panel Size"),
+			id: 'workbench.action.maximizePanel',
+			title: { value: localize('positron.maximizePanel', "Maximize Panel"), original: 'Maximize Panel' },
+			tooltip: localize('positron.maximizePanel', "Maximize Panel"),
 			category: Categories.View,
 			f1: true,
-			icon: positronRestorePanelIcon,
+			icon: positronMaximizePanelIcon,
 			// This action is only enabled when the panel position is bottom and the panel alignment
 			// is center.
 			precondition: ContextKeyExpr.and(PanelPositionContext.isEqualTo('bottom'), PanelAlignmentContext.isEqualTo('center')),
@@ -446,8 +446,8 @@ registerAction2(class extends Action2 {
 			layoutService.setPartHidden(false, Parts.PANEL_PART);
 		}
 
-		// Have the layout service restore the panel.
-		layoutService.restorePanel();
+		// Have the layout service maximize the panel.
+		layoutService.maximizePanel();
 	}
 });
 // --- End Positron ---


### PR DESCRIPTION
This PR adjusts the tense of the tooltips for the minimize, maximize, and restore buttons.

<img width="170" alt="image" src="https://github.com/posit-dev/positron/assets/853239/92147d03-2818-49e0-8b2a-f57554c5ae9e">
<img width="167" alt="image" src="https://github.com/posit-dev/positron/assets/853239/19c81866-bbea-49fe-924e-442fff29021c">
<img width="185" alt="image" src="https://github.com/posit-dev/positron/assets/853239/60698916-8929-4309-83c5-245ed1a0e82d">

It also reorders these buttons to be minimize, restore, maximize:

<img width="798" alt="image" src="https://github.com/posit-dev/positron/assets/853239/dbfd89ad-cf3c-4817-84c7-fbe81a4a3eec">

Hopefully this meets with people's approval.