### PR TITLE
When panel is minimized, restore it instead of toggling it

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1949,32 +1949,6 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 	// --- Start Positron ---
 	/**
-	 * Maximizes the panel.
-	 */
-	maximizePanel(): void {
-		// This method works when the panel position is bottom and the panel alignment is center. It
-		// should not be called, and is not called, otherwise. This is a safety check.
-		if (this.getPanelPosition() === Position.BOTTOM && this.getPanelAlignment() === 'center') {
-			// Get the panel size.
-			const size = this.workbenchGrid.getViewSize(this.panelPartView);
-
-			// If the panel is not maximized, and it's visible, and its height is greater than its
-			// minimum height, save its last non-mazimized height.
-			if (!this.isPanelMaximized() &&
-				this.isVisible(Parts.PANEL_PART) &&
-				size.height > this.panelPartView.minimumHeight) {
-				this.stateModel.setRuntimeValue(
-					LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT,
-					size.height
-				);
-			}
-
-			// Hide the editor. This as the effect of maximizing the panel.
-			this.setEditorHidden(true);
-		}
-	}
-
-	/**
 	 * Minimizes the panel.
 	 */
 	minimizePanel(): void {
@@ -2036,6 +2010,32 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 					LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT
 				)
 			});
+		}
+	}
+
+	/**
+	 * Maximizes the panel.
+	 */
+	maximizePanel(): void {
+		// This method works when the panel position is bottom and the panel alignment is center. It
+		// should not be called, and is not called, otherwise. This is a safety check.
+		if (this.getPanelPosition() === Position.BOTTOM && this.getPanelAlignment() === 'center') {
+			// Get the panel size.
+			const size = this.workbenchGrid.getViewSize(this.panelPartView);
+
+			// If the panel is not maximized, and it's visible, and its height is greater than its
+			// minimum height, save its last non-mazimized height.
+			if (!this.isPanelMaximized() &&
+				this.isVisible(Parts.PANEL_PART) &&
+				size.height > this.panelPartView.minimumHeight) {
+				this.stateModel.setRuntimeValue(
+					LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT,
+					size.height
+				);
+			}
+
+			// Hide the editor. This as the effect of maximizing the panel.
+			this.setEditorHidden(true);
 		}
 	}
 	// --- End Positron ---
@@ -2133,6 +2133,21 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	getWindowBorderRadius(): string | undefined {
 		return this.state.runtime.windowBorder && isMacintosh ? '5px' : undefined;
 	}
+
+	// --- Start Positron ---
+	/**
+	 * Returns true if the panel is minimized.
+	 */
+	isPanelMinimized() {
+		// The panel is minimized when the panel position is bottom and the panel alignment is
+		// center and the editor part is visible and the panel part height is at its minimum value.
+		return this.getPanelPosition() === Position.BOTTOM &&
+			this.getPanelAlignment() === 'center' &&
+			this.isVisible(Parts.EDITOR_PART) &&
+			this.workbenchGrid.getViewSize(this.panelPartView).height ===
+			this.panelPartView.minimumHeight;
+	}
+	// --- End Positron ---
 
 	isPanelMaximized(): boolean {
 

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -65,6 +65,15 @@ export class TogglePanelAction extends Action2 {
 
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		const layoutService = accessor.get(IWorkbenchLayoutService);
+
+		// --- Start Positron ---
+		// If the panel is minimized, restore it instead of toggling it.
+		if (layoutService.isPanelMinimized()) {
+			layoutService.restorePanel();
+			return;
+		}
+		// --- End Positron ---
+
 		layoutService.setPartHidden(layoutService.isVisible(Parts.PANEL_PART), Parts.PANEL_PART);
 	}
 }

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -203,11 +203,6 @@ export interface IWorkbenchLayoutService extends ILayoutService {
 
 	// --- Start Positron ---
 	/**
-	 * Maximizes the panel height.
-	 */
-	maximizePanel(): void;
-
-	/**
 	 * Minimizes the panel height.
 	 */
 	minimizePanel(): void;
@@ -216,6 +211,11 @@ export interface IWorkbenchLayoutService extends ILayoutService {
 	 * Restores the panel height.
 	 */
 	restorePanel(): void;
+
+	/**
+	 * Maximizes the panel height.
+	 */
+	maximizePanel(): void;
 	// --- End Positron ---
 
 	/**
@@ -232,6 +232,13 @@ export interface IWorkbenchLayoutService extends ILayoutService {
 	 * Returns the window border radius if any.
 	 */
 	getWindowBorderRadius(): string | undefined;
+
+	// --- Start Positron ---
+	/**
+	 * Returns true if the panel is maximized.
+	 */
+	isPanelMinimized(): boolean;
+	// --- End Positron ---
 
 	/**
 	 * Returns true if the panel is maximized.

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -634,9 +634,10 @@ export class TestLayoutService implements IWorkbenchLayoutService {
 	async setPanelHidden(_hidden: boolean): Promise<void> { }
 	toggleMaximizedPanel(): void { }
 	// --- Start Positron ---
-	maximizePanel(): void { }
 	minimizePanel(): void { }
 	restorePanel(): void { }
+	maximizePanel(): void { }
+	isPanelMinimized(): boolean { return false; }
 	// --- End Positron ---
 	isPanelMaximized(): boolean { return false; }
 	getMenubarVisibility(): MenuBarVisibility { throw new Error('not implemented'); }


### PR DESCRIPTION
This PR addresses #1791 by adding new logic to the `TogglePanelAction` such that if the panel is minimized, it will be restored instead of toggled. Otherwise, toggling the panel works as it normally does.

Here's a movie of pressing ⌘-J when the panel is minimized:

https://github.com/posit-dev/positron/assets/853239/7dcc44ed-0023-4b7f-b214-7c46c0055758

