### PR TITLE
Improve performance for DataViewer (pad flatData only for intermediate rows, use virtualRow index to calculate scroll page, change loading definition)

### DIFF
--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -13,6 +13,7 @@ import * as ReactTable from '@tanstack/react-table';
 // Local modules.
 import { DataFragment } from './DataFragment';
 import { LoadingOverlay } from './LoadingOverlay';
+import { DataRow, HeaderRow, PaddingRow } from './Rows';
 import { DataFetcher, ResolverLookup } from './fetchData';
 import { DataSet } from './positron-data-viewer';
 
@@ -230,79 +231,24 @@ export const DataPanel = (props: DataPanelProps) => {
 			ref={tableContainerRef}
 		>
 			<table>
-				<thead ref={headerRef}>
-					{table.getHeaderGroups().map(headerGroup => (
-						<tr key={headerGroup.id}>
-							{headerGroup.headers.map(header => {
-								return (
-									<th
-										key={header.id}
-										colSpan={header.colSpan}
-										style={{ width: header.getSize() }}
-									>
-										{header.isPlaceholder ? null : (
-											<div
-												{...{
-													className: header.column.getCanSort()
-														? 'cursor-pointer select-none'
-														: '',
-													onClick: header.column.getToggleSortingHandler(),
-												}}
-											>
-												{ReactTable.flexRender(
-													header.column.columnDef.header,
-													header.getContext()
-												)}
-												{{
-													asc: '🔼', // allow-any-unicode-next-line
-													desc: '🔽', // allow-any-unicode-next-line
-												}[header.column.getIsSorted() as string] ?? null}
-											</div>
-										)}
-									</th>
-								);
-							})}
-						</tr>
-					))}
-				</thead>
+				<HeaderRow ref={headerRef} table={table} />
 				<tbody>
-					{paddingTop > 0 && (
-						<tr>
-							<td style={{ height: `${paddingTop}px` }} />
-						</tr>
-					)}
+					<PaddingRow padding={paddingTop} />
 					{
 						isLoading ?
 							null :
 							virtualRows.map(virtualRow => {
-							const row = rows[virtualRow.index] as ReactTable.Row<any>;
+								const row = rows[virtualRow.index] as ReactTable.Row<any>;
 
-							return (
-								<tr
+								return (
+								<DataRow
 									key={virtualRow.key}
-									data-index={virtualRow.index}
-									style={{height: `${virtualRow.size}px`}}
-								>
-								{
-									row.getVisibleCells().map(cell => {
-										return (
-											<td key={cell.id}>
-												{ReactTable.flexRender(
-													cell.column.columnDef.cell,
-													cell.getContext()
-												)}
-											</td>
-										);
-									})
-								}
-								</tr>
-							);
-					})}
-					{paddingBottom > 0 && (
-						<tr>
-							<td style={{ height: `${paddingBottom}px` }} />
-						</tr>
-					)}
+									virtualRow={virtualRow}
+									row={row}
+								/>);
+							})
+					}
+					<PaddingRow padding={paddingBottom} />
 				</tbody>
 			</table>
 			<LoadingOverlay

--- a/extensions/positron-data-viewer/ui/src/DataPanel.tsx
+++ b/extensions/positron-data-viewer/ui/src/DataPanel.tsx
@@ -134,10 +134,6 @@ export const DataPanel = (props: DataPanelProps) => {
 	// format, but React Table expects data in a row-major format, so we need to
 	// transpose the data. We also need to pad the array with placeholder rows
 	const flatData = React.useMemo(() => {
-		if (!data.pages.length || !data.pageParams.length) {
-			return createEmptyData(0);
-		}
-
 		// We don't expect pages to be in order, but we do expect that there aren't duplicates
 		// That shouldn't be possible based on our implementation of getNext/PrevPageParams,
 		// but we check anyway to future-proof against changes to the query logic

--- a/extensions/positron-data-viewer/ui/src/LoadingOverlay.tsx
+++ b/extensions/positron-data-viewer/ui/src/LoadingOverlay.tsx
@@ -7,23 +7,8 @@ import './DataPanel.css';
 // External libraries.
 import * as React from 'react';
 
-interface OverlayProps {
-	/**
-	 * Whether or not to display the loading overlay
-	 */
-	isLoading: boolean;
-	/**
-	 * A scrollable container element
-	 */
-	container: HTMLDivElement | null;
-	/**
-	 * The header row element of a table
-	 */
-	header: HTMLTableSectionElement | null;
-}
-
-export const LoadingOverlay = (props: OverlayProps) => {
-	const {isLoading, container, header} = props;
+export const LoadingOverlay = (
+	{isLoading, container, header}: {isLoading: boolean; container: HTMLDivElement | null; header: HTMLTableSectionElement | null}) => {
 
 	if (!isLoading || !container || !header) {
 		return null;

--- a/extensions/positron-data-viewer/ui/src/LoadingOverlay.tsx
+++ b/extensions/positron-data-viewer/ui/src/LoadingOverlay.tsx
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import './DataPanel.css';
+
+// External libraries.
+import * as React from 'react';
+
+interface OverlayProps {
+	/**
+	 * Whether or not to display the loading overlay
+	 */
+	isLoading: boolean;
+	/**
+	 * A scrollable container element
+	 */
+	container: HTMLDivElement | null;
+	/**
+	 * The header row element of a table
+	 */
+	header: HTMLTableSectionElement | null;
+}
+
+export const LoadingOverlay = (props: OverlayProps) => {
+	const {isLoading, container, header} = props;
+
+	if (!isLoading || !container || !header) {
+		return null;
+	}
+
+	const {clientWidth, clientHeight, offsetWidth, offsetHeight} = container;
+	const {clientHeight: headerHeight, clientWidth: headerWidth} = header;
+
+	// Vertically and horizontally center the loading overlay
+	// accounting for scrollbars, header, and container size
+	const verticalScrollbarWidth = offsetWidth - clientWidth;
+	const horizontalScrollbarHeight = offsetHeight - clientHeight;
+	const marginTop = (clientHeight - headerHeight) / 2;
+	const marginBottom = horizontalScrollbarHeight;
+	const marginRight = verticalScrollbarWidth;
+	// Use the table header width rather than the full container width
+	// when the table doesn't take up the full width of the container
+	const marginLeft = Math.min(headerWidth, clientWidth) / 2;
+
+	return (
+		<div className='overlay' style={{marginTop, marginBottom, marginRight, marginLeft}}>
+			<div className='loading'>
+				Loading more rows...
+			</div>
+		</div>
+	);
+
+};

--- a/extensions/positron-data-viewer/ui/src/Rows.tsx
+++ b/extensions/positron-data-viewer/ui/src/Rows.tsx
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import './DataPanel.css';
+
+// External libraries.
+import * as React from 'react';
+import * as ReactVirtual from '@tanstack/react-virtual';
+import * as ReactTable from '@tanstack/react-table';
+
+export const DataRow = (
+	{virtualRow, row}: {virtualRow: ReactVirtual.VirtualItem; row: ReactTable.Row<any>}) => {
+
+	return (
+		<tr
+			data-index={virtualRow.index}
+			style={{height: `${virtualRow.size}px`}}
+		>
+		{
+			row.getVisibleCells().map(cell => {
+				return (
+					<td key={cell.id}>
+						{ReactTable.flexRender(
+							cell.column.columnDef.cell,
+							cell.getContext()
+						)}
+					</td>
+				);
+			})
+		}
+		</tr>
+	);
+};
+
+export const PaddingRow = ({padding}: {padding: number}) => {
+	if (padding <= 0) {
+		return null;
+	}
+
+	return (
+		<tr>
+			<td style={{ height: `${padding}px` }} />
+		</tr>
+	);
+};
+
+export const HeaderRow = (
+	{table, ref}: {table: ReactTable.Table<any>; ref: React.RefObject<HTMLTableSectionElement>}) => {
+
+	return (
+		<thead ref={ref}>
+			{table.getHeaderGroups().map(headerGroup => (
+				<tr key={headerGroup.id}>
+					{headerGroup.headers.map(header => {
+						return (
+							<th
+								key={header.id}
+								colSpan={header.colSpan}
+								style={{ width: header.getSize() }}
+							>
+								{header.isPlaceholder ? null : (
+									<div
+										{...{
+											className: header.column.getCanSort()
+												? 'cursor-pointer select-none'
+												: '',
+											onClick: header.column.getToggleSortingHandler(),
+										}}
+									>
+										{ReactTable.flexRender(
+											header.column.columnDef.header,
+											header.getContext()
+										)}
+										{{
+											asc: '🔼', // allow-any-unicode-next-line
+											desc: '🔽', // allow-any-unicode-next-line
+										}[header.column.getIsSorted() as string] ?? null}
+									</div>
+								)}
+							</th>
+						);
+					})}
+				</tr>
+			))}
+		</thead>
+	);
+};

--- a/extensions/positron-data-viewer/ui/src/Rows.tsx
+++ b/extensions/positron-data-viewer/ui/src/Rows.tsx
@@ -45,8 +45,8 @@ export const PaddingRow = ({padding}: {padding: number}) => {
 	);
 };
 
-export const HeaderRow = (
-	{table, ref}: {table: ReactTable.Table<any>; ref: React.RefObject<HTMLTableSectionElement>}) => {
+export const HeaderRow = React.forwardRef(function HeaderRow(
+	{table}: {table: ReactTable.Table<any>}, ref: React.Ref<HTMLTableSectionElement>) {
 
 	return (
 		<thead ref={ref}>
@@ -85,4 +85,4 @@ export const HeaderRow = (
 			))}
 		</thead>
 	);
-};
+});

--- a/extensions/positron-data-viewer/ui/src/app.tsx
+++ b/extensions/positron-data-viewer/ui/src/app.tsx
@@ -20,7 +20,7 @@ import { DataViewerMessage, DataViewerMessageRowRequest, DataViewerMessageRowRes
 //
 // @ts-ignore
 const vscode = acquireVsCodeApi();
-const fetchSize = 100;
+const fetchSize = 500;
 
 // Let the extension know that we're ready to receive the initial data.
 const msg: DataViewerMessageRowRequest = {


### PR DESCRIPTION
Abandoned the previous PR #1831 because seemed to cause much worse performance for large dataframes. Virtual rows will be the full length of the dataset, but that's okay because virtual rows doesn't actually contain any data. Rows will be padded with sparse rows in the middle (if we've skipped over a bunch of rows in the middle of the dataset) but will not be padded at the end -- that seems to steeply increase the cost of rebuilding flatData with every new page fetch. Also we change the definition of isLoading so it is not limited to just the infinite query fetching, but also the steps that come after, including rebuilding flatData and table, making the loading indicator less fickle and more accurate.

Also did some refactoring for readability and changed default fetch size to 500 because I think 100 is overly conservative -- the comms can probably serialize a bigger batch than that, although in the future we might want the fetch size to be set from the backend and account for the number of columns (e.g. do we use a smaller fetch size if the dataset has 1000 columns)

I think we could probably still benefit from some debounce here but every time I've tried to add something in (ie. if we are still in the scrolling state, wait 200 ms before calling fetchMorePages) but I feel like it just slowed down the scrolling overall, so I don't think I've done it effectively, so I've spun off that piece into #1852 since it might need further testing. 

Also, scroll position resets to the top when the component remounts, like when the user tabs away to the editor and then back to the dataviewer, and not only that, but the cache of previously fetched rows clears. That seems unpleasant, but I will file an issue for that and tackle that later.

I also experimented with using `useQueries` rather than `useInfiniteQuery` (see https://github.com/posit-dev/positron/pull/1836). This allows us to run a dynamically defined number of queries, some or all of which are initially disabled, with each page having a separate entry in the cache, rather than infinite query where all pages share a single cache entry. I thought this might better allow us to run queries in parallel, since we don't have to worry about overwriting the single cache entry (which infinite query is particularly strict about), and the implementation kinda worked, but was branched off #1831 and had other performance issues. I might resurrect and try that again but based off this newer PR, to see if that approach is better, but you can still see the general idea in the abandoned #1836 

Addresses #1706 