### PR TITLE
Add custom Positron activation event for extensions to use

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -501,7 +501,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.24"
+      "ark": "0.1.25"
     }
   }
 }

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -11,7 +11,7 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "onCommand:positron.startExtensions"
+    "onCommand:positron.activateInterpreters"
   ],
   "main": "./out/extension.js",
   "capabilities": {

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -11,7 +11,7 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "*"
+    "onCommand:positron.startExtensions"
   ],
   "main": "./out/extension.js",
   "capabilities": {
@@ -501,7 +501,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.25"
+      "ark": "0.1.24"
     }
   }
 }

--- a/extensions/positron-zed/package.json
+++ b/extensions/positron-zed/package.json
@@ -11,7 +11,7 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "*"
+    "onCommand:positron.startExtensions"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/extensions/positron-zed/package.json
+++ b/extensions/positron-zed/package.json
@@ -11,7 +11,7 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "onCommand:positron.startExtensions"
+    "onCommand:positron.activateInterpreters"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -128,7 +128,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 		super();
 
 		// Start the Positron extensions.
-		this._commandService.executeCommand('positron.startExtensions');
+		this._commandService.executeCommand('positron.activateInterpreters');
 
 		// Create the object that tracks the affiliation of runtimes to workspaces.
 		this._workspaceAffiliation =
@@ -907,7 +907,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	//#region Private Methods
 }
 
-CommandsRegistry.registerCommand('positron.startExtensions', () => true);
+CommandsRegistry.registerCommand('positron.activateInterpreters', () => true);
 
 // Instantiate the language runtime service "eagerly", meaning as soon as a
 // consumer depdends on it. This fixes an issue where languages are encountered

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -7,6 +7,7 @@ import { Emitter } from 'vs/base/common/event';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { formatLanguageRuntime, ILanguageRuntime, ILanguageRuntimeGlobalEvent, ILanguageRuntimeService, ILanguageRuntimeStateEvent, LanguageRuntimeDiscoveryPhase, LanguageRuntimeStartupBehavior, RuntimeClientType, RuntimeExitReason, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { FrontEndClientInstance, IFrontEndClientMessageInput, IFrontEndClientMessageOutput } from 'vs/workbench/services/languageRuntime/common/languageRuntimeFrontEndClient';
@@ -116,6 +117,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	constructor(
 		@ILanguageService private readonly _languageService: ILanguageService,
 		@ILogService private readonly _logService: ILogService,
+		@ICommandService private readonly _commandService: ICommandService,
 		@IStorageService private readonly _storageService: IStorageService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
@@ -124,6 +126,9 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	) {
 		// Call the base class's constructor.
 		super();
+
+		// Start the Positron extensions.
+		this._commandService.executeCommand('positron.startExtensions');
 
 		// Create the object that tracks the affiliation of runtimes to workspaces.
 		this._workspaceAffiliation =
@@ -901,6 +906,8 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 
 	//#region Private Methods
 }
+
+CommandsRegistry.registerCommand('positron.startExtensions', () => true);
 
 // Instantiate the language runtime service "eagerly", meaning as soon as a
 // consumer depdends on it. This fixes an issue where languages are encountered


### PR DESCRIPTION
Addresses #1067 with a tiny first step

That issue, along with #936, outline a lot of complex steps that need to be taken to improve runtime startup and discovery. One of the first steps we need is this one, moving activation from `"*"` to something we can control from Positron. This PR makes a (very simple, for now) command and has the extensions activate on this command. The command is, for now, executed when the language runtime service is constructed. This seems to give us fairly similar user-facing behavior compared to `"*"`, as far as I can tell from my explorations.