### PR TITLE
Restore panel in doOpenPaneComposite

### DIFF
--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -387,6 +387,13 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 			}
 		}
 
+		// --- Start Positron ---
+		// If the panel is minimized, restore it.
+		if (this.layoutService.isPanelMinimized()) {
+			this.layoutService.restorePanel();
+		}
+		// --- End Positron ---
+
 		return this.openComposite(id, focus) as PaneComposite;
 	}
 


### PR DESCRIPTION
Address #1795 by restoring the panel when it is minimized and one of its views is clicked.

Here's a movie of this working:

https://github.com/posit-dev/positron/assets/853239/a0c726c2-7b25-46cf-9551-9fc48c5fd19e

