### PR TITLE
Don't focus the console when running a cell

### DIFF
--- a/extensions/positron-code-cells/src/cellManager.ts
+++ b/extensions/positron-code-cells/src/cellManager.ts
@@ -60,7 +60,7 @@ export class CellManager {
 
 	public runCell(cell: Cell): void {
 		const text = this.parser.getCellText(cell, this.editor.document);
-		positron.runtime.executeCode(this.editor.document.languageId, text, true);
+		positron.runtime.executeCode(this.editor.document.languageId, text, false);
 	}
 
 	public runCurrentCell(line?: number): void {


### PR DESCRIPTION
Currently, running a cell moves focus from the editor to the console, which pretty frustrating. I missed that since I brought in https://github.com/posit-dev/positron/pull/1820 without catching up on `main` after https://github.com/posit-dev/positron/pull/1815 was merged.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of why we are making the proposed changes and
* how best to test them.
-->
