### PR TITLE
Bump ark to 0.1.27

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -501,7 +501,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.25"
+      "ark": "0.1.27"
     }
   }
 }


### PR DESCRIPTION
Includes:

- https://github.com/posit-dev/amalthea/pull/149
- https://github.com/posit-dev/amalthea/pull/153
- https://github.com/posit-dev/amalthea/commit/da5fe1437b88af64c3f87b7dc0ba3935425b02b0