### PR TITLE
Add `positron.r.kernel.env` extension setting

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -139,6 +139,12 @@
           "default": "warn",
           "description": "%r.configuration.logLevel.description%"
         },
+        "positron.r.kernel.env": {
+          "scope": "window",
+          "type": "object",
+          "default": {},
+          "description": "%r.configuration.env.description%"
+        },
         "positron.r.trace.server": {
           "scope": "window",
           "type": "string",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -35,6 +35,7 @@
 	"r.configuration.logLevel.debug.description": "Debug messages",
 	"r.configuration.logLevel.trace.description": "Verbose tracing messages",
 	"r.configuration.logLevel.description": "Log level for the R Kernel (requires restart to take effect)",
+	"r.configuration.env.description": "Map of environment variables for the Ark kernel",
 	"r.configuration.packageTesting.description": "Explore and run testthat tests",
 	"r.configuration.restoreWorkspace.description": "Restore the workspace from .RData on startup (requires restart to take effect)",
 	"r.configuration.extraArguments.description": "Extra command-line arguments for R intialization",

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -37,6 +37,7 @@ export async function* rRuntimeProvider(
 	// Check the R kernel log level setting
 	const config = vscode.workspace.getConfiguration('positron.r');
 	const logLevel = config.get<string>('kernel.logLevel') ?? 'warn';
+	const userEnv = config.get<object>('kernel.env') ?? {};
 
 	const binaries = new Set<string>();
 
@@ -133,7 +134,8 @@ export async function* rRuntimeProvider(
 		const env = <Record<string, string>>{
 			'RUST_BACKTRACE': '1',
 			'RUST_LOG': logLevel,
-			'R_HOME': rHome.homepath
+			'R_HOME': rHome.homepath,
+			...userEnv
 		};
 		/* eslint-enable */
 


### PR DESCRIPTION
This lets Ark developers set the envvar implemented in https://github.com/posit-dev/amalthea/pull/157

```json
"positron.r.kernel.env": {
    "RUST_PUSH_RDS_PATH": "~/my_debug.rds"
}
```

