### PR TITLE
Actually disable vscode-jupyter cell affordances

### DIFF
--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -595,6 +595,14 @@ function findContextAttr(domNode: IContextKeyServiceTarget | null): number {
 }
 
 export function setContext(accessor: ServicesAccessor, contextKey: any, contextValue: any) {
+	// --- Start Positron ---
+	// Disable vscode-jupyter's cell-related keybindings, preferring the positron-code-cells
+	// extension instead.
+	// TODO(seem): We can remove this if we eventually decide to unbundle vscode-jupyter.
+	if (contextKey === 'jupyter.hascodecells') {
+		contextValue = false;
+	}
+	// --- End Positron ---
 	const contextKeyService = accessor.get(IContextKeyService);
 	contextKeyService.createKey(String(contextKey), stringifyURIs(contextValue));
 }

--- a/src/vs/workbench/api/common/extHostConfiguration.ts
+++ b/src/vs/workbench/api/common/extHostConfiguration.ts
@@ -185,13 +185,18 @@ export class ExtHostConfigProvider {
 			},
 			get: <T>(key: string, defaultValue?: T) => {
 				// --- Start Positron ---
-				// Disable vscode-jupyter's cell support in preference of the positron-code-cell extension.
+				// Disable vscode-jupyter's cell decorations and code lenses, preferring
+				// the positron-code-cell extension instead.
 				// TODO(seem): We can remove this if we eventually decide to unbundle vscode-jupyter.
-				if (section === 'jupyter' && key === 'interactiveWindow.cellMarker.decorateCells') {
-					return 'None';
-				}
-				if (section === 'jupyter' && key === 'interactiveWindow.codeLens.enable') {
-					return false;
+				if (section === 'jupyter') {
+					switch (key) {
+						case 'interactiveWindow.cellMarker.decorateCells':
+						case 'interactiveWindow.codeLens.enable':
+						// Legacy versions of above settings.
+						case 'decorateCells':
+						case 'enableCellCodeLens':
+							return false;
+					}
 				}
 				// --- End Positron ---
 				this._validateConfigurationAccess(section ? `${section}.${key}` : key, overrides, extensionDescription?.identifier);


### PR DESCRIPTION
Addresses #1431. From my comment there:

> Ah, thank you! So it seems that the setting names were changed in https://github.com/microsoft/vscode-jupyter/pull/12810:
> 
> - `decorateCells` -> `interactiveWindow.cellMarker.decorateCells`
> - `enableCellCodeLens` -> `interactiveWindow.codeLens.enable`
> 
> I tried hooking into this at `registerCodeLensProvider` and `TextEditor.setDecorations` but I don't think we have enough information to disable specifically what we want to.

I ended up just supporting both the legacy and current names of the necessary settings.

I've tested that this works locally with `vscode-jupyter` versions v2023.9.100 and v2023.3.100 (you can install specific versions by clicking the "gear" icon on the selected extension in the Extensions sidebar, then "Install Another Version...".

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of why we are making the proposed changes and
* how best to test them.
-->
