### PR TITLE
Second wave of R test explorer improvement (eg better "run all tests")

### DIFF
--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -10,7 +10,6 @@ import { getRunningRRuntime } from './provider';
 import { getRPackageName } from './contexts';
 import { getRPackageTasks } from './tasks';
 import { randomUUID } from 'crypto';
-import { refreshTestthatStatus } from './testing/watcher';
 
 export async function registerCommands(context: vscode.ExtensionContext, runtimes: Map<string, RRuntime>) {
 

--- a/extensions/positron-r/src/testing/loader.ts
+++ b/extensions/positron-r/src/testing/loader.ts
@@ -3,27 +3,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { Logger } from '../extension';
 import { parseTestsFromFile } from './parser';
 import { ItemType, TestingTools } from './util-testing';
 import { testthatTestFilePattern } from './watcher';
 
-import { Logger } from '../extension';
-
 export async function discoverTestFiles(testingTools: TestingTools) {
-	if (!vscode.workspace.workspaceFolders) {
-		Logger.info('No open workspace; no test discovery.');
-		return;
+	const packageRoot = testingTools.packageRoot;
+	Logger.info(`Discovering testthat test files in ${packageRoot.path}`);
+	const pattern = new vscode.RelativePattern(packageRoot, testthatTestFilePattern);
+	for (const file of await vscode.workspace.findFiles(pattern)) {
+		getOrCreateFileItem(testingTools, file);
 	}
-
-	return Promise.all(
-		vscode.workspace.workspaceFolders.map(async (workspaceFolder) => {
-			Logger.info(`Discovering testthat test files in ${workspaceFolder.uri}`);
-			const pattern = new vscode.RelativePattern(workspaceFolder, testthatTestFilePattern);
-			for (const file of await vscode.workspace.findFiles(pattern)) {
-				getOrCreateFileItem(testingTools, file);
-			}
-		})
-	);
 }
 
 export function getOrCreateFileItem(testingTools: TestingTools, uri: vscode.Uri) {

--- a/extensions/positron-r/src/testing/parser.ts
+++ b/extensions/positron-r/src/testing/parser.ts
@@ -51,11 +51,12 @@ export async function parseTestsFromFile(
 			uri
 		);
 		testItem.range = new vscode.Range(match.testStartPosition, match.testEndPosition);
-		testingTools.testItemData.set(testItem, ItemType.TestCase);
 
 		if (match.testSuperLabel === undefined) {
+			testingTools.testItemData.set(testItem, ItemType.TestThat);
 			tests.set(match.testLabel, testItem);
 		} else {
+			testingTools.testItemData.set(testItem, ItemType.It);
 			if (tests.has(match.testSuperLabel)) {
 				tests.get(match.testSuperLabel)!.children.add(testItem);
 			} else {
@@ -64,7 +65,7 @@ export async function parseTestsFromFile(
 					match.testSuperLabel,
 					uri
 				);
-				testingTools.testItemData.set(supertestItem, ItemType.TestCase);
+				testingTools.testItemData.set(supertestItem, ItemType.Describe);
 				supertestItem.range = new vscode.Range(
 					match.testSuperStartPosition!,
 					match.testSuperEndPosition!

--- a/extensions/positron-r/src/testing/parser.ts
+++ b/extensions/positron-r/src/testing/parser.ts
@@ -39,13 +39,14 @@ export async function parseTestsFromFile(
 	}
 
 	const tests: Map<string, vscode.TestItem> = new Map();
+	const testFile = path.basename(uri.fsPath);
 	for (const match of matches) {
 		if (match === undefined) {
 			continue;
 		}
 
 		const testItem = testingTools.controller.createTestItem(
-			encodeNodeId(uri.fsPath, match.testLabel, match.testSuperLabel),
+			encodeNodeId(testFile, match.testLabel, match.testSuperLabel),
 			match.testLabel,
 			uri
 		);
@@ -59,7 +60,7 @@ export async function parseTestsFromFile(
 				tests.get(match.testSuperLabel)!.children.add(testItem);
 			} else {
 				const supertestItem = testingTools.controller.createTestItem(
-					encodeNodeId(uri.fsPath, match.testSuperLabel),
+					encodeNodeId(testFile, match.testSuperLabel),
 					match.testSuperLabel,
 					uri
 				);

--- a/extensions/positron-r/src/testing/runner-testthat.ts
+++ b/extensions/positron-r/src/testing/runner-testthat.ts
@@ -76,7 +76,19 @@ export async function runThatTest(
 	// TODO @jennybc: if this code stays, figure this out
 	// eslint-disable-next-line no-async-promise-executor
 	return new Promise<string>(async (resolve, reject) => {
-		const childProcess = spawn(command, { cwd, shell: true });
+		// FIXME (@jennybc): once I can ask the current runtime for its LC_CTYPE (and possibly
+		// other locale categories or even LANG), use something like this to make the child
+		// process better match the runtime. Learned this from reprex's UTF-8 test which currently
+		// fails in the test explorer because the reprex is being rendered in the C locale.
+		// const childProcess = spawn(command, {
+		// 	cwd: wd,
+		// 	shell: true,
+		// 	env: {
+		// 		...process.env,
+		// 		LC_CTYPE: 'en_US.UTF-8'
+		// 	}
+		// });
+		const childProcess = spawn(command, { cwd: wd, shell: true });
 		let stdout = '';
 		const testStartDates = new WeakMap<vscode.TestItem, number>();
 		childProcess.stdout!

--- a/extensions/positron-r/src/testing/runner-testthat.ts
+++ b/extensions/positron-r/src/testing/runner-testthat.ts
@@ -113,7 +113,12 @@ export async function runThatTest(
 		const childProcess = spawn(command, { cwd: wd, shell: true });
 		let stdout = '';
 		const testStartDates = new WeakMap<vscode.TestItem, number>();
-		childProcess.stdout!.pipe(split2(JSON.parse))
+		childProcess.stdout!
+			.pipe(split2((line: string) => {
+				try {
+					return JSON.parse(line);
+				} catch { }
+			}))
 			.on('data', (data: TestResult) => {
 				stdout += JSON.stringify(data);
 				Logger.info(`Received test data: ${JSON.stringify(data)}`);

--- a/extensions/positron-r/src/testing/testing.ts
+++ b/extensions/positron-r/src/testing/testing.ts
@@ -103,7 +103,7 @@ export async function discoverTests(context: vscode.ExtensionContext) {
 
 // Temporarily making it explicit here that we only support this scenario:
 // first workspace folder is the root directory of a source R package
-async function getFirstWorkspaceFolder(): Promise<vscode.Uri | null> {
+export async function getFirstWorkspaceFolder(): Promise<vscode.Uri | null> {
 	const workspaceFolders = vscode.workspace.workspaceFolders;
 	if (!workspaceFolders) {
 		return null;

--- a/extensions/positron-r/src/testing/testing.ts
+++ b/extensions/positron-r/src/testing/testing.ts
@@ -8,6 +8,7 @@ import { discoverTestFiles, loadTestsFromFile } from './loader';
 import { createTestthatWatchers } from './watcher';
 import { runHandler } from './runner';
 import { Logger } from '../extension';
+import { detectRPackage, getRPackageName } from '../contexts';
 
 let controller: vscode.TestController | undefined;
 
@@ -44,12 +45,18 @@ function hasTestingController(): boolean {
 	return controller !== undefined;
 }
 
-export function discoverTests(context: vscode.ExtensionContext) {
-	// TODO: check workspace folder(s) for package-hood
-	// if no package, return
-	// if exactly one package among the workspace folders, proceed
-	// consider adding package metadata to testingTools (eg name and filepath)
-	// if >1 package, consult our non-existent policy re: multi-root, multi-package workspace
+export async function discoverTests(context: vscode.ExtensionContext) {
+	// Incremental progress re: vetting the workspace folder(s) and R package-hood
+	const inRPackage = await detectRPackage();
+	if (!inRPackage) {
+		return;
+	}
+	const packageRoot = await getFirstWorkspaceFolder();
+	// we know packageRoot can't be null, but typescript doesn't know that, so check again
+	if (!packageRoot) {
+		return;
+	}
+	const packageName = await getRPackageName();
 
 	controller = vscode.tests.createTestController(
 		'rPackageTests',
@@ -59,9 +66,12 @@ export function discoverTests(context: vscode.ExtensionContext) {
 
 	const testItemData = new WeakMap<vscode.TestItem, ItemType>();
 	const testingTools: TestingTools = {
+		packageRoot,
+		packageName,
 		controller,
 		testItemData,
 	};
+	Logger.info(`Testthat test explorer enabled for '${packageName}' at '${packageRoot.fsPath}'`);
 
 	// The first time this is called, `test` is undefined, therefore we do full file discovery and
 	// set up file watchers for the future.
@@ -89,4 +99,19 @@ export function discoverTests(context: vscode.ExtensionContext) {
 		(request, token) => runHandler(testingTools, request, token),
 		true
 	);
+}
+
+// Temporarily making it explicit here that we only support this scenario:
+// first workspace folder is the root directory of a source R package
+async function getFirstWorkspaceFolder(): Promise<vscode.Uri | null> {
+	const workspaceFolders = vscode.workspace.workspaceFolders;
+	if (!workspaceFolders) {
+		return null;
+	}
+
+	if (workspaceFolders.length > 1) {
+		Logger.info('Test explorer does not support multi-root workspaces. Consulting first workspace folder only.');
+	}
+
+	return workspaceFolders[0].uri;
 }

--- a/extensions/positron-r/src/testing/util-testing.ts
+++ b/extensions/positron-r/src/testing/util-testing.ts
@@ -3,9 +3,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import * as path from 'path';
+import { Logger } from '../extension';
 
 export enum ItemType {
+	Directory = 'directory',
 	File = 'file',
 	TestCase = 'test',
 }
@@ -18,15 +19,15 @@ export interface TestingTools {
 }
 
 export function encodeNodeId(
-	filePath: string,
-	testLabel: string,
+	testFile: string,
+	testLabel: string | undefined = undefined,
 	testSuperLabel: string | undefined = undefined
 ) {
-	let normalizedFilePath = path.normalize(filePath);
-	normalizedFilePath = normalizedFilePath.replace(/^[\\\/]+|[\\\/]+$/g, '');
 	return testSuperLabel
-		? `${normalizedFilePath}&${testSuperLabel}: ${testLabel}`
-		: `${normalizedFilePath}&${testLabel}`;
+		? `${testFile}&${testSuperLabel}: ${testLabel}`
+		: testLabel
+			? `${testFile}&${testLabel}`
+			: testFile;
 }
 
 export interface TestParser {

--- a/extensions/positron-r/src/testing/util-testing.ts
+++ b/extensions/positron-r/src/testing/util-testing.ts
@@ -8,7 +8,9 @@ import { Logger } from '../extension';
 export enum ItemType {
 	Directory = 'directory',
 	File = 'file',
-	TestCase = 'test',
+	TestThat = 'test_that',
+	Describe = 'describe',
+	It = 'it',
 }
 
 export interface TestingTools {

--- a/extensions/positron-r/src/testing/util-testing.ts
+++ b/extensions/positron-r/src/testing/util-testing.ts
@@ -11,6 +11,8 @@ export enum ItemType {
 }
 
 export interface TestingTools {
+	packageRoot: vscode.Uri;
+	packageName: string;
 	controller: vscode.TestController;
 	testItemData: WeakMap<vscode.TestItem, ItemType>;
 }

--- a/extensions/positron-r/src/testing/watcher.ts
+++ b/extensions/positron-r/src/testing/watcher.ts
@@ -10,9 +10,9 @@ import { Logger } from '../extension';
 import { detectRPackage } from '../contexts';
 import { getFirstWorkspaceFolder } from './testing';
 
-const testsPattern = '**/tests';
-const testthatDotRPattern = '**/tests/testthat.[Rr]';
-export const testthatTestFilePattern = '**/tests/testthat/test*.[Rr]';
+const testsPattern = 'tests';
+const testthatDotRPattern = 'tests/testthat.[Rr]';
+export const testthatTestFilePattern = 'tests/testthat/test*.[Rr]';
 
 export async function createTestthatWatchers(testingTools: TestingTools): Promise<vscode.FileSystemWatcher[]> {
 	const packageRoot = testingTools.packageRoot;

--- a/extensions/positron-r/src/testing/watcher.ts
+++ b/extensions/positron-r/src/testing/watcher.ts
@@ -8,34 +8,22 @@ import { getOrCreateFileItem } from './loader';
 import { parseTestsFromFile } from './parser';
 import { Logger } from '../extension';
 import { detectRPackage } from '../contexts';
+import { getFirstWorkspaceFolder } from './testing';
 
 const testsPattern = '**/tests';
 const testthatDotRPattern = '**/tests/testthat.[Rr]';
 export const testthatTestFilePattern = '**/tests/testthat/test*.[Rr]';
 
 export async function createTestthatWatchers(testingTools: TestingTools): Promise<vscode.FileSystemWatcher[]> {
-	if (!vscode.workspace.workspaceFolders) {
-		Logger.info('No open workspace; no test file watchers.');
-		return [];
-	}
-
-	const watchers = await Promise.all(
-		vscode.workspace.workspaceFolders.map(async (workspaceFolder) => {
-			Logger.info(`Constructing testthat file watchers for ${workspaceFolder.uri}`);
-			const watchers = await createWatchers(testingTools, workspaceFolder);
-			return watchers;
-		})
-	);
-
+	const packageRoot = testingTools.packageRoot;
+	Logger.info(`Constructing testthat file watchers for ${packageRoot.path}`);
+	const watchers = await createWatchers(testingTools, packageRoot);
 	return watchers.flat();
 }
 
-async function createWatchers(
-	testingTools: TestingTools,
-	workspaceFolder: vscode.WorkspaceFolder
-) {
+async function createWatchers(testingTools: TestingTools, packageRoot: vscode.Uri) {
 	// watch tests/testthat.R to determine if package uses testthat
-	const dotRPattern = new vscode.RelativePattern(workspaceFolder, testthatDotRPattern);
+	const dotRPattern = new vscode.RelativePattern(packageRoot, testthatDotRPattern);
 	const dotRWatcher = vscode.workspace.createFileSystemWatcher(dotRPattern);
 
 	dotRWatcher.onDidCreate((uri) => {
@@ -47,7 +35,7 @@ async function createWatchers(
 
 	// watch for deletion of tests/ as a 2nd way to detect deletion of tests/testthat.R
 	// workaround for https://github.com/microsoft/vscode/issues/109754
-	const folderPattern = new vscode.RelativePattern(workspaceFolder, testsPattern);
+	const folderPattern = new vscode.RelativePattern(packageRoot, testsPattern);
 	const folderWatcher = vscode.workspace.createFileSystemWatcher(folderPattern);
 
 	folderWatcher.onDidDelete((uri) => {
@@ -55,7 +43,7 @@ async function createWatchers(
 	});
 
 	// watch testthat test files to support test explorer
-	const testFilePattern = new vscode.RelativePattern(workspaceFolder, testthatTestFilePattern);
+	const testFilePattern = new vscode.RelativePattern(packageRoot, testthatTestFilePattern);
 	const testFileWatcher = vscode.workspace.createFileSystemWatcher(testFilePattern);
 
 	testFileWatcher.onDidCreate((uri) => {
@@ -76,39 +64,38 @@ async function createWatchers(
 export async function refreshTestthatStatus(): Promise<void> {
 	let testthatIsConfigured = false;
 	let testthatHasTests = false;
-	Logger.info('refreshing testthat status');
+	Logger.info('Refreshing testthat status');
 
 	try {
-		if (vscode.workspace.workspaceFolders === undefined) {
-			Logger.info('no workspace folders');
-			return;
-		}
-
 		const isRPackage = await detectRPackage();
 		if (!isRPackage) {
-			Logger.info('not an R package');
+			Logger.info('Not working in an R package');
 			return;
 		}
 
-		const workspaceFolder = vscode.workspace.workspaceFolders[0].uri;
+		const packageRoot = await getFirstWorkspaceFolder();
+		// we know packageRoot can't be null, but typescript doesn't know that, so check again
+		if (!packageRoot) {
+			return;
+		}
 
-		const dotRPattern = new vscode.RelativePattern(workspaceFolder, testthatDotRPattern);
+		const dotRPattern = new vscode.RelativePattern(packageRoot, testthatDotRPattern);
 		const testthatDotR = await vscode.workspace.findFiles(dotRPattern, null, 1);
-		if ((testthatDotR).length === 0) {
+		if (testthatDotR.length === 0) {
 			Logger.info('tests/testthat.R not found');
 			return;
 		}
 		Logger.info('found testthat.R');
 		testthatIsConfigured = true;
 
-		const testFilePattern = new vscode.RelativePattern(workspaceFolder, testthatTestFilePattern);
+		const testFilePattern = new vscode.RelativePattern(packageRoot, testthatTestFilePattern);
 		const testFiles = await vscode.workspace.findFiles(testFilePattern, null, 1);
 		Logger.info(`found ${testFiles.length} test files`);
 		testthatHasTests = testFiles.length > 0;
 	} finally {
 		vscode.commands.executeCommand('setContext', 'testthatIsConfigured', testthatIsConfigured);
 		vscode.commands.executeCommand('setContext', 'testthatHasTests', testthatHasTests);
-		Logger.info(`context key testthatIsConfigured set to ${testthatIsConfigured}`);
-		Logger.info(`context key testthatHasTests set to ${testthatHasTests}`);
+		Logger.info(`Context key 'testthatIsConfigured' is '${testthatIsConfigured}'`);
+		Logger.info(`Context key 'testthatHasTests' is '${testthatHasTests}'`);
 	}
 }


### PR DESCRIPTION
The main user-perceivable change here is that "run all of the tests" is no longer slow. This was brought up in [#1763](https://github.com/posit-dev/positron/pull/1763#discussion_r1389611432) when @DavisVaughan saw the dplyr tests take > 2 mins to run, whereas plain old `devtools::test()` took 35s. We now recognize this case and also route it through `devtools::test()`.

But I also basically made a second pass through all of the testing code and made other improvements/fixes:

* It's now explicit that the testing feature only anticipates the case where the first workspace folder is the root directory of an R source package. Fixing the package (directory) to be tested at feature load time eliminates a lot of janky filepath handling.
  - Fixes #1839
  - Addresses a bullet in #1808
  - If/when we relax this, we only need do so in 1 place. E.g. if we decide it's OK for the R package to be located in a subfolder of the first workspace folder or if we're willing to look through multiple workspace folders for an R package.
* Output from the test run that is not from our custom reporter is now ignored, instead of causing an error and a halt. This sort of noise is very common in R packages (I banged my shins on this in manual testing).
* Rationalized test item IDs, which is a bullet from #1808
* If we receive results for an unrecognized test item, we now log that as an error in the output channel, but soldier on with the test run. Motivated by dplyr's "special" test that has a `paste0()` call in its `desc` instead of a string.
