### PR TITLE
Implement standard toolbar keyboard model for TopActionBar

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarCommandButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarCommandButton.tsx
@@ -4,11 +4,12 @@
 
 import 'vs/css!./actionBarCommandButton';
 import * as React from 'react';
-import { useEffect, useState } from 'react'; // eslint-disable-line no-duplicate-imports
+import { useEffect, useRef, useState } from 'react'; // eslint-disable-line no-duplicate-imports
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { CommandCenter } from 'vs/platform/commandCenter/common/commandCenter';
 import { usePositronActionBarContext } from 'vs/platform/positronActionBar/browser/positronActionBarContext';
 import { ActionBarButton, ActionBarButtonProps } from 'vs/platform/positronActionBar/browser/components/actionBarButton';
+import { useRegisterWithActionBar } from 'vs/platform/positronActionBar/browser/useRegisterWithActionBar';
 
 /**
  * ActionBarCommandButtonProps interface.
@@ -26,6 +27,7 @@ export const ActionBarCommandButton = (props: ActionBarCommandButtonProps) => {
 	// Hooks.
 	const positronActionBarContext = usePositronActionBarContext();
 	const [disabled, setDisabled] = useState(!positronActionBarContext.isCommandEnabled(props.commandId));
+	const buttonRef = useRef<HTMLDivElement>(undefined!);
 
 	// Add our event handlers.
 	useEffect(() => {
@@ -51,6 +53,9 @@ export const ActionBarCommandButton = (props: ActionBarCommandButtonProps) => {
 		return () => disposableStore.dispose();
 	}, []);
 
+	// Participate in roving tabindex.
+	useRegisterWithActionBar([buttonRef]);
+
 	// Handlers.
 	const executeHandler = () => positronActionBarContext.commandService.executeCommand(props.commandId);
 
@@ -75,5 +80,5 @@ export const ActionBarCommandButton = (props: ActionBarCommandButtonProps) => {
 	};
 
 	// Render.
-	return <ActionBarButton {...props} tooltip={tooltip} disabled={disabled} onClick={executeHandler} />;
+	return <ActionBarButton {...props} ref={buttonRef} tooltip={tooltip} disabled={disabled} onClick={executeHandler} />;
 };

--- a/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
@@ -10,6 +10,7 @@ import { AnchorAlignment, AnchorAxisAlignment } from 'vs/base/browser/ui/context
 import { IContextMenuEvent } from 'vs/base/browser/contextmenu';
 import { ActionBarButton } from 'vs/platform/positronActionBar/browser/components/actionBarButton';
 import { usePositronActionBarContext } from 'vs/platform/positronActionBar/browser/positronActionBarContext';
+import { useRegisterWithActionBar } from 'vs/platform/positronActionBar/browser/useRegisterWithActionBar';
 
 /**
  * ActionBarMenuButtonProps interface.
@@ -48,6 +49,9 @@ export const ActionBarMenuButton = (props: ActionBarMenuButtonProps) => {
 		}
 
 	}, [positronActionBarContext.menuShowing]);
+
+	// Participate in roving tabindex.
+	useRegisterWithActionBar([buttonRef]);
 
 	// Handlers.
 	const clickHandler = async () => {

--- a/src/vs/platform/positronActionBar/browser/positronActionBarState.tsx
+++ b/src/vs/platform/positronActionBar/browser/positronActionBarState.tsx
@@ -49,6 +49,7 @@ export interface PositronActionBarState extends PositronActionBarServices {
 	resetTooltipLastHiddenAt(): void;
 	menuShowing: boolean;
 	setMenuShowing(menuShowing: boolean): void;
+	focusableComponents: Set<HTMLElement>;
 }
 
 /**
@@ -60,6 +61,7 @@ export const usePositronActionBarState = (services: PositronActionBarServices): 
 	// Hooks.
 	const [lastTooltipHiddenAt, setLastTooltipHiddenAt] = useState<number>(0);
 	const [menuShowing, setMenuShowing] = useState(false);
+	const [focusableComponents] = useState(new Set<HTMLElement>());
 
 	/**
 	 * Appends a command action.
@@ -121,6 +123,7 @@ export const usePositronActionBarState = (services: PositronActionBarServices): 
 		updateTooltipLastHiddenAt: () => setLastTooltipHiddenAt(new Date().getTime()),
 		resetTooltipLastHiddenAt: () => setLastTooltipHiddenAt(0),
 		menuShowing,
-		setMenuShowing
+		setMenuShowing,
+		focusableComponents
 	};
 };

--- a/src/vs/platform/positronActionBar/browser/useRegisterWithActionBar.tsx
+++ b/src/vs/platform/positronActionBar/browser/useRegisterWithActionBar.tsx
@@ -5,11 +5,24 @@
 import { MutableRefObject, useEffect } from 'react';
 import { usePositronActionBarContext } from 'vs/platform/positronActionBar/browser/positronActionBarContext';
 
+/**
+ * Custom hook to register a component with the Positron Action Bar; this is to enable
+ * the roving tabindex pattern for keyboard navigation. Only one component at a time
+ * in the Action Bar is focusable (i.e. tabindex=0) and the rest have tabindex=-1.
+ * The arrow keys are used to move between the components in the Action Bar.
+ */
 export const useRegisterWithActionBar = (refs: MutableRefObject<HTMLElement>[]) => {
 	const positronActionBarContext = usePositronActionBarContext();
 
 	useEffect(() => {
-		refs.forEach(ref => positronActionBarContext.focusableComponents.add(ref.current));
+		refs.forEach(ref => {
+			if (positronActionBarContext.focusableComponents.size === 0) {
+				ref.current.tabIndex = 0; // initially the first component is focusable
+			} else {
+				ref.current.tabIndex = -1;
+			}
+			positronActionBarContext.focusableComponents.add(ref.current);
+		});
 		return () => {
 			refs.forEach(ref => positronActionBarContext.focusableComponents.delete(ref.current));
 		};

--- a/src/vs/platform/positronActionBar/browser/useRegisterWithActionBar.tsx
+++ b/src/vs/platform/positronActionBar/browser/useRegisterWithActionBar.tsx
@@ -12,19 +12,19 @@ import { usePositronActionBarContext } from 'vs/platform/positronActionBar/brows
  * The arrow keys are used to move between the components in the Action Bar.
  */
 export const useRegisterWithActionBar = (refs: MutableRefObject<HTMLElement>[]) => {
-	const positronActionBarContext = usePositronActionBarContext();
+	const { focusableComponents } = usePositronActionBarContext();
 
 	useEffect(() => {
 		refs.forEach(ref => {
-			if (positronActionBarContext.focusableComponents.size === 0) {
+			if (focusableComponents.size === 0) {
 				ref.current.tabIndex = 0; // initially the first component is focusable
 			} else {
 				ref.current.tabIndex = -1;
 			}
-			positronActionBarContext.focusableComponents.add(ref.current);
+			focusableComponents.add(ref.current);
 		});
 		return () => {
-			refs.forEach(ref => positronActionBarContext.focusableComponents.delete(ref.current));
+			refs.forEach(ref => focusableComponents.delete(ref.current));
 		};
 	}, []);
 };

--- a/src/vs/platform/positronActionBar/browser/useRegisterWithActionBar.tsx
+++ b/src/vs/platform/positronActionBar/browser/useRegisterWithActionBar.tsx
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { MutableRefObject, useEffect } from 'react';
+import { usePositronActionBarContext } from 'vs/platform/positronActionBar/browser/positronActionBarContext';
+
+export const useRegisterWithActionBar = (refs: MutableRefObject<HTMLElement>[]) => {
+	const positronActionBarContext = usePositronActionBarContext();
+
+	useEffect(() => {
+		refs.forEach(ref => positronActionBarContext.focusableComponents.add(ref.current));
+		return () => {
+			refs.forEach(ref => positronActionBarContext.focusableComponents.delete(ref.current));
+		};
+	}, []);
+};

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCommandCenter.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCommandCenter.tsx
@@ -8,6 +8,7 @@ import { localize } from 'vs/nls';
 import { MouseEvent } from 'react'; // eslint-disable-line no-duplicate-imports
 import { AnythingQuickAccessProviderRunOptions } from 'vs/platform/quickinput/common/quickAccess';
 import { usePositronTopActionBarContext } from 'vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarContext';
+import { useRegisterWithActionBar } from 'vs/platform/positronActionBar/browser/useRegisterWithActionBar';
 
 /**
  * Localized strings.
@@ -21,6 +22,13 @@ const positronShowQuickAccess = localize('positronShowQuickAccess', "Show Quick 
 export const TopActionBarCommandCenter = () => {
 	// Hooks.
 	const positronTopActionBarContext = usePositronTopActionBarContext();
+
+	// Ref.
+	const searchRef = React.useRef<HTMLButtonElement>(undefined!);
+	const dropdownRef = React.useRef<HTMLButtonElement>(undefined!);
+
+	// Participate in roving tabindex.
+	useRegisterWithActionBar([searchRef, dropdownRef]);
 
 	// Click handler.
 	const clickHandler = (e: MouseEvent<HTMLElement>) => {
@@ -53,12 +61,12 @@ export const TopActionBarCommandCenter = () => {
 				<div className='codicon codicon-positron-search' aria-hidden='true' />
 			</div>
 			<div className='center'>
-				<button className='search' onClick={(e) => clickHandler(e)}>
+				<button className='search' ref={searchRef} onClick={(e) => clickHandler(e)}>
 					<div className='action-bar-button-text'>Search</div>
 				</button>
 			</div>
 			<div className='right'>
-				<button className='drop-down' onClick={(e) => dropDownClickHandler(e)} aria-label={positronShowQuickAccess} >
+				<button className='drop-down' ref={dropdownRef} onClick={(e) => dropDownClickHandler(e)} aria-label={positronShowQuickAccess} >
 					<div className='icon codicon codicon-chevron-down' aria-hidden='true' />
 				</button>
 			</div>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCustomFolderMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCustomFolderMenu.tsx
@@ -8,6 +8,7 @@ import { localize } from 'vs/nls';
 import { KeyboardEvent, useRef } from 'react'; // eslint-disable-line no-duplicate-imports
 import { usePositronTopActionBarContext } from 'vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarContext';
 import { showCustomFolderModalPopup } from 'vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderModalPopup';
+import { useRegisterWithActionBar } from 'vs/platform/positronActionBar/browser/useRegisterWithActionBar';
 
 /**
  * Localized strings.
@@ -24,6 +25,9 @@ export const TopActionBarCustonFolderMenu = () => {
 
 	// Reference hooks.
 	const ref = useRef<HTMLDivElement>(undefined!);
+
+	// Participate in roving tabindex.
+	useRegisterWithActionBar([ref]);
 
 	/**
 	 * Shows the custom folder modal popup.

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarInterpretersManager.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarInterpretersManager.tsx
@@ -9,6 +9,7 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 import { ILanguageRuntime } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { usePositronTopActionBarContext } from 'vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarContext';
 import { showInterpretersManagerModalPopup } from 'vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpretersManagerModalPopup';
+import { useRegisterWithActionBar } from 'vs/platform/positronActionBar/browser/useRegisterWithActionBar';
 
 /**
  * TopActionBarInterpretersManagerProps interface.
@@ -54,6 +55,9 @@ export const TopActionBarInterpretersManager = (props: TopActionBarInterpretersM
 		// Return the cleanup function that will dispose of the disposables.
 		return () => disposableStore.dispose();
 	}, []);
+
+	// Participate in roving tabindex.
+	useRegisterWithActionBar([ref]);
 
 	/**
 	 * Shows the interpreters manager modal popup.

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarPart.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarPart.tsx
@@ -120,7 +120,7 @@ export class PositronTopActionBarPart extends Part implements IPositronTopAction
 	protected override createContentArea(parent: HTMLElement): HTMLElement {
 		// Set the element.
 		this.element = parent;
-		this.element.tabIndex = 0;
+		this.element.tabIndex = -1;
 
 		// Render the Positron top action bar component.
 		this.positronReactRenderer = new PositronReactRenderer(this.element);


### PR DESCRIPTION
Addresses #1669

## Summary

Change the TopActionBar (toolbar) so it has a single tabstop and the arrow keys (left/right/home/end) are used to move focus between the widgets in the toolbar.

This uses the "roving tabindex" approach, where only the currently focused widget has `tabindex=0`, the rest are `tabindex=-1`. Navigation with arrows moves focus to the next/prev item and adjusts the tabindexes accordingly.

This is the [expected keyboard model for toolbars](https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/) (and is how other toolbars in VSCode behave).

## Implementation Details

- Added a `Set<HTMLElement>` to the `positronActionBarState` which holds refs to the toolbar widgets
- Created a custom hook `useRegisterWithActionBar` that components in the toolbar (`actionBarCommandButton`, etc.) use to add themselves to that Set
- Implement keyboard handling in `PositronActionBar` (but only if it's the top-level ActionBar, not the nested one)
- Changed tabindex from 0 to -1 on the PositronTopActionBarPart; we don't want the entire toolbar to get focus when tabbing around, just the buttons within

## Testing Notes

- The first time you Tab or Shift+Tab into the toolbar, focus goes to the first button
- Use left/right arrows to move around (focus will wrap within the toolbar)
- Use Home / End keys to jump to the start/end of the toolbar
- If you leave the toolbar and return later (focus-wise) the last focused element in the toolbar will get focus again
