### PR TITLE
Adding variable overflow indicator

### DIFF
--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableOverflow.css
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableOverflow.css
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+.variable-overflow {
+	display: flex;
+	cursor: pointer;
+	box-sizing: border-box; /* Draw the borders inside the box. */
+	border-top: 0.5px solid var(--vscode-positronVariables-grid);
+	border-bottom: 0.5px solid var(--vscode-positronVariables-grid);
+}
+
+.variable-overflow:hover {
+	background: var(--vscode-positronVariables-rowHoverBackground)
+}
+
+.variable-overflow.selected {
+	color: var(--vscode-positronVariables-inactiveSelectionForeground);
+	background: var(--vscode-positronVariables-inactiveSelectionBackground);
+}
+
+.variable-overflow.focused.selected {
+	color: var(--vscode-positronVariables-activeSelectionForeground);
+	background: var(--vscode-positronVariables-activeSelectionBackground);
+}
+
+.variable-overflow .name-column {
+	display: flex;
+	flex-shrink: 0;
+	overflow: hidden;
+	align-items: center;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.variable-overflow .name-column .name-column-indenter {
+	display: flex;
+}
+
+.variable-overflow .name-value {
+	height: 26px;
+	display: flex;
+	margin-left: 26px;
+	align-items: center;
+}
+
+.variable-overflow .details-column {
+	display: flex;
+	align-items: center;
+}
+
+.variable-overflow .details-column .value {
+	flex-grow: 1;
+	flex-shrink: 1;
+	overflow: hidden;
+	white-space: nowrap;
+	margin: 0 10px 0 8px;
+	text-overflow: ellipsis;
+}

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableOverflow.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableOverflow.tsx
@@ -1,0 +1,103 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'vs/css!./variableOverflow';
+import * as React from 'react';
+import { CSSProperties, MouseEvent } from 'react'; // eslint-disable-line no-duplicate-imports
+import { localize } from 'vs/nls';
+import * as platform from 'vs/base/common/platform';
+import { positronClassNames } from 'vs/base/common/positronUtilities';
+import { ColumnSplitter } from 'vs/workbench/contrib/positronVariables/browser/components/columnSplitter';
+import { IVariableOverflow as IVariableOverflow } from 'vs/workbench/services/positronVariables/common/interfaces/variableOverflow';
+
+/**
+ * VariableOverflowProps interface.
+ */
+export interface VariableOverflowProps {
+	nameColumnWidth: number;
+	detailsColumnWidth: number;
+	variableOverflow: IVariableOverflow;
+	selected: boolean;
+	focused: boolean;
+	style: CSSProperties;
+	onSelected: () => void;
+	onDeselected: () => void;
+	onStartResizeNameColumn: () => void;
+	onResizeNameColumn: (x: number, y: number) => void;
+	onStopResizeNameColumn: (x: number, y: number) => void;
+}
+
+/**
+ * VariableOverflow component.
+ * @param props A VariableOverflowProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const VariableOverflow = (props: VariableOverflowProps) => {
+	/**
+	 * onMouseDown handler.
+	 * @param e A MouseEvent<HTMLElement> that describes a user interaction with the mouse.
+	 */
+	const mouseDownHandler = (e: MouseEvent<HTMLElement>) => {
+		// Consume the event.
+		e.preventDefault();
+		e.stopPropagation();
+
+		// Handle the event.
+		switch (e.button) {
+			// Main button.
+			case 0:
+				if (props.selected && (platform.isMacintosh ? e.metaKey : e.ctrlKey)) {
+					props.onDeselected();
+				} else {
+					props.onSelected();
+				}
+				break;
+
+			// Secondary button.
+			case 2:
+				props.onSelected();
+				break;
+		}
+	};
+
+	// Create the class names.
+	const classNames = positronClassNames(
+		'variable-overflow',
+		{
+			'selected': props.selected
+		},
+		{
+			'focused': props.focused
+		}
+	);
+
+	// Format the value.
+	const value = localize(
+		'positron.moreValues',
+		"{0} more values",
+		props.variableOverflow.overflowValues.toLocaleString()
+	);
+
+	// Render.
+	return (
+		<div className={classNames} onMouseDown={mouseDownHandler} style={props.style}>
+			<div className='name-column' style={{ width: props.nameColumnWidth, minWidth: props.nameColumnWidth }}>
+				<div className='name-column-indenter' style={{ marginLeft: props.variableOverflow.indentLevel * 20 }}>
+					<div className='name-value'>
+						[...]
+					</div>
+				</div>
+			</div>
+			<ColumnSplitter
+				onStartResize={props.onStartResizeNameColumn}
+				onResize={props.onResizeNameColumn}
+				onStopResize={props.onStopResizeNameColumn} />
+			<div className='details-column' style={{ width: props.detailsColumnWidth - 6, minWidth: props.detailsColumnWidth - 6 }}>
+				<div className='value'>
+					{value}
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
@@ -15,8 +15,9 @@ import { IReactComponentContainer } from 'vs/base/browser/positronReactRenderer'
 import { VariableItem } from 'vs/workbench/contrib/positronVariables/browser/components/variableItem';
 import { VariableGroup } from 'vs/workbench/contrib/positronVariables/browser/components/variableGroup';
 import { VariablesEmpty } from 'vs/workbench/contrib/positronVariables/browser/components/variablesEmpty';
+import { VariableOverflow } from 'vs/workbench/contrib/positronVariables/browser/components/variableOverflow';
 import { usePositronVariablesContext } from 'vs/workbench/contrib/positronVariables/browser/positronVariablesContext';
-import { VariableEntry, IPositronVariablesInstance, isVariableGroup, isVariableItem } from 'vs/workbench/services/positronVariables/common/interfaces/positronVariablesInstance';
+import { VariableEntry, IPositronVariablesInstance, isVariableGroup, isVariableItem, isVariableOverflow } from 'vs/workbench/services/positronVariables/common/interfaces/positronVariablesInstance';
 
 /**
  * Constants.
@@ -418,7 +419,6 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 		const entry = variableEntries[index];
 		if (isVariableGroup(entry)) {
 			return (
-				// <div style={style}>Group</div>
 				<VariableGroup
 					key={entry.id}
 					variableGroup={entry}
@@ -451,6 +451,23 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 					positronVariablesInstance={props.positronVariablesInstance}
 				/>
 			);
+		} else if (isVariableOverflow(entry)) {
+			return (
+				<VariableOverflow
+					key={entry.id}
+					nameColumnWidth={nameColumnWidth}
+					detailsColumnWidth={detailsColumnWidth}
+					variableOverflow={entry}
+					style={style}
+					focused={focused}
+					selected={selectedId === entry.id}
+					onSelected={() => selectedHandler(index)}
+					onDeselected={deselectedHandler}
+					onStartResizeNameColumn={startResizeNameColumnHandler}
+					onResizeNameColumn={resizeNameColumnHandler}
+					onStopResizeNameColumn={stopResizeNameColumnHandler}
+				/>
+			);
 		} else {
 			// It's a bug to get here.
 			return null;
@@ -460,7 +477,9 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 	// Create the class names.
 	const classNames = positronClassNames(
 		'variables-instance',
-		{ 'resizing': resizingColumn }
+		{
+			'resizing': resizingColumn
+		}
 	);
 
 	// Render.

--- a/src/vs/workbench/services/positronVariables/common/classes/variableOverflow.ts
+++ b/src/vs/workbench/services/positronVariables/common/classes/variableOverflow.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IVariableOverflow } from 'vs/workbench/services/positronVariables/common/interfaces/variableOverflow';
+
+/**
+ * VariableOverflow class.
+ */
+export class VariableOverflow implements IVariableOverflow {
+	//#region Private Properties
+
+	/**
+	 * Gets the identifier.
+	 */
+	private readonly _id: string;
+
+	/**
+	 * Gets the indent level.
+	 */
+	private readonly _indentLevel: number;
+
+	/**
+	 * Gets the overflow values.
+	 */
+	private readonly _overflowValues: number;
+
+	//#endregion Private Properties
+
+	//#region Public Properties
+
+	/**
+	 * Gets the identifier.
+	 */
+	get id() {
+		return this._id;
+	}
+
+	/**
+	 * Gets the indent level.
+	 */
+	get indentLevel() {
+		return this._indentLevel;
+	}
+
+	/**
+	 * Gets the overflow values.
+	 */
+	get overflowValues() {
+		return this._overflowValues;
+	}
+
+	//#endregion Public Properties
+
+	//#region Constructor
+
+	/**
+	 * Constructor.
+	 * @param id The identifier.
+	 * @param indentLevel The indent level.
+	 * @param overflowValues The overflow values.
+	 */
+	constructor(
+		id: string,
+		indentLevel: number,
+		overflowValues: number,
+	) {
+		this._id = id;
+		this._indentLevel = indentLevel;
+		this._overflowValues = overflowValues;
+	}
+
+	//#endregion Constructor
+}

--- a/src/vs/workbench/services/positronVariables/common/interfaces/positronVariablesInstance.ts
+++ b/src/vs/workbench/services/positronVariables/common/interfaces/positronVariablesInstance.ts
@@ -6,6 +6,7 @@ import { Event } from 'vs/base/common/event';
 import { ILanguageRuntime } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IVariableItem } from 'vs/workbench/services/positronVariables/common/interfaces/variableItem';
 import { IVariableGroup } from 'vs/workbench/services/positronVariables/common/interfaces/variableGroup';
+import { IVariableOverflow as IVariableOverflow } from 'vs/workbench/services/positronVariables/common/interfaces/variableOverflow';
 
 /**
  * PositronVariablesInstanceState enumeration.
@@ -40,12 +41,12 @@ export const enum PositronVariablesSorting {
 /**
  * The VariableEntry type alias.
  */
-export type VariableEntry = IVariableGroup | IVariableItem;
+export type VariableEntry = IVariableGroup | IVariableItem | IVariableOverflow;
 
 /**
  * isVariableGroup user-defined type guard.
  * @param _ The entry.
- * @returns Whether the entry is an IVariableGroup.
+ * @returns A value which indicates whether the entry is an IVariableGroup.
  */
 export const isVariableGroup = (_: VariableEntry): _ is IVariableGroup => {
 	return 'title' in _;
@@ -54,10 +55,19 @@ export const isVariableGroup = (_: VariableEntry): _ is IVariableGroup => {
 /**
  * isVariableItem user-defined type guard.
  * @param _ The entry.
- * @returns Whether the entry is an IVariableItem.
+ * @returns A value which indicates whether the entry is an IVariableItem.
  */
 export const isVariableItem = (_: VariableEntry): _ is IVariableItem => {
 	return 'path' in _;
+};
+
+/**
+ * isVariableOverflow user-defined type guard.
+ * @param _ The entry.
+ * @returns A value which indicates whether the entry is an IVariableOverflow.
+ */
+export const isVariableOverflow = (_: VariableEntry): _ is IVariableOverflow => {
+	return 'overflowValues' in _;
 };
 
 /**

--- a/src/vs/workbench/services/positronVariables/common/interfaces/variableOverflow.ts
+++ b/src/vs/workbench/services/positronVariables/common/interfaces/variableOverflow.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * IVariableOverflow interface.
+ */
+export interface IVariableOverflow {
+	/**
+	 * Gets the identifier.
+	 */
+	readonly id: string;
+
+	/**
+	 * Gets the indent level.
+	 */
+	readonly indentLevel: number;
+
+	/**
+	 * Gets the overflow values.
+	 */
+	readonly overflowValues: number;
+}


### PR DESCRIPTION
This PR addresses #645 by adding a variable overflow indicator.

See the highlighted row in the VARIABLES pane in this screenshot for an example of how this looks.

<img width="1583" alt="image" src="https://github.com/posit-dev/positron/assets/853239/701349e5-2b94-4dd1-8333-d30899af44c6">

Adding you, @jennybc, because you indicated you had some cycles available, @jmcphers as he wrote the issue, and @jjallaire as he's our uber PM.
