### PR TITLE
Enable cli.hyperlink_run and add support for opening x-r-run resources

### DIFF
--- a/extensions/positron-r/resources/scripts/startup.R
+++ b/extensions/positron-r/resources/scripts/startup.R
@@ -13,5 +13,6 @@ options(cli.dynamic = TRUE)
 
 # Tell cli what kind of hyperlinks are supported in the Positron console.
 options(cli.hyperlink = TRUE)
+options(cli.hyperlink_run = TRUE)
 options(cli.hyperlink_help = TRUE)
 options(cli.hyperlink_vignette = TRUE)

--- a/extensions/positron-r/resources/scripts/startup.R
+++ b/extensions/positron-r/resources/scripts/startup.R
@@ -12,6 +12,7 @@ options(cli.default_num_colors = 256L)
 options(cli.dynamic = TRUE)
 
 # Tell cli what kind of hyperlinks are supported in the Positron console.
+# TODO: These would be better as `cli.default_*`, but those don't exist yet.
 options(cli.hyperlink = TRUE)
 options(cli.hyperlink_run = TRUE)
 options(cli.hyperlink_help = TRUE)

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -81,18 +81,25 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 
 		// Dispatch the open.
 		switch (resource.scheme) {
-			// Help resource.
-			case 'x-r-help':
-				console.log('*******************************************************');
-				console.log(`R runtime should open help resource "${resource.path}"`);
-				console.log('*******************************************************');
+			// Run code.
+			case 'x-r-run':
+				console.log('********************************************************************');
+				console.log(`R runtime should run resource "${resource.path}"`);
+				console.log('********************************************************************');
 				return Promise.resolve(true);
 
-			// Vignette resource.
+			// Open help resource.
+			case 'x-r-help':
+				console.log('********************************************************************');
+				console.log(`R runtime should open help resource "${resource.path}"`);
+				console.log('********************************************************************');
+				return Promise.resolve(true);
+
+			// Open vignette resource.
 			case 'x-r-vignette':
-				console.log('*******************************************************');
+				console.log('********************************************************************');
 				console.log(`R runtime should open vignette resource "${resource.path}"`);
-				console.log('*******************************************************');
+				console.log('********************************************************************');
 				return Promise.resolve(true);
 
 			// Unhandled.


### PR DESCRIPTION
This PR adds the final piece of the puzzle to be able to address https://github.com/posit-dev/positron/issues/1469 (see design doc https://github.com/posit-dev/positron/issues/1769).

With this PR, the following R hyperlinks are supported:

```R
# Email
cli::cli_text("Please email {.email brian.lambert@posit.co} for more information.")
cli::cli_text("Please email {.href [Brian Lambert](mailto:brian.lambert@posit.co)} for more information.")

# File
cli::cli_text("Click {.file ~/.zshrc} to edit your .zshrc file.")
cli::cli_text("Click {.file ~/.zshrc:7:5} to edit line 17 column 5 of your .zshrc file.")
cli::cli_text("Click {.file ~/.zshrc:10:5} to edit line 10 column 5 of your .zshrc file.")
cli::cli_text("Please visit {.href [.zshrc](file:///Users/brian/.zshrc)} to open Brian's .zshrc file.")
cli::cli_text("Please visit {.href [.zshrc](file:///Users/brian/.zshrc#17,5)} to open Brian's .zshrc file.")
cli::cli_text("Please visit {.href [.zshrc](file:///Users/brian/.zshrc#5)} to open Brian's .zshrc file.")

# URL
cli::cli_text("Please visit {.url https://posit.co} to learn about us.")
cli::cli_text("Please visit {.href [Posit PBC](https://posit.co)} to learn about us.")

# Help - function
cli::cli_text("Help on function {.help rlang::abort}")

# Help - topic
cli::cli_text("Help on function {.topic rlang::args_dots_empty}")

# Vignette.
cli::cli_text("Help on vignette {.vignette dplyr::grouping}")

# Runnable code
cli::cli_text("Help on run {.run rlang::abort('oh no')}")
```

Note that at the moment, help, vignette, and run hyperlinks do not actually open, but do write to the console indicating that they were clicked. There is a separate issue https://github.com/posit-dev/positron/issues/1906 tracking this work.

<img width="854" alt="image" src="https://github.com/posit-dev/positron/assets/853239/7e50a59b-6e03-4489-965a-db16b5822aa8">


