### PR TITLE
Modify our releases to build both mac and windows

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -274,7 +274,7 @@ jobs:
       - name: Record artifact
         id: artifact
         run: |
-          echo "result=Positron-${{ inputs.short_version }}.dmg" >> $GITHUB_OUTPUT
+          echo "result=positron-darwin-universal-installer" >> $GITHUB_OUTPUT
 
   status:
     if: ${{ failure() }}

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -1,9 +1,20 @@
 name: "Positron: Build macOS Release"
 
-# run builds daily at 2am UTC (10p EST) on weekdays for now, or manually
+# Callable workflow that builds Positron for MacOS
+# Note: our releases are now multi-platform, coordinated by build-release.yml
 on:
-  schedule:
-    - cron: "0 2 * * 1-5"
+  workflow_call:
+    inputs:
+      build_number:
+        required: true
+        type: string
+      short_version:
+        required: true
+        type: string
+    outputs:
+      artifact:
+        description: "The artifact filename"
+        value: ${{ jobs.macos-universal.outputs.artifact }}
   workflow_dispatch:
 
 jobs:
@@ -37,55 +48,10 @@ jobs:
           # nothing, but if there isn't one, start one up now.
           ssh -o "StrictHostKeyChecking no" user229818@NY503.macincloud.com "/bin/zsh -li -c \"if screen -list | grep -q 'No Sockets found'; then screen -dmS agent_session /bin/zsh -li -c 'cd ./actions-runner && ./run.sh'; fi\""
 
-  version_string:
-    name: Determine version
-    runs-on: self-hosted
-    outputs:
-      short_version: ${{ steps.short_version.outputs.result }}
-      build_number: ${{ steps.build_number.outputs.result }}
-    steps:
-      # Fetch full history; required so we can determine the build version with rev-list
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      # Set up Node; needed since the show-version.js script runs under Node
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      # Call version script to determine short version. This is the version
-      # string that we will use later to form the file name of the release
-      # artifact.
-      #
-      # Example: 2022.10.0-123
-      - name: Determine Version (Short)
-        id: short_version
-        run: |
-          result=`./versions/show-version.js --short`
-          echo "result=$result" >> $GITHUB_OUTPUT
-
-      # If we're on main, we will be producing a release later, so make sure
-      # that no release is already in place with this tag
-      - name: Check for Existing Tag
-        id: tag_check
-        if: github.ref == 'refs/heads/main'
-        run: |
-          result=`./versions/show-version.js --short`
-          git fetch --tags
-          tag_exists=`git tag -l "${result}"`
-          if [ -n "${tag_exists}" ]; then exit 78; fi
-
-      # Call again to get just the build number. Example: 123
-      - name: Determine Version (Build Number)
-        id: build_number
-        run: echo "result=$(./versions/show-version.js --build)" >> $GITHUB_OUTPUT
-
   build-archs:
     name: Build macOS
     runs-on: [self-hosted, macos, arm64]
-    needs: [revive_agent, version_string]
+    needs: [revive_agent]
     timeout-minutes: 60
 
     env:
@@ -143,7 +109,7 @@ jobs:
       # Build client
       - name: Build client
         env:
-          POSITRON_BUILD_NUMBER: ${{ needs.version_string.outputs.build_number }}
+          POSITRON_BUILD_NUMBER: ${{ inputs.build_number }}
         run: |
           export NVM_DIR="$HOME/.nvm"
           [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
@@ -157,7 +123,7 @@ jobs:
           # Clean up ZeroMQ build folder from Jupyter Adapter extension
           rm -rf VSCode-darwin-${{ matrix.arch }}/Positron.app/Contents/Resources/app/extensions/jupyter-adapter/node_modules/zeromq/build
           # Zip all remaining app contents
-          zip -Xry $GITHUB_WORKSPACE/positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch }}.zip VSCode-darwin-${{ matrix.arch }}
+          zip -Xry $GITHUB_WORKSPACE/positron-${{ inputs.short_version }}-darwin-${{ matrix.arch }}.zip VSCode-darwin-${{ matrix.arch }}
           popd
 
       # Create build artifact
@@ -165,15 +131,17 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: positron-darwin-${{ matrix.arch }}-archive
-          path: positron-${{ needs.version_string.outputs.short_version }}-darwin-${{ matrix.arch }}.zip
+          path: positron-${{ inputs.short_version }}-darwin-${{ matrix.arch }}.zip
 
   macos-universal:
     name: Create macOS universal binary
-    needs: [version_string, build-archs]
+    needs: [build-archs]
     runs-on: [self-hosted, macos, arm64]
     timeout-minutes: 60
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      artifact: ${{ steps.artifact.outputs.result }}
     steps:
       # Download arm64 and x64 binaries
       - name: Download arm64 client
@@ -189,8 +157,8 @@ jobs:
       # Expand client archives produced in previous workflow steps
       - name: Expand client archives
         run: |
-          unzip positron-${{ needs.version_string.outputs.short_version }}-darwin-arm64.zip
-          unzip positron-${{ needs.version_string.outputs.short_version }}-darwin-x64.zip
+          unzip positron-${{ inputs.short_version }}-darwin-arm64.zip
+          unzip positron-${{ inputs.short_version }}-darwin-x64.zip
 
       - name: Align arm64 and x64 app content
         run: |
@@ -238,7 +206,7 @@ jobs:
       - name: Create universal client disk image
         run: |
           # Create the name of the DMG file we will bundle to
-          export POSITRON_BUNDLE_NAME=Positron-${{ needs.version_string.outputs.short_version }}
+          export POSITRON_BUNDLE_NAME=Positron-${{ inputs.short_version }}
 
           # Create a symlink to /Applications, so that the disk image will have
           # a drag-to-install target for Positron.app.
@@ -257,7 +225,7 @@ jobs:
       - name: Notarize binary
         run: |
           # Create the name of the DMG to notarize
-          export NOTARIZATION_TARGET=$GITHUB_WORKSPACE/Positron-${{ needs.version_string.outputs.short_version }}.dmg
+          export NOTARIZATION_TARGET=$GITHUB_WORKSPACE/Positron-${{ inputs.short_version }}.dmg
 
           # Submit the DMG to Apple's notarization service. This consumes the
           # user name and password of an Apple account under which to perform
@@ -291,40 +259,18 @@ jobs:
           # validation with Gatekeeper.
           xcrun stapler staple $NOTARIZATION_TARGET
 
-      # Create a GitHub release for the universal binary we just created, if
-      # we're running against the main branch
-      #
-      # TODO: This shouldn't be nested inside the macOS build task, but since
-      # macOS is all we're building now, a macOS release and a Positron release
-      # are the same thing.
-      - name: Create release
-        uses: actions/create-release@v1
-        id: create_release
-        if: github.ref == 'refs/heads/main'
-        with:
-          draft: false
-          prerelease: true
-          release_name: ${{ needs.version_string.outputs.short_version }}
-          tag_name: ${{ needs.version_string.outputs.short_version }}
-
-      - name: Upload release artifact
-        uses: actions/upload-release-asset@v1
-        if: github.ref == 'refs/heads/main'
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: Positron-${{ needs.version_string.outputs.short_version }}.dmg
-          asset_name: Positron-${{ needs.version_string.outputs.short_version }}.dmg
-          asset_content_type: application/octet-stream
-
       # Create a regular build artifact for the universal archive, to be
       # downloaded from the actions page for testing purposes.
       - name: Upload
         uses: actions/upload-artifact@v3
         with:
           name: positron-darwin-universal-installer
-          path: Positron-${{ needs.version_string.outputs.short_version }}.dmg
+          path: Positron-${{ inputs.short_version }}.dmg
+
+      - name: Record artifact
+        id: artifact
+        run: |
+          echo "result=Positron-${{ inputs.short_version }}.dmg" >> $GITHUB_OUTPUT
 
   status:
     if: ${{ failure() }}
@@ -337,7 +283,7 @@ jobs:
         with:
           payload: |
             {
-              "message": "Positron build ${{ needs.version_string.outputs.build_number }} failed",
+              "message": "Positron MacOS build ${{ inputs.build_number }} failed",
               "status": "Failure",
               "run_url": "https://github.com/posit-dev/positron/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -16,9 +16,12 @@ on:
         default: ${{ github.sha }}
         type: string
     outputs:
-      artifact:
-        description: "The release artifact filename"
-        value: ${{ jobs.macos-universal.outputs.artifact }}
+      artifact-name:
+        description: "The release artifact name"
+        value: ${{ jobs.macos-universal.outputs.artifact-name }}
+      artifact-file:
+        description: "The release artifact file"
+        value: ${{ jobs.macos-universal.outputs.artifact-file }}
   workflow_dispatch:
 
 jobs:
@@ -145,7 +148,8 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
-      artifact: ${{ steps.artifact.outputs.result }}
+      artifact-file: ${{ steps.artifact-file.outputs.result }}
+      artifact-name: ${{ steps.artifact-name.outputs.result }}
     steps:
       # Download arm64 and x64 binaries
       - name: Download arm64 client
@@ -271,10 +275,15 @@ jobs:
           name: positron-darwin-universal-installer
           path: Positron-${{ inputs.short_version }}.dmg
 
-      - name: Record artifact
-        id: artifact
+      - name: Record artifact name
+        id: artifact-name
         run: |
           echo "result=positron-darwin-universal-installer" >> $GITHUB_OUTPUT
+
+      - name: Record artifact file
+        id: artifact-file
+        run: |
+          echo "result=Positron-${{ inputs.short_version }}.dmg" >> $GITHUB_OUTPUT
 
   status:
     if: ${{ failure() }}

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -6,15 +6,20 @@ on:
   workflow_call:
     inputs:
       build_number:
-        required: true
+        required: false
+        description: "The build distance number only, e.g. 123"
+        default: ${{ github.sha }}
         type: string
       short_version:
         required: true
+        description: "The short version number, including the build distance, e.g. 2023.12.0-123"
+        default: ${{ github.sha }}
         type: string
     outputs:
       artifact:
-        description: "The artifact filename"
+        description: "The release artifact filename"
         value: ${{ jobs.macos-universal.outputs.artifact }}
+  workflow_dispatch:
 
 jobs:
   revive_agent:

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -273,7 +273,7 @@ jobs:
 
   status:
     if: ${{ failure() }}
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: macos-universal
     steps:
       - name: Notify slack if build fails

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -15,7 +15,6 @@ on:
       artifact:
         description: "The artifact filename"
         value: ${{ jobs.macos-universal.outputs.artifact }}
-  workflow_dispatch:
 
 jobs:
   revive_agent:

--- a/.github/workflows/build-release-windows.yml
+++ b/.github/workflows/build-release-windows.yml
@@ -124,7 +124,7 @@ jobs:
 
   status:
     if: ${{ failure() }}
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: build-windows
     steps:
       - name: Notify slack if build fails

--- a/.github/workflows/build-release-windows.yml
+++ b/.github/workflows/build-release-windows.yml
@@ -117,13 +117,13 @@ jobs:
       - name: Upload Positron Installer to Github Archive
         uses: actions/upload-artifact@v3
         with:
-          name: positron-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}-setup.exe
+          name: positron-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}-installer
           path: ${{github.workspace}}\.build\${{ matrix.platform }}-${{ matrix.arch }}\${{ matrix.target }}-setup\PositronSetup.exe
 
       - name: Record artifact
         id: artifact
         run: |
-          echo "result=positron-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}-setup.exe" >> $GITHUB_OUTPUT
+          echo "result=positron-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}-installer" >> $GITHUB_OUTPUT
 
   status:
     if: ${{ failure() }}

--- a/.github/workflows/build-release-windows.yml
+++ b/.github/workflows/build-release-windows.yml
@@ -126,13 +126,15 @@ jobs:
 
       - name: Record artifact name
         id: artifact-name
+        shell: bash
         run: |
           echo "result=positron-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}-installer" >> $GITHUB_OUTPUT
 
       - name: Record artifact file
         id: artifact-file
+        shell: bash
         run: |
-          echo "result=${{github.workspace}}\.build\${{ matrix.platform }}-${{ matrix.arch }}\${{ matrix.target }}-setup\PositronSetup.exe" >> $GITHUB_OUTPUT
+          echo "result=PositronSetup.exe" >> $GITHUB_OUTPUT
 
 
   status:

--- a/.github/workflows/build-release-windows.yml
+++ b/.github/workflows/build-release-windows.yml
@@ -11,9 +11,12 @@ on:
         default: ${{ github.sha }}
         type: string
     outputs:
-      artifact:
-        description: "The release artifact filename"
-        value: ${{ jobs.build-windows.outputs.artifact }}
+      artifact-name:
+        description: "The release artifact name"
+        value: ${{ jobs.build-windows.outputs.artifact-name }}
+      artifact-file:
+        description: "The release artifact file"
+        value: ${{ jobs.build-windows.outputs.artifact-file }}
   workflow_dispatch:
 
 jobs:
@@ -25,7 +28,8 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
-      artifact: ${{ steps.artifact.outputs.result }}
+      artifact-file: ${{ steps.artifact-file.outputs.result }}
+      artifact-name: ${{ steps.artifact-name.outputs.result }}
     strategy:
       max-parallel: 1
       matrix:
@@ -120,10 +124,16 @@ jobs:
           name: positron-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}-installer
           path: ${{github.workspace}}\.build\${{ matrix.platform }}-${{ matrix.arch }}\${{ matrix.target }}-setup\PositronSetup.exe
 
-      - name: Record artifact
-        id: artifact
+      - name: Record artifact name
+        id: artifact-name
         run: |
           echo "result=positron-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}-installer" >> $GITHUB_OUTPUT
+
+      - name: Record artifact file
+        id: artifact-file
+        run: |
+          echo "result=${{github.workspace}}\.build\${{ matrix.platform }}-${{ matrix.arch }}\${{ matrix.target }}-setup\PositronSetup.exe" >> $GITHUB_OUTPUT
+
 
   status:
     if: ${{ failure() }}

--- a/.github/workflows/build-release-windows.yml
+++ b/.github/workflows/build-release-windows.yml
@@ -12,7 +12,6 @@ on:
       artifact:
         description: "The artifact filename"
         value: ${{ jobs.build-windows.outputs.artifact }}
-  workflow_dispatch:
 
 jobs:
   build-windows:

--- a/.github/workflows/build-release-windows.yml
+++ b/.github/workflows/build-release-windows.yml
@@ -5,13 +5,16 @@ name: "Positron: Build Windows Release"
 on:
   workflow_call:
     inputs:
-      build_number:
-        required: true
+      short_version:
+        required: false
+        description: "The short version number, including the build distance, e.g. 2023.12.0-123"
+        default: ${{ github.sha }}
         type: string
     outputs:
       artifact:
-        description: "The artifact filename"
+        description: "The release artifact filename"
         value: ${{ jobs.build-windows.outputs.artifact }}
+  workflow_dispatch:
 
 jobs:
   build-windows:
@@ -53,14 +56,14 @@ jobs:
 
       - name: Build Positron
         env:
-          POSITRON_BUILD_NUMBER: ${{ inputs.build_number }}
+          POSITRON_BUILD_NUMBER: ${{ inputs.short_version }}
         shell: pwsh
         run: |
           yarn gulp vscode-${{ matrix.platform }}-${{ matrix.arch }}
 
       - name: Build Positron Installer for Windows
         env:
-          POSITRON_BUILD_NUMBER: ${{ inputs.build_number }}
+          POSITRON_BUILD_NUMBER: ${{ inputs.short_version }}
         shell: pwsh
         run: |
           yarn gulp vscode-${{ matrix.platform }}-${{ matrix.arch }}-inno-updater
@@ -133,7 +136,7 @@ jobs:
         with:
           payload: |
             {
-              "message": "Positron Windows build ${{ inputs.build_number }} failed",
+              "message": "Positron Windows build ${{ inputs.short_version }} failed",
               "status": "Failure",
               "run_url": "https://github.com/posit-dev/positron/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/build-release-windows.yml
+++ b/.github/workflows/build-release-windows.yml
@@ -1,67 +1,29 @@
 name: "Positron: Build Windows Release"
 
-# Run windows builds daily at 12:00 UTC on weekdays for now, or manually
+# Callable workflow that builds Positron for Windows
+# Note: our releases are now multi-platform, coordinated by build-release.yml
 on:
-  schedule:
-    - cron: "0 12 * * 1-5"
+  workflow_call:
+    inputs:
+      build_number:
+        required: true
+        type: string
+    outputs:
+      artifact:
+        description: "The artifact filename"
+        value: ${{ jobs.build-windows.outputs.artifact }}
   workflow_dispatch:
 
 jobs:
-  version_string:
-    name: Determine version
-    runs-on: ubuntu-latest
-    outputs:
-      short_version: ${{ steps.short_version.outputs.result }}
-      build_number: ${{ steps.build_number.outputs.result }}
-    steps:
-      # Fetch full history; required so we can determine the build version with rev-list
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      # Set up Node (used by show-version.js)
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: .nvmrc
-
-      # Call version script to determine short version. This is the version
-      # string that we will use later to form the file name of the release
-      # artifact.
-      #
-      # Example: 2022.10.0-123
-      - name: Determine Version (Short)
-        id: short_version
-        run: |
-          result=`./versions/show-version.js --short`
-          echo "result=$result" >> $GITHUB_OUTPUT
-
-      # If we're on main, we will be producing a release later, so make sure
-      # that no release is already in place with this tag
-      - name: Check for Existing Tag
-        id: tag_check
-        if: github.ref == 'refs/heads/main'
-        run: |
-          result=`./versions/show-version.js --short`
-          git fetch --tags
-          tag_exists=`git tag -l "${result}"`
-          if [ -n "${tag_exists}" ]; then exit 78; fi
-
-      # Call again to get just the build number. Example: 123
-      - name: Determine Version (Build Number)
-        id: build_number
-        run: echo "result=$(./versions/show-version.js --build)" >> $GITHUB_OUTPUT
-
   build-windows:
     name: Build Windows
     runs-on:
       labels: [windows-latest-8x]
-    needs: [version_string]
     timeout-minutes: 90
-
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+    outputs:
+      artifact: ${{ steps.artifact.outputs.result }}
     strategy:
       max-parallel: 1
       matrix:
@@ -92,14 +54,14 @@ jobs:
 
       - name: Build Positron
         env:
-          POSITRON_BUILD_NUMBER: ${{ needs.version_string.outputs.build_number }}
+          POSITRON_BUILD_NUMBER: ${{ inputs.build_number }}
         shell: pwsh
         run: |
           yarn gulp vscode-${{ matrix.platform }}-${{ matrix.arch }}
 
       - name: Build Positron Installer for Windows
         env:
-          POSITRON_BUILD_NUMBER: ${{ needs.version_string.outputs.build_number }}
+          POSITRON_BUILD_NUMBER: ${{ inputs.build_number }}
         shell: pwsh
         run: |
           yarn gulp vscode-${{ matrix.platform }}-${{ matrix.arch }}-inno-updater
@@ -155,3 +117,26 @@ jobs:
         with:
           name: positron-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}-setup.exe
           path: ${{github.workspace}}\.build\${{ matrix.platform }}-${{ matrix.arch }}\${{ matrix.target }}-setup\PositronSetup.exe
+
+      - name: Record artifact
+        id: artifact
+        run: |
+          echo "result=positron-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}-setup.exe" >> $GITHUB_OUTPUT
+
+  status:
+    if: ${{ failure() }}
+    runs-on: self-hosted
+    needs: build-windows
+    steps:
+      - name: Notify slack if build fails
+        uses: slackapi/slack-github-action@v1.24.0
+        id: slack-failure
+        with:
+          payload: |
+            {
+              "message": "Positron Windows build ${{ inputs.build_number }} failed",
+              "status": "Failure",
+              "run_url": "https://github.com/posit-dev/positron/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -50,19 +50,19 @@ jobs:
         run: echo "result=$(./versions/show-version.js --build)" >> $GITHUB_OUTPUT
 
   macos-installer:
-    uses: ./.github/workflows/build-release-macos.yml@build/multi-platform
+    uses: ./.github/workflows/build-release-macos.yml
     needs: version_string
     secrets: inherit
     with:
-      build-number: ${{ needs.version_string.outputs.build_number }}
-      short-version: ${{ needs.version_string.outputs.short_version }}
+      build-number: ${{ jobs.version_string.outputs.build_number }}
+      short-version: ${{ jobs.version_string.outputs.short_version }}
 
   windows-installer:
-    uses: ./.github/workflows/build-release-windows.yml@build/multi-platform
+    uses: ./.github/workflows/build-release-windows.yml
     needs: version_string
     secrets: inherit
     with:
-      build-number: ${{ needs.version_string.outputs.build_number }}
+      build-number: ${{ jobs.version_string.outputs.build_number }}
 
   releases:
     runs-on: self-hosted

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -54,15 +54,15 @@ jobs:
     needs: version_string
     secrets: inherit
     with:
-      build-number: ${{ jobs.version_string.outputs.build_number }}
-      short-version: ${{ jobs.version_string.outputs.short_version }}
+      build-number: ${{ needs.version_string.outputs.build_number }}
+      short-version: ${{ needs.version_string.outputs.short_version }}
 
   windows-installer:
     uses: ./.github/workflows/build-release-windows.yml
     needs: version_string
     secrets: inherit
     with:
-      build-number: ${{ jobs.version_string.outputs.build_number }}
+      build-number: ${{ needs.version_string.outputs.build_number }}
 
   releases:
     runs-on: self-hosted

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   version_string:
     name: Determine version
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       short_version: ${{ steps.short_version.outputs.result }}
       build_number: ${{ steps.build_number.outputs.result }}
@@ -65,7 +65,7 @@ jobs:
       build_number: ${{ needs.version_string.outputs.build_number }}
 
   releases:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [version_string, macos-installer, windows-installer]
     steps:
       # Create a GitHub release for the installers we just created, if

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -54,15 +54,15 @@ jobs:
     needs: version_string
     secrets: inherit
     with:
-      build-number: ${{ needs.version_string.outputs.build_number }}
-      short-version: ${{ needs.version_string.outputs.short_version }}
+      build_number: ${{ needs.version_string.outputs.build_number }}
+      short_version: ${{ needs.version_string.outputs.short_version }}
 
   windows-installer:
     uses: ./.github/workflows/build-release-windows.yml
     needs: version_string
     secrets: inherit
     with:
-      build-number: ${{ needs.version_string.outputs.build_number }}
+      build_number: ${{ needs.version_string.outputs.build_number }}
 
   releases:
     runs-on: self-hosted

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -69,6 +69,8 @@ jobs:
     needs: [version_string, macos-installer, windows-installer]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       # Create a GitHub release for the installers we just created, if
       # we're running against the main branch
@@ -82,8 +84,15 @@ jobs:
           release_name: ${{ needs.version_string.outputs.short_version }}
           tag_name: ${{ needs.version_string.outputs.short_version }}
 
+  macos-releases:
+    needs: [macos-installer, releases]
+    runs-on: [self-hosted, macos, arm64]
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
       - name: Download MacOS artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
+        id: download-macos-artifact
         # if: github.ref == 'refs/heads/main'
         with:
           name: ${{ needs.macos-installer.outputs.artifact }}
@@ -94,13 +103,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ needs.macos-installer.outputs.artifact }}
+          upload_url: ${{ needs.releases.outputs.upload_url }}
+          asset_path: ${{ steps.download-macos-artifact.outputs.download-path }}
           asset_name: ${{ needs.macos-installer.outputs.artifact }}
           asset_content_type: application/octet-stream
 
+  windows-releases:
+    runs-on:
+      labels: [windows-latest-8x]
+    needs: [windows-installer, releases]
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
       - name: Download Windows artifact
-        uses: actions/download-artifact@v2
+        id: download-windows-artifact
+        uses: actions/download-artifact@v3
         # if: github.ref == 'refs/heads/main'
         with:
           name: ${{ needs.windows-installer.outputs.artifact }}
@@ -111,7 +128,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ needs.windows-installer.outputs.artifact }}
+          upload_url: ${{ needs.releases.outputs.upload_url }}
+          asset_path: ${{ steps.download-windows-artifact.outputs.download-path }}
           asset_name: ${{ needs.windows-installer.outputs.artifact }}
           asset_content_type: application/octet-stream

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -95,7 +95,8 @@ jobs:
         id: download-macos-artifact
         # if: github.ref == 'refs/heads/main'
         with:
-          name: ${{ needs.macos-installer.outputs.artifact }}
+          name: ${{ needs.macos-installer.outputs.artifact-name }}
+          path: ./
 
       - name: Upload MacOS release asset
         uses: actions/upload-release-asset@v1
@@ -104,8 +105,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ needs.releases.outputs.upload_url }}
-          asset_path: ${{ steps.download-macos-artifact.outputs.download-path }}
-          asset_name: ${{ needs.macos-installer.outputs.artifact }}
+          asset_path: ${{ needs.macos-installer.outputs.artifact-file }}
+          asset_name: ${{ needs.macos-installer.outputs.artifact-file }}
           asset_content_type: application/octet-stream
 
   windows-releases:
@@ -120,7 +121,8 @@ jobs:
         uses: actions/download-artifact@v3
         # if: github.ref == 'refs/heads/main'
         with:
-          name: ${{ needs.windows-installer.outputs.artifact }}
+          name: ${{ needs.windows-installer.outputs.artifact-name }}
+          path: ./
 
       - name: Upload Windows release asset
         uses: actions/upload-release-asset@v1
@@ -129,6 +131,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ needs.releases.outputs.upload_url }}
-          asset_path: ${{ steps.download-windows-artifact.outputs.download-path }}
-          asset_name: ${{ needs.windows-installer.outputs.artifact }}
+          asset_path: ${{ needs.windows-installer.outputs.artifact-file }}
+          asset_name: ${{ needs.windows-installer.outputs.artifact-file }}
           asset_content_type: application/octet-stream

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,6 +1,9 @@
 name: "Positron: Build Release"
 
+# Run builds daily at 2am UTC (10p EST) on weekdays for now, or manually
 on:
+  schedule:
+    - cron: "0 2 * * 1-5"
   workflow_dispatch:
 
 jobs:
@@ -77,7 +80,7 @@ jobs:
       - name: Create release
         uses: actions/create-release@v1
         id: create_release
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         with:
           draft: false
           prerelease: true
@@ -93,14 +96,14 @@ jobs:
       - name: Download MacOS artifact
         uses: actions/download-artifact@v3
         id: download-macos-artifact
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         with:
           name: ${{ needs.macos-installer.outputs.artifact-name }}
           path: ./
 
       - name: Upload MacOS release asset
         uses: actions/upload-release-asset@v1
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -119,14 +122,14 @@ jobs:
       - name: Download Windows artifact
         id: download-windows-artifact
         uses: actions/download-artifact@v3
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         with:
           name: ${{ needs.windows-installer.outputs.artifact-name }}
           path: ./
 
       - name: Upload Windows release asset
         uses: actions/upload-release-asset@v1
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -50,16 +50,16 @@ jobs:
         run: echo "result=$(./versions/show-version.js --build)" >> $GITHUB_OUTPUT
 
   macos-installer:
-    uses: posit-dev/positron/.github/workflows/build-release-mac.yml@build/multi-platform
-    needs: [version_string]
+    uses: posit-dev/positron/.github/workflows/build-release-macos.yml@build/multi-platform
+    needs: version_string
     secrets: inherit
     with:
       short-version: ${{ needs.version_string.outputs.short_version }}
       build-number: ${{ needs.version_string.outputs.build_number }}
 
   windows-installer:
-    uses: posit-dev/positron/.github/workflows/build-release-win.yml@build/multi-platform
-    needs: [version_string]
+    uses: posit-dev/positron/.github/workflows/build-release-windows.yml@build/multi-platform
+    needs: version_string
     secrets: inherit
     with:
       build-number: ${{ needs.version_string.outputs.build_number }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -82,7 +82,13 @@ jobs:
           release_name: ${{ needs.version_string.outputs.short_version }}
           tag_name: ${{ needs.version_string.outputs.short_version }}
 
-      - name: Upload MacOS release artifact
+      - name: Download MacOS artifact
+        uses: actions/download-artifact@v2
+        # if: github.ref == 'refs/heads/main'
+        with:
+          name: ${{ needs.macos-installer.outputs.artifact }}
+
+      - name: Upload MacOS release asset
         uses: actions/upload-release-asset@v1
         # if: github.ref == 'refs/heads/main'
         env:
@@ -93,7 +99,13 @@ jobs:
           asset_name: ${{ needs.macos-installer.outputs.artifact }}
           asset_content_type: application/octet-stream
 
-      - name: Upload Windows release artifact
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v2
+        # if: github.ref == 'refs/heads/main'
+        with:
+          name: ${{ needs.windows-installer.outputs.artifact }}
+
+      - name: Upload Windows release asset
         uses: actions/upload-release-asset@v1
         # if: github.ref == 'refs/heads/main'
         env:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -49,17 +49,55 @@ jobs:
         id: build_number
         run: echo "result=$(./versions/show-version.js --build)" >> $GITHUB_OUTPUT
 
-  macos-release:
-    uses: posit-dev/positron/.github/workflows/build-release-macos.yml@feature/build-multi-platform
+  macos-installer:
+    uses: posit-dev/positron/.github/workflows/build-release-mac.yml@build/multi-platform
     needs: [version_string]
-    if: false
+    secrets: inherit
     with:
       short-version: ${{ needs.version_string.outputs.short_version }}
       build-number: ${{ needs.version_string.outputs.build_number }}
 
-  windows-release:
-    uses: posit-dev/positron/.github/workflows/build-release-windows.yml@feature/build-multi-platform
+  windows-installer:
+    uses: posit-dev/positron/.github/workflows/build-release-win.yml@build/multi-platform
     needs: [version_string]
-    if: false
+    secrets: inherit
     with:
       build-number: ${{ needs.version_string.outputs.build_number }}
+
+  releases:
+    runs-on: self-hosted
+    needs: [version_string, macos-installer, windows-installer]
+    steps:
+      # Create a GitHub release for the installers we just created, if
+      # we're running against the main branch
+      - name: Create release
+        uses: actions/create-release@v1
+        id: create_release
+        if: github.ref == 'refs/heads/main'
+        with:
+          draft: false
+          prerelease: true
+          release_name: ${{ needs.version_string.outputs.short_version }}
+          tag_name: ${{ needs.version_string.outputs.short_version }}
+
+      - name: Upload MacOS release artifact
+        uses: actions/upload-release-asset@v1
+        if: github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ needs.macos-installer.outputs.artifact }}
+          asset_name: ${{ needs.macos-installer.outputs.artifact }}
+          asset_content_type: application/octet-stream
+
+      - name: Upload Windows release artifact
+        uses: actions/upload-release-asset@v1
+        if: github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ needs.windows-installer.outputs.artifact }}
+          asset_name: ${{ needs.windows-installer.outputs.artifact }}
+          asset_content_type: application/octet-stream

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -67,6 +67,8 @@ jobs:
   releases:
     runs-on: ubuntu-latest
     needs: [version_string, macos-installer, windows-installer]
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       # Create a GitHub release for the installers we just created, if
       # we're running against the main branch

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -50,15 +50,15 @@ jobs:
         run: echo "result=$(./versions/show-version.js --build)" >> $GITHUB_OUTPUT
 
   macos-installer:
-    uses: posit-dev/positron/.github/workflows/build-release-macos.yml@build/multi-platform
+    uses: ./.github/workflows/build-release-macos.yml@build/multi-platform
     needs: version_string
     secrets: inherit
     with:
-      short-version: ${{ needs.version_string.outputs.short_version }}
       build-number: ${{ needs.version_string.outputs.build_number }}
+      short-version: ${{ needs.version_string.outputs.short_version }}
 
   windows-installer:
-    uses: posit-dev/positron/.github/workflows/build-release-windows.yml@build/multi-platform
+    uses: ./.github/workflows/build-release-windows.yml@build/multi-platform
     needs: version_string
     secrets: inherit
     with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,7 +26,7 @@ jobs:
       # string that we will use later to form the file name of the release
       # artifact.
       #
-      # Example: 2022.10.0-123
+      # Example: 2023.12.0-123
       - name: Determine Version (Short)
         id: short_version
         run: |
@@ -62,7 +62,7 @@ jobs:
     needs: version_string
     secrets: inherit
     with:
-      build_number: ${{ needs.version_string.outputs.build_number }}
+      short_version: ${{ needs.version_string.outputs.short_version }}
 
   releases:
     runs-on: ubuntu-latest
@@ -73,7 +73,7 @@ jobs:
       - name: Create release
         uses: actions/create-release@v1
         id: create_release
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         with:
           draft: false
           prerelease: true
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload MacOS release artifact
         uses: actions/upload-release-asset@v1
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload Windows release artifact
         uses: actions/upload-release-asset@v1
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
We use callable workflows to build platforms independently, and then finally publish the artifacts as assets under a common release.