### PR TITLE
Set `ARK_R_VERSION` and `ARK_R_DYNAMIC_LIBRARY_PATH`

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -142,6 +142,8 @@ export async function* rRuntimeDiscoverer(
 			'RUST_BACKTRACE': '1',
 			'RUST_LOG': logLevel,
 			'R_HOME': rHome.homepath,
+			'ARK_R_VERSION': rHome.version,
+			'ARK_R_DYNAMIC_LIBRARY_PATH': rHome.dynamicLibraryPath,
 			...userEnv
 		};
 		/* eslint-enable */
@@ -149,7 +151,7 @@ export async function* rRuntimeDiscoverer(
 		if (process.platform === 'darwin') {
 
 			const dyldFallbackLibraryPaths: string[] = [];
-			dyldFallbackLibraryPaths.push(`${rHome.homepath}/lib`);
+			dyldFallbackLibraryPaths.push(rHome.dynamicLibraryFolder);
 
 			const defaultDyldFallbackLibraryPath = process.env['DYLD_FALLBACK_LIBRARY_PATH'];
 			if (defaultDyldFallbackLibraryPath) {
@@ -167,17 +169,15 @@ export async function* rRuntimeDiscoverer(
 		}
 
 		if (process.platform === 'win32') {
-			// On Windows, we must place the `bin/` path for the current R version on the PATH
-			// so that the DLLs in that same folder can be resolved properly when ark starts up
+			// On Windows, we must place the dynamic library folder for the current R version on the
+			// PATH so that the DLLs in that same folder can be resolved properly when ark starts up
 			// (like `R.dll`, `Rblas.dll`, `Rgraphapp.dll`, `Riconv.dll`, and `Rlapack.dll`).
 			// https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#standard-search-order-for-unpackaged-apps
-			const binpath = path.join(rHome.homepath, 'bin', 'x64');
-
 			const processPath = process.env['PATH'];
 
 			const subprocessPath = processPath === undefined ?
-				binpath :
-				processPath + ';' + binpath;
+				rHome.dynamicLibraryFolder :
+				processPath + ';' + rHome.dynamicLibraryFolder;
 
 			env['PATH'] = subprocessPath;
 		}

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -19,6 +19,8 @@ export class RInstallation {
 
 	public readonly binpath: string = '';
 	public readonly homepath: string = '';
+	public readonly dynamicLibraryPath: string = '';
+	public readonly dynamicLibraryFolder: string = '';
 	// The semVersion field was added because changing the version field from a string that's
 	// "major.minor" to an instance of SemVer (conveying major.minor.patch) would have
 	// downstream consequence I don't want to take on now. But we can probably rationalize this
@@ -68,6 +70,9 @@ export class RInstallation {
 				return;
 			}
 		}
+
+		this.dynamicLibraryFolder = dynamicLibraryFolder(this.homepath);
+		this.dynamicLibraryPath = dynamicLibraryPath(this.dynamicLibraryFolder);
 
 		// orthogonality is a concern specific to macOS
 		// a non-orthogonal R "binary" is hard-wired to launch the current version of R,
@@ -128,5 +133,31 @@ export class RInstallation {
 		this.valid = true;
 
 		Logger.info(`R installation discovered: ${JSON.stringify(this, null, 2)}`);
+	}
+}
+
+function dynamicLibraryFolder(homePath: string): string {
+	switch (process.platform) {
+		case 'darwin':
+			return path.join(homePath, 'lib');
+		case 'linux':
+			return path.join(homePath, 'lib');
+		case 'win32':
+			return path.join(homePath, 'bin', 'x64');
+		default:
+			throw new Error('Unsupported platform');
+	}
+}
+
+function dynamicLibraryPath(dynamicLibraryFolder: string): string {
+	switch (process.platform) {
+		case 'darwin':
+			return path.join(dynamicLibraryFolder, 'libR.dylib');
+		case 'linux':
+			return path.join(dynamicLibraryFolder, 'libR.so');
+		case 'win32':
+			return path.join(dynamicLibraryFolder, 'R.dll');
+		default:
+			throw new Error('Unsupported platform');
 	}
 }


### PR DESCRIPTION
Joint PR with https://github.com/posit-dev/amalthea/pull/180

- R version because it makes it so much easier on ark if positron-r just passes it through this way
- Dynamic lib path so ark utilities can perform dynamic symbol resolution at runtime