### PR TITLE
Create widget plot client class

### DIFF
--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -59,12 +59,14 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 		// Update the list of primary widgets whenever a new widget comes in
 		this.updatePrimaryWidgets(widgetClient);
 
-		// Remove the widget from our list when it is closed
-		widgetClient.onDidClose(() => {
+		// Listen for the widget client to be disposed (i.e. by the plots service via the
+		// widgetPlotClient) and make sure to remove it fully from the widget service
+		widgetClient.onDidDispose(() => {
 			this._widgets.delete(widgetClient.id);
+			this._primaryWidgets.delete(widgetClient.id);
+			this._secondaryWidgets.delete(widgetClient.id);
 		});
 
-		// Dispose the widget client when this service is disposed
 		this._register(widgetClient);
 	}
 

--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -8,7 +8,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { IPositronIPyWidgetsService, IPositronIPyWidgetMetadata, IPyWidgetHtmlData } from 'vs/workbench/services/positronIPyWidgets/common/positronIPyWidgetsService';
 import { IPyWidgetClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeIPyWidgetClient';
 import { IPositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
-import { WebviewPlotClient } from 'vs/workbench/contrib/positronPlots/browser/webviewPlotClient';
+import { WidgetPlotClient } from 'vs/workbench/contrib/positronPlots/browser/widgetPlotClient';
 
 export interface IPositronIPyWidgetCommOpenData {
 	state: {
@@ -30,13 +30,13 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 	declare readonly _serviceBrand: undefined;
 
 	/** The list of IPyWidgets. */
-	private readonly _widgets: IPyWidgetClientInstance[] = [];
+	private readonly _widgets = new Map<string, IPyWidgetClientInstance>();
 
 	private readonly _primaryWidgets: Set<string> = new Set<string>();
 	private readonly _secondaryWidgets: Set<string> = new Set<string>();
 
 	/** The emitter for the onDidCreatePlot event */
-	private readonly _onDidCreatePlot = new Emitter<WebviewPlotClient>();
+	private readonly _onDidCreatePlot = new Emitter<WidgetPlotClient>();
 
 	/** Creates the Positron plots service instance */
 	constructor(
@@ -54,17 +54,14 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 	private registerIPyWidgetClient(widgetClient: IPyWidgetClientInstance) {
 
 		// Add to our list of widgets
-		this._widgets.push(widgetClient);
+		this._widgets.set(widgetClient.id, widgetClient);
 
 		// Update the list of primary widgets whenever a new widget comes in
 		this.updatePrimaryWidgets(widgetClient);
 
 		// Remove the widget from our list when it is closed
 		widgetClient.onDidClose(() => {
-			const index = this._widgets.indexOf(widgetClient);
-			if (index >= 0) {
-				this._widgets.splice(index, 1);
-			}
+			this._widgets.delete(widgetClient.id);
 		});
 
 		// Dispose the widget client when this service is disposed
@@ -121,13 +118,20 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 				const widgetClient = new IPyWidgetClientInstance(event.client, metadata);
 				this.registerIPyWidgetClient(widgetClient);
 
-				// Combine the widget data, and then create a webview for it
+				// TODO: instead of creating the webview on widget creation/comm_open,
+				// we plan to listen for a new message type from the kernel that indicates
+				// that the widget is ready to be displayed (because the user has requested it)
+				// Once that's available, we will remove this call to createWebview here
 				this.createWebviewWidgets(runtime, event.message);
 			}
 		}));
 	}
 
 	private updatePrimaryWidgets(latestWidget: IPyWidgetClientInstance): void {
+		// TODO: We plan to offload this logic to the Python language runtime, so the
+		// frontend doesn't need to make poor inferences about which widget(s) the user
+		// explicitly requested to view
+
 		// A widget is primary if no other widgets are dependent on it,
 		// and they are "viewable" (i.e. they have both a layout and dom_classes property)
 		latestWidget.dependencies.forEach(dependency => {
@@ -146,7 +150,7 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 		if (!this._primaryWidgets.has(latestWidgetId)) {
 			return;
 		}
-		// Combine our existing list of widgets into a single WebviewPlotClient
+		// Combine our existing list of widgets into a single WidgetPlotClient
 		const htmlData = new IPyWidgetHtmlData(this.positronWidgetInstances);
 
 		this._primaryWidgets.forEach(widgetId => {
@@ -163,40 +167,37 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 		const webview = await this._notebookOutputWebviewService.createNotebookOutputWebview(
 			runtime, widgetMessage);
 		if (webview) {
-			const plotClient = new WebviewPlotClient(webview, widgetMessage);
+			const widgetViewIds = Array.from(this._primaryWidgets);
+			const managedWidgets = widgetViewIds.flatMap((widgetId: string) => {
+				const widget = this._widgets.get(widgetId)!;
+				const dependentWidgets = widget.dependencies.map((dependentWidgetId: string) => {
+					return this._widgets.get(dependentWidgetId)!;
+				});
+				return [widget, ...dependentWidgets];
+			});
+			const plotClient = new WidgetPlotClient(webview, widgetMessage, managedWidgets);
 			this._onDidCreatePlot.fire(plotClient);
 		}
 	}
 
 	/**
-	 * Checks to see whether the service has a widget with the given ID.
+	 * Checks to see whether the service has a widget with the given ID and runtime ID.
 	 *
 	 * @param runtimeId The runtime ID that generated the widget.
 	 * @param widgetId The widget's unique ID.
 	 */
 	private hasWidget(runtimeId: string, widgetId: string): boolean {
-		return this._widgets.some(widget =>
-			widget.metadata.runtime_id === runtimeId &&
-			widget.metadata.id === widgetId);
+		return (
+			this._widgets.has(widgetId) &&
+			this._widgets.get(widgetId)!.metadata.runtime_id === runtimeId
+		);
 	}
 
-	/**
-	 * Remove all widget clients
-	 */
-	removeAllWidgets(): void {
-		this._widgets.forEach(widget => {
-			widget.dispose();
-		});
-
-		// Clear the list of widgets
-		this._widgets.length = 0;
-	}
-
-	onDidCreatePlot: Event<WebviewPlotClient> = this._onDidCreatePlot.event;
+	onDidCreatePlot: Event<WidgetPlotClient> = this._onDidCreatePlot.event;
 
 	// Gets the individual widget client instances.
 	get positronWidgetInstances(): IPyWidgetClientInstance[] {
-		return this._widgets;
+		return Array.from(this._widgets.values());
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -609,8 +609,6 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 
 				// Remove the plot from the list
 				this._plots.splice(index, 1);
-
-				console.log(`Remaining widgets: ${this._positronIPyWidgetsService.positronWidgetInstances.map(widget => widget.id)}`);
 			}
 		});
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -651,7 +651,6 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 			const plots = this._plots.splice(i, 1);
 			plots[0].dispose();
 		}
-		console.log(`Remaining widgets: ${this._positronIPyWidgetsService.positronWidgetInstances.map(widget => widget.id)}`);
 
 		// Update the front end with the now-empty array of plots
 		this._onDidSelectPlot.fire('');

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -609,6 +609,8 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 
 				// Remove the plot from the list
 				this._plots.splice(index, 1);
+
+				console.log(`Remaining widgets: ${this._positronIPyWidgetsService.positronWidgetInstances.map(widget => widget.id)}`);
 			}
 		});
 
@@ -651,9 +653,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 			const plots = this._plots.splice(i, 1);
 			plots[0].dispose();
 		}
-
-		// Also clear out the widget clients from the widget service
-		this._positronIPyWidgetsService.removeAllWidgets();
+		console.log(`Remaining widgets: ${this._positronIPyWidgetsService.positronWidgetInstances.map(widget => widget.id)}`);
 
 		// Update the front end with the now-empty array of plots
 		this._onDidSelectPlot.fire('');

--- a/src/vs/workbench/contrib/positronPlots/browser/widgetPlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/widgetPlotClient.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { INotebookOutputWebview } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
+import { WebviewPlotClient } from 'vs/workbench/contrib/positronPlots/browser/webviewPlotClient';
+import { IPyWidgetClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeIPyWidgetClient';
+import { ILanguageRuntimeMessageOutput } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+
+/**
+ * A Positron plot instance that is backed by a webview.
+ */
+export class WidgetPlotClient extends WebviewPlotClient {
+
+	/**
+	 * Creates a new WebviewPlotClient, which wraps a notebook output webview in
+	 * an object that can be displayed in the Plots pane.
+	 *
+	 * @param webview The webview to wrap.
+	 * @param message The output message from which the webview was created.
+	 * @param code The code that generated the webview (if known)
+	 */
+	constructor(webview: INotebookOutputWebview,
+		message: ILanguageRuntimeMessageOutput,
+		private readonly _widgets: IPyWidgetClientInstance[],) {
+		super(webview, message);
+
+		// Register all widgets with the plot client, so all widgets are disposed
+		// when the plot is disposed/removed.
+		this._widgets.forEach(widget => {
+			this._register(widget);
+		});
+	}
+}

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeIPyWidgetClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeIPyWidgetClient.ts
@@ -54,8 +54,11 @@ export class IPyWidgetClientInstance extends Disposable implements IPositronIPyW
 	/**
 	 * Event that fires when the widget is closed on the runtime side
 	 */
-	onDidClose: Event<void>;
-	private readonly _closeEmitter = new Emitter<void>();
+	private readonly _onDidClose = new Emitter<void>();
+	readonly onDidClose: Event<void> = this._onDidClose.event;
+
+	private readonly _onDidDispose = new Emitter<void>();
+	readonly onDidDispose: Event<void> = this._onDidDispose.event;
 
 	/** Creates the IPyWidget client instance */
 	constructor(
@@ -63,11 +66,9 @@ export class IPyWidgetClientInstance extends Disposable implements IPositronIPyW
 		public metadata: IPositronIPyWidgetMetadata) {
 
 		super();
-		// Connect close emitter event
-		this.onDidClose = this._closeEmitter.event;
 		_client.onDidChangeClientState((state) => {
 			if (state === RuntimeClientState.Closed) {
-				this._closeEmitter.fire();
+				this._onDidClose.fire();
 			}
 		});
 		this._register(this._client);
@@ -119,5 +120,10 @@ export class IPyWidgetClientInstance extends Disposable implements IPositronIPyW
 	 */
 	get id(): string {
 		return this.metadata.id;
+	}
+
+	override dispose(): void {
+		super.dispose();
+		this._onDidDispose.fire();
 	}
 }

--- a/src/vs/workbench/services/positronIPyWidgets/common/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/services/positronIPyWidgets/common/positronIPyWidgetsService.ts
@@ -116,11 +116,6 @@ export interface IPositronIPyWidgetsService {
 	readonly onDidCreatePlot: Event<IPositronPlotClient>;
 
 	/**
-	 * Remove all widget clients
-	 */
-	removeAllWidgets(): void;
-
-	/**
 	 * Placeholder for service initialization.
 	 */
 	initialize(): void;


### PR DESCRIPTION
The previous PR left [this suggestion](https://github.com/posit-dev/positron/pull/1918#discussion_r1414708613) unaddressed:
> I would suggesting extending `WebviewPlotClient` to give it ownership of the widgets, but it's really up to you as long as they eventually get cleaned up when the parent plot is disposed.

and that's exactly what this PR does. Now, triggering removePlot or removeAllPlots in the plots pane will properly dispose of any widgets that are contained within that plot client. To do this we make a new class with a new constructor that takes in a list of all widgets contained within a widget plot. To make this list, we pass in the primary widget(s) and any dependencies of that primary widget(s). 

Also adding some TODO comments because some of this logic needs to get moved out of the frontend and into the positron python extension (e.g. which widgets are primary and should be added to the view spec). We will need to address those very soon in order to add support for more complicated widget types where we really don't want the frontend guessing the primary widgets.