### PR TITLE
Bump ark to 0.1.34

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -509,7 +509,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.33"
+      "ark": "0.1.34"
     }
   }
 }


### PR DESCRIPTION
Mostly for:
https://github.com/posit-dev/amalthea/pull/178 (Windows UTF-8 support)
https://github.com/posit-dev/amalthea/pull/179 (Stability)

https://github.com/posit-dev/amalthea/actions/runs/7215154557