### PR TITLE
1949 fix output run overwrite bug

### DIFF
--- a/src/vs/base/common/ansiOutput.ts
+++ b/src/vs/base/common/ansiOutput.ts
@@ -2063,7 +2063,11 @@ class OutputLine implements ANSIOutputLine {
 
 			// Adjust the total length and splice the new output runs in.
 			this._totalLength = leftOffset + leftTextLength + text.length;
-			this.outputRuns.splice(leftOutputRunIndex, 1, ...outputRuns);
+			this.outputRuns.splice(
+				leftOutputRunIndex,
+				this.outputRuns.length - leftOutputRunIndex,
+				...outputRuns
+			);
 
 			// The insertion is complete.
 			return;

--- a/src/vs/base/test/common/ansiOutput.test.ts
+++ b/src/vs/base/test/common/ansiOutput.test.ts
@@ -581,6 +581,46 @@ suite('ANSIOutout', () => {
 		testOutputLines(10000, CRLF);
 	});
 
+	test('Text that exactly overwriting output runs to the right works', () => {
+		// Setup.
+		const ansiOutput = new ANSIOutput();
+		ansiOutput.processOutput(`${makeSGR(SGRParam.ForegroundRed)}0123456789${makeSGR()}`);
+		ansiOutput.processOutput(`${makeSGR(SGRParam.ForegroundBlue)}0123456789${makeSGR()}`);
+		ansiOutput.processOutput(`${makeSGR(SGRParam.ForegroundGreen)}0123456789${makeSGR()}`);
+		ansiOutput.processOutput(CR);
+		ansiOutput.processOutput("                              ");
+		ansiOutput.processOutput(CR);
+		ansiOutput.processOutput("0123456789");
+		const outputLines = ansiOutput.outputLines;
+
+		// Test.
+		assert.equal(outputLines.length, 1);
+		assert.equal(outputLines[0].outputRuns.length, 1);
+		assert.equal(outputLines[0].outputRuns[0].id.length, 36);
+		assert.equal(outputLines[0].outputRuns[0].format, undefined);
+		assert.equal(outputLines[0].outputRuns[0].text, '0123456789                    ');
+	});
+
+	test('Text that over overwriting output runs to the right works', () => {
+		// Setup.
+		const ansiOutput = new ANSIOutput();
+		ansiOutput.processOutput(`${makeSGR(SGRParam.ForegroundRed)}0123456789${makeSGR()}`);
+		ansiOutput.processOutput(`${makeSGR(SGRParam.ForegroundBlue)}0123456789${makeSGR()}`);
+		ansiOutput.processOutput(`${makeSGR(SGRParam.ForegroundGreen)}0123456789${makeSGR()}`);
+		ansiOutput.processOutput(CR);
+		ansiOutput.processOutput("                                        ");
+		ansiOutput.processOutput(CR);
+		ansiOutput.processOutput("0123456789");
+		const outputLines = ansiOutput.outputLines;
+
+		// Test.
+		assert.equal(outputLines.length, 1);
+		assert.equal(outputLines[0].outputRuns.length, 1);
+		assert.equal(outputLines[0].outputRuns[0].id.length, 36);
+		assert.equal(outputLines[0].outputRuns[0].format, undefined);
+		assert.equal(outputLines[0].outputRuns[0].text, '0123456789                              ');
+	});
+
 	test('Test CUB (Cursor Backward)', () => {
 		// Setup.
 		const ansiOutput = new ANSIOutput();


### PR DESCRIPTION
This PR fixes a defect in `ANSIOutput` that was causing output runs that were overwritten to contain garbage. This example shows the result of running the R command `pak::pak("tidymodels/tune")`. The output in the red boxes should not be there:

![image](https://github.com/posit-dev/positron/assets/853239/69912031-aa70-481b-9240-395996d014d9)

After this PR, the output looks like:

![image](https://github.com/posit-dev/positron/assets/853239/9969ea3e-09ea-490f-b450-d31fa83f848a)



