### PR TITLE
For workspace affiliation, store runtime metadata instead of only runtime ID

### DIFF
--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -2097,25 +2097,10 @@ export class PositronZedLanguageRuntimeProvider implements positron.LanguageRunt
 		private readonly context: vscode.ExtensionContext
 	) { }
 
-	provideLanguageRuntime(runtimeId: string, token: vscode.CancellationToken): positron.LanguageRuntime {
-		let version = null;
-		switch (runtimeId) {
-			case '00000000-0000-0000-0000-000000000200': {
-				version = '2.0.0';
-				break;
-			}
-			case '00000000-0000-0000-0000-000000000100': {
-				version = '1.0.0';
-				break;
-			}
-			case '00000000-0000-0000-0000-000000000098': {
-				version = '0.98.0';
-				break;
-			}
-		}
-		if (!version) {
-			throw new Error('Unknown Zed runtime ID');
-		}
-		return new PositronZedLanguageRuntime(this.context, runtimeId, version);
+	provideLanguageRuntime(runtimeMetadata: positron.LanguageRuntimeMetadata,
+		token: vscode.CancellationToken): positron.LanguageRuntime {
+		return new PositronZedLanguageRuntime(this.context,
+			runtimeMetadata.runtimeId,
+			runtimeMetadata.runtimeShortName);
 	}
 }

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -509,13 +509,13 @@ declare module 'positron' {
 
 	export interface LanguageRuntimeProvider {
 		/**
-		 * Given a `runtimeId`, return the corresponding `LanguageRuntime` object.
+		 * Given runtime metadata, return the corresponding `LanguageRuntime` object.
 		 *
-		 * @param runtimeId The runtime identifier as a string.
+		 * @param runtimeMetadata The runtime metadata.
 		 * @param token A cancellation token.
 		 * @return The language runtime.
 		 */
-		provideLanguageRuntime(runtimeId: string, token: vscode.CancellationToken):
+		provideLanguageRuntime(runtimeMetadata: LanguageRuntimeMetadata, token: vscode.CancellationToken):
 			vscode.ProviderResult<LanguageRuntime>;
 	}
 

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -950,9 +950,9 @@ export class MainThreadLanguageRuntime implements MainThreadLanguageRuntimeShape
 		this._positronIPyWidgetsService.initialize();
 		this._proxy = extHostContext.getProxy(ExtHostPositronContext.ExtHostLanguageRuntime);
 
-		this._languageRuntimeService.onDidRequestLanguageRuntime((ILanguageRuntimeIdEvent) => {
-			this._proxy.$provideLanguageRuntime(ILanguageRuntimeIdEvent.language_id,
-				ILanguageRuntimeIdEvent.runtime_id);
+		this._languageRuntimeService.onDidRequestLanguageRuntime((ILanguageRuntimeMetadata) => {
+			this._proxy.$provideLanguageRuntime(ILanguageRuntimeMetadata.languageId,
+				ILanguageRuntimeMetadata);
 		});
 		this._languageRuntimeService.onDidChangeDiscoveryPhase((phase) => {
 			if (phase === LanguageRuntimeDiscoveryPhase.Discovering) {

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -39,7 +39,7 @@ export interface ExtHostLanguageRuntimeShape {
 	$shutdownLanguageRuntime(handle: number, exitReason: RuntimeExitReason): Promise<void>;
 	$forceQuitLanguageRuntime(handle: number): Promise<void>;
 	$showOutputLanguageRuntime(handle: number): void;
-	$provideLanguageRuntime(languageId: string, runtimeId: string): Promise<void>;
+	$provideLanguageRuntime(languageId: string, runtimeMetadata: ILanguageRuntimeMetadata): Promise<void>;
 	$discoverLanguageRuntimes(): void;
 }
 

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -336,14 +336,14 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 
 	public async $provideLanguageRuntime(
 		languageId: string,
-		runtimeId: string): Promise<void> {
+		runtimeMetadata: positron.LanguageRuntimeMetadata): Promise<void> {
 		const provider = this._runtimeProviders.get(languageId);
 		if (!provider) {
 			throw new Error(`Cannot get runtime provider for '${languageId}'.`);
 		}
-		const runtime = await provider.provider.provideLanguageRuntime(runtimeId, CancellationToken.None);
+		const runtime = await provider.provider.provideLanguageRuntime(runtimeMetadata, CancellationToken.None);
 		if (!runtime) {
-			throw new Error(`Cannot provide runtime '${runtimeId}'.`);
+			throw new Error(`Cannot provide runtime '${runtimeMetadata.runtimeId}'.`);
 		}
 		this.registerLanguageRuntime(provider.extension, runtime);
 	}

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -350,9 +350,9 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	 * @returns A disposable that unregisters the runtime
 	 */
 	registerRuntime(runtime: ILanguageRuntime, startupBehavior: LanguageRuntimeStartupBehavior): IDisposable {
-		// If the runtime has already been registered, return early.
+		// If the runtime has already been registered, throw an error.
 		if (this._registeredRuntimesByRuntimeId.has(runtime.metadata.runtimeId)) {
-			return toDisposable(() => { });
+			throw new Error(`Language runtime ${formatLanguageRuntime(runtime)} has already been registered.`);
 		}
 
 		// Add the runtime to the registered runtimes.

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -350,9 +350,9 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	 * @returns A disposable that unregisters the runtime
 	 */
 	registerRuntime(runtime: ILanguageRuntime, startupBehavior: LanguageRuntimeStartupBehavior): IDisposable {
-		// If the runtime has already been registered, throw an error.
+		// If the runtime has already been registered, return early.
 		if (this._registeredRuntimesByRuntimeId.has(runtime.metadata.runtimeId)) {
-			throw new Error(`Language runtime ${formatLanguageRuntime(runtime)} has already been registered.`);
+			return toDisposable(() => { });
 		}
 
 		// Add the runtime to the registered runtimes.

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -490,14 +490,6 @@ export interface ILanguageRuntimeStateEvent {
 	new_state: RuntimeState;
 }
 
-export interface ILanguageRuntimeIdEvent {
-	/** The ID of the runtime is being provided */
-	runtime_id: string;
-
-	/** The runtime's language */
-	language_id: string;
-}
-
 /* ILanguageRuntimeMetadata contains information about a language runtime that is known
  * before the runtime is started.
  */
@@ -690,7 +682,7 @@ export interface ILanguageRuntimeService {
 	readonly onDidChangeActiveRuntime: Event<ILanguageRuntime | undefined>;
 
 	// An event that fires when a runtime is requested.
-	readonly onDidRequestLanguageRuntime: Event<ILanguageRuntimeIdEvent>;
+	readonly onDidRequestLanguageRuntime: Event<ILanguageRuntimeMetadata>;
 
 	/**
 	 * Gets the running language runtimes.

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation.ts
@@ -5,7 +5,7 @@
 import { Disposable } from 'vs/base/common/lifecycle';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
-import { ILanguageRuntime, ILanguageRuntimeService, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntime, ILanguageRuntimeMetadata, ILanguageRuntimeService, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 
 /**
  * The LanguageRuntimeWorkspaceAffiliation class is responsible for managing the
@@ -48,7 +48,7 @@ export class LanguageRuntimeWorkspaceAffiliation extends Disposable {
 
 		// Save this runtime as the affiliated runtime for the current workspace.
 		this._storageService.store(this.storageKeyForRuntime(runtime),
-			runtime.metadata.runtimeId,
+			JSON.stringify(runtime.metadata),
 			StorageScope.WORKSPACE,
 			StorageTarget.MACHINE);
 
@@ -60,8 +60,12 @@ export class LanguageRuntimeWorkspaceAffiliation extends Disposable {
 			if (newState === RuntimeState.Exiting) {
 				// Just to be safe, check that the runtime is still affiliated
 				// before removing the affiliation
-				const affiliatedRuntimeId = this._storageService.get(
+				const affiliatedRuntimeMetadata = this._storageService.get(
 					this.storageKeyForRuntime(runtime), StorageScope.WORKSPACE);
+				if (!affiliatedRuntimeMetadata) {
+					return;
+				}
+				const affiliatedRuntimeId = JSON.parse(affiliatedRuntimeMetadata).runtimeId;
 				if (runtime.metadata.runtimeId === affiliatedRuntimeId) {
 					// Remove the affiliation
 					this._storageService.remove(this.storageKeyForRuntime(runtime),
@@ -80,9 +84,13 @@ export class LanguageRuntimeWorkspaceAffiliation extends Disposable {
 	 */
 	private onDidRegisterRuntime(runtime: ILanguageRuntime): void {
 
-		// Get the runtime ID that is affiliated with this workspace, if any.
-		const affiliatedRuntimeId = this._storageService.get(
+		// Get the runtime metadata that is affiliated with this workspace, if any.
+		const affiliatedRuntimeMetadata = this._storageService.get(
 			this.storageKeyForRuntime(runtime), StorageScope.WORKSPACE);
+		if (!affiliatedRuntimeMetadata) {
+			return;
+		}
+		const affiliatedRuntimeId = JSON.parse(affiliatedRuntimeMetadata).runtimeId;
 
 		// If the runtime is affiliated with this workspace, start it.
 		if (runtime.metadata.runtimeId === affiliatedRuntimeId) {
@@ -104,10 +112,14 @@ export class LanguageRuntimeWorkspaceAffiliation extends Disposable {
 	 *
 	 * @param languageId The ID of the language for which to get the affiliated runtime.
 	 *
-	 * @returns The runtime ID.
+	 * @returns The runtime metadata.
 	 */
-	public getAffiliatedRuntimeId(languageId: string): string | undefined {
-		return this._storageService.get(`${this.storageKey}.${languageId}`, StorageScope.WORKSPACE);
+	public getAffiliatedRuntimeMetadata(languageId: string): ILanguageRuntimeMetadata | undefined {
+		const stored = this._storageService.get(`${this.storageKey}.${languageId}`, StorageScope.WORKSPACE);
+		if (!stored) {
+			return undefined;
+		}
+		return JSON.parse(stored) as ILanguageRuntimeMetadata;
 	}
 
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation.ts
@@ -65,11 +65,15 @@ export class LanguageRuntimeWorkspaceAffiliation extends Disposable {
 				if (!affiliatedRuntimeMetadata) {
 					return;
 				}
-				const affiliatedRuntimeId = JSON.parse(affiliatedRuntimeMetadata).runtimeId;
-				if (runtime.metadata.runtimeId === affiliatedRuntimeId) {
-					// Remove the affiliation
-					this._storageService.remove(this.storageKeyForRuntime(runtime),
-						StorageScope.WORKSPACE);
+				try {
+					const affiliatedRuntimeId = JSON.parse(affiliatedRuntimeMetadata).runtimeId;
+					if (runtime.metadata.runtimeId === affiliatedRuntimeId) {
+						// Remove the affiliation
+						this._storageService.remove(this.storageKeyForRuntime(runtime),
+							StorageScope.WORKSPACE);
+					}
+				} catch {
+					return;
 				}
 			}
 		}));
@@ -90,20 +94,24 @@ export class LanguageRuntimeWorkspaceAffiliation extends Disposable {
 		if (!affiliatedRuntimeMetadata) {
 			return;
 		}
-		const affiliatedRuntimeId = JSON.parse(affiliatedRuntimeMetadata).runtimeId;
+		try {
+			const affiliatedRuntimeId = JSON.parse(affiliatedRuntimeMetadata).runtimeId;
 
-		// If the runtime is affiliated with this workspace, start it.
-		if (runtime.metadata.runtimeId === affiliatedRuntimeId) {
-			try {
-				this._runtimeService.startRuntime(runtime.metadata.runtimeId,
-					`Affiliated runtime for workspace`);
-			} catch (e) {
-				// This isn't necessarily an error; if another runtime took precedence and has
-				// already started for this workspace, we don't want to start this one.
-				this._logService.debug(`Did not start affiliated runtime ` +
-					`${runtime.metadata.runtimeName} for this workspace: ` +
-					`${e.message}`);
+			// If the runtime is affiliated with this workspace, start it.
+			if (runtime.metadata.runtimeId === affiliatedRuntimeId) {
+				try {
+					this._runtimeService.startRuntime(runtime.metadata.runtimeId,
+						`Affiliated runtime for workspace`);
+				} catch (e) {
+					// This isn't necessarily an error; if another runtime took precedence and has
+					// already started for this workspace, we don't want to start this one.
+					this._logService.debug(`Did not start affiliated runtime ` +
+						`${runtime.metadata.runtimeName} for this workspace: ` +
+						`${e.message}`);
+				}
 			}
+		} catch {
+			return;
 		}
 	}
 
@@ -119,7 +127,11 @@ export class LanguageRuntimeWorkspaceAffiliation extends Disposable {
 		if (!stored) {
 			return undefined;
 		}
-		return JSON.parse(stored) as ILanguageRuntimeMetadata;
+		try {
+			return JSON.parse(stored) as ILanguageRuntimeMetadata;
+		} catch {
+			return undefined;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Addresses #1067 

As expected/discussed, when I have gone to work with the "real" runtimes, I need more than runtime ID to be able to provide a runtime from the extension on demand. My current best idea is that we should store the whole runtime metadata when we do a workspace affiliation. From my initial exploration, this will let us provide R/Python runtimes as we hope to.

This works well with a fresh/new workspace as far as I can tell, but if you have an existing workspace affiliation stored from when we have been using a single string only (`runtimeId`) then Positron gets _very unhappy_. I need to work more on the case of existing affiliations, like with try/catch or similar.