### PR TITLE
Add runtime provider (to register a single runtime on demand) for R

### DIFF
--- a/extensions/positron-r/src/extension.ts
+++ b/extensions/positron-r/src/extension.ts
@@ -10,7 +10,7 @@ import { registerFormatter } from './formatting';
 import { providePackageTasks } from './tasks';
 import { setContexts } from './contexts';
 import { setupTestExplorer, refreshTestExplorer } from './testing/testing';
-import { rRuntimeDiscoverer } from './provider';
+import { RRuntimeProvider, rRuntimeDiscoverer } from './provider';
 import { RRuntime } from './runtime';
 
 export const Logger = vscode.window.createOutputChannel('Positron R Extension', { log: true });
@@ -21,6 +21,8 @@ export function activate(context: vscode.ExtensionContext) {
 	};
 	context.subscriptions.push(Logger.onDidChangeLogLevel(onDidChangeLogLevel));
 	onDidChangeLogLevel(Logger.logLevel);
+
+	positron.runtime.registerLanguageRuntimeProvider('r', new RRuntimeProvider(context));
 
 	const runtimes = new Map<string, RRuntime>();
 	positron.runtime.registerLanguageRuntimeDiscoverer(

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -11,7 +11,7 @@ import * as which from 'which';
 import * as positron from 'positron';
 import * as crypto from 'crypto';
 
-import { RInstallation } from './r-installation';
+import { RInstallation, getRHomePath } from './r-installation';
 import { RRuntime, createJupyterKernelExtra, createJupyterKernelSpec } from './runtime';
 
 const initialDynState = {
@@ -37,9 +37,7 @@ export class RRuntimeProvider implements positron.LanguageRuntimeProvider {
 
 	async provideLanguageRuntime(runtimeMetadata: positron.LanguageRuntimeMetadata, token: vscode.CancellationToken): Promise<positron.LanguageRuntime> {
 
-		//const rHomePath = getRHomePath(runtimeMetadata.runtimePath);
-		//TODO this is just dummy for now:
-		const rHomePath = '/Library/Frameworks/R.framework/Resources';
+		const rHomePath = getRHomePath(runtimeMetadata.runtimePath);
 		if (!rHomePath) {
 			throw new Error(`Cannot find R_HOME for ${runtimeMetadata.runtimePath}`);
 		}

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -12,9 +12,46 @@ import * as positron from 'positron';
 import * as crypto from 'crypto';
 
 import { RInstallation } from './r-installation';
-import { RRuntime, createJupyterKernelExtra } from './runtime';
-import { JupyterKernelSpec } from './jupyter-adapter';
-import { getArkKernelPath } from './kernel';
+import { RRuntime, createJupyterKernelExtra, createJupyterKernelSpec } from './runtime';
+
+const initialDynState = {
+	inputPrompt: '>',
+	continuationPrompt: '+',
+} as positron.LanguageRuntimeDynState;
+
+/**
+ * Provides a single R language runtime for Positron; implements
+ * positron.LanguageRuntimeProvider.
+ *
+ * @param context The extension context.
+ */
+export class RRuntimeProvider implements positron.LanguageRuntimeProvider {
+
+	/**
+	 * Constructor.
+	 * @param context The extension context.
+	 */
+	constructor(
+		private readonly context: vscode.ExtensionContext
+	) { }
+
+	async provideLanguageRuntime(runtimeMetadata: positron.LanguageRuntimeMetadata, token: vscode.CancellationToken): Promise<positron.LanguageRuntime> {
+
+		//const rHomePath = getRHomePath(runtimeMetadata.runtimePath);
+		//TODO this is just dummy for now:
+		const rHomePath = '/Library/Frameworks/R.framework/Resources';
+		if (!rHomePath) {
+			throw new Error(`Cannot find R_HOME for ${runtimeMetadata.runtimePath}`);
+		}
+		const kernelSpec = createJupyterKernelSpec(this.context,
+			rHomePath,
+			runtimeMetadata.runtimeName);
+
+		const extra = createJupyterKernelExtra();
+
+		return new RRuntime(this.context, kernelSpec, runtimeMetadata, initialDynState, extra);
+	}
+}
 
 /**
  * Discovers R language runtimes for Positron; implements
@@ -27,18 +64,6 @@ export async function* rRuntimeDiscoverer(
 	runtimes: Map<string, RRuntime>
 ): AsyncGenerator<positron.LanguageRuntime> {
 	let rInstallations: Array<RInstallation> = [];
-
-	// Path to the kernel executable
-	const kernelPath = getArkKernelPath(context);
-	if (!kernelPath) {
-		throw new Error('Unable to find R kernel');
-	}
-
-	// Check the R kernel log level setting
-	const config = vscode.workspace.getConfiguration('positron.r');
-	const logLevel = config.get<string>('kernel.logLevel') ?? 'warn';
-	const userEnv = config.get<object>('kernel.env') ?? {};
-
 	const binaries = new Set<string>();
 
 	// look in the well-known place for R installations on this OS
@@ -137,51 +162,6 @@ export async function* rRuntimeDiscoverer(
 	// Given that DYLD_FALLBACK_LIBRARY_PATH works fine, we just set that below.
 	for (const rHome of rInstallations) {
 
-		/* eslint-disable */
-		const env = <Record<string, string>>{
-			'RUST_BACKTRACE': '1',
-			'RUST_LOG': logLevel,
-			'R_HOME': rHome.homepath,
-			...userEnv
-		};
-		/* eslint-enable */
-
-		if (process.platform === 'darwin') {
-
-			const dyldFallbackLibraryPaths: string[] = [];
-			dyldFallbackLibraryPaths.push(`${rHome.homepath}/lib`);
-
-			const defaultDyldFallbackLibraryPath = process.env['DYLD_FALLBACK_LIBRARY_PATH'];
-			if (defaultDyldFallbackLibraryPath) {
-				dyldFallbackLibraryPaths.push(defaultDyldFallbackLibraryPath);
-			}
-
-			// Set the DYLD_FALLBACK_LIBRARY_PATH to include the R installation.
-			// This specific environment variable can be blocked from being
-			// inherited by child processes on macOS with SIP enabled, so we
-			// prefix it with 'POSITRON_' here. The script that starts the
-			// kernel will check for this variable and set it as
-			// DYLD_FALLBACK_LIBRARY_PATH if it's present.
-			env['POSITRON_DYLD_FALLBACK_LIBRARY_PATH'] = dyldFallbackLibraryPaths.join(':');
-
-		}
-
-		if (process.platform === 'win32') {
-			// On Windows, we must place the `bin/` path for the current R version on the PATH
-			// so that the DLLs in that same folder can be resolved properly when ark starts up
-			// (like `R.dll`, `Rblas.dll`, `Rgraphapp.dll`, `Riconv.dll`, and `Rlapack.dll`).
-			// https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#standard-search-order-for-unpackaged-apps
-			const binpath = path.join(rHome.homepath, 'bin', 'x64');
-
-			const processPath = process.env['PATH'];
-
-			const subprocessPath = processPath === undefined ?
-				binpath :
-				processPath + ';' + binpath;
-
-			env['PATH'] = subprocessPath;
-		}
-
 		// Is the runtime path within the user's home directory?
 		const homedir = os.homedir();
 		const isUserInstallation = rHome.homepath.startsWith(homedir);
@@ -216,40 +196,9 @@ export async function* rRuntimeDiscoverer(
 		// Full name shown to users
 		const runtimeName = `R ${runtimeShortName}`;
 
-		// R script to run on session startup
-		const startupFile = path.join(context.extensionPath, 'resources', 'scripts', 'startup.R');
-
-		// Create a kernel spec for this R installation
-		const kernelSpec: JupyterKernelSpec = {
-			'argv': [
-				kernelPath,
-				'--connection_file', '{connection_file}',
-				'--log', '{log_file}',
-				'--startup-file', `${startupFile}`,
-				// The arguments after `--` are passed verbatim to R
-				'--',
-				'--interactive',
-			],
-			'display_name': runtimeName, // eslint-disable-line
-			'language': 'R',
-			'env': env,
-		};
-
-		// Unless the user has chosen to restore the workspace, pass the
-		// `--no-restore-data` flag to R.
-		if (!config.get<boolean>('restoreWorkspace')) {
-			kernelSpec.argv.push('--no-restore-data');
-		}
-
-		// If the user has supplied extra arguments to R, pass them along.
-		const extraArgs = config.get<Array<string>>('extraArguments');
-		const quietMode = config.get<boolean>('quietMode');
-		if (quietMode && extraArgs?.indexOf('--quiet') === -1) {
-			extraArgs?.push('--quiet');
-		}
-		if (extraArgs) {
-			kernelSpec.argv.push(...extraArgs);
-		}
+		const kernelSpec = createJupyterKernelSpec(context,
+			rHome.homepath,
+			runtimeName);
 
 		// Get the version of this extension from package.json so we can pass it
 		// to the adapter as the implementation version.
@@ -288,15 +237,10 @@ export async function* rRuntimeDiscoverer(
 			startupBehavior
 		};
 
-		const dynState: positron.LanguageRuntimeDynState = {
-			inputPrompt: '>',
-			continuationPrompt: '+',
-		};
-
 		const extra = createJupyterKernelExtra();
 
 		// Create an adapter for the kernel to fulfill the LanguageRuntime interface.
-		const runtime = new RRuntime(context, kernelSpec, metadata, dynState, extra);
+		const runtime = new RRuntime(context, kernelSpec, metadata, initialDynState, extra);
 		yield runtime;
 		runtimes.set(runtimeId, runtime);
 	}

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -160,7 +160,7 @@ export async function* rRuntimeDiscoverer(
 	// and its usages for more details.
 	//
 	// Given that DYLD_FALLBACK_LIBRARY_PATH works fine, we just set that below.
-	for (const rHome of rInstallations) {
+	for (const rInst of rInstallations) {
 
 		// Is the runtime path within the user's home directory?
 		const homedir = os.homedir();
@@ -197,7 +197,7 @@ export async function* rRuntimeDiscoverer(
 		const runtimeName = `R ${runtimeShortName}`;
 
 		const kernelSpec = createJupyterKernelSpec(context,
-			rHome.homepath,
+			rInst.homepath,
 			runtimeName);
 
 		// Get the version of this extension from package.json so we can pass it

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -43,31 +43,11 @@ export class RInstallation {
 		this.binpath = pth;
 		this.current = current;
 
-		if (os.platform() === 'win32') {
-			// TODO: Windows - do we want something more robust here?
-			this.homepath = path.join(pth, '..', '..');
-		} else {
-			const binLines = readLines(this.binpath);
-			const re = new RegExp('Shell wrapper for R executable');
-			if (!binLines.some(x => re.test(x))) {
-				Logger.info('Binary is not a shell script wrapping the executable');
-				return;
-			}
-			const targetLine = binLines.find(line => line.match('R_HOME_DIR'));
-			if (!targetLine) {
-				Logger.info('Can\'t determine R_HOME_DIR from the binary');
-				return;
-			}
-			// macOS: R_HOME_DIR=/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
-			// macOS non-orthogonal: R_HOME_DIR=/Library/Frameworks/R.framework/Resources
-			// linux: R_HOME_DIR=/opt/R/4.2.3/lib/R
-			const R_HOME_DIR = extractValue(targetLine, 'R_HOME_DIR');
-			this.homepath = R_HOME_DIR;
-			if (this.homepath === '') {
-				Logger.info('Can\'t determine R_HOME_DIR from the binary');
-				return;
-			}
+		const rHomePath = getRHomePath(pth);
+		if (!rHomePath) {
+			return;
 		}
+		this.homepath = rHomePath;
 
 		// orthogonality is a concern specific to macOS
 		// a non-orthogonal R "binary" is hard-wired to launch the current version of R,
@@ -128,5 +108,34 @@ export class RInstallation {
 		this.valid = true;
 
 		Logger.info(`R installation discovered: ${JSON.stringify(this, null, 2)}`);
+	}
+}
+
+export function getRHomePath(pth: string): string | undefined {
+	if (os.platform() === 'win32') {
+		// TODO: Windows - do we want something more robust here?
+		return path.join(pth, '..', '..');
+	} else {
+		const binLines = readLines(pth);
+		const re = new RegExp('Shell wrapper for R executable');
+		if (!binLines.some(x => re.test(x))) {
+			Logger.info('Binary is not a shell script wrapping the executable');
+			return undefined;
+		}
+		const targetLine = binLines.find(line => line.match('R_HOME_DIR'));
+		if (!targetLine) {
+			Logger.info('Can\'t determine R_HOME_DIR from the binary');
+			return undefined;
+		}
+		// macOS: R_HOME_DIR=/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
+		// macOS non-orthogonal: R_HOME_DIR=/Library/Frameworks/R.framework/Resources
+		// linux: R_HOME_DIR=/opt/R/4.2.3/lib/R
+		const R_HOME_DIR = extractValue(targetLine, 'R_HOME_DIR');
+		const homepath = R_HOME_DIR;
+		if (homepath === '') {
+			Logger.info('Can\'t determine R_HOME_DIR from the binary');
+			return undefined;
+		}
+		return homepath;
 	}
 }

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -111,12 +111,12 @@ export class RInstallation {
 	}
 }
 
-export function getRHomePath(pth: string): string | undefined {
+export function getRHomePath(binPath: string): string | undefined {
 	if (os.platform() === 'win32') {
 		// TODO: Windows - do we want something more robust here?
-		return path.join(pth, '..', '..');
+		return path.join(binPath, '..', '..');
 	} else {
-		const binLines = readLines(pth);
+		const binLines = readLines(binPath);
 		const re = new RegExp('Shell wrapper for R executable');
 		if (!binLines.some(x => re.test(x))) {
 			Logger.info('Binary is not a shell script wrapping the executable');

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -4,6 +4,7 @@
 
 import * as positron from 'positron';
 import * as vscode from 'vscode';
+import * as path from 'path';
 import PQueue from 'p-queue';
 
 import { JupyterAdapterApi, JupyterKernelSpec, JupyterLanguageRuntime, JupyterKernelExtra } from './jupyter-adapter';
@@ -11,6 +12,7 @@ import { ArkLsp, LspState } from './lsp';
 import { delay, timeout } from './util';
 import { ArkAttachOnStartup, ArkDelayStartup } from './startup';
 import { RHtmlWidget, getResourceRoots } from './htmlwidgets';
+import { getArkKernelPath } from './kernel';
 import { randomUUID } from 'crypto';
 
 export let lastRuntimePath = '';
@@ -521,4 +523,100 @@ export function createJupyterKernelExtra(): JupyterKernelExtra {
 		attachOnStartup: new ArkAttachOnStartup(),
 		sleepOnStartup: new ArkDelayStartup(),
 	};
+}
+
+export function createJupyterKernelSpec(context: vscode.ExtensionContext, rHomePath: string, runtimeName: string): JupyterKernelSpec {
+
+	// Path to the kernel executable
+	const kernelPath = getArkKernelPath(context);
+	if (!kernelPath) {
+		throw new Error('Unable to find R kernel');
+	}
+
+	// Check the R kernel log level setting
+	const config = vscode.workspace.getConfiguration('positron.r');
+	const logLevel = config.get<string>('kernel.logLevel') ?? 'warn';
+	const userEnv = config.get<object>('kernel.env') ?? {};
+
+	/* eslint-disable */
+	const env = <Record<string, string>>{
+		'RUST_BACKTRACE': '1',
+		'RUST_LOG': logLevel,
+		'R_HOME': rHomePath,
+		...userEnv
+	};
+	/* eslint-enable */
+
+	if (process.platform === 'darwin') {
+
+		const dyldFallbackLibraryPaths: string[] = [];
+		dyldFallbackLibraryPaths.push(`${rHomePath}/lib`);
+
+		const defaultDyldFallbackLibraryPath = process.env['DYLD_FALLBACK_LIBRARY_PATH'];
+		if (defaultDyldFallbackLibraryPath) {
+			dyldFallbackLibraryPaths.push(defaultDyldFallbackLibraryPath);
+		}
+
+		// Set the DYLD_FALLBACK_LIBRARY_PATH to include the R installation.
+		// This specific environment variable can be blocked from being
+		// inherited by child processes on macOS with SIP enabled, so we
+		// prefix it with 'POSITRON_' here. The script that starts the
+		// kernel will check for this variable and set it as
+		// DYLD_FALLBACK_LIBRARY_PATH if it's present.
+		env['POSITRON_DYLD_FALLBACK_LIBRARY_PATH'] = dyldFallbackLibraryPaths.join(':');
+
+	}
+
+	if (process.platform === 'win32') {
+		// On Windows, we must place the `bin/` path for the current R version on the PATH
+		// so that the DLLs in that same folder can be resolved properly when ark starts up
+		// (like `R.dll`, `Rblas.dll`, `Rgraphapp.dll`, `Riconv.dll`, and `Rlapack.dll`).
+		// https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#standard-search-order-for-unpackaged-apps
+		const binpath = path.join(rHomePath, 'bin', 'x64');
+
+		const processPath = process.env['PATH'];
+
+		const subprocessPath = processPath === undefined ?
+			binpath :
+			processPath + ';' + binpath;
+
+		env['PATH'] = subprocessPath;
+	}
+
+	// R script to run on session startup
+	const startupFile = path.join(context.extensionPath, 'resources', 'scripts', 'startup.R');
+
+	// Create a kernel spec for this R installation
+	const kernelSpec: JupyterKernelSpec = {
+		'argv': [
+			kernelPath,
+			'--connection_file', '{connection_file}',
+			'--log', '{log_file}',
+			'--startup-file', `${startupFile}`,
+			// The arguments after `--` are passed verbatim to R
+			'--',
+			'--interactive',
+		],
+		'display_name': runtimeName, // eslint-disable-line
+		'language': 'R',
+		'env': env,
+	};
+
+	// Unless the user has chosen to restore the workspace, pass the
+	// `--no-restore-data` flag to R.
+	if (!config.get<boolean>('restoreWorkspace')) {
+		kernelSpec.argv.push('--no-restore-data');
+	}
+
+	// If the user has supplied extra arguments to R, pass them along.
+	const extraArgs = config.get<Array<string>>('extraArguments');
+	const quietMode = config.get<boolean>('quietMode');
+	if (quietMode && extraArgs?.indexOf('--quiet') === -1) {
+		extraArgs?.push('--quiet');
+	}
+	if (extraArgs) {
+		kernelSpec.argv.push(...extraArgs);
+	}
+
+	return kernelSpec;
 }

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -150,7 +150,8 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 			this._register(this.onDidChangeDiscoveryPhase((phase) => {
 				// When we start discovering runtimes, start the affiliated runtime.
 				if (phase === LanguageRuntimeDiscoveryPhase.Discovering) {
-					this.startAffiliatedRuntimes();
+					this.startAffiliatedRuntimes('zed');
+					this.startAffiliatedRuntimes('r');
 				}
 			}));
 		}
@@ -749,9 +750,8 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	/**
 	 * Starts any affiliated runtimes.
 	 */
-	private startAffiliatedRuntimes(): void {
+	private startAffiliatedRuntimes(languageId: string): void {
 		// TODO: implement for all language packs
-		const languageId = 'zed';
 		const affiliatedRuntimeMetadata =
 			this._workspaceAffiliation.getAffiliatedRuntimeMetadata(languageId);
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -146,11 +146,11 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 		this._workspaceAffiliation =
 			new LanguageRuntimeWorkspaceAffiliation(this, this._storageService, this._logService);
 		this._register(this._workspaceAffiliation);
-		if (this._workspaceAffiliation.hasAffiliatedRuntime()) {
+		const languageIds = this._workspaceAffiliation.getAffiliatedRuntimeLanguageIds();
+		if (languageIds) {
 			this._register(this.onDidChangeDiscoveryPhase((phase) => {
-				// When we start discovering runtimes, start the affiliated runtime.
+				// When we start discovering runtimes, start the affiliated runtime(s).
 				if (phase === LanguageRuntimeDiscoveryPhase.Discovering) {
-					const languageIds = this._workspaceAffiliation.getAffiliatedRuntimeLanguageIds();
 					languageIds?.map(languageId => this.startAffiliatedRuntime(languageId));
 				}
 			}));

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -150,8 +150,8 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 			this._register(this.onDidChangeDiscoveryPhase((phase) => {
 				// When we start discovering runtimes, start the affiliated runtime.
 				if (phase === LanguageRuntimeDiscoveryPhase.Discovering) {
-					this.startAffiliatedRuntimes('zed');
-					this.startAffiliatedRuntimes('r');
+					const languageIds = this._workspaceAffiliation.getAffiliatedRuntimeLanguageIds();
+					languageIds?.map(languageId => this.startAffiliatedRuntime(languageId));
 				}
 			}));
 		}
@@ -750,8 +750,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	/**
 	 * Starts any affiliated runtimes.
 	 */
-	private startAffiliatedRuntimes(languageId: string): void {
-		// TODO: implement for all language packs
+	private startAffiliatedRuntime(languageId: string): void {
 		const affiliatedRuntimeMetadata =
 			this._workspaceAffiliation.getAffiliatedRuntimeMetadata(languageId);
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeWorkspaceAffiliation.ts
@@ -128,6 +128,23 @@ export class LanguageRuntimeWorkspaceAffiliation extends Disposable {
 	}
 
 	/**
+	 * Ascertains what languages are affiliated with the current workspace.
+	 *
+	 * @returns An array of language IDs for which there is a runtime affiliated
+	 */
+	public getAffiliatedRuntimeLanguageIds(): string[] | undefined {
+		// Get the keys from the storage service and find the language Ids.
+		const languageIds = new Array<string>();
+		const keys = this._storageService.keys(StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		for (const key of keys) {
+			if (key.startsWith(this.storageKey)) {
+				languageIds.push(key.replace(`${this.storageKey}.`, ''));
+			}
+		}
+		return languageIds;
+	}
+
+	/**
 	 * Ascertains whether a runtime (of any language) is affiliated with the
 	 * current workspace.
 	 *


### PR DESCRIPTION
I'm opening this up in a pretty rough state because I am noticing that I need the path to the _binary_ to make this work, and so it is very related to #1952.