### PR TITLE
Quote R binpath in test explorer

### DIFF
--- a/extensions/positron-r/src/testing/runner-testthat.ts
+++ b/extensions/positron-r/src/testing/runner-testthat.ts
@@ -88,7 +88,7 @@ export async function runThatTest(
 		`devtools::load_all('${testReporterPath}');` +
 		`devtools::${devtoolsMethod}('${testPath}',` +
 		`${descInsert}reporter = VSCodeReporter)`;
-	const command = `${rBinPath} --no-echo -e "${devtoolsCall}"`;
+	const command = `"${rBinPath}" --no-echo -e "${devtoolsCall}"`;
 	Logger.info(`devtools call is:\n${command}`);
 
 	const wd = testingTools.packageRoot.fsPath;
@@ -265,7 +265,7 @@ async function getDevtoolsVersion(rBinPath: string): Promise<{ major: number; mi
 	// eslint-disable-next-line no-async-promise-executor
 	return new Promise(async (resolve, reject) => {
 		const childProcess = spawn(
-			`${rBinPath} --no-echo -e "writeLines(format(packageVersion('devtools')))"`,
+			`"${rBinPath}" --no-echo -e "writeLines(format(packageVersion('devtools')))"`,
 			{
 				shell: true,
 			}


### PR DESCRIPTION
To fix a problem seen by @cderv on Windows:

```
Error: devtools version could not be detected. Output:
null
'C:\Program' n'est pas reconnu en tant que commande interne
ou externe, un programme ex�cutable ou un fichier de commandes.
```