### PR TITLE
pass enter key events on multiline statements to the code editor widget

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./consoleInput';
+import * as DOM from 'vs/base/browser/dom';
 import * as React from 'react';
 import { FocusEvent, useEffect, useRef } from 'react'; // eslint-disable-line no-duplicate-imports
 import { URI } from 'vs/base/common/uri';
@@ -163,8 +164,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 		// 'scoped' contexts makes that challenging to access here, and I
 		// haven't figured out the 'right' way to get access to those contexts.
 		if (!cmdOrCtrlKey) {
-			// eslint-disable-next-line no-restricted-syntax
-			const suggestWidgets = document.getElementsByClassName('suggest-widget');
+			const suggestWidgets = DOM.getActiveWindow().document.getElementsByClassName('suggest-widget');
 			for (const suggestWidget of suggestWidgets) {
 				if (suggestWidget.classList.contains('visible')) {
 					return;


### PR DESCRIPTION
This is one approach to addressing https://github.com/posit-dev/positron/issues/1552.

The idea is to only consume the Enter key event if we actually execute code. If the runtime says that the code fragment is incomplete, or if the user hits Shift+Enter, we don't consume the key event and let the code editor widget handle it. The code editor widget already auto-indents based on the configuration for the language.

One downside in Python is that if you have a multiline statement like:

```python
if 1:
    print("Hello<cursor>")
```

where `<cursor>` represents your cursor position (which is common since the closing `")` is added automatically), and you press enter, you will end up pushing the `")` to the next line instead of executing since the statement is not complete. This is consistent with IPython but not a great UX IMO. I think that is something to be handled in the Python runtime's `isCodeFragmentComplete` though.

@softwarenerd I'm curious to hear what your thoughts are on this approach.