### PR TITLE
Use new `checkInstalled()` function for R extension commands

### DIFF
--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -45,17 +45,11 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 
 		// Commands for package development tooling
 		vscode.commands.registerCommand('r.packageLoad', async () => {
-			const isInstalled = await checkInstalled('devtools');
-			if (isInstalled) {
-				positron.runtime.executeCode('r', 'devtools::load_all()', true);
-			}
+			executeCodeForCommand('devtools', 'devtools::load_all()');
 		}),
 
 		vscode.commands.registerCommand('r.packageBuild', async () => {
-			const isInstalled = await checkInstalled('devtools');
-			if (isInstalled) {
-				positron.runtime.executeCode('r', 'devtools::build()', true);
-			}
+			executeCodeForCommand('devtools', 'devtools::build()');
 		}),
 
 		vscode.commands.registerCommand('r.packageInstall', async () => {
@@ -103,24 +97,15 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 		}),
 
 		vscode.commands.registerCommand('r.packageTest', async () => {
-			const isInstalled = await checkInstalled('devtools');
-			if (isInstalled) {
-				positron.runtime.executeCode('r', 'devtools::test()', true);
-			}
+			executeCodeForCommand('devtools', 'devtools::test()');
 		}),
 
 		vscode.commands.registerCommand('r.useTestthat', async () => {
-			const isInstalled = await checkInstalled('usethis');
-			if (isInstalled) {
-				positron.runtime.executeCode('r', 'usethis::use_testthat()', true);
-			}
+			executeCodeForCommand('usethis', 'usethis::use_testthat()');
 		}),
 
 		vscode.commands.registerCommand('r.useTest', async () => {
-			const isInstalled = await checkInstalled('usethis');
-			if (isInstalled) {
-				positron.runtime.executeCode('r', 'usethis::use_test("rename-me")', true);
-			}
+			executeCodeForCommand('usethis', 'usethis::use_test("rename-me")');
 		}),
 
 		vscode.commands.registerCommand('r.packageCheck', async () => {
@@ -133,10 +118,7 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 		}),
 
 		vscode.commands.registerCommand('r.packageDocument', async () => {
-			const isInstalled = await checkInstalled('devtools');
-			if (isInstalled) {
-				positron.runtime.executeCode('r', 'devtools::document()', true);
-			}
+			executeCodeForCommand('devtools', 'devtools::document()');
 		}),
 
 		// Command used to source the current file
@@ -219,3 +201,9 @@ function insertOperatorWithSpace(op: string) {
 	});
 }
 
+async function executeCodeForCommand(pkg: string, code: string) {
+	const isInstalled = await checkInstalled(pkg);
+	if (isInstalled) {
+		positron.runtime.executeCode('r', code, true);
+	}
+}

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -5,7 +5,7 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { timeout } from './util';
-import { getRunningRRuntime } from './runtime';
+import { getRunningRRuntime, checkInstalled } from './runtime';
 import { getRPackageName } from './contexts';
 import { getRPackageTasks } from './tasks';
 import { randomUUID } from 'crypto';
@@ -44,18 +44,28 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 		}),
 
 		// Commands for package development tooling
-		vscode.commands.registerCommand('r.packageLoad', () => {
-			positron.runtime.executeCode('r', 'devtools::load_all()', true);
+		vscode.commands.registerCommand('r.packageLoad', async () => {
+			const isInstalled = await checkInstalled('devtools');
+			if (isInstalled) {
+				positron.runtime.executeCode('r', 'devtools::load_all()', true);
+			}
 		}),
 
-		vscode.commands.registerCommand('r.packageBuild', () => {
-			positron.runtime.executeCode('r', 'devtools::build()', true);
+		vscode.commands.registerCommand('r.packageBuild', async () => {
+			const isInstalled = await checkInstalled('devtools');
+			if (isInstalled) {
+				positron.runtime.executeCode('r', 'devtools::build()', true);
+			}
 		}),
 
 		vscode.commands.registerCommand('r.packageInstall', async () => {
 			const packageName = await getRPackageName();
 			const tasks = await getRPackageTasks();
 			const task = tasks.filter(task => task.definition.task === 'r.task.packageInstall')[0];
+			const isInstalled = await checkInstalled(task.definition.pkg);
+			if (!isInstalled) {
+				return;
+			}
 			const runtime = await getRunningRRuntime();
 
 			const execution = await vscode.tasks.executeTask(task);
@@ -92,26 +102,41 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 			});
 		}),
 
-		vscode.commands.registerCommand('r.packageTest', () => {
-			positron.runtime.executeCode('r', 'devtools::test()', true);
+		vscode.commands.registerCommand('r.packageTest', async () => {
+			const isInstalled = await checkInstalled('devtools');
+			if (isInstalled) {
+				positron.runtime.executeCode('r', 'devtools::test()', true);
+			}
 		}),
 
-		vscode.commands.registerCommand('r.useTestthat', () => {
-			positron.runtime.executeCode('r', 'usethis::use_testthat()', true);
+		vscode.commands.registerCommand('r.useTestthat', async () => {
+			const isInstalled = await checkInstalled('usethis');
+			if (isInstalled) {
+				positron.runtime.executeCode('r', 'usethis::use_testthat()', true);
+			}
 		}),
 
-		vscode.commands.registerCommand('r.useTest', () => {
-			positron.runtime.executeCode('r', 'usethis::use_test("rename-me")', true);
+		vscode.commands.registerCommand('r.useTest', async () => {
+			const isInstalled = await checkInstalled('usethis');
+			if (isInstalled) {
+				positron.runtime.executeCode('r', 'usethis::use_test("rename-me")', true);
+			}
 		}),
 
 		vscode.commands.registerCommand('r.packageCheck', async () => {
 			const tasks = await getRPackageTasks();
 			const task = tasks.filter(task => task.definition.task === 'r.task.packageCheck')[0];
-			vscode.tasks.executeTask(task);
+			const isInstalled = await checkInstalled(task.definition.pkg);
+			if (isInstalled) {
+				vscode.tasks.executeTask(task);
+			}
 		}),
 
-		vscode.commands.registerCommand('r.packageDocument', () => {
-			positron.runtime.executeCode('r', 'devtools::document()', true);
+		vscode.commands.registerCommand('r.packageDocument', async () => {
+			const isInstalled = await checkInstalled('devtools');
+			if (isInstalled) {
+				positron.runtime.executeCode('r', 'devtools::document()', true);
+			}
 		}),
 
 		// Command used to source the current file

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -32,16 +32,18 @@ export async function getRPackageTasks(): Promise<vscode.Task[]> {
 		{
 			'task': 'r.task.packageCheck',
 			'message': vscode.l10n.t('{taskName}', { taskName: 'Check R package' }),
-			'shellExecution': `"${runtimeManager.getLastBinpath()}" -e "devtools::check()"`
+			'shellExecution': `"${runtimeManager.getLastBinpath()}" -e "devtools::check()"`,
+			'package': 'devtools'
 		},
 		{
 			'task': 'r.task.packageInstall',
 			'message': vscode.l10n.t('{taskName}', { taskName: 'Install R package' }),
-			'shellExecution': `"${runtimeManager.getLastBinpath()}" -e "devtools::install()"`
+			'shellExecution': `"${runtimeManager.getLastBinpath()}" -e "pak::local_install(upgrade = FALSE)"`,
+			'package': 'pak'
 		}
 	];
 	return allPackageTasks.map(task => new vscode.Task(
-		{ type: 'rPackageTask', task: task.task },
+		{ type: 'rPackageTask', task: task.task, pkg: task.package },
 		vscode.TaskScope.Workspace,
 		task.message,
 		'R',
@@ -54,4 +56,5 @@ type PackageTask = {
 	task: string;
 	message: string;
 	shellExecution: string;
+	package?: string;
 };


### PR DESCRIPTION
Addresses #1631 by switching over the `'r.task.packageInstall'` task to use `pak::local_install(upgrade = FALSE)` instead of devtools.

This PR also sprinkles `checkInstalled()` throughout the R extension commands where needed. There is a fair amount of repetition here now, so maybe I'll make a new function for these simple commands.