### PR TITLE
Add simple data generating mocks for data tool development, clean up comm contract

### DIFF
--- a/positron/comms/data_tool-backend-openrpc.json
+++ b/positron/comms/data_tool-backend-openrpc.json
@@ -15,6 +15,10 @@
 					"type": "object",
 					"name": "table_schema",
 					"description": "The schema for a table-like object",
+					"required": [
+						"columns",
+						"num_rows"
+					],
 					"properties": {
 						"columns": {
 							"type": "array",
@@ -45,25 +49,22 @@
 					}
 				},
 				{
-					"name": "row_end_index",
-					"description": "Last row to fetch (inclusive). May be beyond end",
+					"name": "num_rows",
+					"description": "Number of rows to fetch from start index. May extend beyond end of table",
 					"required": true,
 					"schema": {
 						"type": "integer"
 					}
 				},
 				{
-					"name": "column_start_index",
-					"description": "First column to fetch (inclusive)",
+					"name": "column_indices",
+					"description": "Indices to select, which can be a sequential, sparse, or random selection",
+					"required": true,
 					"schema": {
-						"type": "integer"
-					}
-				},
-				{
-					"name": "column_end_index",
-					"description": "Last column to fetch (inclusive). May extend beyond end",
-					"schema": {
-						"type": "integer"
+						"type": "array",
+						"items": {
+							"type": "integer"
+						}
 					}
 				}
 			],
@@ -102,6 +103,7 @@
 				{
 					"name": "filters",
 					"description": "Zero or more filters to apply",
+					"required": true,
 					"schema": {
 						"type": "array",
 						"items": {
@@ -115,6 +117,9 @@
 					"type": "object",
 					"name": "filter_result",
 					"description": "The result of applying filters to a table",
+					"required": [
+						"selected_num_rows"
+					],
 					"properties": {
 						"selected_num_rows": {
 							"type": "integer",
@@ -132,6 +137,7 @@
 				{
 					"name": "sort_keys",
 					"description": "Pass zero or more keys to sort by. Clears any existing keys",
+					"required": true,
 					"schema": {
 						"type": "array",
 						"items": {
@@ -150,6 +156,7 @@
 				{
 					"name": "profile_id",
 					"description": "Unique identifier for the requested profile",
+					"required": true,
 					"schema": {
 						"type": "string"
 					}
@@ -157,6 +164,7 @@
 				{
 					"name": "profile_type",
 					"description": "The type of analytical column profile",
+					"required": true,
 					"schema": {
 						"type": "string",
 						"enum": [
@@ -168,6 +176,7 @@
 				{
 					"name": "column",
 					"description": "Column name to compute profile for",
+					"required": true,
 					"schema": {
 						"type": "string"
 					}
@@ -221,6 +230,10 @@
 							"description": "Counts of distinct values in column",
 							"items": {
 								"type": "object",
+								"required": [
+									"value",
+									"count"
+								],
 								"properties": {
 									"value": {
 										"type": "string",
@@ -251,6 +264,10 @@
 					"type": "object",
 					"name": "backend_state",
 					"description": "The current backend state",
+					"required": [
+						"filters",
+						"sort_keys"
+					],
 					"properties": {
 						"filters": {
 							"type": "array",
@@ -331,7 +348,8 @@
 				"description": "Specifies a table row filter based on a column's values",
 				"required": [
 					"filter_id",
-					"filter_type"
+					"filter_type",
+					"column"
 				],
 				"properties": {
 					"filter_id": {
@@ -348,6 +366,10 @@
 							"set_membership",
 							"search"
 						]
+					},
+					"column": {
+						"type": "string",
+						"description": "Column name to compute profile for"
 					},
 					"compare_op": {
 						"type": "string",
@@ -399,6 +421,11 @@
 			"column_quantile_value": {
 				"type": "object",
 				"description": "An exact or approximate quantile value from a column",
+				"required": [
+					"q",
+					"value",
+					"exact"
+				],
 				"properties": {
 					"q": {
 						"type": "number",
@@ -417,6 +444,10 @@
 			"column_sort_key": {
 				"type": "object",
 				"description": "Specifies a column to sort by",
+				"required": [
+					"column",
+					"ascending"
+				],
 				"properties": {
 					"column": {
 						"type": "string",

--- a/src/vs/workbench/services/languageRuntime/common/positronDataToolComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataToolComm.ts
@@ -16,12 +16,12 @@ export interface TableSchema {
 	/**
 	 * Schema for each column in the table
 	 */
-	columns?: Array<ColumnSchema>;
+	columns: Array<ColumnSchema>;
 
 	/**
 	 * Numbers of rows in the unfiltered dataset
 	 */
-	num_rows?: number;
+	num_rows: number;
 
 }
 
@@ -48,7 +48,7 @@ export interface FilterResult {
 	/**
 	 * Number of rows in table after applying filters
 	 */
-	selected_num_rows?: number;
+	selected_num_rows: number;
 
 }
 
@@ -110,12 +110,12 @@ export interface FreqtableCounts {
 	/**
 	 * Stringified value
 	 */
-	value?: string;
+	value: string;
 
 	/**
 	 * Number of occurrences of value
 	 */
-	count?: number;
+	count: number;
 
 }
 
@@ -126,12 +126,12 @@ export interface BackendState {
 	/**
 	 * The set of currently applied filters
 	 */
-	filters?: Array<ColumnFilter>;
+	filters: Array<ColumnFilter>;
 
 	/**
 	 * The set of currently applied sorts
 	 */
-	sort_keys?: Array<ColumnSortKey>;
+	sort_keys: Array<ColumnSortKey>;
 
 }
 
@@ -196,6 +196,11 @@ export interface ColumnFilter {
 	filter_type: ColumnFilterFilterType;
 
 	/**
+	 * Column name to compute profile for
+	 */
+	column: string;
+
+	/**
 	 * String representation of a binary comparison
 	 */
 	compare_op?: ColumnFilterCompareOp;
@@ -239,18 +244,18 @@ export interface ColumnQuantileValue {
 	/**
 	 * Quantile number (percentile). E.g. 1 for 1%, 50 for median
 	 */
-	q?: number;
+	q: number;
 
 	/**
 	 * Stringified quantile value
 	 */
-	value?: string;
+	value: string;
 
 	/**
 	 * Whether value is exact or approximate (computed from binned data or
 	 * sketches)
 	 */
-	exact?: boolean;
+	exact: boolean;
 
 }
 
@@ -261,12 +266,12 @@ export interface ColumnSortKey {
 	/**
 	 * Column name to sort by
 	 */
-	column?: string;
+	column: string;
 
 	/**
 	 * Sort order, ascending (true) or descending (false)
 	 */
-	ascending?: boolean;
+	ascending: boolean;
 
 }
 
@@ -339,15 +344,15 @@ export class PositronDataToolComm extends PositronBaseComm {
 	 * Request a rectangular subset of data with values formatted as strings
 	 *
 	 * @param rowStartIndex First row to fetch (inclusive)
-	 * @param rowEndIndex Last row to fetch (inclusive). May be beyond end
-	 * @param columnStartIndex First column to fetch (inclusive)
-	 * @param columnEndIndex Last column to fetch (inclusive). May extend
-	 * beyond end
+	 * @param numRows Number of rows to fetch from start index. May extend
+	 * beyond end of table
+	 * @param columnIndices Indices to select, which can be a sequential,
+	 * sparse, or random selection
 	 *
 	 * @returns Table values formatted as strings
 	 */
-	getDataValues(rowStartIndex: number, rowEndIndex: number, columnStartIndex: number, columnEndIndex: number): Promise<TableData> {
-		return super.performRpc('get_data_values', ['row_start_index', 'row_end_index', 'column_start_index', 'column_end_index'], [rowStartIndex, rowEndIndex, columnStartIndex, columnEndIndex]);
+	getDataValues(rowStartIndex: number, numRows: number, columnIndices: Array<number>): Promise<TableData> {
+		return super.performRpc('get_data_values', ['row_start_index', 'num_rows', 'column_indices'], [rowStartIndex, numRows, columnIndices]);
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataTool/common/positronDataToolMocks.ts
+++ b/src/vs/workbench/services/positronDataTool/common/positronDataToolMocks.ts
@@ -1,0 +1,162 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { generateUuid } from 'vs/base/common/uuid';
+import {
+	ColumnFilter,
+	ColumnFilterCompareOp,
+	ColumnFilterFilterType,
+	ColumnFilterSearchType,
+	ColumnSchema,
+	ProfileResult,
+	TableData,
+	TableSchema
+} from 'vs/workbench/services/languageRuntime/common/positronDataToolComm';
+
+const exampleTypes: [string, object][] = [
+	['int64', {}],
+	['string', {}],
+	['boolean', {}],
+	['double', {}],
+	['timestamp', { timezone: 'America/New_York' }]
+];
+
+export function getTableSchema(numRows: number = 100, numColumns: number = 10): TableSchema {
+	const columns = [];
+	for (let i = 0; i < numColumns; i++) {
+		const typeProto = exampleTypes[i % exampleTypes.length];
+		columns.push(getColumnSchema('column_' + i, typeProto[0], typeProto[1]));
+	}
+	return {
+		columns: columns,
+		num_rows: numRows
+	};
+}
+
+// If you want to add other examples, just append them to the arrays of strings.
+// They do not have to be all the same length.
+const exampleTypeData: Record<string, string[]> = {
+	'int64': ['-12345', '-1', '0', 'null', '1', '12345'],
+	'string': ['Greetings', 'Gr\u00FC\u00DFe', 'Saludos', 'null'],
+	'boolean': ['true', 'false', 'null'],
+	'double': ['1.2345', '-1.2e-17', '0.0', 'null'],
+	'timestamp': ['2021-12-20 12:34:45', '1970-01-01 00:00:00']
+};
+
+/**
+ * Generate some "random" data for the table based on a hand-written prototype, so the results
+ * are always deterministic given a particular schema's types.
+ * @param schema the schema of the table to generate data from
+ * @param rowStartIndex
+ * @param numRows
+ * @param columnIndices Columns to select by index. Can be sequetial, sparse, or random
+ */
+export function getExampleTableData(schema: TableSchema, rowStartIndex: number,
+	numRows: number, columnIndices: Array<number>): TableData {
+	const generatedColumns = [];
+
+	// Don't generate virtual data beyond the extends of the table, and if
+	// rowStartIndex is at or after end of the table, return nothing
+	numRows = Math.max(Math.min(numRows, schema.num_rows - rowStartIndex), 0);
+
+	for (const columnIndex of columnIndices) {
+		const exampleValues: string[] = exampleTypeData[schema.columns[columnIndex].type_name];
+
+		// Just repeat these values deterministically up until the "end" of the table
+		const generatedColumn = [];
+		if (numRows > 0) {
+			for (let i = rowStartIndex; i < rowStartIndex + numRows; i++) {
+				generatedColumn.push(exampleValues[i % exampleValues.length]);
+			}
+		}
+		generatedColumns.push(generatedColumn);
+	}
+	return {
+		columns: generatedColumns,
+		row_labels: []
+	};
+}
+
+export function getColumnSchema(name: string, typeName: string,
+	extraProps: object = {}): ColumnSchema {
+	return {
+		name: name,
+		type_name: typeName,
+		...extraProps
+	} as ColumnSchema;
+}
+
+export function getExampleHistogram(): ProfileResult {
+	// This example is basically made up.
+	return {
+		null_count: 10,
+		min_value: '0',
+		max_value: '100',
+		mean_value: '50',
+		histogram_bin_sizes: [4, 10, 15, 20, 7, 6, 0, 2, 50, 21],
+		histogram_bin_width: 10,
+		histogram_quantiles: [
+			{ q: 25, value: '25', exact: true },
+			{ q: 50, value: '70', exact: true },
+			{ q: 75, value: '82', exact: true }
+		],
+	} as ProfileResult;
+}
+
+export function getExampleFreqtable(): ProfileResult {
+	return {
+		null_count: 10,
+		freqtable_counts: [
+			{ value: 'foo1', count: 25 },
+			{ value: 'bar22', count: 10 },
+			{ value: 'baz3333', count: 7 },
+			{ value: 'qux444444', count: 2 }
+		],
+		freqtable_other_count: 12
+	} as ProfileResult;
+}
+
+// For filtering
+
+function _getFilterWithProps(columnName: string, filterType: ColumnFilterFilterType,
+	props: Partial<ColumnFilter> = {}): ColumnFilter {
+	return {
+		filter_id: generateUuid(),
+		filter_type: filterType,
+		column: columnName,
+		...props
+	} as ColumnFilter;
+}
+
+export function getCompareFilter(columnName: string, op: ColumnFilterCompareOp,
+	value: string) {
+	return _getFilterWithProps(columnName, ColumnFilterFilterType.Compare, {
+		compare_op: op,
+		compare_value: value
+	});
+}
+
+export function getIsNullFilter(columnName: string) {
+	return _getFilterWithProps(columnName, ColumnFilterFilterType.Isnull);
+}
+
+export function getNotNullFilter(columnName: string) {
+	return _getFilterWithProps(columnName, ColumnFilterFilterType.Notnull);
+}
+
+export function getSetMemberFilter(columnName: string, values: string[], inclusive: boolean) {
+	return _getFilterWithProps(columnName, ColumnFilterFilterType.SetMembership, {
+		set_member_values: values,
+		set_member_inclusive: inclusive
+	});
+}
+
+export function getTextSearchFilter(columnName: string, searchTerm: string,
+	searchType: ColumnFilterSearchType, caseSensitive: boolean) {
+	return _getFilterWithProps(columnName, ColumnFilterFilterType.Search, {
+		search_term: searchTerm,
+		search_type: searchType,
+		search_case_sensitive: caseSensitive
+	});
+}

--- a/src/vs/workbench/services/positronDataTool/test/common/positronDataToolMocks.test.ts
+++ b/src/vs/workbench/services/positronDataTool/test/common/positronDataToolMocks.test.ts
@@ -22,16 +22,14 @@ suite('DataToolMocks', () => {
 
 	test('Test getExampleTableData', () => {
 		const schema = mocks.getTableSchema(1000, 10000);
-		let data = mocks.getExampleTableData(schema, 0, 100, 0, 10);
-		assert.equal(data.columns.length, 10);
+		let data = mocks.getExampleTableData(schema, 0, 100, [0, 1, 2, 3, 4]);
+		assert.equal(data.columns.length, 5);
 		assert.equal(data.columns[0].length, 100);
 
-		// Bounds respected
-		data = mocks.getExampleTableData(schema, 999, 100, 9999, 100);
+		data = mocks.getExampleTableData(schema, 999, 100, [999]);
 		assert.equal(data.columns.length, 1);
 		assert.equal(data.columns[0].length, 1);
-
-		data = mocks.getExampleTableData(schema, 1000, 100, 10000, 100);
+		data = mocks.getExampleTableData(schema, 1000, 100, []);
 		assert.equal(data.columns.length, 0);
 	});
 

--- a/src/vs/workbench/services/positronDataTool/test/common/positronDataToolMocks.test.ts
+++ b/src/vs/workbench/services/positronDataTool/test/common/positronDataToolMocks.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import {
+	ColumnFilterCompareOp,
+	ColumnFilterFilterType,
+	ColumnFilterSearchType
+} from 'vs/workbench/services/languageRuntime/common/positronDataToolComm';
+import * as mocks from "vs/workbench/services/positronDataTool/common/positronDataToolMocks";
+
+/**
+ * Basic smoke tests for debugging the mock functions
+ */
+suite('DataToolMocks', () => {
+	test('Test getTableSchema', () => {
+		const schema = mocks.getTableSchema(1000, 10000);
+		assert.equal(schema.columns.length, 10000);
+		assert.equal(schema.num_rows, 1000);
+	});
+
+	test('Test getExampleTableData', () => {
+		const schema = mocks.getTableSchema(1000, 10000);
+		let data = mocks.getExampleTableData(schema, 0, 100, 0, 10);
+		assert.equal(data.columns.length, 10);
+		assert.equal(data.columns[0].length, 100);
+
+		// Bounds respected
+		data = mocks.getExampleTableData(schema, 999, 100, 9999, 100);
+		assert.equal(data.columns.length, 1);
+		assert.equal(data.columns[0].length, 1);
+
+		data = mocks.getExampleTableData(schema, 1000, 100, 10000, 100);
+		assert.equal(data.columns.length, 0);
+	});
+
+	test('Test getCompareFilter', () => {
+		const filter = mocks.getCompareFilter('column_2', ColumnFilterCompareOp.Gt, '1234');
+		assert.equal(filter.filter_type, ColumnFilterFilterType.Compare);
+		assert.equal(filter.column, 'column_2');
+		assert.equal(filter.compare_op, ColumnFilterCompareOp.Gt);
+		assert.equal(filter.compare_value, '1234');
+	});
+
+	test('Test getIsNullFilter', () => {
+		let filter = mocks.getIsNullFilter('column_3');
+		assert.equal(filter.column, 'column_3');
+		assert.equal(filter.filter_type, ColumnFilterFilterType.Isnull);
+
+		filter = mocks.getNotNullFilter('column_3');
+		assert.equal(filter.filter_type, ColumnFilterFilterType.Notnull);
+	});
+
+	test('Test getTextSearchFilter', () => {
+		const filter = mocks.getTextSearchFilter('column_5', 'needle',
+			ColumnFilterSearchType.Contains, false);
+		assert.equal(filter.column, 'column_5');
+		assert.equal(filter.filter_type, ColumnFilterFilterType.Search);
+		assert.equal(filter.search_term, 'needle');
+		assert.equal(filter.search_type, ColumnFilterSearchType.Contains);
+		assert.equal(filter.search_case_sensitive, false);
+	});
+
+	test('Test getSetMemberFilter', () => {
+		const set_values = ['need1', 'need2'];
+		const filter = mocks.getSetMemberFilter('column_6', set_values, true);
+		assert.equal(filter.column, 'column_6');
+		assert.equal(filter.filter_type, ColumnFilterFilterType.SetMembership);
+		assert.equal(filter.set_member_values, set_values);
+		assert.equal(filter.set_member_inclusive, true);
+	});
+
+});


### PR DESCRIPTION
* Cleans up some of the initial data tool comm contracts — makes more fields required, change the data request format to indicate the number of rows requested rather than facing an ambiguous choice about whether the end index is inclusive. 
* Adds simple mock schema and data generators for Brian to use in the UI without having to interact with any backend
* Adds some smoke tests for the mocks (probably inadequate, but at least gets us started)