### PR TITLE
Add the `open_editor` frontend event

### DIFF
--- a/positron/comms/frontend-frontend-openrpc.json
+++ b/positron/comms/frontend-frontend-openrpc.json
@@ -20,6 +20,34 @@
 			]
 		},
 		{
+			"name": "open_editor",
+			"summary": "Open an editor",
+			"description": "This event is used to open an editor with a given file and selection.",
+			"params": [
+				{
+					"name": "file",
+					"description": "The path of the file to open",
+					"schema": {
+						"type": "string"
+					}
+				},
+				{
+					"name": "line",
+					"description": "The line number to jump to",
+					"schema": {
+						"type": "integer"
+					}
+				},
+				{
+					"name": "column",
+					"description": "The column number to jump to",
+					"schema": {
+						"type": "integer"
+					}
+				}
+			]
+		},
+		{
 			"name": "show_message",
 			"summary": "Show a message",
 			"description": "Use this for messages that require immediate attention from the user",

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -727,6 +727,15 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 						}
 					});
 				}));
+				this._register(frontendClient.onDidOpenEditor(event => {
+					this._onDidReceiveRuntimeEventEmitter.fire({
+						runtime_id: runtime.metadata.runtimeId,
+						event: {
+							name: FrontendEvent.OpenEditor,
+							data: event
+						}
+					});
+				}));
 				this._register(frontendClient.onDidShowMessage(event => {
 					this._onDidReceiveRuntimeEventEmitter.fire({
 						runtime_id: runtime.metadata.runtimeId,

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeFrontEndClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeFrontEndClient.ts
@@ -5,7 +5,7 @@
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Event } from 'vs/base/common/event';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
-import { BusyEvent, FrontendEvent, PositronFrontendComm, PromptStateEvent, ShowMessageEvent, WorkingDirectoryEvent } from './positronFrontendComm';
+import { BusyEvent, FrontendEvent, OpenEditorEvent, PositronFrontendComm, PromptStateEvent, ShowMessageEvent, WorkingDirectoryEvent } from './positronFrontendComm';
 
 
 /**
@@ -62,6 +62,7 @@ export class FrontEndClientInstance extends Disposable {
 
 	/** Emitters for events forwarded from the frontend comm */
 	onDidBusy: Event<BusyEvent>;
+	onDidOpenEditor: Event<OpenEditorEvent>;
 	onDidShowMessage: Event<ShowMessageEvent>;
 	onDidPromptState: Event<PromptStateEvent>;
 	onDidWorkingDirectory: Event<WorkingDirectoryEvent>;
@@ -80,6 +81,7 @@ export class FrontEndClientInstance extends Disposable {
 
 		this._comm = new PositronFrontendComm(this._client);
 		this.onDidBusy = this._comm.onDidBusy;
+		this.onDidOpenEditor = this._comm.onDidOpenEditor;
 		this.onDidShowMessage = this._comm.onDidShowMessage;
 		this.onDidPromptState = this._comm.onDidPromptState;
 		this.onDidWorkingDirectory = this._comm.onDidWorkingDirectory;

--- a/src/vs/workbench/services/languageRuntime/common/positronFrontendComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronFrontendComm.ts
@@ -36,6 +36,27 @@ export interface BusyEvent {
 }
 
 /**
+ * Event: Open an editor
+ */
+export interface OpenEditorEvent {
+	/**
+	 * The path of the file to open
+	 */
+	file: string;
+
+	/**
+	 * The line number to jump to
+	 */
+	line: number;
+
+	/**
+	 * The column number to jump to
+	 */
+	column: number;
+
+}
+
+/**
  * Event: Show a message
  */
 export interface ShowMessageEvent {
@@ -75,6 +96,7 @@ export interface WorkingDirectoryEvent {
 
 export enum FrontendEvent {
 	Busy = 'busy',
+	OpenEditor = 'open_editor',
 	ShowMessage = 'show_message',
 	PromptState = 'prompt_state',
 	WorkingDirectory = 'working_directory'
@@ -84,6 +106,7 @@ export class PositronFrontendComm extends PositronBaseComm {
 	constructor(instance: IRuntimeClientInstance<any, any>) {
 		super(instance);
 		this.onDidBusy = super.createEventEmitter('busy', ['busy']);
+		this.onDidOpenEditor = super.createEventEmitter('open_editor', ['file', 'line', 'column']);
 		this.onDidShowMessage = super.createEventEmitter('show_message', ['message']);
 		this.onDidPromptState = super.createEventEmitter('prompt_state', ['input_prompt', 'continuation_prompt']);
 		this.onDidWorkingDirectory = super.createEventEmitter('working_directory', ['directory']);
@@ -115,6 +138,12 @@ export class PositronFrontendComm extends PositronBaseComm {
 	 * is running.
 	 */
 	onDidBusy: Event<BusyEvent>;
+	/**
+	 * Open an editor
+	 *
+	 * This event is used to open an editor with a given file and selection.
+	 */
+	onDidOpenEditor: Event<OpenEditorEvent>;
 	/**
 	 * Show a message
 	 *


### PR DESCRIPTION
The `open_editor` event lets language runtimes instruct Positron to open an editor with a given file and selection (line and column numbers).

This is used in the Python runtime (PR: https://github.com/posit-dev/positron-python/pull/299) to redirect `obj??` (which in IPython shows the source code of `obj`) to open the file defining `obj` at the defining line.

Addresses #762.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of why we are making the proposed changes and
* how best to test them.
-->
