### PR TITLE
Add the `clear_console` frontend event

### DIFF
--- a/positron/comms/frontend-frontend-openrpc.json
+++ b/positron/comms/frontend-frontend-openrpc.json
@@ -20,6 +20,12 @@
 			]
 		},
 		{
+			"name": "clear_console",
+			"summary": "Clear the console",
+			"description": "Use this to clear the console.",
+			"params": []
+		},
+		{
 			"name": "open_editor",
 			"summary": "Open an editor",
 			"description": "This event is used to open an editor with a given file and selection.",

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -727,6 +727,15 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 						}
 					});
 				}));
+				this._register(frontendClient.onDidClearConsole(event => {
+					this._onDidReceiveRuntimeEventEmitter.fire({
+						runtime_id: runtime.metadata.runtimeId,
+						event: {
+							name: FrontendEvent.ClearConsole,
+							data: event
+						}
+					});
+				}));
 				this._register(frontendClient.onDidOpenEditor(event => {
 					this._onDidReceiveRuntimeEventEmitter.fire({
 						runtime_id: runtime.metadata.runtimeId,

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeFrontEndClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeFrontEndClient.ts
@@ -5,7 +5,7 @@
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Event } from 'vs/base/common/event';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
-import { BusyEvent, FrontendEvent, OpenEditorEvent, PositronFrontendComm, PromptStateEvent, ShowMessageEvent, WorkingDirectoryEvent } from './positronFrontendComm';
+import { BusyEvent, ClearConsoleEvent, FrontendEvent, OpenEditorEvent, PositronFrontendComm, PromptStateEvent, ShowMessageEvent, WorkingDirectoryEvent } from './positronFrontendComm';
 
 
 /**
@@ -62,6 +62,7 @@ export class FrontEndClientInstance extends Disposable {
 
 	/** Emitters for events forwarded from the frontend comm */
 	onDidBusy: Event<BusyEvent>;
+	onDidClearConsole: Event<ClearConsoleEvent>;
 	onDidOpenEditor: Event<OpenEditorEvent>;
 	onDidShowMessage: Event<ShowMessageEvent>;
 	onDidPromptState: Event<PromptStateEvent>;
@@ -81,6 +82,7 @@ export class FrontEndClientInstance extends Disposable {
 
 		this._comm = new PositronFrontendComm(this._client);
 		this.onDidBusy = this._comm.onDidBusy;
+		this.onDidClearConsole = this._comm.onDidClearConsole;
 		this.onDidOpenEditor = this._comm.onDidOpenEditor;
 		this.onDidShowMessage = this._comm.onDidShowMessage;
 		this.onDidPromptState = this._comm.onDidPromptState;

--- a/src/vs/workbench/services/languageRuntime/common/positronFrontendComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronFrontendComm.ts
@@ -36,6 +36,12 @@ export interface BusyEvent {
 }
 
 /**
+ * Event: Clear the console
+ */
+export interface ClearConsoleEvent {
+}
+
+/**
  * Event: Open an editor
  */
 export interface OpenEditorEvent {
@@ -96,6 +102,7 @@ export interface WorkingDirectoryEvent {
 
 export enum FrontendEvent {
 	Busy = 'busy',
+	ClearConsole = 'clear_console',
 	OpenEditor = 'open_editor',
 	ShowMessage = 'show_message',
 	PromptState = 'prompt_state',
@@ -106,6 +113,7 @@ export class PositronFrontendComm extends PositronBaseComm {
 	constructor(instance: IRuntimeClientInstance<any, any>) {
 		super(instance);
 		this.onDidBusy = super.createEventEmitter('busy', ['busy']);
+		this.onDidClearConsole = super.createEventEmitter('clear_console', []);
 		this.onDidOpenEditor = super.createEventEmitter('open_editor', ['file', 'line', 'column']);
 		this.onDidShowMessage = super.createEventEmitter('show_message', ['message']);
 		this.onDidPromptState = super.createEventEmitter('prompt_state', ['input_prompt', 'continuation_prompt']);
@@ -138,6 +146,12 @@ export class PositronFrontendComm extends PositronBaseComm {
 	 * is running.
 	 */
 	onDidBusy: Event<BusyEvent>;
+	/**
+	 * Clear the console
+	 *
+	 * Use this to clear the console.
+	 */
+	onDidClearConsole: Event<ClearConsoleEvent>;
 	/**
 	 * Open an editor
 	 *

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -40,6 +40,7 @@ import { ActivityItemInput, ActivityItemInputState } from 'vs/workbench/services
 import { ActivityItemErrorStream, ActivityItemOutputStream } from 'vs/workbench/services/positronConsole/browser/classes/activityItemStream';
 import { IPositronConsoleInstance, IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID, PositronConsoleState } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
 import { formatLanguageRuntime, ILanguageRuntime, ILanguageRuntimeExit, ILanguageRuntimeMessage, ILanguageRuntimeService, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { FrontendEvent } from 'vs/workbench/services/languageRuntime/common/positronFrontendComm';
 
 /**
  * The onDidChangeRuntimeItems throttle threshold and throttle interval. The throttle threshold
@@ -1512,6 +1513,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					this.markInputBusyState(languageRuntimeMessageState.parent_id, false);
 					break;
 				}
+			}
+		}));
+
+		// Add the onDidReceiveRuntimeClientEvent event handler.
+		this._runtimeDisposableStore.add(this._runtime.onDidReceiveRuntimeClientEvent((event) => {
+			if (event.name === FrontendEvent.ClearConsole) {
+				this.clearConsole();
 			}
 		}));
 


### PR DESCRIPTION
The `clear_console` event lets language runtimes instruct Positron to clear the console.

This will be used in the Python runtime to correctly support the `clear` magic command.

Partially addresses #800.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of why we are making the proposed changes and
* how best to test them.
-->
