### PR TITLE
Implement `x-r-run` handler

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -51,6 +51,11 @@ const extensions = [
 		label: 'positron-code-cells',
 		workspaceFolder: path.join(os.tmpdir(), `positron-code-cells-${Math.floor(Math.random() * 100000)}`),
 		mocha: { timeout: 60_000 }
+	},
+	{
+		label: 'positron-r',
+		workspaceFolder: path.join(os.tmpdir(), `positron-r-${Math.floor(Math.random() * 100000)}`),
+		mocha: { timeout: 60_000 }
 	}
 	// --- End Positron ---
 ];

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -503,7 +503,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.40"
+      "ark": "0.1.41"
     }
   }
 }

--- a/extensions/positron-r/src/hyperlink.ts
+++ b/extensions/positron-r/src/hyperlink.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+import { randomUUID } from 'crypto';
+import { RRuntime } from './runtime';
+
+export async function handleRCode(runtime: RRuntime, code: string): Promise<void> {
+	const match = matchRunnable(code);
+
+	if (!match) {
+		// Didn't match our regex. Not safe to run, or not recognizable as R code.
+		return handleNotRunnable(code);
+	}
+	if (!match.groups) {
+		return handleNotRunnable(code);
+	}
+
+	const packageName = match.groups.package;
+	// Not currently used, but could be useful for showing help documentation on hover
+	// const functionName = match.groups.function;
+
+	if (isCorePackage(packageName)) {
+		// We never run code prefixed with a core package name, as this is suspicious
+		return handleNotRunnable(code);
+	}
+
+	if (isBlessedPackage(packageName)) {
+		// Attached or not, if it is a blessed package then we automatically run it
+		return handleAutomaticallyRunnable(runtime, code);
+	}
+	if (await runtime.isPackageAttached(packageName)) {
+		// Only automatically run unknown package code if the package is already attached
+		return handleAutomaticallyRunnable(runtime, code);
+	}
+
+	// Otherwise, it looks like runnable code but isn't safe enough to automatically run
+	return handleManuallyRunnable(runtime, code);
+}
+
+function handleNotRunnable(code: string) {
+	vscode.window.showInformationMessage(
+		`Code hyperlink not recognized. Manually run the following if you trust the hyperlink source: \`${code}\`.`
+	);
+}
+
+function handleManuallyRunnable(_runtime: RRuntime, code: string) {
+	// TODO: Put `code` in the Console for the user, overwriting anything that was there.
+	// Seems like we will need a new API for that.
+	vscode.env.clipboard.writeText(code);
+}
+
+function handleAutomaticallyRunnable(runtime: RRuntime, code: string) {
+	const id = randomUUID();
+
+	// Fire and forget style
+	runtime.execute(
+		code,
+		id,
+		positron.RuntimeCodeExecutionMode.Interactive,
+		positron.RuntimeErrorBehavior.Continue
+	);
+}
+
+function matchRunnable(code: string): RegExpMatchArray | null {
+	const runnableRegExp = /^(?<package>\w+)::(?<function>\w+)[(][^();]*[)]$/;
+	return code.match(runnableRegExp);
+}
+
+function isCorePackage(packageName: string): boolean {
+	const corePackages = ['utils', 'base', 'stats'];
+	return corePackages.includes(packageName);
+}
+
+function isBlessedPackage(packageName: string): boolean {
+	const blessedPackages = ['testthat', 'rlang', 'devtools', 'usethis', 'pkgload', 'pkgdown'];
+	return blessedPackages.includes(packageName);
+}

--- a/extensions/positron-r/src/hyperlink.ts
+++ b/extensions/positron-r/src/hyperlink.ts
@@ -64,7 +64,7 @@ function handleAutomaticallyRunnable(runtime: RRuntime, code: string) {
 	);
 }
 
-function matchRunnable(code: string): RegExpMatchArray | null {
+export function matchRunnable(code: string): RegExpMatchArray | null {
 	// Of the form `package::function(args)` where `args` can't contain `(`, `)`, or `;`.
 	// See https://cli.r-lib.org/reference/links.html#security-considerations.
 	const runnableRegExp = /^(?<package>\w+)::(?<function>\w+)[(][^();]*[)]$/;

--- a/extensions/positron-r/src/hyperlink.ts
+++ b/extensions/positron-r/src/hyperlink.ts
@@ -65,6 +65,8 @@ function handleAutomaticallyRunnable(runtime: RRuntime, code: string) {
 }
 
 function matchRunnable(code: string): RegExpMatchArray | null {
+	// Of the form `package::function(args)` where `args` can't contain `(`, `)`, or `;`.
+	// See https://cli.r-lib.org/reference/links.html#security-considerations.
 	const runnableRegExp = /^(?<package>\w+)::(?<function>\w+)[(][^();]*[)]$/;
 	return code.match(runnableRegExp);
 }

--- a/extensions/positron-r/src/hyperlink.ts
+++ b/extensions/positron-r/src/hyperlink.ts
@@ -41,14 +41,17 @@ export async function handleRCode(runtime: RRuntime, code: string): Promise<void
 }
 
 function handleNotRunnable(code: string) {
-	vscode.window.showInformationMessage(
+	vscode.window.showInformationMessage(vscode.l10n.t(
 		`Code hyperlink not recognized. Manually run the following if you trust the hyperlink source: \`${code}\`.`
-	);
+	));
 }
 
 function handleManuallyRunnable(_runtime: RRuntime, code: string) {
 	// TODO: Put `code` in the Console for the user, overwriting anything that was there.
 	// Seems like we will need a new API for that.
+	vscode.window.showInformationMessage(vscode.l10n.t(
+		`Code hyperlink written to clipboard: \`${code}\`.`
+	));
 	vscode.env.clipboard.writeText(code);
 }
 

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -394,9 +394,10 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 			attached = await this.callMethod('isPackageAttached', packageName);
 		} catch (err) {
 			const runtimeError = err as positron.RuntimeMethodError;
-			vscode.window.showErrorMessage(
+			vscode.window.showErrorMessage(vscode.l10n.t(
 				`Error checking if '${packageName}' is attached: ${runtimeError.message} ` +
-				`(${runtimeError.code})`);
+				`(${runtimeError.code})`
+			));
 		}
 
 		return attached;

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -12,6 +12,7 @@ import { delay, timeout } from './util';
 import { ArkAttachOnStartup, ArkDelayStartup } from './startup';
 import { RHtmlWidget, getResourceRoots } from './htmlwidgets';
 import { randomUUID } from 'crypto';
+import { handleRCode } from './hyperlink';
 
 class RRuntimeManager {
 	private runtimes: Map<string, RRuntime> = new Map();
@@ -130,9 +131,7 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 
 			// Run code.
 			case 'x-r-run':
-				console.log('********************************************************************');
-				console.log(`R runtime should run resource "${resource.path}"`);
-				console.log('********************************************************************');
+				handleRCode(this, resource.path);
 				return Promise.resolve(true);
 
 			// Unhandled.
@@ -386,6 +385,21 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 		}
 		this._packageCache.push({ packageName: pkgName, packageVersion: pkgVersion });
 		return true;
+	}
+
+	async isPackageAttached(packageName: string): Promise<boolean> {
+		let attached = false;
+
+		try {
+			attached = await this.callMethod('isPackageAttached', packageName);
+		} catch (err) {
+			const runtimeError = err as positron.RuntimeMethodError;
+			vscode.window.showErrorMessage(
+				`Error checking if '${packageName}' is attached: ${runtimeError.message} ` +
+				`(${runtimeError.code})`);
+		}
+
+		return attached;
 	}
 
 	private async createKernel(): Promise<JupyterLanguageRuntime> {

--- a/extensions/positron-r/src/test/hyperlink.test.ts
+++ b/extensions/positron-r/src/test/hyperlink.test.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { matchRunnable } from '../hyperlink';
+
+suite('Hyperlink', () => {
+	test('Runnable R code regex enforces safety rules', async () => {
+		const matchSimple = matchRunnable("pkg::fun()");
+		assert.strictEqual(matchSimple?.groups?.package, "pkg");
+		assert.strictEqual(matchSimple?.groups?.function, "fun");
+
+		const matchArgs = matchRunnable("pkg::fun(1 + 1, 2:5)");
+		assert.strictEqual(matchArgs?.groups?.package, "pkg");
+		assert.strictEqual(matchArgs?.groups?.function, "fun");
+
+		const matchUnsafeInnerFunction = matchRunnable("pkg::fun(fun())");
+		assert.strictEqual(matchUnsafeInnerFunction, null);
+
+		const matchUnsafeSemicolon = matchRunnable("pkg::fun({1 + 2; 3 + 4})");
+		assert.strictEqual(matchUnsafeSemicolon, null);
+
+		const matchUnsafeTripleColon = matchRunnable("pkg:::fun()");
+		assert.strictEqual(matchUnsafeTripleColon, null);
+	});
+});

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -127,6 +127,12 @@ echo
 yarn test-extension -l positron-code-cells
 kill_app
 
+echo
+echo "### Positron R tests"
+echo
+yarn test-extension -l positron-r
+kill_app
+
 # --- End Positron ---
 
 # Tests standalone (CommonJS)


### PR DESCRIPTION
- [x] Bump amalthea requirement

Requires https://github.com/posit-dev/amalthea/pull/194
Addresses https://github.com/posit-dev/positron/issues/1906 (Mostly)

Need https://github.com/posit-dev/positron/issues/1507 so we can get the active Console to be able to put manually runnable `code` onto the user's Console input prompt. Right now I am just writing it to the clipboard as a temporary workaround.

There are 3 categories of `code` that can come through `x-r-run`:

- **Not Runnable**: Code that isn't safe to run, or doesn't look like R code. We use a regular expression to check if the R code is in the "safe" format we expect, following these guidelines https://cli.r-lib.org/reference/links.html#security-considerations. Modeled after RStudio's https://github.com/rstudio/rstudio/blob/a8afd4453b535ec80e49b410c302f6881279888b/src/gwt/src/org/rstudio/core/client/hyperlink/RunHyperlink.java#L98.

- **Manually Runnable**: Looks safe enough for the user to run, but isn't from a "blessed" R package and the package in question isn't attached. Ideally if the user clicks this we then put the code on their Console input prompt, but right now we can't do that so instead it copies to clipboard.

- **Automatically Runnable**: Safe enough to run automatically. Either comes from a blessed package like rlang, or the user has attached the package in question and it passed our regex check. This uses `RRuntime`'s `execute()` method to fire off the code. Note that there is a bug in the Console that prevents code being fired in this manner from showing up in the Console history immediately.


https://github.com/posit-dev/positron/assets/19150088/8dcf89d8-3ccc-4591-bdb5-fd3984cf913e

