### PR TITLE
Test hyperlink regex

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -51,6 +51,11 @@ const extensions = [
 		label: 'positron-code-cells',
 		workspaceFolder: path.join(os.tmpdir(), `positron-code-cells-${Math.floor(Math.random() * 100000)}`),
 		mocha: { timeout: 60_000 }
+	},
+	{
+		label: 'positron-r',
+		workspaceFolder: path.join(os.tmpdir(), `positron-r-${Math.floor(Math.random() * 100000)}`),
+		mocha: { timeout: 60_000 }
 	}
 	// --- End Positron ---
 ];

--- a/extensions/positron-r/src/hyperlink.ts
+++ b/extensions/positron-r/src/hyperlink.ts
@@ -64,7 +64,7 @@ function handleAutomaticallyRunnable(runtime: RRuntime, code: string) {
 	);
 }
 
-function matchRunnable(code: string): RegExpMatchArray | null {
+export function matchRunnable(code: string): RegExpMatchArray | null {
 	// Of the form `package::function(args)` where `args` can't contain `(`, `)`, or `;`.
 	// See https://cli.r-lib.org/reference/links.html#security-considerations.
 	const runnableRegExp = /^(?<package>\w+)::(?<function>\w+)[(][^();]*[)]$/;

--- a/extensions/positron-r/src/test/hyperlink.test.ts
+++ b/extensions/positron-r/src/test/hyperlink.test.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { matchRunnable } from '../hyperlink';
+
+suite('Hyperlink', () => {
+	test('Runnable R code regex enforces safety rules', async () => {
+		const matchSimple = matchRunnable("pkg::fun()");
+		assert.strictEqual(matchSimple?.groups?.package, "pkg");
+		assert.strictEqual(matchSimple?.groups?.function, "fun");
+
+		const matchArgs = matchRunnable("pkg::fun(1 + 1, 2:5)");
+		assert.strictEqual(matchArgs?.groups?.package, "pkg");
+		assert.strictEqual(matchArgs?.groups?.function, "fun");
+
+		const matchUnsafeInnerFunction = matchRunnable("pkg::fun(fun())");
+		assert.strictEqual(matchUnsafeInnerFunction, null);
+
+		const matchUnsafeSemicolon = matchRunnable("pkg::fun({1 + 2; 3 + 4})");
+		assert.strictEqual(matchUnsafeSemicolon, null);
+
+		const matchUnsafeTripleColon = matchRunnable("pkg:::fun()");
+		assert.strictEqual(matchUnsafeTripleColon, null);
+	});
+});

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -127,6 +127,12 @@ echo
 yarn test-extension -l positron-code-cells
 kill_app
 
+echo
+echo "### Positron R tests"
+echo
+yarn test-extension -l positron-r
+kill_app
+
 # --- End Positron ---
 
 # Tests standalone (CommonJS)


### PR DESCRIPTION
Merges into https://github.com/posit-dev/positron/pull/2007

Set up first positron-r tests using @seeM's great outline from here https://github.com/posit-dev/positron/pull/1893

```
yarn test-extension -l positron-r
```

does give me:

<img width="723" alt="Screenshot 2024-01-04 at 2 59 51 PM" src="https://github.com/posit-dev/positron/assets/19150088/a37c5c85-a2aa-4520-8501-ad700a85d40f">
