### PR TITLE
Provide API for getting console width; use to set current width in R

### DIFF
--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import * as positron from 'positron';
@@ -479,11 +479,31 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 	private onStateChange(state: positron.RuntimeState): void {
 		this._state = state;
 		if (state === positron.RuntimeState.Ready) {
+			// Start the LSP and DAP servers
 			this._queue.add(async () => {
 				const lsp = this.startLsp();
 				const dap = this.startDap();
 				await Promise.all([lsp, dap]);
 			});
+
+			this._queue.add(async () => {
+				try {
+					// Set the initial console width
+					const width = await positron.window.getConsoleWidth();
+					this.callMethod('setConsoleWidth', width);
+					this._kernel!.emitJupyterLog(`Set initial console width to ${width}`);
+				} catch (err) {
+					// Recoverable (we'll just use the default width); but log
+					// the error.
+					if (this._kernel) {
+						const runtimeError = err as positron.RuntimeMethodError;
+						this._kernel.emitJupyterLog(
+							`Error setting initial console width: ${runtimeError.message} ` +
+							`(${runtimeError.code})`);
+					}
+				}
+			});
+
 		} else if (state === positron.RuntimeState.Exited) {
 			if (this._lsp.state === LspState.running) {
 				this._queue.add(async () => {

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 declare module 'positron' {
@@ -967,6 +967,11 @@ declare module 'positron' {
 		 * console horizontally.
 		 */
 		export const onDidChangeConsoleWidth: vscode.Event<number>;
+
+		/**
+		 * Returns the current width of the console, in characters.
+		 */
+		export function getConsoleWidth(): Thenable<number>;
 	}
 
 	namespace runtime {

--- a/src/vs/workbench/api/browser/positron/mainThreadConsole.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadConsole.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import { DisposableStore } from 'vs/base/common/lifecycle';
@@ -28,6 +28,10 @@ export class MainThreadConsole implements MainThreadConsoleShape {
 			this._positronConsoleService.onDidChangeConsoleWidth((newWidth) => {
 				this._proxy.$onDidChangeConsoleWidth(newWidth);
 			}));
+	}
+
+	$getConsoleWidth(): Promise<number> {
+		return Promise.resolve(this._positronConsoleService.getConsoleWidth());
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import { ExtHostLanguageRuntime } from 'vs/workbench/api/common/positron/extHostLanguageRuntime';
@@ -111,6 +111,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			get onDidChangeConsoleWidth() {
 				return extHostConsole.onDidChangeConsoleWidth;
 			},
+			getConsoleWidth(): Thenable<number> {
+				return extHostConsole.getConsoleWidth();
+			}
 		};
 
 		const languages: typeof positron.languages = {

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import { IDisposable } from 'vs/base/common/lifecycle';
@@ -55,7 +55,9 @@ export interface ExtHostConsoleShape {
 	$onDidChangeConsoleWidth(newWidth: number): void;
 }
 
-export interface MainThreadConsoleShape { }
+export interface MainThreadConsoleShape {
+	$getConsoleWidth(): Promise<number>;
+}
 
 /**
  * The view state of a preview in the Preview panel. Only one preview can be

--- a/src/vs/workbench/api/common/positron/extHostConsole.ts
+++ b/src/vs/workbench/api/common/positron/extHostConsole.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter } from 'vs/base/common/event';
@@ -9,12 +9,24 @@ export class ExtHostConsole implements extHostProtocol.ExtHostConsoleShape {
 
 	private readonly _onDidChangeConsoleWidth = new Emitter<number>();
 
+	private readonly _proxy: extHostProtocol.MainThreadConsoleShape;
+
 	constructor(
 		mainContext: extHostProtocol.IMainPositronContext
 	) {
+		this._proxy = mainContext.getProxy(extHostProtocol.MainPositronContext.MainThreadConsole);
 	}
 
 	onDidChangeConsoleWidth = this._onDidChangeConsoleWidth.event;
+
+	/**
+	 * Queries the main thread for the current width of the console.
+	 *
+	 * @returns The width of the console in characters.
+	 */
+	getConsoleWidth(): Promise<number> {
+		return this._proxy.$getConsoleWidth();
+	}
 
 	// Called by the main thread when the console width changes; fires the
 	// onDidChangeConsoleWidth event to any extensions that are listening.

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from 'vs/base/common/event';
@@ -73,6 +73,11 @@ export interface IPositronConsoleService {
 	 * Placeholder that gets called to "initialize" the PositronConsoleService.
 	 */
 	initialize(): void;
+
+	/**
+	 * Gets the current console width, in characters.
+	 */
+	getConsoleWidth(): number;
 
 	/**
 	 * Executes code in a PositronConsoleInstance.
@@ -199,6 +204,11 @@ export interface IPositronConsoleInstance {
 	 * onDidChangeWidth event if the width has changed.
 	 */
 	setWidthPx(newWidth: number): void;
+
+	/**
+	 * Gets the current width of the console, in pixels.
+	 */
+	getWidthPx(): number;
 
 	/**
 	 * Returns the active text editor widget for the console, if it exists.


### PR DESCRIPTION
This change addresses most of #1973. It adds a new API that can be used to retrieve the width of the current console instance, and uses it in the R extension to set the initial width of the console.

<img width="518" alt="image" src="https://github.com/posit-dev/positron/assets/470418/0a678b1d-d7a1-4922-8251-784e393dfb72">
