### PR TITLE
Commenting out nightly Browser Integration Tests until investigation into failures.

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -77,9 +77,9 @@ jobs:
         timeout-minutes: 15
         run: DISPLAY=:10 ./scripts/test-remote-integration.sh
 
-      - name: Run Integration Tests (Browser, Chromium)
-        id: browser-integration-tests
-        run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
+#      - name: Run Integration Tests (Browser, Chromium)
+#        id: browser-integration-tests
+#        run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
 
       - name: Run Smoke Tests (Electron)
         id: electron-smoke-tests


### PR DESCRIPTION
The Browser Integration tests are failing so I'm going to skip them for now so nightly runs can continue. Will investigate failures to see if we can turn these back on.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of why we are making the proposed changes and
* how best to test them.
-->
