### PR TITLE
Update precommit hook filters to ignore files in scripts/positron

### DIFF
--- a/build/filters.js
+++ b/build/filters.js
@@ -67,6 +67,7 @@ module.exports.unicodeFilter = [
 
 	// --- Start Positron ---
 	'!**/amalthea/**/*',
+	'!scripts/positron/**/*',
 	// --- End Positron ---
 ];
 
@@ -150,7 +151,8 @@ module.exports.indentationFilter = [
 
 	// --- Start Positron ---
 	'!**/amalthea/**/*',
-	'!extensions/positron-r/resources/scripts/*.R'
+	'!extensions/positron-r/resources/scripts/*.R',
+	'!scripts/positron/**/*',
 	// --- End Positron ---
 ];
 


### PR DESCRIPTION
for @wesm -- updating our filters so the precommit hook doesn't complain about files in scripts/positron. We could have it ignore python files only, but I think it's probably fine to just ignore any files in this folder (which once @wesm merges will just be the data tool generate example script for now)