### PR TITLE
Add he.js dependency to remote web package; fixes boot issue on Positron Web

### DIFF
--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -1,30 +1,32 @@
 {
-	"name": "vscode-web",
-	"version": "0.0.0",
-	"private": true,
-	"dependencies": {
-		"@microsoft/1ds-core-js": "^3.2.13",
-		"@microsoft/1ds-post-js": "^3.2.13",
-		"@vscode/iconv-lite-umd": "0.7.0",
-		"@vscode/vscode-languagedetection": "1.0.21",
-		"@xterm/addon-canvas": "0.6.0-beta.14",
-		"@xterm/addon-image": "0.7.0-beta.12",
-		"@xterm/addon-search": "0.14.0-beta.14",
-		"@xterm/addon-serialize": "0.12.0-beta.14",
-		"@xterm/addon-unicode11": "0.7.0-beta.14",
-		"@xterm/addon-webgl": "0.17.0-beta.14",
-		"@xterm/xterm": "5.4.0-beta.14",
-		"jschardet": "3.0.0",
+  "name": "vscode-web",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@microsoft/1ds-core-js": "^3.2.13",
+    "@microsoft/1ds-post-js": "^3.2.13",
+    "@vscode/iconv-lite-umd": "0.7.0",
+    "@vscode/vscode-languagedetection": "1.0.21",
+    "@xterm/addon-canvas": "0.6.0-beta.14",
+    "@xterm/addon-image": "0.7.0-beta.12",
+    "@xterm/addon-search": "0.14.0-beta.14",
+    "@xterm/addon-serialize": "0.12.0-beta.14",
+    "@xterm/addon-unicode11": "0.7.0-beta.14",
+    "@xterm/addon-webgl": "0.17.0-beta.14",
+    "@xterm/xterm": "5.4.0-beta.14",
+    "jschardet": "3.0.0",
+    "he": "^1.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-window": "^1.8.8",
-		"tas-client-umd": "0.1.8",
-		"vscode-oniguruma": "1.7.0",
-		"vscode-textmate": "9.0.0"
-	},
+    "tas-client-umd": "0.1.8",
+    "vscode-oniguruma": "1.7.0",
+    "vscode-textmate": "9.0.0"
+  },
   "customEntryPoints": {
     "react": "umd/react.production.min.js",
     "react-dom": "umd/react-dom.production.min.js",
-    "react-window": "dist/index-prod.umd.js"
-   }
+    "react-window": "dist/index-prod.umd.js",
+    "he": "he.js"
+  }
 }

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -90,6 +90,11 @@
   resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-5.4.0-beta.14.tgz#fa0902f457fe799c65dec6ff784538a087f611d9"
   integrity sha512-69E++VxeLPxBRhR3EGpkDe3R+EhpEZILo0m6TcN+atC4Zm5+WgcqXBCrBhkvpnBA2AhZp51w+hLC/OCwaHE0rg==
 
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/1401.

The issue is pretty simple; we didn't have `he.js` available in the remote web version of Positron, so it didn't boot when that dependency was referenced in our `htmlParser`. 

The code formatter reformatted `package.json` so the change looks larger than it is. 