### PR TITLE
Fortify R installation discovery on Windows

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -519,7 +519,8 @@
     "p-queue": "^6.6.2",
     "split2": "^4.2.0",
     "vscode-languageclient": "^9.0.1",
-    "web-tree-sitter": "^0.20.8"
+    "web-tree-sitter": "^0.20.8",
+    "winreg": "^1.2.5"
   },
   "repository": {
     "type": "git",

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -320,13 +320,16 @@ async function findCurrentRBinary(): Promise<string | undefined> {
 			// In the rig scenario, `whichR` is anticipated to be a batch file that launches the
 			// current version of R ('default' in rig-speak):
 			// Example filepath: C:\Program Files\R\bin\R.bat
-			// Example contents of this file:
+			// Typical contents of this file:
 			// ::4.3.2
 			// @"C:\Program Files\R\R-4.3.2\bin\R" %*
+			// How it looks when r-devel is current:
+			// ::devel
+			// @"C:\Program Files\R\R-devel\bin\R" %*
 			// Note that this binary is not our preferred one, i.e. \bin\x64\R.exe, but it is usable
 			if (path.extname(whichR).toLowerCase() === '.bat') {
 				const batLines = readLines(whichR);
-				const re = new RegExp(`^@"(.+R-[0-9]+[.][0-9]+[.][0-9]+.+)" %[*]$`);
+				const re = new RegExp(`^@"(.+R-(devel|[0-9]+[.][0-9]+[.][0-9]+).+)" %[*]$`);
 				const match = batLines.find((x: string) => re.test(x))?.match(re);
 				if (match) {
 					let whichRResolved = match[1];

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -386,6 +386,8 @@ async function getRegistryInstallPath(hive: string): Promise<string | undefined>
 			key: '\\Software\\R-Core\\R64',
 		});
 
+		Logger.info(`Checking for 'InstallPath' in registry key ${key.key} for hive ${key.hive}`);
+
 		const result = await new Promise<{ value: string }>((resolve, reject) => {
 			key.get('InstallPath', (error, result) => {
 				if (error) {
@@ -397,12 +399,13 @@ async function getRegistryInstallPath(hive: string): Promise<string | undefined>
 		});
 
 		if (!result || typeof result.value !== 'string') {
+			Logger.info(`Invalid value of 'InstallPath'`);
 			return undefined;
 		}
 
 		return result.value;
-	} catch (error) {
-		Logger.error('Error in getRegistryInstallPath():', error);
+	} catch (error: any) {
+		Logger.info(`Unable to get value of 'InstallPath': ${error.message}`);
 		return undefined;
 	}
 }

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -332,13 +332,21 @@ async function findCurrentRBinary(): Promise<string | undefined> {
 				const re = new RegExp(`^@"(.+R-(devel|[0-9]+[.][0-9]+[.][0-9]+).+)" %[*]$`);
 				const match = batLines.find((x: string) => re.test(x))?.match(re);
 				if (match) {
-					let whichRResolved = match[1];
-					// add the extension .exe if it's not already there
-					if (path.extname(whichRResolved).toLowerCase() !== '.exe') {
-						whichRResolved += '.exe';
+					const whichRMatched = match[1];
+					const whichRHome = getRHomePath(whichRMatched);
+					if (!whichRHome) {
+						Logger.info(`Failed to get R home path from ${whichRMatched}`);
+						return undefined;
 					}
-					Logger.info(`Resolved R binary at ${whichRResolved}`);
-					return (whichRResolved);
+					// we prefer the x64 binary
+					const whichRResolved = firstExisting(whichRHome, binFragments());
+					if (whichRResolved) {
+						Logger.info(`Resolved R binary at ${whichRResolved}`);
+						return whichRResolved;
+					} else {
+						Logger.info(`Can\'t find R binary within ${whichRHome}`);
+						return undefined;
+					}
 				}
 			}
 			// TODO: handle the case where whichR isn't picking up the rig case; do people do this,

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -254,7 +254,7 @@ function rHeadquarters(): string {
 		case 'linux':
 			return path.join('/opt', 'R');
 		case 'win32':
-			return path.join('C:\\', 'Program Files', 'R');
+			return path.join(process.env['PROGRAMFILES'] || 'C:\\Program Files', 'R');
 		default:
 			throw new Error('Unsupported platform');
 	}

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -240,8 +240,10 @@ function rHeadquarters(): string[] {
 			return [path.join('/opt', 'R')];
 		case 'win32': {
 			const paths = [
-				path.join(process.env['ProgramW6432'] || 'C:\\Program Files', 'R'),
-				path.join(process.env['PROGRAMFILES'] || 'C:\\Program Files', 'R')
+				// @kevinushey likes to install R here because it does not require administrator
+				// privileges to access
+				'C:\\R',
+				path.join(process.env['ProgramW6432'] || 'C:\\Program Files', 'R')
 			];
 			if (process.env['LOCALAPPDATA']) {
 				paths.push(path.join(process.env['LOCALAPPDATA'], 'Programs', 'R'));

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -328,7 +328,7 @@ async function findCurrentRBinary(): Promise<string | undefined> {
 			// How it looks when r-devel is current:
 			// ::devel
 			// @"C:\Program Files\R\R-devel\bin\R" %*
-			// Note that this binary is not our preferred one, i.e. \bin\x64\R.exe, but it is usable
+			// Note that this is not our preferred x64 binary, so we try to convert it.
 			if (path.extname(whichR).toLowerCase() === '.bat') {
 				const batLines = readLines(whichR);
 				const re = new RegExp(`^@"(.+R-(devel|[0-9]+[.][0-9]+[.][0-9]+).+)" %[*]$`);

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -307,9 +307,11 @@ function binFragments(): string[] {
 }
 
 async function findCurrentRBinary(): Promise<string | undefined> {
-	const registryBinary = findCurrentRBinaryFromRegistry();
-	if (registryBinary) {
-		return registryBinary;
+	if (os.platform() === 'win32') {
+		const registryBinary = findCurrentRBinaryFromRegistry();
+		if (registryBinary) {
+			return registryBinary;
+		}
 	}
 
 	const whichR = await which('R', { nothrow: true }) as string;

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -142,6 +142,8 @@ export async function* rRuntimeDiscoverer(
 		}
 	}
 
+	// TODO: on Windows, check the registry for R installations
+
 	binaries.forEach((b: string) => {
 		rInstallations.push(new RInstallation(b));
 	});
@@ -290,6 +292,9 @@ function binFragment(version: string): string {
 			return path.join(version, 'bin', 'R');
 		case 'win32':
 			return path.join(version, 'bin', 'R.exe');
+		// TODO: I gather it is possible for a Windows installations to only have binaries in the
+		// subfolder, like this:
+		// C:\Program Files\R\R-4.3.2\bin\x64\R.exe
 		default:
 			throw new Error('Unsupported platform');
 	}

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -2,7 +2,6 @@
  *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
-import * as os from 'os';
 import * as semver from 'semver';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -112,40 +111,53 @@ export class RInstallation {
 }
 
 export function getRHomePath(binPath: string): string | undefined {
-	if (os.platform() === 'win32') {
-		// find right-most 'bin' in the path and take everything to the left of it
-		// Example of two possible binPaths that are found in a single Windows installation:
-		// "C:\Program Files\R\R-4.3.2\bin\x64\R.exe"
-		// "C:\Program Files\R\R-4.2.3\bin\R.exe"
-		const binIndex = binPath.lastIndexOf(path.sep + 'bin' + path.sep);
-		if (binIndex === -1) {
-			Logger.info(`Can\'t determine R_HOME_DIR from the path to the R binary: ${binPath}`);
-			return undefined;
-		} else {
-			const pathUpToBin = binPath.substring(0, binIndex);
-			return pathUpToBin;
-		}
-	} else {
-		const binLines = readLines(binPath);
-		const re = new RegExp('Shell wrapper for R executable');
-		if (!binLines.some(x => re.test(x))) {
-			Logger.info('Binary is not a shell script wrapping the executable');
-			return undefined;
-		}
-		const targetLine = binLines.find(line => line.match('R_HOME_DIR'));
-		if (!targetLine) {
-			Logger.info('Can\'t determine R_HOME_DIR from the binary');
-			return undefined;
-		}
-		// macOS: R_HOME_DIR=/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
-		// macOS non-orthogonal: R_HOME_DIR=/Library/Frameworks/R.framework/Resources
-		// linux: R_HOME_DIR=/opt/R/4.2.3/lib/R
-		const R_HOME_DIR = extractValue(targetLine, 'R_HOME_DIR');
-		const homepath = R_HOME_DIR;
-		if (homepath === '') {
-			Logger.info('Can\'t determine R_HOME_DIR from the binary');
-			return undefined;
-		}
-		return homepath;
+	switch (process.platform) {
+		case 'darwin':
+		case 'linux':
+			return getRHomePathNotWindows(binPath);
+		case 'win32':
+			return getRHomePathWindows(binPath);
+		default:
+			throw new Error('Unsupported platform');
 	}
+}
+
+function getRHomePathNotWindows(binPath: string): string | undefined {
+	const binLines = readLines(binPath);
+	const re = new RegExp('Shell wrapper for R executable');
+	if (!binLines.some(x => re.test(x))) {
+		Logger.info('Binary is not a shell script wrapping the executable');
+		return undefined;
+	}
+	const targetLine = binLines.find(line => line.match('R_HOME_DIR'));
+	if (!targetLine) {
+		Logger.info('Can\'t determine R_HOME_DIR from the binary');
+		return undefined;
+	}
+	// macOS: R_HOME_DIR=/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
+	// macOS non-orthogonal: R_HOME_DIR=/Library/Frameworks/R.framework/Resources
+	// linux: R_HOME_DIR=/opt/R/4.2.3/lib/R
+	const R_HOME_DIR = extractValue(targetLine, 'R_HOME_DIR');
+	const homepath = R_HOME_DIR;
+	if (homepath === '') {
+		Logger.info('Can\'t determine R_HOME_DIR from the binary');
+		return undefined;
+	}
+	return homepath;
+}
+
+function getRHomePathWindows(binPath: string): string | undefined {
+	// find right-most 'bin' in the path and take everything to the left of it
+	// Examples of binPaths:
+	// "C:\Program Files\R\R-4.2.3\bin\R.exe"     <-- the path produced by our binFragment() helper
+	// "C:\Program Files\R\R-4.3.2\bin\x64\R.exe" <-- but this also exists
+	const binIndex = binPath.lastIndexOf(path.sep + 'bin' + path.sep);
+	if (binIndex === -1) {
+		Logger.info(`Can\'t determine R_HOME_DIR from the path to the R binary: ${binPath}`);
+		return undefined;
+	} else {
+		const pathUpToBin = binPath.substring(0, binIndex);
+		return pathUpToBin;
+	}
+
 }

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -149,7 +149,7 @@ function getRHomePathNotWindows(binPath: string): string | undefined {
 function getRHomePathWindows(binPath: string): string | undefined {
 	// find right-most 'bin' in the path and take everything to the left of it
 	// Examples of binPaths:
-	// "C:\Program Files\R\R-4.2.3\bin\R.exe"     <-- the path produced by our binFragment() helper
+	// "C:\Program Files\R\R-4.3.2\bin\R.exe"     <-- the path produced by our binFragment() helper
 	// "C:\Program Files\R\R-4.3.2\bin\x64\R.exe" <-- but this also exists
 	const binIndex = binPath.lastIndexOf(path.sep + 'bin' + path.sep);
 	if (binIndex === -1) {

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -126,12 +126,12 @@ function getRHomePathNotWindows(binPath: string): string | undefined {
 	const binLines = readLines(binPath);
 	const re = new RegExp('Shell wrapper for R executable');
 	if (!binLines.some(x => re.test(x))) {
-		Logger.info('Binary is not a shell script wrapping the executable');
+		Logger.info(`Binary is not a shell script wrapping the executable: ${binPath}`);
 		return undefined;
 	}
 	const targetLine = binLines.find(line => line.match('R_HOME_DIR'));
 	if (!targetLine) {
-		Logger.info('Can\'t determine R_HOME_DIR from the binary');
+		Logger.info(`Can\'t determine R_HOME_DIR from the binary: ${binPath}`);
 		return undefined;
 	}
 	// macOS: R_HOME_DIR=/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
@@ -140,7 +140,7 @@ function getRHomePathNotWindows(binPath: string): string | undefined {
 	const R_HOME_DIR = extractValue(targetLine, 'R_HOME_DIR');
 	const homepath = R_HOME_DIR;
 	if (homepath === '') {
-		Logger.info('Can\'t determine R_HOME_DIR from the binary');
+		Logger.info(`Can\'t determine R_HOME_DIR from the binary: ${binPath}`);
 		return undefined;
 	}
 	return homepath;

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -113,8 +113,18 @@ export class RInstallation {
 
 export function getRHomePath(binPath: string): string | undefined {
 	if (os.platform() === 'win32') {
-		// TODO: Windows - do we want something more robust here?
-		return path.join(binPath, '..', '..');
+		// find right-most 'bin' in the path and take everything to the left of it
+		// Example of two possible binPaths that are found in a single Windows installation:
+		// "C:\Program Files\R\R-4.3.2\bin\x64\R.exe"
+		// "C:\Program Files\R\R-4.2.3\bin\R.exe"
+		const binIndex = binPath.lastIndexOf(path.sep + 'bin' + path.sep);
+		if (binIndex === -1) {
+			Logger.info(`Can\'t determine R_HOME_DIR from the path to the R binary: ${binPath}`);
+			return undefined;
+		} else {
+			const pathUpToBin = binPath.substring(0, binIndex);
+			return pathUpToBin;
+		}
 	} else {
 		const binLines = readLines(binPath);
 		const re = new RegExp('Shell wrapper for R executable');

--- a/extensions/positron-r/yarn.lock
+++ b/extensions/positron-r/yarn.lock
@@ -2285,6 +2285,11 @@ which@2.0.2, which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
+winreg@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/winreg/-/winreg-1.2.5.tgz#b650383e89278952494b5d113ba049a5a4fa96d8"
+  integrity sha512-uf7tHf+tw0B1y+x+mKTLHkykBgK2KMs3g+KlzmyMbLvICSHQyB/xOFjTT8qZ3oeTFyU7Bbj4FzXitGG6jvKhYw==
+
 word-wrap@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.4.tgz#cb4b50ec9aca570abd1f52f33cd45b6c61739a9f"


### PR DESCRIPTION
Addresses #2393 

This PR raises our bar for discovering and prioritizing R installations on Windows, hopefully accounting for more scenarios we are going to see in the wild.

Highlights:

* Consults the registry when determining the current/default R version. This is the most official way of recording the current R version.
* `winreg` is a new dependency, so that we can read from the registry. This means everyone needs to `yarn` after we merge this PR.
* Lots of logic moved from being inline to going into helpers, to finesse the added complexity of having nontrivial "windows vs not-windows" branches.
* Explicit prioritization of `R_HOME/bin/x64/R.exe` as the binpath over `R_HOME/bin/R.exe`.
* If we don't learn the current version from the registry, but we find R on the `PATH` because of how rig works on Windows, we read that `.bat` file to learn the R version.
