### PR TITLE
Use display message from python kernel to determine when and what widgets to show

### DIFF
--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -3,10 +3,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from 'vs/base/common/lifecycle';
-import { ILanguageRuntimeService, ILanguageRuntime, RuntimeClientType, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageCommOpen, PositronOutputLocation, RuntimeOutputKind } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeService, ILanguageRuntime, RuntimeClientType, ILanguageRuntimeMessageOutput, PositronOutputLocation, RuntimeOutputKind } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { Emitter, Event } from 'vs/base/common/event';
 import { IPositronIPyWidgetsService, IPositronIPyWidgetMetadata, IPyWidgetHtmlData } from 'vs/workbench/services/positronIPyWidgets/common/positronIPyWidgetsService';
-import { IPyWidgetClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeIPyWidgetClient';
+import { IPyWidgetClientInstance, DisplayWidgetEvent } from 'vs/workbench/services/languageRuntime/common/languageRuntimeIPyWidgetClient';
 import { IPositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
 import { WidgetPlotClient } from 'vs/workbench/contrib/positronPlots/browser/widgetPlotClient';
 
@@ -32,9 +32,6 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 	/** The list of IPyWidgets. */
 	private readonly _widgets = new Map<string, IPyWidgetClientInstance>();
 
-	private readonly _primaryWidgets: Set<string> = new Set<string>();
-	private readonly _secondaryWidgets: Set<string> = new Set<string>();
-
 	/** The emitter for the onDidCreatePlot event */
 	private readonly _onDidCreatePlot = new Emitter<WidgetPlotClient>();
 
@@ -51,20 +48,20 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 		}));
 	}
 
-	private registerIPyWidgetClient(widgetClient: IPyWidgetClientInstance) {
+	private registerIPyWidgetClient(widgetClient: IPyWidgetClientInstance, runtime: ILanguageRuntime) {
 
 		// Add to our list of widgets
 		this._widgets.set(widgetClient.id, widgetClient);
 
-		// Update the list of primary widgets whenever a new widget comes in
-		this.updatePrimaryWidgets(widgetClient);
+		// Raise the plot if it's updated by the runtime
+		widgetClient.onDidEmitDisplay((event) => {
+			this.handleDisplayEvent(event, runtime);
+		});
 
 		// Listen for the widget client to be disposed (i.e. by the plots service via the
 		// widgetPlotClient) and make sure to remove it fully from the widget service
 		widgetClient.onDidDispose(() => {
 			this._widgets.delete(widgetClient.id);
-			this._primaryWidgets.delete(widgetClient.id);
-			this._secondaryWidgets.delete(widgetClient.id);
 		});
 
 		this._register(widgetClient);
@@ -88,7 +85,7 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 			});
 
 			widgetClients.forEach((client) => {
-				this.registerIPyWidgetClient(client);
+				this.registerIPyWidgetClient(client, runtime);
 			});
 		});
 
@@ -118,49 +115,22 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 
 				// Register the widget client and update the list of primary widgets
 				const widgetClient = new IPyWidgetClientInstance(event.client, metadata);
-				this.registerIPyWidgetClient(widgetClient);
-
-				// TODO: instead of creating the webview on widget creation/comm_open,
-				// we plan to listen for a new message type from the kernel that indicates
-				// that the widget is ready to be displayed (because the user has requested it)
-				// Once that's available, we will remove this call to createWebview here
-				this.createWebviewWidgets(runtime, event.message);
+				this.registerIPyWidgetClient(widgetClient, runtime);
 			}
 		}));
 	}
 
-	private updatePrimaryWidgets(latestWidget: IPyWidgetClientInstance): void {
-		// TODO: We plan to offload this logic to the Python language runtime, so the
-		// frontend doesn't need to make poor inferences about which widget(s) the user
-		// explicitly requested to view
+	private async handleDisplayEvent(event: DisplayWidgetEvent, runtime: ILanguageRuntime) {
+		const primaryWidgets = event.view_ids;
 
-		// A widget is primary if no other widgets are dependent on it,
-		// and they are "viewable" (i.e. they have both a layout and dom_classes property)
-		latestWidget.dependencies.forEach(dependency => {
-			// If the widget has a dependency, add it to the secondary list and remove from the primary list
-			this._secondaryWidgets.add(dependency);
-			this._primaryWidgets.delete(dependency);
-		});
-		if (latestWidget.isViewable() && !this._secondaryWidgets.has(latestWidget.id)) {
-			this._primaryWidgets.add(latestWidget.id);
-		}
-	}
-
-	private async createWebviewWidgets(runtime: ILanguageRuntime, message: ILanguageRuntimeMessageCommOpen) {
-		const latestWidgetId = message.comm_id;
-
-		if (!this._primaryWidgets.has(latestWidgetId)) {
-			return;
-		}
 		// Combine our existing list of widgets into a single WidgetPlotClient
 		const htmlData = new IPyWidgetHtmlData(this.positronWidgetInstances);
 
-		this._primaryWidgets.forEach(widgetId => {
+		primaryWidgets.forEach(widgetId => {
 			htmlData.addWidgetView(widgetId);
 		});
 
 		const widgetMessage = {
-			...message,
 			output_location: PositronOutputLocation.Plot,
 			kind: RuntimeOutputKind.IPyWidget,
 			data: htmlData.data,
@@ -169,7 +139,7 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 		const webview = await this._notebookOutputWebviewService.createNotebookOutputWebview(
 			runtime, widgetMessage);
 		if (webview) {
-			const widgetViewIds = Array.from(this._primaryWidgets);
+			const widgetViewIds = Array.from(primaryWidgets);
 			const managedWidgets = widgetViewIds.flatMap((widgetId: string) => {
 				const widget = this._widgets.get(widgetId)!;
 				const dependentWidgets = widget.dependencies.map((dependentWidgetId: string) => {

--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -5,6 +5,7 @@
 import { Disposable } from 'vs/base/common/lifecycle';
 import { ILanguageRuntimeService, ILanguageRuntime, RuntimeClientType, ILanguageRuntimeMessageOutput, PositronOutputLocation, RuntimeOutputKind } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { Emitter, Event } from 'vs/base/common/event';
+import { generateUuid } from 'vs/base/common/uuid';
 import { IPositronIPyWidgetsService, IPositronIPyWidgetMetadata, IPyWidgetHtmlData } from 'vs/workbench/services/positronIPyWidgets/common/positronIPyWidgetsService';
 import { IPyWidgetClientInstance, DisplayWidgetEvent } from 'vs/workbench/services/languageRuntime/common/languageRuntimeIPyWidgetClient';
 import { IPositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
@@ -49,7 +50,6 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 	}
 
 	private registerIPyWidgetClient(widgetClient: IPyWidgetClientInstance, runtime: ILanguageRuntime) {
-
 		// Add to our list of widgets
 		this._widgets.set(widgetClient.id, widgetClient);
 
@@ -130,7 +130,14 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 			htmlData.addWidgetView(widgetId);
 		});
 
+		// None of these fields get used except for data, so we generate a random id and provide
+		// placeholders for the rest
 		const widgetMessage = {
+			id: generateUuid(),
+			type: 'output',
+			event_clock: 0,
+			parent_id: '',
+			when: '',
 			output_location: PositronOutputLocation.Plot,
 			kind: RuntimeOutputKind.IPyWidget,
 			data: htmlData.data,

--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -130,14 +130,14 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 			htmlData.addWidgetView(widgetId);
 		});
 
-		// None of these fields get used except for data, so we generate a random id and provide
-		// placeholders for the rest
+		// None of these required fields get used except for data, so we generate a random id and
+		// provide reasonable placeholders for the rest
 		const widgetMessage = {
 			id: generateUuid(),
 			type: 'output',
 			event_clock: 0,
 			parent_id: '',
-			when: '',
+			when: new Date().toISOString(),
 			output_location: PositronOutputLocation.Plot,
 			kind: RuntimeOutputKind.IPyWidget,
 			data: htmlData.data,

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -302,7 +302,7 @@ window.onload = function() {
 	 *
 	 * @param id The ID of the notebook output
 	 * @param runtime The runtime that emitted the output
-	 * @param html The HTML to render
+	 * @param data A set of records containing the widget state and view mimetype data
 	 *
 	 * @returns A promise that resolves to the new webview.
 	 */

--- a/src/vs/workbench/contrib/positronPlots/browser/widgetPlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/widgetPlotClient.ts
@@ -18,17 +18,14 @@ export class WidgetPlotClient extends WebviewPlotClient {
 	 *
 	 * @param webview The webview to wrap.
 	 * @param message The output message from which the webview was created.
-	 * @param code The code that generated the webview (if known)
 	 */
 	constructor(webview: INotebookOutputWebview,
 		message: ILanguageRuntimeMessageOutput,
-		private readonly _widgets: IPyWidgetClientInstance[],) {
+		// @ts-ignore: unused parameter
+		private readonly _widgets: IPyWidgetClientInstance[]) {
 		super(webview, message);
 
-		// Register all widgets with the plot client, so all widgets are disposed
-		// when the plot is disposed/removed.
-		this._widgets.forEach(widget => {
-			this._register(widget);
-		});
+		// Don't register the widget to the plot client, since it's possible and valid for a widget
+		// to outlive a plot client, or even to be shared by multiple plot clients.
 	}
 }

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeIPyWidgetClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeIPyWidgetClient.ts
@@ -8,7 +8,7 @@ import { IRuntimeClientInstance, RuntimeClientState } from 'vs/workbench/service
 import { IPositronIPyWidgetClient, IPositronIPyWidgetMetadata } from 'vs/workbench/services/positronIPyWidgets/common/positronIPyWidgetsService';
 
 /**
- * The possible types of messages that can be sent to the language runtime from the widget frontend.
+ * The possible types of messages that can be sent from the widget frontend to the language runtime.
  * These are defined by ipywidgets (protocol version 2), we just inherit them.
  * https://github.com/jupyter-widgets/ipywidgets/blob/52663ac472c38ba12575dfb4979fa2d250e79bc3/packages/schema/messages.md#state-synchronization-1
  */
@@ -23,42 +23,59 @@ export enum IPyWidgetClientMessageTypeInput {
 /**
  * The possible types of messages that can be sent from the language runtime to the widget frontend.
  * This does not include the comm_open message, which is handled separately.
- * These are defined by ipywidgets (protocol version 2), we just inherit them.
+ * These are defined by ipywidgets (protocol version 2), we just inherit them, with the exception of
+ * 'display', which is converted into a comm message from the 'display_data' IOpub-style message.
  * https://github.com/jupyter-widgets/ipywidgets/blob/52663ac472c38ba12575dfb4979fa2d250e79bc3/packages/schema/messages.md#state-synchronization-1
  */
 export enum IPyWidgetClientMessageTypeOutput {
 	/** When a widget's state changes in the kernel, notify the frontend */
 	Update = 'update',
+
+	/** When a kernel is ready to display the widget in the UI, notify the frontend */
+	Display = 'display',
 }
 
 /**
- * A message used to send data to the language runtime plot client.
+ * A message used to deliver data from the frontend to the backend.
  */
 export interface IPyWidgetClientMessageInput {
 	msg_type: IPyWidgetClientMessageTypeInput;
 }
 
 /**
- * A message used to receive data from the language runtime plot client.
+ * A message used to deliver data from the backend to the frontend.
  */
 export interface IPyWidgetClientMessageOutput {
 	msg_type: IPyWidgetClientMessageTypeOutput;
 }
 
+export interface DisplayWidgetEvent {
+	/** An array containing the IDs of widgets to be included in the view. */
+	view_ids: string[];
+}
+
+/**
+ * A message requesting a widget be displayed in the Plots pane.
+ */
+export interface IPyWidgetClientMessageDisplay
+	extends IPyWidgetClientMessageOutput, DisplayWidgetEvent {
+}
 
 /**
  * An IPyWidget client instance.
  */
 export class IPyWidgetClientInstance extends Disposable implements IPositronIPyWidgetClient {
 
-	/**
-	 * Event that fires when the widget is closed on the runtime side
-	 */
+	/** Event that fires when the widget is closed on the runtime side. */
 	private readonly _onDidClose = new Emitter<void>();
 	readonly onDidClose: Event<void> = this._onDidClose.event;
 
 	private readonly _onDidDispose = new Emitter<void>();
 	readonly onDidDispose: Event<void> = this._onDidDispose.event;
+
+	/** The emitter for runtime client events. */
+	private readonly _onDidEmitDisplay = this._register(new Emitter<DisplayWidgetEvent>());
+	readonly onDidEmitDisplay: Event<DisplayWidgetEvent>;
 
 	/** Creates the IPyWidget client instance */
 	constructor(
@@ -72,28 +89,24 @@ export class IPyWidgetClientInstance extends Disposable implements IPositronIPyW
 			}
 		});
 		this._register(this._client);
+
+		this._register(this._client.onDidReceiveData(data => this.handleData(data)));
+
+		this.onDidEmitDisplay = this._onDidEmitDisplay.event;
+		this.onDidClose = this._onDidClose.event;
 	}
 
 	/**
-	 * True if this widget has a `layout` property.
+	 * Handles data received from the backend.
+	 *
+	 * @param data Data received from the backend.
 	 */
-	private hasLayout(): boolean {
-		return 'layout' in this.state;
-	}
-
-	/**
-	 * True if this widget has a `_dom_classes` property.
-	 */
-	private hasDomClasses(): boolean {
-		return '_dom_classes' in this.state;
-	}
-
-	/**
-	 * True if this widget is possibly a viewable main widget.
-	 * At minimum, it must have a `layout` property and a `dom_classes` property.
-	 */
-	public isViewable(): boolean {
-		return this.hasLayout() && this.hasDomClasses();
+	private handleData(data: IPyWidgetClientMessageOutput): void {
+		switch (data.msg_type) {
+			case IPyWidgetClientMessageTypeOutput.Display:
+				this._onDidEmitDisplay.fire(data as IPyWidgetClientMessageDisplay);
+				break;
+		}
 	}
 
 	/**


### PR DESCRIPTION
This PR depends on the in-progress https://github.com/posit-dev/positron-python/pull/293 (I tested it with [this branch](https://github.com/posit-dev/positron-python/tree/widget-comm-updates-display) but the key piece is just the the python backend sends a `display` msg_type over an existing widget comm containing the `view_ids` of all widgets to be displayed).

We get to tear out all logic about what is a secondary and primary widget and just use this simple definition: a widget is primary if Python tells us so. And nothing gets displayed upon widget instantiation, widgets only get displayed upon calls to Ipython `display` that trigger our widget hook.

I also undid some of the logic in https://github.com/posit-dev/positron/pull/1946 that let us completely dispose of a widget client once the containing plot client was disposed of. That led to weird situations where a user displayed a widget, removed it from the plots pane, but the widget object still exists as a named variable in the variables pane, and when the user tries to display the widget object again, Positron can't, because it threw away the widget client (while the Python widget object itself still persists). **_Therefore I removed the bit where the display (widget plot client) owns the actual underlying widget itself._**
