### PR TITLE
New `startAffiliatedLanguageRuntimes()` method

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -80,7 +80,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	// The object that manages the runtimes affliated with workspaces.
 	private readonly _workspaceAffiliation: LanguageRuntimeWorkspaceAffiliation;
 
-	// The event emitter for the onDidChangeDisoveryPhase event.
+	// The event emitter for the onDidChangeDiscoveryPhase event.
 	private readonly _onDidChangeDiscoveryPhaseEmitter = this._register(new Emitter<LanguageRuntimeDiscoveryPhase>);
 
 	// The event emitter for the onDidRegisterRuntime event.
@@ -147,15 +147,6 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 		this._workspaceAffiliation =
 			new LanguageRuntimeWorkspaceAffiliation(this, this._storageService, this._logService);
 		this._register(this._workspaceAffiliation);
-		const languageIds = this._workspaceAffiliation.getAffiliatedRuntimeLanguageIds();
-		if (languageIds) {
-			this._register(this.onDidChangeDiscoveryPhase((phase) => {
-				// When we start discovering runtimes, start the affiliated runtime(s).
-				if (phase === LanguageRuntimeDiscoveryPhase.Discovering) {
-					languageIds?.map(languageId => this.startAffiliatedRuntime(languageId));
-				}
-			}));
-		}
 
 		// Register as an opener in the opener service.
 		this._openerService.registerOpener(this);
@@ -190,9 +181,9 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 				`A file with the language ID ${languageId} was opened.`);
 		}));
 
-		// Begin discovering language runtimes once all extensions have been
-		// registered.
+		// Begin registering/discovering language runtimes once all extensions have been started.
 		this._extensionService.whenAllExtensionHostsStarted().then(() => {
+			this.startAffiliatedLanguageRuntimes();
 			this._onDidChangeDiscoveryPhaseEmitter.fire(LanguageRuntimeDiscoveryPhase.Discovering);
 		});
 
@@ -352,9 +343,9 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	 * @returns A disposable that unregisters the runtime
 	 */
 	registerRuntime(runtime: ILanguageRuntime, startupBehavior: LanguageRuntimeStartupBehavior): IDisposable {
-		// If the runtime has already been registered, throw an error.
+		// If the runtime has already been registered, return early.
 		if (this._registeredRuntimesByRuntimeId.has(runtime.metadata.runtimeId)) {
-			throw new Error(`Language runtime ${formatLanguageRuntime(runtime)} has already been registered.`);
+			return toDisposable(() => { });
 		}
 
 		// Add the runtime to the registered runtimes.
@@ -561,6 +552,16 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 
 		// There are no registered runtimes for the language, throw an error.
 		throw new Error(`No language runtimes registered for language ID '${languageId}'.`);
+	}
+
+	/**
+	 * Starts all affiliated runtimes for the workspace.
+	 */
+	startAffiliatedLanguageRuntimes(): void {
+		const languageIds = this._workspaceAffiliation.getAffiliatedRuntimeLanguageIds();
+		if (languageIds) {
+			languageIds?.map(languageId => this.startAffiliatedRuntime(languageId));
+		}
 	}
 
 	/**
@@ -797,7 +798,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	}
 
 	/**
-	 * Starts any affiliated runtimes.
+	 * Starts an affiliated runtime for a single language.
 	 */
 	private startAffiliatedRuntime(languageId: string): void {
 		const affiliatedRuntimeMetadata =

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -438,7 +438,7 @@ export enum LanguageRuntimeStartupBehavior {
 
 export enum LanguageRuntimeDiscoveryPhase {
 	/**
-	 * We are waiting for extensions to register language runtime providers.
+	 * We are waiting for extensions to register language runtime discoverers.
 	 */
 	AwaitingExtensions = 'AwaitingExtensions',
 
@@ -721,6 +721,11 @@ export interface ILanguageRuntimeService {
 	 * @param languageId The language identifier.
 	 */
 	getPreferredRuntime(languageId: string): ILanguageRuntime;
+
+	/**
+	 * Start all affiliated runtimes for the workspace.
+	 */
+	startAffiliatedLanguageRuntimes(): void;
 
 	/**
 	 * Signal that discovery of language runtimes is complete.


### PR DESCRIPTION
Addresses #1067 with another small-ish, iterative change

This PR adds a new method for the `LanguageRuntimeService` that starts up any affiliated language runtimes, instead of trying to do this in the constructor. Organized like this, we can call this _from_ the `MainThreadLanguageRuntime` constructor like `this._languageRuntimeService.startAffiliatedLanguageRuntimes()` at the right time, i.e. ***after*** the `onDidRequestLanguageRuntime` listener gets created.

This PR does not actually move it over there yet, because we need to be able to start up an extension with a runtime provider request (which we don't do yet).