### PR TITLE
OpenRPC: Also emit non-object component type aliases for Python in code generator

### DIFF
--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -587,6 +587,21 @@ JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool,
 			continue;
 		}
 
+		// Create type aliases for all the shared types
+		if (source.components && source.components.schemas) {
+			for (const key of Object.keys(backend.components.schemas)) {
+				const schema = backend.components.schemas[key];
+				if (schema.type !== 'object') {
+					yield formatComment('# ', schema.description);
+					yield `${snakeCaseToSentenceCase(key)} = `;
+					yield deriveType(contracts, PythonTypeMap,
+						[schema.name ? schema.name : key],
+						schema);
+					yield '\n\n';
+				}
+			}
+		}
+
 		// Create enums for all enum types
 		yield* enumVisitor([], source, function* (context: Array<string>, values: Array<string>) {
 			yield '@enum.unique\n';


### PR DESCRIPTION
This just replicates the type aliases as with Rust and TypeScript (there is an instance of this being done in the DataTool comm)