### PR TITLE
force execution of code cells, even for invalid/incomplete code

### DIFF
--- a/extensions/positron-code-cells/src/cellManager.ts
+++ b/extensions/positron-code-cells/src/cellManager.ts
@@ -11,7 +11,7 @@ export interface ExecuteCode {
 }
 
 const defaultExecuteCode: ExecuteCode = async (language, code) => {
-	await positron.runtime.executeCode(language, code, false);
+	await positron.runtime.executeCode(language, code, false, true);
 };
 
 // Provides a set of commands for interacting with Jupyter-like cells in a vscode.TextEditor

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -999,12 +999,15 @@ declare module 'positron' {
 		 * @param languageId The language ID of the code snippet
 		 * @param code The code snippet to execute
 		 * @param focus Whether to focus the runtime's console
+		 * @param skipChecks Whether to bypass runtime code completeness checks. If true, the `code`
+		 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
 		 * @returns A Thenable that resolves with true if the code was sent to a
 		 *   runtime successfully, false otherwise.
 		 */
 		export function executeCode(languageId: string,
 			code: string,
-			focus: boolean): Thenable<boolean>;
+			focus: boolean,
+			skipChecks?: boolean): Thenable<boolean>;
 
 		/**
 		 * Register a language runtime discoverer with Positron.
@@ -1090,9 +1093,9 @@ declare module 'positron' {
 		 * Call a frontend method.
 		 *
 		 * `call()` is designed to be hooked up directly to an RPC mechanism. It takes
-                 * `method` and `params` arguments as defined by the UI frontend OpenRPC contract
-                 * and returns a JSON-RPC response. It never throws, all errors are returned as
-                 * JSON-RPC error responses.
+		 * `method` and `params` arguments as defined by the UI frontend OpenRPC contract
+		 * and returns a JSON-RPC response. It never throws, all errors are returned as
+		 * JSON-RPC error responses.
 		 *
 		 * @param method The method name.
 		 * @param params An object of named parameters for `method`.

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1036,8 +1036,8 @@ export class MainThreadLanguageRuntime implements MainThreadLanguageRuntimeShape
 		this._runtimes.delete(handle);
 	}
 
-	$executeCode(languageId: string, code: string, focus: boolean): Promise<boolean> {
-		return this._positronConsoleService.executeCode(languageId, code, focus);
+	$executeCode(languageId: string, code: string, focus: boolean, skipChecks?: boolean): Promise<boolean> {
+		return this._positronConsoleService.executeCode(languageId, code, focus, skipChecks);
 	}
 
 	public dispose(): void {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -68,8 +68,8 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 		// --- Start Positron ---
 		const runtime: typeof positron.runtime = {
-			executeCode(languageId, code, focus): Thenable<boolean> {
-				return extHostLanguageRuntime.executeCode(languageId, code, focus);
+			executeCode(languageId, code, focus, skipChecks): Thenable<boolean> {
+				return extHostLanguageRuntime.executeCode(languageId, code, focus, skipChecks);
 			},
 			registerLanguageRuntime(runtime: positron.LanguageRuntime): vscode.Disposable {
 				return extHostLanguageRuntime.registerLanguageRuntime(extension, runtime);

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -16,7 +16,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$restartLanguageRuntime(handle: number): Promise<void>;
 	$completeLanguageRuntimeDiscovery(): void;
 	$unregisterLanguageRuntime(handle: number): void;
-	$executeCode(languageId: string, code: string, focus: boolean): Promise<boolean>;
+	$executeCode(languageId: string, code: string, focus: boolean, skipChecks?: boolean): Promise<boolean>;
 	$getPreferredRuntime(languageId: string): Promise<ILanguageRuntimeMetadata>;
 	$getRunningRuntimes(languageId: string): Promise<ILanguageRuntimeMetadata[]>;
 	$emitLanguageRuntimeMessage(handle: number, message: ILanguageRuntimeMessage): void;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -416,8 +416,8 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		});
 	}
 
-	public executeCode(languageId: string, code: string, focus: boolean): Promise<boolean> {
-		return this._proxy.$executeCode(languageId, code, focus);
+	public executeCode(languageId: string, code: string, focus: boolean, skipChecks?: boolean): Promise<boolean> {
+		return this._proxy.$executeCode(languageId, code, focus, skipChecks);
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -84,9 +84,11 @@ export interface IPositronConsoleService {
 	 * @param languageId The language ID.
 	 * @param code The code.
 	 * @param focus A value which indicates whether to focus Positron console instance.
+	 * @param skipChecks Whether to bypass runtime code completeness checks. If true, the `code`
+	 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
 	 * @returns A value which indicates whether the code could be executed.
 	 */
-	executeCode(languageId: string, code: string, focus: boolean): Promise<boolean>;
+	executeCode(languageId: string, code: string, focus: boolean, skipChecks?: boolean): Promise<boolean>;
 }
 
 /**
@@ -248,8 +250,10 @@ export interface IPositronConsoleInstance {
 	/**
 	 * Enqueues code to be executed.
 	 * @param code The code to enqueue.
+	 * @param skipChecks Whether to bypass runtime code completeness checks. If true, the `code`
+	 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
 	 */
-	enqueueCode(code: string): Promise<void>;
+	enqueueCode(code: string, force: boolean): Promise<void>;
 
 	/**
 	 * Executes code.


### PR DESCRIPTION
This is achieved by adding a `force` argument to `positron.runtime.executeCode`. If true, we do not check with the runtime's `isCodeFragmentComplete` and instead immediately execute code.

Addresses #2009. See https://github.com/posit-dev/positron/issues/2009#issuecomment-1883317048 for my motivation for solving the issue by directly executing the code.

I'm not sure about the name `force`. It isn't very clear but I couldn't think of a better alternative. Maybe `skipIsCodeFragmentComplete` / `skipIsComplete` / `skipChecks` / something else?

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of why we are making the proposed changes and
* how best to test them.
-->
