### PR TITLE
Add handling for escape key in activity prompt

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
@@ -86,6 +86,17 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 				break;
 			}
 
+			// Escape key.
+			case 'Escape': {
+				// Consume the event.
+				consumeEvent();
+
+				// Update the prompt state and interrupt it.
+				props.activityItemPrompt.state = ActivityItemPromptState.Interrupted;
+				props.positronConsoleInstance.interruptPrompt(props.activityItemPrompt.id);
+				break;
+			}
+
 			// C key.
 			case 'c': {
 				// Handle Ctrl+C.
@@ -93,7 +104,7 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 					// Consume the event.
 					consumeEvent();
 
-					// Upate the prompt state and interrupt it.
+					// Update the prompt state and interrupt it.
 					props.activityItemPrompt.state = ActivityItemPromptState.Interrupted;
 					props.positronConsoleInstance.interruptPrompt(props.activityItemPrompt.id);
 				}


### PR DESCRIPTION
Addresses #1148 

This is now more consistent with canceling out of Positron console input, as well as more consistent with RStudio behavior.

I do _not_ believe we need to do anything else about checking for more modifiers in the activity prompt; it already does the right thing for <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>c</kbd> and similar, i.e. it does not treat that as if it were <kbd>ctrl</kbd>+<kbd>c</kbd>.