### PR TITLE
Python: add None default for optional dataclass fields when generating comm stubs

### DIFF
--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -750,6 +750,9 @@ JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool,
 					yield deriveType(contracts, PythonTypeMap, [prop, ...context], schema);
 				}
 				yield ' = field(\n';
+				if (!o.required || !o.required.includes(prop)) {
+					yield `        default=None,\n`;
+				}
 				yield `        metadata={\n`;
 				yield `            "description": "${schema.description}",\n`;
 				if (!o.required || !o.required.includes(prop)) {


### PR DESCRIPTION
This greatly improves the ergonomics of data classes that have optional fields (see, e.g. objects with few required fields in data_tool-backend-openrpc.json). For example, to be able to write:

```python
c = ColumnSchema(name='a', type_name='string')
```

as opposed to having to write out a bunch of None parameters for the optional ColumnSchema fields. 

The only downside of this is that there is some validation benefit to requiring a JSON key to be present (e.g. `"description": null`). This seems like an acceptable trade-off, though. 