### PR TITLE
Add dedicated RStudio keymap

### DIFF
--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -38,6 +38,7 @@ const compilations = [
 	'positron-javascript/tsconfig.json',
 	'positron-notebook-controllers/tsconfig.json',
 	'positron-r/tsconfig.json',
+	'positron-rstudio-keymap/tsconfig.json',
 	'positron-python/tsconfig.json',
 	'positron-proxy/tsconfig.json',
 	'positron-zed/tsconfig.json',

--- a/build/npm/dirs.js
+++ b/build/npm/dirs.js
@@ -18,6 +18,7 @@ const dirs = [
 	'extensions/positron-javascript',
 	'extensions/positron-notebook-controllers',
 	'extensions/positron-r',
+	'extensions/positron-rstudio-keymap',
 	'extensions/positron-python',
 	'extensions/positron-proxy',
 	'extensions/positron-zed',

--- a/extensions/positron-rstudio-keymap/LICENSE
+++ b/extensions/positron-rstudio-keymap/LICENSE
@@ -1,0 +1,2 @@
+
+Copyright (c) 2024, RStudio PBC. All rights reserved.

--- a/extensions/positron-rstudio-keymap/LICENSE
+++ b/extensions/positron-rstudio-keymap/LICENSE
@@ -1,2 +1,2 @@
 
-Copyright (c) 2024, RStudio PBC. All rights reserved.
+Copyright (c) 2024 Posit Software, PBC. All rights reserved.

--- a/extensions/positron-rstudio-keymap/extension.webpack.config.js
+++ b/extensions/positron-rstudio-keymap/extension.webpack.config.js
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+
+'use strict';
+
+const withDefaults = require('../shared.webpack.config');
+
+module.exports = withDefaults({
+	context: __dirname,
+	entry: {
+		extension: './src/extension.ts',
+	},
+	externals: {
+		'vscode': { commonjs: 'vscode' },
+	}
+});

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "positron-rstudio-keymap",
+  "displayName": "%displayName%",
+  "description": "%description%",
+  "version": "0.0.1",
+  "publisher": "vscode",
+  "license": "SEE LICENSE IN LICENSE.md",
+  "engines": {
+    "vscode": "^1.75.0"
+  },
+  "categories": [
+    "Keymaps"
+  ],
+  "keywords": [
+    "keymap",
+    "Importer",
+    "Settings",
+    "RStudio"
+  ],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "main": "./out/extension.js",
+  "extensionKind": [
+    "ui",
+    "workspace"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/posit-dev/positron.git"
+  },
+  "scripts": {
+    "vscode:prepublish": "yarn run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "pretest": "yarn run compile && yarn run lint",
+    "postinstall": "ts-node scripts/post-install.ts",
+    "lint": "eslint src --ext ts",
+    "test": "node ./out/test/runTest.js"
+  },
+  "contributes": {
+    "keybindings": [
+      {
+        "mac": "cmd+shift+n",
+        "win": "ctrl+shift+n",
+        "linux": "ctrl+shift+n",
+        "key": "ctrl+shift+n",
+        "command": "r.createNewFile"
+      }
+    ]
+  }
+}

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -136,6 +136,14 @@
         "key": "ctrl+shift+a",
         "when": "config.rstudio.keymap.enable && editorTextFocus",
         "command": "editor.action.formatSelection"
+      },
+      {
+        "mac": "cmd+d",
+        "win": "ctrl+d",
+        "linux": "ctrl+d",
+        "key": "ctrl+d",
+        "when": "config.rstudio.keymap.enable && editorTextFocus",
+        "command": "editor.action.deleteLines"
       }
     ]
   }

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -62,6 +62,13 @@
         "key": "ctrl+shift+c",
         "when": "editorTextFocus",
         "command": "editor.action.commentLine"
+      },
+      {
+        "mac": "ctrl+1",
+        "win": "ctrl+1",
+        "linux": "ctrl+1",
+        "key": "ctrl+1",
+        "command": "workbench.action.focusActiveEditorGroup"
       }
     ]
   }

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -39,12 +39,24 @@
     "test": "node ./out/test/runTest.js"
   },
   "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "%rstudio.keymap.configuration.title%",
+      "properties": {
+        "rstudio.keymap.enable": {
+          "type": "boolean",
+          "default": false,
+          "description": "%rstudio.keymap.enable.description%"
+        }
+      }
+    },
     "keybindings": [
       {
         "mac": "cmd+shift+n",
         "win": "ctrl+shift+n",
         "linux": "ctrl+shift+n",
         "key": "ctrl+shift+n",
+        "when": "config.rstudio.keymap.enable",
         "command": "r.createNewFile"
       },
       {
@@ -52,7 +64,7 @@
         "win": "F2",
         "linux": "F2",
         "key": "F2",
-        "when": "editorTextFocus",
+        "when": "config.rstudio.keymap.enable && editorTextFocus",
         "command": "editor.action.revealDefinition"
       },
       {
@@ -60,7 +72,7 @@
         "win": "ctrl+shift+c",
         "linux": "ctrl+shift+c",
         "key": "ctrl+shift+c",
-        "when": "editorTextFocus",
+        "when": "config.rstudio.keymap.enable && editorTextFocus",
         "command": "editor.action.commentLine"
       },
       {
@@ -68,6 +80,7 @@
         "win": "ctrl+1",
         "linux": "ctrl+1",
         "key": "ctrl+1",
+        "when": "config.rstudio.keymap.enable",
         "command": "workbench.action.focusActiveEditorGroup"
       }
     ]

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -46,6 +46,14 @@
         "linux": "ctrl+shift+n",
         "key": "ctrl+shift+n",
         "command": "r.createNewFile"
+      },
+      {
+        "mac": "F2",
+        "win": "F2",
+        "linux": "F2",
+        "key": "F2",
+        "when": "editorTextFocus",
+        "command": "editor.action.revealDefinition"
       }
     ]
   }

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -128,6 +128,14 @@
         "key": "ctrl+i",
         "when": "config.rstudio.keymap.enable && editorTextFocus",
         "command": "editor.action.reindentselectedlines"
+      },
+      {
+        "mac": "cmd+shift+a",
+        "win": "ctrl+shift+a",
+        "linux": "ctrl+shift+a",
+        "key": "ctrl+shift+a",
+        "when": "config.rstudio.keymap.enable && editorTextFocus",
+        "command": "editor.action.formatSelection"
       }
     ]
   }

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -82,6 +82,14 @@
         "key": "ctrl+1",
         "when": "config.rstudio.keymap.enable",
         "command": "workbench.action.focusActiveEditorGroup"
+      },
+      {
+        "mac": "ctrl+2",
+        "win": "ctrl+2",
+        "linux": "ctrl+2",
+        "key": "ctrl+2",
+        "when": "config.rstudio.keymap.enable",
+        "command": "workbench.action.positronConsole.focusConsole"
       }
     ]
   }

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -118,8 +118,16 @@
         "win": "ctrl+alt+i.",
         "linux": "ctrl+alt+i",
         "key": "ctrl+alt+i",
-        "when": "config.rstudio.keymap.enable",
+        "when": "config.rstudio.keymap.enable && editorTextFocus",
         "command": "quarto.insertCodeCell"
+      },
+      {
+        "mac": "cmd+i",
+        "win": "ctrl+i",
+        "linux": "ctrl+i",
+        "key": "ctrl+i",
+        "when": "config.rstudio.keymap.enable && editorTextFocus",
+        "command": "editor.action.reindentselectedlines"
       }
     ]
   }

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -104,6 +104,22 @@
         "key": "ctrl+.",
         "when": "config.rstudio.keymap.enable",
         "command": "workbench.action.showAllSymbols"
+      },
+      {
+        "mac": "shift+alt+k",
+        "win": "shift+alt+k",
+        "linux": "shift+alt+k",
+        "key": "shift+alt+k",
+        "when": "config.rstudio.keymap.enable",
+        "command": "workbench.action.openGlobalKeybindings"
+      },
+      {
+        "mac": "cmd+alt+i",
+        "win": "ctrl+alt+i.",
+        "linux": "ctrl+alt+i",
+        "key": "ctrl+alt+i",
+        "when": "config.rstudio.keymap.enable",
+        "command": "quarto.insertCodeCell"
       }
     ]
   }

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -34,9 +34,7 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "pretest": "yarn run compile && yarn run lint",
-    "postinstall": "ts-node scripts/post-install.ts",
-    "lint": "eslint src --ext ts",
-    "test": "node ./out/test/runTest.js"
+    "lint": "eslint src --ext ts"
   },
   "contributes": {
     "configuration": {

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -68,6 +68,14 @@
         "command": "editor.action.revealDefinition"
       },
       {
+        "mac": "cmd+option+shift+m",
+        "win": "ctrl+alt+shift+m",
+        "linux": "ctrl+alt+shift+m",
+        "key": "ctrl+alt+shift+m",
+        "when": "config.rstudio.keymap.enable && editorTextFocus",
+        "command": "editor.action.rename"
+      },
+      {
         "mac": "cmd+shift+c",
         "win": "ctrl+shift+c",
         "linux": "ctrl+shift+c",

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -54,6 +54,14 @@
         "key": "F2",
         "when": "editorTextFocus",
         "command": "editor.action.revealDefinition"
+      },
+      {
+        "mac": "cmd+shift+c",
+        "win": "ctrl+shift+c",
+        "linux": "ctrl+shift+c",
+        "key": "ctrl+shift+c",
+        "when": "editorTextFocus",
+        "command": "editor.action.commentLine"
       }
     ]
   }

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -90,6 +90,14 @@
         "key": "ctrl+2",
         "when": "config.rstudio.keymap.enable",
         "command": "workbench.action.positronConsole.focusConsole"
+      },
+      {
+        "mac": "cmd+.",
+        "win": "ctrl+.",
+        "linux": "ctrl+.",
+        "key": "ctrl+.",
+        "when": "config.rstudio.keymap.enable",
+        "command": "workbench.action.showAllSymbols"
       }
     ]
   }

--- a/extensions/positron-rstudio-keymap/package.nls.json
+++ b/extensions/positron-rstudio-keymap/package.nls.json
@@ -1,0 +1,4 @@
+{
+	"displayName": "RStudio Keymap",
+	"description": "RStudio keybindings for Positron"
+}

--- a/extensions/positron-rstudio-keymap/package.nls.json
+++ b/extensions/positron-rstudio-keymap/package.nls.json
@@ -1,4 +1,6 @@
 {
 	"displayName": "RStudio Keymap",
-	"description": "RStudio keybindings for Positron"
+	"description": "RStudio keybindings for Positron",
+	"rstudio.keymap.configuration.title": "RStudio Keymap",
+	"rstudio.keymap.enable.description": "Enable RStudio key mappings for Positron",
 }

--- a/extensions/positron-rstudio-keymap/src/extension.ts
+++ b/extensions/positron-rstudio-keymap/src/extension.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export function activate(_context: vscode.ExtensionContext) {
+}

--- a/extensions/positron-rstudio-keymap/tsconfig.json
+++ b/extensions/positron-rstudio-keymap/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./out",
+		"esModuleInterop": true,
+		"experimentalDecorators": true,
+		"types": [
+			"node"
+		]
+	},
+	"include": [
+		"src/**/*",
+		"../../src/vscode-dts/vscode.d.ts",
+		"../../src/positron-dts/positron.d.ts",
+	]
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -8,7 +8,7 @@ import { Codicon } from 'vs/base/common/codicons';
 import { ITextModel } from 'vs/editor/common/model';
 import { IEditor } from 'vs/editor/common/editorCommon';
 import { ILogService } from 'vs/platform/log/common/log';
-import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
+import { KeyChord, KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { Position } from 'vs/editor/common/core/position';
 import { IStatementRange } from 'vs/editor/common/languages';
 import { CancellationToken } from 'vs/base/common/cancellation';
@@ -35,7 +35,8 @@ import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/b
 const enum PositronConsoleCommandId {
 	ClearConsole = 'workbench.action.positronConsole.clearConsole',
 	ClearInputHistory = 'workbench.action.positronConsole.clearInputHistory',
-	ExecuteCode = 'workbench.action.positronConsole.executeCode'
+	ExecuteCode = 'workbench.action.positronConsole.executeCode',
+	FocusConsole = 'workbench.action.positronConsole.focusConsole'
 }
 
 /**
@@ -102,6 +103,43 @@ export function registerPositronConsoleActions() {
 					message: localize('positron.clearConsole.noActiveConsole', "Cannot clear console. A console is not active."),
 					sticky: false
 				});
+			}
+		}
+	});
+
+	/**
+	 * Register the focus console action. This action places focus in the active console,
+	 * if one exists.
+	 */
+	registerAction2(class extends Action2 {
+		/**
+		 * Constructor.
+		 */
+		constructor() {
+			super({
+				id: PositronConsoleCommandId.FocusConsole,
+				title: {
+					value: localize('workbench.action.positronConsole.focusConsole', "Focus Console"),
+					original: 'Focus Console'
+				},
+				f1: true,
+				keybinding: {
+					weight: KeybindingWeight.WorkbenchContrib,
+					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyF)
+				},
+				category,
+			});
+		}
+
+		/**
+		 * Runs action; places focus in the console's input control.
+		 *
+		 * @param accessor The services accessor.
+		 */
+		async run(accessor: ServicesAccessor) {
+			const positronConsoleService = accessor.get(IPositronConsoleService);
+			if (positronConsoleService.activePositronConsoleInstance) {
+				positronConsoleService.activePositronConsoleInstance.focusInput();
 			}
 		}
 	});


### PR DESCRIPTION
This change adds an RStudio keymap to Positron, and implements all of the keybindings that have been specifically requested by alpha users. Namely:

- <kbd>Ctrl</kbd> + <kbd>1</kbd> to focus Source
- <kbd>Ctrl</kbd> + <kbd>2</kbd> to focus Console
- <kbd>Cmd</kbd> + <kbd>.</kbd> to go to symbol
- <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd> to comment/uncomment a line
- <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>N</kbd> to create a new R file
- <kbd>F2</kbd> to go to definition
- <kbd>Cmd</kbd> + <kbd>I</kbd> to reindent selection
- <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>A</kbd> to reformat selection
- <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd> to insert a new Quarto/R Markdown cell
- <kbd>Cmd</kbd> + <kbd>D</kbd> to delete the current line

There are a lot more keybindings we'll probably end up adding, but these seem to be causing the most friction.

Note that most of the bindings mentioned in #669 are already implemented in the R extension; we felt it was okay to take most of these bindings when the user is editing an R package.

The keymaps are implemented in a new extension which is currently codeless, but will probably have code later so we can add custom RStudio-like logic for other keys/commands. As there is no way to see or disable built-in or bundled extensions, we gate all the extension's bindings on a setting that can be toggled here:

<img width="686" alt="image" src="https://github.com/posit-dev/positron/assets/470418/32d3d86f-d274-4a27-8d92-62bf24143645">

Turning on this setting activates the keybindings (no restart necessary!). 

Addresses https://github.com/posit-dev/positron/issues/669. 