### PR TITLE
Minor revisions to data tool openrpc contract to track positron-python work

### DIFF
--- a/positron/comms/data_tool-backend-openrpc.json
+++ b/positron/comms/data_tool-backend-openrpc.json
@@ -154,14 +154,6 @@
 			"description": "Requests a statistical summary or data profile for a column",
 			"params": [
 				{
-					"name": "profile_id",
-					"description": "Unique identifier for the requested profile",
-					"required": true,
-					"schema": {
-						"type": "string"
-					}
-				},
-				{
 					"name": "profile_type",
 					"description": "The type of analytical column profile",
 					"required": true,
@@ -174,11 +166,11 @@
 					}
 				},
 				{
-					"name": "column",
-					"description": "Column name to compute profile for",
+					"name": "column_index",
+					"description": "Column index to compute profile for",
 					"required": true,
 					"schema": {
-						"type": "string"
+						"type": "integer"
 					}
 				}
 			],
@@ -349,7 +341,7 @@
 				"required": [
 					"filter_id",
 					"filter_type",
-					"column"
+					"column_index"
 				],
 				"properties": {
 					"filter_id": {
@@ -367,15 +359,15 @@
 							"search"
 						]
 					},
-					"column": {
-						"type": "string",
-						"description": "Column name to compute profile for"
+					"column_index": {
+						"type": "integer",
+						"description": "Column index to apply filter to"
 					},
 					"compare_op": {
 						"type": "string",
 						"description": "String representation of a binary comparison",
 						"enum": [
-							"==",
+							"=",
 							"!=",
 							"<",
 							"<=",
@@ -445,13 +437,13 @@
 				"type": "object",
 				"description": "Specifies a column to sort by",
 				"required": [
-					"column",
+					"column_index",
 					"ascending"
 				],
 				"properties": {
-					"column": {
-						"type": "string",
-						"description": "Column name to sort by"
+					"column_index": {
+						"type": "integer",
+						"description": "Column index to sort by"
 					},
 					"ascending": {
 						"type": "boolean",

--- a/src/vs/workbench/services/languageRuntime/common/positronDataToolComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataToolComm.ts
@@ -196,9 +196,9 @@ export interface ColumnFilter {
 	filter_type: ColumnFilterFilterType;
 
 	/**
-	 * Column name to compute profile for
+	 * Column index to apply filter to
 	 */
-	column: string;
+	column_index: number;
 
 	/**
 	 * String representation of a binary comparison
@@ -264,9 +264,9 @@ export interface ColumnQuantileValue {
  */
 export interface ColumnSortKey {
 	/**
-	 * Column name to sort by
+	 * Column index to sort by
 	 */
-	column: string;
+	column_index: number;
 
 	/**
 	 * Sort order, ascending (true) or descending (false)
@@ -298,7 +298,7 @@ export enum ColumnFilterFilterType {
  * Possible values for CompareOp in ColumnFilter
  */
 export enum ColumnFilterCompareOp {
-	EqEq = '==',
+	Eq = '=',
 	NotEq = '!=',
 	Lt = '<',
 	LtEq = '<=',
@@ -387,14 +387,13 @@ export class PositronDataToolComm extends PositronBaseComm {
 	 *
 	 * Requests a statistical summary or data profile for a column
 	 *
-	 * @param profileId Unique identifier for the requested profile
 	 * @param profileType The type of analytical column profile
-	 * @param column Column name to compute profile for
+	 * @param columnIndex Column index to compute profile for
 	 *
 	 * @returns Result of computing column profile
 	 */
-	getColumnProfile(profileId: string, profileType: GetColumnProfileProfileType, column: string): Promise<ProfileResult> {
-		return super.performRpc('get_column_profile', ['profile_id', 'profile_type', 'column'], [profileId, profileType, column]);
+	getColumnProfile(profileType: GetColumnProfileProfileType, columnIndex: number): Promise<ProfileResult> {
+		return super.performRpc('get_column_profile', ['profile_type', 'column_index'], [profileType, columnIndex]);
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataTool/common/positronDataToolMocks.ts
+++ b/src/vs/workbench/services/positronDataTool/common/positronDataToolMocks.ts
@@ -119,42 +119,42 @@ export function getExampleFreqtable(): ProfileResult {
 
 // For filtering
 
-function _getFilterWithProps(columnName: string, filterType: ColumnFilterFilterType,
+function _getFilterWithProps(columnIndex: number, filterType: ColumnFilterFilterType,
 	props: Partial<ColumnFilter> = {}): ColumnFilter {
 	return {
 		filter_id: generateUuid(),
 		filter_type: filterType,
-		column: columnName,
+		column_index: columnIndex,
 		...props
 	} as ColumnFilter;
 }
 
-export function getCompareFilter(columnName: string, op: ColumnFilterCompareOp,
+export function getCompareFilter(columnIndex: number, op: ColumnFilterCompareOp,
 	value: string) {
-	return _getFilterWithProps(columnName, ColumnFilterFilterType.Compare, {
+	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.Compare, {
 		compare_op: op,
 		compare_value: value
 	});
 }
 
-export function getIsNullFilter(columnName: string) {
-	return _getFilterWithProps(columnName, ColumnFilterFilterType.Isnull);
+export function getIsNullFilter(columnIndex: number) {
+	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.Isnull);
 }
 
-export function getNotNullFilter(columnName: string) {
-	return _getFilterWithProps(columnName, ColumnFilterFilterType.Notnull);
+export function getNotNullFilter(columnIndex: number) {
+	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.Notnull);
 }
 
-export function getSetMemberFilter(columnName: string, values: string[], inclusive: boolean) {
-	return _getFilterWithProps(columnName, ColumnFilterFilterType.SetMembership, {
+export function getSetMemberFilter(columnIndex: number, values: string[], inclusive: boolean) {
+	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.SetMembership, {
 		set_member_values: values,
 		set_member_inclusive: inclusive
 	});
 }
 
-export function getTextSearchFilter(columnName: string, searchTerm: string,
+export function getTextSearchFilter(columnIndex: number, searchTerm: string,
 	searchType: ColumnFilterSearchType, caseSensitive: boolean) {
-	return _getFilterWithProps(columnName, ColumnFilterFilterType.Search, {
+	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.Search, {
 		search_term: searchTerm,
 		search_type: searchType,
 		search_case_sensitive: caseSensitive

--- a/src/vs/workbench/services/positronDataTool/test/common/positronDataToolMocks.test.ts
+++ b/src/vs/workbench/services/positronDataTool/test/common/positronDataToolMocks.test.ts
@@ -34,26 +34,26 @@ suite('DataToolMocks', () => {
 	});
 
 	test('Test getCompareFilter', () => {
-		const filter = mocks.getCompareFilter('column_2', ColumnFilterCompareOp.Gt, '1234');
+		const filter = mocks.getCompareFilter(2, ColumnFilterCompareOp.Gt, '1234');
 		assert.equal(filter.filter_type, ColumnFilterFilterType.Compare);
-		assert.equal(filter.column, 'column_2');
+		assert.equal(filter.column_index, 2);
 		assert.equal(filter.compare_op, ColumnFilterCompareOp.Gt);
 		assert.equal(filter.compare_value, '1234');
 	});
 
 	test('Test getIsNullFilter', () => {
-		let filter = mocks.getIsNullFilter('column_3');
-		assert.equal(filter.column, 'column_3');
+		let filter = mocks.getIsNullFilter(3);
+		assert.equal(filter.column_index, 3);
 		assert.equal(filter.filter_type, ColumnFilterFilterType.Isnull);
 
-		filter = mocks.getNotNullFilter('column_3');
+		filter = mocks.getNotNullFilter(3);
 		assert.equal(filter.filter_type, ColumnFilterFilterType.Notnull);
 	});
 
 	test('Test getTextSearchFilter', () => {
-		const filter = mocks.getTextSearchFilter('column_5', 'needle',
+		const filter = mocks.getTextSearchFilter(5, 'needle',
 			ColumnFilterSearchType.Contains, false);
-		assert.equal(filter.column, 'column_5');
+		assert.equal(filter.column_index, 5);
 		assert.equal(filter.filter_type, ColumnFilterFilterType.Search);
 		assert.equal(filter.search_term, 'needle');
 		assert.equal(filter.search_type, ColumnFilterSearchType.Contains);
@@ -62,8 +62,8 @@ suite('DataToolMocks', () => {
 
 	test('Test getSetMemberFilter', () => {
 		const set_values = ['need1', 'need2'];
-		const filter = mocks.getSetMemberFilter('column_6', set_values, true);
-		assert.equal(filter.column, 'column_6');
+		const filter = mocks.getSetMemberFilter(6, set_values, true);
+		assert.equal(filter.column_index, 6);
 		assert.equal(filter.filter_type, ColumnFilterFilterType.SetMembership);
 		assert.equal(filter.set_member_values, set_values);
 		assert.equal(filter.set_member_inclusive, true);


### PR DESCRIPTION
* Refer to columns by index rather than name (to avoid ambiguity)
* Use `=` instead of `==` for equality comparison enum (it generates `Eq` instead of `EqEq` in the generated enum)

Related: https://github.com/posit-dev/positron-python/pull/316