### PR TITLE
Ensure each R runtime is registered only once

### DIFF
--- a/extensions/positron-r/src/extension.ts
+++ b/extensions/positron-r/src/extension.ts
@@ -11,7 +11,6 @@ import { providePackageTasks } from './tasks';
 import { setContexts } from './contexts';
 import { setupTestExplorer, refreshTestExplorer } from './testing/testing';
 import { RRuntimeProvider, rRuntimeDiscoverer } from './provider';
-import { runtimeManager } from './runtime';
 
 
 export const Logger = vscode.window.createOutputChannel('Positron R Extension', { log: true });
@@ -26,7 +25,7 @@ export function activate(context: vscode.ExtensionContext) {
 	positron.runtime.registerLanguageRuntimeProvider('r', new RRuntimeProvider(context));
 
 	positron.runtime.registerLanguageRuntimeDiscoverer(
-		'r', rRuntimeDiscoverer(context, runtimeManager.getRuntimesMap()));
+		'r', rRuntimeDiscoverer(context));
 
 	// Set contexts.
 	setContexts(context);

--- a/extensions/positron-r/src/extension.ts
+++ b/extensions/positron-r/src/extension.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import * as fs from 'fs';
@@ -219,7 +219,7 @@ export async function* rRuntimeDiscoverer(
 		const runtimeId = digest.digest('hex').substring(0, 32);
 
 		// If we already know about the runtime, return it. This can happen if
-		// the runtime was provided eaglerly to Positron.
+		// the runtime was provided eagerly to Positron.
 		if (RRuntimeManager.instance.hasRuntime(runtimeId)) {
 			yield RRuntimeManager.instance.getRuntime(runtimeId);
 			continue;

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -13,7 +13,7 @@ import * as crypto from 'crypto';
 
 import { RInstallation, getRHomePath } from './r-installation';
 import { RRuntime, createJupyterKernelExtra, createJupyterKernelSpec } from './runtime';
-import { runtimeManager } from './runtime-manager';
+import { RRuntimeManager } from './runtime-manager';
 
 const initialDynState = {
 	inputPrompt: '>',
@@ -49,13 +49,14 @@ export class RRuntimeProvider implements positron.LanguageRuntimeProvider {
 		const extra = createJupyterKernelExtra();
 
 		// Use existing runtime if it present.
-		if (runtimeManager.hasRuntime(runtimeMetadata.runtimeId)) {
-			return runtimeManager.getRuntime(runtimeMetadata.runtimeId);
+		if (RRuntimeManager.instance.hasRuntime(runtimeMetadata.runtimeId)) {
+			return RRuntimeManager.instance.getRuntime(runtimeMetadata.runtimeId);
 		}
 
+		// No existing runtime with this ID; create a new one.
 		const runtime = new RRuntime(this.context, kernelSpec, runtimeMetadata,
 			initialDynState, extra);
-		runtimeManager.setRuntime(runtimeMetadata.runtimeId, runtime);
+		RRuntimeManager.instance.setRuntime(runtimeMetadata.runtimeId, runtime);
 		return runtime;
 	}
 }
@@ -219,8 +220,8 @@ export async function* rRuntimeDiscoverer(
 
 		// If we already know about the runtime, return it. This can happen if
 		// the runtime was provided eaglerly to Positron.
-		if (runtimeManager.hasRuntime(runtimeId)) {
-			yield runtimeManager.getRuntime(runtimeId);
+		if (RRuntimeManager.instance.hasRuntime(runtimeId)) {
+			yield RRuntimeManager.instance.getRuntime(runtimeId);
 			continue;
 		}
 
@@ -254,7 +255,7 @@ export async function* rRuntimeDiscoverer(
 
 		// Create an adapter for the kernel to fulfill the LanguageRuntime interface.
 		const runtime = new RRuntime(context, kernelSpec, metadata, initialDynState, extra);
-		runtimeManager.setRuntime(metadata.runtimeId, runtime);
+		RRuntimeManager.instance.setRuntime(metadata.runtimeId, runtime);
 		yield runtime;
 	}
 }

--- a/extensions/positron-r/src/runtime-manager.ts
+++ b/extensions/positron-r/src/runtime-manager.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import { RRuntime } from './runtime';

--- a/extensions/positron-r/src/runtime-manager.ts
+++ b/extensions/positron-r/src/runtime-manager.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+import PQueue from 'p-queue';
+import { RRuntime } from './runtime';
+
+class RRuntimeManager {
+	private runtimes: Map<string, RRuntime> = new Map();
+	private lastBinpath = '';
+
+	constructor() { }
+
+	getRuntime(id: string): RRuntime {
+		const runtime = this.runtimes.get(id);
+		if (!runtime) {
+			throw new Error(`Runtime ${id} not found`);
+		}
+		return runtime;
+	}
+
+	setRuntime(id: string, runtime: RRuntime): void {
+		this.runtimes.set(id, runtime);
+	}
+
+	hasRuntime(id: string): boolean {
+		return this.runtimes.has(id);
+	}
+
+	setLastBinpath(path: string) {
+		this.lastBinpath = path;
+	}
+
+	hasLastBinpath(): boolean {
+		return this.lastBinpath !== '';
+	}
+
+	getLastBinpath(): string {
+		return this.lastBinpath;
+	}
+}
+
+export const runtimeManager: RRuntimeManager = new RRuntimeManager();

--- a/extensions/positron-r/src/runtime-manager.ts
+++ b/extensions/positron-r/src/runtime-manager.ts
@@ -2,44 +2,97 @@
  *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
-import * as positron from 'positron';
-import * as vscode from 'vscode';
-import PQueue from 'p-queue';
 import { RRuntime } from './runtime';
 
-class RRuntimeManager {
-	private runtimes: Map<string, RRuntime> = new Map();
-	private lastBinpath = '';
+/**
+ * Manages all the registered R runtimes. We keep our own references to each
+ * runtime in a singleton instance of this class so that we can invoke
+ * methods/check status directly, without going through Positron's API.
+ */
+export class RRuntimeManager {
+	/// Singleton instance
+	private static _instance: RRuntimeManager;
 
-	constructor() { }
+	/// Map of runtime IDs to RRuntime instances
+	private _runtimes: Map<string, RRuntime> = new Map();
 
+	/// The last binpath that was used
+	private _lastBinpath = '';
+
+	/// Constructor; private since we only want one of these
+	private constructor() { }
+
+	/**
+	 * Accessor for the singleton instance; creates it if it doesn't exist.
+	 */
+	static get instance(): RRuntimeManager {
+		if (!RRuntimeManager._instance) {
+			RRuntimeManager._instance = new RRuntimeManager();
+		}
+		return RRuntimeManager._instance;
+	}
+
+	/**
+	 * Gets the runtime with the given ID, if it's registered.
+	 *
+	 * @param id The ID of the runtime to get
+	 * @returns The runtime. Throws an error if the runtime doesn't exist.
+	 */
 	getRuntime(id: string): RRuntime {
-		const runtime = this.runtimes.get(id);
+		const runtime = this._runtimes.get(id);
 		if (!runtime) {
-			throw new Error(`Runtime ${id} not found`);
+			throw new Error(`Runtime ${id} not found.`);
 		}
 		return runtime;
 	}
 
+	/**
+	 * Registers a runtime with the manager. Throws an error if a runtime with
+	 * the same ID is already registered.
+	 *
+	 * @param id The runtime's ID
+	 * @param runtime The runtime.
+	 */
 	setRuntime(id: string, runtime: RRuntime): void {
-		this.runtimes.set(id, runtime);
+		if (this._runtimes.has(id)) {
+			throw new Error(`Runtime ${id} already registered.`);
+		}
+		this._runtimes.set(id, runtime);
 	}
 
+	/**
+	 * Checks to see whether a runtime with the given ID is registered.
+	 *
+	 * @param id The ID of the runtime to check
+	 * @returns Whether the runtime with the given ID is registered.
+	 */
 	hasRuntime(id: string): boolean {
-		return this.runtimes.has(id);
+		return this._runtimes.has(id);
 	}
 
+	/**
+	 * Sets the last observed R binary path.
+	 *
+	 * @param path The path to the R binary
+	 */
 	setLastBinpath(path: string) {
-		this.lastBinpath = path;
+		this._lastBinpath = path;
 	}
 
+	/**
+	 * Returns the last observed R binary path.
+	 *
+	 * @returns Whether we have a last observed R binary path.
+	 */
 	hasLastBinpath(): boolean {
-		return this.lastBinpath !== '';
+		return this._lastBinpath !== '';
 	}
 
+	/**
+	 * Returns the last observed R binary path.
+	 */
 	getLastBinpath(): string {
-		return this.lastBinpath;
+		return this._lastBinpath;
 	}
 }
 
-export const runtimeManager: RRuntimeManager = new RRuntimeManager();

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -15,7 +15,7 @@ import { RHtmlWidget, getResourceRoots } from './htmlwidgets';
 import { getArkKernelPath } from './kernel';
 import { randomUUID } from 'crypto';
 import { handleRCode } from './hyperlink';
-import { runtimeManager } from './runtime-manager';
+import { RRuntimeManager } from './runtime-manager';
 
 interface RPackageInstallation {
 	packageName: string;
@@ -186,7 +186,7 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 		if (!this._kernel) {
 			this._kernel = await this.createKernel();
 		}
-		runtimeManager.setLastBinpath(this._kernel.metadata.runtimePath);
+		RRuntimeManager.instance.setLastBinpath(this._kernel.metadata.runtimePath);
 
 		// Register for console width changes, if we haven't already
 		if (!this._consoleWidthDisposable) {
@@ -559,7 +559,7 @@ export async function getRunningRRuntime(): Promise<RRuntime> {
 	}
 
 	// For now, there will be only one running R runtime:
-	return runtimeManager.getRuntime(runningRuntimes[0].runtimeId);
+	return RRuntimeManager.instance.getRuntime(runningRuntimes[0].runtimeId);
 }
 
 export function createJupyterKernelExtra(): JupyterKernelExtra {

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -15,31 +15,7 @@ import { RHtmlWidget, getResourceRoots } from './htmlwidgets';
 import { getArkKernelPath } from './kernel';
 import { randomUUID } from 'crypto';
 import { handleRCode } from './hyperlink';
-
-class RRuntimeManager {
-	private runtimes: Map<string, RRuntime> = new Map();
-	private lastBinpath = '';
-
-	constructor() { }
-
-	getRuntimesMap(): Map<string, RRuntime> {
-		return this.runtimes;
-	}
-
-	setLastBinpath(path: string) {
-		this.lastBinpath = path;
-	}
-
-	hasLastBinpath(): boolean {
-		return this.lastBinpath !== '';
-	}
-
-	getLastBinpath(): string {
-		return this.lastBinpath;
-	}
-}
-
-export const runtimeManager: RRuntimeManager = new RRuntimeManager();
+import { runtimeManager } from './runtime-manager';
 
 interface RPackageInstallation {
 	packageName: string;
@@ -583,11 +559,7 @@ export async function getRunningRRuntime(): Promise<RRuntime> {
 	}
 
 	// For now, there will be only one running R runtime:
-	const runtime = runtimeManager.getRuntimesMap().get(runningRuntimes[0].runtimeId);
-	if (!runtime) {
-		throw new Error(`R runtime '${runningRuntimes[0].runtimeId}' is not registered in the extension host`);
-	}
-	return runtime;
+	return runtimeManager.getRuntime(runningRuntimes[0].runtimeId);
 }
 
 export function createJupyterKernelExtra(): JupyterKernelExtra {

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { runtimeManager } from './runtime-manager';
+import { RRuntimeManager } from './runtime-manager';
 
 export class RPackageTaskProvider implements vscode.TaskProvider {
 
@@ -25,20 +25,21 @@ export async function providePackageTasks(context: vscode.ExtensionContext): Pro
 }
 
 export async function getRPackageTasks(): Promise<vscode.Task[]> {
-	if (!runtimeManager.hasLastBinpath()) {
+	if (!RRuntimeManager.instance.hasLastBinpath()) {
 		throw new Error(`No running R runtime to use for R package tasks.`);
 	}
+	const binpath = RRuntimeManager.instance.getLastBinpath();
 	const allPackageTasks: PackageTask[] = [
 		{
 			'task': 'r.task.packageCheck',
 			'message': vscode.l10n.t('{taskName}', { taskName: 'Check R package' }),
-			'shellExecution': `"${runtimeManager.getLastBinpath()}" -e "devtools::check()"`,
+			'shellExecution': `"${binpath}" -e "devtools::check()"`,
 			'package': 'devtools'
 		},
 		{
 			'task': 'r.task.packageInstall',
 			'message': vscode.l10n.t('{taskName}', { taskName: 'Install R package' }),
-			'shellExecution': `"${runtimeManager.getLastBinpath()}" -e "pak::local_install(upgrade = FALSE)"`,
+			'shellExecution': `"${binpath}" -e "pak::local_install(upgrade = FALSE)"`,
 			'package': 'pak'
 		}
 	];

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { runtimeManager } from './runtime';
+import { runtimeManager } from './runtime-manager';
 
 export class RPackageTaskProvider implements vscode.TaskProvider {
 

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';

--- a/extensions/positron-r/src/testing/runner-testthat.ts
+++ b/extensions/positron-r/src/testing/runner-testthat.ts
@@ -12,7 +12,7 @@ import { EXTENSION_ROOT_DIR } from '../constants';
 import { ItemType, TestingTools, encodeNodeId } from './util-testing';
 import { TestResult } from './reporter';
 import { parseTestsFromFile } from './parser';
-import { runtimeManager } from '../runtime-manager';
+import { RRuntimeManager } from '../runtime-manager';
 
 const testReporterPath = path
 	.join(EXTENSION_ROOT_DIR, 'resources', 'testing', 'vscodereporter')
@@ -25,7 +25,7 @@ export async function runThatTest(
 ): Promise<string> {
 	// in all scenarios, we execute devtools::SOMETHING() in a child process
 	// if we can't get the path to the relevant R executable, no point in continuing
-	if (!runtimeManager.hasLastBinpath()) {
+	if (!RRuntimeManager.instance.hasLastBinpath()) {
 		return Promise.resolve('No running R runtime to run R package tests.');
 	}
 
@@ -90,7 +90,8 @@ export async function runThatTest(
 		`devtools::load_all('${testReporterPath}');` +
 		`devtools::${devtoolsMethod}('${testPath}',` +
 		`${descInsert}reporter = VSCodeReporter)`;
-	const command = `"${runtimeManager.getLastBinpath()}" --no-echo -e "${devtoolsCall}"`;
+	const binpath = RRuntimeManager.instance.getLastBinpath();
+	const command = `"${binpath}" --no-echo -e "${devtoolsCall}"`;
 	Logger.info(`devtools call is:\n${command}`);
 
 	const wd = testingTools.packageRoot.fsPath;

--- a/extensions/positron-r/src/testing/runner-testthat.ts
+++ b/extensions/positron-r/src/testing/runner-testthat.ts
@@ -7,11 +7,12 @@ import * as path from 'path';
 import { spawn } from 'child_process';
 import * as split2 from 'split2';
 import { Logger } from '../extension';
-import { checkInstalled, runtimeManager } from '../runtime';
+import { checkInstalled } from '../runtime';
 import { EXTENSION_ROOT_DIR } from '../constants';
 import { ItemType, TestingTools, encodeNodeId } from './util-testing';
 import { TestResult } from './reporter';
 import { parseTestsFromFile } from './parser';
+import { runtimeManager } from '../runtime-manager';
 
 const testReporterPath = path
 	.join(EXTENSION_ROOT_DIR, 'resources', 'testing', 'vscodereporter')


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2072 and several related issues.

The underlying issue here is that the R extension can register the same R version multiple times (e.g. once when asked to provide a specific version of R, and a second time when asked to discover all R versions). This can create a situation where the runtime ID is not unique, and consequently we try to run methods (like `check_installed`) on the wrong one.

The fix is as follows:
- Most importantly, don't create multiple runtimes with the same ID. If Positron asks for a runtime we've already provided, use the exact instance that was previously returned.
- Refactor the `RRuntimeManager` a little so that its private map isn't exposed and we can guarantee safe access. 
- Use a more idiomatic TypeScript singleton pattern for the `RRuntimeManager`, so it's very obvious at the call sites that a global singleton is being engaged.

(More could be done here but wanted to keep this small since it's affecting several scenarios)