### PR TITLE
Remove `libR-sys` specific tweaks

### DIFF
--- a/extensions/jupyter-adapter/resources/kernel-wrapper.sh
+++ b/extensions/jupyter-adapter/resources/kernel-wrapper.sh
@@ -22,14 +22,6 @@ fi
 output_file="$1"
 shift
 
-# If the POSITRON_DYLD_FALLBACK_LIBRARY_PATH environment variable is set, then
-# set it as the DYLD_FALLBACK_LIBRARY_PATH environment variable for the program
-# we are about to run. This is a workaround for behavior on macOS wherein SIP
-# prevents DYLD_FALLBACK_LIBRARY_PATH from being inherited.
-if [ -n "$POSITRON_DYLD_FALLBACK_LIBRARY_PATH" ]; then
-	export DYLD_FALLBACK_LIBRARY_PATH="$POSITRON_DYLD_FALLBACK_LIBRARY_PATH"
-fi
-
 # Start log file with current date
 echo "*** Log started at $(date)" > "$output_file"
 

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -521,7 +521,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.45"
+      "ark": "0.1.46"
     }
   }
 }

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -153,20 +153,6 @@ export async function* rRuntimeDiscoverer(
 	let recommendedForWorkspace = await shouldRecommendForWorkspace();
 
 	// Loop over the R installations and create a language runtime for each one.
-	//
-	// NOTE(Kevin): We previously set DYLD_INSERT_LIBRARIES here, but this appeared
-	// to cause issues when running 'ark' through wrapper scripts in some cases.
-	// It's not entirely clear, but it looks like (at least on Kevin's machine)
-	// we end up with an x86 shell, inside which we attempt to insert an arm64
-	// library, and this ends up causing failure to start at all.
-	//
-	// See:
-	//
-	//     ./positron/extensions/jupyter-adapter/resources/kernel-wrapper.sh
-	//
-	// and its usages for more details.
-	//
-	// Given that DYLD_FALLBACK_LIBRARY_PATH works fine, we just set that below.
 	for (const rInst of rInstallations) {
 
 		// Is the runtime path within the user's home directory?

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -591,22 +591,6 @@ export function createJupyterKernelSpec(context: vscode.ExtensionContext, rHomeP
 	};
 	/* eslint-enable */
 
-	if (process.platform === 'win32') {
-		// On Windows, we must place the `bin/` path for the current R version on the PATH
-		// so that the DLLs in that same folder can be resolved properly when ark starts up
-		// (like `R.dll`, `Rblas.dll`, `Rgraphapp.dll`, `Riconv.dll`, and `Rlapack.dll`).
-		// https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#standard-search-order-for-unpackaged-apps
-		const binpath = path.join(rHomePath, 'bin', 'x64');
-
-		const processPath = process.env['PATH'];
-
-		const subprocessPath = processPath === undefined ?
-			binpath :
-			processPath + ';' + binpath;
-
-		env['PATH'] = subprocessPath;
-	}
-
 	// R script to run on session startup
 	const startupFile = path.join(context.extensionPath, 'resources', 'scripts', 'startup.R');
 

--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -591,26 +591,6 @@ export function createJupyterKernelSpec(context: vscode.ExtensionContext, rHomeP
 	};
 	/* eslint-enable */
 
-	if (process.platform === 'darwin') {
-
-		const dyldFallbackLibraryPaths: string[] = [];
-		dyldFallbackLibraryPaths.push(`${rHomePath}/lib`);
-
-		const defaultDyldFallbackLibraryPath = process.env['DYLD_FALLBACK_LIBRARY_PATH'];
-		if (defaultDyldFallbackLibraryPath) {
-			dyldFallbackLibraryPaths.push(defaultDyldFallbackLibraryPath);
-		}
-
-		// Set the DYLD_FALLBACK_LIBRARY_PATH to include the R installation.
-		// This specific environment variable can be blocked from being
-		// inherited by child processes on macOS with SIP enabled, so we
-		// prefix it with 'POSITRON_' here. The script that starts the
-		// kernel will check for this variable and set it as
-		// DYLD_FALLBACK_LIBRARY_PATH if it's present.
-		env['POSITRON_DYLD_FALLBACK_LIBRARY_PATH'] = dyldFallbackLibraryPaths.join(':');
-
-	}
-
 	if (process.platform === 'win32') {
 		// On Windows, we must place the `bin/` path for the current R version on the PATH
 		// so that the DLLs in that same folder can be resolved properly when ark starts up


### PR DESCRIPTION
- [x] Bump ark version

Requires https://github.com/posit-dev/amalthea/pull/205

With https://github.com/posit-dev/amalthea/pull/205, we no longer depend on libR-sys. More importantly, we now link to the R API _dynamically_ and _fully at runtime_. This has many many benefits, as outlined in https://github.com/posit-dev/amalthea/pull/205, but the most important ones here are:

- We don't need the `DYLD_FALLBACK_LIBRARY_PATH` hacks anymore. This was only required on macOS, and was the way that `ark` found the correct `libR.dylib` on startup. We no longer need to find `libR.dylib` immediately _at startup_. Instead, we locate `libR.dylib` (or `R.dll` or `libR.so`) relative to `R_HOME` from within ark itself and open the shared library at runtime from within ark, and then set up all the R API bindings from there.
- For essentially the same reasons, we don't need to add the folder that contains `R.dll` to the `PATH` on Windows (that was how Windows did dependency lookup at start up time).

The 2nd bullet is particularly nice, because we already got a report where one of our QA engineers had another R related path on the `PATH` that pointed to a different R version's `R.dll` than the one they were trying to start up, which caused a crash. We aren't entirely sure how he had that in the PATH, but it's nice that this avoids that possibility altogether.