### PR TITLE
Add classes variable grouping

### DIFF
--- a/positron/comms/variables-backend-openrpc.json
+++ b/positron/comms/variables-backend-openrpc.json
@@ -221,6 +221,7 @@
 						"enum": [
 							"boolean",
 							"bytes",
+							"class",
 							"collection",
 							"empty",
 							"function",

--- a/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
@@ -141,6 +141,7 @@ export enum ClipboardFormatFormat {
 export enum VariableKind {
 	Boolean = 'boolean',
 	Bytes = 'bytes',
+	Class = 'class',
 	Collection = 'collection',
 	Empty = 'empty',
 	Function = 'function',

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
@@ -23,6 +23,7 @@ import { localize } from 'vs/nls';
 const DATA_GROUP_ID = 'group/data';
 const VALUES_GROUP_ID = 'group/values';
 const FUNCTIONS_GROUP_ID = 'group/functions';
+const CLASSES_GROUP_ID = 'group/classes';
 const SMALL_GROUP_ID = 'group/small';
 const MEDIUM_GROUP_ID = 'group/medium';
 const LARGE_GROUP_ID = 'group/large';
@@ -611,11 +612,14 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 		const dataItems: VariableItem[] = [];
 		const valueItems: VariableItem[] = [];
 		const functionItems: VariableItem[] = [];
+		const classItems: VariableItem[] = [];
 		items.forEach(item => {
 			if (item.kind === VariableKind.Table) {
 				dataItems.push(item);
 			} else if (item.kind === VariableKind.Function) {
 				functionItems.push(item);
+			} else if (item.kind === VariableKind.Class) {
+				classItems.push(item);
 			} else {
 				valueItems.push(item);
 			}
@@ -651,6 +655,16 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 				'Functions',
 				!this._collapsedGroupIds.has(FUNCTIONS_GROUP_ID),
 				this.sortItems(functionItems)
+			));
+		}
+
+		// Add the class items group.
+		if (classItems.length) {
+			this._entries.push(new VariableGroup(
+				CLASSES_GROUP_ID,
+				'Classes',
+				!this._collapsedGroupIds.has(CLASSES_GROUP_ID),
+				this.sortItems(classItems)
 			));
 		}
 	}


### PR DESCRIPTION
there are a bunch of changes https://github.com/posit-dev/positron/issues/1788#issuecomment-1899131148 we discussed to the variable pane and its groupings, several of which probably require some discussion/alignment. One of the more straightforward ones is breaking off Classes as a distinct group from the catch-all Values. If I import a class from a module or submodule, or if I create my own class in the console, it will be grouped under Values, but this doesn't feel quite right. So along with the [accompanying PR on the Python extension](https://github.com/posit-dev/positron-python/pull/320), adding a new category called Classes. (This could in theory be used in the R extension as well, but because of how R imports work, R classes won't show up in the Variables pane the way Python classes currently do, so probably less necessary. We will still need to commit the auto-generated changes to `crates/amalthea/src/comm/variables_comm.rs` though)