### PR TITLE
Add Posit-specific security info to `SECURITY.md`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,41 +1,79 @@
-<!-- BEGIN MICROSOFT SECURITY.MD V0.0.5 BLOCK -->
+## Product Security
 
-## Security
+Posit values the security of its products and customers; we appreciate contributions from the security community to further enhance the security of our software. We ask that you follow these responsible disclosure guidelines.
 
-Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
+- Notify Posit of the vulnerability and provide us a reasonable amount of time to address it before disclosing the issue publicly.
+- Provide details of the vulnerability including the steps necessary to reproduce and validate.
+- Avoid privacy violations, data loss, or service disruption when performing research.
+- Do not modify or access others’ data.
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
+To encourage responsible disclosure, we commit that we will not take legal action against you nor ask law enforcement to investigate if we determine that you have complied with the above responsible disclosure guidelines.
 
-## Reporting Security Issues
+## Product Vulnerability Reporting
 
-**Please do not report security vulnerabilities through public GitHub issues.**
+If you believe you have discovered a vulnerability in one of our products, please contact us immediately so that we may resolve the issue as quickly as possible. You may email the details of the vulnerability to [security@posit.co](mailto:security@posit.co). Please include the following information:
 
-Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
+- Product name and version.
+- A description of the vulnerability and why it is exploitable.
+- Evidence of a successful exploit and complete steps to reproduce the exploit. Screenshots or video are preferred.
+- Please include as much information as possible. If we cannot reproduce the exploit with the information provided, we will be unable to proceed further.
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+We will attempt to respond to all reports within 3 business days however the time to research the issue may be longer. Depending on the outcome, detailed results of the investigation may not be made available until a fix is released.
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
+## Bug Bounty Requests
 
-Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+Posit does not offer a Bug Bounty program.
 
-* Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-* Full paths of source file(s) related to the manifestation of the issue
-* The location of the affected source code (tag/branch/commit or direct URL)
-* Any special configuration required to reproduce the issue
-* Step-by-step instructions to reproduce the issue
-* Proof-of-concept or exploit code (if possible)
-* Impact of the issue, including how an attacker might exploit the issue
+## PGP Key
 
-This information will help us triage your report more quickly.
+If you would like to encrypt your email to us, our PGP key is available below. If you encrypt your email, please include your PGP public key in your message or else the reply.
 
-If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://microsoft.com/msrc/bounty) page for more details about our active programs.
+```
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: SKS 1.1.5
 
-## Preferred Languages
-
-We prefer all communications to be in English.
-
-## Policy
-
-Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/en-us/msrc/cvd).
-
-<!-- END MICROSOFT SECURITY.MD BLOCK -->
+mQINBFmUu44BEAC54GaTQpKBnJKP1DkWV32HdW3hLaSqNQEfAKuu67CsdWQFUZw28psTcQvP
+Ek0Nf8xof/2V49fqQ4RKbJgDkSU3s/vJh/WTfFFubkCVRZGM8KuOrQSuyb5S+wnEYJUZQ2yB
+kE+430HjF906lzcBua8/WzUQV5FuTDD5nG2j3ZRX7kjQg8AULIjKdBf7Kh6bQyoHPJFPeQMz
++8/tu8gd0srvuc5hoaxF+nwyb3ObnStF8wBLx4rskSjW5S2wAPEMy64xfk02dxQf66n6JwbY
+llWF0yNw5Lv9sJFgHsGCaDLi+38eOaaNrOQ0zDOOsgZAyKwxccl40KWbghzuTNo0e+AzKQVH
+GHB0jlUteBl1TM4ZRophWn54/hA567IwUydMZgfRZMJ6/H58k+zYSh+LaIyfQ4HAtptJc3tm
+NlE8Pt4skZvYfOvkEv/GMUsUpCVLXPYXbeIOuaGdkSt49U+BZfMR8Id8w0oQrY4wcVH9H4pu
+ojVuo9O/91KVVlLlNzYE8RigWT16g4JJ/vDYCafXjDs1zta5XemF8sMfM5nrvqYrOzyPVvYD
+XrnvExJPeDSQTblY0dkNPZcG2deypa4isdXC47mKmVof2UQ64GvLDqZ23WPT+BeIZcZ7fpGY
+eMPyvRG4czb9fW0Bdj5Ptki8fn6iA5qRAsZAIY4BAMdcCc8M/QARAQABtDFSU3R1ZGlvIFZ1
+bG5lcmFiaWxpdHkgPHZ1bG5lcmFiaWxpdHlAcnN0dWRpby5jb20+iQI5BBMBCAAjBQJZlLuO
+AhsDBwsJCAcDAgEGFQgCCQoLBBYCAwECHgECF4AACgkQYerLdNnz7GLgOBAAs6awdkmOSM2/
+xV7bIpsliFrZQekFtcT+NPEUKy4vSmdYVqTRvFVTlPrUAha+K3sjDuaV4Zrf7vIfhN+5PNWy
+Hguhv7s+jhN5iOIii+3AUvqMY/vLjZyK8Df9N7ZKa3OfMXMqIQYu4oG+ySfcqeYij8ShyqwV
+JYB/Qrn2jwlV96BfVfsqvAcnc790KfR3Um7ef03o8HdkY1EWA3XH9uMn9mdB5hZTihLEdM/P
+orb6fSKA2+8YUCaNiXPy2m8sg4oEu87vQ1XA7sLz18HsNJMmMLOqtctQAM4evWuoUIwh57lp
+NMGPxwdAsBrOHKwJYuI6majs8TZnQ18Q3OdZ6JriwncFs6W87n5cRfKERtja7WFlxouS2dXe
+vts+YSrOXB7sD3Qy4UtaK2Va+5VhpOmCPKOOOn59du51AkIYbjG0gvc02RhzYgcy2covweDx
+3jkDcP1an2ULydcuX9mOK0INRP2eveCQE4t35Wgc5BgVegLucdcqcbz7kDg6WiR0xvhrbnWf
+bXtpkXG5U6xbIuc/TALAT6njtJ/ruRCezh0+jQ00fPwxMqWzuXb3eLqpRij/F0KTg8eHtZ4/
+qIj7cAiuucCsmSQ/HbqsBZDgHeK610gbltJy9g5qV4rqIVC02UjHqfpI2E1dJbXcWRXV8WmE
+6WSXV3dWE9WJUsdWS3Zk7ZW5Ag0EWZS7jgEQAM72NxacSDshaA9aQ0FgNvqYbWJXJ4CTr4Wr
+eKyJmrY/X6J5BwufUEHN3w/tQQtSw36S2sxafGmkE2/asXwvAY4bm8n0HX9zq/szlJnprinb
+qFVVatkQjf2iQRdo9tbGdYJpeFm+PTCEUI4/aiapESkT0KlUu8O0kYmbL67caNAe/DyPBBP8
+ifPtzwZq5cXLIsyqHgHruh2DYajoBIkO7G/0woEcnytF8KbndT9Zds+0+XXCBZD0vRnOQ61U
+Z3GdlD/45hp7GelajiDumv7BQCKy2dAkths5vvw4cricvRHGvp72rAsg2sJuU+CIZi74hhLO
+05/5DeN1TzXM6GZI9D5tcr7n+fJGLQZWZg07FRF58jJGrpsSbbxmEi1yBUWpdJvrjw5Bjj3s
+ai14Tl51nZgk0vpuBlrg0z55r/Sp/kvQqlAHPazi91rCoRUH32wY9m11rPQPs3o8W/V2ot1D
+0ZLsOW1gojSOuG6e6C0PU6WwzaAqtn3LS5xoFWaB9EL+tgoYIiexHTXAv49mgotk+gUv4Gij
+mgeEMo1RIkMISvUmbnuTWB2b3MnOP3AkorbYysZ+fuW4UImrCCS9UIOwHr28drP7qQkdjvu3
+iWcP1iQPb8JoWAzXOHz1kBe/LwJLmzbABBn5iB8nQrLt+gcJHRpM7IsRAi2smfe6VInGLNL7
+ABEBAAGJAh8EGAEIAAkFAlmUu44CGwwACgkQYerLdNnz7GLdqA//XOLv8LBpQTE+iJDudFqZ
+65swv5yN0oY4vUcr5ybcdkgsq38jJNP48C98mQnpZcHCN+Wzi+F3/uoSrVKk+14t5FNFkgQI
+q+fgrUtTv2fz9sEurj5Zme66/JpIaQZwFsyBSeySv6T306sMJJToe8hl/cDf2P5s8ITAHeNc
+8PoPQZ68LZdt2GCJCvYEJLHYlp0KoFN7wqkVlqgyKxKo16NjXNURZGldyqEVOjIbT2eInzSw
+AEBbve6OXm06riWTMKjsq6dtRTqqLFuGX9joOmvQNWz9qiHP1+no8i/ztNG2cyJizOrJmB/p
+MA6U2/u9rEqDL9qg9k70SXbSRiYu7iU7x/6v6ZSdrDUGbi0N1cOe2oc+By/cgU0rJHKObcaV
+eSp08xxRLvFYT0m0OFExE8iIXZYi9pbkuoq9hDV26IyKBQWr+rdKn1Khzi6xT56/wgw4ZO2S
+rElL+20WFJamutxdCxZkqPWXnxhDnh6UVN2yDKv4h6N4UJwCJJz43zodrtYgl+7OQF82Pi0D
+qzGFBbbKRkP+fZeLwKBf21nBpMdTLbX05NHbE2Paq9g3lg8Rv+alwQj0zAYh9gtssDNFhU2X
+/1hBcgxTKDTZ1scLoMqBIANfUkO64lXQBiTxqYTPUBMQ9yv+7tcHx/pMcg12a7XCjAr0mJbZ
+mvXw0IFW7IYP+tQ=
+=8BUx
+-----END PGP PUBLIC KEY BLOCK-----
+```


### PR DESCRIPTION
Addresses #5 (in fact, the last piece needed for that issue)

I used the language from <https://posit.co/about/product-security/> that is appropriate to open source projects (i.e. nothing where we are sending folks to Support). Let's plan to use this for now, and meet with our internal security folks for input before we make this repo public.