### PR TITLE
Add a disconnect button for the connections pane

### DIFF
--- a/extensions/positron-connections/package.json
+++ b/extensions/positron-connections/package.json
@@ -51,7 +51,7 @@
       },
       {
         "command": "positron.connections.closeConnection",
-        "title": "Close connection",
+        "title": "%commands.closeConnection.title%",
         "icon": "$(debug-disconnect)"
       }
     ],

--- a/extensions/positron-connections/package.json
+++ b/extensions/positron-connections/package.json
@@ -48,8 +48,27 @@
         "title": "%commands.previewTable.title%",
         "category": "%commands.previewTable.category%",
         "icon": "$(eye)"
+      },
+      {
+        "command": "positron.connections.closeConnection",
+        "title": "Close connection",
+        "icon": "$(debug-disconnect)"
       }
-    ]
+    ],
+    "menus": {
+      "view/item/context": [
+        {
+          "command": "positron.connections.closeConnection",
+          "group": "inline",
+          "when": "viewItem == database"
+        },
+        {
+          "command": "positron.connections.previewTable",
+          "group": "inline",
+          "when": "viewItem == table"
+        }
+      ]
+    }
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",

--- a/extensions/positron-connections/package.nls.json
+++ b/extensions/positron-connections/package.nls.json
@@ -4,5 +4,6 @@
 	"view.description": "Database Connections",
 	"view.welcome": "No database connections are currently active.",
 	"commands.previewTable.title": "Preview Table",
-	"commands.previewTable.category": "Connections"
+	"commands.previewTable.category": "Connections",
+	"commands.closeConnection.title": "Close Connection"
 }

--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -49,6 +49,10 @@ export class ConnectionItemDatabase extends ConnectionItemNode {
 	constructor(readonly name: string, readonly client: positron.RuntimeClientInstance) {
 		super(name, 'database', [], client);
 	}
+
+	close() {
+		this.client.performRpc({ msg_type: 'close_connection', name: this.name });
+	}
 }
 
 /**
@@ -116,14 +120,15 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 		if (item instanceof ConnectionItemTable) {
 			// Set the icon for tables
 			treeItem.iconPath = vscode.Uri.file(path.join(this.context.extensionPath, 'media', 'table.svg'));
+			treeItem.contextValue = 'table';
 
 			// Tables can previewed in a new editor
-			treeItem.command = {
-				title: vscode.l10n.t('Preview Table'),
-				command: 'positron.connections.previewTable',
-				tooltip: vscode.l10n.t(`Open ${item.name} in a new editor`),
-				arguments: [item]
-			};
+			// treeItem.command = {
+			// 	title: vscode.l10n.t('Preview Table'),
+			// 	command: 'positron.connections.previewTable',
+			// 	tooltip: vscode.l10n.t(`Open ${item.name} in a new editor`),
+			// 	arguments: [item]
+			// };
 		} else if (item instanceof ConnectionItemNode) {
 			// Set the icon for databases
 			treeItem.iconPath = vscode.Uri.file(path.join(this.context.extensionPath, 'media', 'database.svg'));
@@ -132,6 +137,13 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 			treeItem.iconPath = vscode.Uri.file(path.join(this.context.extensionPath, 'media', 'field.svg'));
 			treeItem.description = '<' + item.dtype + '>';
 		}
+
+		if (item instanceof ConnectionItemDatabase) {
+			// adding the contextValue allows the TreView API to attach specific commands
+			// to databases
+			treeItem.contextValue = 'database';
+		}
+
 		return treeItem;
 	}
 

--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -165,16 +165,6 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 				this._onDidChangeTreeData.fire(undefined);
 			}
 		});
-
-		// Add an event listener that tells the backend that the connection is
-		// getting closed.
-		// We need this because the CommMsg::Close event is not sent to the channel
-		// that handles the connection.
-		client.onDidChangeClientState((state: positron.RuntimeClientState) => {
-			if (state === positron.RuntimeClientState.Closing) {
-				client.performRpc({ msg_type: 'disconnect', name: name });
-			}
-		});
 	}
 
 	/**

--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -121,14 +121,6 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 			// Set the icon for tables
 			treeItem.iconPath = vscode.Uri.file(path.join(this.context.extensionPath, 'media', 'table.svg'));
 			treeItem.contextValue = 'table';
-
-			// Tables can previewed in a new editor
-			// treeItem.command = {
-			// 	title: vscode.l10n.t('Preview Table'),
-			// 	command: 'positron.connections.previewTable',
-			// 	tooltip: vscode.l10n.t(`Open ${item.name} in a new editor`),
-			// 	arguments: [item]
-			// };
 		} else if (item instanceof ConnectionItemNode) {
 			// Set the icon for databases
 			treeItem.iconPath = vscode.Uri.file(path.join(this.context.extensionPath, 'media', 'database.svg'));

--- a/extensions/positron-connections/src/extension.ts
+++ b/extensions/positron-connections/src/extension.ts
@@ -4,7 +4,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { ConnectionItemTable, ConnectionItemsProvider } from './connection';
+import { ConnectionItemDatabase, ConnectionItemTable, ConnectionItemsProvider } from './connection';
 
 /**
  * Activates the extension.
@@ -34,5 +34,11 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('positron.connections.previewTable',
 			(item: ConnectionItemTable) => {
 				item.preview();
+			}));
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('positron.connections.closeConnection',
+			(item: ConnectionItemDatabase) => {
+				item.close();
 			}));
 }

--- a/extensions/positron-zed/src/positronZedConnection.ts
+++ b/extensions/positron-zed/src/positronZedConnection.ts
@@ -77,6 +77,11 @@ export class ZedConnection {
 			case 'preview_table':
 				this.zed.createZedDataView(randomUUID(), message.table);
 				break;
+
+			case 'close_connection':
+				this.zed.closeConnection(this.id, this.name);
+				break;
+
 		}
 	}
 }

--- a/extensions/positron-zed/src/positronZedConnection.ts
+++ b/extensions/positron-zed/src/positronZedConnection.ts
@@ -78,10 +78,6 @@ export class ZedConnection {
 				this.zed.createZedDataView(randomUUID(), message.table);
 				break;
 
-			case 'close_connection':
-				this.zed.closeConnection(this.id, this.name);
-				break;
-
 		}
 	}
 }

--- a/extensions/positron-zed/src/positronZedConnection.ts
+++ b/extensions/positron-zed/src/positronZedConnection.ts
@@ -77,7 +77,6 @@ export class ZedConnection {
 			case 'preview_table':
 				this.zed.createZedDataView(randomUUID(), message.table);
 				break;
-
 		}
 	}
 }

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1059,6 +1059,8 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		} else if (this._data.has(id)) {
 			// Is it ... a data viewer?
 			this._data.delete(id);
+		} else if (this._connections.has(id)) {
+			this._connections.delete(id);
 		} else {
 			throw new Error(`Can't remove client; unknown client id ${id}`);
 		}

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1779,7 +1779,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		this.simulateIdleState(parentId);
 	}
 
-	public closeConnection(parentId: string, code: string) {
+	private closeConnection(parentId: string, code: string) {
 		// Enter busy state and output the code.
 		this.simulateBusyState(parentId);
 		this.simulateInputMessage(parentId, code);

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1777,7 +1777,7 @@ export class PositronZedLanguageRuntime implements positron.LanguageRuntime {
 		this.simulateIdleState(parentId);
 	}
 
-	private closeConnection(parentId: string, code: string) {
+	public closeConnection(parentId: string, code: string) {
 		// Enter busy state and output the code.
 		this.simulateBusyState(parentId);
 		this.simulateInputMessage(parentId, code);


### PR DESCRIPTION
Adress #2050
Joint PR with https://github.com/posit-dev/amalthea/pull/210
Should be merged after #2091

-  Adds a 'disconnect' button to the connections pane

![image](https://github.com/posit-dev/positron/assets/4706822/8da866ec-fbe4-4639-87ca-bb7f3df28c49)

-  Moves the 'preview table' action to an actual action button. A clickable action is actually discouraged in the [TreeView UX manual](https://code.visualstudio.com/api/ux-guidelines/views#tree-views).

Can be tested with Zed:

```
connection hello
```
