### PR TITLE
Add Insert Section command

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -341,7 +341,7 @@
         "command": "r.insertSection",
         "key": "ctrl+k h",
         "mac": "cmd+k h",
-        "when": "editorLangId == r"
+        "when": "editorLangId == r && editorTextFocus"
       }
     ],
     "menus": {

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -336,6 +336,12 @@
         "key": "ctrl+shift+enter",
         "mac": "cmd+shift+enter",
         "when": "editorLangId == r"
+      },
+      {
+        "command": "r.insertSection",
+        "key": "ctrl+k h",
+        "mac": "cmd+k h",
+        "when": "editorLangId == r"
       }
     ],
     "menus": {
@@ -366,6 +372,12 @@
           "category": "R",
           "command": "r.insertLeftAssignmentConsole",
           "when": "editorLangId == r && positronConsoleFocused"
+        },
+        {
+          "category": "R",
+          "command": "r.insertSection",
+          "title": "%r.command.insertSection.title%",
+          "when": "editorLangId == r && editorTextFocus"
         },
         {
           "category": "R",

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -57,6 +57,13 @@
         "enablement": "editorLangId == r && positronConsoleFocused"
       },
       {
+        "command": "r.insertSection",
+        "category": "R",
+        "title": "%r.command.insertSection.title%",
+        "shortTitle": "%r.menu.insertSection.title%",
+        "enablement": "editorLangId == r"
+      },
+      {
         "command": "r.packageLoad",
         "category": "R",
         "title": "%r.command.packageLoad.title%",
@@ -341,7 +348,7 @@
         "command": "r.insertSection",
         "key": "ctrl+k h",
         "mac": "cmd+k h",
-        "when": "editorLangId == r && editorTextFocus"
+        "when": "editorLangId == r"
       }
     ],
     "menus": {
@@ -377,7 +384,7 @@
           "category": "R",
           "command": "r.insertSection",
           "title": "%r.command.insertSection.title%",
-          "when": "editorLangId == r && editorTextFocus"
+          "when": "editorLangId == r"
         },
         {
           "category": "R",

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -383,7 +383,6 @@
         {
           "category": "R",
           "command": "r.insertSection",
-          "title": "%r.command.insertSection.title%",
           "when": "editorLangId == r"
         },
         {

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -7,6 +7,7 @@
 	"r.command.packageLoad.title": "Load R Package",
 	"r.command.insertPipe.title": "Insert the pipe operator",
 	"r.command.insertLeftAssignment.title": "Insert the \"<-\" assignment operator",
+	"r.command.insertSection.title": "Insert a new section",
 	"r.command.packageBuild.title": "Build R Package",
 	"r.command.packageInstall.title": "Install R Package and Restart R",
 	"r.command.packageTest.title": "Test R Package",

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
@@ -241,10 +241,10 @@ function insertSection() {
 			for (let i = section.length; i < 75; i++) {
 				section += '-';
 			}
-			section += '\n';
+			section += '\n\n';
 
 			editor.edit((editBuilder) => {
-				editBuilder.replace(selection, section + text);
+				editBuilder.replace(selection, text + section);
 			});
 		}
 	});

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -230,6 +230,16 @@ function insertSection() {
 				return;
 			}
 
+			// If the user has rulers enabled, we want to make sure the section
+			// header is aligned with the rulers; otherwise, just use a standard
+			// 80 character limit.
+			//
+			// Let the section header run up to 5 characters short of the first
+			// ruler.
+			const config = vscode.workspace.getConfiguration('editor');
+			const rulers = config.get<Array<number>>('rulers');
+			const targetWidth = rulers && rulers.length > 0 ? rulers[0] - 5 : 75;
+
 			// Get the current selection and text.
 			const selection = editor.selection;
 			const text = editor.document.getText(selection);
@@ -237,9 +247,14 @@ function insertSection() {
 			// Create the section header.
 			let section = '\n# ' + sectionName + ' ';
 
-			// Add dashes up to a 75 character limit.
-			for (let i = section.length; i < 75; i++) {
-				section += '-';
+			if (targetWidth - section.length < 4) {
+				// A section header must have at least 4 dashes
+				section += '----';
+			} else {
+				// Add dashes up to the target width.
+				for (let i = section.length; i < targetWidth; i++) {
+					section += '-';
+				}
 			}
 			section += '\n\n';
 

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -144,6 +144,14 @@
         "key": "ctrl+d",
         "when": "config.rstudio.keymap.enable && editorTextFocus",
         "command": "editor.action.deleteLines"
+      },
+      {
+        "mac": "cmd+shift+r",
+        "win": "ctrl+shift+r",
+        "linux": "ctrl+shift+r",
+        "key": "ctrl+shift+r",
+        "when": "config.rstudio.keymap.enable && editorTextFocus && editorLangId == r",
+        "command": "r.insertSection"
       }
     ]
   }


### PR DESCRIPTION
Quick change to add an Insert Section command to Positron via the R extension.

<img width="943" alt="image" src="https://github.com/posit-dev/positron/assets/470418/23e74980-1a3a-43ff-8dbe-fc82daf6d483">

The RStudio keybinding (Cmd+Shift+R) is already taken in VS Code by the Search Again command, so we use Cmd+K H (mnemonic: insert Header) instead, unless, of course, the RStudio Keymap is enabled.