### PR TITLE
Add more RStudio keybindings

### DIFF
--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -152,6 +152,22 @@
         "key": "ctrl+shift+r",
         "when": "config.rstudio.keymap.enable && editorTextFocus && editorLangId == r",
         "command": "r.insertSection"
+      },
+      {
+        "mac": "ctrl+alt+left",
+        "win": "ctrl+alt+left",
+        "linux": "ctrl+alt+left",
+        "key": "ctrl+alt+left",
+        "when": "config.rstudio.keymap.enable",
+        "command": "workbench.action.previousEditorInGroup"
+      },
+      {
+        "mac": "ctrl+alt+right",
+        "win": "ctrl+alt+right",
+        "linux": "ctrl+alt+right",
+        "key": "ctrl+alt+right",
+        "when": "config.rstudio.keymap.enable",
+        "command": "workbench.action.nextEditorInGroup"
       }
     ]
   }

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from 'vs/nls';

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -211,7 +211,8 @@ export function registerLanguageRuntimeActions() {
 		[
 			{
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Numpad0
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Numpad0,
+				secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.F10]
 			},
 			{
 				weight: KeybindingWeight.WorkbenchContrib,


### PR DESCRIPTION
This change makes some keybinding adjustments recommended by @andrie. Specifically:

- **Ctrl + Alt + Left / Ctrl + Alt + Right** now navigate to previous/next editor when the RStudio keymap is active.
- **Cmd or Ctrl + Shift + F10** is now an alternate/secondary binding for Restart Interpreter. This binding wasn't already taken, so I added it to Positron directly rather than the RStudio keymap specifically.
- **Focus Console** now works harder to focus the console --  if the panel is invisible and/or the console isn't selected in the panel, we take care of that first. 