### PR TITLE
Use same `clear-all` icon in Console as search, output, debug etc

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -284,7 +284,7 @@ export const ActionBar = (props: ActionBarProps) => {
 						}
 						{showDeveloperUI &&
 							<ActionBarButton
-								iconId='sparkle'
+								iconId='positron-list'
 								align='right'
 								tooltip={positronToggleTrace}
 								ariaLabel={positronToggleTrace}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -284,7 +284,7 @@ export const ActionBar = (props: ActionBarProps) => {
 						}
 						{showDeveloperUI &&
 							<ActionBarButton
-								iconId='positron-list'
+								iconId='sparkle'
 								align='right'
 								tooltip={positronToggleTrace}
 								ariaLabel={positronToggleTrace}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -300,7 +300,7 @@ export const ActionBar = (props: ActionBarProps) => {
 						/>
 						<ActionBarSeparator />
 						<ActionBarButton
-							iconId='positron-clear-pane'
+							iconId='clear-all'
 							align='right'
 							tooltip={positronClearConsole}
 							ariaLabel={positronClearConsole}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -284,7 +284,7 @@ export const ActionBar = (props: ActionBarProps) => {
 						}
 						{showDeveloperUI &&
 							<ActionBarButton
-								iconId='positron-list'
+								iconId='wand'
 								align='right'
 								tooltip={positronToggleTrace}
 								ariaLabel={positronToggleTrace}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -113,7 +113,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 					<ActionBarRegion location='right'>
 						<HistoryPolicyMenuButton plotsService={positronPlotsContext.positronPlotsService} />
 						<ActionBarSeparator />
-						<ActionBarButton iconId='positron-clear-pane' align='right' disabled={noPlots} tooltip={positronClearAllPlots} ariaLabel={positronClearAllPlots} onClick={clearAllPlotsHandler} />
+						<ActionBarButton iconId='clear-all' align='right' disabled={noPlots} tooltip={positronClearAllPlots} ariaLabel={positronClearAllPlots} onClick={clearAllPlotsHandler} />
 					</ActionBarRegion>
 				</PositronActionBar>
 			</div>

--- a/src/vs/workbench/contrib/positronVariables/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/actionBars.tsx
@@ -119,7 +119,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 					<ActionBarRegion location='right'>
 						<ActionBarButton align='right' iconId='positron-refresh' tooltip={positronRefreshObjects} ariaLabel={positronRefreshObjects} onClick={refreshObjectsHandler} />
 						<ActionBarSeparator />
-						<ActionBarButton align='right' iconId='positron-clear-pane' tooltip={positronDeleteAllObjects} ariaLabel={positronDeleteAllObjects} onClick={deleteAllObjectsHandler} />
+						<ActionBarButton align='right' iconId='clear-all' tooltip={positronDeleteAllObjects} ariaLabel={positronDeleteAllObjects} onClick={deleteAllObjectsHandler} />
 					</ActionBarRegion>
 				</PositronActionBar>
 				<PositronActionBar size='small' borderBottom={true} gap={kSecondaryActionBarGap} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>


### PR DESCRIPTION
Addresses #1559

This was bothering me again today and has come up in usability testing. We have feedback that our `'positron-clear-pane'` icon looks like it will _close_ the console, rather than clear it. As @gtritchie points out, this `'clear-all'` icon is the one that means "clear this thing" for Search, Output, the Debug Console, etc. 