### PR TITLE
More care with quoting to make PowerShell happy

### DIFF
--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -44,28 +44,15 @@ export async function getRPackageTasks(): Promise<vscode.Task[]> {
 		}
 	];
 	// the explicit quoting treatment is necessary to avoid headaches on Windows, with PowerShell
-	const allPackageTasks: PackageTask[] = taskData.map(data => ({
-		task: data.task,
-		message: data.message,
-		shellExecution: new vscode.ShellExecution(
+	return taskData.map(data => new vscode.Task(
+		{ type: 'rPackageTask', task: data.task, pkg: data.package },
+		vscode.TaskScope.Workspace,
+		data.message,
+		'R',
+		new vscode.ShellExecution(
 			binpath,
 			['-e', { value: data.rcode, quoting: vscode.ShellQuoting.Strong }]
 		),
-		package: data.package
-	}));
-	return allPackageTasks.map(task => new vscode.Task(
-		{ type: 'rPackageTask', task: task.task, pkg: task.package },
-		vscode.TaskScope.Workspace,
-		task.message,
-		'R',
-		task.shellExecution,
 		[]
 	));
 }
-
-type PackageTask = {
-	task: string;
-	message: string;
-	shellExecution: vscode.ShellExecution;
-	package?: string;
-};


### PR DESCRIPTION
Addresses #2099

I was able to reproduce this and this PR rescues things for me.

The big idea is to provide the task's kibbles and bits individually and let VS Code figure out how to quote it, with stern instructions to use `ShellQuoting.Strong`:

> Strong string quoting should be used. This for example uses " for Windows cmd and ' for bash and PowerShell. Strong quoting treats arguments as literal strings. Under PowerShell `echo 'The value is $(2 * 3)'` will print `The value is $(2 * 3)`

https://code.visualstudio.com/api/references/vscode-api#ShellQuoting