### PR TITLE
fix: use child entry size to determine truncation indicators

### DIFF
--- a/src/vs/workbench/services/positronVariables/common/classes/variableItem.ts
+++ b/src/vs/workbench/services/positronVariables/common/classes/variableItem.ts
@@ -227,8 +227,9 @@ export class VariableItem implements IVariableItem {
 			await Promise.all(promises);
 		}
 
-		// If this variable is truncated, add the variable overflow.
-		if (this._variable.data.is_truncated) {
+		// If this variable's length is longer than the child
+		// entries received, add the variable overflow.
+		if (this._variable.data.length > this._childEntries.size) {
 			// Create the variable overflow.
 			const variableOverflow = new VariableOverflow(
 				generateUuid(),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of why we are making the proposed changes and
* how best to test them.
-->

building off #645, but removes usage of `is_truncated` from this logic (which should only be used to determine if a string is truncated). Rather, compare the length of the data given by the language runtime to the number of child entries that are going to be displayed