### PR TITLE
Remove Ark double in positron-r

### DIFF
--- a/extensions/positron-r/positron.json
+++ b/extensions/positron-r/positron.json
@@ -13,23 +13,6 @@
 			"to": "resources/js"
 		},
 		{
-			"from": "resources/ark/ark",
-			"to": "./dist/bin",
-			"platforms": ["darwin"]
-		},
-		{
-			"from": "resources/ark/modules/public/*.R",
-			"to": "./dist/bin/modules/public"
-		},
-		{
-			"from": "resources/ark/modules/private/*.R",
-			"to": "./dist/bin/modules/private"
-		},
-		{
-			"from": "resources/ark/modules/rstudioapi/*.R",
-			"to": "./dist/bin/modules/rstudioapi"
-		},
-		{
 			"from": "resources/testing/tree-sitter-r.wasm",
 			"to": "resources/testing"
 		},

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -29,7 +29,7 @@ export function getArkKernelPath(context: vscode.ExtensionContext): string | und
 	const kernelName = os.platform() === 'win32' ? 'ark.exe' : 'ark';
 
 	// No kernel path specified; try the default (embedded) kernel. This is where the kernel
-	// is placed in release builds.
+	// is placed in development and release builds.
 	const path = require('path');
 	const fs = require('fs');
 	const embeddedKernel = path.join(context.extensionPath, 'resources', 'ark', kernelName);
@@ -54,12 +54,5 @@ export function getArkKernelPath(context: vscode.ExtensionContext): string | und
 	}
 	if (devKernel) {
 		return devKernel;
-	}
-
-	// Finally, look for a local copy of the kernel in our `resources` directory. This is
-	// where the kernel is placed by the `install-kernel` script in development builds.
-	const localKernel = path.join(context.extensionPath, 'resources', 'ark', kernelName);
-	if (fs.existsSync(localKernel)) {
-		return localKernel;
 	}
 }

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -32,7 +32,7 @@ export function getArkKernelPath(context: vscode.ExtensionContext): string | und
 	// is placed in release builds.
 	const path = require('path');
 	const fs = require('fs');
-	const embeddedKernel = path.join(context.extensionPath, 'dist', 'bin', kernelName);
+	const embeddedKernel = path.join(context.extensionPath, 'resources', 'ark', kernelName);
 	if (fs.existsSync(embeddedKernel)) {
 		return embeddedKernel;
 	}


### PR DESCRIPTION
I noticed that we are bundling ark twice in positron-r. We copy it from `resources` to `dist` and both copies end up bundled.  I believe this dates back to when we were embedding ark in the repo. Now that we download or copy ark into `resources`, this should be the only needed copy.

I've built `Positron.app` with this branch and verified that positron-r is still able to find ark.