### PR TITLE
Add menu title for R extension "Insert a new section"

### DIFF
--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -18,6 +18,7 @@
 	"r.menu.createNewFile.title": "R File",
 	"r.menu.insertPipe.title": "Insert the pipe operator",
 	"r.menu.insertLeftAssignment.title": "Insert the \"<-\" assignment operator",
+	"r.menu.insertSection.title": "Insert a new section",
 	"r.menu.packageLoad.title": "Load R Package",
 	"r.menu.packageBuild.title": "Build R Package",
 	"r.menu.packageInstall.title": "Install R Package and Restart R",


### PR DESCRIPTION
A follow up to #2103 because we were seeing this warning:

```
[positron-r]: Couldn't find message for key r.menu.insertSection.title.
```