### PR TITLE
Skip rather than register duplicate runtimes

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -204,10 +204,10 @@ export async function* rRuntimeDiscoverer(
 		digest.update(rVersion);
 		const runtimeId = digest.digest('hex').substring(0, 32);
 
-		// If we already know about the runtime, return it. This can happen if
-		// the runtime was provided eagerly to Positron.
+		// If we already know about the runtime, skip it (it's already been
+		// registered). This can happen if the runtime was provided eagerly to
+		// Positron.
 		if (RRuntimeManager.instance.hasRuntime(runtimeId)) {
-			yield RRuntimeManager.instance.getRuntime(runtimeId);
 			continue;
 		}
 


### PR DESCRIPTION
This change fixes an issue in which R can show two data viewers (or connections) instead of one. It's a regression from https://github.com/posit-dev/positron/pull/2080. The issue is that we still register the runtime twice on the Positron side, even though it's only registered once on the R side, resulting in some event handlers getting double-registered. 

The fix is to skip registration entirely for runtimes that are already registered. 

Addresses https://github.com/posit-dev/positron/issues/2113. 