### PR TITLE
split off non-renderer changes into separate PR

### DIFF
--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -323,8 +323,14 @@ window.onload = function() {
 		const htmlManagerPath = asWebviewUri(
 			URI.joinPath(pythonExtension.extensionLocation, 'resources/js/@jupyter-widgets/html-manager/dist/embed-amd.js'));
 
-		const jupyterMatplotlibPath = asWebviewUri(
-			URI.joinPath(pythonExtension.extensionLocation, 'resources/js/jupyter-matplotlib/dist/index.js'));
+		let additionalScripts = '';
+		const usesJupyterMatplotlib = managerState.includes('"model_module":"jupyter-matplotlib"');
+
+		if (usesJupyterMatplotlib) {
+			const jupyterMatplotlibPath = asWebviewUri(
+				URI.joinPath(pythonExtension.extensionLocation, 'resources/js/jupyter-matplotlib/dist/index.js'));
+			additionalScripts += `<script src='${jupyterMatplotlibPath}'></script>`;
+		}
 
 		// Create the metadata for the webview
 		const webviewInitInfo: WebviewInitInfo = {
@@ -363,8 +369,9 @@ window.onload = function() {
 <!-- Load the HTML manager, which is used to render the widgets -->
 <script src='${htmlManagerPath}'></script>
 
-<!-- Load jupyter-matplotlib, which is used to render matplotlib widgets -->
-<script src='${jupyterMatplotlibPath}'></script>
+<!-- Load additional dependencies that may be required by the widget type -->
+<!-- If these are not included, they will just be loaded from CDN -->
+${additionalScripts}
 
 <!-- The state of all the widget models on the page -->
 <script type="${MIME_TYPE_WIDGET_STATE}">

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -323,6 +323,9 @@ window.onload = function() {
 		const htmlManagerPath = asWebviewUri(
 			URI.joinPath(pythonExtension.extensionLocation, 'resources/js/@jupyter-widgets/html-manager/dist/embed-amd.js'));
 
+		const jupyterMatplotlibPath = asWebviewUri(
+			URI.joinPath(pythonExtension.extensionLocation, 'resources/js/jupyter-matplotlib/dist/index.js'));
+
 		// Create the metadata for the webview
 		const webviewInitInfo: WebviewInitInfo = {
 			contentOptions: {
@@ -359,6 +362,9 @@ window.onload = function() {
 
 <!-- Load the HTML manager, which is used to render the widgets -->
 <script src='${htmlManagerPath}'></script>
+
+<!-- Load jupyter-matplotlib, which is used to render matplotlib widgets -->
+<script src='${jupyterMatplotlibPath}'></script>
 
 <!-- The state of all the widget models on the page -->
 <script type="${MIME_TYPE_WIDGET_STATE}">


### PR DESCRIPTION
Since #2164 is not fully functional, I'm splitting off a smaller subset of changes needed for the widget client language runtime messages, as well as loading the jupyter-matplotlib dependency locally instead of from CDN, in the interest of getting these changes merged whether or not we move forward with #2164 . 