### PR TITLE
Improve the behavior of Tab and Cmd+Up in the Console

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -346,8 +346,9 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 
 			// Up arrow processing.
 			case KeyCode.UpArrow: {
-				if (cmdOrCtrlKey) {
-					// If the cmd or ctrl key is pressed, engage the history browser with the
+				if (cmdOrCtrlKey && !historyBrowserActiveRef.current) {
+					// If the cmd or ctrl key is pressed, and the history
+					// browser is not up, engage the history browser with the
 					// prefix match strategy. This behavior mimics RStudio.
 					engageHistoryBrowser(new HistoryPrefixMatchStrategy(
 						historyNavigatorRef.current!
@@ -358,7 +359,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 
 				// If the history browser is present, Up should select the
 				// previous history item.
-				if (historyBrowserActiveRef.current) {
+				else if (historyBrowserActiveRef.current) {
 					setHistoryBrowserSelectedIndex(Math.max(
 						0, historyBrowserSelectedIndexRef.current - 1));
 					consumeEvent();

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -398,8 +398,6 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			// Down arrow processing.
 			case KeyCode.DownArrow: {
 
-				console.log(`Down arrow pressed. browser active: ${historyBrowserActiveRef.current}`);
-
 				// If the history browser is up, update the selected index.
 				if (historyBrowserActiveRef.current) {
 					setHistoryBrowserSelectedIndex(Math.min(

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -340,8 +340,8 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				if (historyBrowserActiveRef.current) {
 					acceptHistoryMatch(historyBrowserSelectedIndexRef.current);
 					consumeEvent();
-					break;
 				}
+				break;
 			}
 
 			// Up arrow processing.


### PR DESCRIPTION
Fixes two small issues in the Console around the new history search tools:

- Pressing `<Tab>` now works normally when the history browser is closed (before this change, it incorrectly advanced the history)
- Pressing `Cmd` + `Up` a second time when the history browser is already up navigates the browser, as in RStudio

Addresses https://github.com/posit-dev/positron/issues/2148.