### PR TITLE
Override default tab size and word separators for R files

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -209,6 +209,12 @@
         }
       }
     },
+    "configurationDefaults": {
+      "[r]": {
+        "editor.tabSize": 2,
+        "editor.wordSeparators": "`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?"
+      }
+    },
     "languages": [
       {
         "id": "r",


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/1739
Addresses https://github.com/posit-dev/positron/issues/2171

Sanity returns!


https://github.com/posit-dev/positron/assets/19150088/8729b9f5-0500-408b-b3a7-215a7da6ec86

