### PR TITLE
Forward fully adjusted console input width on to API consumers

### DIFF
--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -481,7 +481,7 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 
 			this._queue.add(async () => {
 				try {
-					// Set the initial console width
+					// Set the initial console input width
 					const width = await positron.window.getConsoleWidth();
 					this.callMethod('setConsoleWidth', width);
 					this._kernel!.emitJupyterLog(`Set initial console width to ${width}`);

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -979,14 +979,14 @@ declare module 'positron' {
 		export function getConsoleForLanguage(id: string): Console | undefined;
 
 		/**
-		 * Fires when the width of the console changes. The new width is passed as
+		 * Fires when the width of the console input changes. The new width is passed as
 		 * a number, which represents the number of characters that can fit in the
 		 * console horizontally.
 		 */
 		export const onDidChangeConsoleWidth: vscode.Event<number>;
 
 		/**
-		 * Returns the current width of the console, in characters.
+		 * Returns the current width of the console input, in characters.
 		 */
 		export function getConsoleWidth(): Thenable<number>;
 	}

--- a/src/vs/workbench/api/common/positron/extHostConsoleService.ts
+++ b/src/vs/workbench/api/common/positron/extHostConsoleService.ts
@@ -31,9 +31,9 @@ export class ExtHostConsoleService implements extHostProtocol.ExtHostConsoleServ
 	onDidChangeConsoleWidth = this._onDidChangeConsoleWidth.event;
 
 	/**
-	 * Queries the main thread for the current width of the console.
+	 * Queries the main thread for the current width of the console input.
 	 *
-	 * @returns The width of the console in characters.
+	 * @returns The width of the console input in characters.
 	 */
 	getConsoleWidth(): Promise<number> {
 		return this._proxy.$getConsoleWidth();

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -539,8 +539,8 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 		consoleInputWidth -= 14;
 	}
 
-	// Forward the adjusted width to the console instance.
-	props.positronConsoleInstance.setWidthPx(adjustedWidth);
+	// Forward the console input width to the console instance.
+	props.positronConsoleInstance.setWidthPx(consoleInputWidth);
 
 	// Render.
 	return (

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -75,7 +75,7 @@ export interface IPositronConsoleService {
 	initialize(): void;
 
 	/**
-	 * Gets the current console width, in characters.
+	 * Gets the current console input width, in characters.
 	 */
 	getConsoleWidth(): number;
 
@@ -202,13 +202,13 @@ export interface IPositronConsoleInstance {
 	focusInput(): void;
 
 	/**
-	 * Tells the console its current width, in pixels. Fires the
+	 * Tells the console its current console input width, in pixels. Fires the
 	 * onDidChangeWidth event if the width has changed.
 	 */
 	setWidthPx(newWidth: number): void;
 
 	/**
-	 * Gets the current width of the console, in pixels.
+	 * Gets the current width of the console input, in pixels.
 	 */
 	getWidthPx(): number;
 

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -450,10 +450,10 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 	}
 
 	/**
-	 * Gets the current console width, in characters; throws an error if there is no active
+	 * Gets the current console input width, in characters; throws an error if there is no active
 	 * Positron console instance.
 	 *
-	 * @returns The current console width, in characters.
+	 * @returns The current console input width, in characters.
 	 */
 	getConsoleWidth(): number {
 		if (this._activePositronConsoleInstance) {
@@ -663,7 +663,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	private _inputTextEditor: IEditor | undefined;
 
 	/**
-	 * The current width of the console.
+	 * The current width of the console input.
 	 */
 	private _width = 0;
 
@@ -709,7 +709,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	}
 
 	/**
-	 * Sets the console's width in pixels.
+	 * Sets the console input's width in pixels.
 	 *
 	 * @param newWidth The new width, in pixels.
 	 */
@@ -721,9 +721,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	}
 
 	/**
-	 * Gets the console's width in pixels.
+	 * Gets the console input's width in pixels.
 	 *
-	 * @returns The console's current width in pixels.
+	 * @returns The console input's current width in pixels.
 	 */
 	getWidthPx(): number {
 		return this._width;


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2074
Addresses https://github.com/posit-dev/positron/issues/2176

I'm like 75% confident this is the right fix, so someone who knows more should definitely judge this PR.

In the first commit, you'll see two variables:
- `adjustedWidth`: The width of the console after taking the padding into account
- `consoleInputWidth`: The width of the console after also taking the vertical scrollbar into account

If this video is anything to go by, I believe that the downstream consumers of `getConsoleWidth()` really need `consoleInputWidth`, not `adjustedWidth`. i.e. it looks like the vertical scrollbar is embedded into the console instance in a way that it definitely affects how many characters can be printed in the console by R/Python.

I suppose _technically_ we may want to go through and update the functions from `getConsoleWidth()` -> `getConsoleInputWidth()` and whatnot, but honestly this is probably the only variant of "console width" that extensions will probably care about, so I'm satisfied with just tweaking the docs a little (i can revert that too if you don't even want to go that far)

https://github.com/posit-dev/positron/assets/19150088/8edf0290-0f55-4c3c-a2a5-6b8a8cd15502

<img width="963" alt="Screenshot 2024-01-31 at 4 12 00 PM" src="https://github.com/posit-dev/positron/assets/19150088/50843595-d5c4-4393-aa1d-96cc90a5b846">

<img width="959" alt="Screenshot 2024-01-31 at 4 12 48 PM" src="https://github.com/posit-dev/positron/assets/19150088/130d762c-4c8f-452e-a85f-97ecce972724">
