### PR TITLE
Generate __post_init__ for arrays of components in Python dataclasses

### DIFF
--- a/positron/comms/data_tool-backend-openrpc.json
+++ b/positron/comms/data_tool-backend-openrpc.json
@@ -103,14 +103,22 @@
 							"type": "array",
 							"description": "The columns of data",
 							"items": {
-								"$ref": "#/components/schemas/column_formatted_data"
+								"type": "array",
+								"description": "Column values formatted as strings",
+								"items": {
+									"type": "string"
+								}
 							}
 						},
 						"row_labels": {
 							"type": "array",
 							"description": "Zero or more arrays of row labels",
 							"items": {
-								"$ref": "#/components/schemas/column_formatted_data"
+								"type": "array",
+								"description": "Column values formatted as strings",
+								"items": {
+									"type": "string"
+								}
 							}
 						}
 					}

--- a/src/vs/workbench/services/languageRuntime/common/positronDataToolComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataToolComm.ts
@@ -37,12 +37,12 @@ export interface TableData {
 	/**
 	 * The columns of data
 	 */
-	columns: Array<ColumnFormattedData>;
+	columns: Array<Array<string>>;
 
 	/**
 	 * Zero or more arrays of row labels
 	 */
-	row_labels?: Array<ColumnFormattedData>;
+	row_labels?: Array<Array<string>>;
 
 }
 


### PR DESCRIPTION
Following on discussion from Slack, this boxes any unboxed dicts passed to a `List[SomeDataType]` in a `SomeDataType` dataclass in Python. This only impacted reused components because these were being pulled out into their own standalone dataclasses