### PR TITLE
Use more portable paths in the test explorer

### DIFF
--- a/extensions/positron-r/src/testing/runner-testthat.ts
+++ b/extensions/positron-r/src/testing/runner-testthat.ts
@@ -76,13 +76,14 @@ export async function runThatTest(
 	}
 
 	const isSingleTest = testType === ItemType.TestThat;
-	const testPath = testType === ItemType.Directory ? testingTools.packageRoot.fsPath : test!.uri!.fsPath;
-
+	let testPath = testType === ItemType.Directory ? testingTools.packageRoot.fsPath : test!.uri!.fsPath;
 	Logger.info(
 		`Started running ${isSingleTest ? 'single test' : 'all tests'
 		} in ${testType === ItemType.Directory ? 'directory' : 'file'
 		} '${testPath}'`
 	);
+	// use POSIX path separators in the test-running R snippet for better portability
+	testPath = testPath.replace(/\\/g, '/');
 
 	const devtoolsMethod = testType === ItemType.Directory ? 'test' : 'test_active_file';
 	const descInsert = isSingleTest ? ` desc = '${test?.label || '<all tests>'}', ` : '';


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/1808#issuecomment-1920164409

With the R extension's log level set to "debug", you can get this info about the error:

```
Error: ℹ Loading vscodereporter
Error: '\U' used without hex digits in character string (<input>:1:32)
Execution halted
```

I was able to reproduce the problem in a windows VM and this fixes it for me.

Relevant context:

* Prior to this PR, the test-running command looked something like this:

    ```
    "C:\Program Files\R\R-4.3.2\bin\R.exe" --no-echo -e "devtools::load_all('d:/Users/jenny/source/repos/positron/extensions/positron-r/resources/testing/vscodereporter');devtools::test_active_file('d:\Users\jenny\source\repos\rematch2\tests\testthat\test-all.R', desc = 'corner cases', reporter = VSCodeReporter)"
    ```

    Note the paths in the snippet of R code and, specifically, the different path separators. The problem was the Windows-style path where the backslashes aren't escaped, i.e. doubled. In the error above, you can tell that the `load_all()` command actually succeeds, so it's the path in `test_active_file()` that is the problem. The solution is to use POSIX-style path separation. Here's how the test-running command looks with this PR:

    ```
    "C:\Program Files\R\R-4.3.2\bin\R.exe" --no-echo -e "devtools::load_all('d:/Users/jenny/source/repos/positron/extensions/positron-r/resources/testing/vscodereporter');devtools::test_active_file('d:/Users/jenny/source/repos/rematch2/tests/testthat/test-exec.R',reporter = VSCodeReporter)"
    ```
* This treatment was already in place for the path to the embedded test reporter package and now it's clear why. https://github.com/posit-dev/positron/blob/9362409efbe4b15b75c4ab713ee3ae57cf60f464/extensions/positron-r/src/testing/runner-testthat.ts#L17-L19
* This approach is consistent with the advice given in the [R for Windows FAQ](https://cran.r-project.org/bin/windows/base/rw-FAQ.html#R-can_0027t-find-my-file):

  > Backslashes have to be doubled in R character strings, so for example one needs `"d:\\R-4.3.2\\library\\xgobi\\scripts\\xgobi.bat"`. You can make life easier for yourself by using forward slashes as path separators: they do work under Windows. 
* FWIW `child_process.spawn(..., { shell: true })` is launching a `cmd.exe` shell on Windows, but this turns out to be neither here nor there in terms of this problem.