### PR TITLE
Bump ark to 0.1.52

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -527,7 +527,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.51"
+      "ark": "0.1.52"
     }
   }
 }


### PR DESCRIPTION
For https://github.com/posit-dev/amalthea/commit/1e46368f0799fd007dc477df5df42132ef9e7c32. Plots in Ark were accidentally broken by https://github.com/posit-dev/amalthea/pull/206 which now requires qualifying functions outside of base with a namespace (e.g. graphic functions from `grDevices::`).

The R error was propagated to Rust, and then as a JSON-RPC error response, but it was silently ignored by the frontend, see https://github.com/posit-dev/positron/issues/2195.