### PR TITLE
Propagate help comm errors

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotInstance.tsx
@@ -33,6 +33,7 @@ interface DynamicPlotInstanceProps {
 export const DynamicPlotInstance = (props: DynamicPlotInstanceProps) => {
 
 	const [uri, setUri] = useState('');
+	const [error, setError] = useState('');
 	const progressRef = React.useRef<HTMLDivElement>(null);
 	const plotsContext = usePositronPlotsContext();
 
@@ -61,6 +62,7 @@ export const DynamicPlotInstance = (props: DynamicPlotInstanceProps) => {
 			}
 			const message = localize('positronPlots.renderError', "Error rendering plot to {0} x {1}: {2} ({3})", plotSize.width, plotSize.height, e.message, e.code);
 			plotsContext.notificationService.warn(message);
+			setError(message);
 		});
 
 		// When the plot is rendered, update the URI.
@@ -155,14 +157,18 @@ export const DynamicPlotInstance = (props: DynamicPlotInstanceProps) => {
 	};
 
 	// Render method for the placeholder
-	const placeholderImage = () => {
+	const placeholderImage = (text: string) => {
 		const style = {
 			width: props.width + 'px',
 			height: props.height + 'px'
 		};
+
+		text = text.length ? text : `Rendering plot (${props.width} x ${props.height})`;
+
+		// display error here
 		return <div className='image-placeholder' style={style}>
 			<div className='image-placeholder-text'>
-				Rendering plot ({props.width} x {props.height})
+				{text}
 			</div>
 		</div>;
 	};
@@ -173,7 +179,7 @@ export const DynamicPlotInstance = (props: DynamicPlotInstanceProps) => {
 		<div className='plot-instance dynamic-plot-instance'>
 			<div ref={progressRef}></div>
 			{uri && renderedImage()}
-			{!uri && placeholderImage()}
+			{!uri && placeholderImage(error)}
 		</div>
 	);
 };

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -365,6 +365,7 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 					this.scheduleRender(queuedRender, 0);
 				}
 			}).catch((err) => {
+				this._stateEmitter.fire(PlotClientState.Rendered);
 				request.error(err);
 			});
 	}

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -364,6 +364,8 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 					this._currentRender = queuedRender;
 					this.scheduleRender(queuedRender, 0);
 				}
+			}).catch((err) => {
+				request.error(err);
 			});
 	}
 


### PR DESCRIPTION
Addresses #2195

We had most of the error handling in place, just needed a bit of glue.

- Now produces a warning notification when a help comm responds with an error thanks to the error propagation.
- We mark the plot as rendered after an error so that the progress bar gets disposed.
- The error message is shown in the plot placeholder. I feel like this is sufficient notification, should we get rid of the warning?

In this example the R function `.ps.graphics.renderPlotFromCurrentDevice()` throws "tilt":

<img width="581" alt="Screenshot 2024-02-02 at 16 36 35" src="https://github.com/posit-dev/positron/assets/4465050/694fe764-d8b1-46ff-a206-72c1a5b86837">

