### PR TITLE
Don't stop LSP in the middle of startup

### DIFF
--- a/extensions/positron-r/src/runtime.ts
+++ b/extensions/positron-r/src/runtime.ts
@@ -231,9 +231,20 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 		}
 	}
 
+	// Keep track of LSP init to avoid stopping in the middle of startup
+	private _lspStarting: Promise<void> = Promise.resolve();
+
 	async restart(): Promise<void> {
 		if (this._kernel) {
-			// Stop the LSP client before restarting the kernel
+			// Stop the LSP client before restarting the kernel. Don't stop it
+			// until fully started to avoid an inconsistent state where the
+			// deactivation request comes in between the creation of the LSP
+			// comm and the LSP client.
+			//
+			// A cleaner way to set this up might be to put `this._lsp` in
+			// charge of creating the LSP comm, then `deactivate()` could
+			// keep track of this state itself.
+			await this._lspStarting;
 			await this._lsp.deactivate(true);
 			return this._kernel.restart();
 		} else {
@@ -475,6 +486,8 @@ export class RRuntime implements positron.LanguageRuntime, vscode.Disposable {
 			// Start the LSP and DAP servers
 			this._queue.add(async () => {
 				const lsp = this.startLsp();
+				this._lspStarting = lsp;
+
 				const dap = this.startDap();
 				await Promise.all([lsp, dap]);
 			});

--- a/extensions/positron-r/src/util.ts
+++ b/extensions/positron-r/src/util.ts
@@ -21,6 +21,11 @@ export function delay(ms: number) {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+export async function whenTimeout<T>(ms: number, fn: () => T): Promise<T> {
+	await delay(ms);
+	return fn();
+}
+
 export function timeout(ms: number, reason: string) {
 	return new Promise((_, reject) => {
 		setTimeout(() => reject(`Timeout while ${reason}`), ms);


### PR DESCRIPTION
Alternative fix for https://github.com/posit-dev/amalthea/pull/234

@DavisVaughan I figured out the underlying cause of the restart instability. It was because we ended up in a state where we tried to clean up the LSP client right in between the creation of the LSP comm and the creation of the LSP client. So the cleanup would not do anything and then the client was incorrectly created afterwards.

With this PR and https://github.com/posit-dev/amalthea/pull/236 to fix the deadlock you've identified in https://github.com/posit-dev/amalthea/pull/234, quick successions of restart become reliable again!