### PR TITLE
Data Viewer: Add data caching, debounce fetch requests 

### DIFF
--- a/src/vs/workbench/services/positronDataTool/browser/positronDataToolDataGridInstance.ts
+++ b/src/vs/workbench/services/positronDataTool/browser/positronDataToolDataGridInstance.ts
@@ -248,6 +248,10 @@ export class PositronDataToolDataGridInstance extends DataGridInstance {
 			} satisfies ColumnSortKey
 		)));
 
+		// Clear the data cache
+		this._fetchManager.clear();
+		this._lastFetchResult = undefined;
+
 		// Refetch data.
 		await this.doFetchData();
 	}

--- a/src/vs/workbench/services/positronDataTool/browser/positronDataToolDataGridInstance.ts
+++ b/src/vs/workbench/services/positronDataTool/browser/positronDataToolDataGridInstance.ts
@@ -2,21 +2,152 @@
  *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
-import { generateUuid } from 'vs/base/common/uuid';
 import { IColumnSortKey } from 'vs/base/browser/ui/dataGrid/interfaces/columnSortKey';
 import { DataGridInstance } from 'vs/base/browser/ui/dataGrid/classes/dataGridInstance';
 import { PositronDataToolColumn } from 'vs/workbench/services/positronDataTool/browser/positronDataToolColumn';
 import { DataToolClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataToolClient';
 import { ColumnSortKey, TableData, TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataToolComm';
 
-interface CachedTableData {
-	firstColumnIndex: number;
-	columnIndices: number[];
+interface FetchRange {
+	/// Start index is inclusive
+	rowStartIndex: number;
 
-	firstRowIndex: number;
-	lastRowIndex: number;
+	/// End index is exclusive
+	rowEndIndex: number;
 
-	tableData: TableData;
+	/// Start index is inclusive
+	columnStartIndex: number;
+
+	/// End index is exclusive
+	columnEndIndex: number;
+}
+
+function rangeIncludes(range: FetchRange, inRange: FetchRange) {
+	return (range.rowStartIndex < inRange.rowStartIndex &&
+		range.rowEndIndex >= inRange.rowEndIndex &&
+		range.columnStartIndex < inRange.columnStartIndex &&
+		range.columnEndIndex >= inRange.columnEndIndex);
+}
+
+interface FetchResult extends FetchRange {
+	data: TableData;
+	lastUsedTime: number;
+}
+
+type FetchFunc = (req: FetchRange) => Promise<TableData>;
+
+export class PositronDataToolFetchManager {
+	private readonly ROW_CACHE_WINDOW = 100;
+	private readonly COLUMN_CACHE_WINDOW = 10;
+
+	private _cachedResults: Array<FetchResult> = [];
+
+	// Number of cells cached
+	private _cacheSize: number = 0;
+
+	// We cache up to this many cells. After that, we start dropping the
+	// least-recently used cached data
+	private readonly MAX_NUM_CACHED_CELLS = 100_000;
+
+	// The active fetch, so we can avoid spamming the backend with too many requests
+	private _pendingFetch?: { range: FetchRange; promise: Promise<FetchResult> };
+
+	// If we need to fetch more data and there is already a pending fetch,
+	// then we queue the next fetch with setTimeout, which will be immediately canceled
+	// and superseded by another fetch (e.g. if the user is moving around the waffle
+	// really fast).
+	private _debounceTimer?: any;
+
+	// We'll try a 100ms debounce timeout to start
+	private _debounceMillis = 100;
+
+	private readonly _fetcher: FetchFunc;
+
+	constructor(fetcher: FetchFunc) {
+		this._fetcher = fetcher;
+	}
+
+	/// Execute fetch request and handle throttling requests so that we do not spam the
+	/// backend with tons of requests if the user is moving around the waffle quickly.
+	fetch(range: FetchRange): Promise<FetchResult> {
+		if (this._pendingFetch) {
+			// If there is a pending fetch, clear any existing timer for a follow up request,
+			// and set a new timer
+			clearTimeout(this._debounceTimer);
+
+			let deferredResolve: (r: FetchResult) => void;
+			const deferredPromise: Promise<FetchResult> = new Promise(resolve => {
+				deferredResolve = resolve;
+			});
+			this._debounceTimer = setTimeout(async () => {
+				const promise = this.cacheRange(range);
+				this._pendingFetch = { range, promise };
+				const result = await promise;
+				deferredResolve(result);
+			}, this._debounceMillis);
+
+			return deferredPromise;
+		} else {
+			this._pendingFetch = { range, promise: this.cacheRange(range) };
+			return this._pendingFetch.promise;
+		}
+	}
+
+	private async cacheRange(range: FetchRange): Promise<FetchResult> {
+		// Determine if the range is contained in any cached result
+		for (const cachedResult of this._cachedResults) {
+			if (rangeIncludes(range, cachedResult)) {
+				return cachedResult;
+			}
+		}
+
+		// See if the range is contained in any of the cached data
+		const cacheRange = structuredClone(range);
+
+		cacheRange.rowEndIndex += this.ROW_CACHE_WINDOW;
+		cacheRange.columnEndIndex += this.COLUMN_CACHE_WINDOW;
+
+		const data = await this._fetcher(cacheRange);
+
+		// Set this based on actual number of columns returned
+		cacheRange.columnEndIndex = cacheRange.columnStartIndex + data.columns.length;
+
+		if (data.columns.length === 0) {
+			// No data was returned, so set numRows to 0
+			range.rowEndIndex = range.rowStartIndex;
+		} else {
+			range.rowEndIndex = range.rowStartIndex + data.columns[0].length;
+		}
+
+		const lastUsedTime = new Date().getTime();
+		const result: FetchResult = { data, lastUsedTime, ...cacheRange };
+
+		const getTotalCells = (range: FetchRange) => {
+			return ((range.columnEndIndex - range.columnStartIndex) *
+				(range.rowEndIndex - range.rowStartIndex));
+		};
+
+		const numCells = getTotalCells(cacheRange);
+
+		while (this._cacheSize + numCells > this.MAX_NUM_CACHED_CELLS) {
+			// Evict results from cache based on recency of use
+			let oldest = 0;
+			for (let i = 1; i < this._cachedResults.length; ++i) {
+				if (this._cachedResults[i].lastUsedTime < this._cachedResults[oldest].lastUsedTime) {
+					oldest = i;
+				}
+			}
+			this._cacheSize -= getTotalCells(this._cachedResults[oldest]);
+			this._cachedResults.splice(oldest, 1);
+		}
+		this._cachedResults.push(result);
+
+		return result;
+	}
+
+	clear() {
+		this._cachedResults = [];
+	}
 }
 
 /**
@@ -30,9 +161,9 @@ export class PositronDataToolDataGridInstance extends DataGridInstance {
 
 	private _tableSchema?: TableSchema;
 
-	private _lastFetchIdentifier = '';
+	private _fetchManager: PositronDataToolFetchManager;
 
-	private _cachedTableData?: CachedTableData;
+	private _lastFetchResult?: FetchResult;
 
 	constructor(dataToolClientInstance: DataToolClientInstance) {
 		// Call the base class's constructor.
@@ -45,6 +176,25 @@ export class PositronDataToolDataGridInstance extends DataGridInstance {
 
 		// Set the data tool client instance.
 		this._dataToolClientInstance = dataToolClientInstance;
+
+		this._fetchManager = new PositronDataToolFetchManager(async (req: FetchRange) => {
+			const start = new Date().getTime();
+
+			// Build the column indices to fetch.
+			const columnIndices: number[] = [];
+			for (let i = req.columnStartIndex; i < req.columnEndIndex; i++) {
+				columnIndices.push(i);
+			}
+
+			const data = await this._dataToolClientInstance.getDataValues(
+				req.rowStartIndex,
+				req.rowEndIndex - req.rowStartIndex,
+				columnIndices
+			);
+			const end = new Date().getTime();
+			console.log(`Fetching data took ${end - start}ms`);
+			return data;
+		});
 	}
 
 	/**
@@ -105,46 +255,27 @@ export class PositronDataToolDataGridInstance extends DataGridInstance {
 			return;
 		}
 
-		// Set the first column index and first row index.
-		const firstColumnIndex = this.firstColumnIndex;
-		const firstRowIndex = this.firstRowIndex;
+		const rangeToFetch: FetchRange = {
+			rowStartIndex: this.firstRowIndex,
+			rowEndIndex: this.firstRowIndex + this.visibleRows,
+			columnStartIndex: this.firstColumnIndex,
+			columnEndIndex: this.firstColumnIndex + this.visibleColumns + 1
+		};
 
-		// Build the column indices to fetch.
-		const columnIndices: number[] = [];
-		for (let i = this.firstColumnIndex; i < Math.min(this.firstColumnIndex + this.visibleColumns + 1, this.columns); i++) {
-			columnIndices.push(i);
+		if (this.needToFetch(rangeToFetch)) {
+			this._lastFetchResult = await this._fetchManager.fetch(rangeToFetch);
 		}
-
-		// Generate a fetch identifier.
-		const fetchIdentifier = this._lastFetchIdentifier = generateUuid();
-
-		// Fetch data.
-		const start = new Date().getTime();
-		const tableData = await this._dataToolClientInstance.getDataValues(
-			firstRowIndex,
-			this.visibleRows + 10,
-			columnIndices
-		);
-
-
-		if (fetchIdentifier !== this._lastFetchIdentifier) {
-			console.log('+++++++++++++++++++ DISCARDING FETCHED DATA');
-		}
-
-		const end = new Date().getTime();
-		console.log(`Fetching data took ${end - start}ms`);
-
-		// Set the cached data.
-		this._cachedTableData = {
-			firstColumnIndex,
-			columnIndices,
-			firstRowIndex,
-			lastRowIndex: firstRowIndex + this.visibleRows + 10,
-			tableData
-		} satisfies CachedTableData;
 
 		// Fire the onDidUpdate event.
 		this._onDidUpdateEmitter.fire();
+	}
+
+	private needToFetch(range: FetchRange) {
+		if (!this._lastFetchResult) {
+			return true;
+		} else {
+			return rangeIncludes(range, this._lastFetchResult);
+		}
 	}
 
 	fetchData() {
@@ -162,27 +293,27 @@ export class PositronDataToolDataGridInstance extends DataGridInstance {
 	 */
 	rowLabel(rowIndex: number) {
 		// If there isn't any cached data, return undefined.
-		if (!this._cachedTableData) {
+		if (!this._lastFetchResult) {
 			return undefined;
 		}
 
 		// If the row isn't cached, return undefined.
-		if (rowIndex < this._cachedTableData.firstRowIndex ||
-			rowIndex > this._cachedTableData.lastRowIndex
+		if (rowIndex < this._lastFetchResult.rowStartIndex ||
+			rowIndex > this._lastFetchResult.rowEndIndex
 		) {
 			return undefined;
 		}
 
 		// If there are no row labels, return the row index.
-		if (!this._cachedTableData.tableData.row_labels) {
+		if (!this._lastFetchResult.data.row_labels) {
 			return `${rowIndex + 1}`;
 		}
 
 		// Calculate the cached row index.
-		const cachedRowIndex = rowIndex - this._cachedTableData.firstRowIndex;
+		const cachedRowIndex = rowIndex - this._lastFetchResult.rowStartIndex;
 
 		// Return the cached row label.
-		return this._cachedTableData.tableData.row_labels[0][cachedRowIndex];
+		return this._lastFetchResult.data.row_labels[0][cachedRowIndex];
 	}
 
 	/**
@@ -193,27 +324,24 @@ export class PositronDataToolDataGridInstance extends DataGridInstance {
 	 */
 	cell(columnIndex: number, rowIndex: number): string | undefined {
 		// If there isn't any cached data, return undefined.
-		if (!this._cachedTableData) {
+		if (!this._lastFetchResult) {
 			return undefined;
 		}
 
-		// If the row isn't cached, return undefined.
-		if (rowIndex < this._cachedTableData.firstRowIndex ||
-			rowIndex > this._cachedTableData.lastRowIndex
+		// If the cell isn't cached, return undefined.
+		if (rowIndex < this._lastFetchResult.rowStartIndex ||
+			rowIndex >= this._lastFetchResult.rowEndIndex ||
+			columnIndex < this._lastFetchResult.columnStartIndex ||
+			columnIndex >= this._lastFetchResult.columnEndIndex
 		) {
 			return undefined;
 		}
 
-		// If the column isn't cached, return undefined.
-		const colIndex = this._cachedTableData.columnIndices.indexOf(columnIndex);
-		if (colIndex === -1) {
-			return undefined;
-		}
-
-		// Calculate the cached row index.
-		const cachedRowIndex = rowIndex - this._cachedTableData.firstRowIndex;
+		// Calculate the cache indices.
+		const cachedRowIndex = rowIndex - this._lastFetchResult.rowStartIndex;
+		const cachedColIndex = columnIndex - this._lastFetchResult.columnStartIndex;
 
 		// Return the cached value.
-		return this._cachedTableData.tableData.columns[colIndex][cachedRowIndex];
+		return this._lastFetchResult.data.columns[cachedColIndex][cachedRowIndex];
 	}
 }

--- a/src/vs/workbench/services/positronDataTool/browser/positronDataToolDataGridInstance.ts
+++ b/src/vs/workbench/services/positronDataTool/browser/positronDataToolDataGridInstance.ts
@@ -274,7 +274,7 @@ export class PositronDataToolDataGridInstance extends DataGridInstance {
 		if (!this._lastFetchResult) {
 			return true;
 		} else {
-			return rangeIncludes(range, this._lastFetchResult);
+			return !rangeIncludes(range, this._lastFetchResult);
 		}
 	}
 

--- a/src/vs/workbench/services/positronDataTool/browser/positronDataToolDataGridInstance.ts
+++ b/src/vs/workbench/services/positronDataTool/browser/positronDataToolDataGridInstance.ts
@@ -23,10 +23,10 @@ interface FetchRange {
 }
 
 function rangeIncludes(range: FetchRange, inRange: FetchRange) {
-	return (range.rowStartIndex < inRange.rowStartIndex &&
-		range.rowEndIndex >= inRange.rowEndIndex &&
-		range.columnStartIndex < inRange.columnStartIndex &&
-		range.columnEndIndex >= inRange.columnEndIndex);
+	return (range.rowStartIndex >= inRange.rowStartIndex &&
+		range.rowEndIndex <= inRange.rowEndIndex &&
+		range.columnStartIndex >= inRange.columnStartIndex &&
+		range.columnEndIndex <= inRange.columnEndIndex);
 }
 
 interface FetchResult extends FetchRange {
@@ -104,7 +104,10 @@ export class PositronDataToolFetchManager {
 		// See if the range is contained in any of the cached data
 		const cacheRange = structuredClone(range);
 
+		cacheRange.rowStartIndex = Math.max(0, cacheRange.rowStartIndex - this.ROW_CACHE_WINDOW);
 		cacheRange.rowEndIndex += this.ROW_CACHE_WINDOW;
+
+		cacheRange.columnStartIndex = Math.max(0, cacheRange.columnStartIndex - this.COLUMN_CACHE_WINDOW);
 		cacheRange.columnEndIndex += this.COLUMN_CACHE_WINDOW;
 
 		const data = await this._fetcher(cacheRange);
@@ -259,7 +262,7 @@ export class PositronDataToolDataGridInstance extends DataGridInstance {
 			rowStartIndex: this.firstRowIndex,
 			rowEndIndex: this.firstRowIndex + this.visibleRows,
 			columnStartIndex: this.firstColumnIndex,
-			columnEndIndex: this.firstColumnIndex + this.visibleColumns + 1
+			columnEndIndex: this.firstColumnIndex + this.visibleColumns
 		};
 
 		if (this.needToFetch(rangeToFetch)) {

--- a/src/vs/workbench/services/positronDataTool/browser/positronDataToolDataGridInstance.ts
+++ b/src/vs/workbench/services/positronDataTool/browser/positronDataToolDataGridInstance.ts
@@ -130,9 +130,9 @@ export class PositronDataToolFetchManager {
 				(range.rowEndIndex - range.rowStartIndex));
 		};
 
-		const numCells = getTotalCells(cacheRange);
+		this._cacheSize += getTotalCells(cacheRange);
 
-		while (this._cacheSize + numCells > this.MAX_NUM_CACHED_CELLS) {
+		while (this._cacheSize > this.MAX_NUM_CACHED_CELLS) {
 			// Evict results from cache based on recency of use
 			let oldest = 0;
 			for (let i = 1; i < this._cachedResults.length; ++i) {

--- a/src/vs/workbench/services/positronDataTool/browser/positronDataToolDataGridInstance.ts
+++ b/src/vs/workbench/services/positronDataTool/browser/positronDataToolDataGridInstance.ts
@@ -6,152 +6,8 @@ import { IColumnSortKey } from 'vs/base/browser/ui/dataGrid/interfaces/columnSor
 import { DataGridInstance } from 'vs/base/browser/ui/dataGrid/classes/dataGridInstance';
 import { PositronDataToolColumn } from 'vs/workbench/services/positronDataTool/browser/positronDataToolColumn';
 import { DataToolClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataToolClient';
-import { ColumnSortKey, TableData, TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataToolComm';
-
-interface FetchRange {
-	/// Start index is inclusive
-	rowStartIndex: number;
-
-	/// End index is exclusive
-	rowEndIndex: number;
-
-	/// Start index is inclusive
-	columnStartIndex: number;
-
-	/// End index is exclusive
-	columnEndIndex: number;
-}
-
-function rangeIncludes(range: FetchRange, inRange: FetchRange) {
-	return (range.rowStartIndex >= inRange.rowStartIndex &&
-		range.rowEndIndex <= inRange.rowEndIndex &&
-		range.columnStartIndex >= inRange.columnStartIndex &&
-		range.columnEndIndex <= inRange.columnEndIndex);
-}
-
-interface FetchResult extends FetchRange {
-	data: TableData;
-	lastUsedTime: number;
-}
-
-type FetchFunc = (req: FetchRange) => Promise<TableData>;
-
-export class PositronDataToolFetchManager {
-	private readonly ROW_CACHE_WINDOW = 100;
-	private readonly COLUMN_CACHE_WINDOW = 10;
-
-	private _cachedResults: Array<FetchResult> = [];
-
-	// Number of cells cached
-	private _cacheSize: number = 0;
-
-	// We cache up to this many cells. After that, we start dropping the
-	// least-recently used cached data
-	private readonly MAX_NUM_CACHED_CELLS = 100_000;
-
-	// The active fetch, so we can avoid spamming the backend with too many requests
-	private _pendingFetch?: { range: FetchRange; promise: Promise<FetchResult> };
-
-	// If we need to fetch more data and there is already a pending fetch,
-	// then we queue the next fetch with setTimeout, which will be immediately canceled
-	// and superseded by another fetch (e.g. if the user is moving around the waffle
-	// really fast).
-	private _debounceTimer?: any;
-
-	// We'll try a 100ms debounce timeout to start
-	private _debounceMillis = 100;
-
-	private readonly _fetcher: FetchFunc;
-
-	constructor(fetcher: FetchFunc) {
-		this._fetcher = fetcher;
-	}
-
-	/// Execute fetch request and handle throttling requests so that we do not spam the
-	/// backend with tons of requests if the user is moving around the waffle quickly.
-	fetch(range: FetchRange): Promise<FetchResult> {
-		if (this._pendingFetch) {
-			// If there is a pending fetch, clear any existing timer for a follow up request,
-			// and set a new timer
-			clearTimeout(this._debounceTimer);
-
-			let deferredResolve: (r: FetchResult) => void;
-			const deferredPromise: Promise<FetchResult> = new Promise(resolve => {
-				deferredResolve = resolve;
-			});
-			this._debounceTimer = setTimeout(async () => {
-				const promise = this.cacheRange(range);
-				this._pendingFetch = { range, promise };
-				const result = await promise;
-				deferredResolve(result);
-			}, this._debounceMillis);
-
-			return deferredPromise;
-		} else {
-			this._pendingFetch = { range, promise: this.cacheRange(range) };
-			return this._pendingFetch.promise;
-		}
-	}
-
-	private async cacheRange(range: FetchRange): Promise<FetchResult> {
-		// Determine if the range is contained in any cached result
-		for (const cachedResult of this._cachedResults) {
-			if (rangeIncludes(range, cachedResult)) {
-				return cachedResult;
-			}
-		}
-
-		// See if the range is contained in any of the cached data
-		const cacheRange = structuredClone(range);
-
-		cacheRange.rowStartIndex = Math.max(0, cacheRange.rowStartIndex - this.ROW_CACHE_WINDOW);
-		cacheRange.rowEndIndex += this.ROW_CACHE_WINDOW;
-
-		cacheRange.columnStartIndex = Math.max(0, cacheRange.columnStartIndex - this.COLUMN_CACHE_WINDOW);
-		cacheRange.columnEndIndex += this.COLUMN_CACHE_WINDOW;
-
-		const data = await this._fetcher(cacheRange);
-
-		// Set this based on actual number of columns returned
-		cacheRange.columnEndIndex = cacheRange.columnStartIndex + data.columns.length;
-
-		if (data.columns.length === 0) {
-			// No data was returned, so set numRows to 0
-			range.rowEndIndex = range.rowStartIndex;
-		} else {
-			range.rowEndIndex = range.rowStartIndex + data.columns[0].length;
-		}
-
-		const lastUsedTime = new Date().getTime();
-		const result: FetchResult = { data, lastUsedTime, ...cacheRange };
-
-		const getTotalCells = (range: FetchRange) => {
-			return ((range.columnEndIndex - range.columnStartIndex) *
-				(range.rowEndIndex - range.rowStartIndex));
-		};
-
-		this._cacheSize += getTotalCells(cacheRange);
-
-		while (this._cacheSize > this.MAX_NUM_CACHED_CELLS) {
-			// Evict results from cache based on recency of use
-			let oldest = 0;
-			for (let i = 1; i < this._cachedResults.length; ++i) {
-				if (this._cachedResults[i].lastUsedTime < this._cachedResults[oldest].lastUsedTime) {
-					oldest = i;
-				}
-			}
-			this._cacheSize -= getTotalCells(this._cachedResults[oldest]);
-			this._cachedResults.splice(oldest, 1);
-		}
-		this._cachedResults.push(result);
-
-		return result;
-	}
-
-	clear() {
-		this._cachedResults = [];
-	}
-}
+import { ColumnSortKey, TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataToolComm';
+import { FetchRange, FetchResult, PositronDataToolCache } from 'vs/workbench/services/positronDataTool/common/positronDataToolCache';
 
 /**
  * PositronDataToolDataGridInstance class.
@@ -164,7 +20,7 @@ export class PositronDataToolDataGridInstance extends DataGridInstance {
 
 	private _tableSchema?: TableSchema;
 
-	private _fetchManager: PositronDataToolFetchManager;
+	private _cache: PositronDataToolCache;
 
 	private _lastFetchResult?: FetchResult;
 
@@ -180,7 +36,7 @@ export class PositronDataToolDataGridInstance extends DataGridInstance {
 		// Set the data tool client instance.
 		this._dataToolClientInstance = dataToolClientInstance;
 
-		this._fetchManager = new PositronDataToolFetchManager(async (req: FetchRange) => {
+		this._cache = new PositronDataToolCache(async (req: FetchRange) => {
 			const start = new Date().getTime();
 
 			// Build the column indices to fetch.
@@ -248,12 +104,15 @@ export class PositronDataToolDataGridInstance extends DataGridInstance {
 			} satisfies ColumnSortKey
 		)));
 
-		// Clear the data cache
-		this._fetchManager.clear();
-		this._lastFetchResult = undefined;
-
 		// Refetch data.
+		this.resetCache();
 		await this.doFetchData();
+	}
+
+	private resetCache() {
+		// Clear the data cache
+		this._cache.clear();
+		this._lastFetchResult = undefined;
 	}
 
 	private async doFetchData(): Promise<void> {
@@ -270,7 +129,7 @@ export class PositronDataToolDataGridInstance extends DataGridInstance {
 		};
 
 		if (this.needToFetch(rangeToFetch)) {
-			this._lastFetchResult = await this._fetchManager.fetch(rangeToFetch);
+			this._lastFetchResult = await this._cache.fetch(rangeToFetch);
 		}
 
 		// Fire the onDidUpdate event.
@@ -281,7 +140,7 @@ export class PositronDataToolDataGridInstance extends DataGridInstance {
 		if (!this._lastFetchResult) {
 			return true;
 		} else {
-			return !rangeIncludes(range, this._lastFetchResult);
+			return !PositronDataToolCache.rangeIncludes(range, this._lastFetchResult);
 		}
 	}
 

--- a/src/vs/workbench/services/positronDataTool/common/positronDataToolCache.ts
+++ b/src/vs/workbench/services/positronDataTool/common/positronDataToolCache.ts
@@ -29,6 +29,8 @@ export class PositronDataToolCache {
 	private readonly ROW_CACHE_WINDOW = 100;
 	private readonly COLUMN_CACHE_WINDOW = 10;
 
+	private _tableShape: [number, number];
+
 	private _cachedResults: Array<FetchResult> = [];
 
 	// Number of cells cached
@@ -52,7 +54,8 @@ export class PositronDataToolCache {
 
 	private readonly _fetcher: FetchFunc;
 
-	constructor(fetcher: FetchFunc) {
+	constructor(tableShape: [number, number], fetcher: FetchFunc) {
+		this._tableShape = tableShape;
 		this._fetcher = fetcher;
 	}
 
@@ -107,10 +110,12 @@ export class PositronDataToolCache {
 		range = structuredClone(range);
 
 		range.rowStartIndex = Math.max(0, range.rowStartIndex - this.ROW_CACHE_WINDOW);
-		range.rowEndIndex += this.ROW_CACHE_WINDOW;
+		range.rowEndIndex = Math.min(this._tableShape[0],
+			range.rowEndIndex + this.ROW_CACHE_WINDOW);
 
 		range.columnStartIndex = Math.max(0, range.columnStartIndex - this.COLUMN_CACHE_WINDOW);
-		range.columnEndIndex += this.COLUMN_CACHE_WINDOW;
+		range.columnEndIndex = Math.min(this._tableShape[1],
+			range.columnEndIndex + this.COLUMN_CACHE_WINDOW);
 
 		const data = await this._fetcher(range);
 

--- a/src/vs/workbench/services/positronDataTool/common/positronDataToolCache.ts
+++ b/src/vs/workbench/services/positronDataTool/common/positronDataToolCache.ts
@@ -1,0 +1,166 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TableData } from 'vs/workbench/services/languageRuntime/common/positronDataToolComm';
+
+export interface FetchRange {
+	/// Start index is inclusive
+	rowStartIndex: number;
+
+	/// End index is exclusive
+	rowEndIndex: number;
+
+	/// Start index is inclusive
+	columnStartIndex: number;
+
+	/// End index is exclusive
+	columnEndIndex: number;
+}
+
+export interface FetchResult extends FetchRange {
+	data: TableData;
+	lastUsedTime: number;
+}
+
+type FetchFunc = (req: FetchRange) => Promise<TableData>;
+
+export class PositronDataToolCache {
+	private readonly ROW_CACHE_WINDOW = 100;
+	private readonly COLUMN_CACHE_WINDOW = 10;
+
+	private _cachedResults: Array<FetchResult> = [];
+
+	// Number of cells cached
+	private _cacheSize: number = 0;
+
+	// We cache up to this many cells. After that, we start dropping the
+	// least-recently used cached data
+	private _maxCacheSize: number = 100_000;
+
+	// The active fetch, so we can avoid spamming the backend with too many requests
+	private _pendingFetch?: { range: FetchRange; promise: Promise<FetchResult> };
+
+	// If we need to fetch more data and there is already a pending fetch,
+	// then we queue the next fetch with setTimeout, which will be immediately canceled
+	// and superseded by another fetch (e.g. if the user is moving around the waffle
+	// really fast).
+	private _debounceTimer?: any;
+
+	// We'll try a 100ms debounce timeout to start
+	private _debounceMillis = 100;
+
+	private readonly _fetcher: FetchFunc;
+
+	constructor(fetcher: FetchFunc) {
+		this._fetcher = fetcher;
+	}
+
+	public static getTotalCells(range: FetchRange) {
+		return ((range.columnEndIndex - range.columnStartIndex) *
+			(range.rowEndIndex - range.rowStartIndex));
+	}
+
+	public static rangeIncludes(range: FetchRange, inRange: FetchRange) {
+		return (range.rowStartIndex >= inRange.rowStartIndex &&
+			range.rowEndIndex <= inRange.rowEndIndex &&
+			range.columnStartIndex >= inRange.columnStartIndex &&
+			range.columnEndIndex <= inRange.columnEndIndex);
+	}
+
+	/// Execute fetch request and handle throttling requests so that we do not spam the
+	/// backend with tons of requests if the user is moving around the waffle quickly.
+	fetch(range: FetchRange): Promise<FetchResult> {
+		if (this._pendingFetch) {
+			// If there is a pending fetch, clear any existing timer for a follow up request,
+			// and set a new timer
+			clearTimeout(this._debounceTimer);
+
+			let deferredResolve: (r: FetchResult) => void;
+			const deferredPromise: Promise<FetchResult> = new Promise(resolve => {
+				deferredResolve = resolve;
+			});
+			this._debounceTimer = setTimeout(async () => {
+				const promise = this.cacheRange(range);
+				this._pendingFetch = { range, promise };
+				const result = await promise;
+				deferredResolve(result);
+			}, this._debounceMillis);
+
+			return deferredPromise;
+		} else {
+			this._pendingFetch = { range, promise: this.cacheRange(range) };
+			return this._pendingFetch.promise;
+		}
+	}
+
+	private async cacheRange(range: FetchRange): Promise<FetchResult> {
+		// Determine if the range is contained in any cached result
+		for (const cachedResult of this._cachedResults) {
+			if (PositronDataToolCache.rangeIncludes(range, cachedResult)) {
+				cachedResult.lastUsedTime = new Date().getTime();
+				return cachedResult;
+			}
+		}
+
+		// See if the range is contained in any of the cached data
+		range = structuredClone(range);
+
+		range.rowStartIndex = Math.max(0, range.rowStartIndex - this.ROW_CACHE_WINDOW);
+		range.rowEndIndex += this.ROW_CACHE_WINDOW;
+
+		range.columnStartIndex = Math.max(0, range.columnStartIndex - this.COLUMN_CACHE_WINDOW);
+		range.columnEndIndex += this.COLUMN_CACHE_WINDOW;
+
+		const data = await this._fetcher(range);
+
+		// Set this based on actual number of columns returned
+		range.columnEndIndex = range.columnStartIndex + data.columns.length;
+
+		if (data.columns.length === 0) {
+			// No data was returned, so set numRows to 0
+			range.rowEndIndex = range.rowStartIndex;
+		} else {
+			range.rowEndIndex = range.rowStartIndex + data.columns[0].length;
+		}
+
+		const currentTime = new Date().getTime();
+		const result: FetchResult = { data, lastUsedTime: currentTime, ...range };
+
+		const numCachedCells = PositronDataToolCache.getTotalCells(range);
+		this.trimCache(numCachedCells);
+		this._cacheSize += numCachedCells;
+		this._cachedResults.push(result);
+
+		return result;
+	}
+
+	clear() {
+		this._cachedResults = [];
+		this._cacheSize = 0;
+	}
+
+	currentCacheSize(): number {
+		return this._cacheSize;
+	}
+
+	setMaxCacheSize(newCacheSize: number) {
+		this._maxCacheSize = newCacheSize;
+		this.trimCache();
+	}
+
+	private trimCache(additionalCells: number = 0) {
+		while (this._cacheSize + additionalCells > this._maxCacheSize &&
+			this._cachedResults.length > 0) {
+			// Evict results from cache based on recency of use
+			let oldest = 0;
+			for (let i = 1; i < this._cachedResults.length; ++i) {
+				if (this._cachedResults[i].lastUsedTime < this._cachedResults[oldest].lastUsedTime) {
+					oldest = i;
+				}
+			}
+			this._cacheSize -= PositronDataToolCache.getTotalCells(this._cachedResults[oldest]);
+			this._cachedResults.splice(oldest, 1);
+		}
+	}
+}

--- a/src/vs/workbench/services/positronDataTool/common/positronDataToolMocks.ts
+++ b/src/vs/workbench/services/positronDataTool/common/positronDataToolMocks.ts
@@ -57,7 +57,7 @@ export function getExampleTableData(schema: TableSchema, rowStartIndex: number,
 	numRows: number, columnIndices: Array<number>): TableData {
 	const generatedColumns = [];
 
-	// Don't generate virtual data beyond the extends of the table, and if
+	// Don't generate virtual data beyond the extent of the table, and if
 	// rowStartIndex is at or after end of the table, return nothing
 	numRows = Math.max(Math.min(numRows, schema.num_rows - rowStartIndex), 0);
 
@@ -68,7 +68,7 @@ export function getExampleTableData(schema: TableSchema, rowStartIndex: number,
 		const generatedColumn = [];
 		if (numRows > 0) {
 			for (let i = rowStartIndex; i < rowStartIndex + numRows; i++) {
-				generatedColumn.push(exampleValues[i % exampleValues.length]);
+				generatedColumn.push(exampleValues[i % exampleValues.length] + ` {i}`);
 			}
 		}
 		generatedColumns.push(generatedColumn);

--- a/src/vs/workbench/services/positronDataTool/test/common/positronDataToolInternals.test.ts
+++ b/src/vs/workbench/services/positronDataTool/test/common/positronDataToolInternals.test.ts
@@ -14,8 +14,8 @@ import * as mocks from "vs/workbench/services/positronDataTool/common/positronDa
 class MockDataCache extends PositronDataToolCache {
 	private schema: TableSchema;
 
-	constructor(schema: TableSchema) {
-		super(async (req: FetchRange) => {
+	constructor(tableShape: [number, number], schema: TableSchema) {
+		super(tableShape, async (req: FetchRange) => {
 			// Build the column indices to fetch.
 			const columnIndices: number[] = [];
 			for (let i = req.columnStartIndex; i < req.columnEndIndex; i++) {
@@ -46,8 +46,10 @@ suite('DataToolInternals', () => {
 	// ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('Fetch caches results correctly', async () => {
-		const schema = mocks.getTableSchema(100000, 1000);
-		const fetcher = new MockDataCache(schema);
+		const numRows = 100000;
+		const numColumns = 1000;
+		const schema = mocks.getTableSchema(numRows, numColumns);
+		const fetcher = new MockDataCache([numRows, numColumns], schema);
 
 		const range: FetchRange = {
 			rowStartIndex: 100,

--- a/src/vs/workbench/services/positronDataTool/test/common/positronDataToolInternals.test.ts
+++ b/src/vs/workbench/services/positronDataTool/test/common/positronDataToolInternals.test.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataToolComm';
+import {
+	FetchRange,
+	PositronDataToolCache
+} from "vs/workbench/services/positronDataTool/common/positronDataToolCache";
+import * as mocks from "vs/workbench/services/positronDataTool/common/positronDataToolMocks";
+
+
+class MockDataCache extends PositronDataToolCache {
+	private schema: TableSchema;
+
+	constructor(schema: TableSchema) {
+		super(async (req: FetchRange) => {
+			// Build the column indices to fetch.
+			const columnIndices: number[] = [];
+			for (let i = req.columnStartIndex; i < req.columnEndIndex; i++) {
+				columnIndices.push(i);
+			}
+
+			const data = mocks.getExampleTableData(this.schema,
+				req.rowStartIndex,
+				req.rowEndIndex - req.rowStartIndex,
+				columnIndices
+			);
+			return data;
+		});
+
+		this.schema = schema;
+	}
+}
+
+function getTotalCells(range: FetchRange) {
+	return ((range.columnEndIndex - range.columnStartIndex) *
+		(range.rowEndIndex - range.rowStartIndex));
+}
+
+/**
+ * Testing internal business logic
+ */
+suite('DataToolInternals', () => {
+	// ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('Fetch caches results correctly', async () => {
+		const schema = mocks.getTableSchema(100000, 1000);
+		const fetcher = new MockDataCache(schema);
+
+		const range: FetchRange = {
+			rowStartIndex: 100,
+			rowEndIndex: 200,
+			columnStartIndex: 100,
+			columnEndIndex: 120
+		};
+
+		const data = await fetcher.fetch(range);
+		const timestamp = data.lastUsedTime;
+		assert.equal(data.rowStartIndex, range.rowStartIndex - 100);
+		assert.equal(data.rowEndIndex, range.rowEndIndex + 100);
+		assert.equal(data.columnStartIndex, range.columnStartIndex - 10);
+		assert.equal(data.columnEndIndex, range.columnEndIndex + 10);
+
+		const cacheSize = fetcher.currentCacheSize();
+		assert.equal(cacheSize, getTotalCells(data));
+
+		let sameData = await fetcher.fetch(range);
+		assert.strictEqual(data, sameData);
+		// Check the timestamp is updated
+		assert.notEqual(timestamp, sameData.lastUsedTime);
+
+		// Fetch another range (overlapping, even), and make sure that our fetches
+		// are as expected
+		const range2 = structuredClone(range);
+		range2.rowStartIndex = 200;
+		range2.rowEndIndex = 400;
+		const data2 = await fetcher.fetch(range2);
+
+		assert.equal(fetcher.currentCacheSize(), cacheSize + getTotalCells(data2));
+
+		sameData = await fetcher.fetch(range);
+		assert.strictEqual(data, sameData);
+
+		sameData = await fetcher.fetch(range2);
+		assert.strictEqual(data2, sameData);
+
+		// Now, we'll set the data cache size lower and make a large request to show that we
+		// evict the first two change
+		assert.ok(fetcher.currentCacheSize() < 100000);
+		fetcher.setMaxCacheSize(10000);
+
+		const largeRange: FetchRange = {
+			rowStartIndex: 0,
+			rowEndIndex: 2000,
+			columnStartIndex: 0,
+			columnEndIndex: 10
+		};
+		const largeData = await fetcher.fetch(largeRange);
+
+		// largeData is now the only thing cached
+		assert.equal(fetcher.currentCacheSize(), getTotalCells(largeData));
+
+		// Was cached even though it was big
+		sameData = await fetcher.fetch(largeRange);
+		assert.strictEqual(largeData, sameData);
+
+		fetcher.clear();
+		assert.equal(fetcher.currentCacheSize(), 0);
+	});
+});


### PR DESCRIPTION
This fetches an additional 100 rows and 10 columns on both sides of the request made by the waffle, and then caches that. Subsequent fetch requests will use the existing data block until more data is needed. If the cached data exceeds a set quantity of cells (currently 100K cells), then the least-recently-used chunks will be dropped. 

We probably also need to debounce the React renders, but that can be done later. 

See related #2210 