### PR TITLE
Refactor to pydantic v1

### DIFF
--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -691,36 +691,13 @@ function* createPythonComm(name: string,
 from __future__ import annotations
 
 import enum
-from dataclasses import dataclass, field
-from typing import Dict, List, Union, Optional
-JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool, None]
+from typing import Any, List, Literal, Optional, Union
+
+from ._vendor.pydantic import BaseModel, Field
 
 `;
-	function* generatePostInit(props: Array<{ name: string, schema: any, isRequired: boolean }>, required?: any) {
-		// Add __post_init__ if any properties need additional boxing
-		const postInitProps: Array<{ name: String, klass: String, isRequired: boolean }> = [];
-		for (const { name, schema, isRequired } of props) {
-			if (schema.type == 'array' && schema.items.$ref) {
-				// The property is a List[OtherType], and that needs boxing
-				const klass = parseRef(schema.items.$ref, contracts);
-				postInitProps.push({ name, klass, isRequired });
-			}
-		}
 
-		if (postInitProps.length > 0) {
-			yield `    def __post_init__(self):\n`;
-			yield `        """ Revive parameters after initialization """\n`;
-
-			for (const item of postInitProps) {
-				if (!item.isRequired) {
-					yield `        if self.${item.name} is not None:\n    `
-				}
-				yield `        self.${item.name} = [\n`;
-				yield `            ${item.klass}(**d) if isinstance(d, dict) else d\n`;
-				yield `            for d in self.${item.name}]  # type: ignore\n\n`;
-			}
-		}
-	}
+	const models = Array<string>();
 
 	const contracts = [backend, frontend];
 	for (const source of contracts) {
@@ -768,7 +745,7 @@ JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool,
 			yield '\n\n';
 		});
 
-		// Create dataclasses for all object types
+		// Create pydantic models for all object types
 		yield* objectVisitor([], source, function* (
 			context: Array<string>,
 			o: Record<string, any>) {
@@ -776,15 +753,15 @@ JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool,
 			let name = o.name ? o.name : context[0] === 'items' ? context[1] : context[0];
 			name = snakeCaseToSentenceCase(name);
 
-			// Empty object specs map to `JsonData`
+			// Empty object specs map to `Any`
 			const props = Object.keys(o.properties);
 			if ((!props || !props.length) && o.additionalProperties === true) {
-				return yield `${name} = JsonData\n`;
+				return yield `${name} = Any\n`;
 			}
 
 			// Preamble
-			yield '@dataclass\n';
-			yield `class ${name}:\n`;
+			models.push(name);
+			yield `class ${models[models.length - 1]}(BaseModel):\n`;
 
 			// Docstring
 			if (o.description) {
@@ -800,13 +777,6 @@ JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool,
 				yield '\n';
 			}
 
-			yield* generatePostInit(Object.keys(o.properties).map(name => {
-				return {
-					name, schema: o.properties[name],
-					isRequired: !o.required || o.required.includes(name)
-				};
-			}), o.required);
-
 			// Fields
 			for (const prop of Object.keys(o.properties)) {
 				const schema = o.properties[prop];
@@ -818,17 +788,12 @@ JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool,
 				} else {
 					yield deriveType(contracts, PythonTypeMap, [prop, ...context], schema);
 				}
-				yield ' = field(\n';
+				yield ' = Field(\n';
 				if (!o.required || !o.required.includes(prop)) {
-					yield `        default=None, \n`;
+					yield `        default=None,\n`;
 				}
-				yield `        metadata = { \n`;
-				yield `            "description": "${schema.description}", \n`;
-				if (!o.required || !o.required.includes(prop)) {
-					yield `            "default": None, \n`;
-				}
-				yield `        } \n`;
-				yield `    ) \n\n`;
+				yield `        description="${schema.description}",\n`;
+				yield `    )\n\n`;
 			}
 			yield '\n\n';
 		});
@@ -859,20 +824,12 @@ JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool,
 			const params: Array<MethodParam> = method.params;
 
 			if (params.length > 0) {
-				yield `@dataclass\n`;
-				yield `class ${snakeCaseToSentenceCase(method.name)}Params:\n`;
+				models.push(`${snakeCaseToSentenceCase(method.name)}Params`);
+				yield `class ${models[models.length - 1]}(BaseModel):\n`;
 				yield `    """\n`;
 				yield formatComment('    ', method.description);
 				yield `    """\n`;
 				yield `\n`;
-
-				yield* generatePostInit(params.map(param => {
-					return {
-						name: param.name,
-						schema: param.schema,
-						isRequired: param.required ?? true,
-					};
-				}));
 
 				for (const param of params) {
 					if (param.schema.enum) {
@@ -880,52 +837,51 @@ JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool,
 					} else {
 						yield `    ${param.name}: ${deriveType(contracts, PythonTypeMap, [param.name], param.schema)}`;
 					}
-					yield ' = field(\n';
-					yield `        metadata={\n`;
-					yield `            "description": "${param.description}",\n`;
-					yield `        }\n`;
+					yield ' = Field(\n';
+					yield `        description="${param.description}",\n`;
 					yield `    )\n\n`;
 				}
 			}
 
-			yield `@dataclass\n`;
-			yield `class ${snakeCaseToSentenceCase(method.name)}Request:\n`;
+			models.push(`${snakeCaseToSentenceCase(method.name)}Request`);
+			yield `class ${models[models.length - 1]}(BaseModel):\n`;
 			yield `    """\n`;
 			yield formatComment('    ', method.description);
 			yield `    """\n`;
 			yield `\n`;
 			if (method.params.length > 0) {
-				yield `    def __post_init__(self):\n`;
-				yield `        """ Revive RPC parameters after initialization """\n`;
-				yield `        if isinstance(self.params, dict):\n`;
-				yield `             self.params = `;
-				yield `${snakeCaseToSentenceCase(method.name)}Params(**self.params)\n`;
-				yield `\n`;
-				yield `    params: ${snakeCaseToSentenceCase(method.name)}Params = field(\n`;
-				yield `        metadata={\n`;
-				yield `            "description": "Parameters to the ${snakeCaseToSentenceCase(method.name)} method"\n`;
-				yield `        }\n`;
+				yield `    params: ${snakeCaseToSentenceCase(method.name)}Params = Field(\n`;
+				yield `        description="Parameters to the ${snakeCaseToSentenceCase(method.name)} method",\n`;
 				yield `    )\n`;
 				yield `\n`;
 			}
-			yield `    method: ${snakeCaseToSentenceCase(name)}BackendRequest = field(\n`;
-			yield `        metadata={\n`;
-			yield `            "description": "The JSON-RPC method name (${method.name})"\n`;
-			yield `        },\n`;
-			yield `        default=`;
-			yield `${snakeCaseToSentenceCase(name)}BackendRequest.${snakeCaseToSentenceCase(method.name)}\n`;
+			yield `    method: Literal[${snakeCaseToSentenceCase(name)}BackendRequest.${snakeCaseToSentenceCase(method.name)}] = Field(\n`;
+			yield `        description="The JSON-RPC method name (${method.name})",\n`;
 			yield `    )\n`;
 			yield '\n';
-			yield `    jsonrpc: str = field(\n`;
-			yield `        metadata={\n`;
-			yield `            "description": "The JSON-RPC version specifier"\n`;
-			yield `        },\n`;
-			yield `        default="2.0"`;
+			yield `    jsonrpc: str = Field(\n`;
+			yield `        default="2.0",`;
+			yield `        description="The JSON-RPC version specifier",\n`;
 			yield `    )\n`;
 			yield `\n`;
 		}
 	}
 
+	// Create the backend message content class
+	if (backend) {
+		yield `class ${snakeCaseToSentenceCase(name)}BackendMessageContent(BaseModel):\n`;
+		yield `    comm_id: str\n`;
+		if (backend.methods.length === 1) {
+			yield `    data: ${snakeCaseToSentenceCase(backend.methods[0].name)}Request`;
+		} else {
+			yield `    data: Union[\n`;
+			for (const method of backend.methods) {
+				yield `        ${snakeCaseToSentenceCase(method.name)}Request,\n`;
+			}
+			yield `    ] = Field(..., discriminator="method")\n`;
+		}
+		yield `\n`;
+	}
 
 	if (frontend) {
 		yield `@enum.unique\n`;
@@ -946,8 +902,8 @@ JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool,
 
 		for (const method of frontend.methods) {
 			if (method.params.length > 0) {
-				yield `@dataclass\n`;
-				yield `class ${snakeCaseToSentenceCase(method.name)}Params:\n`;
+				models.push(`${snakeCaseToSentenceCase(method.name)}Params`);
+				yield `class ${models[models.length - 1]}(BaseModel):\n`;
 				yield `    """\n`;
 				yield formatComment('    ', method.summary);
 				yield `    """\n`;
@@ -958,14 +914,15 @@ JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool,
 					} else {
 						yield `    ${param.name}: ${deriveType(contracts, PythonTypeMap, [param.name], param.schema)}`;
 					}
-					yield ' = field(\n';
-					yield `        metadata={\n`;
-					yield `            "description": "${param.description}"\n`;
-					yield `        }\n`;
+					yield ' = Field(\n';
+					yield `        description="${param.description}",\n`;
 					yield `    )\n\n`;
 				}
 			}
 		}
+	}
+	for (const model of models) {
+		yield `${model}.update_forward_refs()\n\n`;
 	}
 }
 

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -761,7 +761,7 @@ from ._vendor.pydantic import BaseModel, Field
 
 			// Preamble
 			models.push(name);
-			yield `class ${models[models.length - 1]}(BaseModel):\n`;
+			yield `class ${name}(BaseModel):\n`;
 
 			// Docstring
 			if (o.description) {
@@ -824,8 +824,9 @@ from ._vendor.pydantic import BaseModel, Field
 			const params: Array<MethodParam> = method.params;
 
 			if (params.length > 0) {
-				models.push(`${snakeCaseToSentenceCase(method.name)}Params`);
-				yield `class ${models[models.length - 1]}(BaseModel):\n`;
+				const klass = `${snakeCaseToSentenceCase(method.name)}Params`;
+				models.push(klass);
+				yield `class ${klass}(BaseModel):\n`;
 				yield `    """\n`;
 				yield formatComment('    ', method.description);
 				yield `    """\n`;
@@ -843,8 +844,9 @@ from ._vendor.pydantic import BaseModel, Field
 				}
 			}
 
-			models.push(`${snakeCaseToSentenceCase(method.name)}Request`);
-			yield `class ${models[models.length - 1]}(BaseModel):\n`;
+			const klass = `${snakeCaseToSentenceCase(method.name)}Request`;
+			models.push(klass);
+			yield `class ${klass}(BaseModel):\n`;
 			yield `    """\n`;
 			yield formatComment('    ', method.description);
 			yield `    """\n`;

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -26,7 +26,7 @@ if (args.length) {
 	comms = comms.filter(comm => args.includes(comm));
 }
 
-if (comms.length == 0) {
+if (comms.length === 0) {
 	console.log(`
 	  No comms to process! Possible reasons include:
 	    * No files found in '${commsDir}'
@@ -58,14 +58,14 @@ interface CommMetadata {
 }
 
 interface MethodParam {
-	name: string,
-	description: string,
-	required?: boolean,
+	name: string;
+	description: string;
+	required?: boolean;
 	schema: {
-		type: string,
-		enum?: string[],
-		items?: any
-	}
+		type: string;
+		enum?: string[];
+		items?: any;
+	};
 }
 
 // Maps from JSON schema types to Typescript types
@@ -624,8 +624,8 @@ use serde::Serialize;
 	}
 
 	if (frontend && frontend.methods.some((method: any) => method.result && method.result.schema)) {
-		const enumRequestType = `${snakeCaseToSentenceCase(name)}FrontendRequest`
-		const enumReplyType = `${snakeCaseToSentenceCase(name)}FrontendReply`
+		const enumRequestType = `${snakeCaseToSentenceCase(name)}FrontendRequest`;
+		const enumReplyType = `${snakeCaseToSentenceCase(name)}FrontendReply`;
 		yield `/**
 * Conversion of JSON values to frontend RPC Reply types
 */
@@ -643,7 +643,7 @@ pub fn ${name}_frontend_reply_from_value(
 				const hasParams = method.params.length > 0;
 
 				const schema = method.result.schema;
-				const replyHasParams = schema && schema.type !== 'null'
+				const replyHasParams = schema && schema.type !== 'null';
 
 				const variant = hasParams ? `${variantName}(_)` : variantName;
 
@@ -902,8 +902,9 @@ from ._vendor.pydantic import BaseModel, Field
 
 		for (const method of frontend.methods) {
 			if (method.params.length > 0) {
-				models.push(`${snakeCaseToSentenceCase(method.name)}Params`);
-				yield `class ${models[models.length - 1]}(BaseModel):\n`;
+				const klass = `${snakeCaseToSentenceCase(method.name)}Params`;
+				models.push(klass);
+				yield `class ${klass}(BaseModel):\n`;
 				yield `    """\n`;
 				yield formatComment('    ', method.summary);
 				yield `    """\n`;
@@ -1312,7 +1313,7 @@ async function createCommInterface() {
 				}
 
 				// Write the output file
-				console.log(`Writing to ${tsOutputFile}`)
+				console.log(`Writing to ${tsOutputFile}`);
 				writeFileSync(tsOutputFile, ts, { encoding: 'utf-8' });
 
 				// Create the Rust output file
@@ -1323,7 +1324,7 @@ async function createCommInterface() {
 				}
 
 				// Write the output file
-				console.log(`Writing to ${rustOutputFile}`)
+				console.log(`Writing to ${rustOutputFile}`);
 				writeFileSync(rustOutputFile, rust, { encoding: 'utf-8' });
 
 				// Create the Python output file
@@ -1334,7 +1335,7 @@ async function createCommInterface() {
 				}
 
 				// Write the output file
-				console.log(`Writing to ${pythonOutputFile}`)
+				console.log(`Writing to ${pythonOutputFile}`);
 				writeFileSync(pythonOutputFile, python, { encoding: 'utf-8' });
 
 				// Use black to format the Python file; the lint tests for the


### PR DESCRIPTION
Now that we're able to vendor Python dependencies without affecting the user's environment, I'd like to vote for going back to Pydantic.

It isn't too syntactically different, but does give us a bunch of benefits over dataclasses. The biggest by far is data validation, and therefore better type-safety throughout the backend. We also get recursive deserialization (we're currently hacking around this with a custom `__post_init__`), and tagged unions!

I'll wait on merging this until https://github.com/posit-dev/positron-python/pull/324 has been merged, then bump the submodule in this PR.

Partially addresses https://github.com/posit-dev/positron/issues/2218.