### PR TITLE
Add ctrl+alt+m to "review changes"

### DIFF
--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -168,6 +168,14 @@
         "key": "ctrl+alt+right",
         "when": "config.rstudio.keymap.enable",
         "command": "workbench.action.nextEditorInGroup"
+      },
+      {
+        "mac": "ctrl+alt+m",
+        "win": "ctrl+alt+m",
+        "linux": "ctrl+alt+m",
+        "key": "ctrl+alt+m",
+        "when": "config.rstudio.keymap.enable",
+        "command": "workbench.view.scm"
       }
     ]
   }


### PR DESCRIPTION
This change adds <kbd>Ctrl</kbd> <kbd>Option</kbd> <kbd>M</kbd> as a keybinding when the RStudio keymap is activated. In RStudio this maps to Review Changes; in Positron it now opens the Git pane (which is _pretty much_ the same thing). 

Addresses https://github.com/posit-dev/positron/issues/2220.