### PR TITLE
Compare the last history entry with trimmed code

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -759,7 +759,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 						1000
 					));
 				} else {
-					if (historyNavigatorRef.current.last().input !== code) {
+					if (historyNavigatorRef.current.last().input !== trimmedCode) {
 						historyNavigatorRef.current.add(createInputHistoryEntry());
 					}
 				}


### PR DESCRIPTION
Compare the last history entry with trimmed code, since that's what gets added to the history navigator.

Addresses #2226.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of why we are making the proposed changes and
* how best to test them.
-->
