### PR TITLE
Remove Quarto from bundled extensions

### DIFF
--- a/product.json
+++ b/product.json
@@ -85,21 +85,6 @@
 			}
 		},
 		{
-			"name": "quarto.quarto",
-			"version": "1.107.0",
-			"repo": "https://github.com/quarto-dev/quarto/tree/main/apps/vscode",
-			"metadata": {
-				"id": "0c8ba31b-5771-4fa9-bc20-a9f2e69a77ad",
-				"publisherId": {
-					"publisherId": "4c107a56-c3e3-4f93-b127-071cae1c6c52",
-					"publisherName": "quarto",
-					"displayName": "Quarto",
-					"flags": "verified"
-				},
-				"publisherDisplayName": "Quarto"
-			}
-		},
-		{
 			"name": "ms-toolsai.jupyter-keymap",
 			"version": "1.1.2",
 			"repo": "https://github.com/Microsoft/vscode-jupyter-keymap",


### PR DESCRIPTION
Pursuant to discussions at Work Week, remove Quarto from our built-in bundled extension set.

Addresses #2236. 