### PR TITLE
Use kernel wrapper, even on Windows with Python

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -632,19 +632,9 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		const showTerminal = config.get('showTerminal', false);
 
 		const wrapperName = os.platform() === 'win32' ? 'kernel-wrapper.bat' : 'kernel-wrapper.sh';
+		const shellPath = path.join(this._context.extensionPath, 'resources', wrapperName);
 
-		// On Windows, temporarily just invoke the python process without
-		// a wrapper. TODO: Remove this temporary hack for windows once we can
-		// get a powershell wrapper working.
-		let shellPath, shellArgs;
-		if (os.platform() === 'win32' && this._spec.language === 'Python') {
-			const argsCopy = [...args];
-			shellPath = argsCopy.shift();
-			shellArgs = argsCopy;
-		} else {
-			shellPath = path.join(this._context.extensionPath, 'resources', wrapperName);
-			shellArgs = [logFile].concat(args);
-		}
+		const shellArgs = [logFile].concat(args);
 
 		// Use the VS Code terminal API to create a terminal for the kernel
 		this._terminal = vscode.window.createTerminal(<vscode.TerminalOptions>{


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/1540

In https://github.com/posit-dev/positron/pull/1954, I fixed up our kernel wrapper batch file so that it works with R.

@petetronic and I also confirmed that it worked for Python https://github.com/posit-dev/positron/pull/1954#discussion_r1429194801, but at the time we didn't make the change there because I was nervous about breaking things before Christmas break.

I now think it is time to pull the trigger on this change, since it is one of the remaining issues for the Windows Epic