### PR TITLE
Bump ark to 0.1.54

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -527,7 +527,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.52"
+      "ark": "0.1.54"
     }
   }
 }


### PR DESCRIPTION
- https://github.com/posit-dev/amalthea/pull/224 (diagnostics improvements)
- https://github.com/posit-dev/amalthea/pull/236 (stability during restarts)
- https://github.com/posit-dev/amalthea/pull/237 (rstudioapi tweaks)
- https://github.com/posit-dev/amalthea/pull/232 (xquartz related tweaks)