### PR TITLE
Mark Rust files as `@generated` for rustfmt

### DIFF
--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -372,7 +372,9 @@ function* objectVisitor(
  * @returns A generator that yields the Rust code for the comm
  */
 function* createRustComm(name: string, frontend: any, backend: any): Generator<string> {
-	yield `/*---------------------------------------------------------------------------------------------
+	yield `// @generated
+
+/*---------------------------------------------------------------------------------------------
  *  Copyright (C) ${year} Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 


### PR DESCRIPTION
Results in https://github.com/posit-dev/amalthea/pull/241

Minor tweak to the comm generator that generates the Rust files with `// @generated` at the top.

This allows a project wide call to `rustfmt` (i.e. `cargo +nightly fmt -v`) to ignore these files. Eventually they have plans to make it so that format-on-save while inside those files will also pick up on `@generated` and not reformat it, but that doesn't currently work (but that's ok, we don't typically touch these rust files unless we are debugging something).
https://github.com/rust-lang/rustfmt/blob/8486837d557c152fee52383852835d4941602423/src/formatting.rs#L79-L80

The alternative is to try and run fmt on the files during generation time to ensure that they comply with our rules, but that would require everyone to have an up to date nightly version of rust installed and I just didn't feel like it was worth the pain of trying to set up and enforce that. (I saw we do it for python with black, but even that caused me a little pain to get it set up)