### PR TITLE
Use the `contains_data` request to show the Preview table UI

### DIFF
--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -33,6 +33,14 @@ export class ConnectionItem {
 		readonly name: string,
 		readonly client: positron.RuntimeClientInstance) {
 	}
+
+	async icon(): Promise<string | vscode.Uri | { light: vscode.Uri; dark: vscode.Uri }> {
+		return '';
+	}
+
+	async contains_data(): Promise<boolean> {
+		return false;
+	}
 }
 
 /**
@@ -74,6 +82,26 @@ export class ConnectionItemNode extends ConnectionItem {
 		this.iconPath = this.kind;
 		return this.iconPath;
 	}
+
+	override async contains_data() {
+		if (this.containsData) {
+			return this.containsData;
+		}
+
+		const response = await this.client.performRpc({ msg_type: 'contains_data_request', path: this.path }) as any;
+		this.containsData = response.contains_data as boolean;
+
+		return this.containsData;
+	}
+
+	async preview() {
+		if (!this.contains_data()) {
+			// This should never happen, as no UI is provided to preview data when the item
+			// does not contain data.
+			throw new Error('This item does not contain data');
+		}
+		await this.client.performRpc({ msg_type: 'preview_table', table: this.name, path: this.path });
+	}
 }
 
 /**
@@ -90,24 +118,16 @@ export class ConnectionItemDatabase extends ConnectionItemNode {
 }
 
 /**
- * A connection item representing a table in a database
- */
-export class ConnectionItemTable extends ConnectionItemNode {
-	/**
-	 * Preview the table's contents
-	 */
-	preview() {
-		this.client.performRpc({ msg_type: 'preview_table', table: this.name, path: this.path });
-	}
-}
-
-/**
  * A connection item representing a field in a table
  */
 export class ConnectionItemField extends ConnectionItem {
 	constructor(readonly name: string, readonly dtype: string, readonly client: positron.RuntimeClientInstance) {
 		super(name, client);
 		this.dtype = dtype;
+	}
+
+	override async icon() {
+		return 'field';
 	}
 }
 
@@ -157,16 +177,15 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 				vscode.TreeItemCollapsibleState.Collapsed :
 				vscode.TreeItemCollapsibleState.None);
 
-		if (item instanceof ConnectionItemTable) {
-			// Set the icon for tables
-			treeItem.iconPath = await this.getTreeItemIcon(item);
+		treeItem.iconPath = await this.getTreeItemIcon(item);
+
+		if (await item.contains_data()) {
+			// if the item contains data, we set the contextValue enabling the UI for previewing the data
 			treeItem.contextValue = 'table';
-		} else if (item instanceof ConnectionItemNode) {
-			// Set the icon for other levels in the hierarchy.
-			treeItem.iconPath = await this.getTreeItemIcon(item);
-		} else if (item instanceof ConnectionItemField) {
-			// Set the icon for fields
-			treeItem.iconPath = vscode.Uri.file(path.join(this.context.extensionPath, 'media', 'field.svg'));
+		}
+
+		if (item instanceof ConnectionItemField) {
+			// shows the field datatype as the treeItem description
 			treeItem.description = '<' + item.dtype + '>';
 		}
 
@@ -179,7 +198,7 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 		return treeItem;
 	}
 
-	async getTreeItemIcon(item: ConnectionItemNode): Promise<vscode.Uri | { light: vscode.Uri; dark: vscode.Uri }> {
+	async getTreeItemIcon(item: ConnectionItem): Promise<vscode.Uri | { light: vscode.Uri; dark: vscode.Uri }> {
 		const icon = await item.icon();
 
 		if (typeof icon === 'string') {
@@ -223,36 +242,34 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 	 * @param element The element to get the children for
 	 * @returns The children of the element
 	 */
-	async getChildren(element?: ConnectionItem): Promise<ConnectionItem[]> {
+	async getChildren(element?: ConnectionItemNode): Promise<ConnectionItem[]> {
+
+		if (!element) {
+			// At the root, return the top-level connections
+			return this._connections;
+		}
+
 		// Fields don't have children
 		if (element instanceof ConnectionItemField) {
 			return [];
 		}
 
-		if (element) {
-			if (element instanceof ConnectionItemTable) {
-				const response = await element.client.performRpc({ msg_type: 'fields_request', table: element.name, path: element.path }) as any;
-				const fields = response.fields as Array<{ name: string; dtype: string }>;
-				return fields.map((field) => {
-					return new ConnectionItemField(field.name, field.dtype, element.client);
-				});
-			} else if (element instanceof ConnectionItemNode) {
-				const response = await element.client.performRpc({ msg_type: 'tables_request', name: element.name, kind: element.kind, path: element.path }) as any;
-				const children = response.tables as Array<{ name: string; kind: string }>;
-				return await Promise.all(children.map(async (obj) => {
-					const path = [...element.path, { name: obj.name, kind: obj.kind }];
-					const response = await element.client.performRpc({ msg_type: 'contains_data_request', path: path }) as any;
-					const contains_data = response.contains_data as boolean;
-					if (contains_data) {
-						return new ConnectionItemTable(obj.name, obj.kind, path, element.client);
-					} else {
-						return new ConnectionItemNode(obj.name, obj.kind, path, element.client);
-					}
-				}));
-			}
+		// The node is a view or a table so we want to get the fields on it.
+		if (await element.contains_data()) {
+			const response = await element.client.performRpc({ msg_type: 'fields_request', table: element.name, path: element.path }) as any;
+			const fields = response.fields as Array<{ name: string; dtype: string }>;
+			return fields.map((field) => {
+				return new ConnectionItemField(field.name, field.dtype, element.client);
+			});
 		}
 
-		// At the root, return the top-level connections
-		return this._connections;
+		// The node is a database, schema, or catalog, so we want to get the next set of elements in
+		// the tree.
+		const response = await element.client.performRpc({ msg_type: 'tables_request', name: element.name, kind: element.kind, path: element.path }) as any;
+		const children = response.tables as Array<{ name: string; kind: string }>;
+		return children.map((obj) => {
+			const path = [...element.path, { name: obj.name, kind: obj.kind }];
+			return new ConnectionItemNode(obj.name, obj.kind, path, element.client);
+		});
 	}
 }

--- a/extensions/positron-connections/src/extension.ts
+++ b/extensions/positron-connections/src/extension.ts
@@ -4,7 +4,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { ConnectionItemDatabase, ConnectionItemTable, ConnectionItemsProvider } from './connection';
+import { ConnectionItemDatabase, ConnectionItemNode, ConnectionItemsProvider } from './connection';
 
 /**
  * Activates the extension.
@@ -32,7 +32,7 @@ export function activate(context: vscode.ExtensionContext) {
 	// Register a command to preview a table
 	context.subscriptions.push(
 		vscode.commands.registerCommand('positron.connections.previewTable',
-			(item: ConnectionItemTable) => {
+			(item: ConnectionItemNode) => {
 				item.preview();
 			}));
 

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -527,7 +527,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.57"
+      "ark": "0.1.58"
     }
   }
 }


### PR DESCRIPTION
This PR targets https://github.com/posit-dev/positron/issues/2287 and is a pair of https://github.com/posit-dev/amalthea/pull/248

We now use the `contains_data()` method to detect if a ConnectionItemNode should be displayed with the Preview table UI or just a regular item. Before that, we relied on the type of the object, but the connections contract allows implementors to define other kinds of objects to act like tables - one common example is db views.

In this PR we also got rid of the `ConnectionItemTable` which was a subclass of `ConnectionItemNode` as we now use the `contains_data()` method instead of that class to activate the Tables UI. We also refactored `getChildren` to be an async function which IMHO is slighly easier to read.
