### PR TITLE
Notify users about RPC errors within the connections pane

### DIFF
--- a/extensions/positron-connections/package.json
+++ b/extensions/positron-connections/package.json
@@ -53,12 +53,22 @@
         "command": "positron.connections.closeConnection",
         "title": "%commands.closeConnection.title%",
         "icon": "$(debug-disconnect)"
+      },
+      {
+        "command": "positron.connections.refresh",
+        "title": "%commands.refresh.title%",
+        "icon": "$(refresh)"
       }
     ],
     "menus": {
       "view/item/context": [
         {
           "command": "positron.connections.closeConnection",
+          "group": "inline",
+          "when": "viewItem == database"
+        },
+        {
+          "command": "positron.connections.refresh",
           "group": "inline",
           "when": "viewItem == database"
         },

--- a/extensions/positron-connections/package.nls.json
+++ b/extensions/positron-connections/package.nls.json
@@ -5,5 +5,6 @@
 	"view.welcome": "No database connections are currently active.",
 	"commands.previewTable.title": "Preview Table",
 	"commands.previewTable.category": "Connections",
-	"commands.closeConnection.title": "Close Connection"
+	"commands.closeConnection.title": "Close Connection",
+	"commands.refresh.title": "Refresh connection"
 }

--- a/extensions/positron-connections/src/extension.ts
+++ b/extensions/positron-connections/src/extension.ts
@@ -41,4 +41,10 @@ export function activate(context: vscode.ExtensionContext) {
 			(item: ConnectionItemDatabase) => {
 				item.close();
 			}));
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('positron.connections.refresh',
+			() => {
+				connectionProvider.refresh();
+			}));
 }


### PR DESCRIPTION
Targets #2311 

This makes it easier for users to debug what could be causing problems as we surface the R error messages.
It also makes the UI slightly more resistant to failures so we don't get into a state where only restarting the R kernel can fix it.

To be merged after #2306 