### PR TITLE
Support schema and data change events in Data Explorer protocol

### DIFF
--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -374,13 +374,6 @@
 					}
 				}
 			},
-			"column_formatted_data": {
-				"type": "array",
-				"description": "Column values formatted as strings",
-				"items": {
-					"type": "string"
-				}
-			},
 			"column_filter": {
 				"type": "object",
 				"description": "Specifies a table row filter based on a column's values",

--- a/positron/comms/data_explorer-frontend-openrpc.json
+++ b/positron/comms/data_explorer-frontend-openrpc.json
@@ -1,0 +1,29 @@
+{
+	"openrpc": "1.3.0",
+	"info": {
+		"title": "Data Explorer Frontend",
+		"version": "1.0.0"
+	},
+	"methods": [
+		{
+			"name": "schema_update",
+			"summary": "Reset after a schema change",
+			"description": "Fully reset and redraw the data explorer after a schema change.",
+			"params": [
+				{
+					"name": "discard_state",
+					"description": "If true, the UI should discard the filter/sort state.",
+					"schema": {
+						"type": "boolean"
+					}
+				}
+			]
+		},
+		{
+			"name": "data_update",
+			"summary": "Clear cache and request fresh data",
+			"description": "Triggered when there is any data change detected, clearing cache data and triggering a refresh/redraw.",
+			"params": []
+		}
+	]
+}

--- a/src/vs/base/browser/ui/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/base/browser/ui/positronDataGrid/classes/dataGridInstance.ts
@@ -373,12 +373,12 @@ export abstract class DataGridInstance extends Disposable {
 	/**
 	 * Gets or sets the first column index.
 	 */
-	private _firstColumnIndex = 0;
+	protected _firstColumnIndex = 0;
 
 	/**
 	 * Gets or sets the first row index.
 	 */
-	private _firstRowIndex = 0;
+	protected _firstRowIndex = 0;
 
 	/**
 	 * Gets or sets the cursor column index.

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -6,6 +6,7 @@
 // AUTO-GENERATED from data_explorer.json; do not edit.
 //
 
+import { Event } from 'vs/base/common/event';
 import { PositronBaseComm } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
 
@@ -342,13 +343,32 @@ export enum ColumnFilterSearchType {
 }
 
 /**
- * Column values formatted as strings
+ * Event: Reset after a schema change
  */
-export type ColumnFormattedData = Array<string>;
+export interface SchemaUpdateEvent {
+	/**
+	 * If true, the UI should discard the filter/sort state.
+	 */
+	discard_state: boolean;
+
+}
+
+/**
+ * Event: Clear cache and request fresh data
+ */
+export interface DataUpdateEvent {
+}
+
+export enum DataExplorerFrontendEvent {
+	SchemaUpdate = 'schema_update',
+	DataUpdate = 'data_update'
+}
 
 export class PositronDataExplorerComm extends PositronBaseComm {
 	constructor(instance: IRuntimeClientInstance<any, any>) {
 		super(instance);
+		this.onDidSchemaUpdate = super.createEventEmitter('schema_update', ['discard_state']);
+		this.onDidDataUpdate = super.createEventEmitter('data_update', []);
 	}
 
 	/**
@@ -436,5 +456,19 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 		return super.performRpc('get_state', [], []);
 	}
 
+
+	/**
+	 * Reset after a schema change
+	 *
+	 * Fully reset and redraw the data explorer after a schema change.
+	 */
+	onDidSchemaUpdate: Event<SchemaUpdateEvent>;
+	/**
+	 * Clear cache and request fresh data
+	 *
+	 * Triggered when there is any data change detected, clearing cache data
+	 * and triggering a refresh/redraw.
+	 */
+	onDidDataUpdate: Event<DataUpdateEvent>;
 }
 


### PR DESCRIPTION
UI side of https://github.com/posit-dev/positron-python/pull/389.

There is a parameter indicating whether the DE tab should reset the state of UI components like sorting or filter, so we will need to address that in a follow up PR