### PR TITLE
bundle black-formatter as built-in extension

### DIFF
--- a/product.json
+++ b/product.json
@@ -173,6 +173,21 @@
 				},
 				"publisherDisplayName": "ms-pyright"
 			}
+		},
+		{
+			"name": "ms-python.black-formatter",
+			"version": "2024.0.1",
+			"repo": "https://github.com/microsoft/vscode-black-formatter",
+			"metadata": {
+				"id": "859e640c-c157-47da-8699-9080b81c8371",
+				"publisherId": {
+					"publisherId": "998b010b-e2af-44a5-a6cd-0b5fd3b9b6f8",
+					"publisherName": "ms-python",
+					"displayName": "Black Formatter",
+					"flags": "verified"
+				},
+				"publisherDisplayName": "ms-python"
+			}
 		}
 	],
 	"extensionsGallery": {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

Related to #2249 -- this would make format-on-save a much easier out of the box. `ms-python.black-formatter` [is in openvsx](https://open-vsx.org/extension/ms-python/black-formatter). 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

The current way we handle nudging users to download this extension is having a popup of "Recommended extensions". If we don't think it is necessary to bundle black, then I think the linked issue can be closed as-is and we can rely on this popup

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

unknown level of risk-- this is bundling a new extension, so making sure a new build includes this would be a sufficient validation of change
