### PR TITLE
Return table shape from data explorer get_state RPC

### DIFF
--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -277,14 +277,14 @@
 					"name": "table_state",
 					"description": "The current backend table state",
 					"required": [
-						"shape",
+						"table_shape",
 						"filters",
 						"sort_keys"
 					],
 					"properties": {
-						"shape": {
+						"table_shape": {
 							"type": "object",
-							"name": "shape",
+							"name": "table_shape",
 							"description": "Provides number of rows and columns in table",
 							"required": [
 								"num_rows",

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -33,9 +33,7 @@
 					"name": "table_schema",
 					"description": "The schema for a table-like object",
 					"required": [
-						"columns",
-						"num_rows",
-						"total_num_columns"
+						"columns"
 					],
 					"properties": {
 						"columns": {
@@ -44,14 +42,6 @@
 							"items": {
 								"$ref": "#/components/schemas/column_schema"
 							}
-						},
-						"num_rows": {
-							"type": "integer",
-							"description": "Numbers of rows in the unfiltered dataset"
-						},
-						"total_num_columns": {
-							"type": "integer",
-							"description": "Total number of columns in the unfiltered dataset"
 						}
 					}
 				}
@@ -287,10 +277,30 @@
 					"name": "backend_state",
 					"description": "The current backend state",
 					"required": [
+						"table_shape",
 						"filters",
 						"sort_keys"
 					],
 					"properties": {
+						"table_shape": {
+							"type": "object",
+							"name": "table_shape",
+							"description": "Provides number of rows and columns in table",
+							"required": [
+								"num_rows",
+								"num_colums"
+							],
+							"properties": {
+								"num_rows": {
+									"type": "integer",
+									"description": "Numbers of rows in the unfiltered dataset"
+								},
+								"num_columns": {
+									"type": "integer",
+									"description": "Number of columns in the unfiltered dataset"
+								}
+							}
+						},
 						"filters": {
 							"type": "array",
 							"description": "The set of currently applied filters",

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -269,26 +269,26 @@
 		{
 			"name": "get_state",
 			"summary": "Get the state",
-			"description": "Request the current backend state (applied filters and sort columns)",
+			"description": "Request the current table state (applied filters and sort columns)",
 			"params": [],
 			"result": {
 				"schema": {
 					"type": "object",
-					"name": "backend_state",
-					"description": "The current backend state",
+					"name": "table_state",
+					"description": "The current backend table state",
 					"required": [
-						"table_shape",
+						"shape",
 						"filters",
 						"sort_keys"
 					],
 					"properties": {
-						"table_shape": {
+						"shape": {
 							"type": "object",
-							"name": "table_shape",
+							"name": "shape",
 							"description": "Provides number of rows and columns in table",
 							"required": [
 								"num_rows",
-								"num_colums"
+								"num_columns"
 							],
 							"properties": {
 								"num_rows": {

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -45,7 +45,7 @@ const tsOutputDir = `${__dirname}/../../src/vs/workbench/services/languageRuntim
 const rustOutputDir = `${__dirname}/../../../amalthea/crates/amalthea/src/comm`;
 
 /// The directory to write the generated Python files to
-const pythonOutputDir = `${__dirname}/../../extensions/positron-python/pythonFiles/positron`;
+const pythonOutputDir = `${__dirname}/../../extensions/positron-python/pythonFiles/positron/positron_ipykernel`;
 
 const year = new Date().getFullYear();
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -6,7 +6,14 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { generateUuid } from 'vs/base/common/uuid';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
-import { ColumnSortKey, PositronDataExplorerComm, SchemaUpdateEvent, TableData, TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import {
+	ColumnSortKey,
+	PositronDataExplorerComm,
+	SchemaUpdateEvent,
+	TableData,
+	TableSchema,
+	TableState
+} from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * A data explorer client instance.
@@ -79,6 +86,14 @@ export class DataExplorerClientInstance extends Disposable {
 	 */
 	async getSchema(startIndex: number, numColumns: number): Promise<TableSchema> {
 		return this._positronDataExplorerComm.getSchema(startIndex, numColumns);
+	}
+
+	/**
+	 * Get the current active state of the data explorer backend.
+	 * @returns A promose that resolves to the current table state.
+	 */
+	async getState(): Promise<TableState> {
+		return this._positronDataExplorerComm.getState();
 	}
 
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -116,13 +116,13 @@ export interface FreqtableCounts {
 }
 
 /**
- * The current backend state
+ * The current backend table state
  */
-export interface BackendState {
+export interface TableState {
 	/**
 	 * Provides number of rows and columns in table
 	 */
-	table_shape: TableShape;
+	shape: Shape;
 
 	/**
 	 * The set of currently applied filters
@@ -139,7 +139,7 @@ export interface BackendState {
 /**
  * Provides number of rows and columns in table
  */
-export interface TableShape {
+export interface Shape {
 	/**
 	 * Numbers of rows in the unfiltered dataset
 	 */
@@ -148,7 +148,7 @@ export interface TableShape {
 	/**
 	 * Number of columns in the unfiltered dataset
 	 */
-	num_columns?: number;
+	num_columns: number;
 
 }
 
@@ -458,12 +458,12 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	/**
 	 * Get the state
 	 *
-	 * Request the current backend state (applied filters and sort columns)
+	 * Request the current table state (applied filters and sort columns)
 	 *
 	 *
-	 * @returns The current backend state
+	 * @returns The current backend table state
 	 */
-	getState(): Promise<BackendState> {
+	getState(): Promise<TableState> {
 		return super.performRpc('get_state', [], []);
 	}
 

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -19,16 +19,6 @@ export interface TableSchema {
 	 */
 	columns: Array<ColumnSchema>;
 
-	/**
-	 * Numbers of rows in the unfiltered dataset
-	 */
-	num_rows: number;
-
-	/**
-	 * Total number of columns in the unfiltered dataset
-	 */
-	total_num_columns: number;
-
 }
 
 /**
@@ -130,6 +120,11 @@ export interface FreqtableCounts {
  */
 export interface BackendState {
 	/**
+	 * Provides number of rows and columns in table
+	 */
+	table_shape: TableShape;
+
+	/**
 	 * The set of currently applied filters
 	 */
 	filters: Array<ColumnFilter>;
@@ -138,6 +133,22 @@ export interface BackendState {
 	 * The set of currently applied sorts
 	 */
 	sort_keys: Array<ColumnSortKey>;
+
+}
+
+/**
+ * Provides number of rows and columns in table
+ */
+export interface TableShape {
+	/**
+	 * Numbers of rows in the unfiltered dataset
+	 */
+	num_rows: number;
+
+	/**
+	 * Number of columns in the unfiltered dataset
+	 */
+	num_columns?: number;
 
 }
 

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -122,7 +122,7 @@ export interface TableState {
 	/**
 	 * Provides number of rows and columns in table
 	 */
-	shape: Shape;
+	table_shape: TableShape;
 
 	/**
 	 * The set of currently applied filters
@@ -139,7 +139,7 @@ export interface TableState {
 /**
  * Provides number of rows and columns in table
  */
-export interface Shape {
+export interface TableShape {
 	/**
 	 * Numbers of rows in the unfiltered dataset
 	 */

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -33,10 +33,12 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	private readonly _dataExplorerClientInstance: DataExplorerClientInstance;
 
+	private tableShape?: [number, number];
+
 	private _dataCache?: TableDataCache;
 	private _lastFetchedData?: FetchedData;
 
-	private _schemaCache: TableSchemaCache;
+	private _schemaCache?: TableSchemaCache;
 	private _lastFetchedSchema?: FetchedSchema;
 
 	//#endregion Private Properties
@@ -72,13 +74,6 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			cellBorder: true
 		});
 
-		this._schemaCache = new TableSchemaCache(
-			async (req: SchemaFetchRange) => {
-				return this._dataExplorerClientInstance.getSchema(req.startIndex,
-					req.endIndex - req.startIndex);
-			}
-		);
-
 		// Set the data explorer client instance.
 		this._dataExplorerClientInstance = dataExplorerClientInstance;
 
@@ -92,12 +87,16 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			this._firstColumnIndex = 0;
 			this._firstRowIndex = 0;
 
-			// Resets data schema, fetches initial schema and data
+			// Resets data schema, fetches table shape, initial schema, and data
 			this.initialize();
 		});
 
 		this._dataExplorerClientInstance.onDidDataUpdate(async (_evt) => {
 			this._lastFetchedData = undefined;
+
+			const state = await this._dataExplorerClientInstance.getState();
+			this.tableShape = [state.shape.num_rows, state.shape.num_columns];
+
 			this._dataCache?.clear();
 			this.fetchData();
 		});
@@ -109,42 +108,47 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * Gets the number of columns.
 	 */
 	get columns() {
-		return this._lastFetchedSchema ? this._lastFetchedSchema.schema.total_num_columns : 0;
+		return this.tableShape ? this.tableShape[1] : 0;
 	}
 
 	/**
 	 * Gets the number of rows.
 	 */
 	get rows() {
-		return this._lastFetchedSchema ? this._lastFetchedSchema.schema.num_rows : 0;
+		return this.tableShape ? this.tableShape[0] : 0;
 	}
 
 	/**
 	 *
 	 */
-	initialize() {
-		this._schemaCache.clear();
-		this._schemaCache.initialize().then(async (_) => {
-			this._lastFetchedSchema = await this._schemaCache?.fetch({ startIndex: 0, endIndex: 1000 });
+	async initialize() {
+		const state = await this._dataExplorerClientInstance.getState();
+		this.tableShape = [state.shape.num_rows, state.shape.num_columns];
+		this._schemaCache = new TableSchemaCache(
+			this.tableShape,
+			async (req: SchemaFetchRange) => {
+				return this._dataExplorerClientInstance.getSchema(req.startIndex,
+					req.endIndex - req.startIndex);
+			}
+		);
+		this._lastFetchedSchema = await this._schemaCache?.fetch({ startIndex: 0, endIndex: 1000 });
+		this._dataCache = new TableDataCache(
+			this.tableShape,
+			async (req: DataFetchRange) => {
+				// Build the column indices to fetch.
+				const columnIndices: number[] = [];
+				for (let i = req.columnStartIndex; i < req.columnEndIndex; i++) {
+					columnIndices.push(i);
+				}
+				return this._dataExplorerClientInstance.getDataValues(
+					req.rowStartIndex,
+					req.rowEndIndex - req.rowStartIndex,
+					columnIndices
+				);
+			});
 
-			this._dataCache = new TableDataCache(
-				this._schemaCache?.tableShape!,
-				async (req: DataFetchRange) => {
-					// Build the column indices to fetch.
-					const columnIndices: number[] = [];
-					for (let i = req.columnStartIndex; i < req.columnEndIndex; i++) {
-						columnIndices.push(i);
-					}
-					return this._dataExplorerClientInstance.getDataValues(
-						req.rowStartIndex,
-						req.rowEndIndex - req.rowStartIndex,
-						columnIndices
-					);
-				});
-
-			// Fetch data.
-			this.fetchData();
-		});
+		// Fetch data.
+		this.fetchData();
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -95,7 +95,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			this._lastFetchedData = undefined;
 
 			const state = await this._dataExplorerClientInstance.getState();
-			this.tableShape = [state.shape.num_rows, state.shape.num_columns];
+			this.tableShape = [state.table_shape.num_rows, state.table_shape.num_columns];
 
 			this._dataCache?.clear();
 			this.fetchData();
@@ -123,7 +123,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	async initialize() {
 		const state = await this._dataExplorerClientInstance.getState();
-		this.tableShape = [state.shape.num_rows, state.shape.num_columns];
+		this.tableShape = [state.table_shape.num_rows, state.table_shape.num_columns];
 		this._schemaCache = new TableSchemaCache(
 			this.tableShape,
 			async (req: SchemaFetchRange) => {

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -71,7 +71,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 * Gets the number of rows.
 	 */
 	get rows() {
-		return this._tableSchema ? this._tableSchema.total_num_columns : 0;
+		return this._tableSchema ? this._tableSchema.columns.length : 0;
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerCache.ts
@@ -154,6 +154,10 @@ export class TableDataCache extends FetchCache<DataFetchRange, FetchedData> {
 		this._fetchFunc = fetchFunc;
 	}
 
+	updateShape(newShape: [number, number]) {
+		this._tableShape = newShape;
+	}
+
 	getRangeTotalSize(range: DataFetchRange): number {
 		return ((range.columnEndIndex - range.columnStartIndex) *
 			(range.rowEndIndex - range.rowStartIndex));
@@ -197,17 +201,16 @@ export class TableSchemaCache extends FetchCache<SchemaFetchRange, FetchedSchema
 	private readonly SCHEMA_WINDOW = 50;
 
 	private _fetchFunc;
-	public tableShape: [number, number];
+	private _tableShape: [number, number];
 
-	constructor(fetchFunc: SchemaFetchFunc, maxCacheSize: number = 10_000) {
+	constructor(tableShape: [number, number], fetchFunc: SchemaFetchFunc, maxCacheSize: number = 10_000) {
 		super(maxCacheSize);
-		this.tableShape = [0, 0];
+		this._tableShape = tableShape;
 		this._fetchFunc = fetchFunc;
 	}
 
-	async initialize() {
-		const init_schema = await this._fetchFunc({ startIndex: 0, endIndex: 0 });
-		this.tableShape = [init_schema.num_rows, init_schema.total_num_columns];
+	updateShape(newShape: [number, number]) {
+		this._tableShape = newShape;
 	}
 
 	getRangeTotalSize(range: SchemaFetchRange): number {
@@ -223,7 +226,7 @@ export class TableSchemaCache extends FetchCache<SchemaFetchRange, FetchedSchema
 		range = structuredClone(range);
 
 		range.startIndex = Math.max(0, range.startIndex - this.SCHEMA_WINDOW);
-		range.endIndex = Math.min(this.tableShape[1], range.endIndex + this.SCHEMA_WINDOW);
+		range.endIndex = Math.min(this._tableShape[1], range.endIndex + this.SCHEMA_WINDOW);
 
 		const schema = await this._fetchFunc(range);
 

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
@@ -30,8 +30,6 @@ export function getTableSchema(numRows: number = 100, numColumns: number = 10): 
 	}
 	return {
 		columns: columns,
-		num_rows: numRows,
-		total_num_columns: numColumns
 	};
 }
 
@@ -53,13 +51,13 @@ const exampleTypeData: Record<string, string[]> = {
  * @param numRows
  * @param columnIndices Columns to select by index. Can be sequetial, sparse, or random
  */
-export function getExampleTableData(schema: TableSchema, rowStartIndex: number,
+export function getExampleTableData(shape: [number, number], schema: TableSchema, rowStartIndex: number,
 	numRows: number, columnIndices: Array<number>): TableData {
 	const generatedColumns = [];
 
 	// Don't generate virtual data beyond the extent of the table, and if
 	// rowStartIndex is at or after end of the table, return nothing
-	numRows = Math.max(Math.min(numRows, schema.num_rows - rowStartIndex), 0);
+	numRows = Math.max(Math.min(numRows, shape[0] - rowStartIndex), 0);
 
 	for (const columnIndex of columnIndices) {
 		const exampleValues: string[] = exampleTypeData[schema.columns[columnIndex].type_name];

--- a/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import {
 	ColumnFilterCompareOp,
 	ColumnFilterFilterType,
@@ -14,22 +15,26 @@ import * as mocks from "vs/workbench/services/positronDataExplorer/common/positr
  * Basic smoke tests for debugging the mock functions
  */
 suite('DataExplorerMocks', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
 	test('Test getTableSchema', () => {
 		const schema = mocks.getTableSchema(1000, 10000);
 		assert.equal(schema.columns.length, 10000);
-		assert.equal(schema.num_rows, 1000);
 	});
 
 	test('Test getExampleTableData', () => {
 		const schema = mocks.getTableSchema(1000, 10000);
-		let data = mocks.getExampleTableData(schema, 0, 100, [0, 1, 2, 3, 4]);
+
+		const tableShape: [number, number] = [1000, 10000];
+
+		let data = mocks.getExampleTableData(tableShape, schema, 0, 100, [0, 1, 2, 3, 4]);
 		assert.equal(data.columns.length, 5);
 		assert.equal(data.columns[0].length, 100);
 
-		data = mocks.getExampleTableData(schema, 999, 100, [999]);
+		data = mocks.getExampleTableData(tableShape, schema, 999, 100, [999]);
 		assert.equal(data.columns.length, 1);
 		assert.equal(data.columns[0].length, 1);
-		data = mocks.getExampleTableData(schema, 1000, 100, []);
+		data = mocks.getExampleTableData(tableShape, schema, 1000, 100, []);
 		assert.equal(data.columns.length, 0);
 	});
 


### PR DESCRIPTION
addresses #2341 

This enables us to clean up some of the live update and data cache management code, and doesn't require calling `get_schema` just to get the table shape. 

Requires 
- https://github.com/posit-dev/positron-python/pull/393
- https://github.com/posit-dev/amalthea/pull/253