### PR TITLE
require non-whitespace character after '*'

### DIFF
--- a/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
@@ -1,495 +1,552 @@
 {
-    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-    "comment": "https://macromates.com/manual/en/language_grammars",
-    "name": "R",
-    "scopeName": "source.r",
-    "fileTypes": ["R", "r", "Rprofile"],
-    "foldingStartMarker": "\\{\\s*(?:#|$)",
-    "foldingStopMarker": "^\\s*\\}",
-    "variables": {
-        "bracket": "keyword.operator",
-        "identifier": "constant.other",
-        "latex": "keyword.other",
-        "operator": "keyword.operator",
-        "parameter": "entity.name.tag",
-        "roxygen-tag": "keyword.other"
-    },
-    "patterns": [
-        {
-            "include": "#roxygen-example"
-        },
-        {
-            "include": "#basic"
-        }
-    ],
-    "repository": {
-        "basic": {
-            "patterns": [
-                {
-                    "include": "#section"
-                },
-                {
-                    "include": "#roxygen"
-                },
-                {
-                    "include": "#comment"
-                },
-                {
-                    "include": "#expression"
-                }
-            ]
-        },
-        "basic-roxygen-example": {
-            "patterns": [
-                {
-                    "name": "comment.line",
-                    "match": "^\\s*#+'"
-                },
-                {
-                    "include": "#comment"
-                },
-                {
-                    "include": "#expression"
-                }
-            ]
-        },
-        "brackets": {
-            "patterns": [
-                {
-                    "name": "keyword.operator",
-                    "begin": "\\{",
-                    "end": "\\}",
-                    "patterns": [
-                        {
-                            "include": "#basic"
-                        }
-                    ]
-                },
-                {
-                    "name": "keyword.operator",
-                    "begin": "\\[",
-                    "end": "\\]",
-                    "patterns": [
-                        {
-                            "match": "([\\w.]+)\\s*(?==[^=])",
-                            "captures": {
-                                "1": { "name": "entity.name.tag"}
-                            }
-                        },
-                        {
-                            "include": "#basic"
-                        }
-                    ]
-                },
-                {
-                    "name": "keyword.operator",
-                    "begin": "\\(",
-                    "end": "\\)",
-                    "patterns": [
-                        {
-                            "match": "([\\w.]+)\\s*(?==[^=])",
-                            "captures": {
-                                "1": { "name": "entity.name.tag"}
-                            }
-                        },
-                        {
-                            "include": "#basic"
-                        }
-                    ]
-                }
-            ]
-        },
-        "comment": {
-            "name": "comment.line",
-            "match": "#.*"
-        },
-        "escapes": {
-            "patterns": [
-                {
-                    "include": "#escape-code"
-                },
-                {
-                    "include": "#escape-hex"
-                },
-                {
-                    "include": "#escape-octal"
-                },
-                {
-                    "include": "#escape-unicode"
-                },
-                {
-                    "include": "#escape-invalid"
-                }
-            ]
-        },
-        "escape-code": {
-            "name": "constant.character.escape",
-            "match": "\\\\[abefnrtv'\"`\\\\]"
-        },
-        "escape-hex": {
-            "name": "constant.numeric",
-            "match": "\\\\x[0-9a-fA-F]+"
-        },
-        "escape-octal": {
-            "name": "constant.character.escape",
-            "match": "\\\\\\d{1,3}"
-        },
-        "escape-unicode": {
-            "name": "constant.character.escape",
-            "match": "\\\\[uU](?:[0-9a-fA-F]+|\\{[0-9a-fA-F]+\\})"
-        },
-        "escape-invalid": {
-            "name": "invalid",
-            "match": "\\\\."
-        },
-        "expression": {
-            "patterns": [
-                {
-                    "include": "#brackets"
-                },
-                {
-                    "include": "#raw-strings"
-                },
-                {
-                    "include": "#strings"
-                },
-                {
-                    "include": "#function-definition"
-                },
-                {
-                    "include": "#keywords"
-                },
-                {
-                    "include": "#function-call"
-                },
-                {
-                    "include": "#identifiers"
-                },
-                {
-                    "include": "#numbers"
-                },
-                {
-                    "include": "#operators"
-                }
-            ]
-        },
-        "function-call": {
-            "name": "entity.name.function",
-            "match": "([\\w.]+)(?=\\()"
-        },
-        "function-definition": {
-            "name": "keyword",
-            "begin": "(function)\\s*(\\()",
-            "beginCaptures": {
-                "1": { "name": "keyword" },
-                "2": { "name": "keyword.operator" }
-            },
-            "end": "(\\))",
-            "endCaptures": {
-                "1": { "name": "keyword.operator" }
-            },
-            "patterns": [
-                {
-                    "begin": "([\\w.]+)",
-                    "beginCaptures": {
-                        "1": { "name": "entity.name.tag" }
-                    },
-                    "end": "(?=[,)])",
-                    "patterns": [
-                        {
-                            "include": "#basic"
-                        }
-                    ]
-                },
-                {
-                    "include": "#basic"
-                }
-            ]
-        },
-        "identifiers": {
-            "patterns": [
-                {
-                    "include": "#identifier-syntactic"
-                },
-                {
-                    "include": "#identifier-quoted"
-                }
-            ]
-        },
-        "identifier-syntactic": {
-            "name": "constant.other",
-            "match": "[\\p{L}\\p{Nl}.][\\p{L}\\p{Nl}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}.]*"
-        },
-        "identifier-quoted": {
-            "name": "constant.other",
-            "begin": "`",
-            "end": "`",
-            "patterns": [
-                {
-                    "match": "\\\\`"
-                }
-            ]
-        },
-        "keywords": {
-            "patterns": [
-                {
-                    "include": "#keywords-control"
-                },
-                {
-                    "include": "#keywords-builtin"
-                },
-                {
-                    "include": "#keywords-constant"
-                }
-            ]
-        },
-        "keywords-control": {
-            "name": "keyword",
-            "match": "(?:\\\\|function|if|else|in|break|next|repeat|for|while)\\b"
-        },
-        "keywords-builtin": {
-            "name": "keyword.other",
-            "match": "(?:setGroupGeneric|setRefClass|setGeneric|NextMethod|setMethod|UseMethod|tryCatch|setClass|warning|require|library|R6Class|return|switch|attach|detach|source|stop|try)(?=\\()"
-        },
-        "keywords-constant": {
-            "name": "constant.language",
-            "match": "(?:NA_character_|NA_integer_|NA_complex_|NA_real_|TRUE|FALSE|NULL|Inf|NaN|NA|T|F)\\b"
-        },
-        "latex": {
-            "patterns": [
-                {
-                    "name": "keyword.other",
-                    "match": "\\\\\\w+"
-                }
-            ]
-        },
-        "markdown": {
-            "patterns": [
-                {
-                    "begin": "([`]{3,})\\s*(.*)",
-                    "beginCaptures": {
-                        "1": { "name": "comment.line" },
-                        "2": { "name": "entity.name.section" }
-                    },
-                    "end": "(\\1)",
-                    "endCaptures": {
-                        "1": { "name": "comment.line" }
-                    },
-                    "patterns": [
-                        {
-                            "name": "comment.line",
-                            "match": "^\\s*#+'"
-                        }
-                    ]
-                },
-                {
-                    "match": "(\\[)(?:(\\w+)(:{2,3}))?(\\w+)(\\(\\))?(\\])",
-                    "captures": {
-                        "1": { "name": "keyword.operator" },
-                        "2": { "name": "constant.other" },
-                        "3": { "name": "keyword.operator" },
-                        "4": { "name": "entity.name.function" },
-                        "5": { "name": "keyword.operator" },
-                        "6": { "name": "keyword.operator" }
-                    }
-                },
-                {
-                    "name": "markdown.bold",
-                    "match": "(\\s+|^)(__.+?__)\\b"
-                },
-                {
-                    "name": "markdown.italic",
-                    "match": "(\\s+|^)(_(?=[^_])(?:(?:\\\\.)|(?:[^_\\\\]))*?_)\\b"
-                },
-                {
-                    "name": "markdown.bold",
-                    "match": "([*][*].+?[*][*])"
-                },
-                {
-                    "name": "markdown.italic",
-                    "match": "([*](?=[^*])(?:(?:\\\\.)|(?:[^*\\\\]))*?[*])"
-                },
-                {
-                    "name": "markup.quote",
-                    "begin": "`",
-                    "end": "`"
-                },
-                {
-                    "name": "markup.underline.link",
-                    "match": "(<)([^>]*)(>)"
-                }
-            ]
-        },
-        "numbers": {
-            "patterns": [
-                {
-                    "name": "constant.numeric",
-                    "match": "0[xX][0-9a-fA-F]+(?:p[-+]?\\d+)?[iL]?"
-                },
-                {
-                    "name": "constant.numeric",
-                    "match": "(?:(?:\\d+(?:\\.\\d*)?)|(?:\\.\\d+))(?:[eE][+-]?\\d*)?[iL]?"
-                }
-            ]
-        },
-        "operators": {
-            "name": "keyword.operator",
-            "match": "%.*?%|:::|::|:=|\\|>|=>|%%|>=|<=|==|!=|<<-|->>|->|<-|\\|\\||&&|=|\\+|-|\\*\\*?|/|\\^|>|<|!|&|\\||~|\\$|:|@|\\?|,"
-        },
-        "strings": {
-            "patterns": [
-                {
-                    "include": "#qstring"
-                },
-                {
-                    "include": "#qqstring"
-                }
-            ]
-        },
-        "qstring": {
-            "name": "string.quoted.single",
-            "begin": "'",
-            "end": "'",
-            "patterns": [
-                {
-                    "include": "#escapes"
-                }
-            ]
-        },
-        "qqstring": {
-            "name": "string.quoted.double",
-            "begin": "\"",
-            "end": "\"",
-            "patterns": [
-                {
-                    "include": "#escapes"
-                }
-            ]
-        },
-        "raw-strings": {
-            "name": "string.quoted.other",
-            "patterns": [
-                {
-                    "name": "string.quoted.other",
-                    "begin": "[rR]\"(-*)\\{",
-                    "end": "\\}\\1\""
-                },
-                {
-                    "name": "string.quoted.other",
-                    "begin": "[rR]'(-*)\\{",
-                    "end": "\\}\\1'"
-                },
-                {
-                    "name": "string.quoted.other",
-                    "begin": "[rR]\"(-*)\\[",
-                    "end": "\\]\\1\""
-                },
-                {
-                    "name": "string.quoted.other",
-                    "begin": "[rR]'(-*)\\[",
-                    "end": "\\]\\1'"
-                },
-                {
-                    "name": "string.quoted.other",
-                    "begin": "[rR]\"(-*)\\(",
-                    "end": "\\)\\1\""
-                },
-                {
-                    "name": "string.quoted.other",
-                    "begin": "[rR]'(-*)\\(",
-                    "end": "\\)\\1'"
-                }
-            ]
-        },
-        "roxygen": {
-            "begin": "(^\\s*#+')",
-            "beginCaptures": {
-                "1": { "name": "comment.line.roxygen" }
-            },
-            "end": "$",
-            "patterns": [
-                {
-                    "include": "#markdown"
-                },
-                {
-                    "include": "#roxygen-tokens"
-                },
-                {
-                    "include": "#latex"
-                },
-                {
-                    "name": "comment.line",
-                    "match": "."
-                }
-            ]
-        },
-        "roxygen-example": {
-            "begin": "(^\\s*#+')\\s*(@examples)\\s*$",
-            "beginCaptures": {
-                "1": { "name": "comment.line" },
-                "2": { "name": "keyword.other" }
-            },
-            "end": "(^\\s*#+')\\s*(@\\w*)",
-            "endCaptures": {
-                "1": { "name": "comment.line" },
-                "2": { "name": "keyword.other" }
-            },
-            "patterns": [
-                {
-                    "name": "comment.line",
-                    "match": "^\\s*#+'"
-                },
-                {
-                    "name": "keyword.operator",
-                    "match": "[\\[\\(\\{\\}\\)\\]]"
-                },
-                {
-                    "include": "#latex"
-                },
-                {
-                    "include": "#roxygen-tokens"
-                },
-                {
-                    "include": "#basic-roxygen-example"
-                }
-            ]
-        },
-        "roxygen-tokens": {
-            "patterns": [
-                {
-                    "name": "constant.character.escape",
-                    "match": "@@"
-                },
-                {
-                    "begin": "(@(?:param|field|slot))\\s*",
-                    "beginCaptures": {
-                        "1": { "name": "keyword.other" }
-                    },
-                    "end": "(?:\\s|$)",
-                    "patterns": [
-                        {
-                            "name": "entity.name.tag",
-                            "match": "([\\w.]+)"
-                        },
-                        {
-                            "name": "keyword.operator",
-                            "match": ","
-                        }
-                    ]
-                },
-                {
-                    "name": "keyword.other",
-                    "match": "@(?!@)\\w*"
-                }
-            ]
-        },
-        "section": {
-            "match": "^\\s*(#+)\\s*(.*?)(={4,}|-{4,}|#{4,})\\s*$",
-            "captures": {
-                "1": { "name": "comment.line" },
-                "2": { "name": "entity.name.section" },
-                "3": { "name": "comment.line" }
-            }
-        }
-    }
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"comment": "https://macromates.com/manual/en/language_grammars",
+	"name": "R",
+	"scopeName": "source.r",
+	"fileTypes": [
+		"R",
+		"r",
+		"Rprofile"
+	],
+	"foldingStartMarker": "\\{\\s*(?:#|$)",
+	"foldingStopMarker": "^\\s*\\}",
+	"variables": {
+		"bracket": "keyword.operator",
+		"identifier": "constant.other",
+		"latex": "keyword.other",
+		"operator": "keyword.operator",
+		"parameter": "entity.name.tag",
+		"roxygen-tag": "keyword.other"
+	},
+	"patterns": [
+		{
+			"include": "#roxygen-example"
+		},
+		{
+			"include": "#basic"
+		}
+	],
+	"repository": {
+		"basic": {
+			"patterns": [
+				{
+					"include": "#section"
+				},
+				{
+					"include": "#roxygen"
+				},
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"basic-roxygen-example": {
+			"patterns": [
+				{
+					"name": "comment.line",
+					"match": "^\\s*#+'"
+				},
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"brackets": {
+			"patterns": [
+				{
+					"name": "keyword.operator",
+					"begin": "\\{",
+					"end": "\\}",
+					"patterns": [
+						{
+							"include": "#basic"
+						}
+					]
+				},
+				{
+					"name": "keyword.operator",
+					"begin": "\\[",
+					"end": "\\]",
+					"patterns": [
+						{
+							"match": "([\\w.]+)\\s*(?==[^=])",
+							"captures": {
+								"1": {
+									"name": "entity.name.tag"
+								}
+							}
+						},
+						{
+							"include": "#basic"
+						}
+					]
+				},
+				{
+					"name": "keyword.operator",
+					"begin": "\\(",
+					"end": "\\)",
+					"patterns": [
+						{
+							"match": "([\\w.]+)\\s*(?==[^=])",
+							"captures": {
+								"1": {
+									"name": "entity.name.tag"
+								}
+							}
+						},
+						{
+							"include": "#basic"
+						}
+					]
+				}
+			]
+		},
+		"comment": {
+			"name": "comment.line",
+			"match": "#.*"
+		},
+		"escapes": {
+			"patterns": [
+				{
+					"include": "#escape-code"
+				},
+				{
+					"include": "#escape-hex"
+				},
+				{
+					"include": "#escape-octal"
+				},
+				{
+					"include": "#escape-unicode"
+				},
+				{
+					"include": "#escape-invalid"
+				}
+			]
+		},
+		"escape-code": {
+			"name": "constant.character.escape",
+			"match": "\\\\[abefnrtv'\"`\\\\]"
+		},
+		"escape-hex": {
+			"name": "constant.numeric",
+			"match": "\\\\x[0-9a-fA-F]+"
+		},
+		"escape-octal": {
+			"name": "constant.character.escape",
+			"match": "\\\\\\d{1,3}"
+		},
+		"escape-unicode": {
+			"name": "constant.character.escape",
+			"match": "\\\\[uU](?:[0-9a-fA-F]+|\\{[0-9a-fA-F]+\\})"
+		},
+		"escape-invalid": {
+			"name": "invalid",
+			"match": "\\\\."
+		},
+		"expression": {
+			"patterns": [
+				{
+					"include": "#brackets"
+				},
+				{
+					"include": "#raw-strings"
+				},
+				{
+					"include": "#strings"
+				},
+				{
+					"include": "#function-definition"
+				},
+				{
+					"include": "#keywords"
+				},
+				{
+					"include": "#function-call"
+				},
+				{
+					"include": "#identifiers"
+				},
+				{
+					"include": "#numbers"
+				},
+				{
+					"include": "#operators"
+				}
+			]
+		},
+		"function-call": {
+			"name": "entity.name.function",
+			"match": "([\\w.]+)(?=\\()"
+		},
+		"function-definition": {
+			"name": "keyword",
+			"begin": "(function)\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword"
+				},
+				"2": {
+					"name": "keyword.operator"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "([\\w.]+)",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.tag"
+						}
+					},
+					"end": "(?=[,)])",
+					"patterns": [
+						{
+							"include": "#basic"
+						}
+					]
+				},
+				{
+					"include": "#basic"
+				}
+			]
+		},
+		"identifiers": {
+			"patterns": [
+				{
+					"include": "#identifier-syntactic"
+				},
+				{
+					"include": "#identifier-quoted"
+				}
+			]
+		},
+		"identifier-syntactic": {
+			"name": "constant.other",
+			"match": "[\\p{L}\\p{Nl}.][\\p{L}\\p{Nl}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}.]*"
+		},
+		"identifier-quoted": {
+			"name": "constant.other",
+			"begin": "`",
+			"end": "`",
+			"patterns": [
+				{
+					"match": "\\\\`"
+				}
+			]
+		},
+		"keywords": {
+			"patterns": [
+				{
+					"include": "#keywords-control"
+				},
+				{
+					"include": "#keywords-builtin"
+				},
+				{
+					"include": "#keywords-constant"
+				}
+			]
+		},
+		"keywords-control": {
+			"name": "keyword",
+			"match": "(?:\\\\|function|if|else|in|break|next|repeat|for|while)\\b"
+		},
+		"keywords-builtin": {
+			"name": "keyword.other",
+			"match": "(?:setGroupGeneric|setRefClass|setGeneric|NextMethod|setMethod|UseMethod|tryCatch|setClass|warning|require|library|R6Class|return|switch|attach|detach|source|stop|try)(?=\\()"
+		},
+		"keywords-constant": {
+			"name": "constant.language",
+			"match": "(?:NA_character_|NA_integer_|NA_complex_|NA_real_|TRUE|FALSE|NULL|Inf|NaN|NA|T|F)\\b"
+		},
+		"latex": {
+			"patterns": [
+				{
+					"name": "keyword.other",
+					"match": "\\\\\\w+"
+				}
+			]
+		},
+		"markdown": {
+			"patterns": [
+				{
+					"begin": "([`]{3,})\\s*(.*)",
+					"beginCaptures": {
+						"1": {
+							"name": "comment.line"
+						},
+						"2": {
+							"name": "entity.name.section"
+						}
+					},
+					"end": "(\\1)",
+					"endCaptures": {
+						"1": {
+							"name": "comment.line"
+						}
+					},
+					"patterns": [
+						{
+							"name": "comment.line",
+							"match": "^\\s*#+'"
+						}
+					]
+				},
+				{
+					"match": "(\\[)(?:(\\w+)(:{2,3}))?(\\w+)(\\(\\))?(\\])",
+					"captures": {
+						"1": {
+							"name": "keyword.operator"
+						},
+						"2": {
+							"name": "constant.other"
+						},
+						"3": {
+							"name": "keyword.operator"
+						},
+						"4": {
+							"name": "entity.name.function"
+						},
+						"5": {
+							"name": "keyword.operator"
+						},
+						"6": {
+							"name": "keyword.operator"
+						}
+					}
+				},
+				{
+					"name": "markdown.bold",
+					"match": "(\\s+|^)(__.+?__)\\b"
+				},
+				{
+					"name": "markdown.italic",
+					"match": "(\\s+|^)(_(?=[^_])(?:(?:\\\\.)|(?:[^_\\\\]))*?_)\\b"
+				},
+				{
+					"name": "markdown.bold",
+					"match": "([*][*].+?[*][*])"
+				},
+				{
+					"name": "markdown.italic",
+					"match": "([*](?=[^*\\s])(?:(?:\\\\.)|(?:[^*\\\\]))*?[*])"
+				},
+				{
+					"name": "markup.quote",
+					"begin": "`",
+					"end": "`",
+					"patterns": [
+						{
+							"match": "\\\\`"
+						}
+					]
+				},
+				{
+					"name": "markup.underline.link",
+					"match": "(<)([^>]*)(>)"
+				}
+			]
+		},
+		"numbers": {
+			"patterns": [
+				{
+					"name": "constant.numeric",
+					"match": "0[xX][0-9a-fA-F]+(?:p[-+]?\\d+)?[iL]?"
+				},
+				{
+					"name": "constant.numeric",
+					"match": "(?:(?:\\d+(?:\\.\\d*)?)|(?:\\.\\d+))(?:[eE][+-]?\\d*)?[iL]?"
+				}
+			]
+		},
+		"operators": {
+			"name": "keyword.operator",
+			"match": "%.*?%|:::|::|:=|\\|>|=>|%%|>=|<=|==|!=|<<-|->>|->|<-|\\|\\||&&|=|\\+|-|\\*\\*?|/|\\^|>|<|!|&|\\||~|\\$|:|@|\\?|,"
+		},
+		"strings": {
+			"patterns": [
+				{
+					"include": "#qstring"
+				},
+				{
+					"include": "#qqstring"
+				}
+			]
+		},
+		"qstring": {
+			"name": "string.quoted.single",
+			"begin": "'",
+			"end": "'",
+			"patterns": [
+				{
+					"include": "#escapes"
+				}
+			]
+		},
+		"qqstring": {
+			"name": "string.quoted.double",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"include": "#escapes"
+				}
+			]
+		},
+		"raw-strings": {
+			"name": "string.quoted.other",
+			"patterns": [
+				{
+					"name": "string.quoted.other",
+					"begin": "[rR]\"(-*)\\{",
+					"end": "\\}\\1\""
+				},
+				{
+					"name": "string.quoted.other",
+					"begin": "[rR]'(-*)\\{",
+					"end": "\\}\\1'"
+				},
+				{
+					"name": "string.quoted.other",
+					"begin": "[rR]\"(-*)\\[",
+					"end": "\\]\\1\""
+				},
+				{
+					"name": "string.quoted.other",
+					"begin": "[rR]'(-*)\\[",
+					"end": "\\]\\1'"
+				},
+				{
+					"name": "string.quoted.other",
+					"begin": "[rR]\"(-*)\\(",
+					"end": "\\)\\1\""
+				},
+				{
+					"name": "string.quoted.other",
+					"begin": "[rR]'(-*)\\(",
+					"end": "\\)\\1'"
+				}
+			]
+		},
+		"roxygen": {
+			"begin": "(^\\s*#+')",
+			"beginCaptures": {
+				"1": {
+					"name": "comment.line.roxygen"
+				}
+			},
+			"end": "$",
+			"patterns": [
+				{
+					"include": "#markdown"
+				},
+				{
+					"include": "#roxygen-tokens"
+				},
+				{
+					"include": "#latex"
+				},
+				{
+					"name": "comment.line",
+					"match": "."
+				}
+			]
+		},
+		"roxygen-example": {
+			"begin": "(^\\s*#+')\\s*(@examples)\\s*$",
+			"beginCaptures": {
+				"1": {
+					"name": "comment.line"
+				},
+				"2": {
+					"name": "keyword.other"
+				}
+			},
+			"end": "(^\\s*#+')\\s*(@\\w*)",
+			"endCaptures": {
+				"1": {
+					"name": "comment.line"
+				},
+				"2": {
+					"name": "keyword.other"
+				}
+			},
+			"patterns": [
+				{
+					"name": "comment.line",
+					"match": "^\\s*#+'"
+				},
+				{
+					"name": "keyword.operator",
+					"match": "[\\[\\(\\{\\}\\)\\]]"
+				},
+				{
+					"include": "#latex"
+				},
+				{
+					"include": "#roxygen-tokens"
+				},
+				{
+					"include": "#basic-roxygen-example"
+				}
+			]
+		},
+		"roxygen-tokens": {
+			"patterns": [
+				{
+					"name": "constant.character.escape",
+					"match": "@@"
+				},
+				{
+					"begin": "(@(?:param|field|slot))\\s*",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.other"
+						}
+					},
+					"end": "(?:\\s|$)",
+					"patterns": [
+						{
+							"name": "entity.name.tag",
+							"match": "([\\w.]+)"
+						},
+						{
+							"name": "keyword.operator",
+							"match": ","
+						}
+					]
+				},
+				{
+					"name": "keyword.other",
+					"match": "@(?!@)\\w*"
+				}
+			]
+		},
+		"section": {
+			"match": "^\\s*(#+)\\s*(.*?)(={4,}|-{4,}|#{4,})\\s*$",
+			"captures": {
+				"1": {
+					"name": "comment.line"
+				},
+				"2": {
+					"name": "entity.name.section"
+				},
+				"3": {
+					"name": "comment.line"
+				}
+			}
+		}
+	}
 }

--- a/extensions/positron-r/syntaxes/r.tmGrammar.src.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.src.json
@@ -1,495 +1,552 @@
 {
-    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-    "comment": "https://macromates.com/manual/en/language_grammars",
-    "name": "R",
-    "scopeName": "source.r",
-    "fileTypes": ["R", "r", "Rprofile"],
-    "foldingStartMarker": "\\{\\s*(?:#|$)",
-    "foldingStopMarker": "^\\s*\\}",
-    "variables": {
-        "bracket": "keyword.operator",
-        "identifier": "constant.other",
-        "latex": "keyword.other",
-        "operator": "keyword.operator",
-        "parameter": "entity.name.tag",
-        "roxygen-tag": "keyword.other"
-    },
-    "patterns": [
-        {
-            "include": "#roxygen-example"
-        },
-        {
-            "include": "#basic"
-        }
-    ],
-    "repository": {
-        "basic": {
-            "patterns": [
-                {
-                    "include": "#section"
-                },
-                {
-                    "include": "#roxygen"
-                },
-                {
-                    "include": "#comment"
-                },
-                {
-                    "include": "#expression"
-                }
-            ]
-        },
-        "basic-roxygen-example": {
-            "patterns": [
-                {
-                    "name": "comment.line",
-                    "match": "^\\s*#+'"
-                },
-                {
-                    "include": "#comment"
-                },
-                {
-                    "include": "#expression"
-                }
-            ]
-        },
-        "brackets": {
-            "patterns": [
-                {
-                    "name": "{{ bracket }}",
-                    "begin": "\\{",
-                    "end": "\\}",
-                    "patterns": [
-                        {
-                            "include": "#basic"
-                        }
-                    ]
-                },
-                {
-                    "name": "{{ bracket }}",
-                    "begin": "\\[",
-                    "end": "\\]",
-                    "patterns": [
-                        {
-                            "match": "([\\w.]+)\\s*(?==[^=])",
-                            "captures": {
-                                "1": { "name": "{{ parameter }}"}
-                            }
-                        },
-                        {
-                            "include": "#basic"
-                        }
-                    ]
-                },
-                {
-                    "name": "{{ bracket }}",
-                    "begin": "\\(",
-                    "end": "\\)",
-                    "patterns": [
-                        {
-                            "match": "([\\w.]+)\\s*(?==[^=])",
-                            "captures": {
-                                "1": { "name": "{{ parameter }}"}
-                            }
-                        },
-                        {
-                            "include": "#basic"
-                        }
-                    ]
-                }
-            ]
-        },
-        "comment": {
-            "name": "comment.line",
-            "match": "#.*"
-        },
-        "escapes": {
-            "patterns": [
-                {
-                    "include": "#escape-code"
-                },
-                {
-                    "include": "#escape-hex"
-                },
-                {
-                    "include": "#escape-octal"
-                },
-                {
-                    "include": "#escape-unicode"
-                },
-                {
-                    "include": "#escape-invalid"
-                }
-            ]
-        },
-        "escape-code": {
-            "name": "constant.character.escape",
-            "match": "\\\\[abefnrtv'\"`\\\\]"
-        },
-        "escape-hex": {
-            "name": "constant.numeric",
-            "match": "\\\\x[0-9a-fA-F]+"
-        },
-        "escape-octal": {
-            "name": "constant.character.escape",
-            "match": "\\\\\\d{1,3}"
-        },
-        "escape-unicode": {
-            "name": "constant.character.escape",
-            "match": "\\\\[uU](?:[0-9a-fA-F]+|\\{[0-9a-fA-F]+\\})"
-        },
-        "escape-invalid": {
-            "name": "invalid",
-            "match": "\\\\."
-        },
-        "expression": {
-            "patterns": [
-                {
-                    "include": "#brackets"
-                },
-                {
-                    "include": "#raw-strings"
-                },
-                {
-                    "include": "#strings"
-                },
-                {
-                    "include": "#function-definition"
-                },
-                {
-                    "include": "#keywords"
-                },
-                {
-                    "include": "#function-call"
-                },
-                {
-                    "include": "#identifiers"
-                },
-                {
-                    "include": "#numbers"
-                },
-                {
-                    "include": "#operators"
-                }
-            ]
-        },
-        "function-call": {
-            "name": "entity.name.function",
-            "match": "([\\w.]+)(?=\\()"
-        },
-        "function-definition": {
-            "name": "keyword",
-            "begin": "(function)\\s*(\\()",
-            "beginCaptures": {
-                "1": { "name": "keyword" },
-                "2": { "name": "{{ bracket }}" }
-            },
-            "end": "(\\))",
-            "endCaptures": {
-                "1": { "name": "{{ bracket }}" }
-            },
-            "patterns": [
-                {
-                    "begin": "([\\w.]+)",
-                    "beginCaptures": {
-                        "1": { "name": "{{ parameter }}" }
-                    },
-                    "end": "(?=[,)])",
-                    "patterns": [
-                        {
-                            "include": "#basic"
-                        }
-                    ]
-                },
-                {
-                    "include": "#basic"
-                }
-            ]
-        },
-        "identifiers": {
-            "patterns": [
-                {
-                    "include": "#identifier-syntactic"
-                },
-                {
-                    "include": "#identifier-quoted"
-                }
-            ]
-        },
-        "identifier-syntactic": {
-            "name": "{{ identifier }}",
-            "match": "[\\p{L}\\p{Nl}.][\\p{L}\\p{Nl}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}.]*"
-        },
-        "identifier-quoted": {
-            "name": "{{ identifier }}",
-            "begin": "`",
-            "end": "`",
-            "patterns": [
-                {
-                    "match": "\\\\`"
-                }
-            ]
-        },
-        "keywords": {
-            "patterns": [
-                {
-                    "include": "#keywords-control"
-                },
-                {
-                    "include": "#keywords-builtin"
-                },
-                {
-                    "include": "#keywords-constant"
-                }
-            ]
-        },
-        "keywords-control": {
-            "name": "keyword",
-            "match": "(?:\\\\|function|if|else|in|break|next|repeat|for|while)\\b"
-        },
-        "keywords-builtin": {
-            "name": "keyword.other",
-            "match": "(?:setGroupGeneric|setRefClass|setGeneric|NextMethod|setMethod|UseMethod|tryCatch|setClass|warning|require|library|R6Class|return|switch|attach|detach|source|stop|try)(?=\\()"
-        },
-        "keywords-constant": {
-            "name": "constant.language",
-            "match": "(?:NA_character_|NA_integer_|NA_complex_|NA_real_|TRUE|FALSE|NULL|Inf|NaN|NA|T|F)\\b"
-        },
-        "latex": {
-            "patterns": [
-                {
-                    "name": "keyword.other",
-                    "match": "\\\\\\w+"
-                }
-            ]
-        },
-        "markdown": {
-            "patterns": [
-                {
-                    "begin": "([`]{3,})\\s*(.*)",
-                    "beginCaptures": {
-                        "1": { "name": "comment.line" },
-                        "2": { "name": "entity.name.section" }
-                    },
-                    "end": "(\\1)",
-                    "endCaptures": {
-                        "1": { "name": "comment.line" }
-                    },
-                    "patterns": [
-                        {
-                            "name": "comment.line",
-                            "match": "^\\s*#+'"
-                        }
-                    ]
-                },
-                {
-                    "match": "(\\[)(?:(\\w+)(:{2,3}))?(\\w+)(\\(\\))?(\\])",
-                    "captures": {
-                        "1": { "name": "{{ bracket }}" },
-                        "2": { "name": "{{ identifier }}" },
-                        "3": { "name": "{{ operator }}" },
-                        "4": { "name": "entity.name.function" },
-                        "5": { "name": "{{ bracket }}" },
-                        "6": { "name": "{{ bracket }}" }
-                    }
-                },
-                {
-                    "name": "markdown.bold",
-                    "match": "(\\s+|^)(__.+?__)\\b"
-                },
-                {
-                    "name": "markdown.italic",
-                    "match": "(\\s+|^)(_(?=[^_])(?:(?:\\\\.)|(?:[^_\\\\]))*?_)\\b"
-                },
-                {
-                    "name": "markdown.bold",
-                    "match": "([*][*].+?[*][*])"
-                },
-                {
-                    "name": "markdown.italic",
-                    "match": "([*](?=[^*])(?:(?:\\\\.)|(?:[^*\\\\]))*?[*])"
-                },
-                {
-                    "name": "markup.quote",
-                    "begin": "`",
-                    "end": "`"
-                },
-                {
-                    "name": "markup.underline.link",
-                    "match": "(<)([^>]*)(>)"
-                }
-            ]
-        },
-        "numbers": {
-            "patterns": [
-                {
-                    "name": "constant.numeric",
-                    "match": "0[xX][0-9a-fA-F]+(?:p[-+]?\\d+)?[iL]?"
-                },
-                {
-                    "name": "constant.numeric",
-                    "match": "(?:(?:\\d+(?:\\.\\d*)?)|(?:\\.\\d+))(?:[eE][+-]?\\d*)?[iL]?"
-                }
-            ]
-        },
-        "operators": {
-            "name": "{{ operator }}",
-            "match": "%.*?%|:::|::|:=|\\|>|=>|%%|>=|<=|==|!=|<<-|->>|->|<-|\\|\\||&&|=|\\+|-|\\*\\*?|/|\\^|>|<|!|&|\\||~|\\$|:|@|\\?|,"
-        },
-        "strings": {
-            "patterns": [
-                {
-                    "include": "#qstring"
-                },
-                {
-                    "include": "#qqstring"
-                }
-            ]
-        },
-        "qstring": {
-            "name": "string.quoted.single",
-            "begin": "'",
-            "end": "'",
-            "patterns": [
-                {
-                    "include": "#escapes"
-                }
-            ]
-        },
-        "qqstring": {
-            "name": "string.quoted.double",
-            "begin": "\"",
-            "end": "\"",
-            "patterns": [
-                {
-                    "include": "#escapes"
-                }
-            ]
-        },
-        "raw-strings": {
-            "name": "string.quoted.other",
-            "patterns": [
-                {
-                    "name": "string.quoted.other",
-                    "begin": "[rR]\"(-*)\\{",
-                    "end": "\\}\\1\""
-                },
-                {
-                    "name": "string.quoted.other",
-                    "begin": "[rR]'(-*)\\{",
-                    "end": "\\}\\1'"
-                },
-                {
-                    "name": "string.quoted.other",
-                    "begin": "[rR]\"(-*)\\[",
-                    "end": "\\]\\1\""
-                },
-                {
-                    "name": "string.quoted.other",
-                    "begin": "[rR]'(-*)\\[",
-                    "end": "\\]\\1'"
-                },
-                {
-                    "name": "string.quoted.other",
-                    "begin": "[rR]\"(-*)\\(",
-                    "end": "\\)\\1\""
-                },
-                {
-                    "name": "string.quoted.other",
-                    "begin": "[rR]'(-*)\\(",
-                    "end": "\\)\\1'"
-                }
-            ]
-        },
-        "roxygen": {
-            "begin": "(^\\s*#+')",
-            "beginCaptures": {
-                "1": { "name": "comment.line.roxygen" }
-            },
-            "end": "$",
-            "patterns": [
-                {
-                    "include": "#markdown"
-                },
-                {
-                    "include": "#roxygen-tokens"
-                },
-                {
-                    "include": "#latex"
-                },
-                {
-                    "name": "comment.line",
-                    "match": "."
-                }
-            ]
-        },
-        "roxygen-example": {
-            "begin": "(^\\s*#+')\\s*(@examples)\\s*$",
-            "beginCaptures": {
-                "1": { "name": "comment.line" },
-                "2": { "name": "{{ roxygen-tag }}" }
-            },
-            "end": "(^\\s*#+')\\s*(@\\w*)",
-            "endCaptures": {
-                "1": { "name": "comment.line" },
-                "2": { "name": "{{ roxygen-tag }}" }
-            },
-            "patterns": [
-                {
-                    "name": "comment.line",
-                    "match": "^\\s*#+'"
-                },
-                {
-                    "name": "{{ bracket }}",
-                    "match": "[\\[\\(\\{\\}\\)\\]]"
-                },
-                {
-                    "include": "#latex"
-                },
-                {
-                    "include": "#roxygen-tokens"
-                },
-                {
-                    "include": "#basic-roxygen-example"
-                }
-            ]
-        },
-        "roxygen-tokens": {
-            "patterns": [
-                {
-                    "name": "constant.character.escape",
-                    "match": "@@"
-                },
-                {
-                    "begin": "(@(?:param|field|slot))\\s*",
-                    "beginCaptures": {
-                        "1": { "name": "{{ roxygen-tag }}" }
-                    },
-                    "end": "(?:\\s|$)",
-                    "patterns": [
-                        {
-                            "name": "{{ parameter }}",
-                            "match": "([\\w.]+)"
-                        },
-                        {
-                            "name": "keyword.operator",
-                            "match": ","
-                        }
-                    ]
-                },
-                {
-                    "name": "{{ roxygen-tag }}",
-                    "match": "@(?!@)\\w*"
-                }
-            ]
-        },
-        "section": {
-            "match": "^\\s*(#+)\\s*(.*?)(={4,}|-{4,}|#{4,})\\s*$",
-            "captures": {
-                "1": { "name": "comment.line" },
-                "2": { "name": "entity.name.section" },
-                "3": { "name": "comment.line" }
-            }
-        }
-    }
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"comment": "https://macromates.com/manual/en/language_grammars",
+	"name": "R",
+	"scopeName": "source.r",
+	"fileTypes": [
+		"R",
+		"r",
+		"Rprofile"
+	],
+	"foldingStartMarker": "\\{\\s*(?:#|$)",
+	"foldingStopMarker": "^\\s*\\}",
+	"variables": {
+		"bracket": "keyword.operator",
+		"identifier": "constant.other",
+		"latex": "keyword.other",
+		"operator": "keyword.operator",
+		"parameter": "entity.name.tag",
+		"roxygen-tag": "keyword.other"
+	},
+	"patterns": [
+		{
+			"include": "#roxygen-example"
+		},
+		{
+			"include": "#basic"
+		}
+	],
+	"repository": {
+		"basic": {
+			"patterns": [
+				{
+					"include": "#section"
+				},
+				{
+					"include": "#roxygen"
+				},
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"basic-roxygen-example": {
+			"patterns": [
+				{
+					"name": "comment.line",
+					"match": "^\\s*#+'"
+				},
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"brackets": {
+			"patterns": [
+				{
+					"name": "{{ bracket }}",
+					"begin": "\\{",
+					"end": "\\}",
+					"patterns": [
+						{
+							"include": "#basic"
+						}
+					]
+				},
+				{
+					"name": "{{ bracket }}",
+					"begin": "\\[",
+					"end": "\\]",
+					"patterns": [
+						{
+							"match": "([\\w.]+)\\s*(?==[^=])",
+							"captures": {
+								"1": {
+									"name": "{{ parameter }}"
+								}
+							}
+						},
+						{
+							"include": "#basic"
+						}
+					]
+				},
+				{
+					"name": "{{ bracket }}",
+					"begin": "\\(",
+					"end": "\\)",
+					"patterns": [
+						{
+							"match": "([\\w.]+)\\s*(?==[^=])",
+							"captures": {
+								"1": {
+									"name": "{{ parameter }}"
+								}
+							}
+						},
+						{
+							"include": "#basic"
+						}
+					]
+				}
+			]
+		},
+		"comment": {
+			"name": "comment.line",
+			"match": "#.*"
+		},
+		"escapes": {
+			"patterns": [
+				{
+					"include": "#escape-code"
+				},
+				{
+					"include": "#escape-hex"
+				},
+				{
+					"include": "#escape-octal"
+				},
+				{
+					"include": "#escape-unicode"
+				},
+				{
+					"include": "#escape-invalid"
+				}
+			]
+		},
+		"escape-code": {
+			"name": "constant.character.escape",
+			"match": "\\\\[abefnrtv'\"`\\\\]"
+		},
+		"escape-hex": {
+			"name": "constant.numeric",
+			"match": "\\\\x[0-9a-fA-F]+"
+		},
+		"escape-octal": {
+			"name": "constant.character.escape",
+			"match": "\\\\\\d{1,3}"
+		},
+		"escape-unicode": {
+			"name": "constant.character.escape",
+			"match": "\\\\[uU](?:[0-9a-fA-F]+|\\{[0-9a-fA-F]+\\})"
+		},
+		"escape-invalid": {
+			"name": "invalid",
+			"match": "\\\\."
+		},
+		"expression": {
+			"patterns": [
+				{
+					"include": "#brackets"
+				},
+				{
+					"include": "#raw-strings"
+				},
+				{
+					"include": "#strings"
+				},
+				{
+					"include": "#function-definition"
+				},
+				{
+					"include": "#keywords"
+				},
+				{
+					"include": "#function-call"
+				},
+				{
+					"include": "#identifiers"
+				},
+				{
+					"include": "#numbers"
+				},
+				{
+					"include": "#operators"
+				}
+			]
+		},
+		"function-call": {
+			"name": "entity.name.function",
+			"match": "([\\w.]+)(?=\\()"
+		},
+		"function-definition": {
+			"name": "keyword",
+			"begin": "(function)\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword"
+				},
+				"2": {
+					"name": "{{ bracket }}"
+				}
+			},
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "{{ bracket }}"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "([\\w.]+)",
+					"beginCaptures": {
+						"1": {
+							"name": "{{ parameter }}"
+						}
+					},
+					"end": "(?=[,)])",
+					"patterns": [
+						{
+							"include": "#basic"
+						}
+					]
+				},
+				{
+					"include": "#basic"
+				}
+			]
+		},
+		"identifiers": {
+			"patterns": [
+				{
+					"include": "#identifier-syntactic"
+				},
+				{
+					"include": "#identifier-quoted"
+				}
+			]
+		},
+		"identifier-syntactic": {
+			"name": "{{ identifier }}",
+			"match": "[\\p{L}\\p{Nl}.][\\p{L}\\p{Nl}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}.]*"
+		},
+		"identifier-quoted": {
+			"name": "{{ identifier }}",
+			"begin": "`",
+			"end": "`",
+			"patterns": [
+				{
+					"match": "\\\\`"
+				}
+			]
+		},
+		"keywords": {
+			"patterns": [
+				{
+					"include": "#keywords-control"
+				},
+				{
+					"include": "#keywords-builtin"
+				},
+				{
+					"include": "#keywords-constant"
+				}
+			]
+		},
+		"keywords-control": {
+			"name": "keyword",
+			"match": "(?:\\\\|function|if|else|in|break|next|repeat|for|while)\\b"
+		},
+		"keywords-builtin": {
+			"name": "keyword.other",
+			"match": "(?:setGroupGeneric|setRefClass|setGeneric|NextMethod|setMethod|UseMethod|tryCatch|setClass|warning|require|library|R6Class|return|switch|attach|detach|source|stop|try)(?=\\()"
+		},
+		"keywords-constant": {
+			"name": "constant.language",
+			"match": "(?:NA_character_|NA_integer_|NA_complex_|NA_real_|TRUE|FALSE|NULL|Inf|NaN|NA|T|F)\\b"
+		},
+		"latex": {
+			"patterns": [
+				{
+					"name": "keyword.other",
+					"match": "\\\\\\w+"
+				}
+			]
+		},
+		"markdown": {
+			"patterns": [
+				{
+					"begin": "([`]{3,})\\s*(.*)",
+					"beginCaptures": {
+						"1": {
+							"name": "comment.line"
+						},
+						"2": {
+							"name": "entity.name.section"
+						}
+					},
+					"end": "(\\1)",
+					"endCaptures": {
+						"1": {
+							"name": "comment.line"
+						}
+					},
+					"patterns": [
+						{
+							"name": "comment.line",
+							"match": "^\\s*#+'"
+						}
+					]
+				},
+				{
+					"match": "(\\[)(?:(\\w+)(:{2,3}))?(\\w+)(\\(\\))?(\\])",
+					"captures": {
+						"1": {
+							"name": "{{ bracket }}"
+						},
+						"2": {
+							"name": "{{ identifier }}"
+						},
+						"3": {
+							"name": "{{ operator }}"
+						},
+						"4": {
+							"name": "entity.name.function"
+						},
+						"5": {
+							"name": "{{ bracket }}"
+						},
+						"6": {
+							"name": "{{ bracket }}"
+						}
+					}
+				},
+				{
+					"name": "markdown.bold",
+					"match": "(\\s+|^)(__.+?__)\\b"
+				},
+				{
+					"name": "markdown.italic",
+					"match": "(\\s+|^)(_(?=[^_])(?:(?:\\\\.)|(?:[^_\\\\]))*?_)\\b"
+				},
+				{
+					"name": "markdown.bold",
+					"match": "([*][*].+?[*][*])"
+				},
+				{
+					"name": "markdown.italic",
+					"match": "([*](?=[^*\\s])(?:(?:\\\\.)|(?:[^*\\\\]))*?[*])"
+				},
+				{
+					"name": "markup.quote",
+					"begin": "`",
+					"end": "`",
+					"patterns": [
+						{
+							"match": "\\\\`"
+						}
+					]
+				},
+				{
+					"name": "markup.underline.link",
+					"match": "(<)([^>]*)(>)"
+				}
+			]
+		},
+		"numbers": {
+			"patterns": [
+				{
+					"name": "constant.numeric",
+					"match": "0[xX][0-9a-fA-F]+(?:p[-+]?\\d+)?[iL]?"
+				},
+				{
+					"name": "constant.numeric",
+					"match": "(?:(?:\\d+(?:\\.\\d*)?)|(?:\\.\\d+))(?:[eE][+-]?\\d*)?[iL]?"
+				}
+			]
+		},
+		"operators": {
+			"name": "{{ operator }}",
+			"match": "%.*?%|:::|::|:=|\\|>|=>|%%|>=|<=|==|!=|<<-|->>|->|<-|\\|\\||&&|=|\\+|-|\\*\\*?|/|\\^|>|<|!|&|\\||~|\\$|:|@|\\?|,"
+		},
+		"strings": {
+			"patterns": [
+				{
+					"include": "#qstring"
+				},
+				{
+					"include": "#qqstring"
+				}
+			]
+		},
+		"qstring": {
+			"name": "string.quoted.single",
+			"begin": "'",
+			"end": "'",
+			"patterns": [
+				{
+					"include": "#escapes"
+				}
+			]
+		},
+		"qqstring": {
+			"name": "string.quoted.double",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"include": "#escapes"
+				}
+			]
+		},
+		"raw-strings": {
+			"name": "string.quoted.other",
+			"patterns": [
+				{
+					"name": "string.quoted.other",
+					"begin": "[rR]\"(-*)\\{",
+					"end": "\\}\\1\""
+				},
+				{
+					"name": "string.quoted.other",
+					"begin": "[rR]'(-*)\\{",
+					"end": "\\}\\1'"
+				},
+				{
+					"name": "string.quoted.other",
+					"begin": "[rR]\"(-*)\\[",
+					"end": "\\]\\1\""
+				},
+				{
+					"name": "string.quoted.other",
+					"begin": "[rR]'(-*)\\[",
+					"end": "\\]\\1'"
+				},
+				{
+					"name": "string.quoted.other",
+					"begin": "[rR]\"(-*)\\(",
+					"end": "\\)\\1\""
+				},
+				{
+					"name": "string.quoted.other",
+					"begin": "[rR]'(-*)\\(",
+					"end": "\\)\\1'"
+				}
+			]
+		},
+		"roxygen": {
+			"begin": "(^\\s*#+')",
+			"beginCaptures": {
+				"1": {
+					"name": "comment.line.roxygen"
+				}
+			},
+			"end": "$",
+			"patterns": [
+				{
+					"include": "#markdown"
+				},
+				{
+					"include": "#roxygen-tokens"
+				},
+				{
+					"include": "#latex"
+				},
+				{
+					"name": "comment.line",
+					"match": "."
+				}
+			]
+		},
+		"roxygen-example": {
+			"begin": "(^\\s*#+')\\s*(@examples)\\s*$",
+			"beginCaptures": {
+				"1": {
+					"name": "comment.line"
+				},
+				"2": {
+					"name": "{{ roxygen-tag }}"
+				}
+			},
+			"end": "(^\\s*#+')\\s*(@\\w*)",
+			"endCaptures": {
+				"1": {
+					"name": "comment.line"
+				},
+				"2": {
+					"name": "{{ roxygen-tag }}"
+				}
+			},
+			"patterns": [
+				{
+					"name": "comment.line",
+					"match": "^\\s*#+'"
+				},
+				{
+					"name": "{{ bracket }}",
+					"match": "[\\[\\(\\{\\}\\)\\]]"
+				},
+				{
+					"include": "#latex"
+				},
+				{
+					"include": "#roxygen-tokens"
+				},
+				{
+					"include": "#basic-roxygen-example"
+				}
+			]
+		},
+		"roxygen-tokens": {
+			"patterns": [
+				{
+					"name": "constant.character.escape",
+					"match": "@@"
+				},
+				{
+					"begin": "(@(?:param|field|slot))\\s*",
+					"beginCaptures": {
+						"1": {
+							"name": "{{ roxygen-tag }}"
+						}
+					},
+					"end": "(?:\\s|$)",
+					"patterns": [
+						{
+							"name": "{{ parameter }}",
+							"match": "([\\w.]+)"
+						},
+						{
+							"name": "keyword.operator",
+							"match": ","
+						}
+					]
+				},
+				{
+					"name": "{{ roxygen-tag }}",
+					"match": "@(?!@)\\w*"
+				}
+			]
+		},
+		"section": {
+			"match": "^\\s*(#+)\\s*(.*?)(={4,}|-{4,}|#{4,})\\s*$",
+			"captures": {
+				"1": {
+					"name": "comment.line"
+				},
+				"2": {
+					"name": "entity.name.section"
+				},
+				"3": {
+					"name": "comment.line"
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/1771.

### Approach

When attempting to highlight Markdown italicized text, require a non-space character following a `*`.

Also reformatted to use tabs, as that appears to be what is requested via the project's root `.editorconfig`. https://github.com/posit-dev/positron/pull/2348/files?diff=unified&w=1 gives a view without whitespace changes.

An alternative fix here would be to have a separate rule which consumes bulleted list markers at the start of a line, so that they wouldn't ever be considered for highlight as italicized text.

### QA Notes

Test via notes in https://github.com/posit-dev/positron/issues/1771.