### PR TITLE
Plot static zoom

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -20,7 +20,9 @@ import { usePositronPlotsContext } from 'vs/workbench/contrib/positronPlots/brow
 import { ActionBarSeparator } from 'vs/platform/positronActionBar/browser/components/actionBarSeparator';
 import { SizingPolicyMenuButton } from 'vs/workbench/contrib/positronPlots/browser/components/sizingPolicyMenuButton';
 import { HistoryPolicyMenuButton } from 'vs/workbench/contrib/positronPlots/browser/components/historyPolicyMenuButton';
+import { ZommPlotMenuButton } from 'vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton';
 import { PlotClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimePlotClient';
+import { StaticPlotClient } from 'vs/workbench/services/positronPlots/common/staticPlotClient';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 
 // Constants.
@@ -46,6 +48,8 @@ export interface ActionBarsProps {
 	readonly keybindingService: IKeybindingService;
 	readonly layoutService: IWorkbenchLayoutService;
 	readonly notificationService: INotificationService;
+	readonly zoomHandler: (zoomLevel: number) => void;
+	readonly zoomLevel: number;
 }
 
 /**
@@ -69,6 +73,10 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	const enableSizingPolicy = hasPlots &&
 		positronPlotsContext.positronPlotInstances[positronPlotsContext.selectedInstanceIndex]
 		instanceof PlotClientInstance;
+
+	const enableExpandPlot = hasPlots &&
+		positronPlotsContext.positronPlotInstances[positronPlotsContext.selectedInstanceIndex]
+		instanceof StaticPlotClient;
 
 	useEffect(() => {
 		// Empty for now.
@@ -95,6 +103,10 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		}
 	};
 
+	const zoomPlotHandler = (zoomLevel: number) => {
+		props.zoomHandler(zoomLevel);
+	};
+
 	// Render.
 	return (
 		<PositronActionBarContextProvider {...props}>
@@ -103,6 +115,8 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 					<ActionBarRegion location='left'>
 						<ActionBarButton iconId='positron-left-arrow' disabled={disableLeft} tooltip={positronShowPreviousPlot} ariaLabel={positronShowPreviousPlot} onPressed={showPreviousPlotHandler} />
 						<ActionBarButton iconId='positron-right-arrow' disabled={disableRight} tooltip={positronShowNextPlot} ariaLabel={positronShowNextPlot} onPressed={showNextPlotHandler} />
+
+						{enableExpandPlot && <ZommPlotMenuButton actionHandler={zoomPlotHandler} zoomLevel={props.zoomLevel} />}
 						{enableSizingPolicy && <ActionBarSeparator />}
 						{enableSizingPolicy && <SizingPolicyMenuButton
 							layoutService={props.layoutService}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -20,7 +20,7 @@ import { usePositronPlotsContext } from 'vs/workbench/contrib/positronPlots/brow
 import { ActionBarSeparator } from 'vs/platform/positronActionBar/browser/components/actionBarSeparator';
 import { SizingPolicyMenuButton } from 'vs/workbench/contrib/positronPlots/browser/components/sizingPolicyMenuButton';
 import { HistoryPolicyMenuButton } from 'vs/workbench/contrib/positronPlots/browser/components/historyPolicyMenuButton';
-import { ZommPlotMenuButton } from 'vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton';
+import { ZoomPlotMenuButton } from 'vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton';
 import { PlotClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimePlotClient';
 import { StaticPlotClient } from 'vs/workbench/services/positronPlots/common/staticPlotClient';
 import { INotificationService } from 'vs/platform/notification/common/notification';
@@ -116,7 +116,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						<ActionBarButton iconId='positron-left-arrow' disabled={disableLeft} tooltip={positronShowPreviousPlot} ariaLabel={positronShowPreviousPlot} onPressed={showPreviousPlotHandler} />
 						<ActionBarButton iconId='positron-right-arrow' disabled={disableRight} tooltip={positronShowNextPlot} ariaLabel={positronShowNextPlot} onPressed={showNextPlotHandler} />
 
-						{enableZoomPlot && <ZommPlotMenuButton actionHandler={zoomPlotHandler} zoomLevel={props.zoomLevel} />}
+						{enableZoomPlot && <ZoomPlotMenuButton actionHandler={zoomPlotHandler} zoomLevel={props.zoomLevel} />}
 						{enableSizingPolicy && <ActionBarSeparator />}
 						{enableSizingPolicy && <SizingPolicyMenuButton
 							layoutService={props.layoutService}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -74,7 +74,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		positronPlotsContext.positronPlotInstances[positronPlotsContext.selectedInstanceIndex]
 		instanceof PlotClientInstance;
 
-	const enableExpandPlot = hasPlots &&
+	const enableZoomPlot = hasPlots &&
 		positronPlotsContext.positronPlotInstances[positronPlotsContext.selectedInstanceIndex]
 		instanceof StaticPlotClient;
 
@@ -116,7 +116,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						<ActionBarButton iconId='positron-left-arrow' disabled={disableLeft} tooltip={positronShowPreviousPlot} ariaLabel={positronShowPreviousPlot} onPressed={showPreviousPlotHandler} />
 						<ActionBarButton iconId='positron-right-arrow' disabled={disableRight} tooltip={positronShowNextPlot} ariaLabel={positronShowNextPlot} onPressed={showNextPlotHandler} />
 
-						{enableExpandPlot && <ZommPlotMenuButton actionHandler={zoomPlotHandler} zoomLevel={props.zoomLevel} />}
+						{enableZoomPlot && <ZommPlotMenuButton actionHandler={zoomPlotHandler} zoomLevel={props.zoomLevel} />}
 						{enableSizingPolicy && <ActionBarSeparator />}
 						{enableSizingPolicy && <SizingPolicyMenuButton
 							layoutService={props.layoutService}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
@@ -27,6 +27,7 @@ interface PlotContainerProps {
 	y: number;
 	visible: boolean;
 	showHistory: boolean;
+	zoom: number;
 }
 
 /**
@@ -94,7 +95,8 @@ export const PlotsContainer = (props: PlotContainerProps) => {
 		} else if (plotInstance instanceof StaticPlotClient) {
 			return <StaticPlotInstance
 				key={plotInstance.id}
-				plotClient={plotInstance} />;
+				plotClient={plotInstance}
+				zoom={props.zoom} />;
 		} else if (plotInstance instanceof WebviewPlotClient) {
 			return <WebviewPlotInstance
 				key={plotInstance.id}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
@@ -40,7 +40,22 @@ export const StaticPlotInstance = (props: StaticPlotInstanceProps) => {
 	};
 
 	React.useEffect(() => {
-		setZoomMultiplier(props.zoom === ZoomLevel.Double ? 2 : 1);
+		switch (props.zoom) {
+			case ZoomLevel.Fifty:
+				setZoomMultiplier(.5);
+				break;
+			case ZoomLevel.SeventyFive:
+				setZoomMultiplier(.75);
+				break;
+			case ZoomLevel.TwoHundred:
+				setZoomMultiplier(2);
+				break;
+			case ZoomLevel.OneHundred:
+			case ZoomLevel.Fill:
+			default:
+				setZoomMultiplier(1);
+				break;
+		}
 	}, [props.zoom]);
 
 	React.useLayoutEffect(() => {
@@ -56,8 +71,6 @@ export const StaticPlotInstance = (props: StaticPlotInstanceProps) => {
 		}
 
 		setClasses(classes);
-
-		console.log('clientWidth', clientWidth, 'clientHeight', clientHeight);
 	});
 
 	const getStyle = (): React.CSSProperties => {
@@ -67,26 +80,10 @@ export const StaticPlotInstance = (props: StaticPlotInstanceProps) => {
 			height: '100%',
 		};
 		switch (props.zoom) {
-			case ZoomLevel.Actual:
-				if (zoomHeight) {
-					style = {
-						maxWidth: 'none',
-						maxHeight: 'none',
-						top: '50%',
-						left: 0,
-						transform: 'translateY(-50%)',
-					};
-				} else {
-					style = {
-						maxWidth: 'none',
-						maxHeight: 'none',
-						left: '50%',
-						top: 0,
-						transform: 'translateX(-50%)',
-					};
-				}
-				break;
-			case ZoomLevel.Double:
+			case ZoomLevel.Fifty:
+			case ZoomLevel.SeventyFive:
+			case ZoomLevel.OneHundred:
+			case ZoomLevel.TwoHundred:
 				if (zoomHeight) {
 					style = {
 						maxWidth: 'none',

--- a/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
@@ -106,7 +106,6 @@ export const StaticPlotInstance = (props: StaticPlotInstanceProps) => {
 					height: '100%',
 					position: 'unset',
 					transform: 'none',
-
 				};
 				break;
 		}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
@@ -40,22 +40,7 @@ export const StaticPlotInstance = (props: StaticPlotInstanceProps) => {
 	};
 
 	React.useEffect(() => {
-		switch (props.zoom) {
-			case ZoomLevel.Fifty:
-				setZoomMultiplier(.5);
-				break;
-			case ZoomLevel.SeventyFive:
-				setZoomMultiplier(.75);
-				break;
-			case ZoomLevel.TwoHundred:
-				setZoomMultiplier(2);
-				break;
-			case ZoomLevel.OneHundred:
-			case ZoomLevel.Fill:
-			default:
-				setZoomMultiplier(1);
-				break;
-		}
+		setZoomMultiplier(props.zoom.valueOf());
 	}, [props.zoom]);
 
 	React.useLayoutEffect(() => {
@@ -66,6 +51,9 @@ export const StaticPlotInstance = (props: StaticPlotInstanceProps) => {
 
 		let classes = '';
 
+		// If the plot cannot fit in the container, override the centering
+		// so it can be scrolled to the edge. Otherwise, the the very edge of the plot
+		// cannot be seen.
 		if (clientWidth < width * zoomMultiplier && clientHeight < height * zoomMultiplier) {
 			classes += 'oversized';
 		}
@@ -74,7 +62,7 @@ export const StaticPlotInstance = (props: StaticPlotInstanceProps) => {
 	});
 
 	const getStyle = (): React.CSSProperties => {
-		const zoomHeight = width / height >= 1;
+		const wide = width / height >= 1;
 		let style: React.CSSProperties = {
 			width: '100%',
 			height: '100%',
@@ -84,7 +72,9 @@ export const StaticPlotInstance = (props: StaticPlotInstanceProps) => {
 			case ZoomLevel.SeventyFive:
 			case ZoomLevel.OneHundred:
 			case ZoomLevel.TwoHundred:
-				if (zoomHeight) {
+				// If the plot is wider than it is tall, center it vertically.
+				// Otherwise, center it horizontally.
+				if (wide) {
 					style = {
 						maxWidth: 'none',
 						maxHeight: 'none',

--- a/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from 'react';
+import { ZoomLevel } from 'vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton';
 import { StaticPlotClient } from 'vs/workbench/services/positronPlots/common/staticPlotClient';
 
 /**
@@ -10,6 +11,7 @@ import { StaticPlotClient } from 'vs/workbench/services/positronPlots/common/sta
  */
 interface StaticPlotInstanceProps {
 	plotClient: StaticPlotClient;
+	zoom: ZoomLevel;
 }
 
 /**
@@ -23,11 +25,112 @@ interface StaticPlotInstanceProps {
  * @returns The rendered component.
  */
 export const StaticPlotInstance = (props: StaticPlotInstanceProps) => {
+	const [width, setWidth] = React.useState<number>(1);
+	const [height, setHeight] = React.useState<number>(1);
+	const imageWrapperRef = React.useRef<HTMLDivElement>(null);
+	const [zoomMultiplier, setZoomMultiplier] = React.useState<number>(1);
+	const [classes, setClasses] = React.useState<string>('');
+
+	const onImgLoad = (event: React.SyntheticEvent<HTMLImageElement>) => {
+		const img = event.target as HTMLImageElement;
+		const width = img.naturalWidth;
+		const height = img.naturalHeight;
+		setWidth(width);
+		setHeight(height);
+	};
+
+	React.useEffect(() => {
+		setZoomMultiplier(props.zoom === ZoomLevel.Double ? 2 : 1);
+	}, [props.zoom]);
+
+	React.useLayoutEffect(() => {
+		if (!imageWrapperRef.current || props.zoom === ZoomLevel.Fill) {
+			return;
+		}
+		const { clientWidth, clientHeight } = imageWrapperRef.current;
+
+		let classes = '';
+
+		if (clientWidth < width * zoomMultiplier && clientHeight < height * zoomMultiplier) {
+			classes += 'oversized';
+		}
+
+		setClasses(classes);
+
+		console.log('clientWidth', clientWidth, 'clientHeight', clientHeight);
+	});
+
+	const getStyle = (): React.CSSProperties => {
+		const zoomHeight = width / height >= 1;
+		let style: React.CSSProperties = {
+			width: '100%',
+			height: '100%',
+		};
+		switch (props.zoom) {
+			case ZoomLevel.Actual:
+				if (zoomHeight) {
+					style = {
+						maxWidth: 'none',
+						maxHeight: 'none',
+						top: '50%',
+						left: 0,
+						transform: 'translateY(-50%)',
+					};
+				} else {
+					style = {
+						maxWidth: 'none',
+						maxHeight: 'none',
+						left: '50%',
+						top: 0,
+						transform: 'translateX(-50%)',
+					};
+				}
+				break;
+			case ZoomLevel.Double:
+				if (zoomHeight) {
+					style = {
+						maxWidth: 'none',
+						maxHeight: 'none',
+						top: '50%',
+						left: 0,
+						transform: 'translateY(-50%)',
+					};
+				} else {
+					style = {
+						maxWidth: 'none',
+						maxHeight: 'none',
+						left: '50%',
+						top: 0,
+						transform: 'translateX(-50%)',
+					};
+				}
+				break;
+			case ZoomLevel.Fill:
+			default:
+				break;
+		}
+		return style;
+	};
+
+	const applyZoom = (value: number): string => {
+		if (props.zoom !== ZoomLevel.Fill) {
+			return `${value * zoomMultiplier}px`;
+		}
+
+		return '100%';
+	};
+
 	return (
 		<div className='plot-instance static-plot-instance'>
-			<div className='image-wrapper'>
+			<div className='image-wrapper' ref={imageWrapperRef}>
 				<img src={props.plotClient.uri}
-					alt={props.plotClient.code ? props.plotClient.code : 'Plot ' + props.plotClient.id} />
+					alt={props.plotClient.code ? props.plotClient.code : 'Plot ' + props.plotClient.id}
+					className={classes}
+					onLoad={onImgLoad}
+					style={getStyle()}
+					width={applyZoom(width)}
+					height={applyZoom(height)}
+				/>
 			</div>
 		</div>);
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton.tsx
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from 'react';
+import * as nls from 'vs/nls';
+import { IAction } from 'vs/base/common/actions';
+import { ActionBarMenuButton } from 'vs/platform/positronActionBar/browser/components/actionBarMenuButton';
+
+export enum ZoomLevel {
+	Fill,
+	Actual,
+	Double,
+}
+
+interface ZoomPlotMenuButtonProps {
+	readonly actionHandler: (zoomLevel: ZoomLevel) => void;
+	readonly zoomLevel: number;
+}
+
+const zoomLevelMap = new Map<ZoomLevel, string>([
+	[ZoomLevel.Fill, nls.localize('positronZoomFill', 'Fill')],
+	[ZoomLevel.Actual, nls.localize('positronZoomActual', 'Actual')],
+	[ZoomLevel.Double, nls.localize('positronZoomDouble', '2x')],
+]);
+const zoomPlotTooltip = nls.localize('positronZoomPlotTooltip', "Set the plot zoom");
+
+/**
+ * SizingPolicyMenuButton component.
+ * @param props A SizingPolicyMenuButtonProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const ZommPlotMenuButton = (props: ZoomPlotMenuButtonProps) => {
+	const zoomLevels = [ZoomLevel.Fill, ZoomLevel.Actual, ZoomLevel.Double];
+	// State.
+	const [activeZoomLabel, setActiveZoomLabel] =
+		React.useState(zoomLevelMap.get(props.zoomLevel) || ZoomLevel[props.zoomLevel]);
+
+	// Builds the actions.
+	const actions = () => {
+		const actions: IAction[] = [];
+
+		zoomLevels.forEach((zoomLevel) => {
+			const zoomLabel = zoomLevelMap.get(zoomLevel) || ZoomLevel[zoomLevel];
+
+			actions.push({
+				id: ZoomLevel[zoomLevel],
+				label: zoomLabel,
+				tooltip: '',
+
+				class: undefined,
+				enabled: true,
+				run: () => {
+					setActiveZoomLabel(zoomLabel);
+					props.actionHandler(zoomLevel);
+				}
+			});
+		});
+
+		return actions;
+	};
+
+	return (
+		<ActionBarMenuButton
+			iconId='symbol-ruler'
+			text={activeZoomLabel}
+			tooltip={zoomPlotTooltip}
+			actions={actions}
+		/>
+	);
+};

--- a/src/vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton.tsx
@@ -8,11 +8,11 @@ import { IAction } from 'vs/base/common/actions';
 import { ActionBarMenuButton } from 'vs/platform/positronActionBar/browser/components/actionBarMenuButton';
 
 export enum ZoomLevel {
-	Fill,
-	Fifty,
-	SeventyFive,
-	OneHundred,
-	TwoHundred,
+	Fill = 0,
+	Fifty = 0.5,
+	SeventyFive = 0.75,
+	OneHundred = 1,
+	TwoHundred = 2,
 }
 
 interface ZoomPlotMenuButtonProps {

--- a/src/vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton.tsx
@@ -34,7 +34,7 @@ const zoomPlotTooltip = nls.localize('positronZoomPlotTooltip', "Set the plot zo
  * @param props A SizingPolicyMenuButtonProps that contains the component properties.
  * @returns The rendered component.
  */
-export const ZommPlotMenuButton = (props: ZoomPlotMenuButtonProps) => {
+export const ZoomPlotMenuButton = (props: ZoomPlotMenuButtonProps) => {
 	const zoomLevels = [ZoomLevel.Fill, ZoomLevel.Fifty, ZoomLevel.SeventyFive, ZoomLevel.OneHundred, ZoomLevel.TwoHundred];
 	// State.
 	const [activeZoomLabel, setActiveZoomLabel] =

--- a/src/vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton.tsx
@@ -9,8 +9,10 @@ import { ActionBarMenuButton } from 'vs/platform/positronActionBar/browser/compo
 
 export enum ZoomLevel {
 	Fill,
-	Actual,
-	Double,
+	Fifty,
+	SeventyFive,
+	OneHundred,
+	TwoHundred,
 }
 
 interface ZoomPlotMenuButtonProps {
@@ -20,8 +22,10 @@ interface ZoomPlotMenuButtonProps {
 
 const zoomLevelMap = new Map<ZoomLevel, string>([
 	[ZoomLevel.Fill, nls.localize('positronZoomFill', 'Fill')],
-	[ZoomLevel.Actual, nls.localize('positronZoomActual', 'Actual')],
-	[ZoomLevel.Double, nls.localize('positronZoomDouble', '2x')],
+	[ZoomLevel.Fifty, nls.localize('positronZoomFifty', '50%')],
+	[ZoomLevel.SeventyFive, nls.localize('positronZoomSeventyFive', '75%')],
+	[ZoomLevel.OneHundred, nls.localize('positronZoomActual', '100%')],
+	[ZoomLevel.TwoHundred, nls.localize('positronZoomDouble', '200%')],
 ]);
 const zoomPlotTooltip = nls.localize('positronZoomPlotTooltip', "Set the plot zoom");
 
@@ -31,7 +35,7 @@ const zoomPlotTooltip = nls.localize('positronZoomPlotTooltip', "Set the plot zo
  * @returns The rendered component.
  */
 export const ZommPlotMenuButton = (props: ZoomPlotMenuButtonProps) => {
-	const zoomLevels = [ZoomLevel.Fill, ZoomLevel.Actual, ZoomLevel.Double];
+	const zoomLevels = [ZoomLevel.Fill, ZoomLevel.Fifty, ZoomLevel.SeventyFive, ZoomLevel.OneHundred, ZoomLevel.TwoHundred];
 	// State.
 	const [activeZoomLabel, setActiveZoomLabel] =
 		React.useState(zoomLevelMap.get(props.zoomLevel) || ZoomLevel[props.zoomLevel]);

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
@@ -150,6 +150,20 @@
 	position: relative;
 }
 
+.plot-instance .image-wrapper {
+	display: block;
+	object-fit: none;
+	position: absolute;
+	overflow: scroll;
+	width: 100%;
+	height: 100%;
+}
+
+.plot-instance .image-wrapper img.oversized {
+	position: unset!important;
+	transform: none!important;
+}
+
 .plot-instance .image-wrapper img,
 .plot-thumbnail .image-wrapper img {
 	display: block;

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
@@ -159,11 +159,6 @@
 	height: 100%;
 }
 
-.plot-instance .image-wrapper img.oversized {
-	position: unset!important;
-	transform: none!important;
-}
-
 .plot-instance .image-wrapper img,
 .plot-thumbnail .image-wrapper img {
 	display: block;

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.tsx
@@ -14,6 +14,7 @@ import { PlotsContainer } from 'vs/workbench/contrib/positronPlots/browser/compo
 import { ActionBars } from 'vs/workbench/contrib/positronPlots/browser/components/actionBars';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { PositronPlotsViewPane } from 'vs/workbench/contrib/positronPlots/browser/positronPlotsView';
+import { ZoomLevel } from 'vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton';
 
 /**
  * PositronPlotsProps interface.
@@ -57,6 +58,10 @@ export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 		}
 	};
 
+	const zoomHandler = (zoom: number) => {
+		setZoom(zoom);
+	};
+
 	// Hooks.
 	const [width, setWidth] = useState(props.reactComponentContainer.width);
 	const [height, setHeight] = useState(props.reactComponentContainer.height);
@@ -65,6 +70,7 @@ export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 	const [visible, setVisible] = useState(props.reactComponentContainer.containerVisible);
 	const [showHistory, setShowHistory] = useState(computeHistoryVisibility(
 		props.positronPlotsService.historyPolicy));
+	const [zoom, setZoom] = useState(ZoomLevel.Fill);
 
 	// Add IReactComponentContainer event handlers.
 	useEffect(() => {
@@ -113,14 +119,15 @@ export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 	// Render.
 	return (
 		<PositronPlotsContextProvider {...props}>
-			<ActionBars {...props} />
+			<ActionBars {...props} zoomHandler={zoomHandler} zoomLevel={zoom} />
 			<PlotsContainer
 				showHistory={showHistory}
 				visible={visible}
 				width={width}
 				height={height - 34}
 				x={posX}
-				y={posY} />
+				y={posY}
+				zoom={zoom} />
 		</PositronPlotsContextProvider>
 	);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent
Address #2330

Wide plot:
![image](https://github.com/posit-dev/positron/assets/9591545/0480f223-56ba-47b1-a6e2-9de690ce7e06)

Tall plot showing menu options:
![image](https://github.com/posit-dev/positron/assets/9591545/2fb2a9b2-267b-4738-95e8-5a90f53df50b)


### Approach
Add a menu button to the action bar to select a zoom level (Fill, 50%, 75%, 100%, 200%). Fill is the default and fills the image to the pane size. The other options scale the image pixel size with a multiplier and any overflow can be scrolled into view.

### QA Notes
The plot zoom setting applies to all of the static plots in the pane. Changing the value and switching plots will use the same value.

The menu button will update its label with the selected option.

Dynamic plots are not zoomable since they are scaled to fit the pane.

For sample code for a static plot, see #2052
