### PR TITLE
Fix #2125 Ctrl-L not clearing console 

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -81,10 +81,13 @@ export function registerPositronConsoleActions() {
 				},
 				f1: true,
 				category,
-				precondition: PositronConsoleFocused,
 				keybinding: {
+					when: PositronConsoleFocused,
 					weight: KeybindingWeight.WorkbenchContrib,
-					primary: KeyMod.WinCtrl | KeyCode.KeyL
+					primary: KeyMod.CtrlCmd | KeyCode.KeyL,
+					mac: {
+						primary: KeyMod.WinCtrl | KeyCode.KeyL
+					}
 				},
 			});
 		}


### PR DESCRIPTION
### Intent

Fix #2125 so that Ctrl+L will clear the console when running Positron on Windows.

### Approach

The fix was to use `KeyMod.CtrlCmd | KeyCode.KeyL` for Windows and Linux and `KeyMod.WinCtrl | KeyCode.KeyL` on macOS.
