### PR TITLE
ignore dirs that crash the gulp watcher during positron-python integration tests

### DIFF
--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -232,9 +232,22 @@ const tasks = compilations.map(function (tsconfigFile) {
 		// --- Start Positron ---
 		// Add '!**/*.tsx'.
 		const nonts = gulp.src(src, srcOpts).pipe(filter(['**', '!**/*.ts', '!**/*.tsx']));
-		// --- End Positron ---
+
+		// The Python extension's integration tests create and delete directories in a way that
+		// crashes the watcher. For the positron-python task, ignore these known directories.
+		// (Note that these need to be ignored at `watcher` -- `gulp.src` is not enough.)
+		if (relativeDirname === 'positron-python') {
+			ignored = [
+				path.join(srcBase, 'testTestingRootWkspc/**'),
+				path.join(srcBase, 'test/1/**'),
+				path.join(srcBase, 'test/should-not-exist/**'),
+			];
+		} else {
+			ignored = [];
+		}
 		const input = es.merge(nonts, pipeline.tsProjectSrc());
-		const watchInput = watcher(src, { ...srcOpts, ...{ readDelay: 200 } });
+		const watchInput = watcher(src, { ...srcOpts, ...{ ignored, readDelay: 200 } });
+		// --- End Positron ---
 
 		return watchInput
 			.pipe(util.incremental(pipeline, input))


### PR DESCRIPTION
With https://github.com/posit-dev/positron-python/pull/401 merged to `positron-python`, running those integration tests locally will crash an existing `yarn watch-extensions` task. This is unfortunately the best solution I could find.

Related to #890.