### PR TITLE
skipChecks in run function

### DIFF
--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1572,7 +1572,7 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 		this.simulateOutputMessage(parentId, `Executing ${languageId} snippet: ${codeToExecute}`);
 
 		// Perform the execution
-		const success = await positron.runtime.executeCode(languageId, codeToExecute, true);
+		const success = await positron.runtime.executeCode(languageId, codeToExecute, true, true);
 		if (!success) {
 			this.simulateOutputMessage(parentId, `Failed; is there an active console for ${languageId}?`);
 		}

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1098,7 +1098,7 @@ declare module 'positron' {
 		 * @param languageId The language ID of the code snippet
 		 * @param code The code snippet to execute
 		 * @param focus Whether to focus the runtime's console
-		 * @param skipChecks Whether to bypass runtime code completeness checks. If true, the `code`
+		 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 		 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
 		 * @returns A Thenable that resolves with true if the code was sent to a
 		 *   runtime successfully, false otherwise.
@@ -1106,7 +1106,7 @@ declare module 'positron' {
 		export function executeCode(languageId: string,
 			code: string,
 			focus: boolean,
-			skipChecks?: boolean): Thenable<boolean>;
+			allowIncomplete?: boolean): Thenable<boolean>;
 
 		/**
 		 * Register a language runtime manager with Positron. Returns a

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1102,8 +1102,8 @@ export class MainThreadLanguageRuntime
 		}
 	}
 
-	$executeCode(languageId: string, code: string, focus: boolean, skipChecks?: boolean): Promise<boolean> {
-		return this._positronConsoleService.executeCode(languageId, code, focus, skipChecks);
+	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean): Promise<boolean> {
+		return this._positronConsoleService.executeCode(languageId, code, focus, allowIncomplete);
 	}
 
 	public dispose(): void {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -68,8 +68,8 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 		// --- Start Positron ---
 		const runtime: typeof positron.runtime = {
-			executeCode(languageId, code, focus, skipChecks): Thenable<boolean> {
-				return extHostLanguageRuntime.executeCode(languageId, code, focus, skipChecks);
+			executeCode(languageId, code, focus, allowIncomplete): Thenable<boolean> {
+				return extHostLanguageRuntime.executeCode(languageId, code, focus, allowIncomplete);
 			},
 			registerLanguageRuntimeManager(
 				manager: positron.LanguageRuntimeManager): vscode.Disposable {

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -35,7 +35,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$startLanguageRuntime(runtimeId: string, sessionName: string, sessionMode: LanguageRuntimeSessionMode, notebookUri: URI | undefined): Promise<string>;
 	$completeLanguageRuntimeDiscovery(): void;
 	$unregisterLanguageRuntime(handle: number): void;
-	$executeCode(languageId: string, code: string, focus: boolean, skipChecks?: boolean): Promise<boolean>;
+	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean): Promise<boolean>;
 	$getPreferredRuntime(languageId: string): Promise<ILanguageRuntimeMetadata>;
 	$restartSession(handle: number): Promise<void>;
 	$emitLanguageRuntimeMessage(handle: number, message: ILanguageRuntimeMessage): void;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -619,8 +619,8 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		});
 	}
 
-	public executeCode(languageId: string, code: string, focus: boolean, skipChecks?: boolean): Promise<boolean> {
-		return this._proxy.$executeCode(languageId, code, focus, skipChecks);
+	public executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean): Promise<boolean> {
+		return this._proxy.$executeCode(languageId, code, focus, allowIncomplete);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -268,7 +268,7 @@ export function registerPositronConsoleActions() {
 		 * Runs action.
 		 * @param accessor The services accessor.
 		 */
-		async run(accessor: ServicesAccessor) {
+		async run(accessor: ServicesAccessor, opts: { allowIncomplete?: boolean } = {}) {
 			// Access services.
 			const editorService = accessor.get(IEditorService);
 			const languageFeaturesService = accessor.get(ILanguageFeaturesService);
@@ -508,9 +508,13 @@ export function registerPositronConsoleActions() {
 				return;
 			}
 
+			// Whether to allow incomplete code to be executed.
+			// By default, we don't allow incomplete code to be executed, but the language runtime can override this.
+			const { allowIncomplete } = opts;
+
 			// Ask the Positron console service to execute the code. Do not focus the console as
 			// this will rip focus away from the editor.
-			if (!await positronConsoleService.executeCode(languageId, code, false)) {
+			if (!await positronConsoleService.executeCode(languageId, code, false, allowIncomplete)) {
 				const languageName = languageService.getLanguageName(languageId);
 				notificationService.notify({
 					severity: Severity.Info,

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -510,7 +510,10 @@ export function registerPositronConsoleActions() {
 
 			// Whether to allow incomplete code to be executed.
 			// By default, we don't allow incomplete code to be executed, but the language runtime can override this.
+			// This means that if allowIncomplete is false or undefined, the incomplete code will not be sent to the backend for execution.
+			// The console will continue to wait for more input until the user completes the code, or cancels out of the operation.
 			const { allowIncomplete } = opts;
+
 
 			// Ask the Positron console service to execute the code. Do not focus the console as
 			// this will rip focus away from the editor.

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -84,11 +84,11 @@ export interface IPositronConsoleService {
 	 * @param languageId The language ID.
 	 * @param code The code.
 	 * @param focus A value which indicates whether to focus Positron console instance.
-	 * @param skipChecks Whether to bypass runtime code completeness checks. If true, the `code`
+	 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 	 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
 	 * @returns A value which indicates whether the code could be executed.
 	 */
-	executeCode(languageId: string, code: string, focus: boolean, skipChecks?: boolean): Promise<boolean>;
+	executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean): Promise<boolean>;
 }
 
 /**
@@ -267,10 +267,10 @@ export interface IPositronConsoleInstance {
 	/**
 	 * Enqueues code to be executed.
 	 * @param code The code to enqueue.
-	 * @param skipChecks Whether to bypass runtime code completeness checks. If true, the `code`
+	 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 	 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
 	 */
-	enqueueCode(code: string, force: boolean): Promise<void>;
+	enqueueCode(code: string, allowIncomplete?: boolean): Promise<void>;
 
 	/**
 	 * Executes code.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -362,11 +362,11 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 	 * @param languageId The language ID.
 	 * @param code The code.
 	 * @param focus A value which indicates whether to focus the Positron console instance.
-	 * @param skipChecks Whether to bypass runtime code completeness checks. If true, the `code`
+	 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 	 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
 	 * @returns A value which indicates whether the code could be executed.
 	 */
-	async executeCode(languageId: string, code: string, focus: boolean, skipChecks?: boolean) {
+	async executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean) {
 		// When code is executed in the console service, ensure that the panel is restored, if it
 		// needs to be, and open the console view.
 		this._layoutService.restorePanel();
@@ -418,7 +418,7 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 		}
 
 		// Enqueue the code in the Positron console instance.
-		await positronConsoleInstance.enqueueCode(code, skipChecks);
+		await positronConsoleInstance.enqueueCode(code, allowIncomplete);
 
 		// Success.
 		return Promise.resolve(true);
@@ -967,10 +967,10 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	/**
 	 * Enqueues code.
 	 * @param code The code to enqueue.
-	 * @param skipChecks Whether to bypass runtime code completeness checks. If true, the `code`
+	 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 	 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
 	 */
-	async enqueueCode(code: string, skipChecks?: boolean) {
+	async enqueueCode(code: string, allowIncomplete?: boolean) {
 		// If there is a pending input runtime item, all the code in it was enqueued before this
 		// code, so add this code to it and wait for it to be processed the next time the runtime
 		// becomes idle.
@@ -990,7 +990,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 		// Code should be executed if the caller skips checks, or if the runtime says the code is complete.
 		const shouldExecuteCode = async (code: string) => {
-			if (skipChecks) {
+			if (allowIncomplete) {
 				return true;
 			}
 			const codeStatus = await this.session.isCodeFragmentComplete(code);


### PR DESCRIPTION
Addresses #2107, so that the Cmd+Enter command (`workbench.action.positronConsole.executeCode`) skips checks and automatically executes the potentially invalid/incomplete code in the Console (raising the invalid/incomplete error immediately).