### PR TITLE
Connections OpenRPC

### DIFF
--- a/extensions/positron-connections/package.json
+++ b/extensions/positron-connections/package.json
@@ -53,6 +53,11 @@
         "command": "positron.connections.closeConnection",
         "title": "%commands.closeConnection.title%",
         "icon": "$(debug-disconnect)"
+      },
+      {
+        "command": "positron.connections.refresh",
+        "title": "%commands.refresh.title%",
+        "icon": "$(refresh)"
       }
     ],
     "menus": {
@@ -66,6 +71,11 @@
           "command": "positron.connections.previewTable",
           "group": "inline",
           "when": "viewItem == table"
+        },
+        {
+          "command": "positron.connections.refresh",
+          "group": "inline",
+          "when": "viewItem == database"
         }
       ]
     }

--- a/extensions/positron-connections/package.nls.json
+++ b/extensions/positron-connections/package.nls.json
@@ -5,5 +5,6 @@
 	"view.welcome": "No database connections are currently active.",
 	"commands.previewTable.title": "Preview Table",
 	"commands.previewTable.category": "Connections",
-	"commands.closeConnection.title": "Close Connection"
+	"commands.closeConnection.title": "Close Connection",
+	"commands.refresh.title": "Refresh connection"
 }

--- a/extensions/positron-connections/src/comms/BaseComm.ts
+++ b/extensions/positron-connections/src/comms/BaseComm.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 // This is a copy of PositronBaseCommm.ts adapted to work on the extensions land.

--- a/extensions/positron-connections/src/comms/BaseComm.ts
+++ b/extensions/positron-connections/src/comms/BaseComm.ts
@@ -1,0 +1,145 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// This is a copy of PositronBaseCommm.ts adapted to work on the extensions land.
+// It mainly ports the logic that is used to check argument types and prepare and RPC request
+// to the backend as well as the logic to handle errors returned by the backend.
+
+import * as positron from 'positron';
+
+/**
+ * An enum representing the set of JSON-RPC error codes.
+ */
+export enum JsonRpcErrorCode {
+	ParseError = -32700,
+	InvalidRequest = -32600,
+	MethodNotFound = -32601,
+	InvalidParams = -32602,
+	InternalError = -32603,
+	ServerErrorStart = -32000,
+	ServerErrorEnd = -32099
+}
+
+/**
+ * An error returned by a runtime method call.
+ */
+export interface PositronCommError {
+	/** An error code */
+	code: JsonRpcErrorCode;
+
+	/** A human-readable error message */
+	message: string;
+
+	/**
+	 * A name for the error, for compatibility with the Error object.
+	 * Usually `RPC Error ${code}`.
+	 */
+	name: string;
+
+	/** Additional error information (optional) */
+	data: any | undefined;
+}
+
+/**
+ * A base class for Positron comm instances. This class handles communication
+ * with the backend, and provides methods for creating event emitters and
+ * performing RPCs.
+ *
+ * Used by generated comm classes.
+ */
+export class PositronBaseComm {
+
+	/**
+	 * Create a new Positron com
+	 *
+	 * @param clientInstance The client instance to use for communication with the backend.
+	 *  This instance must be connected to the backend before it is passed to this class.
+	 */
+	constructor(private readonly clientInstance: positron.RuntimeClientInstance) { }
+
+	/**
+	 * Perform an RPC and wait for the result.
+	 *
+	 * @param rpcName The name of the RPC to perform.
+	 * @param paramNames The parameter names
+	 * @param paramValues The parameter values
+	 * @returns A promise that resolves to the result of the RPC, or rejects
+	 *  with a PositronCommError.
+	 */
+	protected async performRpc<T>(rpcName: string,
+		paramNames: Array<string>,
+		paramValues: Array<any>): Promise<T> {
+
+		// Create the RPC arguments from the parameter names and values. This
+		// allows us to pass the parameters as positional parameters, but
+		// still have them be named parameters in the RPC.
+		const rpcArgs: any = {};
+		for (let i = 0; i < paramNames.length; i++) {
+			rpcArgs[paramNames[i]] = paramValues[i];
+		}
+
+		// Form the request object
+		const request: any = {
+			jsonrpc: '2.0',
+			method: rpcName,
+		};
+
+		// Amend params if we have any (methods which take no parameters
+		// should not have a params field)
+		if (paramNames.length > 0) {
+			request.params = rpcArgs;
+		}
+
+		// Perform the RPC
+		let response = {} as any;
+		try {
+			response = await this.clientInstance.performRpc(request);
+		} catch (err: any) {
+			// Convert the error to a runtime method error. This handles errors
+			// that occur while performing the RPC; if the RPC is successfully
+			// sent and a response received, errors named in the response are
+			// handled below.
+			const error: PositronCommError = {
+				code: JsonRpcErrorCode.InternalError,
+				message: err.message,
+				name: err.name,
+				data: err, // Wrap the underlying error in a data object
+			};
+			throw error;
+		}
+
+		// If the response is an error, throw it
+		if (Object.keys(response).includes('error')) {
+			const error: PositronCommError = response.error;
+
+			// Populate the error object with the name of the error code
+			// for conformity with code that expects an Error object.
+			error.name = `RPC Error ${response.error.code}`;
+
+			throw error;
+		}
+
+		// JSON-RPC specifies that the return value must have either a 'result'
+		// or an 'error'; make sure we got a result before we pass it back.
+		if (!Object.keys(response).includes('result')) {
+			const error: PositronCommError = {
+				code: JsonRpcErrorCode.InternalError,
+				message: `Invalid response from ${this.clientInstance.getClientId()}: ` +
+					`no 'result' field. ` +
+					`(response = ${JSON.stringify(response)})`,
+				name: `InvalidResponseError`,
+				data: {},
+			};
+
+			throw error;
+		}
+
+		// Otherwise, return the result
+		return response.result;
+	}
+
+	dispose() {
+		this.clientInstance.dispose();
+	}
+}

--- a/extensions/positron-connections/src/comms/ConnectionsComms.ts
+++ b/extensions/positron-connections/src/comms/ConnectionsComms.ts
@@ -1,0 +1,121 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// This file is a copy of positronConnectionsComms.ts modifying the PositronConnectionsComm class
+// to extend from PositronBaseComm instead of the original PositronBaseComm class and taking a
+// positron.RuntimeClientInstance instance as a parameter in the constructor instead of an
+// IRuntimeClientInstance instance.
+
+import { PositronBaseComm } from './BaseComm';
+import * as positron from 'positron';
+
+//
+// AUTO-GENERATED from connections.json; do not edit.
+//
+
+/**
+ * ObjectSchema in Schemas
+ */
+export interface ObjectSchema {
+	/**
+	 * Name of the underlying object
+	 */
+	name: string;
+
+	/**
+	 * The object type (table, catalog, schema)
+	 */
+	kind: string;
+
+}
+
+/**
+ * FieldSchema in Schemas
+ */
+export interface FieldSchema {
+	/**
+	 * Name of the field
+	 */
+	name: string;
+
+	/**
+	 * The field data type
+	 */
+	dtype: string;
+
+}
+
+export class PositronConnectionsComm extends PositronBaseComm {
+	constructor(public instance: positron.RuntimeClientInstance) {
+		super(instance);
+	}
+
+	/**
+	 * List objects within a data source
+	 *
+	 * List objects within a data source, such as schemas, catalogs, tables
+	 * and views.
+	 *
+	 * @param path The path to object that we want to list children.
+	 *
+	 * @returns Array of objects names and their kinds.
+	 */
+	listObjects(path: Array<ObjectSchema>): Promise<Array<ObjectSchema>> {
+		return super.performRpc('list_objects', ['path'], [path]);
+	}
+
+	/**
+	 * List fields of an object
+	 *
+	 * List fields of an object, such as columns of a table or view.
+	 *
+	 * @param path The path to object that we want to list fields.
+	 *
+	 * @returns Array of field names and data types.
+	 */
+	listFields(path: Array<ObjectSchema>): Promise<Array<FieldSchema>> {
+		return super.performRpc('list_fields', ['path'], [path]);
+	}
+
+	/**
+	 * Check if an object contains data
+	 *
+	 * Check if an object contains data, such as a table or view.
+	 *
+	 * @param path The path to object that we want to check if it contains
+	 * data.
+	 *
+	 * @returns Boolean indicating if the object contains data.
+	 */
+	containsData(path: Array<ObjectSchema>): Promise<boolean> {
+		return super.performRpc('contains_data', ['path'], [path]);
+	}
+
+	/**
+	 * Get icon of an object
+	 *
+	 * Get icon of an object, such as a table or view.
+	 *
+	 * @param path The path to object that we want to get the icon.
+	 *
+	 * @returns The icon of the object.
+	 */
+	getIcon(path: Array<ObjectSchema>): Promise<string> {
+		return super.performRpc('get_icon', ['path'], [path]);
+	}
+
+	/**
+	 * Preview object data
+	 *
+	 * Preview object data, such as a table or view.
+	 *
+	 * @param path The path to object that we want to preview.
+	 *
+	 * @returns undefined
+	 */
+	previewObject(path: Array<ObjectSchema>): Promise<null> {
+		return super.performRpc('preview_object', ['path'], [path]);
+	}
+
+}

--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -278,8 +278,8 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 
 		let contains_data: boolean;
 		try {
-			// a failure here is unlikely as if continas_data() fails before, we would return a
-			// non collapisble treeItem, this getChildren wouldn't be called.
+			// a failure here is unlikely as if contains_data() fails before, we would return a
+			// non collapsible treeItem, this getChildren wouldn't be called.
 			// anyway, if this happens we still send a retry notification and return no children.
 			contains_data = await element.contains_data();
 		} catch (err: any) {

--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -161,7 +161,7 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 		} catch (err: any) {
 			// when contains_data fails, we show an error message that asks for a refresh.
 			// we also display an error tree item instead, so we can proceed with the rest of the tree
-			this.showErrorMessageWithRefresh(`Error checking if '${item.name}' contains_data: ${err.message}`);
+			this.showErrorMessageWithRefresh(vscode.l10n.t(`Error checking if '{0}' contains_data: {1}`, item.name, err.message));
 			return this.errorTreeItem(item.name, err);
 		}
 
@@ -203,7 +203,7 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 			}
 		} catch (err: any) {
 			// not having an icon is not fatal as we can fallback to the type, but is worth notifying
-			vscode.window.showErrorMessage(`Error getting icon for '${item.name}': ${err.message}`);
+			vscode.window.showErrorMessage(vscode.l10n.t(`Error getting icon for '{0}' : {1}`, item.name, err.message));
 		}
 
 		// fallback to the item kind
@@ -213,7 +213,7 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 	async showErrorMessageWithRefresh(message: string) {
 		const answer = await vscode.window.showErrorMessage(message,
 			{
-				title: 'Retry',
+				title: vscode.l10n.t('Retry'),
 				execute: async () => {
 					this.refresh();
 				}
@@ -224,7 +224,7 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 
 	errorTreeItem(name: string, error: any): vscode.TreeItem {
 		const treeItem = new vscode.TreeItem(name, vscode.TreeItemCollapsibleState.None);
-		treeItem.description = 'Error loading item.';
+		treeItem.description = vscode.l10n.t('Error loading item.');
 		treeItem.tooltip = error.message;
 		treeItem.iconPath = new vscode.ThemeIcon('error', new vscode.ThemeColor('errorForeground'));
 		return treeItem;
@@ -283,7 +283,7 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 			// anyway, if this happens we still send a retry notification and return no children.
 			contains_data = await element.contains_data();
 		} catch (err: any) {
-			this.showErrorMessageWithRefresh(`Error checking if '${element.name}' contains_data: ${err.message}`);
+			this.showErrorMessageWithRefresh(vscode.l10n.t(`Error checking if '{0}' contains_data: {1}`, element.name, err.message));
 			return [];
 		}
 

--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -5,6 +5,7 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import path = require('path');
+import { PositronConnectionsComm } from './comms/ConnectionsComms';
 
 /**
  * Enumerates the possible types of connection icons
@@ -26,16 +27,12 @@ export class ConnectionItem {
 	 * Create a new ConnectionItem instance
 	 *
 	 * @param name The name of the item
-	 * @param client A reference to the client instance (comm) that owns the
-	 *   item
+	 * @param client A reference to the client instance (comm) that owns the item
 	 */
+
 	constructor(
 		readonly name: string,
-		readonly client: positron.RuntimeClientInstance) {
-	}
-
-	async icon(): Promise<string | vscode.Uri | { light: vscode.Uri; dark: vscode.Uri }> {
-		return '';
+		readonly client: PositronConnectionsComm) {
 	}
 
 	async contains_data(): Promise<boolean> {
@@ -51,47 +48,24 @@ export class ConnectionItem {
  * @param path The path to the node. This is represented as a list of tuples (name, type). Later,
  *   we can use the path to get the node children by doing something like
  * 	 `getChildren(schema='hello', table='world')`
- * @param iconPath The path to an icon returned by the backend. If a path is not provided
- *  by the backend, the kind is used instead, to look up an icon in the extension's media
- * 	folder.
  */
 export class ConnectionItemNode extends ConnectionItem {
 	readonly kind: string;
 	readonly path: Array<{ name: string; kind: string }>;
-	private iconPath?: string | vscode.Uri | { light: vscode.Uri; dark: vscode.Uri };
-	private containsData?: boolean;
+	private _contains_data?: boolean;
 
-	constructor(readonly name: string, kind: string, path: Array<{ name: string; kind: string }>, client: positron.RuntimeClientInstance) {
+	constructor(readonly name: string, kind: string, path: Array<{ name: string; kind: string }>, client: PositronConnectionsComm) {
 		super(name, client);
 		this.kind = kind;
 		this.path = path;
 	}
 
 	async icon() {
-		if (this.iconPath) {
-			return this.iconPath;
-		}
-
-		const response = await this.client.performRpc({ msg_type: 'icon_request', path: this.path }) as any;
-
-		if (response.icon) {
-			this.iconPath = vscode.Uri.file(response.icon);
-			return this.iconPath;
-		}
-
-		this.iconPath = this.kind;
-		return this.iconPath;
+		return await this.client.getIcon(this.path);
 	}
 
 	override async contains_data() {
-		if (this.containsData) {
-			return this.containsData;
-		}
-
-		const response = await this.client.performRpc({ msg_type: 'contains_data_request', path: this.path }) as any;
-		this.containsData = response.contains_data as boolean;
-
-		return this.containsData;
+		return await this.client.containsData(this.path);
 	}
 
 	async preview() {
@@ -100,7 +74,8 @@ export class ConnectionItemNode extends ConnectionItem {
 			// does not contain data.
 			throw new Error('This item does not contain data');
 		}
-		await this.client.performRpc({ msg_type: 'preview_table', table: this.name, path: this.path });
+
+		await this.client.previewObject(this.path);
 	}
 }
 
@@ -108,26 +83,35 @@ export class ConnectionItemNode extends ConnectionItem {
  * A connection item representing a database connection (top-level)
  */
 export class ConnectionItemDatabase extends ConnectionItemNode {
-	constructor(readonly name: string, readonly client: positron.RuntimeClientInstance) {
+	constructor(readonly name: string, readonly client: PositronConnectionsComm) {
 		super(name, 'database', [], client);
 	}
 
 	close() {
 		this.client.dispose();
 	}
+
+	async contains_data() {
+		// database roots never contain data (even if empty) as they can't be a table itself
+		return false;
+	}
 }
 
 /**
  * A connection item representing a field in a table
  */
-export class ConnectionItemField extends ConnectionItem {
-	constructor(readonly name: string, readonly dtype: string, readonly client: positron.RuntimeClientInstance) {
-		super(name, client);
+export class ConnectionItemField extends ConnectionItemNode {
+	constructor(readonly name: string, readonly dtype: string, readonly client: PositronConnectionsComm) {
+		super(name, 'field', [], client);
 		this.dtype = dtype;
 	}
 
-	override async icon() {
-		return 'field';
+	async icon() {
+		return ''; // fields can't have custom icons
+	}
+
+	async contains_data() {
+		return false;
 	}
 }
 
@@ -167,9 +151,22 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 	 * @param item The item to get the tree item for
 	 * @returns A TreeItem for the item
 	 */
-	async getTreeItem(item: ConnectionItem): Promise<vscode.TreeItem> {
+	async getTreeItem(item: ConnectionItemNode): Promise<vscode.TreeItem> {
+
+		// Check if the item contains data
+		// If that fails we want to quicly return a treeItem that is not ispectable
+		let contains_data: boolean;
+		try {
+			contains_data = await item.contains_data();
+		} catch (err: any) {
+			// when contains_data fails, we show an error message that asks for a refresh.
+			// we also display an error tree item instead, so we can proceed with the rest of the tree
+			this.showErrorMessageWithRefresh(`Error checking if '${item.name}' contains_data: ${err.message}`);
+			return this.errorTreeItem(item.name, err);
+		}
+
 		// Both databases and tables can be expanded.
-		const collapsibleState = item instanceof ConnectionItemNode;
+		const collapsibleState = !(item instanceof ConnectionItemField);
 
 		// Create the tree item.
 		const treeItem = new vscode.TreeItem(item.name,
@@ -179,7 +176,7 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 
 		treeItem.iconPath = await this.getTreeItemIcon(item);
 
-		if (await item.contains_data()) {
+		if (contains_data) {
 			// if the item contains data, we set the contextValue enabling the UI for previewing the data
 			treeItem.contextValue = 'table';
 		}
@@ -198,14 +195,39 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 		return treeItem;
 	}
 
-	async getTreeItemIcon(item: ConnectionItem): Promise<vscode.Uri | { light: vscode.Uri; dark: vscode.Uri }> {
-		const icon = await item.icon();
-
-		if (typeof icon === 'string') {
-			return this._icons[icon];
+	async getTreeItemIcon(item: ConnectionItemNode): Promise<vscode.Uri | { light: vscode.Uri; dark: vscode.Uri }> {
+		try {
+			const icon = await item.icon();
+			if (icon !== '') {
+				return vscode.Uri.file(icon);
+			}
+		} catch (err: any) {
+			// not having an icon is not fatal as we can fallback to the type, but is worth notifying
+			vscode.window.showErrorMessage(`Error getting icon for '${item.name}': ${err.message}`);
 		}
 
-		return icon;
+		// fallback to the item kind
+		return this._icons[item.kind];
+	}
+
+	async showErrorMessageWithRefresh(message: string) {
+		const answer = await vscode.window.showErrorMessage(message,
+			{
+				title: 'Retry',
+				execute: async () => {
+					this.refresh();
+				}
+			}
+		);
+		answer?.execute();
+	}
+
+	errorTreeItem(name: string, error: any): vscode.TreeItem {
+		const treeItem = new vscode.TreeItem(name, vscode.TreeItemCollapsibleState.None);
+		treeItem.description = 'Error loading item.';
+		treeItem.tooltip = error.message;
+		treeItem.iconPath = new vscode.ThemeIcon('error', new vscode.ThemeColor('errorForeground'));
+		return treeItem;
 	}
 
 	/**
@@ -214,7 +236,7 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 	 * @param client The client instance that owns the connection
 	 * @param name The name of the connection
 	 */
-	addConnection(client: positron.RuntimeClientInstance, name: string) {
+	addConnection(client: PositronConnectionsComm, name: string) {
 		// Add the connection to the list
 		this._connections.push(new ConnectionItemDatabase(name, client));
 
@@ -224,12 +246,12 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 
 		// Add an event listener to the client so that we can remove the
 		// connection when it closes.
-		client.onDidChangeClientState((state: positron.RuntimeClientState) => {
+		client.instance.onDidChangeClientState((state: positron.RuntimeClientState) => {
 			if (state === positron.RuntimeClientState.Closed) {
 				// Get the ID and discard the connection matching the ID
-				const clientId = client.getClientId();
+				const clientId = client.instance.getClientId();
 				this._connections = this._connections.filter((connection) => {
-					return connection.client.getClientId() !== clientId;
+					return connection.client.instance.getClientId() !== clientId;
 				});
 				this._onDidChangeTreeData.fire(undefined);
 			}
@@ -254,10 +276,20 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 			return [];
 		}
 
+		let contains_data: boolean;
+		try {
+			// a failure here is unlikely as if continas_data() fails before, we would return a
+			// non collapisble treeItem, this getChildren wouldn't be called.
+			// anyway, if this happens we still send a retry notification and return no children.
+			contains_data = await element.contains_data();
+		} catch (err: any) {
+			this.showErrorMessageWithRefresh(`Error checking if '${element.name}' contains_data: ${err.message}`);
+			return [];
+		}
+
 		// The node is a view or a table so we want to get the fields on it.
 		if (await element.contains_data()) {
-			const response = await element.client.performRpc({ msg_type: 'fields_request', table: element.name, path: element.path }) as any;
-			const fields = response.fields as Array<{ name: string; dtype: string }>;
+			const fields = await element.client.listFields(element.path);
 			return fields.map((field) => {
 				return new ConnectionItemField(field.name, field.dtype, element.client);
 			});
@@ -265,11 +297,14 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 
 		// The node is a database, schema, or catalog, so we want to get the next set of elements in
 		// the tree.
-		const response = await element.client.performRpc({ msg_type: 'tables_request', name: element.name, kind: element.kind, path: element.path }) as any;
-		const children = response.tables as Array<{ name: string; kind: string }>;
+		const children = await element.client.listObjects(element.path);
 		return children.map((obj) => {
 			const path = [...element.path, { name: obj.name, kind: obj.kind }];
 			return new ConnectionItemNode(obj.name, obj.kind, path, element.client);
 		});
+	}
+
+	public refresh() {
+		this._onDidChangeTreeData.fire(undefined);
 	}
 }

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -533,7 +533,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.63"
+      "ark": "0.1.64"
     }
   }
 }

--- a/positron/comms/connections-backend-openrpc.json
+++ b/positron/comms/connections-backend-openrpc.json
@@ -1,0 +1,178 @@
+{
+	"openrpc": "1.3.0",
+	"info": {
+		"title": "Connections Pane Backend",
+		"version": "1.0.0"
+	},
+	"methods": [
+		{
+			"name": "list_objects",
+			"summary": "List objects within a data source",
+			"description": "List objects within a data source, such as schemas, catalogs, tables and views.",
+			"params": [
+				{
+					"name": "path",
+					"description": "The path to object that we want to list children.",
+					"required": true,
+					"schema": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/object_schema"
+						}
+					}
+				}
+			],
+			"result": {
+				"schema": {
+					"type": "array",
+					"name": "objects",
+					"description": "Array of objects names and their kinds.",
+					"items": {
+						"$ref": "#/components/schemas/object_schema"
+					}
+				}
+			}
+		},
+		{
+			"name": "list_fields",
+			"summary": "List fields of an object",
+			"description": "List fields of an object, such as columns of a table or view.",
+			"params": [
+				{
+					"name": "path",
+					"description": "The path to object that we want to list fields.",
+					"required": true,
+					"schema": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/object_schema"
+						}
+					}
+				}
+			],
+			"result": {
+				"schema": {
+					"type": "array",
+					"name": "fields",
+					"description": "Array of field names and data types.",
+					"items": {
+						"$ref": "#/components/schemas/field_schema"
+					}
+				}
+			}
+		},
+		{
+			"name": "contains_data",
+			"summary": "Check if an object contains data",
+			"description": "Check if an object contains data, such as a table or view.",
+			"params": [
+				{
+					"name": "path",
+					"description": "The path to object that we want to check if it contains data.",
+					"required": true,
+					"schema": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/object_schema"
+						}
+					}
+				}
+			],
+			"result": {
+				"schema": {
+					"type": "boolean",
+					"name": "contains_data",
+					"description": "Boolean indicating if the object contains data."
+				}
+			}
+		},
+		{
+			"name": "get_icon",
+			"summary": "Get icon of an object",
+			"description": "Get icon of an object, such as a table or view.",
+			"params": [
+				{
+					"name": "path",
+					"description": "The path to object that we want to get the icon.",
+					"required": true,
+					"schema": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/object_schema"
+						}
+					}
+				}
+			],
+			"result": {
+				"schema": {
+					"type": "string",
+					"name": "icon",
+					"required": false,
+					"description": "The icon of the object."
+				}
+			}
+		},
+		{
+			"name": "preview_object",
+			"summary": "Preview object data",
+			"description": "Preview object data, such as a table or view.",
+			"params": [
+				{
+					"name": "path",
+					"description": "The path to object that we want to preview.",
+					"required": true,
+					"schema": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/object_schema"
+						}
+					}
+				}
+			],
+			"result": {
+				"schema": {
+					"type": "null"
+				}
+			}
+		}
+	],
+	"components": {
+		"contentDescriptors": {},
+		"schemas": {
+			"object_schema": {
+				"type": "object",
+				"required": [
+					"name",
+					"kind"
+				],
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "Name of the underlying object"
+					},
+					"kind": {
+						"type": "string",
+						"description": "The object type (table, catalog, schema)"
+					}
+				}
+			},
+			"field_schema": {
+				"type": "object",
+				"required": [
+					"name",
+					"dtype"
+				],
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "Name of the field"
+					},
+					"dtype": {
+						"type": "string",
+						"description": "The field data type"
+					}
+				}
+			}
+		}
+	}
+}

--- a/positron/comms/connections.json
+++ b/positron/comms/connections.json
@@ -1,0 +1,9 @@
+{
+	"name": "conections",
+	"initiator": "backend",
+	"initial_data": {
+		"schema": {
+			"type": "null"
+		}
+	}
+}

--- a/src/vs/workbench/services/languageRuntime/common/positronConnectionsComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronConnectionsComm.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+//
+// AUTO-GENERATED from connections.json; do not edit.
+//
+
+import { PositronBaseComm } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
+import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
+
+/**
+ * ObjectSchema in Schemas
+ */
+export interface ObjectSchema {
+	/**
+	 * Name of the underlying object
+	 */
+	name: string;
+
+	/**
+	 * The object type (table, catalog, schema)
+	 */
+	kind: string;
+
+}
+
+/**
+ * FieldSchema in Schemas
+ */
+export interface FieldSchema {
+	/**
+	 * Name of the field
+	 */
+	name: string;
+
+	/**
+	 * The field data type
+	 */
+	dtype: string;
+
+}
+
+export class PositronConnectionsComm extends PositronBaseComm {
+	constructor(instance: IRuntimeClientInstance<any, any>) {
+		super(instance);
+	}
+
+	/**
+	 * List objects within a data source
+	 *
+	 * List objects within a data source, such as schemas, catalogs, tables
+	 * and views.
+	 *
+	 * @param path The path to object that we want to list children.
+	 *
+	 * @returns Array of objects names and their kinds.
+	 */
+	listObjects(path: Array<ObjectSchema>): Promise<Array<ObjectSchema>> {
+		return super.performRpc('list_objects', ['path'], [path]);
+	}
+
+	/**
+	 * List fields of an object
+	 *
+	 * List fields of an object, such as columns of a table or view.
+	 *
+	 * @param path The path to object that we want to list fields.
+	 *
+	 * @returns Array of field names and data types.
+	 */
+	listFields(path: Array<ObjectSchema>): Promise<Array<FieldSchema>> {
+		return super.performRpc('list_fields', ['path'], [path]);
+	}
+
+	/**
+	 * Check if an object contains data
+	 *
+	 * Check if an object contains data, such as a table or view.
+	 *
+	 * @param path The path to object that we want to check if it contains
+	 * data.
+	 *
+	 * @returns Boolean indicating if the object contains data.
+	 */
+	containsData(path: Array<ObjectSchema>): Promise<boolean> {
+		return super.performRpc('contains_data', ['path'], [path]);
+	}
+
+	/**
+	 * Get icon of an object
+	 *
+	 * Get icon of an object, such as a table or view.
+	 *
+	 * @param path The path to object that we want to get the icon.
+	 *
+	 * @returns The icon of the object.
+	 */
+	getIcon(path: Array<ObjectSchema>): Promise<string> {
+		return super.performRpc('get_icon', ['path'], [path]);
+	}
+
+	/**
+	 * Preview object data
+	 *
+	 * Preview object data, such as a table or view.
+	 *
+	 * @param path The path to object that we want to preview.
+	 *
+	 * @returns undefined
+	 */
+	previewObject(path: Array<ObjectSchema>): Promise<null> {
+		return super.performRpc('preview_object', ['path'], [path]);
+	}
+
+}
+


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

This PR adds OpenRPC definitions for the connections pane actions.
See related https://github.com/posit-dev/amalthea/pull/262

### Approach

We added OpenRPC definitions in the [`connections-backend-openrpc.json`](https://github.com/posit-dev/positron/blob/edb170a040e5b665a62373c7a21683367459b8ea/positron/comms/connections-backend-openrpc.json), which autogenerates [`positronConnectionsComm`](https://github.com/posit-dev/positron/blob/edb170a040e5b665a62373c7a21683367459b8ea/src/vs/workbench/services/languageRuntime/common/positronConnectionsComm.ts). Because the connections pane is an extension, we can't really use [`positronConnectionsComm`](https://github.com/posit-dev/positron/blob/edb170a040e5b665a62373c7a21683367459b8ea/src/vs/workbench/services/languageRuntime/common/positronConnectionsComm.ts) so we ported it's logic over to [ConnectionsComms.ts](https://github.com/posit-dev/positron/blob/60b234911e75538f2f9d8d1901a5b22b6044bee1/extensions/positron-connections/src/comms/ConnectionsComms.ts) and [`BaseComm.ts`](https://github.com/posit-dev/positron/blob/60b234911e75538f2f9d8d1901a5b22b6044bee1/extensions/positron-connections/src/comms/BaseComm.ts). This is targeting #2328

When adapting [`connections.ts`](https://github.com/posit-dev/positron/blob/8cf88709b8871fbe5cd8b9108a36d27cc6bab04f/extensions/positron-connections/src/connection.ts) we also introduced better error handling support (targetting #2311). We also added an update button which is related to handling errors and targets #2299 .
