### PR TITLE
Switch to a simpler module for reading from registry

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -516,11 +516,11 @@
     "vsce": "^2.11.0"
   },
   "dependencies": {
+    "@vscode/windows-registry": "^1.1.0",
     "p-queue": "^6.6.2",
     "split2": "^4.2.0",
     "vscode-languageclient": "^9.0.1",
-    "web-tree-sitter": "^0.20.8",
-    "winreg": "^1.2.5"
+    "web-tree-sitter": "^0.20.8"
   },
   "repository": {
     "type": "git",

--- a/extensions/positron-r/yarn.lock
+++ b/extensions/positron-r/yarn.lock
@@ -244,6 +244,11 @@
     rimraf "^3.0.2"
     unzipper "^0.10.11"
 
+"@vscode/windows-registry@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@vscode/windows-registry/-/windows-registry-1.1.0.tgz#03dace7c29c46f658588b9885b9580e453ad21f9"
+  integrity sha512-5AZzuWJpGscyiMOed0IuyEwt6iKmV5Us7zuwCDCFYMIq7tsvooO9BUiciywsvuthGz6UG4LSpeDeCxvgMVhnIw==
+
 acorn-jsx@^5.3.1:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
@@ -2284,11 +2289,6 @@ which@2.0.2, which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
-
-winreg@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/winreg/-/winreg-1.2.5.tgz#b650383e89278952494b5d113ba049a5a4fa96d8"
-  integrity sha512-uf7tHf+tw0B1y+x+mKTLHkykBgK2KMs3g+KlzmyMbLvICSHQyB/xOFjTT8qZ3oeTFyU7Bbj4FzXitGG6jvKhYw==
 
 word-wrap@^1.2.3:
   version "1.2.4"


### PR DESCRIPTION
The [@vscode/windows-registry module](https://www.npmjs.com/package/@vscode/windows-registry?activeTab=readme) is maintained by Microsoft and is described like so:

> This module only has what is needed to support VS Code and is intended to be a lightweight module.

Seems like a great fit for our purposes. I see it used elsewhere in VS Code.

Given our simple needs at this point, this is more pleasant to work with than winreg. Not sure why I didn't find/choose it the first time.

