### PR TITLE
ignore more positron-python paths that crash the gulp watcher

### DIFF
--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -238,9 +238,10 @@ const tasks = compilations.map(function (tsconfigFile) {
 		// (Note that these need to be ignored at `watcher` -- `gulp.src` is not enough.)
 		if (relativeDirname === 'positron-python') {
 			ignored = [
-				path.join(srcBase, 'testTestingRootWkspc/**'),
 				path.join(srcBase, 'test/1/**'),
 				path.join(srcBase, 'test/should-not-exist/**'),
+				path.join(srcBase, 'testMultiRootWkspc/**'),
+				path.join(srcBase, 'testTestingRootWkspc/**'),
 			];
 		} else {
 			ignored = [];


### PR DESCRIPTION
Relates to https://github.com/posit-dev/positron/issues/890.