### PR TITLE
Deal with less common file hyperlinks on Windows

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.tsx
@@ -4,6 +4,7 @@
 
 import 'vs/css!./outputRun';
 import * as React from 'react';
+import * as platform from 'vs/base/common/platform';
 import { CSSProperties, MouseEvent } from 'react'; // eslint-disable-line no-duplicate-imports
 import { localize } from 'vs/nls';
 import { ANSIColor, ANSIOutputRun, ANSIStyle } from 'vs/base/common/ansiOutput';
@@ -54,6 +55,11 @@ export const OutputRun = (props: OutputRunProps) => {
 		let url = props.outputRun.hyperlink.url;
 		if (!url.startsWith(`${Schemas.file}:`)) {
 			return url;
+		}
+
+		// a hack that, at least, pinpoints the problem / solution
+		if (platform.isWindows) {
+			url = url.replace(/\\/g, '/').replace(/file:\/\/(?!\/)/g, 'file:///');
 		}
 
 		// Get the line parameter. If it's not present, return the URL.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/outputRun.tsx
@@ -15,6 +15,7 @@ import { Schemas } from 'vs/base/common/network';
  * Constants.
  */
 const numberRegex = /^\d+$/;
+const fileURLThatNeedsASlash = /^(file:\/\/)([a-zA-Z]:)/;
 const fileURLWithLine = /^(file:\/\/\/.+):(\d+)$/;
 const fileURLWithLineAndColumn = /^(file:\/\/\/.+):(\d+):(\d+)$/;
 
@@ -57,9 +58,15 @@ export const OutputRun = (props: OutputRunProps) => {
 			return url;
 		}
 
-		// a hack that, at least, pinpoints the problem / solution
+		// anticipate file URLs produced by, e.g., some versions of the cli R package
+		// BEFORE example:
+		// file://D:\\Users\\jenny\\source\\repos\\glue\\tests\\testthat\\test-glue.R
+		// AFTER example:
+		// file:///D:/Users/jenny/source/repos/glue/tests/testthat/test-glue.R
 		if (platform.isWindows) {
-			url = url.replace(/\\/g, '/').replace(/file:\/\/(?!\/)/g, 'file:///');
+			url = url
+				.replace(/\\/g, '/')
+				.replace(fileURLThatNeedsASlash, '$1/$2');
 		}
 
 		// Get the line parameter. If it's not present, return the URL.


### PR DESCRIPTION
Addresses #2413 

I give more context in #2413 but the TL;DR is that Positron does need to make a special allowance for the current file hyperlinks produced by the cli R package on Windows.

There is a path towards having cli emit more conventional hyperlinks, which Positron will opt in to once that's possible. Changes in the cli package are constrained by the need to also not break file hyperlinks on Windows in RStudio.