### PR TITLE
Revert "Switch to a simpler module for reading from registry (#2410)"

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -516,11 +516,11 @@
     "vsce": "^2.11.0"
   },
   "dependencies": {
-    "@vscode/windows-registry": "^1.1.0",
     "p-queue": "^6.6.2",
     "split2": "^4.2.0",
     "vscode-languageclient": "^9.0.1",
-    "web-tree-sitter": "^0.20.8"
+    "web-tree-sitter": "^0.20.8",
+    "winreg": "^1.2.5"
   },
   "repository": {
     "type": "git",

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -10,13 +10,13 @@ import * as vscode from 'vscode';
 import * as which from 'which';
 import * as positron from 'positron';
 import * as crypto from 'crypto';
+import * as winreg from 'winreg';
 
 import { RInstallation, getRHomePath } from './r-installation';
 import { RRuntime, createJupyterKernelExtra, createJupyterKernelSpec } from './runtime';
 import { RRuntimeManager } from './runtime-manager';
 import { Logger } from './extension';
 import { readLines } from './util';
-import { HKEY } from '@vscode/windows-registry';
 
 const initialDynState = {
 	inputPrompt: '>',
@@ -362,8 +362,8 @@ async function findCurrentRBinary(): Promise<string | undefined> {
 }
 
 async function findCurrentRBinaryFromRegistry(): Promise<string | undefined> {
-	const userPath = await getRegistryInstallPath('HKEY_CURRENT_USER');
-	const machinePath = await getRegistryInstallPath('HKEY_LOCAL_MACHINE');
+	const userPath = await getRegistryInstallPath(winreg.HKCU);
+	const machinePath = await getRegistryInstallPath(winreg.HKLM);
 	if (!userPath && !machinePath) {
 		return undefined;
 	}
@@ -378,17 +378,34 @@ async function findCurrentRBinaryFromRegistry(): Promise<string | undefined> {
 	return binPath;
 }
 
-async function getRegistryInstallPath(hive: 'HKEY_CURRENT_USER' | 'HKEY_LOCAL_MACHINE'): Promise<string | undefined> {
-	// 'R64' here is another place where we explicitly ignore 32-bit R
-	const R64_KEY: string = 'Software\\R-Core\\R64';
-	const registry = await import('@vscode/windows-registry');
-
+async function getRegistryInstallPath(hive: string): Promise<string | undefined> {
 	try {
-		Logger.info(`Checking for 'InstallPath' in registry key ${R64_KEY} for hive ${hive}`);
-		const pth = registry.GetStringRegKey(hive as HKEY, R64_KEY, 'InstallPath') || '';
-		return pth;
-	} catch (err) {
-		Logger.info(err as string);
+		const key = new winreg({
+			hive: hive as keyof typeof winreg,
+			// 'R64' here is another place where we explicitly ignore 32-bit R
+			key: '\\Software\\R-Core\\R64',
+		});
+
+		Logger.info(`Checking for 'InstallPath' in registry key ${key.key} for hive ${key.hive}`);
+
+		const result = await new Promise<{ value: string }>((resolve, reject) => {
+			key.get('InstallPath', (error, result) => {
+				if (error) {
+					reject(error);
+				} else {
+					resolve(result);
+				}
+			});
+		});
+
+		if (!result || typeof result.value !== 'string') {
+			Logger.info(`Invalid value of 'InstallPath'`);
+			return undefined;
+		}
+
+		return result.value;
+	} catch (error: any) {
+		Logger.info(`Unable to get value of 'InstallPath': ${error.message}`);
 		return undefined;
 	}
 }

--- a/extensions/positron-r/yarn.lock
+++ b/extensions/positron-r/yarn.lock
@@ -244,11 +244,6 @@
     rimraf "^3.0.2"
     unzipper "^0.10.11"
 
-"@vscode/windows-registry@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@vscode/windows-registry/-/windows-registry-1.1.0.tgz#03dace7c29c46f658588b9885b9580e453ad21f9"
-  integrity sha512-5AZzuWJpGscyiMOed0IuyEwt6iKmV5Us7zuwCDCFYMIq7tsvooO9BUiciywsvuthGz6UG4LSpeDeCxvgMVhnIw==
-
 acorn-jsx@^5.3.1:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
@@ -2289,6 +2284,11 @@ which@2.0.2, which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+winreg@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/winreg/-/winreg-1.2.5.tgz#b650383e89278952494b5d113ba049a5a4fa96d8"
+  integrity sha512-uf7tHf+tw0B1y+x+mKTLHkykBgK2KMs3g+KlzmyMbLvICSHQyB/xOFjTT8qZ3oeTFyU7Bbj4FzXitGG6jvKhYw==
 
 word-wrap@^1.2.3:
   version "1.2.4"


### PR DESCRIPTION
This reverts commit 88413d533861beaff32269b9de2042c27c47e63c, in order to fix the following build issue:

```
[03:12:24] Error in plugin "webpack-stream"
Message:
    Module parse failed: Unexpected character '�' (1:2)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file.
```
