### PR TITLE
Temporarily disable flaky integration tests on ci

### DIFF
--- a/.github/workflows/positron-ci.yml
+++ b/.github/workflows/positron-ci.yml
@@ -62,9 +62,10 @@ jobs:
         id: nodejs-unit-tests
         run: yarn test-node
 
-      - name: Run Integration Tests (Electron)
-        id: electron-integration-tests
-        run: DISPLAY=:10 ./scripts/test-integration.sh
+      # TODO: Re-enable integration tests once reliable
+      # - name: Run Integration Tests (Electron)
+      #   id: electron-integration-tests
+      #   run: DISPLAY=:10 ./scripts/test-integration.sh
 
       - name: Run Smoke Tests (Electron)
         id: electron-smoke-tests


### PR DESCRIPTION
### Intent

Stabilize CI builds.

### Approach

Fix CI by commenting out the Electron integration tests on linux until we can stabilize this step.

### QA Notes

We'll set these up in an alternate workflow until we can solve the issues running the Electron integration tests on linux reliably.
