### PR TITLE
Bring session to foreground when executing code

### DIFF
--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -406,6 +406,10 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 		// Activate the Positron console instance.
 		if (positronConsoleInstance !== this._activePositronConsoleInstance) {
 			this.setActivePositronConsoleInstance(positronConsoleInstance);
+
+			// Set the foreground session so that other panes (e.g. Variables)
+			// will show the results of the code we're about to evaluate.
+			this._runtimeSessionService.foregroundSession = positronConsoleInstance.session;
 		}
 
 		// Focus the Positron console instance, if we're supposed to.


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/1345. 

### Approach

When executing code that requires the console to switch to a new language, update the rest of the UI to show views for the same language (session) we switched to.

### QA Notes

Test via notes in #1345. 

Note that (intentionally) this change only has an effect when the console needs to switch languages. If e.g. your console is showing Python and your variables pane is showing R, and you execute Python code, nothing new will happen. 