### PR TITLE
Add React version detection

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,11 @@
 		"ecmaVersion": 6,
 		"sourceType": "module"
 	},
+	"settings": {
+		"react": {
+			"version": "detect"
+		}
+	},
 	"plugins": [
 		"@typescript-eslint",
 		"jsdoc",


### PR DESCRIPTION
### Intent

This PR fixes the warning:

```Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration```

### Approach

We needed to add this:

```
	"settings": {
		"react": {
			"version": "detect"
		}
	},
```

To the eslintrc.json file.
