### PR TITLE
Register R sessions with manager on construction

### DIFF
--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -82,6 +82,9 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 			inputPrompt: '>',
 		};
 
+		// Register this session with the session manager
+		RSessionManager.instance.setSession(metadata.sessionId, this);
+
 		this.onDidChangeRuntimeState((state) => {
 			this.onStateChange(state);
 		});


### PR DESCRIPTION
### Intent

Addresses an issue spotted by @jennybc, a regression from the runtime sessions work: `callMethod` and other tools that need an active R sessions do not work. For example, _Format Document_ can't find an active R session.

### Approach

Register sessions with the session manager when they are constructed.

### QA Notes

Testing _Format Document_ should be sufficient for validating this change.