### PR TITLE
Fix missing menu item foreground colors

### DIFF
--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItem.css
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItem.css
@@ -11,6 +11,7 @@
 	text-align: left;
 	align-items: center;
 	background: transparent;
+	color: var(--vscode-positronContextMenu-foreground);
 }
 
 .custom-folder-menu-item:hover {

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderRecentlyUsedMenuItem.css
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderRecentlyUsedMenuItem.css
@@ -13,6 +13,7 @@
 	align-content: center;
 	background: transparent;
 	grid-template-columns: 1fr min-content;
+	color: var(--vscode-positronContextMenu-foreground);
 }
 
 .custom-folder-recently-used-menu-item:hover {


### PR DESCRIPTION
### Intent

Address #2447 by adding missing menu item foreground colors to the custom folder menu.

### Approach

Updated the necessary CSS.

<img width="319" alt="image" src="https://github.com/posit-dev/positron/assets/853239/0d2872a4-9c2b-4813-a4ad-ea4ae845768d">

### QA Notes

None.