### PR TITLE
Ignore session managers other than the first

### DIFF
--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -180,7 +180,8 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		}
 		if (this._sessionManager) {
 			this._logService.warn(
-				`Language runtime service already has a session manager registered!`);
+				`Language runtime service already has a session manager registered! Ignoring.`);
+			return;
 		}
 		this._sessionManager = manager;
 	}


### PR DESCRIPTION
### Intent

This change addresses an issue reported by @blairj09 in which Positron can't start R or Python sessions. More context, and logs, in this Slack thread:

https://positpbc.slack.com/archives/C05M2EZCPGR/p1710369775412109

I was not able to reproduce the issue myself (nor have many other people on the same build), but the logs provided by James make it clear what's going on: somehow, a second, defunct instance of `MainThreadLanguageRuntime` is getting constructed and is trying to register itself as the session manager. 

After that happens, we use the defunct instance to attempt to start sessions, which it can't do since it isn't connected to any language packs.

### Approach

The fix is to only allow one `MainThreadLanguageRuntime` to be register itself; any subsequent attempts at registration are refused (with a logged warning).

The fix is really a band-aid; if we find that this issue merits more attention, we should spend some time figuring out how it's possible to have two instances of the proxy class.

### QA Notes

No repro for this one, unfortunately.

@blairj09 has tested a private release I built with the change (https://github.com/posit-dev/positron/actions/runs/8283858792) and confirmed it fixes the problem for him.