### PR TITLE
Detect the active language from Positron when creating a notebook

### DIFF
--- a/extensions/ipynb/src/ipynbMain.ts
+++ b/extensions/ipynb/src/ipynbMain.ts
@@ -9,6 +9,10 @@ import { ensureAllNewCellsHaveCellIds } from './cellIdService';
 import { notebookImagePasteSetup } from './notebookImagePaste';
 import { AttachmentCleaner } from './notebookAttachmentCleaner';
 
+// --- Start Positron ---
+import * as positron from 'positron';
+// --- End Positron ---
+
 // From {nbformat.INotebookMetadata} in @jupyterlab/coreutils
 type NotebookMetadata = {
 	kernelspec?: {
@@ -70,7 +74,10 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	context.subscriptions.push(vscode.commands.registerCommand('ipynb.newUntitledIpynb', async () => {
-		const language = 'python';
+		// --- Start Positron ---
+		// Try to use Positron's foreground session's language, fall back to 'python' (as before this change).
+		const language = (await positron.runtime.getForegroundSession())?.runtimeMetadata?.languageId ?? 'python';
+		// --- End Positron ---
 		const cell = new vscode.NotebookCellData(vscode.NotebookCellKind.Code, '', language);
 		const data = new vscode.NotebookData([cell]);
 		data.metadata = {

--- a/extensions/ipynb/src/notebookSerializer.ts
+++ b/extensions/ipynb/src/notebookSerializer.ts
@@ -86,6 +86,15 @@ export class NotebookSerializer implements vscode.NotebookSerializer {
 		// use the preferred language from document metadata or the first cell language as the notebook preferred cell language
 		const preferredCellLanguage = notebookContent.metadata?.language_info?.name ?? data.cells.find(cell => cell.kind === vscode.NotebookCellKind.Code)?.languageId;
 
+		// --- Start Positron ---
+		// Set the notebook's language info if necessary. This fixes a bug where serializing a
+		// notebook with no language info reverts all cells to 'python'.
+		if (!notebookContent.metadata?.language_info?.name && preferredCellLanguage) {
+			notebookContent.metadata = notebookContent.metadata || {};
+			notebookContent.metadata.language_info = notebookContent.metadata.language_info || { name: preferredCellLanguage };
+		}
+		// --- Start Positron ---
+
 		notebookContent.cells = data.cells
 			.map(cell => createJupyterCellFromNotebookCell(cell, preferredCellLanguage))
 			.map(pruneCell);

--- a/extensions/ipynb/src/notebookSerializer.ts
+++ b/extensions/ipynb/src/notebookSerializer.ts
@@ -93,8 +93,7 @@ export class NotebookSerializer implements vscode.NotebookSerializer {
 			notebookContent.metadata = notebookContent.metadata || {};
 			notebookContent.metadata.language_info = notebookContent.metadata.language_info || { name: preferredCellLanguage };
 		}
-		// --- Start Positron ---
-
+		// --- End Positron ---
 		notebookContent.cells = data.cells
 			.map(cell => createJupyterCellFromNotebookCell(cell, preferredCellLanguage))
 			.map(pruneCell);

--- a/extensions/ipynb/tsconfig.json
+++ b/extensions/ipynb/tsconfig.json
@@ -8,7 +8,10 @@
 		"src/**/*",
 		"../../src/vscode-dts/vscode.d.ts",
 		"../../src/vscode-dts/vscode.proposed.documentPaste.d.ts",
-		"../../src/vscode-dts/vscode.proposed.dropMetadata.d.ts"
+		"../../src/vscode-dts/vscode.proposed.dropMetadata.d.ts",
+		// --- Start Positron ---
+		"../../src/positron-dts/positron.d.ts",
+		// --- End Positron ---
 
 	]
 }

--- a/extensions/ipynb/tsconfig.json
+++ b/extensions/ipynb/tsconfig.json
@@ -8,8 +8,8 @@
 		"src/**/*",
 		"../../src/vscode-dts/vscode.d.ts",
 		"../../src/vscode-dts/vscode.proposed.documentPaste.d.ts",
-		"../../src/vscode-dts/vscode.proposed.dropMetadata.d.ts",
 		// --- Start Positron ---
+		"../../src/vscode-dts/vscode.proposed.dropMetadata.d.ts",
 		"../../src/positron-dts/positron.d.ts",
 		// --- End Positron ---
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1127,6 +1127,11 @@ declare module 'positron' {
 		export function getPreferredRuntime(languageId: string): Thenable<LanguageRuntimeMetadata>;
 
 		/**
+		 * Get the active foreground session, if any.
+		 */
+		export function getForegroundSession(): Thenable<LanguageRuntimeSession | undefined>;
+
+		/**
 		 * Select and start a runtime previously registered with Positron. Any
 		 * previously active runtimes for the language will be shut down.
 		 *

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1056,6 +1056,10 @@ export class MainThreadLanguageRuntime
 		return Promise.resolve(this._runtimeStartupService.getPreferredRuntime(languageId));
 	}
 
+	$getForegroundSession(): Promise<string | undefined> {
+		return Promise.resolve(this._runtimeSessionService.foregroundSession?.sessionId);
+	}
+
 	// Called by the extension host to select a previously registered language runtime
 	$selectLanguageRuntime(runtimeId: string): Promise<void> {
 		return this._runtimeSessionService.selectRuntime(

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -81,6 +81,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			getPreferredRuntime(languageId: string): Thenable<positron.LanguageRuntimeMetadata> {
 				return extHostLanguageRuntime.getPreferredRuntime(languageId);
 			},
+			getForegroundSession(): Thenable<positron.LanguageRuntimeSession | undefined> {
+				return extHostLanguageRuntime.getForegroundSession();
+			},
 			selectLanguageRuntime(runtimeId: string): Thenable<void> {
 				return extHostLanguageRuntime.selectLanguageRuntime(runtimeId);
 			},

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -37,6 +37,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$unregisterLanguageRuntime(handle: number): void;
 	$executeCode(languageId: string, code: string, focus: boolean, skipChecks?: boolean): Promise<boolean>;
 	$getPreferredRuntime(languageId: string): Promise<ILanguageRuntimeMetadata>;
+	$getForegroundSession(): Promise<string | undefined>;
 	$restartSession(handle: number): Promise<void>;
 	$emitLanguageRuntimeMessage(handle: number, message: ILanguageRuntimeMessage): void;
 	$emitLanguageRuntimeState(handle: number, clock: number, state: RuntimeState): void;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -533,6 +533,18 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		return runtime;
 	}
 
+	public async getForegroundSession(): Promise<positron.LanguageRuntimeSession | undefined> {
+		const sessionId = await this._proxy.$getForegroundSession();
+		if (!sessionId) {
+			return;
+		}
+		const session = this._runtimeSessions.find(session => session.metadata.sessionId === sessionId);
+		if (!session) {
+			throw new Error(`Session ID '${sessionId}' not found.`);
+		}
+		return session;
+	}
+
 	/**
 	 * Registers a new language runtime manager with the extension host.
 	 *

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -540,7 +540,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		}
 		const session = this._runtimeSessions.find(session => session.metadata.sessionId === sessionId);
 		if (!session) {
-			throw new Error(`Session ID '${sessionId}' not found.`);
+			throw new Error(`Session ID '${sessionId}' was marked as the foreground session, but is not known to the extension host.`);
 		}
 		return session;
 	}


### PR DESCRIPTION
### Intent

Addresses #2456 and #2470.

### Approach

The first issue is addressed by adding `positron.runtime.getForegroundSession` to the Positron API. It then uses the method to determine the language for a new notebook in the `ipynb.newUntitledIpynb` command.

The second issue is addressed by ensuring that the notebook document's language is set when it's inferred from the first cell.

### QA Notes

See the linked issues to repro.