### PR TITLE
Add `POSITRON` env var, as parallel of `RSTUDIO` env var

### DIFF
--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -614,6 +614,7 @@ export function createJupyterKernelSpec(context: vscode.ExtensionContext,
 
 	/* eslint-disable */
 	const env = <Record<string, string>>{
+		'POSITRON': '1',
 		'RUST_BACKTRACE': '1',
 		'RUST_LOG': logLevel,
 		'R_HOME': rHomePath,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses #1494

### Approach

This PR adds an R env var for Positron:

``` r
Sys.getenv("POSITRON")
#> [1] "1"
```

<sup>Created on 2024-03-17 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

That works like this one in RStudio:

``` r
Sys.getenv("RSTUDIO")
#> [1] "1"
```

<sup>Created on 2024-03-17 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

### QA Notes

I'll follow this up [with docs added here](https://github.com/posit-dev/positron-beta/wiki#compatibility), to recommend that users of the vscode-R extension add this env var to their `.Rprofile` like they have the RStudio one.