### PR TITLE
New task for `devtools::test()` in new session

### DIFF
--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -105,7 +105,12 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 		}),
 
 		vscode.commands.registerCommand('r.packageTest', async () => {
-			executeCodeForCommand('devtools', 'devtools::test()');
+			const tasks = await getRPackageTasks();
+			const task = tasks.filter(task => task.definition.task === 'r.task.packageTest')[0];
+			const isInstalled = await checkInstalled(task.definition.pkg);
+			if (isInstalled) {
+				vscode.tasks.executeTask(task);
+			}
 		}),
 
 		vscode.commands.registerCommand('r.useTestthat', async () => {

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -41,6 +41,12 @@ export async function getRPackageTasks(): Promise<vscode.Task[]> {
 			message: vscode.l10n.t('{taskName}', { taskName: 'Install R package' }),
 			rcode: 'pak::local_install(upgrade = FALSE)',
 			package: 'pak'
+		},
+		{
+			task: 'r.task.packageTest',
+			message: vscode.l10n.t('{taskName}', { taskName: 'Test R package' }),
+			rcode: 'devtools::test()',
+			package: 'devtools'
 		}
 	];
 	// the explicit quoting treatment is necessary to avoid headaches on Windows, with PowerShell


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses #2378

### Approach

This PR adds a new task for `'r.task.packageTest'` that is analogous to `'r.task.packageCheck'`.

### QA Notes

This can be tested by running the "R: Test R Package" command from the command palette; it now runs in a separate session through a terminal.