### PR TITLE
Bump ark to 0.1.65

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -533,7 +533,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.64"
+      "ark": "0.1.65"
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

I and others are wondering if the problems I was observing in #2463 are because ark didn't get bumped correctly. I believe I have gone through the correct dance of removing my local ark build, `yarn`, etc etc etc to test out that I am really using the new 0.1.65 ark locally:

```r
> .ps.ark.version()
                                                                           branch 
                                                                           "main" 
                                                                           commit 
                                                                        "3efa8e1" 
                                                                             date 
                                                        "2024-03-17 15:00:02 MDT" 
                                                                           flavor 
                                                                        "release" 
                                                                             path 
"/Users/juliasilge/Work/rstudio/positron/extensions/positron-r/resources/ark/ark" 
                                                                          version 
                                                                         "0.1.65" 
```

And locally now, I do see the rstudioapi shims working correctly. 🤞 

