### PR TITLE
Add OpenRPC method for `show_dialog`

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -533,7 +533,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.65"
+      "ark": "0.1.66"
     }
   }
 }

--- a/positron/comms/ui-frontend-openrpc.json
+++ b/positron/comms/ui-frontend-openrpc.json
@@ -109,6 +109,28 @@
 			}
 		},
 		{
+			"name": "show_dialog",
+			"summary": "Show a dialog",
+			"description": "Use this for a modal dialog that the user can only accept",
+			"params": [
+				{
+					"name": "title",
+					"description": "The title of the dialog",
+					"schema": {
+						"type": "string"
+					}
+				},
+				{
+					"name": "message",
+					"description": "The message to display in the dialog",
+					"schema": {
+						"type": "string"
+					}
+				}
+			],
+			"result": {}
+		},
+		{
 			"name": "prompt_state",
 			"summary": "New state of the primary and secondary prompts",
 			"description": "Languages like R allow users to change the way their prompts look. This event signals a change in the prompt configuration.",

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1241,7 +1241,7 @@ declare module 'positron' {
 		 * @param title The title of the dialog
 		 * @param message The message to display in the dialog
 		 *
-		 * @returns A Thenable that resolves when the user clicks OK.
+		 * @returns A Thenable that resolves when the user dismisses the dialog.
 		 */
 		export function showDialog(title: string, message: string): Thenable<null>;
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1068,6 +1068,19 @@ declare module 'positron' {
 			cancelButtonTitle?: string): Thenable<boolean>;
 
 		/**
+		 * Create and show a different simple modal dialog prompt.
+		 *
+		 * @param title The title of the dialog
+		 * @param message The message to display in the dialog
+		 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
+		 *
+		 * @returns A Thenable that resolves when the user clicks OK.
+		 */
+		export function showSimpleModalDialogPrompt2(title: string,
+			message: string,
+			okButtonTitle?: string): Thenable<null>;
+
+		/**
 		 * Get the `Console` for a runtime language `id`
 		 *
 		 * @param id The runtime language `id` to retrieve a `Console` for, i.e. 'r' or 'python'.
@@ -1221,6 +1234,17 @@ declare module 'positron' {
 		 *   if the user clicked Cancel.
 		 */
 		export function showQuestion(title: string, message: string, okButtonTitle: string, cancelButtonTitle: string): Thenable<boolean>;
+
+		/**
+		 * Create and show a different simple modal dialog prompt.
+		 *
+		 * @param title The title of the dialog
+		 * @param message The message to display in the dialog
+		 *
+		 * @returns A Thenable that resolves when the user clicks OK.
+		 */
+		export function showDialog(title: string, message: string): Thenable<null>;
+
 
 	}
 }

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1076,7 +1076,7 @@ declare module 'positron' {
 		 *
 		 * @returns A Thenable that resolves when the user clicks OK.
 		 */
-		export function showSimpleModalDialogPrompt2(title: string,
+		export function showSimpleModalDialogMessage(title: string,
 			message: string,
 			okButtonTitle?: string): Thenable<null>;
 

--- a/src/vs/base/browser/ui/positronModalDialog/components/okCancelActionBar.tsx
+++ b/src/vs/base/browser/ui/positronModalDialog/components/okCancelActionBar.tsx
@@ -23,6 +23,14 @@ interface OKCancelActionBarProps {
 }
 
 /**
+ * OKActionBarProps interface.
+ */
+interface OKActionBarProps {
+	okButtonTitle?: string;
+	accept: () => void;
+}
+
+/**
  * OKCancelActionBar component.
  * @param props An OKCancelActionBarProps that contains the component properties.
  * @returns The rendered component.
@@ -36,6 +44,22 @@ export const OKCancelActionBar = (props: OKCancelActionBarProps) => {
 			</Button>
 			<Button className='action-bar-button' onPressed={props.cancel}>
 				{props.cancelButtonTitle ?? localize('positronCancel', "Cancel")}
+			</Button>
+		</div>
+	);
+};
+
+/**
+ * OKCancelActionBar component.
+ * @param props An OKCancelActionBarProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const OKActionBar = (props: OKActionBarProps) => {
+	// Render.
+	return (
+		<div className='ok-action-bar top-separator'>
+			<Button className='action-bar-button default' onPressed={props.accept}>
+				{props.okButtonTitle ?? localize('positronOK', "OK")}
 			</Button>
 		</div>
 	);

--- a/src/vs/base/browser/ui/positronModalDialog/components/okCancelActionBar.tsx
+++ b/src/vs/base/browser/ui/positronModalDialog/components/okCancelActionBar.tsx
@@ -23,14 +23,6 @@ interface OKCancelActionBarProps {
 }
 
 /**
- * OKActionBarProps interface.
- */
-interface OKActionBarProps {
-	okButtonTitle?: string;
-	accept: () => void;
-}
-
-/**
  * OKCancelActionBar component.
  * @param props An OKCancelActionBarProps that contains the component properties.
  * @returns The rendered component.
@@ -44,22 +36,6 @@ export const OKCancelActionBar = (props: OKCancelActionBarProps) => {
 			</Button>
 			<Button className='action-bar-button' onPressed={props.cancel}>
 				{props.cancelButtonTitle ?? localize('positronCancel', "Cancel")}
-			</Button>
-		</div>
-	);
-};
-
-/**
- * OKCancelActionBar component.
- * @param props An OKCancelActionBarProps that contains the component properties.
- * @returns The rendered component.
- */
-export const OKActionBar = (props: OKActionBarProps) => {
-	// Render.
-	return (
-		<div className='ok-action-bar top-separator'>
-			<Button className='action-bar-button default' onPressed={props.accept}>
-				{props.okButtonTitle ?? localize('positronOK', "OK")}
 			</Button>
 		</div>
 	);

--- a/src/vs/workbench/api/browser/positron/mainThreadModalDialogs.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadModalDialogs.ts
@@ -21,8 +21,8 @@ export class MainThreadModalDialogs implements MainThreadModalDialogsShape {
 		return this._positronModalDialogsService.showSimpleModalDialogPrompt(title, message, okButtonTitle, cancelButtonTitle);
 	}
 
-	$showSimpleModalDialogPrompt2(title: string, message: string, okButtonTitle?: string): Promise<null> {
-		return this._positronModalDialogsService.showSimpleModalDialogPrompt2(title, message, okButtonTitle);
+	$showSimpleModalDialogMessage(title: string, message: string, okButtonTitle?: string): Promise<null> {
+		return this._positronModalDialogsService.showSimpleModalDialogMessage(title, message, okButtonTitle);
 	}
 
 	public dispose(): void {

--- a/src/vs/workbench/api/browser/positron/mainThreadModalDialogs.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadModalDialogs.ts
@@ -21,6 +21,10 @@ export class MainThreadModalDialogs implements MainThreadModalDialogsShape {
 		return this._positronModalDialogsService.showSimpleModalDialogPrompt(title, message, okButtonTitle, cancelButtonTitle);
 	}
 
+	$showSimpleModalDialogPrompt2(title: string, message: string, okButtonTitle?: string): Promise<null> {
+		return this._positronModalDialogsService.showSimpleModalDialogPrompt2(title, message, okButtonTitle);
+	}
+
 	public dispose(): void {
 		this._disposables.dispose();
 	}

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -123,6 +123,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			showSimpleModalDialogPrompt(title: string, message: string, okButtonTitle?: string, cancelButtonTitle?: string): Thenable<boolean> {
 				return extHostModalDialogs.showSimpleModalDialogPrompt(title, message, okButtonTitle, cancelButtonTitle);
 			},
+			showSimpleModalDialogPrompt2(title: string, message: string, okButtonTitle?: string): Thenable<null> {
+				return extHostModalDialogs.showSimpleModalDialogPrompt2(title, message, okButtonTitle);
+			},
 			getConsoleForLanguage(id: string) {
 				return extHostConsoleService.getConsoleForLanguage(id);
 			},
@@ -154,6 +157,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			},
 			lastActiveEditorContext(): Thenable<positron.EditorContext | null> {
 				return extHostMethods.lastActiveEditorContext();
+			},
+			showDialog(title: string, message: string): Thenable<null> {
+				return extHostMethods.showDialog(title, message);
 			},
 			showQuestion(title: string, message: string, okButtonTitle: string, cancelButtonTitle: string): Thenable<boolean> {
 				return extHostMethods.showQuestion(title, message, okButtonTitle, cancelButtonTitle);

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -123,8 +123,8 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			showSimpleModalDialogPrompt(title: string, message: string, okButtonTitle?: string, cancelButtonTitle?: string): Thenable<boolean> {
 				return extHostModalDialogs.showSimpleModalDialogPrompt(title, message, okButtonTitle, cancelButtonTitle);
 			},
-			showSimpleModalDialogPrompt2(title: string, message: string, okButtonTitle?: string): Thenable<null> {
-				return extHostModalDialogs.showSimpleModalDialogPrompt2(title, message, okButtonTitle);
+			showSimpleModalDialogMessage(title: string, message: string, okButtonTitle?: string): Thenable<null> {
+				return extHostModalDialogs.showSimpleModalDialogMessage(title, message, okButtonTitle);
 			},
 			getConsoleForLanguage(id: string) {
 				return extHostConsoleService.getConsoleForLanguage(id);

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -69,6 +69,7 @@ export interface ExtHostLanguageRuntimeShape {
 // This is the interface that the main process exposes to the extension host
 export interface MainThreadModalDialogsShape extends IDisposable {
 	$showSimpleModalDialogPrompt(title: string, message: string, okButtonTitle?: string, cancelButtonTitle?: string): Promise<boolean>;
+	$showSimpleModalDialogPrompt2(title: string, message: string, okButtonTitle?: string): Promise<null>;
 }
 
 // The interface to the main thread exposed by the extension host
@@ -89,6 +90,8 @@ export interface MainThreadMethodsShape { }
 
 export interface ExtHostMethodsShape {
 	lastActiveEditorContext(): Promise<IEditorContext | null>;
+	showDialog(title: string, message: string): Promise<null>;
+	showQuestion(title: string, message: string, okButtonTitle: string, cancelButtonTitle: string): Promise<boolean>;
 }
 
 /**

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -69,7 +69,7 @@ export interface ExtHostLanguageRuntimeShape {
 // This is the interface that the main process exposes to the extension host
 export interface MainThreadModalDialogsShape extends IDisposable {
 	$showSimpleModalDialogPrompt(title: string, message: string, okButtonTitle?: string, cancelButtonTitle?: string): Promise<boolean>;
-	$showSimpleModalDialogPrompt2(title: string, message: string, okButtonTitle?: string): Promise<null>;
+	$showSimpleModalDialogMessage(title: string, message: string, okButtonTitle?: string): Promise<null>;
 }
 
 // The interface to the main thread exposed by the extension host

--- a/src/vs/workbench/api/common/positron/extHostMethods.ts
+++ b/src/vs/workbench/api/common/positron/extHostMethods.ts
@@ -76,6 +76,16 @@ export class ExtHostMethods implements extHostProtocol.ExtHostMethodsShape {
 						params.cancel_button_title as string);
 					break;
 				}
+				case UiFrontendRequest.ShowDialog: {
+					if (!params ||
+						!Object.keys(params).includes('title') ||
+						!Object.keys(params).includes('message')) {
+						return newInvalidParamsError(method);
+					}
+					result = await this.showDialog(params.title as string,
+						params.message as string);
+					break;
+				}
 				case UiFrontendRequest.DebugSleep: {
 					if (!params || !Object.keys(params).includes('ms')) {
 						return newInvalidParamsError(method);
@@ -158,6 +168,10 @@ export class ExtHostMethods implements extHostProtocol.ExtHostMethodsShape {
 			selection: selections[0],
 			selections: selections
 		};
+	}
+
+	async showDialog(title: string, message: string): Promise<null> {
+		return this.dialogs.showSimpleModalDialogPrompt2(title, message);
 	}
 
 	async showQuestion(title: string, message: string, okButtonTitle: string, cancelButtonTitle: string): Promise<boolean> {

--- a/src/vs/workbench/api/common/positron/extHostMethods.ts
+++ b/src/vs/workbench/api/common/positron/extHostMethods.ts
@@ -171,7 +171,7 @@ export class ExtHostMethods implements extHostProtocol.ExtHostMethodsShape {
 	}
 
 	async showDialog(title: string, message: string): Promise<null> {
-		return this.dialogs.showSimpleModalDialogPrompt2(title, message);
+		return this.dialogs.showSimpleModalDialogMessage(title, message);
 	}
 
 	async showQuestion(title: string, message: string, okButtonTitle: string, cancelButtonTitle: string): Promise<boolean> {

--- a/src/vs/workbench/api/common/positron/extHostModalDialogs.ts
+++ b/src/vs/workbench/api/common/positron/extHostModalDialogs.ts
@@ -19,4 +19,8 @@ export class ExtHostModalDialogs implements extHostProtocol.ExtHostModalDialogsS
 		return this._proxy.$showSimpleModalDialogPrompt(title, message, okButtonTitle, cancelButtonTitle);
 	}
 
+	public showSimpleModalDialogPrompt2(title: string, message: string, okButtonTitle?: string): Promise<null> {
+		return this._proxy.$showSimpleModalDialogPrompt2(title, message, okButtonTitle);
+	}
+
 }

--- a/src/vs/workbench/api/common/positron/extHostModalDialogs.ts
+++ b/src/vs/workbench/api/common/positron/extHostModalDialogs.ts
@@ -19,8 +19,8 @@ export class ExtHostModalDialogs implements extHostProtocol.ExtHostModalDialogsS
 		return this._proxy.$showSimpleModalDialogPrompt(title, message, okButtonTitle, cancelButtonTitle);
 	}
 
-	public showSimpleModalDialogPrompt2(title: string, message: string, okButtonTitle?: string): Promise<null> {
-		return this._proxy.$showSimpleModalDialogPrompt2(title, message, okButtonTitle);
+	public showSimpleModalDialogMessage(title: string, message: string, okButtonTitle?: string): Promise<null> {
+		return this._proxy.$showSimpleModalDialogMessage(title, message, okButtonTitle);
 	}
 
 }

--- a/src/vs/workbench/contrib/positronModalDialogs/browser/positronModalDialogs.tsx
+++ b/src/vs/workbench/contrib/positronModalDialogs/browser/positronModalDialogs.tsx
@@ -289,7 +289,7 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 	 *
 	 * @returns A promise that resolves when the user dismisses the dialog.
 	 */
-	showSimpleModalDialogPrompt2(title: string,
+	showSimpleModalDialogMessage(title: string,
 		message: string,
 		okButtonTitle?: string | undefined): Promise<null> {
 

--- a/src/vs/workbench/contrib/positronModalDialogs/browser/positronModalDialogs.tsx
+++ b/src/vs/workbench/contrib/positronModalDialogs/browser/positronModalDialogs.tsx
@@ -201,6 +201,59 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 	}
 
 	/**
+	 * Shows a modal dialog prompt.
+	 *
+	 * @param title The title of the dialog
+	 * @param message The message to display in the dialog
+	 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
+	 *
+	 * @returns A dialog instance, with an event that fires when the user accepts.
+	 */
+	showModalDialogPrompt2(title: string,
+		message: string,
+		okButtonTitle?: string): IModalDialogPromptInstance {
+
+		const positronModalReactRenderer =
+			new PositronModalReactRenderer(this.layoutService.mainContainer);
+
+		// Single-shot emitter for the user's choice.
+		const choiceEmitter = new Emitter<boolean>();
+
+		const acceptHandler = () => {
+			positronModalReactRenderer.dispose();
+			choiceEmitter.fire(true);
+			choiceEmitter.dispose();
+		};
+
+		// Render the dialog. As the messaage is variably sized, it'd be
+		// nice if we could auto-scale the dialog, but fix it to 200 for
+		// now.
+		const ModalDialog = () => {
+			return (
+				<PositronModalDialog renderer={positronModalReactRenderer} title={title} width={400} height={200} accept={acceptHandler} >
+					<ContentArea>
+						{message}
+					</ContentArea>
+					<OKActionBar
+						okButtonTitle={okButtonTitle}
+						accept={acceptHandler} />
+				</PositronModalDialog>
+			);
+		};
+
+		positronModalReactRenderer.render(<ModalDialog />);
+
+		return {
+			onChoice: choiceEmitter.event,
+			close() {
+				choiceEmitter.fire(true);
+				choiceEmitter.dispose();
+				positronModalReactRenderer.dispose();
+			}
+		};
+	}
+
+	/**
 	 * Shows a simple modal dialog prompt. This is a simpler variant of
 	 * `showModalDialogPrompt` for convenience. If you need to be able to force
 	 * the dialog to close, use the `showModalDialogPrompt` method instead.
@@ -223,6 +276,28 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 		return new Promise<boolean>((resolve) => {
 			dialog.onChoice((choice) => {
 				resolve(choice);
+			});
+		});
+	}
+
+	/**
+	 * Shows a simple modal dialog prompt for the user to accept.
+	 *
+	 * @param title The title of the dialog
+	 * @param message The message to display in the dialog
+	 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
+	 *
+	 * @returns A promise that resolves when the user clicks OK.
+	 */
+	showSimpleModalDialogPrompt2(title: string,
+		message: string,
+		okButtonTitle?: string | undefined): Promise<null> {
+
+		// Show the dialog and return a promise that resolves when the user makes a choice.
+		const dialog = this.showModalDialogPrompt2(title, message, okButtonTitle);
+		return new Promise<null>((resolve) => {
+			dialog.onChoice(() => {
+				resolve(null);
 			});
 		});
 	}

--- a/src/vs/workbench/contrib/positronModalDialogs/browser/positronModalDialogs.tsx
+++ b/src/vs/workbench/contrib/positronModalDialogs/browser/positronModalDialogs.tsx
@@ -207,7 +207,7 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 	 * @param message The message to display in the dialog
 	 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
 	 *
-	 * @returns A dialog instance, with an event that fires when the user accepts.
+	 * @returns A dialog instance, with an event that fires when the user dismisses the dialog.
 	 */
 	showModalDialogPrompt2(title: string,
 		message: string,
@@ -287,7 +287,7 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 	 * @param message The message to display in the dialog
 	 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
 	 *
-	 * @returns A promise that resolves when the user clicks OK.
+	 * @returns A promise that resolves when the user dismisses the dialog.
 	 */
 	showSimpleModalDialogPrompt2(title: string,
 		message: string,

--- a/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
@@ -254,6 +254,24 @@ export interface ShowQuestionRequest {
 }
 
 /**
+ * Request: Show a dialog
+ *
+ * Use this for a modal dialog that the user can only accept
+ */
+export interface ShowDialogRequest {
+	/**
+	 * The title of the dialog
+	 */
+	title: string;
+
+	/**
+	 * The message to display in the dialog
+	 */
+	message: string;
+
+}
+
+/**
  * Request: Sleep for n seconds
  *
  * Useful for testing in the backend a long running frontend method
@@ -287,6 +305,7 @@ export enum UiFrontendEvent {
 
 export enum UiFrontendRequest {
 	ShowQuestion = 'show_question',
+	ShowDialog = 'show_dialog',
 	DebugSleep = 'debug_sleep',
 	LastActiveEditorContext = 'last_active_editor_context'
 }

--- a/src/vs/workbench/services/positronModalDialogs/common/positronModalDialogs.ts
+++ b/src/vs/workbench/services/positronModalDialogs/common/positronModalDialogs.ts
@@ -84,7 +84,7 @@ export interface IPositronModalDialogsService {
 	 * @param message The message to display in the dialog
 	 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
 	 *
-	 * @returns A promise that resolves when the user clicks OK.
+	 * @returns A promise that resolves when the user dismisses the dialog.
 	 */
 	showSimpleModalDialogPrompt2(title: string,
 		message: string,

--- a/src/vs/workbench/services/positronModalDialogs/common/positronModalDialogs.ts
+++ b/src/vs/workbench/services/positronModalDialogs/common/positronModalDialogs.ts
@@ -86,7 +86,7 @@ export interface IPositronModalDialogsService {
 	 *
 	 * @returns A promise that resolves when the user dismisses the dialog.
 	 */
-	showSimpleModalDialogPrompt2(title: string,
+	showSimpleModalDialogMessage(title: string,
 		message: string,
 		okButtonTitle?: string): Promise<null>;
 }

--- a/src/vs/workbench/services/positronModalDialogs/common/positronModalDialogs.ts
+++ b/src/vs/workbench/services/positronModalDialogs/common/positronModalDialogs.ts
@@ -76,4 +76,17 @@ export interface IPositronModalDialogsService {
 		message: string,
 		okButtonTitle?: string,
 		cancelButtonTitle?: string): Promise<boolean>;
+
+	/**
+	 * Shows a different simple modal dialog prompt.
+	 *
+	 * @param title The title of the dialog
+	 * @param message The message to display in the dialog
+	 * @param okButtonTitle The title of the OK button (optional; defaults to 'OK')
+	 *
+	 * @returns A promise that resolves when the user clicks OK.
+	 */
+	showSimpleModalDialogPrompt2(title: string,
+		message: string,
+		okButtonTitle?: string): Promise<null>;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses #1312  for `rstudioapi::showDialog()`. The existing `showSimpleModalDialogPrompt()` we have is more like what RStudio has as `rstudioapi::showQuestion()` so here we are adding a new dialog with only an OK button that resolves when it is clicked.

### Approach

There is a fair amount of boilerplate copied for the new dialog, because it is _very_ similar to our existing available dialog. I experimented with trying to change the existing dialog to have a signature sort of like this:

```typescript
showModalDialogPrompt(title: string,
		message: string,
		okButtonTitle?: string,
		cancelButtonTitle?: string | boolean)
```		

And then pass `false` in to turn off the cancel button, but that was a pretty big mess. I think it's better to just make a whole new dialog, even though it is repetitive.

### QA Notes

Partner PR for ark is coming.