### PR TITLE
Remove MS electron build id from the About dialog

### DIFF
--- a/src/vs/workbench/electron-sandbox/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/electron-sandbox/parts/dialogs/dialogHandler.ts
@@ -96,10 +96,9 @@ export class NativeDialogHandler extends AbstractDialogHandler {
 				this.productService.date ? `${this.productService.date}${useAgo ? ' (' + fromNow(new Date(this.productService.date), true) + ')' : ''}` : 'Unknown',
 			);
 			return localize({ key: 'aboutDetail', comment: ['Electron, Chromium, Node.js and V8 are product names that need no translation'] },
-				"{0}\nElectron: {1}\nElectronBuildId: {2}\nChromium: {3}\nNode.js: {4}\nV8: {5}\nOS: {6}",
+				"{0}\nElectron: {1}\nChromium: {2}\nNode.js: {3}\nV8: {4}\nOS: {5}",
 				productDetail,
 				process.versions['electron'],
-				process.versions['microsoft-build'],
 				process.versions['chrome'],
 				process.versions['node'],
 				process.versions['v8'],


### PR DESCRIPTION
### Intent

Remove unknown ElectronBuildId entry from the About dialog.

### Approach

We simply remove the entry from the dialog display as we do not set a ms build id that would be used to show an ElectronBuildId.

### QA Notes

This entry in the dialog appears to be for desktop / electron only. The browser UI does not seem to have this info.
