### PR TITLE
Transmit R session's LANG to the child process for the test runner

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -533,7 +533,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.66"
+      "ark": "0.1.67"
     }
   }
 }


### PR DESCRIPTION
Companion to https://github.com/posit-dev/amalthea/pull/270.

Addresses https://github.com/posit-dev/positron/issues/1808#issuecomment-1832621822.

How to test:

Pre-requisite: you will need to be on macOS to truly test this. *(Windows is actually (!!) unaffected by this problem, but I have still tested these 2 PRs together on Window and all seems well.)*

Get the source of this R package: <https://github.com/jennybc/localetest>.
*Note this is a public package, but I don't explain its purpose anywhere. It just looks like an experiment.*
Perhaps using `usethis::create_from_github("jennybc/localetest")`.
This package contains exactly 1 snapshot test, specific for macOS, the only affected OS.

Run the test suite via `devtools::test()` in the Console or via Cmd + Shift + T (basically use any method other than Positron's test explorer).
The test should pass.

Now run the test suite via Positron's test explorer (accessible via the flask icon).
With a Positron dev build from this PR (along with the amalthea PR), the test should also pass.

With a Positron **release** build, the snapshot test should fail and will look something like this (i.e. the `LANG` env var is undefined and several locale categories are `"C"` instead of `"en_US.UTF-8"`.

```
Snapshot of code has changed (variant 'darwin'):
old[1:11] vs new[1:11]
  Code
    Sys.getenv("LANG")
  Output
-   [1] "en_US.UTF-8"
+   [1] ""
  Code
    Sys.getlocale()
  Output
-   [1] "C/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8"
+   [1] "C"
  Code
    Sys.getlocale("LC_COLLATE")
and 1 more ...

old[13:23] vs new[13:23]
  Code
    Sys.getlocale("LC_CTYPE")
  Output
-   [1] "en_US.UTF-8"
+   [1] "C"
  Code
    Sys.getlocale("LC_MONETARY")
  Output
-   [1] "en_US.UTF-8"
+   [1] "C"
  Code
    Sys.getlocale("LC_NUMERIC")
and 1 more ...

     old                        | new                            
[25] Code                       | Code                       [25]
[26]   Sys.getlocale("LC_TIME") |   Sys.getlocale("LC_TIME") [26]
[27] Output                     | Output                     [27]
[28]   [1] "en_US.UTF-8"        -   [1] "C"                  [28]

* Run `testthat::snapshot_accept('darwin/locale')` to accept the change.
* Run `testthat::snapshot_review('darwin/locale')` to interactively review the change.
```