### PR TITLE
Don't allow typing into the console pane if there's no runtime

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -315,14 +315,14 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [editorFontInfo, lastScrollTopRef, positronConsoleContext.activePositronConsoleInstance?.session, positronConsoleContext.configurationService, positronConsoleContext.positronPlotsService, positronConsoleContext.runtimeSessionService, positronConsoleContext.viewsService, props.positronConsoleInstance, props.reactComponentContainer, setLastScrollTop]);
 
 	useLayoutEffect(() => {
 		// If the view is not scroll locked, scroll to the bottom to reveal the most recent items.
 		if (!scrollLockRef.current) {
 			scrollVertically(consoleInstanceRef.current.scrollHeight);
 		}
-	}, [marker]);
+	}, [marker, scrollLockRef]);
 
 	/**
 	 * onClick event handler.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -605,7 +605,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 					}
 				})}
 			</div>
-			{!props.positronConsoleInstance.promptActive &&
+			{!props.positronConsoleInstance.promptActive && props.positronConsoleInstance.runtimeAttached &&
 				<ConsoleInput
 					width={consoleInputWidth}
 					positronConsoleInstance={props.positronConsoleInstance}

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -143,6 +143,11 @@ export interface IPositronConsoleInstance {
 	readonly promptActive: boolean;
 
 	/**
+	 * Whether or not we are currently attached to the runtime.
+	 */
+	readonly runtimeAttached: boolean;
+
+	/**
 	 * The onFocusInput event.
 	 */
 	readonly onFocusInput: Event<void>;

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -540,7 +540,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	/**
 	 * Whether or not we are currently attached to the runtime.
 	 */
-	private _runtimeAttached = false;
+	runtimeAttached = false;
 
 	/**
 	 * Gets or sets the state.
@@ -735,7 +735,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * Gets the currently attached runtime session, or undefined if there is no runtime attached.
 	 */
 	get attachedRuntimeSession(): ILanguageRuntimeSession | undefined {
-		return this._runtimeAttached ? this._session : undefined;
+		return this.runtimeAttached ? this._session : undefined;
 	}
 
 	/**
@@ -1069,7 +1069,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	setRuntimeSession(session: ILanguageRuntimeSession, attachMode: SessionAttachMode) {
 		// Is this the same runtime we're currently attached to?
 		if (this._session && this._session.sessionId === session.sessionId) {
-			if (this._runtimeAttached) {
+			if (this.runtimeAttached) {
 				// Yes, it's the same one. If we're already attached, we're
 				// done; just let the user know we're starting up if we are
 				// currently showing as Exited.
@@ -1248,7 +1248,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 */
 	private attachRuntime(attachMode: SessionAttachMode) {
 		// Mark the runtime as attached.
-		this._runtimeAttached = true;
+		this.runtimeAttached = true;
 
 		// If trace is enabled, add a trace runtime item.
 		if (this._trace) {
@@ -1295,7 +1295,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					setTimeout(() => {
 						// If we're still in the Exited state and haven't
 						// disposed, then do it now.
-						if (this._runtimeState === RuntimeState.Exited && this._runtimeAttached) {
+						if (this._runtimeState === RuntimeState.Exited && this.runtimeAttached) {
 							this.detachRuntime();
 
 							this.addRuntimeItem(new RuntimeItemExited(
@@ -1354,7 +1354,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			));
 
 			// If we haven't already detached the runtime, do it now.
-			if (this._runtimeState === RuntimeState.Exited && this._runtimeAttached) {
+			if (this._runtimeState === RuntimeState.Exited && this.runtimeAttached) {
 				this.detachRuntime();
 			}
 		}));
@@ -1737,9 +1737,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			this.addRuntimeItemTrace(`Detach session ${this._session.metadata.sessionName}`);
 		}
 
-		if (this._runtimeAttached) {
+		if (this.runtimeAttached) {
 			// We are currently attached; detach.
-			this._runtimeAttached = false;
+			this.runtimeAttached = false;
 			this._onDidAttachRuntime.fire(undefined);
 
 			// Clear the executing state of all ActivityItemInputs inputs. When a runtime exits, it

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -540,7 +540,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	/**
 	 * Whether or not we are currently attached to the runtime.
 	 */
-	runtimeAttached = false;
+	private _runtimeAttached = false;
 
 	/**
 	 * Gets or sets the state.
@@ -798,6 +798,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 */
 	get promptActive(): boolean {
 		return this._promptActive;
+	}
+
+	/**
+	 * Gets a value which indicates whether a runtime is attached.
+	 */
+	get runtimeAttached(): boolean {
+		return this._runtimeAttached;
 	}
 
 	/**
@@ -1248,7 +1255,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 */
 	private attachRuntime(attachMode: SessionAttachMode) {
 		// Mark the runtime as attached.
-		this.runtimeAttached = true;
+		this._runtimeAttached = true;
 
 		// If trace is enabled, add a trace runtime item.
 		if (this._trace) {
@@ -1739,7 +1746,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 		if (this.runtimeAttached) {
 			// We are currently attached; detach.
-			this.runtimeAttached = false;
+			this._runtimeAttached = false;
 			this._onDidAttachRuntime.fire(undefined);
 
 			// Clear the executing state of all ActivityItemInputs inputs. When a runtime exits, it


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Fix for #531. Removes the input field that previously stuck around after the runtime closed. 

### Approach

There was an existing private variable on the `PositronConsoleInstance` class that kept track of if the instance had an active runtime: `._runtimeAttached`. This PR elevates that attribute to a public one on the interface (sans the `_` prefix) and adds that to the conditional rendering of the trailing `<ConsoleInput/>` component in `<ConsoleInstance/>`. 

I also fixed the dependency array eslint errors for `<ConsoleInstance/>`. (Simply because the git hook complained about it.)

<img width="886" alt="Screenshot 2024-03-19 at 5 05 55 PM" src="https://github.com/posit-dev/positron/assets/6764693/7e6d669d-f67a-41f6-937f-7f2f3e56d5f6">

<img width="758" alt="Screenshot 2024-03-19 at 5 03 42 PM" src="https://github.com/posit-dev/positron/assets/6764693/1f5d3718-4458-469c-9624-4ecd448efc4f">

