### PR TITLE
Set the language info in the notebook metadata when selecting a controller

### DIFF
--- a/extensions/positron-notebook-controllers/src/notebookController.ts
+++ b/extensions/positron-notebook-controllers/src/notebookController.ts
@@ -294,6 +294,7 @@ export class NotebookController implements vscode.Disposable {
  * */
 async function setNotebookLanguage(notebook: vscode.NotebookDocument, languageId: string): Promise<void> {
 	// Set the language in the notebook's metadata.
+	// This follows the approach from the vscode-jupyter extension.
 	if (notebook.metadata?.custom?.metadata?.language_info?.name !== languageId) {
 		const edit = new vscode.WorkspaceEdit();
 		edit.set(notebook.uri, [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses a part of #2478 that I missed in #2479: the notebook's metadata was not being updated.

### Approach

This follows the approach from the Jupyter extension to manually apply a `WorkspaceEdit` that updates the notebook metadata.

### QA Notes

See the linked issue for a repro.