### PR TITLE
Fix saving an untitled notebook reverting the selected kernel

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -1759,9 +1759,17 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		if (viewState?.selectedKernelId && this.textModel) {
 			const matching = this.notebookKernelService.getMatchingKernel(this.textModel);
 			const kernel = matching.all.find(k => k.id === viewState.selectedKernelId);
-			// Selected kernel may have already been picked prior to the view state loading
-			// If so, don't overwrite it with the saved kernel.
-			if (kernel && !matching.selected) {
+			// --- Start Positron ---
+			// Upstream, this if statement additionally checked `!matching.selected` in an attempt
+			// to fix a bug where an interactive window may use the wrong kernel. However, that fix
+			// caused another bug where saving an untitled notebook and overwriting an existing
+			// notebook no longer retains the selected kernel. It also turned out that the upstream
+			// PR to include `!matching.selected` did not fix the original bug, so we'll leave it out.
+			//
+			// See https://github.com/microsoft/vscode-jupyter/issues/10734 and the linked PRs for
+			// more details.
+			if (kernel) {
+				// --- End Positron ---
 				this.notebookKernelService.selectKernelForNotebook(kernel, this.textModel);
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent
Addresses #2497.

### Approach
See the code comments. Note that this needs to be merged after #2496 otherwise it breaks saving an untitled notebook.

### QA Notes
See the linked issue for a repro.