### PR TITLE
Even on macOS, RStudio has used Ctrl + . for this

### DIFF
--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -98,7 +98,7 @@
         "command": "workbench.action.positronConsole.focusConsole"
       },
       {
-        "mac": "cmd+.",
+        "mac": "ctrl+.",
         "win": "ctrl+.",
         "linux": "ctrl+.",
         "key": "ctrl+.",


### PR DESCRIPTION
My muscle memory has surfaced that I really, really expect Ctrl + `.` here, instead of Cmd + `.`.