### PR TITLE
Auto select kernel using Positron foreground session

### DIFF
--- a/extensions/positron-notebook-controllers/src/extension.ts
+++ b/extensions/positron-notebook-controllers/src/extension.ts
@@ -29,7 +29,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 	// Update notebook affinity when a notebook is opened.
 	context.subscriptions.push(vscode.workspace.onDidOpenNotebookDocument(async (notebook) => {
-		trace(`onDidOpenNotebookDocument: ${notebook.uri.path}`);
 		manager.updateNotebookAffinity(notebook);
 	}));
 

--- a/extensions/positron-notebook-controllers/src/extension.ts
+++ b/extensions/positron-notebook-controllers/src/extension.ts
@@ -1,33 +1,40 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { initializeLogging, trace } from './logging';
-import { NotebookController } from './notebookController';
+import { NotebookControllerManager } from './notebookControllerManager';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 	initializeLogging();
 
-	const knownLanguageIds = new Set<string>();
-	// Ensure that a notebook controller is registered for a given language.
-	const ensureNotebookController = (languageId: string) => {
-		if (!knownLanguageIds.has(languageId)) {
-			const controller = new NotebookController(languageId);
-			knownLanguageIds.add(languageId);
-			context.subscriptions.push(controller);
-			trace(`Registered notebook controller for language: ${languageId}`);
-		}
-	};
+	const manager = new NotebookControllerManager();
+	context.subscriptions.push(manager);
 
 	// Register notebook controllers for newly registered runtimes.
 	context.subscriptions.push(positron.runtime.onDidRegisterRuntime((runtime) => {
-		ensureNotebookController(runtime.languageId);
+		if (!manager.controllers.has(runtime.languageId)) {
+			manager.createNotebookController(runtime.languageId);
+		}
 	}));
 
 	// Register notebook controllers for existing runtimes.
 	for (const runtime of await positron.runtime.getRegisteredRuntimes()) {
-		ensureNotebookController(runtime.languageId);
+		if (!manager.controllers.has(runtime.languageId)) {
+			manager.createNotebookController(runtime.languageId);
+		}
+	}
+
+	// Update notebook affinity when a notebook is opened.
+	context.subscriptions.push(vscode.workspace.onDidOpenNotebookDocument(async (notebook) => {
+		trace(`onDidOpenNotebookDocument: ${notebook.uri.path}`);
+		manager.updateNotebookAffinity(notebook);
+	}));
+
+	// Update notebook affinity for notebooks that are already opened.
+	for (const notebook of vscode.workspace.notebookDocuments) {
+		manager.updateNotebookAffinity(notebook);
 	}
 }

--- a/extensions/positron-notebook-controllers/src/extension.ts
+++ b/extensions/positron-notebook-controllers/src/extension.ts
@@ -4,7 +4,7 @@
 
 import * as positron from 'positron';
 import * as vscode from 'vscode';
-import { initializeLogging, trace } from './logging';
+import { initializeLogging } from './logging';
 import { NotebookControllerManager } from './notebookControllerManager';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {

--- a/extensions/positron-notebook-controllers/src/notebookController.ts
+++ b/extensions/positron-notebook-controllers/src/notebookController.ts
@@ -13,13 +13,13 @@ import { PromiseHandles, delay, noop } from './util';
  */
 export class NotebookController implements vscode.Disposable {
 
-	private disposables: vscode.Disposable[] = [];
+	private readonly disposables: vscode.Disposable[] = [];
 
 	/** The wrapped VSCode notebook controller. */
-	private controller: vscode.NotebookController;
+	public readonly controller: vscode.NotebookController;
 
 	/** Deferred notebook runtime data objects keyed by notebook. */
-	private notebookRuntimes: Map<vscode.NotebookDocument, PromiseHandles<NotebookRuntimeData>> = new Map();
+	private readonly notebookRuntimes: Map<vscode.NotebookDocument, PromiseHandles<NotebookRuntimeData>> = new Map();
 
 	/** Incremented for each cell we create to give it a unique ID. */
 	private static CELL_COUNTER = 0;
@@ -27,7 +27,7 @@ export class NotebookController implements vscode.Disposable {
 	/**
 	 * @param languageId The language ID for which this controller is responsible.
 	 */
-	constructor(private languageId: string) {
+	constructor(private readonly languageId: string) {
 		// Create a VSCode notebook controller for this language.
 		this.controller = vscode.notebooks.createNotebookController(
 			`positron-${languageId}`,
@@ -71,7 +71,7 @@ export class NotebookController implements vscode.Disposable {
 				// already selected.
 
 				// Start updating the notebook's language info as soon as possible, but only await it at the end.
-				const setNotebookLanguagePromise = setNotebookLanguage(e.notebook, this.languageId);
+				const setNotebookLanguagePromise = updateNotebookLanguage(e.notebook, this.languageId);
 
 				// Set the notebook's deferred runtime data. This needs to be set before any awaits.
 				// When a user executes code without a controller selected, they will be presented
@@ -291,8 +291,8 @@ export class NotebookController implements vscode.Disposable {
  * @param notebook Notebook whose language to set.
  * @param languageId The VSCode-compatible language ID compatible.
  * @returns Promise that resolves when the language has been set.
- * */
-async function setNotebookLanguage(notebook: vscode.NotebookDocument, languageId: string): Promise<void> {
+ */
+async function updateNotebookLanguage(notebook: vscode.NotebookDocument, languageId: string): Promise<void> {
 	// Set the language in the notebook's metadata.
 	// This follows the approach from the vscode-jupyter extension.
 	if (notebook.metadata?.custom?.metadata?.language_info?.name !== languageId) {

--- a/extensions/positron-notebook-controllers/src/notebookControllerManager.ts
+++ b/extensions/positron-notebook-controllers/src/notebookControllerManager.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { trace } from './logging';
+import { NotebookController } from './notebookController';
+
+/**
+ * Manages notebook controllers.
+ */
+export class NotebookControllerManager implements vscode.Disposable {
+	private readonly disposables: vscode.Disposable[] = [];
+
+	/** Notebook controllers keyed by languageId. */
+	public readonly controllers = new Map<string, NotebookController>();
+
+	/**
+	 * Create a notebook controller for a language.
+	 *
+	 * @param languageId The language ID for which to create a notebook controller.
+	 */
+	public createNotebookController(languageId: string): void {
+		if (!this.controllers.has(languageId)) {
+			const controller = new NotebookController(languageId);
+			this.controllers.set(languageId, controller);
+			this.disposables.push(controller);
+			trace(`Registered notebook controller for language: ${languageId}`);
+		}
+	}
+
+	/**
+	 * Update a notebook's affinity for all known controllers.
+	 *
+	 * Positron automates certain decisions if a notebook only has a single 'preferred' controller.
+	 *
+	 * @param notebook The notebook whose affinity to update.
+	 * @returns Promise that resolves when the notebook's affinity has been updated across all controllers.
+	 */
+	public async updateNotebookAffinity(notebook: vscode.NotebookDocument): Promise<void> {
+		// If the notebook is untitled, wait for its data to be updated. This works around the fact
+		// that `vscode.openNotebookDocument(notebookType, content)` first creates a notebook
+		// (triggering `onDidOpenNotebookDocument`), and later updates its content (triggering
+		// `onDidChangeNotebookDocument`).
+		if (notebook.uri.scheme === 'untitled') {
+			const event = await nextNotebookDocumentChange(notebook, 50);
+			if (event) {
+				notebook = event.notebook;
+			}
+		}
+
+		// Detect the notebook's language.
+		// First try the notebook metadata.
+		const metadata = notebook.metadata?.custom?.metadata;
+		const languageId = metadata?.language_info?.name
+			?? metadata?.kernelspec?.language
+			// Fall back to the first cell's language.
+			?? notebook.getCells()?.[0].document.languageId;
+
+		// Get the preferred controller for the language.
+		const preferredController = languageId && this.controllers.get(languageId);
+
+		// Set the affinity across all known controllers.
+		for (const controller of this.controllers.values()) {
+			const affinity = controller === preferredController
+				? vscode.NotebookControllerAffinity.Preferred
+				: vscode.NotebookControllerAffinity.Default;
+			controller.controller.updateNotebookAffinity(notebook, affinity);
+		}
+	}
+
+	dispose(): void {
+		this.disposables.forEach(d => d.dispose());
+	}
+}
+
+/**
+ * Wait for the next change event for a notebook.
+ *
+ * @param notebook The notebook document.
+ * @param timeoutMs Timeout duration in milliseconds.
+ * @returns Promise that resolves when the next change event occurs for a notebook,
+ * or resolves with undefined if the timeout is reached.
+ */
+function nextNotebookDocumentChange(
+	notebook: vscode.NotebookDocument, timeoutMs: number
+): Promise<vscode.NotebookDocumentChangeEvent | undefined> {
+	return new Promise((resolve) => {
+		const timeout = setTimeout(() => {
+			disposable.dispose();
+			resolve(undefined);
+		}, timeoutMs);
+
+		const disposable = vscode.workspace.onDidChangeNotebookDocument((e) => {
+			if (e.notebook === notebook) {
+				clearTimeout(timeout);
+				disposable.dispose();
+				resolve(e);
+			}
+		});
+	});
+}

--- a/extensions/positron-notebook-controllers/src/notebookControllerManager.ts
+++ b/extensions/positron-notebook-controllers/src/notebookControllerManager.ts
@@ -66,6 +66,7 @@ export class NotebookControllerManager implements vscode.Disposable {
 				? vscode.NotebookControllerAffinity.Preferred
 				: vscode.NotebookControllerAffinity.Default;
 			controller.controller.updateNotebookAffinity(notebook, affinity);
+			trace(`Updated notebook affinity for language: ${languageId}, notebook: ${notebook.uri.path}, affinity: ${affinity}`);
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

(I use "kernel" and "controller" interchangeably below. My bad, that's how it is in the code. I think it was originally named "kernel" and that's still the case inside VSCode core. The extension API calls them "controllers".

### Intent

Addresses #2477.

Also addresses #2509, which is very inconvenient to repro without also addressing #2477, since it requires the notebook to have a single controller with "preferred" affinity. See the issue for more details.

### Approach

I extracted some code out of extension activation into the new `NotebookControllerManager` class. That class also now sets each notebook's "affinity" when the notebook is opened. The idea is that only a single controller, the one matching the notebook's language, is set to "preferred" and the rest are left at "default".

I also updated the notebook editor widget to select the preferred controller if there is only one. I opted for that approach since there are a bunch of things that already use that same heuristic in VSCode's notebooks. It'll also play nicely with third party extensions that register runtimes and corresponding controllers for other languages. One downside is that if third party extensions register controllers for Python/R and set their controller as "preferred" too, our controllers won't automatically be selected. We can change this down the line if needed.

There were a few unfortunate workarounds that we needed to do to get this to work – will add comments on those lines specifically.

### QA Notes

See the issues for verification steps.