### PR TITLE
Correctly show preview table errors

### DIFF
--- a/extensions/positron-connections/src/extension.ts
+++ b/extensions/positron-connections/src/extension.ts
@@ -34,12 +34,9 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('positron.connections.previewTable',
 			(item: ConnectionItemNode) => {
-				try {
-					item.preview();
-				} catch (e: any) {
-					// this is not fatal, but worth notifying
+				item.preview().catch((e: any) => {
 					vscode.window.showErrorMessage(`Error previewing '${item.name}': ${e.message}`);
-				}
+				});
 			}));
 
 	context.subscriptions.push(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

Fixes a bug that would prevent errors from being displayed when calling `item.preview()` resulted in an error. See #2528 
