### PR TITLE
Fix disabled button regression

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -112,7 +112,11 @@ export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<Props>>((p
 	return (
 		<button
 			ref={ref}
-			className={positronClassNames('button', props.className)}
+			className={positronClassNames(
+				'button',
+				props.className,
+				{ 'disabled': props.disabled }
+			)}
 			tabIndex={0}
 			disabled={props.disabled}
 			role='button'


### PR DESCRIPTION
### Intent

This fixes a disabled button regression where disabled buttons were not styled properly.

### Approach

Restore the `disabled` class name on disabled buttons.

### QA Notes

Just check that disabled buttons appear to be disabled.