### PR TITLE
Use EXTENSION_ROOT_DIR if that is all we need to know about extension

### DIFF
--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -5,6 +5,7 @@
 import * as os from 'os';
 import * as vscode from 'vscode';
 import { LOGGER } from './extension';
+import { EXTENSION_ROOT_DIR } from './constants';
 
 /**
  * Attempts to locate a copy of the Ark kernel. The kernel is searched for in the following
@@ -18,7 +19,7 @@ import { LOGGER } from './extension';
  * @param context The extension context.
  * @returns A path to the Ark kernel, or undefined if the kernel could not be found.
  */
-export function getArkKernelPath(context: vscode.ExtensionContext): string | undefined {
+export function getArkKernelPath(): string | undefined {
 
 	// First, check to see whether there is an override for the kernel path.
 	const arkConfig = vscode.workspace.getConfiguration('positron.r');
@@ -35,7 +36,7 @@ export function getArkKernelPath(context: vscode.ExtensionContext): string | und
 	// whichever is newest. This is the location where the kernel is typically built
 	// by developers, who have `positron` and `amalthea` directories side-by-side.
 	let devKernel = undefined;
-	const positronParent = path.dirname(path.dirname(path.dirname(context.extensionPath)));
+	const positronParent = path.dirname(path.dirname(path.dirname(EXTENSION_ROOT_DIR)));
 	const devDebugKernel = path.join(positronParent, 'amalthea', 'target', 'debug', kernelName);
 	const devReleaseKernel = path.join(positronParent, 'amalthea', 'target', 'release', kernelName);
 	const debugModified = fs.statSync(devDebugKernel, { throwIfNoEntry: false })?.mtime;
@@ -53,7 +54,7 @@ export function getArkKernelPath(context: vscode.ExtensionContext): string | und
 
 	// Now try the default (embedded) kernel. This is where the kernel is placed in
 	// development and release builds.
-	const embeddedKernel = path.join(context.extensionPath, 'resources', 'ark', kernelName);
+	const embeddedKernel = path.join(EXTENSION_ROOT_DIR, 'resources', 'ark', kernelName);
 	if (fs.existsSync(embeddedKernel)) {
 		return embeddedKernel;
 	}

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -15,6 +15,7 @@ import * as winreg from 'winreg';
 import { RInstallation, RMetadataExtra, getRHomePath } from './r-installation';
 import { LOGGER } from './extension';
 import { readLines } from './util';
+import { EXTENSION_ROOT_DIR } from './constants';
 
 /**
  * Discovers R language runtimes for Positron; implements
@@ -22,9 +23,7 @@ import { readLines } from './util';
  *
  * @param context The extension context.
  */
-export async function* rRuntimeDiscoverer(
-	context: vscode.ExtensionContext
-): AsyncGenerator<positron.LanguageRuntimeMetadata> {
+export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRuntimeMetadata> {
 	let rInstallations: Array<RInstallation> = [];
 	const binaries = new Set<string>();
 
@@ -164,7 +163,7 @@ export async function* rRuntimeDiscoverer(
 			languageVersion: rVersion,
 			base64EncodedIconSvg:
 				fs.readFileSync(
-					path.join(context.extensionPath, 'resources', 'branding', 'r-icon.svg')
+					path.join(EXTENSION_ROOT_DIR, 'resources', 'branding', 'r-icon.svg')
 				).toString('base64'),
 			sessionLocation: positron.LanguageRuntimeSessionLocation.Workspace,
 			startupBehavior,

--- a/extensions/positron-r/src/runtime-manager.ts
+++ b/extensions/positron-r/src/runtime-manager.ts
@@ -13,7 +13,7 @@ export class RRuntimeManager implements positron.LanguageRuntimeManager {
 	constructor(private readonly _context: vscode.ExtensionContext) { }
 
 	discoverRuntimes(): AsyncGenerator<positron.LanguageRuntimeMetadata> {
-		return rRuntimeDiscoverer(this._context);
+		return rRuntimeDiscoverer();
 	}
 
 	createSession(
@@ -24,7 +24,7 @@ export class RRuntimeManager implements positron.LanguageRuntimeManager {
 		// data
 		const metadataExtra = runtimeMetadata.extraRuntimeData as RMetadataExtra;
 		const kernelExtra = createJupyterKernelExtra();
-		const kernelSpec = createJupyterKernelSpec(this._context,
+		const kernelSpec = createJupyterKernelSpec(
 			metadataExtra.homepath,
 			runtimeMetadata.runtimeName,
 			sessionMetadata.sessionMode);

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -16,6 +16,7 @@ import { getArkKernelPath } from './kernel';
 import { randomUUID } from 'crypto';
 import { handleRCode } from './hyperlink';
 import { RSessionManager } from './session-manager';
+import { EXTENSION_ROOT_DIR } from './constants';
 import { existsSync } from 'fs';
 
 interface RPackageInstallation {
@@ -612,7 +613,6 @@ export function createJupyterKernelExtra(): JupyterKernelExtra {
 /**
  * Create a new Jupyter kernel spec.
  *
- * @param context The extension context
  * @param rHomePath The R_HOME path for the R version
  * @param runtimeName The (display) name of the runtime
  * @param sessionMode The mode in which to create the session
@@ -620,13 +620,13 @@ export function createJupyterKernelExtra(): JupyterKernelExtra {
  * @returns A JupyterKernelSpec definining the kernel's path, arguments, and
  *  metadata.
  */
-export function createJupyterKernelSpec(context: vscode.ExtensionContext,
+export function createJupyterKernelSpec(
 	rHomePath: string,
 	runtimeName: string,
 	sessionMode: positron.LanguageRuntimeSessionMode): JupyterKernelSpec {
 
 	// Path to the kernel executable
-	const kernelPath = getArkKernelPath(context);
+	const kernelPath = getArkKernelPath();
 	if (!kernelPath) {
 		throw new Error('Unable to find R kernel');
 	}
@@ -659,7 +659,7 @@ export function createJupyterKernelSpec(context: vscode.ExtensionContext,
 	}
 
 	// R script to run on session startup
-	const startupFile = path.join(context.extensionPath, 'resources', 'scripts', 'startup.R');
+	const startupFile = path.join(EXTENSION_ROOT_DIR, 'resources', 'scripts', 'startup.R');
 
 	// Create a kernel spec for this R installation
 	const kernelSpec: JupyterKernelSpec = {


### PR DESCRIPTION
This is a modest housekeeping PR that makes some other things I'm working on easier / cleaner (future PRs, such as #2552).

We've long had existing facilities for storing/getting the path to positron-r:

https://github.com/posit-dev/positron/commit/448ee3697417c1a127590a19bd767f8240541fa3

It's also common to see similar arrangments in other extensions, such as the python extension (https://github.com/posit-dev/positron-python/blob/3af654fa8641e23658a01fc6efa7f6326c9c503f/src/client/constants.ts#L4).

We're using `EXTENSION_ROOT_DIR` to build paths in some places (e.g. the testing explorer), but not in others.

This PR makes simplifications to prefer `EXTENSION_ROOT_DIR` over `context.extensionPath` and, in some cases, this means we no longer need to hand `context` around.