### PR TITLE
R runtime metadata helper

### DIFF
--- a/extensions/positron-r/src/runtime-manager.ts
+++ b/extensions/positron-r/src/runtime-manager.ts
@@ -78,7 +78,7 @@ export class RRuntimeManager implements positron.LanguageRuntimeManager {
 		}
 
 		// Looks like a valid R installation.
-		return Promise.resolve(makeMetadata(inst));
+		return Promise.resolve(makeMetadata(inst, positron.LanguageRuntimeStartupBehavior.Immediate));
 	}
 
 	restoreSession(

--- a/extensions/positron-r/src/runtime-manager.ts
+++ b/extensions/positron-r/src/runtime-manager.ts
@@ -4,7 +4,7 @@
 
 import * as positron from 'positron';
 import * as vscode from 'vscode';
-import { findCurrentRBinary, rRuntimeDiscoverer } from './provider';
+import { findCurrentRBinary, makeMetadata, rRuntimeDiscoverer } from './provider';
 import { RInstallation, RMetadataExtra } from './r-installation';
 import { RSession, createJupyterKernelExtra, createJupyterKernelSpec } from './session';
 
@@ -78,7 +78,7 @@ export class RRuntimeManager implements positron.LanguageRuntimeManager {
 		}
 
 		// Looks like a valid R installation.
-		return Promise.resolve(metadata);
+		return Promise.resolve(makeMetadata(inst));
 	}
 
 	restoreSession(


### PR DESCRIPTION
Addresses #2316

## QA

*I'm being hyperspecific below but the main point is to switch between patch versions of R. On macOS, these will have the same binpath, but, obviously, different R versions.*

Setup:

* Install R 4.3.2, possibly via rig, with `rig add 4.3.2`.
* Open an R-flavored workspace in Positron, like an R package. If R 4.3.2 doesn't automatically launch, start it explicitly and use R 4.3.2.
* Quit Positron. We want to ensure that R 4.3.2 is going to be found as the affiliated runtime on our _next_ Positron launch.

The actual "test":
* Upgrade R to 4.3.3, possibly via rig, with `rig add release`.
* Re-launch Positron, presumably in the workspace above.
* Look at the R version in the Console and advertised in the interpreter drop down.
* Get the actual R version with `R.version.string`.

Before this PR, you will still see R advertised as being 4.3.2, but it's actually 4.3.3. You will also see both R 4.3.2 and R 4.3.3 in the interpreter list, even though they both refer to the same binary (seen on hover).

With this PR, the actual R version should always match what it's advertised as. And there will only be 1 R 4.3.z listed in the interpreters list.

You can also test by downgrading from 4.3.3 to 4.3.2. The direction doesn't matter. What matters is switching between patch versions of the same minor version. FWIW my experience with seeing and fixing this has been on macOS.