### PR TITLE
Exclude exited sessions when detecting active console session

### DIFF
--- a/extensions/positron-r/src/session-manager.ts
+++ b/extensions/positron-r/src/session-manager.ts
@@ -85,7 +85,7 @@ export class RSessionManager {
 
 		// We would not expect to see more than one console session since
 		// Positron currently only allows one console session per language. If
-		// this constraint is relaxed in the future, we can remove this morning.
+		// this constraint is relaxed in the future, we can remove this warning.
 		if (consoleSessions.length > 1) {
 			console.warn(`${consoleSessions.length} R console sessions found; ` +
 				`returning the most recently started one.`);

--- a/extensions/positron-r/src/session-manager.ts
+++ b/extensions/positron-r/src/session-manager.ts
@@ -67,11 +67,31 @@ export class RSessionManager {
 	 * @returns The R console session, or undefined if there isn't one.
 	 */
 	getConsoleSession(): RSession | undefined {
-		for (const session of this._sessions.values()) {
-			if (session.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console) {
-				return session;
-			}
+		// Sort the sessions by creation time (descending)
+		const sessions = Array.from(this._sessions.values());
+		sessions.sort((a, b) => b.created - a.created);
+
+		// Remove any sessions that aren't console sessions and have either
+		// never started or have exited
+		const consoleSessions = sessions.filter(s =>
+			s.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console &&
+			s.state !== positron.RuntimeState.Uninitialized &&
+			s.state !== positron.RuntimeState.Exited);
+
+		// No console sessions
+		if (consoleSessions.length === 0) {
+			return undefined;
 		}
+
+		// We would not expect to see more than one console session since
+		// Positron currently only allows one console session per language. If
+		// this constraint is relaxed in the future, we can remove this morning.
+		if (consoleSessions.length > 1) {
+			console.warn(`${consoleSessions.length} R console sessions found; ` +
+				`returning the most recently started one.`);
+		}
+
+		return consoleSessions[0];
 	}
 
 	/**

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -67,6 +67,9 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	/** The current state of the runtime */
 	private _state: positron.RuntimeState = positron.RuntimeState.Uninitialized;
 
+	/** A timestamp assigned when the session was created. */
+	private _created: number;
+
 	/** Cache for which packages we know are installed in this runtime **/
 	private _packageCache = new Array<RPackageInstallation>();
 
@@ -91,6 +94,9 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 			inputPrompt: '>',
 		};
 
+		// Timestamp the session creation
+		this._created = Date.now();
+
 		// Register this session with the session manager
 		RSessionManager.instance.setSession(metadata.sessionId, this);
 
@@ -102,6 +108,20 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	onDidEndSession: vscode.Event<positron.LanguageRuntimeExit>;
 	onDidReceiveRuntimeMessage: vscode.Event<positron.LanguageRuntimeMessage>;
 	onDidChangeRuntimeState: vscode.Event<positron.RuntimeState>;
+
+	/**
+	 * Accessor for the current state of the runtime.
+	 */
+	get state(): positron.RuntimeState {
+		return this._state;
+	}
+
+	/**
+	 * Accessor for the creation time of the runtime.
+	 */
+	get created(): number {
+		return this._created;
+	}
 
 	/**
 	 * Opens a resource in the runtime.


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/2553.

This is a regression from the multi-session work; the problem is that in some cases, the R language pack can try to send commands to a previous console session instead of the current one.

### Approach

The fix is to ignore exited console sessions when attempting to figure out which one we should talk to when sending commands such as Format Document. 

I've also added some defensiveness around multiple console sessions; if this ever happens, we warn and return whichever is newest. 

### QA Notes

Test via notes in https://github.com/posit-dev/positron/issues/2553. 