### PR TITLE
Add `saveAllTitled` command

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileConstants.ts
+++ b/src/vs/workbench/contrib/files/browser/fileConstants.ts
@@ -28,6 +28,11 @@ export const SAVE_FILE_WITHOUT_FORMATTING_LABEL = nls.localize2('saveWithoutForm
 export const SAVE_ALL_COMMAND_ID = 'saveAll';
 export const SAVE_ALL_LABEL = nls.localize2('saveAll', "Save All");
 
+// --- Start Positron ---
+export const SAVE_ALL_TITLED_COMMAND_ID = 'saveAllTitled';
+export const SAVE_ALL_TITLED_LABEL = nls.localize2('saveAllTitled', "Save All Titled");
+// --- End Positron ---
+
 export const SAVE_ALL_IN_GROUP_COMMAND_ID = 'workbench.files.action.saveAllInGroup';
 
 export const SAVE_FILES_COMMAND_ID = 'workbench.action.files.saveFiles';

--- a/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
@@ -55,6 +55,11 @@ import { ILocalizedString } from 'vs/platform/action/common/action';
 import { mainWindow } from 'vs/base/browser/window';
 import { EditorGroupView } from 'vs/workbench/browser/parts/editor/editorGroupView';
 
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { SAVE_ALL_TITLED_COMMAND_ID, SAVE_ALL_TITLED_LABEL } from 'vs/workbench/contrib/files/browser/fileConstants';
+// --- End Positron ---
+
 const $ = dom.$;
 
 export class OpenEditorsView extends ViewPane {
@@ -877,6 +882,23 @@ registerAction2(class extends Action2 {
 		await commandService.executeCommand(SAVE_ALL_COMMAND_ID);
 	}
 });
+
+// --- Start Positron ---
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.files.saveAllTitled',
+			title: SAVE_ALL_TITLED_LABEL,
+			f1: true,
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const commandService = accessor.get(ICommandService);
+		await commandService.executeCommand(SAVE_ALL_TITLED_COMMAND_ID);
+	}
+});
+// --- End Positron ---
 
 registerAction2(class extends Action2 {
 	constructor() {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2392 because it was reported in private beta and is also really annoying me 😆 
See also https://github.com/microsoft/vscode/issues/77023
For https://github.com/posit-dev/amalthea/pull/279, but we can merge this first

This introduces `workbench.action.files.saveAllTitled` as a command alongside the pre-existing `workbench.action.files.saveAll`. It is:
- Accessible from the command palette as `Save All Titled`, alongside the pre-existing `Save All`
- Accessible via `executeCommand('workbench.action.files.saveAllTitled')`, i.e. for ark to call through the rstudioapi, or for someone to register their own keybinding against.

Unlike `Save All`, it does not appear in the `File -> Save All` menu, or in the `Open Editors` menu, because it is a less common action and we don't really want to promote it in that way.


https://github.com/posit-dev/positron/assets/19150088/b638c914-530d-4423-bade-366efefbde10

<img width="633" alt="Screenshot 2024-03-28 at 11 40 58 AM" src="https://github.com/posit-dev/positron/assets/19150088/6ec91729-f4ed-492d-9502-91e8ff12baa7">
