### PR TITLE
R: Add snapshot tests for indentation

### DIFF
--- a/extensions/positron-r/src/test/README.md
+++ b/extensions/positron-r/src/test/README.md
@@ -1,0 +1,5 @@
+Launch tests by running this from the repository root:
+
+```sh
+yarn test-extension -l positron-r
+```

--- a/extensions/positron-r/src/test/editor-utils.ts
+++ b/extensions/positron-r/src/test/editor-utils.ts
@@ -1,0 +1,93 @@
+// From testUtils.ts in the typescript-language-feature extension
+// https://github.com/posit-dev/positron/blob/main/extensions/typescript-language-features/src/test/testUtils.ts
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import { join } from 'path';
+import * as vscode from 'vscode';
+
+export function rndName() {
+	let name = '';
+	const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+	for (let i = 0; i < 10; i++) {
+		name += possible.charAt(Math.floor(Math.random() * possible.length));
+	}
+	return name;
+}
+
+export function createRandomFile(contents = '', fileExtension = 'txt'): Thenable<vscode.Uri> {
+	return new Promise((resolve, reject) => {
+		const tmpFile = join(os.tmpdir(), rndName() + '.' + fileExtension);
+		fs.writeFile(tmpFile, contents, (error) => {
+			if (error) {
+				return reject(error);
+			}
+
+			resolve(vscode.Uri.file(tmpFile));
+		});
+	});
+}
+
+export function deleteFile(file: vscode.Uri): Thenable<boolean> {
+	return new Promise((resolve, reject) => {
+		fs.unlink(file.fsPath, (err) => {
+			if (err) {
+				reject(err);
+			} else {
+				resolve(true);
+			}
+		});
+	});
+} export const CURSOR = '$$CURSOR$$';
+
+export function withRandomFileEditor(
+	contents: string,
+	fileExtension: string,
+	run: (editor: vscode.TextEditor, doc: vscode.TextDocument) => Thenable<void>
+): Thenable<boolean> {
+	const cursorIndex = contents.indexOf(CURSOR);
+	return createRandomFile(contents.replace(CURSOR, ''), fileExtension).then(file => {
+		return vscode.workspace.openTextDocument(file).then(doc => {
+			return vscode.window.showTextDocument(doc).then((editor) => {
+				if (cursorIndex >= 0) {
+					const pos = doc.positionAt(cursorIndex);
+					editor.selection = new vscode.Selection(pos, pos);
+				}
+				return run(editor, doc).then(_ => {
+					if (doc.isDirty) {
+						return doc.save().then(() => {
+							return deleteFile(file);
+						});
+					} else {
+						return deleteFile(file);
+					}
+				});
+			});
+		});
+	});
+}
+
+const onDocumentChange = (doc: vscode.TextDocument): Promise<vscode.TextDocument> => {
+	return new Promise<vscode.TextDocument>(resolve => {
+		const sub = vscode.workspace.onDidChangeTextDocument(e => {
+			if (e.document !== doc) {
+				return;
+			}
+			sub.dispose();
+			resolve(e.document);
+		});
+	});
+};
+
+export const type = async (document: vscode.TextDocument, text: string): Promise<vscode.TextDocument> => {
+	const onChange = onDocumentChange(document);
+	await vscode.commands.executeCommand('type', { text });
+	await onChange;
+	return document;
+};

--- a/extensions/positron-r/src/test/indentation.test.ts
+++ b/extensions/positron-r/src/test/indentation.test.ts
@@ -3,6 +3,7 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import { CURSOR, type, withFileEditor } from './editor-utils';
 import { EXTENSION_ROOT_DIR } from '../constants';
+import { removeLeadingLines } from '../util';
 
 const snapshotsFolder = `${EXTENSION_ROOT_DIR}/src/test/snapshots`;
 const snippetsPath = `${snapshotsFolder}/indentation-cases.R`;
@@ -51,10 +52,13 @@ async function regenerateIndentSnapshots() {
 	const snapshots: string[] = ['# File generated from `indentation-cases.R`.\n\n'];
 
 	for (const snippet of snippets) {
+		const bareSnippet = snippet.split('\n').slice(0, -1).join('\n');
+
 		await withFileEditor(snippet, 'R', async (_editor, doc) => {
 			// Type one newline character to trigger indentation
 			await type(doc, `\n${CURSOR}`);
-			snapshots.push(doc.getText());
+			const snapshot = removeLeadingLines(doc.getText(), /^$|^#/);
+			snapshots.push(bareSnippet + '\n# ->\n' + snapshot);
 		});
 	}
 

--- a/extensions/positron-r/src/test/indentation.test.ts
+++ b/extensions/positron-r/src/test/indentation.test.ts
@@ -36,7 +36,6 @@ suite('Indentation', () => {
 
 		// Notify if snapshots were outdated
 		assert.strictEqual(expected, current);
-		console.log('dirname: ', __dirname);
 	});
 });
 
@@ -58,5 +57,5 @@ async function regenerateIndentSnapshots() {
 		});
 	}
 
-	return snapshots.join('# --- \n');
+	return snapshots.join('# ---\n');
 }

--- a/extensions/positron-r/src/test/indentation.test.ts
+++ b/extensions/positron-r/src/test/indentation.test.ts
@@ -18,7 +18,7 @@ async function init() {
 
 	// Prevents `ENOENT: no such file or directory` errors caused by us
 	// deleting temporary editor files befor Code had the opportunity to
-	// save the user history of these files (see )
+	// save the user history of these files.
 	config.update('workbench.localHistory.enabled', false, vscode.ConfigurationTarget.Workspace);
 }
 

--- a/extensions/positron-r/src/test/indentation.test.ts
+++ b/extensions/positron-r/src/test/indentation.test.ts
@@ -2,8 +2,9 @@ import * as vscode from 'vscode';
 import * as assert from 'assert';
 import * as fs from 'fs';
 import { CURSOR, type, withFileEditor } from './editor-utils';
+import { EXTENSION_ROOT_DIR } from '../constants';
 
-const snapshotsFolder = `${__dirname}/../../src/test/snapshots`;
+const snapshotsFolder = `${EXTENSION_ROOT_DIR}/src/test/snapshots`;
 const snippetsPath = `${snapshotsFolder}/indentation-cases.R`;
 const snapshotsPath = `${snapshotsFolder}/indentation-snapshots.R`;
 

--- a/extensions/positron-r/src/test/indentation.test.ts
+++ b/extensions/positron-r/src/test/indentation.test.ts
@@ -1,11 +1,62 @@
+import * as vscode from 'vscode';
 import * as assert from 'assert';
-import { withRandomFileEditor, CURSOR, type } from './editor-utils';
+import * as fs from 'fs';
+import { CURSOR, type, withFileEditor } from './editor-utils';
+
+const snapshotsFolder = `${__dirname}/../../src/test/snapshots`;
+const snippetsPath = `${snapshotsFolder}/indentation-cases.R`;
+const snapshotsPath = `${snapshotsFolder}/indentation-snapshots.R`;
+
+// FIXME: This should normally be run as part of tests setup in `before()` but
+// it's somehow not defined
+async function init() {
+	// Open workspace with custom configuration for snapshots. If you need
+	// custom settings set them there via `config.update()`.
+	const uri = vscode.Uri.file(snapshotsFolder);
+	await vscode.commands.executeCommand('vscode.openFolder', uri, false);
+	const config = vscode.workspace.getConfiguration();
+
+	// Prevents `ENOENT: no such file or directory` errors caused by us
+	// deleting temporary editor files befor Code had the opportunity to
+	// save the user history of these files (see )
+	config.update('workbench.localHistory.enabled', false, vscode.ConfigurationTarget.Workspace);
+}
 
 suite('Indentation', () => {
-	test('test', async () => {
-		return withRandomFileEditor(`1 +${CURSOR}`, 'R', async (_editor, document) => {
-			await type(document, '\n2');
-			assert.strictEqual(document.getText(), '1 +\n  2');
-		});
+	// This regenerates snapshots in place. If the snapshots differ from last
+	// run, a failure is emitted. You can either commit the new output or discard
+	// it if that's a bug to fix.
+	test('Regenerate and check', async () => {
+		await init();
+		const expected = fs.readFileSync(snapshotsPath, 'utf8');
+		const current = await regenerateIndentSnapshots();
+
+		// Update snapshot file
+		fs.writeFileSync(snapshotsPath, current, 'utf8');
+
+		// Notify if snapshots were outdated
+		assert.strictEqual(expected, current);
+		console.log('dirname: ', __dirname);
 	});
 });
+
+async function regenerateIndentSnapshots() {
+	const snippets = fs.
+		readFileSync(snippetsPath, 'utf8').
+		split('# ---\n');
+
+	// Remove documentation snippet
+	snippets.splice(0, 1);
+
+	const snapshots: string[] = ['# File generated from `indentation-cases.R`.\n\n'];
+
+	for (const snippet of snippets) {
+		await withFileEditor(snippet, 'R', async (_editor, doc) => {
+			// Type one newline character to trigger indentation
+			await type(doc, `\n${CURSOR}`);
+			snapshots.push(doc.getText());
+		});
+	}
+
+	return snapshots.join('# --- \n');
+}

--- a/extensions/positron-r/src/test/indentation.test.ts
+++ b/extensions/positron-r/src/test/indentation.test.ts
@@ -1,0 +1,11 @@
+import * as assert from 'assert';
+import { withRandomFileEditor, CURSOR, type } from './editor-utils';
+
+suite('Indentation', () => {
+	test('test', async () => {
+		return withRandomFileEditor(`1 +${CURSOR}`, 'R', async (_editor, document) => {
+			await type(document, '\n2');
+			assert.strictEqual(document.getText(), '1 +\n  2');
+		});
+	});
+});

--- a/extensions/positron-r/src/test/snapshots/.vscode/settings.json
+++ b/extensions/positron-r/src/test/snapshots/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "workbench.localHistory.enabled": false
+}

--- a/extensions/positron-r/src/test/snapshots/indentation-cases.R
+++ b/extensions/positron-r/src/test/snapshots/indentation-cases.R
@@ -1,0 +1,82 @@
+# Indentation snapshots. Edit cases in `indentation-cases.R` and observe results
+# in `indentation-snapshots.R`.
+#
+# The cursor position is represented by a string containing angular brackets. A
+# newline is typed at that position, triggering indentation rules. The result is
+# saved in the snapshot file.
+#
+# Snippets are separated by `# ---`. This makes it possible to extract them and
+# process them separately to prevent interferences between test cases.
+
+# ---
+1 +"<>"
+
+# ---
+1 +
+	2 +"<>"
+
+# ---
+data |>"<>"
+
+# ---
+data |>
+	fn()"<>"
+
+# ---
+# https://github.com/posit-dev/positron/issues/1727
+# FIXME
+data |>
+	fn()
+"<>"
+
+# ---
+# https://github.com/posit-dev/positron/issues/1316
+data |>
+	fn() |>"<>"
+
+# ---
+# With trailing whitespace
+# https://github.com/posit-dev/positron/pull/1655#issuecomment-1780093395
+data |>
+	fn() |> "<>"
+
+# ---
+data |>
+	fn1() |>
+	fn2() |>"<>"
+
+# ---
+# FIXME
+data |>
+	fn1() |>
+	fn2(
+    "arg"
+  )"<>"
+
+# ---
+# https://github.com/posit-dev/positron-beta/discussions/46
+# FIXME
+data |>
+	fn("<>")
+
+# ---
+# FIXME
+{
+	fn(function() {}"<>")
+}
+
+# ---
+# FIXME
+{
+	fn(function() {
+    #
+	}"<>")
+}
+
+# ---
+for (i in NA) NULL"<>"
+
+# ---
+# https://github.com/posit-dev/positron/issues/1880
+# FIXME
+for (i in 1) fn()"<>"

--- a/extensions/positron-r/src/test/snapshots/indentation-cases.R
+++ b/extensions/positron-r/src/test/snapshots/indentation-cases.R
@@ -50,8 +50,8 @@ data |>
 data |>
 	fn1() |>
 	fn2(
-    "arg"
-  )"<>"
+		"arg"
+	)"<>"
 
 # ---
 # https://github.com/posit-dev/positron-beta/discussions/46
@@ -69,7 +69,7 @@ data |>
 # FIXME
 {
 	fn(function() {
-    #
+		#
 	}"<>")
 }
 

--- a/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
+++ b/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
@@ -1,19 +1,33 @@
 # File generated from `indentation-cases.R`.
 
 # ---
+1 +"<>"
+
+# ->
 1 +
   "<>"
 
 # ---
+1 +
+	2 +"<>"
+
+# ->
 1 +
 	2 +
 	"<>"
 
 # ---
+data |>"<>"
+
+# ->
 data |>
   "<>"
 
 # ---
+data |>
+	fn()"<>"
+
+# ->
 data |>
 	fn()
 "<>"
@@ -23,11 +37,20 @@ data |>
 # FIXME
 data |>
 	fn()
+"<>"
+
+# ->
+data |>
+	fn()
 
 	"<>"
 
 # ---
 # https://github.com/posit-dev/positron/issues/1316
+data |>
+	fn() |>"<>"
+
+# ->
 data |>
 	fn() |>
 	"<>"
@@ -36,10 +59,19 @@ data |>
 # With trailing whitespace
 # https://github.com/posit-dev/positron/pull/1655#issuecomment-1780093395
 data |>
+	fn() |> "<>"
+
+# ->
+data |>
 	fn() |> 
 	"<>"
 
 # ---
+data |>
+	fn1() |>
+	fn2() |>"<>"
+
+# ->
 data |>
 	fn1() |>
 	fn2() |>
@@ -51,6 +83,13 @@ data |>
 	fn1() |>
 	fn2(
 		"arg"
+	)"<>"
+
+# ->
+data |>
+	fn1() |>
+	fn2(
+		"arg"
 	)
 	"<>"
 
@@ -58,11 +97,20 @@ data |>
 # https://github.com/posit-dev/positron-beta/discussions/46
 # FIXME
 data |>
+	fn("<>")
+
+# ->
+data |>
 	fn(
 "<>")
 
 # ---
 # FIXME
+{
+	fn(function() {}"<>")
+}
+
+# ->
 {
 	fn(function() {}
 "<>")
@@ -73,16 +121,28 @@ data |>
 {
 	fn(function() {
 		#
+	}"<>")
+}
+
+# ->
+{
+	fn(function() {
+		#
 	}
 "<>")
 }
 
 # ---
+for (i in NA) NULL"<>"
+
+# ->
 for (i in NA) NULL
 "<>"
 
 # ---
 # https://github.com/posit-dev/positron/issues/1880
 # FIXME
+for (i in 1) fn()"<>"
+# ->
 for (i in 1) fn()
   "<>"

--- a/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
+++ b/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
@@ -1,24 +1,24 @@
 # File generated from `indentation-cases.R`.
 
-# --- 
+# ---
 1 +
   "<>"
 
-# --- 
+# ---
 1 +
 	2 +
 	"<>"
 
-# --- 
+# ---
 data |>
   "<>"
 
-# --- 
+# ---
 data |>
 	fn()
 "<>"
 
-# --- 
+# ---
 # https://github.com/posit-dev/positron/issues/1727
 # FIXME
 data |>
@@ -26,26 +26,26 @@ data |>
 
 	"<>"
 
-# --- 
+# ---
 # https://github.com/posit-dev/positron/issues/1316
 data |>
 	fn() |>
 	"<>"
 
-# --- 
+# ---
 # With trailing whitespace
 # https://github.com/posit-dev/positron/pull/1655#issuecomment-1780093395
 data |>
 	fn() |> 
 	"<>"
 
-# --- 
+# ---
 data |>
 	fn1() |>
 	fn2() |>
 	"<>"
 
-# --- 
+# ---
 # FIXME
 data |>
 	fn1() |>
@@ -54,21 +54,21 @@ data |>
 	)
 	"<>"
 
-# --- 
+# ---
 # https://github.com/posit-dev/positron-beta/discussions/46
 # FIXME
 data |>
 	fn(
 "<>")
 
-# --- 
+# ---
 # FIXME
 {
 	fn(function() {}
 "<>")
 }
 
-# --- 
+# ---
 # FIXME
 {
 	fn(function() {
@@ -77,11 +77,11 @@ data |>
 "<>")
 }
 
-# --- 
+# ---
 for (i in NA) NULL
 "<>"
 
-# --- 
+# ---
 # https://github.com/posit-dev/positron/issues/1880
 # FIXME
 for (i in 1) fn()

--- a/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
+++ b/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
@@ -1,0 +1,88 @@
+# File generated from `indentation-cases.R`.
+
+# --- 
+1 +
+  "<>"
+
+# --- 
+1 +
+	2 +
+	"<>"
+
+# --- 
+data |>
+  "<>"
+
+# --- 
+data |>
+	fn()
+"<>"
+
+# --- 
+# https://github.com/posit-dev/positron/issues/1727
+# FIXME
+data |>
+	fn()
+
+	"<>"
+
+# --- 
+# https://github.com/posit-dev/positron/issues/1316
+data |>
+	fn() |>
+	"<>"
+
+# --- 
+# With trailing whitespace
+# https://github.com/posit-dev/positron/pull/1655#issuecomment-1780093395
+data |>
+	fn() |> 
+	"<>"
+
+# --- 
+data |>
+	fn1() |>
+	fn2() |>
+	"<>"
+
+# --- 
+# FIXME
+data |>
+	fn1() |>
+	fn2(
+    "arg"
+  )
+  "<>"
+
+# --- 
+# https://github.com/posit-dev/positron-beta/discussions/46
+# FIXME
+data |>
+	fn(
+"<>")
+
+# --- 
+# FIXME
+{
+	fn(function() {}
+"<>")
+}
+
+# --- 
+# FIXME
+{
+	fn(function() {
+    #
+	}
+"<>")
+}
+
+# --- 
+for (i in NA) NULL
+"<>"
+
+# --- 
+# https://github.com/posit-dev/positron/issues/1880
+# FIXME
+for (i in 1) fn()
+  "<>"

--- a/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
+++ b/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
@@ -50,9 +50,9 @@ data |>
 data |>
 	fn1() |>
 	fn2(
-    "arg"
-  )
-  "<>"
+		"arg"
+	)
+	"<>"
 
 # --- 
 # https://github.com/posit-dev/positron-beta/discussions/46
@@ -72,7 +72,7 @@ data |>
 # FIXME
 {
 	fn(function() {
-    #
+		#
 	}
 "<>")
 }

--- a/extensions/positron-r/src/util.ts
+++ b/extensions/positron-r/src/util.ts
@@ -48,3 +48,18 @@ export function extractValue(str: string, key: string, delim: string = '='): str
 	const m = str.match(re);
 	return m?.[1] ?? '';
 }
+
+export function removeLeadingLines(x: string, pattern: RegExp): string {
+	const lines = x.split('\n');
+	let output = lines;
+
+	for (const line of lines) {
+		if (pattern.test(line)) {
+			output = output.slice(1);
+			continue;
+		}
+		break;
+	}
+
+	return output.join('\n');
+}


### PR DESCRIPTION
This adds snapshot tests for indentation issues described in:

- https://github.com/posit-dev/positron/issues/1683
- https://github.com/posit-dev/positron-beta/discussions/46
- https://github.com/posit-dev/positron/issues/1727
- https://github.com/posit-dev/positron/issues/1880
- https://github.com/posit-dev/positron/issues/1316
- https://github.com/posit-dev/positron/pull/1655#issuecomment-1780093395

Closes #1694.

I initially tried to import the indentation test cases from ESS (https://github.com/emacs-ess/ESS/blob/master/test/styles/RStudio-.R). However those tests assume you can do something like the reindent lines action.

- Reindent lines doesn't work here because it only uses regular indentation rules without on-enter rules, which isn't consistent with what happens when the user types Enter.

- Pasting with auto-indent doesn't work either because it doesn't match the behaviour the user would see when typing the code manually. For instance, typing a closing delimiter like `)` triggers a "matching indent", see https://github.com/posit-dev/positron/blob/06743ca425ca904204d95f5716b7203752a29c3e/src/vs/editor/common/cursor/cursorTypeOperations.ts#L947-L963. This special dedenting behaviour doesn't happen on paste.

- Typing the whole file in a loop one character at a time doesn't work either, because typing an opening delimiter like `{` auto-closes it, which corrupts the snapshots. Disabling auto-closing doesn't help because without the closing delimiters, we can't reproduce some of the regexp rules sensitive to those delimiters.

After struggling a while I gave up on this approach. I think we need to test only one action per snapshot case. This is what is implemented in the `indentation-cases.R` (inputs) and `indentation-snapshots.R` (outputs) files. These contain a list of fenced snapshots with a special marker indicating the cursor position. The snapshots are inserted in an editor and a newline is typed at the cursor. The result is pushed to the snapshot files.

The infrastructure for this is based on the Typescript tests for indentation that @juliasilge discovered: https://github.com/posit-dev/positron/blob/main/extensions/typescript-language-features/src/test/unit/onEnter.test.ts#L36C1-L36C1. These are disabled because of intermittent failures on Windows so we'll have to watch out for that.

I've added a VS Code workspace inside the test folder to hold overridden settings. That's a bit of a heavier setup that I'd like but I don't think it's possible to create a virtual context where we could override settings for unit tests?

In terms of workflow these snapshots are in line with the way testthat handled snapshots pre edition 3. The snapshots are always regeneratedv If they don't match this is an error, but rerunning the test will no longer fail as the snapshots have been updated. The differences should be inspected with git and either accepted if the new output is correct, or discarded if it's not. 