### PR TITLE
Fix bug where dirty positron notebook editors wont close

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
@@ -7,7 +7,7 @@ import { IReference } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { IEditorOptions } from 'vs/platform/editor/common/editor';
-import { EditorInputCapabilities, GroupIdentifier, ISaveOptions, IUntypedEditorInput } from 'vs/workbench/common/editor';
+import { EditorInputCapabilities, GroupIdentifier, IRevertOptions, ISaveOptions, IUntypedEditorInput } from 'vs/workbench/common/editor';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { IResolvedNotebookEditorModel } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { INotebookEditorModelResolverService } from 'vs/workbench/contrib/notebook/common/notebookEditorModelResolverService';
@@ -118,6 +118,12 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 */
 	override get typeId(): string {
 		return PositronNotebookEditorInput.ID;
+	}
+
+	override async revert(_group: GroupIdentifier, options?: IRevertOptions): Promise<void> {
+		if (this._editorModelReference && this._editorModelReference.object.isDirty()) {
+			await this._editorModelReference.object.revert(options);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Addresses #2576 

### Intent
Fixes issue noted by @seeM that you can get into a situation where a Positron notebook won't close. 

### Approach
The problem was that the notebook input was requested to run the `.revert()` method. This method is defined as a no-op on the base-class `EditorInput` that `PositronNotebookEditorInput` extends. This method is called by the workbench service when trying to close the editor and then it checks to make sure the revert was successful by looking at the dirty status again. Since we weren't doing anything it takes that as us telling it to not close. 

