### PR TITLE
Fix Data Explorer crash when changing a pandas.DataFrame schema after first sorting a column

### DIFF
--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer.py
@@ -715,14 +715,14 @@ class DataExplorerService:
             should_discard_state,
         ) = table_view.ui_should_update_schema(new_table)
 
-        # The schema is the same, but the data has changed. We'll just
-        # set a new table view and preserve the view state and be done
-        # with it.
-        self.table_views[comm_id] = _get_table_view(
-            new_table,
-            filters=table_view.filters,
-            sort_keys=table_view.sort_keys,
-        )
+        if should_discard_state:
+            self.table_views[comm_id] = _get_table_view(new_table)
+        else:
+            self.table_views[comm_id] = _get_table_view(
+                new_table,
+                filters=table_view.filters,
+                sort_keys=table_view.sort_keys,
+            )
 
         if should_update_schema:
             _fire_schema_update(discard_state=should_discard_state)

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -719,6 +719,8 @@ def test_pandas_change_schema_after_sort(
     shell.user_ns.update({"df": df})
     _open_viewer(variables_comm, ["df"])
 
+    # Sort a column that is out of bounds for the table after the
+    # schema change below
     pandas_fixture.set_sort_columns("df", [{"column_index": 4, "ascending": True}])
 
     expected_df = df[["a", "b"]]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

Addresses #2579 

The sort keys weren't being discarded, and the backend was trying to sort a column index that no longer existed.

### QA Notes

Load `flights.parquet` in Google Drive, sort by `sched_arr_time`, then change the dataset to

```
flights = flights[['origin', 'dest']]
```

Before this change, the Python runtime was throwing an exception