### PR TITLE
Implement accumulated improvements to Data Explorer backend protocol, add batch profile requests. In Python implement between, search filter types, prototype search_schema RPC, improve filter API

### DIFF
--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer.py
@@ -108,14 +108,12 @@ class DataExplorerTableView(abc.ABC):
             request.params.start_index, request.params.num_columns
         ).dict()
 
-    def search_schema(
-        self, request: SearchSchemaRequest
-    ) -> SearchSchemaResult:
+    def search_schema(self, request: SearchSchemaRequest):
         return self._search_schema(
             request.params.search_term,
             request.params.start_index,
             request.params.max_results,
-        )
+        ).dict()
 
     def get_data_values(self, request: GetDataValuesRequest):
         self._recompute_if_needed()
@@ -138,17 +136,9 @@ class DataExplorerTableView(abc.ABC):
 
     def get_column_profiles(self, request: GetColumnProfilesRequest):
         self._recompute_if_needed()
-        return self._get_column_profiles(request.params)
+        results = []
 
-    def get_state(self, request: GetStateRequest):
-        return self._get_state().dict()
-
-    def _get_column_profiles(
-        self, params: GetColumnProfilesParams
-    ) -> List[ColumnProfileResult]:
-        results: List[ColumnProfileResult] = []
-
-        for req in params.profiles:
+        for req in request.params.profiles:
             if req.type == ColumnProfileRequestType.NullCount:
                 count = self._prof_null_count(req.column_index)
                 result = ColumnProfileResult(null_count=count)
@@ -163,9 +153,12 @@ class DataExplorerTableView(abc.ABC):
                 result = ColumnProfileResult(histogram=histogram)
             else:
                 raise NotImplementedError(req.type)
-            results.append(result)
+            results.append(result.dict())
 
         return results
+
+    def get_state(self, request: GetStateRequest):
+        return self._get_state().dict()
 
     @abc.abstractmethod
     def invalidate_computations(self):

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer.py
@@ -105,9 +105,7 @@ class DataExplorerTableView(abc.ABC):
             return False
 
     def get_schema(self, request: GetSchemaRequest):
-        return self._get_schema(
-            request.params.start_index, request.params.num_columns
-        ).dict()
+        return self._get_schema(request.params.start_index, request.params.num_columns).dict()
 
     def search_schema(self, request: SearchSchemaRequest):
         return self._search_schema(
@@ -295,9 +293,7 @@ class PandasView(DataExplorerTableView):
         # search term changes, we discard the last search result. We
         # might add an LRU cache here or something if it helps
         # performance.
-        self._search_schema_last_result: Optional[
-            Tuple[str, List[ColumnSchema]]
-        ] = None
+        self._search_schema_last_result: Optional[Tuple[str, List[ColumnSchema]]] = None
 
     def invalidate_computations(self):
         self.filtered_indices = self.view_indices = None
@@ -345,9 +341,7 @@ class PandasView(DataExplorerTableView):
             column_raw_name = self.table.columns[column_index]
             column_name = str(column_raw_name)
 
-            col_schema = self._get_single_column_schema(
-                column_index, column_name
-            )
+            col_schema = self._get_single_column_schema(column_index, column_name)
             column_schemas.append(col_schema)
 
         return TableSchema(columns=column_schemas)
@@ -373,9 +367,7 @@ class PandasView(DataExplorerTableView):
             total_num_matches=len(matches),
         )
 
-    def _search_schema_get_matches(
-        self, search_term: str
-    ) -> List[ColumnSchema]:
+    def _search_schema_get_matches(self, search_term: str) -> List[ColumnSchema]:
         matches = []
         for column_index in range(len(self.table.columns)):
             column_raw_name = self.table.columns[column_index]
@@ -385,9 +377,7 @@ class PandasView(DataExplorerTableView):
             if search_term not in column_name.lower():
                 continue
 
-            col_schema = self._get_single_column_schema(
-                column_index, column_name
-            )
+            col_schema = self._get_single_column_schema(column_index, column_name)
             matches.append(col_schema)
 
         return matches
@@ -396,9 +386,7 @@ class PandasView(DataExplorerTableView):
         from pandas.api.types import infer_dtype
 
         if column_index not in self._inferred_dtypes:
-            self._inferred_dtypes[column_index] = infer_dtype(
-                self.table.iloc[:, column_index]
-            )
+            self._inferred_dtypes[column_index] = infer_dtype(self.table.iloc[:, column_index])
         return self._inferred_dtypes[column_index]
 
     def _get_single_column_schema(self, column_index: int, column_name: str):
@@ -451,9 +439,7 @@ class PandasView(DataExplorerTableView):
         else:
             # No filtering or sorting, just slice directly
             indices = self.table.index[row_start : row_start + num_rows]
-            columns = [
-                col.iloc[row_start : row_start + num_rows] for col in columns
-            ]
+            columns = [col.iloc[row_start : row_start + num_rows] for col in columns]
 
         formatted_columns = [_pandas_format_values(col) for col in columns]
 
@@ -586,9 +572,7 @@ class PandasView(DataExplorerTableView):
                 self.view_indices = self.filtered_indices.take(sort_indexer)
             else:
                 # Data is not filtered
-                self.view_indices = nargsort(
-                    column, kind="mergesort", ascending=key.ascending
-                )
+                self.view_indices = nargsort(column, kind="mergesort", ascending=key.ascending)
         elif len(self.sort_keys) > 1:
             # Multiple sorting keys
             cols_to_sort = []
@@ -629,9 +613,7 @@ class PandasView(DataExplorerTableView):
 
     def _get_state(self) -> TableState:
         return TableState(
-            table_shape=TableShape(
-                num_rows=self.table.shape[0], num_columns=self.table.shape[1]
-            ),
+            table_shape=TableShape(num_rows=self.table.shape[0], num_columns=self.table.shape[1]),
             row_filters=self.filters,
             sort_keys=self.sort_keys,
         )
@@ -818,9 +800,7 @@ class DataExplorerService:
             for comm_id in list(self.path_to_comm_ids[path]):
                 self._update_explorer_for_comm(comm_id, path, new_variable)
 
-    def _update_explorer_for_comm(
-        self, comm_id: str, path: PathKey, new_variable
-    ):
+    def _update_explorer_for_comm(self, comm_id: str, path: PathKey, new_variable):
         """
         If a variable is updated, we have to handle the different scenarios:
 
@@ -854,9 +834,7 @@ class DataExplorerService:
         # data explorer open for a nested value, then we need to use
         # the same variables inspection logic to resolve it here.
         if len(path) > 1:
-            is_found, new_table = _resolve_value_from_path(
-                new_variable, path[1:]
-            )
+            is_found, new_table = _resolve_value_from_path(new_variable, path[1:])
             if not is_found:
                 raise KeyError(f"Path {', '.join(path)} not found in value")
         else:
@@ -875,9 +853,7 @@ class DataExplorerService:
 
         def _fire_schema_update(discard_state=False):
             msg = SchemaUpdateParams(discard_state=discard_state)
-            comm.send_event(
-                DataExplorerFrontendEvent.SchemaUpdate.value, msg.dict()
-            )
+            comm.send_event(DataExplorerFrontendEvent.SchemaUpdate.value, msg.dict())
 
         if type(new_table) is not type(table_view.table):  # noqa: E721
             # Data type has changed. For now, we will signal the UI to
@@ -922,9 +898,7 @@ class DataExplorerService:
         else:
             _fire_data_update()
 
-    def handle_msg(
-        self, msg: CommMessage[DataExplorerBackendMessageContent], raw_msg
-    ):
+    def handle_msg(self, msg: CommMessage[DataExplorerBackendMessageContent], raw_msg):
         """
         Handle messages received from the client via the
         positron.data_explorer comm.

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer.py
@@ -37,7 +37,6 @@ from .data_explorer_comm import (
     DataExplorerFrontendEvent,
     FilterResult,
     GetColumnProfilesRequest,
-    GetColumnProfilesParams,
     GetDataValuesRequest,
     GetSchemaRequest,
     GetStateRequest,

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer_comm.py
@@ -365,53 +365,91 @@ class ColumnProfileResult(BaseModel):
 
     null_count: Optional[int] = Field(
         default=None,
-        description="Number of null values in column",
+        description="Result from null_count request",
     )
 
-    min_value: Optional[str] = Field(
+    summary_stats: Optional[ColumnSummaryStats] = Field(
         default=None,
-        description="Minimum value as string computed as part of histogram",
+        description="Results from summary_stats request",
     )
 
-    max_value: Optional[str] = Field(
+    histogram: Optional[ColumnHistogram] = Field(
         default=None,
-        description="Maximum value as string computed as part of histogram",
+        description="Results from summary_stats request",
+    )
+
+    freqtable: Optional[ColumnFreqtable] = Field(
+        default=None,
+        description="Results from freqtable request",
+    )
+
+
+class ColumnSummaryStats(BaseModel):
+    """
+    ColumnSummaryStats in Schemas
+    """
+
+    min_value: str = Field(
+        description="Minimum value as string",
+    )
+
+    max_value: str = Field(
+        description="Maximum value as string",
     )
 
     mean_value: Optional[str] = Field(
         default=None,
-        description="Average value as string computed as part of histogram",
+        description="Average value as string",
     )
 
-    sample_quantiles: Optional[List[ColumnQuantileValue]] = Field(
+    median: Optional[str] = Field(
         default=None,
-        description="Quantile values computed from histogram bins",
+        description="Sample median (50% value) value as string",
     )
 
-    histogram_bin_sizes: Optional[List[int]] = Field(
+    q25: Optional[str] = Field(
         default=None,
+        description="25th percentile value as string",
+    )
+
+    q75: Optional[str] = Field(
+        default=None,
+        description="75th percentile value as string",
+    )
+
+
+class ColumnHistogram(BaseModel):
+    """
+    Result from a histogram profile request
+    """
+
+    bin_sizes: List[int] = Field(
         description="Absolute count of values in each histogram bin",
     )
 
-    histogram_bin_width: Optional[float] = Field(
-        default=None,
+    bin_width: float = Field(
         description="Absolute floating-point width of a histogram bin",
     )
 
-    freqtable_counts: Optional[List[FreqtableCounts]] = Field(
+
+class ColumnFreqtable(BaseModel):
+    """
+    Result from a freqtable profile request
+    """
+
+    counts: Optional[List[ColumnFreqtableItem]] = Field(
         default=None,
         description="Counts of distinct values in column",
     )
 
-    freqtable_other_count: Optional[int] = Field(
-        default=None,
-        description="Number of other values not accounted for in counts",
+    other_count: int = Field(
+        description="Number of other values not accounted for in counts. May be 0",
     )
 
 
-class FreqtableCounts(BaseModel):
+class ColumnFreqtableItem(BaseModel):
     """
-    Items in FreqtableCounts
+    Entry in a column's frequency table
     """
 
     value: str = Field(
@@ -758,7 +796,13 @@ ColumnProfileRequest.update_forward_refs()
 
 ColumnProfileResult.update_forward_refs()
 
-FreqtableCounts.update_forward_refs()
+ColumnSummaryStats.update_forward_refs()
+
+ColumnHistogram.update_forward_refs()
+
+ColumnFreqtable.update_forward_refs()
+
+ColumnFreqtableItem.update_forward_refs()
 
 ColumnQuantileValue.update_forward_refs()
 

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer_comm.py
@@ -52,11 +52,11 @@ class ColumnFilterFilterType(str, enum.Enum):
 
     Compare = "compare"
 
-    Isnull = "isnull"
+    IsNull = "is_null"
 
     NotBetween = "not_between"
 
-    Notnull = "notnull"
+    NotNull = "not_null"
 
     Search = "search"
 
@@ -107,12 +107,12 @@ class ColumnProfileRequestType(str, enum.Enum):
 
     SummaryStats = "summary_stats"
 
-    Freqtable = "freqtable"
+    FrequencyTable = "frequency_table"
 
     Histogram = "histogram"
 
 
-class SchemaSearchResult(BaseModel):
+class SearchSchemaResult(BaseModel):
     """
     Result in Methods
     """
@@ -378,9 +378,9 @@ class ColumnProfileResult(BaseModel):
         description="Results from summary_stats request",
     )
 
-    freqtable: Optional[ColumnFreqtable] = Field(
+    frequency_table: Optional[ColumnFrequencyTable] = Field(
         default=None,
-        description="Results from freqtable request",
+        description="Results from frequency_table request",
     )
 
 
@@ -432,13 +432,12 @@ class ColumnHistogram(BaseModel):
     )
 
 
-class ColumnFreqtable(BaseModel):
+class ColumnFrequencyTable(BaseModel):
     """
-    Result from a freqtable profile request
+    Result from a frequency_table profile request
     """
 
-    counts: Optional[List[ColumnFreqtableItem]] = Field(
-        default=None,
+    counts: List[ColumnFrequencyTableItem] = Field(
         description="Counts of distinct values in column",
     )
 
@@ -447,7 +446,7 @@ class ColumnFreqtable(BaseModel):
     )
 
 
-class ColumnFreqtableItem(BaseModel):
+class ColumnFrequencyTableItem(BaseModel):
     """
     Entry in a column's frequency table
     """
@@ -768,7 +767,7 @@ class SchemaUpdateParams(BaseModel):
     )
 
 
-SchemaSearchResult.update_forward_refs()
+SearchSchemaResult.update_forward_refs()
 
 TableData.update_forward_refs()
 
@@ -800,9 +799,9 @@ ColumnSummaryStats.update_forward_refs()
 
 ColumnHistogram.update_forward_refs()
 
-ColumnFreqtable.update_forward_refs()
+ColumnFrequencyTable.update_forward_refs()
 
-ColumnFreqtableItem.update_forward_refs()
+ColumnFrequencyTableItem.update_forward_refs()
 
 ColumnQuantileValue.update_forward_refs()
 

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer_comm.py
@@ -18,17 +18,6 @@ from ._vendor.pydantic import BaseModel, Field
 
 
 @enum.unique
-class GetColumnProfileProfileType(str, enum.Enum):
-    """
-    Possible values for ProfileType in GetColumnProfile
-    """
-
-    Freqtable = "freqtable"
-
-    Histogram = "histogram"
-
-
-@enum.unique
 class ColumnSchemaTypeDisplay(str, enum.Enum):
     """
     Possible values for TypeDisplay in ColumnSchema
@@ -59,21 +48,25 @@ class ColumnFilterFilterType(str, enum.Enum):
     Possible values for FilterType in ColumnFilter
     """
 
-    Isnull = "isnull"
-
-    Notnull = "notnull"
+    Between = "between"
 
     Compare = "compare"
 
-    SetMembership = "set_membership"
+    Isnull = "isnull"
+
+    NotBetween = "not_between"
+
+    Notnull = "notnull"
 
     Search = "search"
 
+    SetMembership = "set_membership"
+
 
 @enum.unique
-class ColumnFilterCompareOp(str, enum.Enum):
+class CompareFilterParamsOp(str, enum.Enum):
     """
-    Possible values for CompareOp in ColumnFilter
+    Possible values for Op in CompareFilterParams
     """
 
     Eq = "="
@@ -90,9 +83,9 @@ class ColumnFilterCompareOp(str, enum.Enum):
 
 
 @enum.unique
-class ColumnFilterSearchType(str, enum.Enum):
+class SearchFilterParamsType(str, enum.Enum):
     """
-    Possible values for SearchType in ColumnFilter
+    Possible values for Type in SearchFilterParams
     """
 
     Contains = "contains"
@@ -104,13 +97,33 @@ class ColumnFilterSearchType(str, enum.Enum):
     Regex = "regex"
 
 
-class TableSchema(BaseModel):
+@enum.unique
+class ColumnProfileRequestType(str, enum.Enum):
     """
-    The schema for a table-like object
+    Possible values for Type in ColumnProfileRequest
     """
 
-    columns: List[ColumnSchema] = Field(
-        description="Schema for each column in the table",
+    NullCount = "null_count"
+
+    SummaryStats = "summary_stats"
+
+    Freqtable = "freqtable"
+
+    Histogram = "histogram"
+
+
+class SchemaSearchResult(BaseModel):
+    """
+    Result in Methods
+    """
+
+    matches: Optional[TableSchema] = Field(
+        default=None,
+        description="A schema containing matching columns up to the max_results limit",
+    )
+
+    total_num_matches: int = Field(
+        description="The total number of columns matching the search term",
     )
 
 
@@ -136,70 +149,6 @@ class FilterResult(BaseModel):
 
     selected_num_rows: int = Field(
         description="Number of rows in table after applying filters",
-    )
-
-
-class ProfileResult(BaseModel):
-    """
-    Result of computing column profile
-    """
-
-    null_count: int = Field(
-        description="Number of null values in column",
-    )
-
-    min_value: Optional[str] = Field(
-        default=None,
-        description="Minimum value as string computed as part of histogram",
-    )
-
-    max_value: Optional[str] = Field(
-        default=None,
-        description="Maximum value as string computed as part of histogram",
-    )
-
-    mean_value: Optional[str] = Field(
-        default=None,
-        description="Average value as string computed as part of histogram",
-    )
-
-    histogram_bin_sizes: Optional[List[int]] = Field(
-        default=None,
-        description="Absolute count of values in each histogram bin",
-    )
-
-    histogram_bin_width: Optional[float] = Field(
-        default=None,
-        description="Absolute floating-point width of a histogram bin",
-    )
-
-    histogram_quantiles: Optional[List[ColumnQuantileValue]] = Field(
-        default=None,
-        description="Quantile values computed from histogram bins",
-    )
-
-    freqtable_counts: Optional[List[FreqtableCounts]] = Field(
-        default=None,
-        description="Counts of distinct values in column",
-    )
-
-    freqtable_other_count: Optional[int] = Field(
-        default=None,
-        description="Number of other values not accounted for in counts",
-    )
-
-
-class FreqtableCounts(BaseModel):
-    """
-    Items in FreqtableCounts
-    """
-
-    value: str = Field(
-        description="Stringified value",
-    )
-
-    count: int = Field(
-        description="Number of occurrences of value",
     )
 
 
@@ -244,6 +193,10 @@ class ColumnSchema(BaseModel):
         description="Name of column as UTF-8 string",
     )
 
+    column_index: int = Field(
+        description="The position of the column within the schema",
+    )
+
     type_name: str = Field(
         description="Exact name of data type used by underlying table",
     )
@@ -283,6 +236,16 @@ class ColumnSchema(BaseModel):
     )
 
 
+class TableSchema(BaseModel):
+    """
+    The schema for a table-like object
+    """
+
+    columns: List[ColumnSchema] = Field(
+        description="Schema for each column in the table",
+    )
+
+
 class ColumnFilter(BaseModel):
     """
     Specifies a table row filter based on a column's values
@@ -300,39 +263,163 @@ class ColumnFilter(BaseModel):
         description="Column index to apply filter to",
     )
 
-    compare_op: Optional[ColumnFilterCompareOp] = Field(
+    between_params: Optional[BetweenFilterParams] = Field(
         default=None,
+        description="Parameters for the 'between' and 'not_between' filter types",
+    )
+
+    compare_params: Optional[CompareFilterParams] = Field(
+        default=None,
+        description="Parameters for the 'compare' filter type",
+    )
+
+    search_params: Optional[SearchFilterParams] = Field(
+        default=None,
+        description="Parameters for the 'search' filter type",
+    )
+
+    set_membership_params: Optional[SetMembershipFilterParams] = Field(
+        default=None,
+        description="Parameters for the 'set_membership' filter type",
+    )
+
+
+class BetweenFilterParams(BaseModel):
+    """
+    Parameters for the 'between' and 'not_between' filter types
+    """
+
+    left_value: str = Field(
+        description="The lower limit for filtering",
+    )
+
+    right_value: str = Field(
+        description="The upper limit for filtering",
+    )
+
+
+class CompareFilterParams(BaseModel):
+    """
+    Parameters for the 'compare' filter type
+    """
+
+    op: CompareFilterParamsOp = Field(
         description="String representation of a binary comparison",
     )
 
-    compare_value: Optional[str] = Field(
-        default=None,
+    value: str = Field(
         description="A stringified column value for a comparison filter",
     )
 
-    set_member_values: Optional[List[str]] = Field(
-        default=None,
+
+class SetMembershipFilterParams(BaseModel):
+    """
+    Parameters for the 'set_membership' filter type
+    """
+
+    values: List[str] = Field(
         description="Array of column values for a set membership filter",
     )
 
-    set_member_inclusive: Optional[bool] = Field(
-        default=None,
+    inclusive: bool = Field(
         description="Filter by including only values passed (true) or excluding (false)",
     )
 
-    search_type: Optional[ColumnFilterSearchType] = Field(
-        default=None,
+
+class SearchFilterParams(BaseModel):
+    """
+    Parameters for the 'search' filter type
+    """
+
+    type: SearchFilterParamsType = Field(
         description="Type of search to perform",
     )
 
-    search_term: Optional[str] = Field(
-        default=None,
+    term: str = Field(
         description="String value/regex to search for in stringified data",
     )
 
-    search_case_sensitive: Optional[bool] = Field(
-        default=None,
+    case_sensitive: bool = Field(
         description="If true, do a case-sensitive search, otherwise case-insensitive",
+    )
+
+
+class ColumnProfileRequest(BaseModel):
+    """
+    A single column profile request
+    """
+
+    column_index: int = Field(
+        description="The ordinal column index to profile",
+    )
+
+    type: ColumnProfileRequestType = Field(
+        description="The type of analytical column profile",
+    )
+
+
+class ColumnProfileResult(BaseModel):
+    """
+    Result of computing column profile
+    """
+
+    null_count: Optional[int] = Field(
+        default=None,
+        description="Number of null values in column",
+    )
+
+    min_value: Optional[str] = Field(
+        default=None,
+        description="Minimum value as string computed as part of histogram",
+    )
+
+    max_value: Optional[str] = Field(
+        default=None,
+        description="Maximum value as string computed as part of histogram",
+    )
+
+    mean_value: Optional[str] = Field(
+        default=None,
+        description="Average value as string computed as part of histogram",
+    )
+
+    sample_quantiles: Optional[List[ColumnQuantileValue]] = Field(
+        default=None,
+        description="Quantile values computed from histogram bins",
+    )
+
+    histogram_bin_sizes: Optional[List[int]] = Field(
+        default=None,
+        description="Absolute count of values in each histogram bin",
+    )
+
+    histogram_bin_width: Optional[float] = Field(
+        default=None,
+        description="Absolute floating-point width of a histogram bin",
+    )
+
+    freqtable_counts: Optional[List[FreqtableCounts]] = Field(
+        default=None,
+        description="Counts of distinct values in column",
+    )
+
+    freqtable_other_count: Optional[int] = Field(
+        default=None,
+        description="Number of other values not accounted for in counts",
+    )
+
+
+class FreqtableCounts(BaseModel):
+    """
+    Items in FreqtableCounts
+    """
+
+    value: str = Field(
+        description="Stringified value",
+    )
+
+    count: int = Field(
+        description="Number of occurrences of value",
     )
 
 
@@ -377,6 +464,9 @@ class DataExplorerBackendRequest(str, enum.Enum):
     # Request schema
     GetSchema = "get_schema"
 
+    # Search schema by column name
+    SearchSchema = "search_schema"
+
     # Get a rectangle of data values
     GetDataValues = "get_data_values"
 
@@ -386,8 +476,8 @@ class DataExplorerBackendRequest(str, enum.Enum):
     # Set or clear sort-by-column(s)
     SetSortColumns = "set_sort_columns"
 
-    # Get a column profile
-    GetColumnProfile = "get_column_profile"
+    # Request a batch of column profiles
+    GetColumnProfiles = "get_column_profiles"
 
     # Get the state
     GetState = "get_state"
@@ -418,6 +508,43 @@ class GetSchemaRequest(BaseModel):
 
     method: Literal[DataExplorerBackendRequest.GetSchema] = Field(
         description="The JSON-RPC method name (get_schema)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
+
+
+class SearchSchemaParams(BaseModel):
+    """
+    Search schema for column names matching a passed substring
+    """
+
+    search_term: str = Field(
+        description="Substring to match for (currently case insensitive",
+    )
+
+    start_index: int = Field(
+        description="Index (starting from zero) of first result to fetch",
+    )
+
+    max_results: int = Field(
+        description="Maximum number of resulting column schemas to fetch from the start index",
+    )
+
+
+class SearchSchemaRequest(BaseModel):
+    """
+    Search schema for column names matching a passed substring
+    """
+
+    params: SearchSchemaParams = Field(
+        description="Parameters to the SearchSchema method",
+    )
+
+    method: Literal[DataExplorerBackendRequest.SearchSchema] = Field(
+        description="The JSON-RPC method name (search_schema)",
     )
 
     jsonrpc: str = Field(
@@ -523,31 +650,27 @@ class SetSortColumnsRequest(BaseModel):
     )
 
 
-class GetColumnProfileParams(BaseModel):
+class GetColumnProfilesParams(BaseModel):
     """
-    Requests a statistical summary or data profile for a column
+    Requests a statistical summary or data profile for batch of columns
     """
 
-    profile_type: GetColumnProfileProfileType = Field(
-        description="The type of analytical column profile",
-    )
-
-    column_index: int = Field(
-        description="Column index to compute profile for",
+    profiles: List[ColumnProfileRequest] = Field(
+        description="Array of requested profiles",
     )
 
 
-class GetColumnProfileRequest(BaseModel):
+class GetColumnProfilesRequest(BaseModel):
     """
-    Requests a statistical summary or data profile for a column
+    Requests a statistical summary or data profile for batch of columns
     """
 
-    params: GetColumnProfileParams = Field(
-        description="Parameters to the GetColumnProfile method",
+    params: GetColumnProfilesParams = Field(
+        description="Parameters to the GetColumnProfiles method",
     )
 
-    method: Literal[DataExplorerBackendRequest.GetColumnProfile] = Field(
-        description="The JSON-RPC method name (get_column_profile)",
+    method: Literal[DataExplorerBackendRequest.GetColumnProfiles] = Field(
+        description="The JSON-RPC method name (get_column_profiles)",
     )
 
     jsonrpc: str = Field(
@@ -575,10 +698,11 @@ class DataExplorerBackendMessageContent(BaseModel):
     comm_id: str
     data: Union[
         GetSchemaRequest,
+        SearchSchemaRequest,
         GetDataValuesRequest,
         SetColumnFiltersRequest,
         SetSortColumnsRequest,
-        GetColumnProfileRequest,
+        GetColumnProfilesRequest,
         GetStateRequest,
     ] = Field(..., discriminator="method")
 
@@ -606,15 +730,11 @@ class SchemaUpdateParams(BaseModel):
     )
 
 
-TableSchema.update_forward_refs()
+SchemaSearchResult.update_forward_refs()
 
 TableData.update_forward_refs()
 
 FilterResult.update_forward_refs()
-
-ProfileResult.update_forward_refs()
-
-FreqtableCounts.update_forward_refs()
 
 TableState.update_forward_refs()
 
@@ -622,7 +742,23 @@ TableShape.update_forward_refs()
 
 ColumnSchema.update_forward_refs()
 
+TableSchema.update_forward_refs()
+
 ColumnFilter.update_forward_refs()
+
+BetweenFilterParams.update_forward_refs()
+
+CompareFilterParams.update_forward_refs()
+
+SetMembershipFilterParams.update_forward_refs()
+
+SearchFilterParams.update_forward_refs()
+
+ColumnProfileRequest.update_forward_refs()
+
+ColumnProfileResult.update_forward_refs()
+
+FreqtableCounts.update_forward_refs()
 
 ColumnQuantileValue.update_forward_refs()
 
@@ -631,6 +767,10 @@ ColumnSortKey.update_forward_refs()
 GetSchemaParams.update_forward_refs()
 
 GetSchemaRequest.update_forward_refs()
+
+SearchSchemaParams.update_forward_refs()
+
+SearchSchemaRequest.update_forward_refs()
 
 GetDataValuesParams.update_forward_refs()
 
@@ -644,9 +784,9 @@ SetSortColumnsParams.update_forward_refs()
 
 SetSortColumnsRequest.update_forward_refs()
 
-GetColumnProfileParams.update_forward_refs()
+GetColumnProfilesParams.update_forward_refs()
 
-GetColumnProfileRequest.update_forward_refs()
+GetColumnProfilesRequest.update_forward_refs()
 
 GetStateRequest.update_forward_refs()
 

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer_comm.py
@@ -90,11 +90,11 @@ class SearchFilterParamsType(str, enum.Enum):
 
     Contains = "contains"
 
-    Startswith = "startswith"
+    StartsWith = "starts_with"
 
-    Endswith = "endswith"
+    EndsWith = "ends_with"
 
-    Regex = "regex"
+    RegexMatch = "regex_match"
 
 
 @enum.unique

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer_comm.py
@@ -43,9 +43,9 @@ class ColumnSchemaTypeDisplay(str, enum.Enum):
 
 
 @enum.unique
-class ColumnFilterFilterType(str, enum.Enum):
+class RowFilterFilterType(str, enum.Enum):
     """
-    Possible values for FilterType in ColumnFilter
+    Possible values for FilterType in RowFilter
     """
 
     Between = "between"
@@ -161,8 +161,9 @@ class TableState(BaseModel):
         description="Provides number of rows and columns in table",
     )
 
-    filters: List[ColumnFilter] = Field(
-        description="The set of currently applied filters",
+    row_filters: Optional[List[RowFilter]] = Field(
+        default=None,
+        description="The set of currently applied row filters",
     )
 
     sort_keys: List[ColumnSortKey] = Field(
@@ -246,16 +247,16 @@ class TableSchema(BaseModel):
     )
 
 
-class ColumnFilter(BaseModel):
+class RowFilter(BaseModel):
     """
-    Specifies a table row filter based on a column's values
+    Specifies a table row filter based on a single column's values
     """
 
     filter_id: str = Field(
         description="Unique identifier for this filter",
     )
 
-    filter_type: ColumnFilterFilterType = Field(
+    filter_type: RowFilterFilterType = Field(
         description="Type of filter to apply",
     )
 
@@ -507,8 +508,8 @@ class DataExplorerBackendRequest(str, enum.Enum):
     # Get a rectangle of data values
     GetDataValues = "get_data_values"
 
-    # Set column filters
-    SetColumnFilters = "set_column_filters"
+    # Set row filters based on column values
+    SetRowFilters = "set_row_filters"
 
     # Set or clear sort-by-column(s)
     SetSortColumns = "set_sort_columns"
@@ -627,27 +628,27 @@ class GetDataValuesRequest(BaseModel):
     )
 
 
-class SetColumnFiltersParams(BaseModel):
+class SetRowFiltersParams(BaseModel):
     """
-    Set or clear column filters on table, replacing any previous filters
+    Set or clear row filters on table, replacing any previous filters
     """
 
-    filters: List[ColumnFilter] = Field(
+    filters: List[RowFilter] = Field(
         description="Zero or more filters to apply",
     )
 
 
-class SetColumnFiltersRequest(BaseModel):
+class SetRowFiltersRequest(BaseModel):
     """
-    Set or clear column filters on table, replacing any previous filters
+    Set or clear row filters on table, replacing any previous filters
     """
 
-    params: SetColumnFiltersParams = Field(
-        description="Parameters to the SetColumnFilters method",
+    params: SetRowFiltersParams = Field(
+        description="Parameters to the SetRowFilters method",
     )
 
-    method: Literal[DataExplorerBackendRequest.SetColumnFilters] = Field(
-        description="The JSON-RPC method name (set_column_filters)",
+    method: Literal[DataExplorerBackendRequest.SetRowFilters] = Field(
+        description="The JSON-RPC method name (set_row_filters)",
     )
 
     jsonrpc: str = Field(
@@ -737,7 +738,7 @@ class DataExplorerBackendMessageContent(BaseModel):
         GetSchemaRequest,
         SearchSchemaRequest,
         GetDataValuesRequest,
-        SetColumnFiltersRequest,
+        SetRowFiltersRequest,
         SetSortColumnsRequest,
         GetColumnProfilesRequest,
         GetStateRequest,
@@ -781,7 +782,7 @@ ColumnSchema.update_forward_refs()
 
 TableSchema.update_forward_refs()
 
-ColumnFilter.update_forward_refs()
+RowFilter.update_forward_refs()
 
 BetweenFilterParams.update_forward_refs()
 
@@ -819,9 +820,9 @@ GetDataValuesParams.update_forward_refs()
 
 GetDataValuesRequest.update_forward_refs()
 
-SetColumnFiltersParams.update_forward_refs()
+SetRowFiltersParams.update_forward_refs()
 
-SetColumnFiltersRequest.update_forward_refs()
+SetRowFiltersRequest.update_forward_refs()
 
 SetSortColumnsParams.update_forward_refs()
 

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -682,7 +682,6 @@ def _set_member_filter(column_index, values, inclusive=True):
 
 def test_pandas_filter_between(de_fixture: DataExplorerFixture):
     dxf = de_fixture
-    table_name = "simple"
     df = SIMPLE_PANDAS_DF
     column = "a"
     column_index = df.columns.get_loc(column)

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -450,7 +450,7 @@ def test_pandas_get_state(pandas_fixture: PandasFixture):
 
     result = pandas_fixture.get_state("simple")
     assert result["sort_keys"] == sort_keys
-    assert result["filters"] == [ColumnFilter(**f) for f in filters]
+    assert result["row_filters"] == [RowFilter(**f) for f in filters]
 
 
 def test_pandas_get_schema(pandas_fixture: PandasFixture):

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -13,7 +13,7 @@ from .._vendor.pydantic import BaseModel
 from ..access_keys import encode_access_key
 from ..data_explorer import COMPARE_OPS, DataExplorerService
 from ..data_explorer_comm import (
-    ColumnFilter,
+    RowFilter,
     ColumnProfileResult,
     ColumnSchema,
     ColumnSortKey,
@@ -370,10 +370,8 @@ class PandasFixture:
     def get_data_values(self, table_name, **params):
         return self.do_json_rpc(table_name, "get_data_values", **params)
 
-    def set_column_filters(self, table_name, filters=None):
-        return self.do_json_rpc(
-            table_name, "set_column_filters", filters=filters
-        )
+    def set_row_filters(self, table_name, filters=None):
+        return self.do_json_rpc(table_name, "set_row_filters", filters=filters)
 
     def set_sort_columns(self, table_name, sort_keys=None):
         return self.do_json_rpc(
@@ -391,7 +389,7 @@ class PandasFixture:
         self.register_table(table_id, table)
         self.register_table(ex_id, expected_table)
 
-        response = self.set_column_filters(table_id, filters=filter_set)
+        response = self.set_row_filters(table_id, filters=filter_set)
         assert response == FilterResult(selected_num_rows=len(expected_table))
         self.compare_tables(table_id, ex_id, table.shape)
 
@@ -402,7 +400,7 @@ class PandasFixture:
         self.register_table(ex_id, expected_table)
 
         if filters is not None:
-            self.set_column_filters(table_id, filters)
+            self.set_row_filters(table_id, filters)
 
         response = self.set_sort_columns(table_id, sort_keys=sort_keys)
         assert response is None
@@ -448,7 +446,7 @@ def test_pandas_get_state(pandas_fixture: PandasFixture):
     ]
     filters = [_compare_filter(0, ">", 0), _compare_filter(0, "<", 5)]
     pandas_fixture.set_sort_columns("simple", sort_keys=sort_keys)
-    pandas_fixture.set_column_filters("simple", filters=filters)
+    pandas_fixture.set_row_filters("simple", filters=filters)
 
     result = pandas_fixture.get_state("simple")
     assert result["sort_keys"] == sort_keys
@@ -650,8 +648,8 @@ def test_pandas_filter_compare(pandas_fixture: PandasFixture):
 
     # Test that passing empty filter set resets to unfiltered state
     filt = _compare_filter(column_index, "<", str(compare_value))
-    _ = pandas_fixture.set_column_filters(table_name, filters=[filt])
-    response = pandas_fixture.set_column_filters(table_name, filters=[])
+    _ = pandas_fixture.set_row_filters(table_name, filters=[filt])
+    response = pandas_fixture.set_row_filters(table_name, filters=[])
     assert response == FilterResult(selected_num_rows=len(df))
 
     # register the whole table to make sure the filters are really cleared
@@ -854,7 +852,7 @@ def test_pandas_profile_null_counts(pandas_fixture: PandasFixture):
     for table, filters, filtered_table, profiles in filter_cases:
         table_id = guid()
         pf.register_table(table_id, table)
-        pf.set_column_filters(table_id, filters)
+        pf.set_row_filters(table_id, filters)
 
         filtered_id = guid()
         pf.register_table(filtered_id, filtered_table)

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -175,9 +175,7 @@ def test_explorer_delete_variable(
         assert len(paths) > 0
 
         comms = [
-            de_service.comms[comm_id]
-            for p in paths
-            for comm_id in de_service.path_to_comm_ids[p]
+            de_service.comms[comm_id] for p in paths for comm_id in de_service.path_to_comm_ids[p]
         ]
         variables_comm.handle_msg(msg)
 
@@ -193,22 +191,14 @@ def test_explorer_delete_variable(
     _check_delete_variable("y")
 
 
-def _check_update_variable(
-    de_service, name, update_type="schema", discard_state=True
-):
+def _check_update_variable(de_service, name, update_type="schema", discard_state=True):
     paths = de_service.get_paths_for_variable(name)
     assert len(paths) > 0
 
-    comms = [
-        de_service.comms[comm_id]
-        for p in paths
-        for comm_id in de_service.path_to_comm_ids[p]
-    ]
+    comms = [de_service.comms[comm_id] for p in paths for comm_id in de_service.path_to_comm_ids[p]]
 
     if update_type == "schema":
-        expected_msg = json_rpc_notification(
-            "schema_update", {"discard_state": discard_state}
-        )
+        expected_msg = json_rpc_notification("schema_update", {"discard_state": discard_state})
     else:
         expected_msg = json_rpc_notification("data_update", {})
 
@@ -274,18 +264,14 @@ def test_explorer_variable_updates(
     'key2': y['key2'].copy()}
     """
     )
-    _check_update_variable(
-        de_service, "y", update_type="update", discard_state=False
-    )
+    _check_update_variable(de_service, "y", update_type="update", discard_state=False)
 
     shell.run_cell(
         """y = {'key1': y['key1'].iloc[:-1, :-1],
     'key2': y['key2'].copy().iloc[:, 1:]}
     """
     )
-    _check_update_variable(
-        de_service, "y", update_type="schema", discard_state=True
-    )
+    _check_update_variable(de_service, "y", update_type="schema", discard_state=True)
 
 
 def test_register_table(de_service: DataExplorerService):
@@ -383,14 +369,10 @@ class DataExplorerFixture:
         return self.do_json_rpc(table_name, "set_row_filters", filters=filters)
 
     def set_sort_columns(self, table_name, sort_keys=None):
-        return self.do_json_rpc(
-            table_name, "set_sort_columns", sort_keys=sort_keys
-        )
+        return self.do_json_rpc(table_name, "set_sort_columns", sort_keys=sort_keys)
 
     def get_column_profiles(self, table_name, profiles):
-        return self.do_json_rpc(
-            table_name, "get_column_profiles", profiles=profiles
-        )
+        return self.do_json_rpc(table_name, "get_column_profiles", profiles=profiles)
 
     def check_filter_case(self, table, filter_set, expected_table):
         table_id = guid()
@@ -415,9 +397,7 @@ class DataExplorerFixture:
         assert response is None
         self.compare_tables(table_id, ex_id, table.shape)
 
-    def compare_tables(
-        self, table_id: str, expected_id: str, table_shape: tuple
-    ):
+    def compare_tables(self, table_id: str, expected_id: str, table_shape: tuple):
         # Query the data and check it yields the same result as the
         # manually constructed data frame without the filter
         response = self.get_data_values(
@@ -572,9 +552,7 @@ def test_pandas_search_schema(de_fixture: DataExplorerFixture):
 
     # Make a data frame with those column names
     arr = np.arange(10)
-    df = pd.DataFrame(
-        {name: arr for name in column_names}, columns=pd.Index(column_names)
-    )
+    df = pd.DataFrame({name: arr for name in column_names}, columns=pd.Index(column_names))
 
     dxf.register_table("df", df)
 
@@ -667,9 +645,7 @@ def _filter(filter_type, column_index, **kwargs):
 
 
 def _compare_filter(column_index, op, value):
-    return _filter(
-        "compare", column_index, compare_params={"op": op, "value": value}
-    )
+    return _filter("compare", column_index, compare_params={"op": op, "value": value})
 
 
 def _between_filter(column_index, left_value, right_value, op="between"):
@@ -681,14 +657,10 @@ def _between_filter(column_index, left_value, right_value, op="between"):
 
 
 def _not_between_filter(column_index, left_value, right_value):
-    return _between_filter(
-        column_index, left_value, right_value, op="not_between"
-    )
+    return _between_filter(column_index, left_value, right_value, op="not_between")
 
 
-def _search_filter(
-    column_index, term, case_sensitive=False, search_type="contains"
-):
+def _search_filter(column_index, term, case_sensitive=False, search_type="contains"):
     return _filter(
         "search",
         column_index,
@@ -733,11 +705,7 @@ def test_pandas_filter_between(de_fixture: DataExplorerFixture):
         )
         dxf.check_filter_case(
             df,
-            [
-                _not_between_filter(
-                    column_index, str(left_value), str(right_value)
-                )
-            ],
+            [_not_between_filter(column_index, str(left_value), str(right_value))],
             ex_not_between,
         )
 
@@ -913,14 +881,11 @@ def test_pandas_set_sort_columns(de_fixture: DataExplorerFixture):
     ]
 
     # Test sort AND filter
-    filter_cases = {
-        "df2": [(lambda x: x[x["a"] > 0], [_compare_filter(0, ">", 0)])]
-    }
+    filter_cases = {"df2": [(lambda x: x[x["a"] > 0], [_compare_filter(0, ">", 0)])]}
 
     for df_name, keys, expected_params in cases:
         wrapped_keys = [
-            {"column_index": index, "ascending": ascending}
-            for index, ascending in keys
+            {"column_index": index, "ascending": ascending} for index, ascending in keys
         ]
         df = tables[df_name]
 
@@ -932,9 +897,7 @@ def test_pandas_set_sort_columns(de_fixture: DataExplorerFixture):
 
         for filter_f, filters in filter_cases.get(df_name, []):
             expected_filtered = filter_f(df).sort_values(**expected_params)
-            de_fixture.check_sort_case(
-                df, wrapped_keys, expected_filtered, filters=filters
-            )
+            de_fixture.check_sort_case(df, wrapped_keys, expected_filtered, filters=filters)
 
 
 def test_pandas_change_schema_after_sort(
@@ -964,9 +927,7 @@ def test_pandas_change_schema_after_sort(
 
     # Sort last column, and we will then change the schema
     shell.run_cell("df = df[['a', 'b']]")
-    _check_update_variable(
-        de_service, "df", update_type="schema", discard_state=True
-    )
+    _check_update_variable(de_service, "df", update_type="schema", discard_state=True)
 
     # Call get_data_values and make sure it works
     de_fixture.compare_tables("df", "expected_df", expected_df.shape)
@@ -1019,17 +980,13 @@ def test_pandas_profile_null_counts(de_fixture: DataExplorerFixture):
     for table_name, profiles, ex_results in cases:
         results = dxf.get_column_profiles(table_name, profiles)
 
-        ex_results = [
-            ColumnProfileResult(null_count=count) for count in ex_results
-        ]
+        ex_results = [ColumnProfileResult(null_count=count) for count in ex_results]
 
         assert results == ex_results
 
     # Test profiling with filter
     # format: (table, filters, filtered_table, profiles)
-    filter_cases = [
-        (df1, [_filter("not_null", 0)], df1[df1["a"].notnull()], all_profiles)
-    ]
+    filter_cases = [(df1, [_filter("not_null", 0)], df1[df1["a"].notnull()], all_profiles)]
     for table, filters, filtered_table, profiles in filter_cases:
         table_id = guid()
         dxf.register_table(table_id, table)

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/ui_comm.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/ui_comm.py
@@ -195,12 +195,6 @@ class UiFrontendEvent(str, enum.Enum):
     # Execute a Positron command
     ExecuteCommand = "execute_command"
 
-    # Open a workspace
-    OpenWorkspace = "open_workspace"
-
-    # Show a URL in Positron's Viewer pane
-    ShowUrl = "show_url"
-
 
 class BusyParams(BaseModel):
     """
@@ -262,20 +256,6 @@ class ShowQuestionParams(BaseModel):
     )
 
 
-class ShowDialogParams(BaseModel):
-    """
-    Show a dialog
-    """
-
-    title: str = Field(
-        description="The title of the dialog",
-    )
-
-    message: str = Field(
-        description="The message to display in the dialog",
-    )
-
-
 class PromptStateParams(BaseModel):
     """
     New state of the primary and secondary prompts
@@ -320,30 +300,6 @@ class ExecuteCommandParams(BaseModel):
     )
 
 
-class OpenWorkspaceParams(BaseModel):
-    """
-    Open a workspace
-    """
-
-    path: str = Field(
-        description="The path for the workspace to be opened",
-    )
-
-    new_window: bool = Field(
-        description="Should the workspace be opened in a new window?",
-    )
-
-
-class ShowUrlParams(BaseModel):
-    """
-    Show a URL in Positron's Viewer pane
-    """
-
-    url: str = Field(
-        description="The URL to display",
-    )
-
-
 EditorContext.update_forward_refs()
 
 TextDocument.update_forward_refs()
@@ -364,8 +320,6 @@ ShowMessageParams.update_forward_refs()
 
 ShowQuestionParams.update_forward_refs()
 
-ShowDialogParams.update_forward_refs()
-
 PromptStateParams.update_forward_refs()
 
 WorkingDirectoryParams.update_forward_refs()
@@ -373,7 +327,3 @@ WorkingDirectoryParams.update_forward_refs()
 DebugSleepParams.update_forward_refs()
 
 ExecuteCommandParams.update_forward_refs()
-
-OpenWorkspaceParams.update_forward_refs()
-
-ShowUrlParams.update_forward_refs()

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/ui_comm.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/ui_comm.py
@@ -195,6 +195,12 @@ class UiFrontendEvent(str, enum.Enum):
     # Execute a Positron command
     ExecuteCommand = "execute_command"
 
+    # Open a workspace
+    OpenWorkspace = "open_workspace"
+
+    # Show a URL in Positron's Viewer pane
+    ShowUrl = "show_url"
+
 
 class BusyParams(BaseModel):
     """
@@ -256,6 +262,20 @@ class ShowQuestionParams(BaseModel):
     )
 
 
+class ShowDialogParams(BaseModel):
+    """
+    Show a dialog
+    """
+
+    title: str = Field(
+        description="The title of the dialog",
+    )
+
+    message: str = Field(
+        description="The message to display in the dialog",
+    )
+
+
 class PromptStateParams(BaseModel):
     """
     New state of the primary and secondary prompts
@@ -300,6 +320,30 @@ class ExecuteCommandParams(BaseModel):
     )
 
 
+class OpenWorkspaceParams(BaseModel):
+    """
+    Open a workspace
+    """
+
+    path: str = Field(
+        description="The path for the workspace to be opened",
+    )
+
+    new_window: bool = Field(
+        description="Should the workspace be opened in a new window?",
+    )
+
+
+class ShowUrlParams(BaseModel):
+    """
+    Show a URL in Positron's Viewer pane
+    """
+
+    url: str = Field(
+        description="The URL to display",
+    )
+
+
 EditorContext.update_forward_refs()
 
 TextDocument.update_forward_refs()
@@ -320,6 +364,8 @@ ShowMessageParams.update_forward_refs()
 
 ShowQuestionParams.update_forward_refs()
 
+ShowDialogParams.update_forward_refs()
+
 PromptStateParams.update_forward_refs()
 
 WorkingDirectoryParams.update_forward_refs()
@@ -327,3 +373,7 @@ WorkingDirectoryParams.update_forward_refs()
 DebugSleepParams.update_forward_refs()
 
 ExecuteCommandParams.update_forward_refs()
+
+OpenWorkspaceParams.update_forward_refs()
+
+ShowUrlParams.update_forward_refs()

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -224,7 +224,7 @@
 			],
 			"result": {
 				"schema": {
-					"name": "column_profile_batch",
+					"name": "column_profile_results",
 					"type": "array",
 					"items": {
 						"$ref": "#/components/schemas/column_profile_result"
@@ -542,63 +542,113 @@
 				"description": "Result of computing column profile",
 				"properties": {
 					"null_count": {
-						"type": "integer",
-						"description": "Number of null values in column"
+						"description": "Result from null_count request",
+						"type": "integer"
 					},
+					"summary_stats": {
+						"description": "Results from summary_stats request",
+						"$ref": "#/components/schemas/column_summary_stats"
+					},
+					"histogram": {
+						"description": "Results from summary_stats request",
+						"$ref": "#/components/schemas/column_histogram"
+					},
+					"freqtable": {
+						"description": "Results from freqtable request",
+						"$ref": "#/components/schemas/column_freqtable"
+					}
+				}
+			},
+			"column_summary_stats": {
+				"type": "object",
+				"required": [
+					"min_value",
+					"max_value"
+				],
+				"properties": {
 					"min_value": {
 						"type": "string",
-						"description": "Minimum value as string computed as part of histogram"
+						"description": "Minimum value as string"
 					},
 					"max_value": {
 						"type": "string",
-						"description": "Maximum value as string computed as part of histogram"
+						"description": "Maximum value as string"
 					},
 					"mean_value": {
 						"type": "string",
-						"description": "Average value as string computed as part of histogram"
+						"description": "Average value as string"
 					},
-					"sample_quantiles": {
-						"type": "array",
-						"description": "Quantile values computed from histogram bins",
-						"items": {
-							"$ref": "#/components/schemas/column_quantile_value"
-						}
+					"median": {
+						"type": "string",
+						"description": "Sample median (50% value) value as string"
 					},
-					"histogram_bin_sizes": {
+					"q25": {
+						"type": "string",
+						"description": "25th percentile value as string"
+					},
+					"q75": {
+						"type": "string",
+						"description": "75th percentile value as string"
+					}
+				}
+			},
+			"column_histogram": {
+				"type": "object",
+				"description": "Result from a histogram profile request",
+				"required": [
+					"bin_sizes",
+					"bin_width"
+				],
+				"properties": {
+					"bin_sizes": {
 						"type": "array",
 						"description": "Absolute count of values in each histogram bin",
 						"items": {
 							"type": "integer"
 						}
 					},
-					"histogram_bin_width": {
+					"bin_width": {
 						"type": "number",
 						"description": "Absolute floating-point width of a histogram bin"
-					},
-					"freqtable_counts": {
+					}
+				}
+			},
+			"column_freqtable": {
+				"type": "object",
+				"description": "Result from a freqtable profile request",
+				"required": [
+					"freqtable_counts",
+					"other_count"
+				],
+				"properties": {
+					"counts": {
 						"type": "array",
 						"description": "Counts of distinct values in column",
 						"items": {
-							"type": "object",
-							"required": [
-								"value",
-								"count"
-							],
-							"properties": {
-								"value": {
-									"type": "string",
-									"description": "Stringified value"
-								},
-								"count": {
-									"type": "integer",
-									"description": "Number of occurrences of value"
-								}
-							}
+							"$ref": "#/components/schemas/column_freqtable_item"
 						}
 					},
-					"freqtable_other_count": {
+					"other_count": {
 						"type": "integer",
-						"description": "Number of other values not accounted for in counts"
+						"description": "Number of other values not accounted for in counts. May be 0"
+					}
+				}
+			},
+			"column_freqtable_item": {
+				"type": "object",
+				"description": "Entry in a column's frequency table",
+				"required": [
+					"value",
+					"count"
+				],
+				"properties": {
+					"value": {
+						"type": "string",
+						"description": "Stringified value"
+					},
+					"count": {
+						"type": "integer",
+						"description": "Number of occurrences of value"
 					}
 				}
 			},

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -29,19 +29,56 @@
 			],
 			"result": {
 				"schema": {
+					"$ref": "#/components/schemas/table_schema"
+				}
+			}
+		},
+		{
+			"name": "search_schema",
+			"summary": "Search schema by column name",
+			"description": "Search schema for column names matching a passed substring",
+			"params": [
+				{
+					"name": "search_term",
+					"description": "Substring to match for (currently case insensitive",
+					"required": true,
+					"schema": {
+						"type": "string"
+					}
+				},
+				{
+					"name": "start_index",
+					"description": "Index (starting from zero) of first result to fetch",
+					"required": false,
+					"schema": {
+						"type": "integer"
+					}
+				},
+				{
+					"name": "max_results",
+					"description": "Maximum number of resulting column schemas to fetch from the start index",
+					"required": true,
+					"schema": {
+						"type": "integer"
+					}
+				}
+			],
+			"result": {
+				"schema": {
+					"name": "schema_search_result",
 					"type": "object",
-					"name": "table_schema",
-					"description": "The schema for a table-like object",
 					"required": [
-						"columns"
+						"schema",
+						"total_num_matches"
 					],
 					"properties": {
-						"columns": {
-							"type": "array",
-							"description": "Schema for each column in the table",
-							"items": {
-								"$ref": "#/components/schemas/column_schema"
-							}
+						"matches": {
+							"description": "A schema containing matching columns up to the max_results limit",
+							"$ref": "#/components/schemas/table_schema"
+						},
+						"total_num_matches": {
+							"description": "The total number of columns matching the search term",
+							"type": "integer"
 						}
 					}
 				}
@@ -169,99 +206,28 @@
 			"result": {}
 		},
 		{
-			"name": "get_column_profile",
-			"summary": "Get a column profile",
-			"description": "Requests a statistical summary or data profile for a column",
+			"name": "get_column_profiles",
+			"summary": "Request a batch of column profiles",
+			"description": "Requests a statistical summary or data profile for batch of columns",
 			"params": [
 				{
-					"name": "profile_type",
-					"description": "The type of analytical column profile",
+					"name": "profiles",
+					"description": "Array of requested profiles",
 					"required": true,
 					"schema": {
-						"type": "string",
-						"enum": [
-							"freqtable",
-							"histogram"
-						]
-					}
-				},
-				{
-					"name": "column_index",
-					"description": "Column index to compute profile for",
-					"required": true,
-					"schema": {
-						"type": "integer"
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/column_profile_request"
+						}
 					}
 				}
 			],
 			"result": {
 				"schema": {
-					"type": "object",
-					"name": "profile_result",
-					"description": "Result of computing column profile",
-					"required": [
-						"null_count"
-					],
-					"properties": {
-						"null_count": {
-							"type": "integer",
-							"description": "Number of null values in column"
-						},
-						"min_value": {
-							"type": "string",
-							"description": "Minimum value as string computed as part of histogram"
-						},
-						"max_value": {
-							"type": "string",
-							"description": "Maximum value as string computed as part of histogram"
-						},
-						"mean_value": {
-							"type": "string",
-							"description": "Average value as string computed as part of histogram"
-						},
-						"histogram_bin_sizes": {
-							"type": "array",
-							"description": "Absolute count of values in each histogram bin",
-							"items": {
-								"type": "integer"
-							}
-						},
-						"histogram_bin_width": {
-							"type": "number",
-							"description": "Absolute floating-point width of a histogram bin"
-						},
-						"histogram_quantiles": {
-							"type": "array",
-							"description": "Quantile values computed from histogram bins",
-							"items": {
-								"$ref": "#/components/schemas/column_quantile_value"
-							}
-						},
-						"freqtable_counts": {
-							"type": "array",
-							"description": "Counts of distinct values in column",
-							"items": {
-								"type": "object",
-								"required": [
-									"value",
-									"count"
-								],
-								"properties": {
-									"value": {
-										"type": "string",
-										"description": "Stringified value"
-									},
-									"count": {
-										"type": "integer",
-										"description": "Number of occurrences of value"
-									}
-								}
-							}
-						},
-						"freqtable_other_count": {
-							"type": "integer",
-							"description": "Number of other values not accounted for in counts"
-						}
+					"name": "column_profile_batch",
+					"type": "array",
+					"items": {
+						"$ref": "#/components/schemas/column_profile_result"
 					}
 				}
 			}
@@ -328,6 +294,7 @@
 				"description": "Schema for a column in a table",
 				"required": [
 					"column_name",
+					"column_index",
 					"type_name",
 					"type_display"
 				],
@@ -335,6 +302,10 @@
 					"column_name": {
 						"type": "string",
 						"description": "Name of column as UTF-8 string"
+					},
+					"column_index": {
+						"type": "integer",
+						"description": "The position of the column within the schema"
 					},
 					"type_name": {
 						"type": "string",
@@ -384,6 +355,22 @@
 					}
 				}
 			},
+			"table_schema": {
+				"type": "object",
+				"description": "The schema for a table-like object",
+				"required": [
+					"columns"
+				],
+				"properties": {
+					"columns": {
+						"type": "array",
+						"description": "Schema for each column in the table",
+						"items": {
+							"$ref": "#/components/schemas/column_schema"
+						}
+					}
+				}
+			},
 			"column_filter": {
 				"type": "object",
 				"description": "Specifies a table row filter based on a column's values",
@@ -401,18 +388,64 @@
 						"type": "string",
 						"description": "Type of filter to apply",
 						"enum": [
-							"isnull",
-							"notnull",
+							"between",
 							"compare",
-							"set_membership",
-							"search"
+							"isnull",
+							"not_between",
+							"notnull",
+							"search",
+							"set_membership"
 						]
 					},
 					"column_index": {
 						"type": "integer",
 						"description": "Column index to apply filter to"
 					},
-					"compare_op": {
+					"between_params": {
+						"description": "Parameters for the 'between' and 'not_between' filter types",
+						"$ref": "#/components/schemas/between_filter_params"
+					},
+					"compare_params": {
+						"description": "Parameters for the 'compare' filter type",
+						"$ref": "#/components/schemas/compare_filter_params"
+					},
+					"search_params": {
+						"description": "Parameters for the 'search' filter type",
+						"$ref": "#/components/schemas/search_filter_params"
+					},
+					"set_membership_params": {
+						"description": "Parameters for the 'set_membership' filter type",
+						"$ref": "#/components/schemas/set_membership_filter_params"
+					}
+				}
+			},
+			"between_filter_params": {
+				"type": "object",
+				"description": "Parameters for the 'between' and 'not_between' filter types",
+				"required": [
+					"left_value",
+					"right_value"
+				],
+				"properties": {
+					"left_value": {
+						"type": "string",
+						"description": "The lower limit for filtering"
+					},
+					"right_value": {
+						"type": "string",
+						"description": "The upper limit for filtering"
+					}
+				}
+			},
+			"compare_filter_params": {
+				"type": "object",
+				"description": "Parameters for the 'compare' filter type",
+				"required": [
+					"op",
+					"value"
+				],
+				"properties": {
+					"op": {
 						"type": "string",
 						"description": "String representation of a binary comparison",
 						"enum": [
@@ -424,22 +457,43 @@
 							">="
 						]
 					},
-					"compare_value": {
+					"value": {
 						"type": "string",
 						"description": "A stringified column value for a comparison filter"
-					},
-					"set_member_values": {
+					}
+				}
+			},
+			"set_membership_filter_params": {
+				"type": "object",
+				"description": "Parameters for the 'set_membership' filter type",
+				"required": [
+					"values",
+					"inclusive"
+				],
+				"properties": {
+					"values": {
 						"type": "array",
 						"description": "Array of column values for a set membership filter",
 						"items": {
 							"type": "string"
 						}
 					},
-					"set_member_inclusive": {
+					"inclusive": {
 						"type": "boolean",
 						"description": "Filter by including only values passed (true) or excluding (false)"
-					},
-					"search_type": {
+					}
+				}
+			},
+			"search_filter_params": {
+				"type": "object",
+				"description": "Parameters for the 'search' filter type",
+				"required": [
+					"type",
+					"term",
+					"case_sensitive"
+				],
+				"properties": {
+					"type": {
 						"type": "string",
 						"description": "Type of search to perform",
 						"enum": [
@@ -449,13 +503,102 @@
 							"regex"
 						]
 					},
-					"search_term": {
+					"term": {
 						"type": "string",
 						"description": "String value/regex to search for in stringified data"
 					},
-					"search_case_sensitive": {
+					"case_sensitive": {
 						"type": "boolean",
 						"description": "If true, do a case-sensitive search, otherwise case-insensitive"
+					}
+				}
+			},
+			"column_profile_request": {
+				"type": "object",
+				"description": "A single column profile request",
+				"required": [
+					"column_index",
+					"type"
+				],
+				"properties": {
+					"column_index": {
+						"type": "integer",
+						"description": "The ordinal column index to profile"
+					},
+					"type": {
+						"type": "string",
+						"description": "The type of analytical column profile",
+						"enum": [
+							"null_count",
+							"summary_stats",
+							"freqtable",
+							"histogram"
+						]
+					}
+				}
+			},
+			"column_profile_result": {
+				"type": "object",
+				"description": "Result of computing column profile",
+				"properties": {
+					"null_count": {
+						"type": "integer",
+						"description": "Number of null values in column"
+					},
+					"min_value": {
+						"type": "string",
+						"description": "Minimum value as string computed as part of histogram"
+					},
+					"max_value": {
+						"type": "string",
+						"description": "Maximum value as string computed as part of histogram"
+					},
+					"mean_value": {
+						"type": "string",
+						"description": "Average value as string computed as part of histogram"
+					},
+					"sample_quantiles": {
+						"type": "array",
+						"description": "Quantile values computed from histogram bins",
+						"items": {
+							"$ref": "#/components/schemas/column_quantile_value"
+						}
+					},
+					"histogram_bin_sizes": {
+						"type": "array",
+						"description": "Absolute count of values in each histogram bin",
+						"items": {
+							"type": "integer"
+						}
+					},
+					"histogram_bin_width": {
+						"type": "number",
+						"description": "Absolute floating-point width of a histogram bin"
+					},
+					"freqtable_counts": {
+						"type": "array",
+						"description": "Counts of distinct values in column",
+						"items": {
+							"type": "object",
+							"required": [
+								"value",
+								"count"
+							],
+							"properties": {
+								"value": {
+									"type": "string",
+									"description": "Stringified value"
+								},
+								"count": {
+									"type": "integer",
+									"description": "Number of occurrences of value"
+								}
+							}
+						}
+					},
+					"freqtable_other_count": {
+						"type": "integer",
+						"description": "Number of other values not accounted for in counts"
 					}
 				}
 			},

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -40,7 +40,7 @@
 			"params": [
 				{
 					"name": "search_term",
-					"description": "Substring to match for (currently case insensitive",
+					"description": "Substring to match for (currently case insensitive)",
 					"required": true,
 					"schema": {
 						"type": "string"

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -65,7 +65,7 @@
 			],
 			"result": {
 				"schema": {
-					"name": "schema_search_result",
+					"name": "search_schema_result",
 					"type": "object",
 					"required": [
 						"schema",
@@ -390,9 +390,9 @@
 						"enum": [
 							"between",
 							"compare",
-							"isnull",
+							"is_null",
 							"not_between",
-							"notnull",
+							"not_null",
 							"search",
 							"set_membership"
 						]
@@ -531,7 +531,7 @@
 						"enum": [
 							"null_count",
 							"summary_stats",
-							"freqtable",
+							"frequency_table",
 							"histogram"
 						]
 					}
@@ -553,9 +553,9 @@
 						"description": "Results from summary_stats request",
 						"$ref": "#/components/schemas/column_histogram"
 					},
-					"freqtable": {
-						"description": "Results from freqtable request",
-						"$ref": "#/components/schemas/column_freqtable"
+					"frequency_table": {
+						"description": "Results from frequency_table request",
+						"$ref": "#/components/schemas/column_frequency_table"
 					}
 				}
 			},
@@ -613,11 +613,11 @@
 					}
 				}
 			},
-			"column_freqtable": {
+			"column_frequency_table": {
 				"type": "object",
-				"description": "Result from a freqtable profile request",
+				"description": "Result from a frequency_table profile request",
 				"required": [
-					"freqtable_counts",
+					"counts",
 					"other_count"
 				],
 				"properties": {
@@ -625,7 +625,7 @@
 						"type": "array",
 						"description": "Counts of distinct values in column",
 						"items": {
-							"$ref": "#/components/schemas/column_freqtable_item"
+							"$ref": "#/components/schemas/column_frequency_table_item"
 						}
 					},
 					"other_count": {
@@ -634,7 +634,7 @@
 					}
 				}
 			},
-			"column_freqtable_item": {
+			"column_frequency_table_item": {
 				"type": "object",
 				"description": "Entry in a column's frequency table",
 				"required": [

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -153,9 +153,9 @@
 			}
 		},
 		{
-			"name": "set_column_filters",
-			"summary": "Set column filters",
-			"description": "Set or clear column filters on table, replacing any previous filters",
+			"name": "set_row_filters",
+			"summary": "Set row filters based on column values",
+			"description": "Set or clear row filters on table, replacing any previous filters",
 			"params": [
 				{
 					"name": "filters",
@@ -164,7 +164,7 @@
 					"schema": {
 						"type": "array",
 						"items": {
-							"$ref": "#/components/schemas/column_filter"
+							"$ref": "#/components/schemas/row_filter"
 						}
 					}
 				}
@@ -267,11 +267,11 @@
 								}
 							}
 						},
-						"filters": {
+						"row_filters": {
 							"type": "array",
-							"description": "The set of currently applied filters",
+							"description": "The set of currently applied row filters",
 							"items": {
-								"$ref": "#/components/schemas/column_filter"
+								"$ref": "#/components/schemas/row_filter"
 							}
 						},
 						"sort_keys": {
@@ -371,9 +371,9 @@
 					}
 				}
 			},
-			"column_filter": {
+			"row_filter": {
 				"type": "object",
-				"description": "Specifies a table row filter based on a column's values",
+				"description": "Specifies a table row filter based on a single column's values",
 				"required": [
 					"filter_id",
 					"filter_type",

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -498,9 +498,9 @@
 						"description": "Type of search to perform",
 						"enum": [
 							"contains",
-							"startswith",
-							"endswith",
-							"regex"
+							"starts_with",
+							"ends_with",
+							"regex_match"
 						]
 					},
 					"term": {

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -6,7 +6,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { generateUuid } from 'vs/base/common/uuid';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
-import { ColumnSchema, ColumnSortKey, PositronDataExplorerComm, SchemaUpdateEvent, TableData, TableSchema, TableState } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { ColumnProfileRequest, ColumnProfileResult, ColumnSchema, ColumnSortKey, PositronDataExplorerComm, SchemaUpdateEvent, TableData, TableSchema, TableState } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * TableSchemaSearchResult interface. This is here temporarily until searching the tabe schema
@@ -161,6 +161,17 @@ export class DataExplorerClientInstance extends Disposable {
 		columnIndices: Array<number>
 	): Promise<TableData> {
 		return this._positronDataExplorerComm.getDataValues(rowStartIndex, numRows, columnIndices);
+	}
+
+	/**
+	 * Request a batch of column profiles
+	 * @param profiles An array of profile types and colum indexes
+	 * @returns A Promise<Array<ColumnProfileResult>> that resolves when the operation is complete.
+	 */
+	async getColumnProfiles(
+		profiles: Array<ColumnProfileRequest>
+	): Promise<Array<ColumnProfileResult>> {
+		return this._positronDataExplorerComm.getColumnProfiles(profiles);
 	}
 
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -13,7 +13,7 @@ import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/co
 /**
  * Result in Methods
  */
-export interface SchemaSearchResult {
+export interface SearchSchemaResult {
 	/**
 	 * A schema containing matching columns up to the max_results limit
 	 */
@@ -303,9 +303,9 @@ export interface ColumnProfileResult {
 	histogram?: ColumnHistogram;
 
 	/**
-	 * Results from freqtable request
+	 * Results from frequency_table request
 	 */
-	freqtable?: ColumnFreqtable;
+	frequency_table?: ColumnFrequencyTable;
 
 }
 
@@ -362,13 +362,13 @@ export interface ColumnHistogram {
 }
 
 /**
- * Result from a freqtable profile request
+ * Result from a frequency_table profile request
  */
-export interface ColumnFreqtable {
+export interface ColumnFrequencyTable {
 	/**
 	 * Counts of distinct values in column
 	 */
-	counts?: Array<ColumnFreqtableItem>;
+	counts: Array<ColumnFrequencyTableItem>;
 
 	/**
 	 * Number of other values not accounted for in counts. May be 0
@@ -380,7 +380,7 @@ export interface ColumnFreqtable {
 /**
  * Entry in a column's frequency table
  */
-export interface ColumnFreqtableItem {
+export interface ColumnFrequencyTableItem {
 	/**
 	 * Stringified value
 	 */
@@ -452,9 +452,9 @@ export enum ColumnSchemaTypeDisplay {
 export enum ColumnFilterFilterType {
 	Between = 'between',
 	Compare = 'compare',
-	Isnull = 'isnull',
+	IsNull = 'is_null',
 	NotBetween = 'not_between',
-	Notnull = 'notnull',
+	NotNull = 'not_null',
 	Search = 'search',
 	SetMembership = 'set_membership'
 }
@@ -487,7 +487,7 @@ export enum SearchFilterParamsType {
 export enum ColumnProfileRequestType {
 	NullCount = 'null_count',
 	SummaryStats = 'summary_stats',
-	Freqtable = 'freqtable',
+	FrequencyTable = 'frequency_table',
 	Histogram = 'histogram'
 }
 
@@ -547,7 +547,7 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 *
 	 * @returns undefined
 	 */
-	searchSchema(searchTerm: string, startIndex: number, maxResults: number): Promise<SchemaSearchResult> {
+	searchSchema(searchTerm: string, startIndex: number, maxResults: number): Promise<SearchSchemaResult> {
 		return super.performRpc('search_schema', ['search_term', 'start_index', 'max_results'], [searchTerm, startIndex, maxResults]);
 	}
 

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -288,56 +288,99 @@ export interface ColumnProfileRequest {
  */
 export interface ColumnProfileResult {
 	/**
-	 * Number of null values in column
+	 * Result from null_count request
 	 */
 	null_count?: number;
 
 	/**
-	 * Minimum value as string computed as part of histogram
+	 * Results from summary_stats request
 	 */
-	min_value?: string;
+	summary_stats?: ColumnSummaryStats;
 
 	/**
-	 * Maximum value as string computed as part of histogram
+	 * Results from summary_stats request
 	 */
-	max_value?: string;
+	histogram?: ColumnHistogram;
 
 	/**
-	 * Average value as string computed as part of histogram
+	 * Results from freqtable request
 	 */
-	mean_value?: string;
-
-	/**
-	 * Quantile values computed from histogram bins
-	 */
-	sample_quantiles?: Array<ColumnQuantileValue>;
-
-	/**
-	 * Absolute count of values in each histogram bin
-	 */
-	histogram_bin_sizes?: Array<number>;
-
-	/**
-	 * Absolute floating-point width of a histogram bin
-	 */
-	histogram_bin_width?: number;
-
-	/**
-	 * Counts of distinct values in column
-	 */
-	freqtable_counts?: Array<FreqtableCounts>;
-
-	/**
-	 * Number of other values not accounted for in counts
-	 */
-	freqtable_other_count?: number;
+	freqtable?: ColumnFreqtable;
 
 }
 
 /**
- * Items in FreqtableCounts
+ * ColumnSummaryStats in Schemas
  */
-export interface FreqtableCounts {
+export interface ColumnSummaryStats {
+	/**
+	 * Minimum value as string
+	 */
+	min_value: string;
+
+	/**
+	 * Maximum value as string
+	 */
+	max_value: string;
+
+	/**
+	 * Average value as string
+	 */
+	mean_value?: string;
+
+	/**
+	 * Sample median (50% value) value as string
+	 */
+	median?: string;
+
+	/**
+	 * 25th percentile value as string
+	 */
+	q25?: string;
+
+	/**
+	 * 75th percentile value as string
+	 */
+	q75?: string;
+
+}
+
+/**
+ * Result from a histogram profile request
+ */
+export interface ColumnHistogram {
+	/**
+	 * Absolute count of values in each histogram bin
+	 */
+	bin_sizes: Array<number>;
+
+	/**
+	 * Absolute floating-point width of a histogram bin
+	 */
+	bin_width: number;
+
+}
+
+/**
+ * Result from a freqtable profile request
+ */
+export interface ColumnFreqtable {
+	/**
+	 * Counts of distinct values in column
+	 */
+	counts?: Array<ColumnFreqtableItem>;
+
+	/**
+	 * Number of other values not accounted for in counts. May be 0
+	 */
+	other_count: number;
+
+}
+
+/**
+ * Entry in a column's frequency table
+ */
+export interface ColumnFreqtableItem {
 	/**
 	 * Stringified value
 	 */

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -63,9 +63,9 @@ export interface TableState {
 	table_shape: TableShape;
 
 	/**
-	 * The set of currently applied filters
+	 * The set of currently applied row filters
 	 */
-	filters: Array<ColumnFilter>;
+	row_filters?: Array<RowFilter>;
 
 	/**
 	 * The set of currently applied sorts
@@ -158,9 +158,9 @@ export interface TableSchema {
 }
 
 /**
- * Specifies a table row filter based on a column's values
+ * Specifies a table row filter based on a single column's values
  */
-export interface ColumnFilter {
+export interface RowFilter {
 	/**
 	 * Unique identifier for this filter
 	 */
@@ -169,7 +169,7 @@ export interface ColumnFilter {
 	/**
 	 * Type of filter to apply
 	 */
-	filter_type: ColumnFilterFilterType;
+	filter_type: RowFilterFilterType;
 
 	/**
 	 * Column index to apply filter to
@@ -447,9 +447,9 @@ export enum ColumnSchemaTypeDisplay {
 }
 
 /**
- * Possible values for FilterType in ColumnFilter
+ * Possible values for FilterType in RowFilter
  */
-export enum ColumnFilterFilterType {
+export enum RowFilterFilterType {
 	Between = 'between',
 	Compare = 'compare',
 	IsNull = 'is_null',
@@ -569,16 +569,16 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	}
 
 	/**
-	 * Set column filters
+	 * Set row filters based on column values
 	 *
-	 * Set or clear column filters on table, replacing any previous filters
+	 * Set or clear row filters on table, replacing any previous filters
 	 *
 	 * @param filters Zero or more filters to apply
 	 *
 	 * @returns The result of applying filters to a table
 	 */
-	setColumnFilters(filters: Array<ColumnFilter>): Promise<FilterResult> {
-		return super.performRpc('set_column_filters', ['filters'], [filters]);
+	setRowFilters(filters: Array<RowFilter>): Promise<FilterResult> {
+		return super.performRpc('set_row_filters', ['filters'], [filters]);
 	}
 
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -476,9 +476,9 @@ export enum CompareFilterParamsOp {
  */
 export enum SearchFilterParamsType {
 	Contains = 'contains',
-	Startswith = 'startswith',
-	Endswith = 'endswith',
-	Regex = 'regex'
+	StartsWith = 'starts_with',
+	EndsWith = 'ends_with',
+	RegexMatch = 'regex_match'
 }
 
 /**

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -140,7 +140,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 					{props.columnSchema.column_name}
 				</div>
 				<div className='missing-values'>
-					29%
+					{props.instance.getColumnNullPercent(props.columnIndex)}%
 				</div>
 
 			</div>

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -223,6 +223,13 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		);
 	}
 
+	getColumnNullPercent(columnIndex: number): number | undefined {
+		const nullCount = this._dataExplorerCache.getColumnNullCount(columnIndex);
+		// TODO: Is floor what we want?
+		return nullCount === undefined ? undefined : Math.floor(
+			nullCount * 100 / this._dataExplorerCache.rows);
+	}
+
 	//#endregion DataGridInstance Methods
 
 	//#region Public Events

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
@@ -5,9 +5,9 @@
 import { generateUuid } from 'vs/base/common/uuid';
 import {
 	ColumnFilter,
-	ColumnFilterCompareOp,
+	CompareFilterParamsOp,
 	ColumnFilterFilterType,
-	ColumnFilterSearchType,
+	SearchFilterParamsType,
 	ColumnSchema,
 	ColumnProfileResult,
 	TableData,
@@ -129,12 +129,10 @@ function _getFilterWithProps(columnIndex: number, filterType: ColumnFilterFilter
 	} as ColumnFilter;
 }
 
-export function getCompareFilter(columnIndex: number, op: ColumnFilterCompareOp,
+export function getCompareFilter(columnIndex: number, op: CompareFilterParamsOp,
 	value: string) {
-	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.Compare, {
-		compare_op: op,
-		compare_value: value
-	});
+	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.Compare,
+		{ compare_params: { op, value } });
 }
 
 export function getIsNullFilter(columnIndex: number) {
@@ -147,16 +145,13 @@ export function getNotNullFilter(columnIndex: number) {
 
 export function getSetMemberFilter(columnIndex: number, values: string[], inclusive: boolean) {
 	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.SetMembership, {
-		set_member_values: values,
-		set_member_inclusive: inclusive
+		set_membership_params: { values, inclusive }
 	});
 }
 
 export function getTextSearchFilter(columnIndex: number, searchTerm: string,
-	searchType: ColumnFilterSearchType, caseSensitive: boolean) {
+	searchType: SearchFilterParamsType, caseSensitive: boolean) {
 	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.Search, {
-		search_term: searchTerm,
-		search_type: searchType,
-		search_case_sensitive: caseSensitive
+		search_params: { term: searchTerm, type: searchType, case_sensitive: caseSensitive }
 	});
 }

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
@@ -9,7 +9,7 @@ import {
 	ColumnFilterFilterType,
 	ColumnFilterSearchType,
 	ColumnSchema,
-	ProfileResult,
+	ColumnProfileResult,
 	TableData,
 	TableSchema
 } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
@@ -87,7 +87,7 @@ export function getColumnSchema(colName: string, typeName: string, typeDisplay: 
 	} as ColumnSchema;
 }
 
-export function getExampleHistogram(): ProfileResult {
+export function getExampleHistogram(): ColumnProfileResult {
 	// This example is basically made up.
 	return {
 		null_count: 10,
@@ -101,10 +101,10 @@ export function getExampleHistogram(): ProfileResult {
 			{ q: 50, value: '70', exact: true },
 			{ q: 75, value: '82', exact: true }
 		],
-	} as ProfileResult;
+	} as ColumnProfileResult;
 }
 
-export function getExampleFreqtable(): ProfileResult {
+export function getExampleFreqtable(): ColumnProfileResult {
 	return {
 		null_count: 10,
 		freqtable_counts: [
@@ -114,7 +114,7 @@ export function getExampleFreqtable(): ProfileResult {
 			{ value: 'qux444444', count: 2 }
 		],
 		freqtable_other_count: 12
-	} as ProfileResult;
+	} as ColumnProfileResult;
 }
 
 // For filtering

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
@@ -4,12 +4,12 @@
 
 import { generateUuid } from 'vs/base/common/uuid';
 import {
-	ColumnFilter,
 	CompareFilterParamsOp,
-	ColumnFilterFilterType,
 	SearchFilterParamsType,
 	ColumnSchema,
 	ColumnProfileResult,
+	RowFilter,
+	RowFilterFilterType,
 	TableData,
 	TableSchema
 } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
@@ -119,39 +119,39 @@ export function getExampleFreqtable(): ColumnProfileResult {
 
 // For filtering
 
-function _getFilterWithProps(columnIndex: number, filterType: ColumnFilterFilterType,
-	props: Partial<ColumnFilter> = {}): ColumnFilter {
+function _getFilterWithProps(columnIndex: number, filterType: RowFilterFilterType,
+	props: Partial<RowFilter> = {}): RowFilter {
 	return {
 		filter_id: generateUuid(),
 		filter_type: filterType,
 		column_index: columnIndex,
 		...props
-	} as ColumnFilter;
+	} as RowFilter;
 }
 
 export function getCompareFilter(columnIndex: number, op: CompareFilterParamsOp,
 	value: string) {
-	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.Compare,
+	return _getFilterWithProps(columnIndex, RowFilterFilterType.Compare,
 		{ compare_params: { op, value } });
 }
 
 export function getIsNullFilter(columnIndex: number) {
-	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.IsNull);
+	return _getFilterWithProps(columnIndex, RowFilterFilterType.IsNull);
 }
 
 export function getNotNullFilter(columnIndex: number) {
-	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.NotNull);
+	return _getFilterWithProps(columnIndex, RowFilterFilterType.NotNull);
 }
 
 export function getSetMemberFilter(columnIndex: number, values: string[], inclusive: boolean) {
-	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.SetMembership, {
+	return _getFilterWithProps(columnIndex, RowFilterFilterType.SetMembership, {
 		set_membership_params: { values, inclusive }
 	});
 }
 
 export function getTextSearchFilter(columnIndex: number, searchTerm: string,
 	searchType: SearchFilterParamsType, caseSensitive: boolean) {
-	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.Search, {
+	return _getFilterWithProps(columnIndex, RowFilterFilterType.Search, {
 		search_params: { term: searchTerm, type: searchType, case_sensitive: caseSensitive }
 	});
 }

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
@@ -136,11 +136,11 @@ export function getCompareFilter(columnIndex: number, op: CompareFilterParamsOp,
 }
 
 export function getIsNullFilter(columnIndex: number) {
-	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.Isnull);
+	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.IsNull);
 }
 
 export function getNotNullFilter(columnIndex: number) {
-	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.Notnull);
+	return _getFilterWithProps(columnIndex, ColumnFilterFilterType.NotNull);
 }
 
 export function getSetMemberFilter(columnIndex: number, values: string[], inclusive: boolean) {

--- a/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
@@ -5,9 +5,9 @@
 import * as assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import {
-	ColumnFilterCompareOp,
+	CompareFilterParamsOp,
 	ColumnFilterFilterType,
-	ColumnFilterSearchType
+	SearchFilterParamsType
 } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import * as mocks from "vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks";
 
@@ -39,11 +39,14 @@ suite('DataExplorerMocks', () => {
 	});
 
 	test('Test getCompareFilter', () => {
-		const filter = mocks.getCompareFilter(2, ColumnFilterCompareOp.Gt, '1234');
+		const filter = mocks.getCompareFilter(2, CompareFilterParamsOp.Gt, '1234');
 		assert.equal(filter.filter_type, ColumnFilterFilterType.Compare);
 		assert.equal(filter.column_index, 2);
-		assert.equal(filter.compare_op, ColumnFilterCompareOp.Gt);
-		assert.equal(filter.compare_value, '1234');
+
+		const params = filter.compare_params!;
+
+		assert.equal(params.op, CompareFilterParamsOp.Gt);
+		assert.equal(params.value, '1234');
 	});
 
 	test('Test getIsNullFilter', () => {
@@ -57,12 +60,15 @@ suite('DataExplorerMocks', () => {
 
 	test('Test getTextSearchFilter', () => {
 		const filter = mocks.getTextSearchFilter(5, 'needle',
-			ColumnFilterSearchType.Contains, false);
+			SearchFilterParamsType.Contains, false);
 		assert.equal(filter.column_index, 5);
 		assert.equal(filter.filter_type, ColumnFilterFilterType.Search);
-		assert.equal(filter.search_term, 'needle');
-		assert.equal(filter.search_type, ColumnFilterSearchType.Contains);
-		assert.equal(filter.search_case_sensitive, false);
+
+		const params = filter.search_params!;
+
+		assert.equal(params.term, 'needle');
+		assert.equal(params.type, SearchFilterParamsType.Contains);
+		assert.equal(params.case_sensitive, false);
 	});
 
 	test('Test getSetMemberFilter', () => {
@@ -70,8 +76,11 @@ suite('DataExplorerMocks', () => {
 		const filter = mocks.getSetMemberFilter(6, set_values, true);
 		assert.equal(filter.column_index, 6);
 		assert.equal(filter.filter_type, ColumnFilterFilterType.SetMembership);
-		assert.equal(filter.set_member_values, set_values);
-		assert.equal(filter.set_member_inclusive, true);
+
+		const params = filter.set_membership_params!;
+
+		assert.equal(params.values, set_values);
+		assert.equal(params.inclusive, true);
 	});
 
 });

--- a/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
@@ -52,10 +52,10 @@ suite('DataExplorerMocks', () => {
 	test('Test getIsNullFilter', () => {
 		let filter = mocks.getIsNullFilter(3);
 		assert.equal(filter.column_index, 3);
-		assert.equal(filter.filter_type, ColumnFilterFilterType.Isnull);
+		assert.equal(filter.filter_type, ColumnFilterFilterType.IsNull);
 
 		filter = mocks.getNotNullFilter(3);
-		assert.equal(filter.filter_type, ColumnFilterFilterType.Notnull);
+		assert.equal(filter.filter_type, ColumnFilterFilterType.NotNull);
 	});
 
 	test('Test getTextSearchFilter', () => {

--- a/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
@@ -6,7 +6,7 @@ import * as assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import {
 	CompareFilterParamsOp,
-	ColumnFilterFilterType,
+	RowFilterFilterType,
 	SearchFilterParamsType
 } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import * as mocks from "vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks";
@@ -40,7 +40,7 @@ suite('DataExplorerMocks', () => {
 
 	test('Test getCompareFilter', () => {
 		const filter = mocks.getCompareFilter(2, CompareFilterParamsOp.Gt, '1234');
-		assert.equal(filter.filter_type, ColumnFilterFilterType.Compare);
+		assert.equal(filter.filter_type, RowFilterFilterType.Compare);
 		assert.equal(filter.column_index, 2);
 
 		const params = filter.compare_params!;
@@ -52,17 +52,17 @@ suite('DataExplorerMocks', () => {
 	test('Test getIsNullFilter', () => {
 		let filter = mocks.getIsNullFilter(3);
 		assert.equal(filter.column_index, 3);
-		assert.equal(filter.filter_type, ColumnFilterFilterType.IsNull);
+		assert.equal(filter.filter_type, RowFilterFilterType.IsNull);
 
 		filter = mocks.getNotNullFilter(3);
-		assert.equal(filter.filter_type, ColumnFilterFilterType.NotNull);
+		assert.equal(filter.filter_type, RowFilterFilterType.NotNull);
 	});
 
 	test('Test getTextSearchFilter', () => {
 		const filter = mocks.getTextSearchFilter(5, 'needle',
 			SearchFilterParamsType.Contains, false);
 		assert.equal(filter.column_index, 5);
-		assert.equal(filter.filter_type, ColumnFilterFilterType.Search);
+		assert.equal(filter.filter_type, RowFilterFilterType.Search);
 
 		const params = filter.search_params!;
 
@@ -75,7 +75,7 @@ suite('DataExplorerMocks', () => {
 		const set_values = ['need1', 'need2'];
 		const filter = mocks.getSetMemberFilter(6, set_values, true);
 		assert.equal(filter.column_index, 6);
-		assert.equal(filter.filter_type, ColumnFilterFilterType.SetMembership);
+		assert.equal(filter.filter_type, RowFilterFilterType.SetMembership);
 
 		const params = filter.set_membership_params!;
 


### PR DESCRIPTION
This PR has a batch of improvements to try to catch up with the UI's current state so we can start hooking up filtering for real:

* Modifies filter API and get_column_profiles APIs to group parameters in optional interfaces, e.g. `BetweenFilterParams`, `SetMembershipFilterParams`
* Adds search_schema RPC to support column dropdown searching large schemas
* Changes column profile requests to be batch based, so we can request a batch of column null counts all at once
* Renames "set_column_filters" RPC to "set_row_filters" to normalize terminology since we will eventually have "column filters" (e.g. column names starting with "foo") that hide a subset of the columns from view
* Adds summary_stats profile type to provide detailed column summary statistics when needed in the UI
* Adds and implements "between" and "not_between" filter types in Python
* Basic implementation of case-sensitive and case-insensitive text searching (contains/startswith/endswith/regex_match) in Python
* Hooks up basic null percentages into the current summary pane. This code can surely be improved

The focus of the next week will be hooking all this up with the recently-built filtering UI and making sure it works properly.