### PR TITLE
Bugfix/plot crop

### DIFF
--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/plots.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/plots.py
@@ -98,12 +98,10 @@ class PositronDisplayPublisherHook:
             pixel_ratio = request.params.pixel_ratio or 1.0
 
             if width_px != 0 and height_px != 0:
-                format_dict, md_dict = self._resize_pickled_figure(
-                    pickled, width_px, height_px, pixel_ratio
-                )
+                format_dict = self._resize_pickled_figure(pickled, width_px, height_px, pixel_ratio)
                 data = format_dict["image/png"]
                 output = PlotResult(data=data, mime_type="image/png").dict()
-                figure_comm.send_result(data=output, metadata=md_dict)
+                figure_comm.send_result(data=output, metadata={"mime_type": "image/png"})
 
         else:
             logger.warning(f"Unhandled request: {request}")
@@ -213,7 +211,7 @@ class PositronDisplayPublisherHook:
 
         if was_interactive:
             plt.ion()
-        return (format_dict, {})
+        return format_dict
 
     def _is_figure_empty(self, figure):
         children = figure.get_children()

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/plots.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/plots.py
@@ -11,7 +11,6 @@ import uuid
 from typing import Dict, List, Optional, Tuple
 
 import comm
-from IPython.core.formatters import format_display_data
 
 from .plot_comm import PlotBackendMessageContent, PlotResult, RenderRequest
 from .positron_comm import CommMessage, JsonRpcErrorCode, PositronComm
@@ -157,7 +156,7 @@ class PositronDisplayPublisherHook:
         new_height_px: int = 460,
         pixel_ratio: float = 1.0,
         formats: list = ["image/png"],
-    ) -> Tuple[dict, dict]:
+    ) -> dict:
         # Delay importing matplotlib until the kernel and shell has been
         # initialized otherwise the graphics backend will be reset to the gui
         import matplotlib.pyplot as plt
@@ -201,7 +200,7 @@ class PositronDisplayPublisherHook:
 
         # Render the figure to a buffer
         # using format_display_data() crops the figure to smaller than requested size
-        figure.savefig(figure_buffer, format="png", dpi=dpi)
+        figure.savefig(figure_buffer, format="png")
         figure_buffer.seek(0)
         image_data = base64.b64encode(figure_buffer.read()).decode()
 

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/plots.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/plots.py
@@ -8,7 +8,7 @@ import io
 import logging
 import pickle
 import uuid
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import comm
 

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_plots.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_plots.py
@@ -2,7 +2,9 @@
 # Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
 #
 
+import base64
 import codecs
+import io
 import pickle
 from pathlib import Path
 from typing import Iterable, cast
@@ -204,16 +206,20 @@ def test_hook_render(figure_comm: DummyComm, images_path: Path) -> None:
     width_in = width_px / BASE_DPI
     height_in = height_px / BASE_DPI
 
+    fig_buffer = io.BytesIO()
     fig_ref = cast(Figure, plt.figure())
     fig_axes = cast(Axes, fig_ref.subplots())
     fig_axes.plot([1, 2])
     fig_ref.set_dpi(dpi)
     fig_ref.set_size_inches(width_in, height_in)
+    fig_ref.set_layout_engine("tight")
 
     # Serialize the reference figure as a base64-encoded image
-    data_ref, _ = format_display_data(fig_ref, include=["image/png"], exclude=[])  # type: ignore
+    # data_ref, _ = format_display_data(fig_ref, include=["image/png"], exclude=[])  # type: ignore
+    fig_ref.savefig(fig_buffer, format="png", dpi=dpi)
+    fig_buffer.seek(0)
     expected = images_path / "test-hook-render-expected.png"
-    _save_base64_image(data_ref["image/png"], expected)
+    _save_base64_image(base64.b64encode(fig_buffer.read()).decode(), expected)
 
     # Compare the actual vs expected figures
     err = compare_images(str(actual), str(expected), tol=0)

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_plots.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_plots.py
@@ -12,7 +12,7 @@ from typing import Iterable, cast
 import matplotlib
 import matplotlib.pyplot as plt
 import pytest
-from IPython.core.formatters import DisplayFormatter, format_display_data
+from IPython.core.formatters import DisplayFormatter
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from matplotlib.testing.compare import compare_images

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_plots.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_plots.py
@@ -189,7 +189,7 @@ def test_hook_render(figure_comm: DummyComm, images_path: Path) -> None:
     reply = figure_comm.messages[0]
     assert reply["msg_type"] == "comm_msg"
     assert reply["buffers"] is None
-    assert reply["metadata"] == {}
+    assert reply["metadata"] == {"mime_type": "image/png"}
 
     # Check that the reply data is an `image` message
     image_msg = reply["data"]

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_plots.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_plots.py
@@ -215,8 +215,7 @@ def test_hook_render(figure_comm: DummyComm, images_path: Path) -> None:
     fig_ref.set_layout_engine("tight")
 
     # Serialize the reference figure as a base64-encoded image
-    # data_ref, _ = format_display_data(fig_ref, include=["image/png"], exclude=[])  # type: ignore
-    fig_ref.savefig(fig_buffer, format="png", dpi=dpi)
+    fig_ref.savefig(fig_buffer, format="png")
     fig_buffer.seek(0)
     expected = images_path / "test-hook-render-expected.png"
     _save_base64_image(base64.b64encode(fig_buffer.read()).decode(), expected)


### PR DESCRIPTION
### Intent
Address https://github.com/posit-dev/positron/issues/502
Original PR: github.com/posit-dev/positron-python/pull/432

### Approach
The plot is requested with a size that will fill the plot pane. The resulting image was cropped and being displayed at 100% scale so it doesn't fill the pane. Calling format_display_figure was setting options that results in a cropped image.

Rendering the figure to a buffer and base64 encoding it is doing the same as format_display_figure but doesn't seem to crop the image. I don't know why it gets cropped or which option that causes it.

Another issue was setting BASE_DPI to 96 (100 is the matplotlib default) that caused a slight change in the resulting image size. Using 96dpi would convert a requested image size of 100x100 to 96x96@96dpi. I think this is a result of how matplotlib requires the image to be set in inches. We convert the resolution into inches but also changed the DPI. Since we are setting a lower DPI, there are less pixels per inch (aka DPI) and the image is smaller than requested.

### QA Notes
This can be reproduced with a dynamic plot using code like this:
```python
import numpy as np
import matplotlib.pyplot as plt

v = np.arange(365, 0, -1)

fig, ax = plt.subplots()
ax.set_xlabel('Day of the year')
ax.set_ylabel('Days until New Year\'s Eve')

plt.xlim(0, 365)
plt.ylim(1, 365)

plt.plot(v)
```

Switching the sizing to `Fill` should fill the Plot pane image area (minus space at the top of the image reserved for the progress bar; about 2 pixels).

The current issue looks like this:
![image](https://github.com/posit-dev/positron/assets/9591545/93dcc131-2392-46c7-83af-8079131a104e)

When rendered with the fix:
![image](https://github.com/posit-dev/positron/assets/9591545/5ac64197-c412-4616-8624-2c1e0dd177bb)

It's most noticeable in the `Fill` mode but other modes also show how the image doesn't fill in the expected direction.