### PR TITLE
Connections pane integration with the variables pane

### DIFF
--- a/extensions/positron-connections/src/comms/BaseComm.ts
+++ b/extensions/positron-connections/src/comms/BaseComm.ts
@@ -7,6 +7,8 @@
 // to the backend as well as the logic to handle errors returned by the backend.
 
 import * as positron from 'positron';
+import { Disposable, Event } from 'vscode';
+import { randomUUID } from 'crypto';
 
 /**
  * An enum representing the set of JSON-RPC error codes.
@@ -18,7 +20,7 @@ export enum JsonRpcErrorCode {
 	InvalidParams = -32602,
 	InternalError = -32603,
 	ServerErrorStart = -32000,
-	ServerErrorEnd = -32099
+	ServerErrorEnd = -32099,
 }
 
 /**
@@ -42,6 +44,51 @@ export interface PositronCommError {
 }
 
 /**
+ * An event emitter that can be used to fire events from the backend to the
+ * frontend.
+ */
+class PositronCommEmitter<T> {
+	private _event?: Event<T>;
+	private _listeners: Record<string, (data: T) => void> = {};
+	/**
+	 * Create a new event emitter.
+	 *
+	 * @param name The name of the event, as a JSON-RPC method name.
+	 * @param properties The names of the properties in the event payload; used
+	 *   to convert positional parameters to named parameters.
+	 */
+	constructor(readonly name: string, readonly properties: string[]) {
+		this.name = name;
+		this.properties = properties;
+	}
+
+	get event(): Event<T> {
+		if (!this._event) {
+			this._event = (listener: (data: T) => void, thisArgs?, disposables?) => {
+				if (disposables) {
+					throw new Error('Disposables are not supported');
+				}
+
+				if (thisArgs) {
+					throw new Error('thisArgs is not supported');
+				}
+
+				const uuid = randomUUID();
+				this._listeners[uuid] = listener;
+				return new Disposable(() => {
+					delete this._listeners[uuid];
+				});
+			};
+		}
+		return this._event;
+	}
+
+	fire(data: T) {
+		Object.values(this._listeners).map((listener) => listener(data));
+	}
+}
+
+/**
  * A base class for Positron comm instances. This class handles communication
  * with the backend, and provides methods for creating event emitters and
  * performing RPCs.
@@ -49,14 +96,15 @@ export interface PositronCommError {
  * Used by generated comm classes.
  */
 export class PositronBaseComm {
-
 	/**
 	 * Create a new Positron com
 	 *
 	 * @param clientInstance The client instance to use for communication with the backend.
 	 *  This instance must be connected to the backend before it is passed to this class.
 	 */
-	constructor(private readonly clientInstance: positron.RuntimeClientInstance) { }
+	constructor(
+		private readonly clientInstance: positron.RuntimeClientInstance
+	) { }
 
 	/**
 	 * Perform an RPC and wait for the result.
@@ -67,10 +115,11 @@ export class PositronBaseComm {
 	 * @returns A promise that resolves to the result of the RPC, or rejects
 	 *  with a PositronCommError.
 	 */
-	protected async performRpc<T>(rpcName: string,
+	protected async performRpc<T>(
+		rpcName: string,
 		paramNames: Array<string>,
-		paramValues: Array<any>): Promise<T> {
-
+		paramValues: Array<any>
+	): Promise<T> {
 		// Create the RPC arguments from the parameter names and values. This
 		// allows us to pass the parameters as positional parameters, but
 		// still have them be named parameters in the RPC.
@@ -125,7 +174,8 @@ export class PositronBaseComm {
 		if (!Object.keys(response).includes('result')) {
 			const error: PositronCommError = {
 				code: JsonRpcErrorCode.InternalError,
-				message: `Invalid response from ${this.clientInstance.getClientId()}: ` +
+				message:
+					`Invalid response from ${this.clientInstance.getClientId()}: ` +
 					`no 'result' field. ` +
 					`(response = ${JSON.stringify(response)})`,
 				name: `InvalidResponseError`,
@@ -142,4 +192,38 @@ export class PositronBaseComm {
 	dispose() {
 		this.clientInstance.dispose();
 	}
+
+	/**
+	 * Create a new event emitter.
+	 * @param name The name of the event, as a JSON-RPC method name.
+	 * @param properties The names of the properties in the event payload; used
+	 *  to convert positional parameters to named parameters.
+	 * @returns
+	 */
+	protected createEventEmitter<T>(
+		name: string,
+		properties: string[]
+	): Event<T> {
+		this.clientInstance.onDidSendEvent((event: any) => {
+			if (event.method === name) {
+				const args = event.params;
+				const namedArgs: any = {};
+				for (let i = 0; i < properties.length; i++) {
+					namedArgs[properties[i]] = args[i];
+				}
+				this._emitters.get(name)?.fire(namedArgs);
+			}
+		});
+
+		const emitter = new PositronCommEmitter<T>(name, properties);
+		this._emitters.set(name, emitter);
+		//this._register(emitter);
+		return emitter.event;
+	}
+
+	/**
+	 * A map of event names to emitters. This is used to create event emitters
+	 * from the backend to the frontend.
+	 */
+	private _emitters = new Map<string, PositronCommEmitter<any>>();
 }

--- a/extensions/positron-connections/src/comms/ConnectionsComms.ts
+++ b/extensions/positron-connections/src/comms/ConnectionsComms.ts
@@ -9,6 +9,7 @@
 
 import { PositronBaseComm } from './BaseComm';
 import * as positron from 'positron';
+import { Event } from 'vscode';
 
 //
 // AUTO-GENERATED from connections.json; do not edit.
@@ -46,9 +47,20 @@ export interface FieldSchema {
 
 }
 
+/**
+ * Event: Request to focus the Connections pane
+ */
+export interface FocusEvent {
+}
+
+export enum ConnectionsFrontendEvent {
+	Focus = 'focus'
+}
+
 export class PositronConnectionsComm extends PositronBaseComm {
 	constructor(public instance: positron.RuntimeClientInstance) {
 		super(instance);
+		this.onDidFocus = super.createEventEmitter('focus', []);
 	}
 
 	/**
@@ -118,4 +130,8 @@ export class PositronConnectionsComm extends PositronBaseComm {
 		return super.performRpc('preview_object', ['path'], [path]);
 	}
 
+	/**
+	 * Request to focus the Connections pane
+	 */
+	onDidFocus: Event<FocusEvent>;
 }

--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -256,6 +256,10 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 				this._onDidChangeTreeData.fire(undefined);
 			}
 		});
+
+		client.onDidFocus(() => {
+			vscode.commands.executeCommand('connections.focus', { preserveFocus: true });
+		});
 	}
 
 	/**

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -224,6 +224,9 @@ class ConnectionsService:
         self.comms[comm_id] = connections_comm
 
     def _wrap_connection(self, obj: Any) -> Connection:
+        # this check is redundant with the if branches below, but allows us to make
+        # sure the `object_is_supported` method is always in sync with what we really
+        # support in the connections pane.
         if not self.object_is_supported(obj):
             type_name = type(obj).__name__
             raise UnsupportedConnectionError(f"Unsupported connection type {type_name}")

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -342,7 +342,7 @@ class ConnectionsService:
         """
         Closes all comms and runs the `disconnect` callback.
         """
-        for comm_id in self.comms.keys():
+        for comm_id in list(self.comms.keys()):
             self._close_connection(comm_id)
 
         self.comms = {}  # implicitly deleting comms

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -5,16 +5,20 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import (TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple,
-                    TypedDict, Union)
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, TypedDict, Union
 
 import comm
 
 from .access_keys import decode_access_key, encode_access_key
-from .connections_comm import (ConnectionsBackendMessageContent,
-                               ContainsDataRequest, GetIconRequest,
-                               ListFieldsRequest, ListObjectsRequest,
-                               ObjectSchema, PreviewObjectRequest)
+from .connections_comm import (
+    ConnectionsBackendMessageContent,
+    ContainsDataRequest,
+    GetIconRequest,
+    ListFieldsRequest,
+    ListObjectsRequest,
+    ObjectSchema,
+    PreviewObjectRequest,
+)
 from .positron_comm import CommMessage, JsonRpcErrorCode, PositronComm
 from .third_party import pd_, sqlalchemy_
 from .utils import JsonData, JsonRecord, safe_isinstance
@@ -220,7 +224,6 @@ class ConnectionsService:
         self.comms[comm_id] = connections_comm
 
     def _wrap_connection(self, obj: Any) -> Connection:
-
         if not self.object_is_supported(obj):
             type_name = type(obj).__name__
             raise UnsupportedConnectionError(f"Unsupported connection type {type_name}")

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -227,7 +227,7 @@ class ConnectionsService:
             obj, "sqlalchemy", "Engine"
         )
 
-    def variable_has_active_connections(self, variable_path: List[str]) -> bool:
+    def variable_has_active_connection(self, variable_path: List[str]) -> bool:
         """
         Checks if the given variable path has an active connection.
         """

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -287,7 +287,7 @@ class ConnectionsService:
         """
         Handles front-end initiated close requests
         """
-        paths = set(self.comm_id_to_path.get(comm_id, set()))
+        paths: Set[PathKey] = set(self.comm_id_to_path.get(comm_id, set()))
 
         if not paths:
             # id the connection is not associated with any variable path, we close it

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -218,6 +218,9 @@ class ConnectionsService:
             return SQLite3Connection(obj)
         elif safe_isinstance(obj, "sqlalchemy", "Engine"):
             return SQLAlchemyConnection(obj)
+        else:
+            type_name = type(obj).__name__
+            raise UnsupportedConnectionError(f"Unsupported connection type {type(obj)}")
 
     def object_is_supported(self, obj: Any) -> bool:
         """
@@ -227,11 +230,11 @@ class ConnectionsService:
             obj, "sqlalchemy", "Engine"
         )
 
-    def variable_has_active_connection(self, variable_path: List[str]) -> bool:
+    def variable_has_active_connection(self, variable_name: str) -> bool:
         """
         Checks if the given variable path has an active connection.
         """
-        return tuple(variable_path) in self.path_to_comm_ids
+        return ([variable_name]) in self.path_to_comm_ids
 
     def handle_variable_updated(self, variable_name, value) -> None:
         """

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -284,7 +284,7 @@ class ConnectionsService:
         """
         Handles front-end initiated close requests
         """
-        paths = list(self.comm_id_to_path.get(comm_id, set()))
+        paths = set(self.comm_id_to_path.get(comm_id, set()))
 
         if not paths:
             # id the connection is not associated with any variable path, we close it

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -234,13 +234,13 @@ class ConnectionsService:
         """
         Checks if the given variable path has an active connection.
         """
-        return ([variable_name]) in self.path_to_comm_ids
+        return (variable_name,) in self.path_to_comm_ids
 
-    def handle_variable_updated(self, variable_name, value) -> None:
+    def handle_variable_updated(self, variable_name: str, value: Any) -> None:
         """
         Handles a variable being updated in the kernel.
         """
-        comm_id = self.path_to_comm_ids.get(tuple(variable_name))
+        comm_id = self.path_to_comm_ids.get((variable_name,))
         if comm_id is None:
             return
 
@@ -258,6 +258,7 @@ class ConnectionsService:
 
         # if the connections is different, we handle it as if it was a variable deletion
         # TODO: we don't really want to close the connection, but 'delete' the variable
+        #       as a connection might be pointed by multiple variable paths/names
         self._close_connection(comm_id)
 
     def _close_connection(self, comm_id: str):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -277,7 +277,9 @@ class ConnectionsService:
         """
         Handles a variable being deleted in the kernel.
         """
-        for path in self.path_to_comm_ids:
+        # copy the keys, as we might modify the dict in the loop
+        paths = set(self.path_to_comm_ids.keys())
+        for path in paths:
             key = decode_access_key(path[0])
             if key == variable_name:
                 self._unregister_variable_path(path)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections_comm.py
@@ -225,6 +225,16 @@ class ConnectionsBackendMessageContent(BaseModel):
     ] = Field(..., discriminator="method")
 
 
+@enum.unique
+class ConnectionsFrontendEvent(str, enum.Enum):
+    """
+    An enumeration of all the possible events that can be sent to the frontend connections comm.
+    """
+
+    # Request to focus the Connections pane
+    Focus = "focus"
+
+
 ObjectSchema.update_forward_refs()
 
 FieldSchema.update_forward_refs()

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -906,7 +906,8 @@ class PolarsDataFrameInspector(BaseTableInspector["pl.DataFrame", "pl.Series"]):
 
 
 class ConnectionInspector(ObjectInspector):
-    CLASS_QNAME = ["sqlite3.Connection", "sqlalchemy.engine.base.Engine"]
+    # in older Python versions (eg 3.9) the qualname for sqlite3.Connection is just "Connection"
+    CLASS_QNAME = ["Connection", "sqlite3.Connection", "sqlalchemy.engine.base.Engine"]
 
     def has_viewer(self) -> bool:
         return True

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -905,6 +905,16 @@ class PolarsDataFrameInspector(BaseTableInspector["pl.DataFrame", "pl.Series"]):
         return self.value.write_csv(file=None, separator="\t")
 
 
+class ConnectionInspector(ObjectInspector):
+    CLASS_QNAME = ["sqlite3.Connection", "sqlalchemy.engine.base.Engine"]
+
+    def has_viewer(self) -> bool:
+        return True
+
+    def get_kind(self) -> str:
+        return "connection"
+
+
 INSPECTOR_CLASSES: Dict[str, Type[PositronInspector]] = {
     PandasDataFrameInspector.CLASS_QNAME: PandasDataFrameInspector,
     PandasSeriesInspector.CLASS_QNAME: PandasSeriesInspector,
@@ -915,6 +925,7 @@ INSPECTOR_CLASSES: Dict[str, Type[PositronInspector]] = {
     **dict.fromkeys(PolarsDataFrameInspector.CLASS_QNAME, PolarsDataFrameInspector),
     **dict.fromkeys(PolarsSeriesInspector.CLASS_QNAME, PolarsSeriesInspector),
     DatetimeInspector.CLASS_QNAME: DatetimeInspector,
+    **dict.fromkeys(ConnectionInspector.CLASS_QNAME, ConnectionInspector),
     "boolean": BooleanInspector,
     "bytes": BytesInspector,
     "class": ClassInspector,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_connections.py
@@ -149,7 +149,6 @@ class TestSQLiteConnectionsService:
 
 
 class TestVariablePaneIntegration:
-
     @pytest.mark.parametrize("con", get_sqlite_connections())
     def test_open_then_delete(
         self,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_connections.py
@@ -214,9 +214,9 @@ class TestVariablePaneIntegration:
         variables_comm.messages.clear()
 
     def _view_in_connections_pane(self, variables_comm: DummyComm, path):
-        paths = [encode_access_key(p) for p in path]
-        msg = _make_msg("view", {"path": paths}, comm_id="dummy_comm_id")
+        encoded_paths = [encode_access_key(p) for p in path]
+        msg = _make_msg("view", {"path": encoded_paths}, comm_id="dummy_comm_id")
         variables_comm.handle_msg(msg)
         assert variables_comm.messages == [json_rpc_response({})]
         variables_comm.messages.clear()
-        return tuple(path)
+        return tuple(encoded_paths)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_connections.py
@@ -197,6 +197,25 @@ class TestVariablePaneIntegration:
         assert connections_service.path_to_comm_ids[path] is not None
         assert connections_service.variable_has_active_connection("x")
 
+    @pytest.mark.parametrize("con", get_sqlite_connections())
+    def test_frontend_comm_closed(
+        self,
+        shell: PositronShell,
+        connections_service: ConnectionsService,
+        variables_comm: DummyComm,
+        con,
+    ):
+        self._assign_variables(shell, variables_comm, x=con)
+        path = self._view_in_connections_pane(variables_comm, ["x"])
+
+        comm_id = connections_service.path_to_comm_ids[path]
+        assert comm_id is not None
+
+        connections_service.comms[comm_id].comm.handle_close({})
+
+        assert connections_service.comms.get(comm_id) is None
+        assert connections_service.path_to_comm_ids.get(path) is None
+
     # TODO: reuse code from test_data_explorer.py
     def _assign_variables(self, shell: PositronShell, variables_comm: DummyComm, **variables):
         # A hack to make sure that change events are fired when we

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -164,6 +164,9 @@ class VariablesService:
             if exp_service.variable_has_active_explorers(name):
                 exp_service.handle_variable_deleted(name)
 
+            if con_service.variable_has_active_connection(name):
+                con_service.handle_variable_deleted(name)
+
         for name, value in assigned.items():
             if exp_service.variable_has_active_explorers(name):
                 exp_service.handle_variable_updated(name, value)
@@ -554,7 +557,6 @@ class VariablesService:
         """Opens a Connections comm for the variable at the requested
         path in the current user session.
         """
-        # Use the leaf segment to get the title
         self.kernel.connections_service.register_connection(value, variable_path=path)
         self._send_result({})
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -128,7 +128,7 @@ class VariablesService:
             self._send_formatted_var(request.params.path, request.params.format)
 
         elif isinstance(request, ViewRequest):
-            self._open_data_explorer(request.params.path)
+            self._perform_view_action(request.params.path)
 
         else:
             logger.warning(f"Unhandled request: {request}")
@@ -159,6 +159,7 @@ class VariablesService:
         # Look for any assigned or removed variables that are active
         # in the data explorer service
         exp_service = self.kernel.data_explorer_service
+        con_service = self.kernel.connections_service
         for name in removed:
             if exp_service.variable_has_active_explorers(name):
                 exp_service.handle_variable_deleted(name)
@@ -166,6 +167,9 @@ class VariablesService:
         for name, value in assigned.items():
             if exp_service.variable_has_active_explorers(name):
                 exp_service.handle_variable_updated(name, value)
+
+            if con_service.variable_has_active_connection(name):
+                con_service.handle_variable_updated(name, value)
 
         # Ensure the number of changes does not exceed our maximum items
         if len(assigned) > MAX_ITEMS or len(removed) > MAX_ITEMS:
@@ -515,11 +519,11 @@ class VariablesService:
                 f"Cannot find variable at '{path}' to inspect",
             )
 
-    def _open_data_explorer(self, path: List[str]) -> None:
-        """Opens a DataExplorer comm for the variable at the requested
-        path in the current user session.
-
+    def _perform_view_action(self, path: List[str]) -> None:
         """
+        Performs the view action depending of the variable type.
+        """
+
         if path is None:
             return
 
@@ -530,11 +534,28 @@ class VariablesService:
                 f"Cannot find variable at '{path}' to view",
             )
 
+        if self.kernel.connections_service.object_is_supported(value):
+            self._open_connections_pane(path, value)
+        else:
+            self._open_data_explorer(path, value)
+
+    def _open_data_explorer(self, path: List[str], value: Any) -> None:
+        """Opens a DataExplorer comm for the variable at the requested
+        path in the current user session.
+        """
         # Use the leaf segment to get the title
         access_key = path[-1]
 
         title = str(decode_access_key(access_key))
         self.kernel.data_explorer_service.register_table(value, title, variable_path=path)
+        self._send_result({})
+
+    def _open_connections_pane(self, path: List[str], value: Any) -> None:
+        """Opens a Connections comm for the variable at the requested
+        path in the current user session.
+        """
+        # Use the leaf segment to get the title
+        self.kernel.connections_service.register_connection(value, variable_path=path)
         self._send_result({})
 
     def _send_event(self, name: str, payload: JsonRecord) -> None:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables_comm.py
@@ -58,6 +58,8 @@ class VariableKind(str, enum.Enum):
 
     Lazy = "lazy"
 
+    Connection = "connection"
+
 
 class VariableList(BaseModel):
     """

--- a/positron/comms/connections-frontend-openrpc.json
+++ b/positron/comms/connections-frontend-openrpc.json
@@ -1,0 +1,14 @@
+{
+	"openrpc": "1.3.0",
+	"info": {
+		"title": "Connections frontend",
+		"version": "1.0.0"
+	},
+	"methods": [
+		{
+			"name": "focus",
+			"summary": "Request to focus the Connections pane",
+			"params": []
+		}
+	]
+}

--- a/positron/comms/variables-backend-openrpc.json
+++ b/positron/comms/variables-backend-openrpc.json
@@ -230,7 +230,8 @@
 							"other",
 							"string",
 							"table",
-							"lazy"
+							"lazy",
+							"connection"
 						],
 						"description": "The kind of value the variable represents, such as 'string' or 'number'"
 					},

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
@@ -332,9 +332,17 @@ export const VariableItem = (props: VariableItemProps) => {
 	 */
 	const RightColumn = () => {
 		if (!props.disabled && props.variableItem.hasViewer) {
+			let icon = 'codicon codicon-open-preview';
+			if (props.variableItem.kind === 'table') {
+				icon = 'codicon codicon-table';
+			} else if (props.variableItem.kind === 'connection') {
+				icon = 'codicon codicon-database';
+			}
+			icon = 'viewer-icon ' + icon + ' ' + props.variableItem.kind;
+
 			return (
 				<div className='right-column'>
-					<div className='viewer-icon codicon codicon-table' onMouseDown={viewerMouseDownHandler}></div>
+					<div className={icon} onMouseDown={viewerMouseDownHandler}></div>
 				</div>
 			);
 		} else if (props.rightColumnVisible) {

--- a/src/vs/workbench/services/languageRuntime/common/positronConnectionsComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronConnectionsComm.ts
@@ -6,6 +6,7 @@
 // AUTO-GENERATED from connections.json; do not edit.
 //
 
+import { Event } from 'vs/base/common/event';
 import { PositronBaseComm } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
 
@@ -41,9 +42,20 @@ export interface FieldSchema {
 
 }
 
+/**
+ * Event: Request to focus the Connections pane
+ */
+export interface FocusEvent {
+}
+
+export enum ConnectionsFrontendEvent {
+	Focus = 'focus'
+}
+
 export class PositronConnectionsComm extends PositronBaseComm {
 	constructor(instance: IRuntimeClientInstance<any, any>) {
 		super(instance);
+		this.onDidFocus = super.createEventEmitter('focus', []);
 	}
 
 	/**
@@ -113,5 +125,10 @@ export class PositronConnectionsComm extends PositronBaseComm {
 		return super.performRpc('preview_object', ['path'], [path]);
 	}
 
+
+	/**
+	 * Request to focus the Connections pane
+	 */
+	onDidFocus: Event<FocusEvent>;
 }
 

--- a/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
@@ -150,7 +150,8 @@ export enum VariableKind {
 	Other = 'other',
 	String = 'string',
 	Table = 'table',
-	Lazy = 'lazy'
+	Lazy = 'lazy',
+	Connection = 'connection'
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

This PR integrates the variables pane with the connections pane. When variables are assigned and they are known to the connections pane we display a small icon, that triggers the registration of that connection with the connections pane.
Addresses https://github.com/posit-dev/positron/issues/2503


### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

1. Added a new inspector that catches supported connections and enables the `view` buttom for them:

https://github.com/posit-dev/positron/blob/f233f3ee41366f6f9110abc16310e3418f4b7300/extensions/positron-python/pythonFiles/positron/positron_ipykernel/inspectors.py#L902-L909

2. Made the variables pane preview handling depend on the type of object, and for supported values we will
    enable register the object with the connections service:

https://github.com/posit-dev/positron/blob/f233f3ee41366f6f9110abc16310e3418f4b7300/extensions/positron-python/pythonFiles/positron/positron_ipykernel/variables.py#L519-L537

 3. Add listeners to variable updates/deletions in the variables service allowing the connections service to handle those events, if required.

https://github.com/posit-dev/positron/blob/f233f3ee41366f6f9110abc16310e3418f4b7300/extensions/positron-python/pythonFiles/positron/positron_ipykernel/variables.py#L157-L169


### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

A small video below showing different scenarios that we expect this PR to work with:

https://github.com/posit-dev/positron/assets/4706822/a08050c9-b84d-4b35-a804-fe051f201b9d


