### PR TITLE
Temporarily disable pip package snapshot CI tests

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/positron-python-ci.yml'
       - 'extensions/positron-python/**'
   pull_request:
     branches:
       - main
     paths:
+      - '.github/workflows/positron-python-ci.yml'
       - 'extensions/positron-python/**'
 
 
@@ -196,18 +198,18 @@ jobs:
           - os: 'ubuntu-latest'
             python: '3.12'
             time-elapsed: ''
-          - os: 'ubuntu-latest'
-            python: '3.10'
-            time-elapsed: '3 months'
-          - os: 'ubuntu-latest'
-            python: '3.10'
-            time-elapsed: '6 months'
-          - os: 'ubuntu-latest'
-            python: '3.10'
-            time-elapsed: '9 months'
-          - os: 'ubuntu-latest'
-            python: '3.10'
-            time-elapsed: '1 year'
+          # - os: 'ubuntu-latest'
+          #   python: '3.10'
+          #   time-elapsed: '3 months'
+          # - os: 'ubuntu-latest'
+          #   python: '3.10'
+          #   time-elapsed: '6 months'
+          # - os: 'ubuntu-latest'
+          #   python: '3.10'
+          #   time-elapsed: '9 months'
+          # - os: 'ubuntu-latest'
+          #   python: '3.10'
+          #   time-elapsed: '1 year'
 
     steps:
       - name: Checkout
@@ -235,7 +237,7 @@ jobs:
         run: |
           python -m pip config set global.index-url https://packagemanager.posit.co/pypi/${{ env.SNAPSHOT_DATE }}/simple
           python -m pip config set global.trusted-host packagemanager.posit.co
-          python -m pip install --prefer-binary --force-reinstall --no-dependencies -r pythonFiles/positron/data-science-requirements.txt
+          python -m pip install --prefer-binary --force-reinstall -r pythonFiles/positron/data-science-requirements.txt
 
       - name: Run Positron IPyKernel unit tests
         run: pytest pythonFiles/positron


### PR DESCRIPTION
polars forces a downgrade of the typing_extensions library which breaks newer IPython in CI:

```
 Collecting typing_extensions>=4.0.1 (from polars->-r pythonFiles/positron/data-science-requirements.txt (line 2))
  Downloading https://packagemanager.rstudio.com/pypi/2023-04-01/packages/typing-extensions/fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4/typing_extensions-4.5.0-py3-none-any.whl (27 kB)
```

See for example

https://github.com/posit-dev/positron/actions/runs/8514455041/job/23320206526?pr=2593

This temporarily disables these tests until we can sort out a proper fix to unblock other PRs. It also makes sure that these tests run when the CI configuration changes. 