### PR TITLE
Bump ark to 0.1.74

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -533,7 +533,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.73"
+      "ark": "0.1.74"
     }
   }
 }


### PR DESCRIPTION
Bumps ark to 0.1.74; this change makes ark (minimally) compatible with the new data explorer comms.