### PR TITLE
Bug fix/occluding viewer panes

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
@@ -169,6 +169,12 @@ export class PositronHelpView extends ViewPane implements IReactComponentContain
 		@IThemeService themeService: IThemeService,
 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService
 	) {
+		// Override minimum size option if it isn't already somehow set. There doesn't seem to be a
+		// way to set this in any sort of configuration hence the need to override it here. If this
+		// isn't set, then the help pane will occlude parts of the editor when it is resized to be
+		// very small.
+		options = { ...options, minimumBodySize: 0 };
+
 		// Call the base class's constructor.
 		super(
 			options,

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
@@ -173,6 +173,7 @@ export class PositronHelpView extends ViewPane implements IReactComponentContain
 		// way to set this in any sort of configuration hence the need to override it here. If this
 		// isn't set, then the help pane will occlude parts of the editor when it is resized to be
 		// very small.
+		// TODO: See about disposing the webview entirely when the size is too small to see.
 		options = { ...options, minimumBodySize: 0 };
 
 		// Call the base class's constructor.

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
@@ -85,10 +85,8 @@ export class PositronPreviewViewPane extends ViewPane implements IReactComponent
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IPositronPreviewService private readonly positronPreviewService: IPositronPreviewService
 	) {
-		// Override minimum size option if it isn't already somehow set. There doesn't seem to be a
-		// way to set this in any sort of configuration hence the need to override it here. If this
-		// isn't set, then the help pane will occlude parts of the editor when it is resized to be
-		// very small.
+		// Override minimum size option if it isn't already somehow set. See `PositronHelpView` for
+		// more context.
 		options = { ...options, minimumBodySize: 0 };
 
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
@@ -85,6 +85,12 @@ export class PositronPreviewViewPane extends ViewPane implements IReactComponent
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IPositronPreviewService private readonly positronPreviewService: IPositronPreviewService
 	) {
+		// Override minimum size option if it isn't already somehow set. There doesn't seem to be a
+		// way to set this in any sort of configuration hence the need to override it here. If this
+		// isn't set, then the help pane will occlude parts of the editor when it is resized to be
+		// very small.
+		options = { ...options, minimumBodySize: 0 };
+
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
 		this._register(this.onDidChangeBodyVisibility(() => this.onDidChangeVisibility(this.isBodyVisible())));
 		this._positronPreviewContainer = DOM.$('.positron-preview-container');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Fix problem where viewer and help-pane can occlude other parts of the editor. 

Addresses #1997 


### Approach

This issue was caused by there being a minimum height for the vertical size of a `ViewPane` of 120 pixels. 

This was causing the layout method to never tell the editor to be smaller than 120px tall. 