### PR TITLE
fix new project feature flagging

### DIFF
--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -47,8 +47,8 @@ export class PositronNewProjectAction extends Action2 {
 			},
 			category: workspacesCategory,
 			f1: true,
-			// TODO: remove feature flag IsDevelopmentContext when the feature is ready
-			precondition: ContextKeyExpr.and(EnterMultiRootWorkspaceSupportContext, IsDevelopmentContext),
+			// TODO: [New Project] Remove feature flag when New Project action is ready for release
+			precondition: ContextKeyExpr.and(EnterMultiRootWorkspaceSupportContext, IsDevelopmentContext.isEqualTo(true)),
 			menu: {
 				id: MenuId.MenubarFileMenu,
 				group: '1_newfolder',

--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -48,11 +48,15 @@ export class PositronNewProjectAction extends Action2 {
 			category: workspacesCategory,
 			f1: true,
 			// TODO: [New Project] Remove feature flag when New Project action is ready for release
+			// This disables (greys out) the action in the New menu, the application bar File menu, and the command palette when not in a development context
 			precondition: ContextKeyExpr.and(EnterMultiRootWorkspaceSupportContext, IsDevelopmentContext.isEqualTo(true)),
 			menu: {
 				id: MenuId.MenubarFileMenu,
 				group: '1_newfolder',
 				order: 3,
+				// TODO: [New Project] Remove feature flag when New Project action is ready for release
+				// This removes the action from the application bar File menu when not in a development context
+				when: IsDevelopmentContext.isEqualTo(true)
 			}
 		});
 	}

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
@@ -9,6 +9,7 @@ import { IAction, Separator } from 'vs/base/common/actions';
 import { ActionBarMenuButton } from 'vs/platform/positronActionBar/browser/components/actionBarMenuButton';
 import { usePositronActionBarContext } from 'vs/platform/positronActionBar/browser/positronActionBarContext';
 import { PositronNewFolderAction, PositronNewFolderFromGitAction, PositronNewProjectAction } from 'vs/workbench/browser/actions/positronActions';
+import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
 
 /**
  * Localized strings.
@@ -33,9 +34,12 @@ export const TopActionBarNewMenu = () => {
 			label: positronNewFile
 		});
 		actions.push(new Separator());
-		positronActionBarContext.appendCommandAction(actions, {
-			id: PositronNewProjectAction.ID
-		});
+		// TODO: [New Project] Remove feature flag when New Project action is ready for release
+		if (IsDevelopmentContext.getValue(positronActionBarContext.contextKeyService) === true) {
+			positronActionBarContext.appendCommandAction(actions, {
+				id: PositronNewProjectAction.ID
+			});
+		}
 		positronActionBarContext.appendCommandAction(actions, {
 			id: PositronNewFolderAction.ID
 		});

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
@@ -35,6 +35,7 @@ export const TopActionBarNewMenu = () => {
 		});
 		actions.push(new Separator());
 		// TODO: [New Project] Remove feature flag when New Project action is ready for release
+		// This removes the action from the New menu in the action bar when not in a development context
 		if (IsDevelopmentContext.getValue(positronActionBarContext.contextKeyService) === true) {
 			positronActionBarContext.appendCommandAction(actions, {
 				id: PositronNewProjectAction.ID

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
@@ -143,12 +143,13 @@ export const CustomFolderMenuItems = (props: CustomFolderMenuItemsProps) => {
 		);
 	};
 
-	// TODO: [New Project] Remove feature flag when New Project action is ready for release
 	const isDevContext = IsDevelopmentContext.getValue(props.contextKeyService) === true;
 
 	// Render.
 	return (
 		<div className='custom-folder-menu-items'>
+			{/* TODO: [New Project] Remove feature flag when New Project action is ready for release */}
+			{/* This removes the action from the custom folder menu in the action bar when when not in a development context */}
 			{isDevContext ?
 				<CommandActionCustomFolderMenuItem id={PositronNewProjectAction.ID} />
 				: null

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
@@ -22,6 +22,7 @@ import { CustomFolderMenuItem } from 'vs/workbench/browser/parts/positronTopActi
 import { CustomFolderMenuSeparator } from 'vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuSeparator';
 import { CustomFolderRecentlyUsedMenuItem } from 'vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderRecentlyUsedMenuItem';
 import { PositronNewFolderAction, PositronNewFolderFromGitAction, PositronNewProjectAction, PositronOpenFolderInNewWindowAction } from 'vs/workbench/browser/actions/positronActions';
+import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
 
 /**
  * Constants.
@@ -142,10 +143,16 @@ export const CustomFolderMenuItems = (props: CustomFolderMenuItemsProps) => {
 		);
 	};
 
+	// TODO: [New Project] Remove feature flag when New Project action is ready for release
+	const isDevContext = IsDevelopmentContext.getValue(props.contextKeyService) === true;
+
 	// Render.
 	return (
 		<div className='custom-folder-menu-items'>
-			<CommandActionCustomFolderMenuItem id={PositronNewProjectAction.ID} />
+			{isDevContext ?
+				<CommandActionCustomFolderMenuItem id={PositronNewProjectAction.ID} />
+				: null
+			}
 			<CommandActionCustomFolderMenuItem id={PositronNewFolderAction.ID} />
 			<CommandActionCustomFolderMenuItem id={PositronNewFolderFromGitAction.ID} />
 			<CustomFolderMenuSeparator />

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
@@ -150,10 +150,7 @@ export const CustomFolderMenuItems = (props: CustomFolderMenuItemsProps) => {
 		<div className='custom-folder-menu-items'>
 			{/* TODO: [New Project] Remove feature flag when New Project action is ready for release */}
 			{/* This removes the action from the custom folder menu in the action bar when when not in a development context */}
-			{isDevContext ?
-				<CommandActionCustomFolderMenuItem id={PositronNewProjectAction.ID} />
-				: null
-			}
+			{isDevContext && <CommandActionCustomFolderMenuItem id={PositronNewProjectAction.ID} />}
 			<CommandActionCustomFolderMenuItem id={PositronNewFolderAction.ID} />
 			<CommandActionCustomFolderMenuItem id={PositronNewFolderFromGitAction.ID} />
 			<CustomFolderMenuSeparator />


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

- Addresses https://github.com/posit-dev/positron/issues/2609

### Approach

- Don't include the New Project action in release builds (previously the options were greyed out)
- Use the `IsDevelopmentContext` check to omit the option in release builds for:
    - the application action bar (File > New Project)
    - the positron action bar New > New Project
    - the positron action bar custom menu Folder > New Project
    - the command prompt Workspaces: New Project

Tested locally in a dev build and in a release build.

### QA Notes

The option should show in a dev build in all four locations, and not show in a release build in all four locations.

#### Dev build

<img width="300" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/82f56879-08e4-48a8-b084-6e5ba3fe824a">

<img width="300" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/c02800ad-97d8-4a8d-ad37-91132928b3c0">

<img width="300" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/cf610c29-e50c-4bce-8554-e96c011e5b28">

<img width="400" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/47a4fd0d-8be5-4a49-a512-e14f99854637">

#### Release build

<img width="300" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/bd3cf11e-1e76-4d4c-95f0-ebbe1a5626be">

<img width="300" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/ea05b50c-5547-4f37-945a-b093f9b0c0e5">

<img width="300" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/a4ce5358-3f80-45ec-9984-c5d00e2c57d3">

<img width="400" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/18da50dd-5864-47d6-b9ec-687a91ee8783">
