### PR TITLE
[python] open stdout localhost links in terminal in Viewer

### DIFF
--- a/extensions/positron-python/positron-dts/positron.d.ts
+++ b/extensions/positron-python/positron-dts/positron.d.ts
@@ -1087,6 +1087,17 @@ declare module 'positron' {
 		 * Returns the current width of the console input, in characters.
 		 */
 		export function getConsoleWidth(): Thenable<number>;
+
+		/**
+		 * Create and show a new preview panel for a URL. This is a convenience
+		 * method that creates a new webview panel and sets its content to the
+		 * given URL.
+		 *
+		 * @param url The URL to preview
+		 *
+		 * @return New preview panel.
+		 */
+		export function previewUrl(url: vscode.Uri): PreviewPanel;
 	}
 
 	namespace runtime {

--- a/extensions/positron-python/src/client/positron/extension.ts
+++ b/extensions/positron-python/src/client/positron/extension.ts
@@ -12,7 +12,7 @@ import { IServiceContainer } from '../ioc/types';
 import { traceError, traceInfo } from '../logging';
 import { PythonRuntimeManager } from './manager';
 import { createPythonRuntimeMetadata } from './runtime';
-import { provider } from './linkProvider';
+import { provideTerminalLinks, handleTerminalLink } from './linkProvider';
 
 export async function activatePositron(
     activatedPromise: Promise<void>,
@@ -31,7 +31,7 @@ export async function activatePositron(
         traceInfo('activatePositron: awaiting extension activation');
         await activatedPromise;
 
-        vscode.window.registerTerminalLinkProvider(provider);
+        vscode.window.registerTerminalLinkProvider({ provideTerminalLinks, handleTerminalLink });
 
         const registerRuntime = async (interpreterPath: string) => {
             if (!manager.registeredPythonRuntimes.has(interpreterPath)) {

--- a/extensions/positron-python/src/client/positron/extension.ts
+++ b/extensions/positron-python/src/client/positron/extension.ts
@@ -11,6 +11,13 @@ import { IServiceContainer } from '../ioc/types';
 import { traceError, traceInfo } from '../logging';
 import { PythonRuntimeManager } from './manager';
 import { createPythonRuntimeMetadata } from './runtime';
+import * as vscode from 'vscode';
+
+export const UrlRegex = /(http|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+)|(localhost))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])/gi;
+
+interface CustomTerminalLink extends vscode.TerminalLink {
+    data: string;
+}
 
 export async function activatePositron(
     activatedPromise: Promise<void>,
@@ -28,6 +35,36 @@ export async function activatePositron(
         // Wait for all extension components to be activated before registering event listeners
         traceInfo('activatePositron: awaiting extension activation');
         await activatedPromise;
+
+        vscode.window.registerTerminalLinkProvider({
+            provideTerminalLinks: (context: vscode.TerminalLinkContext, _token: vscode.CancellationToken) => {
+                // Detect the first instance of the word "link" if it exists and linkify it
+                const matches = [...context.line.matchAll(UrlRegex)];
+                if (matches.length === 0) {
+                    return [];
+                }
+
+                return matches.map((match) => {
+                    const line = context.line;
+
+                    const startIndex = line.indexOf(match[0]);
+
+                    const uri = vscode.Uri.parse(match[0]);
+                    positron.window.previewUrl(uri);
+
+                    return {
+                        startIndex,
+                        length: match[0].length,
+                        tooltip: 'Open in Viewer',
+                        data: match[0],
+                    };
+                });
+            },
+            handleTerminalLink: (link: CustomTerminalLink) => {
+                const uri = vscode.Uri.parse(link.data);
+                positron.window.previewUrl(uri);
+            },
+        });
 
         const registerRuntime = async (interpreterPath: string) => {
             if (!manager.registeredPythonRuntimes.has(interpreterPath)) {

--- a/extensions/positron-python/src/client/positron/linkProvider.ts
+++ b/extensions/positron-python/src/client/positron/linkProvider.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// eslint-disable-next-line import/no-unresolved
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+
+const UrlRegex = /(http|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+)|(localhost))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])/gi;
+
+interface PositronTerminalLink extends vscode.TerminalLink {
+    data: string;
+}
+
+const _links: string[] = [];
+
+export const provider = {
+    provideTerminalLinks: (context: vscode.TerminalLinkContext, _token: vscode.CancellationToken) => {
+        const matches = [...context.line.matchAll(UrlRegex)];
+        if (matches.length === 0) {
+            return [];
+        }
+
+        return matches.map((match) => {
+            const startIndex = context.line.indexOf(match[0]);
+
+            if (!_links.includes(match[0])) {
+                const uri = vscode.Uri.parse(match[0]);
+                positron.window.previewUrl(uri);
+            }
+            // fix, people will want to open the same link multiple times
+            // are we able to get context of the viewer?
+            // or use some sort of other context from link/application/process lifespan?
+            _links.push(match[0]);
+
+            return {
+                startIndex,
+                length: match[0].length,
+                tooltip: 'Open in Viewer',
+                data: match[0],
+            } as PositronTerminalLink;
+        });
+    },
+    handleTerminalLink: (link: PositronTerminalLink) => {
+        const uri = vscode.Uri.parse(link.data);
+        positron.window.previewUrl(uri);
+    },
+};

--- a/extensions/positron-python/src/client/positron/linkProvider.ts
+++ b/extensions/positron-python/src/client/positron/linkProvider.ts
@@ -6,43 +6,79 @@
 import * as positron from 'positron';
 import * as vscode from 'vscode';
 
-const UrlRegex = /(http|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+)|(localhost))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])/gi;
+// Assuming localHosts is an array of localhost URLs
+const localHosts: string[] = [
+    'localhost',
+    '127.0.0.1',
+    '[0:0:0:0:0:0:0:1]',
+    '[::1]',
+    '0.0.0.0',
+    '[0:0:0:0:0:0:0:0]',
+    '[::]',
+];
+
+const urlPattern = /(http|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+)|(localhost))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])/gi;
+const localHostsPattern = new RegExp(
+    `(?:https?:\/\/)(${localHosts.join('|')})([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~/+#-])`,
+    'gi',
+);
 
 interface PositronTerminalLink extends vscode.TerminalLink {
     data: string;
+    openInViewer: boolean;
 }
 
-const _links: string[] = [];
+const _links: Map<Thenable<number | undefined>, string> = new Map();
 
-export const provider = {
-    provideTerminalLinks: (context: vscode.TerminalLinkContext, _token: vscode.CancellationToken) => {
-        const matches = [...context.line.matchAll(UrlRegex)];
-        if (matches.length === 0) {
-            return [];
-        }
+export function provideTerminalLinks(
+    context: vscode.TerminalLinkContext,
+    _token: vscode.CancellationToken,
+): vscode.ProviderResult<PositronTerminalLink[]> {
+    const matches = [...context.line.matchAll(urlPattern)];
 
-        return matches.map((match) => {
-            const startIndex = context.line.indexOf(match[0]);
+    if (matches.length === 0) {
+        return [];
+    }
 
-            if (!_links.includes(match[0])) {
-                const uri = vscode.Uri.parse(match[0]);
-                positron.window.previewUrl(uri);
+    return matches.map((match) => {
+        const startIndex = context.line.indexOf(match[0]);
+
+        // if localhost, preview through viewer
+        if (localHostsPattern.test(match[0])) {
+            const pid = context.terminal.processId
+            if (!_links.has(pid) || _links.get(pid) !== match[0]) {
+                positron.window.previewUrl(vscode.Uri.parse(match[0]));
+
+                // set pid to latest localhost address
+                _links.set(pid, match[0]);
+
+                return {
+                    startIndex,
+                    length: match[0].length,
+                    tooltip: 'Open link in Viewer',
+                    data: match[0],
+                    openInViewer: true,
+                } as PositronTerminalLink;
             }
-            // fix, people will want to open the same link multiple times
-            // are we able to get context of the viewer?
-            // or use some sort of other context from link/application/process lifespan?
-            _links.push(match[0]);
+        }
+        // otherwise, treat as external link
+        return {
+            startIndex,
+            length: match[0].length,
+            tooltip: 'Open link in browser',
+            data: match[0],
+            openInViewer: false,
+        } as PositronTerminalLink;
+    });
+}
 
-            return {
-                startIndex,
-                length: match[0].length,
-                tooltip: 'Open in Viewer',
-                data: match[0],
-            } as PositronTerminalLink;
-        });
-    },
-    handleTerminalLink: (link: PositronTerminalLink) => {
+export function handleTerminalLink(link: PositronTerminalLink): void {
+    const config = vscode.workspace.getConfiguration('positron.viewer');
+
+    if (link.openInViewer && config.get<boolean>('openLocalhostUrls')) {
         const uri = vscode.Uri.parse(link.data);
         positron.window.previewUrl(uri);
-    },
-};
+    } else {
+        vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(link.data));
+    }
+}

--- a/extensions/positron-python/src/client/positron/linkProvider.ts
+++ b/extensions/positron-python/src/client/positron/linkProvider.ts
@@ -45,7 +45,7 @@ export function provideTerminalLinks(
 
         // if localhost, preview through viewer
         if (localHostsPattern.test(match[0])) {
-            const pid = context.terminal.processId
+            const pid = context.terminal.processId;
             if (!_links.has(pid) || _links.get(pid) !== match[0]) {
                 positron.window.previewUrl(vscode.Uri.parse(match[0]));
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

addresses #1302 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

right now it is super twitchy, and links will pop up in viewer multiple times (whenever cursor nears link). The actual opening of the link might have to move out of `provideTerminalLinks`, or at least do some handling to not open so aggressively.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

small apps you can try:

1. `pip install vetiver`

create a file:
```python
from vetiver import VetiverModel, VetiverAPI, mock

x, y = mock.get_mock_data()
m = mock.get_mock_model().fit(x, y)
v = VetiverModel(m, "my_model")

VetiverAPI(v).run()
```

and then click the Play button to "Run Python file in terminal"

2. `pip install shiny`

create a file:
```python
from shiny import ui, render, App

app_ui = ui.page_fluid(
    ui.input_slider("slider", "Slider", 0, 100, 50),  
    ui.output_text_verbatim("value"),
)

def server(input, output, session):
    @render.text
    def value():
        return f"{input.slider()}"

app = App(app_ui, server)
```

and then type `shiny run filename.py`
