### PR TITLE
Fix how `nls.localize` is called in NewFolderModalDialog and NewFolderFromGitModalDialog

### DIFF
--- a/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
@@ -135,7 +135,10 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 			renderer={props.renderer}
 			width={400}
 			height={300}
-			title={localize('positronNewFolderFromGitModalDialogTitle', "New Folder from Git")}
+			title={(() => localize(
+				'positronNewFolderFromGitModalDialogTitle',
+				"New Folder from Git"
+			))()}
 			onAccept={async () => {
 				props.renderer.dispose();
 				await props.createFolder(result);
@@ -146,15 +149,18 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 				<LabeledTextInput
 					ref={folderNameRef}
 					value={result.repo}
-					label={localize('positron.GitRepositoryURL', "Git repository URL")}
+					label={(() => localize(
+						'positron.GitRepositoryURL',
+						"Git repository URL"
+					))()}
 					autoFocus
 					onChange={e => setResult({ ...result, repo: e.target.value })}
 				/>
 				<LabeledFolderInput
-					label={localize(
+					label={(() => localize(
 						'positron.createFolderAsSubfolderOf',
 						"Create folder as subfolder of"
-					)}
+					))()}
 					value={result.parentFolder}
 					onBrowse={browseHandler}
 					onChange={e => setResult({ ...result, parentFolder: e.target.value })}
@@ -162,7 +168,10 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 			</VerticalStack>
 			<VerticalSpacer>
 				<Checkbox
-					label={localize('positron.openInNewWindow', "Open in a new window")}
+					label={(() => localize(
+						'positron.openInNewWindow',
+						"Open in a new window"
+					))()}
 					onChanged={checked => setResult({ ...result, newWindow: checked })} />
 			</VerticalSpacer>
 		</OKCancelModalDialog>

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
@@ -137,7 +137,7 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 			renderer={props.renderer}
 			width={400}
 			height={300}
-			title={localize('positronNewFolderModalDialogTitle', "New Folder")}
+			title={(() => localize('positronNewFolderModalDialogTitle', "New Folder"))()}
 			onAccept={async () => {
 				props.renderer.dispose();
 				await props.createFolder(result);
@@ -146,16 +146,16 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 			<VerticalStack>
 				<LabeledTextInput
 					ref={folderNameRef}
-					label={localize('positron.folderName', "Folder name")}
+					label={(() => localize('positron.folderName', "Folder name"))()}
 					autoFocus
 					value={result.folder}
 					onChange={e => setResult({ ...result, folder: e.target.value })}
 				/>
 				<LabeledFolderInput
-					label={localize(
+					label={(() => localize(
 						'positron.createFolderAsSubfolderOf',
 						"Create folder as subfolder of"
-					)}
+					))()}
 					value={result.parentFolder}
 					onBrowse={browseHandler}
 					onChange={e => setResult({ ...result, parentFolder: e.target.value })}
@@ -163,7 +163,10 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 			</VerticalStack>
 			<VerticalSpacer>
 				<Checkbox
-					label={localize('positron.openInNewWindow', "Open in a new window")}
+					label={(() => localize(
+						'positron.openInNewWindow',
+						"Open in a new window"
+					))()}
 					onChanged={checked => setResult({ ...result, newWindow: checked })}
 				/>
 			</VerticalSpacer>


### PR DESCRIPTION
### Intent

Using `nls.localize` to localize text in React components is flaky in production builds. Sometimes it works (e.g. `DeleteAllVariablesModalDialog`) and sometimes it doesn't work (e.g. `NewFolderModalDialog` and `NewFolderFromGitModalDialog`).

_This problem only appears in production builds._

The problem manifests as some localized text working properly and some localized text not working properly in the JSX for a component. 

For example, prior to the work in this PR, in the `NewFolderModalDialog` you will see:

<img width="422" alt="image" src="https://github.com/posit-dev/positron/assets/853239/d5741ed3-0e4a-4421-881d-4f91dd5e42f7">

Even though every string in this dialog is localized with a call to `nls.localize`, only the one for the checkbox actually works. (See below for analysis of why this is happening.)

### Approach

`nls.localize` is not what it appears to be. It looks like any other function in Visual Studio Code, but it is really a macro of sorts that compiles like code but gets rewritten into other code by the `vscode-nls-dev` package in production builds.

After a lot of research, I found that in some cases, `nls.localize` will work as expected, and in other cases, it will not. (I do not yet understand why this is the case.)

For example, prior to this PR, for the `NewFolderModalDialog` component, the generated code looks like this in `out/vs/workbench/workbench.desktop.main.js`:

```
        // Render.
        return (React.createElement(positronOKCancelModalDialog_1.$KHb, { renderer: props.renderer, width: 400, height: 300, title: (0, nls_1.localize)('positronNewFolderModalDialogTitle', "New Folder"), onAccept: async () => {
                props.renderer.dispose();
                await props.createFolder(result);
            }, onCancel: () => props.renderer.dispose() },
            React.createElement(verticalStack_1.$AHb, null,
                React.createElement(labeledTextInput_1.$DHb, { ref: folderNameRef, label: (0, nls_1.localize)('positron.folderName', "Folder name"), autoFocus: true, value: result.folder, onChange: e => setResult({ ...result, folder: e.target.value }) }),
                React.createElement(labeledFolderInput_1.$LHb, { label: (0, nls_1.localize)('positron.createFolderAsSubfolderOf', "Create folder as subfolder of"), value: result.parentFolder, onBrowse: browseHandler, onChange: e => setResult({ ...result, parentFolder: e.target.value }) })),
            React.createElement(verticalSpacer_1.$BHb, null,
                React.createElement(checkbox_1.$zHb, { label: (0, nls_1.localize)(0, null), onChanged: checked => setResult({ ...result, newWindow: checked }) }))));
```

And this in `out/vs/workbench/workbench.desktop.main.nls.js` where the localized strings are stored:

```JSON
	"vs/workbench/browser/positronModalDialogs/newFolderModalDialog": [
		"Open in a new window"
	],
```

What you can see here is that of the four calls to `nsl.localize` in the JSX for the `NewFolderModalDialog` component, only one of them, the one for the checkbox, was properly localized and stored in the `out/vs/workbench/workbench.desktop.main.nls.js` file.

The calls to `nls.localize` that were not properly localized do not get rewritten and contain the original source code:

```JavaScript
(0, nls_1.localize)('positronNewFolderModalDialogTitle', "New Folder")
(0, nls_1.localize)('positron.folderName', "Folder name")
(0, nls_1.localize)('positron.createFolderAsSubfolderOf', "Create folder as subfolder of")
```

An the call to `nls.localize` that was properly localized gets rewritten as:

```JavaScript
(0, nls_1.localize)(0, null)
```

Where the call to`(0, nls_1.localize)(0, null)` results in the 0th entry of the `vs/workbench/browser/positronModalDialogs/newFolderModalDialog` key being retrieved from the `out/vs/workbench/workbench.desktop.main.nls.js` file at runtime. Hence why this is the only properly localized string in the dialog:

<img width="422" alt="image" src="https://github.com/posit-dev/positron/assets/853239/d5741ed3-0e4a-4421-881d-4f91dd5e42f7">

I tried an enormous number of things to figure out a way to fix or work around this problem.

What I came up with was to place each use of `nls.localize` into an anonymous function and invoke that function in the JSX where it is needed.

With this approach, the NewFolderModalDialog component goes from this:

```TypeScript
// Render.
return (
	<OKCancelModalDialog
		renderer={props.renderer}
		width={400}
		height={300}
		title={localize('positronNewFolderModalDialogTitle', "New Folder")}
		onAccept={async () => {
			props.renderer.dispose();
			await props.createFolder(result);
		}}
		onCancel={() => props.renderer.dispose()}>
		<VerticalStack>
			<LabeledTextInput
				ref={folderNameRef}
				label={localize('positron.folderName', "Folder name")}
				autoFocus
				value={result.folder}
				onChange={e => setResult({ ...result, folder: e.target.value })}
			/>
			<LabeledFolderInput
				label={localize(
					'positron.createFolderAsSubfolderOf',
					"Create folder as subfolder of"
				)}
				value={result.parentFolder}
				onBrowse={browseHandler}
				onChange={e => setResult({ ...result, parentFolder: e.target.value })}
			/>
		</VerticalStack>
		<VerticalSpacer>
			<Checkbox
				label={localize('positron.openInNewWindow', "Open in a new window")}
				onChanged={checked => setResult({ ...result, newWindow: checked })}
			/>
		</VerticalSpacer>
	</OKCancelModalDialog>
);
```

To this:

```TypeScript
// Render.
return (
	<OKCancelModalDialog
		renderer={props.renderer}
		width={400}
		height={300}
		title={(() => localize('positronNewFolderModalDialogTitle', "New Folder"))()}
		onAccept={async () => {
			props.renderer.dispose();
			await props.createFolder(result);
		}}
		onCancel={() => props.renderer.dispose()}>
		<VerticalStack>
			<LabeledTextInput
				ref={folderNameRef}
				label={(() => localize('positron.folderName', "Folder name"))()}
				autoFocus
				value={result.folder}
				onChange={e => setResult({ ...result, folder: e.target.value })}
			/>
			<LabeledFolderInput
				label={(() => localize(
					'positron.createFolderAsSubfolderOf',
					"Create folder as subfolder of"
				))()}
				value={result.parentFolder}
				onBrowse={browseHandler}
				onChange={e => setResult({ ...result, parentFolder: e.target.value })}
			/>
		</VerticalStack>
		<VerticalSpacer>
			<Checkbox
				label={(() => localize(
					'positron.openInNewWindow',
					"Open in a new window"
				))()}
				onChanged={checked => setResult({ ...result, newWindow: checked })}
			/>
		</VerticalSpacer>
	</OKCancelModalDialog>
);
```

Where each call to `nls.localize` goes from this:

`title={localize('positronNewFolderModalDialogTitle', "New Folder")}`

to this:

`title={(() => localize('positronNewFolderModalDialogTitle', "New Folder"))()}`

With this approach, the generated code now looks like this in `out/vs/workbench/workbench.desktop.main.js`:

```
        // Render.
        return (React.createElement(positronOKCancelModalDialog_1.$KHb, { renderer: props.renderer, width: 400, height: 300, title: (() => (0, nls_1.localize)(0, null))(), onAccept: async () => {
                props.renderer.dispose();
                await props.createFolder(result);
            }, onCancel: () => props.renderer.dispose() },
            React.createElement(verticalStack_1.$AHb, null,
                React.createElement(labeledTextInput_1.$DHb, { ref: folderNameRef, label: (() => (0, nls_1.localize)(1, null))(), autoFocus: true, value: result.folder, onChange: e => setResult({ ...result, folder: e.target.value }) }),
                React.createElement(labeledFolderInput_1.$LHb, { label: (() => (0, nls_1.localize)(2, null))(), value: result.parentFolder, onBrowse: browseHandler, onChange: e => setResult({ ...result, parentFolder: e.target.value }) })),
            React.createElement(verticalSpacer_1.$BHb, null,
                React.createElement(checkbox_1.$zHb, { label: (() => (0, nls_1.localize)(3, null))(), onChanged: checked => setResult({ ...result, newWindow: checked }) }))));
```

And this in `out/vs/workbench/workbench.desktop.main.nls.js` where the localized strings are stored:

```JSON
	"vs/workbench/browser/positronModalDialogs/newFolderModalDialog": [
		"New Folder",
		"Folder name",
		"Create folder as subfolder of",
		"Open in a new window"
	],
```

As can be seen, each localized string was processed and stored in the `out/vs/workbench/workbench.desktop.main.nls.js` file and each call to `nsl.localize` was rewritten to lookup an index into this array at runtime:

```
(() => (0, nls_1.localize)(0, null))()
(() => (0, nls_1.localize)(1, null))(),
(() => (0, nls_1.localize)(2, null))()
(() => (0, nls_1.localize)(3, null))()
```

Note: I tried to use a higher-order function to invoke the anonymous function, but this didn't work. It resulted in the same problem. Only an anonymous function, immediately invoked, solved the problem.

**This is a workaround**

I believe that a real fix for this problem might require that we fork and modify the `vscode-nls-dev` package to make it deal with JSX better than it does now. This will take _considerably_ more research to figure out.

For now, I feel this workaround offers us a path forward. It allows us to inline calls to `nsl.localize` in the JSX where they are needed. It avoids having to preload localized strings _outside_ of the JSX where they are needed, which is worse than this workaround in terms of memory usage and complexity.

When a better solution can be found, it will be pretty easy to mechanically find and fix all the anonymous functions that were created for this workaround.

I've worked out they beginnings of a Regex to do this:

`\{\(\(\)([\s\t\n]*)=>([\s\t\n]*)localize\(([\s\t\n]*)'[^']*'([\s\t\n]*),([\s\t\n]*)"[^"]+"([\s\t\n])*\)\)\(\)\}`

<img width="2328" alt="image" src="https://github.com/posit-dev/positron/assets/853239/a698606a-caac-46c8-b163-3ceaa0d0c14b">

