### PR TITLE
Hook up editor contributions to positron notebooks

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -8,6 +8,7 @@ import { EditorExtensionsRegistry, IEditorContributionDescription } from 'vs/edi
 import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { FloatingEditorClickMenu } from 'vs/workbench/browser/codeeditor';
 import { CellEditorOptions } from 'vs/workbench/contrib/notebook/browser/view/cellParts/cellEditorOptions';
 import { useNotebookInstance } from 'vs/workbench/contrib/positronNotebook/browser/NotebookInstanceProvider';
 import { useServices } from 'vs/workbench/contrib/positronNotebook/browser/ServicesProvider';
@@ -134,7 +135,7 @@ function getNotebookEditorContributions(): IEditorContributionDescription[] {
 
 	const skipContributions = [
 		'editor.contrib.review',
-		// FloatingEditorClickMenu.ID,
+		FloatingEditorClickMenu.ID,
 		'editor.contrib.dirtydiff',
 		'editor.contrib.testingOutputPeek',
 		'editor.contrib.testingDecorations',

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import * as DOM from 'vs/base/browser/dom';
+import { EditorExtensionsRegistry, IEditorContributionDescription } from 'vs/editor/browser/editorExtensions';
 
 import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -60,7 +61,6 @@ export function useCellEditorWidget(cell: IPositronNotebookCell) {
 		const editorContextKeyService = services.scopedContextKeyProviderCallback(editorPartRef.current);
 		const editorInstaService = services.instantiationService.createChild(new ServiceCollection([IContextKeyService, editorContextKeyService]));
 		const editorOptions = new CellEditorOptions(instance.getBaseCellEditorOptions(language), instance.notebookOptions, services.configurationService);
-		const editorContributions = instance.creationOptions?.cellEditorContributions ?? [];
 
 		const editor = editorInstaService.createInstance(CodeEditorWidget, nativeContainer, {
 			...editorOptions.getDefaultValue(),
@@ -69,7 +69,7 @@ export function useCellEditorWidget(cell: IPositronNotebookCell) {
 				height: 200
 			},
 		}, {
-			contributions: editorContributions
+			contributions: getNotebookEditorContributions()
 		});
 
 
@@ -125,3 +125,24 @@ export function useCellEditorWidget(cell: IPositronNotebookCell) {
 }
 
 
+/**
+ * Get the notebook options for the editor widget.
+ * Taken directly from `getDefaultNotebookCreationOptions()` in notebookEditorWidget.ts
+*/
+function getNotebookEditorContributions(): IEditorContributionDescription[] {
+	// Taken directly from `getDefaultNotebookCreationOptions()` in notebookEditorWidget.ts
+
+	// We inlined the id to avoid loading comment contrib in tests
+	const skipContributions = [
+		'editor.contrib.review',
+		// FloatingEditorClickMenu.ID,
+		'editor.contrib.dirtydiff',
+		'editor.contrib.testingOutputPeek',
+		'editor.contrib.testingDecorations',
+		'store.contrib.stickyScrollController',
+		'editor.contrib.findController',
+		'editor.contrib.emptyTextEditorHint'
+	];
+
+	return EditorExtensionsRegistry.getEditorContributions().filter(c => skipContributions.indexOf(c.id) === -1);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -145,6 +145,6 @@ function getNotebookEditorContributions(): IEditorContributionDescription[] {
 	];
 
 	// In the future we may want to be more selective about which contributions we include if our
-	// feature set diverges more drastically from the standaard notebooks.
+	// feature set diverges more drastically from the standard notebooks.
 	return EditorExtensionsRegistry.getEditorContributions().filter(c => skipContributions.indexOf(c.id) === -1);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -132,7 +132,6 @@ export function useCellEditorWidget(cell: IPositronNotebookCell) {
 function getNotebookEditorContributions(): IEditorContributionDescription[] {
 	// Taken directly from `getDefaultNotebookCreationOptions()` in notebookEditorWidget.ts
 
-	// We inlined the id to avoid loading comment contrib in tests
 	const skipContributions = [
 		'editor.contrib.review',
 		// FloatingEditorClickMenu.ID,
@@ -144,5 +143,7 @@ function getNotebookEditorContributions(): IEditorContributionDescription[] {
 		'editor.contrib.emptyTextEditorHint'
 	];
 
+	// In the future we may want to be more selective about which contributions we include if our
+	// feature set diverges more drastically from the standaard notebooks.
 	return EditorExtensionsRegistry.getEditorContributions().filter(c => skipContributions.indexOf(c.id) === -1);
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

Addresses #2353 

<img width="598" alt="image" src="https://github.com/posit-dev/positron/assets/6764693/8d3b0506-90f4-4208-a6c5-a4b54804e6a8">

_Positron Notebooks, now with an actually useful editing experience!_ 

### Intent

Add contributions to the editor widgets for each cell. Prior to this you basically only got syntax highlighting in the editor cells. This fixes that by bringing in all the contributions used on typical notebooks. 

### Approach

Used the same search-for-contribution methods used in the vscode notebooks. Function was extracted from a larger `getDefaultNotebookCreationOptions()` function that also contained other info we didn't need for our notebooks. 
