### PR TITLE
Fix how `nls.localize` is called in NewProjectModalDialog wizard steps

### DIFF
--- a/src/vs/workbench/browser/positronNewProjectWizard/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/steps/projectNameLocationStep.tsx
@@ -62,29 +62,50 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 	//   - Support mixed paragraph and code text, possibly using something like nls.
 	return (
 		<PositronWizardStep
-			title={localize('projectNameLocationStep.title', 'Set project name and location')}
+			title={(() => localize(
+				'projectNameLocationStep.title',
+				'Set project name and location'
+			))()}
 			cancelButtonConfig={{ onClick: props.cancel }}
 			nextButtonConfig={{ onClick: nextStep }}
 			backButtonConfig={{ onClick: props.back }}
 		>
 			<PositronWizardSubStep
-				title={localize('projectNameLocationSubStep.projectName.label', 'Project Name')}
+				title={(() => localize(
+					'projectNameLocationSubStep.projectName.label',
+					'Project Name'
+				))()}
 			// description={'Enter a name for your new ' + newProjectResult.projectType}
 			>
 				<LabeledTextInput
-					label={localize('projectNameLocationSubStep.projectName.description', 'Enter a name for your new {0}', projectConfig.projectType)}
+					label={(() => localize(
+						'projectNameLocationSubStep.projectName.description',
+						'Enter a name for your new {0}',
+						projectConfig.projectType
+					))()}
 					autoFocus
 					value={projectConfig.projectName}
 					onChange={e => setProjectConfig({ ...projectConfig, projectName: e.target.value })}
 				/>
 			</PositronWizardSubStep>
 			<PositronWizardSubStep
-				title={localize('projectNameLocationSubStep.parentDirectory.label', 'Parent Directory')}
+				title={(() => localize(
+					'projectNameLocationSubStep.parentDirectory.label',
+					'Parent Directory'
+				))()}
 				// description='Select a directory to create your project in.'
-				feedback={localize('projectNameLocationSubStep.parentDirectory.feedback', 'Your project will be created at: {0}/{1}', projectConfig.parentFolder, projectConfig.projectName)}
+				feedback={(() => localize(
+					'projectNameLocationSubStep.parentDirectory.feedback',
+					'Your project will be created at: {0}/{1}',
+					projectConfig.parentFolder,
+					projectConfig.projectName
+				))()}
 			>
 				<LabeledFolderInput
-					label={localize('projectNameLocationSubStep.parentDirectory.description', 'Select a directory to create your project in')}
+					label={(() => localize(
+						'projectNameLocationSubStep.parentDirectory.description',
+						'Select a directory to create your project in'
+					))()}
 					value={projectConfig.parentFolder} // this should be <code>formatted
 					onBrowse={browseHandler}
 					onChange={e => setProjectConfig({ ...projectConfig, parentFolder: e.target.value })}
@@ -99,7 +120,10 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 			<PositronWizardSubStep>
 				{/* TODO: display a warning/message if the user doesn't have git set up */}
 				<Checkbox
-					label={localize('projectNameLocationSubStep.initGitRepo.label', 'Initialize project as Git repository')}
+					label={(() => localize(
+						'projectNameLocationSubStep.initGitRepo.label',
+						'Initialize project as Git repository'
+					))()}
 					onChanged={checked => setProjectConfig({ ...projectConfig, initGitRepo: checked })}
 				/>
 			</PositronWizardSubStep>

--- a/src/vs/workbench/browser/positronNewProjectWizard/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/steps/pythonEnvironmentStep.tsx
@@ -121,16 +121,25 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 
 	return (
 		<PositronWizardStep
-			title={localize('pythonEnvironmentStep.title', 'Set up Python environment')}
+			title={(() => localize(
+				'pythonEnvironmentStep.title',
+				'Set up Python environment'
+			))()}
 			backButtonConfig={{ onClick: props.back }}
 			cancelButtonConfig={{ onClick: props.cancel }}
 			okButtonConfig={{
 				onClick: props.accept,
-				title: localize('positronNewProjectWizard.createButtonTitle', "Create"),
+				title: (() => localize(
+					'positronNewProjectWizard.createButtonTitle',
+					"Create"
+				))(),
 			}}
 		>
 			<PositronWizardSubStep
-				title={localize('pythonEnvironmentSubStep.howToSetUpEnv', 'How would you like to set up your Python project environment?')}
+				title={(() => localize(
+					'pythonEnvironmentSubStep.howToSetUpEnv',
+					'How would you like to set up your Python project environment?'
+				))()}
 			>
 				{/* TODO: create radiogroup and radiobutton components */}
 				<div style={{ display: 'flex', flexDirection: 'column', rowGap: '4px' }}>
@@ -149,16 +158,30 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 				</div>
 			</PositronWizardSubStep>
 			<PositronWizardSubStep
-				title={localize('pythonEnvironmentSubStep.label', 'Python Environment')}
-				description={localize('pythonEnvironmentSubStep.description', 'Select an environment type for your project.')}
+				title={(() => localize(
+					'pythonEnvironmentSubStep.label',
+					'Python Environment'
+				))()}
+				description={(() => localize(
+					'pythonEnvironmentSubStep.description',
+					'Select an environment type for your project.'
+				))()}
 				// TODO: construct the env location based on the envTypeEntries above, instead of inline here
-				feedback={localize('pythonEnvironmentSubStep.feedback', 'The {0} environment will be created at: {1}', projectConfig.pythonEnvType, `${projectConfig.parentFolder}/${projectConfig.projectName}/${projectConfig.pythonEnvType === 'Venv' ? '.venv' : 'Conda' ? '.conda' : ''}`)}
+				feedback={(() => localize(
+					'pythonEnvironmentSubStep.feedback',
+					'The {0} environment will be created at: {1}',
+					projectConfig.pythonEnvType,
+					`${projectConfig.parentFolder}/${projectConfig.projectName}/${projectConfig.pythonEnvType === 'Venv' ? '.venv' : 'Conda' ? '.conda' : ''}`
+				))()}
 			>
 				{/* TODO: how to pre-select an option? */}
 				<DropDownListBox
 					keybindingService={keybindingService}
 					layoutService={layoutService}
-					title={localize('pythonEnvironmentSubStep.dropDown.title', 'Select an environment type')}
+					title={(() => localize(
+						'pythonEnvironmentSubStep.dropDown.title',
+						'Select an environment type'
+					))()}
 					entries={envTypeEntries}
 					onSelectionChanged={identifier => onEnvTypeSelected(identifier)}
 				/>
@@ -167,15 +190,24 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 			{/*       onhover tooltip, display the following note if we don't detect ipykernel for the selected interpreter */}
 			{/*       <p>Note: Positron will install <code>ipykernel</code> in this environment for Python language support.</p> */}
 			<PositronWizardSubStep
-				title={localize('pythonInterpreterSubStep.title', 'Python Interpreter')}
-				description={localize('pythonInterpreterSubStep.description', 'Select a Python installation for your project. You can modify this later if you change your mind.')}
+				title={(() => localize(
+					'pythonInterpreterSubStep.title',
+					'Python Interpreter'
+				))()}
+				description={(() => localize(
+					'pythonInterpreterSubStep.description',
+					'Select a Python installation for your project. You can modify this later if you change your mind.'
+				))()}
 			>
 				{startupPhase !== RuntimeStartupPhase.Complete ?
 					// TODO: how to disable clicking on the combo box while loading?
 					<DropDownListBox
 						keybindingService={keybindingService}
 						layoutService={layoutService}
-						title={localize('pythonInterpreterSubStep.dropDown.title.loading', 'Loading interpreters...')}
+						title={(() => localize(
+							'pythonInterpreterSubStep.dropDown.title.loading',
+							'Loading interpreters...'
+						))()}
 						entries={[]}
 						onSelectionChanged={() => { }}
 					/> : null
@@ -185,7 +217,10 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 					<DropDownListBox
 						keybindingService={keybindingService}
 						layoutService={layoutService}
-						title={localize('pythonInterpreterSubStep.dropDown.title', 'Select a Python interpreter')}
+						title={(() => localize(
+							'pythonInterpreterSubStep.dropDown.title',
+							'Select a Python interpreter'
+						))()}
 						// TODO: if the runtime startup phase is complete, but there are no suitable interpreters, show a message
 						// that no suitable interpreters were found and the user should install an interpreter with minimum version
 						entries={interpreterEntries}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses the NewProject modal part of https://github.com/posit-dev/positron/issues/2590.

In the New Project modal case, clicking `Next` to navigate to the Project Name & Location step would result in the following error in the console:

![image](https://github.com/posit-dev/positron/assets/25834218/95ed7c4e-3187-455c-a977-a277bbbb98a2)

#### workbench.js:2289
<img width="528" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/62a95e5d-0f74-464c-a65a-ac5d45ad203e">

#### workbench.js:2337
<img width="520" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/85f9ba84-0fd6-471a-a4b0-774571043b7e">

### Approach

Leverages the method described in https://github.com/posit-dev/positron/pull/2618 to avoid `localize` errors.

Something interesting...after I tested this change locally, I tried opening the release builds where this issue was previously occurring, and I could no longer reproduce the missing string error. 🤔

### QA Notes

Since the New Project feature is currently disabled in release builds, you'll have to build a release locally, changing at least one of the `isDevelopmentContext` feature flags (see [here](https://github.com/posit-dev/positron/pull/2611/files)) to `false` in order to enable the New Project action in at least one place. Feel free to ping me for help, or I can provide a locally built Mac release.