### PR TITLE
Fix remaining calls to localize in React components

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
@@ -51,7 +51,7 @@ export const ActionBarFilter = (props: ActionBarFilterProps) => {
 					ref={inputRef}
 					type='text'
 					className='text-input'
-					placeholder={localize('positronFilterPlacehold', "filter")}
+					placeholder={(() => localize('positronFilterPlacehold', "filter"))()}
 					value={filterText}
 					onFocus={() => setFocused(true)}
 					onBlur={() => setFocused(false)}

--- a/src/vs/platform/positronActionBar/browser/components/actionBarFind.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFind.tsx
@@ -53,7 +53,7 @@ export const ActionBarFind = (props: ActionBarFindProps) => {
 					ref={inputRef}
 					type='text'
 					className='text-input'
-					placeholder={localize('positronFindPlacehold', "find")}
+					placeholder={(() => localize('positronFindPlacehold', "find"))()}
 					value={findText}
 					onFocus={() => setFocused(true)}
 					onBlur={() => setFocused(false)}
@@ -64,8 +64,8 @@ export const ActionBarFind = (props: ActionBarFindProps) => {
 					</button>
 				)}
 			</div>
-			<ActionBarButton layout='tight' iconId='chevron-up' align='right' tooltip={localize('positronFindPrevious', "Find previous")} disabled={!props.findResults} onPressed={() => props.onFindPrevious!()} />
-			<ActionBarButton layout='tight' iconId='chevron-down' align='right' tooltip={localize('positronFindNext', "Find next")} disabled={!props.findResults} onPressed={() => props.onFindNext!()} />
+			<ActionBarButton layout='tight' iconId='chevron-up' align='right' tooltip={(() => localize('positronFindPrevious', "Find previous"))()} disabled={!props.findResults} onPressed={() => props.onFindPrevious!()} />
+			<ActionBarButton layout='tight' iconId='chevron-down' align='right' tooltip={(() => localize('positronFindNext', "Find next"))()} disabled={!props.findResults} onPressed={() => props.onFindNext!()} />
 		</div>
 	);
 };

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
@@ -99,7 +99,7 @@ export const CustomFolderMenuItems = (props: CustomFolderMenuItemsProps) => {
 		return (
 			<>
 				<CustomFolderMenuSeparator />
-				{props.recentlyOpened.workspaces.slice(0, 10).map(recent => {
+				{props.recentlyOpened.workspaces.slice(0, 10).map((recent, index) => {
 					// Setup the handler.
 					let uri: URI;
 					let label: string;
@@ -120,6 +120,7 @@ export const CustomFolderMenuItems = (props: CustomFolderMenuItemsProps) => {
 					// Render.
 					return (
 						<CustomFolderRecentlyUsedMenuItem
+							key={index}
 							label={label}
 							enabled={true}
 							onOpen={e => {
@@ -156,11 +157,11 @@ export const CustomFolderMenuItems = (props: CustomFolderMenuItemsProps) => {
 			<CustomFolderMenuSeparator />
 			<CommandActionCustomFolderMenuItem
 				id={OpenFolderAction.ID}
-				label={localize('positronOpenFolder', "Open Folder...")} />
+				label={(() => localize('positronOpenFolder', "Open Folder..."))()} />
 			<CommandActionCustomFolderMenuItem id={PositronOpenFolderInNewWindowAction.ID} />
 			<CommandActionCustomFolderMenuItem
 				id={kCloseFolder}
-				label={localize('positronCloseFolder', "Close Folder")}
+				label={(() => localize('positronCloseFolder', "Close Folder"))()}
 				separator={true}
 				when={ContextKeyExpr.and(
 					WorkbenchStateContext.isEqualTo('folder'),

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterActions.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterActions.tsx
@@ -104,7 +104,7 @@ export const InterpreterActions = (props: PropsWithChildren<InterpreterActionsPr
 				>
 					<span
 						className='codicon codicon-positron-interrupt-runtime'
-						title={localize('positronInterruptInterpreter', "Interrupt the interpreter")}
+						title={(() => localize('positronInterruptInterpreter', "Interrupt the interpreter"))()}
 						style={{ color: 'red' }}
 					/>
 				</PositronButton>
@@ -123,7 +123,7 @@ export const InterpreterActions = (props: PropsWithChildren<InterpreterActionsPr
 				>
 					<span
 						className='codicon codicon-positron-restart-runtime'
-						title={localize('positronRestartInterpreter', "Restart the interpreter")}
+						title={(() => localize('positronRestartInterpreter', "Restart the interpreter"))()}
 					/>
 				</PositronButton>
 			}
@@ -142,7 +142,7 @@ export const InterpreterActions = (props: PropsWithChildren<InterpreterActionsPr
 				<PositronButton className='action-button' onPressed={shutdown}>
 					<span
 						className='codicon codicon-positron-power-button'
-						title={localize('positronStopTheInterpreter', "Stop the interpreter")}
+						title={(() => localize('positronStopTheInterpreter', "Stop the interpreter"))()}
 					/>
 				</PositronButton>
 			}
@@ -159,7 +159,7 @@ export const InterpreterActions = (props: PropsWithChildren<InterpreterActionsPr
 				<PositronButton className='action-button' onPressed={() => props.onStart()}>
 					<span
 						className='codicon codicon-positron-power-button'
-						title={localize('positronStartTheInterpreter', "Start the interpreter")}
+						title={(() => localize('positronStartTheInterpreter', "Start the interpreter"))()}
 					/>
 				</PositronButton>
 			}

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/primaryInterpreter.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/primaryInterpreter.tsx
@@ -90,7 +90,7 @@ export const PrimaryInterpreter = (props: PrimaryInterpreterProps) => {
 					<PositronButton className='action-button' onPressed={props.onShowAllVersions}>
 						<span
 							className='codicon codicon-positron-more-options'
-							title={localize('positronShowAllVersions', "Show all versions")}
+							title={(() => localize('positronShowAllVersions', "Show all versions"))()}
 						/>
 					</PositronButton>
 				}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -549,10 +549,10 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					keybindingService={props.renderer.keybindingService}
 					layoutService={props.renderer.layoutService}
 					dataExplorerClientInstance={props.dataExplorerClientInstance}
-					title={localize(
+					title={(() => localize(
 						'positron.addEditRowFilter.selectColumn',
 						"Select Column"
-					)}
+					))()}
 					selectedColumnSchema={selectedColumnSchema}
 					onSelectedColumnSchemaChanged={columnSchema => {
 						// Set the selected column schema.
@@ -569,10 +569,10 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					disabled={selectedColumnSchema === undefined}
 					keybindingService={props.renderer.keybindingService}
 					layoutService={props.renderer.layoutService}
-					title={localize(
+					title={(() => localize(
 						'positron.addEditRowFilter.selectCondition',
 						"Select Condition"
-					)}
+					))()}
 					entries={conditionEntries()}
 					selectedIdentifier={selectedCondition}
 					onSelectionChanged={identifier => {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSearch.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSearch.tsx
@@ -42,7 +42,7 @@ export const ColumnSearch = (props: ColumnSearchProps) => {
 					ref={inputRef}
 					type='text'
 					className='text-input'
-					placeholder={localize('positron.searchPlacehold', "search")}
+					placeholder={(() => localize('positron.searchPlacehold', "search"))()}
 					value={searchText}
 					onFocus={() => setFocused(true)}
 					onBlur={() => setFocused(false)}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -150,7 +150,7 @@ export const RowFilterBar = () => {
 			<Button
 				ref={filterButtonRef}
 				className='row-filter-button'
-				ariaLabel={localize('positron.dataExplorer.filtering', "Filtering")}
+				ariaLabel={(() => localize('positron.dataExplorer.filtering', "Filtering"))()}
 				onPressed={filterButtonPressedHandler}
 			>
 				<div className='codicon codicon-positron-row-filter' />
@@ -180,7 +180,7 @@ export const RowFilterBar = () => {
 				<Button
 					ref={addFilterButtonRef}
 					className='add-row-filter-button'
-					ariaLabel={localize('positron.dataExplorer.addFilter', "Add filter")}
+					ariaLabel={(() => localize('positron.dataExplorer.addFilter', "Add filter"))()}
 					onPressed={() => showAddEditRowFilterModalPopup(addFilterButtonRef.current)}
 				>
 					<div className='codicon codicon-positron-add-filter' />

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -135,7 +135,7 @@ const NewProjectModalDialog = (props: NewProjectModalDialogProps) => {
 		<PositronModalDialog
 			renderer={props.renderer}
 			width={700} height={500}
-			title={localize('positronNewProjectWizard.title', "Create New Project")}
+			title={(() => localize('positronNewProjectWizard.title', "Create New Project"))()}
 			onAccept={acceptHandler}
 			onCancel={cancelHandler}
 		>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -315,9 +315,11 @@ export const ActionBar = (props: ActionBarProps) => {
 						<div className='action-bar-separator' />
 						{directoryLabel &&
 							<div className='directory-label'
-								aria-label={
-									localize('directoryLabel', "Current Working Directory")
-								}>
+								aria-label={(() => localize(
+									'directoryLabel',
+									"Current Working Directory"
+								))()}
+							>
 								<span className='codicon codicon-folder' role='presentation'></span>
 								<span className='label' title={directoryLabel}>{directoryLabel}</span>
 							</div>

--- a/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
@@ -173,7 +173,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 					{/* <ActionBarSeparator /> */}
 					{/* <ActionBarButton
 						iconId='positron-open-in-new-window'
-						tooltip={localize('positronShowInNewWindow', "Show in new window")}
+						tooltip={(() => localize('positronShowInNewWindow', "Show in new window"))()}
 					/> */}
 
 				</PositronActionBar>

--- a/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.tsx
@@ -15,7 +15,7 @@ export function AddCellButtons({ index }: { index: number }) {
 	return <div className='positron-add-cell-buttons'>
 		<Button
 			className='action action-button'
-			ariaLabel={localize('addCodeCell', 'Add code cell')}
+			ariaLabel={(() => localize('addCodeCell', 'Add code cell'))()}
 			onPressed={() => {
 				notebookInstance.addCell(CellKind.Code, index);
 			}}
@@ -25,7 +25,7 @@ export function AddCellButtons({ index }: { index: number }) {
 		</Button>
 		<Button
 			className='action action-button'
-			ariaLabel={localize('addMarkdownell', 'Add markdown cell')}
+			ariaLabel={(() => localize('addMarkdownell', 'Add markdown cell'))()}
 			onPressed={() => {
 				notebookInstance.addCell(CellKind.Markup, index);
 			}}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -28,7 +28,7 @@ export function PositronNotebookComponent() {
 				<div className='positron-notebook-cells-action-bar'>
 					<Button
 						className='action action-button run-button'
-						ariaLabel={localize('runAllCells', 'Run all cells')}
+						ariaLabel={(() => localize('runAllCells', 'Run all cells'))()}
 						onPressed={() => { notebookInstance.runAllCells(); }}
 					>
 						<span className='action-label'>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeferredImage.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeferredImage.tsx
@@ -103,7 +103,7 @@ export function DeferredImage({ src = 'no-source', ...props }: React.ComponentPr
 		case 'pending':
 			return <div
 				className='positron-notebooks-deferred-img-placeholder'
-				aria-label={localize('deferredImageLoading', 'Loading image...')}
+				aria-label={(() => localize('deferredImageLoading', 'Loading image...'))()}
 				role='img'
 				{...props}
 			></div>;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -15,7 +15,7 @@ export function NotebookCellActionBar({ cell, children }: { cell: IPositronNoteb
 		{children}
 		<Button
 			className='action-button'
-			ariaLabel={localize('deleteCell', 'Delete cell')}
+			ariaLabel={(() => localize('deleteCell', 'Delete cell'))()}
 			onPressed={() => cell.delete()}
 		>
 			<div className='button-icon codicon codicon-trash' />

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/setPlotSizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/setPlotSizeModalDialog.tsx
@@ -107,7 +107,7 @@ const SetPlotSizeModalDialog = (props: SetPlotSizeModalDialogProps) => {
 			renderer={props.renderer}
 			width={350}
 			height={200}
-			title={localize('positronSetPlotSizeModalDialogTitle', "Custom Plot Size")}
+			title={(() => localize('positronSetPlotSizeModalDialogTitle', "Custom Plot Size"))()}
 			onAccept={acceptHandler}
 			onCancel={cancelHandler}>
 			<ContentArea>

--- a/src/vs/workbench/contrib/positronVariables/browser/modalDialogs/deleteAllVariablesModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/modalDialogs/deleteAllVariablesModalDialog.tsx
@@ -41,9 +41,12 @@ export const DeleteAllVariablesModalDialog = (props: DeleteAllVariablesModalDial
 			renderer={props.renderer}
 			width={375}
 			height={175}
-			title={localize('positron.deleteAllVariablesModalDialogTitle', "Delete All Variables")}
-			okButtonTitle={localize('positron.yes', "Yes")}
-			cancelButtonTitle={localize('positron.no', "No")}
+			title={(() => localize(
+				'positron.deleteAllVariablesModalDialogTitle',
+				"Delete All Variables"
+			))()}
+			okButtonTitle={(() => localize('positron.yes', "Yes"))()}
+			cancelButtonTitle={(() => localize('positron.no', "No"))()}
 			onAccept={async () => {
 				props.renderer.dispose();
 				await props.deleteAllVariablesAction({
@@ -54,10 +57,10 @@ export const DeleteAllVariablesModalDialog = (props: DeleteAllVariablesModalDial
 		>
 			<VerticalStack>
 				<div>
-					{localize(
+					{(() => localize(
 						'positron.deleteAllVariablesModalDialogText',
 						"Are you sure you want to delete all variables? This operation cannot be undone."
-					)}
+					))()}
 				</div>
 				{/* Disabled for Private Alpha. */}
 				{/* <Checkbox label='Include hidden objects' onChanged={checked => setResult({ ...result, includeHiddenObjects: checked })} /> */}


### PR DESCRIPTION
### Intent

This PR is a follow on PR to https://github.com/posit-dev/positron/pull/2618

### Approach

This PR wraps calls to `nls.localize` in an immediately-invoked anonymous function in every React component that was not fixed in https://github.com/posit-dev/positron/pull/2618 or https://github.com/posit-dev/positron/pull/2625.

### QA Notes

None.