### PR TITLE
Fixes codicons regression

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/button/button.css
+++ b/src/vs/base/browser/ui/positronComponents/button/button.css
@@ -2,22 +2,22 @@
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
-.button {
+.positron-button {
 	border: none;
 	cursor: pointer;
 	background-color: transparent;
 	font-family: unset !important;
 }
 
-.button:focus {
+.positron-button:focus {
 	outline: none !important;
 }
 
-.button:focus-visible {
+.positron-button:focus-visible {
 	border-radius: 4px;
 	outline: 1px solid var(--vscode-focusBorder) !important;
 }
 
-.button.solid:focus-visible {
+.positron-button.solid:focus-visible {
 	outline-offset: 2px !important;
 }

--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -113,7 +113,7 @@ export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<Props>>((p
 		<button
 			ref={ref}
 			className={positronClassNames(
-				'button',
+				'positron-button',
 				props.className,
 				{ 'disabled': props.disabled }
 			)}


### PR DESCRIPTION
### Intent

This PR addresses https://github.com/posit-dev/positron/issues/2601.

![image](https://github.com/posit-dev/positron/assets/853239/61ab5ef5-0a0c-458a-95a1-15e3acefe9e9)

In this issue, codicons on the find widget were loading correctly.

### Approach

The problem turned out to be a regression caused by adding this line to `button.css`:

```
font-family: unset !important;
```

This line was added because the default styling of a `button` element uses Arial as the font.

The fix for this was to change the class name of the Positron Button component to `positron-button` so that its styling doesn't conflict with buttons in the the find widget.

### QA Notes

The find widget should now look normal:

<img width="440" alt="image" src="https://github.com/posit-dev/positron/assets/853239/24a92857-8369-4bf1-b77b-d3bbaf582caa">
