### PR TITLE
Basic copy plot to clipboard

### DIFF
--- a/src/vs/platform/clipboard/browser/clipboardService.ts
+++ b/src/vs/platform/clipboard/browser/clipboardService.ts
@@ -189,6 +189,17 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 		return this.resources;
 	}
 
+	// --- Start Positron ---
+	async writeImage(data: string): Promise<void> {
+		const blob = new Blob([data], { type: 'image/png' });
+		navigator.clipboard.write([
+			new ClipboardItem({
+				[blob.type]: blob
+			}
+			)]);
+	}
+	// --- End Positron ---
+
 	private async computeResourcesStateHash(): Promise<number | undefined> {
 		if (this.resources.length === 0) {
 			return undefined; // no resources, no hash needed

--- a/src/vs/platform/clipboard/common/clipboardService.ts
+++ b/src/vs/platform/clipboard/common/clipboardService.ts
@@ -37,6 +37,10 @@ export interface IClipboardService {
 	 */
 	writeResources(resources: URI[]): Promise<void>;
 
+	// --- Start Positron ---
+	writeImage(data: string): Promise<void>;
+	// --- End Positron ---
+
 	/**
 	 * Reads resources from the system clipboard.
 	 */

--- a/src/vs/platform/clipboard/test/common/testClipboardService.ts
+++ b/src/vs/platform/clipboard/test/common/testClipboardService.ts
@@ -36,6 +36,12 @@ export class TestClipboardService implements IClipboardService {
 		this.resources = resources;
 	}
 
+	// --- Start Positron ---
+	async writeImage(data: string): Promise<void> {
+		// no-op
+	}
+	// --- End Positron ---
+
 	async readResources(): Promise<URI[]> {
 		return this.resources ?? [];
 	}

--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -152,6 +152,10 @@ export interface ICommonNativeHostService {
 	readClipboardBuffer(format: string): Promise<VSBuffer>;
 	hasClipboard(format: string, type?: 'selection' | 'clipboard'): Promise<boolean>;
 
+	// --- Start Positron ---
+	writeClipboardImage(dataUri: string): Promise<void>;
+	// --- End Positron ---
+
 	// macOS Touchbar
 	newWindowTab(): Promise<void>;
 	showPreviousWindowTab(): Promise<void>;

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { exec } from 'child_process';
-import { app, BrowserWindow, clipboard, Display, Menu, MessageBoxOptions, MessageBoxReturnValue, OpenDevToolsOptions, OpenDialogOptions, OpenDialogReturnValue, powerMonitor, SaveDialogOptions, SaveDialogReturnValue, screen, shell } from 'electron';
+import { app, BrowserWindow, clipboard, Display, Menu, MessageBoxOptions, MessageBoxReturnValue, nativeImage, OpenDevToolsOptions, OpenDialogOptions, OpenDialogReturnValue, powerMonitor, SaveDialogOptions, SaveDialogReturnValue, screen, shell } from 'electron';
 import { arch, cpus, freemem, loadavg, platform, release, totalmem, type } from 'os';
 import { promisify } from 'util';
 import { memoize } from 'vs/base/common/decorators';
@@ -646,6 +646,12 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 	async hasClipboard(windowId: number | undefined, format: string, type?: 'selection' | 'clipboard'): Promise<boolean> {
 		return clipboard.has(format, type);
 	}
+
+	// --- Start Positron ---
+	async writeClipboardImage(windowId: number | undefined, dataUri: string): Promise<void> {
+		return clipboard.writeImage(nativeImage.createFromDataURL(dataUri));
+	}
+	// --- End Positron ---
 
 	//#endregion
 

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { exec } from 'child_process';
-import { app, BrowserWindow, clipboard, Display, Menu, MessageBoxOptions, MessageBoxReturnValue, nativeImage, OpenDevToolsOptions, OpenDialogOptions, OpenDialogReturnValue, powerMonitor, SaveDialogOptions, SaveDialogReturnValue, screen, shell } from 'electron';
+import { app, BrowserWindow, clipboard, Display, Menu, MessageBoxOptions, MessageBoxReturnValue, OpenDevToolsOptions, OpenDialogOptions, OpenDialogReturnValue, powerMonitor, SaveDialogOptions, SaveDialogReturnValue, screen, shell } from 'electron';
 import { arch, cpus, freemem, loadavg, platform, release, totalmem, type } from 'os';
 import { promisify } from 'util';
 import { memoize } from 'vs/base/common/decorators';
@@ -43,6 +43,11 @@ import { IV8Profile } from 'vs/platform/profiling/common/profiling';
 import { IAuxiliaryWindowsMainService } from 'vs/platform/auxiliaryWindow/electron-main/auxiliaryWindows';
 import { IAuxiliaryWindow } from 'vs/platform/auxiliaryWindow/electron-main/auxiliaryWindow';
 import { CancellationError } from 'vs/base/common/errors';
+
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { nativeImage } from 'electron';
+// --- End Positron ---
 
 export interface INativeHostMainService extends AddFirstParameterToFunctions<ICommonNativeHostService, Promise<unknown> /* only methods, not events */, number | undefined /* window ID */> { }
 

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -111,14 +111,13 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	};
 
 	const copyPlotHandler = () => {
-		const copyResult = positronPlotsContext.positronPlotsService.copyPlotToClipboard();
-
-		if (copyResult) {
-			positronPlotsContext.notificationService.info(localize('positronPlotsServiceCopyToClipboard', 'Plot copied to clipboard'));
-		} else {
-			positronPlotsContext.notificationService.error(localize('positronPlotsServiceCopyToClipboardError', 'Failed to copy plot to clipboard'));
-
-		}
+		positronPlotsContext.positronPlotsService.copyPlotToClipboard()
+			.then(() => {
+				positronPlotsContext.notificationService.info(localize('positronPlotsServiceCopyToClipboard', 'Plot copied to clipboard'));
+			})
+			.catch((error) => {
+				positronPlotsContext.notificationService.error(localize('positronPlotsServiceCopyToClipboardError', 'Failed to copy plot to clipboard: {0}', error.message));
+			});
 
 	};
 

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -111,7 +111,15 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	};
 
 	const copyPlotHandler = () => {
-		positronPlotsContext.positronPlotsService.copyPlotToClipboard();
+		const copyResult = positronPlotsContext.positronPlotsService.copyPlotToClipboard();
+
+		if (copyResult) {
+			positronPlotsContext.notificationService.info(localize('positronPlotsServiceCopyToClipboard', 'Plot copied to clipboard'));
+		} else {
+			positronPlotsContext.notificationService.error(localize('positronPlotsServiceCopyToClipboardError', 'Failed to copy plot to clipboard'));
+
+		}
+
 	};
 
 	// Render.
@@ -124,8 +132,6 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 							ariaLabel={localize('positronShowPreviousPlot', "Show previous plot")} onPressed={showPreviousPlotHandler} />
 						<ActionBarButton iconId='positron-right-arrow' disabled={disableRight} tooltip={localize('positronShowNextPlot', "Show next plot")}
 							ariaLabel={localize('positronShowNextPlot', "Show next plot")} onPressed={showNextPlotHandler} />
-						<ActionBarButton iconId='copy' disabled={!hasPlots} tooltip={localize('positron-copy-plot', "Copy plot to clipboard")} ariaLabel={localize('positron-copy-plot', "Copy plot to clipboard")}
-							onPressed={copyPlotHandler} />
 
 						{(enableSizingPolicy || enableSavingPlots || enableZoomPlot) && <ActionBarSeparator />}
 						{enableSavingPlots && <ActionBarButton iconId='positron-save' tooltip={localize('positronSavePlot', "Save plot")}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -72,6 +72,12 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		&& (selectedPlot instanceof PlotClientInstance
 			|| selectedPlot instanceof StaticPlotClient);
 
+	const enableCopyPlot = hasPlots &&
+		(positronPlotsContext.positronPlotInstances[positronPlotsContext.selectedInstanceIndex]
+			instanceof StaticPlotClient
+			|| positronPlotsContext.positronPlotInstances[positronPlotsContext.selectedInstanceIndex]
+			instanceof PlotClientInstance);
+
 	useEffect(() => {
 		// Empty for now.
 	});
@@ -124,6 +130,8 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						{(enableSizingPolicy || enableSavingPlots || enableZoomPlot) && <ActionBarSeparator />}
 						{enableSavingPlots && <ActionBarButton iconId='positron-save' tooltip={localize('positronSavePlot', "Save plot")}
 							ariaLabel={localize('positronSavePlot', "Save plot")} onPressed={savePlotHandler} />}
+						{enableCopyPlot && <ActionBarButton iconId='copy' disabled={!hasPlots} tooltip={localize('positron-copy-plot', "Copy plot to clipboard")} ariaLabel={localize('positron-copy-plot', "Copy plot to clipboard")}
+							onPressed={copyPlotHandler} />}
 						{enableZoomPlot && <ZoomPlotMenuButton actionHandler={zoomPlotHandler} zoomLevel={props.zoomLevel} />}
 						{enableSizingPolicy &&
 							<SizingPolicyMenuButton

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -104,6 +104,10 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		positronPlotsContext.positronPlotsService.savePlot();
 	};
 
+	const copyPlotHandler = () => {
+		positronPlotsContext.positronPlotsService.copyPlotToClipboard();
+	};
+
 	// Render.
 	return (
 		<PositronActionBarContextProvider {...props}>
@@ -114,6 +118,8 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 							ariaLabel={localize('positronShowPreviousPlot', "Show previous plot")} onPressed={showPreviousPlotHandler} />
 						<ActionBarButton iconId='positron-right-arrow' disabled={disableRight} tooltip={localize('positronShowNextPlot', "Show next plot")}
 							ariaLabel={localize('positronShowNextPlot', "Show next plot")} onPressed={showNextPlotHandler} />
+						<ActionBarButton iconId='copy' disabled={!hasPlots} tooltip={localize('positron-copy-plot', "Copy plot to clipboard")} ariaLabel={localize('positron-copy-plot', "Copy plot to clipboard")}
+							onPressed={copyPlotHandler} />
 
 						{(enableSizingPolicy || enableSavingPlots || enableZoomPlot) && <ActionBarSeparator />}
 						{enableSavingPlots && <ActionBarButton iconId='positron-save' tooltip={localize('positronSavePlot', "Save plot")}

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -747,20 +747,23 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		});
 	}
 
-	copyPlotToClipboard(): boolean {
+	async copyPlotToClipboard(): Promise<void> {
 		const plot = this._plots.find(plot => plot.id === this.selectedPlotId);
-		let copyStatus = false;
 		if (plot instanceof StaticPlotClient) {
-			this._clipboardService.writeImage(plot.uri);
-			copyStatus = true;
+			try {
+				await this._clipboardService.writeImage(plot.uri);
+			} catch (error) {
+				throw new Error(error.message);
+			}
 		} else if (plot instanceof PlotClientInstance) {
 			if (plot.lastRender?.uri) {
-				this._clipboardService.writeImage(plot.lastRender.uri);
-				copyStatus = true;
+				try {
+					await this._clipboardService.writeImage(plot.lastRender.uri);
+				} catch (error) {
+					throw new Error(error.message);
+				}
 			}
 		}
-
-		return copyStatus;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -747,15 +747,20 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		});
 	}
 
-	copyPlotToClipboard(): void {
+	copyPlotToClipboard(): boolean {
 		const plot = this._plots.find(plot => plot.id === this.selectedPlotId);
+		let copyStatus = false;
 		if (plot instanceof StaticPlotClient) {
 			this._clipboardService.writeImage(plot.uri);
+			copyStatus = true;
 		} else if (plot instanceof PlotClientInstance) {
 			if (plot.lastRender?.uri) {
 				this._clipboardService.writeImage(plot.lastRender.uri);
+				copyStatus = true;
 			}
 		}
+
+		return copyStatus;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -750,10 +750,11 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	copyPlotToClipboard(): void {
 		const plot = this._plots.find(plot => plot.id === this.selectedPlotId);
 		if (plot instanceof StaticPlotClient) {
-			// this._clipboardService.writeResources([URI.parse(plot.uri)]);
 			this._clipboardService.writeImage(plot.uri);
 		} else if (plot instanceof PlotClientInstance) {
-			this._clipboardService.writeResources([plot.lastRender?.uri.toString() ? URI.parse(plot.lastRender.uri) : URI.parse('')]);
+			if (plot.lastRender?.uri) {
+				this._clipboardService.writeImage(plot.lastRender.uri);
+			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -31,6 +31,7 @@ import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/la
 import { URI } from 'vs/base/common/uri';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 
 /** The maximum number of recent executions to store. */
 const MaxRecentExecutions = 10;
@@ -107,7 +108,8 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		@IFileDialogService private readonly _fileDialogService: IFileDialogService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
-		@IKeybindingService private readonly _keybindingService: IKeybindingService) {
+		@IKeybindingService private readonly _keybindingService: IKeybindingService,
+		@IClipboardService private _clipboardService: IClipboardService) {
 		super();
 
 		// Register for language runtime service startups
@@ -743,6 +745,16 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 				this.savePlotAs({ path: result, uri });
 			}
 		});
+	}
+
+	copyPlotToClipboard(): void {
+		const plot = this._plots.find(plot => plot.id === this.selectedPlotId);
+		if (plot instanceof StaticPlotClient) {
+			// this._clipboardService.writeResources([URI.parse(plot.uri)]);
+			this._clipboardService.writeImage(plot.uri);
+		} else if (plot instanceof PlotClientInstance) {
+			this._clipboardService.writeResources([plot.lastRender?.uri.toString() ? URI.parse(plot.lastRender.uri) : URI.parse('')]);
+		}
 	}
 
 	/**

--- a/src/vs/workbench/services/clipboard/electron-sandbox/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/electron-sandbox/clipboardService.ts
@@ -48,6 +48,12 @@ export class NativeClipboardService implements IClipboardService {
 		}
 	}
 
+	// --- Start Positron ---
+	async writeImage(data: string): Promise<void> {
+		return this.nativeHostService.writeClipboardImage(data);
+	}
+	// --- End Positron ---
+
 	async readResources(): Promise<URI[]> {
 		return this.bufferToResources(await this.nativeHostService.readClipboardBuffer(NativeClipboardService.FILE_FORMAT));
 	}

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -150,7 +150,12 @@ export interface IPositronPlotsService {
 	 */
 	selectHistoryPolicy(policy: HistoryPolicy): void;
 
-	copyPlotToClipboard(): void;
+	/**
+	 * Copies the selected plot to the clipboard.
+	 *
+	 * @returns true if the plot was copied to the clipboard, false otherwise.
+	 */
+	copyPlotToClipboard(): boolean;
 
 	/**
 	 * Saves the plot.

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -153,9 +153,9 @@ export interface IPositronPlotsService {
 	/**
 	 * Copies the selected plot to the clipboard.
 	 *
-	 * @returns true if the plot was copied to the clipboard, false otherwise.
+	 * @throws An error if the plot cannot be copied.
 	 */
-	copyPlotToClipboard(): boolean;
+	copyPlotToClipboard(): Promise<void>;
 
 	/**
 	 * Saves the plot.

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -150,6 +150,8 @@ export interface IPositronPlotsService {
 	 */
 	selectHistoryPolicy(policy: HistoryPolicy): void;
 
+	copyPlotToClipboard(): void;
+
 	/**
 	 * Saves the plot.
 	 */

--- a/src/vs/workbench/test/electron-sandbox/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-sandbox/workbenchTestServices.ts
@@ -153,6 +153,10 @@ export class TestNativeHostService implements INativeHostService {
 	async hasClipboard(format: string, type?: 'selection' | 'clipboard' | undefined): Promise<boolean> { return false; }
 	async windowsGetStringRegKey(hive: 'HKEY_CURRENT_USER' | 'HKEY_LOCAL_MACHINE' | 'HKEY_CLASSES_ROOT' | 'HKEY_USERS' | 'HKEY_CURRENT_CONFIG', path: string, name: string): Promise<string | undefined> { return undefined; }
 	async profileRenderer(): Promise<any> { throw new Error(); }
+
+	// --- Start Positron ---
+	async writeClipboardImage(dataUri: string): Promise<void> { }
+	// --- End Positron ---
 }
 
 export class TestExtensionTipsService extends AbstractNativeExtensionTipsService {


### PR DESCRIPTION
### Intent
Address #421 

### Approach
Adds a Plots pane action button to copy the current plot to the clipboard. This currently writes the same image as shown without any ability to set any options (for dynamic plots).

The clipboard service needed to add support for Electron's `clipboard.writeImage` API. It can conveniently handle a data URI that we already have from rendering the plot for the pane.

### QA Notes
This is basic support for copying to the clipboard for desktop. It's unknown if this works in the web. The web API to access the clipboard does need permission so this may fail until obtaining permission is implemented.