### PR TITLE
Add 'get_supported_features' RPC for data explorer backend

### DIFF
--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/data_explorer.py
@@ -112,9 +112,7 @@ class DataExplorerTableView(abc.ABC):
             return False
 
     def get_schema(self, request: GetSchemaRequest):
-        return self._get_schema(
-            request.params.start_index, request.params.num_columns
-        ).dict()
+        return self._get_schema(request.params.start_index, request.params.num_columns).dict()
 
     def search_schema(self, request: SearchSchemaRequest):
         return self._search_schema(
@@ -309,9 +307,7 @@ class PandasView(DataExplorerTableView):
         # search term changes, we discard the last search result. We
         # might add an LRU cache here or something if it helps
         # performance.
-        self._search_schema_last_result: Optional[
-            Tuple[str, List[ColumnSchema]]
-        ] = None
+        self._search_schema_last_result: Optional[Tuple[str, List[ColumnSchema]]] = None
 
         # Putting this here rather than in the class body before
         # Python < 3.10 has fussier rules about staticmethods
@@ -390,9 +386,7 @@ class PandasView(DataExplorerTableView):
             total_num_matches=len(matches),
         )
 
-    def _search_schema_get_matches(
-        self, search_term: str
-    ) -> List[ColumnSchema]:
+    def _search_schema_get_matches(self, search_term: str) -> List[ColumnSchema]:
         matches = []
         for column_index in range(len(self.table.columns)):
             column_raw_name = self.table.columns[column_index]
@@ -411,9 +405,7 @@ class PandasView(DataExplorerTableView):
         from pandas.api.types import infer_dtype
 
         if column_index not in self._inferred_dtypes:
-            self._inferred_dtypes[column_index] = infer_dtype(
-                self.table.iloc[:, column_index]
-            )
+            self._inferred_dtypes[column_index] = infer_dtype(self.table.iloc[:, column_index])
         return self._inferred_dtypes[column_index]
 
     def _get_single_column_schema(self, column_index: int):
@@ -470,9 +462,7 @@ class PandasView(DataExplorerTableView):
         else:
             # No filtering or sorting, just slice directly
             indices = self.table.index[row_start : row_start + num_rows]
-            columns = [
-                col.iloc[row_start : row_start + num_rows] for col in columns
-            ]
+            columns = [col.iloc[row_start : row_start + num_rows] for col in columns]
 
         formatted_columns = [_pandas_format_values(col) for col in columns]
 
@@ -608,9 +598,7 @@ class PandasView(DataExplorerTableView):
                 self.view_indices = self.filtered_indices.take(sort_indexer)
             else:
                 # Data is not filtered
-                self.view_indices = nargsort(
-                    column, kind="mergesort", ascending=key.ascending
-                )
+                self.view_indices = nargsort(column, kind="mergesort", ascending=key.ascending)
         elif len(self.sort_keys) > 1:
             # Multiple sorting keys
             cols_to_sort = []
@@ -679,9 +667,7 @@ class PandasView(DataExplorerTableView):
 
         return ColumnSummaryStats(
             type_display=ColumnDisplayType.String,
-            string_stats=SummaryStatsString(
-                num_empty=num_empty, num_unique=num_unique
-            ),
+            string_stats=SummaryStatsString(num_empty=num_empty, num_unique=num_unique),
         )
 
     @staticmethod
@@ -692,9 +678,7 @@ class PandasView(DataExplorerTableView):
 
         return ColumnSummaryStats(
             type_display=ColumnDisplayType.Boolean,
-            boolean_stats=SummaryStatsBoolean(
-                true_count=true_count, false_count=false_count
-            ),
+            boolean_stats=SummaryStatsBoolean(true_count=true_count, false_count=false_count),
         )
 
     def _prof_freq_table(self, column_index: int):
@@ -705,9 +689,7 @@ class PandasView(DataExplorerTableView):
 
     def _get_state(self) -> TableState:
         return TableState(
-            table_shape=TableShape(
-                num_rows=self.table.shape[0], num_columns=self.table.shape[1]
-            ),
+            table_shape=TableShape(num_rows=self.table.shape[0], num_columns=self.table.shape[1]),
             row_filters=self.filters,
             sort_keys=self.sort_keys,
         )
@@ -923,9 +905,7 @@ class DataExplorerService:
             for comm_id in list(self.path_to_comm_ids[path]):
                 self._update_explorer_for_comm(comm_id, path, new_variable)
 
-    def _update_explorer_for_comm(
-        self, comm_id: str, path: PathKey, new_variable
-    ):
+    def _update_explorer_for_comm(self, comm_id: str, path: PathKey, new_variable):
         """
         If a variable is updated, we have to handle the different scenarios:
 
@@ -959,9 +939,7 @@ class DataExplorerService:
         # data explorer open for a nested value, then we need to use
         # the same variables inspection logic to resolve it here.
         if len(path) > 1:
-            is_found, new_table = _resolve_value_from_path(
-                new_variable, path[1:]
-            )
+            is_found, new_table = _resolve_value_from_path(new_variable, path[1:])
             if not is_found:
                 raise KeyError(f"Path {', '.join(path)} not found in value")
         else:
@@ -980,9 +958,7 @@ class DataExplorerService:
 
         def _fire_schema_update(discard_state=False):
             msg = SchemaUpdateParams(discard_state=discard_state)
-            comm.send_event(
-                DataExplorerFrontendEvent.SchemaUpdate.value, msg.dict()
-            )
+            comm.send_event(DataExplorerFrontendEvent.SchemaUpdate.value, msg.dict())
 
         if type(new_table) is not type(table_view.table):  # noqa: E721
             # Data type has changed. For now, we will signal the UI to
@@ -1027,9 +1003,7 @@ class DataExplorerService:
         else:
             _fire_data_update()
 
-    def handle_msg(
-        self, msg: CommMessage[DataExplorerBackendMessageContent], raw_msg
-    ):
+    def handle_msg(self, msg: CommMessage[DataExplorerBackendMessageContent], raw_msg):
         """
         Handle messages received from the client via the
         positron.data_explorer comm.

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -144,9 +144,7 @@ def test_explorer_open_close_delete(
     assert len(de_service.table_views) == 0
 
 
-def _assign_variables(
-    shell: PositronShell, variables_comm: DummyComm, **variables
-):
+def _assign_variables(shell: PositronShell, variables_comm: DummyComm, **variables):
     # A hack to make sure that change events are fired when we
     # manipulate user_ns
     shell.kernel.variables_service.snapshot_user_ns()
@@ -187,9 +185,7 @@ def test_explorer_delete_variable(
         assert len(paths) > 0
 
         comms = [
-            de_service.comms[comm_id]
-            for p in paths
-            for comm_id in de_service.path_to_comm_ids[p]
+            de_service.comms[comm_id] for p in paths for comm_id in de_service.path_to_comm_ids[p]
         ]
         variables_comm.handle_msg(msg)
 
@@ -205,22 +201,14 @@ def test_explorer_delete_variable(
     _check_delete_variable("y")
 
 
-def _check_update_variable(
-    de_service, name, update_type="schema", discard_state=True
-):
+def _check_update_variable(de_service, name, update_type="schema", discard_state=True):
     paths = de_service.get_paths_for_variable(name)
     assert len(paths) > 0
 
-    comms = [
-        de_service.comms[comm_id]
-        for p in paths
-        for comm_id in de_service.path_to_comm_ids[p]
-    ]
+    comms = [de_service.comms[comm_id] for p in paths for comm_id in de_service.path_to_comm_ids[p]]
 
     if update_type == "schema":
-        expected_msg = json_rpc_notification(
-            "schema_update", {"discard_state": discard_state}
-        )
+        expected_msg = json_rpc_notification("schema_update", {"discard_state": discard_state})
     else:
         expected_msg = json_rpc_notification("data_update", {})
 
@@ -287,18 +275,14 @@ def test_explorer_variable_updates(
     'key2': y['key2'].copy()}
     """
     )
-    _check_update_variable(
-        de_service, "y", update_type="update", discard_state=False
-    )
+    _check_update_variable(de_service, "y", update_type="update", discard_state=False)
 
     shell.run_cell(
         """y = {'key1': y['key1'].iloc[:-1, :-1],
     'key2': y['key2'].copy().iloc[:, 1:]}
     """
     )
-    _check_update_variable(
-        de_service, "y", update_type="schema", discard_state=True
-    )
+    _check_update_variable(de_service, "y", update_type="schema", discard_state=True)
 
 
 def test_register_table(de_service: DataExplorerService):
@@ -399,14 +383,10 @@ class DataExplorerFixture:
         return self.do_json_rpc(table_name, "set_row_filters", filters=filters)
 
     def set_sort_columns(self, table_name, sort_keys=None):
-        return self.do_json_rpc(
-            table_name, "set_sort_columns", sort_keys=sort_keys
-        )
+        return self.do_json_rpc(table_name, "set_sort_columns", sort_keys=sort_keys)
 
     def get_column_profiles(self, table_name, profiles):
-        return self.do_json_rpc(
-            table_name, "get_column_profiles", profiles=profiles
-        )
+        return self.do_json_rpc(table_name, "get_column_profiles", profiles=profiles)
 
     def check_filter_case(self, table, filter_set, expected_table):
         table_id = guid()
@@ -431,9 +411,7 @@ class DataExplorerFixture:
         assert response is None
         self.compare_tables(table_id, ex_id, table.shape)
 
-    def compare_tables(
-        self, table_id: str, expected_id: str, table_shape: tuple
-    ):
+    def compare_tables(self, table_id: str, expected_id: str, table_shape: tuple):
         # Query the data and check it yields the same result as the
         # manually constructed data frame without the filter
         response = self.get_data_values(
@@ -479,7 +457,32 @@ def test_pandas_get_state(dxf: DataExplorerFixture):
 
 
 def test_pandas_get_supported_features(dxf: DataExplorerFixture):
-    pass
+    dxf.register_table("example", SIMPLE_PANDAS_DF)
+    features = dxf.get_supported_features("example")
+
+    search_schema = features["search_schema"]
+    row_filters = features["set_row_filters"]
+    column_profiles = features["get_column_profiles"]
+
+    assert search_schema["supported"]
+
+    assert row_filters["supported"]
+    assert not row_filters["supports_conditions"]
+    assert set(row_filters["supported_types"]) == {
+        "is_null",
+        "not_null",
+        "between",
+        "compare",
+        "not_between",
+        "search",
+        "set_membership",
+    }
+
+    assert column_profiles["supported"]
+    assert set(column_profiles["supported_types"]) == {
+        "null_count",
+        "summary_stats",
+    }
 
 
 def test_pandas_get_schema(dxf: DataExplorerFixture):
@@ -586,9 +589,7 @@ def test_pandas_search_schema(dxf: DataExplorerFixture):
 
     # Make a data frame with those column names
     arr = np.arange(10)
-    df = pd.DataFrame(
-        {name: arr for name in column_names}, columns=pd.Index(column_names)
-    )
+    df = pd.DataFrame({name: arr for name in column_names}, columns=pd.Index(column_names))
 
     dxf.register_table("df", df)
 
@@ -647,9 +648,7 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
     assert result["row_labels"] == [["0", "1", "2", "3", "4"]]
 
     # Edge cases: request beyond end of table
-    response = dxf.get_data_values(
-        "simple", row_start_index=5, num_rows=10, column_indices=[0]
-    )
+    response = dxf.get_data_values("simple", row_start_index=5, num_rows=10, column_indices=[0])
     assert response["columns"] == [[]]
 
     # Issue #2149 -- return empty result when requesting non-existent
@@ -681,9 +680,7 @@ def _filter(filter_type, column_index, **kwargs):
 
 
 def _compare_filter(column_index, op, value):
-    return _filter(
-        "compare", column_index, compare_params={"op": op, "value": value}
-    )
+    return _filter("compare", column_index, compare_params={"op": op, "value": value})
 
 
 def _between_filter(column_index, left_value, right_value, op="between"):
@@ -695,14 +692,10 @@ def _between_filter(column_index, left_value, right_value, op="between"):
 
 
 def _not_between_filter(column_index, left_value, right_value):
-    return _between_filter(
-        column_index, left_value, right_value, op="not_between"
-    )
+    return _between_filter(column_index, left_value, right_value, op="not_between")
 
 
-def _search_filter(
-    column_index, term, case_sensitive=False, search_type="contains"
-):
+def _search_filter(column_index, term, case_sensitive=False, search_type="contains"):
     return _filter(
         "search",
         column_index,
@@ -745,11 +738,7 @@ def test_pandas_filter_between(dxf: DataExplorerFixture):
         )
         dxf.check_filter_case(
             df,
-            [
-                _not_between_filter(
-                    column_index, str(left_value), str(right_value)
-                )
-            ],
+            [_not_between_filter(column_index, str(left_value), str(right_value))],
             ex_not_between,
         )
 
@@ -925,14 +914,11 @@ def test_pandas_set_sort_columns(dxf: DataExplorerFixture):
     ]
 
     # Test sort AND filter
-    filter_cases = {
-        "df2": [(lambda x: x[x["a"] > 0], [_compare_filter(0, ">", 0)])]
-    }
+    filter_cases = {"df2": [(lambda x: x[x["a"] > 0], [_compare_filter(0, ">", 0)])]}
 
     for df_name, keys, expected_params in cases:
         wrapped_keys = [
-            {"column_index": index, "ascending": ascending}
-            for index, ascending in keys
+            {"column_index": index, "ascending": ascending} for index, ascending in keys
         ]
         df = tables[df_name]
 
@@ -944,9 +930,7 @@ def test_pandas_set_sort_columns(dxf: DataExplorerFixture):
 
         for filter_f, filters in filter_cases.get(df_name, []):
             expected_filtered = filter_f(df).sort_values(**expected_params)
-            dxf.check_sort_case(
-                df, wrapped_keys, expected_filtered, filters=filters
-            )
+            dxf.check_sort_case(df, wrapped_keys, expected_filtered, filters=filters)
 
 
 def test_pandas_change_schema_after_sort(
@@ -976,9 +960,7 @@ def test_pandas_change_schema_after_sort(
 
     # Sort last column, and we will then change the schema
     shell.run_cell("df = df[['a', 'b']]")
-    _check_update_variable(
-        de_service, "df", update_type="schema", discard_state=True
-    )
+    _check_update_variable(de_service, "df", update_type="schema", discard_state=True)
 
     # Call get_data_values and make sure it works
     dxf.compare_tables("df", "expected_df", expected_df.shape)
@@ -1039,17 +1021,13 @@ def test_pandas_profile_null_counts(dxf: DataExplorerFixture):
     for table_name, profiles, ex_results in cases:
         results = dxf.get_column_profiles(table_name, profiles)
 
-        ex_results = [
-            ColumnProfileResult(null_count=count) for count in ex_results
-        ]
+        ex_results = [ColumnProfileResult(null_count=count) for count in ex_results]
 
         assert results == ex_results
 
     # Test profiling with filter
     # format: (table, filters, filtered_table, profiles)
-    filter_cases = [
-        (df1, [_filter("not_null", 0)], df1[df1["a"].notnull()], all_profiles)
-    ]
+    filter_cases = [(df1, [_filter("not_null", 0)], df1[df1["a"].notnull()], all_profiles)]
     for table, filters, filtered_table, profiles in filter_cases:
         table_id = guid()
         dxf.register_table(table_id, table)

--- a/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/pythonFiles/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -144,7 +144,9 @@ def test_explorer_open_close_delete(
     assert len(de_service.table_views) == 0
 
 
-def _assign_variables(shell: PositronShell, variables_comm: DummyComm, **variables):
+def _assign_variables(
+    shell: PositronShell, variables_comm: DummyComm, **variables
+):
     # A hack to make sure that change events are fired when we
     # manipulate user_ns
     shell.kernel.variables_service.snapshot_user_ns()
@@ -185,7 +187,9 @@ def test_explorer_delete_variable(
         assert len(paths) > 0
 
         comms = [
-            de_service.comms[comm_id] for p in paths for comm_id in de_service.path_to_comm_ids[p]
+            de_service.comms[comm_id]
+            for p in paths
+            for comm_id in de_service.path_to_comm_ids[p]
         ]
         variables_comm.handle_msg(msg)
 
@@ -201,14 +205,22 @@ def test_explorer_delete_variable(
     _check_delete_variable("y")
 
 
-def _check_update_variable(de_service, name, update_type="schema", discard_state=True):
+def _check_update_variable(
+    de_service, name, update_type="schema", discard_state=True
+):
     paths = de_service.get_paths_for_variable(name)
     assert len(paths) > 0
 
-    comms = [de_service.comms[comm_id] for p in paths for comm_id in de_service.path_to_comm_ids[p]]
+    comms = [
+        de_service.comms[comm_id]
+        for p in paths
+        for comm_id in de_service.path_to_comm_ids[p]
+    ]
 
     if update_type == "schema":
-        expected_msg = json_rpc_notification("schema_update", {"discard_state": discard_state})
+        expected_msg = json_rpc_notification(
+            "schema_update", {"discard_state": discard_state}
+        )
     else:
         expected_msg = json_rpc_notification("data_update", {})
 
@@ -275,14 +287,18 @@ def test_explorer_variable_updates(
     'key2': y['key2'].copy()}
     """
     )
-    _check_update_variable(de_service, "y", update_type="update", discard_state=False)
+    _check_update_variable(
+        de_service, "y", update_type="update", discard_state=False
+    )
 
     shell.run_cell(
         """y = {'key1': y['key1'].iloc[:-1, :-1],
     'key2': y['key2'].copy().iloc[:, 1:]}
     """
     )
-    _check_update_variable(de_service, "y", update_type="schema", discard_state=True)
+    _check_update_variable(
+        de_service, "y", update_type="schema", discard_state=True
+    )
 
 
 def test_register_table(de_service: DataExplorerService):
@@ -373,6 +389,9 @@ class DataExplorerFixture:
     def get_state(self, table_name):
         return self.do_json_rpc(table_name, "get_state")
 
+    def get_supported_features(self, table_name):
+        return self.do_json_rpc(table_name, "get_supported_features")
+
     def get_data_values(self, table_name, **params):
         return self.do_json_rpc(table_name, "get_data_values", **params)
 
@@ -380,10 +399,14 @@ class DataExplorerFixture:
         return self.do_json_rpc(table_name, "set_row_filters", filters=filters)
 
     def set_sort_columns(self, table_name, sort_keys=None):
-        return self.do_json_rpc(table_name, "set_sort_columns", sort_keys=sort_keys)
+        return self.do_json_rpc(
+            table_name, "set_sort_columns", sort_keys=sort_keys
+        )
 
     def get_column_profiles(self, table_name, profiles):
-        return self.do_json_rpc(table_name, "get_column_profiles", profiles=profiles)
+        return self.do_json_rpc(
+            table_name, "get_column_profiles", profiles=profiles
+        )
 
     def check_filter_case(self, table, filter_set, expected_table):
         table_id = guid()
@@ -408,7 +431,9 @@ class DataExplorerFixture:
         assert response is None
         self.compare_tables(table_id, ex_id, table.shape)
 
-    def compare_tables(self, table_id: str, expected_id: str, table_shape: tuple):
+    def compare_tables(
+        self, table_id: str, expected_id: str, table_shape: tuple
+    ):
         # Query the data and check it yields the same result as the
         # manually constructed data frame without the filter
         response = self.get_data_values(
@@ -451,6 +476,10 @@ def test_pandas_get_state(dxf: DataExplorerFixture):
     result = dxf.get_state("simple")
     assert result["sort_keys"] == sort_keys
     assert result["row_filters"] == [RowFilter(**f) for f in filters]
+
+
+def test_pandas_get_supported_features(dxf: DataExplorerFixture):
+    pass
 
 
 def test_pandas_get_schema(dxf: DataExplorerFixture):
@@ -557,7 +586,9 @@ def test_pandas_search_schema(dxf: DataExplorerFixture):
 
     # Make a data frame with those column names
     arr = np.arange(10)
-    df = pd.DataFrame({name: arr for name in column_names}, columns=pd.Index(column_names))
+    df = pd.DataFrame(
+        {name: arr for name in column_names}, columns=pd.Index(column_names)
+    )
 
     dxf.register_table("df", df)
 
@@ -616,7 +647,9 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
     assert result["row_labels"] == [["0", "1", "2", "3", "4"]]
 
     # Edge cases: request beyond end of table
-    response = dxf.get_data_values("simple", row_start_index=5, num_rows=10, column_indices=[0])
+    response = dxf.get_data_values(
+        "simple", row_start_index=5, num_rows=10, column_indices=[0]
+    )
     assert response["columns"] == [[]]
 
     # Issue #2149 -- return empty result when requesting non-existent
@@ -648,7 +681,9 @@ def _filter(filter_type, column_index, **kwargs):
 
 
 def _compare_filter(column_index, op, value):
-    return _filter("compare", column_index, compare_params={"op": op, "value": value})
+    return _filter(
+        "compare", column_index, compare_params={"op": op, "value": value}
+    )
 
 
 def _between_filter(column_index, left_value, right_value, op="between"):
@@ -660,15 +695,19 @@ def _between_filter(column_index, left_value, right_value, op="between"):
 
 
 def _not_between_filter(column_index, left_value, right_value):
-    return _between_filter(column_index, left_value, right_value, op="not_between")
+    return _between_filter(
+        column_index, left_value, right_value, op="not_between"
+    )
 
 
-def _search_filter(column_index, term, case_sensitive=False, search_type="contains"):
+def _search_filter(
+    column_index, term, case_sensitive=False, search_type="contains"
+):
     return _filter(
         "search",
         column_index,
         search_params={
-            "type": search_type,
+            "search_type": search_type,
             "term": term,
             "case_sensitive": case_sensitive,
         },
@@ -706,7 +745,11 @@ def test_pandas_filter_between(dxf: DataExplorerFixture):
         )
         dxf.check_filter_case(
             df,
-            [_not_between_filter(column_index, str(left_value), str(right_value))],
+            [
+                _not_between_filter(
+                    column_index, str(left_value), str(right_value)
+                )
+            ],
             ex_not_between,
         )
 
@@ -882,11 +925,14 @@ def test_pandas_set_sort_columns(dxf: DataExplorerFixture):
     ]
 
     # Test sort AND filter
-    filter_cases = {"df2": [(lambda x: x[x["a"] > 0], [_compare_filter(0, ">", 0)])]}
+    filter_cases = {
+        "df2": [(lambda x: x[x["a"] > 0], [_compare_filter(0, ">", 0)])]
+    }
 
     for df_name, keys, expected_params in cases:
         wrapped_keys = [
-            {"column_index": index, "ascending": ascending} for index, ascending in keys
+            {"column_index": index, "ascending": ascending}
+            for index, ascending in keys
         ]
         df = tables[df_name]
 
@@ -898,7 +944,9 @@ def test_pandas_set_sort_columns(dxf: DataExplorerFixture):
 
         for filter_f, filters in filter_cases.get(df_name, []):
             expected_filtered = filter_f(df).sort_values(**expected_params)
-            dxf.check_sort_case(df, wrapped_keys, expected_filtered, filters=filters)
+            dxf.check_sort_case(
+                df, wrapped_keys, expected_filtered, filters=filters
+            )
 
 
 def test_pandas_change_schema_after_sort(
@@ -928,14 +976,16 @@ def test_pandas_change_schema_after_sort(
 
     # Sort last column, and we will then change the schema
     shell.run_cell("df = df[['a', 'b']]")
-    _check_update_variable(de_service, "df", update_type="schema", discard_state=True)
+    _check_update_variable(
+        de_service, "df", update_type="schema", discard_state=True
+    )
 
     # Call get_data_values and make sure it works
     dxf.compare_tables("df", "expected_df", expected_df.shape)
 
 
 def _profile_request(column_index, profile_type):
-    return {"column_index": column_index, "type": profile_type}
+    return {"column_index": column_index, "profile_type": profile_type}
 
 
 def _get_null_count(column_index):
@@ -989,13 +1039,17 @@ def test_pandas_profile_null_counts(dxf: DataExplorerFixture):
     for table_name, profiles, ex_results in cases:
         results = dxf.get_column_profiles(table_name, profiles)
 
-        ex_results = [ColumnProfileResult(null_count=count) for count in ex_results]
+        ex_results = [
+            ColumnProfileResult(null_count=count) for count in ex_results
+        ]
 
         assert results == ex_results
 
     # Test profiling with filter
     # format: (table, filters, filtered_table, profiles)
-    filter_cases = [(df1, [_filter("not_null", 0)], df1[df1["a"].notnull()], all_profiles)]
+    filter_cases = [
+        (df1, [_filter("not_null", 0)], df1[df1["a"].notnull()], all_profiles)
+    ]
     for table, filters, filtered_table, profiles in filter_cases:
         table_id = guid()
         dxf.register_table(table_id, table)

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -244,7 +244,7 @@
 					"description": "The current backend table state",
 					"required": [
 						"table_shape",
-						"filters",
+						"row_filters",
 						"sort_keys"
 					],
 					"properties": {
@@ -280,6 +280,38 @@
 							"items": {
 								"$ref": "#/components/schemas/column_sort_key"
 							}
+						}
+					}
+				}
+			}
+		},
+		{
+			"name": "get_supported_features",
+			"summary": "Query the backend to determine supported features",
+			"description": "Query the backend to determine supported features, to enable feature toggling",
+			"params": [],
+			"result": {
+				"schema": {
+					"type": "object",
+					"name": "supported_features",
+					"description": "For each field, returns flags indicating supported features",
+					"required": [
+						"search_schema",
+						"set_row_filters",
+						"get_column_profiles"
+					],
+					"properties": {
+						"search_schema": {
+							"description": "Support for 'search_schema' RPC and its features",
+							"$ref": "#/components/schemas/search_schema_features"
+						},
+						"set_row_filters": {
+							"description": "Support for 'set_row_filters' RPC and its features",
+							"$ref": "#/components/schemas/set_row_filters_features"
+						},
+						"get_column_profiles": {
+							"description": "Support for 'get_column_profiles' RPC and its features",
+							"$ref": "#/components/schemas/get_column_profiles_features"
 						}
 					}
 				}
@@ -390,17 +422,8 @@
 						"description": "Unique identifier for this filter"
 					},
 					"filter_type": {
-						"type": "string",
-						"description": "Type of filter to apply",
-						"enum": [
-							"between",
-							"compare",
-							"is_null",
-							"not_between",
-							"not_null",
-							"search",
-							"set_membership"
-						]
+						"description": "Type of row filter to apply",
+						"$ref": "#/components/schemas/row_filter_type"
 					},
 					"column_index": {
 						"type": "integer",
@@ -423,6 +446,19 @@
 						"$ref": "#/components/schemas/set_membership_filter_params"
 					}
 				}
+			},
+			"row_filter_type": {
+				"type": "string",
+				"description": "Type of row filter",
+				"enum": [
+					"between",
+					"compare",
+					"is_null",
+					"not_between",
+					"not_null",
+					"search",
+					"set_membership"
+				]
 			},
 			"between_filter_params": {
 				"type": "object",
@@ -493,20 +529,14 @@
 				"type": "object",
 				"description": "Parameters for the 'search' filter type",
 				"required": [
-					"type",
+					"search_type",
 					"term",
 					"case_sensitive"
 				],
 				"properties": {
-					"type": {
-						"type": "string",
-						"description": "Type of search to perform",
-						"enum": [
-							"contains",
-							"starts_with",
-							"ends_with",
-							"regex_match"
-						]
+					"search_type": {
+						"$ref": "#/components/schemas/search_filter_type",
+						"description": "Type of search to perform"
 					},
 					"term": {
 						"type": "string",
@@ -518,29 +548,43 @@
 					}
 				}
 			},
+			"search_filter_type": {
+				"type": "string",
+				"description": "Type of string search filter to perform",
+				"enum": [
+					"contains",
+					"starts_with",
+					"ends_with",
+					"regex_match"
+				]
+			},
 			"column_profile_request": {
 				"type": "object",
 				"description": "A single column profile request",
 				"required": [
 					"column_index",
-					"type"
+					"profile_type"
 				],
 				"properties": {
 					"column_index": {
 						"type": "integer",
 						"description": "The ordinal column index to profile"
 					},
-					"type": {
-						"type": "string",
+					"profile_type": {
 						"description": "The type of analytical column profile",
-						"enum": [
-							"null_count",
-							"summary_stats",
-							"frequency_table",
-							"histogram"
-						]
+						"$ref": "#/components/schemas/column_profile_type"
 					}
 				}
+			},
+			"column_profile_type": {
+				"type": "string",
+				"description": "Type of analytical column profile",
+				"enum": [
+					"null_count",
+					"summary_stats",
+					"frequency_table",
+					"histogram"
+				]
 			},
 			"column_profile_result": {
 				"type": "object",
@@ -753,6 +797,66 @@
 					"ascending": {
 						"type": "boolean",
 						"description": "Sort order, ascending (true) or descending (false)"
+					}
+				}
+			},
+			"search_schema_features": {
+				"type": "object",
+				"description": "Feature flags for 'search_schema' RPC",
+				"required": [
+					"supported"
+				],
+				"properties": {
+					"supported": {
+						"type": "boolean",
+						"description": "Whether this RPC method is supported at all"
+					}
+				}
+			},
+			"set_row_filters_features": {
+				"type": "object",
+				"description": "Feature flags for 'set_row_filters' RPC",
+				"required": [
+					"supported",
+					"supports_conditions",
+					"supported_types"
+				],
+				"properties": {
+					"supported": {
+						"type": "boolean",
+						"description": "Whether this RPC method is supported at all"
+					},
+					"supports_conditions": {
+						"type": "boolean",
+						"description": "Whether AND/OR filter conditions are supported"
+					},
+					"supported_types": {
+						"type": "array",
+						"description": "A list of supported types",
+						"items": {
+							"$ref": "#/components/schemas/row_filter_type"
+						}
+					}
+				}
+			},
+			"get_column_profiles_features": {
+				"type": "object",
+				"description": "Feature flags for 'get_column_profiles' RPC",
+				"required": [
+					"supported",
+					"supported_types"
+				],
+				"properties": {
+					"supported": {
+						"type": "boolean",
+						"description": "Whether this RPC method is supported at all"
+					},
+					"supported_types": {
+						"type": "array",
+						"description": "A list of supported types",
+						"items": {
+							"$ref": "#/components/schemas/column_profile_type"
+						}
 					}
 				}
 			}

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -65,7 +65,7 @@ export interface TableState {
 	/**
 	 * The set of currently applied row filters
 	 */
-	row_filters?: Array<RowFilter>;
+	row_filters: Array<RowFilter>;
 
 	/**
 	 * The set of currently applied sorts
@@ -87,6 +87,27 @@ export interface TableShape {
 	 * Number of columns in the unfiltered dataset
 	 */
 	num_columns: number;
+
+}
+
+/**
+ * For each field, returns flags indicating supported features
+ */
+export interface SupportedFeatures {
+	/**
+	 * Support for 'search_schema' RPC and its features
+	 */
+	search_schema: SearchSchemaFeatures;
+
+	/**
+	 * Support for 'set_row_filters' RPC and its features
+	 */
+	set_row_filters: SetRowFiltersFeatures;
+
+	/**
+	 * Support for 'get_column_profiles' RPC and its features
+	 */
+	get_column_profiles: GetColumnProfilesFeatures;
 
 }
 
@@ -167,9 +188,9 @@ export interface RowFilter {
 	filter_id: string;
 
 	/**
-	 * Type of filter to apply
+	 * Type of row filter to apply
 	 */
-	filter_type: RowFilterFilterType;
+	filter_type: RowFilterType;
 
 	/**
 	 * Column index to apply filter to
@@ -253,7 +274,7 @@ export interface SearchFilterParams {
 	/**
 	 * Type of search to perform
 	 */
-	type: SearchFilterParamsType;
+	search_type: SearchFilterType;
 
 	/**
 	 * String value/regex to search for in stringified data
@@ -279,7 +300,7 @@ export interface ColumnProfileRequest {
 	/**
 	 * The type of analytical column profile
 	 */
-	type: ColumnProfileRequestType;
+	profile_type: ColumnProfileType;
 
 }
 
@@ -486,6 +507,54 @@ export interface ColumnSortKey {
 }
 
 /**
+ * Feature flags for 'search_schema' RPC
+ */
+export interface SearchSchemaFeatures {
+	/**
+	 * Whether this RPC method is supported at all
+	 */
+	supported: boolean;
+
+}
+
+/**
+ * Feature flags for 'set_row_filters' RPC
+ */
+export interface SetRowFiltersFeatures {
+	/**
+	 * Whether this RPC method is supported at all
+	 */
+	supported: boolean;
+
+	/**
+	 * Whether AND/OR filter conditions are supported
+	 */
+	supports_conditions: boolean;
+
+	/**
+	 * A list of supported types
+	 */
+	supported_types: Array<RowFilterType>;
+
+}
+
+/**
+ * Feature flags for 'get_column_profiles' RPC
+ */
+export interface GetColumnProfilesFeatures {
+	/**
+	 * Whether this RPC method is supported at all
+	 */
+	supported: boolean;
+
+	/**
+	 * A list of supported types
+	 */
+	supported_types: Array<ColumnProfileType>;
+
+}
+
+/**
  * Possible values for ColumnDisplayType
  */
 export enum ColumnDisplayType {
@@ -501,9 +570,9 @@ export enum ColumnDisplayType {
 }
 
 /**
- * Possible values for FilterType in RowFilter
+ * Possible values for RowFilterType
  */
-export enum RowFilterFilterType {
+export enum RowFilterType {
 	Between = 'between',
 	Compare = 'compare',
 	IsNull = 'is_null',
@@ -526,9 +595,9 @@ export enum CompareFilterParamsOp {
 }
 
 /**
- * Possible values for Type in SearchFilterParams
+ * Possible values for SearchFilterType
  */
-export enum SearchFilterParamsType {
+export enum SearchFilterType {
 	Contains = 'contains',
 	StartsWith = 'starts_with',
 	EndsWith = 'ends_with',
@@ -536,9 +605,9 @@ export enum SearchFilterParamsType {
 }
 
 /**
- * Possible values for Type in ColumnProfileRequest
+ * Possible values for ColumnProfileType
  */
-export enum ColumnProfileRequestType {
+export enum ColumnProfileType {
 	NullCount = 'null_count',
 	SummaryStats = 'summary_stats',
 	FrequencyTable = 'frequency_table',
@@ -672,6 +741,19 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 */
 	getState(): Promise<TableState> {
 		return super.performRpc('get_state', [], []);
+	}
+
+	/**
+	 * Query the backend to determine supported features
+	 *
+	 * Query the backend to determine supported features, to enable feature
+	 * toggling
+	 *
+	 *
+	 * @returns For each field, returns flags indicating supported features
+	 */
+	getSupportedFeatures(): Promise<SupportedFeatures> {
+		return super.performRpc('get_supported_features', [], []);
 	}
 
 

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
@@ -4,7 +4,7 @@
 
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
-import { ColumnProfileRequestType, ColumnSchema, ColumnSummaryStats, TableData } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { ColumnProfileType, ColumnSchema, ColumnSummaryStats, TableData } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
 
 /**
@@ -213,7 +213,7 @@ export class DataExplorerCache extends Disposable {
 			columnIndices.map(column_index => {
 				return {
 					column_index,
-					type: ColumnProfileRequestType.SummaryStats
+					profile_type: ColumnProfileType.SummaryStats
 				};
 			})
 		);
@@ -330,7 +330,7 @@ export class DataExplorerCache extends Disposable {
 				columnNullCountIndices.map(column_index => {
 					return {
 						column_index,
-						type: ColumnProfileRequestType.NullCount
+						profile_type: ColumnProfileType.NullCount
 					};
 				})
 			);

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
@@ -5,11 +5,11 @@
 import { generateUuid } from 'vs/base/common/uuid';
 import {
 	CompareFilterParamsOp,
-	SearchFilterParamsType,
+	SearchFilterType,
 	ColumnSchema,
 	ColumnProfileResult,
 	RowFilter,
-	RowFilterFilterType,
+	RowFilterType,
 	TableData,
 	TableSchema
 } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
@@ -119,7 +119,7 @@ export function getExampleFreqtable(): ColumnProfileResult {
 
 // For filtering
 
-function _getFilterWithProps(columnIndex: number, filterType: RowFilterFilterType,
+function _getFilterWithProps(columnIndex: number, filterType: RowFilterType,
 	props: Partial<RowFilter> = {}): RowFilter {
 	return {
 		filter_id: generateUuid(),
@@ -131,27 +131,27 @@ function _getFilterWithProps(columnIndex: number, filterType: RowFilterFilterTyp
 
 export function getCompareFilter(columnIndex: number, op: CompareFilterParamsOp,
 	value: string) {
-	return _getFilterWithProps(columnIndex, RowFilterFilterType.Compare,
+	return _getFilterWithProps(columnIndex, RowFilterType.Compare,
 		{ compare_params: { op, value } });
 }
 
 export function getIsNullFilter(columnIndex: number) {
-	return _getFilterWithProps(columnIndex, RowFilterFilterType.IsNull);
+	return _getFilterWithProps(columnIndex, RowFilterType.IsNull);
 }
 
 export function getNotNullFilter(columnIndex: number) {
-	return _getFilterWithProps(columnIndex, RowFilterFilterType.NotNull);
+	return _getFilterWithProps(columnIndex, RowFilterType.NotNull);
 }
 
 export function getSetMemberFilter(columnIndex: number, values: string[], inclusive: boolean) {
-	return _getFilterWithProps(columnIndex, RowFilterFilterType.SetMembership, {
+	return _getFilterWithProps(columnIndex, RowFilterType.SetMembership, {
 		set_membership_params: { values, inclusive }
 	});
 }
 
 export function getTextSearchFilter(columnIndex: number, searchTerm: string,
-	searchType: SearchFilterParamsType, caseSensitive: boolean) {
-	return _getFilterWithProps(columnIndex, RowFilterFilterType.Search, {
-		search_params: { term: searchTerm, type: searchType, case_sensitive: caseSensitive }
+	searchType: SearchFilterType, caseSensitive: boolean) {
+	return _getFilterWithProps(columnIndex, RowFilterType.Search, {
+		search_params: { term: searchTerm, search_type: searchType, case_sensitive: caseSensitive }
 	});
 }

--- a/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
@@ -6,8 +6,8 @@ import * as assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import {
 	CompareFilterParamsOp,
-	RowFilterFilterType,
-	SearchFilterParamsType
+	RowFilterType,
+	SearchFilterType
 } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import * as mocks from "vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks";
 
@@ -40,7 +40,7 @@ suite('DataExplorerMocks', () => {
 
 	test('Test getCompareFilter', () => {
 		const filter = mocks.getCompareFilter(2, CompareFilterParamsOp.Gt, '1234');
-		assert.equal(filter.filter_type, RowFilterFilterType.Compare);
+		assert.equal(filter.filter_type, RowFilterType.Compare);
 		assert.equal(filter.column_index, 2);
 
 		const params = filter.compare_params!;
@@ -52,22 +52,22 @@ suite('DataExplorerMocks', () => {
 	test('Test getIsNullFilter', () => {
 		let filter = mocks.getIsNullFilter(3);
 		assert.equal(filter.column_index, 3);
-		assert.equal(filter.filter_type, RowFilterFilterType.IsNull);
+		assert.equal(filter.filter_type, RowFilterType.IsNull);
 
 		filter = mocks.getNotNullFilter(3);
-		assert.equal(filter.filter_type, RowFilterFilterType.NotNull);
+		assert.equal(filter.filter_type, RowFilterType.NotNull);
 	});
 
 	test('Test getTextSearchFilter', () => {
 		const filter = mocks.getTextSearchFilter(5, 'needle',
-			SearchFilterParamsType.Contains, false);
+			SearchFilterType.Contains, false);
 		assert.equal(filter.column_index, 5);
-		assert.equal(filter.filter_type, RowFilterFilterType.Search);
+		assert.equal(filter.filter_type, RowFilterType.Search);
 
 		const params = filter.search_params!;
 
 		assert.equal(params.term, 'needle');
-		assert.equal(params.type, SearchFilterParamsType.Contains);
+		assert.equal(params.search_type, SearchFilterType.Contains);
 		assert.equal(params.case_sensitive, false);
 	});
 
@@ -75,7 +75,7 @@ suite('DataExplorerMocks', () => {
 		const set_values = ['need1', 'need2'];
 		const filter = mocks.getSetMemberFilter(6, set_values, true);
 		assert.equal(filter.column_index, 6);
-		assert.equal(filter.filter_type, RowFilterFilterType.SetMembership);
+		assert.equal(filter.filter_type, RowFilterType.SetMembership);
 
 		const params = filter.set_membership_params!;
 


### PR DESCRIPTION
Addresses #2201. This is just a starting point and will be refined to add more granular feature flagging, but wanted to break the seal on this.

Summary

* Adds feature flags for search_schema, set_row_filters, and get_column_profiles
* For filtering and profiles, indicates which row filter types / profile types are supported
* Return basic feature flags for pandas objects (each type of data structure can return different feature flags, so it isn't necessarily global to the runtime but rather local to the particular data type)
* Extracted row filter type and profile type into shared enums

Also addresses #2599 (renaming search_filter_params.type to search_type)

Associated amalthea PR: https://github.com/posit-dev/amalthea/pull/298