### PR TITLE
Adding theme colors for the null count graph

### DIFF
--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1962,7 +1962,7 @@ export const POSITRON_DATA_EXPLORER_BORDER_COLOR = registerColor('positronDataEx
 
 // Positron data explorer missing values graph background fill color.
 export const POSITRON_DATA_EXPLORER_MISSING_VALUES_GRAPH_BACKGROUND_FILL_COLOR = registerColor('positronDataExplorer.columnNullPercentGraphBackgroundFill', {
-	dark: '#ea3d3d',
+	dark: '#bc1a1b',
 	light: '#ea3d3d',
 	hcDark: '#ea3d3d',
 	hcLight: '#ea3d3d',
@@ -1970,7 +1970,7 @@ export const POSITRON_DATA_EXPLORER_MISSING_VALUES_GRAPH_BACKGROUND_FILL_COLOR =
 
 // Positron data explorer missing values graph background stroke color.
 export const POSITRON_DATA_EXPLORER_MISSING_VALUES_GRAPH_BACKGROUND_STROKE_COLOR = registerColor('positronDataExplorer.columnNullPercentGraphBackgroundStroke', {
-	dark: '#7e94a5',
+	dark: '#738594',
 	light: '#7e94a5',
 	hcDark: '#7e94a5',
 	hcLight: '#7e94a5',
@@ -1978,7 +1978,7 @@ export const POSITRON_DATA_EXPLORER_MISSING_VALUES_GRAPH_BACKGROUND_STROKE_COLOR
 
 // Positron data explorer missing values graph indicator fill color.
 export const POSITRON_DATA_EXPLORER_MISSING_VALUES_GRAPH_INDICATOR_FILL_COLOR = registerColor('positronDataExplorer.columnNullPercentGraphIndicatorFill', {
-	dark: '#e5edf3',
+	dark: '#b0b9bf',
 	light: '#e5edf3',
 	hcDark: '#e5edf3',
 	hcLight: '#e5edf3',


### PR DESCRIPTION
### Intent

Update the column null percent graph dark theme colors.

### Approach

Updates were made to `theme.ts` to supply new colors for the column null percent graph dark theme. It now looks like:

![image](https://github.com/posit-dev/positron/assets/853239/316ea739-7f46-40e1-905e-71745bb930be)

### QA Notes

The column null percent component should look right in the light and dark themes.