### PR TITLE
Fix `localize` call for row filter button

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -592,10 +592,10 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					className='solid button-apply-row-filter'
 					onPressed={applyRowFilter}
 				>
-					{localize(
+					{(() => localize(
 						'positron.addEditRowFilter.applyFilter',
 						"Apply Filter"
-					)}
+					))()}
 				</Button>
 			</div>
 		</PositronModalPopup>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Fixes the missing text in the row filter button described in https://github.com/posit-dev/positron/issues/2590#issuecomment-2037573584.

#### Before
![image](https://github.com/posit-dev/positron/assets/25834218/a619c800-84d5-4842-a851-30f4e064679b)

#### After
<img width="321" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/8dd01955-eb2f-4468-8b9c-6d709f3df652">

### Approach

Same approach as
- https://github.com/posit-dev/positron/pull/2618
- https://github.com/posit-dev/positron/pull/2625
- https://github.com/posit-dev/positron/pull/2629

Tested in a local release build ✅ 

### QA Notes

- Load a dataset and open the data viewer
- Click the `+` to add a row filter
- Verify that the `APPLY FILTER` text shows up on the button
