### PR TITLE
Consistently use indentation of 4 spaces in indentation snapshots

### DIFF
--- a/extensions/positron-r/src/test/editor-utils.ts
+++ b/extensions/positron-r/src/test/editor-utils.ts
@@ -61,6 +61,10 @@ export async function withFileEditor(
 		const doc = await vscode.workspace.openTextDocument(file);
 		const editor = await vscode.window.showTextDocument(doc);
 
+		editor.options.insertSpaces = true;
+		editor.options.indentSize = 4;
+		editor.options.tabSize = 4;
+
 		if (cursorIndex >= 0) {
 			const pos = doc.positionAt(cursorIndex);
 			editor.selection = new vscode.Selection(pos, pos);

--- a/extensions/positron-r/src/test/snapshots/.vscode/settings.json
+++ b/extensions/positron-r/src/test/snapshots/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "workbench.localHistory.enabled": false
+    "workbench.localHistory.enabled": false,
+    "editor.insertSpaces": true,
+    "editor.indentSize": 4,
+    "editor.tabSize": 4,
 }

--- a/extensions/positron-r/src/test/snapshots/indentation-cases.R
+++ b/extensions/positron-r/src/test/snapshots/indentation-cases.R
@@ -20,123 +20,123 @@ data |>"<>"
 # Starting a pipeline (one empty line)
 # FIXME
 data |>
-	"<>"
+    "<>"
 
 # ---
 # Starting a pipeline (multiple empty lines)
 # FIXME
 data |>
 
-	"<>"
+    "<>"
 
 # ---
 # Continuing a pipeline
 1 +
-	2 +"<>"
+    2 +"<>"
 
 # ---
 # Continuing a one-liner pipeline
 # https://github.com/posit-dev/positron/issues/1316
 data |>
-	fn() |>"<>"
+    fn() |>"<>"
 
 # ---
 # Continuing a one-liner pipeline (trailing whitespace)
 # https://github.com/posit-dev/positron/pull/1655#issuecomment-1780093395
 data |>
-	fn() |> "<>"
+    fn() |> "<>"
 
 # ---
 # Continuing a one-liner pipeline (trailing comment)
 data |>
-	fn() |> "<>" # foo
+    fn() |> "<>" # foo
 
 # ---
 # Continuing a one-liner pipeline (comment line)
 # FIXME
 data |>
-	fn1() |>
-	# foo"<>"
+    fn1() |>
+    # foo"<>"
 
 # ---
 # Continuing a one-liner pipeline (after a comment line)
 # FIXME
 data |>
-	fn1() |>
-	# foo
-  "<>"
+    fn1() |>
+    # foo
+    "<>"
 
 # ---
 # Continuing a one-liner pipeline (longer pipeline)
 data |>
-	fn1() |>
-	fn2() |>"<>"
+    fn1() |>
+    fn2() |>"<>"
 
 
 # ---
 # Continuing a multi-liner pipeline
 # FIXME
 data |>
-	fn1(
-		x,
-		y
-	) |>"<>"
+    fn1(
+        x,
+        y
+    ) |>"<>"
 
 # ---
 # Continuing a multi-liner pipeline (trailing expression)
 # FIXME
 data |>
-	fn1(
-		x,
-		y
-	) |> "<>" fn2()
+    fn1(
+        x,
+        y
+    ) |> "<>" fn2()
 
 # ---
 # Dedent after pipeline
 data |>
-	fn()"<>"
+    fn()"<>"
 
 # ---
 # Dedent after pipeline (trailing comment)
 data |>
-	fn()"<>" # foo
+    fn()"<>" # foo
 
 # ---
 # Dedent after pipeline (multiple lines)
 # FIXME
 data |>
-	fn1() |>
-	fn2(
-		"arg"
-	)"<>"
+    fn1() |>
+    fn2(
+        "arg"
+    )"<>"
 
 # ---
 # Stickiness of dedent after pipeline
 # https://github.com/posit-dev/positron/issues/1727
 data |>
-	fn()
+    fn()
 "<>"
 
 # ---
 # Stickiness of dedent after pipeline (trailing comment)
 data |>
-	fn()
+    fn()
 "<>" # foo
 
 # ---
 # Indent after function in call
 # FIXME
 {
-	fn(function() {}"<>")
+    fn(function() {}"<>")
 }
 
 # ---
 # Indent after function in call (multiple lines)
 # FIXME
 {
-	fn(function() {
-		#
-	}"<>")
+    fn(function() {
+        #
+    }"<>")
 }
 
 # ---
@@ -152,22 +152,22 @@ for (i in 1) fn()"<>"
 # ---
 # Breaking parentheses
 foo("<>") +
-	bar()
+    bar()
 
 # ---
 # Breaking parentheses in a pipeline
 # https://github.com/posit-dev/positron/issues/2650
 # https://github.com/posit-dev/positron-beta/discussions/46
 foo() +
-	bar("<>")
+    bar("<>")
 
 # ---
 # Breaking parentheses in a pipeline (comment in the way)
 foo() +
-	bar("<>") # foo
+    bar("<>") # foo
 
 # ---
 # Breaking parentheses in the middle of a pipeline
 foo() +
-	bar("<>") +
-	baz()
+    bar("<>") +
+    baz()

--- a/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
+++ b/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
@@ -6,7 +6,7 @@
 
 # ->
 1 +
-  "<>"
+    "<>"
 
 # ---
 # Starting a pipeline (pipe operator)
@@ -14,17 +14,17 @@ data |>"<>"
 
 # ->
 data |>
-  "<>"
+    "<>"
 
 # ---
 # Starting a pipeline (one empty line)
 # FIXME
 data |>
-	"<>"
+    "<>"
 
 # ->
 data |>
-	
+    
 "<>"
 
 # ---
@@ -32,191 +32,191 @@ data |>
 # FIXME
 data |>
 
-	"<>"
+    "<>"
 
 # ->
 data |>
 
-	
+    
 "<>"
 
 # ---
 # Continuing a pipeline
 1 +
-	2 +"<>"
+    2 +"<>"
 
 # ->
 1 +
-	2 +
-	"<>"
+    2 +
+    "<>"
 
 # ---
 # Continuing a one-liner pipeline
 # https://github.com/posit-dev/positron/issues/1316
 data |>
-	fn() |>"<>"
+    fn() |>"<>"
 
 # ->
 data |>
-	fn() |>
-	"<>"
+    fn() |>
+    "<>"
 
 # ---
 # Continuing a one-liner pipeline (trailing whitespace)
 # https://github.com/posit-dev/positron/pull/1655#issuecomment-1780093395
 data |>
-	fn() |> "<>"
+    fn() |> "<>"
 
 # ->
 data |>
-	fn() |> 
-	"<>"
+    fn() |> 
+    "<>"
 
 # ---
 # Continuing a one-liner pipeline (trailing comment)
 data |>
-	fn() |> "<>" # foo
+    fn() |> "<>" # foo
 
 # ->
 data |>
-	fn() |> 
-	"<>" # foo
+    fn() |> 
+    "<>" # foo
 
 # ---
 # Continuing a one-liner pipeline (comment line)
 # FIXME
 data |>
-	fn1() |>
-	# foo"<>"
+    fn1() |>
+    # foo"<>"
 
 # ->
 data |>
-	fn1() |>
-	# foo
+    fn1() |>
+    # foo
 "<>"
 
 # ---
 # Continuing a one-liner pipeline (after a comment line)
 # FIXME
 data |>
-	fn1() |>
-	# foo
-  "<>"
+    fn1() |>
+    # foo
+    "<>"
 
 # ->
 data |>
-	fn1() |>
-	# foo
-  
+    fn1() |>
+    # foo
+    
 "<>"
 
 # ---
 # Continuing a one-liner pipeline (longer pipeline)
 data |>
-	fn1() |>
-	fn2() |>"<>"
+    fn1() |>
+    fn2() |>"<>"
 
 
 # ->
 data |>
-	fn1() |>
-	fn2() |>
-	"<>"
+    fn1() |>
+    fn2() |>
+    "<>"
 
 
 # ---
 # Continuing a multi-liner pipeline
 # FIXME
 data |>
-	fn1(
-		x,
-		y
-	) |>"<>"
+    fn1(
+        x,
+        y
+    ) |>"<>"
 
 # ->
 data |>
-	fn1(
-		x,
-		y
-	) |>
-		"<>"
+    fn1(
+        x,
+        y
+    ) |>
+        "<>"
 
 # ---
 # Continuing a multi-liner pipeline (trailing expression)
 # FIXME
 data |>
-	fn1(
-		x,
-		y
-	) |> "<>" fn2()
+    fn1(
+        x,
+        y
+    ) |> "<>" fn2()
 
 # ->
 data |>
-	fn1(
-		x,
-		y
-	) |> 
-		"<>" fn2()
+    fn1(
+        x,
+        y
+    ) |> 
+        "<>" fn2()
 
 # ---
 # Dedent after pipeline
 data |>
-	fn()"<>"
+    fn()"<>"
 
 # ->
 data |>
-	fn()
+    fn()
 "<>"
 
 # ---
 # Dedent after pipeline (trailing comment)
 data |>
-	fn()"<>" # foo
+    fn()"<>" # foo
 
 # ->
 data |>
-	fn()
+    fn()
 "<>" # foo
 
 # ---
 # Dedent after pipeline (multiple lines)
 # FIXME
 data |>
-	fn1() |>
-	fn2(
-		"arg"
-	)"<>"
+    fn1() |>
+    fn2(
+        "arg"
+    )"<>"
 
 # ->
 data |>
-	fn1() |>
-	fn2(
-		"arg"
-	)
-	"<>"
+    fn1() |>
+    fn2(
+        "arg"
+    )
+    "<>"
 
 # ---
 # Stickiness of dedent after pipeline
 # https://github.com/posit-dev/positron/issues/1727
 data |>
-	fn()
+    fn()
 "<>"
 
 # ->
 data |>
-	fn()
+    fn()
 
 "<>"
 
 # ---
 # Stickiness of dedent after pipeline (trailing comment)
 data |>
-	fn()
+    fn()
 "<>" # foo
 
 # ->
 data |>
-	fn()
+    fn()
 
 "<>"# foo
 
@@ -224,12 +224,12 @@ data |>
 # Indent after function in call
 # FIXME
 {
-	fn(function() {}"<>")
+    fn(function() {}"<>")
 }
 
 # ->
 {
-	fn(function() {}
+    fn(function() {}
 "<>")
 }
 
@@ -237,16 +237,16 @@ data |>
 # Indent after function in call (multiple lines)
 # FIXME
 {
-	fn(function() {
-		#
-	}"<>")
+    fn(function() {
+        #
+    }"<>")
 }
 
 # ->
 {
-	fn(function() {
-		#
-	}
+    fn(function() {
+        #
+    }
 "<>")
 }
 
@@ -266,51 +266,51 @@ for (i in 1) fn()"<>"
 
 # ->
 for (i in 1) fn()
-  "<>"
+    "<>"
 
 # ---
 # Breaking parentheses
 foo("<>") +
-	bar()
+    bar()
 
 # ->
 foo(
-	"<>"
+    "<>"
 ) +
-	bar()
+    bar()
 
 # ---
 # Breaking parentheses in a pipeline
 # https://github.com/posit-dev/positron/issues/2650
 # https://github.com/posit-dev/positron-beta/discussions/46
 foo() +
-	bar("<>")
+    bar("<>")
 
 # ->
 foo() +
-	bar(
-		"<>"
-	)
+    bar(
+        "<>"
+    )
 
 # ---
 # Breaking parentheses in a pipeline (comment in the way)
 foo() +
-	bar("<>") # foo
+    bar("<>") # foo
 
 # ->
 foo() +
-	bar(
-		"<>"
-	) # foo
+    bar(
+        "<>"
+    ) # foo
 
 # ---
 # Breaking parentheses in the middle of a pipeline
 foo() +
-	bar("<>") +
-	baz()
+    bar("<>") +
+    baz()
 # ->
 foo() +
-	bar(
-		"<>"
-	) +
-	baz()
+    bar(
+        "<>"
+    ) +
+    baz()


### PR DESCRIPTION
This makes it easier to inspect the file and diffs on github.