### PR TITLE
Fix notebook error formatting

### DIFF
--- a/extensions/positron-python/python_files/.vscode/settings.json
+++ b/extensions/positron-python/python_files/.vscode/settings.json
@@ -9,7 +9,8 @@
         "editor.rulers": [100],
     },
     "python.testing.pytestArgs": [
-        "tests"
+        "tests",
+        "positron/positron_ipykernel/tests"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -62,7 +62,6 @@ class SessionMode(str, enum.Enum):
 
     @classmethod
     def trait(cls) -> traitlets.Enum:
-        # return traitlets.Enum(sorted(cls), help=cls.__doc__, default_value=cls.Default)  # type: ignore
         return traitlets.Enum(sorted(cls), help=cls.__doc__)
 
 
@@ -427,9 +426,6 @@ class PositronIPyKernel(IPythonKernel):
 
 
 class PositronIPKernelApp(IPKernelApp):
-    kernel: PositronIPyKernel
-    shell: PositronShell
-
     # Use the PositronIPyKernel class.
     kernel_class: Type[PositronIPyKernel] = traitlets.Type(PositronIPyKernel)  # type: ignore
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
@@ -3,13 +3,19 @@
 #
 
 from typing import Iterable
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import comm
 import pytest
+from traitlets.config import Config
 from positron_ipykernel.connections import ConnectionsService
 from positron_ipykernel.data_explorer import DataExplorerService
-from positron_ipykernel.positron_ipkernel import PositronIPyKernel, PositronShell
+from positron_ipykernel.positron_ipkernel import (
+    PositronIPKernelApp,
+    PositronIPyKernel,
+    PositronShell,
+    SessionMode,
+)
 from positron_ipykernel.variables import VariablesService
 
 
@@ -43,10 +49,15 @@ def kernel() -> PositronIPyKernel:
     """
     The Positron kernel, configured for testing purposes.
     """
-    # Create a Positron kernel. The kernel calls shell_class.instance() to get the globally
-    # registered shell instance, and IPython registers a TerminalInteractiveShell instead of a
-    # PositronShell. This causes a traitlets validation error unless we pass the shell_class explicitly.
-    kernel = PositronIPyKernel.instance(shell_class=PositronShell)
+    # Mock the application object. We haven't needed to use it in tests yet, but we do need it to
+    # pass our custom attributes down to the shell.
+    app = MagicMock(PositronIPKernelApp)
+    app.config = Config()  # Needed to avoid traitlets errors
+
+    # Positron-specific attributes:
+    app.session_mode = SessionMode.Console
+
+    kernel = PositronIPyKernel.instance(parent=app)
 
     return kernel
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
@@ -122,7 +122,7 @@ export function parseOutputData(output: ICellOutput['outputs'][number]): ParsedO
 		}
 
 		if (mime === 'application/vnd.code.notebook.error') {
-			return { type: 'error', content: parsedMessage.message };
+			return { type: 'error', content: parsedMessage.stack };
 		}
 
 	} catch (e) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
@@ -4,4 +4,6 @@
 
 .positron-notebook-text-output {
 	font-family: var(--monaco-monospace-font, monospace);
+	font-size:  var(--notebook-cell-output-font-size, 12px);
+	white-space: pre-wrap;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Address #2607.

### Approach

Plumb the new session mode arg through to the shell and kernel, then use it to determine whether we should format tracebacks.

There's some tension between VSCode and Positron notebook UIs here. VSCode notebooks do error formatting in the notebook-renderers extension, whereas Positron notebooks expect the runtime to do formatting via ANSI/OSC8 escape codes. We may need a way to configure the runtime to still do error formatting for Positron notebooks but not VSCode notebooks, but since we aren't enabling Positron notebooks yet I think this is okay to merge.

### QA Notes

See the issue for a repro.