### PR TITLE
Increase default indent in tree explorer of sidebar

### DIFF
--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -1416,7 +1416,11 @@ configurationRegistry.registerConfiguration({
 		},
 		[treeIndentKey]: {
 			type: 'number',
-			default: 8,
+			// --- Start Positron ---
+			// https://github.com/posit-dev/positron/issues/2688
+			// default: 8,
+			default: 18,
+			// --- End Positron ---
 			minimum: 4,
 			maximum: 40,
 			description: localize('tree indent setting', "Controls tree indentation in pixels.")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

Addresses https://github.com/posit-dev/positron/issues/2688.

This increases the default indentation of the tree explorer of the sidebar so it's not as dense. This makes it easier to identify the structure of the tree at a glance.

Old default:

<img width="351" alt="Screenshot 2024-04-07 at 13 03 21" src="https://github.com/posit-dev/positron/assets/4465050/c0d3fb7c-306c-4034-a365-e0f5b1a42f8b">

New default:

<img width="346" alt="Screenshot 2024-04-07 at 13 03 10" src="https://github.com/posit-dev/positron/assets/4465050/e0d8fd51-652e-468a-87fa-9f749df6740e">

I just picked the indentation level that felt most comfortable / looked better to me. I tried picking a level that allows aligning elements but that seems hard because the node arrows are not positioned in the same way depending on whether the node is opened or closed, and the file icons also seem to affect alignment in different ways.