### PR TITLE
Fix React error when Jupyter socket times out and increase socket connection timeouts

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -1577,11 +1577,11 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 	 * Creates a detailed error object to emit to the client when the kernel fails
 	 * to start.
 	 *
-	 * @param message The error message
+	 * @param error The source error message or object
 	 * @returns A StartupFailure object containing the error message and the
 	 *   contents of the kernel's log file, if it exists
 	 */
-	private createStartupFailure(message: string): StartupFailure {
+	private createStartupFailure(err: any): StartupFailure {
 		// Read the content of the log file, if it exists; this may contain more detail
 		// about why the kernel exited.
 		let logFileContent = '';
@@ -1599,6 +1599,6 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			.join('\n');
 
 		// Create a startup failure message
-		return new StartupFailure(message, logFileContent);
+		return new StartupFailure(err.toString(), logFileContent);
 	}
 }

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -344,12 +344,12 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		this.log(`Connecting to kernel sockets defined in ${session.state.connectionFile}...`);
 
 		// Wait for the sockets to connect or the timeout to expire. Note that
-		// each socket has 10 second timeout for connecting, so this is just an
+		// each socket has 15 second timeout for connecting, so this is just an
 		// additional safeguard.
 		await withTimeout(
 			this.connect(session.state.connectionFile),
-			15000,
-			`Timed out waiting 15 seconds for kernel to connect to sockets`);
+			20000,
+			`Timed out waiting 20 seconds for kernel to connect to sockets`);
 
 		// We're connected! Establish the socket listeners
 		return this.establishSocketListeners();

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -344,12 +344,12 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		this.log(`Connecting to kernel sockets defined in ${session.state.connectionFile}...`);
 
 		// Wait for the sockets to connect or the timeout to expire. Note that
-		// each socket has 15 second timeout for connecting, so this is just an
+		// each socket has 20 second timeout for connecting, so this is just an
 		// additional safeguard.
 		await withTimeout(
 			this.connect(session.state.connectionFile),
-			20000,
-			`Timed out waiting 20 seconds for kernel to connect to sockets`);
+			25000,
+			`Timed out waiting 25 seconds for kernel to connect to sockets`);
 
 		// We're connected! Establish the socket listeners
 		return this.establishSocketListeners();

--- a/extensions/jupyter-adapter/src/JupyterSocket.ts
+++ b/extensions/jupyter-adapter/src/JupyterSocket.ts
@@ -253,10 +253,10 @@ export class JupyterSocket implements vscode.Disposable {
 			}
 			// Compute how long we've been waiting
 			const waitTime = Date.now() - startTime;
-			if (waitTime >= 10000) {
+			if (waitTime >= 15000) {
 				// If we've been waiting for more than 10 seconds, reject the promise
-				this._logger(`${this._title} socket connect timed out after 10 seconds`);
-				this._connectPromise.reject(new Error('Socket connect timed out after 10 seconds'));
+				this._logger(`${this._title} socket connect timed out after 15 seconds`);
+				this._connectPromise.reject(new Error('Socket connect timed out after 15 seconds'));
 				this._connectPromise = undefined;
 
 				// Return to the uninitialized state so a new connection can be attempted if

--- a/extensions/jupyter-adapter/src/JupyterSocket.ts
+++ b/extensions/jupyter-adapter/src/JupyterSocket.ts
@@ -253,10 +253,10 @@ export class JupyterSocket implements vscode.Disposable {
 			}
 			// Compute how long we've been waiting
 			const waitTime = Date.now() - startTime;
-			if (waitTime >= 15000) {
-				// If we've been waiting for more than 10 seconds, reject the promise
-				this._logger(`${this._title} socket connect timed out after 15 seconds`);
-				this._connectPromise.reject(new Error('Socket connect timed out after 15 seconds'));
+			if (waitTime >= 20000) {
+				// If we've been waiting for more than 20 seconds, reject the promise
+				this._logger(`${this._title} socket connect timed out after 20 seconds`);
+				this._connectPromise.reject(new Error('Socket connect timed out after 20 seconds'));
 				this._connectPromise = undefined;
 
 				// Return to the uninitialized state so a new connection can be attempted if


### PR DESCRIPTION
The startup failure event's `message` was an `Error` instead of a string, which caused a minified react error when the startup failure trace item was added to the console.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Address #1385.

### Approach

See the code changes.

### QA Notes

This is hard to QA since the error that leads to this bug is a socket time out, which _may_ just be because I'm using an older Windows laptop (will investigate that separately).