### PR TITLE
Add other plot save formats

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
@@ -59,6 +59,10 @@ class RenderParams(BaseModel):
         description="The pixel ratio of the display device",
     )
 
+    format: str = Field(
+        description="The requested plot format",
+    )
+
 
 class RenderRequest(BaseModel):
     """

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
@@ -26,6 +26,11 @@ DEFAULT_WIDTH_IN = 6.4
 DEFAULT_HEIGHT_IN = 4.8
 BASE_DPI = 100
 
+MIME_TYPE = {
+    "png": "image/png",
+    "svg": "image/svg+xml",
+    "pdf": "application/pdf",
+}
 
 class PositronDisplayPublisherHook:
     def __init__(self, target_name: str, session_mode: SessionMode):
@@ -116,7 +121,7 @@ class PositronDisplayPublisherHook:
 
             if width_px != 0 and height_px != 0:
                 format_dict = self._resize_pickled_figure(pickled, width_px, height_px, pixel_ratio, [format])
-                mime_type = f'image/{format}'
+                mime_type = MIME_TYPE[format]
                 data = format_dict[mime_type]
                 output = PlotResult(data=data, mime_type=mime_type).dict()
                 figure_comm.send_result(data=output, metadata={"mime_type": mime_type})
@@ -220,7 +225,7 @@ class PositronDisplayPublisherHook:
         figure.savefig(figure_buffer, format=formats[0])
         figure_buffer.seek(0)
         image_data = base64.b64encode(figure_buffer.read()).decode()
-        key = f'image/{formats[0]}'
+        key = MIME_TYPE[formats[0]]
 
         format_dict = {key: image_data}
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
@@ -30,6 +30,7 @@ MIME_TYPE = {
     "png": "image/png",
     "svg": "image/svg+xml",
     "pdf": "application/pdf",
+    "jpeg": "image/jpeg",
 }
 
 class PositronDisplayPublisherHook:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
@@ -33,6 +33,7 @@ MIME_TYPE = {
     "jpeg": "image/jpeg",
 }
 
+
 class PositronDisplayPublisherHook:
     def __init__(self, target_name: str, session_mode: SessionMode):
         self.target_name = target_name
@@ -121,7 +122,9 @@ class PositronDisplayPublisherHook:
             format = request.params.format or "png"
 
             if width_px != 0 and height_px != 0:
-                format_dict = self._resize_pickled_figure(pickled, width_px, height_px, pixel_ratio, [format])
+                format_dict = self._resize_pickled_figure(
+                    pickled, width_px, height_px, pixel_ratio, [format]
+                )
                 mime_type = MIME_TYPE[format]
                 data = format_dict[mime_type]
                 output = PlotResult(data=data, mime_type=mime_type).dict()

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
@@ -162,7 +162,7 @@ def test_hook_call(hook: PositronDisplayPublisherHook, images_path: Path) -> Non
 def render_request(comm_id: str, width_px: int = 500, height_px: int = 500, pixel_ratio: int = 1):
     return json_rpc_request(
         "render",
-        {"width": width_px, "height": height_px, "pixel_ratio": pixel_ratio},
+        {"width": width_px, "height": height_px, "pixel_ratio": pixel_ratio, "format": "png"},
         comm_id=comm_id,
     )
 

--- a/positron/comms/plot-backend-openrpc.json
+++ b/positron/comms/plot-backend-openrpc.json
@@ -36,7 +36,8 @@
 					"description": "The requested plot format",
 					"schema": {
 						"type": "string"
-					}
+					},
+					"required": false
 				}
 			],
 			"result": {

--- a/positron/comms/plot-backend-openrpc.json
+++ b/positron/comms/plot-backend-openrpc.json
@@ -30,6 +30,13 @@
 					"schema": {
 						"type": "number"
 					}
+				},
+				{
+					"name": "format",
+					"description": "The requested plot format",
+					"schema": {
+						"type": "string"
+					}
 				}
 			],
 			"result": {

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.css
@@ -4,9 +4,10 @@
 
 .plot-preview-input {
 	height: 100%;
-	grid-template-rows: 1fr 2fr 4px 9fr;
+	grid-template-rows: 1fr 1fr 2fr 4px 9fr;
 	grid-template-areas:
 		"browse"
+		"file"
 		"plot-input"
 		"preview-progress"
 		"preview";
@@ -28,6 +29,17 @@
 	grid-area: input;
 }
 
+.plot-preview-input .file {
+	display: flex;
+	flex-direction: row;
+	column-gap: 10px;
+	align-items: flex-end;
+}
+
+.plot-preview-input .file button {
+	margin-top: 4px;
+}
+
 .plot-input div.error {
 	padding-top: 4px;
 	grid-column: 1 / span 3;
@@ -40,8 +52,12 @@
 	width: auto;
 }
 
-.plot-preview-input .labeled-text-input input {
+.plot-preview-input .plot-input .labeled-text-input input {
 	width: 100px;
+}
+
+.plot-preview-input .file .labeled-text-input input {
+	width: 200px;
 }
 
 .plot-preview-input .preview-progress {

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -150,21 +150,15 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 	const acceptHandler = async () => {
 		if (validateInput()) {
 			setRendering(true);
+
 			const extension = path.value.fsPath.split('.').pop()?.toLowerCase();
-			// const format = extension === 'png' || extension === 'svg' ? extension : 'png';
-			let format = PlotFormat.PNG;
-			switch (extension) {
-				case 'svg':
-					format = PlotFormat.SVG;
-					break;
-				case 'pdf':
-					format = PlotFormat.PDF;
-					break;
-				case 'png':
-				default:
-					format = PlotFormat.PNG;
-					break;
+			let format = extension as PlotFormat;
+
+			// default to PNG if the format is unknown
+			if (!Object.values(PlotFormat).includes(format)) {
+				format = PlotFormat.PNG;
 			}
+
 			const plotResult = await generatePreview(format);
 
 			if (plotResult) {

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -128,8 +128,8 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 	}, [props.plotClient.lastRender?.uri]);
 
 	const validateInput = React.useCallback((): boolean => {
-		return directory.valid && width.valid && height.valid && dpi.valid;
-	}, [directory, width, height, dpi]);
+		return directory.valid && width.valid && height.valid && dpi.valid && name.valid;
+	}, [directory, width, height, dpi, name]);
 
 	React.useEffect(() => {
 		validateInput();
@@ -341,6 +341,12 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 									{!dpi.valid && (() => localize(
 										'positron.savePlotModalDialog.dpiMinMaxError',
 										"DPI must be between 1 and 300."
+									))()}
+								</div>
+								<div>
+									{!name.valid && (() => localize(
+										'positron.savePlotModalDialog.invalidNameError',
+										"Plot name cannot be empty."
 									))()}
 								</div>
 							</div>

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -26,8 +26,9 @@ export interface SavePlotOptions {
 }
 
 export enum PlotFormat {
-	PNG = 'PNG',
-	SVG = 'SVG',
+	PNG = 'png',
+	SVG = 'svg',
+	PDF = 'pdf',
 }
 
 const SAVE_PLOT_MODAL_DIALOG_WIDTH = 500;
@@ -99,7 +100,7 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 
 	const filterEntries: FileFilter[] = [];
 	for (const filter in PlotFormat) {
-		filterEntries.push({ extensions: [filter.toLowerCase()], name: filter });
+		filterEntries.push({ extensions: [filter.toLowerCase()], name: filter.toUpperCase() });
 	}
 
 	React.useEffect(() => {
@@ -149,7 +150,20 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 		if (validateInput()) {
 			setRendering(true);
 			const extension = path.value.fsPath.split('.').pop()?.toLowerCase();
-			const format = extension === 'png' || extension === 'svg' ? extension : 'png';
+			// const format = extension === 'png' || extension === 'svg' ? extension : 'png';
+			let format = PlotFormat.PNG;
+			switch (extension) {
+				case 'svg':
+					format = PlotFormat.SVG;
+					break;
+				case 'pdf':
+					format = PlotFormat.PDF;
+					break;
+				case 'png':
+				default:
+					format = PlotFormat.PNG;
+					break;
+			}
 			const plotResult = await generatePreview(format);
 
 			if (plotResult) {
@@ -171,14 +185,14 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 		}
 		setRendering(true);
 		try {
-			const plotResult = await generatePreview('png');
+			const plotResult = await generatePreview(PlotFormat.PNG);
 			setUri(plotResult.uri);
 		} finally {
 			setRendering(false);
 		}
 	};
 
-	const generatePreview = async (format: 'png' | 'svg'): Promise<IRenderedPlot> => {
+	const generatePreview = async (format: PlotFormat): Promise<IRenderedPlot> => {
 		return props.plotClient.preview(height.value, width.value, dpi.value / BASE_DPI, format);
 	};
 

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -29,6 +29,7 @@ export enum PlotFormat {
 	PNG = 'png',
 	SVG = 'svg',
 	PDF = 'pdf',
+	JPEG = 'jpeg',
 }
 
 const SAVE_PLOT_MODAL_DIALOG_WIDTH = 500;

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -66,7 +66,6 @@ export const showSavePlotModalDialog = (
 	renderer.render(
 		<SavePlotModalDialog
 			layoutService={layoutService}
-			keybindingService={keybindingService}
 			fileDialogService={fileDialogService}
 			renderer={renderer}
 			plotWidth={plotWidth}
@@ -80,7 +79,6 @@ export const showSavePlotModalDialog = (
 
 interface SavePlotModalDialogProps {
 	layoutService: IWorkbenchLayoutService;
-	keybindingService: IKeybindingService;
 	fileDialogService: IFileDialogService;
 	renderer: PositronModalReactRenderer;
 	plotWidth: number;

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -24,14 +24,14 @@ import { WebviewPlotClient } from 'vs/workbench/contrib/positronPlots/browser/we
 import { IPositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
 import { IPositronIPyWidgetsService } from 'vs/workbench/services/positronIPyWidgets/common/positronIPyWidgetsService';
 import { Schemas } from 'vs/base/common/network';
-import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IDialogService, IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { decodeBase64 } from 'vs/base/common/buffer';
 import { SavePlotOptions, showSavePlotModalDialog } from 'vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
-import { URI } from 'vs/base/common/uri';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { localize } from 'vs/nls';
 
 /** The maximum number of recent executions to store. */
 const MaxRecentExecutions = 10;
@@ -109,7 +109,8 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
-		@IClipboardService private _clipboardService: IClipboardService) {
+		@IClipboardService private _clipboardService: IClipboardService,
+		@IDialogService private readonly _dialogService: IDialogService) {
 		super();
 
 		// Register for language runtime service startups
@@ -682,7 +683,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		if (this._selectedPlotId) {
 			const plot = this._plots.find(plot => plot.id === this._selectedPlotId);
 			const workspaceFolder = this._workspaceContextService.getWorkspace().folders[0]?.uri;
-			const suggestedPath = workspaceFolder ? URI.joinPath(workspaceFolder, 'plot.png') : undefined;
+			const suggestedPath = workspaceFolder ?? undefined;
 			if (plot) {
 				let uri = '';
 
@@ -692,7 +693,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 					this.showSavePlotDialog(uri);
 				} else if (plot instanceof PlotClientInstance) {
 					// if it's a dynamic plot, present options dialog
-					showSavePlotModalDialog(this._layoutService, this._keybindingService, this._fileDialogService, plot, this.savePlotAs, suggestedPath);
+					showSavePlotModalDialog(this._layoutService, this._keybindingService, this._dialogService, this._fileService, this._fileDialogService, plot, this.savePlotAs, suggestedPath);
 				} else {
 					// if it's a webview plot, do nothing
 					return;
@@ -712,7 +713,8 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		const data = matches[2];
 
 		htmlFileSystemProvider.writeFile(options.path, decodeBase64(data).buffer, { create: true, overwrite: true, unlock: true, atomic: false })
-			.then(() => {
+			.catch((error: Error) => {
+				this._dialogService.error(localize('positronPlotsService.savePlotError.unknown', 'Error saving plot: {0}', error.message));
 			});
 	};
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -76,6 +76,9 @@ interface RenderRequest {
 
 	/** The pixel ratio of the device for which the plot was rendered */
 	pixel_ratio: number;
+
+	/** The format of the plot */
+	format: string;
 }
 
 /**
@@ -246,9 +249,10 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 	 * @param height The plot height, in pixels
 	 * @param width The plot width, in pixels
 	 * @param pixel_ratio The device pixel ratio (e.g. 1 for standard displays, 2 for retina displays)
+	 * @param format The format of the plot ('png', 'svg')
 	 * @returns A promise that resolves to a rendered image, or rejects with an error.
 	 */
-	public render(height: number, width: number, pixel_ratio: number): Promise<IRenderedPlot> {
+	public render(height: number, width: number, pixel_ratio: number, format = 'png'): Promise<IRenderedPlot> {
 		// Deal with whole pixels only
 		height = Math.floor(height);
 		width = Math.floor(width);
@@ -269,7 +273,8 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 		const request: RenderRequest = {
 			height,
 			width,
-			pixel_ratio
+			pixel_ratio,
+			format
 		};
 		const deferred = new DeferredRender(request);
 
@@ -309,7 +314,7 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 	 * @param pixel_ratio The device pixel ratio (e.g. 1 for standard displays, 2 for retina displays)
 	 * @returns A promise that resolves when the render request is scheduled, or rejects with an error.
 	 */
-	public preview(height: number, width: number, pixel_ratio: number): Promise<IRenderedPlot> {
+	public preview(height: number, width: number, pixel_ratio: number, format: string): Promise<IRenderedPlot> {
 		// Deal with whole pixels only
 		height = Math.floor(height);
 		width = Math.floor(width);
@@ -318,7 +323,8 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 		const request: RenderRequest = {
 			height,
 			width,
-			pixel_ratio
+			pixel_ratio,
+			format
 		};
 		const deferred = new DeferredRender(request);
 
@@ -384,7 +390,8 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 		const renderRequest = request.renderRequest;
 		this._comm.render(renderRequest.height,
 			renderRequest.width,
-			renderRequest.pixel_ratio).then((response) => {
+			renderRequest.pixel_ratio,
+			renderRequest.format).then((response) => {
 
 				// Ignore if the request was cancelled or already fulfilled
 				if (!request.isComplete) {
@@ -490,7 +497,8 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 		const req = new DeferredRender({
 			height: Math.floor(height!),
 			width: Math.floor(width!),
-			pixel_ratio: pixel_ratio!
+			pixel_ratio: pixel_ratio!,
+			format: this._currentRender?.renderRequest.format ?? 'png'
 		});
 
 		this.scheduleRender(req, 0);

--- a/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
@@ -51,11 +51,12 @@ export class PositronPlotComm extends PositronBaseComm {
 	 * @param height The requested plot height, in pixels
 	 * @param width The requested plot width, in pixels
 	 * @param pixelRatio The pixel ratio of the display device
+	 * @param format The requested plot format
 	 *
 	 * @returns A rendered plot
 	 */
-	render(height: number, width: number, pixelRatio: number): Promise<PlotResult> {
-		return super.performRpc('render', ['height', 'width', 'pixel_ratio'], [height, width, pixelRatio]);
+	render(height: number, width: number, pixelRatio: number, format: string): Promise<PlotResult> {
+		return super.performRpc('render', ['height', 'width', 'pixel_ratio', 'format'], [height, width, pixelRatio, format]);
 	}
 
 


### PR DESCRIPTION
### Intent
Address #2657 

### Approach
Adds a format option when selecting where to save the plot. This adds a new parameter to the render request and updates the Python extension to render the other formats. Ark will have its own PR to add in that support. Until Ark supports the other formats, plot saving will always save as a PNG regardless of the chosen format.

![image](https://github.com/posit-dev/positron/assets/9591545/98ba6f4c-80be-4d26-9612-ec5ebad58572)

### QA Notes
Sample plot for Python
```python
import numpy as np
import matplotlib.pyplot as plt

with plt.xkcd():
    # plt in widget mode
    # %matplotlib ipympl
    # v = np.array([1, 3, 5, 365])
    v = np.arange(365, 0, -1)
    # w = np.array([4, 6, 2, 10, 8, 1])

    fig, ax = plt.subplots()
    fig.set_facecolor('whitesmoke')
    fig.set_edgecolor('black')
    ax.set_xlabel('Day of the year')
    ax.set_ylabel('Days until New Year\'s Eve')

    plt.xlim(0, 365)
    plt.ylim(1, 365)

    plt.plot(v)
    # plt.plot(w)
```

Sample plot for R
```R
library(ggplot2)
data("midwest")
ggplot(midwest, aes(x=area, y=poptotal)) + geom_point()
```