### PR TITLE
Triage render issues with null counts, expanded profiles in data explorer

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -44,7 +44,7 @@ const createRowFilters = (rowFilterDescriptors: RowFilterDescriptor[]) => {
 		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsNotEmpty) {
 			rowFilters.push({
 				filter_id: rowFilterDescriptor.identifier,
-				filter_type: RowFilterType.IsNull,
+				filter_type: RowFilterType.NotNull,
 				column_index: rowFilterDescriptor.columnSchema.column_index
 			});
 		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsLessThan) {

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnNullPercent.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnNullPercent.tsx
@@ -23,11 +23,26 @@ interface ColumnNullPercentProps {
  */
 export const ColumnNullPercent = (props: ColumnNullPercentProps) => {
 	// Render.
+	let svgWidth = 50;
+	if (props.columnNullPercent !== undefined) {
+		svgWidth = props.columnNullPercent === 0.0 ?
+			50 :
+			Math.max(50 * ((100 - props.columnNullPercent) / 100), 3);
+	}
 	return (
 		<div className='column-null-percent'>
-			<div className={positronClassNames('text-percent', { 'zero': props.columnNullPercent === 0.0 })}>
-				{props.columnNullPercent}%
-			</div>
+			{props.columnNullPercent !== undefined ?
+				(
+					<div className={positronClassNames('text-percent', { 'zero': props.columnNullPercent === 0.0 })}>
+						{props.columnNullPercent}%
+					</div>
+				) :
+				(
+					<div className={positronClassNames('text-percent')}>
+						...
+					</div>
+				)
+			}
 			<div className='graph-percent'>
 				<svg viewBox='0 0 52 14' shapeRendering='geometricPrecision'>
 					<g>
@@ -43,10 +58,7 @@ export const ColumnNullPercent = (props: ColumnNullPercentProps) => {
 						<rect className='indicator'
 							x='1'
 							y='1'
-							width={props.columnNullPercent === 0.0 ?
-								50 :
-								Math.max(50 * ((100 - props.columnNullPercent) / 100), 3)
-							}
+							width={svgWidth}
 							height='12'
 							rx='6'
 							ry='6'

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -76,8 +76,6 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 	 * @returns The profile component.
 	 */
 	const profile = () => {
-		// Hack just to get things working
-		props.instance.computeColumnSummaryStats(props.columnIndex);
 		// Determine the alignment based on type.
 		switch (props.columnSchema.type_display) {
 			case ColumnDisplayType.Number:
@@ -90,7 +88,10 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				return null;
 
 			case ColumnDisplayType.String:
-				return <ProfileString />;
+				return <ProfileString
+					instance={props.instance}
+					columnIndex={props.columnIndex}
+				/>;
 
 			case ColumnDisplayType.Date:
 				return null;

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/profileNumber.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/profileNumber.tsx
@@ -24,8 +24,8 @@ interface ProfileNumberProps {
  * @returns The rendered component.
  */
 export const ProfileNumber = (props: ProfileNumberProps) => {
-	// Hack
 	let stats: any = props.instance.getColumnSummaryStats(props.columnIndex)?.number_stats!;
+	const nullCount = props.instance.getColumnNullCount(props.columnIndex);
 	if (!stats) {
 		stats = {};
 	}
@@ -41,7 +41,7 @@ export const ProfileNumber = (props: ProfileNumberProps) => {
 			</div>
 			<div className='values'>
 				<div className='values-left'>
-					<div className='value'>-999999</div>
+					<div className='value'>{nullCount}</div>
 					<div className='value'>{stats.mean}</div>
 					<div className='value'>{stats.median}</div>
 					<div className='value'>{stats.stdev}</div>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/profileString.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/profileString.tsx
@@ -7,11 +7,14 @@ import 'vs/css!./profileString';
 
 // React.
 import * as React from 'react';
+import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
 
 /**
  * ProfileStringProps interface.
  */
 interface ProfileStringProps {
+	instance: TableSummaryDataGridInstance;
+	columnIndex: number;
 }
 
 /**
@@ -20,6 +23,11 @@ interface ProfileStringProps {
  * @returns The rendered component.
  */
 export const ProfileString = (props: ProfileStringProps) => {
+	let stats: any = props.instance.getColumnSummaryStats(props.columnIndex)?.string_stats!;
+	const nullCount = props.instance.getColumnNullCount(props.columnIndex);
+	if (!stats) {
+		stats = {};
+	}
 	return (
 		<div className='tabular-info'>
 			<div className='labels'>
@@ -29,15 +37,15 @@ export const ProfileString = (props: ProfileStringProps) => {
 			</div>
 			<div className='values'>
 				<div className='values-left'>
-					<div className='value'>12</div>
-					<div className='value'>1</div>
-					<div className='value'>4</div>
+					<div className='value'>{nullCount}</div>
+					<div className='value'>{stats.num_empty}</div>
+					<div className='value'>{stats.num_unique}</div>
 				</div>
-				<div className='values-right'>
+				{/* <div className='values-right'>
 					<div className='value'>&nbsp;</div>
 					<div className='value'>.51</div>
 					<div className='value'>.20</div>
-				</div>
+				</div> */}
 			</div>
 		</div>
 	);

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -9,6 +9,7 @@ import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntim
 import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
 import { PositronDataExplorerLayout } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
 import { IPositronDataExplorerInstance } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance';
+import { DataExplorerCache } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
 
 /**
  * PositronDataExplorerInstance class.
@@ -20,6 +21,8 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	 * Gets the DataExplorerClientInstance.
 	 */
 	private readonly _dataExplorerClientInstance: DataExplorerClientInstance;
+
+	private readonly _dataCache: DataExplorerCache;
 
 	/**
 	 * Gets or sets the layout.
@@ -72,11 +75,14 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 
 		// Initialize.
 		this._dataExplorerClientInstance = dataExplorerClientInstance;
+		this._dataCache = new DataExplorerCache(dataExplorerClientInstance);
 		this._tableSchemaDataGridInstance = new TableSummaryDataGridInstance(
-			dataExplorerClientInstance
+			dataExplorerClientInstance,
+			this._dataCache
 		);
 		this._tableDataDataGridInstance = new TableDataDataGridInstance(
-			dataExplorerClientInstance
+			dataExplorerClientInstance,
+			this._dataCache
 		);
 
 		// Add event handlers.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -39,7 +39,9 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * Constructor.
 	 * @param dataExplorerClientInstance The DataExplorerClientInstance.
 	 */
-	constructor(dataExplorerClientInstance: DataExplorerClientInstance) {
+	constructor(dataExplorerClientInstance: DataExplorerClientInstance,
+		dataCache: DataExplorerCache
+	) {
 		// Call the base class's constructor.
 		super({
 			columnHeaders: true,
@@ -64,8 +66,8 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		// Setup the data explorer client instance.
 		this._dataExplorerClientInstance = dataExplorerClientInstance;
 
-		// Allocate and initialize the DataExplorerCache.
-		this._dataExplorerCache = new DataExplorerCache(dataExplorerClientInstance);
+		// Set the shared data cache
+		this._dataExplorerCache = dataCache;
 
 		// Add the onDidUpdateCache event handler.
 		this._register(this._dataExplorerCache.onDidUpdateCache(() =>

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
@@ -111,19 +111,12 @@ export class DataExplorerCache extends Disposable {
 		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(async () => {
 			// Clear the column schema cache, row label cache, and data cell cache.
 			this._columnSchemaCache.clear();
-			this._columnNullCountCache.clear();
-			this._columnSummaryStatsCache.clear();
-			this._rowLabelCache.clear();
-			this._dataCellCache.clear();
+			this.invalidateDataCache();
 		}));
 
 		// Add the onDidDataUpdate event handler.
 		this._register(this._dataExplorerClientInstance.onDidDataUpdate(async () => {
-			// Clear the row label cache and data cell cache.
-			this._rowLabelCache.clear();
-			this._dataCellCache.clear();
-			this._columnNullCountCache.clear();
-			this._columnSummaryStatsCache.clear();
+			this.invalidateDataCache();
 		}));
 	}
 
@@ -207,7 +200,12 @@ export class DataExplorerCache extends Disposable {
 		return this._columnSummaryStatsCache.get(columnIndex);
 	}
 
-	async updateColumnSummaryStats(columnIndices: Array<number>) {
+	async cacheColumnSummaryStats(columnIndices: Array<number>) {
+		// Filter out summary stats that are already cached
+		columnIndices = columnIndices.filter(columnIndex =>
+			!this._columnSummaryStatsCache.has(columnIndex)
+		);
+
 		// Request the profiles
 		const results = await this._dataExplorerClientInstance.getColumnProfiles(
 			columnIndices.map(column_index => {


### PR DESCRIPTION
Addresses #2743. This also fixes an issue with "is not empty" filter sending an IsNull filter instead of NotNull.

[Screencast from 2024-04-11 20-26-25.webm](https://github.com/posit-dev/positron/assets/329591/8f44e917-3392-40a5-9bb6-e504bdf9553b)
