### PR TITLE
Switch `PositronHelpContribution` to new `registerWorkbenchContribution2()`

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelp.contribution.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelp.contribution.ts
@@ -10,14 +10,13 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 import { PositronHelpFocused } from 'vs/workbench/common/contextkeys';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
-import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ViewPaneContainer } from 'vs/workbench/browser/parts/views/viewPaneContainer';
 import { PositronHelpView } from 'vs/workbench/contrib/positronHelp/browser/positronHelpView';
 import { POSITRON_HELP_VIEW_ID } from 'vs/workbench/contrib/positronHelp/browser/positronHelpService';
 import { POSITRON_HELP_COPY } from 'vs/workbench/contrib/positronHelp/browser/positronHelpIdentifiers';
 import { ICommandAndKeybindingRule, KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
-import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from 'vs/workbench/common/contributions';
+import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from 'vs/workbench/common/contributions';
 import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
 import { registerAction2 } from 'vs/platform/actions/common/actions';
 import { LookupHelpTopic, ShowHelpAtCursor } from 'vs/workbench/contrib/positronHelp/browser/positronHelpActions';
@@ -80,6 +79,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 
 
 class PositronHelpContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.positronHelp';
+
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService
 	) {
@@ -93,6 +95,7 @@ class PositronHelpContribution extends Disposable implements IWorkbenchContribut
 	}
 }
 
-Registry.
-	as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).
-	registerWorkbenchContribution(PositronHelpContribution, LifecyclePhase.Restored);
+// Really does need to be `WorkbenchPhase.BlockStartup`. Any later and the keybindings registered
+// by `ShowHelpAtCursor` are registered "too late", i.e. after the core set of system keybindings
+// have been set https://github.com/posit-dev/positron/issues/2523.
+registerWorkbenchContribution2(PositronHelpContribution.ID, PositronHelpContribution, WorkbenchPhase.BlockStartup);


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2523

In https://github.com/posit-dev/positron/pull/2367 we updated to 1.87 VS Code. That included this commit where our `PositronHelpContribution` initialization time was changed from `Ready` (early) to `Restored` (one state later)
https://github.com/posit-dev/positron/pull/2367/commits/5d58375c723e2091499d44b4e3dc14d46d65d838.

https://github.com/posit-dev/positron/blob/207637c14d8ac70c1cc63bd86387818b55b67c1d/src/vs/workbench/services/lifecycle/common/lifecycle.ts#L152-L181

It turns out that `Restored` is "too late" to be able to register keybindings if you want them to get populated in the initial round of system keybinding setup. Here's a video with current `main`, the command _is there_ but it looks like it doesn't have a keybinding registered to it. However, if you set a User keybinding for it then that is enough to tickle a keybindings refresh and `F1` automagically populates again. i.e. we technically knew what the default was, but were not able to set it in time!

https://github.com/posit-dev/positron/assets/19150088/4f87418d-3b0e-4939-9c60-a86d4de76654

We changed from `Ready` to `Restored` in the first place because the 1.87 upstream merge included https://github.com/microsoft/vscode/pull/203802 (discussions in https://github.com/microsoft/vscode/issues/203947, https://github.com/microsoft/vscode/issues/203445) which added a new `registerWorkbenchContribution2()`, deprecated the old `registerWorkbenchContribution()`, and restricted the `instantiation` argument of the old one to no longer allow `Ready`.

To continue to use something like `Ready`, I switched us to the new `registerWorkbenchContribution2()` system, which seemed straightforward, and used `WorkbenchPhase.BlockRestore`, which is actually a direct mapping from `Ready`:

https://github.com/posit-dev/positron/blob/207637c14d8ac70c1cc63bd86387818b55b67c1d/src/vs/workbench/common/contributions.ts#L31-L62

Lastly, note that in https://github.com/posit-dev/positron/pull/2367/commits/5d58375c723e2091499d44b4e3dc14d46d65d838 we also changed the `PositronDataExplorerContribution` from `Starting` to `Restored` for the same reasons as above. Unlike the help contribution, the data explorer contribution registers its actions (and their keybindings) _outside_ of the `PositronDataExplorerContribution` class itself, so AFAICT it was unaffected by changing the instantiation state. However, we should keep an eye out for any data explorer weirdness going forward and remember that this may be the cause of it.
https://github.com/posit-dev/positron/blob/207637c14d8ac70c1cc63bd86387818b55b67c1d/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts#L64-L67

Here's a video of everything working as expected now:


https://github.com/posit-dev/positron/assets/19150088/33a48948-3d14-4f4a-a949-a3718147e0ef

