### PR TITLE
[python] handle exceptions if they are raised by children in variables pane

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -232,7 +232,12 @@ class ObjectInspector(PositronInspector[T], ABC):
         return len([p for p in dir(self.value) if not (p.startswith("_"))])
 
     def get_child(self, key: str) -> Any:
-        return getattr(self.value, key)
+        if isinstance(self.value, property):
+            pass
+        try:
+            return getattr(self.value, key)
+        except Exception as e:
+            return str(f"{type(e).__name__}: {e}")
 
     def get_items(self) -> Iterable[Tuple[str, Any]]:
         for key in dir(self.value):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -237,7 +237,8 @@ class ObjectInspector(PositronInspector[T], ABC):
         try:
             return getattr(self.value, key)
         except Exception as e:
-            return str(f"{type(e).__name__}: {e}")
+            logger.warning(msg=f"{type(e).__name__}: {e}")
+            return "Unable to show value."
 
     def get_items(self) -> Iterable[Tuple[str, Any]]:
         for key in dir(self.value):


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

addresses #2532 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

This was occurring since `fsspec.filesystem("gcs").buckets()` was returning an HTTPError. 

If there is any Exception (in this case it was an `HTTPError`), pass the error as a string to be displayed in. Also, do not inspect properties, which might execute code.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

```
pip install fsspec gcsfs
```

```python
import fsspec

fs = fsspec.filesystem("gcs")
```

and then try to expand in variables pane. 