### PR TITLE
Batch of row filtering improvements, backend RPC cleanup. Add less-equal, greater-equal, null/not-null filter types, put supported features in get_state result

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -24,6 +24,7 @@ import comm
 
 from .access_keys import decode_access_key
 from .data_explorer_comm import (
+    BackendState,
     ColumnFrequencyTable,
     ColumnHistogram,
     ColumnSummaryStats,
@@ -35,7 +36,6 @@ from .data_explorer_comm import (
     ColumnSortKey,
     DataExplorerBackendMessageContent,
     DataExplorerFrontendEvent,
-    DataExplorerState,
     FilterResult,
     GetColumnProfilesFeatures,
     GetColumnProfilesRequest,
@@ -222,7 +222,7 @@ class DataExplorerTableView(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def _get_state(self) -> DataExplorerState:
+    def _get_state(self) -> BackendState:
         pass
 
 
@@ -724,13 +724,13 @@ class PandasView(DataExplorerTableView):
         get_column_profiles=_column_profile_features,
     )
 
-    def _get_state(self) -> DataExplorerState:
+    def _get_state(self) -> BackendState:
         if self.view_indices is not None:
             num_rows = len(self.view_indices)
         else:
             num_rows = self.table.shape[0]
 
-        return DataExplorerState(
+        return BackendState(
             table_shape=TableShape(num_rows=num_rows, num_columns=self.table.shape[1]),
             row_filters=self.filters,
             sort_keys=self.sort_keys,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -35,14 +35,15 @@ from .data_explorer_comm import (
     ColumnSortKey,
     DataExplorerBackendMessageContent,
     DataExplorerFrontendEvent,
+    DataExplorerState,
     FilterResult,
     GetColumnProfilesFeatures,
     GetColumnProfilesRequest,
     GetDataValuesRequest,
     GetSchemaRequest,
     GetStateRequest,
-    GetSupportedFeaturesRequest,
     RowFilter,
+    RowFilterCondition,
     RowFilterType,
     SchemaUpdateParams,
     SearchFilterType,
@@ -59,7 +60,6 @@ from .data_explorer_comm import (
     TableData,
     TableSchema,
     TableShape,
-    TableState,
 )
 from .positron_comm import CommMessage, PositronComm
 from .third_party import pd_
@@ -166,9 +166,6 @@ class DataExplorerTableView(abc.ABC):
     def get_state(self, request: GetStateRequest):
         return self._get_state().dict()
 
-    def get_supported_features(self, request: GetSupportedFeaturesRequest):
-        return self._get_supported_features().dict()
-
     @abc.abstractmethod
     def invalidate_computations(self):
         pass
@@ -225,11 +222,7 @@ class DataExplorerTableView(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def _get_state(self) -> TableState:
-        pass
-
-    @abc.abstractmethod
-    def _get_supported_features(self) -> SupportedFeatures:
+    def _get_state(self) -> DataExplorerState:
         pass
 
 
@@ -482,7 +475,7 @@ class PandasView(DataExplorerTableView):
             # reflect the filtered_indices that have just been updated
             self._sort_data()
 
-    def _set_row_filters(self, filters) -> FilterResult:
+    def _set_row_filters(self, filters: List[RowFilter]) -> FilterResult:
         self.filters = filters
 
         if len(filters) == 0:
@@ -491,20 +484,32 @@ class PandasView(DataExplorerTableView):
             self._update_view_indices()
             return FilterResult(selected_num_rows=len(self.table))
 
-        # Evaluate all the filters and AND them together
+        # Evaluate all the filters and combine them using the
+        # indicated conditions
         combined_mask = None
         for filt in filters:
+            if filt.is_valid is False:
+                # If filter is invalid, do not evaluate it
+                continue
+
             single_mask = self._eval_filter(filt)
             if combined_mask is None:
                 combined_mask = single_mask
-            else:
+            elif filt.condition == RowFilterCondition.And:
                 combined_mask &= single_mask
+            elif filt.condition == RowFilterCondition.Or:
+                combined_mask |= single_mask
 
-        self.filtered_indices = combined_mask.nonzero()[0]
+        if combined_mask is None:
+            self.filtered_indices = None
+            selected_num_rows = len(self.table)
+        else:
+            self.filtered_indices = combined_mask.nonzero()[0]
+            selected_num_rows = len(self.filtered_indices)
 
         # Update the view indices, re-sorting if needed
         self._update_view_indices()
-        return FilterResult(selected_num_rows=len(self.filtered_indices))
+        return FilterResult(selected_num_rows=selected_num_rows)
 
     def _eval_filter(self, filt: RowFilter):
         col = self.table.iloc[:, filt.column_index]
@@ -531,8 +536,12 @@ class PandasView(DataExplorerTableView):
             op = COMPARE_OPS[params.op]
             # pandas comparison filters return False for null values
             mask = op(col, _coerce_value_param(params.value, col.dtype))
+        elif filt.filter_type == RowFilterType.IsEmpty:
+            mask = col.str.len() == 0
         elif filt.filter_type == RowFilterType.IsNull:
             mask = col.isnull()
+        elif filt.filter_type == RowFilterType.NotEmpty:
+            mask = col.str.len() != 0
         elif filt.filter_type == RowFilterType.NotNull:
             mask = col.notnull()
         elif filt.filter_type == RowFilterType.SetMembership:
@@ -687,45 +696,45 @@ class PandasView(DataExplorerTableView):
     def _prof_histogram(self, column_index: int):
         raise NotImplementedError
 
-    def _get_state(self) -> TableState:
+    _row_filter_features = SetRowFiltersFeatures(
+        supported=True,
+        supports_conditions=False,
+        supported_types=[
+            RowFilterType.Between,
+            RowFilterType.Compare,
+            RowFilterType.IsNull,
+            RowFilterType.NotNull,
+            RowFilterType.NotBetween,
+            RowFilterType.Search,
+            RowFilterType.SetMembership,
+        ],
+    )
+
+    _column_profile_features = GetColumnProfilesFeatures(
+        supported=True,
+        supported_types=[
+            ColumnProfileType.NullCount,
+            ColumnProfileType.SummaryStats,
+        ],
+    )
+
+    FEATURES = SupportedFeatures(
+        search_schema=SearchSchemaFeatures(supported=True),
+        set_row_filters=_row_filter_features,
+        get_column_profiles=_column_profile_features,
+    )
+
+    def _get_state(self) -> DataExplorerState:
         if self.view_indices is not None:
             num_rows = len(self.view_indices)
         else:
             num_rows = self.table.shape[0]
 
-        return TableState(
+        return DataExplorerState(
             table_shape=TableShape(num_rows=num_rows, num_columns=self.table.shape[1]),
             row_filters=self.filters,
             sort_keys=self.sort_keys,
-        )
-
-    def _get_supported_features(self) -> SupportedFeatures:
-        row_filter_features = SetRowFiltersFeatures(
-            supported=True,
-            supports_conditions=False,
-            supported_types=[
-                RowFilterType.Between,
-                RowFilterType.Compare,
-                RowFilterType.IsNull,
-                RowFilterType.NotNull,
-                RowFilterType.NotBetween,
-                RowFilterType.Search,
-                RowFilterType.SetMembership,
-            ],
-        )
-
-        column_profile_features = GetColumnProfilesFeatures(
-            supported=True,
-            supported_types=[
-                ColumnProfileType.NullCount,
-                ColumnProfileType.SummaryStats,
-            ],
-        )
-
-        return SupportedFeatures(
-            search_schema=SearchSchemaFeatures(supported=True),
-            set_row_filters=row_filter_features,
-            get_column_profiles=column_profile_features,
+            supported_features=self.FEATURES,
         )
 
 
@@ -1020,4 +1029,13 @@ class DataExplorerService:
         table = self.table_views[comm_id]
 
         result = getattr(table, request.method.value)(request)
+
+        # To help remember to convert pydantic types to dicts
+        if result is not None:
+            if isinstance(result, list):
+                for x in result:
+                    assert isinstance(x, dict)
+            else:
+                assert isinstance(result, dict)
+
         comm.send_result(result)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -167,7 +167,7 @@ class FilterResult(BaseModel):
     )
 
 
-class DataExplorerState(BaseModel):
+class BackendState(BaseModel):
     """
     The current backend state for the data explorer
     """
@@ -269,6 +269,10 @@ class RowFilter(BaseModel):
     """
     Specifies a table row filter based on a single column's values
     """
+
+    filter_id: str = Field(
+        description="Unique identifier for this filter",
+    )
 
     filter_type: RowFilterType = Field(
         description="Type of row filter to apply",
@@ -903,7 +907,7 @@ TableData.update_forward_refs()
 
 FilterResult.update_forward_refs()
 
-DataExplorerState.update_forward_refs()
+BackendState.update_forward_refs()
 
 TableShape.update_forward_refs()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -43,6 +43,17 @@ class ColumnDisplayType(str, enum.Enum):
 
 
 @enum.unique
+class RowFilterCondition(str, enum.Enum):
+    """
+    Possible values for Condition in RowFilter
+    """
+
+    And = "and"
+
+    Or = "or"
+
+
+@enum.unique
 class RowFilterType(str, enum.Enum):
     """
     Possible values for RowFilterType
@@ -52,9 +63,13 @@ class RowFilterType(str, enum.Enum):
 
     Compare = "compare"
 
+    IsEmpty = "is_empty"
+
     IsNull = "is_null"
 
     NotBetween = "not_between"
+
+    NotEmpty = "not_empty"
 
     NotNull = "not_null"
 
@@ -152,9 +167,9 @@ class FilterResult(BaseModel):
     )
 
 
-class TableState(BaseModel):
+class DataExplorerState(BaseModel):
     """
-    The current backend table state
+    The current backend state for the data explorer
     """
 
     table_shape: TableShape = Field(
@@ -169,6 +184,10 @@ class TableState(BaseModel):
         description="The set of currently applied sorts",
     )
 
+    supported_features: SupportedFeatures = Field(
+        description="The features currently supported by the backend instance",
+    )
+
 
 class TableShape(BaseModel):
     """
@@ -181,24 +200,6 @@ class TableShape(BaseModel):
 
     num_columns: int = Field(
         description="Number of columns in the unfiltered dataset",
-    )
-
-
-class SupportedFeatures(BaseModel):
-    """
-    For each field, returns flags indicating supported features
-    """
-
-    search_schema: SearchSchemaFeatures = Field(
-        description="Support for 'search_schema' RPC and its features",
-    )
-
-    set_row_filters: SetRowFiltersFeatures = Field(
-        description="Support for 'set_row_filters' RPC and its features",
-    )
-
-    get_column_profiles: GetColumnProfilesFeatures = Field(
-        description="Support for 'get_column_profiles' RPC and its features",
     )
 
 
@@ -269,16 +270,21 @@ class RowFilter(BaseModel):
     Specifies a table row filter based on a single column's values
     """
 
-    filter_id: str = Field(
-        description="Unique identifier for this filter",
-    )
-
     filter_type: RowFilterType = Field(
         description="Type of row filter to apply",
     )
 
     column_index: int = Field(
         description="Column index to apply filter to",
+    )
+
+    condition: RowFilterCondition = Field(
+        description="The binary condition to use to combine with preceding row filters",
+    )
+
+    is_valid: Optional[bool] = Field(
+        default=None,
+        description="Whether the filter is valid and supported by the backend, if undefined then true",
     )
 
     between_params: Optional[BetweenFilterParams] = Field(
@@ -556,6 +562,24 @@ class ColumnSortKey(BaseModel):
     )
 
 
+class SupportedFeatures(BaseModel):
+    """
+    For each field, returns flags indicating supported features
+    """
+
+    search_schema: SearchSchemaFeatures = Field(
+        description="Support for 'search_schema' RPC and its features",
+    )
+
+    set_row_filters: SetRowFiltersFeatures = Field(
+        description="Support for 'set_row_filters' RPC and its features",
+    )
+
+    get_column_profiles: GetColumnProfilesFeatures = Field(
+        description="Support for 'get_column_profiles' RPC and its features",
+    )
+
+
 class SearchSchemaFeatures(BaseModel):
     """
     Feature flags for 'search_schema' RPC
@@ -624,9 +648,6 @@ class DataExplorerBackendRequest(str, enum.Enum):
 
     # Get the state
     GetState = "get_state"
-
-    # Query the backend to determine supported features
-    GetSupportedFeatures = "get_supported_features"
 
 
 class GetSchemaParams(BaseModel):
@@ -840,22 +861,6 @@ class GetStateRequest(BaseModel):
     )
 
 
-class GetSupportedFeaturesRequest(BaseModel):
-    """
-    Query the backend to determine supported features, to enable feature
-    toggling
-    """
-
-    method: Literal[DataExplorerBackendRequest.GetSupportedFeatures] = Field(
-        description="The JSON-RPC method name (get_supported_features)",
-    )
-
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
-
-
 class DataExplorerBackendMessageContent(BaseModel):
     comm_id: str
     data: Union[
@@ -866,7 +871,6 @@ class DataExplorerBackendMessageContent(BaseModel):
         SetSortColumnsRequest,
         GetColumnProfilesRequest,
         GetStateRequest,
-        GetSupportedFeaturesRequest,
     ] = Field(..., discriminator="method")
 
 
@@ -899,11 +903,9 @@ TableData.update_forward_refs()
 
 FilterResult.update_forward_refs()
 
-TableState.update_forward_refs()
+DataExplorerState.update_forward_refs()
 
 TableShape.update_forward_refs()
-
-SupportedFeatures.update_forward_refs()
 
 ColumnSchema.update_forward_refs()
 
@@ -941,6 +943,8 @@ ColumnQuantileValue.update_forward_refs()
 
 ColumnSortKey.update_forward_refs()
 
+SupportedFeatures.update_forward_refs()
+
 SearchSchemaFeatures.update_forward_refs()
 
 SetRowFiltersFeatures.update_forward_refs()
@@ -972,7 +976,5 @@ GetColumnProfilesParams.update_forward_refs()
 GetColumnProfilesRequest.update_forward_refs()
 
 GetStateRequest.update_forward_refs()
-
-GetSupportedFeaturesRequest.update_forward_refs()
 
 SchemaUpdateParams.update_forward_refs()

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -373,9 +373,6 @@ class DataExplorerFixture:
     def get_state(self, table_name):
         return self.do_json_rpc(table_name, "get_state")
 
-    def get_supported_features(self, table_name):
-        return self.do_json_rpc(table_name, "get_supported_features")
-
     def get_data_values(self, table_name, **params):
         return self.do_json_rpc(table_name, "get_data_values", **params)
 
@@ -460,9 +457,9 @@ def test_pandas_get_state(dxf: DataExplorerFixture):
     assert result["row_filters"] == [RowFilter(**f) for f in filters]
 
 
-def test_pandas_get_supported_features(dxf: DataExplorerFixture):
+def test_pandas_supported_features(dxf: DataExplorerFixture):
     dxf.register_table("example", SIMPLE_PANDAS_DF)
-    features = dxf.get_supported_features("example")
+    features = dxf.get_state("example")["supported_features"]
 
     search_schema = features["search_schema"]
     row_filters = features["set_row_filters"]
@@ -672,37 +669,58 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
     #     )
 
 
-def _filter(filter_type, column_index, **kwargs):
+def _filter(filter_type, column_index, condition="and", is_valid=None, **kwargs):
     kwargs.update(
         {
-            "filter_id": guid(),
             "filter_type": filter_type,
             "column_index": column_index,
+            "condition": condition,
+            "is_valid": is_valid,
         }
     )
     return kwargs
 
 
-def _compare_filter(column_index, op, value):
-    return _filter("compare", column_index, compare_params={"op": op, "value": value})
+def _compare_filter(column_index, op, value, condition="and", is_valid=None):
+    return _filter(
+        "compare",
+        column_index,
+        condition=condition,
+        is_valid=is_valid,
+        compare_params={"op": op, "value": value},
+    )
 
 
-def _between_filter(column_index, left_value, right_value, op="between"):
+def _between_filter(column_index, left_value, right_value, op="between", condition="and"):
     return _filter(
         op,
         column_index,
+        condition=condition,
         between_params={"left_value": left_value, "right_value": right_value},
     )
 
 
-def _not_between_filter(column_index, left_value, right_value):
-    return _between_filter(column_index, left_value, right_value, op="not_between")
+def _not_between_filter(column_index, left_value, right_value, condition="and"):
+    return _between_filter(
+        column_index,
+        left_value,
+        right_value,
+        op="not_between",
+        condition=condition,
+    )
 
 
-def _search_filter(column_index, term, case_sensitive=False, search_type="contains"):
+def _search_filter(
+    column_index,
+    term,
+    case_sensitive=False,
+    search_type="contains",
+    condition="and",
+):
     return _filter(
         "search",
         column_index,
+        condition=condition,
         search_params={
             "search_type": search_type,
             "term": term,
@@ -711,10 +729,16 @@ def _search_filter(column_index, term, case_sensitive=False, search_type="contai
     )
 
 
-def _set_member_filter(column_index, values, inclusive=True):
+def _set_member_filter(
+    column_index,
+    values,
+    inclusive=True,
+    condition="and",
+):
     return _filter(
         "set_membership",
         column_index,
+        condition=condition,
         set_membership_params={"values": values, "inclusive": inclusive},
     )
 
@@ -747,6 +771,25 @@ def test_pandas_filter_between(dxf: DataExplorerFixture):
         )
 
 
+def test_pandas_filter_conditions(dxf: DataExplorerFixture):
+    # Test AND/OR conditions when filtering
+    df = SIMPLE_PANDAS_DF
+    filters = [
+        _compare_filter(0, ">=", 3, condition="or"),
+        _compare_filter(3, "<=", -4.5, condition="or"),
+        _compare_filter(3, "<=", -4.5, condition="or"),
+    ]
+
+    expected_df = df[(df["a"] >= 3) | (df["d"] <= -4.5)]
+    dxf.check_filter_case(df, filters, expected_df)
+
+    # Test a single condition with or set
+    filters = [
+        _compare_filter(0, ">=", 3, condition="or"),
+    ]
+    dxf.check_filter_case(df, filters, df[df["a"] >= 3])
+
+
 def test_pandas_filter_compare(dxf: DataExplorerFixture):
     # Just use the 'a' column to smoke test comparison filters on
     # integers
@@ -773,6 +816,40 @@ def test_pandas_filter_compare(dxf: DataExplorerFixture):
     ex_id = guid()
     dxf.register_table(ex_id, df)
     dxf.compare_tables(table_name, ex_id, df.shape)
+
+
+def test_pandas_filter_is_valid(dxf: DataExplorerFixture):
+    # Test AND/OR conditions when filtering
+    df = SIMPLE_PANDAS_DF
+    filters = [
+        _compare_filter(0, ">=", 3),
+        _compare_filter(0, "<", 3, is_valid=False),
+    ]
+
+    expected_df = df[df["a"] >= 3]
+    dxf.check_filter_case(df, filters, expected_df)
+
+    # No filter is valid
+    filters = [
+        _compare_filter(0, ">=", 3, is_valid=False),
+        _compare_filter(0, "<", 3, is_valid=False),
+    ]
+
+    dxf.check_filter_case(df, filters, df)
+
+
+def test_pandas_filter_empty(dxf: DataExplorerFixture):
+    df = pd.DataFrame(
+        {
+            "a": ["foo", "bar", "", "", "", None, "baz", ""],
+            "b": [b"foo", b"bar", b"", b"", None, b"", b"baz", b""],
+        }
+    )
+
+    dxf.check_filter_case(df, [_filter("is_empty", 0)], df[df["a"].str.len() == 0])
+    dxf.check_filter_case(df, [_filter("not_empty", 0)], df[df["a"].str.len() != 0])
+    dxf.check_filter_case(df, [_filter("is_empty", 1)], df[df["b"].str.len() == 0])
+    dxf.check_filter_case(df, [_filter("not_empty", 1)], df[df["b"].str.len() != 0])
 
 
 def test_pandas_filter_is_null_not_null(dxf: DataExplorerFixture):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -672,6 +672,7 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
 def _filter(filter_type, column_index, condition="and", is_valid=None, **kwargs):
     kwargs.update(
         {
+            "filter_id": guid(),
             "filter_type": filter_type,
             "column_index": column_index,
             "condition": condition,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -778,6 +778,7 @@ def test_pandas_filter_conditions(dxf: DataExplorerFixture):
     filters = [
         _compare_filter(0, ">=", 3, condition="or"),
         _compare_filter(3, "<=", -4.5, condition="or"),
+        # Delbierately duplicated
         _compare_filter(3, "<=", -4.5, condition="or"),
     ]
 

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -240,12 +240,13 @@
 			"result": {
 				"schema": {
 					"type": "object",
-					"name": "table_state",
-					"description": "The current backend table state",
+					"name": "data_explorer_state",
+					"description": "The current backend state for the data explorer",
 					"required": [
 						"table_shape",
 						"row_filters",
-						"sort_keys"
+						"sort_keys",
+						"supported_features"
 					],
 					"properties": {
 						"table_shape": {
@@ -280,38 +281,10 @@
 							"items": {
 								"$ref": "#/components/schemas/column_sort_key"
 							}
-						}
-					}
-				}
-			}
-		},
-		{
-			"name": "get_supported_features",
-			"summary": "Query the backend to determine supported features",
-			"description": "Query the backend to determine supported features, to enable feature toggling",
-			"params": [],
-			"result": {
-				"schema": {
-					"type": "object",
-					"name": "supported_features",
-					"description": "For each field, returns flags indicating supported features",
-					"required": [
-						"search_schema",
-						"set_row_filters",
-						"get_column_profiles"
-					],
-					"properties": {
-						"search_schema": {
-							"description": "Support for 'search_schema' RPC and its features",
-							"$ref": "#/components/schemas/search_schema_features"
 						},
-						"set_row_filters": {
-							"description": "Support for 'set_row_filters' RPC and its features",
-							"$ref": "#/components/schemas/set_row_filters_features"
-						},
-						"get_column_profiles": {
-							"description": "Support for 'get_column_profiles' RPC and its features",
-							"$ref": "#/components/schemas/get_column_profiles_features"
+						"supported_features": {
+							"description": "The features currently supported by the backend instance",
+							"$ref": "#/components/schemas/supported_features"
 						}
 					}
 				}
@@ -412,15 +385,11 @@
 				"type": "object",
 				"description": "Specifies a table row filter based on a single column's values",
 				"required": [
-					"filter_id",
 					"filter_type",
-					"column_index"
+					"column_index",
+					"condition"
 				],
 				"properties": {
-					"filter_id": {
-						"type": "string",
-						"description": "Unique identifier for this filter"
-					},
 					"filter_type": {
 						"description": "Type of row filter to apply",
 						"$ref": "#/components/schemas/row_filter_type"
@@ -428,6 +397,18 @@
 					"column_index": {
 						"type": "integer",
 						"description": "Column index to apply filter to"
+					},
+					"condition": {
+						"type": "string",
+						"description": "The binary condition to use to combine with preceding row filters",
+						"enum": [
+							"and",
+							"or"
+						]
+					},
+					"is_valid": {
+						"type": "boolean",
+						"description": "Whether the filter is valid and supported by the backend, if undefined then true"
 					},
 					"between_params": {
 						"description": "Parameters for the 'between' and 'not_between' filter types",
@@ -453,8 +434,10 @@
 				"enum": [
 					"between",
 					"compare",
+					"is_empty",
 					"is_null",
 					"not_between",
+					"not_empty",
 					"not_null",
 					"search",
 					"set_membership"
@@ -797,6 +780,29 @@
 					"ascending": {
 						"type": "boolean",
 						"description": "Sort order, ascending (true) or descending (false)"
+					}
+				}
+			},
+			"supported_features": {
+				"type": "object",
+				"description": "For each field, returns flags indicating supported features",
+				"required": [
+					"search_schema",
+					"set_row_filters",
+					"get_column_profiles"
+				],
+				"properties": {
+					"search_schema": {
+						"description": "Support for 'search_schema' RPC and its features",
+						"$ref": "#/components/schemas/search_schema_features"
+					},
+					"set_row_filters": {
+						"description": "Support for 'set_row_filters' RPC and its features",
+						"$ref": "#/components/schemas/set_row_filters_features"
+					},
+					"get_column_profiles": {
+						"description": "Support for 'get_column_profiles' RPC and its features",
+						"$ref": "#/components/schemas/get_column_profiles_features"
 					}
 				}
 			},

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -240,7 +240,7 @@
 			"result": {
 				"schema": {
 					"type": "object",
-					"name": "data_explorer_state",
+					"name": "backend_state",
 					"description": "The current backend state for the data explorer",
 					"required": [
 						"table_shape",
@@ -385,11 +385,16 @@
 				"type": "object",
 				"description": "Specifies a table row filter based on a single column's values",
 				"required": [
+					"filter_id",
 					"filter_type",
 					"column_index",
 					"condition"
 				],
 				"properties": {
+					"filter_id": {
+						"type": "string",
+						"description": "Unique identifier for this filter"
+					},
 					"filter_type": {
 						"description": "Type of row filter to apply",
 						"$ref": "#/components/schemas/row_filter_type"

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
@@ -12,10 +12,14 @@ export enum RowFilterCondition {
 	// Conditions with no parameters.
 	CONDITION_IS_EMPTY = 'is-empty',
 	CONDITION_IS_NOT_EMPTY = 'is-not-empty',
+	CONDITION_IS_NULL = 'is-null',
+	CONDITION_IS_NOT_NULL = 'is-not-null',
 
 	// Conditions with one parameter.
 	CONDITION_IS_LESS_THAN = 'is-less-than',
+	CONDITION_IS_LESS_OR_EQUAL = 'is-less-than-or-equal-to',
 	CONDITION_IS_GREATER_THAN = 'is-greater-than',
+	CONDITION_IS_GREATER_OR_EQUAL = 'is-greater-than-or-equal-to',
 	CONDITION_IS_EQUAL_TO = 'is-equal-to',
 
 	// Conditions with two parameters.
@@ -87,6 +91,46 @@ export class RowFilterDescriptorIsNotEmpty extends BaseRowFilterDescriptor {
 }
 
 /**
+ * RowFilterDescriptorIsNull class.
+ */
+export class RowFilterDescriptorIsNull extends BaseRowFilterDescriptor {
+	/**
+	 * Constructor.
+	 * @param columnSchema The column schema.
+	 */
+	constructor(columnSchema: ColumnSchema) {
+		super(columnSchema);
+	}
+
+	/**
+	 * Gets the row filter condition.
+	 */
+	get rowFilterCondition() {
+		return RowFilterCondition.CONDITION_IS_NULL;
+	}
+}
+
+/**
+ * RowFilterDescriptorIsNotEmpty class.
+ */
+export class RowFilterDescriptorIsNotNull extends BaseRowFilterDescriptor {
+	/**
+	 * Constructor.
+	 * @param columnSchema The column schema.
+	 */
+	constructor(columnSchema: ColumnSchema) {
+		super(columnSchema);
+	}
+
+	/**
+	 * Gets the row filter condition.
+	 */
+	get rowFilterCondition() {
+		return RowFilterCondition.CONDITION_IS_NOT_NULL;
+	}
+}
+
+/**
  * SingleValueRowFilterDescriptor class.
  */
 export abstract class SingleValueRowFilterDescriptor extends BaseRowFilterDescriptor {
@@ -122,6 +166,27 @@ export class RowFilterDescriptorIsLessThan extends SingleValueRowFilterDescripto
 }
 
 /**
+ * RowFilterDescriptorIsLessOrEqual class.
+ */
+export class RowFilterDescriptorIsLessOrEqual extends SingleValueRowFilterDescriptor {
+	/**
+	 * Constructor.
+	 * @param columnSchema The column schema.
+	 * @param value The value.
+	 */
+	constructor(columnSchema: ColumnSchema, value: string) {
+		super(columnSchema, value);
+	}
+
+	/**
+	 * Gets the row filter condition.
+	 */
+	get rowFilterCondition() {
+		return RowFilterCondition.CONDITION_IS_LESS_OR_EQUAL;
+	}
+}
+
+/**
  * RowFilterDescriptorIsGreaterThan class.
  */
 export class RowFilterDescriptorIsGreaterThan extends SingleValueRowFilterDescriptor {
@@ -139,6 +204,27 @@ export class RowFilterDescriptorIsGreaterThan extends SingleValueRowFilterDescri
 	 */
 	get rowFilterCondition() {
 		return RowFilterCondition.CONDITION_IS_GREATER_THAN;
+	}
+}
+
+/**
+ * RowFilterDescriptorIsGreaterOrEqual class.
+ */
+export class RowFilterDescriptorIsGreaterOrEqual extends SingleValueRowFilterDescriptor {
+	/**
+	 * Constructor.
+	 * @param columnSchema The column schema.
+	 * @param value The value.
+	 */
+	constructor(columnSchema: ColumnSchema, value: string) {
+		super(columnSchema, value);
+	}
+
+	/**
+	 * Gets the row filter condition.
+	 */
+	get rowFilterCondition() {
+		return RowFilterCondition.CONDITION_IS_GREATER_OR_EQUAL;
 	}
 }
 
@@ -232,8 +318,12 @@ export class RowFilterDescriptorIsNotBetween extends RangeRowFilterDescriptor {
 export type RowFilterDescriptor =
 	RowFilterDescriptorIsEmpty |
 	RowFilterDescriptorIsNotEmpty |
+	RowFilterDescriptorIsNull |
+	RowFilterDescriptorIsNotNull |
 	RowFilterDescriptorIsLessThan |
+	RowFilterDescriptorIsLessOrEqual |
 	RowFilterDescriptorIsGreaterThan |
+	RowFilterDescriptorIsGreaterOrEqual |
 	RowFilterDescriptorIsEqualTo |
 	RowFilterDescriptorIsBetween |
 	RowFilterDescriptorIsNotBetween;

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
@@ -21,6 +21,7 @@ export enum RowFilterCondition {
 	CONDITION_IS_GREATER_THAN = 'is-greater-than',
 	CONDITION_IS_GREATER_OR_EQUAL = 'is-greater-than-or-equal-to',
 	CONDITION_IS_EQUAL_TO = 'is-equal-to',
+	CONDITION_IS_NOT_EQUAL_TO = 'is-not-equal-to',
 
 	// Conditions with two parameters.
 	CONDITION_IS_BETWEEN = 'is-between',
@@ -246,6 +247,28 @@ export class RowFilterDescriptorIsEqualTo extends SingleValueRowFilterDescriptor
 	 */
 	get rowFilterCondition() {
 		return RowFilterCondition.CONDITION_IS_EQUAL_TO;
+	}
+}
+
+
+/**
+ * RowFilterDescriptorIsNotEqualTo class.
+ */
+export class RowFilterDescriptorIsNotEqualTo extends SingleValueRowFilterDescriptor {
+	/**
+	 * Constructor.
+	 * @param columnSchema The column schema.
+	 * @param value The value.
+	 */
+	constructor(columnSchema: ColumnSchema, value: string) {
+		super(columnSchema, value);
+	}
+
+	/**
+	 * Gets the row filter condition.
+	 */
+	get rowFilterCondition() {
+		return RowFilterCondition.CONDITION_IS_NOT_EQUAL_TO;
 	}
 }
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
@@ -24,7 +24,8 @@ import {
 	RowFilterDescriptorIsNotBetween,
 	RowFilterDescriptorIsNotEmpty,
 	RowFilterDescriptorIsNotNull,
-	RowFilterDescriptorIsNull
+	RowFilterDescriptorIsNull,
+	RowFilterDescriptorIsNotEqualTo
 } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
 
 /**
@@ -102,6 +103,12 @@ export const RowFilterWidget = forwardRef<HTMLButtonElement, RowFilterWidgetProp
 			return <>
 				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
 				<span className='space-before space-after'>=</span>
+				<span>{props.rowFilter.value}</span>
+			</>;
+		} else if (props.rowFilter instanceof RowFilterDescriptorIsNotEqualTo) {
+			return <>
+				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='space-before space-after'>!=</span>
 				<span>{props.rowFilter.value}</span>
 			</>;
 		} else if (props.rowFilter instanceof RowFilterDescriptorIsBetween) {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
@@ -12,7 +12,20 @@ import { forwardRef } from 'react'; // eslint-disable-line no-duplicate-imports
 // Other dependencies.
 import { localize } from 'vs/nls';
 import { Button } from 'vs/base/browser/ui/positronComponents/button/button';
-import { RowFilterDescriptor, RowFilterDescriptorIsBetween, RowFilterDescriptorIsEmpty, RowFilterDescriptorIsEqualTo, RowFilterDescriptorIsGreaterThan, RowFilterDescriptorIsLessThan, RowFilterDescriptorIsNotBetween, RowFilterDescriptorIsNotEmpty } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
+import {
+	RowFilterDescriptor,
+	RowFilterDescriptorIsBetween,
+	RowFilterDescriptorIsEmpty,
+	RowFilterDescriptorIsEqualTo,
+	RowFilterDescriptorIsGreaterThan,
+	RowFilterDescriptorIsGreaterOrEqual,
+	RowFilterDescriptorIsLessThan,
+	RowFilterDescriptorIsLessOrEqual,
+	RowFilterDescriptorIsNotBetween,
+	RowFilterDescriptorIsNotEmpty,
+	RowFilterDescriptorIsNotNull,
+	RowFilterDescriptorIsNull
+} from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
 
 /**
  * RowFilterWidgetProps interface.
@@ -46,16 +59,43 @@ export const RowFilterWidget = forwardRef<HTMLButtonElement, RowFilterWidgetProp
 					{localize('positron.dataExplorer.rowFilterWidget.isNotEmpty', "is not empty")}
 				</span>
 			</>;
+		} else if (props.rowFilter instanceof RowFilterDescriptorIsNull) {
+			return <>
+				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='space-before'>
+					{localize('positron.dataExplorer.rowFilterWidget.isNull', "is null")}
+				</span>
+			</>;
+		} else if (props.rowFilter instanceof RowFilterDescriptorIsNotNull) {
+			return <>
+				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='space-before'>
+					{localize('positron.dataExplorer.rowFilterWidget.isNotNull', "is not null")}
+				</span>
+			</>;
+
 		} else if (props.rowFilter instanceof RowFilterDescriptorIsLessThan) {
 			return <>
 				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
 				<span className='space-before space-after'>&lt;</span>
 				<span>{props.rowFilter.value}</span>
 			</>;
+		} else if (props.rowFilter instanceof RowFilterDescriptorIsLessOrEqual) {
+			return <>
+				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='space-before space-after'>&lt;=</span>
+				<span>{props.rowFilter.value}</span>
+			</>;
 		} else if (props.rowFilter instanceof RowFilterDescriptorIsGreaterThan) {
 			return <>
 				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
 				<span className='space-before space-after'>&gt;</span>
+				<span>{props.rowFilter.value}</span>
+			</>;
+		} else if (props.rowFilter instanceof RowFilterDescriptorIsGreaterOrEqual) {
+			return <>
+				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='space-before space-after'>&gt;=</span>
 				<span>{props.rowFilter.value}</span>
 			</>;
 		} else if (props.rowFilter instanceof RowFilterDescriptorIsEqualTo) {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -33,7 +33,8 @@ import {
 	RowFilterDescriptorIsBetween,
 	RowFilterDescriptorIsNotBetween,
 	RowFilterDescriptorIsLessOrEqual,
-	RowFilterDescriptorIsGreaterOrEqual
+	RowFilterDescriptorIsGreaterOrEqual,
+	RowFilterDescriptorIsNotEqualTo
 } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
 
 /**
@@ -95,6 +96,8 @@ const createRowFilters = (rowFilterDescriptors: RowFilterDescriptor[]) => {
 			rowFilters.push(getCompareFilter(rowFilterDescriptor.value, CompareFilterParamsOp.GtEq));
 		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsEqualTo) {
 			rowFilters.push(getCompareFilter(rowFilterDescriptor.value, CompareFilterParamsOp.Eq));
+		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsNotEqualTo) {
+			rowFilters.push(getCompareFilter(rowFilterDescriptor.value, CompareFilterParamsOp.NotEq));
 		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsBetween) {
 			rowFilters.push({
 				filter_type: RowFilterType.Between,

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -18,10 +18,23 @@ import { ContextMenuItem } from 'vs/workbench/browser/positronComponents/context
 import { ContextMenuSeparator } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenuSeparator';
 import { usePositronDataExplorerContext } from 'vs/workbench/browser/positronDataExplorer/positronDataExplorerContext';
 import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer';
-import { CompareFilterParamsOp, RowFilter, RowFilterType } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { CompareFilterParamsOp, RowFilter, RowFilterCondition, RowFilterType } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { RowFilterWidget } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget';
 import { AddEditRowFilterModalPopup } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup';
-import { RowFilterDescriptor, RowFilterDescriptorIsEmpty, RowFilterDescriptorIsNotEmpty, RowFilterDescriptorIsLessThan, RowFilterDescriptorIsGreaterThan, RowFilterDescriptorIsEqualTo, RowFilterDescriptorIsBetween, RowFilterDescriptorIsNotBetween } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
+import {
+	RowFilterDescriptor,
+	RowFilterDescriptorIsEmpty,
+	RowFilterDescriptorIsNotEmpty,
+	RowFilterDescriptorIsNull,
+	RowFilterDescriptorIsNotNull,
+	RowFilterDescriptorIsLessThan,
+	RowFilterDescriptorIsGreaterThan,
+	RowFilterDescriptorIsEqualTo,
+	RowFilterDescriptorIsBetween,
+	RowFilterDescriptorIsNotBetween,
+	RowFilterDescriptorIsLessOrEqual,
+	RowFilterDescriptorIsGreaterOrEqual
+} from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
 
 /**
  * Creates row filters from row filter descriptors.
@@ -35,67 +48,70 @@ const createRowFilters = (rowFilterDescriptors: RowFilterDescriptor[]) => {
 		rowFilterDescriptor
 	) => {
 		//
+		const sharedParams = {
+			filter_id: rowFilterDescriptor.identifier,
+			column_index: rowFilterDescriptor.columnSchema.column_index,
+			condition: RowFilterCondition.And
+		};
+
+		const getCompareFilter = (value: string, op: CompareFilterParamsOp): RowFilter => {
+			return {
+				filter_type: RowFilterType.Compare,
+				compare_params: {
+					op,
+					value
+				},
+				...sharedParams
+			};
+		};
+
 		if (rowFilterDescriptor instanceof RowFilterDescriptorIsEmpty) {
 			rowFilters.push({
-				filter_id: rowFilterDescriptor.identifier,
-				filter_type: RowFilterType.IsNull,
-				column_index: rowFilterDescriptor.columnSchema.column_index
+				filter_type: RowFilterType.IsEmpty,
+				...sharedParams
 			});
 		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsNotEmpty) {
 			rowFilters.push({
-				filter_id: rowFilterDescriptor.identifier,
+				filter_type: RowFilterType.NotEmpty,
+				...sharedParams
+			});
+		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsNull) {
+			rowFilters.push({
+				filter_type: RowFilterType.IsNull,
+				...sharedParams
+			});
+		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsNotNull) {
+			rowFilters.push({
 				filter_type: RowFilterType.NotNull,
-				column_index: rowFilterDescriptor.columnSchema.column_index
+				...sharedParams
 			});
 		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsLessThan) {
-			rowFilters.push({
-				filter_id: rowFilterDescriptor.identifier,
-				filter_type: RowFilterType.Compare,
-				column_index: rowFilterDescriptor.columnSchema.column_index,
-				compare_params: {
-					op: CompareFilterParamsOp.Lt,
-					value: rowFilterDescriptor.value
-				}
-			});
+			rowFilters.push(getCompareFilter(rowFilterDescriptor.value, CompareFilterParamsOp.Lt));
+		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsLessOrEqual) {
+			rowFilters.push(getCompareFilter(rowFilterDescriptor.value, CompareFilterParamsOp.LtEq));
 		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsGreaterThan) {
-			rowFilters.push({
-				filter_id: rowFilterDescriptor.identifier,
-				filter_type: RowFilterType.Compare,
-				column_index: rowFilterDescriptor.columnSchema.column_index,
-				compare_params: {
-					op: CompareFilterParamsOp.Gt,
-					value: rowFilterDescriptor.value
-				}
-			});
+			rowFilters.push(getCompareFilter(rowFilterDescriptor.value, CompareFilterParamsOp.Gt));
+		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsGreaterOrEqual) {
+			rowFilters.push(getCompareFilter(rowFilterDescriptor.value, CompareFilterParamsOp.GtEq));
 		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsEqualTo) {
-			rowFilters.push({
-				filter_id: rowFilterDescriptor.identifier,
-				filter_type: RowFilterType.Compare,
-				column_index: rowFilterDescriptor.columnSchema.column_index,
-				compare_params: {
-					op: CompareFilterParamsOp.Eq,
-					value: rowFilterDescriptor.value
-				}
-			});
+			rowFilters.push(getCompareFilter(rowFilterDescriptor.value, CompareFilterParamsOp.Eq));
 		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsBetween) {
 			rowFilters.push({
-				filter_id: rowFilterDescriptor.identifier,
 				filter_type: RowFilterType.Between,
-				column_index: rowFilterDescriptor.columnSchema.column_index,
 				between_params: {
 					left_value: rowFilterDescriptor.lowerLimit,
 					right_value: rowFilterDescriptor.upperLimit
-				}
+				},
+				...sharedParams
 			});
 		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsNotBetween) {
 			rowFilters.push({
-				filter_id: rowFilterDescriptor.identifier,
 				filter_type: RowFilterType.NotBetween,
-				column_index: rowFilterDescriptor.columnSchema.column_index,
 				between_params: {
 					left_value: rowFilterDescriptor.lowerLimit,
 					right_value: rowFilterDescriptor.upperLimit
-				}
+				},
+				...sharedParams
 			});
 		}
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -6,7 +6,19 @@ import { generateUuid } from 'vs/base/common/uuid';
 import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
-import { ColumnProfileRequest, ColumnProfileResult, ColumnSchema, ColumnSortKey, FilterResult, PositronDataExplorerComm, RowFilter, SchemaUpdateEvent, TableData, TableSchema, TableState } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import {
+	BackendState,
+	ColumnProfileRequest,
+	ColumnProfileResult,
+	ColumnSchema,
+	ColumnSortKey,
+	FilterResult,
+	PositronDataExplorerComm,
+	RowFilter,
+	SchemaUpdateEvent,
+	TableData,
+	TableSchema
+} from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * TableSchemaSearchResult interface. This is here temporarily until searching the tabe schema
@@ -97,7 +109,7 @@ export class DataExplorerClientInstance extends Disposable {
 	 * Get the current active state of the data explorer backend.
 	 * @returns A promose that resolves to the current table state.
 	 */
-	async getState(): Promise<TableState> {
+	async getState(): Promise<BackendState> {
 		return this._positronDataExplorerComm.getState();
 	}
 

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -56,7 +56,7 @@ export interface FilterResult {
 /**
  * The current backend state for the data explorer
  */
-export interface DataExplorerState {
+export interface BackendState {
 	/**
 	 * Provides number of rows and columns in table
 	 */
@@ -166,6 +166,11 @@ export interface TableSchema {
  * Specifies a table row filter based on a single column's values
  */
 export interface RowFilter {
+	/**
+	 * Unique identifier for this filter
+	 */
+	filter_id: string;
+
 	/**
 	 * Type of row filter to apply
 	 */
@@ -760,7 +765,7 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 *
 	 * @returns The current backend state for the data explorer
 	 */
-	getState(): Promise<DataExplorerState> {
+	getState(): Promise<BackendState> {
 		return super.performRpc('get_state', [], []);
 	}
 


### PR DESCRIPTION
Addresses #2732, #2731 

This patch implements a batch of pending improvements. Even though there are backend OpenRPC changes, because it only affects filtering it won't impact the R runtime but the next iteration will need to update the comm. 

* Only shows is-empty, is-not-empty filters for string data (see video below)
* Adds >=, <=, is-null, and not-null filter types to the UI
* Adds "condition" for combining filters, either AND (default) or OR and implements this in Python
* Adds "is_valid" field to RowFilter so we can invalidate filters and show them in the UI (support for invalidating filters will come in the next PR)
* Moved SupportedFeatures value to the result of get_state. The state isn't really being used anywhere in the UI so this shouldn't break R

[Screencast from 2024-04-12 16-38-43.webm](https://github.com/posit-dev/positron/assets/329591/8b1d9789-06b0-4cb4-b6ae-080b667f4d88)
