### PR TITLE
Set hotExit to onExitAndWindowClose by default

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -127,6 +127,7 @@ const hotExitConfiguration: IConfigurationPropertySchema = isNative ?
 		'scope': ConfigurationScope.APPLICATION,
 		'enum': [HotExitConfiguration.OFF, HotExitConfiguration.ON_EXIT, HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE],
 		// --- Start Positron ---
+		// 'default': HotExitConfiguration.ON_EXIT,
 		'default': HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE,
 		// --- End Positron ---
 		'markdownEnumDescriptions': [

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -126,7 +126,9 @@ const hotExitConfiguration: IConfigurationPropertySchema = isNative ?
 		'type': 'string',
 		'scope': ConfigurationScope.APPLICATION,
 		'enum': [HotExitConfiguration.OFF, HotExitConfiguration.ON_EXIT, HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE],
-		'default': HotExitConfiguration.ON_EXIT,
+		// --- Start Positron ---
+		'default': HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE,
+		// --- End Positron ---
 		'markdownEnumDescriptions': [
 			nls.localize('hotExit.off', 'Disable hot exit. A prompt will show when attempting to close a window with editors that have unsaved changes.'),
 			nls.localize('hotExit.onExit', 'Hot exit will be triggered when the last window is closed on Windows/Linux or when the `workbench.action.quit` command is triggered (command palette, keybinding, menu). All windows without folders opened will be restored upon next launch. A list of previously opened windows with unsaved files can be accessed via `File > Open Recent > More...`'),


### PR DESCRIPTION
### Intent

Addresses #2760

From VSCode docs:
"Hot exit will be triggered when the application is closed, that is when the last window is closed on Windows/Linux or when the workbench.action.quit command is triggered (from the Command Palette, keyboard shortcut or menu), and also for any window with a folder opened regardless of whether it is the last window. All windows without folders opened will be restored upon next launch."

### Approach

Update files.hotExit default to onExitAndWindowClose

### QA Notes

Testing requires creating unsaved files in multiple folders, closing them one by one and/or quitting the application, and then re-opening those folders and confirming unsaved files are present.
