### PR TITLE
Fix recycling old variables pane instance for notebooks

### DIFF
--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -14,6 +14,7 @@ import { LanguageRuntimeSessionMode, formatLanguageRuntimeSession } from 'vs/wor
 import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../runtimeSession/common/runtimeSessionService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { RuntimeClientState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
+import { isEqual } from 'vs/base/common/resources';
 
 /**
  * PositronVariablesService class.
@@ -208,8 +209,7 @@ class PositronVariablesService extends Disposable implements IPositronVariablesS
 				// Check the runtime ID and notebook URI for a match.
 				return positronVariablesInstance.session.runtimeMetadata.runtimeId ===
 					session.runtimeMetadata.runtimeId &&
-					positronVariablesInstance.session.metadata.notebookUri ===
-					session.metadata.notebookUri;
+					isEqual(positronVariablesInstance.session.metadata.notebookUri, session.metadata.notebookUri);
 			});
 
 		if (existingInstance) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Address #2658.

### Approach

I think the URI objects were different so the `===` failed. I noticed that `isEqual` is used elsewhere in VSCode.

### QA Notes

See the linked issue.