### PR TITLE
Fix save path overwrite check

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -181,7 +181,8 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 
 	const acceptHandler = async () => {
 		if (validateInput()) {
-			const fileExists = await props.fileService.exists(directory.value);
+			const filePath = URI.joinPath(directory.value, `${name.value}.${format}`);
+			const fileExists = await props.fileService.exists(filePath);
 			if (fileExists) {
 				const confirmation = await props.dialogService.confirm({
 					message: localize('positron.savePlotModalDialog.fileExists', "The file already exists. Do you want to overwrite it?"),
@@ -196,7 +197,6 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 
 			generatePreview(format)
 				.then(async (plotResult) => {
-					const filePath = URI.joinPath(directory.value, `${name.value}.${format}`);
 					props.savePlotCallback({ uri: plotResult.uri, path: filePath });
 				})
 				.finally(() => {


### PR DESCRIPTION
### Intent
Address #2729 

### Approach
Fixing the path check to include the file name.

### QA Notes
Fixes the warning showing when the file isn't overwriting anything.