### PR TITLE
Add case insensitive string row filters to UI (contains, starts with, ends with, regex matches), reduce some code duplication

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.css
@@ -3,8 +3,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 @keyframes fade-in {
-	0% { opacity: 0; }
-	100% { opacity: 1; }
+	0% {
+		opacity: 0;
+	}
+
+	100% {
+		opacity: 1;
+	}
 }
 
 .positron-modal-popup-container {
@@ -14,7 +19,7 @@
 	height: 100%;
 	position: absolute;
 	outline: none !important;
-	animation: fade-in 0.25s;
+	/* animation: fade-in 0.25s; */
 	/* Makes some devices run their hardware acceleration. */
 	transform: translate3d(0px, 0px, 0px);
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { generateUuid } from 'vs/base/common/uuid';
-import { ColumnSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { ColumnSchema, CompareFilterParamsOp, SearchFilterType } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * RowFilterCondition enumeration.
@@ -22,6 +22,10 @@ export enum RowFilterCondition {
 	CONDITION_IS_GREATER_OR_EQUAL = 'is-greater-than-or-equal-to',
 	CONDITION_IS_EQUAL_TO = 'is-equal-to',
 	CONDITION_IS_NOT_EQUAL_TO = 'is-not-equal-to',
+	CONDITION_SEARCH_CONTAINS = 'search-contains',
+	CONDITION_SEARCH_STARTS_WITH = 'search-starts-with',
+	CONDITION_SEARCH_ENDS_WITH = 'search-ends-width',
+	CONDITION_SEARCH_REGEX_MATCHES = 'search-regex',
 
 	// Conditions with two parameters.
 	CONDITION_IS_BETWEEN = 'is-between',
@@ -146,129 +150,117 @@ export abstract class SingleValueRowFilterDescriptor extends BaseRowFilterDescri
 }
 
 /**
- * RowFilterDescriptorIsLessThan class.
+ * RowFilterDescriptorComparison class.
  */
-export class RowFilterDescriptorIsLessThan extends SingleValueRowFilterDescriptor {
+export class RowFilterDescriptorComparison extends SingleValueRowFilterDescriptor {
 	/**
 	 * Constructor.
 	 * @param columnSchema The column schema.
 	 * @param value The value.
+	 * @param condition The filter condition.
 	 */
-	constructor(columnSchema: ColumnSchema, value: string) {
+	condition: RowFilterCondition;
+
+	constructor(columnSchema: ColumnSchema, value: string, condition: RowFilterCondition) {
 		super(columnSchema, value);
+		this.condition = condition;
+	}
+
+	get operatorText() {
+		switch (this.condition) {
+			case RowFilterCondition.CONDITION_IS_EQUAL_TO:
+				return '=';
+			case RowFilterCondition.CONDITION_IS_GREATER_OR_EQUAL:
+				return '>=';
+			case RowFilterCondition.CONDITION_IS_GREATER_THAN:
+				return '>';
+			case RowFilterCondition.CONDITION_IS_LESS_OR_EQUAL:
+				return '<=';
+			case RowFilterCondition.CONDITION_IS_LESS_THAN:
+				return '<';
+			case RowFilterCondition.CONDITION_IS_NOT_EQUAL_TO:
+				return '!=';
+			default:
+				return '';
+		}
+	}
+
+	get compareFilterOp() {
+		switch (this.condition) {
+			case RowFilterCondition.CONDITION_IS_EQUAL_TO:
+				return CompareFilterParamsOp.Eq;
+			case RowFilterCondition.CONDITION_IS_GREATER_OR_EQUAL:
+				return CompareFilterParamsOp.GtEq;
+			case RowFilterCondition.CONDITION_IS_GREATER_THAN:
+				return CompareFilterParamsOp.Gt;
+			case RowFilterCondition.CONDITION_IS_LESS_OR_EQUAL:
+				return CompareFilterParamsOp.LtEq;
+			case RowFilterCondition.CONDITION_IS_LESS_THAN:
+				return CompareFilterParamsOp.Lt;
+			default:
+				// CONDITION_IS_NOT_EQUAL_TO
+				return CompareFilterParamsOp.NotEq;
+		}
 	}
 
 	/**
 	 * Gets the row filter condition.
 	 */
 	get rowFilterCondition() {
-		return RowFilterCondition.CONDITION_IS_LESS_THAN;
+		return this.condition;
 	}
 }
 
 /**
- * RowFilterDescriptorIsLessOrEqual class.
+ * RowFilterDescriptorSearch class.
  */
-export class RowFilterDescriptorIsLessOrEqual extends SingleValueRowFilterDescriptor {
+export class RowFilterDescriptorSearch extends SingleValueRowFilterDescriptor {
 	/**
 	 * Constructor.
 	 * @param columnSchema The column schema.
 	 * @param value The value.
+	 * @param condition The filter condition.
 	 */
-	constructor(columnSchema: ColumnSchema, value: string) {
+	condition: RowFilterCondition;
+
+	constructor(columnSchema: ColumnSchema, value: string, condition: RowFilterCondition) {
 		super(columnSchema, value);
+		this.condition = condition;
+	}
+
+	get operatorText() {
+		switch (this.condition) {
+			case RowFilterCondition.CONDITION_SEARCH_CONTAINS:
+				return 'contains';
+			case RowFilterCondition.CONDITION_SEARCH_STARTS_WITH:
+				return 'starts with';
+			case RowFilterCondition.CONDITION_SEARCH_ENDS_WITH:
+				return 'ends with';
+			default:
+				// CONDITION_SEARCH_REGEX_MATCHES
+				return 'matches regex';
+		}
+	}
+
+	get searchOp() {
+		switch (this.condition) {
+			case RowFilterCondition.CONDITION_SEARCH_CONTAINS:
+				return SearchFilterType.Contains;
+			case RowFilterCondition.CONDITION_SEARCH_STARTS_WITH:
+				return SearchFilterType.StartsWith;
+			case RowFilterCondition.CONDITION_SEARCH_ENDS_WITH:
+				return SearchFilterType.EndsWith;
+			default:
+				// CONDITION_SEARCH_REGEX_MATCHES
+				return SearchFilterType.RegexMatch;
+		}
 	}
 
 	/**
 	 * Gets the row filter condition.
 	 */
 	get rowFilterCondition() {
-		return RowFilterCondition.CONDITION_IS_LESS_OR_EQUAL;
-	}
-}
-
-/**
- * RowFilterDescriptorIsGreaterThan class.
- */
-export class RowFilterDescriptorIsGreaterThan extends SingleValueRowFilterDescriptor {
-	/**
-	 * Constructor.
-	 * @param columnSchema The column schema.
-	 * @param value The value.
-	 */
-	constructor(columnSchema: ColumnSchema, value: string) {
-		super(columnSchema, value);
-	}
-
-	/**
-	 * Gets the row filter condition.
-	 */
-	get rowFilterCondition() {
-		return RowFilterCondition.CONDITION_IS_GREATER_THAN;
-	}
-}
-
-/**
- * RowFilterDescriptorIsGreaterOrEqual class.
- */
-export class RowFilterDescriptorIsGreaterOrEqual extends SingleValueRowFilterDescriptor {
-	/**
-	 * Constructor.
-	 * @param columnSchema The column schema.
-	 * @param value The value.
-	 */
-	constructor(columnSchema: ColumnSchema, value: string) {
-		super(columnSchema, value);
-	}
-
-	/**
-	 * Gets the row filter condition.
-	 */
-	get rowFilterCondition() {
-		return RowFilterCondition.CONDITION_IS_GREATER_OR_EQUAL;
-	}
-}
-
-/**
- * RowFilterDescriptorIsEqualTo class.
- */
-export class RowFilterDescriptorIsEqualTo extends SingleValueRowFilterDescriptor {
-	/**
-	 * Constructor.
-	 * @param columnSchema The column schema.
-	 * @param value The value.
-	 */
-	constructor(columnSchema: ColumnSchema, value: string) {
-		super(columnSchema, value);
-	}
-
-	/**
-	 * Gets the row filter condition.
-	 */
-	get rowFilterCondition() {
-		return RowFilterCondition.CONDITION_IS_EQUAL_TO;
-	}
-}
-
-
-/**
- * RowFilterDescriptorIsNotEqualTo class.
- */
-export class RowFilterDescriptorIsNotEqualTo extends SingleValueRowFilterDescriptor {
-	/**
-	 * Constructor.
-	 * @param columnSchema The column schema.
-	 * @param value The value.
-	 */
-	constructor(columnSchema: ColumnSchema, value: string) {
-		super(columnSchema, value);
-	}
-
-	/**
-	 * Gets the row filter condition.
-	 */
-	get rowFilterCondition() {
-		return RowFilterCondition.CONDITION_IS_NOT_EQUAL_TO;
+		return this.condition;
 	}
 }
 
@@ -339,14 +331,10 @@ export class RowFilterDescriptorIsNotBetween extends RangeRowFilterDescriptor {
  * RowFilterDescriptor type.
  */
 export type RowFilterDescriptor =
+	RowFilterDescriptorComparison |
 	RowFilterDescriptorIsEmpty |
 	RowFilterDescriptorIsNotEmpty |
 	RowFilterDescriptorIsNull |
 	RowFilterDescriptorIsNotNull |
-	RowFilterDescriptorIsLessThan |
-	RowFilterDescriptorIsLessOrEqual |
-	RowFilterDescriptorIsGreaterThan |
-	RowFilterDescriptorIsGreaterOrEqual |
-	RowFilterDescriptorIsEqualTo |
 	RowFilterDescriptorIsBetween |
 	RowFilterDescriptorIsNotBetween;

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
@@ -24,7 +24,7 @@ export enum RowFilterCondition {
 	CONDITION_IS_NOT_EQUAL_TO = 'is-not-equal-to',
 	CONDITION_SEARCH_CONTAINS = 'search-contains',
 	CONDITION_SEARCH_STARTS_WITH = 'search-starts-with',
-	CONDITION_SEARCH_ENDS_WITH = 'search-ends-width',
+	CONDITION_SEARCH_ENDS_WITH = 'search-ends-with',
 	CONDITION_SEARCH_REGEX_MATCHES = 'search-regex',
 
 	// Conditions with two parameters.
@@ -337,4 +337,5 @@ export type RowFilterDescriptor =
 	RowFilterDescriptorIsNull |
 	RowFilterDescriptorIsNotNull |
 	RowFilterDescriptorIsBetween |
-	RowFilterDescriptorIsNotBetween;
+	RowFilterDescriptorIsNotBetween |
+	RowFilterDescriptorSearch;

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
@@ -14,18 +14,14 @@ import { localize } from 'vs/nls';
 import { Button } from 'vs/base/browser/ui/positronComponents/button/button';
 import {
 	RowFilterDescriptor,
+	RowFilterDescriptorComparison,
 	RowFilterDescriptorIsBetween,
 	RowFilterDescriptorIsEmpty,
-	RowFilterDescriptorIsEqualTo,
-	RowFilterDescriptorIsGreaterThan,
-	RowFilterDescriptorIsGreaterOrEqual,
-	RowFilterDescriptorIsLessThan,
-	RowFilterDescriptorIsLessOrEqual,
 	RowFilterDescriptorIsNotBetween,
 	RowFilterDescriptorIsNotEmpty,
 	RowFilterDescriptorIsNotNull,
 	RowFilterDescriptorIsNull,
-	RowFilterDescriptorIsNotEqualTo
+	RowFilterDescriptorSearch
 } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
 
 /**
@@ -75,40 +71,16 @@ export const RowFilterWidget = forwardRef<HTMLButtonElement, RowFilterWidgetProp
 				</span>
 			</>;
 
-		} else if (props.rowFilter instanceof RowFilterDescriptorIsLessThan) {
+		} else if (props.rowFilter instanceof RowFilterDescriptorComparison) {
 			return <>
 				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
-				<span className='space-before space-after'>&lt;</span>
+				<span className='space-before space-after'>{props.rowFilter.operatorText}</span>
 				<span>{props.rowFilter.value}</span>
 			</>;
-		} else if (props.rowFilter instanceof RowFilterDescriptorIsLessOrEqual) {
+		} else if (props.rowFilter instanceof RowFilterDescriptorSearch) {
 			return <>
 				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
-				<span className='space-before space-after'>&lt;=</span>
-				<span>{props.rowFilter.value}</span>
-			</>;
-		} else if (props.rowFilter instanceof RowFilterDescriptorIsGreaterThan) {
-			return <>
-				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
-				<span className='space-before space-after'>&gt;</span>
-				<span>{props.rowFilter.value}</span>
-			</>;
-		} else if (props.rowFilter instanceof RowFilterDescriptorIsGreaterOrEqual) {
-			return <>
-				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
-				<span className='space-before space-after'>&gt;=</span>
-				<span>{props.rowFilter.value}</span>
-			</>;
-		} else if (props.rowFilter instanceof RowFilterDescriptorIsEqualTo) {
-			return <>
-				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
-				<span className='space-before space-after'>=</span>
-				<span>{props.rowFilter.value}</span>
-			</>;
-		} else if (props.rowFilter instanceof RowFilterDescriptorIsNotEqualTo) {
-			return <>
-				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
-				<span className='space-before space-after'>!=</span>
+				<span className='space-before space-after'>{props.rowFilter.operatorText}</span>
 				<span>{props.rowFilter.value}</span>
 			</>;
 		} else if (props.rowFilter instanceof RowFilterDescriptorIsBetween) {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -18,23 +18,19 @@ import { ContextMenuItem } from 'vs/workbench/browser/positronComponents/context
 import { ContextMenuSeparator } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenuSeparator';
 import { usePositronDataExplorerContext } from 'vs/workbench/browser/positronDataExplorer/positronDataExplorerContext';
 import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer';
-import { CompareFilterParamsOp, RowFilter, RowFilterCondition, RowFilterType } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { RowFilter, RowFilterCondition, RowFilterType } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { RowFilterWidget } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget';
 import { AddEditRowFilterModalPopup } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup';
 import {
 	RowFilterDescriptor,
+	RowFilterDescriptorComparison,
 	RowFilterDescriptorIsEmpty,
 	RowFilterDescriptorIsNotEmpty,
 	RowFilterDescriptorIsNull,
 	RowFilterDescriptorIsNotNull,
-	RowFilterDescriptorIsLessThan,
-	RowFilterDescriptorIsGreaterThan,
-	RowFilterDescriptorIsEqualTo,
 	RowFilterDescriptorIsBetween,
 	RowFilterDescriptorIsNotBetween,
-	RowFilterDescriptorIsLessOrEqual,
-	RowFilterDescriptorIsGreaterOrEqual,
-	RowFilterDescriptorIsNotEqualTo
+	RowFilterDescriptorSearch
 } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
 
 /**
@@ -53,17 +49,6 @@ const createRowFilters = (rowFilterDescriptors: RowFilterDescriptor[]) => {
 			filter_id: rowFilterDescriptor.identifier,
 			column_index: rowFilterDescriptor.columnSchema.column_index,
 			condition: RowFilterCondition.And
-		};
-
-		const getCompareFilter = (value: string, op: CompareFilterParamsOp): RowFilter => {
-			return {
-				filter_type: RowFilterType.Compare,
-				compare_params: {
-					op,
-					value
-				},
-				...sharedParams
-			};
 		};
 
 		if (rowFilterDescriptor instanceof RowFilterDescriptorIsEmpty) {
@@ -86,18 +71,25 @@ const createRowFilters = (rowFilterDescriptors: RowFilterDescriptor[]) => {
 				filter_type: RowFilterType.NotNull,
 				...sharedParams
 			});
-		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsLessThan) {
-			rowFilters.push(getCompareFilter(rowFilterDescriptor.value, CompareFilterParamsOp.Lt));
-		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsLessOrEqual) {
-			rowFilters.push(getCompareFilter(rowFilterDescriptor.value, CompareFilterParamsOp.LtEq));
-		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsGreaterThan) {
-			rowFilters.push(getCompareFilter(rowFilterDescriptor.value, CompareFilterParamsOp.Gt));
-		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsGreaterOrEqual) {
-			rowFilters.push(getCompareFilter(rowFilterDescriptor.value, CompareFilterParamsOp.GtEq));
-		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsEqualTo) {
-			rowFilters.push(getCompareFilter(rowFilterDescriptor.value, CompareFilterParamsOp.Eq));
-		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsNotEqualTo) {
-			rowFilters.push(getCompareFilter(rowFilterDescriptor.value, CompareFilterParamsOp.NotEq));
+		} else if (rowFilterDescriptor instanceof RowFilterDescriptorComparison) {
+			rowFilters.push({
+				filter_type: RowFilterType.Compare,
+				compare_params: {
+					op: rowFilterDescriptor.compareFilterOp,
+					value: rowFilterDescriptor.value
+				},
+				...sharedParams
+			});
+		} else if (rowFilterDescriptor instanceof RowFilterDescriptorSearch) {
+			rowFilters.push({
+				filter_type: RowFilterType.Search,
+				search_params: {
+					search_type: rowFilterDescriptor.searchOp,
+					term: rowFilterDescriptor.value,
+					case_sensitive: false
+				},
+				...sharedParams
+			});
 		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsBetween) {
 			rowFilters.push({
 				filter_type: RowFilterType.Between,


### PR DESCRIPTION
These new row filters were implemented / tested in Python but are now exposed for string types. 

I also deleted some code duplication related to the UI code for comparison row filters. I double checked manually that these filters perform correctly after the refactoring. 

[Screencast from 2024-04-15 14-12-37.webm](https://github.com/posit-dev/positron/assets/329591/f149c406-e29b-410d-bdd8-4219a216aa0d)

also addresses #2733 by removing modal fade-in