### PR TITLE
Add table display name to Data Explorer get_state RPC, show variable name in editor tab label

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -172,6 +172,10 @@ class BackendState(BaseModel):
     The current backend state for the data explorer
     """
 
+    display_name: str = Field(
+        description="Variable name or other string to display for tab name in UI",
+    )
+
     table_shape: TableShape = Field(
         description="Provides number of rows and columns in table",
     )

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
 #
 
-import uuid
 from typing import Any, Dict, List, Optional, Type, cast
 
 import numpy as np
@@ -22,16 +21,13 @@ from ..data_explorer_comm import (
 )
 from .conftest import DummyComm, PositronShell
 from .test_variables import BIG_ARRAY_LENGTH
+from ..utils import guid
 from .utils import json_rpc_notification, json_rpc_request, json_rpc_response
 
 TARGET_NAME = "positron.dataExplorer"
 
 # ----------------------------------------------------------------------
 # pytest fixtures
-
-
-def guid():
-    return str(uuid.uuid4())
 
 
 def get_new_comm(
@@ -261,6 +257,7 @@ def test_explorer_variable_updates(
 
     dxf = DataExplorerFixture(de_service)
     new_state = dxf.get_state("x")
+    assert new_state["display_name"] == "x"
     assert new_state["table_shape"]["num_rows"] == 5
     assert new_state["table_shape"]["num_columns"] == 1
     assert new_state["sort_keys"] == [ColumnSortKey(**k) for k in x_sort_keys]
@@ -441,6 +438,7 @@ def _wrap_json(model: Type[BaseModel], data: JsonRecords):
 
 def test_pandas_get_state(dxf: DataExplorerFixture):
     result = dxf.get_state("simple")
+    assert result["display_name"] == "simple"
     assert result["table_shape"]["num_rows"] == 5
     assert result["table_shape"]["num_columns"] == 6
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
@@ -8,10 +8,22 @@ import numbers
 import pprint
 import sys
 import types
+import uuid
 from binascii import b2a_base64
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Coroutine, Dict, List, Optional, Set, Tuple, TypeVar, Union, cast
+from typing import (
+    Any,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
 
 JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool, None]
 JsonRecord = Dict[str, JsonData]
@@ -258,6 +270,10 @@ def alias_home(path: Path) -> Path:
         return Path("~") / path.relative_to(home_dir)
     except ValueError:
         return path
+
+
+def guid():
+    return str(uuid.uuid4())
 
 
 def positron_ipykernel_usage():

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -15,7 +15,13 @@ from comm.base_comm import BaseComm
 from .access_keys import decode_access_key, encode_access_key
 from .inspectors import get_inspector
 from .positron_comm import CommMessage, JsonRpcErrorCode, PositronComm
-from .utils import JsonData, JsonRecord, cancel_tasks, create_task, get_qualname
+from .utils import (
+    JsonData,
+    JsonRecord,
+    cancel_tasks,
+    create_task,
+    get_qualname,
+)
 from .variables_comm import (
     ClearRequest,
     ClipboardFormatFormat,

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -243,12 +243,17 @@
 					"name": "backend_state",
 					"description": "The current backend state for the data explorer",
 					"required": [
+						"display_name",
 						"table_shape",
 						"row_filters",
 						"sort_keys",
 						"supported_features"
 					],
 					"properties": {
+						"display_name": {
+							"type": "string",
+							"description": "Variable name or other string to display for tab name in UI"
+						},
 						"table_shape": {
 							"type": "object",
 							"name": "table_shape",

--- a/src/vs/workbench/browser/positronDataExplorer/positronDataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/positronDataExplorer.tsx
@@ -17,7 +17,6 @@ import { PositronActionBarServices } from 'vs/platform/positronActionBar/browser
 import { PositronDataExplorerContextProvider } from 'vs/workbench/browser/positronDataExplorer/positronDataExplorerContext';
 import { DataExplorerPanel } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/dataExplorerPanel';
 import { IPositronDataExplorerInstance } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance';
-import { PositronDataExplorerEditorInput } from 'vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput';
 
 /**
  * PositronDataExplorerServices interface.

--- a/src/vs/workbench/browser/positronDataExplorer/positronDataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/positronDataExplorer.tsx
@@ -17,6 +17,7 @@ import { PositronActionBarServices } from 'vs/platform/positronActionBar/browser
 import { PositronDataExplorerContextProvider } from 'vs/workbench/browser/positronDataExplorer/positronDataExplorerContext';
 import { DataExplorerPanel } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/dataExplorerPanel';
 import { IPositronDataExplorerInstance } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance';
+import { PositronDataExplorerEditorInput } from 'vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput';
 
 /**
  * PositronDataExplorerServices interface.

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
@@ -31,6 +31,7 @@ class PositronDataExplorerContribution extends Disposable {
 			`${Schemas.positronDataExplorer}:**/**`,
 			{
 				id: PositronDataExplorerEditorInput.EditorID,
+				// Label will be overwritten elsewhere
 				label: localize('positronDataExplorer', "Positron Data Explorer"),
 				priority: RegisteredEditorPriority.builtin
 			},

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -278,6 +278,10 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 				// Logging.
 				console.log(`PositronDataExplorerEditor ${this._instance} create PositronReactRenderer`);
 
+				// Hack -- this is usually set by setInput but we're setting it temporarily to be
+				// able to edit the editor tab name
+				this._input = input;
+
 				// Success.
 				return;
 			}

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput.ts
@@ -2,7 +2,6 @@
  *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from 'vs/nls';
 import { URI } from 'vs/base/common/uri';
 import { IUntypedEditorInput } from 'vs/workbench/common/editor';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
@@ -24,6 +23,8 @@ export class PositronDataExplorerEditorInput extends EditorInput {
 	static readonly EditorID: string = 'workbench.editor.positronDataExplorer';
 
 	//#endregion Static Properties
+
+	_name: string = 'Data Explorer';
 
 	//#region Constructor & Dispose
 
@@ -67,7 +68,13 @@ export class PositronDataExplorerEditorInput extends EditorInput {
 	 * @returns The display name of this input.
 	 */
 	override getName(): string {
-		return localize('positronDataExplorerInputName', "Positron Data Explorer");
+		// This is where the tab name comes from
+		return this._name;
+	}
+
+	setName(name: string) {
+		this._name = name;
+		this._onDidChangeLabel.fire();
 	}
 
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -58,6 +58,11 @@ export interface FilterResult {
  */
 export interface BackendState {
 	/**
+	 * Variable name or other string to display for tab name in UI
+	 */
+	display_name: string;
+
+	/**
 	 * Provides number of rows and columns in table
 	 */
 	table_shape: TableShape;

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -192,8 +192,17 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 		const start = new Date();
 
 		// Open the editor.
-		await this._editorService.openEditor({
+		const editor = await this._editorService.openEditor({
 			resource: PositronDataExplorerUri.generate(dataExplorerClientInstance.identifier)
+		});
+
+		// PositronDataExplorerEditorInput
+		dataExplorerClientInstance.getState().then((state) => {
+			// Hack to be able to call PositronDataExplorerEditorInput.setName without eslint errors;
+			const dxInput = editor?.input as any;
+			if (state.display_name !== undefined) {
+				dxInput.setName?.(`Data: ${state.display_name}`);
+			}
 		});
 
 		const end = new Date();

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -196,9 +196,9 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 			resource: PositronDataExplorerUri.generate(dataExplorerClientInstance.identifier)
 		});
 
-		// PositronDataExplorerEditorInput
 		dataExplorerClientInstance.getState().then((state) => {
-			// Hack to be able to call PositronDataExplorerEditorInput.setName without eslint errors;
+			// Hack to be able to call PositronDataExplorerEditorInput.setName without
+			// eslint errors;
 			const dxInput = editor?.input as any;
 			if (state.display_name !== undefined) {
 				dxInput.setName?.(`Data: ${state.display_name}`);


### PR DESCRIPTION
This adds simple plumbing to show the variable name in the editor table opening a data explorer

![image](https://github.com/posit-dev/positron/assets/329591/debd15d9-cd65-4ba1-abf7-91dee9753c8a)

This isn't supported yet in R, but I checked that this change does not break with the current Ark release. 

Addresses #2568 for Python