### PR TITLE
fix import error when matplotlib is not installed

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/matplotlib_backend.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/matplotlib_backend.py
@@ -3,6 +3,14 @@
 #
 """
 The matplotlib backend for Positron.
+
+NOTE: DO NOT DIRECTLY IMPORT THIS MODULE!
+
+This module assumes that it is only ever imported by matplotlib when it sets its backend.
+Given that, it doesn't check whether matplotlib is installed in the user's environment,
+and runs code on import e.g. to enable matplotlib interactive mode. This is the same approach
+taken by IPython's matplotlib-inline backend, and seems to be the only way to run code when
+the backend is set by matplotlib.
 """
 
 from __future__ import annotations
@@ -21,6 +29,10 @@ from matplotlib.figure import Figure
 from .plots import Plot
 
 logger = logging.getLogger(__name__)
+
+
+# Enable interactive mode when this backend is used. See the note at the top of the file.
+matplotlib.interactive(True)
 
 
 class FigureManagerPositron(FigureManagerBase):
@@ -177,17 +189,6 @@ class FigureCanvasPositron(FigureCanvasAgg):
     def _hash_buffer_rgba(self) -> str:
         """Hash the canvas contents for change detection."""
         return hashlib.sha1(self.buffer_rgba()).hexdigest()
-
-
-def enable_positron_matplotlib_backend() -> None:
-    """
-    Enable this backend.
-    """
-    # Enable interactive mode to allow for redraws after each cell execution.
-    matplotlib.interactive(True)
-
-    # Set the backend.
-    matplotlib.use("module://positron_ipykernel.matplotlib_backend")
 
 
 # Fulfill the matplotlib backend API.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import enum
 import logging
+import os
 import re
 import warnings
 from pathlib import Path
@@ -27,7 +28,6 @@ from .connections import ConnectionsService
 from .data_explorer import DataExplorerService
 from .help import HelpService, help
 from .lsp import LSPService
-from .matplotlib_backend import enable_positron_matplotlib_backend
 from .plots import PlotsService
 from .session_mode import SessionMode
 from .ui import UiService
@@ -417,13 +417,13 @@ class PositronIPKernelApp(IPKernelApp):
     session_mode: SessionMode = SessionMode.trait()  # type: ignore
 
     def init_gui_pylab(self):
-        try:
-            # Enable the Positron matplotlib backend if we're not in a notebook.
-            # If we're in a notebook, use IPython's default backend via the super() call below.
-            if self.session_mode != SessionMode.NOTEBOOK:
-                enable_positron_matplotlib_backend()
-        except Exception:
-            logger.error("Error setting matplotlib backend")
+        # Enable the Positron matplotlib backend if we're not in a notebook.
+        # If we're in a notebook, use IPython's default backend via the super() call below.
+        if self.session_mode != SessionMode.NOTEBOOK:
+            # Matplotlib uses the MPLBACKEND environment variable to determine the backend to use.
+            # It imports the backend module when it's first needed.
+            if not os.environ.get("MPLBACKEND"):
+                os.environ["MPLBACKEND"] = "module://positron_ipykernel.matplotlib_backend"
 
         return super().init_gui_pylab()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
@@ -12,7 +12,6 @@ import matplotlib.pyplot as plt
 import pytest
 from PIL import Image
 
-from positron_ipykernel.matplotlib_backend import enable_positron_matplotlib_backend
 from positron_ipykernel.plots import PlotsService
 from positron_ipykernel.positron_ipkernel import PositronIPyKernel, _CommTarget
 
@@ -34,10 +33,9 @@ TARGET_NAME = "target_name"
 
 @pytest.fixture(autouse=True)
 def setup_positron_matplotlib_backend() -> None:
-    enable_positron_matplotlib_backend()
-
-    assert matplotlib.get_backend() == "module://positron_ipykernel.matplotlib_backend"
-    assert matplotlib.is_interactive()
+    # The backend is set in the kernel app, which isn't currently available in our tests,
+    # so set it here too.
+    matplotlib.use("module://positron_ipykernel.matplotlib_backend")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
See the discussion on Slack: https://positpbc.slack.com/archives/C04FPQK3H9C/p1713294558805659.