### PR TITLE
Feature/project wizard step input validation feedback

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -580,6 +580,7 @@
 		"--vscode-positronModalDialog-defaultButtonForeground",
 		"--vscode-positronModalDialog-defaultButtonHoverBackground",
 		"--vscode-positronModalDialog-foreground",
+		"--vscode-positronModalDialog-preformattedTextForeground",
 		"--vscode-positronModalDialog-projectTypeBackground",
 		"--vscode-positronModalDialog-projectTypeBackgroundHover",
 		"--vscode-positronModalDialog-projectTypeBackgroundSelected",

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -14,6 +14,7 @@ import { PositronWizardSubStep } from 'vs/workbench/browser/positronNewProjectWi
 import { LabeledTextInput } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/labeledTextInput';
 import { LabeledFolderInput } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/labeledFolderInput';
 import { Checkbox } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/checkbox';
+import { WizardFormattedText, WizardFormattedTextType } from 'vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText';
 
 /**
  * The ProjectNameLocationStep component is the second step in the new project wizard.
@@ -46,7 +47,6 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 
 	// Navigate to the next step in the wizard, based on the selected project type.
 	const nextStep = () => {
-		// TODO: add handling for R and Jupyter projects
 		switch (projectConfig.projectType) {
 			case NewProjectType.RProject:
 				props.next(NewProjectWizardStep.RConfiguration);
@@ -57,10 +57,6 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 		}
 	};
 
-	// General TODOs:
-	//   - Create text input and folder input components which allow for the
-	//     title + description + input box labelling in the mockups
-	//   - Support mixed paragraph and code text, possibly using something like nls.
 	return (
 		<PositronWizardStep
 			title={(() => localize(
@@ -79,7 +75,6 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 					'projectNameLocationSubStep.projectName.label',
 					'Project Name'
 				))()}
-			// description={'Enter a name for your new ' + newProjectResult.projectType}
 			>
 				<LabeledTextInput
 					label={(() => localize(
@@ -97,29 +92,25 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 					'projectNameLocationSubStep.parentDirectory.label',
 					'Parent Directory'
 				))()}
-				// description='Select a directory to create your project in.'
-				feedback={(() => localize(
-					'projectNameLocationSubStep.parentDirectory.feedback',
-					'Your project will be created at: {0}/{1}',
-					projectConfig.parentFolder,
-					projectConfig.projectName
-				))()}
+				feedback={() =>
+					<WizardFormattedText type={WizardFormattedTextType.Info}>
+						{(() => localize(
+							'projectNameLocationSubStep.parentDirectory.feedback',
+							'Your project will be created at: ',
+						))()}
+						<code>{projectConfig.parentFolder}/{projectConfig.projectName}</code>
+					</WizardFormattedText>
+				}
 			>
 				<LabeledFolderInput
 					label={(() => localize(
 						'projectNameLocationSubStep.parentDirectory.description',
 						'Select a directory to create your project in'
 					))()}
-					value={projectConfig.parentFolder} // TODO: this should be <code>formatted
+					value={projectConfig.parentFolder}
 					onBrowse={browseHandler}
 					onChange={e => setProjectConfig({ ...projectConfig, parentFolder: e.target.value })}
 				/>
-				{/* <div style={{ marginBottom: '16px' }}>
-					Your project will be created at:&nbsp;
-					<span style={{ fontFamily: 'monospace', color: '#D7BA7D' }}>
-						{newProjectResult.parentFolder + '/' + newProjectResult.projectName}
-					</span>
-				</div> */}
 			</PositronWizardSubStep>
 			<PositronWizardSubStep>
 				{/* TODO: display a warning/message if the user doesn't have git set up */}

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -2,8 +2,11 @@
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
+// React.
 import * as React from 'react';
-import { PropsWithChildren } from 'react';  // eslint-disable-line no-duplicate-imports
+import { PropsWithChildren, useState } from 'react';  // eslint-disable-line no-duplicate-imports
+
+// Other dependencies.
 import { localize } from 'vs/nls';
 import { useNewProjectWizardContext } from 'vs/workbench/browser/positronNewProjectWizard/newProjectWizardContext';
 import { URI } from 'vs/base/common/uri';
@@ -29,6 +32,19 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 	const projectConfig = newProjectWizardState.projectConfig;
 	const setProjectConfig = newProjectWizardState.setProjectConfig;
 	const fileDialogs = newProjectWizardState.fileDialogService;
+
+	// Hooks.
+	const [showProjectNameFeedback, setShowProjectNameFeedback] = useState(false);
+
+	// Set the project name.
+	const setProjectName = (projectName: string) => {
+		setProjectConfig({ ...projectConfig, projectName });
+		if (!projectName.trim()) {
+			setShowProjectNameFeedback(true);
+		} else {
+			setShowProjectNameFeedback(false);
+		}
+	};
 
 	// The browse handler.
 	const browseHandler = async () => {
@@ -75,6 +91,16 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 					'projectNameLocationSubStep.projectName.label',
 					'Project Name'
 				))()}
+				feedback={showProjectNameFeedback
+					? () =>
+						<WizardFormattedText type={WizardFormattedTextType.Error}>
+							{(() => localize(
+								'projectNameLocationSubStep.projectName.feedback',
+								'Please enter a project name'
+							))()}
+						</WizardFormattedText>
+					: undefined
+				}
 			>
 				<LabeledTextInput
 					label={(() => localize(
@@ -84,7 +110,7 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 					))()}
 					autoFocus
 					value={projectConfig.projectName}
-					onChange={e => setProjectConfig({ ...projectConfig, projectName: e.target.value })}
+					onChange={e => setProjectName(e.target.value)}
 				/>
 			</PositronWizardSubStep>
 			<PositronWizardSubStep

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -22,6 +22,7 @@ import { EnvironmentSetupType, LanguageIds, PythonEnvironmentType } from 'vs/wor
 import { InterpreterEntry } from 'vs/workbench/browser/positronNewProjectWizard/components/steps/pythonInterpreterEntry';
 import { DropdownEntry } from 'vs/workbench/browser/positronNewProjectWizard/components/steps/dropdownEntry';
 import { InterpreterInfo, getSelectedInterpreter } from 'vs/workbench/browser/positronNewProjectWizard/utilities/interpreterDropDownUtils';
+import { WizardFormattedText, WizardFormattedTextType } from 'vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText';
 
 /**
  * The PythonEnvironmentStep component is specific to Python projects in the new project wizard.
@@ -229,16 +230,26 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 						'pythonEnvironmentSubStep.description',
 						'Select an environment type for your project.'
 					))()}
-					feedback={(() => localize(
-						'pythonEnvironmentSubStep.feedback',
-						'The {0} environment will be created at: {1}',
-						envType,
-						locationForNewEnv(
-							projectConfig.parentFolder,
-							projectConfig.projectName,
-							envType
-						)
-					))()}
+					feedback={() =>
+						<WizardFormattedText type={WizardFormattedTextType.Info}>
+							{(() => localize(
+								'pythonEnvironmentSubStep.feedback1',
+								'The ',
+							))()}
+							<code>{envType}</code>
+							{(() => localize(
+								'pythonEnvironmentSubStep.feedback2',
+								' environment will be created at: ',
+							))()}
+							<code>
+								{locationForNewEnv(
+									projectConfig.parentFolder,
+									projectConfig.projectName,
+									envType
+								)}
+							</code>
+						</WizardFormattedText>
+					}
 				>
 					<DropDownListBox
 						keybindingService={keybindingService}

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -233,13 +233,8 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 					feedback={() =>
 						<WizardFormattedText type={WizardFormattedTextType.Info}>
 							{(() => localize(
-								'pythonEnvironmentSubStep.feedback1',
-								'The ',
-							))()}
-							<code>{envType}</code>
-							{(() => localize(
-								'pythonEnvironmentSubStep.feedback2',
-								' environment will be created at: ',
+								'pythonEnvironmentSubStep.feedback',
+								'The environment will be created at: ',
 							))()}
 							<code>
 								{locationForNewEnv(

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -77,7 +77,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 			identifier: EnvironmentSetupType.NewEnvironment,
 			title: localize(
 				'pythonEnvironmentStep.newEnvironment.radioLabel',
-				'Create a new Python environment _(Recommended)_'
+				'Create a new Python environment (Recommended)'
 			)
 		}),
 		new RadioButtonItem({

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText.css
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText.css
@@ -3,18 +3,38 @@
  *--------------------------------------------------------------------------------------------*/
 
 .wizard-step
-.wizard-formatted-text-info {
-	color: var(--vscode-foreground);
+.wizard-formatted-text {
+	display: flex;
+	flex-direction: row;
+	column-gap: 2px;
+	align-items: center;
 }
 
 .wizard-step
-.wizard-formatted-text-warning {
+.wizard-formatted-text-info {
 	color: var(--vscode-descriptionForeground);
 }
 
 .wizard-step
+.wizard-formatted-text-warning {
+	color: var(--vscode-editorWarning-foreground);
+}
+
+.wizard-step
+.wizard-formatted-text-warning
+.wizard-formatted-text-icon {
+	color: var(--vscode-editorWarning-foreground);
+}
+
+.wizard-step
 .wizard-formatted-text-error {
-	color: var(--vscode-errorForeground);
+	color: var(--vscode-editorError-foreground);
+}
+
+.wizard-step
+.wizard-formatted-text-error
+.wizard-formatted-text-icon {
+	color: var(--vscode-editorError-foreground);
 }
 
 .wizard-step

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText.css
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText.css
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+.wizard-step
+.wizard-formatted-text-info {
+	color: var(--vscode-foreground);
+}
+
+.wizard-step
+.wizard-formatted-text-warning {
+	color: var(--vscode-descriptionForeground);
+}
+
+.wizard-step
+.wizard-formatted-text-error {
+	color: var(--vscode-errorForeground);
+}
+
+.wizard-step
+.wizard-formatted-text
+code {
+	color: var(--vscode-textPreformat-foreground);
+	font-family: var(--monaco-monospace-font);
+	font-size: 11px;
+}

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText.css
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText.css
@@ -40,7 +40,9 @@
 .wizard-step
 .wizard-formatted-text
 code {
-	color: var(--vscode-textPreformat-foreground);
+	color: var(--vscode-positronModalDialog-preformattedTextForeground);
+	border-radius: 4px;
+	padding: 1px 3px;
 	font-family: var(--monaco-monospace-font);
 	font-size: 11px;
 }

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText.tsx
@@ -40,6 +40,7 @@ export interface WizardFormattedTextProps {
  * @returns The rendered component.
  */
 export const WizardFormattedText = (props: PropsWithChildren<WizardFormattedTextProps>) => {
+	// Show an icon in the formatted text if the text type is not Info.
 	const iconClass = props.type !== WizardFormattedTextType.Info
 		? `codicon codicon-${props.type}`
 		: undefined;

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText.tsx
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import 'vs/css!./wizardFormattedText';
+
+// React.
+import * as React from 'react';
+import { PropsWithChildren } from 'react';  // eslint-disable-line no-duplicate-imports
+
+/**
+ * WizardFormattedTextType enum.
+ */
+export enum WizardFormattedTextType {
+	Info = 'info',
+	Warning = 'warning',
+	Error = 'error'
+}
+
+/**
+ * WizardFormattedTextProps interface.
+ */
+export interface WizardFormattedTextProps {
+	type: WizardFormattedTextType;
+	id?: string;
+	className?: string;
+}
+
+/**
+ * WizardFormattedText component.
+ * @param props A PropsWithChildren<WizardFormattedTextProps> that contains the component properties.
+ * @returns The rendered component.
+ */
+export const WizardFormattedText = (props: PropsWithChildren<WizardFormattedTextProps>) => {
+	// Render.
+	return (
+		<div className={`wizard-formatted-text ${props.className}`}>
+			<div className={`wizard-formatted-text-${props.type}`} id={props.id}>
+				{props.children}
+			</div>
+		</div>
+	);
+};

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText.tsx
@@ -19,12 +19,19 @@ export enum WizardFormattedTextType {
 }
 
 /**
+ * WizardFormattedTextItem interface.
+ */
+export interface WizardFormattedTextItem {
+	type: WizardFormattedTextType;
+	text: string;
+}
+
+/**
  * WizardFormattedTextProps interface.
  */
 export interface WizardFormattedTextProps {
 	type: WizardFormattedTextType;
 	id?: string;
-	className?: string;
 }
 
 /**
@@ -33,12 +40,15 @@ export interface WizardFormattedTextProps {
  * @returns The rendered component.
  */
 export const WizardFormattedText = (props: PropsWithChildren<WizardFormattedTextProps>) => {
+	const iconClass = props.type !== WizardFormattedTextType.Info
+		? `codicon codicon-${props.type}`
+		: undefined;
+
 	// Render.
 	return (
-		<div className={`wizard-formatted-text ${props.className}`}>
-			<div className={`wizard-formatted-text-${props.type}`} id={props.id}>
-				{props.children}
-			</div>
+		<div className={`wizard-formatted-text wizard-formatted-text-${props.type}`} id={props.id}>
+			{iconClass && <div className={`wizard-formatted-text-icon ${iconClass}`}></div>}
+			{props.children}
 		</div>
 	);
 };

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/wizardStep.css
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/wizardStep.css
@@ -20,10 +20,3 @@
 	margin-top: 16px;
 	margin-bottom: 32px;
 }
-
-.positron-modal-dialog-box
-.wizard-step
-code {
-	color: var(--vscode-textPreformat-foreground);
-	font-size: 11px;
-}

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/wizardSubStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/wizardSubStep.tsx
@@ -2,7 +2,10 @@
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
+// CSS.
 import 'vs/css!./wizardSubStep';
+
+// React.
 import * as React from 'react';
 import { PropsWithChildren } from 'react';  // eslint-disable-line no-duplicate-imports
 
@@ -14,20 +17,19 @@ export interface PositronWizardSubStepProps {
 	titleId?: string;
 	description?: string;
 	descriptionId?: string;
-	feedback?: string;
-	feedbackId?: string;
+	feedback?: () => JSX.Element;
 }
 
 /**
- * OKCancelBackNextModalDialog component.
- * @param props A PropsWithChildren<OKCancelBackNextModalDialogProps> that contains the component properties.
+ * PositronWizardSubStep component.
+ * @param props A PropsWithChildren<PositronWizardSubStepProps> that contains the component properties.
  * @returns The rendered component.
  */
 export const PositronWizardSubStep = (props: PropsWithChildren<PositronWizardSubStepProps>) => {
 	// TODO: on focus change outside of the input element, perform validation of input
 	//       if input is invalid, notify wizardstep parent to disable the next/confirm buttons
 	//       in input is valid , notify wizardstep parent to enable the next/confirm buttons
-
+	const Feedback = () => props.feedback ? props.feedback() : null;
 	// Render.
 	return (
 		<div className='wizard-sub-step'>
@@ -44,11 +46,9 @@ export const PositronWizardSubStep = (props: PropsWithChildren<PositronWizardSub
 			<div className='wizard-sub-step-input'>
 				{props.children}
 			</div>
-			{props.feedback ?
-				<div className='wizard-sub-step-feedback' id={props.feedbackId}>
-					{props.feedback}
-				</div> : null
-			}
+			<div className='wizard-sub-step-feedback'>
+				{props.feedback ? <Feedback /> : null}
+			</div>
 		</div>
 	);
 };

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/wizardSubStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/wizardSubStep.tsx
@@ -26,10 +26,6 @@ export interface PositronWizardSubStepProps {
  * @returns The rendered component.
  */
 export const PositronWizardSubStep = (props: PropsWithChildren<PositronWizardSubStepProps>) => {
-	// TODO: on focus change outside of the input element, perform validation of input
-	//       if input is invalid, notify wizardstep parent to disable the next/confirm buttons
-	//       in input is valid , notify wizardstep parent to enable the next/confirm buttons
-	const Feedback = () => props.feedback ? props.feedback() : null;
 	// Render.
 	return (
 		<div className='wizard-sub-step'>
@@ -47,7 +43,7 @@ export const PositronWizardSubStep = (props: PropsWithChildren<PositronWizardSub
 				{props.children}
 			</div>
 			<div className='wizard-sub-step-feedback'>
-				{props.feedback ? <Feedback /> : null}
+				{props.feedback ? props.feedback() : null}
 			</div>
 		</div>
 	);

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -48,10 +48,12 @@ export const showNewProjectModalDialog = async (
 		<NewProjectWizardContextProvider
 			services={{
 				fileDialogService,
+				fileService,
 				keybindingService,
 				languageRuntimeService,
 				layoutService,
 				logService,
+				pathService,
 				runtimeSessionService,
 				runtimeStartupService,
 			}}

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.tsx
@@ -11,6 +11,8 @@ import { EnvironmentSetupType, NewProjectType, NewProjectWizardStep, PythonEnvir
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ILogService } from 'vs/platform/log/common/log';
+import { IPathService } from 'vs/workbench/services/path/common/pathService';
+import { IFileService } from 'vs/platform/files/common/files';
 
 /**
  * NewProjectWizardServices interface. Defines the set of services that are required by the New
@@ -18,10 +20,12 @@ import { ILogService } from 'vs/platform/log/common/log';
  */
 interface NewProjectWizardServices {
 	fileDialogService: IFileDialogService;
+	fileService: IFileService;
 	keybindingService: IKeybindingService;
 	languageRuntimeService: ILanguageRuntimeService;
 	layoutService: IWorkbenchLayoutService;
 	logService: ILogService;
+	pathService: IPathService;
 	runtimeSessionService: IRuntimeSessionService;
 	runtimeStartupService: IRuntimeStartupService;
 }

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from 'vs/base/common/uri';
+import { IFileService } from 'vs/platform/files/common/files';
+import { IPathService } from 'vs/workbench/services/path/common/pathService';
+
+/**
+ * Determines if the specified folder is an existing directory.
+ * @param folder The folder to check.
+ * @param parentFolder The parent folder of the folder to check.
+ * @param pathService The path service.
+ * @param fileService The file service.
+ * @returns A promise that resolves to true if the folder is an existing directory; otherwise, false.
+ */
+export const isExistingDirectory = async (
+	folder: string,
+	parentFolder: string,
+	pathService: IPathService,
+	fileService: IFileService
+) => {
+	const folderPath = URI.file((await pathService.path).join(parentFolder, folder));
+	return await fileService.exists(folderPath);
+};

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground, treeIndentGuidesStroke, errorForeground, listActiveSelectionBackground, listActiveSelectionForeground, editorForeground, toolbarHoverBackground, inputBorder, widgetBorder } from 'vs/platform/theme/common/colorRegistry';
+import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground, treeIndentGuidesStroke, errorForeground, listActiveSelectionBackground, listActiveSelectionForeground, editorForeground, toolbarHoverBackground, inputBorder, widgetBorder, textPreformatForeground, textPreformatBackground } from 'vs/platform/theme/common/colorRegistry';
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
 import { Color } from 'vs/base/common/color';
 import { ColorScheme } from 'vs/platform/theme/common/theme';
@@ -1467,6 +1467,14 @@ export const POSITRON_MODAL_DIALOG_SEPARATOR = registerColor('positronModalDialo
 	hcDark: '#3a3d41',
 	hcLight: darken(POSITRON_MODAL_DIALOG_BACKGROUND, 0.2)
 }, localize('positronModalDialog.separator', "Positron modal dialog separator color."));
+
+// Positron modal dialog preformatted text foreground color.
+export const POSITRON_MODAL_DIALOG_PREFORMATTED_TEXT_FOREGROUND = registerColor('positronModalDialog.preformattedTextForeground', {
+	dark: textPreformatForeground,
+	light: textPreformatForeground,
+	hcDark: contrastBorder,
+	hcLight: contrastBorder
+}, localize('positronModalDialog.preformattedTextForeground', "Positron modal dialog preformatted text foreground color."));
 
 // < --- Positron Modal Dialog Title Bar --- >
 

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground, treeIndentGuidesStroke, errorForeground, listActiveSelectionBackground, listActiveSelectionForeground, editorForeground, toolbarHoverBackground, inputBorder, widgetBorder, textPreformatForeground, textPreformatBackground } from 'vs/platform/theme/common/colorRegistry';
+import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground, treeIndentGuidesStroke, errorForeground, listActiveSelectionBackground, listActiveSelectionForeground, editorForeground, toolbarHoverBackground, inputBorder, widgetBorder, textPreformatForeground } from 'vs/platform/theme/common/colorRegistry';
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
 import { Color } from 'vs/base/common/color';
 import { ColorScheme } from 'vs/platform/theme/common/theme';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

- More UI scaffolding for #2110 

#### Demo

https://github.com/posit-dev/positron/assets/25834218/9476667a-c2f7-4822-a575-a876362bb926

#### Themes

https://github.com/posit-dev/positron/assets/25834218/2f41fc38-65e4-4e93-bf9c-ce32262ae9d6

### Approach

- support pre-formatted text in substep feedback by making the `WizardSubStep` `feedback` property owner-draw (the parent component defines the `feedback` element instead of just passing a string)
- show an error and prevent navigating to the next step when the project name is empty or only whitespace
- show a warning but allow navigating to the next step if the project name is an existing directory

### QA Notes

The project name input validation does not cover checking if the project name only contains valid symbols (i.e. it is possible to enter any symbols such as `$`, `%` and `\` which can result in an incompatible directory name depending on the operating system). This sort of validation should be added at the component level, since we need to check valid file/directory text input in various places (project wizard, save plot modal, etc.) -- see https://github.com/posit-dev/positron/issues/2781.
