### PR TITLE
Use correct Pandoc architecture on Linux

### DIFF
--- a/.github/workflows/build-release-linux.yml
+++ b/.github/workflows/build-release-linux.yml
@@ -57,6 +57,7 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
           POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+          npm_config_arch: ${{ matrix.arch }}
         run: |
           # Install Yarn
           npm install -g yarn
@@ -70,6 +71,8 @@ jobs:
           yarn --immutable --network-timeout 120000
 
       - name: Build Positron
+        env:
+          npm_config_arch: ${{ matrix.arch }}
         run: |
           yarn gulp vscode-linux-${{ matrix.arch }}
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/2737. 

### Approach

The Pandoc install script relies on `npm_config_arch` to figure out which Pandoc to bundle; the fix is to set this value when producing Linux binaries.

(We could also just check OS arch on Linux, but we do need to rely on the matrix arch for at least macOS since we cross-compile there, so it felt better to make it consistent.)

### QA Notes

Ensure that the Linux release of Positron has a working copy of Pandoc. You can see where Pandoc is installed by running `rmarkdown::find_pandoc()`. 