### PR TITLE
Add title argument to `%view`

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -181,7 +181,7 @@ class ConnectionsService:
         elif safe_isinstance(obj, "sqlalchemy", "Engine"):
             return SQLAlchemyConnection(obj)
 
-        raise ValueError(f"Unsupported connection type {type_name}")
+        raise TypeError(f"Unsupported connection type {type_name}")
 
     def _close_connection(self, comm_id: str):
         try:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/matplotlib_backend.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/matplotlib_backend.py
@@ -39,15 +39,15 @@ class FigureManagerPositron(FigureManagerBase):
     """
     Interface for the matplotlib backend to interact with the Positron frontend.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     canvas
         The canvas for this figure.
     num
         The figure number.
 
-    Attributes:
-    -----------
+    Attributes
+    ----------
     canvas
         The canvas for this figure.
     """
@@ -110,13 +110,13 @@ class FigureCanvasPositron(FigureCanvasAgg):
     """
     The canvas for a figure in the Positron backend.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     figure
         The figure to draw on this canvas.
 
-    Attributes:
-    -----------
+    Attributes
+    ----------
     manager
         The manager for this canvas.
     """
@@ -135,8 +135,8 @@ class FigureCanvasPositron(FigureCanvasAgg):
         """
         Draw the canvas; send an update event if the canvas has changed.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         is_rendering
             Whether the canvas is being rendered, to avoid recursively requesting an update from the
             frontend.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
@@ -29,8 +29,8 @@ class Plot:
     """
     The backend representation of a frontend plot instance.
 
-    Paramaters:
-    -----------
+    Paramaters
+    ----------
     comm
         The communication channel to the frontend plot instance.
     render
@@ -121,8 +121,8 @@ class PlotsService:
     """
     The plots service is responsible for managing `Plot` instances.
 
-    Paramaters:
-    -----------
+    Paramaters
+    ----------
     target_name
         The name of the target for plot comms, as defined in the frontend.
     session_mode
@@ -154,8 +154,8 @@ class PlotsService:
         """
         Close a plot.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         plot
             The plot to close.
         """

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_comm.py
@@ -71,13 +71,13 @@ class PositronComm:
     """
     A wrapper around a base IPython comm that provides a JSON-RPC interface.
 
-    Paramaters:
-    -----------
+    Paramaters
+    ----------
     comm
         The wrapped IPython comm.
 
-    Attributes:
-    -----------
+    Attributes
+    ----------
     comm
         The wrapped IPython comm.
     comm_id
@@ -91,8 +91,8 @@ class PositronComm:
         """
         Create a Positron comm.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         target_name
             The name of the target for the comm, as defined in the frontend.
         comm_id
@@ -132,8 +132,8 @@ class PositronComm:
         """
         Register a callback for an RPC request from the frontend.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         callback
             Called when a message is received, with both the parsed message `msg: CommMessage` and
             original `raw_msg`. Not called if the `raw_msg` could not be parsed; instead, a JSON-RPC
@@ -191,8 +191,8 @@ class PositronComm:
         """
         Send a JSON-RPC result to the frontend-side version of this comm.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         data
             The result data to send.
         metadata
@@ -212,8 +212,8 @@ class PositronComm:
         """
         Send a JSON-RPC notification (event) to the frontend-side version of this comm.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         name
             The name of the event.
         payload
@@ -230,8 +230,8 @@ class PositronComm:
         """
         Send a JSON-RPC result to the frontend-side version of this comm.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         code
             The error code to send.
         message

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -115,13 +115,25 @@ class PositronMagics(Magics):
         help="The object to view.",
     )
     @magic_arguments.argument(
-        "-t",
-        "--title",
-        help="""The title of the Data Explorer tab. Defaults to the object's name.""",
+        "title",
+        nargs="?",
+        help="The title of the Data Explorer tab. Defaults to the object's name.",
     )
     @line_magic
     def view(self, line: str) -> None:
-        """View an object in the Positron Data Explorer."""
+        """
+        View an object in the Positron Data Explorer.
+
+        Examples
+        --------
+        View an object:
+
+        >>> %view df
+
+        View an object with a custom title (quotes are required if the title contains spaces):
+
+        >>> %view df "My Dataset"
+        """
         args = magic_arguments.parse_argstring(self.view, line)
 
         # Find the object.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -134,7 +134,16 @@ class PositronMagics(Magics):
 
         >>> %view df "My Dataset"
         """
-        args = magic_arguments.parse_argstring(self.view, line)
+        try:
+            args = magic_arguments.parse_argstring(self.view, line)
+        except UsageError as e:
+            if (
+                len(e.args) > 0
+                and isinstance(e.args[0], str)
+                and e.args[0].startswith("unrecognized arguments")
+            ):
+                raise UsageError(f"{e.args[0]}. Did you quote the title?")
+            raise
 
         # Find the object.
         info = self.shell._ofind(args.object)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
@@ -99,6 +99,13 @@ def shell() -> Iterable[PositronShell]:
 
 
 @pytest.fixture
+def mock_connections_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
+    mock = Mock()
+    monkeypatch.setattr(shell.kernel, "connections_service", mock)
+    return mock
+
+
+@pytest.fixture
 def mock_dataexplorer_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell.kernel, "data_explorer_service", mock)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_ipkernel.py
@@ -52,6 +52,17 @@ def test_view_undefined(shell: PositronShell, mock_dataexplorer_service: Mock, c
     assert capsys.readouterr().err == f"UsageError: name '{name}' is not defined\n"
 
 
+def test_view_title_unquoated(
+    shell: PositronShell, mock_dataexplorer_service: Mock, capsys
+) -> None:
+    shell.run_cell("%view x A custom title")
+    mock_dataexplorer_service.register_table.assert_not_called()
+    assert (
+        capsys.readouterr().err
+        == "UsageError: unrecognized arguments: custom title. Did you quote the title?\n"
+    )
+
+
 def test_view_unsupported_type(
     shell: PositronShell, mock_dataexplorer_service: Mock, capsys
 ) -> None:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_ipkernel.py
@@ -7,8 +7,6 @@ from pathlib import Path
 from typing import Any, cast
 from unittest.mock import Mock
 
-import pandas as pd
-import pytest
 from IPython.utils.syspathcontext import prepended_to_syspath
 
 from positron_ipykernel.help import help
@@ -16,7 +14,7 @@ from positron_ipykernel.session_mode import SessionMode
 from positron_ipykernel.utils import alias_home
 
 from .conftest import PositronShell
-from .utils import assert_dataset_registered
+from .utils import assert_register_table_called
 
 # The idea for these tests is to mock out communications with Positron
 # via our various comms, and only test IPython interactions. For
@@ -34,45 +32,71 @@ def test_override_help(shell: PositronShell) -> None:
     assert shell.user_ns_hidden["help"] == help
 
 
-def test_view_pandas_df_expression(shell: PositronShell, mock_dataexplorer_service: Mock) -> None:
-    expr = "pd.DataFrame({'x': [1,2,3]})"
-
-    shell.run_cell(
-        f"""import pandas as pd
-%view {expr}"""
-    )
-
-    obj = pd.DataFrame({"x": [1, 2, 3]})
-    assert_dataset_registered(mock_dataexplorer_service, obj, expr)
+def test_view(shell: PositronShell, mock_dataexplorer_service: Mock) -> None:
+    name = "x"
+    shell.run_cell(f"{name} = object()\n%view {name}")
+    assert_register_table_called(mock_dataexplorer_service, shell.user_ns[name], name)
 
 
-def test_view_pandas_df_var(shell: PositronShell, mock_dataexplorer_service: Mock) -> None:
-    name = "a"
-    shell.run_cell(
-        f"""import pandas as pd
-{name} = pd.DataFrame({{'x': [1,2,3]}})
-%view {name}"""
-    )
-
-    obj = shell.user_ns[name]
-    assert_dataset_registered(mock_dataexplorer_service, obj, name)
+def test_view_with_title(shell: PositronShell, mock_dataexplorer_service: Mock) -> None:
+    name = "x"
+    title = "A custom title"
+    shell.run_cell(f"{name} = object()\n%view {name} -t '{title}'")
+    assert_register_table_called(mock_dataexplorer_service, shell.user_ns[name], title)
 
 
-def test_view_polars_df_var(shell: PositronShell, mock_dataexplorer_service: Mock) -> None:
-    name = "a"
-    shell.run_cell(
-        f"""import polars as pl
-{name} = pl.DataFrame({{'x': [1,2,3]}})
-%view {name}"""
-    )
-
-    obj = shell.user_ns[name]
-    assert_dataset_registered(mock_dataexplorer_service, obj, name)
+def test_view_undefined(shell: PositronShell, mock_dataexplorer_service: Mock, capsys) -> None:
+    name = "x"
+    shell.run_cell(f"%view {name}")
+    mock_dataexplorer_service.register_table.assert_not_called()
+    assert capsys.readouterr().err == f"UsageError: name '{name}' is not defined\n"
 
 
-def test_view_unsupported_type(shell: PositronShell) -> None:
-    with pytest.raises(TypeError):
-        shell.run_line_magic("view", "12")
+def test_view_unsupported_type(
+    shell: PositronShell, mock_dataexplorer_service: Mock, capsys
+) -> None:
+    name = "x"
+    mock_dataexplorer_service.register_table = Mock(side_effect=TypeError)
+
+    shell.run_cell(f"{name} = object()\n%view {name}")
+
+    assert_register_table_called(mock_dataexplorer_service, shell.user_ns[name], name)
+    assert capsys.readouterr().err == "UsageError: cannot view object of type 'object'\n"
+
+
+def assert_register_connection_called(mock_connections_service: Mock, obj: Any) -> None:
+    call_args_list = mock_connections_service.register_connection.call_args_list
+    assert len(call_args_list) == 1
+
+    (passed_connection,) = call_args_list[0].args
+    assert passed_connection is obj
+
+
+def test_connection_show(shell: PositronShell, mock_connections_service: Mock) -> None:
+    name = "x"
+    shell.run_cell(f"{name} = object()\n%connection_show {name}")
+    assert_register_connection_called(mock_connections_service, shell.user_ns[name])
+
+
+def test_connection_show_undefined(
+    shell: PositronShell, mock_connections_service: Mock, capsys
+) -> None:
+    name = "x"
+    shell.run_cell(f"%connection_show {name}")
+    mock_connections_service.register_connection.assert_not_called()
+    assert capsys.readouterr().err == f"UsageError: name '{name}' is not defined\n"
+
+
+def test_connection_show_unsupported_type(
+    shell: PositronShell, mock_connections_service: Mock, capsys
+) -> None:
+    name = "x"
+    mock_connections_service.register_connection = Mock(side_effect=TypeError)
+
+    shell.run_cell(f"{name} = object()\n%connection_show {name}")
+
+    assert_register_connection_called(mock_connections_service, shell.user_ns[name])
+    assert capsys.readouterr().err == "UsageError: cannot show object of type 'object'\n"
 
 
 code = """def f():

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_ipkernel.py
@@ -41,7 +41,7 @@ def test_view(shell: PositronShell, mock_dataexplorer_service: Mock) -> None:
 def test_view_with_title(shell: PositronShell, mock_dataexplorer_service: Mock) -> None:
     name = "x"
     title = "A custom title"
-    shell.run_cell(f'{name} = object()\n%view {name} -t "{title}"')
+    shell.run_cell(f'{name} = object()\n%view {name} "{title}"')
     assert_register_table_called(mock_dataexplorer_service, shell.user_ns[name], title)
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_ipkernel.py
@@ -41,7 +41,7 @@ def test_view(shell: PositronShell, mock_dataexplorer_service: Mock) -> None:
 def test_view_with_title(shell: PositronShell, mock_dataexplorer_service: Mock) -> None:
     name = "x"
     title = "A custom title"
-    shell.run_cell(f"{name} = object()\n%view {name} -t '{title}'")
+    shell.run_cell(f'{name} = object()\n%view {name} -t "{title}"')
     assert_register_table_called(mock_dataexplorer_service, shell.user_ns[name], title)
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 import polars as pl
 import pytest
+
 from positron_ipykernel.access_keys import encode_access_key
 from positron_ipykernel.positron_comm import JsonRpcErrorCode
 from positron_ipykernel.positron_ipkernel import PositronIPyKernel
@@ -24,7 +25,7 @@ from positron_ipykernel.variables import (
 
 from .conftest import DummyComm, PositronShell
 from .utils import (
-    assert_dataset_registered,
+    assert_register_table_called,
     comm_open_message,
     json_rpc_error,
     json_rpc_notification,
@@ -367,7 +368,7 @@ def test_handle_view(
     # An acknowledgment message is sent
     assert variables_comm.messages == [json_rpc_response({})]
 
-    assert_dataset_registered(mock_dataexplorer_service, shell.user_ns["x"], "x")
+    assert_register_table_called(mock_dataexplorer_service, shell.user_ns["x"], "x")
 
 
 def test_handle_view_error(variables_comm: DummyComm) -> None:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/utils.py
@@ -30,19 +30,13 @@ def preserve_working_directory():
         os.chdir(cwd)
 
 
-def assert_dataset_registered(mock_datatool_service: Mock, obj: Any, title: str) -> None:
-    call_args_list = mock_datatool_service.register_table.call_args_list
-
+def assert_register_table_called(mock_dataexplorer_service: Mock, obj: Any, title: str) -> None:
+    call_args_list = mock_dataexplorer_service.register_table.call_args_list
     assert len(call_args_list) == 1
 
     passed_table, passed_title = call_args_list[0].args
-
     assert passed_title == title
-
-    try:
-        assert passed_table.equals(obj)
-    except AttributeError:  # polars.DataFrame.equals was introduced in v0.19.16
-        assert passed_table.frame_equal(obj)
+    assert passed_table is obj
 
 
 def comm_message(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Address #2396.

### Approach

I used the `magic_arguments` module from IPython. This also gives us better help messages, although we could still do some work to parse those and render them neatly in the help pane.

I also removed the ability to pass an expression to `%view` and `%connection_show`. My motivation is that I think we would want to encourage users defining variables before using these UIs, especially if e.g. a UI like the data explorer might eventually allow edits to the underlying data. The trade-off is that users need to define the variable in one additional statement before calling the magic, which I don't think is too bad.