### PR TITLE
add `renv` external documentation link to project wizard

### DIFF
--- a/src/vs/base/browser/ui/ExternalLink/ExternalLink.tsx
+++ b/src/vs/base/browser/ui/ExternalLink/ExternalLink.tsx
@@ -31,5 +31,8 @@ export function ExternalLink(props: ExternalLinkProps) {
 			e.preventDefault();
 			openerService.open(href);
 		}}
-	/>;
+	>
+		{props.children}
+	</a>
+		;
 }

--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -24,6 +24,7 @@ import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/c
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
 import { ILogService } from 'vs/platform/log/common/log';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
 
 /**
  * The PositronNewProjectAction.
@@ -78,6 +79,7 @@ export class PositronNewProjectAction extends Action2 {
 			accessor.get(ILanguageRuntimeService),
 			accessor.get(IWorkbenchLayoutService),
 			accessor.get(ILogService),
+			accessor.get(IOpenerService),
 			accessor.get(IPathService),
 			accessor.get(IRuntimeSessionService),
 			accessor.get(IRuntimeStartupService),

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.css
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.css
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+.positron-modal-dialog-box
+.wizard-step
+.renv-configuration {
+	display: flex;
+	flex-direction: row;
+	column-gap: 6px;
+}
+
+.positron-modal-dialog-box
+.wizard-step
+.renv-configuration
+.codicon-link-external {
+	color: var(--vscode-textLink-foreground);
+	cursor: pointer;
+	font-size: 14px;
+}

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.css
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.css
@@ -13,6 +13,14 @@
 .positron-modal-dialog-box
 .wizard-step
 .renv-configuration
+.renv-docs-external-link {
+	display: flex;
+	align-items: center;
+}
+
+.positron-modal-dialog-box
+.wizard-step
+.renv-configuration
 .codicon-link-external {
 	color: var(--vscode-textLink-foreground);
 	cursor: pointer;

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
@@ -180,6 +180,7 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 						onChanged={checked => setProjectConfig({ ...projectConfig, useRenv: checked })}
 					/>
 					<ExternalLink
+						className='renv-docs-external-link'
 						openerService={newProjectWizardState.openerService}
 						href='https://rstudio.github.io/renv/articles/renv.html'
 						title='https://rstudio.github.io/renv/articles/renv.html'

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
@@ -2,6 +2,9 @@
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
+// CSS.
+import 'vs/css!./rConfigurationStep';
+
 // React.
 import * as React from 'react';
 import { PropsWithChildren, useEffect, useState } from 'react';  // eslint-disable-line no-duplicate-imports
@@ -20,6 +23,7 @@ import { getRInterpreterEntries } from 'vs/workbench/browser/positronNewProjectW
 import { InterpreterEntry } from 'vs/workbench/browser/positronNewProjectWizard/components/steps/pythonInterpreterEntry';
 import { LanguageIds } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
 import { getSelectedInterpreter } from 'vs/workbench/browser/positronNewProjectWizard/utilities/interpreterDropDownUtils';
+import { ExternalLink } from 'vs/base/browser/ui/ExternalLink/ExternalLink';
 
 /**
  * The RConfigurationStep component is specific to R projects in the new project wizard.
@@ -167,13 +171,22 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 					'Additional Configuration'
 				))()}
 			>
-				<Checkbox
-					label={(() => localize(
-						'rConfigurationStep.additionalConfigSubStep.useRenv.label',
-						'Use `renv` to create a reproducible environment'
-					))()}
-					onChanged={checked => setProjectConfig({ ...projectConfig, useRenv: checked })}
-				/>
+				<div className='renv-configuration'>
+					<Checkbox
+						label={(() => localize(
+							'rConfigurationStep.additionalConfigSubStep.useRenv.label',
+							'Use `renv` to create a reproducible environment'
+						))()}
+						onChanged={checked => setProjectConfig({ ...projectConfig, useRenv: checked })}
+					/>
+					<ExternalLink
+						openerService={newProjectWizardState.openerService}
+						href='https://rstudio.github.io/renv/articles/renv.html'
+						title='https://rstudio.github.io/renv/articles/renv.html'
+					>
+						<div className='codicon codicon-link-external' />
+					</ExternalLink>
+				</div>
 			</PositronWizardSubStep>
 		</PositronWizardStep>
 	);

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -20,6 +20,7 @@ import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { IFileService } from 'vs/platform/files/common/files';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ILogService } from 'vs/platform/log/common/log';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
 
 /**
  * Shows the NewProjectModalDialog.
@@ -32,6 +33,7 @@ export const showNewProjectModalDialog = async (
 	languageRuntimeService: ILanguageRuntimeService,
 	layoutService: IWorkbenchLayoutService,
 	logService: ILogService,
+	openerService: IOpenerService,
 	pathService: IPathService,
 	runtimeSessionService: IRuntimeSessionService,
 	runtimeStartupService: IRuntimeStartupService,
@@ -53,6 +55,7 @@ export const showNewProjectModalDialog = async (
 				languageRuntimeService,
 				layoutService,
 				logService,
+				openerService,
 				pathService,
 				runtimeSessionService,
 				runtimeStartupService,

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.tsx
@@ -11,6 +11,7 @@ import { EnvironmentSetupType, NewProjectType, NewProjectWizardStep, PythonEnvir
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ILogService } from 'vs/platform/log/common/log';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { IFileService } from 'vs/platform/files/common/files';
 
@@ -25,6 +26,7 @@ interface NewProjectWizardServices {
 	languageRuntimeService: ILanguageRuntimeService;
 	layoutService: IWorkbenchLayoutService;
 	logService: ILogService;
+	openerService: IOpenerService;
 	pathService: IPathService;
 	runtimeSessionService: IRuntimeSessionService;
 	runtimeStartupService: IRuntimeStartupService;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

- More UI work for #2110 

Add an external link icon to `renv` documentation in the project wizard.

<img width="379" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/c779b41f-4cfa-4ce8-8731-8f630f2f7327">

https://github.com/posit-dev/positron/assets/25834218/a8551d38-6468-4c5e-86dc-96f03ba4bfcc

### Approach

- allow `ExternalLink` to include `props.children`
- add external link to renv documentation

### QA Notes

- Clicking the link shouldn't check/uncheck the checkbox
- The link opens in a separate web browser
