### PR TITLE
Test parsing and running upgrades

### DIFF
--- a/build/filters.js
+++ b/build/filters.js
@@ -152,6 +152,7 @@ module.exports.indentationFilter = [
 	// --- Start Positron ---
 	'!**/amalthea/**/*',
 	'!extensions/positron-r/resources/scripts/*.R',
+	'!extensions/positron-r/resources/testing/**',
 	'!scripts/positron/**/*',
 	// --- End Positron ---
 ];
@@ -196,6 +197,7 @@ module.exports.copyrightFilter = [
 
 	// --- Start Positron ---
 	'!**/amalthea/**/*',
+	'!extensions/positron-r/resources/testing/**',
 	// --- End Positron ---
 ];
 

--- a/extensions/positron-r/positron.json
+++ b/extensions/positron-r/positron.json
@@ -17,6 +17,10 @@
 			"to": "resources/testing"
 		},
 		{
+			"from": "resources/testing/*.scm",
+			"to": "resources/testing"
+		},
+		{
 			"from": "resources/testing/vscodereporter/*",
 			"to": "resources/testing"
 		},

--- a/extensions/positron-r/resources/testing/describe.scm
+++ b/extensions/positron-r/resources/testing/describe.scm
@@ -1,6 +1,10 @@
 (call
 	function: [
 		(identifier) @parent_function
+        (namespace_operator
+			lhs: (identifier)
+            rhs: (identifier) @parent_function
+        )
 	] (#eq? @parent_function "describe")
 	arguments: (arguments
 		(argument
@@ -11,6 +15,10 @@
 				body: (call
 					function: [
 						(identifier) @function
+                        (namespace_operator
+							lhs: (identifier)
+							rhs: (identifier) @function
+						)
 					] (#eq? @function "it")
 					arguments: (arguments
 						(argument

--- a/extensions/positron-r/resources/testing/describe.scm
+++ b/extensions/positron-r/resources/testing/describe.scm
@@ -1,24 +1,24 @@
 (call
 	function: [
-		(identifier) @_superfunction.name
-	] (#eq? @_superfunction.name "describe")
+		(identifier) @parent_function
+	] (#eq? @parent_function "describe")
 	arguments: (arguments
 		(argument
-			value: (string) @superlabel
+			value: (string) @parent_desc
 		)
 		(argument
 			value: (braced_expression
 				body: (call
 					function: [
-						(identifier) @_function.name
-					] (#eq? @_function.name "it")
+						(identifier) @function
+					] (#eq? @function "it")
 					arguments: (arguments
 						(argument
-							value: (string) @label
+							value: (string) @desc
 						)
 					)
 				) @call
 			)
 		)
 	)
-) @supercall
+) @parent_call

--- a/extensions/positron-r/resources/testing/describe.scm
+++ b/extensions/positron-r/resources/testing/describe.scm
@@ -1,10 +1,10 @@
 (call
 	function: [
 		(identifier) @parent_function
-        (namespace_operator
+		(namespace_operator
 			lhs: (identifier)
-            rhs: (identifier) @parent_function
-        )
+			rhs: (identifier) @parent_function
+		)
 	] (#eq? @parent_function "describe")
 	arguments: (arguments
 		(argument
@@ -15,7 +15,7 @@
 				body: (call
 					function: [
 						(identifier) @function
-                        (namespace_operator
+						(namespace_operator
 							lhs: (identifier)
 							rhs: (identifier) @function
 						)

--- a/extensions/positron-r/resources/testing/describe.scm
+++ b/extensions/positron-r/resources/testing/describe.scm
@@ -1,0 +1,24 @@
+(call
+	function: [
+		(identifier) @_superfunction.name
+	] (#eq? @_superfunction.name "describe")
+	arguments: (arguments
+		(argument
+			value: (string) @superlabel
+		)
+		(argument
+			value: (braced_expression
+				body: (call
+					function: [
+						(identifier) @_function.name
+					] (#eq? @_function.name "it")
+					arguments: (arguments
+						(argument
+							value: (string) @label
+						)
+					)
+				) @call
+			)
+		)
+	)
+) @supercall

--- a/extensions/positron-r/resources/testing/test_that.scm
+++ b/extensions/positron-r/resources/testing/test_that.scm
@@ -1,6 +1,10 @@
 (call
 	function: [
 		(identifier) @function
+        (namespace_operator
+        	lhs: (identifier)
+            rhs: (identifier) @function
+        )
 	] (#eq? @function "test_that")
 	arguments: (arguments
 		(argument

--- a/extensions/positron-r/resources/testing/test_that.scm
+++ b/extensions/positron-r/resources/testing/test_that.scm
@@ -1,10 +1,10 @@
 (call
 	function: [
 		(identifier) @function
-        (namespace_operator
+		(namespace_operator
 			lhs: (identifier)
-            rhs: (identifier) @function
-        )
+			rhs: (identifier) @function
+		)
 	] (#eq? @function "test_that")
 	arguments: (arguments
 		(argument

--- a/extensions/positron-r/resources/testing/test_that.scm
+++ b/extensions/positron-r/resources/testing/test_that.scm
@@ -1,10 +1,10 @@
 (call
 	function: [
-		(identifier) @_function.name
-	] (#eq? @_function.name "test_that")
+		(identifier) @function
+	] (#eq? @function "test_that")
 	arguments: (arguments
 		(argument
-			 value: (string) @label
+			 value: (string) @desc
 		)
 	)
 ) @call

--- a/extensions/positron-r/resources/testing/test_that.scm
+++ b/extensions/positron-r/resources/testing/test_that.scm
@@ -1,0 +1,10 @@
+(call
+	function: [
+		(identifier) @_function.name
+	] (#eq? @_function.name "test_that")
+	arguments: (arguments
+		(argument
+			 value: (string) @label
+		)
+	)
+) @call

--- a/extensions/positron-r/resources/testing/test_that.scm
+++ b/extensions/positron-r/resources/testing/test_that.scm
@@ -2,13 +2,13 @@
 	function: [
 		(identifier) @function
         (namespace_operator
-        	lhs: (identifier)
+			lhs: (identifier)
             rhs: (identifier) @function
         )
 	] (#eq? @function "test_that")
 	arguments: (arguments
 		(argument
-			 value: (string) @desc
+			value: (string) @desc
 		)
 	)
 ) @call

--- a/extensions/positron-r/src/testing/parser.ts
+++ b/extensions/positron-r/src/testing/parser.ts
@@ -210,7 +210,7 @@ async function getMatchesForQuery(
 	return matches;
 }
 
-const toVSCodePosition = (pos: any) => new vscode.Position(pos.row, pos.column);
+const toVSCodePosition = (pos: Parser.Point) => new vscode.Position(pos.row, pos.column);
 
 function processCapture(
 	captureFunction: Parser.QueryCapture,

--- a/extensions/positron-r/src/testing/parser.ts
+++ b/extensions/positron-r/src/testing/parser.ts
@@ -125,6 +125,14 @@ interface Match {
 
 	/** Where the matched call ends in the test file. */
 	endPos: vscode.Position;
+
+	/**
+	 * Is this a top-level call in the testthat file? Only top-level tests can be run individually.
+	 * This is really about making sure we can distinguish a top-level `describe()` (runnable) from
+	 * a `describe()` that's nested inside another `describe()` call (only runnable as part of its
+	 * enclosing `describe()` or test file).
+	 */
+	topLevel: boolean | null;
 }
 
 
@@ -135,7 +143,7 @@ interface Match {
 interface TestMatch {
 	/** Data for the call itself. */
 	match: Match;
-	/** Data for the parent `describe()` call. Only applies to an `it()` call. */
+	/** Data for the parent `describe()` call. Only applies to `describe()` and `it()` calls. */
 	parentMatch?: Match;
 }
 
@@ -184,6 +192,7 @@ function processCapture(
 		// we start at 1 and end at (length - 1) because we don't want the surrounding quotes
 		desc: captureDesc.node.text.substring(1, captureDesc.node.text.length - 1),
 		startPos: toVSCodePosition(captureCall.node.startPosition),
-		endPos: toVSCodePosition(captureCall.node.endPosition)
+		endPos: toVSCodePosition(captureCall.node.endPosition),
+		topLevel: captureCall.node.parent && captureCall.node.parent.type === 'program'
 	};
 }

--- a/extensions/positron-r/src/testing/parser.ts
+++ b/extensions/positron-r/src/testing/parser.ts
@@ -122,29 +122,40 @@ async function findTests(uri: vscode.Uri) {
 		queryPath = path.join(EXTENSION_ROOT_DIR, 'resources', 'testing', 'describe.scm');
 		queryContent = await vscode.workspace.fs.readFile(vscode.Uri.file(queryPath));
 		query = R!.query(queryContent.toString());
-
 		raw_matches = query.matches(tree.rootNode);
 
 		for (const match of raw_matches) {
 			if (match === undefined) {
 				continue;
 			}
-			matches.push({
-				testSuperLabel: match.captures[2].node.text.substring(
-					1,
-					match.captures[2].node.text.length - 1
-				),
-				testSuperStartPosition: toVSCodePosition(
-					match.captures[0].node.startPosition
-				),
-				testSuperEndPosition: toVSCodePosition(match.captures[0].node.endPosition),
-				testLabel: match.captures[5].node.text.substring(
-					1,
-					match.captures[5].node.text.length - 1
-				),
-				testStartPosition: toVSCodePosition(match.captures[3].node.startPosition),
-				testEndPosition: toVSCodePosition(match.captures[3].node.endPosition),
-			});
+
+			const testSuperFunctionCapture = match.captures.find(capture => capture.name === '_superfunction.name');
+			const testSuperLabelCapture = match.captures.find(capture => capture.name === 'superlabel');
+			const testSuperCallCapture = match.captures.find(capture => capture.name === 'supercall');
+			const testFunctionCapture = match.captures.find(capture => capture.name === '_function.name');
+			const testLabelCapture = match.captures.find(capture => capture.name === 'label');
+			const testCallCapture = match.captures.find(capture => capture.name === 'call');
+
+			if (testSuperFunctionCapture && testSuperLabelCapture && testSuperCallCapture &&
+				testFunctionCapture && testLabelCapture && testCallCapture) {
+				matches.push({
+					testSuperFunction: testSuperFunctionCapture.node.text,
+					testSuperLabel: testSuperLabelCapture.node.text.substring(
+						1,
+						testSuperLabelCapture.node.text.length - 1
+					),
+					testSuperStartPosition: toVSCodePosition(testSuperCallCapture.node.startPosition),
+					testSuperEndPosition: toVSCodePosition(testSuperCallCapture.node.endPosition),
+
+					testFunction: testFunctionCapture.node.text,
+					testLabel: testLabelCapture.node.text.substring(
+						1,
+						testLabelCapture.node.text.length - 1
+					),
+					testStartPosition: toVSCodePosition(testCallCapture.node.startPosition),
+					testEndPosition: toVSCodePosition(testCallCapture.node.endPosition)
+				});
+			}
 		}
 
 		return matches;

--- a/extensions/positron-r/src/testing/parser.ts
+++ b/extensions/positron-r/src/testing/parser.ts
@@ -167,10 +167,7 @@ async function getMatchesForQuery(
 	const document = await vscode.workspace.openTextDocument(uri);
 	const query = R!.query(queryString);
 	const tree = parser!.parse(document.getText());
-	return getTestMatches(query, tree);
-}
 
-function getTestMatches(query: Parser.Query, tree: Parser.Tree): TestMatch[] {
 	const raw_matches = query.matches(tree.rootNode);
 	const matches: TestMatch[] = [];
 
@@ -188,12 +185,22 @@ function getTestMatches(query: Parser.Query, tree: Parser.Tree): TestMatch[] {
 				match: processCapture(testFunctionCapture, testDescCapture, testCallCapture)
 			};
 
-			const testParentFunctionCapture = match.captures.find(capture => capture.name === 'parent_function');
-			const testParentDescCapture = match.captures.find(capture => capture.name === 'parent_desc');
-			const testParentCallCapture = match.captures.find(capture => capture.name === 'parent_call');
+			const testParentFunctionCapture = match.captures.find(
+				capture => capture.name === 'parent_function'
+			);
+			const testParentDescCapture = match.captures.find(
+				capture => capture.name === 'parent_desc'
+			);
+			const testParentCallCapture = match.captures.find(
+				capture => capture.name === 'parent_call'
+			);
 
 			if (testParentFunctionCapture && testParentDescCapture && testParentCallCapture) {
-				tm.parentMatch = processCapture(testParentFunctionCapture, testParentDescCapture, testParentCallCapture);
+				tm.parentMatch = processCapture(
+					testParentFunctionCapture,
+					testParentDescCapture,
+					testParentCallCapture
+				);
 			}
 
 			matches.push(tm);

--- a/extensions/positron-r/src/testing/parser.ts
+++ b/extensions/positron-r/src/testing/parser.ts
@@ -102,12 +102,13 @@ async function findTests(uri: vscode.Uri) {
 				continue;
 			}
 
-			//const testFunctionCapture = match.captures.find(capture => capture.name === '_function.name');
+			const testFunctionCapture = match.captures.find(capture => capture.name === '_function.name');
 			const testLabelCapture = match.captures.find(capture => capture.name === 'label');
 			const testCallCapture = match.captures.find(capture => capture.name === 'call');
 
-			if (testLabelCapture && testCallCapture) {
+			if (testFunctionCapture && testLabelCapture && testCallCapture) {
 				matches.push({
+					testFunction: testFunctionCapture.node.text,
 					testLabel: testLabelCapture.node.text.substring(
 						1,
 						testLabelCapture.node.text.length - 1

--- a/extensions/positron-r/src/testing/reporter.d.ts
+++ b/extensions/positron-r/src/testing/reporter.d.ts
@@ -15,6 +15,10 @@ export interface TestResult {
 	 */
 	filename?: string;
 	/**
+	 * Location relevant to the result, e.g. test-thingy.R:3:3
+	 */
+	location?: string;
+	/**
 	 * Test label if available
 	 */
 	test?: string;

--- a/extensions/positron-r/src/testing/runner-testthat.ts
+++ b/extensions/positron-r/src/testing/runner-testthat.ts
@@ -86,7 +86,8 @@ export async function runThatTest(
 	testPath = testPath.replace(/\\/g, '/');
 
 	const devtoolsMethod = testType === ItemType.Directory ? 'test' : 'test_active_file';
-	const descInsert = isSingleTest ? ` desc = '${test?.label || '<all tests>'}', ` : '';
+	const escapedLabel = test?.label.replace(/(['"`])/g, '\\$1');
+	const descInsert = isSingleTest ? ` desc = '${escapedLabel || '<all tests>'}', ` : '';
 	const devtoolsCall =
 		`devtools::load_all('${testReporterPath}');` +
 		`devtools::${devtoolsMethod}('${testPath}',` +

--- a/extensions/positron-r/src/testing/runner-testthat.ts
+++ b/extensions/positron-r/src/testing/runner-testthat.ts
@@ -190,7 +190,16 @@ export async function runThatTest(
 								case 'skip':
 									run.skipped(testItem!);
 									if (data.message) {
-										run.appendOutput(data.message, undefined, testItem);
+										// Currently skip messages leak out to the TEST RESULTS
+										// area, which is presumably not the long-term plan for
+										// how we want to use that space.
+										// But in the meantime, let's at least break lines.
+										// appendOutput method is documented to need CRLF not LF.
+										run.appendOutput(
+											data.message + ': ' + data.location + '\r\n',
+											undefined,
+											testItem
+										);
 									}
 									break;
 								case 'error':

--- a/extensions/positron-r/src/testing/runner-testthat.ts
+++ b/extensions/positron-r/src/testing/runner-testthat.ts
@@ -59,7 +59,7 @@ export async function runThatTest(
 		case ItemType.Describe: {
 			const testthatInstalled = await checkInstalled('testthat', '3.2.1');
 			if (!testthatInstalled) {
-				return Promise.resolve('testthat >= 3.2.1 is needed to run R a single describe() test.');
+				return Promise.resolve('testthat >= 3.2.1 is needed to run a single describe() test.');
 			}
 			LOGGER.info('Single describe() test');
 			break;

--- a/extensions/positron-r/src/testing/runner.ts
+++ b/extensions/positron-r/src/testing/runner.ts
@@ -69,7 +69,7 @@ export async function runHandler(
 				LOGGER.info(`Running test with label "${test!.label}"`);
 			}
 			const stdout = await runThatTest(testingTools, run, test);
-			LOGGER.debug(`Test output:\n${stdout}`);
+			LOGGER.info(`Test output:\n${stdout}`);
 		} catch (error) {
 			LOGGER.error(`Run errored with reason: "${error}"`);
 			if (test) {


### PR DESCRIPTION
### Intent

* Addresses #2639
* Addresses #2634 
* Improves output for skipped tests (addresses https://github.com/posit-dev/positron/issues/1808#issuecomment-1861241962)
* (No issue for this but actually the most important bit ...) externalizes the tree-sitter queries used to identify test items and load up the test controller.
  - In combination with https://github.com/DavisVaughan/r-tree-sitter, this paves the way for bringing these queries under test. I.e. I hope to test these against various test files in the R package.
  - Also lays the foundation for possible extensibility, i.e. being able to work with `test_that()`-like functions exported by packages other than testthat or internal helpers for a specific package.

### QA Notes

In a workspace that is an R package, click on the flask in the activity bar to activate the test explorer. If the package has testthat tests, the relevant test files will appear in a tree view, for navigation, execution, and display of test results.

I have put up a toy R package that can be used to exercise the bug fixes and features in this PR: https://github.com/jennybc/testfun. I would install this with `pak::pak("jennybc/testfun")`. Another good option is `remotes::install_github("jennybc/testfun")`.

#### More intelligent handling of quotes inside test desc in R test explorer #2639

Run the entire test suite or just the file `test-banana.R` or just the individual test ``'subtraction `still` "works"'``. You can use the ▶️  button in the test explorer tree view or the ▶️  button in the gutter of test file to run a test item (file or test) or the double ▶️  button at the top of the explorer to run all tests.

The test ``'subtraction `still` "works"'`` (and any other tests that have vexing quotes in the description) should run and pass.

#### Provide more support for describe() tests in the test explorer #2634

Use the test explorer to navigate to `test-mathstuff.R` and use the expando to reveal all the tests. Clear all test results from the menu accessed via the `...` in the upper right corner of the TEST tree view. Here is the expected behaviour:

* Running the single `describe("matrix()", { ... })` should work: it should run, there should be green checks for both of its `it()`s and for the `describe()` itself. No _other_ test items in this file should appear as being run; they should still have the grey circle.
* The single `describe("addition()", { ... })` should work _if you run it from the gutter_. A `describe()` with exactly 1 `it()` cannot be run from the explorer's treeview (VS Code tries to run just the child `it()`) and I'm still analyzing whether this is our problem or a bug in VS Code. This is a known issue; see #2805.
* The nested `describe()`s and the enclosing `describe("top-level describe with describe inside", { ... })` cannot be run individually and this is a known issue. For now, such a structure can only be run when the entire file is run. See #2805.

#### Improved output for skipped tests https://github.com/posit-dev/positron/issues/1808#issuecomment-1861241962

Run the single test file `test-apple-wtf.R`. The messages appearing in the TEST OUTPUT tab of the lower panel should appear one to a line and include the test file location where the skip originated.

Good:
```
Reason: I am a skip message: test-apple-wtf.R:2:3
Reason: I am also a skip message: test-apple-wtf.R:9:3
```

Bad:
```
Reason: I am a skip messageReason: I am also a skip message
```