### PR TITLE
Don't let console steal focus from the user

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -37,6 +37,10 @@ import { EmptyHistoryMatchStrategy, HistoryMatch, HistoryMatchStrategy } from 'v
 import { HistoryPrefixMatchStrategy } from 'vs/workbench/contrib/positronConsole/common/historyPrefixMatchStrategy';
 import { HistoryInfixMatchStrategy } from 'vs/workbench/contrib/positronConsole/common/historyInfixMatchStrategy';
 import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditor/codeEditorWidget';
+import { getActiveElement } from 'vs/base/browser/dom';
+import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
+import { InQuickPickContextKey } from 'vs/workbench/browser/quickaccess';
+import { TerminalContextKeys } from 'vs/workbench/contrib/terminal/common/terminalContextKey';
 
 // Position enumeration.
 const enum Position {
@@ -675,7 +679,17 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 						// https://github.com/posit-dev/positron/issues/2802
 						// Only take focus if there is no focused editor to avoid stealing
 						// focus when the user could be actively working in an editor
-						if (!positronConsoleContext.codeEditorService.getFocusedCodeEditor()) {
+
+						const ctxt = positronConsoleContext.contextKeyService.getContext(getActiveElement());
+
+						// Sensitive to all editor contexts, simple (e.g. git commit textbox) or not (e.g. code editor)
+						const inTextInput = ctxt.getValue(EditorContextKeys.textInputFocus.key);
+						// Sensitive to all quick pick contexts, e.g. the commande palette or the file picker						const inQuickPick = positronConsoleContext.contextKeyService.getContextKeyValue(InQuickPickContextKey.key);
+						const inQuickPick = ctxt.getValue(InQuickPickContextKey.key);
+						// Sensitive to terminal focus
+						const inTerminal = ctxt.getValue(TerminalContextKeys.focus.key);
+
+						if (!inTextInput && !inQuickPick && !inTerminal) {
 							codeEditorWidget.focus();
 						}
 					}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -672,7 +672,12 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			positronConsoleContext.positronConsoleService.onDidChangeActivePositronConsoleInstance(
 				positronConsoleInstance => {
 					if (positronConsoleInstance === props.positronConsoleInstance) {
-						codeEditorWidget.focus();
+						// https://github.com/posit-dev/positron/issues/2802
+						// Only take focus if there is no focused editor to avoid stealing
+						// focus when the user could be actively working in an editor
+						if (!positronConsoleContext.codeEditorService.getFocusedCodeEditor()) {
+							codeEditorWidget.focus();
+						}
 					}
 				}
 			)
@@ -680,6 +685,8 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 
 		// Add the onFocusInput event handler.
 		disposableStore.add(props.positronConsoleInstance.onFocusInput(() => {
+			// Focus the input editor when the Console takes focus, i.e. when the
+			// user clicks somewhere on the console output
 			codeEditorWidget.focus();
 		}));
 
@@ -776,9 +783,6 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				codeEditorWidget.render(true);
 			})
 		);
-
-		// Focus the console.
-		codeEditorWidget.focus();
 
 		// Return the cleanup function that will dispose of the disposables.
 		return () => disposableStore.dispose();

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
@@ -20,7 +20,7 @@ import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/
 import { IPositronConsoleInstance, IPositronConsoleService } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
-import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 /**
  * PositronConsoleServices interface. Defines the set of services that are required by the Positron
@@ -42,7 +42,7 @@ export interface PositronConsoleServices extends PositronActionBarServices {
 	readonly positronPlotsService: IPositronPlotsService;
 	readonly viewsService: IViewsService;
 	readonly workbenchLayoutService: IWorkbenchLayoutService;
-	readonly codeEditorService: ICodeEditorService;
+	readonly contextKeyService: IContextKeyService;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
@@ -20,6 +20,7 @@ import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/
 import { IPositronConsoleInstance, IPositronConsoleService } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
+import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 
 /**
  * PositronConsoleServices interface. Defines the set of services that are required by the Positron
@@ -41,6 +42,7 @@ export interface PositronConsoleServices extends PositronActionBarServices {
 	readonly positronPlotsService: IPositronPlotsService;
 	readonly viewsService: IViewsService;
 	readonly workbenchLayoutService: IWorkbenchLayoutService;
+	readonly codeEditorService: ICodeEditorService;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -33,7 +33,6 @@ import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
-import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 
 /**
  * PositronConsoleViewPane class.
@@ -204,8 +203,7 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 		@IThemeService themeService: IThemeService,
 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
 		@IViewsService private readonly viewsService: IViewsService,
-		@IWorkbenchLayoutService private readonly workbenchLayoutService: IWorkbenchLayoutService,
-		@ICodeEditorService private readonly codeEditorService: ICodeEditorService
+		@IWorkbenchLayoutService private readonly workbenchLayoutService: IWorkbenchLayoutService
 	) {
 		super(
 			options,
@@ -287,7 +285,6 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 				positronPlotsService={this.positronPlotsService}
 				viewsService={this.viewsService}
 				workbenchLayoutService={this.workbenchLayoutService}
-				codeEditorService={this.codeEditorService}
 				reactComponentContainer={this}
 			/>
 		);

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -33,6 +33,7 @@ import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
+import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 
 /**
  * PositronConsoleViewPane class.
@@ -203,7 +204,8 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 		@IThemeService themeService: IThemeService,
 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
 		@IViewsService private readonly viewsService: IViewsService,
-		@IWorkbenchLayoutService private readonly workbenchLayoutService: IWorkbenchLayoutService
+		@IWorkbenchLayoutService private readonly workbenchLayoutService: IWorkbenchLayoutService,
+		@ICodeEditorService private readonly codeEditorService: ICodeEditorService
 	) {
 		super(
 			options,
@@ -285,6 +287,7 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 				positronPlotsService={this.positronPlotsService}
 				viewsService={this.viewsService}
 				workbenchLayoutService={this.workbenchLayoutService}
+				codeEditorService={this.codeEditorService}
 				reactComponentContainer={this}
 			/>
 		);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Don't let the console steal focus from the user if they may be actively working in a code editor.
Addresses https://github.com/posit-dev/positron/issues/2802

### Approach

Check that no editor are focused before taking focus. This way we don't take focus if an editor has focus, but we still take it when there is no editor opened or when another widget, such as the runtime launcher, has focus:

https://github.com/posit-dev/positron/assets/4465050/8ae14449-932d-4b3d-b62c-1b7ee7623154

https://github.com/posit-dev/positron/assets/4465050/1e17cc3b-fbdf-43a6-b2fe-359eda944625


### QA Notes

See screencasts for expected behaviour.
