### PR TITLE
Scroll console to bottom after restart and viewpane size change

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -4,7 +4,7 @@
 
 import 'vs/css!./consoleInstance';
 import * as React from 'react';
-import { KeyboardEvent, MouseEvent, UIEvent, useCallback, useEffect, useLayoutEffect, useRef, useState, WheelEvent } from 'react'; // eslint-disable-line no-duplicate-imports
+import { KeyboardEvent, MouseEvent, UIEvent, useEffect, useLayoutEffect, useRef, useState, WheelEvent } from 'react'; // eslint-disable-line no-duplicate-imports
 import * as nls from 'vs/nls';
 import * as DOM from 'vs/base/browser/dom';
 import { generateUuid } from 'vs/base/common/uuid';
@@ -113,11 +113,11 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 		consoleInstanceRef.current.scrollHeight > consoleInstanceRef.current.clientHeight;
 
 	// Scrolls to the bottom.
-	const scrollToBottom = useCallback(() => {
+	const scrollToBottom = () => {
 		setScrollLock(false);
 		setIgnoreNextScrollEvent(true);
 		scrollVertically(consoleInstanceRef.current.scrollHeight);
-	}, [setIgnoreNextScrollEvent, setScrollLock]);
+	};
 
 	// Scrolls the console vertically.
 	const scrollVertically = (y: number) => {
@@ -292,8 +292,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			if (state === PositronConsoleState.Starting) {
 				// Scroll to bottom when restarting
 				// https://github.com/posit-dev/positron/issues/2807
-				// scrollToBottom();
-				scrollVertically(consoleInstanceRef.current.scrollHeight);
+				scrollToBottom();
 			}
 		}));
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -317,6 +317,12 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			scrollToBottom();
 		}));
 
+		disposableStore.add(props.reactComponentContainer.onSizeChanged(_ => {
+			if (!scrollLockRef.current) {
+				scrollToBottom();
+			}
+		}));
+
 		// Add the onDidSelectPlot event handler.
 		disposableStore.add(props.positronConsoleInstance.onDidSelectPlot(plotId => {
 			// Ensure that the Plots pane is visible.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -44,7 +44,7 @@ import { RuntimeItemReconnected } from 'vs/workbench/services/positronConsole/br
 import { RuntimeStartupFailure } from 'vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure';
 import { RuntimeItemPendingInput } from 'vs/workbench/services/positronConsole/browser/classes/runtimeItemPendingInput';
 import { RuntimeItemRestartButton } from 'vs/workbench/services/positronConsole/browser/classes/runtimeItemRestartButton';
-import { IPositronConsoleInstance } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
+import { IPositronConsoleInstance, PositronConsoleState } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
 import { RuntimeItemStartupFailure } from 'vs/workbench/services/positronConsole/browser/classes/runtimeItemStartupFailure';
 import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_CUT, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
 
@@ -272,6 +272,11 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 
 		// Add the onDidChangeState event handler.
 		disposableStore.add(props.positronConsoleInstance.onDidChangeState(state => {
+			if (state === PositronConsoleState.Starting) {
+				// Scroll to bottom when restarting
+				// https://github.com/posit-dev/positron/issues/2807
+				scrollVertically(consoleInstanceRef.current.scrollHeight);
+			}
 		}));
 
 		// Add the onDidChangeTrace event handler.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

# Scroll to bottom after restart

Addresses https://github.com/posit-dev/positron/issues/1179
Addresses https://github.com/posit-dev/positron/issues/2807

### Intent

Currently restarting a console breaks autoscroll. The PR fixes that.

https://github.com/posit-dev/positron/assets/4465050/058df0e1-8491-413c-949f-7f2d2857f629


### Approach

We now scroll to bottom each time the console is restarted. This fixes the broken autoscroll and this also means that if the user intentionally scrolled the console up, we now scroll to bottom after they do the action of restarting. I think this improves workflow because if the user intentionally restarts, chances are it's to do something in the console right away.



https://github.com/posit-dev/positron/assets/4465050/8113f1e2-f169-4235-be5c-00ecf1e7fd42


### QA Notes


# Scroll to bottom on size changed when scroll-lock is disabled

Addresses #1384
Addresses #2119

The size-changed event is called when the console height is changed and when the font size is changed. If we are not in scroll-lock mode, we scroll to the bottom to preserve auto-scroll.