### PR TITLE
Set `LD_LIBRARY_PATH` in Ark environment on Linux

### DIFF
--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -667,6 +667,12 @@ export function createJupyterKernelSpec(
 	};
 	/* eslint-enable */
 
+	if (process.platform === 'linux') {
+		// Workaround for
+		// https://github.com/posit-dev/positron/issues/1619#issuecomment-1971552522
+		env['LD_LIBRARY_PATH'] = rHomePath + '/lib';
+	}
+
 	// Inject the path to the Pandoc executable into the environment; R packages
 	// that use Pandoc for rendering will need this.
 	//


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Progress towards https://github.com/posit-dev/positron/issues/1619.

Since https://github.com/posit-dev/amalthea/pull/205, we link to R dynamically. We thought a great side benefit of this would be to make Ark fully self contained while able to select which R to link to by itself. However it turns out that that the .so libraries of R packages still need to be able to link to some `libR.so` file at load-time (even though we've opened it dynamically already and exposed its symbols to all subsequently loaded plugins, which means there is no actual need to link to it again). If the libraries are linked against libR with a relative rather than absolute path, as is typical on Linux, and if the default locations for linkage do not contain a libR.so file, then loading a package .so library fails.

### Approach

Set `LD_LIBRARY_PATH` to `$R_HOME/lib` so the linker is able to open a `libR.so` file. This will not be used at all for symbol resolution but it allows loading a package without error on Linux.

### QA Notes

We're not closing the linked issue yet as there are more problems, in particular with RPM-based distributions, but with this change we should support Ubuntu 22 and hopefully Debian.