### PR TITLE
Connections pane disconnected state

### DIFF
--- a/extensions/positron-connections/package.json
+++ b/extensions/positron-connections/package.json
@@ -58,9 +58,34 @@
         "command": "positron.connections.refresh",
         "title": "%commands.refresh.title%",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "positron.connections.removeFromHistory",
+        "title": "%commands.removeFromHistory.title%",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "positron.connections.reopenConnection",
+        "title": "%commands.reopenConnection.title%",
+        "icon": "$(open-preview)"
+      },
+      {
+        "command": "positron.connections.copyCodeToClipboard",
+        "title": "%commands.copyCodeToClipboard.title%",
+        "icon": "$(clippy)"
+      },
+      {
+        "command": "positron.connections.clearConnectionsHistory",
+        "title": "%commands.clearConnectionsHistory.title%",
+        "icon": "$(clear-all)"
       }
     ],
     "menus": {
+      "view/title": [
+        {
+          "command": "positron.connections.clearConnectionsHistory"
+        }
+      ],
       "view/item/context": [
         {
           "command": "positron.connections.closeConnection",
@@ -76,6 +101,27 @@
           "command": "positron.connections.refresh",
           "group": "inline",
           "when": "viewItem == database"
+        },
+        {
+          "command": "positron.connections.removeFromHistory",
+          "group": "inline",
+          "when": "viewItem =~ /disconnected/"
+        },
+        {
+          "command": "positron.connections.reopenConnection",
+          "group": "inline",
+          "when": "viewItem =~ /disconnected-hasCode/"
+        },
+        {
+          "command": "positron.connections.reopenConnection",
+          "group": "code",
+          "when": "viewItem =~ /disconnected-hasCode/",
+          "contextualTitle": "Connect to database"
+        },
+        {
+          "command": "positron.connections.copyCodeToClipboard",
+          "when": "viewItem =~ /disconnected-hasCode/",
+          "group": "code"
         }
       ]
     }

--- a/extensions/positron-connections/package.nls.json
+++ b/extensions/positron-connections/package.nls.json
@@ -6,5 +6,9 @@
 	"commands.previewTable.title": "Preview Table",
 	"commands.previewTable.category": "Connections",
 	"commands.closeConnection.title": "Close Connection",
-	"commands.refresh.title": "Refresh connection"
+	"commands.refresh.title": "Refresh connection",
+	"commands.removeFromHistory.title": "Remove connection from history",
+	"commands.reopenConnection.title": "Execute connection code in the console",
+	"commands.copyCodeToClipboard.title": "Copy connection code to clipboard",
+	"commands.clearConnectionsHistory.title": "Clear connections history"
 }

--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -5,7 +5,8 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import path = require('path');
-import { PositronConnectionsComm } from './comms/ConnectionsComms';
+import fs = require('fs');
+import { PositronConnectionsComm, ObjectSchema, FieldSchema } from './comms/ConnectionsComms';
 
 /**
  * Enumerates the possible types of connection icons
@@ -19,6 +20,20 @@ enum ConnectionIcon {
 	Field = 'field',
 }
 
+enum ConnectionState {
+	Active = 'active',
+	Disconnected = 'disconnected',
+}
+
+interface ConnectionMetadata {
+	name: string;
+	language_id: string;
+	host?: string;
+	type?: string;
+	code?: string;
+	icon?: string; // base64 encoded icon image (if available)
+}
+
 /**
  * Base class for connection items.
  */
@@ -30,42 +45,50 @@ export class ConnectionItem {
 	 * @param client A reference to the client instance (comm) that owns the item
 	 */
 
-	constructor(
-		readonly name: string,
-		readonly client: PositronConnectionsComm) {
-	}
+	constructor(readonly name: string, readonly state: ConnectionState) { }
+}
 
-	async contains_data(): Promise<boolean> {
-		return false;
+export function isDisconnectedConnectionItem(
+	item: ConnectionItem
+): item is DisconnectedConnectionItem {
+	return item instanceof DisconnectedConnectionItem;
+}
+
+export class DisconnectedConnectionItem extends ConnectionItem {
+	constructor(readonly metadata: ConnectionMetadata) {
+		super(metadata.name, ConnectionState.Disconnected);
+	}
+	async icon() {
+		if (this.metadata.icon) {
+			return this.metadata.icon;
+		}
+		// we return an empty string to be consistent with what the active connections return
+		return '';
 	}
 }
 
-/**
- * A connection item representing a node in the tree objects allowed in
- * the database connection.
- *
- * @param kind The kind of the node (e.g. 'schema', 'table', etc.)
- * @param path The path to the node. This is represented as a list of tuples (name, type). Later,
- *   we can use the path to get the node children by doing something like
- * 	 `getChildren(schema='hello', table='world')`
- */
-export class ConnectionItemNode extends ConnectionItem {
-	readonly kind: string;
-	readonly path: Array<{ name: string; kind: string }>;
-	private _contains_data?: boolean;
+export function isActiveConnectionItem(
+	item: ConnectionItem
+): item is ActiveConnectionItem {
+	return item instanceof ActiveConnectionItem;
+}
 
-	constructor(readonly name: string, kind: string, path: Array<{ name: string; kind: string }>, client: PositronConnectionsComm) {
-		super(name, client);
-		this.kind = kind;
-		this.path = path;
+export class ActiveConnectionItem extends ConnectionItem {
+	constructor(
+		readonly name: string,
+		readonly kind: string,
+		readonly path: Array<ObjectSchema>,
+		readonly client: PositronConnectionsComm
+	) {
+		super(name, ConnectionState.Active);
+	}
+
+	async contains_data(): Promise<boolean> {
+		return await this.client.containsData(this.path);
 	}
 
 	async icon() {
 		return await this.client.getIcon(this.path);
-	}
-
-	override async contains_data() {
-		return await this.client.containsData(this.path);
 	}
 
 	async preview() {
@@ -77,40 +100,80 @@ export class ConnectionItemNode extends ConnectionItem {
 
 		await this.client.previewObject(this.path);
 	}
-}
 
-/**
- * A connection item representing a database connection (top-level)
- */
-export class ConnectionItemDatabase extends ConnectionItemNode {
-	constructor(readonly name: string, readonly client: PositronConnectionsComm) {
-		super(name, 'database', [], client);
+	async listObjects(): Promise<Array<ObjectSchema>> {
+		return await this.client.listObjects(this.path);
+	}
+
+	async listFields(): Promise<Array<FieldSchema>> {
+		return await this.client.listFields(this.path);
 	}
 
 	close() {
+		throw new Error('close() not implemented');
+	}
+}
+
+function isDatabaseConnectionItem(
+	item: ConnectionItem
+): item is DatabaseConnectionItem {
+	return item instanceof DatabaseConnectionItem;
+}
+
+/**
+ * A connection item representing an active database connection (top-level)
+ */
+export class DatabaseConnectionItem extends ActiveConnectionItem {
+	constructor(
+		readonly metadata: ConnectionMetadata,
+		readonly client: PositronConnectionsComm
+	) {
+		super(metadata.name, 'database', [], client);
+		if (!metadata.icon) {
+			this.icon().then((icon) => {
+				if (icon !== '') {
+					const uri = vscode.Uri.parse(icon);
+					metadata.icon =
+						'data:image/png;base64,' +
+						fs.readFileSync(uri.fsPath, { encoding: 'base64' });
+				}
+			});
+		}
+	}
+
+	override close() {
 		this.client.dispose();
 	}
 
-	async contains_data() {
+	override async contains_data() {
 		// database roots never contain data (even if empty) as they can't be a table itself
 		return false;
 	}
 }
 
+function isFieldConnectionItem(
+	item: ConnectionItem
+): item is FieldConnectionItem {
+	return item instanceof FieldConnectionItem;
+}
+
 /**
  * A connection item representing a field in a table
  */
-export class ConnectionItemField extends ConnectionItemNode {
-	constructor(readonly name: string, readonly dtype: string, readonly client: PositronConnectionsComm) {
+export class FieldConnectionItem extends ActiveConnectionItem {
+	constructor(
+		readonly name: string,
+		readonly dtype: string,
+		readonly client: PositronConnectionsComm
+	) {
 		super(name, 'field', [], client);
-		this.dtype = dtype;
 	}
 
-	async icon() {
+	override async icon() {
 		return ''; // fields can't have custom icons
 	}
 
-	async contains_data() {
+	override async contains_data() {
 		return false;
 	}
 }
@@ -118,18 +181,22 @@ export class ConnectionItemField extends ConnectionItemNode {
 /**
  * Provides connection items to the Connections treeview.
  */
-export class ConnectionItemsProvider implements vscode.TreeDataProvider<ConnectionItem> {
-
+export class ConnectionItemsProvider
+	implements vscode.TreeDataProvider<ConnectionItem> {
 	// Fires when the tree data is changed. We fire this when a new connection
 	// is created.
-	private _onDidChangeTreeData: vscode.EventEmitter<ConnectionItem | undefined> =
-		new vscode.EventEmitter<ConnectionItem | undefined>();
+	private _onDidChangeTreeData: vscode.EventEmitter<
+		ConnectionItem | undefined
+	> = new vscode.EventEmitter<ConnectionItem | undefined>();
 
 	// The list of active connections
 	private _connections: ConnectionItem[] = [];
 
 	// The list of icons bundled for connections
 	private _icons: { [key: string]: { light: vscode.Uri; dark: vscode.Uri } } = {};
+
+	private treeItemDecorationProvider: TreeItemDecorationProvider =
+		new TreeItemDecorationProvider();
 
 	/**
 	 * Create a new ConnectionItemsProvider instance
@@ -144,6 +211,19 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 				dark: vscode.Uri.file(path.join(context.extensionPath, 'media', `${icon}-dark.svg`))
 			};
 		});
+		vscode.window.registerFileDecorationProvider(
+			this.treeItemDecorationProvider
+		);
+		this._connections = this.context.workspaceState.keys().map((name) => {
+			const metadata: ConnectionMetadata | undefined =
+				this.context.workspaceState.get(name);
+			if (metadata) {
+				return new DisconnectedConnectionItem(metadata);
+			} else {
+				throw new Error('Unexpected state: connection metadata not found');
+			}
+		});
+		this.fireOnDidChangeTreeData();
 	}
 
 	onDidChangeTreeData: vscode.Event<ConnectionItem | undefined> | undefined;
@@ -154,7 +234,39 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 	 * @param item The item to get the tree item for
 	 * @returns A TreeItem for the item
 	 */
-	async getTreeItem(item: ConnectionItemNode): Promise<vscode.TreeItem> {
+	async getTreeItem(item: ConnectionItem): Promise<vscode.TreeItem> {
+		if (isDisconnectedConnectionItem(item)) {
+			const treeItem = new vscode.TreeItem(
+				item.name,
+				vscode.TreeItemCollapsibleState.None
+			);
+
+			if (item.metadata.code) {
+				treeItem.contextValue = 'disconnected-hasCode';
+			} else {
+				treeItem.contextValue = 'disconnected';
+			}
+
+			const icon = await item.icon();
+			if (icon !== '') {
+				treeItem.iconPath = vscode.Uri.parse(icon);
+			} else {
+				treeItem.iconPath = this._icons[ConnectionIcon.Database];
+			}
+
+			// this resourseUri is used by the FileDecorationProvider to show the connection
+			// text with a slighy lighter font
+			treeItem.resourceUri = vscode.Uri.parse(
+				'connections://disconnected' + '.' + item.metadata.language_id
+			);
+			treeItem.tooltip = item.metadata.name;
+
+			return treeItem;
+		}
+
+		if (!isActiveConnectionItem(item)) {
+			throw new Error('Only ActiveConnectionItem instances are supported');
+		}
 
 		// Check if the item contains data
 		// If that fails we want to quicly return a treeItem that is not ispectable
@@ -164,18 +276,26 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 		} catch (err: any) {
 			// when contains_data fails, we show an error message that asks for a refresh.
 			// we also display an error tree item instead, so we can proceed with the rest of the tree
-			this.showErrorMessageWithRefresh(vscode.l10n.t(`Error checking if '{0}' contains_data: {1}`, item.name, err.message));
+			this.showErrorMessageWithRefresh(
+				vscode.l10n.t(
+					`Error checking if '{0}' contains_data: {1}`,
+					item.name,
+					err.message
+				)
+			);
 			return this.errorTreeItem(item.name, err);
 		}
 
 		// Both databases and tables can be expanded.
-		const collapsibleState = !(item instanceof ConnectionItemField);
+		const collapsibleState = !isFieldConnectionItem(item);
 
 		// Create the tree item.
-		const treeItem = new vscode.TreeItem(item.name,
-			collapsibleState ?
-				vscode.TreeItemCollapsibleState.Collapsed :
-				vscode.TreeItemCollapsibleState.None);
+		const treeItem = new vscode.TreeItem(
+			item.name,
+			collapsibleState
+				? vscode.TreeItemCollapsibleState.Collapsed
+				: vscode.TreeItemCollapsibleState.None
+		);
 
 		treeItem.iconPath = await this.getTreeItemIcon(item);
 
@@ -184,21 +304,27 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 			treeItem.contextValue = 'table';
 		}
 
-		if (item instanceof ConnectionItemField) {
+		if (isFieldConnectionItem(item)) {
 			// shows the field datatype as the treeItem description
 			treeItem.description = '<' + item.dtype + '>';
 		}
 
-		if (item instanceof ConnectionItemDatabase) {
+		if (isDatabaseConnectionItem(item)) {
 			// adding the contextValue allows the TreView API to attach specific commands
 			// to databases
 			treeItem.contextValue = 'database';
+			treeItem.tooltip = item.name;
+			treeItem.resourceUri = vscode.Uri.parse(
+				'connections://connected.' + item.metadata.language_id
+			);
 		}
 
 		return treeItem;
 	}
 
-	async getTreeItemIcon(item: ConnectionItemNode): Promise<vscode.Uri | { light: vscode.Uri; dark: vscode.Uri }> {
+	async getTreeItemIcon(
+		item: ActiveConnectionItem
+	): Promise<vscode.Uri | { light: vscode.Uri; dark: vscode.Uri }> {
 		try {
 			const icon = await item.icon();
 			if (icon !== '') {
@@ -206,7 +332,13 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 			}
 		} catch (err: any) {
 			// not having an icon is not fatal as we can fallback to the type, but is worth notifying
-			vscode.window.showErrorMessage(vscode.l10n.t(`Error getting icon for '{0}' : {1}`, item.name, err.message));
+			vscode.window.showErrorMessage(
+				vscode.l10n.t(
+					`Error getting icon for '{0}' : {1}`,
+					item.name,
+					err.message
+				)
+			);
 		}
 
 		// fallback to the item kind
@@ -214,22 +346,26 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 	}
 
 	async showErrorMessageWithRefresh(message: string) {
-		const answer = await vscode.window.showErrorMessage(message,
-			{
-				title: vscode.l10n.t('Retry'),
-				execute: async () => {
-					this.refresh();
-				}
-			}
-		);
+		const answer = await vscode.window.showErrorMessage(message, {
+			title: vscode.l10n.t('Retry'),
+			execute: async () => {
+				this.refresh();
+			},
+		});
 		answer?.execute();
 	}
 
 	errorTreeItem(name: string, error: any): vscode.TreeItem {
-		const treeItem = new vscode.TreeItem(name, vscode.TreeItemCollapsibleState.None);
+		const treeItem = new vscode.TreeItem(
+			name,
+			vscode.TreeItemCollapsibleState.None
+		);
 		treeItem.description = vscode.l10n.t('Error loading item.');
 		treeItem.tooltip = error.message;
-		treeItem.iconPath = new vscode.ThemeIcon('error', new vscode.ThemeColor('errorForeground'));
+		treeItem.iconPath = new vscode.ThemeIcon(
+			'error',
+			new vscode.ThemeColor('errorForeground')
+		);
 		return treeItem;
 	}
 
@@ -239,29 +375,61 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 	 * @param client The client instance that owns the connection
 	 * @param name The name of the connection
 	 */
-	addConnection(client: PositronConnectionsComm, name: string) {
+	addConnection(client: PositronConnectionsComm, metadata: ConnectionMetadata) {
 		// Add the connection to the list
-		this._connections.push(new ConnectionItemDatabase(name, client));
+		// if there's already a connection with the same name, we replace it
+		// TODO: we want to check by type and host instead in the future.
+		const index = this._connections.findIndex((connection) => {
+			if (connection.name === metadata.name) {
+				return true;
+			}
+			return false;
+		});
+
+		const conn = new DatabaseConnectionItem(metadata, client);
+		if (index < 0) {
+			this._connections.push(conn);
+		} else {
+			this._connections[index] = conn;
+		}
+
+		this.context.workspaceState.update(conn.name, conn.metadata);
 
 		// Fire the event to indicate that the tree data has changed. This will
 		// trigger a refresh.
-		this._onDidChangeTreeData.fire(undefined);
+		this.fireOnDidChangeTreeData();
 
 		// Add an event listener to the client so that we can remove the
 		// connection when it closes.
-		client.instance.onDidChangeClientState((state: positron.RuntimeClientState) => {
-			if (state === positron.RuntimeClientState.Closed) {
-				// Get the ID and discard the connection matching the ID
-				const clientId = client.instance.getClientId();
-				this._connections = this._connections.filter((connection) => {
-					return connection.client.instance.getClientId() !== clientId;
-				});
-				this._onDidChangeTreeData.fire(undefined);
+		client.instance.onDidChangeClientState(
+			(state: positron.RuntimeClientState) => {
+				if (state === positron.RuntimeClientState.Closed) {
+					// Get the ID and discard the connection matching the ID
+					const clientId = client.instance.getClientId();
+					this._connections = this._connections.map((connection) => {
+						if (!isActiveConnectionItem(connection)) {
+							return connection;
+						}
+
+						if (connection.client.instance.getClientId() !== clientId) {
+							return connection;
+						}
+
+						if (connection instanceof DatabaseConnectionItem) {
+							return new DisconnectedConnectionItem(connection.metadata);
+						}
+
+						throw new Error('Unexpected connection type');
+					});
+					this.fireOnDidChangeTreeData();
+				}
 			}
-		});
+		);
 
 		client.onDidFocus(() => {
-			vscode.commands.executeCommand('connections.focus', { preserveFocus: true });
+			vscode.commands.executeCommand('connections.focus', {
+				preserveFocus: true,
+			});
 		});
 	}
 
@@ -271,15 +439,19 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 	 * @param element The element to get the children for
 	 * @returns The children of the element
 	 */
-	async getChildren(element?: ConnectionItemNode): Promise<ConnectionItem[]> {
-
+	async getChildren(element?: ConnectionItem): Promise<ConnectionItem[]> {
 		if (!element) {
 			// At the root, return the top-level connections
 			return this._connections;
 		}
 
-		// Fields don't have children
-		if (element instanceof ConnectionItemField) {
+		if (!isActiveConnectionItem(element)) {
+			// Non-active connections don't have children
+			return [];
+		}
+
+		if (isFieldConnectionItem(element)) {
+			// Fields don't have children
 			return [];
 		}
 
@@ -290,28 +462,110 @@ export class ConnectionItemsProvider implements vscode.TreeDataProvider<Connecti
 			// anyway, if this happens we still send a retry notification and return no children.
 			contains_data = await element.contains_data();
 		} catch (err: any) {
-			this.showErrorMessageWithRefresh(vscode.l10n.t(`Error checking if '{0}' contains_data: {1}`, element.name, err.message));
+			this.showErrorMessageWithRefresh(
+				vscode.l10n.t(
+					`Error checking if '{0}' contains_data: {1}`,
+					element.name,
+					err.message
+				)
+			);
 			return [];
 		}
 
 		// The node is a view or a table so we want to get the fields on it.
-		if (await element.contains_data()) {
-			const fields = await element.client.listFields(element.path);
+		if (contains_data) {
+			const fields = await element.listFields();
 			return fields.map((field) => {
-				return new ConnectionItemField(field.name, field.dtype, element.client);
+				return new FieldConnectionItem(field.name, field.dtype, element.client);
 			});
 		}
 
 		// The node is a database, schema, or catalog, so we want to get the next set of elements in
 		// the tree.
-		const children = await element.client.listObjects(element.path);
+		const children = await element.listObjects();
 		return children.map((obj) => {
 			const path = [...element.path, { name: obj.name, kind: obj.kind }];
-			return new ConnectionItemNode(obj.name, obj.kind, path, element.client);
+			return new ActiveConnectionItem(obj.name, obj.kind, path, element.client);
 		});
 	}
 
 	public refresh() {
+		this.fireOnDidChangeTreeData();
+	}
+
+	/**
+	 * Removes a connection from the history.
+	 *
+	 * @param item The connection to remove
+	 */
+	removeFromHistory(item: DisconnectedConnectionItem) {
+		this.context.workspaceState.update(item.name, undefined);
+		this._connections = this._connections.filter((connection) => {
+			return connection.name !== item.name;
+		});
+		this.fireOnDidChangeTreeData();
+	}
+
+	/**
+	 * Clears the connection history.
+	 */
+	clearConnectionsHistory() {
+		this.context.workspaceState.keys().forEach((key) => {
+			this.context.workspaceState.update(key, undefined);
+		});
+		this._connections = this._connections.filter((connection) => {
+			return !isDisconnectedConnectionItem(connection);
+		});
+		this.fireOnDidChangeTreeData();
+	}
+
+	fireOnDidChangeTreeData() {
 		this._onDidChangeTreeData.fire(undefined);
+		this.treeItemDecorationProvider.updateFileDecorations([]);
+	}
+}
+
+/**
+ * Provides decorations for the Connections tree view.
+ *
+ * This provider is initialized by the TreeDataProvider and is used to modify the style of
+ * the tree items in the Connections tree view.
+ *
+ */
+export class TreeItemDecorationProvider
+	implements vscode.FileDecorationProvider {
+	private readonly _onDidChangeFileDecorations: vscode.EventEmitter<
+		vscode.Uri | vscode.Uri[]
+	> = new vscode.EventEmitter<vscode.Uri | vscode.Uri[]>();
+	readonly onDidChangeFileDecorations: vscode.Event<vscode.Uri | vscode.Uri[]> =
+		this._onDidChangeFileDecorations.event;
+
+	provideFileDecoration(
+		uri: vscode.Uri,
+		token: vscode.CancellationToken
+	): vscode.ProviderResult<vscode.FileDecoration> {
+		// https://code.visualstudio.com/api/references/theme-color#lists-and-trees
+		if (uri.scheme === 'connections') {
+			const [status, language_id] = uri.authority.split('.', 2);
+			if (status === 'disconnected') {
+				return {
+					color: new vscode.ThemeColor('list.deemphasizedForeground'),
+					// allow-any-unicode-next-line
+					badge: '⭘', // we use this unicode character that symbolizes 'power off'
+					tooltip: vscode.l10n.t('Disconnected'),
+				};
+			} else {
+				return {
+					badge: language_id.substring(0, 2),
+					tooltip: vscode.l10n.t('Connected'),
+				};
+			}
+		}
+
+		return undefined;
+	}
+
+	updateFileDecorations(uris: vscode.Uri[]): void {
+		this._onDidChangeFileDecorations.fire(uris);
 	}
 }

--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -28,7 +28,7 @@ enum ConnectionState {
 interface ConnectionMetadata {
 	name: string;
 	language_id: string;
-	// host and type are used to indentidy a unique connection
+	// host and type are used to identify a unique connection
 	host: string;
 	type: string;
 	code?: string;

--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -380,12 +380,7 @@ export class ConnectionItemsProvider
 		// Add the connection to the list
 		// if there's already a connection with the same name, we replace it
 		const index = this._connections.findIndex((connection) => {
-			if (connection.metadata.language_id === metadata.language_id &&
-				connection.metadata.host === metadata.host &&
-				connection.metadata.type === metadata.type) {
-				return true;
-			}
-			return false;
+			return compareConnectionsMetadata(connection.metadata, metadata);
 		});
 
 		const conn = new DatabaseConnectionItem(metadata, client);
@@ -508,7 +503,7 @@ export class ConnectionItemsProvider
 	removeFromHistory(item: DisconnectedConnectionItem) {
 		this.context.workspaceState.update(item.name, undefined);
 		this._connections = this._connections.filter((connection) => {
-			return connection.name !== item.name;
+			return !compareConnectionsMetadata(connection.metadata, item.metadata);
 		});
 		this.fireOnDidChangeTreeData();
 	}
@@ -575,4 +570,11 @@ export class TreeItemDecorationProvider
 	updateFileDecorations(uris: vscode.Uri[]): void {
 		this._onDidChangeFileDecorations.fire(uris);
 	}
+}
+
+// Connections are considered identical if they have the same language_id, host, and type.
+function compareConnectionsMetadata(a: ConnectionMetadata, b: ConnectionMetadata): boolean {
+	return a.language_id === b.language_id &&
+		a.host === b.host &&
+		a.type === b.type;
 }

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -310,7 +310,7 @@ class ConnectionsService:
             self._unregister_variable_path(tuple(variable_path))
             return
         except Exception:
-            # Most likely the object refers to a closed conneciton. In this case
+            # Most likely the object refers to a closed connection. In this case
             # we also close the connection.
             self._unregister_variable_path(tuple(variable_path))
             return

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -201,6 +201,8 @@ class ConnectionsService:
             data={
                 "name": connection.display_name,
                 "language_id": "python",
+                "host": connection.host,
+                "type": connection.type,
                 "code": connection.code,
             },
         )

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -592,7 +592,7 @@ class SQLAlchemyConnection(Connection):
     def __init__(self, conn):
         self.conn: sqlalchemy.Engine = conn
         self.display_name = f"SQLAlchemy ({conn.name})"
-        self.host = conn.url
+        self.host = conn.url.render_as_string()
         self.type = "SQLAlchemy"
 
     def list_objects(self, path: List[ObjectSchema]):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -61,12 +61,23 @@ PathKey = Tuple[str, ...]
 class Connection:
     """
     Base class representing a connection to a data source.
+
+    Attributes:
+        type: The type of the connection as a free form string. It's used along with `host` to
+            determine the uniqueness of a connection.
+        host: The host of the connection as a free form string.
+        display_name: The name of the connection to be displayed in the UI.
+        icon: The path to an icon to be used by the UI.
+        code: The code used to recreate the connection.
+        conn: The connection object.
+        actions: A list of actions to be displayed in the UI.
     """
 
     type: str
     host: str
     display_name: Optional[str] = None
     icon: Optional[str] = None
+    code: Optional[str] = None
     conn: Any = None
     actions: Any = None
 
@@ -187,7 +198,11 @@ class ConnectionsService:
         base_comm = comm.create_comm(
             target_name=self._comm_target_name,
             comm_id=comm_id,
-            data={"name": connection.display_name, "language_id": "python"},
+            data={
+                "name": connection.display_name,
+                "language_id": "python",
+                "code": connection.code,
+            },
         )
 
         self._register_variable_path(variable_path, comm_id)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -913,10 +913,7 @@ class PolarsDataFrameInspector(BaseTableInspector["pl.DataFrame", "pl.Series"]):
         return self.value.write_csv(file=None, separator="\t")
 
 
-class ConnectionInspector(ObjectInspector):
-    # in older Python versions (eg 3.9) the qualname for sqlite3.Connection is just "Connection"
-    CLASS_QNAME = ["Connection", "sqlite3.Connection", "sqlalchemy.engine.base.Engine"]
-
+class BaseConnectionInspector(ObjectInspector):
     def has_viewer(self) -> bool:
         return self._is_active(self.value)
 
@@ -931,9 +928,29 @@ class ConnectionInspector(ObjectInspector):
         raise CopyError("Connections are not copiable")
 
     def _is_active(self, value) -> bool:
+        raise NotImplementedError
+
+
+class SQLiteConnectionInspector(BaseConnectionInspector):
+    # in older Python versions (eg 3.9) the qualname for sqlite3.Connection is just "Connection"
+    CLASS_QNAME = ["Connection", "sqlite3.Connection"]
+
+    def _is_active(self, value) -> bool:
         try:
             # a connection is active if you can acquire a cursor from it
             value.cursor()
+        except Exception:
+            return False
+        return True
+
+
+class SQLAlchemyEngineInspector(BaseConnectionInspector):
+    CLASS_QNAME = ["sqlalchemy.engine.base.Engine"]
+
+    def _is_active(self, value) -> bool:
+        try:
+            # a connection is active if you can acquire a connection from it
+            value.connect()
         except Exception:
             return False
         return True
@@ -949,7 +966,8 @@ INSPECTOR_CLASSES: Dict[str, Type[PositronInspector]] = {
     **dict.fromkeys(PolarsDataFrameInspector.CLASS_QNAME, PolarsDataFrameInspector),
     **dict.fromkeys(PolarsSeriesInspector.CLASS_QNAME, PolarsSeriesInspector),
     DatetimeInspector.CLASS_QNAME: DatetimeInspector,
-    **dict.fromkeys(ConnectionInspector.CLASS_QNAME, ConnectionInspector),
+    **dict.fromkeys(SQLiteConnectionInspector.CLASS_QNAME, SQLiteConnectionInspector),
+    **dict.fromkeys(SQLAlchemyEngineInspector.CLASS_QNAME, SQLAlchemyEngineInspector),
     "boolean": BooleanInspector,
     "bytes": BytesInspector,
     "class": ClassInspector,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-class UncopiableError(Exception):
+class CopyError(Exception):
     """
     Raised by inspector.copy() when an object can't be copied.
     """

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -928,7 +928,7 @@ class ConnectionInspector(ObjectInspector):
 
     def copy(self) -> Any:
         # Connections are mutable but not copiable.
-        raise UncopiableError("Connections are not copiable")
+        raise CopyError("Connections are not copiable")
 
     def _is_active(self, value) -> bool:
         try:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -932,17 +932,11 @@ class ConnectionInspector(ObjectInspector):
 
     def _is_active(self, value) -> bool:
         try:
+            # a connection is active if you can acquire a cursor from it
             value.cursor()
         except Exception:
             return False
         return True
-
-    def equals(self, value: Any) -> bool:
-        if not super().equals(value):
-            return False
-
-        # check if the connection is still open
-        return self._is_active(value)
 
 
 INSPECTOR_CLASSES: Dict[str, Type[PositronInspector]] = {

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -13,15 +13,9 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 from comm.base_comm import BaseComm
 
 from .access_keys import decode_access_key, encode_access_key
-from .inspectors import get_inspector
+from .inspectors import UncopiableError, get_inspector
 from .positron_comm import CommMessage, JsonRpcErrorCode, PositronComm
-from .utils import (
-    JsonData,
-    JsonRecord,
-    cancel_tasks,
-    create_task,
-    get_qualname,
-)
+from .utils import JsonData, JsonRecord, cancel_tasks, create_task, get_qualname
 from .variables_comm import (
     ClearRequest,
     ClipboardFormatFormat,
@@ -293,7 +287,12 @@ class VariablesService:
                     mutable_vars_excluded[key] = value
                 else:
                     comparison_cost += cost
-                    mutable_vars_copied[key] = inspector.copy()
+                    try:
+                        mutable_vars_copied[key] = inspector.copy()
+                    except UncopiableError:
+                        # when a variable is mutable, but not copiable we can't
+                        # detect changes on it
+                        mutable_vars_excluded[key] = value
             else:
                 immutable_vars[key] = value
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 from comm.base_comm import BaseComm
 
 from .access_keys import decode_access_key, encode_access_key
-from .inspectors import UncopiableError, get_inspector
+from .inspectors import CopyError, get_inspector
 from .positron_comm import CommMessage, JsonRpcErrorCode, PositronComm
 from .utils import JsonData, JsonRecord, cancel_tasks, create_task, get_qualname
 from .variables_comm import (
@@ -289,7 +289,7 @@ class VariablesService:
                     comparison_cost += cost
                     try:
                         mutable_vars_copied[key] = inspector.copy()
-                    except UncopiableError:
+                    except CopyError:
                         # when a variable is mutable, but not copiable we can't
                         # detect changes on it
                         mutable_vars_excluded[key] = value


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Adds a disconnected state for the connections pane, with some UI for users to reconnect a closed connection.
Addresses https://github.com/posit-dev/positron/issues/2739
Also addresses #2756 
We are also addressing: https://github.com/posit-dev/positron/issues/2792

### Approach

- Adds a new connectionTreeItem class that is used for closed connections
- Store connections metadata in the project state using vscode's API for storing state
- Various UI elements to re-connect, discard connections, copy connection code, etc.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.


https://github.com/posit-dev/positron/assets/4706822/707b6ae8-fb20-4a71-9a4e-9f730192385e

