### PR TITLE
Include .deb Linux release in push to private beta

### DIFF
--- a/.github/workflows/build-push-beta.yml
+++ b/.github/workflows/build-push-beta.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           version: tags/${{ env.RELEASE_TAG }}
           regex: true
-          file: "Positron-.*\\.(dmg|exe|deb|rpm)"
+          file: "Positron-.*\\.(dmg|exe|deb)"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release to Private Beta
@@ -39,7 +39,7 @@ jobs:
 
             Positron is currently in Private Beta.
 
-            To download Positron, go to **Assets** and select the `.dmg` for Mac (Universal), `.exe` for Windows x64 (System), `.deb` for Debian-based Linux (Ubuntu), or `.rpm` for Red Hat-based Linux.
+            To download Positron, go to **Assets** and select the `.dmg` for Mac (Universal), `.exe` for Windows x64 (System), or `.deb` for Debian-based Linux (Ubuntu).
 
             Releases are made available under the terms of the [Software Evaluation License](https://github.com/posit-dev/positron-beta?tab=License-1-ov-file) from [Posit Software, PBC](https://posit.co/).
 
@@ -49,4 +49,3 @@ jobs:
             Positron-${{ env.RELEASE_TAG }}-Setup.exe
             Positron-${{ env.RELEASE_TAG }}.dmg
             Positron-${{ env.RELEASE_TAG }}.deb
-            Positron-${{ env.RELEASE_TAG }}.rpm

--- a/.github/workflows/build-push-beta.yml
+++ b/.github/workflows/build-push-beta.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
 
       - name: Download Release Assets
-        uses: dsaltares/fetch-gh-release-asset@master
+        uses: dsaltares/fetch-gh-release-asset@1.1.1
         with:
           version: tags/${{ env.RELEASE_TAG }}
           regex: true
-          file: "Positron-.*\\.(dmg|exe|deb)"
+          file: "Positron-[0-9\\.\\-]*(?:-Setup|)\\.(?:dmg|exe|deb)"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release to Private Beta

--- a/.github/workflows/build-push-beta.yml
+++ b/.github/workflows/build-push-beta.yml
@@ -27,7 +27,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          repository: posit-dev/positron-beta
+          repository: posit-dev/positron-temp-beta
           tag_name: ${{ env.RELEASE_TAG }}
           prerelease: true
           fail_on_unmatched_files: true

--- a/.github/workflows/build-push-beta.yml
+++ b/.github/workflows/build-push-beta.yml
@@ -15,12 +15,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Download Release Assets
+      - name: Download Windows Release Asset
         uses: dsaltares/fetch-gh-release-asset@1.1.1
         with:
           version: tags/${{ env.RELEASE_TAG }}
-          regex: true
-          file: "Positron-[0-9\\.\\-]*(?:-Setup|)\\.(?:dmg|exe|deb)"
+          file: Positron-${{ env.RELEASE_TAG }}-Setup.exe
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download MacOS Release Asset
+        uses: dsaltares/fetch-gh-release-asset@1.1.1
+        with:
+          version: tags/${{ env.RELEASE_TAG }}
+          file: Positron-${{ env.RELEASE_TAG }}.dmg
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Debian Linux Release Asset
+        uses: dsaltares/fetch-gh-release-asset@1.1.1
+        with:
+          version: tags/${{ env.RELEASE_TAG }}
+          file: Positron-${{ env.RELEASE_TAG }}.deb
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release to Private Beta

--- a/.github/workflows/build-push-beta.yml
+++ b/.github/workflows/build-push-beta.yml
@@ -15,18 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Download Windows Release Asset
+      - name: Download Release Assets
         uses: dsaltares/fetch-gh-release-asset@master
         with:
           version: tags/${{ env.RELEASE_TAG }}
-          file: Positron-${{ env.RELEASE_TAG }}-Setup.exe
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download MacOS Release Asset
-        uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          version: tags/${{ env.RELEASE_TAG }}
-          file: Positron-${{ env.RELEASE_TAG }}.dmg
+          regex: true
+          file: "Positron-.*\\.(dmg|exe|deb|rpm)"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release to Private Beta
@@ -45,7 +39,7 @@ jobs:
 
             Positron is currently in Private Beta.
 
-            To download Positron, go to **Assets** and select the `.dmg` for Mac (Universal) or `.exe` for Windows x64 (System).
+            To download Positron, go to **Assets** and select the `.dmg` for Mac (Universal), `.exe` for Windows x64 (System), `.deb` for Debian-based Linux (Ubuntu), or `.rpm` for Red Hat-based Linux.
 
             Releases are made available under the terms of the [Software Evaluation License](https://github.com/posit-dev/positron-beta?tab=License-1-ov-file) from [Posit Software, PBC](https://posit.co/).
 
@@ -54,3 +48,5 @@ jobs:
           files: |
             Positron-${{ env.RELEASE_TAG }}-Setup.exe
             Positron-${{ env.RELEASE_TAG }}.dmg
+            Positron-${{ env.RELEASE_TAG }}.deb
+            Positron-${{ env.RELEASE_TAG }}.rpm

--- a/.github/workflows/build-push-beta.yml
+++ b/.github/workflows/build-push-beta.yml
@@ -40,7 +40,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          repository: posit-dev/positron-temp-beta
+          repository: posit-dev/positron-beta
           tag_name: ${{ env.RELEASE_TAG }}
           prerelease: true
           fail_on_unmatched_files: true


### PR DESCRIPTION
Copies the Mac, Windows and Debian-based Linux release assets to the private beta.

Also pin the version of GHA fetch-gh-release-asset.