### PR TITLE
Define plot format enum in comms

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
@@ -17,6 +17,21 @@ from typing import Any, List, Literal, Optional, Union
 from ._vendor.pydantic import BaseModel, Field
 
 
+@enum.unique
+class RenderFormat(str, enum.Enum):
+    """
+    Possible values for Format in Render
+    """
+
+    Png = "png"
+
+    Jpeg = "jpeg"
+
+    Svg = "svg"
+
+    Pdf = "pdf"
+
+
 class PlotResult(BaseModel):
     """
     A rendered plot
@@ -59,7 +74,7 @@ class RenderParams(BaseModel):
         description="The pixel ratio of the display device",
     )
 
-    format: str = Field(
+    format: RenderFormat = Field(
         description="The requested plot format",
     )
 

--- a/positron/comms/plot-backend-openrpc.json
+++ b/positron/comms/plot-backend-openrpc.json
@@ -35,7 +35,13 @@
 					"name": "format",
 					"description": "The requested plot format",
 					"schema": {
-						"type": "string"
+						"type": "string",
+						"enum": [
+							"png",
+							"jpeg",
+							"svg",
+							"pdf"
+						]
 					},
 					"required": false
 				}

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -22,17 +22,11 @@ import { FileFilter } from 'electron';
 import { DropDownListBox } from 'vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBox';
 import { DropDownListBoxItem } from 'vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBoxItem';
 import { IFileService } from 'vs/platform/files/common/files';
+import { RenderFormat } from 'vs/workbench/services/languageRuntime/common/positronPlotComm';
 
 export interface SavePlotOptions {
 	uri: string;
 	path: URI;
-}
-
-export enum PlotFormat {
-	PNG = 'png',
-	SVG = 'svg',
-	PDF = 'pdf',
-	JPEG = 'jpeg',
 }
 
 const SAVE_PLOT_MODAL_DIALOG_WIDTH = 500;
@@ -110,7 +104,7 @@ interface DirectoryState {
 const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 	const [directory, setDirectory] = React.useState<DirectoryState>({ value: props.suggestedPath ?? URI.file(''), valid: true });
 	const [name, setName] = React.useState({ value: 'plot', valid: true });
-	const [format, setFormat] = React.useState(PlotFormat.PNG);
+	const [format, setFormat] = React.useState(RenderFormat.Png);
 	const [width, setWidth] = React.useState({ value: props.plotWidth, valid: true });
 	const [height, setHeight] = React.useState({ value: props.plotHeight, valid: true });
 	const [dpi, setDpi] = React.useState({ value: 100, valid: true });
@@ -119,7 +113,7 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 	const inputRef = React.useRef<HTMLInputElement>(null);
 
 	const filterEntries: FileFilter[] = [];
-	for (const filter in PlotFormat) {
+	for (const filter in RenderFormat) {
 		filterEntries.push({ extensions: [filter.toLowerCase()], name: filter.toUpperCase() });
 	}
 
@@ -216,14 +210,14 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 		}
 		setRendering(true);
 		try {
-			const plotResult = await generatePreview(PlotFormat.PNG);
+			const plotResult = await generatePreview(RenderFormat.Png);
 			setUri(plotResult.uri);
 		} finally {
 			setRendering(false);
 		}
 	};
 
-	const generatePreview = async (format: PlotFormat): Promise<IRenderedPlot> => {
+	const generatePreview = async (format: RenderFormat): Promise<IRenderedPlot> => {
 		return props.plotClient.preview(height.value, width.value, dpi.value / BASE_DPI, format);
 	};
 
@@ -281,10 +275,10 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 										keybindingService={props.keybindingService}
 										layoutService={props.layoutService}
 										entries={[
-											new DropDownListBoxItem<PlotFormat, PlotFormat>({ identifier: PlotFormat.PNG, title: PlotFormat.PNG.toUpperCase(), value: PlotFormat.PNG }),
-											new DropDownListBoxItem<PlotFormat, PlotFormat>({ identifier: PlotFormat.JPEG, title: PlotFormat.JPEG.toUpperCase(), value: PlotFormat.JPEG }),
-											new DropDownListBoxItem<PlotFormat, PlotFormat>({ identifier: PlotFormat.SVG, title: PlotFormat.SVG.toUpperCase(), value: PlotFormat.SVG }),
-											new DropDownListBoxItem<PlotFormat, PlotFormat>({ identifier: PlotFormat.PDF, title: PlotFormat.PDF.toUpperCase(), value: PlotFormat.PDF }),
+											new DropDownListBoxItem<RenderFormat, RenderFormat>({ identifier: RenderFormat.Png, title: RenderFormat.Png.toUpperCase(), value: RenderFormat.Png }),
+											new DropDownListBoxItem<RenderFormat, RenderFormat>({ identifier: RenderFormat.Jpeg, title: RenderFormat.Jpeg.toUpperCase(), value: RenderFormat.Jpeg }),
+											new DropDownListBoxItem<RenderFormat, RenderFormat>({ identifier: RenderFormat.Svg, title: RenderFormat.Svg.toUpperCase(), value: RenderFormat.Svg }),
+											new DropDownListBoxItem<RenderFormat, RenderFormat>({ identifier: RenderFormat.Pdf, title: RenderFormat.Pdf.toUpperCase(), value: RenderFormat.Pdf }),
 										]} />
 								</label>
 							</div>

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -7,7 +7,7 @@ import { IRuntimeClientInstance, RuntimeClientState } from 'vs/workbench/service
 import { Event, Emitter } from 'vs/base/common/event';
 import { DeferredPromise } from 'vs/base/common/async';
 import { IPositronPlotClient } from 'vs/workbench/services/positronPlots/common/positronPlots';
-import { PositronPlotComm } from 'vs/workbench/services/languageRuntime/common/positronPlotComm';
+import { PositronPlotComm, RenderFormat } from 'vs/workbench/services/languageRuntime/common/positronPlotComm';
 
 /**
  * The possible states for the plot client instance
@@ -78,7 +78,7 @@ interface RenderRequest {
 	pixel_ratio: number;
 
 	/** The format of the plot */
-	format: string;
+	format: RenderFormat;
 }
 
 /**
@@ -263,7 +263,7 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 	 * @param format The format of the plot ('png', 'svg')
 	 * @returns A promise that resolves to a rendered image, or rejects with an error.
 	 */
-	public render(height: number, width: number, pixel_ratio: number, format = 'png'): Promise<IRenderedPlot> {
+	public render(height: number, width: number, pixel_ratio: number, format = RenderFormat.Png): Promise<IRenderedPlot> {
 		// Deal with whole pixels only
 		height = Math.floor(height);
 		width = Math.floor(width);
@@ -325,7 +325,7 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 	 * @param pixel_ratio The device pixel ratio (e.g. 1 for standard displays, 2 for retina displays)
 	 * @returns A promise that resolves when the render request is scheduled, or rejects with an error.
 	 */
-	public preview(height: number, width: number, pixel_ratio: number, format: string): Promise<IRenderedPlot> {
+	public preview(height: number, width: number, pixel_ratio: number, format: RenderFormat): Promise<IRenderedPlot> {
 		// Deal with whole pixels only
 		height = Math.floor(height);
 		width = Math.floor(width);
@@ -509,7 +509,7 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 			height: Math.floor(height!),
 			width: Math.floor(width!),
 			pixel_ratio: pixel_ratio!,
-			format: this._currentRender?.renderRequest.format ?? 'png'
+			format: this._currentRender?.renderRequest.format ?? RenderFormat.Png
 		});
 
 		this.scheduleRender(req, 0);

--- a/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
@@ -27,6 +27,16 @@ export interface PlotResult {
 }
 
 /**
+ * Possible values for Format in Render
+ */
+export enum RenderFormat {
+	Png = 'png',
+	Jpeg = 'jpeg',
+	Svg = 'svg',
+	Pdf = 'pdf'
+}
+
+/**
  * Event: Notification that a plot has been updated on the backend.
  */
 export interface UpdateEvent {
@@ -63,7 +73,7 @@ export class PositronPlotComm extends PositronBaseComm {
 	 *
 	 * @returns A rendered plot
 	 */
-	render(height: number, width: number, pixelRatio: number, format: string): Promise<PlotResult> {
+	render(height: number, width: number, pixelRatio: number, format: RenderFormat): Promise<PlotResult> {
 		return super.performRpc('render', ['height', 'width', 'pixel_ratio', 'format'], [height, width, pixelRatio, format]);
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent
Based on feedback from changes for #2657, refactor the plot comms format parameter to use an enum.

Amalthea PR: https://github.com/posit-dev/amalthea/pull/317

### Approach
Regen the comms with the enum and reference it instead of the React scoped enum.

### QA Notes
This a change that does not affect how plot saving works
