### PR TITLE
Data Explorer: Implement partial state eviction when row filters become invalid for pandas, add error messages, invalid filter state, fix row filter bar state synchronization

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -544,6 +544,7 @@
 		"--vscode-positronDataExplorer-columnNullPercentGraphBackgroundFill",
 		"--vscode-positronDataExplorer-columnNullPercentGraphBackgroundStroke",
 		"--vscode-positronDataExplorer-columnNullPercentGraphIndicatorFill",
+		"--vscode-positronDataExplorer-invalidFilterBackground",
 		"--vscode-positronDataExplorer-selectionBackground",
 		"--vscode-positronDataGrid-background",
 		"--vscode-positronDataGrid-border",

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -352,7 +352,7 @@ class PandasView(DataExplorerTableView):
         shifted_columns: Dict[int, int] = {}
         schema_changes: Dict[int, ColumnSchema] = {}
 
-        # First, we look for deleted columns
+        # First, we look for detectable deleted columns
         deleted_columns: Set[int] = set()
         if not self.table.columns.equals(new_table.columns):
             for old_index, column in enumerate(self.table.columns):
@@ -486,6 +486,7 @@ class PandasView(DataExplorerTableView):
         new_sort_keys = []
         for i, key in enumerate(self.sort_keys):
             column_index = key.column_index
+            prior_name = self._sort_key_schemas[i].column_name
 
             key = key.copy()
 
@@ -494,7 +495,6 @@ class PandasView(DataExplorerTableView):
                 # A schema change is only valid if the column name is
                 # the same, otherwise it's a deletion
                 change = schema_changes[column_index]
-                prior_name = self._sort_key_schemas[i].column_name
                 if prior_name == change.column_name:
                     key.column_schema = change.copy()
                 else:
@@ -502,7 +502,9 @@ class PandasView(DataExplorerTableView):
                     continue
             elif column_index in shifted_columns:
                 key.column_index = shifted_columns[column_index]
-            elif column_index in deleted_columns:
+            elif column_index in deleted_columns or prior_name != str(
+                new_table.columns[column_index]
+            ):
                 # Column deleted
                 continue
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -10,7 +10,6 @@ import logging
 import operator
 from typing import (
     TYPE_CHECKING,
-    Any,
     Callable,
     Dict,
     List,
@@ -661,7 +660,7 @@ class PandasView(DataExplorerTableView):
             # Simply reset if empty filter set passed
             self.filtered_indices = None
             self._update_view_indices()
-            return FilterResult(selected_num_rows=len(self.table))
+            return FilterResult(selected_num_rows=len(self.table), had_errors=False)
 
         # Evaluate all the filters and combine them using the
         # indicated conditions
@@ -1208,7 +1207,7 @@ class DataExplorerService:
             # looking at invalid.
             return self._close_explorer(comm_id)
 
-        if type(new_table) is not type(table_view.table):  # noqa:
+        if not isinstance(new_table, type(table_view.table)):
             # Data structure type has changed. For now, we drop the
             # entire state: sorting keys, filters, etc. and start
             # over. At some point we can return here and selectively

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -282,8 +282,8 @@ class RowFilter(BaseModel):
         description="Type of row filter to apply",
     )
 
-    column_index: int = Field(
-        description="Column index to apply filter to",
+    column_schema: ColumnSchema = Field(
+        description="Column to apply filter to",
     )
 
     condition: RowFilterCondition = Field(
@@ -888,21 +888,11 @@ class DataExplorerFrontendEvent(str, enum.Enum):
     An enumeration of all the possible events that can be sent to the frontend data_explorer comm.
     """
 
-    # Reset after a schema change
+    # Request to sync after a schema change
     SchemaUpdate = "schema_update"
 
     # Clear cache and request fresh data
     DataUpdate = "data_update"
-
-
-class SchemaUpdateParams(BaseModel):
-    """
-    Reset after a schema change
-    """
-
-    discard_state: bool = Field(
-        description="If true, the UI should discard the filter/sort state.",
-    )
 
 
 SearchSchemaResult.update_forward_refs()
@@ -984,5 +974,3 @@ GetColumnProfilesParams.update_forward_refs()
 GetColumnProfilesRequest.update_forward_refs()
 
 GetStateRequest.update_forward_refs()
-
-SchemaUpdateParams.update_forward_refs()

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -561,8 +561,8 @@ class ColumnSortKey(BaseModel):
     Specifies a column to sort by
     """
 
-    column_index: int = Field(
-        description="Column index to sort by",
+    column_schema: ColumnSchema = Field(
+        description="Column to sort by",
     )
 
     ascending: bool = Field(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -166,6 +166,11 @@ class FilterResult(BaseModel):
         description="Number of rows in table after applying filters",
     )
 
+    had_errors: Optional[bool] = Field(
+        default=None,
+        description="Flag indicating if there were errors in evaluation",
+    )
+
 
 class BackendState(BaseModel):
     """
@@ -293,6 +298,11 @@ class RowFilter(BaseModel):
     is_valid: Optional[bool] = Field(
         default=None,
         description="Whether the filter is valid and supported by the backend, if undefined then true",
+    )
+
+    error_message: Optional[str] = Field(
+        default=None,
+        description="Optional error message when the filter is invalid",
     )
 
     between_params: Optional[BetweenFilterParams] = Field(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -561,8 +561,8 @@ class ColumnSortKey(BaseModel):
     Specifies a column to sort by
     """
 
-    column_schema: ColumnSchema = Field(
-        description="Column to sort by",
+    column_index: int = Field(
+        description="Column index to sort by",
     )
 
     ascending: bool = Field(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
@@ -99,45 +99,35 @@ def shell() -> Iterable[PositronShell]:
 
 
 @pytest.fixture
-def mock_connections_service(
-    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
-) -> Mock:
+def mock_connections_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell.kernel, "connections_service", mock)
     return mock
 
 
 @pytest.fixture
-def mock_dataexplorer_service(
-    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
-) -> Mock:
+def mock_dataexplorer_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell.kernel, "data_explorer_service", mock)
     return mock
 
 
 @pytest.fixture
-def mock_ui_service(
-    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
-) -> Mock:
+def mock_ui_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell.kernel, "ui_service", mock)
     return mock
 
 
 @pytest.fixture
-def mock_help_service(
-    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
-) -> Mock:
+def mock_help_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell.kernel, "help_service", mock)
     return mock
 
 
 @pytest.fixture
-def mock_displayhook(
-    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
-) -> Mock:
+def mock_displayhook(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell, "displayhook", mock)
     return mock

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
@@ -10,7 +10,6 @@ import pytest
 from traitlets.config import Config
 
 from positron_ipykernel.connections import ConnectionsService
-from positron_ipykernel.data_explorer import DataExplorerService
 from positron_ipykernel.positron_ipkernel import (
     PositronIPKernelApp,
     PositronIPyKernel,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
@@ -99,35 +99,45 @@ def shell() -> Iterable[PositronShell]:
 
 
 @pytest.fixture
-def mock_connections_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
+def mock_connections_service(
+    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
+) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell.kernel, "connections_service", mock)
     return mock
 
 
 @pytest.fixture
-def mock_dataexplorer_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
+def mock_dataexplorer_service(
+    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
+) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell.kernel, "data_explorer_service", mock)
     return mock
 
 
 @pytest.fixture
-def mock_ui_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
+def mock_ui_service(
+    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
+) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell.kernel, "ui_service", mock)
     return mock
 
 
 @pytest.fixture
-def mock_help_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
+def mock_help_service(
+    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
+) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell.kernel, "help_service", mock)
     return mock
 
 
 @pytest.fixture
-def mock_displayhook(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
+def mock_displayhook(
+    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
+) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell, "displayhook", mock)
     return mock
@@ -156,15 +166,17 @@ def variables_comm(variables_service: VariablesService) -> DummyComm:
     return variables_comm
 
 
-@pytest.fixture()
-def de_service(kernel: PositronIPyKernel) -> DataExplorerService:
+@pytest.fixture
+def de_service(kernel: PositronIPyKernel):
     """
     The Positron dataviewer service.
     """
-    return kernel.data_explorer_service
+    fixture = kernel.data_explorer_service
+    yield fixture
+    fixture.shutdown()
 
 
-@pytest.fixture()
+@pytest.fixture
 def connections_service(kernel: PositronIPyKernel) -> ConnectionsService:
     """
     The Positron connections service.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -140,9 +140,7 @@ def test_explorer_open_close_delete(
     assert len(de_service.table_views) == 0
 
 
-def _assign_variables(
-    shell: PositronShell, variables_comm: DummyComm, **variables
-):
+def _assign_variables(shell: PositronShell, variables_comm: DummyComm, **variables):
     # A hack to make sure that change events are fired when we
     # manipulate user_ns
     shell.kernel.variables_service.snapshot_user_ns()
@@ -183,9 +181,7 @@ def test_explorer_delete_variable(
         assert len(paths) > 0
 
         comms = [
-            de_service.comms[comm_id]
-            for p in paths
-            for comm_id in de_service.path_to_comm_ids[p]
+            de_service.comms[comm_id] for p in paths for comm_id in de_service.path_to_comm_ids[p]
         ]
         variables_comm.handle_msg(msg)
 
@@ -205,11 +201,7 @@ def _check_update_variable(de_service, name, update_type="schema"):
     paths = de_service.get_paths_for_variable(name)
     assert len(paths) > 0
 
-    comms = [
-        de_service.comms[comm_id]
-        for p in paths
-        for comm_id in de_service.path_to_comm_ids[p]
-    ]
+    comms = [de_service.comms[comm_id] for p in paths for comm_id in de_service.path_to_comm_ids[p]]
 
     if update_type == "schema":
         expected_msg = json_rpc_notification("schema_update", {})
@@ -266,9 +258,7 @@ class DataExplorerFixture:
         self._table_views = {}
 
     def assign_and_open_viewer(self, table_name: str, table):
-        _assign_variables(
-            self.shell, self.variables_comm, **{table_name: table}
-        )
+        _assign_variables(self.shell, self.variables_comm, **{table_name: table})
         path_df = _open_viewer(self.variables_comm, [table_name])
         comm_id = list(self.de_service.path_to_comm_ids[path_df])[0]
 
@@ -351,14 +341,10 @@ class DataExplorerFixture:
         return self.do_json_rpc(table_name, "set_row_filters", filters=filters)
 
     def set_sort_columns(self, table_name, sort_keys=None):
-        return self.do_json_rpc(
-            table_name, "set_sort_columns", sort_keys=sort_keys
-        )
+        return self.do_json_rpc(table_name, "set_sort_columns", sort_keys=sort_keys)
 
     def get_column_profiles(self, table_name, profiles):
-        return self.do_json_rpc(
-            table_name, "get_column_profiles", profiles=profiles
-        )
+        return self.do_json_rpc(table_name, "get_column_profiles", profiles=profiles)
 
     def check_filter_case(self, table, filter_set, expected_table):
         table_id = guid()
@@ -371,9 +357,7 @@ class DataExplorerFixture:
         ex_num_rows = len(expected_table)
         assert response == FilterResult(selected_num_rows=ex_num_rows)
 
-        assert (
-            self.get_state(table_id)["table_shape"]["num_rows"] == ex_num_rows
-        )
+        assert self.get_state(table_id)["table_shape"]["num_rows"] == ex_num_rows
         self.compare_tables(table_id, ex_id, table.shape)
 
     def check_sort_case(self, table, sort_keys, expected_table, filters=None):
@@ -389,9 +373,7 @@ class DataExplorerFixture:
         assert response is None
         self.compare_tables(table_id, ex_id, table.shape)
 
-    def compare_tables(
-        self, table_id: str, expected_id: str, table_shape: tuple
-    ):
+    def compare_tables(self, table_id: str, expected_id: str, table_shape: tuple):
         # Query the data and check it yields the same result as the
         # manually constructed data frame without the filter
         response = self.get_data_values(
@@ -431,8 +413,8 @@ def test_pandas_get_state(dxf: DataExplorerFixture):
     schema = dxf.get_schema("simple")["columns"]
 
     sort_keys = [
-        {"column_index": 0, "ascending": True},
-        {"column_index": 1, "ascending": False},
+        {"column_schema": schema[0], "ascending": True},
+        {"column_schema": schema[1], "ascending": False},
     ]
     filters = [
         _compare_filter(schema[0], ">", 0),
@@ -585,9 +567,7 @@ def test_pandas_search_schema(dxf: DataExplorerFixture):
 
     # Make a data frame with those column names
     arr = np.arange(10)
-    df = pd.DataFrame(
-        {name: arr for name in column_names}, columns=pd.Index(column_names)
-    )
+    df = pd.DataFrame({name: arr for name in column_names}, columns=pd.Index(column_names))
 
     dxf.register_table("df", df)
 
@@ -646,9 +626,7 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
     assert result["row_labels"] == [["0", "1", "2", "3", "4"]]
 
     # Edge cases: request beyond end of table
-    response = dxf.get_data_values(
-        "simple", row_start_index=5, num_rows=10, column_indices=[0]
-    )
+    response = dxf.get_data_values("simple", row_start_index=5, num_rows=10, column_indices=[0])
     assert response["columns"] == [[]]
 
     # Issue #2149 -- return empty result when requesting non-existent
@@ -668,9 +646,7 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
     #     )
 
 
-def _filter(
-    filter_type, column_schema, condition="and", is_valid=None, **kwargs
-):
+def _filter(filter_type, column_schema, condition="and", is_valid=None, **kwargs):
     kwargs.update(
         {
             "filter_id": guid(),
@@ -693,9 +669,7 @@ def _compare_filter(column_schema, op, value, condition="and", is_valid=None):
     )
 
 
-def _between_filter(
-    column_schema, left_value, right_value, op="between", condition="and"
-):
+def _between_filter(column_schema, left_value, right_value, op="between", condition="and"):
     return _filter(
         op,
         column_schema,
@@ -704,9 +678,7 @@ def _between_filter(
     )
 
 
-def _not_between_filter(
-    column_schema, left_value, right_value, condition="and"
-):
+def _not_between_filter(column_schema, left_value, right_value, condition="and"):
     return _between_filter(
         column_schema,
         left_value,
@@ -766,20 +738,12 @@ def test_pandas_filter_between(dxf: DataExplorerFixture):
 
         dxf.check_filter_case(
             df,
-            [
-                _between_filter(
-                    column_schema, str(left_value), str(right_value)
-                )
-            ],
+            [_between_filter(column_schema, str(left_value), str(right_value))],
             ex_between,
         )
         dxf.check_filter_case(
             df,
-            [
-                _not_between_filter(
-                    column_schema, str(left_value), str(right_value)
-                )
-            ],
+            [_not_between_filter(column_schema, str(left_value), str(right_value))],
             ex_not_between,
         )
 
@@ -866,18 +830,10 @@ def test_pandas_filter_empty(dxf: DataExplorerFixture):
 
     schema = dxf.get_schema_for(df)["columns"]
 
-    dxf.check_filter_case(
-        df, [_filter("is_empty", schema[0])], df[df["a"].str.len() == 0]
-    )
-    dxf.check_filter_case(
-        df, [_filter("not_empty", schema[0])], df[df["a"].str.len() != 0]
-    )
-    dxf.check_filter_case(
-        df, [_filter("is_empty", schema[1])], df[df["b"].str.len() == 0]
-    )
-    dxf.check_filter_case(
-        df, [_filter("not_empty", schema[1])], df[df["b"].str.len() != 0]
-    )
+    dxf.check_filter_case(df, [_filter("is_empty", schema[0])], df[df["a"].str.len() == 0])
+    dxf.check_filter_case(df, [_filter("not_empty", schema[0])], df[df["a"].str.len() != 0])
+    dxf.check_filter_case(df, [_filter("is_empty", schema[1])], df[df["b"].str.len() == 0])
+    dxf.check_filter_case(df, [_filter("not_empty", schema[1])], df[df["b"].str.len() != 0])
 
 
 def test_pandas_filter_is_null_not_null(dxf: DataExplorerFixture):
@@ -1029,10 +985,11 @@ def test_pandas_variable_updates(
 
     # Do a simple update and make sure that sort keys are preserved
     x_comm_id = list(de_service.path_to_comm_ids[path_x])[0]
-    x_sort_keys = [{"column_index": 0, "ascending": True}]
+    x_schema = dxf.get_schema_for(x)["columns"]
+    x_sort_keys = [{"column_schema": x_schema[0], "ascending": True}]
     msg = json_rpc_request(
         "set_sort_columns",
-        params={"sort_keys": [{"column_index": 0, "ascending": True}]},
+        params={"sort_keys": x_sort_keys},  # type: ignore
         comm_id=x_comm_id,
     )
     de_service.comms[x_comm_id].comm.handle_msg(msg)
@@ -1070,16 +1027,18 @@ def test_pandas_variable_updates(
     _check_update_variable(de_service, "y", update_type="schema")
 
 
-def test_pandas_schema_change_update_filters(dxf: DataExplorerFixture):
-    df = pd.DataFrame(
-        {"a": [1, 2, 3, 4, 5], "b": ["foo", "bar", None, "baz", "qux"]}
-    )
+def test_pandas_schema_change_state_updates(dxf: DataExplorerFixture):
+    df = pd.DataFrame({"a": [1, 2, 3, 4, 5], "b": ["foo", "bar", None, "baz", "qux"]})
 
     dxf.assign_and_open_viewer("df", df.copy())
     schema = dxf.get_schema("df")["columns"]
 
     def _check_scenario(var, scenario, code: str):
-        row_filters = list(zip(*scenario))[0]
+        row_filters = list(zip(*scenario["filters"]))[0]
+
+        if "sort_keys" in scenario:
+            dxf.set_sort_columns(var, sort_keys=scenario["sort_keys"])
+
         dxf.set_row_filters(var, filters=row_filters)
         dxf.execute_code(code)
 
@@ -1089,7 +1048,10 @@ def test_pandas_schema_change_update_filters(dxf: DataExplorerFixture):
         updated_filters = state["row_filters"]
         new_schema = dxf.get_schema(var)["columns"]
 
-        for i, (_, is_still_valid) in enumerate(scenario):
+        if "sort_keys" in scenario:
+            assert state["sort_keys"] == scenario["updated_sort_keys"]
+
+        for i, (_, is_still_valid) in enumerate(scenario["filters"]):
             assert updated_filters[i]["is_valid"] == is_still_valid
 
             orig_col_schema = row_filters[i]["column_schema"]
@@ -1108,70 +1070,84 @@ def test_pandas_schema_change_update_filters(dxf: DataExplorerFixture):
 
     # Scenario 1: convert "a" from integer to string
     # (filter, is_valid_after_change)
-    scenario1 = [
-        # is null, not null, set membership remain valid
-        (_filter("is_null", schema[0]), True),
-        (_filter("not_null", schema[0]), True),
-        (_set_member_filter(schema[0], ["1", "2"]), True),
-        # range comparison becomes invalid
-        (_compare_filter(schema[0], "<", "4"), False),
-        (_compare_filter(schema[0], "<=", "4"), False),
-        (_compare_filter(schema[0], ">=", "4"), False),
-        (_compare_filter(schema[0], ">", "4"), False),
-        # equals, not-equals remain valid
-        (_compare_filter(schema[0], "=", "4"), True),
-        (_compare_filter(schema[0], "!=", "4"), True),
-        # between, not between becomes invalid
-        (_between_filter(schema[0], "1", "3"), False),
-        (_not_between_filter(schema[0], "1", "3"), False),
-    ]
+    scenario1 = {
+        "filters": [
+            # is null, not null, set membership remain valid
+            (_filter("is_null", schema[0]), True),
+            (_filter("not_null", schema[0]), True),
+            (_set_member_filter(schema[0], ["1", "2"]), True),
+            # range comparison becomes invalid
+            (_compare_filter(schema[0], "<", "4"), False),
+            (_compare_filter(schema[0], "<=", "4"), False),
+            (_compare_filter(schema[0], ">=", "4"), False),
+            (_compare_filter(schema[0], ">", "4"), False),
+            # equals, not-equals remain valid
+            (_compare_filter(schema[0], "=", "4"), True),
+            (_compare_filter(schema[0], "!=", "4"), True),
+            # between, not between becomes invalid
+            (_between_filter(schema[0], "1", "3"), False),
+            (_not_between_filter(schema[0], "1", "3"), False),
+        ]
+    }
 
     _check_scenario("df", scenario1, "df['a'] = df['a'].astype(str)")
 
     # Scenario 2: convert "a" from int64 to int16
     dxf.assign_and_open_viewer("df2", df.copy())
     schema = dxf.get_schema("df2")["columns"]
-    scenario2 = [
-        (_filter("is_null", schema[0]), True),
-        (_compare_filter(schema[0], "<", "4"), True),
-        (_between_filter(schema[0], "1", "3"), True),
-    ]
+    scenario2 = {
+        "filters": [
+            (_filter("is_null", schema[0]), True),
+            (_compare_filter(schema[0], "<", "4"), True),
+            (_between_filter(schema[0], "1", "3"), True),
+        ]
+    }
     _check_scenario("df2", scenario2, "df2['a'] = df2['a'].astype('int16')")
 
     # Scenario 3: delete "a" in place
     dxf.assign_and_open_viewer("df3", df.copy())
     schema = dxf.get_schema("df3")["columns"]
-    scenario3 = [
-        (_filter("is_null", schema[0]), False),
-        (_compare_filter(schema[0], "<", "4"), False),
-    ]
+    scenario3 = {
+        "filters": [
+            (_filter("is_null", schema[0]), False),
+            (_compare_filter(schema[0], "<", "4"), False),
+        ],
+        "sort_keys": [{"column_schema": schema[0], "ascending": True}],
+        "updated_sort_keys": [],
+    }
     _check_scenario("df3", scenario3, "del df3['a']")
 
     # Scenario 4: delete "a" in a new DataFrame
     dxf.assign_and_open_viewer("df4", df.copy())
     schema = dxf.get_schema("df4")["columns"]
-    scenario3 = [
-        (_filter("is_null", schema[0]), False),
-        (_compare_filter(schema[0], "<", "4"), False),
-    ]
-    _check_scenario("df4", scenario3, "df4 = df4[['b']]")
+    scenario4 = {
+        "filters": [
+            (_filter("is_null", schema[0]), False),
+            (_compare_filter(schema[0], "<", "4"), False),
+        ]
+    }
+    _check_scenario("df4", scenario4, "df4 = df4[['b']]")
 
     # Scenario 5: replace a column in place with a new name
     dxf.assign_and_open_viewer("df5", df.copy())
     schema = dxf.get_schema("df5")["columns"]
-    scenario3 = [
-        (_compare_filter(schema[1], "=", "foo"), False),
-    ]
-    _check_scenario("df5", scenario3, "df5.insert(1, 'c', df5.pop('b'))")
+    scenario5 = {
+        "filters": [
+            (_compare_filter(schema[1], "=", "foo"), False),
+        ]
+    }
+    _check_scenario("df5", scenario5, "df5.insert(1, 'c', df5.pop('b'))")
 
     # Scenario 6: add some columns, but do not disturb filters
     dxf.assign_and_open_viewer("df6", df.copy())
     schema = dxf.get_schema("df6")["columns"]
-    scenario3 = [
-        (_compare_filter(schema[0], "=", "1"), True),
-        (_compare_filter(schema[1], "=", "foo"), True),
-    ]
-    _check_scenario("df6", scenario3, "df6['c'] = df6['b']")
+    scenario6 = {
+        "filters": [
+            (_compare_filter(schema[0], "=", "1"), True),
+            (_compare_filter(schema[1], "=", "foo"), True),
+        ]
+    }
+    _check_scenario("df6", scenario6, "df6['c'] = df6['b']")
 
 
 def test_pandas_set_sort_columns(dxf: DataExplorerFixture):
@@ -1209,18 +1185,15 @@ def test_pandas_set_sort_columns(dxf: DataExplorerFixture):
     ]
 
     # Test sort AND filter
-    filter_cases = {
-        "df2": [
-            (lambda x: x[x["a"] > 0], [_compare_filter(df2_schema[0], ">", 0)])
-        ]
-    }
+    filter_cases = {"df2": [(lambda x: x[x["a"] > 0], [_compare_filter(df2_schema[0], ">", 0)])]}
 
-    for df_name, keys, expected_params in cases:
-        wrapped_keys = [
-            {"column_index": index, "ascending": ascending}
-            for index, ascending in keys
-        ]
+    for df_name, sort_keys, expected_params in cases:
         df = tables[df_name]
+        schema = dxf.get_schema_for(df)["columns"]
+        wrapped_keys = [
+            {"column_schema": schema[index], "ascending": ascending}
+            for index, ascending in sort_keys
+        ]
 
         expected_params["kind"] = "mergesort"
 
@@ -1230,9 +1203,7 @@ def test_pandas_set_sort_columns(dxf: DataExplorerFixture):
 
         for filter_f, filters in filter_cases.get(df_name, []):
             expected_filtered = filter_f(df).sort_values(**expected_params)
-            dxf.check_sort_case(
-                df, wrapped_keys, expected_filtered, filters=filters
-            )
+            dxf.check_sort_case(df, wrapped_keys, expected_filtered, filters=filters)
 
 
 def test_pandas_change_schema_after_sort(
@@ -1253,13 +1224,15 @@ def test_pandas_change_schema_after_sort(
     _assign_variables(shell, variables_comm, df=df)
     _open_viewer(variables_comm, ["df"])
 
+    schema = dxf.get_schema("df")["columns"]
+
     # Sort a column that is out of bounds for the table after the
     # schema change below
     dxf.set_sort_columns(
         "df",
         [
-            {"column_index": 4, "ascending": True},
-            {"column_index": 0, "ascending": False},
+            {"column_schema": schema[4], "ascending": True},
+            {"column_schema": schema[0], "ascending": False},
         ],
     )
 
@@ -1272,12 +1245,11 @@ def test_pandas_change_schema_after_sort(
 
     # Call get_data_values and make sure it works
     dxf.compare_tables("df", "expected_df", expected_df.shape)
+    schema = dxf.get_schema("df")["columns"]
 
     # Check that the out of bounds column index was evicted, and the
     # shift was correct
-    dxf.get_state("df")["sort_keys"] = [
-        {"column_index": 1, "ascending": False}
-    ]
+    dxf.get_state("df")["sort_keys"] = [{"column_schema": schema[1], "ascending": False}]
 
 
 def _profile_request(column_index, profile_type):
@@ -1335,9 +1307,7 @@ def test_pandas_profile_null_counts(dxf: DataExplorerFixture):
     for table_name, profiles, ex_results in cases:
         results = dxf.get_column_profiles(table_name, profiles)
 
-        ex_results = [
-            ColumnProfileResult(null_count=count) for count in ex_results
-        ]
+        ex_results = [ColumnProfileResult(null_count=count) for count in ex_results]
 
         assert results == ex_results
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -355,7 +355,7 @@ class DataExplorerFixture:
         response = self.set_row_filters(table_id, filters=filter_set)
 
         ex_num_rows = len(expected_table)
-        assert response == FilterResult(selected_num_rows=ex_num_rows)
+        assert response == FilterResult(selected_num_rows=ex_num_rows, had_errors=False)
 
         assert self.get_state(table_id)["table_shape"]["num_rows"] == ex_num_rows
         self.compare_tables(table_id, ex_id, table.shape)
@@ -790,7 +790,7 @@ def test_pandas_filter_compare(dxf: DataExplorerFixture):
     filt = _compare_filter(schema[0], "<", str(compare_value))
     _ = dxf.set_row_filters(table_name, filters=[filt])
     response = dxf.set_row_filters(table_name, filters=[])
-    assert response == FilterResult(selected_num_rows=len(df))
+    assert response == FilterResult(selected_num_rows=len(df), had_errors=False)
 
     # register the whole table to make sure the filters are really cleared
     ex_id = guid()
@@ -985,7 +985,6 @@ def test_pandas_variable_updates(
 
     # Do a simple update and make sure that sort keys are preserved
     x_comm_id = list(de_service.path_to_comm_ids[path_x])[0]
-    x_schema = dxf.get_schema_for(x)["columns"]
     x_sort_keys = [{"column_index": 0, "ascending": True}]
     msg = json_rpc_request(
         "set_sort_columns",
@@ -1222,8 +1221,6 @@ def test_pandas_change_schema_after_sort(
     _assign_variables(shell, variables_comm, df=df)
     _open_viewer(variables_comm, ["df"])
 
-    schema = dxf.get_schema("df")["columns"]
-
     # Sort a column that is out of bounds for the table after the
     # schema change below
     dxf.set_sort_columns(
@@ -1243,7 +1240,6 @@ def test_pandas_change_schema_after_sort(
 
     # Call get_data_values and make sure it works
     dxf.compare_tables("df", "expected_df", expected_df.shape)
-    schema = dxf.get_schema("df")["columns"]
 
     # Check that the out of bounds column index was evicted, and the
     # shift was correct

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -413,8 +413,8 @@ def test_pandas_get_state(dxf: DataExplorerFixture):
     schema = dxf.get_schema("simple")["columns"]
 
     sort_keys = [
-        {"column_schema": schema[0], "ascending": True},
-        {"column_schema": schema[1], "ascending": False},
+        {"column_index": 0, "ascending": True},
+        {"column_index": 1, "ascending": False},
     ]
     filters = [
         _compare_filter(schema[0], ">", 0),
@@ -986,7 +986,7 @@ def test_pandas_variable_updates(
     # Do a simple update and make sure that sort keys are preserved
     x_comm_id = list(de_service.path_to_comm_ids[path_x])[0]
     x_schema = dxf.get_schema_for(x)["columns"]
-    x_sort_keys = [{"column_schema": x_schema[0], "ascending": True}]
+    x_sort_keys = [{"column_index": 0, "ascending": True}]
     msg = json_rpc_request(
         "set_sort_columns",
         params={"sort_keys": x_sort_keys},  # type: ignore
@@ -1008,7 +1008,7 @@ def test_pandas_variable_updates(
     assert new_state["sort_keys"] == [ColumnSortKey(**k) for k in x_sort_keys]
 
     # Execute code that triggers an update event for big_x because it's large
-    shell.run_cell("print('hello world')")
+    shell.run_cell("None")
     _check_update_variable(de_service, "big_x", update_type="schema")
 
     # Update nested values in y and check for schema updates
@@ -1112,7 +1112,7 @@ def test_pandas_schema_change_state_updates(dxf: DataExplorerFixture):
             (_filter("is_null", schema[0]), False),
             (_compare_filter(schema[0], "<", "4"), False),
         ],
-        "sort_keys": [{"column_schema": schema[0], "ascending": True}],
+        "sort_keys": [{"column_index": 0, "ascending": True}],
         "updated_sort_keys": [],
     }
     _check_scenario("df3", scenario3, "del df3['a']")
@@ -1189,10 +1189,8 @@ def test_pandas_set_sort_columns(dxf: DataExplorerFixture):
 
     for df_name, sort_keys, expected_params in cases:
         df = tables[df_name]
-        schema = dxf.get_schema_for(df)["columns"]
         wrapped_keys = [
-            {"column_schema": schema[index], "ascending": ascending}
-            for index, ascending in sort_keys
+            {"column_index": index, "ascending": ascending} for index, ascending in sort_keys
         ]
 
         expected_params["kind"] = "mergesort"
@@ -1231,8 +1229,8 @@ def test_pandas_change_schema_after_sort(
     dxf.set_sort_columns(
         "df",
         [
-            {"column_schema": schema[4], "ascending": True},
-            {"column_schema": schema[0], "ascending": False},
+            {"column_index": 4, "ascending": True},
+            {"column_index": 0, "ascending": False},
         ],
     )
 
@@ -1249,7 +1247,7 @@ def test_pandas_change_schema_after_sort(
 
     # Check that the out of bounds column index was evicted, and the
     # shift was correct
-    dxf.get_state("df")["sort_keys"] = [{"column_schema": schema[1], "ascending": False}]
+    dxf.get_state("df")["sort_keys"] = [{"column_index": 1, "ascending": False}]
 
 
 def _profile_request(column_index, profile_type):

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -779,13 +779,13 @@
 				"type": "object",
 				"description": "Specifies a column to sort by",
 				"required": [
-					"column_schema",
+					"column_index",
 					"ascending"
 				],
 				"properties": {
-					"column_schema": {
-						"description": "Column to sort by",
-						"$ref": "#/components/schemas/column_schema"
+					"column_index": {
+						"type": "integer",
+						"description": "Column index to sort by"
 					},
 					"ascending": {
 						"type": "boolean",

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -779,13 +779,13 @@
 				"type": "object",
 				"description": "Specifies a column to sort by",
 				"required": [
-					"column_index",
+					"column_schema",
 					"ascending"
 				],
 				"properties": {
-					"column_index": {
-						"type": "integer",
-						"description": "Column index to sort by"
+					"column_schema": {
+						"description": "Column to sort by",
+						"$ref": "#/components/schemas/column_schema"
 					},
 					"ascending": {
 						"type": "boolean",

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -181,6 +181,10 @@
 						"selected_num_rows": {
 							"type": "integer",
 							"description": "Number of rows in table after applying filters"
+						},
+						"had_errors": {
+							"type": "boolean",
+							"description": "Flag indicating if there were errors in evaluation"
 						}
 					}
 				}
@@ -419,6 +423,10 @@
 					"is_valid": {
 						"type": "boolean",
 						"description": "Whether the filter is valid and supported by the backend, if undefined then true"
+					},
+					"error_message": {
+						"type": "string",
+						"description": "Optional error message when the filter is invalid"
 					},
 					"between_params": {
 						"description": "Parameters for the 'between' and 'not_between' filter types",

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -392,7 +392,7 @@
 				"required": [
 					"filter_id",
 					"filter_type",
-					"column_index",
+					"column_schema",
 					"condition"
 				],
 				"properties": {
@@ -404,9 +404,9 @@
 						"description": "Type of row filter to apply",
 						"$ref": "#/components/schemas/row_filter_type"
 					},
-					"column_index": {
-						"type": "integer",
-						"description": "Column index to apply filter to"
+					"column_schema": {
+						"description": "Column to apply filter to",
+						"$ref": "#/components/schemas/column_schema"
 					},
 					"condition": {
 						"type": "string",

--- a/positron/comms/data_explorer-frontend-openrpc.json
+++ b/positron/comms/data_explorer-frontend-openrpc.json
@@ -7,17 +7,9 @@
 	"methods": [
 		{
 			"name": "schema_update",
-			"summary": "Reset after a schema change",
-			"description": "Fully reset and redraw the data explorer after a schema change.",
-			"params": [
-				{
-					"name": "discard_state",
-					"description": "If true, the UI should discard the filter/sort state.",
-					"schema": {
-						"type": "boolean"
-					}
-				}
-			]
+			"summary": "Request to sync after a schema change",
+			"description": "Notify the data explorer to do a state sync after a schema change.",
+			"params": []
 		},
 		{
 			"name": "data_update",

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -1334,7 +1334,7 @@ async function createCommInterface() {
 				// Use black to format the Python file; the lint tests for the
 				// Python extension require that the Python files have exactly the
 				// format that black produces.
-				execSync(`python3 -m black ${pythonOutputFile}`, { stdio: 'ignore' });
+				execSync(`python3 -m ruff format ${pythonOutputFile}`, { stdio: 'ignore' });
 			}
 		} catch (e: any) {
 			if (e.message) {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -147,7 +147,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 
 	// State hooks.
 	const [selectedColumnSchema, setSelectedColumnSchema] = useState<ColumnSchema | undefined>(
-		props.editRowFilter?.columnSchema
+		props.editRowFilter?.schema
 	);
 	const [selectedFilterType, setSelectedFilterType] = useState<RowFilterDescrType | undefined>(
 		props.editRowFilter?.descrType
@@ -168,7 +168,9 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			return '';
 		}
 	});
-	const [errorText, setErrorText] = useState<string | undefined>(undefined);
+	const [errorText, setErrorText] = useState<string | undefined>(
+		props.editRowFilter?.props.errorMessage
+	);
 
 	// useEffect for when the selectedFilterType changes.
 	useEffect(() => {
@@ -582,25 +584,27 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		switch (selectedFilterType) {
 			// Apply the is empty row filter.
 			case RowFilterDescrType.IS_EMPTY: {
-				applyRowFilter(new RowFilterDescriptorIsEmpty(selectedColumnSchema));
+				applyRowFilter(new RowFilterDescriptorIsEmpty({ columnSchema: selectedColumnSchema }));
 				break;
 			}
 
 			// Apply the is not empty row filter.
 			case RowFilterDescrType.IS_NOT_EMPTY: {
-				applyRowFilter(new RowFilterDescriptorIsNotEmpty(selectedColumnSchema));
+				applyRowFilter(new RowFilterDescriptorIsNotEmpty({ columnSchema: selectedColumnSchema }));
 				break;
 			}
 
 			// Apply the is null row filter.
 			case RowFilterDescrType.IS_NULL: {
-				applyRowFilter(new RowFilterDescriptorIsNull(selectedColumnSchema));
+				applyRowFilter(new RowFilterDescriptorIsNull(
+					{ columnSchema: selectedColumnSchema }));
 				break;
 			}
 
 			// Apply the is not null row filter.
 			case RowFilterDescrType.IS_NOT_NULL: {
-				applyRowFilter(new RowFilterDescriptorIsNotNull(selectedColumnSchema));
+				applyRowFilter(new RowFilterDescriptorIsNotNull(
+					{ columnSchema: selectedColumnSchema }));
 				break;
 			}
 
@@ -613,7 +617,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					return;
 				}
 				applyRowFilter(new RowFilterDescriptorSearch(
-					selectedColumnSchema,
+					{ columnSchema: selectedColumnSchema },
 					firstRowFilterValue,
 					selectedFilterType
 				));
@@ -631,7 +635,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					return;
 				}
 				applyRowFilter(new RowFilterDescriptorComparison(
-					selectedColumnSchema,
+					{ columnSchema: selectedColumnSchema },
 					firstRowFilterValue,
 					selectedFilterType
 				));
@@ -647,7 +651,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					return;
 				}
 				applyRowFilter(new RowFilterDescriptorIsBetween(
-					selectedColumnSchema,
+					{ columnSchema: selectedColumnSchema },
 					firstRowFilterValue,
 					secondRowFilterValue
 				));
@@ -663,7 +667,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					return;
 				}
 				applyRowFilter(new RowFilterDescriptorIsNotBetween(
-					selectedColumnSchema,
+					{ columnSchema: selectedColumnSchema },
 					firstRowFilterValue,
 					secondRowFilterValue
 				));

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -24,7 +24,7 @@ import { DropDownColumnSelector } from 'vs/workbench/browser/positronDataExplore
 import {
 	RangeRowFilterDescriptor,
 	RowFilterDescriptor,
-	RowFilterCondition,
+	RowFilterDescrType,
 	RowFilterDescriptorComparison,
 	RowFilterDescriptorIsBetween,
 	RowFilterDescriptorIsEmpty,
@@ -87,41 +87,41 @@ const validateRowFilterValue = (columnSchema: ColumnSchema, value: string) => {
 	}
 };
 
-const conditionNumParams = (cond: RowFilterCondition | undefined) => {
-	switch (cond) {
+const filterNumParams = (filterType: RowFilterDescrType | undefined) => {
+	switch (filterType) {
 		case undefined:
-		case RowFilterCondition.CONDITION_IS_EMPTY:
-		case RowFilterCondition.CONDITION_IS_NOT_EMPTY:
-		case RowFilterCondition.CONDITION_IS_NULL:
-		case RowFilterCondition.CONDITION_IS_NOT_NULL:
+		case RowFilterDescrType.IS_EMPTY:
+		case RowFilterDescrType.IS_NOT_EMPTY:
+		case RowFilterDescrType.IS_NULL:
+		case RowFilterDescrType.IS_NOT_NULL:
 			return 0;
-		case RowFilterCondition.CONDITION_IS_EQUAL_TO:
-		case RowFilterCondition.CONDITION_IS_NOT_EQUAL_TO:
-		case RowFilterCondition.CONDITION_IS_GREATER_OR_EQUAL:
-		case RowFilterCondition.CONDITION_IS_GREATER_THAN:
-		case RowFilterCondition.CONDITION_IS_LESS_OR_EQUAL:
-		case RowFilterCondition.CONDITION_IS_LESS_THAN:
-		case RowFilterCondition.CONDITION_SEARCH_CONTAINS:
-		case RowFilterCondition.CONDITION_SEARCH_STARTS_WITH:
-		case RowFilterCondition.CONDITION_SEARCH_ENDS_WITH:
-		case RowFilterCondition.CONDITION_SEARCH_REGEX_MATCHES:
+		case RowFilterDescrType.IS_EQUAL_TO:
+		case RowFilterDescrType.IS_NOT_EQUAL_TO:
+		case RowFilterDescrType.IS_GREATER_OR_EQUAL:
+		case RowFilterDescrType.IS_GREATER_THAN:
+		case RowFilterDescrType.IS_LESS_OR_EQUAL:
+		case RowFilterDescrType.IS_LESS_THAN:
+		case RowFilterDescrType.SEARCH_CONTAINS:
+		case RowFilterDescrType.SEARCH_STARTS_WITH:
+		case RowFilterDescrType.SEARCH_ENDS_WITH:
+		case RowFilterDescrType.SEARCH_REGEX_MATCHES:
 			return 1;
-		case RowFilterCondition.CONDITION_IS_BETWEEN:
-		case RowFilterCondition.CONDITION_IS_NOT_BETWEEN:
+		case RowFilterDescrType.IS_BETWEEN:
+		case RowFilterDescrType.IS_NOT_BETWEEN:
 			return 2;
 	}
 };
 
 /**
- * Checks whether a RowFilterCondition is a comparison or not.
- * @param cond A row filter condition.
- * @returns Whether the condition is a comparison.
+ * Checks whether a RowFilterDescrType is a comparison or not.
+ * @param filterType A row filter descr type.
+ * @returns Whether the filter is a comparison.
  */
-const isSingleParam = (cond: RowFilterCondition | undefined) => {
-	if (cond === undefined) {
+const isSingleParam = (filterType: RowFilterDescrType | undefined) => {
+	if (filterType === undefined) {
 		return false;
 	}
-	return conditionNumParams(cond) === 1;
+	return filterNumParams(filterType) === 1;
 };
 
 /**
@@ -149,8 +149,8 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 	const [selectedColumnSchema, setSelectedColumnSchema] = useState<ColumnSchema | undefined>(
 		props.editRowFilter?.columnSchema
 	);
-	const [selectedCondition, setSelectedCondition] = useState<RowFilterCondition | undefined>(
-		props.editRowFilter?.rowFilterCondition
+	const [selectedFilterType, setSelectedFilterType] = useState<RowFilterDescrType | undefined>(
+		props.editRowFilter?.descrType
 	);
 	const [firstRowFilterValue, setFirstRowFilterValue] = useState<string>(() => {
 		if (props.editRowFilter instanceof SingleValueRowFilterDescriptor) {
@@ -170,17 +170,17 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 	});
 	const [errorText, setErrorText] = useState<string | undefined>(undefined);
 
-	// useEffect for when the selectedCondition changes.
+	// useEffect for when the selectedFilterType changes.
 	useEffect(() => {
-		// When there is a selected condition, drive focus into the first row filter parameter.
-		if (selectedCondition) {
+		// When there is a selected type, drive focus into the first row filter parameter.
+		if (selectedFilterType) {
 			firstRowFilterParameterRef.current?.focus();
 		}
-	}, [selectedCondition]);
+	}, [selectedFilterType]);
 
 	/**
-	 * Returns the condition entries for the condition drop down list box.
-	 * @returns The condition entries for the condition drop down list box.
+	 * Returns the entries for the filter type drop down list box.
+	 * @returns The entries for the filter type drop down list box.
 	 */
 	const conditionEntries = () => {
 		// If there isn't a column schema, return an empty set of condition entries.
@@ -189,77 +189,77 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		}
 
 		// Build the condition entries.
-		const conditionEntries: DropDownListBoxEntry<RowFilterCondition, void>[] = [];
+		const conditionEntries: DropDownListBoxEntry<RowFilterDescrType, void>[] = [];
 
 		// Every type allows is null and is not null conditions.
 		conditionEntries.push(new DropDownListBoxItem({
-			identifier: RowFilterCondition.CONDITION_IS_NULL,
+			identifier: RowFilterDescrType.IS_NULL,
 			title: localize(
 				'positron.addEditRowFilter.conditionIsNull',
 				"is null"
 			),
-			value: RowFilterCondition.CONDITION_IS_NULL
+			value: RowFilterDescrType.IS_NULL
 		}));
 		conditionEntries.push(new DropDownListBoxItem({
-			identifier: RowFilterCondition.CONDITION_IS_NOT_NULL,
+			identifier: RowFilterDescrType.IS_NOT_NULL,
 			title: localize(
 				'positron.addEditRowFilter.conditionIsNotNull',
 				"is not null"
 			),
-			value: RowFilterCondition.CONDITION_IS_NOT_NULL
+			value: RowFilterDescrType.IS_NOT_NULL
 		}));
 		conditionEntries.push(new DropDownListBoxSeparator());
 
 		if (selectedColumnSchema.type_display === ColumnDisplayType.String) {
 			conditionEntries.push(new DropDownListBoxItem({
-				identifier: RowFilterCondition.CONDITION_SEARCH_CONTAINS,
+				identifier: RowFilterDescrType.SEARCH_CONTAINS,
 				title: localize(
 					'positron.addEditRowFilter.conditionSearchContains',
 					"contains"
 				),
-				value: RowFilterCondition.CONDITION_SEARCH_CONTAINS
+				value: RowFilterDescrType.SEARCH_CONTAINS
 			}));
 			conditionEntries.push(new DropDownListBoxItem({
-				identifier: RowFilterCondition.CONDITION_SEARCH_STARTS_WITH,
+				identifier: RowFilterDescrType.SEARCH_STARTS_WITH,
 				title: localize(
 					'positron.addEditRowFilter.conditionSearchStartsWith',
 					"starts with"
 				),
-				value: RowFilterCondition.CONDITION_SEARCH_STARTS_WITH
+				value: RowFilterDescrType.SEARCH_STARTS_WITH
 			}));
 			conditionEntries.push(new DropDownListBoxItem({
-				identifier: RowFilterCondition.CONDITION_SEARCH_ENDS_WITH,
+				identifier: RowFilterDescrType.SEARCH_ENDS_WITH,
 				title: localize(
 					'positron.addEditRowFilter.conditionSearchEndsWith',
 					"ends with"
 				),
-				value: RowFilterCondition.CONDITION_SEARCH_ENDS_WITH
+				value: RowFilterDescrType.SEARCH_ENDS_WITH
 			}));
 			conditionEntries.push(new DropDownListBoxItem({
-				identifier: RowFilterCondition.CONDITION_SEARCH_REGEX_MATCHES,
+				identifier: RowFilterDescrType.SEARCH_REGEX_MATCHES,
 				title: localize(
 					'positron.addEditRowFilter.conditionSearchRegexMatches',
 					"regex matches"
 				),
-				value: RowFilterCondition.CONDITION_SEARCH_REGEX_MATCHES
+				value: RowFilterDescrType.SEARCH_REGEX_MATCHES
 			}));
 
 			// String types support is empty, is not empty filter types
 			conditionEntries.push(new DropDownListBoxItem({
-				identifier: RowFilterCondition.CONDITION_IS_EMPTY,
+				identifier: RowFilterDescrType.IS_EMPTY,
 				title: localize(
 					'positron.addEditRowFilter.conditionIsEmpty',
 					"is empty"
 				),
-				value: RowFilterCondition.CONDITION_IS_EMPTY
+				value: RowFilterDescrType.IS_EMPTY
 			}));
 			conditionEntries.push(new DropDownListBoxItem({
-				identifier: RowFilterCondition.CONDITION_IS_NOT_EMPTY,
+				identifier: RowFilterDescrType.IS_NOT_EMPTY,
 				title: localize(
 					'positron.addEditRowFilter.conditionIsNotEmpty',
 					"is not empty"
 				),
-				value: RowFilterCondition.CONDITION_IS_NOT_EMPTY
+				value: RowFilterDescrType.IS_NOT_EMPTY
 			}));
 			conditionEntries.push(new DropDownListBoxSeparator());
 		}
@@ -271,36 +271,36 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			case ColumnDisplayType.Datetime:
 			case ColumnDisplayType.Time:
 				conditionEntries.push(new DropDownListBoxItem({
-					identifier: RowFilterCondition.CONDITION_IS_LESS_THAN,
+					identifier: RowFilterDescrType.IS_LESS_THAN,
 					title: localize(
 						'positron.addEditRowFilter.conditionIsLessThan',
 						"is less than"
 					),
-					value: RowFilterCondition.CONDITION_IS_LESS_THAN
+					value: RowFilterDescrType.IS_LESS_THAN
 				}));
 				conditionEntries.push(new DropDownListBoxItem({
-					identifier: RowFilterCondition.CONDITION_IS_LESS_OR_EQUAL,
+					identifier: RowFilterDescrType.IS_LESS_OR_EQUAL,
 					title: localize(
 						'positron.addEditRowFilter.conditionIsLessThanOrEqual',
 						"is less than or equal to"
 					),
-					value: RowFilterCondition.CONDITION_IS_LESS_OR_EQUAL
+					value: RowFilterDescrType.IS_LESS_OR_EQUAL
 				}));
 				conditionEntries.push(new DropDownListBoxItem({
-					identifier: RowFilterCondition.CONDITION_IS_GREATER_THAN,
+					identifier: RowFilterDescrType.IS_GREATER_THAN,
 					title: localize(
 						'positron.addEditRowFilter.conditionIsGreaterThan',
 						"is greater than"
 					),
-					value: RowFilterCondition.CONDITION_IS_GREATER_THAN
+					value: RowFilterDescrType.IS_GREATER_THAN
 				}));
 				conditionEntries.push(new DropDownListBoxItem({
-					identifier: RowFilterCondition.CONDITION_IS_GREATER_OR_EQUAL,
+					identifier: RowFilterDescrType.IS_GREATER_OR_EQUAL,
 					title: localize(
 						'positron.addEditRowFilter.conditionIsGreaterThanOrEqual',
 						"is greater than or equal to"
 					),
-					value: RowFilterCondition.CONDITION_IS_GREATER_OR_EQUAL
+					value: RowFilterDescrType.IS_GREATER_OR_EQUAL
 				}));
 				break;
 		}
@@ -314,20 +314,20 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			case ColumnDisplayType.Datetime:
 			case ColumnDisplayType.Time:
 				conditionEntries.push(new DropDownListBoxItem({
-					identifier: RowFilterCondition.CONDITION_IS_EQUAL_TO,
+					identifier: RowFilterDescrType.IS_EQUAL_TO,
 					title: localize(
 						'positron.addEditRowFilter.conditionIsEqualTo',
 						"is equal to"
 					),
-					value: RowFilterCondition.CONDITION_IS_EQUAL_TO
+					value: RowFilterDescrType.IS_EQUAL_TO
 				}));
 				conditionEntries.push(new DropDownListBoxItem({
-					identifier: RowFilterCondition.CONDITION_IS_NOT_EQUAL_TO,
+					identifier: RowFilterDescrType.IS_NOT_EQUAL_TO,
 					title: localize(
 						'positron.addEditRowFilter.conditionIsNotEqualTo',
 						"is not equal to"
 					),
-					value: RowFilterCondition.CONDITION_IS_NOT_EQUAL_TO
+					value: RowFilterDescrType.IS_NOT_EQUAL_TO
 				}));
 				break;
 		}
@@ -340,20 +340,20 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			case ColumnDisplayType.Time:
 				conditionEntries.push(new DropDownListBoxSeparator());
 				conditionEntries.push(new DropDownListBoxItem({
-					identifier: RowFilterCondition.CONDITION_IS_BETWEEN,
+					identifier: RowFilterDescrType.IS_BETWEEN,
 					title: localize(
 						'positron.addEditRowFilter.conditionIsBetween',
 						"is between"
 					),
-					value: RowFilterCondition.CONDITION_IS_BETWEEN
+					value: RowFilterDescrType.IS_BETWEEN
 				}));
 				conditionEntries.push(new DropDownListBoxItem({
-					identifier: RowFilterCondition.CONDITION_IS_NOT_BETWEEN,
+					identifier: RowFilterDescrType.IS_NOT_BETWEEN,
 					title: localize(
 						'positron.addEditRowFilter.conditionIsNotBetween',
 						"is not between"
 					),
-					value: RowFilterCondition.CONDITION_IS_NOT_BETWEEN
+					value: RowFilterDescrType.IS_NOT_BETWEEN
 				}));
 				break;
 		}
@@ -362,7 +362,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		return conditionEntries;
 	};
 
-	const numParams = conditionNumParams(selectedCondition);
+	const numParams = filterNumParams(selectedFilterType);
 
 	// Set the first row filter parameter component.
 	const firstRowFilterParameterComponent = (() => {
@@ -458,7 +458,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		}
 
 		// Ensure that the user has selected a condition.
-		if (!selectedCondition) {
+		if (!selectedFilterType) {
 			setErrorText(localize(
 				'positron.addEditRowFilter.pleaseSelectCondition',
 				"Please select the condition."
@@ -478,9 +478,9 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			// Validate that the first row filter value is not empty.
 			if (value.length === 0) {
 				// Set the error text.
-				switch (selectedCondition) {
-					case RowFilterCondition.CONDITION_IS_BETWEEN:
-					case RowFilterCondition.CONDITION_IS_NOT_BETWEEN:
+				switch (selectedFilterType) {
+					case RowFilterDescrType.IS_BETWEEN:
+					case RowFilterDescrType.IS_NOT_BETWEEN:
 						setErrorText(localize(
 							'positron.addEditRowFilter.pleaseSupplyLowerLimit',
 							"Please supply the lower limit."
@@ -503,9 +503,9 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			// Validate the first row filter value.
 			if (!validateRowFilterValue(selectedColumnSchema, value)) {
 				// Set the error text.
-				switch (selectedCondition) {
-					case RowFilterCondition.CONDITION_IS_BETWEEN:
-					case RowFilterCondition.CONDITION_IS_NOT_BETWEEN:
+				switch (selectedFilterType) {
+					case RowFilterDescrType.IS_BETWEEN:
+					case RowFilterDescrType.IS_NOT_BETWEEN:
 						setErrorText(localize(
 							'positron.addEditRowFilter.pleaseSupplyValidLowerLimit',
 							"Please supply a valid lower limit."
@@ -579,67 +579,67 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		};
 
 		// Validate the condition and row filter values. If things are valid, add the row filter.
-		switch (selectedCondition) {
+		switch (selectedFilterType) {
 			// Apply the is empty row filter.
-			case RowFilterCondition.CONDITION_IS_EMPTY: {
+			case RowFilterDescrType.IS_EMPTY: {
 				applyRowFilter(new RowFilterDescriptorIsEmpty(selectedColumnSchema));
 				break;
 			}
 
 			// Apply the is not empty row filter.
-			case RowFilterCondition.CONDITION_IS_NOT_EMPTY: {
+			case RowFilterDescrType.IS_NOT_EMPTY: {
 				applyRowFilter(new RowFilterDescriptorIsNotEmpty(selectedColumnSchema));
 				break;
 			}
 
 			// Apply the is null row filter.
-			case RowFilterCondition.CONDITION_IS_NULL: {
+			case RowFilterDescrType.IS_NULL: {
 				applyRowFilter(new RowFilterDescriptorIsNull(selectedColumnSchema));
 				break;
 			}
 
 			// Apply the is not null row filter.
-			case RowFilterCondition.CONDITION_IS_NOT_NULL: {
+			case RowFilterDescrType.IS_NOT_NULL: {
 				applyRowFilter(new RowFilterDescriptorIsNotNull(selectedColumnSchema));
 				break;
 			}
 
 			// Apply comparison row filter.
-			case RowFilterCondition.CONDITION_SEARCH_CONTAINS:
-			case RowFilterCondition.CONDITION_SEARCH_STARTS_WITH:
-			case RowFilterCondition.CONDITION_SEARCH_ENDS_WITH:
-			case RowFilterCondition.CONDITION_SEARCH_REGEX_MATCHES: {
+			case RowFilterDescrType.SEARCH_CONTAINS:
+			case RowFilterDescrType.SEARCH_STARTS_WITH:
+			case RowFilterDescrType.SEARCH_ENDS_WITH:
+			case RowFilterDescrType.SEARCH_REGEX_MATCHES: {
 				if (!validateFirstRowFilterValue()) {
 					return;
 				}
 				applyRowFilter(new RowFilterDescriptorSearch(
 					selectedColumnSchema,
 					firstRowFilterValue,
-					selectedCondition
+					selectedFilterType
 				));
 				break;
 			}
 
 			// Apply comparison row filter.
-			case RowFilterCondition.CONDITION_IS_LESS_THAN:
-			case RowFilterCondition.CONDITION_IS_LESS_OR_EQUAL:
-			case RowFilterCondition.CONDITION_IS_GREATER_THAN:
-			case RowFilterCondition.CONDITION_IS_GREATER_OR_EQUAL:
-			case RowFilterCondition.CONDITION_IS_EQUAL_TO:
-			case RowFilterCondition.CONDITION_IS_NOT_EQUAL_TO: {
+			case RowFilterDescrType.IS_LESS_THAN:
+			case RowFilterDescrType.IS_LESS_OR_EQUAL:
+			case RowFilterDescrType.IS_GREATER_THAN:
+			case RowFilterDescrType.IS_GREATER_OR_EQUAL:
+			case RowFilterDescrType.IS_EQUAL_TO:
+			case RowFilterDescrType.IS_NOT_EQUAL_TO: {
 				if (!validateFirstRowFilterValue()) {
 					return;
 				}
 				applyRowFilter(new RowFilterDescriptorComparison(
 					selectedColumnSchema,
 					firstRowFilterValue,
-					selectedCondition
+					selectedFilterType
 				));
 				break;
 			}
 
 			// Apply the is between row filter.
-			case RowFilterCondition.CONDITION_IS_BETWEEN: {
+			case RowFilterDescrType.IS_BETWEEN: {
 				if (!validateFirstRowFilterValue()) {
 					return;
 				}
@@ -655,7 +655,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			}
 
 			// Apply the is not between row filter.
-			case RowFilterCondition.CONDITION_IS_NOT_BETWEEN: {
+			case RowFilterDescrType.IS_NOT_BETWEEN: {
 				if (!validateFirstRowFilterValue()) {
 					return;
 				}
@@ -708,7 +708,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 						setSelectedColumnSchema(columnSchema);
 
 						// Reset the selected condition.
-						setSelectedCondition(undefined);
+						setSelectedFilterType(undefined);
 
 						// Clear the filter values and error text.
 						clearFilterValuesAndErrorText();
@@ -723,12 +723,12 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 						"Select Condition"
 					))()}
 					entries={conditionEntries()}
-					selectedIdentifier={selectedCondition}
+					selectedIdentifier={selectedFilterType}
 					onSelectionChanged={dropDownListBoxItem => {
-						const prevSelected = selectedCondition;
+						const prevSelected = selectedFilterType;
 						const nextSelected = dropDownListBoxItem.options.identifier;
 						// Set the selected condition.
-						setSelectedCondition(nextSelected);
+						setSelectedFilterType(nextSelected);
 
 						// Clear the filter values and error text.
 						if (!(isSingleParam(prevSelected) && isSingleParam(nextSelected))) {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
@@ -3,33 +3,33 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { generateUuid } from 'vs/base/common/uuid';
-import { ColumnSchema, CompareFilterParamsOp, SearchFilterType } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { ColumnSchema, CompareFilterParamsOp, RowFilter, RowFilterCondition, RowFilterType, SearchFilterType, TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
- * RowFilterCondition enumeration.
+ * RowFilterDescrType enumeration.
  */
-export enum RowFilterCondition {
-	// Conditions with no parameters.
-	CONDITION_IS_EMPTY = 'is-empty',
-	CONDITION_IS_NOT_EMPTY = 'is-not-empty',
-	CONDITION_IS_NULL = 'is-null',
-	CONDITION_IS_NOT_NULL = 'is-not-null',
+export enum RowFilterDescrType {
+	// Filters with no parameters.
+	IS_EMPTY = 'is-empty',
+	IS_NOT_EMPTY = 'is-not-empty',
+	IS_NULL = 'is-null',
+	IS_NOT_NULL = 'is-not-null',
 
-	// Conditions with one parameter.
-	CONDITION_IS_LESS_THAN = 'is-less-than',
-	CONDITION_IS_LESS_OR_EQUAL = 'is-less-than-or-equal-to',
-	CONDITION_IS_GREATER_THAN = 'is-greater-than',
-	CONDITION_IS_GREATER_OR_EQUAL = 'is-greater-than-or-equal-to',
-	CONDITION_IS_EQUAL_TO = 'is-equal-to',
-	CONDITION_IS_NOT_EQUAL_TO = 'is-not-equal-to',
-	CONDITION_SEARCH_CONTAINS = 'search-contains',
-	CONDITION_SEARCH_STARTS_WITH = 'search-starts-with',
-	CONDITION_SEARCH_ENDS_WITH = 'search-ends-with',
-	CONDITION_SEARCH_REGEX_MATCHES = 'search-regex',
+	// Filters with one parameter.
+	IS_LESS_THAN = 'is-less-than',
+	IS_LESS_OR_EQUAL = 'is-less-than-or-equal-to',
+	IS_GREATER_THAN = 'is-greater-than',
+	IS_GREATER_OR_EQUAL = 'is-greater-than-or-equal-to',
+	IS_EQUAL_TO = 'is-equal-to',
+	IS_NOT_EQUAL_TO = 'is-not-equal-to',
+	SEARCH_CONTAINS = 'search-contains',
+	SEARCH_STARTS_WITH = 'search-starts-with',
+	SEARCH_ENDS_WITH = 'search-ends-with',
+	SEARCH_REGEX_MATCHES = 'search-regex',
 
-	// Conditions with two parameters.
-	CONDITION_IS_BETWEEN = 'is-between',
-	CONDITION_IS_NOT_BETWEEN = 'is-not-between'
+	// Filters with two parameters.
+	IS_BETWEEN = 'is-between',
+	IS_NOT_BETWEEN = 'is-not-between'
 }
 
 /**
@@ -44,15 +44,29 @@ abstract class BaseRowFilterDescriptor {
 	/**
 	 * Constructor.
 	 * @param columnSchema The column schema.
+	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
-	constructor(public readonly columnSchema: ColumnSchema) {
+	constructor(public readonly columnSchema: ColumnSchema,
+		public readonly isValid: boolean
+	) {
 		this.identifier = generateUuid();
+		this.isValid = isValid;
 	}
 
 	/**
-	 * Gets the row filter condition.
+	 * Gets the row filter UI type.
 	 */
-	abstract get rowFilterCondition(): RowFilterCondition;
+	abstract get descrType(): RowFilterDescrType;
+
+	abstract get backendFilter(): RowFilter;
+
+	protected _sharedBackendParams() {
+		return {
+			filter_id: this.identifier,
+			column_schema: this.columnSchema,
+			condition: RowFilterCondition.And
+		};
+	}
 }
 
 /**
@@ -62,16 +76,29 @@ export class RowFilterDescriptorIsEmpty extends BaseRowFilterDescriptor {
 	/**
 	 * Constructor.
 	 * @param columnSchema The column schema.
+	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
-	constructor(columnSchema: ColumnSchema) {
-		super(columnSchema);
+	constructor(columnSchema: ColumnSchema,
+		isValid: boolean = true
+	) {
+		super(columnSchema, isValid);
 	}
 
 	/**
 	 * Gets the row filter condition.
 	 */
-	get rowFilterCondition() {
-		return RowFilterCondition.CONDITION_IS_EMPTY;
+	get descrType() {
+		return RowFilterDescrType.IS_EMPTY;
+	}
+
+	/**
+	 * Get the backend OpenRPC type.
+	 */
+	get backendFilter() {
+		return {
+			filter_type: RowFilterType.IsEmpty,
+			...this._sharedBackendParams()
+		};
 	}
 }
 
@@ -82,16 +109,29 @@ export class RowFilterDescriptorIsNotEmpty extends BaseRowFilterDescriptor {
 	/**
 	 * Constructor.
 	 * @param columnSchema The column schema.
+	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
-	constructor(columnSchema: ColumnSchema) {
-		super(columnSchema);
+	constructor(columnSchema: ColumnSchema,
+		isValid: boolean = true
+	) {
+		super(columnSchema, isValid);
 	}
 
 	/**
 	 * Gets the row filter condition.
 	 */
-	get rowFilterCondition() {
-		return RowFilterCondition.CONDITION_IS_NOT_EMPTY;
+	get descrType() {
+		return RowFilterDescrType.IS_NOT_EMPTY;
+	}
+
+	/**
+	 * Get the backend OpenRPC type.
+	 */
+	get backendFilter() {
+		return {
+			filter_type: RowFilterType.NotEmpty,
+			...this._sharedBackendParams()
+		};
 	}
 }
 
@@ -102,16 +142,29 @@ export class RowFilterDescriptorIsNull extends BaseRowFilterDescriptor {
 	/**
 	 * Constructor.
 	 * @param columnSchema The column schema.
+	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
-	constructor(columnSchema: ColumnSchema) {
-		super(columnSchema);
+	constructor(columnSchema: ColumnSchema,
+		isValid: boolean = true
+	) {
+		super(columnSchema, isValid);
 	}
 
 	/**
 	 * Gets the row filter condition.
 	 */
-	get rowFilterCondition() {
-		return RowFilterCondition.CONDITION_IS_NULL;
+	get descrType() {
+		return RowFilterDescrType.IS_NULL;
+	}
+
+	/**
+	 * Get the backend OpenRPC type.
+	 */
+	get backendFilter() {
+		return {
+			filter_type: RowFilterType.IsNull,
+			...this._sharedBackendParams()
+		};
 	}
 }
 
@@ -122,16 +175,29 @@ export class RowFilterDescriptorIsNotNull extends BaseRowFilterDescriptor {
 	/**
 	 * Constructor.
 	 * @param columnSchema The column schema.
+	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
-	constructor(columnSchema: ColumnSchema) {
-		super(columnSchema);
+	constructor(columnSchema: ColumnSchema,
+		isValid: boolean = true
+	) {
+		super(columnSchema, isValid);
 	}
 
 	/**
 	 * Gets the row filter condition.
 	 */
-	get rowFilterCondition() {
-		return RowFilterCondition.CONDITION_IS_NOT_NULL;
+	get descrType() {
+		return RowFilterDescrType.IS_NOT_NULL;
+	}
+
+	/**
+	 * Get the backend OpenRPC type.
+	 */
+	get backendFilter() {
+		return {
+			filter_type: RowFilterType.NotNull,
+			...this._sharedBackendParams()
+		};
 	}
 }
 
@@ -143,9 +209,12 @@ export abstract class SingleValueRowFilterDescriptor extends BaseRowFilterDescri
 	 * Constructor.
 	 * @param columnSchema The column schema.
 	 * @param value The value.
+	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
-	constructor(columnSchema: ColumnSchema, public readonly value: string) {
-		super(columnSchema);
+	constructor(columnSchema: ColumnSchema, public readonly value: string,
+		isValid: boolean = true
+	) {
+		super(columnSchema, isValid);
 	}
 }
 
@@ -157,57 +226,73 @@ export class RowFilterDescriptorComparison extends SingleValueRowFilterDescripto
 	 * Constructor.
 	 * @param columnSchema The column schema.
 	 * @param value The value.
-	 * @param condition The filter condition.
+	 * @param descrType The filter condition.
+	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
-	condition: RowFilterCondition;
+	_descrType: RowFilterDescrType;
 
-	constructor(columnSchema: ColumnSchema, value: string, condition: RowFilterCondition) {
-		super(columnSchema, value);
-		this.condition = condition;
+	constructor(columnSchema: ColumnSchema, value: string, descrType: RowFilterDescrType,
+		isValid: boolean = true
+	) {
+		super(columnSchema, value, isValid);
+		this._descrType = descrType;
 	}
 
 	get operatorText() {
-		switch (this.condition) {
-			case RowFilterCondition.CONDITION_IS_EQUAL_TO:
+		switch (this.descrType) {
+			case RowFilterDescrType.IS_EQUAL_TO:
 				return '=';
-			case RowFilterCondition.CONDITION_IS_GREATER_OR_EQUAL:
+			case RowFilterDescrType.IS_GREATER_OR_EQUAL:
 				return '>=';
-			case RowFilterCondition.CONDITION_IS_GREATER_THAN:
+			case RowFilterDescrType.IS_GREATER_THAN:
 				return '>';
-			case RowFilterCondition.CONDITION_IS_LESS_OR_EQUAL:
+			case RowFilterDescrType.IS_LESS_OR_EQUAL:
 				return '<=';
-			case RowFilterCondition.CONDITION_IS_LESS_THAN:
+			case RowFilterDescrType.IS_LESS_THAN:
 				return '<';
-			case RowFilterCondition.CONDITION_IS_NOT_EQUAL_TO:
+			case RowFilterDescrType.IS_NOT_EQUAL_TO:
 				return '!=';
 			default:
 				return '';
 		}
 	}
 
-	get compareFilterOp() {
-		switch (this.condition) {
-			case RowFilterCondition.CONDITION_IS_EQUAL_TO:
-				return CompareFilterParamsOp.Eq;
-			case RowFilterCondition.CONDITION_IS_GREATER_OR_EQUAL:
-				return CompareFilterParamsOp.GtEq;
-			case RowFilterCondition.CONDITION_IS_GREATER_THAN:
-				return CompareFilterParamsOp.Gt;
-			case RowFilterCondition.CONDITION_IS_LESS_OR_EQUAL:
-				return CompareFilterParamsOp.LtEq;
-			case RowFilterCondition.CONDITION_IS_LESS_THAN:
-				return CompareFilterParamsOp.Lt;
-			default:
-				// CONDITION_IS_NOT_EQUAL_TO
-				return CompareFilterParamsOp.NotEq;
-		}
+	/**
+	 * Get the backend OpenRPC type.
+	 */
+	get backendFilter() {
+		const getCompareOp = () => {
+			switch (this.descrType) {
+				case RowFilterDescrType.IS_EQUAL_TO:
+					return CompareFilterParamsOp.Eq;
+				case RowFilterDescrType.IS_GREATER_OR_EQUAL:
+					return CompareFilterParamsOp.GtEq;
+				case RowFilterDescrType.IS_GREATER_THAN:
+					return CompareFilterParamsOp.Gt;
+				case RowFilterDescrType.IS_LESS_OR_EQUAL:
+					return CompareFilterParamsOp.LtEq;
+				case RowFilterDescrType.IS_LESS_THAN:
+					return CompareFilterParamsOp.Lt;
+				default:
+					// IS_NOT_EQUAL_TO
+					return CompareFilterParamsOp.NotEq;
+			}
+		};
+		return {
+			filter_type: RowFilterType.Compare,
+			compare_params: {
+				op: getCompareOp(),
+				value: this.value
+			},
+			...this._sharedBackendParams()
+		};
 	}
 
 	/**
 	 * Gets the row filter condition.
 	 */
-	get rowFilterCondition() {
-		return this.condition;
+	get descrType() {
+		return this._descrType;
 	}
 }
 
@@ -219,48 +304,67 @@ export class RowFilterDescriptorSearch extends SingleValueRowFilterDescriptor {
 	 * Constructor.
 	 * @param columnSchema The column schema.
 	 * @param value The value.
-	 * @param condition The filter condition.
+	 * @param descrType The filter condition.
+	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
-	condition: RowFilterCondition;
+	_descrType: RowFilterDescrType;
 
-	constructor(columnSchema: ColumnSchema, value: string, condition: RowFilterCondition) {
-		super(columnSchema, value);
-		this.condition = condition;
+	constructor(columnSchema: ColumnSchema, value: string, descrType: RowFilterDescrType,
+		isValid: boolean = true
+	) {
+		super(columnSchema, value, isValid);
+		this._descrType = descrType;
 	}
 
 	get operatorText() {
-		switch (this.condition) {
-			case RowFilterCondition.CONDITION_SEARCH_CONTAINS:
+		switch (this._descrType) {
+			case RowFilterDescrType.SEARCH_CONTAINS:
 				return 'contains';
-			case RowFilterCondition.CONDITION_SEARCH_STARTS_WITH:
+			case RowFilterDescrType.SEARCH_STARTS_WITH:
 				return 'starts with';
-			case RowFilterCondition.CONDITION_SEARCH_ENDS_WITH:
+			case RowFilterDescrType.SEARCH_ENDS_WITH:
 				return 'ends with';
 			default:
-				// CONDITION_SEARCH_REGEX_MATCHES
+				// SEARCH_REGEX_MATCHES
 				return 'matches regex';
 		}
 	}
 
-	get searchOp() {
-		switch (this.condition) {
-			case RowFilterCondition.CONDITION_SEARCH_CONTAINS:
-				return SearchFilterType.Contains;
-			case RowFilterCondition.CONDITION_SEARCH_STARTS_WITH:
-				return SearchFilterType.StartsWith;
-			case RowFilterCondition.CONDITION_SEARCH_ENDS_WITH:
-				return SearchFilterType.EndsWith;
-			default:
-				// CONDITION_SEARCH_REGEX_MATCHES
-				return SearchFilterType.RegexMatch;
-		}
-	}
 
 	/**
 	 * Gets the row filter condition.
 	 */
-	get rowFilterCondition() {
-		return this.condition;
+	get descrType() {
+		return this._descrType;
+	}
+
+	/**
+	 * Get the backend OpenRPC type.
+	 */
+	get backendFilter() {
+		const getSearchOp = () => {
+			switch (this._descrType) {
+				case RowFilterDescrType.SEARCH_CONTAINS:
+					return SearchFilterType.Contains;
+				case RowFilterDescrType.SEARCH_STARTS_WITH:
+					return SearchFilterType.StartsWith;
+				case RowFilterDescrType.SEARCH_ENDS_WITH:
+					return SearchFilterType.EndsWith;
+				default:
+					// SEARCH_REGEX_MATCHES
+					return SearchFilterType.RegexMatch;
+			}
+		};
+
+		return {
+			filter_type: RowFilterType.Search,
+			search_params: {
+				search_type: getSearchOp(),
+				term: this.value,
+				case_sensitive: false
+			},
+			...this._sharedBackendParams()
+		};
 	}
 }
 
@@ -273,13 +377,15 @@ export abstract class RangeRowFilterDescriptor extends BaseRowFilterDescriptor {
 	 * @param columnSchema The column schema.
 	 * @param lowerLimit The lower limit.
 	 * @param upperLimit The lower limit.
+	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
 	constructor(
 		columnSchema: ColumnSchema,
 		public readonly lowerLimit: string,
-		public readonly upperLimit: string
+		public readonly upperLimit: string,
+		isValid: boolean = true
 	) {
-		super(columnSchema);
+		super(columnSchema, isValid);
 	}
 }
 
@@ -292,16 +398,33 @@ export class RowFilterDescriptorIsBetween extends RangeRowFilterDescriptor {
 	 * @param columnSchema The column schema.
 	 * @param lowerLimit The lower limit.
 	 * @param upperLimit The lower limit.
+	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
-	constructor(columnSchema: ColumnSchema, lowerLimit: string, upperLimit: string) {
-		super(columnSchema, lowerLimit, upperLimit);
+	constructor(columnSchema: ColumnSchema, lowerLimit: string, upperLimit: string,
+		isValid: boolean = true
+	) {
+		super(columnSchema, lowerLimit, upperLimit, isValid);
 	}
 
 	/**
 	 * Gets the row filter condition.
 	 */
-	get rowFilterCondition() {
-		return RowFilterCondition.CONDITION_IS_BETWEEN;
+	get descrType() {
+		return RowFilterDescrType.IS_BETWEEN;
+	}
+
+	/**
+	 * Get the backend OpenRPC type.
+	 */
+	get backendFilter() {
+		return {
+			filter_type: RowFilterType.Between,
+			between_params: {
+				left_value: this.lowerLimit,
+				right_value: this.upperLimit
+			},
+			...this._sharedBackendParams()
+		};
 	}
 }
 
@@ -322,8 +445,71 @@ export class RowFilterDescriptorIsNotBetween extends RangeRowFilterDescriptor {
 	/**
 	 * Gets the row filter condition.
 	 */
-	get rowFilterCondition() {
-		return RowFilterCondition.CONDITION_IS_NOT_BETWEEN;
+	get descrType() {
+		return RowFilterDescrType.IS_NOT_BETWEEN;
+	}
+
+	/**
+	 * Get the backend OpenRPC type.
+	 */
+	get backendFilter() {
+		return {
+			filter_type: RowFilterType.NotBetween,
+			between_params: {
+				left_value: this.lowerLimit,
+				right_value: this.upperLimit
+			},
+			...this._sharedBackendParams()
+		};
+	}
+}
+
+
+export function getRowFilterDescriptor(backendFilter: RowFilter) {
+	switch (backendFilter.filter_type) {
+		case RowFilterType.Compare: {
+			const params = backendFilter.compare_params!;
+			let descrType = undefined;
+			switch (params.op) {
+				case CompareFilterParamsOp.Eq:
+					descrType = RowFilterDescrType.IS_EQUAL_TO;
+					break;
+				case CompareFilterParamsOp.NotEq:
+					descrType = RowFilterDescrType.IS_NOT_EQUAL_TO;
+					break;
+				case CompareFilterParamsOp.Lt:
+					descrType = RowFilterDescrType.IS_LESS_THAN;
+					break;
+				case CompareFilterParamsOp.LtEq:
+					descrType = RowFilterDescrType.IS_LESS_OR_EQUAL;
+					break;
+				case CompareFilterParamsOp.Gt:
+					descrType = RowFilterDescrType.IS_GREATER_THAN;
+					break;
+				case CompareFilterParamsOp.GtEq:
+					descrType = RowFilterDescrType.IS_GREATER_OR_EQUAL;
+					break;
+			}
+			return new RowFilterDescriptorComparison(backendFilter.column_schema,
+				params.value, descrType
+			);
+		}
+		case RowFilterType.Between:
+			break;
+		case RowFilterType.IsEmpty:
+			break;
+		case RowFilterType.IsNull:
+			break;
+		case RowFilterType.NotBetween:
+			break;
+		case RowFilterType.NotEmpty:
+			break;
+		case RowFilterType.NotNull:
+			break;
+		case RowFilterType.Search:
+			break;
+		case RowFilterType.SetMembership:
+			break;
 	}
 }
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
@@ -39,6 +39,12 @@ export enum RowFilterDescrType {
 	IS_NOT_BETWEEN = 'is-not-between'
 }
 
+interface RowFilterCommonProps {
+	readonly columnSchema: ColumnSchema;
+	readonly isValid?: boolean;
+	readonly errorMessage?: string;
+}
+
 /**
  * BaseRowFilterDescriptor class.
  */
@@ -50,14 +56,10 @@ abstract class BaseRowFilterDescriptor {
 
 	/**
 	 * Constructor.
-	 * @param columnSchema The column schema.
-	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
+	 * @param props The common row filter descriptor properties.
 	 */
-	constructor(public readonly columnSchema: ColumnSchema,
-		public readonly isValid: boolean | undefined
-	) {
+	constructor(public readonly props: RowFilterCommonProps) {
 		this.identifier = generateUuid();
-		this.isValid = isValid;
 	}
 
 	/**
@@ -67,10 +69,14 @@ abstract class BaseRowFilterDescriptor {
 
 	abstract get backendFilter(): RowFilter;
 
+	get schema() {
+		return this.props.columnSchema;
+	}
+
 	protected _sharedBackendParams() {
 		return {
 			filter_id: this.identifier,
-			column_schema: this.columnSchema,
+			column_schema: this.props.columnSchema,
 			condition: RowFilterCondition.And
 		};
 	}
@@ -82,13 +88,10 @@ abstract class BaseRowFilterDescriptor {
 export class RowFilterDescriptorIsEmpty extends BaseRowFilterDescriptor {
 	/**
 	 * Constructor.
-	 * @param columnSchema The column schema.
-	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
+	 * @param props The common row filter descriptor properties.
 	 */
-	constructor(columnSchema: ColumnSchema,
-		isValid = true
-	) {
-		super(columnSchema, isValid);
+	constructor(props: RowFilterCommonProps) {
+		super(props);
 	}
 
 	/**
@@ -115,13 +118,10 @@ export class RowFilterDescriptorIsEmpty extends BaseRowFilterDescriptor {
 export class RowFilterDescriptorIsNotEmpty extends BaseRowFilterDescriptor {
 	/**
 	 * Constructor.
-	 * @param columnSchema The column schema.
-	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
+	 * @param props The common row filter descriptor properties.
 	 */
-	constructor(columnSchema: ColumnSchema,
-		isValid = true
-	) {
-		super(columnSchema, isValid);
+	constructor(props: RowFilterCommonProps) {
+		super(props);
 	}
 
 	/**
@@ -148,13 +148,10 @@ export class RowFilterDescriptorIsNotEmpty extends BaseRowFilterDescriptor {
 export class RowFilterDescriptorIsNull extends BaseRowFilterDescriptor {
 	/**
 	 * Constructor.
-	 * @param columnSchema The column schema.
-	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
+	 * @param props The common row filter descriptor properties.
 	 */
-	constructor(columnSchema: ColumnSchema,
-		isValid = true
-	) {
-		super(columnSchema, isValid);
+	constructor(props: RowFilterCommonProps) {
+		super(props);
 	}
 
 	/**
@@ -181,13 +178,10 @@ export class RowFilterDescriptorIsNull extends BaseRowFilterDescriptor {
 export class RowFilterDescriptorIsNotNull extends BaseRowFilterDescriptor {
 	/**
 	 * Constructor.
-	 * @param columnSchema The column schema.
-	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
+	 * @param props The common row filter descriptor properties.
 	 */
-	constructor(columnSchema: ColumnSchema,
-		isValid = true
-	) {
-		super(columnSchema, isValid);
+	constructor(props: RowFilterCommonProps) {
+		super(props);
 	}
 
 	/**
@@ -214,14 +208,12 @@ export class RowFilterDescriptorIsNotNull extends BaseRowFilterDescriptor {
 export abstract class SingleValueRowFilterDescriptor extends BaseRowFilterDescriptor {
 	/**
 	 * Constructor.
-	 * @param columnSchema The column schema.
+	 * @param props The common row filter descriptor properties.
 	 * @param value The value.
-	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
-	constructor(columnSchema: ColumnSchema, public readonly value: string,
-		isValid = true
-	) {
-		super(columnSchema, isValid);
+	constructor(props: RowFilterCommonProps,
+		public readonly value: string) {
+		super(props);
 	}
 }
 
@@ -231,17 +223,14 @@ export abstract class SingleValueRowFilterDescriptor extends BaseRowFilterDescri
 export class RowFilterDescriptorComparison extends SingleValueRowFilterDescriptor {
 	/**
 	 * Constructor.
-	 * @param columnSchema The column schema.
+	 * @param props The common row filter descriptor properties.
 	 * @param value The value.
 	 * @param descrType The filter condition.
-	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
 	_descrType: RowFilterDescrType;
 
-	constructor(columnSchema: ColumnSchema, value: string, descrType: RowFilterDescrType,
-		isValid = true
-	) {
-		super(columnSchema, value, isValid);
+	constructor(props: RowFilterCommonProps, value: string, descrType: RowFilterDescrType) {
+		super(props, value);
 		this._descrType = descrType;
 	}
 
@@ -309,17 +298,14 @@ export class RowFilterDescriptorComparison extends SingleValueRowFilterDescripto
 export class RowFilterDescriptorSearch extends SingleValueRowFilterDescriptor {
 	/**
 	 * Constructor.
-	 * @param columnSchema The column schema.
+	 * @param props The common row filter descriptor properties.
 	 * @param value The value.
 	 * @param descrType The filter condition.
-	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
 	_descrType: RowFilterDescrType;
 
-	constructor(columnSchema: ColumnSchema, value: string, descrType: RowFilterDescrType,
-		isValid = true
-	) {
-		super(columnSchema, value, isValid);
+	constructor(props: RowFilterCommonProps, value: string, descrType: RowFilterDescrType) {
+		super(props, value);
 		this._descrType = descrType;
 	}
 
@@ -381,15 +367,13 @@ export class RowFilterDescriptorSearch extends SingleValueRowFilterDescriptor {
 export class RowFilterDescriptorSetMembership extends BaseRowFilterDescriptor {
 	/**
 	 * Constructor.
-	 * @param columnSchema The column schema.
+	 * @param props The common row filter descriptor properties.
 	 * @param values The values to include.
-	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
 	values: Array<string>;
 
-	constructor(columnSchema: ColumnSchema, values: Array<string>, isValid = true
-	) {
-		super(columnSchema, isValid);
+	constructor(props: RowFilterCommonProps, values: Array<string>) {
+		super(props);
 		this.values = values;
 	}
 
@@ -426,18 +410,16 @@ export class RowFilterDescriptorSetMembership extends BaseRowFilterDescriptor {
 export abstract class RangeRowFilterDescriptor extends BaseRowFilterDescriptor {
 	/**
 	 * Constructor.
-	 * @param columnSchema The column schema.
+	 * @param props The common row filter descriptor properties.
 	 * @param lowerLimit The lower limit.
 	 * @param upperLimit The lower limit.
-	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
 	constructor(
-		columnSchema: ColumnSchema,
+		props: RowFilterCommonProps,
 		public readonly lowerLimit: string,
 		public readonly upperLimit: string,
-		isValid = true
 	) {
-		super(columnSchema, isValid);
+		super(props);
 	}
 }
 
@@ -447,15 +429,12 @@ export abstract class RangeRowFilterDescriptor extends BaseRowFilterDescriptor {
 export class RowFilterDescriptorIsBetween extends RangeRowFilterDescriptor {
 	/**
 	 * Constructor.
-	 * @param columnSchema The column schema.
+	 * @param props The common row filter descriptor properties.
 	 * @param lowerLimit The lower limit.
 	 * @param upperLimit The lower limit.
-	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
-	constructor(columnSchema: ColumnSchema, lowerLimit: string, upperLimit: string,
-		isValid = true
-	) {
-		super(columnSchema, lowerLimit, upperLimit, isValid);
+	constructor(props: RowFilterCommonProps, lowerLimit: string, upperLimit: string) {
+		super(props, lowerLimit, upperLimit);
 	}
 
 	/**
@@ -486,13 +465,12 @@ export class RowFilterDescriptorIsBetween extends RangeRowFilterDescriptor {
 export class RowFilterDescriptorIsNotBetween extends RangeRowFilterDescriptor {
 	/**
 	 * Constructor.
-	 * @param columnSchema The column schema.
+	 * @param props The common row filter descriptor properties.
 	 * @param lowerLimit The lower limit.
 	 * @param upperLimit The lower limit.
-	 * @param isValid Flag if the filter is valid or invalid and ignored by backend.
 	 */
-	constructor(columnSchema: ColumnSchema, lowerLimit: string, upperLimit: string, isValid = true) {
-		super(columnSchema, lowerLimit, upperLimit);
+	constructor(props: RowFilterCommonProps, lowerLimit: string, upperLimit: string) {
+		super(props, lowerLimit, upperLimit);
 	}
 
 	/**
@@ -548,52 +526,47 @@ function getSearchDescrType(searchType: SearchFilterType) {
 }
 
 export function getRowFilterDescriptor(backendFilter: RowFilter) {
+	const commonProps = {
+		columnSchema: backendFilter.column_schema,
+		isValid: backendFilter.is_valid,
+		errorMessage: backendFilter.error_message
+	};
 	switch (backendFilter.filter_type) {
 		case RowFilterType.Compare: {
 			const params = backendFilter.compare_params!;
-			return new RowFilterDescriptorComparison(backendFilter.column_schema,
+			return new RowFilterDescriptorComparison(commonProps,
 				params.value, getCompareDescrType(params.op),
-				backendFilter.is_valid
 			);
 		}
 		case RowFilterType.Between: {
 			const params = backendFilter.between_params!;
-			return new RowFilterDescriptorIsBetween(backendFilter.column_schema,
-				params.left_value, params.right_value, backendFilter.is_valid
+			return new RowFilterDescriptorIsBetween(commonProps,
+				params.left_value, params.right_value
 			);
 		}
 		case RowFilterType.NotBetween: {
 			const params = backendFilter.between_params!;
-			return new RowFilterDescriptorIsNotBetween(backendFilter.column_schema,
-				params.left_value, params.right_value, backendFilter.is_valid
+			return new RowFilterDescriptorIsNotBetween(commonProps,
+				params.left_value, params.right_value
 			);
 		}
 		case RowFilterType.IsEmpty:
-			return new RowFilterDescriptorIsEmpty(backendFilter.column_schema,
-				backendFilter.is_valid
-			);
+			return new RowFilterDescriptorIsEmpty(commonProps);
 		case RowFilterType.NotEmpty:
-			return new RowFilterDescriptorIsNotEmpty(backendFilter.column_schema,
-				backendFilter.is_valid
-			);
+			return new RowFilterDescriptorIsNotEmpty(commonProps);
 		case RowFilterType.IsNull:
-			return new RowFilterDescriptorIsNull(backendFilter.column_schema,
-				backendFilter.is_valid
-			);
+			return new RowFilterDescriptorIsNull(commonProps);
 		case RowFilterType.NotNull:
-			return new RowFilterDescriptorIsNotNull(backendFilter.column_schema,
-				backendFilter.is_valid
-			);
+			return new RowFilterDescriptorIsNotNull(commonProps);
 		case RowFilterType.Search: {
 			const params = backendFilter.search_params!;
-			return new RowFilterDescriptorSearch(backendFilter.column_schema,
-				params.term, getSearchDescrType(params.search_type),
-				backendFilter.is_valid);
+			return new RowFilterDescriptorSearch(commonProps,
+				params.term, getSearchDescrType(params.search_type));
 		}
 		case RowFilterType.SetMembership: {
 			const params = backendFilter.set_membership_params!;
-			return new RowFilterDescriptorSetMembership(backendFilter.column_schema,
-				params.values, backendFilter.is_valid
+			return new RowFilterDescriptorSetMembership(commonProps,
+				params.values
 			);
 		}
 	}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
@@ -486,8 +486,8 @@ export function getRowFilterDescriptor(backendFilter: RowFilter) {
 				case CompareFilterParamsOp.Gt:
 					descrType = RowFilterDescrType.IS_GREATER_THAN;
 					break;
-				case CompareFilterParamsOp.GtEq:
 					descrType = RowFilterDescrType.IS_GREATER_OR_EQUAL;
+					case CompareFilterParamsOp.GtEq:
 					break;
 			}
 			return new RowFilterDescriptorComparison(backendFilter.column_schema,

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.css
@@ -16,12 +16,16 @@
 	background-color: var(--vscode-positronDataExplorer-background);
 }
 
+.invalid-row-filter-widget {
+	color: var(--vscode-positronDataExplorer-background) !important;
+	background-color: var(--vscode-positronDataExplorer-invalidFilterBackground) !important;
+}
+
 .row-filter-widget:hover {
 	background-color: var(--vscode-positronDataExplorer-contrastBackground);
 }
 
-.row-filter-widget
-.boolean-operator {
+.row-filter-widget .boolean-operator {
 	height: 100%;
 	padding: 0 6px;
 	display: flex;
@@ -30,33 +34,25 @@
 	border-right: 1px solid var(--vscode-positronDataExplorer-border);
 }
 
-.row-filter-widget
-.title {
+.row-filter-widget .title {
 	margin: 0 2px 0 6px;
 }
 
-.row-filter-widget
-.title
-.column-name {
+.row-filter-widget .title .column-name {
 	font-weight: 600;
 }
 
-.row-filter-widget
-.title
-.space-before::before {
+.row-filter-widget .title .space-before::before {
 	content: " ";
 	white-space: pre;
 }
 
-.row-filter-widget
-.title
-.space-after::after {
+.row-filter-widget .title .space-after::after {
 	content: " ";
 	white-space: pre;
 }
 
-.row-filter-widget
-.clear-filter-button {
+.row-filter-widget .clear-filter-button {
 	width: 18px;
 	height: 18px;
 	display: flex;
@@ -69,20 +65,17 @@
 	justify-content: center;
 }
 
-.row-filter-widget
-.clear-filter-button:hover {
+.row-filter-widget .clear-filter-button:hover {
 	border: 1px solid var(--vscode-positronDataExplorer-border);
 
 	/* outline: 1px solid var(--vscode-focusBorder); */
 	background-color: var(--vscode-positronDataExplorer-contrastBackground);
 }
 
-.row-filter-widget
-.clear-button:focus {
+.row-filter-widget .clear-button:focus {
 	outline: none !important;
 }
 
-.row-filter-widget
-.clear-button:focus-visible {
+.row-filter-widget .clear-button:focus-visible {
 	outline: 1px solid var(--vscode-focusBorder);
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
@@ -44,28 +44,28 @@ export const RowFilterWidget = forwardRef<HTMLButtonElement, RowFilterWidgetProp
 	const title = (() => {
 		if (props.rowFilter instanceof RowFilterDescriptorIsEmpty) {
 			return <>
-				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='column-name'>{props.rowFilter.schema.column_name}</span>
 				<span className='space-before'>
 					{localize('positron.dataExplorer.rowFilterWidget.isEmpty', "is empty")}
 				</span>
 			</>;
 		} else if (props.rowFilter instanceof RowFilterDescriptorIsNotEmpty) {
 			return <>
-				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='column-name'>{props.rowFilter.schema.column_name}</span>
 				<span className='space-before'>
 					{localize('positron.dataExplorer.rowFilterWidget.isNotEmpty', "is not empty")}
 				</span>
 			</>;
 		} else if (props.rowFilter instanceof RowFilterDescriptorIsNull) {
 			return <>
-				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='column-name'>{props.rowFilter.schema.column_name}</span>
 				<span className='space-before'>
 					{localize('positron.dataExplorer.rowFilterWidget.isNull', "is null")}
 				</span>
 			</>;
 		} else if (props.rowFilter instanceof RowFilterDescriptorIsNotNull) {
 			return <>
-				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='column-name'>{props.rowFilter.schema.column_name}</span>
 				<span className='space-before'>
 					{localize('positron.dataExplorer.rowFilterWidget.isNotNull', "is not null")}
 				</span>
@@ -73,37 +73,37 @@ export const RowFilterWidget = forwardRef<HTMLButtonElement, RowFilterWidgetProp
 
 		} else if (props.rowFilter instanceof RowFilterDescriptorComparison) {
 			return <>
-				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='column-name'>{props.rowFilter.schema.column_name}</span>
 				<span className='space-before space-after'>{props.rowFilter.operatorText}</span>
 				<span>{props.rowFilter.value}</span>
 			</>;
 		} else if (props.rowFilter instanceof RowFilterDescriptorSearch) {
 			return <>
-				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='column-name'>{props.rowFilter.schema.column_name}</span>
 				<span className='space-before space-after'>{props.rowFilter.operatorText}</span>
 				<span>{props.rowFilter.value}</span>
 			</>;
 		} else if (props.rowFilter instanceof RowFilterDescriptorIsBetween) {
 			return <>
-				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='column-name'>{props.rowFilter.schema.column_name}</span>
 				<span className='space-before space-after'>&gt;=</span>
 				<span>{props.rowFilter.lowerLimit}</span>
 				<span className='space-before space-after'>
 					{localize('positron.dataExplorer.rowFilterWidget.and', "and")}
 				</span>
-				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='column-name'>{props.rowFilter.schema.column_name}</span>
 				<span className='space-before space-after'>&lt;=</span>
 				<span>{props.rowFilter.upperLimit}</span>
 			</>;
 		} else if (props.rowFilter instanceof RowFilterDescriptorIsNotBetween) {
 			return <>
-				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='column-name'>{props.rowFilter.schema.column_name}</span>
 				<span className='space-before space-after'>&lt;</span>
 				<span>{props.rowFilter.lowerLimit}</span>
 				<span className='space-before space-after'>
 					{localize('positron.dataExplorer.rowFilterWidget.and', "and")}
 				</span>
-				<span className='column-name'>{props.rowFilter.columnSchema.column_name}</span>
+				<span className='column-name'>{props.rowFilter.schema.column_name}</span>
 				<span className='space-before space-after'>&gt;</span>
 				<span>{props.rowFilter.upperLimit}</span>
 			</>;
@@ -114,7 +114,7 @@ export const RowFilterWidget = forwardRef<HTMLButtonElement, RowFilterWidgetProp
 	})();
 
 	let buttonClass = 'row-filter-widget';
-	if (!props.rowFilter.isValid) {
+	if (!props.rowFilter.props.isValid) {
 		buttonClass = `${buttonClass} invalid-row-filter-widget`;
 	}
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
@@ -114,7 +114,7 @@ export const RowFilterWidget = forwardRef<HTMLButtonElement, RowFilterWidgetProp
 	})();
 
 	let buttonClass = 'row-filter-widget';
-	if (!props.rowFilter.props.isValid) {
+	if (props.rowFilter.props.isValid === false) {
 		buttonClass = `${buttonClass} invalid-row-filter-widget`;
 	}
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
@@ -113,11 +113,16 @@ export const RowFilterWidget = forwardRef<HTMLButtonElement, RowFilterWidgetProp
 		}
 	})();
 
+	let buttonClass = 'row-filter-widget';
+	if (!props.rowFilter.isValid) {
+		buttonClass = `${buttonClass} invalid-row-filter-widget`;
+	}
+
 	// Render.
 	return (
 		<Button
 			ref={ref}
-			className='row-filter-widget'
+			className={buttonClass}
 			onPressed={() => props.onEdit()}
 		>
 			{props.booleanOperator &&

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -24,7 +24,7 @@ import {
 	getRowFilterDescriptor,
 	RowFilterDescriptor,
 } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
-import { BackendState, RowFilterType } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { BackendState } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * RowFilterBar component.

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -24,7 +24,6 @@ import {
 	getRowFilterDescriptor,
 	RowFilterDescriptor,
 } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
-import { BackendState } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * RowFilterBar component.
@@ -175,10 +174,11 @@ export const RowFilterBar = () => {
 		);
 	};
 
-	const syncFromBackendState = (state: BackendState) => {
+	// Set up event handler for backend state sync updating the filter bar
+	context.instance.dataExplorerClientInstance.onDidUpdateBackendState((state) => {
 		const newDescriptors = state.row_filters.map(getRowFilterDescriptor);
 		setRowFilterDescriptors(newDescriptors);
-	};
+	});
 
 	// Render.
 	return (

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -18,103 +18,13 @@ import { ContextMenuItem } from 'vs/workbench/browser/positronComponents/context
 import { ContextMenuSeparator } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenuSeparator';
 import { usePositronDataExplorerContext } from 'vs/workbench/browser/positronDataExplorer/positronDataExplorerContext';
 import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer';
-import { RowFilter, RowFilterCondition, RowFilterType } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { RowFilterWidget } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget';
 import { AddEditRowFilterModalPopup } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup';
 import {
+	getRowFilterDescriptor,
 	RowFilterDescriptor,
-	RowFilterDescriptorComparison,
-	RowFilterDescriptorIsEmpty,
-	RowFilterDescriptorIsNotEmpty,
-	RowFilterDescriptorIsNull,
-	RowFilterDescriptorIsNotNull,
-	RowFilterDescriptorIsBetween,
-	RowFilterDescriptorIsNotBetween,
-	RowFilterDescriptorSearch
 } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
-
-/**
- * Creates row filters from row filter descriptors.
- * @param rowFilterDescriptors The row filter descriptors.
- * @returns The row filters.
- */
-const createRowFilters = (rowFilterDescriptors: RowFilterDescriptor[]) => {
-	// Create the set of row filters.
-	return rowFilterDescriptors.reduce<RowFilter[]>((
-		rowFilters,
-		rowFilterDescriptor
-	) => {
-		//
-		const sharedParams = {
-			filter_id: rowFilterDescriptor.identifier,
-			column_index: rowFilterDescriptor.columnSchema.column_index,
-			condition: RowFilterCondition.And
-		};
-
-		if (rowFilterDescriptor instanceof RowFilterDescriptorIsEmpty) {
-			rowFilters.push({
-				filter_type: RowFilterType.IsEmpty,
-				...sharedParams
-			});
-		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsNotEmpty) {
-			rowFilters.push({
-				filter_type: RowFilterType.NotEmpty,
-				...sharedParams
-			});
-		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsNull) {
-			rowFilters.push({
-				filter_type: RowFilterType.IsNull,
-				...sharedParams
-			});
-		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsNotNull) {
-			rowFilters.push({
-				filter_type: RowFilterType.NotNull,
-				...sharedParams
-			});
-		} else if (rowFilterDescriptor instanceof RowFilterDescriptorComparison) {
-			rowFilters.push({
-				filter_type: RowFilterType.Compare,
-				compare_params: {
-					op: rowFilterDescriptor.compareFilterOp,
-					value: rowFilterDescriptor.value
-				},
-				...sharedParams
-			});
-		} else if (rowFilterDescriptor instanceof RowFilterDescriptorSearch) {
-			rowFilters.push({
-				filter_type: RowFilterType.Search,
-				search_params: {
-					search_type: rowFilterDescriptor.searchOp,
-					term: rowFilterDescriptor.value,
-					case_sensitive: false
-				},
-				...sharedParams
-			});
-		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsBetween) {
-			rowFilters.push({
-				filter_type: RowFilterType.Between,
-				between_params: {
-					left_value: rowFilterDescriptor.lowerLimit,
-					right_value: rowFilterDescriptor.upperLimit
-				},
-				...sharedParams
-			});
-		} else if (rowFilterDescriptor instanceof RowFilterDescriptorIsNotBetween) {
-			rowFilters.push({
-				filter_type: RowFilterType.NotBetween,
-				between_params: {
-					left_value: rowFilterDescriptor.lowerLimit,
-					right_value: rowFilterDescriptor.upperLimit
-				},
-				...sharedParams
-			});
-		}
-
-		// Return the row filters.
-		return rowFilters;
-	}, []);
-};
-
+import { BackendState, RowFilterType } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * RowFilterBar component.
@@ -178,9 +88,9 @@ export const RowFilterBar = () => {
 			setRowFilterDescriptors(newRowFilterDescriptors);
 
 			// Set the new row filters.
-			await context.instance.tableDataDataGridInstance.setRowFilters(createRowFilters(
-				newRowFilterDescriptors
-			));
+			await context.instance.tableDataDataGridInstance.setRowFilters(
+				newRowFilterDescriptors.map(descr => descr.backendFilter)
+			);
 		};
 
 		// Show the add /edit row filter modal popup.
@@ -260,9 +170,14 @@ export const RowFilterBar = () => {
 		setRowFilterDescriptors(newRowFilterDescriptors);
 
 		// Set the new row filters.
-		await context.instance.tableDataDataGridInstance.setRowFilters(createRowFilters(
-			newRowFilterDescriptors
-		));
+		await context.instance.tableDataDataGridInstance.setRowFilters(
+			newRowFilterDescriptors.map(descr => descr.backendFilter)
+		);
+	};
+
+	const syncFromBackendState = (state: BackendState) => {
+		const newDescriptors = state.row_filters.map(getRowFilterDescriptor);
+		setRowFilterDescriptors(newDescriptors);
 	};
 
 	// Render.

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -218,9 +218,11 @@ interface CellSelectionRange {
 }
 
 /**
- * ColumnSortKey class.
+ * ColumnSortKeyDescriptor class.
+ *
+ * "Descriptor" added to disambiguate from ColumnSortKey in generated comm.
  */
-class ColumnSortKey implements IColumnSortKey {
+export class ColumnSortKeyDescriptor implements IColumnSortKey {
 	//#region Private Properties
 
 	/**
@@ -476,12 +478,16 @@ export abstract class DataGridInstance extends Disposable {
 	 */
 	private readonly _rowHeights = new Map<number, number>();
 
+	//#endregion Private Properties
+
+	//#region Protected Properties
+
 	/**
 	 * Gets the column sort keys.
 	 */
-	private readonly _columnSortKeys = new Map<number, ColumnSortKey>();
+	protected readonly _columnSortKeys = new Map<number, ColumnSortKeyDescriptor>();
 
-	//#endregion Private Properties
+	//#endregion Protected Properties
 
 	//#region Protected Events
 
@@ -994,7 +1000,7 @@ export abstract class DataGridInstance extends Disposable {
 			// Add the column sort key.
 			this._columnSortKeys.set(
 				columnIndex,
-				new ColumnSortKey(this._columnSortKeys.size, columnIndex, ascending)
+				new ColumnSortKeyDescriptor(this._columnSortKeys.size, columnIndex, ascending)
 			);
 
 			// Fire the onDidUpdate event.

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -2094,6 +2094,14 @@ export const POSITRON_DATA_EXPLORER_CONTRAST_BACKGROUND_COLOR = registerColor('p
 	hcLight: editorBackground
 }, localize('positronDataExplorer.contrastBackground', "Positron data explorer contrast background color."));
 
+// Positron data explorer invalid filter background color.
+export const POSITRON_DATA_GRID_INVALID_FILTER_BACKGROUND_COLOR = registerColor('positronDataExplorer.invalidFilterBackground', {
+	dark: '#e95b5b',
+	light: '#e95b5b',
+	hcDark: '#e95b5b',
+	hcLight: '#e95b5b'
+}, localize('positronDataExplorer.invalidFilterBackground', "Positron data grid selection background color."));
+
 // Positron data explorer selection background color.
 export const POSITRON_DATA_EXPLORER_SELECTION_BACKGROUND_COLOR = registerColor('positronDataExplorer.selectionBackground', {
 	dark: lighten(editorBackground, 0.2),

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -2100,7 +2100,7 @@ export const POSITRON_DATA_GRID_INVALID_FILTER_BACKGROUND_COLOR = registerColor(
 	light: '#e95b5b',
 	hcDark: '#e95b5b',
 	hcLight: '#e95b5b'
-}, localize('positronDataExplorer.invalidFilterBackground', "Positron data grid selection background color."));
+}, localize('positronDataExplorer.invalidFilterBackground', "Positron data grid invalid background color."));
 
 // Positron data explorer selection background color.
 export const POSITRON_DATA_EXPLORER_SELECTION_BACKGROUND_COLOR = registerColor('positronDataExplorer.selectionBackground', {

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -48,9 +48,9 @@ export class DataExplorerClientInstance extends Disposable {
 	private readonly _identifier = generateUuid();
 
 	/**
-	 * The current backend state.
+	 * The current cached backend state.
 	 */
-	private _backendState: BackendState | undefined = undefined;
+	public cachedBackendState: BackendState | undefined = undefined;
 
 	/**
 	 * A promise resolving to an active request for the backend state.
@@ -104,7 +104,6 @@ export class DataExplorerClientInstance extends Disposable {
 		});
 
 		this._positronDataExplorerComm.onDidDataUpdate(async (_evt) => {
-			this.updateBackendState();
 			this._onDidDataUpdateEmitter.fire();
 		});
 	}
@@ -126,18 +125,18 @@ export class DataExplorerClientInstance extends Disposable {
 
 	/**
 	 * Get the current active state of the data explorer backend.
-	 * @returns A promose that resolves to the current table state.
+	 * @returns A promose that resolves to the current backend state.
 	 */
 	async getBackendState(): Promise<BackendState> {
 		if (this._backendPromise) {
 			// If there is a request for the state pending
 			return this._backendPromise;
-		} else if (this._backendState === undefined) {
+		} else if (this.cachedBackendState === undefined) {
 			// The state is being requested for the first time
 			return this.updateBackendState();
 		} else {
 			// The state was previously computed
-			return this._backendState;
+			return this.cachedBackendState;
 		}
 	}
 
@@ -151,14 +150,14 @@ export class DataExplorerClientInstance extends Disposable {
 		}
 
 		this._backendPromise = this._positronDataExplorerComm.getState();
-		this._backendState = await this._backendPromise;
+		this.cachedBackendState = await this._backendPromise;
 		this._backendPromise = undefined;
 
 		// Notify listeners
-		this._onDidUpdateBackendStateEmitter.fire(this._backendState);
+		this._onDidUpdateBackendStateEmitter.fire(this.cachedBackendState);
 
 		// Fulfill to anyone waiting on the backend state.
-		return this._backendState;
+		return this.cachedBackendState;
 	}
 
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -71,7 +71,7 @@ export class DataExplorerClientInstance extends Disposable {
 	 * @param client The runtime client instance.
 	 */
 	constructor(client: IRuntimeClientInstance<any, any>) {
-		// Call the disposable constrcutor.
+		// Call the disposable constructor.
 		super();
 
 		// Create and register the PositronDataExplorerComm on the client.

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -495,9 +495,9 @@ export interface ColumnQuantileValue {
  */
 export interface ColumnSortKey {
 	/**
-	 * Column index to sort by
+	 * Column to sort by
 	 */
-	column_index: number;
+	column_schema: ColumnSchema;
 
 	/**
 	 * Sort order, ascending (true) or descending (false)

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -495,9 +495,9 @@ export interface ColumnQuantileValue {
  */
 export interface ColumnSortKey {
 	/**
-	 * Column to sort by
+	 * Column index to sort by
 	 */
-	column_schema: ColumnSchema;
+	column_index: number;
 
 	/**
 	 * Sort order, ascending (true) or descending (false)

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -51,6 +51,11 @@ export interface FilterResult {
 	 */
 	selected_num_rows: number;
 
+	/**
+	 * Flag indicating if there were errors in evaluation
+	 */
+	had_errors?: boolean;
+
 }
 
 /**
@@ -196,6 +201,11 @@ export interface RowFilter {
 	 * then true
 	 */
 	is_valid?: boolean;
+
+	/**
+	 * Optional error message when the filter is invalid
+	 */
+	error_message?: string;
 
 	/**
 	 * Parameters for the 'between' and 'not_between' filter types

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -182,9 +182,9 @@ export interface RowFilter {
 	filter_type: RowFilterType;
 
 	/**
-	 * Column index to apply filter to
+	 * Column to apply filter to
 	 */
-	column_index: number;
+	column_schema: ColumnSchema;
 
 	/**
 	 * The binary condition to use to combine with preceding row filters
@@ -646,14 +646,9 @@ export enum ColumnProfileType {
 }
 
 /**
- * Event: Reset after a schema change
+ * Event: Request to sync after a schema change
  */
 export interface SchemaUpdateEvent {
-	/**
-	 * If true, the UI should discard the filter/sort state.
-	 */
-	discard_state: boolean;
-
 }
 
 /**
@@ -670,7 +665,7 @@ export enum DataExplorerFrontendEvent {
 export class PositronDataExplorerComm extends PositronBaseComm {
 	constructor(instance: IRuntimeClientInstance<any, any>) {
 		super(instance);
-		this.onDidSchemaUpdate = super.createEventEmitter('schema_update', ['discard_state']);
+		this.onDidSchemaUpdate = super.createEventEmitter('schema_update', []);
 		this.onDidDataUpdate = super.createEventEmitter('data_update', []);
 	}
 
@@ -776,9 +771,9 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 
 
 	/**
-	 * Reset after a schema change
+	 * Request to sync after a schema change
 	 *
-	 * Fully reset and redraw the data explorer after a schema change.
+	 * Notify the data explorer to do a state sync after a schema change.
 	 */
 	onDidSchemaUpdate: Event<SchemaUpdateEvent>;
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -200,7 +200,7 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 			// Hack to be able to call PositronDataExplorerEditorInput.setName without
 			// eslint errors;
 			const dxInput = editor?.input as any;
-			if (state.display_name !== undefined) {
+			if (dxInput !== undefined && state.display_name !== undefined) {
 				dxInput.setName?.(`Data: ${state.display_name}`);
 			}
 		});

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -196,7 +196,7 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 			resource: PositronDataExplorerUri.generate(dataExplorerClientInstance.identifier)
 		});
 
-		dataExplorerClientInstance.getState().then((state) => {
+		dataExplorerClientInstance.onDidUpdateBackendState((state) => {
 			// Hack to be able to call PositronDataExplorerEditorInput.setName without
 			// eslint errors;
 			const dxInput = editor?.input as any;
@@ -205,8 +205,10 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 			}
 		});
 
-		const end = new Date();
+		// Trigger the initial state update.
+		dataExplorerClientInstance.updateBackendState();
 
+		const end = new Date();
 		console.log(`this._editorService.openEditor took ${end.getTime() - start.getTime()}ms`);
 	}
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -204,6 +204,9 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		// Set the row filters.
 		await this._dataExplorerClientInstance.setRowFilters(filters);
 
+		// Synchronize the backend state.
+		await this._dataExplorerClientInstance.updateBackendState();
+
 		// Reload the data grid.
 		this._dataExplorerCache.invalidateDataCache();
 		this.softReset();

--- a/src/vs/workbench/services/positronDataExplorer/common/columnSchemaCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/columnSchemaCache.ts
@@ -173,7 +173,7 @@ export class ColumnSchemaCache extends Disposable {
 		this._searchText = searchText;
 
 		// // Get the size of the data.
-		// const tableState = await this._dataExplorerClientInstance.getState();
+		// const tableState = await this._dataExplorerClientInstance.getBackendState();
 		// this._columns = tableState.table_shape.num_columns;
 
 		// Set the start column index and the end column index of the columns to cache.

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
@@ -274,7 +274,7 @@ export class DataExplorerCache extends Disposable {
 		} = cacheUpdateDescriptor;
 
 		// Get the size of the data.
-		const tableState = await this._dataExplorerClientInstance.getState();
+		const tableState = await this._dataExplorerClientInstance.getBackendState();
 		this._columns = tableState.table_shape.num_columns;
 		this._rows = tableState.table_shape.num_rows;
 

--- a/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
@@ -41,7 +41,7 @@ suite('DataExplorerMocks', () => {
 	test('Test getCompareFilter', () => {
 		const filter = mocks.getCompareFilter(2, CompareFilterParamsOp.Gt, '1234');
 		assert.equal(filter.filter_type, RowFilterType.Compare);
-		assert.equal(filter.column_index, 2);
+		assert.equal(filter.column_schema.column_index, 2);
 
 		const params = filter.compare_params!;
 
@@ -51,7 +51,7 @@ suite('DataExplorerMocks', () => {
 
 	test('Test getIsNullFilter', () => {
 		let filter = mocks.getIsNullFilter(3);
-		assert.equal(filter.column_index, 3);
+		assert.equal(filter.column_schema.column_index, 3);
 		assert.equal(filter.filter_type, RowFilterType.IsNull);
 
 		filter = mocks.getNotNullFilter(3);
@@ -61,7 +61,7 @@ suite('DataExplorerMocks', () => {
 	test('Test getTextSearchFilter', () => {
 		const filter = mocks.getTextSearchFilter(5, 'needle',
 			SearchFilterType.Contains, false);
-		assert.equal(filter.column_index, 5);
+		assert.equal(filter.column_schema.column_index, 5);
 		assert.equal(filter.filter_type, RowFilterType.Search);
 
 		const params = filter.search_params!;
@@ -74,7 +74,7 @@ suite('DataExplorerMocks', () => {
 	test('Test getSetMemberFilter', () => {
 		const set_values = ['need1', 'need2'];
 		const filter = mocks.getSetMemberFilter(6, set_values, true);
-		assert.equal(filter.column_index, 6);
+		assert.equal(filter.column_schema.column_index, 6);
 		assert.equal(filter.filter_type, RowFilterType.SetMembership);
 
 		const params = filter.set_membership_params!;

--- a/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
@@ -39,7 +39,9 @@ suite('DataExplorerMocks', () => {
 	});
 
 	test('Test getCompareFilter', () => {
-		const filter = mocks.getCompareFilter(2, CompareFilterParamsOp.Gt, '1234');
+		const schema = mocks.getTableSchema(1000, 10);
+
+		const filter = mocks.getCompareFilter(schema.columns[2], CompareFilterParamsOp.Gt, '1234');
 		assert.equal(filter.filter_type, RowFilterType.Compare);
 		assert.equal(filter.column_schema.column_index, 2);
 
@@ -50,16 +52,18 @@ suite('DataExplorerMocks', () => {
 	});
 
 	test('Test getIsNullFilter', () => {
-		let filter = mocks.getIsNullFilter(3);
+		const schema = mocks.getTableSchema(1000, 10);
+		let filter = mocks.getIsNullFilter(schema.columns[3]);
 		assert.equal(filter.column_schema.column_index, 3);
 		assert.equal(filter.filter_type, RowFilterType.IsNull);
 
-		filter = mocks.getNotNullFilter(3);
+		filter = mocks.getNotNullFilter(schema.columns[3]);
 		assert.equal(filter.filter_type, RowFilterType.NotNull);
 	});
 
 	test('Test getTextSearchFilter', () => {
-		const filter = mocks.getTextSearchFilter(5, 'needle',
+		const schema = mocks.getTableSchema(1000, 10);
+		const filter = mocks.getTextSearchFilter(schema.columns[5], 'needle',
 			SearchFilterType.Contains, false);
 		assert.equal(filter.column_schema.column_index, 5);
 		assert.equal(filter.filter_type, RowFilterType.Search);
@@ -72,8 +76,9 @@ suite('DataExplorerMocks', () => {
 	});
 
 	test('Test getSetMemberFilter', () => {
+		const schema = mocks.getTableSchema(1000, 10);
 		const set_values = ['need1', 'need2'];
-		const filter = mocks.getSetMemberFilter(6, set_values, true);
+		const filter = mocks.getSetMemberFilter(schema.columns[6], set_values, true);
 		assert.equal(filter.column_schema.column_index, 6);
 		assert.equal(filter.filter_type, RowFilterType.SetMembership);
 


### PR DESCRIPTION
There is some more tire kicking and probably small fixes needed here, but wanted to get this up for review.

General summary:

* Does fairly rigorous filter invalidation based on schema changes (column deletions, shifts, or type changes) for pandas. 
* Column sort keys are also partially evicted when a column is deleted in the backend -- need to check that this works correctly in the front end. 
* Fixes issue with UI where the row filter buttons disappeared when switching to an editor tab and then back to the data explorer
* Adds "invalid filter" CSS state (highlighting filter in red) when a filter is invalid
* Added `error_message` optional field to `RowFilter` so that error messages from the backend can be shown in the dropdown modal. Maybe we will want to handle these messages differently, but this at least gives us a start
* Changes `RowFilter.column_index` to `RowFilter.column_schema`. This makes it easier to detect schema changes that affect filters and make them shift or become invalid
* Switches to `ruff` when formatting the generated Positron comms
* Adds "updatedBackendState" event to make it easier to update React states when filtering or schema updates triggers a state synchronization.

Addresses #2584, #2644, #2326