### PR TITLE
Fix creating a mutable collection of figures duplicating a plot

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_comm.py
@@ -183,7 +183,12 @@ class PositronComm:
                 )
                 return
 
-            callback(comm_msg, raw_msg)
+            # Catch any errors in the callback and send them to the frontend.
+            try:
+                callback(comm_msg, raw_msg)
+            except Exception as exception:
+                logger.exception(f"Error handling comm message: {comm_msg}")
+                self.send_error(JsonRpcErrorCode.INTERNAL_ERROR, str(exception))
 
         self.comm.on_msg(handle_msg)
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -286,7 +286,8 @@ class PositronShell(ZMQInteractiveShell):
 
             figs = Gcf.figs
             Gcf.figs = OrderedDict()
-        except Exception:
+        except ImportError:
+            figs = None
             Gcf = None
 
         try:
@@ -294,7 +295,7 @@ class PositronShell(ZMQInteractiveShell):
         except Exception:
             logger.warning("Failed to snapshot user namespace", exc_info=True)
         finally:
-            if Gcf is not None:
+            if Gcf is not None and figs is not None:
                 Gcf.figs = figs
 
     def _handle_post_run_cell(self, info: ExecutionInfo) -> None:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -280,7 +280,7 @@ class PositronShell(ZMQInteractiveShell):
         # namespace, we may deepcopy a figure. This calls Figure.__getstate__ and __setstate__. If
         # the figure exists in Gcf.figs during __getstate__, then __setstate__ will create a
         # figure manager which may incorrectly be shown in the frontend.
-        # See https://github.com/posit-dev/positron/issues/2824.
+        # See https://github.com/posit-dev/positron/issues/2824
         try:
             from matplotlib._pylab_helpers import Gcf
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
@@ -100,7 +100,7 @@ class TestSession(Session):
 def shell() -> Iterable[PositronShell]:
     shell = PositronShell.instance()
 
-    shell.displayhook.session = TestSession()
+    shell.displayhook.session = TestSession()  # type: ignore
 
     # TODO: For some reason these vars are in user_ns but not user_ns_hidden during tests. For now,
     #       manually add them to user_ns_hidden to replicate running in Positron.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
@@ -60,20 +60,20 @@ def test_comm_open(kernel: PositronIPyKernel) -> None:
         #
         # Same types
         #
-        ("import numpy as np", [f"np.array({x})" for x in [3, [3], [[3]]]]),
-        ("import torch", [f"torch.tensor({x})" for x in [3, [3], [[3]]]]),
+        ("import numpy as np", [f"x = np.array({x})" for x in [3, [3], [[3]]]]),
+        ("import torch", [f"x = torch.tensor({x})" for x in [3, [3], [[3]]]]),
         pytest.param(
             "import pandas as pd",
-            [f"pd.Series({x})" for x in [[], [3], [3, 3], ["3"]]],
+            [f"x = pd.Series({x})" for x in [[], [3], [3, 3], ["3"]]],
         ),
         pytest.param(
             "import polars as pl",
-            [f"pl.Series({x})" for x in [[], [3], [3, 3], ["3"]]],
+            [f"x = pl.Series({x})" for x in [[], [3], [3, 3], ["3"]]],
         ),
         (
             "import pandas as pd",
             [
-                f"pd.DataFrame({x})"
+                f"x = pd.DataFrame({x})"
                 for x in [
                     {"a": []},
                     {"a": [3]},
@@ -85,7 +85,7 @@ def test_comm_open(kernel: PositronIPyKernel) -> None:
         (
             "import polars as pl",
             [
-                f"pl.DataFrame({x})"
+                f"x = pl.DataFrame({x})"
                 for x in [
                     {"a": []},
                     {"a": [3]},
@@ -94,11 +94,11 @@ def test_comm_open(kernel: PositronIPyKernel) -> None:
                 ]
             ],
         ),
-        #
+        # Nested mutable types
+        ("", ["x = [{}]", "x[0]['a'] = 0"]),
+        ("", ["x = {'a': []}", "x['a'].append(0)"]),
         # Changing types
-        #
-        ("", ["3", "'3'"]),
-        ("import numpy as np", ["3", "np.array(3)"]),
+        ("import numpy as np", ["x = 3", "x = np.array(3)"]),
     ],
 )
 def test_change_detection(
@@ -117,7 +117,7 @@ def test_change_detection(
 
 def _assert_assigned(shell: PositronShell, value_code: str, variables_comm: DummyComm):
     # Assign the value to a variable.
-    shell.run_cell(f"x = {value_code}")
+    shell.run_cell(value_code)
 
     # Test that the expected `update` message was sent with the
     # expected `assigned` value.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Address #2824.

### Approach

Described in https://github.com/posit-dev/positron/issues/2824#issuecomment-2069217246.

There are also two unrelated improvements in this PR:

1. We now catch any errors in message callbacks across all services, and respond with a JSON RPC error. This should avoid the timeouts we'd been seeing. If the corresponding frontend service handles the error, the user will get immediate feedback.
2. Use a custom `Session` object for the shell in tests so that cell execution errors are logged. Currently, they fail silently.

### QA Notes

See the test case here, and the linked issue