### PR TITLE
Data Explorer: do not clear sort keys from UI state after applying a row filter

### DIFF
--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -2060,7 +2060,6 @@ export abstract class DataGridInstance extends Disposable {
 		this._rowSelectionIndexes.clear();
 		this._columnWidths.clear();
 		this._rowHeights.clear();
-		this._columnSortKeys.clear();
 	}
 
 	//#endregion Protected Methods


### PR DESCRIPTION
Addresses #2803 

The sort keys were being cleared unnecessarily in `DataGridInstance.softReset`. Instead, we should only change this map when the user performs actions or the backend state is synchronized. 