### PR TITLE
Data Explorer: Do not divide by zero when computing null percentages of table with zero rows

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -235,9 +235,13 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 
 	getColumnNullPercent(columnIndex: number): number | undefined {
 		const nullCount = this._dataExplorerCache.getColumnNullCount(columnIndex);
-		// TODO: Is floor what we want?
-		return nullCount === undefined ? undefined : Math.floor(
-			nullCount * 100 / this._dataExplorerCache.rows);
+		if (this._dataExplorerCache.rows === 0) {
+			// #2770: do not divide by zero
+			return 0;
+		} else {
+			return nullCount === undefined ? undefined : Math.floor(
+				nullCount * 100 / this._dataExplorerCache.rows);
+		}
 	}
 
 	getColumnSummaryStats(columnIndex: number): ColumnSummaryStats | undefined {


### PR DESCRIPTION
This addresses #2770 where "NaN%" would show up as the null percentage as the result of dividing by zero. Instead 0% is now shown when the table has no rows after filtering (or looking at a 0-row data frame).