### PR TITLE
Re-enable Welcome page

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -31,6 +31,10 @@ import { StartupPageEditorResolverContribution, StartupPageRunnerContribution } 
 import { ExtensionsInput } from 'vs/workbench/contrib/extensions/common/extensionsInput';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
 
+// --- Start Positron ---
+import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
+// --- End Positron ---
+
 export * as icons from 'vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedIcons';
 
 registerAction2(class extends Action2 {
@@ -44,7 +48,13 @@ registerAction2(class extends Action2 {
 				id: MenuId.MenubarHelpMenu,
 				group: '1_welcome',
 				order: 1,
-			}
+				// --- Start Positron ---
+				when: IsDevelopmentContext
+				// --- End Positron ---
+			},
+			// --- Start Positron ---
+			precondition: IsDevelopmentContext
+			// --- End Positron ---
 		});
 	}
 
@@ -217,6 +227,9 @@ registerAction2(class extends Action2 {
 			title: localize2('welcome.showAllWalkthroughs', 'Open Walkthrough...'),
 			category,
 			f1: true,
+			// --- Start Positron ---
+			precondition: IsDevelopmentContext
+			// --- End Positron ---
 		});
 	}
 

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -30,6 +30,11 @@ import { localize } from 'vs/nls';
 import { IEditorResolverService, RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
 import { TerminalCommandId } from 'vs/workbench/contrib/terminal/common/terminal';
 
+// --- Start Positron ---
+import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+// --- End Positron ---
+
 export const restoreWalkthroughsConfigurationKey = 'workbench.welcomePage.restorableWalkthroughs';
 export type RestoreWalkthroughsConfigurationValue = { folder: string; category?: string; step?: string };
 
@@ -76,6 +81,9 @@ export class StartupPageRunnerContribution implements IWorkbenchContribution {
 	static readonly ID = 'workbench.contrib.startupPageRunner';
 
 	constructor(
+		// --- Start Positron ---
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		// --- End Positron ---
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IEditorService private readonly editorService: IEditorService,
 		@IWorkingCopyBackupService private readonly workingCopyBackupService: IWorkingCopyBackupService,
@@ -115,7 +123,10 @@ export class StartupPageRunnerContribution implements IWorkbenchContribution {
 			return;
 		}
 
-		const enabled = isStartupPageEnabled(this.configurationService, this.contextService, this.environmentService);
+		// --- Start Positron ---
+		const enabled = isStartupPageEnabled(this.configurationService, this.contextService, this.environmentService)
+			&& isPositronStartupPageEnabled(this.contextKeyService);
+		// --- End Positron ---
 		if (enabled && this.lifecycleService.startupKind !== StartupKind.ReloadedWindow) {
 			const hasBackups = await this.workingCopyBackupService.hasBackups();
 			if (hasBackups) { return; }
@@ -232,3 +243,9 @@ function isStartupPageEnabled(configurationService: IConfigurationService, conte
 		|| (contextService.getWorkbenchState() === WorkbenchState.EMPTY && startupEditor.value === 'welcomePageInEmptyWorkbench')
 		|| startupEditor.value === 'terminal';
 }
+
+// --- Start Positron ---
+function isPositronStartupPageEnabled(contextKeyService: IContextKeyService): boolean {
+	return IsDevelopmentContext.getValue(contextKeyService) === true;
+}
+// --- End Positron ---

--- a/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
@@ -257,7 +257,9 @@ const Button = (title: string, href: string) => `[${title}](${href})`;
 export const walkthroughs: GettingStartedWalkthroughContent = [
 	{
 		id: 'Setup',
-		title: localize('gettingStarted.setup.title', "Get Started with VS Code"),
+		// --- Start Positron ---
+		title: localize('gettingStarted.setup.title', "Get Started with Positron"),
+		// --- End Positron ---
 		description: localize('gettingStarted.setup.description', "Customize your editor, learn the basics, and start coding"),
 		isFeatured: true,
 		icon: setupIcon,

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -348,10 +348,10 @@ import 'vs/workbench/contrib/surveys/browser/languageSurveys.contribution';
 
 // Welcome
 // --- Start Positron ---
-// For Private Alpha, disable the getting started contribution. This allows us to hide the editor by
-// default in layout.ts.
-// import 'vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution';
+// Note: See startupPage.ts and gettingStarted.contribution.ts for how Positron customizes
+// welcome page enablement.
 // --- End Positron ---
+import 'vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution';
 import 'vs/workbench/contrib/welcomeWalkthrough/browser/walkThrough.contribution';
 import 'vs/workbench/contrib/welcomeViews/common/viewsWelcome.contribution';
 import 'vs/workbench/contrib/welcomeViews/common/newFile.contribution';


### PR DESCRIPTION
### Intent
Re-enabling welcome screen for #2815 

### Approach
Sets the welcome command and screen to be enabled in dev mode. Quick rebrand of the getting started walkthrough.

### QA Notes
Only shown in dev mode.