### PR TITLE
Data Explorer: show both filtered and unfiltered row count and percent of total in bottom status bar

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -978,14 +978,23 @@ class PandasView(DataExplorerTableView):
     )
 
     def _get_state(self) -> BackendState:
+        table_unfiltered_shape = TableShape(
+            num_rows=self.table.shape[0], num_columns=self.table.shape[1]
+        )
+
         if self.view_indices is not None:
-            num_rows = len(self.view_indices)
+            # Account for filters
+            table_shape = TableShape(
+                num_rows=len(self.view_indices),
+                num_columns=self.table.shape[1],
+            )
         else:
-            num_rows = self.table.shape[0]
+            table_shape = table_unfiltered_shape
 
         return BackendState(
             display_name=self.display_name,
-            table_shape=TableShape(num_rows=num_rows, num_columns=self.table.shape[1]),
+            table_shape=table_shape,
+            table_unfiltered_shape=table_unfiltered_shape,
             row_filters=self.filters,
             sort_keys=self.sort_keys,
             supported_features=self.FEATURES,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -182,12 +182,11 @@ class BackendState(BaseModel):
     )
 
     table_shape: TableShape = Field(
-        description="Number of rows and columns in table including any filters",
+        description="Number of rows and columns in table with filters applied",
     )
 
-    table_unfiltered_shape: Optional[TableShape] = Field(
-        default=None,
-        description="Number of rows and columns in table without any filters",
+    table_unfiltered_shape: TableShape = Field(
+        description="Number of rows and columns in table without any filters applied",
     )
 
     row_filters: List[RowFilter] = Field(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -270,11 +270,11 @@ class TableShape(BaseModel):
     """
 
     num_rows: int = Field(
-        description="Numbers of rows in the unfiltered dataset",
+        description="Numbers of rows in the table",
     )
 
     num_columns: int = Field(
-        description="Number of columns in the unfiltered dataset",
+        description="Number of columns in the table",
     )
 
 
@@ -870,7 +870,8 @@ class GetColumnProfilesRequest(BaseModel):
 
 class GetStateRequest(BaseModel):
     """
-    Request the current table state (applied filters and sort columns)
+    Request the current backend state (shape, filters, sort keys,
+    features)
     """
 
     method: Literal[DataExplorerBackendRequest.GetState] = Field(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -182,7 +182,12 @@ class BackendState(BaseModel):
     )
 
     table_shape: TableShape = Field(
-        description="Provides number of rows and columns in table",
+        description="Number of rows and columns in table including any filters",
+    )
+
+    table_unfiltered_shape: Optional[TableShape] = Field(
+        default=None,
+        description="Number of rows and columns in table without any filters",
     )
 
     row_filters: List[RowFilter] = Field(
@@ -195,20 +200,6 @@ class BackendState(BaseModel):
 
     supported_features: SupportedFeatures = Field(
         description="The features currently supported by the backend instance",
-    )
-
-
-class TableShape(BaseModel):
-    """
-    Provides number of rows and columns in table
-    """
-
-    num_rows: int = Field(
-        description="Numbers of rows in the unfiltered dataset",
-    )
-
-    num_columns: int = Field(
-        description="Number of columns in the unfiltered dataset",
     )
 
 
@@ -271,6 +262,20 @@ class TableSchema(BaseModel):
 
     columns: List[ColumnSchema] = Field(
         description="Schema for each column in the table",
+    )
+
+
+class TableShape(BaseModel):
+    """
+    Provides number of rows and columns in a table
+    """
+
+    num_rows: int = Field(
+        description="Numbers of rows in the unfiltered dataset",
+    )
+
+    num_columns: int = Field(
+        description="Number of columns in the unfiltered dataset",
     )
 
 
@@ -913,11 +918,11 @@ FilterResult.update_forward_refs()
 
 BackendState.update_forward_refs()
 
-TableShape.update_forward_refs()
-
 ColumnSchema.update_forward_refs()
 
 TableSchema.update_forward_refs()
+
+TableShape.update_forward_refs()
 
 RowFilter.update_forward_refs()
 

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -259,23 +259,12 @@
 							"description": "Variable name or other string to display for tab name in UI"
 						},
 						"table_shape": {
-							"type": "object",
-							"name": "table_shape",
-							"description": "Provides number of rows and columns in table",
-							"required": [
-								"num_rows",
-								"num_columns"
-							],
-							"properties": {
-								"num_rows": {
-									"type": "integer",
-									"description": "Numbers of rows in the unfiltered dataset"
-								},
-								"num_columns": {
-									"type": "integer",
-									"description": "Number of columns in the unfiltered dataset"
-								}
-							}
+							"description": "Number of rows and columns in table including any filters",
+							"$ref": "#/components/schemas/table_shape"
+						},
+						"table_unfiltered_shape": {
+							"description": "Number of rows and columns in table without any filters",
+							"$ref": "#/components/schemas/table_shape"
 						},
 						"row_filters": {
 							"type": "array",
@@ -387,6 +376,24 @@
 						"items": {
 							"$ref": "#/components/schemas/column_schema"
 						}
+					}
+				}
+			},
+			"table_shape": {
+				"type": "object",
+				"description": "Provides number of rows and columns in a table",
+				"required": [
+					"num_rows",
+					"num_columns"
+				],
+				"properties": {
+					"num_rows": {
+						"type": "integer",
+						"description": "Numbers of rows in the unfiltered dataset"
+					},
+					"num_columns": {
+						"type": "integer",
+						"description": "Number of columns in the unfiltered dataset"
 					}
 				}
 			},

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -239,7 +239,7 @@
 		{
 			"name": "get_state",
 			"summary": "Get the state",
-			"description": "Request the current table state (applied filters and sort columns)",
+			"description": "Request the current backend state (shape, filters, sort keys, features)",
 			"params": [],
 			"result": {
 				"schema": {
@@ -390,11 +390,11 @@
 				"properties": {
 					"num_rows": {
 						"type": "integer",
-						"description": "Numbers of rows in the unfiltered dataset"
+						"description": "Numbers of rows in the table"
 					},
 					"num_columns": {
 						"type": "integer",
-						"description": "Number of columns in the unfiltered dataset"
+						"description": "Number of columns in the table"
 					}
 				}
 			},

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -249,6 +249,7 @@
 					"required": [
 						"display_name",
 						"table_shape",
+						"table_unfiltered_shape",
 						"row_filters",
 						"sort_keys",
 						"supported_features"
@@ -259,11 +260,11 @@
 							"description": "Variable name or other string to display for tab name in UI"
 						},
 						"table_shape": {
-							"description": "Number of rows and columns in table including any filters",
+							"description": "Number of rows and columns in table with filters applied",
 							"$ref": "#/components/schemas/table_shape"
 						},
 						"table_unfiltered_shape": {
-							"description": "Number of rows and columns in table without any filters",
+							"description": "Number of rows and columns in table without any filters applied",
 							"$ref": "#/components/schemas/table_shape"
 						},
 						"row_filters": {

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -68,14 +68,14 @@ export interface BackendState {
 	display_name: string;
 
 	/**
-	 * Number of rows and columns in table including any filters
+	 * Number of rows and columns in table with filters applied
 	 */
 	table_shape: TableShape;
 
 	/**
-	 * Number of rows and columns in table without any filters
+	 * Number of rows and columns in table without any filters applied
 	 */
-	table_unfiltered_shape?: TableShape;
+	table_unfiltered_shape: TableShape;
 
 	/**
 	 * The set of currently applied row filters

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -166,12 +166,12 @@ export interface TableSchema {
  */
 export interface TableShape {
 	/**
-	 * Numbers of rows in the unfiltered dataset
+	 * Numbers of rows in the table
 	 */
 	num_rows: number;
 
 	/**
-	 * Number of columns in the unfiltered dataset
+	 * Number of columns in the table
 	 */
 	num_columns: number;
 
@@ -775,7 +775,8 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	/**
 	 * Get the state
 	 *
-	 * Request the current table state (applied filters and sort columns)
+	 * Request the current backend state (shape, filters, sort keys,
+	 * features)
 	 *
 	 *
 	 * @returns The current backend state for the data explorer

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -68,9 +68,14 @@ export interface BackendState {
 	display_name: string;
 
 	/**
-	 * Provides number of rows and columns in table
+	 * Number of rows and columns in table including any filters
 	 */
 	table_shape: TableShape;
+
+	/**
+	 * Number of rows and columns in table without any filters
+	 */
+	table_unfiltered_shape?: TableShape;
 
 	/**
 	 * The set of currently applied row filters
@@ -86,22 +91,6 @@ export interface BackendState {
 	 * The features currently supported by the backend instance
 	 */
 	supported_features: SupportedFeatures;
-
-}
-
-/**
- * Provides number of rows and columns in table
- */
-export interface TableShape {
-	/**
-	 * Numbers of rows in the unfiltered dataset
-	 */
-	num_rows: number;
-
-	/**
-	 * Number of columns in the unfiltered dataset
-	 */
-	num_columns: number;
 
 }
 
@@ -169,6 +158,22 @@ export interface TableSchema {
 	 * Schema for each column in the table
 	 */
 	columns: Array<ColumnSchema>;
+
+}
+
+/**
+ * Provides number of rows and columns in a table
+ */
+export interface TableShape {
+	/**
+	 * Numbers of rows in the unfiltered dataset
+	 */
+	num_rows: number;
+
+	/**
+	 * Number of columns in the unfiltered dataset
+	 */
+	num_columns: number;
 
 }
 


### PR DESCRIPTION
Addresses #2832.

This adds a `table_unfiltered_shape` member to `BackendState`. When the data is unfiltered, this should be equal to `table_shape`. Alternately, we could make `table_shape` the unfiltered shape and return the filtered shape in `table_filtered_shape` member. Both approaches seem equivalent to me, so as long as they are documented properly it seems fine. 