### PR TITLE
Disable Jupyter interactive window setting

### DIFF
--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -21,6 +21,7 @@ import { MarkdownString } from 'vs/base/common/htmlContent';
 
 // --- Start Positron ---
 // Ignore properties contributed by vscode-jupyter related in favor of Positron code cells and console.
+// These are disabled in the settings UI. To override their actual values see extHostConfiguration.ts.
 // TODO(seem): We can remove this if we eventually decide to unbundle vscode-jupyter.
 const IGNORED_JUPYTER_CONFIGURATION_PROPERTIES = new Set([
 	'jupyter.decorateCells',
@@ -32,6 +33,7 @@ const IGNORED_JUPYTER_CONFIGURATION_PROPERTIES = new Set([
 	'jupyter.interactiveWindow.codeLens.commands',
 	'jupyter.interactiveWindow.codeLens.enable',
 	'jupyter.interactiveWindow.codeLens.enableGotoCell',
+	// The typo in the following property is intentional, don't fix it.
 	'jupyter.interactiveWindow.codeLes.debugCommands',
 	'jupyter.interactiveWindow.creationMode',
 	'jupyter.interactiveWindow.textEditor.autoAddNewCell',

--- a/src/vs/workbench/api/common/extHostConfiguration.ts
+++ b/src/vs/workbench/api/common/extHostConfiguration.ts
@@ -185,13 +185,14 @@ export class ExtHostConfigProvider {
 			},
 			get: <T>(key: string, defaultValue?: T) => {
 				// --- Start Positron ---
-				// Disable vscode-jupyter's cell decorations and code lenses, preferring
-				// the positron-code-cell extension instead.
+				// Disable vscode-jupyter's cell decorations, code lenses, and interactive window
+				// entrpoints, preferring Positron alternatives instead.
 				// TODO(seem): We can remove this if we eventually decide to unbundle vscode-jupyter.
 				if (section === 'jupyter') {
 					switch (key) {
 						case 'interactiveWindow.cellMarker.decorateCells':
 						case 'interactiveWindow.codeLens.enable':
+						case 'interactiveWindow.textEditor.executeSelection':
 						// Legacy versions of above settings.
 						case 'decorateCells':
 						case 'enableCellCodeLens':


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Address #2144.

### QA Notes

Manually add the setting `"jupyter.interactiveWindow.textEditor.executeSelection": true` to your settings.json file, open a Python file and press Shift+Enter. It should not open an "Interactive Window" tab.