### PR TITLE
Add `"when": "isRPackage"` for the install/restart command

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -403,6 +403,11 @@
         },
         {
           "category": "R",
+          "command": "r.packageInstall",
+          "when": "isRPackage"
+        },
+        {
+          "category": "R",
           "command": "r.packageTest",
           "when": "isRPackage"
         },


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses #2858 

### Approach

We had correctly added `"when"` for the keyboard shortcut but not for this command's contribution to the command palette:

![Screenshot 2024-04-23 at 12 24 12 PM](https://github.com/posit-dev/positron/assets/12505835/bb7d6339-ce62-436d-a6da-719190a579db)


### QA Notes

- Open a workspace that _is_ an R package? You can still find the command in the command palette.
- Open a workspace that is _not_ an R package (such as only Python or R but not a package)? You can now **not** find this command in the command palette.