### PR TITLE
Fixes to Console and Variables keybindings

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
@@ -75,44 +75,59 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 			e.stopPropagation();
 		};
 
-		// Process the key.
-		switch (e.key) {
-			// Enter key.
-			case 'Enter': {
-				// Consume the event.
-				consumeEvent();
+		// Determine that a key is pressed without any modifiers
+		const noModifierKey = !e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey;
 
-				// Upate the prompt state and reply to it.
-				const value = inputRef.current?.value;
-				props.activityItemPrompt.state = ActivityItemPromptState.Answered;
-				props.activityItemPrompt.answer = !props.activityItemPrompt.password ? value : '';
-				props.positronConsoleInstance.replyToPrompt(props.activityItemPrompt.id, value);
-				break;
-			}
+		// Determine whether the ctrl key is pressed without other modifiers.
+		const onlyCtrlKey = e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey;
 
-			// Escape key.
-			case 'Escape': {
-				// Consume the event.
-				consumeEvent();
+		if (noModifierKey) {
+			switch (e.key) {
+				// Enter key.
+				case 'Enter': {
+					// Consume the event.
+					consumeEvent();
 
-				// Update the prompt state and interrupt it.
-				props.activityItemPrompt.state = ActivityItemPromptState.Interrupted;
-				props.positronConsoleInstance.interruptPrompt(props.activityItemPrompt.id);
-				break;
-			}
+					// Upate the prompt state and reply to it.
+					const value = inputRef.current?.value;
+					props.activityItemPrompt.state = ActivityItemPromptState.Answered;
+					props.activityItemPrompt.answer = !props.activityItemPrompt.password ? value : '';
+					props.positronConsoleInstance.replyToPrompt(props.activityItemPrompt.id, value);
+					return;
+				}
 
-			// C key.
-			case 'c': {
-				// Handle Ctrl+C.
-				if (e.ctrlKey) {
+				// Escape key.
+				case 'Escape': {
 					// Consume the event.
 					consumeEvent();
 
 					// Update the prompt state and interrupt it.
 					props.activityItemPrompt.state = ActivityItemPromptState.Interrupted;
 					props.positronConsoleInstance.interruptPrompt(props.activityItemPrompt.id);
+					return;
 				}
-				break;
+
+				default: {
+					return;
+				}
+			}
+		}
+
+		if (onlyCtrlKey) {
+			switch (e.key) {
+				// C key.
+				case 'c': {
+					consumeEvent();
+
+					// Update the prompt state and interrupt it.
+					props.activityItemPrompt.state = ActivityItemPromptState.Interrupted;
+					props.positronConsoleInstance.interruptPrompt(props.activityItemPrompt.id);
+					return;
+				}
+
+				default: {
+					return;
+				}
 			}
 		}
 	};

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -370,7 +370,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 		// Handle the key.
 		if (noModifierKey) {
 			// Handle scrolling keys.
-			switch (e.code) {
+			switch (e.key) {
 				// Page up key.
 				case 'PageUp':
 					consumeEvent();
@@ -402,9 +402,9 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 
 		if (onlyCmdOrCtrlKey) {
 			// Process the key.
-			switch (e.code) {
+			switch (e.key) {
 				// A key.
-				case 'KeyA': {
+				case 'a': {
 					// Handle select all shortcut.
 					if (getSelection()) {
 						// Consume the event.
@@ -417,7 +417,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 				}
 
 				// C key.
-				case 'KeyC': {
+				case 'c': {
 					// Consume the event.
 					consumeEvent();
 
@@ -431,7 +431,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 				}
 
 				// V key.
-				case 'KeyV': {
+				case 'v': {
 					// Consume the event.
 					consumeEvent();
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -403,6 +403,13 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 		if (onlyCmdOrCtrlKey) {
 			// Process the key.
 			switch (e.key) {
+				// We don't handle 'x' here because:
+				// - It's already correctly disabled in the read-only parts
+				//   of the output. It's also disabled when the selection
+				//   overlaps writable and read-only sections.
+				// - It's easier to let the native command handle the writable
+				//   parts.
+
 				// A key.
 				case 'a': {
 					// Handle select all shortcut.

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
@@ -15,7 +15,7 @@ import { registerPositronConsoleActions } from 'vs/workbench/contrib/positronCon
 import { POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
 import { ICommandAndKeybindingRule, KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
-import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_CUT, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
+import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
 
 // The Positron console view icon.
 const positronConsoleViewIcon = registerIcon(
@@ -63,14 +63,18 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 	}
 }], VIEW_CONTAINER);
 
-// Register keybinding rule for cut.
-KeybindingsRegistry.registerCommandAndKeybindingRule({
-	id: POSITRON_CONSOLE_CUT,
-	weight: KeybindingWeight.WorkbenchContrib,
-	primary: KeyMod.CtrlCmd | KeyCode.KeyX,
-	when: PositronConsoleFocused,
-	handler: accessor => { }
-} satisfies ICommandAndKeybindingRule);
+// The following is commented out because it prevents `cut` from working in the
+// console input
+// https://github.com/posit-dev/positron/issues/2549
+
+// // Register keybinding rule for cut.
+// KeybindingsRegistry.registerCommandAndKeybindingRule({
+// 	id: POSITRON_CONSOLE_CUT,
+// 	weight: KeybindingWeight.WorkbenchContrib,
+// 	primary: KeyMod.CtrlCmd | KeyCode.KeyX,
+// 	when: PositronConsoleFocused,
+// 	handler: accessor => { }
+// } satisfies ICommandAndKeybindingRule);
 
 // Register keybinding rule for copy.
 KeybindingsRegistry.registerCommandAndKeybindingRule({

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
@@ -308,9 +308,9 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 		}
 
 		if (onlyCmdOrCtrlKey) {
-			switch (e.code) {
+			switch (e.key) {
 				// C key.
-				case 'KeyC': {
+				case 'c': {
 					// Process the key.
 					if (selectedId) {
 						const selectedEntryIndex = variableEntries.findIndex(entry =>

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
@@ -162,152 +162,175 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 			0
 		);
 
-		// Process the code.
-		switch (e.code) {
-			// Home key.
-			case 'Home': {
-				consumeEvent();
-				listRef.current.scrollTo(0);
-				break;
-			}
+		// Determine that a key is pressed without any modifiers
+		const noModifierKey = !e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey;
 
-			// End key.
-			case 'End': {
-				consumeEvent();
-				listRef.current.scrollTo(maxScrollOffset());
-				break;
-			}
+		// Determine whether the cmd or ctrl key is pressed without other modifiers.
+		const onlyCmdOrCtrlKey = (isMacintosh ? e.metaKey : e.ctrlKey) &&
+			(isMacintosh ? !e.ctrlKey : !e.metaKey) &&
+			!e.shiftKey &&
+			!e.altKey;
 
-			// Page up key.
-			case 'PageUp': {
-				consumeEvent();
-				listRef.current.scrollTo(Math.max(scrollOffsetRef.current - props.height, 0));
-				break;
-			}
-
-			// Page down key.
-			case 'PageDown': {
-				consumeEvent();
-				listRef.current.scrollTo(
-					Math.min(
-						scrollOffsetRef.current + props.height,
-						maxScrollOffset()
-					)
-				);
-				break;
-			}
-
-			// Up arrow key.
-			case 'ArrowUp': {
-				consumeEvent();
-				if (!selectedId) {
-					if (variableEntries.length) {
-						setSelectedId(variableEntries[variableEntries.length - 1].id);
-						listRef.current.scrollToItem(variableEntries.length - 1);
-					}
-				} else {
-					const selectedIndex = variableEntries.findIndex(entry =>
-						entry.id === selectedId
-					);
-					if (selectedIndex > 0) {
-						const index = selectedIndex - 1;
-						setSelectedId(variableEntries[index].id);
-						listRef.current.scrollToItem(index);
-					}
+		if (noModifierKey) {
+			// Process the code.
+			switch (e.code) {
+				// Home key.
+				case 'Home': {
+					consumeEvent();
+					listRef.current.scrollTo(0);
+					return;
 				}
-				break;
-			}
 
-			// Down arrow key.
-			case 'ArrowDown': {
-				consumeEvent();
-				if (!selectedId) {
-					if (variableEntries.length) {
-						setSelectedId(variableEntries[0].id);
-						listRef.current.scrollToItem(0);
-					}
-				} else {
-					const selectedEntryIndex = variableEntries.findIndex(entry =>
-						entry.id === selectedId
-					);
-					if (selectedEntryIndex < variableEntries.length - 1) {
-						const index = selectedEntryIndex + 1;
-						setSelectedId(variableEntries[index].id);
-						listRef.current.scrollToItem(index);
-					}
+				// End key.
+				case 'End': {
+					consumeEvent();
+					listRef.current.scrollTo(maxScrollOffset());
+					return;
 				}
-				break;
-			}
 
-			// Left arrow key.
-			case 'ArrowLeft': {
-				consumeEvent();
-				if (selectedId) {
-					const selectedEntryIndex = variableEntries.findIndex(entry =>
-						entry.id === selectedId
-					);
-					const selectedVariableEntry = variableEntries[selectedEntryIndex];
-					if (isVariableGroup(selectedVariableEntry)) {
-						if (selectedVariableEntry.expanded) {
-							props.positronVariablesInstance.collapseVariableGroup(
-								selectedVariableEntry.id
-							);
-						}
-					} else if (isVariableItem(selectedVariableEntry) &&
-						selectedVariableEntry.hasChildren) {
-						if (selectedVariableEntry.expanded) {
-							props.positronVariablesInstance.collapseVariableItem(
-								selectedVariableEntry.path
-							);
-						}
-					}
+				// Page up key.
+				case 'PageUp': {
+					consumeEvent();
+					listRef.current.scrollTo(Math.max(scrollOffsetRef.current - props.height, 0));
+					return;
 				}
-				break;
-			}
 
-			// Right arrow key.
-			case 'ArrowRight': {
-				consumeEvent();
-				if (selectedId) {
-					const selectedEntryIndex = variableEntries.findIndex(entry =>
-						entry.id === selectedId
+				// Page down key.
+				case 'PageDown': {
+					consumeEvent();
+					listRef.current.scrollTo(
+						Math.min(
+							scrollOffsetRef.current + props.height,
+							maxScrollOffset()
+						)
 					);
-					const selectedVariableEntry = variableEntries[selectedEntryIndex];
-					if (isVariableGroup(selectedVariableEntry)) {
-						if (!selectedVariableEntry.expanded) {
-							props.positronVariablesInstance.expandVariableGroup(
-								selectedVariableEntry.id
-							);
-						}
-					} else if (isVariableItem(selectedVariableEntry) &&
-						selectedVariableEntry.hasChildren) {
-						if (!selectedVariableEntry.expanded) {
-							props.positronVariablesInstance.expandVariableItem(
-								selectedVariableEntry.path
-							);
-						}
-					}
+					return;
 				}
-				break;
-			}
 
-			// C key.
-			case 'KeyC': {
-				// Process the key.
-				if (isMacintosh ? e.metaKey : e.ctrlKey && selectedId) {
-					const selectedEntryIndex = variableEntries.findIndex(entry =>
-						entry.id === selectedId
-					);
-					const selectedEntry = variableEntries[selectedEntryIndex];
-					if (isVariableItem(selectedEntry)) {
-						consumeEvent();
-						const text = await selectedEntry.formatForClipboard(
-							e.shiftKey ? 'text/html' : 'text/plain'
+				// Up arrow key.
+				case 'ArrowUp': {
+					consumeEvent();
+					if (!selectedId) {
+						if (variableEntries.length) {
+							setSelectedId(variableEntries[variableEntries.length - 1].id);
+							listRef.current.scrollToItem(variableEntries.length - 1);
+						}
+					} else {
+						const selectedIndex = variableEntries.findIndex(entry =>
+							entry.id === selectedId
 						);
-						positronVariablesContext.clipboardService.writeText(text);
+						if (selectedIndex > 0) {
+							const index = selectedIndex - 1;
+							setSelectedId(variableEntries[index].id);
+							listRef.current.scrollToItem(index);
+						}
 					}
+					return;
 				}
-				break;
+
+				// Down arrow key.
+				case 'ArrowDown': {
+					consumeEvent();
+					if (!selectedId) {
+						if (variableEntries.length) {
+							setSelectedId(variableEntries[0].id);
+							listRef.current.scrollToItem(0);
+						}
+					} else {
+						const selectedEntryIndex = variableEntries.findIndex(entry =>
+							entry.id === selectedId
+						);
+						if (selectedEntryIndex < variableEntries.length - 1) {
+							const index = selectedEntryIndex + 1;
+							setSelectedId(variableEntries[index].id);
+							listRef.current.scrollToItem(index);
+						}
+					}
+					return;
+				}
+
+				// Left arrow key.
+				case 'ArrowLeft': {
+					consumeEvent();
+					if (selectedId) {
+						const selectedEntryIndex = variableEntries.findIndex(entry =>
+							entry.id === selectedId
+						);
+						const selectedVariableEntry = variableEntries[selectedEntryIndex];
+						if (isVariableGroup(selectedVariableEntry)) {
+							if (selectedVariableEntry.expanded) {
+								props.positronVariablesInstance.collapseVariableGroup(
+									selectedVariableEntry.id
+								);
+							}
+						} else if (isVariableItem(selectedVariableEntry) &&
+							selectedVariableEntry.hasChildren) {
+							if (selectedVariableEntry.expanded) {
+								props.positronVariablesInstance.collapseVariableItem(
+									selectedVariableEntry.path
+								);
+							}
+						}
+					}
+					return;
+				}
+
+				// Right arrow key.
+				case 'ArrowRight': {
+					consumeEvent();
+					if (selectedId) {
+						const selectedEntryIndex = variableEntries.findIndex(entry =>
+							entry.id === selectedId
+						);
+						const selectedVariableEntry = variableEntries[selectedEntryIndex];
+						if (isVariableGroup(selectedVariableEntry)) {
+							if (!selectedVariableEntry.expanded) {
+								props.positronVariablesInstance.expandVariableGroup(
+									selectedVariableEntry.id
+								);
+							}
+						} else if (isVariableItem(selectedVariableEntry) &&
+							selectedVariableEntry.hasChildren) {
+							if (!selectedVariableEntry.expanded) {
+								props.positronVariablesInstance.expandVariableItem(
+									selectedVariableEntry.path
+								);
+							}
+						}
+					}
+					return;
+				}
+
+				default: {
+					return;
+				}
+			}
+		}
+
+		if (onlyCmdOrCtrlKey) {
+			switch (e.code) {
+				// C key.
+				case 'KeyC': {
+					// Process the key.
+					if (selectedId) {
+						const selectedEntryIndex = variableEntries.findIndex(entry =>
+							entry.id === selectedId
+						);
+						const selectedEntry = variableEntries[selectedEntryIndex];
+						if (isVariableItem(selectedEntry)) {
+							consumeEvent();
+							const text = await selectedEntry.formatForClipboard(
+								e.shiftKey ? 'text/html' : 'text/plain'
+							);
+							positronVariablesContext.clipboardService.writeText(text);
+						}
+					}
+					return;
+				}
+
+				default: {
+					return;
+				}
 			}
 		}
 	};


### PR DESCRIPTION
These fixes depend on each other so I gathered them in a single PR. Each commit can be cleanly reviewed separately though. Happy to split in multiple PRs if that would be preferred.

### Fix shadowing of user keybindings

Addresses #2857.

The first commit improves the detection of extra modifiers in our keydown handlers for Console and Variables viewpanes. This allows unrelated commands to dispatch correctly, e.g. our Cmd+C handler will not prevent a user keybinding Shift+Cmd+C from running.

QA notes: The keys handled in these locations should still work as expected:

- https://github.com/posit-dev/positron/blob/206252327966c421b508c2f6c8f9a8698dd5d0db/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx#L342

- https://github.com/posit-dev/positron/blob/206252327966c421b508c2f6c8f9a8698dd5d0db/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx#L69

- https://github.com/posit-dev/positron/blob/206252327966c421b508c2f6c8f9a8698dd5d0db/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx#L152

In particular, typing text when the console is scrolled up should scroll _all the way_ to the bottom, there should not be some pixels left to scroll.

Some of the keybindings such as for Copy, Cut, Paste, and Select all differ depending on the platform. MacOs uses the Cmd prefix key whereas other platforms use Ctrl.


### Fix keybindings in foreign keyboard layouts

Addresses #2724.

The second commit changes our handlers to use the `key` field of keyboard events instead of `code` fields. The former represents the character typed according to the user's keyboard layout. The latter represents the physical location on the keyboard, which doesn't match the layout.


### Restore cut command in console

Addresses #2549.

Third commit removes a registered keybinding for Cmd/Ctrl+X that was bound to an empty command. It was added in #1118, I assume to pair it with the context menu action for Cut. However removing it does not affect the context menu. And it turns out that the default Cut implementation pretty much does what we want:

- It's disabled when the selection is read-only or overlaps with a read-only section.
- It's enabled when the selection is writable, as in our input code editor.


### Add paste handler to readline prompts

Addresses #2863.

Fourth commit implements select-all and paste in readline prompts. Paste is a quick stopgap implementation on top of the `<input>` HTML element. The direct HTML manipulation confuses undo/redo. I think we'd be better off using a VS Code code text editor that accepts text edits so that undo/redo work out of the box.