### PR TITLE
Fix toggling of Console and Variables panes

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -597,6 +597,20 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 		}
 	};
 
+	/**
+	 * onFocus event handler.
+	 */
+	const focusHandler = () => {
+		props.reactComponentContainer.focusChanged?.(true);
+	};
+
+	/**
+	 * onBlur event handler.
+	 */
+	const blurHandler = () => {
+		props.reactComponentContainer.focusChanged?.(false);
+	};
+
 	// Calculate the adjusted width (to account for indentation of the entire console instance).
 	const adjustedWidth = props.width - 10;
 
@@ -622,6 +636,8 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 				whiteSpace: wordWrap ? 'pre-wrap' : 'pre',
 				zIndex: props.active ? 'auto' : -1
 			}}
+			onFocus={focusHandler}
+			onBlur={blurHandler}
 			onClick={clickHandler}
 			onKeyDown={keyDownHandler}
 			onMouseDown={mouseDownHandler}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -647,7 +647,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 					} else if (runtimeItem instanceof RuntimeItemExited) {
 						return <RuntimeExited key={runtimeItem.id} runtimeItemExited={runtimeItem} />;
 					} else if (runtimeItem instanceof RuntimeItemRestartButton) {
-						return <RuntimeRestartButton key={runtimeItem.id} runtimeItemRestartButton={runtimeItem} />;
+						return <RuntimeRestartButton key={runtimeItem.id} runtimeItemRestartButton={runtimeItem} positronConsoleInstance={props.positronConsoleInstance}/>;
 					} else if (runtimeItem instanceof RuntimeItemStartupFailure) {
 						return <RuntimeStartupFailure key={runtimeItem.id} runtimeItemStartupFailure={runtimeItem} />;
 					} else if (runtimeItem instanceof RuntimeItemTrace) {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeRestartButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeRestartButton.tsx
@@ -6,10 +6,14 @@ import 'vs/css!./runtimeRestartButton';
 import * as nls from 'vs/nls';
 import * as React from 'react';
 import { RuntimeItemRestartButton } from 'vs/workbench/services/positronConsole/browser/classes/runtimeItemRestartButton';
+import { IPositronConsoleInstance } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
+import { useEffect } from 'react';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 
 // RuntimeRestartButtonProps interface.
 export interface RuntimeRestartButtonProps {
 	runtimeItemRestartButton: RuntimeItemRestartButton;
+	positronConsoleInstance: IPositronConsoleInstance;
 }
 
 /**
@@ -22,6 +26,18 @@ export const RuntimeRestartButton = (props: RuntimeRestartButtonProps) => {
 
 	const restartRef = React.useRef<HTMLButtonElement>(null);
 	const restartLabel = nls.localize('positron.restartLabel', "Restart {0}", props.runtimeItemRestartButton.languageName);
+
+	useEffect(() => {
+		const disposableStore = new DisposableStore();
+
+		disposableStore.add(props.positronConsoleInstance.onFocusInput(() => {
+			// Focus the button when the Console takes focus, i.e. when the
+			// user clicks somewhere on the console output
+			restartRef.current?.focus();
+		}));
+
+		return () => disposableStore.dispose();
+	});
 
 	const handleRestart = () => {
 		// Invoke the restart callback.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeRestartButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeRestartButton.tsx
@@ -37,7 +37,7 @@ export const RuntimeRestartButton = (props: RuntimeRestartButtonProps) => {
 		}));
 
 		return () => disposableStore.dispose();
-	});
+        },[props.positronConsoleInstance]);
 
 	const handleRestart = () => {
 		// Invoke the restart callback.

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -115,7 +115,7 @@ export function registerPositronConsoleActions() {
 	 * Register the focus console action. This action places focus in the active console,
 	 * if one exists.
 	 *
-	 * This action is an alias for `workbench.panel.positronConsole.focus`.
+	 * This action is equivalent to the `workbench.panel.positronConsole.focus` command.
 	 */
 	registerAction2(class extends Action2 {
 		/**
@@ -147,7 +147,8 @@ export function registerPositronConsoleActions() {
 			const layoutService = accessor.get(IWorkbenchLayoutService);
 			const viewsService = accessor.get(IViewsService);
 
-			// Ensure that the panel and console are visible.
+			// Ensure that the panel and console are visible. This is essentially
+			// equivalent to what `workbench.panel.positronConsole.focus` does.
 			layoutService.restorePanel();
 			await viewsService.openView(POSITRON_CONSOLE_VIEW_ID, true);
 		}

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -114,6 +114,8 @@ export function registerPositronConsoleActions() {
 	/**
 	 * Register the focus console action. This action places focus in the active console,
 	 * if one exists.
+	 *
+	 * This action is an alias for `workbench.panel.positronConsole.focus`.
 	 */
 	registerAction2(class extends Action2 {
 		/**
@@ -144,21 +146,10 @@ export function registerPositronConsoleActions() {
 
 			const layoutService = accessor.get(IWorkbenchLayoutService);
 			const viewsService = accessor.get(IViewsService);
-			const positronConsoleService = accessor.get(IPositronConsoleService);
 
 			// Ensure that the panel and console are visible.
 			layoutService.restorePanel();
 			await viewsService.openView(POSITRON_CONSOLE_VIEW_ID, true);
-
-			// Look up the active console instance.
-			const activeInstance = positronConsoleService.activePositronConsoleInstance;
-			if (!activeInstance) {
-				// No console to focus; don't do anything.
-				return;
-			}
-
-			// Drive focus to the console's input control.
-			activeInstance.focusInput();
 		}
 	});
 

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -309,7 +309,13 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 		// Trigger event that eventually causes console input widgets (main
 		// input, readline input, or restart buttons) to focus. Must be after
 		// the super call.
-		this.positronConsoleService.activePositronConsoleInstance?.focusInput();
+		//
+		// We do this at the next tick because in some cases `focus()` is called
+		// when the viewpane is not visible yet (don't trust `this.isBodyVisible()`).
+		// In this case the `focus()` call fails (don't trust `this.onFocus()`).
+		// This happens for instance with `workbench.action.togglePanel` or
+		// `workbench.action.toggleSecondarySideBar`.
+		setTimeout(() => this.positronConsoleService.activePositronConsoleInstance?.focusInput());
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -125,7 +125,14 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 	}
 
 	focusChanged(focused: boolean) {
+		// NOTE: A blurring event fires up when selecting text in the console
+		// (i.e. the code editor widget is no longer focused). Can/should we do
+		// better? The blurring event also happens with `ViewPane::onDidBlur()`.
 		this._positronConsoleFocusedContextKey.set(focused);
+
+		if (focused) {
+			this._onFocusedEmitter.fire();
+		}
 	}
 
 	/**
@@ -283,13 +290,6 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 				reactComponentContainer={this}
 			/>
 		);
-
-		// We used to create our own focus tracker for `this.element` but the focus events
-		// did not fire correctly when the viewpane was toggled
-		this.onDidFocus(e => {
-			// Relay the event for the IReactComponentContainer `onFocused()` method.
-			this._onFocusedEmitter.fire();
-		});
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -228,6 +228,13 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 			themeService,
 			telemetryService);
 
+		// Make the view pane focusable even when there are no components
+		// available to take the focus (such as the console input). This happens
+		// when no interpreter has been started yet. The viewpane must be able
+		// to take focus at all times because otherwise blurring events do not
+		// occur and the viewpane management state becomes confused on toggle.
+		this.element.tabIndex = 0;
+
 		// Bind the PositronConsoleFocused context key.
 		this._positronConsoleFocusedContextKey = PositronConsoleFocused.bindTo(contextKeyService);
 

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -33,6 +33,8 @@ import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
+import { disposableTimeout } from 'vs/base/common/async';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 
 /**
  * PositronConsoleViewPane class.
@@ -91,6 +93,8 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 	 * Gets or sets the PositronConsoleFocused context key.
 	 */
 	private _positronConsoleFocusedContextKey: IContextKey<boolean>;
+
+	private _disposableStore: DisposableStore;
 
 	//#endregion Private Properties
 
@@ -243,6 +247,8 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 			// Relay event for our `IReactComponentContainer` implementation
 			this._onVisibilityChangedEmitter.fire(visible);
 		}));
+
+		this._disposableStore = this._register(new DisposableStore());
 	}
 
 	/**
@@ -315,7 +321,7 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 		// In this case the `focus()` call fails (don't trust `this.onFocus()`).
 		// This happens for instance with `workbench.action.togglePanel` or
 		// `workbench.action.toggleSecondarySideBar`.
-		setTimeout(() => this.positronConsoleService.activePositronConsoleInstance?.focusInput());
+		disposableTimeout(() => this.positronConsoleService.activePositronConsoleInstance?.focusInput(), 0, this._disposableStore);
 	}
 
 	/**
@@ -344,4 +350,3 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 
 	//#endregion Public Overrides
 }
-

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
@@ -190,6 +190,12 @@ export class PositronHelpView extends ViewPane implements IReactComponentContain
 			telemetryService
 		);
 
+		// Make the viewpane focusable even when there are no components
+		// available to take the focus. The viewpane must be able to take focus
+		// at all times because otherwise blurring events do not occur and the
+		// viewpane management state becomes confused on toggle.
+		this.element.tabIndex = 0;
+
 		// Create containers.
 		this.positronHelpContainer = DOM.$('.positron-help-container');
 		this.helpActionBarsContainer = DOM.$('.help-action-bars-container');

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsView.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsView.tsx
@@ -163,6 +163,12 @@ export class PositronPlotsViewPane extends ViewPane implements IReactComponentCo
 		// Call the base class's constructor.
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
 
+		// Make the viewpane focusable even when there are no components
+		// available to take the focus. The viewpane must be able to take focus
+		// at all times because otherwise blurring events do not occur and the
+		// viewpane management state becomes confused on toggle.
+		this.element.tabIndex = 0;
+
 		// Register the onDidChangeBodyVisibility event handler.
 		this._register(this.onDidChangeBodyVisibility(visible => {
 			this._onVisibilityChangedEmitter.fire(visible);

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
@@ -90,6 +90,13 @@ export class PositronPreviewViewPane extends ViewPane implements IReactComponent
 		options = { ...options, minimumBodySize: 0 };
 
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
+
+		// Make the viewpane focusable even when there are no components
+		// available to take the focus. The viewpane must be able to take focus
+		// at all times because otherwise blurring events do not occur and the
+		// viewpane management state becomes confused on toggle.
+		this.element.tabIndex = 0;
+
 		this._register(this.onDidChangeBodyVisibility(() => this.onDidChangeVisibility(this.isBodyVisible())));
 		this._positronPreviewContainer = DOM.$('.positron-preview-container');
 	}

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessionsView.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessionsView.tsx
@@ -194,6 +194,12 @@ export class PositronRuntimeSessionsViewPane extends ViewPane implements IReactC
 			themeService,
 			telemetryService);
 
+		// Make the viewpane focusable even when there are no components
+		// available to take the focus. The viewpane must be able to take focus
+		// at all times because otherwise blurring events do not occur and the
+		// viewpane management state becomes confused on toggle.
+		this.element.tabIndex = 0;
+
 		// Register the onDidChangeBodyVisibility event handler.
 		this._register(this.onDidChangeBodyVisibility(visible => {
 			if (!visible) {

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
@@ -107,7 +107,7 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 			setClientState(state);
 		}));
 
-		// Register event to drive focus inside the variable tree
+		// Register listener to drive focus inside the variable tree
 		disposableStore.add(props.positronVariablesInstance.onFocusElement(state => {
 			outerRef.current.focus();
 		}));

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
@@ -107,6 +107,11 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 			setClientState(state);
 		}));
 
+		// Register event to drive focus inside the variable tree
+		disposableStore.add(props.positronVariablesInstance.onFocusElement(state => {
+			outerRef.current.focus();
+		}));
+
 		// Request the initial refresh.
 		props.positronVariablesInstance.requestRefresh();
 

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
@@ -121,6 +121,9 @@ export class PositronVariablesViewPane extends ViewPane implements IReactCompone
 	 */
 	focusChanged(focused: boolean) {
 		this._positronVariablesFocusedContextKey?.set(focused);
+		if (focused) {
+			this._onFocusedEmitter.fire();
+		}
 	}
 
 	/**
@@ -244,11 +247,6 @@ export class PositronVariablesViewPane extends ViewPane implements IReactCompone
 		this._positronVariablesFocusedContextKey = PositronVariablesFocused.bindTo(
 			scopedContextKeyService
 		);
-
-		this.onDidFocus(e => {
-			// Relay the event for the IReactComponentContainer `onFocused()` method.
-			this._onFocusedEmitter.fire();
-		});
 
 		// Create the PositronReactRenderer for the PositronVariables component and render it.
 		this._positronReactRenderer = new PositronReactRenderer(this._positronVariablesContainer);

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
@@ -281,8 +281,7 @@ export class PositronVariablesViewPane extends ViewPane implements IReactCompone
 		// Call the base class's method.
 		super.focus();
 
-		// Trigger event that eventually causes console input widgets (main
-		// input, readline input, or restart buttons) to focus
+		// Trigger event that eventually causes variable pane widgets to focus
 		this._positronVariablesService.activePositronVariablesInstance?.focusElement();
 	}
 

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
@@ -205,6 +205,12 @@ export class PositronVariablesViewPane extends ViewPane implements IReactCompone
 			themeService,
 			telemetryService);
 
+		// Make the viewpane focusable even when there are no components
+		// available to take the focus. The viewpane must be able to take focus
+		// at all times because otherwise blurring events do not occur and the
+		// viewpane management state becomes confused on toggle.
+		this.element.tabIndex = 0;
+
 		// Register the onDidChangeBodyVisibility event handler.
 		this._register(this.onDidChangeBodyVisibility(visible => {
 			// The browser will automatically set scrollTop to 0 on child components that have been

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
@@ -245,6 +245,11 @@ export class PositronVariablesViewPane extends ViewPane implements IReactCompone
 			scopedContextKeyService
 		);
 
+		this.onDidFocus(e => {
+			// Relay the event for the IReactComponentContainer `onFocused()` method.
+			this._onFocusedEmitter.fire();
+		});
+
 		// Create the PositronReactRenderer for the PositronVariables component and render it.
 		this._positronReactRenderer = new PositronReactRenderer(this._positronVariablesContainer);
 		this._register(this._positronReactRenderer);
@@ -272,8 +277,9 @@ export class PositronVariablesViewPane extends ViewPane implements IReactCompone
 		// Call the base class's method.
 		super.focus();
 
-		// Fire the onFocused event.
-		this._onFocusedEmitter.fire();
+		// Trigger event that eventually causes console input widgets (main
+		// input, readline input, or restart buttons) to focus
+		this._positronVariablesService.activePositronVariablesInstance?.focusElement();
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -937,7 +937,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * Pastes text into the console.
 	 */
 	pasteText(text: string) {
-		this._onFocusInputEmitter.fire();
+		this.focusInput();
 		this._onDidPasteTextEmitter.fire(text);
 	}
 

--- a/src/vs/workbench/services/positronVariables/common/interfaces/positronVariablesInstance.ts
+++ b/src/vs/workbench/services/positronVariables/common/interfaces/positronVariablesInstance.ts
@@ -94,6 +94,12 @@ export interface IPositronVariablesInstance {
 	readonly onDidChangeState: Event<RuntimeClientState>;
 
 	/**
+	 * The onFocusElement event.
+	 * Used by variable widgets to respond to focus requests.
+	 */
+	readonly onFocusElement: Event<void>;
+
+	/**
 	 * Requests refresh.
 	 */
 	requestRefresh(): void;
@@ -139,4 +145,9 @@ export interface IPositronVariablesInstance {
 	 * @param filterText The filter text.
 	 */
 	setFilterText(filterText: string): void;
+
+	/**
+	 * Focuses element in the variable tree.
+	 */
+	focusElement(): void;
 }

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
@@ -102,6 +102,11 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 	 */
 	private readonly _onDidChangeStateEmitter = this._register(new Emitter<RuntimeClientState>());
 
+	/**
+	 * The _onFocusInput event emitter.
+	 */
+	private readonly _onFocusElementEmitter = this._register(new Emitter<void>);
+
 	//#endregion Private Properties
 
 	//#region Constructor & Dispose
@@ -208,6 +213,11 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 	 * onDidChangeState event.
 	 */
 	readonly onDidChangeState: Event<RuntimeClientState> = this._onDidChangeStateEmitter.event;
+
+	/**
+	 * onFocusElement event.
+	 */
+	readonly onFocusElement = this._onFocusElementEmitter.event;
 
 	/**
 	 * Requests refresh.
@@ -381,6 +391,14 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 
 		// Attach the runtime.
 		this.attachRuntime();
+	}
+
+	/**
+	 * Focuses current element in the variable tree.
+	 *
+	 */
+	focusElement(): void {
+		this._onFocusElementEmitter.fire();
 	}
 
 	//#endregion Public Methods


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/811.

This PR fixes issues related to driving focus into the Variables, Console, and other panes. It makes it so that calling the `focus()` method on the viewpane of these components always focuses _something_. This is necessary because once `focus()` has been called, the viewpane manager marks it as the active pane until an `onBlur()` event is triggered on the pane. If nothing is selected, `focusout` cannot bubble out when the focus goes elsewhere and the manager thinks the pane is still active, which breaks the toggling feature.

To fix this I used two strategies:

- All viewpanes now get a `tabIndex` attribute to make them focusable. This makes sure the bug can no longer happen.

- The console and the variable panes now drive the focus to inner elements more consistently. For instance we now focus the restart button if there is one, which can be useful for keyboard users to quickly restart without the mouse. The variable pane focuses the currently selected node in its tree.

In addition the console focus tracker was not fired up properly on toggle. I fixed that and took the opportunity to make our event handling more consistent. The console pane is now using the React events under the hood, like we do for the variable pane.

Following these changes, the `workbench.panel.positronConsole.focus` command (autogenerated) and the `workbench.action.positronConsole.focusConsole` command (which we added) are now behaving exactly the same. It used to be that only the latter would focus input properly. We could now remove the former or keep it as an alias.

QA notes:

To trigger toggling you can use the `View: Toggle Console` and `View: Toggle Variables` from the command palette. ~If you bind this to a keybinding, beware that until https://github.com/posit-dev/positron/pull/2864 is fixed some of the keybindings might be swallowed by our keydown handlers.~ Edit: Now fixed.

The toggling command should drive focus into the variable tree nodes, the console input, the readline input if any (type `readline("foo> ")` in the R console to get one), or the restart button if the console has been stopped. The toggling commands should still work when there is no active console instance, for example during discovery of runtimes or in a project where autostart is disabled.

The panel or side bar toggling (depending on where the console is) should work the same way, with focus driven to the input.