### PR TITLE
Use macos-13 to avoid errors setting up Python

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -245,7 +245,7 @@ jobs:
         working-directory: ${{ env.special-working-directory }}/${{ env.PROJECT_DIR}}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         python: ['3.x']
         test-suite: [ts-unit, venv, single-workspace, debugger, functional, smoke]
         # TODO: Add integration tests on windows and ubuntu. This requires updating

--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -126,7 +126,9 @@ jobs:
           - os: 'ubuntu-latest'
             python: '3.8'
             pytest-version: 'pytest<8.1.1'
-          - os: 'macos-latest'
+          # TODO: go back to macos-latest once we have a stable version of Python 3.9
+          # on that image.
+          - os: 'macos-13'
             python: '3.9'
             pytest-version: 'pytest<8.1.1'
           - os: 'windows-latest'
@@ -180,7 +182,7 @@ jobs:
         include:
           - os: 'ubuntu-latest'
             python: '3.8'
-          - os: 'macos-latest'
+          - os: 'macos-13'
             python: '3.9'
           - os: 'windows-latest'
             python: '3.10'


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

Addresses #2874 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

macOS-latest now runs on arm64 but that image does not install Python 3.9 : https://github.com/actions/runner-images/issues/9770

We set our runner to the macOS-13 image, that should run on x64 which has older python versions installed.

Also moved to macOS-12 for the TypesScript tests as this is the version [it last passed](https://github.com/posit-dev/positron/actions/runs/8806550417/job/24171636451#step:1:4)

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
