### PR TITLE
Add custom error handlers for `LanguageClientOptions`

### DIFF
--- a/extensions/positron-python/src/client/positron/errorHandler.ts
+++ b/extensions/positron-python/src/client/positron/errorHandler.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// Keep in sync with positron-r's `error-handler.ts`
+
+import {
+	CloseAction,
+	CloseHandlerResult,
+	ErrorAction,
+	ErrorHandler,
+	ErrorHandlerResult,
+	Message
+} from 'vscode-languageclient/node';
+
+import { traceWarn } from '../logging';
+
+// The `DefaultErrorHandler` adds restarts on close, which we don't want. We want to be fully in
+// control over restarting the client side of the LSP, both because we have our own runtime restart
+// behavior, and because we have state that relies on client status changes being accurate (i.e.
+// in `this._client.onDidChangeState()`). Additionally, we set `handled: true` to avoid a toast
+// notification that is inactionable from the user's point of view.
+// https://github.com/posit-dev/positron/pull/2880
+// https://github.com/microsoft/vscode-languageserver-node/blob/8e625564b531da607859b8cb982abb7cdb2fbe2e/client/src/common/client.ts#L420
+// https://github.com/microsoft/vscode-languageserver-node/blob/8e625564b531da607859b8cb982abb7cdb2fbe2e/client/src/common/client.ts#L1617
+export class PythonErrorHandler implements ErrorHandler {
+	constructor(
+		private readonly _version: string,
+		private readonly _port: number
+	) {
+	}
+
+	public error(error: Error, _message: Message, count: number): ErrorHandlerResult {
+		traceWarn(`Python (${this._version}) language client error occurred (port ${this._port}). '${error.name}' with message: ${error.message}. This is error number ${count}.`);
+		return { action: ErrorAction.Shutdown };
+	}
+
+	public closed(): CloseHandlerResult {
+		traceWarn(`Python (${this._version}) language client was closed unexpectedly (port ${this._port}).`);
+		return { action: CloseAction.DoNotRestart, handled: true };
+	}
+}

--- a/extensions/positron-python/src/client/positron/errorHandler.ts
+++ b/extensions/positron-python/src/client/positron/errorHandler.ts
@@ -5,12 +5,12 @@
 // Keep in sync with positron-r's `error-handler.ts`
 
 import {
-	CloseAction,
-	CloseHandlerResult,
-	ErrorAction,
-	ErrorHandler,
-	ErrorHandlerResult,
-	Message
+    CloseAction,
+    CloseHandlerResult,
+    ErrorAction,
+    ErrorHandler,
+    ErrorHandlerResult,
+    Message,
 } from 'vscode-languageclient/node';
 
 import { traceWarn } from '../logging';
@@ -24,19 +24,17 @@ import { traceWarn } from '../logging';
 // https://github.com/microsoft/vscode-languageserver-node/blob/8e625564b531da607859b8cb982abb7cdb2fbe2e/client/src/common/client.ts#L420
 // https://github.com/microsoft/vscode-languageserver-node/blob/8e625564b531da607859b8cb982abb7cdb2fbe2e/client/src/common/client.ts#L1617
 export class PythonErrorHandler implements ErrorHandler {
-	constructor(
-		private readonly _version: string,
-		private readonly _port: number
-	) {
-	}
+    constructor(private readonly _version: string, private readonly _port: number) {}
 
-	public error(error: Error, _message: Message, count: number): ErrorHandlerResult {
-		traceWarn(`Python (${this._version}) language client error occurred (port ${this._port}). '${error.name}' with message: ${error.message}. This is error number ${count}.`);
-		return { action: ErrorAction.Shutdown };
-	}
+    public error(error: Error, _message: Message, count: number): ErrorHandlerResult {
+        traceWarn(
+            `Python (${this._version}) language client error occurred (port ${this._port}). '${error.name}' with message: ${error.message}. This is error number ${count}.`,
+        );
+        return { action: ErrorAction.Shutdown };
+    }
 
-	public closed(): CloseHandlerResult {
-		traceWarn(`Python (${this._version}) language client was closed unexpectedly (port ${this._port}).`);
-		return { action: CloseAction.DoNotRestart, handled: true };
-	}
+    public closed(): CloseHandlerResult {
+        traceWarn(`Python (${this._version}) language client was closed unexpectedly (port ${this._port}).`);
+        return { action: CloseAction.DoNotRestart, handled: true };
+    }
 }

--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -46,7 +46,7 @@ export class PythonLsp implements vscode.Disposable {
         private readonly _version: string,
         private readonly _clientOptions: LanguageClientOptions,
         private readonly _notebookUri: vscode.Uri | undefined,
-    ) { }
+    ) {}
 
     /**
      * Activate the language server; returns a promise that resolves when the LSP is
@@ -85,10 +85,10 @@ export class PythonLsp implements vscode.Disposable {
         this._clientOptions.documentSelector = this._notebookUri
             ? [{ language: 'python', pattern: this._notebookUri.path }]
             : [
-                { language: 'python', scheme: 'untitled' },
-                { language: 'python', scheme: 'inmemory' }, // Console
-                { language: 'python', pattern: '**/*.py' },
-            ];
+                  { language: 'python', scheme: 'untitled' },
+                  { language: 'python', scheme: 'inmemory' }, // Console
+                  { language: 'python', pattern: '**/*.py' },
+              ];
 
         // Override default error handler with one that doesn't automatically restart the client,
         // and that logs to the appropriate place.
@@ -170,22 +170,22 @@ export class PythonLsp implements vscode.Disposable {
         // partially initialized client.
         await this._initializing;
 
-        const promise = awaitStop ?
-            // If the kernel hasn't exited, we can just await the promise directly
-            this._client!.stop() :
-            // The promise returned by `stop()` never resolves if the server
-            // side is disconnected, so rather than awaiting it when the runtime
-            // has exited, we wait for the client to change state to `stopped`,
-            // which does happen reliably.
-            new Promise<void>((resolve) => {
-                const disposable = this._client!.onDidChangeState((event) => {
-                    if (event.newState === State.Stopped) {
-                        resolve();
-                        disposable.dispose();
-                    }
-                });
-                this._client!.stop();
-            });
+        const promise = awaitStop
+            ? // If the kernel hasn't exited, we can just await the promise directly
+              this._client!.stop()
+            : // The promise returned by `stop()` never resolves if the server
+              // side is disconnected, so rather than awaiting it when the runtime
+              // has exited, we wait for the client to change state to `stopped`,
+              // which does happen reliably.
+              new Promise<void>((resolve) => {
+                  const disposable = this._client!.onDidChangeState((event) => {
+                      if (event.newState === State.Stopped) {
+                          resolve();
+                          disposable.dispose();
+                      }
+                  });
+                  this._client!.stop();
+              });
 
         // Don't wait more than a couple of seconds for the client to stop.
         const timeout = new Promise<void>((_, reject) => {

--- a/extensions/positron-r/src/error-handler.ts
+++ b/extensions/positron-r/src/error-handler.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// Keep in sync with positron-python's `errorHandler.ts`
+
+import {
+	CloseAction,
+	CloseHandlerResult,
+	ErrorAction,
+	ErrorHandler,
+	ErrorHandlerResult,
+	Message
+} from 'vscode-languageclient/node';
+
+import { LOGGER } from './extension';
+
+// The `DefaultErrorHandler` adds restarts on close, which we don't want. We want to be fully in
+// control over restarting the client side of the LSP, both because we have our own runtime restart
+// behavior, and because we have state that relies on client status changes being accurate (i.e.
+// in `this._client.onDidChangeState()`). Additionally, we set `handled: true` to avoid a toast
+// notification that is inactionable from the user's point of view.
+// https://github.com/posit-dev/positron/pull/2880
+// https://github.com/microsoft/vscode-languageserver-node/blob/8e625564b531da607859b8cb982abb7cdb2fbe2e/client/src/common/client.ts#L420
+// https://github.com/microsoft/vscode-languageserver-node/blob/8e625564b531da607859b8cb982abb7cdb2fbe2e/client/src/common/client.ts#L1617
+export class RErrorHandler implements ErrorHandler {
+	constructor(
+		private readonly _version: string,
+		private readonly _port: number
+	) {
+	}
+
+	public error(error: Error, _message: Message, count: number): ErrorHandlerResult {
+		LOGGER.warn(`ARK (R ${this._version}) language client error occurred (port ${this._port}). '${error.name}' with message: ${error.message}. This is error number ${count}.`);
+		return { action: ErrorAction.Shutdown };
+	}
+
+	public closed(): CloseHandlerResult {
+		LOGGER.warn(`ARK (R ${this._version}) language client was closed unexpectedly (port ${this._port}).`);
+		return { action: CloseAction.DoNotRestart, handled: true };
+	}
+}

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -10,14 +10,8 @@ import { LOGGER } from './extension';
 import { RErrorHandler } from './error-handler';
 
 import {
-	CloseAction,
-	CloseHandlerResult,
-	ErrorAction,
-	ErrorHandler,
-	ErrorHandlerResult,
 	LanguageClient,
 	LanguageClientOptions,
-	Message,
 	State,
 	StreamInfo,
 } from 'vscode-languageclient/node';

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -110,7 +110,7 @@ export class ArkLsp implements vscode.Disposable {
 				{
 					fileEvents: vscode.workspace.createFileSystemWatcher('**/*.R')
 				},
-			errorHandler: new ArkErrorHandler(this._version, port)
+			errorHandler: new ArkLanguageClientErrorHandler(this._version, port)
 		};
 
 		// With a `.` rather than a `-` so vscode-languageserver can look up related options correctly
@@ -242,9 +242,10 @@ export class ArkLsp implements vscode.Disposable {
 // behavior, and because we have state that relies on client status changes being accurate (i.e.
 // in `this._client.onDidChangeState()`). Additionally, we set `handled: true` to avoid a toast
 // notification that is inactionable from the user's point of view.
+// https://github.com/posit-dev/positron/pull/2880
 // https://github.com/microsoft/vscode-languageserver-node/blob/8e625564b531da607859b8cb982abb7cdb2fbe2e/client/src/common/client.ts#L420
 // https://github.com/microsoft/vscode-languageserver-node/blob/8e625564b531da607859b8cb982abb7cdb2fbe2e/client/src/common/client.ts#L1617
-class ArkErrorHandler implements ErrorHandler {
+class ArkLanguageClientErrorHandler implements ErrorHandler {
 	constructor(
 		private readonly _version: string,
 		private readonly _port: number


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/1556

I realized while looking into `q()` behavior that some of our language server issues are related to the `DefaultErrorHandler` that is created by vscode-languageserver-node for us.

It builds in a restart behavior which I actually don't think we want.
https://github.com/microsoft/vscode-languageserver-node/blob/8e625564b531da607859b8cb982abb7cdb2fbe2e/client/src/common/client.ts#L420-L449

That can result in this odd chain of events

```
2024-04-24 16:16:39.866 [info] Loading Ark from disk in adjacent repo. Make sure it's up-to-date.
2024-04-24 16:16:40.348 [info] Creating Positron R 4.3.1 language client (port 44616)...
2024-04-24 16:16:40.348 [info] ARK (R 4.3.1) language client state changed uninitialized => starting
2024-04-24 16:16:40.365 [info] ARK (R 4.3.1) language client init successful
2024-04-24 16:16:40.365 [info] ARK (R 4.3.1) language client state changed starting => running

// we run rlang:::node_caar(1) and R crashes, client tries to restart itself, but fails
2024-04-24 16:16:46.995 [info] ARK (R 4.3.1) language client state changed running => stopped
2024-04-24 16:16:46.995 [info] ARK (R 4.3.1) language client state changed stopped => starting
2024-04-24 16:16:46.999 [info] ARK (R 4.3.1) language client state changed starting => stopped

// our actual restart behavior kicks in
2024-04-24 16:16:47.359 [info] Loading Ark from disk in adjacent repo. Make sure it's up-to-date.
2024-04-24 16:16:47.780 [info] Creating Positron R 4.3.1 language client (port 57504)...
2024-04-24 16:16:47.780 [info] ARK (R 4.3.1) language client state changed uninitialized => starting
2024-04-24 16:16:47.785 [info] ARK (R 4.3.1) language client init successful
2024-04-24 16:16:47.785 [info] ARK (R 4.3.1) language client state changed starting => running
```

While the client tries to auto restart itself with the `DefaultErrorHandler`, it also emits these two inactionable messages alongside our own error message

<img width="476" alt="Screenshot 2024-04-24 at 4 19 15 PM" src="https://github.com/posit-dev/positron/assets/19150088/1e1e6921-9cfe-4801-bbf3-b70f09464395">

The solution is to provide your own error handler, which allows us to log the crash using our `LOGGER`, but otherwise shut down with no attempts to restart, expecting that someone else will restart us as required.

---

Note that this does _not_ solve the duplicate `Positron R Language Server` output channel problem.

<img width="252" alt="Screenshot 2024-04-24 at 4 21 23 PM" src="https://github.com/posit-dev/positron/assets/19150088/a73d71c9-2071-4cce-93d4-9f24b7eb4161">

