### PR TITLE
Disable Microsoft telemetry

### DIFF
--- a/src/vs/platform/telemetry/common/1dsAppender.ts
+++ b/src/vs/platform/telemetry/common/1dsAppender.ts
@@ -18,8 +18,12 @@ export interface IAppInsightsCore {
 	unload(isAsync: boolean, unloadComplete: (unloadState: ITelemetryUnloadState) => void): void;
 }
 
-const endpointUrl = 'https://mobile.events.data.microsoft.com/OneCollector/1.0';
-const endpointHealthUrl = 'https://mobile.events.data.microsoft.com/ping';
+// --- Start Positron ---
+// const endpointUrl = 'https://mobile.events.data.microsoft.com/OneCollector/1.0';
+// const endpointHealthUrl = 'https://mobile.events.data.microsoft.com/ping';
+const endpointUrl = 'https://mobile.events.0.0.0.0/OneCollector/1.0';
+const endpointHealthUrl = 'https://mobile.events.0.0.0.0/ping';
+// --- End Positron ---
 
 async function getClient(instrumentationKey: string, addInternalFlag?: boolean, xhrOverride?: IXHROverride): Promise<IAppInsightsCore> {
 	const oneDs = await importAMDNodeModule<typeof import('@microsoft/1ds-core-js')>('@microsoft/1ds-core-js', 'dist/ms.core.js');

--- a/src/vs/platform/telemetry/common/1dsAppender.ts
+++ b/src/vs/platform/telemetry/common/1dsAppender.ts
@@ -21,8 +21,8 @@ export interface IAppInsightsCore {
 // --- Start Positron ---
 // const endpointUrl = 'https://mobile.events.data.microsoft.com/OneCollector/1.0';
 // const endpointHealthUrl = 'https://mobile.events.data.microsoft.com/ping';
-const endpointUrl = 'https://mobile.events.0.0.0.0/OneCollector/1.0';
-const endpointHealthUrl = 'https://mobile.events.0.0.0.0/ping';
+const endpointUrl = 'https://0.0.0.0/OneCollector/1.0';
+const endpointHealthUrl = 'https://0.0.0.0/ping';
 // --- End Positron ---
 
 async function getClient(instrumentationKey: string, addInternalFlag?: boolean, xhrOverride?: IXHROverride): Promise<IAppInsightsCore> {

--- a/src/vs/platform/telemetry/common/telemetryService.ts
+++ b/src/vs/platform/telemetry/common/telemetryService.ts
@@ -214,7 +214,10 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 				localize('telemetry.telemetryLevel.off', "Disables all product telemetry.")
 			],
 			'markdownDescription': getTelemetryLevelSettingDescription(),
-			'default': TelemetryConfiguration.ON,
+			// --- Start Positron ---
+			// 'default': TelemetryConfiguration.ON,
+			'default': TelemetryConfiguration.OFF,
+			// --- End Positron ---
 			'restricted': true,
 			'scope': ConfigurationScope.APPLICATION,
 			'tags': ['usesOnlineServices', 'telemetry']

--- a/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
@@ -147,7 +147,10 @@ registry.registerConfiguration({
 		'workbench.settings.enableNaturalLanguageSearch': {
 			'type': 'boolean',
 			'description': nls.localize('enableNaturalLanguageSettingsSearch', "Controls whether to enable the natural language search mode for settings. The natural language search is provided by a Microsoft online service."),
-			'default': true,
+			// --- Start Positron ---
+			// 'default': true,
+			'default': false,
+			// --- End Positron ---
 			'scope': ConfigurationScope.WINDOW,
 			'tags': ['usesOnlineServices']
 		},

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -288,7 +288,10 @@ import { MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL } from 'vs/platform/window/electron-sand
 			'telemetry.enableCrashReporter': {
 				'type': 'boolean',
 				'description': localize('telemetry.enableCrashReporting', "Enable crash reports to be collected. This helps us improve stability. \nThis option requires restart to take effect."),
-				'default': true,
+				// --- Start Positron ---
+				// 'default': true,
+				'default': false,
+				// --- End Positron ---
 				'tags': ['usesOnlineServices', 'telemetry'],
 				'markdownDeprecationMessage': localize('enableCrashReporterDeprecated', "If this setting is false, no telemetry will be sent regardless of the new setting's value. Deprecated due to being combined into the {0} setting.", `\`#${TELEMETRY_SETTING_ID}#\``),
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses #2522 

### Approach

This PR takes a similar approach as VSCodium. I took a look at this info when deciding what to do/remove:

- https://github.com/VSCodium/vscodium/blob/master/docs/index.md#getting-all-the-telemetry-out
- https://github.com/VSCodium/vscodium/blob/master/undo_telemetry.sh
- https://github.com/VSCodium/vscodium/blob/master/update_settings.sh

### QA Notes

To see if there are other references to these servers, you can search for `data.microsoft.com` in the codebase.

Also, you can try rebuilding Positron from scratch and then doing `rg --no-ignore -l "data.microsoft.com" . ` from Positron's directory. You'll see a lot of stuff, but it is only `node_modules`. If you do `rg -l "data.microsoft.com" .` you'll only see the `1dsAppender.ts` we have edited here in this PR.