### PR TITLE
Build REH for linux

### DIFF
--- a/.github/workflows/build-release-linux.yml
+++ b/.github/workflows/build-release-linux.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           yarn gulp vscode-linux-${{ matrix.arch }}
 
-      - name: Prepare binary
+      - name: Prepare Linux packages
         run: |
           yarn gulp vscode-linux-${{ matrix.arch }}-prepare-deb
           yarn gulp vscode-linux-${{ matrix.arch }}-prepare-rpm
@@ -103,6 +103,23 @@ jobs:
         with:
           name: positron-binary-deb
           path: Positron-${{ inputs.short_version }}.deb
+
+      # Build the Remote Extension Host (REH) version of Positron. This
+      # contains the bits that are copied into SSH hosts or containers for
+      # remote development workflows.
+      - name: Build Positron Remote Extension Host
+        env:
+          npm_config_arch: ${{ matrix.arch }}
+        run: |
+          yarn gulp vscode-reh-linux-${{ matrix.arch }}
+          cd ..
+          tar czvf positron-reh-linux-${{ matrix.arch }}-${{ inputs.short_version }}.tar.gz vscode-reh-linux-${{ matrix.arch }}
+
+      - name: Upload REH .tar.gz
+        uses: actions/upload-artifact@v4
+        with:
+          name: positron-binary-reh
+          path: ../positron-reh-linux-${{ matrix.arch }}-${{ inputs.short_version }}.tar.gz
 
   status:
     if: ${{ failure() }}

--- a/.github/workflows/build-release-linux.yml
+++ b/.github/workflows/build-release-linux.yml
@@ -113,13 +113,13 @@ jobs:
         run: |
           yarn gulp vscode-reh-linux-${{ matrix.arch }}
           cd ..
-          tar czvf positron-reh-linux-${{ matrix.arch }}-${{ inputs.short_version }}.tar.gz vscode-reh-linux-${{ matrix.arch }}
+          tar czvf positron-reh-linux-${{ matrix.arch }}-${{ inputs.short_version }}.tar.gz positron/vscode-reh-linux-${{ matrix.arch }}
 
       - name: Upload REH .tar.gz
         uses: actions/upload-artifact@v4
         with:
           name: positron-binary-reh
-          path: ../positron-reh-linux-${{ matrix.arch }}-${{ inputs.short_version }}.tar.gz
+          path: positron-reh-linux-${{ matrix.arch }}-${{ inputs.short_version }}.tar.gz
 
   status:
     if: ${{ failure() }}

--- a/.github/workflows/build-release-linux.yml
+++ b/.github/workflows/build-release-linux.yml
@@ -34,9 +34,9 @@ jobs:
       POSITRON_BUILD_NUMBER: ${{ inputs.build_number }}
 
     strategy:
-      max-parallel: 1
       matrix:
         arch: [x64]
+        flavor: [installer, reh]
 
     steps:
       # Checkout sources
@@ -70,7 +70,8 @@ jobs:
           # dependencies
           yarn --immutable --network-timeout 120000
 
-      - name: Build Positron
+      - name: Build Positron Client
+        if: matrix.flavor == 'installer'
         env:
           npm_config_arch: ${{ matrix.arch }}
         run: |
@@ -86,6 +87,7 @@ jobs:
       # file and are just a convenient way of matching the generated
       # filename.
       - name: Build binary
+        if: matrix.flavor == 'installer'
         run: |
           yarn gulp vscode-linux-${{ matrix.arch }}-build-deb
           yarn gulp vscode-linux-${{ matrix.arch }}-build-rpm
@@ -93,12 +95,14 @@ jobs:
           mv .build/linux/rpm/*/*.rpm Positron-${{ inputs.short_version }}.rpm
 
       - name: Upload .rpm
+        if: matrix.flavor == 'installer'
         uses: actions/upload-artifact@v4
         with:
           name: positron-binary-rpm
           path: Positron-${{ inputs.short_version }}.rpm
 
       - name: Upload .deb
+        if: matrix.flavor == 'installer'
         uses: actions/upload-artifact@v4
         with:
           name: positron-binary-deb
@@ -108,14 +112,16 @@ jobs:
       # contains the bits that are copied into SSH hosts or containers for
       # remote development workflows.
       - name: Build Positron Remote Extension Host
+        if: matrix.flavor == 'reh'
         env:
           npm_config_arch: ${{ matrix.arch }}
         run: |
           yarn gulp vscode-reh-linux-${{ matrix.arch }}
           cd ..
-          tar czvf positron-reh-linux-${{ matrix.arch }}-${{ inputs.short_version }}.tar.gz positron/vscode-reh-linux-${{ matrix.arch }}
+          tar czvf positron/positron-reh-linux-${{ matrix.arch }}-${{ inputs.short_version }}.tar.gz vscode-reh-linux-${{ matrix.arch }}
 
       - name: Upload REH .tar.gz
+        if: matrix.flavor == 'reh'
         uses: actions/upload-artifact@v4
         with:
           name: positron-binary-reh


### PR DESCRIPTION
As part of the supporting work for remote development with Positron, this change adds REH (Remote Extension Host) Linux builds to the Linux build matrix. 