### PR TITLE
Save and restore scroll state on visibility change

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -322,10 +322,14 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 				// scrolling to 0 followed by our scroll to `lastScrollTop` is
 				// unfortunately noticeable, though not too bad.
 				setTimeout(() => {
-					if (props.positronConsoleInstance.scrollLocked) {
-						scrollVertically(props.positronConsoleInstance.lastScrollTop);
-					} else {
-						scrollToBottom();
+					// Since we are in a timeout and teardown might have been called,
+					// check that our component is still mounted
+					if (consoleInstanceRef.current) {
+						if (props.positronConsoleInstance.scrollLocked) {
+							scrollVertically(props.positronConsoleInstance.lastScrollTop);
+						} else {
+							scrollToBottom();
+						}
 					}
 				});
 			}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -4,7 +4,7 @@
 
 import 'vs/css!./consoleInstance';
 import * as React from 'react';
-import { KeyboardEvent, MouseEvent, UIEvent, useEffect, useLayoutEffect, useRef, useState, WheelEvent } from 'react'; // eslint-disable-line no-duplicate-imports
+import { KeyboardEvent, MouseEvent, UIEvent, useCallback, useEffect, useLayoutEffect, useRef, useState, WheelEvent } from 'react'; // eslint-disable-line no-duplicate-imports
 import * as nls from 'vs/nls';
 import * as DOM from 'vs/base/browser/dom';
 import { generateUuid } from 'vs/base/common/uuid';
@@ -103,8 +103,6 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	const [trace, setTrace] = useState(props.positronConsoleInstance.trace);
 	const [wordWrap, setWordWrap] = useState(props.positronConsoleInstance.wordWrap);
 	const [marker, setMarker] = useState(generateUuid());
-	const [, setLastScrollTop, lastScrollTopRef] = useStateRef(0);
-	const [, setScrollLock, scrollLockRef] = useStateRef(false);
 	const [, setIgnoreNextScrollEvent, ignoreNextScrollEventRef] = useStateRef(false);
 
 
@@ -113,11 +111,11 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 		consoleInstanceRef.current.scrollHeight > consoleInstanceRef.current.clientHeight;
 
 	// Scrolls to the bottom.
-	const scrollToBottom = () => {
-		setScrollLock(false);
+	const scrollToBottom = useCallback(() => {
+		props.positronConsoleInstance.scrollLocked = false;
 		setIgnoreNextScrollEvent(true);
 		scrollVertically(consoleInstanceRef.current.scrollHeight);
-	};
+	}, [props.positronConsoleInstance, setIgnoreNextScrollEvent]);
 
 	// Scrolls the console vertically.
 	const scrollVertically = (y: number) => {
@@ -277,16 +275,6 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			}
 		));
 
-		// Add the onSaveScrollPosition event handler.
-		disposableStore.add(props.reactComponentContainer.onSaveScrollPosition(() => {
-			setLastScrollTop(consoleInstanceRef.current.scrollTop);
-		}));
-
-		// Add the onRestoreScrollPosition event handler.
-		disposableStore.add(props.reactComponentContainer.onRestoreScrollPosition(() => {
-			consoleInstanceRef.current.scrollTop = lastScrollTopRef.current;
-		}));
-
 		// Add the onDidChangeState event handler.
 		disposableStore.add(props.positronConsoleInstance.onDidChangeState(state => {
 			if (state === PositronConsoleState.Starting) {
@@ -316,8 +304,35 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			scrollToBottom();
 		}));
 
+		disposableStore.add(props.reactComponentContainer.onVisibilityChanged(visible => {
+			if (visible) {
+				// The browser will automatically set scrollTop to 0 on child
+				// components that have been hidden and made visible. (This is
+				// called "desperate" elsewhere in Visual Studio Code.  Search
+				// for that word and you'll see other examples of hacks that
+				// have been added to to fix this problem.).  To counteract this
+				// we restore the scroll state saved on the last scroll event.
+				//
+				// We restore in the next tick because otherwise our scrolling
+				// gets overwritten by whatever is setting the scrollTop to 0 on
+				// redraw. This is also what VS Code's debug console does.
+				//
+				// Note that the scroll-to-zero somehow only happens when we are
+				// not scrolled all the way to the bottom. In this case, the
+				// scrolling to 0 followed by our scroll to `lastScrollTop` is
+				// unfortunately noticeable, though not too bad.
+				setTimeout(() => {
+					if (props.positronConsoleInstance.scrollLocked) {
+						scrollVertically(props.positronConsoleInstance.lastScrollTop);
+					} else {
+						scrollToBottom();
+					}
+				});
+			}
+		}));
+
 		disposableStore.add(props.reactComponentContainer.onSizeChanged(_ => {
-			if (!scrollLockRef.current) {
+			if (!props.positronConsoleInstance.scrollLocked) {
 				scrollToBottom();
 			}
 		}));
@@ -343,14 +358,14 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, [editorFontInfo, lastScrollTopRef, positronConsoleContext.activePositronConsoleInstance?.session, positronConsoleContext.configurationService, positronConsoleContext.positronPlotsService, positronConsoleContext.runtimeSessionService, positronConsoleContext.viewsService, props.positronConsoleInstance, props.reactComponentContainer, scrollToBottom, setLastScrollTop]);
+	}, [editorFontInfo, positronConsoleContext.activePositronConsoleInstance?.session, positronConsoleContext.configurationService, positronConsoleContext.positronPlotsService, positronConsoleContext.runtimeSessionService, positronConsoleContext.viewsService, props.positronConsoleInstance, props.reactComponentContainer, scrollToBottom]);
 
 	useLayoutEffect(() => {
 		// If the view is not scroll locked, scroll to the bottom to reveal the most recent items.
-		if (!scrollLockRef.current) {
+		if (!props.positronConsoleInstance.scrollLocked) {
 			scrollVertically(consoleInstanceRef.current.scrollHeight);
 		}
-	}, [marker, scrollLockRef]);
+	}, [marker, props.positronConsoleInstance.scrollLocked]);
 
 	/**
 	 * onClick event handler.
@@ -402,7 +417,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 				// Page up key.
 				case 'PageUp':
 					consumeEvent();
-					setScrollLock(scrollable());
+					props.positronConsoleInstance.scrollLocked = scrollable();
 					scrollVertically(consoleInstanceRef.current.scrollTop - pageHeight());
 					return;
 
@@ -416,7 +431,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 				case 'Home':
 					// Consume the event, set scroll lock, and scroll to the top.
 					consumeEvent();
-					setScrollLock(scrollable());
+					props.positronConsoleInstance.scrollLocked = scrollable();
 					scrollVertically(0);
 					return;
 
@@ -557,8 +572,12 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 				consoleInstanceRef.current.scrollTop
 			);
 
-			// Update scroll lock.
-			setScrollLock(scrollPosition >= 1);
+			// Update scroll lock state
+			props.positronConsoleInstance.scrollLocked = scrollPosition >= 1;
+
+			// This used to be saved in an event handler when visibility changed
+			// to `false` but the `scrollTop` already became 0 at that point.
+			props.positronConsoleInstance.lastScrollTop = consoleInstanceRef.current.scrollTop;
 		}
 	};
 
@@ -568,8 +587,8 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	 */
 	const wheelHandler = (e: WheelEvent<HTMLDivElement>) => {
 		// Negative delta Y immediantly engages scroll lock, if the console is scrollable.
-		if (e.deltaY < 0 && !scrollLockRef.current) {
-			setScrollLock(scrollable());
+		if (e.deltaY < 0 && !props.positronConsoleInstance.scrollLocked) {
+			props.positronConsoleInstance.scrollLocked = scrollable();
 			return;
 		}
 	};

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -222,17 +222,8 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 
 		// Register the onDidChangeBodyVisibility event handler.
 		this._register(this.onDidChangeBodyVisibility(visible => {
-			// The browser will automatically set scrollTop to 0 on child components that have been
-			// hidden and made visible. (This is called "desperate" elsewhere in Visual Studio Code.
-			// Search for that word and you'll see other examples of hacks that have been added to
-			// to fix this problem.) IReactComponentContainers can counteract this behavior by
-			// firing onSaveScrollPosition and onRestoreScrollPosition events to have their children
-			// save and restore their scroll positions.
-			if (!visible) {
-				this._onSaveScrollPositionEmitter.fire();
-			} else {
-				this._onRestoreScrollPositionEmitter.fire();
-			}
+			// Relay event for our `IReactComponentContainer` implementation
+			this._onVisibilityChangedEmitter.fire(visible);
 		}));
 	}
 

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -148,6 +148,16 @@ export interface IPositronConsoleInstance {
 	readonly runtimeAttached: boolean;
 
 	/**
+	 * Is scroll-lock engaged?
+	 */
+	scrollLocked: boolean;
+
+	/**
+	 * Last saved scroll top.
+	 */
+	lastScrollTop: number;
+
+	/**
 	 * The onFocusInput event.
 	 */
 	readonly onFocusInput: Event<void>;

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -588,6 +588,16 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	private _promptActive = false;
 
 	/**
+	 * Is scroll-lock engaged?
+	 */
+	private _scrollLocked = false;
+
+	/**
+	 * Last saved scroll top.
+	 */
+	private _lastScrollTop = 0;
+
+	/**
 	 * The _onFocusInput event emitter.
 	 */
 	private readonly _onFocusInputEmitter = this._register(new Emitter<void>);
@@ -805,6 +815,26 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 */
 	get runtimeAttached(): boolean {
 		return this._runtimeAttached;
+	}
+
+	/**
+	 * Is scroll-lock engaged?
+	 */
+	get scrollLocked(): boolean {
+		return this._scrollLocked;
+	}
+	set scrollLocked(value: boolean) {
+		this._scrollLocked = value;
+	}
+
+	/**
+	 * Last saved scroll top.
+	 */
+	get lastScrollTop(): number {
+		return this._lastScrollTop;
+	}
+	set lastScrollTop(value: number) {
+		this._lastScrollTop = value;
 	}
 
 	/**


### PR DESCRIPTION
Branched from #2808 (needs to be merged first).

### Intent

Addresses #2868. The scroll state is now preserved when toggling the visibility of the console, either through a keybinding or through the top-right icon.


### Approach

We were already saving the scrolling state but we did this in Ref variables that were getting thrown away once the component left the DOM. With this PR we now save the state outside of the React component, in the console instance.

I noticed that saving the scroll state when visibility changed to `false` wasn't working as expected, the `scrollTop` had become 0 at that point. We are now saving this state on every scroll events instead. To simplify things I moved the scroll restoration to our visibility handler. This event was not wired up before the PR and I've now done that.

When visibility changes to `true` we restore the scroll state in the next tick. That's because whatever is setting the scrolltop back to 0 is doing it after the handler is called. This causes a visible glitch when scroll-lock is enabled. Somehow this does not happen when we are scrolled to the bottom, maybe there's something somewhere that really wants scrolling to be either at the top or the bottom but I didn't figure out what's going on.

### QA Notes

Both auto-scroll when the console is scrolled to the bottom and scroll-lock when it isn't should still work as before, and now also be preserved on visibility toggle. You can engage auto-scroll with this R code: `repeat { Sys.sleep(0.2); writeLines('a')}`.

In the case of scroll-lock, you might notice a visible scroll to zero before scroll is restored to its original state. I couldn't find a way to make this smoother.


https://github.com/posit-dev/positron/assets/4465050/c09046b1-efb7-4173-94f5-e76601e5b96f

