### PR TITLE
Fix/suppress log noise around comms

### DIFF
--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -890,7 +890,7 @@ export class LanguageRuntimeSessionAdapter
 		this._kernel.log(`Starting LSP server ${clientId} for ${clientAddress}`);
 
 		// Notify Positron that we're handling messages from this client
-		positron.runtime.registerClientInstance(clientId);
+		this._disposables.push(positron.runtime.registerClientInstance(clientId));
 
 		await this.createClient(
 			clientId,
@@ -929,7 +929,7 @@ export class LanguageRuntimeSessionAdapter
 		this._kernel.log(`Starting DAP server ${clientId} for ${serverAddress}`);
 
 		// Notify Positron that we're handling messages from this client
-		positron.runtime.registerClientInstance(clientId);
+		this._disposables.push(positron.runtime.registerClientInstance(clientId));
 
 		await this.createClient(
 			clientId,

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -889,6 +889,9 @@ export class LanguageRuntimeSessionAdapter
 		const clientId = `positron-lsp-${this.runtimeMetadata.languageId}-${LanguageRuntimeSessionAdapter._clientCounter++}-${uniqueId}`;
 		this._kernel.log(`Starting LSP server ${clientId} for ${clientAddress}`);
 
+		// Notify Positron that we're handling messages from this client
+		positron.runtime.registerClientInstance(clientId);
+
 		await this.createClient(
 			clientId,
 			positron.RuntimeClientType.Lsp,
@@ -924,6 +927,9 @@ export class LanguageRuntimeSessionAdapter
 		const uniqueId = Math.floor(Math.random() * 0x100000000).toString(16);
 		const clientId = `positron-dap-${this.runtimeMetadata.languageId}-${LanguageRuntimeSessionAdapter._clientCounter++}-${uniqueId}`;
 		this._kernel.log(`Starting DAP server ${clientId} for ${serverAddress}`);
+
+		// Notify Positron that we're handling messages from this client
+		positron.runtime.registerClientInstance(clientId);
 
 		await this.createClient(
 			clientId,

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1201,6 +1201,14 @@ declare module 'positron' {
 		export function registerClientHandler(handler: RuntimeClientHandler): vscode.Disposable;
 
 		/**
+		 * Register a runtime client instance. Registering the instance
+		 * indicates that the caller has ownership of the instance, and that
+		 * messages the instance receives do not need to be forwarded to the
+		 * Positron core.
+		 */
+		export function registerClientInstance(clientInstanceId: string): vscode.Disposable;
+
+		/**
 		 * An event that fires when a new runtime is registered.
 		 */
 		export const onDidRegisterRuntime: vscode.Event<LanguageRuntimeMetadata>;

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -113,6 +113,12 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 				return extHostLanguageRuntime.registerClientHandler(handler);
 			},
 			registerClientInstance(clientInstanceId: string): vscode.Disposable {
+				/**
+				 * Register a runtime client instance. Registering the instance
+				 * indicates that the caller has ownership of the instance, and that
+				 * messages the instance receives do not need to be forwarded to the
+				 * Positron core.
+				 */
 				return extHostLanguageRuntime.registerClientInstance(clientInstanceId);
 			},
 			get onDidRegisterRuntime() {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -112,6 +112,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			registerClientHandler(handler: positron.RuntimeClientHandler): vscode.Disposable {
 				return extHostLanguageRuntime.registerClientHandler(handler);
 			},
+			registerClientInstance(clientInstanceId: string): vscode.Disposable {
+				return extHostLanguageRuntime.registerClientInstance(clientInstanceId);
+			},
 			get onDidRegisterRuntime() {
 				return extHostLanguageRuntime.onDidRegisterRuntime;
 			}

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -5,7 +5,8 @@
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Event } from 'vs/base/common/event';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
-import { BusyEvent, ClearConsoleEvent, UiFrontendEvent, OpenEditorEvent, OpenWorkspaceEvent, PositronUiComm, PromptStateEvent, ShowMessageEvent, WorkingDirectoryEvent, ExecuteCommandEvent, ShowUrlEvent, SetEditorSelectionsEvent } from './positronUiComm';
+import { BusyEvent, ClearConsoleEvent, UiFrontendEvent, OpenEditorEvent, OpenWorkspaceEvent, PromptStateEvent, ShowMessageEvent, WorkingDirectoryEvent, ExecuteCommandEvent, ShowUrlEvent, SetEditorSelectionsEvent } from './positronUiComm';
+import { PositronUiCommInstance } from 'vs/workbench/services/languageRuntime/common/positronUiCommInstance';
 
 
 /**
@@ -58,7 +59,7 @@ export interface IUiClientMessageOutputEvent
  * the backend know when Positron is connected.
  */
 export class UiClientInstance extends Disposable {
-	private _comm: PositronUiComm;
+	private _comm: PositronUiCommInstance;
 
 	/** Emitters for events forwarded from the UI comm */
 	onDidBusy: Event<BusyEvent>;
@@ -84,7 +85,7 @@ export class UiClientInstance extends Disposable {
 		super();
 		this._register(this._client);
 
-		this._comm = new PositronUiComm(this._client);
+		this._comm = new PositronUiCommInstance(this._client);
 		this.onDidBusy = this._comm.onDidBusy;
 		this.onDidClearConsole = this._comm.onDidClearConsole;
 		this.onDidSetEditorSelections = this._comm.onDidSetEditorSelections;

--- a/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
@@ -127,7 +127,7 @@ export class PositronBaseComm extends Disposable {
 				console.warn(`Dropping event '${data.method}' ` +
 					`on comm ${this.clientInstance.getClientId()}: ` +
 					`${JSON.stringify(data.params)} ` +
-					`(No listeners for event event '${data.method}'`);
+					`(No listeners for event '${data.method}'`);
 			}
 		}));
 

--- a/src/vs/workbench/services/languageRuntime/common/positronUiCommInstance.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronUiCommInstance.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
+import { PositronUiComm } from 'vs/workbench/services/languageRuntime/common/positronUiComm';
+
+export class PositronUiCommInstance extends PositronUiComm {
+	constructor(client: IRuntimeClientInstance<any, any>) {
+		super(client);
+
+		// Create a stub CallMethodReply event emitter. This allows us to
+		// gracefully handle the case wherein an RPC is initiated on the
+		// extension side. When the RPC reply is received, it is delivered to
+		// the main thread, too, but since the main thread didn't intiate the
+		// RPC, the message is unexpected and generates a warning.
+		super.createEventEmitter('CallMethodReply', []);
+	}
+}


### PR DESCRIPTION
### Intent

Cleans up errors/warnings that are logged unnecessarily. 

Addresses https://github.com/posit-dev/positron/issues/2380
Addresses https://github.com/posit-dev/positron/issues/1611

### Approach

- Create a way for the extensions to let the front end know that they are managing a particular client instance. Messages from these instances aren't passed to the front end. 
- Create a dummy listener for `CallMethodReply`. I'm less happy about how this works, but it allows us to keep defenses up for other messages that might signal real problems.

In general, I think that these problems indicate that we might need better or different abstractions around handling comms. Some comms are wholly owned by extensions, and others are wholly owned by the front end, and still others (e.g. the UI comm) are used by both. So in an ideal world, a comm would have a representation that allowed this ownership to be made explicit, and for messages and replies to be better scoped to the initiator. 

Don't want to really mess with this infrastructure right now, though, so these band-aids should keep the log spam down.

### QA Notes

This is really easy to repro (just start Positron) -- see issues for details. In general we'd like to be in a place where there are NO warnings/errors during a successful startup, so that if we do see any we know something is wrong and requires investigation.