### PR TITLE
Connections pane on the auxiliary sidebar by default

### DIFF
--- a/extensions/positron-connections/package.json
+++ b/extensions/positron-connections/package.json
@@ -18,10 +18,10 @@
   },
   "contributes": {
     "viewsContainers": {
-      "activitybar": [
+      "auxiliarybar": [
         {
           "id": "positron-connections",
-          "title": "%view.description%",
+          "title": "%view.title%",
           "icon": "media/database.svg"
         }
       ]
@@ -30,7 +30,7 @@
       "positron-connections": [
         {
           "id": "connections",
-          "name": "%view.description%",
+          "name": "%view.title%",
           "icon": "media/database.svg",
           "contextualTitle": "%view.description%"
         }
@@ -58,9 +58,34 @@
         "command": "positron.connections.refresh",
         "title": "%commands.refresh.title%",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "positron.connections.removeFromHistory",
+        "title": "%commands.removeFromHistory.title%",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "positron.connections.reopenConnection",
+        "title": "%commands.reopenConnection.title%",
+        "icon": "$(open-preview)"
+      },
+      {
+        "command": "positron.connections.copyCodeToClipboard",
+        "title": "%commands.copyCodeToClipboard.title%",
+        "icon": "$(clippy)"
+      },
+      {
+        "command": "positron.connections.clearConnectionsHistory",
+        "title": "%commands.clearConnectionsHistory.title%",
+        "icon": "$(clear-all)"
       }
     ],
     "menus": {
+      "view/title": [
+        {
+          "command": "positron.connections.clearConnectionsHistory"
+        }
+      ],
       "view/item/context": [
         {
           "command": "positron.connections.closeConnection",
@@ -76,6 +101,27 @@
           "command": "positron.connections.refresh",
           "group": "inline",
           "when": "viewItem == database"
+        },
+        {
+          "command": "positron.connections.removeFromHistory",
+          "group": "inline",
+          "when": "viewItem =~ /disconnected/"
+        },
+        {
+          "command": "positron.connections.reopenConnection",
+          "group": "inline",
+          "when": "viewItem =~ /disconnected-hasCode/"
+        },
+        {
+          "command": "positron.connections.reopenConnection",
+          "group": "code",
+          "when": "viewItem =~ /disconnected-hasCode/",
+          "contextualTitle": "Connect to database"
+        },
+        {
+          "command": "positron.connections.copyCodeToClipboard",
+          "when": "viewItem =~ /disconnected-hasCode/",
+          "group": "code"
         }
       ]
     }

--- a/extensions/positron-connections/package.nls.json
+++ b/extensions/positron-connections/package.nls.json
@@ -2,6 +2,7 @@
 	"displayName": "Positron Connections",
 	"description": "Provides a view of active database connections.",
 	"view.description": "Database Connections",
+	"view.title": "Connections",
 	"view.welcome": "No database connections are currently active.",
 	"commands.previewTable.title": "Preview Table",
 	"commands.previewTable.category": "Connections",

--- a/src/vs/workbench/api/browser/viewsExtensionPoint.ts
+++ b/src/vs/workbench/api/browser/viewsExtensionPoint.ts
@@ -358,6 +358,11 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
 					case 'panel':
 						panelOrder = this.registerCustomViewContainers(value, description, panelOrder, existingViewContainers, ViewContainerLocation.Panel);
 						break;
+					// --- Start Positron ---
+					case 'auxiliarybar':
+						this.registerAuxiliaryBarViewContainers(value, description, existingViewContainers);
+						break;
+					// --- End Positron ---
 				}
 			});
 		}
@@ -457,6 +462,14 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
 
 		return viewContainer;
 	}
+
+	// --- Start Positron ---
+	private registerAuxiliaryBarViewContainers(containers: IUserFriendlyViewsContainerDescriptor[], extension: IExtensionDescription, existingViewContainers: ViewContainer[]): void {
+		const viewContainersRegistry = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry);
+		const order = 5 + viewContainersRegistry.all.filter(v => !!v.extensionId && viewContainersRegistry.getViewContainerLocation(v) === ViewContainerLocation.AuxiliaryBar).length + 1;
+		this.registerCustomViewContainers(containers, extension, order, existingViewContainers, ViewContainerLocation.AuxiliaryBar);
+	}
+	// --- End Positron ---
 
 	private deregisterCustomViewContainer(viewContainer: ViewContainer): void {
 		this.viewContainersRegistry.deregisterViewContainer(viewContainer);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

The primary sidebar already contains too much information and we want the connections pane to be less prominent in the ui.
Adresses #2439 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

VScode doesn't allow extensions to contribute to the secondary sidebar, even though users can drag view containers into it.
This PR, allows extensions to contribute to that sidebar then makes the connections pane by default be placed there.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

When starting positron, the connections pane should be on the secondary sidebar. If you moved the connections pane before, yoou might need to right click on it and then click in 'Reset location' for it to go the default location.

![image](https://github.com/posit-dev/positron/assets/4706822/1f9e3ab1-c8fd-40d5-8afc-53990ef04198)

