### PR TITLE
Create New Project contrib and store project configuration

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -515,6 +515,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/services/positronNewProject",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/services/positronPlots",
 			"project": "vscode-workbench"
 		},

--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -26,6 +26,7 @@ import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/com
 import { ILogService } from 'vs/platform/log/common/log';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IStorageService } from 'vs/platform/storage/common/storage';
+import { USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 
 /**
  * The PositronNewProjectAction.
@@ -40,6 +41,9 @@ export class PositronNewProjectAction extends Action2 {
 	 * Constructor.
 	 */
 	constructor() {
+		// TODO: [New Project] Remove feature flag when New Project action is ready for release
+		// This disables (greys out) the action in the New menu, the application bar File menu, and the command palette when not in a development context
+		const projectWizardEnabled = ContextKeyExpr.deserialize(`config.${USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY}`) ?? IsDevelopmentContext;
 		super({
 			id: PositronNewProjectAction.ID,
 			title: {
@@ -49,16 +53,15 @@ export class PositronNewProjectAction extends Action2 {
 			},
 			category: workspacesCategory,
 			f1: true,
-			// TODO: [New Project] Remove feature flag when New Project action is ready for release
-			// This disables (greys out) the action in the New menu, the application bar File menu, and the command palette when not in a development context
-			precondition: ContextKeyExpr.and(EnterMultiRootWorkspaceSupportContext, IsDevelopmentContext.isEqualTo(true)),
+			precondition: ContextKeyExpr.and(
+				EnterMultiRootWorkspaceSupportContext,
+				projectWizardEnabled
+			),
 			menu: {
 				id: MenuId.MenubarFileMenu,
 				group: '1_newfolder',
 				order: 3,
-				// TODO: [New Project] Remove feature flag when New Project action is ready for release
-				// This removes the action from the application bar File menu when not in a development context
-				when: IsDevelopmentContext.isEqualTo(true)
+				when: projectWizardEnabled
 			}
 		});
 	}

--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -25,6 +25,7 @@ import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/com
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { IStorageService } from 'vs/platform/storage/common/storage';
 
 /**
  * The PositronNewProjectAction.
@@ -83,6 +84,7 @@ export class PositronNewProjectAction extends Action2 {
 			accessor.get(IPathService),
 			accessor.get(IRuntimeSessionService),
 			accessor.get(IRuntimeStartupService),
+			accessor.get(IStorageService),
 		);
 	}
 }

--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -42,8 +42,9 @@ export class PositronNewProjectAction extends Action2 {
 	 */
 	constructor() {
 		// TODO: [New Project] Remove feature flag when New Project action is ready for release
-		// This disables (greys out) the action in the New menu, the application bar File menu, and the command palette when not in a development context
-		const projectWizardEnabled = ContextKeyExpr.deserialize(`config.${USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY}`) ?? IsDevelopmentContext;
+		// This removes the action in the New menu, the application bar File menu, and the command
+		// palette when the feature flag is not enabled.
+		const projectWizardEnabled = ContextKeyExpr.deserialize(`config.${USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY}`);
 		super({
 			id: PositronNewProjectAction.ID,
 			title: {
@@ -55,14 +56,14 @@ export class PositronNewProjectAction extends Action2 {
 			f1: true,
 			precondition: ContextKeyExpr.and(
 				EnterMultiRootWorkspaceSupportContext,
-				projectWizardEnabled
+				ContextKeyExpr.or(projectWizardEnabled, IsDevelopmentContext)
 			),
 			menu: {
 				id: MenuId.MenubarFileMenu,
 				group: '1_newfolder',
 				order: 3,
-				when: projectWizardEnabled
-			}
+				when: ContextKeyExpr.or(projectWizardEnabled, IsDevelopmentContext),
+			},
 		});
 	}
 

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
@@ -41,10 +41,10 @@ export const TopActionBarNewMenu = () => {
 		const projectWizardEnabled =
 			ContextKeyExpr.deserialize(
 				`config.${USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY}`
-			) ?? IsDevelopmentContext;
+			);
 		positronActionBarContext.appendCommandAction(actions, {
 			id: PositronNewProjectAction.ID,
-			when: projectWizardEnabled,
+			when: ContextKeyExpr.or(projectWizardEnabled, IsDevelopmentContext),
 		});
 		positronActionBarContext.appendCommandAction(actions, {
 			id: PositronNewFolderAction.ID

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
@@ -10,6 +10,8 @@ import { ActionBarMenuButton } from 'vs/platform/positronActionBar/browser/compo
 import { usePositronActionBarContext } from 'vs/platform/positronActionBar/browser/positronActionBarContext';
 import { PositronNewFolderAction, PositronNewFolderFromGitAction, PositronNewProjectAction } from 'vs/workbench/browser/actions/positronActions';
 import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
+import { USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 
 /**
  * Localized strings.
@@ -36,11 +38,14 @@ export const TopActionBarNewMenu = () => {
 		actions.push(new Separator());
 		// TODO: [New Project] Remove feature flag when New Project action is ready for release
 		// This removes the action from the New menu in the action bar when not in a development context
-		if (IsDevelopmentContext.getValue(positronActionBarContext.contextKeyService) === true) {
-			positronActionBarContext.appendCommandAction(actions, {
-				id: PositronNewProjectAction.ID
-			});
-		}
+		const projectWizardEnabled =
+			ContextKeyExpr.deserialize(
+				`config.${USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY}`
+			) ?? IsDevelopmentContext;
+		positronActionBarContext.appendCommandAction(actions, {
+			id: PositronNewProjectAction.ID,
+			when: projectWizardEnabled,
+		});
 		positronActionBarContext.appendCommandAction(actions, {
 			id: PositronNewFolderAction.ID
 		});

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
@@ -23,6 +23,7 @@ import { CustomFolderMenuSeparator } from 'vs/workbench/browser/parts/positronTo
 import { CustomFolderRecentlyUsedMenuItem } from 'vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderRecentlyUsedMenuItem';
 import { PositronNewFolderAction, PositronNewFolderFromGitAction, PositronNewProjectAction, PositronOpenFolderInNewWindowAction } from 'vs/workbench/browser/actions/positronActions';
 import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
+import { USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 
 /**
  * Constants.
@@ -144,14 +145,20 @@ export const CustomFolderMenuItems = (props: CustomFolderMenuItemsProps) => {
 		);
 	};
 
-	const isDevContext = IsDevelopmentContext.getValue(props.contextKeyService) === true;
+	{/* TODO: [New Project] Remove feature flag when New Project action is ready for release */ }
+	{/* This removes the action from the custom folder menu in the action bar when when not in a development context */ }
+	const projectWizardEnabled =
+		ContextKeyExpr.deserialize(
+			`config.${USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY}`
+		) ?? IsDevelopmentContext;
 
 	// Render.
 	return (
 		<div className='custom-folder-menu-items'>
-			{/* TODO: [New Project] Remove feature flag when New Project action is ready for release */}
-			{/* This removes the action from the custom folder menu in the action bar when when not in a development context */}
-			{isDevContext && <CommandActionCustomFolderMenuItem id={PositronNewProjectAction.ID} />}
+			<CommandActionCustomFolderMenuItem
+				id={PositronNewProjectAction.ID}
+				when={projectWizardEnabled}
+			/>
 			<CommandActionCustomFolderMenuItem id={PositronNewFolderAction.ID} />
 			<CommandActionCustomFolderMenuItem id={PositronNewFolderFromGitAction.ID} />
 			<CustomFolderMenuSeparator />

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
@@ -150,14 +150,14 @@ export const CustomFolderMenuItems = (props: CustomFolderMenuItemsProps) => {
 	const projectWizardEnabled =
 		ContextKeyExpr.deserialize(
 			`config.${USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY}`
-		) ?? IsDevelopmentContext;
+		);
 
 	// Render.
 	return (
 		<div className='custom-folder-menu-items'>
 			<CommandActionCustomFolderMenuItem
 				id={PositronNewProjectAction.ID}
-				when={projectWizardEnabled}
+				when={ContextKeyExpr.or(projectWizardEnabled, IsDevelopmentContext)}
 			/>
 			<CommandActionCustomFolderMenuItem id={PositronNewFolderAction.ID} />
 			<CommandActionCustomFolderMenuItem id={PositronNewFolderFromGitAction.ID} />

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -228,6 +228,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 				installIpykernel: willInstallIpykernel
 			});
 		}
+		// Pass an empty dependency array to run this effect only once when the component is mounted.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
@@ -282,6 +283,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
+		// Pass an empty dependency array to run this effect only once when the component is mounted.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -210,7 +210,25 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 		await updateEnvConfig(envSetupType, envType, selectedRuntime);
 	};
 
-	// Hook to update the interpreter entries when the runtime discovery phase is complete
+	// Update the project configuration with the initial selections. This is done once when the
+	// component is mounted, assuming the runtime discovery phase is complete. If the runtime
+	// discovery phase is not complete, the project configuration will be updated when the phase is
+	// complete in the other useEffect hook below.
+	useEffect(() => {
+		if (runtimeStartupComplete()) {
+			setProjectConfig({
+				...projectConfig,
+				pythonEnvSetupType: envSetupType,
+				pythonEnvType: envType,
+				selectedRuntime: selectedInterpreter,
+				installIpykernel: willInstallIpykernel
+			});
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	// Hook to update the interpreter entries when the runtime discovery phase is complete. The
+	// interpreter discovery phase may still be in progress when the component is mounted.
 	useEffect(() => {
 		// Create the disposable store for cleanup.
 		const disposableStore = new DisposableStore();

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -94,7 +94,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 		})
 	];
 
-	// Utils
+	// Utility function to get the interpreter based on the selected interpreter entries.
 	const getInterpreter = (entries: DropDownListBoxEntry<string, InterpreterInfo>[]) => {
 		return getSelectedInterpreter(
 			selectedInterpreter,
@@ -103,6 +103,8 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 			LanguageIds.Python
 		);
 	};
+
+	// Utility function to check if ipykernel needs to be installed for the selected interpreter.
 	const getInstallIpykernel = async (
 		envSetupType: EnvironmentSetupType,
 		pythonInterpreter: ILanguageRuntimeMetadata | undefined
@@ -130,6 +132,8 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 		return install;
 	};
 
+	// Utility function to update the project configuration with the environment setup type,
+	// environment type, selected interpreter, and ipykernel installation flag.
 	const updateEnvConfig = async (
 		envSetupType: EnvironmentSetupType,
 		envType: PythonEnvironmentType | undefined,
@@ -141,7 +145,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 		// Update the project configuration with the new environment type.
 		setEnvType(envType);
 
-		// Update the interpreter entries once the runtime discovery phase is complete.
+		// Update the interpreter entries.
 		const entries = getPythonInterpreterEntries(
 			runtimeStartupService,
 			languageRuntimeService,
@@ -245,7 +249,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 						// Update the project configuration with the new environment type.
 						setEnvType(envType);
 
-						// Update the interpreter entries once the runtime discovery phase is complete.
+						// Update the interpreter entries.
 						const entries = getPythonInterpreterEntries(
 							runtimeStartupService,
 							languageRuntimeService,

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -42,28 +42,30 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 	const languageRuntimeService = newProjectWizardState.languageRuntimeService;
 
 	// Hooks to manage the startup phase and interpreter entries.
-	const [startupPhase, setStartupPhase] = useState(runtimeStartupService.startupPhase);
-	const runtimeStartupComplete = () => startupPhase === RuntimeStartupPhase.Complete;
+	const [startupPhase, setStartupPhase] = useState(
+		runtimeStartupService.startupPhase
+	);
+	const runtimeStartupComplete = () =>
+		startupPhase === RuntimeStartupPhase.Complete;
 	const [envSetupType, setEnvSetupType] = useState(
 		projectConfig.pythonEnvSetupType ?? EnvironmentSetupType.NewEnvironment
 	);
 	const [envType, setEnvType] = useState<PythonEnvironmentType | undefined>(
 		projectConfig.pythonEnvType ?? PythonEnvironmentType.Venv
 	);
-	const [interpreterEntries, setInterpreterEntries] =
-		useState(
-			// It's possible that the runtime discovery phase is not complete, so we need to check
-			// for that before creating the interpreter entries.
-			!runtimeStartupComplete() ?
-				[] :
-				getPythonInterpreterEntries(
-					runtimeStartupService,
-					languageRuntimeService,
-					envSetupType,
-					envType
-				)
-		);
-	const [selectedInterpreter, setSelectedInterpreter] = useState(
+	const [interpreterEntries, setInterpreterEntries] = useState(() =>
+		// It's possible that the runtime discovery phase is not complete, so we need to check
+		// for that before creating the interpreter entries.
+		!runtimeStartupComplete()
+			? []
+			: getPythonInterpreterEntries(
+				runtimeStartupService,
+				languageRuntimeService,
+				envSetupType,
+				envType
+			)
+	);
+	const [selectedInterpreter, setSelectedInterpreter] = useState(() =>
 		getSelectedInterpreter(
 			projectConfig.selectedRuntime,
 			interpreterEntries,

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -178,9 +178,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 	const onEnvSetupSelected = async (pythonEnvSetupType: EnvironmentSetupType) => {
 		await updateEnvConfig(
 			pythonEnvSetupType,
-			pythonEnvSetupType === EnvironmentSetupType.NewEnvironment
-				? envType
-				: undefined,
+			envType,
 			selectedInterpreter
 		);
 	};

--- a/src/vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectConfiguration.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectConfiguration.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * NewProjectConfiguration interface. Defines the configuration for a new project.
+ */
+export interface NewProjectConfiguration {
+	readonly runtimeId: string;
+	readonly projectType: string;
+	readonly projectFolder: string;
+	readonly initGitRepo: boolean;
+	readonly pythonEnvType: string;
+	readonly installIpykernel: boolean;
+	readonly useRenv: boolean;
+}

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -23,6 +23,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { NewProjectConfiguration } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectConfiguration';
+import { EnvironmentSetupType } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
 
 /**
  * Shows the NewProjectModalDialog.
@@ -75,13 +76,19 @@ export const showNewProjectModalDialog = async (
 						await fileService.createFolder(folder);
 					}
 
+					// The python environment type is only relevant if a new environment is being created.
+					const pythonEnvType =
+						result.pythonEnvSetupType === EnvironmentSetupType.NewEnvironment
+							? result.pythonEnvType
+							: '';
+
 					// Create the new project configuration.
 					const newProjectConfig: NewProjectConfiguration = {
 						runtimeId: result.selectedRuntime?.runtimeId || '',
 						projectType: result.projectType || '',
 						projectFolder: folder.fsPath,
 						initGitRepo: result.initGitRepo,
-						pythonEnvType: result.pythonEnvType || '',
+						pythonEnvType: pythonEnvType || '',
 						installIpykernel: result.installIpykernel || false,
 						useRenv: result.useRenv || false,
 					};

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -9,7 +9,7 @@ import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/la
 import { NewProjectWizardContextProvider, useNewProjectWizardContext } from 'vs/workbench/browser/positronNewProjectWizard/newProjectWizardContext';
 import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
-import { NewProjectConfiguration } from 'vs/workbench/browser/positronNewProjectWizard/newProjectWizardState';
+import { NewProjectWizardConfiguration } from 'vs/workbench/browser/positronNewProjectWizard/newProjectWizardState';
 import { NewProjectWizardStepContainer } from 'vs/workbench/browser/positronNewProjectWizard/newProjectWizardStepContainer';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
@@ -21,6 +21,8 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
+import { NewProjectConfiguration } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectConfiguration';
 
 /**
  * Shows the NewProjectModalDialog.
@@ -37,6 +39,7 @@ export const showNewProjectModalDialog = async (
 	pathService: IPathService,
 	runtimeSessionService: IRuntimeSessionService,
 	runtimeStartupService: IRuntimeStartupService,
+	storageService: IStorageService
 ): Promise<void> => {
 	// Create the renderer.
 	const renderer = new PositronModalReactRenderer({
@@ -66,11 +69,36 @@ export const showNewProjectModalDialog = async (
 			<NewProjectModalDialog
 				renderer={renderer}
 				createProject={async result => {
-					// Create the new project.
+					// Create the new project folder if it doesn't already exist.
 					const folder = URI.file((await pathService.path).join(result.parentFolder, result.projectName));
 					if (!(await fileService.exists(folder))) {
 						await fileService.createFolder(folder);
 					}
+
+					// Create the new project configuration.
+					const newProjectConfig: NewProjectConfiguration = {
+						runtimeId: result.selectedRuntime?.runtimeId || '',
+						projectType: result.projectType || '',
+						projectFolder: folder.fsPath,
+						initGitRepo: result.initGitRepo,
+						pythonEnvType: result.pythonEnvType || '',
+						installIpykernel: result.installIpykernel || false,
+						useRenv: result.useRenv || false,
+					};
+
+					// Store the new project configuration in the StorageService.
+					// The object is stringified here and can be parsed back into a
+					// NewProjectConfiguration object when read from storage.
+					storageService.store(
+						'positron.newProjectConfig',
+						JSON.stringify(newProjectConfig),
+						StorageScope.APPLICATION,
+						StorageTarget.MACHINE
+					);
+
+					// Any context-dependent work needs to be done before opening the folder
+					// because the extension host gets destroyed when a new project is opened,
+					// whether the folder is opened in a new window or in the existing window.
 					await commandService.executeCommand(
 						'vscode.openFolder',
 						folder,
@@ -80,11 +108,11 @@ export const showNewProjectModalDialog = async (
 						}
 					);
 
-					// TODO: whether the folder is opened in a new window or not, we will need to store the
-					// project configuration in some workspace state so that we can use it to start the runtime.
-					// The extension host gets destroyed when a new project is opened in the same window.
-					//   - Where can the new project config be stored?
-					//       - See IStorageService, maybe StorageScope.WORKSPACE and StorageTarget.MACHINE
+					// TODO: handle if the new project is the same directory as the current workspace
+					// in this case, a window doesn't get opened, so the new project initialization
+					// doesn't happen unless we listen to some event. Maybe a different command can be
+					// executed to initialize the new project in the current workspace instead of
+					// vscode.openFolder.
 
 					// 1) Create the directory for the new project (done above)
 					// 2) Set up the initial workspace for the new project
@@ -115,7 +143,7 @@ export const showNewProjectModalDialog = async (
 
 interface NewProjectModalDialogProps {
 	renderer: PositronModalReactRenderer;
-	createProject: (result: NewProjectConfiguration) => Promise<void>;
+	createProject: (result: NewProjectWizardConfiguration) => Promise<void>;
 }
 
 /**

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.tsx
@@ -44,10 +44,10 @@ export interface NewProjectWizardStateProps {
 }
 
 /**
- * NewProjectConfiguration interface. Defines the configuration for a new project.
- * This information is used to initialize the workspace for a new project.
+ * NewProjectWizardConfiguration interface. Used to keep track of the new project configuration state
+ * in the New Project Wizard Modal.
  */
-export interface NewProjectConfiguration {
+export interface NewProjectWizardConfiguration {
 	readonly selectedRuntime: ILanguageRuntimeMetadata | undefined;
 	readonly projectType: NewProjectType | undefined;
 	readonly projectName: string;
@@ -64,10 +64,10 @@ export interface NewProjectConfiguration {
  * NewProjectWizardState interface. Defines the state of the New Project Wizard.
  */
 export interface NewProjectWizardState extends NewProjectWizardServices {
-	projectConfig: NewProjectConfiguration;
+	projectConfig: NewProjectWizardConfiguration;
 	wizardSteps: NewProjectWizardStep[]; // TODO: remove: this is for debugging
 	currentStep: NewProjectWizardStep;
-	setProjectConfig(config: NewProjectConfiguration): void;
+	setProjectConfig(config: NewProjectWizardConfiguration): void;
 	goToNextStep: (step: NewProjectWizardStep) => void;
 	goToPreviousStep: () => void;
 }
@@ -81,13 +81,13 @@ export const useNewProjectWizardState = (
 	props: NewProjectWizardStateProps
 ): NewProjectWizardState => {
 	// Hooks.
-	const [projectConfig, setProjectConfig] = useState<NewProjectConfiguration>({
+	const [projectConfig, setProjectConfig] = useState<NewProjectWizardConfiguration>({
 		selectedRuntime: undefined,
 		projectType: undefined,
 		projectName: '',
 		parentFolder: props.parentFolder ?? '',
 		initGitRepo: false,
-		openInNewWindow: true,
+		openInNewWindow: false,
 		pythonEnvSetupType: undefined,
 		pythonEnvType: undefined,
 		installIpykernel: undefined,

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils.ts
@@ -119,7 +119,7 @@ export const getPythonInterpreterEntries = (
 export const locationForNewEnv = (
 	parentFolder: string,
 	projectName: string,
-	envType: PythonEnvironmentType
+	envType: PythonEnvironmentType | undefined
 ) => {
 	// TODO: this only works for Venv and Conda environments. We'll need to expand on this to add
 	// support for other environment types.

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils.ts
@@ -77,7 +77,7 @@ export const getPythonInterpreterEntries = (
 	runtimeStartupService: IRuntimeStartupService,
 	languageRuntimeService: ILanguageRuntimeService,
 	envSetupType: EnvironmentSetupType,
-	envType: PythonEnvironmentType
+	envType: PythonEnvironmentType | undefined
 ) => {
 	switch (envSetupType) {
 		case EnvironmentSetupType.NewEnvironment:

--- a/src/vs/workbench/contrib/positronNewProject/browser/positronNewProject.contribution.ts
+++ b/src/vs/workbench/contrib/positronNewProject/browser/positronNewProject.contribution.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { onUnexpectedError } from 'vs/base/common/errors';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
+// import { ICommandService } from 'vs/platform/commands/common/commands';
+import { ILogService } from 'vs/platform/log/common/log';
+import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
+import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
+import { NewProjectConfiguration } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectConfiguration';
+import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from 'vs/workbench/common/contributions';
+import { ILifecycleService, LifecyclePhase, StartupKind } from 'vs/workbench/services/lifecycle/common/lifecycle';
+// import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+
+class PositronNewProjectContribution extends Disposable implements IWorkbenchContribution {
+	static readonly ID = 'workbench.contrib.positronNewProject';
+
+	constructor(
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		// @ICommandService private readonly _commandService: ICommandService,
+		// @IExtensionService private readonly _extensionService: IExtensionService,
+		@ILogService private readonly _logService: ILogService,
+		@ILifecycleService private readonly _lifecycleService: ILifecycleService,
+		@IStorageService private readonly _storageService: IStorageService,
+		@IWorkspaceContextService private readonly _contextService: IWorkspaceContextService,
+	) {
+		super();
+		console.log('PositronNewProjectContribution constructor');
+		// TODO: remove dev build feature flag
+		if (IsDevelopmentContext.getValue(this._contextKeyService) === true) {
+			console.log('PositronNewProjectContribution dev build');
+			// Whether the project was opened in a new window or the existing window, the startup kind
+			// will be `StartupKind.NewWindow`.
+			if (this._lifecycleService.startupKind === StartupKind.NewWindow) {
+				console.log('PositronNewProjectContribution new window');
+				this.run().then(undefined, onUnexpectedError);
+			} else {
+				console.log('PositronNewProjectContribution not new window: ', this._lifecycleService.startupKind);
+			}
+		}
+	}
+
+	private async run() {
+		// Not sure if needed: wait until after the workbench has been restored
+		await this._lifecycleService.when(LifecyclePhase.Restored);
+
+		const newProjectConfigStr = this._storageService.get('positron.newProjectConfig', StorageScope.APPLICATION);
+
+		if (!newProjectConfigStr) {
+			this._logService.error('No new project configuration found in storage');
+			return;
+		}
+
+		const newProjectConfig = JSON.parse(newProjectConfigStr) as NewProjectConfiguration;
+		const newProjectPath = newProjectConfig.projectFolder;
+		const currentFolderPath = this._contextService.getWorkspace().folders[0].uri.fsPath;
+
+		if (newProjectPath === currentFolderPath) {
+			console.log('New project path matches current workspace folder path!');
+
+			// Do new project initialization
+
+			// Remove the new project configuration from storage
+			this._storageService.remove('positron.newProjectConfig', StorageScope.APPLICATION);
+		} else {
+			console.log('New project path does not match current workspace folder path');
+			console.log('\tNew project path:', newProjectPath);
+			console.log('\tCurrent workspace folder path:', currentFolderPath);
+		}
+
+	}
+}
+
+registerWorkbenchContribution2(PositronNewProjectContribution.ID, PositronNewProjectContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/contrib/positronNewProject/browser/positronNewProject.contribution.ts
+++ b/src/vs/workbench/contrib/positronNewProject/browser/positronNewProject.contribution.ts
@@ -4,45 +4,47 @@
 
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { Disposable } from 'vs/base/common/lifecycle';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
-// import { ICommandService } from 'vs/platform/commands/common/commands';
+import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { NewProjectConfiguration } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectConfiguration';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from 'vs/workbench/common/contributions';
 import { ILifecycleService, LifecyclePhase, StartupKind } from 'vs/workbench/services/lifecycle/common/lifecycle';
-// import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { projectWizardEnabled } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
+import { IPositronNewProjectService, PositronNewProjectService } from 'vs/workbench/services/positronNewProject/common/positronNewProjectService';
 
+// Register the Positron New Project service
+registerSingleton(IPositronNewProjectService, PositronNewProjectService, InstantiationType.Delayed);
+
+/**
+ * PositronNewProjectContribution class.
+ */
 class PositronNewProjectContribution extends Disposable implements IWorkbenchContribution {
 	static readonly ID = 'workbench.contrib.positronNewProject';
 
 	constructor(
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
-		// @ICommandService private readonly _commandService: ICommandService,
-		// @IExtensionService private readonly _extensionService: IExtensionService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ILogService private readonly _logService: ILogService,
 		@ILifecycleService private readonly _lifecycleService: ILifecycleService,
 		@IStorageService private readonly _storageService: IStorageService,
 		@IWorkspaceContextService private readonly _contextService: IWorkspaceContextService,
 	) {
 		super();
-		console.log('PositronNewProjectContribution constructor');
-		// TODO: remove dev build feature flag
-		if (IsDevelopmentContext.getValue(this._contextKeyService) === true) {
-			console.log('PositronNewProjectContribution dev build');
+		// TODO: [New Project] Remove feature flag when New Project action is ready for release
+		if (projectWizardEnabled(this._contextKeyService, this._configurationService)) {
 			// Whether the project was opened in a new window or the existing window, the startup kind
 			// will be `StartupKind.NewWindow`.
 			if (this._lifecycleService.startupKind === StartupKind.NewWindow) {
-				console.log('PositronNewProjectContribution new window');
 				this.run().then(undefined, onUnexpectedError);
-			} else {
-				console.log('PositronNewProjectContribution not new window: ', this._lifecycleService.startupKind);
 			}
 		}
 	}
 
+	// TODO: move some of this logic to the PositronNewProjectService
 	private async run() {
 		// Not sure if needed: wait until after the workbench has been restored
 		await this._lifecycleService.when(LifecyclePhase.Restored);
@@ -59,19 +61,13 @@ class PositronNewProjectContribution extends Disposable implements IWorkbenchCon
 		const currentFolderPath = this._contextService.getWorkspace().folders[0].uri.fsPath;
 
 		if (newProjectPath === currentFolderPath) {
-			console.log('New project path matches current workspace folder path!');
+			// TODO: Do new project initialization
 
-			// Do new project initialization
-
-			// Remove the new project configuration from storage
+			// Once initialization is done, remove the new project configuration from storage
 			this._storageService.remove('positron.newProjectConfig', StorageScope.APPLICATION);
-		} else {
-			console.log('New project path does not match current workspace folder path');
-			console.log('\tNew project path:', newProjectPath);
-			console.log('\tCurrent workspace folder path:', currentFolderPath);
 		}
-
 	}
 }
 
+// Register the PositronNewProjectContribution
 registerWorkbenchContribution2(PositronNewProjectContribution.ID, PositronNewProjectContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
@@ -116,6 +116,9 @@ export const startEntries: GettingStartedStartEntryContent = [
 		title: localize('gettingStarted.newProject.title', "New Project..."),
 		description: localize('gettingStarted.newProject.description', "Create a new project."),
 		icon: Codicon.newFolder,
+		// TODO: [New Project] Remove feature flag when New Project action is ready for release
+		// This removes the New Project entry from the Welcome page when the feature is not enabled.
+		when: 'config.positron.projectWizardEnabled || isDevelopment',
 		content: {
 			type: 'startEntry',
 			command: 'command:positron.workbench.action.newProject',

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectEnablement.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectEnablement.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from 'vs/nls';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import {
+	ConfigurationScope,
+	Extensions,
+	IConfigurationRegistry,
+} from 'vs/platform/configuration/common/configurationRegistry';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { positronConfigurationNodeBase } from 'vs/workbench/services/languageRuntime/common/languageRuntime';
+
+/**
+ * This config setting is used to determine whether to use the Positron Project Wizard based on the
+ * user's selection in Settings. This flag is used while the New Project Wizard is being developed,
+ * to manually enable the wizard in release builds.
+ */
+
+// Key for the configuration setting that determines whether to use the Positron Project Wizard
+export const USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY =
+	'positron.projectWizardEnabled';
+
+/**
+ * Return true if in a development build, or retrieve the value of the configuration setting that
+ * determines whether to use the Positron Project Wizard.
+ * @param contextKeyService The context key service
+ * @param configurationService The configuration service
+ * @returns Whether to enable the Positron Project Wizard
+ */
+export function projectWizardEnabled(
+	contextKeyService: IContextKeyService,
+	configurationService: IConfigurationService
+) {
+	return (
+		IsDevelopmentContext.getValue(contextKeyService) ||
+		Boolean(
+			configurationService.getValue(USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY)
+		)
+	);
+}
+
+// Register the configuration setting that determines whether to use the Positron Project Wizard
+const configurationRegistry = Registry.as<IConfigurationRegistry>(
+	Extensions.Configuration
+);
+configurationRegistry.registerConfiguration({
+	...positronConfigurationNodeBase,
+	scope: ConfigurationScope.MACHINE_OVERRIDABLE,
+	properties: {
+		[USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY]: {
+			type: 'boolean',
+			default: false,
+			markdownDescription: localize(
+				'positron.enablePositronProjectWizard',
+				'Enable the Positron Project Wizard for creating new projects.'
+			),
+		},
+	},
+});

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from 'vs/base/common/lifecycle';
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+
+const POSITRON_NEW_PROJECT_SERVICE_ID = 'positronNewProjectService';
+
+export const IPositronNewProjectService = createDecorator<IPositronNewProjectService>(POSITRON_NEW_PROJECT_SERVICE_ID);
+
+/**
+ * IPositronNewProjectService interface.
+ */
+export interface IPositronNewProjectService {
+	readonly _serviceBrand: undefined;
+
+	isCurrentWindowNewProject(): boolean;
+}
+
+/**
+ * PositronNewProjectService class.
+ */
+export class PositronNewProjectService extends Disposable implements IPositronNewProjectService {
+	declare readonly _serviceBrand: undefined;
+
+	// TODO: implement
+	isCurrentWindowNewProject() {
+		return true;
+	}
+}

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -435,6 +435,7 @@ import 'vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSess
 import 'vs/workbench/contrib/languageRuntime/browser/languageRuntime.contribution';
 import 'vs/workbench/contrib/executionHistory/common/executionHistory';
 import 'vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgets.contribution';
+import 'vs/workbench/contrib/positronNewProject/browser/positronNewProject.contribution';
 
 // Workbench services
 import 'vs/workbench/services/languageRuntime/common/languageRuntime';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

- Most of this work is scaffolding for #2818, #2819, #2820
- Address https://github.com/posit-dev/positron/issues/2939
    - related to https://github.com/posit-dev/positron/issues/2878

#### Summary
- scaffolding to set up New Project contrib and service
- storing the new project config in the storage service
- some cleanup and refactoring to ensure the project config is stored correctly
- adding config setting to support testing the project wizard work in release builds

#### Config Setting Preview
<img width="710" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/0a57231e-72b9-4e0a-b505-e466c215420e">

### Approach

- store the project configuration in the storage service
    - create interface for this data so it can be JSON stringified on write and JSON parsed on read
    - use `StorageScope.APPLICATION` so any workspace can check to see if it is the new project workspace and `StorageTarget.MACHINE` since the new project is being created on the machine
- scaffold NewProject contrib and service, where the new project initialization will occur (selecting interpreter, creating new files, etc.)
- add configuration flag so the project wizard can be enabled via settings in release builds (setting ID `positron.projectWizardEnabled`)
    - project wizard will still be enabled by default in dev builds
    - update existing `IsDevelopmentContext` checks to also check this config setting

Next, I'll be leveraging the stored info in the NewProject contribution and service to initialize the project.

### QA Notes

The project wizard should be accessible in release builds by enabling the `positron.projectWizardEnabled` setting.
