### PR TITLE
Temporarily disable code cell code folding to fix folding in R and Python files

### DIFF
--- a/extensions/positron-code-cells/src/extension.ts
+++ b/extensions/positron-code-cells/src/extension.ts
@@ -7,7 +7,6 @@ import { initializeLogging } from './logging';
 import { CellCodeLensProvider } from './codeLenses';
 import { registerCommands } from './commands';
 import { activateDecorations } from './decorations';
-import { CellFoldingRangeProvider } from './folding';
 import { activateContextKeys } from './context';
 
 export const IGNORED_SCHEMES = ['vscode-notebook-cell', 'vscode-interactive-input'];
@@ -20,7 +19,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(
 		vscode.languages.registerCodeLensProvider('*', new CellCodeLensProvider()),
 
-		vscode.languages.registerFoldingRangeProvider('*', new CellFoldingRangeProvider()),
+		// Temporarily disabled because registering this provider causes it to
+		// become the *only* folding range provider for R and Python files,
+		// suppressing the built-in folding range provider.
+		//
+		// We can re-enable this when the R and Python language packs supply
+		// their own folding range providers.
+		//
+		// https://github.com/posit-dev/positron/issues/1908
+
+		// vscode.languages.registerFoldingRangeProvider('*', new CellFoldingRangeProvider()),
 	);
 
 	activateDecorations(context.subscriptions);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses #1908.

### Approach

It turns out that we broke R and Python code folding when we introduced folding for code cells. Because the code cell folding range provider registers itself as a folding provider for R and Python files, and R and Python currently do not supply their own folding providers, it becomes the _only_ folding provider for those file types, suppressing the built-in indentation-based provider. 

The fix is to temporarily disable the code cell folding rules. 

### QA Notes

Repro cases are in #1908.

This intentionally breaks code folding rules for code cells (so those will no longer be foldable). I will file a followup issue to get them re-enabled, but I think that can be done after beta. 