### PR TITLE
Focus the viewpane on the next tick

### DIFF
--- a/src/vs/workbench/browser/positronViewPane/positronViewPane.ts
+++ b/src/vs/workbench/browser/positronViewPane/positronViewPane.ts
@@ -71,9 +71,7 @@ export abstract class PositronViewPane extends ViewPane {
 
 			// Drive focus to an inner element if any. Also needs to be at the next tick,
 			// and after the `super.focus()` call.
-			if (this.focusElement) {
-				this.focusElement();
-			}
+		        this.focusElement?.();
 		};
 		disposableTimeout(focus, 0, this._disposableStore);
 	}

--- a/src/vs/workbench/browser/positronViewPane/positronViewPane.ts
+++ b/src/vs/workbench/browser/positronViewPane/positronViewPane.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { disposableTimeout } from 'vs/base/common/async';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { IViewPaneOptions, ViewPane } from 'vs/workbench/browser/parts/views/viewPane';
+import { IViewDescriptorService } from 'vs/workbench/common/views';
+
+export abstract class PositronViewPane extends ViewPane {
+	private _disposableStore: DisposableStore;
+
+	/**
+	 * Drive focus to an element inside the view.
+	 * Called automatically by `focus()`.
+	 */
+	focusElement?(): void;
+
+	constructor(
+		options: IViewPaneOptions,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@IContextMenuService contextMenuService: IContextMenuService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IOpenerService openerService: IOpenerService,
+		@IThemeService themeService: IThemeService,
+		@ITelemetryService telemetryService: ITelemetryService,
+	) {
+		super(
+			options,
+			keybindingService,
+			contextMenuService,
+			configurationService,
+			contextKeyService,
+			viewDescriptorService,
+			instantiationService,
+			openerService,
+			themeService,
+			telemetryService
+		);
+		this._disposableStore = this._register(new DisposableStore());
+
+		// Make the viewpane focusable even when there are no components
+		// available to take the focus. The viewpane must be able to take focus
+		// at all times because otherwise blurring events do not occur and the
+		// viewpane management state becomes confused on toggle.
+		this.element.tabIndex = 0;
+	}
+
+	override focus(): void {
+		// We focus at the next tick because in some cases `focus()` is called
+		// when the viewpane is not visible yet (don't trust `this.isBodyVisible()`).
+		// In this case the `focus()` call fails (don't trust `this.onFocus()`).
+		// This happens for instance with `workbench.action.togglePanel` or
+		// `workbench.action.toggleSecondarySideBar`. Not doing it at the next tick
+		// would result in broken viewpane toggling, see
+		// https://github.com/posit-dev/positron/pull/2867
+		const focus = () => {
+			// The base class focuses the whole pane (we set its tabIndex to make this possible).
+			super.focus();
+
+			// Drive focus to an inner element if any. Also needs to be at the next tick,
+			// and after the `super.focus()` call.
+			if (this.focusElement) {
+				this.focusElement();
+			}
+		};
+		disposableTimeout(focus, 0, this._disposableStore);
+	}
+
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -110,7 +110,10 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	const scrollable = () =>
 		consoleInstanceRef.current.scrollHeight > consoleInstanceRef.current.clientHeight;
 
-	// Scrolls to the bottom.
+	// Scroll to the bottom.
+	// Wrapped in a `useCallback()` because the function is used as dependency
+	// in a `useEffect()`. Caching it prevents the `useEffect()` from being
+	// called on every rerender.
 	const scrollToBottom = useCallback(() => {
 		props.positronConsoleInstance.scrollLocked = false;
 		setIgnoreNextScrollEvent(true);

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -22,7 +22,7 @@ import { IViewDescriptorService } from 'vs/workbench/common/views';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { ViewPane, IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
+import { IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { PositronConsole } from 'vs/workbench/contrib/positronConsole/browser/positronConsole';
@@ -33,13 +33,12 @@ import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
-import { disposableTimeout } from 'vs/base/common/async';
-import { DisposableStore } from 'vs/base/common/lifecycle';
+import { PositronViewPane } from 'vs/workbench/browser/positronViewPane/positronViewPane';
 
 /**
  * PositronConsoleViewPane class.
  */
-export class PositronConsoleViewPane extends ViewPane implements IReactComponentContainer {
+export class PositronConsoleViewPane extends PositronViewPane implements IReactComponentContainer {
 	//#region Private Properties
 
 	/**
@@ -93,8 +92,6 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 	 * Gets or sets the PositronConsoleFocused context key.
 	 */
 	private _positronConsoleFocusedContextKey: IContextKey<boolean>;
-
-	private _disposableStore: DisposableStore;
 
 	//#endregion Private Properties
 
@@ -232,13 +229,6 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 			themeService,
 			telemetryService);
 
-		// Make the view pane focusable even when there are no components
-		// available to take the focus (such as the console input). This happens
-		// when no interpreter has been started yet. The viewpane must be able
-		// to take focus at all times because otherwise blurring events do not
-		// occur and the viewpane management state becomes confused on toggle.
-		this.element.tabIndex = 0;
-
 		// Bind the PositronConsoleFocused context key.
 		this._positronConsoleFocusedContextKey = PositronConsoleFocused.bindTo(contextKeyService);
 
@@ -247,8 +237,6 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 			// Relay event for our `IReactComponentContainer` implementation
 			this._onVisibilityChangedEmitter.fire(visible);
 		}));
-
-		this._disposableStore = this._register(new DisposableStore());
 	}
 
 	/**
@@ -306,28 +294,14 @@ export class PositronConsoleViewPane extends ViewPane implements IReactComponent
 	}
 
 	/**
-	 * focus override method.
+	 * Drive focus to inner element.
+	 * Called by `super.focus()`.
 	 */
-	override focus(): void {
+	override focusElement(): void {
 		// Trigger event that eventually causes console input widgets (main
 		// input, readline input, or restart buttons) to focus. Must be after
 		// the super call.
-		//
-		// We do this at the next tick because in some cases `focus()` is called
-		// when the viewpane is not visible yet (don't trust `this.isBodyVisible()`).
-		// In this case the `focus()` call fails (don't trust `this.onFocus()`).
-		// This happens for instance with `workbench.action.togglePanel` or
-		// `workbench.action.toggleSecondarySideBar`. Not doing it at the next tick
-		// would result in broken viewpane toggling, see
-		// https://github.com/posit-dev/positron/pull/2867
-		const focus = () => {
-			// The base class focuses the whole pane (we set its tabIndex to make this possible).
-			// Also needs to be in the next tick.
-			super.focus();
-
-			return this.positronConsoleService.activePositronConsoleInstance?.focusInput();
-		};
-		disposableTimeout(focus, 0, this._disposableStore);
+		this.positronConsoleService.activePositronConsoleInstance?.focusInput();
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
@@ -17,15 +17,16 @@ import { IHelpEntry } from 'vs/workbench/contrib/positronHelp/browser/helpEntry'
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { ViewPane, IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
+import { IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
 import { ActionBars } from 'vs/workbench/contrib/positronHelp/browser/components/actionBars';
 import { IPositronHelpService } from 'vs/workbench/contrib/positronHelp/browser/positronHelpService';
 import { IReactComponentContainer, ISize, PositronReactRenderer } from 'vs/base/browser/positronReactRenderer';
+import { PositronViewPane } from 'vs/workbench/browser/positronViewPane/positronViewPane';
 
 /**
  * PositronHelpView class.
  */
-export class PositronHelpView extends ViewPane implements IReactComponentContainer {
+export class PositronHelpView extends PositronViewPane implements IReactComponentContainer {
 	//#region Private Properties
 
 	// The width. This value is set in layoutBody and is used to implement the
@@ -189,12 +190,6 @@ export class PositronHelpView extends ViewPane implements IReactComponentContain
 			themeService,
 			telemetryService
 		);
-
-		// Make the viewpane focusable even when there are no components
-		// available to take the focus. The viewpane must be able to take focus
-		// at all times because otherwise blurring events do not occur and the
-		// viewpane management state becomes confused on toggle.
-		this.element.tabIndex = 0;
 
 		// Create containers.
 		this.positronHelpContainer = DOM.$('.positron-help-container');

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsView.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsView.tsx
@@ -16,18 +16,19 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { ViewPane, IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
+import { IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { PositronPlots } from 'vs/workbench/contrib/positronPlots/browser/positronPlots';
 import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IElementPosition, IReactComponentContainer, ISize, PositronReactRenderer } from 'vs/base/browser/positronReactRenderer';
 import { IPositronPlotsService } from 'vs/workbench/services/positronPlots/common/positronPlots';
 import { INotificationService } from 'vs/platform/notification/common/notification';
+import { PositronViewPane } from 'vs/workbench/browser/positronViewPane/positronViewPane';
 
 /**
  * PositronPlotsViewPane class.
  */
-export class PositronPlotsViewPane extends ViewPane implements IReactComponentContainer {
+export class PositronPlotsViewPane extends PositronViewPane implements IReactComponentContainer {
 	//#region Private Properties
 
 	// The onSizeChanged emitter.
@@ -162,12 +163,6 @@ export class PositronPlotsViewPane extends ViewPane implements IReactComponentCo
 	) {
 		// Call the base class's constructor.
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
-
-		// Make the viewpane focusable even when there are no components
-		// available to take the focus. The viewpane must be able to take focus
-		// at all times because otherwise blurring events do not occur and the
-		// viewpane management state becomes confused on toggle.
-		this.element.tabIndex = 0;
 
 		// Register the onDidChangeBodyVisibility event handler.
 		this._register(this.onDidChangeBodyVisibility(visible => {

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
@@ -14,7 +14,7 @@ import { IElementPosition, IReactComponentContainer, ISize, PositronReactRendere
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { ViewPane, IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
+import { IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
 import { Event, Emitter } from 'vs/base/common/event';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
@@ -22,11 +22,12 @@ import { IPositronPreviewService } from 'vs/workbench/contrib/positronPreview/br
 import { PositronPreview } from 'vs/workbench/contrib/positronPreview/browser/positronPreview';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
+import { PositronViewPane } from 'vs/workbench/browser/positronViewPane/positronViewPane';
 
 /**
  * PositronPreviewViewPane class.
  */
-export class PositronPreviewViewPane extends ViewPane implements IReactComponentContainer {
+export class PositronPreviewViewPane extends PositronViewPane implements IReactComponentContainer {
 	//#region Private Properties
 
 	// The PositronReactRenderer.
@@ -90,12 +91,6 @@ export class PositronPreviewViewPane extends ViewPane implements IReactComponent
 		options = { ...options, minimumBodySize: 0 };
 
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
-
-		// Make the viewpane focusable even when there are no components
-		// available to take the focus. The viewpane must be able to take focus
-		// at all times because otherwise blurring events do not occur and the
-		// viewpane management state becomes confused on toggle.
-		this.element.tabIndex = 0;
 
 		this._register(this.onDidChangeBodyVisibility(() => this.onDidChangeVisibility(this.isBodyVisible())));
 		this._positronPreviewContainer = DOM.$('.positron-preview-container');

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessionsView.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessionsView.tsx
@@ -15,17 +15,18 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { ViewPane, IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
+import { IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { PositronSessions } from 'vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessions';
 import { IReactComponentContainer, ISize, PositronReactRenderer } from 'vs/base/browser/positronReactRenderer';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
+import { PositronViewPane } from 'vs/workbench/browser/positronViewPane/positronViewPane';
 
 /**
  * PositronSessionsViewPane class.
  */
-export class PositronRuntimeSessionsViewPane extends ViewPane implements IReactComponentContainer {
+export class PositronRuntimeSessionsViewPane extends PositronViewPane implements IReactComponentContainer {
 	//#region Private Properties
 
 	/**
@@ -193,12 +194,6 @@ export class PositronRuntimeSessionsViewPane extends ViewPane implements IReactC
 			openerService,
 			themeService,
 			telemetryService);
-
-		// Make the viewpane focusable even when there are no components
-		// available to take the focus. The viewpane must be able to take focus
-		// at all times because otherwise blurring events do not occur and the
-		// viewpane management state becomes confused on toggle.
-		this.element.tabIndex = 0;
 
 		// Register the onDidChangeBodyVisibility event handler.
 		this._register(this.onDidChangeBodyVisibility(visible => {

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
@@ -17,7 +17,7 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { ViewPane, IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
+import { IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPane';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { PositronVariables } from 'vs/workbench/contrib/positronVariables/browser/positronVariables';
@@ -25,11 +25,12 @@ import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/c
 import { IReactComponentContainer, ISize, PositronReactRenderer } from 'vs/base/browser/positronReactRenderer';
 import { IPositronVariablesService } from 'vs/workbench/services/positronVariables/common/interfaces/positronVariablesService';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
+import { PositronViewPane } from 'vs/workbench/browser/positronViewPane/positronViewPane';
 
 /**
  * PositronVariablesViewPane class.
  */
-export class PositronVariablesViewPane extends ViewPane implements IReactComponentContainer {
+export class PositronVariablesViewPane extends PositronViewPane implements IReactComponentContainer {
 	//#region Private Properties
 
 	/**
@@ -205,12 +206,6 @@ export class PositronVariablesViewPane extends ViewPane implements IReactCompone
 			themeService,
 			telemetryService);
 
-		// Make the viewpane focusable even when there are no components
-		// available to take the focus. The viewpane must be able to take focus
-		// at all times because otherwise blurring events do not occur and the
-		// viewpane management state becomes confused on toggle.
-		this.element.tabIndex = 0;
-
 		// Register the onDidChangeBodyVisibility event handler.
 		this._register(this.onDidChangeBodyVisibility(visible => {
 			// The browser will automatically set scrollTop to 0 on child components that have been
@@ -275,12 +270,10 @@ export class PositronVariablesViewPane extends ViewPane implements IReactCompone
 	}
 
 	/**
-	 * focus override method.
+	 * Drive focus to inner element.
+	 * Called by `super.focus()`.
 	 */
-	override focus(): void {
-		// Call the base class's method.
-		super.focus();
-
+	override focusElement(): void {
 		// Trigger event that eventually causes variable pane widgets to focus
 		this._positronVariablesService.activePositronVariablesInstance?.focusElement();
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

Follow-up to https://github.com/posit-dev/positron/pull/2867
Addresses another aspect of #811
Closes #2904 

### Intent

Prevent panel toggling from breaking viewpane toggling when there is no focusable element in the pane.


### Approach

In #2867 we made viewpanes focusable by giving them a `tabIndex`. The `ViewPane::focus()` method (called via `super.focus()`) is in charge of focusing that pane. This allows `focus()` to succeed, which is necessary for viewpane toggling to work as expected.

However when you toggle the whole panel (e.g. with Cmd-J or the icon in the top-right), as opposed to toggling specifically the console viewpane, our `focus()` method is called too early before the pane is mounted to the DOM. This causes the focus call to fails, which then breaks viewpane toggling. To work around that I put our input focus call in a timeout. But because I didn't do the same with `super.focus()`, we can still get in a broken state by toggling the whole pane when there is no input to focus, which can happen during runtime discovery or when a runtime has crashed during startup. This PR fixes that omission.

I also added the comment that you requested in the other PR @nstrayer.


### QA Notes

One way of reproducing is to disable automatic startup of interpreters. Without starting an interpreter, use the viewpane toggling command:

<img width="605" alt="Screenshot 2024-04-26 at 09 04 34" src="https://github.com/posit-dev/positron/assets/4465050/440e2bf5-ba18-4e32-b8f5-18600437b4d1">

Do this a few times and you should see the console toggle.

Now use the _panel_ toggling command, e.g. Cmd-J by default on mac (or the secondary side bar if the console is there). Do this a few times, it should work. However, before the fix, the console toggling command would now be broken. With the fix you should still be able to use it.