### PR TITLE
Disable escape and preserve input on interrupt

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.css
@@ -38,3 +38,7 @@
 	text-align: right;
 	display: inline-block;
 }
+
+.activity-input.cancelled {
+	opacity: 0.65;
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.css
@@ -40,5 +40,5 @@
 }
 
 .activity-input.cancelled {
-	opacity: 0.65;
+	color: var(--vscode-positronTopActionBar-disabledForeground);
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
@@ -56,7 +56,8 @@ export const ActivityInput = (props: ActivityInputProps) => {
 	// Generate the class names.
 	const classNames = positronClassNames(
 		'activity-input',
-		{ 'executing': state === ActivityItemInputState.Executing }
+		{ 'executing': state === ActivityItemInputState.Executing },
+		{ 'cancelled': state === ActivityItemInputState.Cancelled }
 	);
 
 	// Render.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
@@ -103,17 +103,6 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 					return;
 				}
 
-				// Escape key.
-				case 'Escape': {
-					// Consume the event.
-					consumeEvent();
-
-					// Update the prompt state and interrupt it.
-					props.activityItemPrompt.state = ActivityItemPromptState.Interrupted;
-					props.positronConsoleInstance.interruptPrompt(props.activityItemPrompt.id);
-					return;
-				}
-
 				default: {
 					return;
 				}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -260,23 +260,6 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 
 		// Process the key code.
 		switch (e.keyCode) {
-			// Escape handling.
-			case KeyCode.Escape: {
-				// If the history browser is active, deactivate it.
-				if (historyBrowserActiveRef.current) {
-					disengageHistoryBrowser();
-					consumeEvent();
-					break;
-				}
-
-				// Consume the event.
-				consumeEvent();
-
-				// Interrupt the console.
-				props.positronConsoleInstance.interrupt();
-				break;
-			}
-
 			// Ctrl-A handling.
 			case KeyCode.KeyA: {
 				// If the cmd or ctrl key is pressed, see if the user wants to select all.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -302,7 +302,8 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 					consumeEvent();
 
 					// Interrupt the console.
-					props.positronConsoleInstance.interrupt();
+					const code = codeEditorWidgetRef.current.getValue();
+					props.positronConsoleInstance.interrupt(code);
 				}
 				break;
 			}

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemInput.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemInput.ts
@@ -11,7 +11,8 @@ import { ANSIOutput, ANSIOutputLine } from 'vs/base/common/ansiOutput';
 export const enum ActivityItemInputState {
 	Provisional = 'provisional',
 	Executing = 'executing',
-	Completed = 'completed'
+	Completed = 'completed',
+	Cancelled = 'cancelled'
 }
 
 /**

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -277,7 +277,7 @@ export interface IPositronConsoleInstance {
 	/**
 	 * Interrupts the console.
 	 */
-	interrupt(): void;
+	interrupt(code: string): void;
 
 	/**
 	 * Enqueues code to be executed.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -972,7 +972,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	/**
 	 * Interrupts the console.
 	 */
-	interrupt() {
+	interrupt(code: string) {
 		// Get the runtime state.
 		const runtimeState = this._session.getRuntimeState();
 
@@ -989,13 +989,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			this.addOrUpdateUpdateRuntimeItemActivity(
 				id,
 				new ActivityItemInput(
-					ActivityItemInputState.Completed,
+					ActivityItemInputState.Cancelled,
 					id,
 					id,
 					new Date(),
 					this._session.dynState.inputPrompt,
 					this._session.dynState.continuationPrompt,
-					''
+					code,
 				)
 			);
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

Addresses https://github.com/posit-dev/positron/issues/1161

### Intent

Currently Escape and Ctrl+C wipe out console input without any way of retrieving it. This is problematic because escape is also the way to close completions in Positron. It's very easy to hit Escape one more time by mistake and then you lose your console input and have to type it again.

Similarly, hitting Ctrl-C will remove the input entirely. This is not consistent with how it usually works in a terminal where Ctrl-C gives you a fresh prompt but still preserves the unevaluated input in the console.

Worth noting that in RStudio, escape behaves the same way. We think it's more problematic in Positron though as completions pop up more often / more snappily which causes users to get in the habit of escaping. Also the parameter-list popup might show up and it's not currently closable via escape, causing our handler to wipe out input instead.

We discussed at the R meeting trying out another approach where escape no longer cancels current input.

### Approach

- We no longer handle escape
- Ctrl-C now inserts a new kind of activity item that is greyed out to hint the input was not run. The greyeing is done with transparency, as I noticed we do that elsewhere.

https://github.com/posit-dev/positron/assets/4465050/805d47bf-15b3-409f-9f79-64799977ecad

With light theme:

<img width="410" alt="Screenshot 2024-04-26 at 15 20 06" src="https://github.com/posit-dev/positron/assets/4465050/60ae10f7-e0c4-4aad-8ab5-eb8d420b2998">


### QA Notes

The greyed out cancelled input on Ctrl-C should work correctly (be noticeable but still readable) with different colour themes.