### PR TITLE
Let ark have maximum control over smart select in R files

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -212,7 +212,9 @@
     "configurationDefaults": {
       "[r]": {
         "editor.tabSize": 2,
-        "editor.wordSeparators": "`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?"
+        "editor.wordSeparators": "`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?",
+        "editor.smartSelect.selectSubwords": false,
+        "editor.smartSelect.selectLeadingAndTrailingWhitespace": false
       }
     },
     "languages": [

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -213,7 +213,6 @@
       "[r]": {
         "editor.tabSize": 2,
         "editor.wordSeparators": "`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?",
-        "editor.smartSelect.selectSubwords": false,
         "editor.smartSelect.selectLeadingAndTrailingWhitespace": false
       }
     },


### PR DESCRIPTION
Since we have a holistic tree-sitter approach that works well

This goes along with https://github.com/posit-dev/amalthea/pull/321, in particular https://github.com/posit-dev/amalthea/pull/321#issuecomment-2079501691, where the videos show that selecting trailing/leading whitespace often makes no sense when "expanding" the selection, and often results in "incomplete" chunks of code to select.

I think this feature and the subword selection feature are reasonable to have on if you don't implement smart select yourself, but we have a holistic smart select based on more precise tree-sitter nodes, and it feels like it works pretty well, so these extra selections seem to be getting in the way with no noticeable benefits.