### PR TITLE
Add status icons to Data Explorer

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/status-active.svg
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/status-active.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 24 24">
+  <path d="M12,18c-3.3,0-6-2.7-6-6s2.7-6,6-6v-2c-4.4,0-8,3.6-8,8s3.6,8,8,8,8-3.6,8-8h-2c0,3.3-2.7,6-6,6Z" fill="#23b87a" stroke-width="0"/>
+  <circle cx="12" cy="5" r="3" fill="#23b87a" stroke-width="0"/>
+</svg>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/status-disconnected.svg
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/status-disconnected.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 24 24">
+  <path d="M6.3,10c.8-2.3,3-4,5.7-4s4.8,1.7,5.7,4h2.1c-.9-3.4-4-6-7.7-6s-6.8,2.6-7.7,6h2.1Z" fill="#d93939" stroke-width="0"/>
+  <path d="M17.7,14c-.8,2.3-3,4-5.7,4s-4.8-1.7-5.7-4h-2.1c.9,3.4,4,6,7.7,6s6.8-2.6,7.7-6h-2.1Z" fill="#d93939" stroke-width="0"/>
+</svg>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/status-idle.svg
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/status-idle.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 24 24">
+  <path d="M12,4c-4.4,0-8,3.6-8,8s3.6,8,8,8,8-3.6,8-8-3.6-8-8-8ZM12,18c-3.3,0-6-2.7-6-6s2.7-6,6-6,6,2.7,6,6-2.7,6-6,6Z" fill="#3a76b3" stroke-width="0"/>
+</svg>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.css
@@ -2,53 +2,53 @@
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
-.data-explorer-panel
-.status-bar {
+.data-explorer-panel .status-bar {
 	display: flex;
-	padding: 0 8px;
+	padding: 0;
 	align-items: center;
 	grid-row: status-bar / end;
 	border-top: 1px solid var(--vscode-positronDataExplorer-border);
 	background-color: var(--vscode-positronDataExplorer-contrastBackground);
 }
 
-.data-explorer-panel
-.status-bar
-.label {
+.data-explorer-panel .status-bar .label {
 	opacity: 80%;
 }
 
-.data-explorer-panel
-.status-bar
-.status-bar-indicator {
-	cursor: pointer;
-	border-radius: 3px;
-	box-sizing: border-box;
-	justify-content: left;
+.data-explorer-panel .status-bar .status-bar-indicator {
+	padding: 0 2px;
+	margin-right: 8px;
+	height: 100%;
 	display: flex;
+	align-items: center;
+	padding-left: 2px;
+	border-right: 1px solid var(--vscode-positronDataExplorer-border);
 }
 
-.data-explorer-panel
-.status-bar
-.status-bar-indicator
-.action-bar-separator {
+.data-explorer-panel .status-bar .status-bar-indicator .action-bar-separator {
 	margin-left: 4px;
 }
 
-.data-explorer-panel
-.status-bar
-.status-bar-indicator .title {
-	margin: 0 6px 0px 2px;
+.data-explorer-panel .status-bar .status-bar-indicator .icon {
+	height: 20px;
+	width: 20px;
 }
 
-.data-explorer-panel
-.status-bar
-.status-bar-indicator .title.computing {
-	background-color: var(--vscode-positronDataExplorer-statusIndicatorComputing) !important;
+.data-explorer-panel .status-bar .status-bar-indicator .icon.computing {
+	background-image: url(status-active.svg);
+	animation: rotate-computing 1.5s linear infinite;
 }
 
-.data-explorer-panel
-.status-bar
-.status-bar-indicator .title.disconnected {
-	background-color: var(--vscode-positronDataExplorer-statusIndicatorDisconnected) !important;
+@keyframes rotate-computing {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.data-explorer-panel .status-bar .status-bar-indicator .icon.idle {
+	background-image: url(status-idle.svg);
+}
+
+.data-explorer-panel .status-bar .status-bar-indicator .icon.disconnected {
+	background-image: url(status-disconnected.svg);
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.css
@@ -36,10 +36,10 @@
 
 .data-explorer-panel .status-bar .status-bar-indicator .icon.computing {
 	background-image: url(status-active.svg);
-	animation: rotate-computing 1.5s linear infinite;
+	animation: status-icon-rotate-computing 1.5s linear infinite;
 }
 
-@keyframes rotate-computing {
+@keyframes status-icon-rotate-computing {
 	to {
 		transform: rotate(360deg);
 	}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.tsx
@@ -10,6 +10,7 @@ import * as React from 'react';
 import { useEffect, useState } from 'react'; // eslint-disable-line no-duplicate-imports
 
 // Other dependencies.
+import * as nls from 'vs/nls';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { usePositronDataExplorerContext } from 'vs/workbench/browser/positronDataExplorer/positronDataExplorerContext';
 import { DataExplorerClientStatus } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
@@ -20,16 +21,15 @@ interface ActivityIndicatorProps {
 
 const StatusBarActivityIndicator = (props: ActivityIndicatorProps) => {
 	const getStatusText = () => {
-		// TODO: localize
 		switch (props.status) {
 			case DataExplorerClientStatus.Idle:
-				return 'Idle';
+				return nls.localize('positron.dataExplorer.idle', 'Idle');
 			case DataExplorerClientStatus.Computing:
-				return 'Computing';
+				return nls.localize('positron.dataExplorer.computing', 'Computing');
 			case DataExplorerClientStatus.Disconnected:
-				return 'Disconnected';
+				return nls.localize('positron.dataExplorer.disconnected', 'Disconnected');
 			case DataExplorerClientStatus.Error:
-				return 'Error';
+				return nls.localize('positron.dataExplorer.error', 'Error');
 		}
 	};
 
@@ -48,13 +48,9 @@ const StatusBarActivityIndicator = (props: ActivityIndicatorProps) => {
 
 	return (
 		<div className='status-bar-indicator'>
-			{/* TODO: Use different CSS  */}
-			<div className='action-bar-separator' aria-hidden='true' >
-				<div className='action-bar-separator-icon codicon codicon-positron-separator' />
-			</div>
-			<div className={`title ${getStatusClass()}`}>
-				{getStatusText()}
-			</div>
+			<div className={`icon ${getStatusClass()}`}
+				title={getStatusText()}
+				aria-label={getStatusText()}></div>
 		</div>
 	);
 };
@@ -107,6 +103,9 @@ export const StatusBar = () => {
 
 		return (
 			<div className='status-bar'>
+				<StatusBarActivityIndicator
+					status={clientStatus}
+				/>
 				<span className='label'>Showing</span>
 				<span>&nbsp;</span>
 				<span className='counter'>{numRows.toLocaleString()}</span>
@@ -128,6 +127,9 @@ export const StatusBar = () => {
 	} else {
 		return (
 			<div className='status-bar'>
+				<StatusBarActivityIndicator
+					status={clientStatus}
+				/>
 				<span className='counter'>{numRows.toLocaleString()}</span>
 				<span>&nbsp;</span>
 				<span className='label'>rows</span>
@@ -135,9 +137,6 @@ export const StatusBar = () => {
 				<span className='counter'>{numColumns.toLocaleString()}</span>
 				<span>&nbsp;</span>
 				<span className='label'>columns</span>
-				<StatusBarActivityIndicator
-					status={clientStatus}
-				/>
 			</div>
 		);
 	}


### PR DESCRIPTION
### Intent

Updates the status bar on the Data Explorer with an icon representing its current state (idle, computing, or disconnected). 

<img width="203" alt="image" src="https://github.com/posit-dev/positron/assets/470418/5157958b-3369-4941-8d44-5f8359ca59ab">

Addresses https://github.com/posit-dev/positron/issues/2914.

### Approach

Add icons and design.

### QA Notes

This change is purely visual.
