### PR TITLE
Restore higher limit for listing top level variables in Python

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
@@ -198,7 +198,7 @@ def test_list_1000(shell: PositronShell, variables_comm: DummyComm) -> None:
 
 
 def test_update_max_children_plus_one(shell: PositronShell, variables_comm: DummyComm) -> None:
-    # Create and update 101 variables, which is more than MAX_CHILDREN
+    # Create and update more than MAX_CHILDREN variables
     n = MAX_CHILDREN + 1
     add_value = 500
     msg: Any = create_and_update_n_vars(n, add_value, shell, variables_comm)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
@@ -177,7 +177,6 @@ def test_handle_refresh(shell: PositronShell, variables_comm: DummyComm) -> None
 
 
 def test_list_1000(shell: PositronShell, variables_comm: DummyComm) -> None:
-
     # Create 1000 variables
     for j in range(0, 1000, 1):
         shell.user_ns["var{}".format(j)] = j
@@ -197,7 +196,6 @@ def test_list_1000(shell: PositronShell, variables_comm: DummyComm) -> None:
 
 
 def test_update_101(shell: PositronShell, variables_comm: DummyComm) -> None:
-
     # Create 101 variables
     assign_101 = ""
     for j in range(0, 101, 1):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -215,7 +215,7 @@ class VariablesService:
         }
         """
         variables = self._get_filtered_vars()
-        filtered_variables = _summarize_children(variables)
+        filtered_variables = _summarize_children(variables, MAX_ITEMS)
 
         msg = RefreshParams(
             variables=filtered_variables,
@@ -735,7 +735,7 @@ def _summarize_variable(key: Any, value: Any) -> Optional[Variable]:
 def _summarize_children(parent: Any, limit: int = MAX_CHILDREN) -> List[Variable]:
     children = []
     for i, (key, value) in enumerate(get_inspector(parent).get_items()):
-        if i > limit:
+        if len(children) >= limit:
             break
         summary = _summarize_variable(key, value)
         if summary is not None:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -180,7 +180,7 @@ class VariablesService:
 
         # Filter out hidden assigned variables
         variables = self._get_filtered_vars(assigned)
-        filtered_assigned = _summarize_children(variables)
+        filtered_assigned = _summarize_children(variables, MAX_ITEMS)
 
         # Filter out hidden removed variables and encode access keys
         hidden = self._get_user_ns_hidden()
@@ -424,7 +424,7 @@ class VariablesService:
 
     def _list_all_vars(self) -> List[Variable]:
         variables = self._get_filtered_vars()
-        return _summarize_children(variables)
+        return _summarize_children(variables, MAX_ITEMS)
 
     def _send_list(self) -> None:
         filtered_variables = self._list_all_vars()
@@ -732,10 +732,10 @@ def _summarize_variable(key: Any, value: Any) -> Optional[Variable]:
         )
 
 
-def _summarize_children(parent: Any) -> List[Variable]:
+def _summarize_children(parent: Any, limit: int = MAX_CHILDREN) -> List[Variable]:
     children = []
     for i, (key, value) in enumerate(get_inspector(parent).get_items()):
-        if i > MAX_CHILDREN:
+        if i > limit:
             break
         summary = _summarize_variable(key, value)
         if summary is not None:


### PR DESCRIPTION
Also use the higher limit for updates, as more than 100 new variables could be created in an execution.

Addresses https://github.com/posit-dev/positron/issues/2893

### Intent

Positron limits the number of child values to 100 shown when expanding a variable in the Variables view, but this limit shouldn't apply to the root variables list. 

A higher limit, arbitrarily agreed on previously as 10,000 variables, had been implemented, but Python regressed some months earlier during refactoring and reverted back to using the 100 limit for child values.

### QA Notes

Please test the creation and updating of > 100 variables. You could also test the upper limit of 10,000 top level variables as a cap. Also test that no more than 100 child values are returned when expanding a complex variable (e.g. a dictionary with more than 100 keys, or a list with more than 100 values).