### PR TITLE
Fix HTML widget resource paths on Windows

### DIFF
--- a/extensions/positron-r/resources/js/htmlwidget.js
+++ b/extensions/positron-r/resources/js/htmlwidget.js
@@ -16,6 +16,11 @@
  * port of `asWebviewUri` from VS Code.
  */
 const asWebviewUri = (path) => {
+	// Ensure path starts with '/'. On Windows, the path starts with the drive letter, e.g.
+	// c/Users/bob/path/to/file.
+	if (!path.startsWith('/')) {
+		path = '/' + path;
+	}
 	return 'https://file%2B.vscode-resource.vscode-cdn.net' + path;
 };
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/2843

<img width="1131" alt="image" src="https://github.com/posit-dev/positron/assets/470418/d7433ae4-ebbf-4ed3-9144-b7fde63389f1">


### Approach

Pretty simple: we translate HTML widget resource URLs to URLs that can be loaded in a VS Code webview. That translation presumed that the path always started with a `/`. This isn't true on Windows, so we add a `/` to the path if it doesn't already start with one.

This is the minimal fix for the problem; it would probably be better to find a way to use the official `asWebviewUri` implementation.

### QA Notes

Note that this minimal fix does not attempt to fix any of the HTML widgets that are otherwise incompatible with Positron; this is just intended to bring Windows up to the same level of compatibility as macOS and Linux.