### PR TITLE
Start notebook sessions in the notebook's parent directory

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -709,6 +709,8 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		// Use the VS Code terminal API to create a terminal for the kernel
 		this._terminal = vscode.window.createTerminal(<vscode.TerminalOptions>{
 			name: this._spec.display_name,
+			// Always start notebook sessions in the directory of the notebook
+			cwd: this._notebookUri ? path.dirname(this._notebookUri.path) : undefined,
 			shellPath: shellPath,
 			shellArgs: shellArgs,
 			env,

--- a/extensions/positron-notebook-controllers/src/notebookSessionService.ts
+++ b/extensions/positron-notebook-controllers/src/notebookSessionService.ts
@@ -4,6 +4,7 @@
 
 import * as positron from 'positron';
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { log } from './extension';
 import { ResourceMap } from './map';
 
@@ -192,7 +193,7 @@ export class NotebookSessionService implements vscode.Disposable {
 		try {
 			const session = await positron.runtime.startLanguageRuntime(
 				preferredRuntime.runtimeId,
-				notebookUri.path, // Use the notebook's path as the session name.
+				path.basename(notebookUri.path), // Use the notebook's file name as the session name.
 				notebookUri);
 			log.info(
 				`Starting session for language runtime ${session.metadata.sessionId} `


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/2648.

<img width="687" alt="image" src="https://github.com/posit-dev/positron/assets/470418/de5bc2b1-9919-45c5-add7-096d3f40ae95">

### Approach

When starting the hidden terminal backing an R or Python Jupyter session, we now use the notebook's parent path (if known) as the process's current working directory. 

### QA Notes

I also dropped the full path from the notebook session names (because it was super unwieldy). Notebook session names are now just the notebook file's name. 