### PR TITLE
Use disposable timeout in scroll restoring handler

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -47,6 +47,7 @@ import { RuntimeItemRestartButton } from 'vs/workbench/services/positronConsole/
 import { IPositronConsoleInstance, PositronConsoleState } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
 import { RuntimeItemStartupFailure } from 'vs/workbench/services/positronConsole/browser/classes/runtimeItemStartupFailure';
 import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_CUT, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
+import { disposableTimeout } from 'vs/base/common/async';
 
 // ConsoleInstanceProps interface.
 interface ConsoleInstanceProps {
@@ -321,17 +322,14 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 				// not scrolled all the way to the bottom. In this case, the
 				// scrolling to 0 followed by our scroll to `lastScrollTop` is
 				// unfortunately noticeable, though not too bad.
-				setTimeout(() => {
-					// Since we are in a timeout and teardown might have been called,
-					// check that our component is still mounted
-					if (consoleInstanceRef.current) {
-						if (props.positronConsoleInstance.scrollLocked) {
-							scrollVertically(props.positronConsoleInstance.lastScrollTop);
-						} else {
-							scrollToBottom();
-						}
+				const restoreScrollTop = () => {
+					if (props.positronConsoleInstance.scrollLocked) {
+						scrollVertically(props.positronConsoleInstance.lastScrollTop);
+					} else {
+						scrollToBottom();
 					}
-				});
+				};
+				disposableTimeout(restoreScrollTop, 0, disposableStore);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -588,10 +588,6 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	 * @param e A WheelEvent<HTMLDivElement> that describes a user interaction with the wheel.
 	 */
 	const wheelHandler = (e: WheelEvent<HTMLDivElement>) => {
-		// Also save state here, apparently `scrollHandler` is not always called?
-		// https://github.com/posit-dev/positron/issues/2868#issuecomment-2083264595
-		props.positronConsoleInstance.lastScrollTop = consoleInstanceRef.current.scrollTop;
-
 		// Negative delta Y immediantly engages scroll lock, if the console is scrollable.
 		if (e.deltaY < 0 && !props.positronConsoleInstance.scrollLocked) {
 			props.positronConsoleInstance.scrollLocked = scrollable();

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -588,6 +588,10 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	 * @param e A WheelEvent<HTMLDivElement> that describes a user interaction with the wheel.
 	 */
 	const wheelHandler = (e: WheelEvent<HTMLDivElement>) => {
+		// Also save state here, apparently `scrollHandler` is not always called?
+		// https://github.com/posit-dev/positron/issues/2868#issuecomment-2083264595
+		props.positronConsoleInstance.lastScrollTop = consoleInstanceRef.current.scrollTop;
+
 		// Negative delta Y immediantly engages scroll lock, if the console is scrollable.
 		if (e.deltaY < 0 && !props.positronConsoleInstance.scrollLocked) {
 			props.positronConsoleInstance.scrollLocked = scrollable();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses https://github.com/posit-dev/positron/issues/2868#issuecomment-2083264595

The scroll state of the console isn't restored if @juliasilge scrolls with her mouse.


### Approach

Save the scroll state in `onWheel` in addition to `onScroll`.

From what I've read, this shouldn't be necessary as `onScroll` should be called in any case. Also I borrowed a mouse but coudn't reproduce Julia's issue.

@juliasilge would you mind trying out this branch and see if that makes any difference?


### QA Notes
