### PR TITLE
Create new command to activate dev extensions

### DIFF
--- a/extensions/positron-javascript/package.json
+++ b/extensions/positron-javascript/package.json
@@ -10,7 +10,9 @@
   "categories": [
     "Programming Languages"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onCommand:positron.action.activateDeveloperExtensions"
+  ],
   "main": "./out/extension.js",
   "scripts": {
     "vscode:prepublish": "yarn run compile",

--- a/extensions/positron-zed/package.json
+++ b/extensions/positron-zed/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "./out/extension.js",
   "activationEvents": [
-    "onStartupFinished"
+    "onCommand:positron.action.activateDeveloperExtensions"
   ],
   "contributes": {
     "languages": [

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1046,6 +1046,9 @@ export class MainThreadLanguageRuntime
 			}
 		});
 
+		// Start the Positron developer extensions.
+		this._commandService.executeCommand('positron.action.activateDeveloperExtensions');
+
 		this._runtimeSessionService.registerSessionManager(this);
 	}
 

--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -25,6 +25,7 @@ import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/com
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { Categories } from 'vs/platform/action/common/actionCommonCategories';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 
@@ -229,6 +230,29 @@ export class PositronOpenFolderInNewWindowAction extends Action2 {
 		});
 	}
 }
+
+export class PositronActivateDeveloperExtensionsAction extends Action2 {
+
+	static readonly ID = 'positron.action.activateDeveloperExtensions';
+
+	constructor() {
+		super({
+			id: PositronActivateDeveloperExtensionsAction.ID,
+			title: {
+				value: localize('positronActivateDeveloperExtensionsAction', 'Activate Developer Extensions...'),
+				original: 'Open Folder in New Window...'
+			},
+			category: Categories.Developer,
+			f1: true,
+			precondition: IsDevelopmentContext.isEqualTo(true),
+		});
+	}
+
+	override async run(): Promise<boolean> {
+		return true;
+	}
+}
+
 
 // Register the actions defined above.
 registerAction2(PositronNewProjectAction);

--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -240,11 +240,11 @@ export class PositronActivateDeveloperExtensionsAction extends Action2 {
 			id: PositronActivateDeveloperExtensionsAction.ID,
 			title: {
 				value: localize('positronActivateDeveloperExtensionsAction', 'Activate Developer Extensions...'),
-				original: 'Open Folder in New Window...'
+				original: 'Activate Developer Extensions...'
 			},
 			category: Categories.Developer,
 			f1: true,
-			precondition: IsDevelopmentContext.isEqualTo(true),
+			precondition: IsDevelopmentContext,
 		});
 	}
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -6,7 +6,6 @@ import * as nls from 'vs/nls';
 import { Emitter } from 'vs/base/common/event';
 import { ILogService } from 'vs/platform/log/common/log';
 import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
-import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { ILanguageRuntimeMetadata, ILanguageRuntimeService, formatLanguageRuntimeMetadata } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { Registry } from 'vs/platform/registry/common/platform';
@@ -119,8 +118,6 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 
 	//#endregion ILanguageRuntimeService Implementation
 }
-
-CommandsRegistry.registerCommand('positron.activateInterpreters', () => true);
 
 // Instantiate the language runtime service "eagerly", meaning as soon as a
 // consumer depdends on it. This fixes an issue where languages are encountered


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses #2923

### Approach

Instead of activating on `"onStartupFinished"` like our other extensions, our developer-only extensions (positron-zed and positron-javascript) can now activate on a special command made just for them.

### QA Notes

In a dev build, we should still have positron-zed available, but in a release build, we should not, plus there should be no errors in the logs about trying/failing to activate them.