### PR TITLE
Fix UTF-8 encoding issues in the Viewer pane

### DIFF
--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import { VSBuffer, encodeBase64 } from 'vs/base/common/buffer';
@@ -48,6 +48,12 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 			if (mimeType === 'text/plain') {
 				continue;
 			}
+
+			// Don't render HTML outputs here; we'll render them as raw HTML below
+			if (mimeType === 'text/html') {
+				continue;
+			}
+
 			const renderer = this._notebookService.getPreferredRenderer(mimeType);
 			if (renderer) {
 				return this.createNotebookRenderOutput(output.id, runtime,
@@ -219,7 +225,8 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 
 	// Activate the renderer and create the data object
 	var renderer = activate(ctx);
-	var rawData = atob('${rawData}');
+	var utf8bytes = Uint8Array.from(atob('${rawData}'), (m) => m.codePointAt(0));
+	var rawData = new TextDecoder().decode(utf8bytes);
 	var data = {
 		id: '${id}',
 		mime: '${mimeType}',


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/1768. 

<img width="395" alt="image" src="https://github.com/posit-dev/positron/assets/470418/120e3d08-518f-4e61-913e-782eef83d55b">


### Approach

The problem was that we were passing UTF-8 encoded data to the HTML output renderer, but it was being decoded as plain bytes when deserialized on the other side of the window boundary. It requires a surprising number of API calls to untangle this. See https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem for more information.

The fix is twofold:

- First, if we're given raw HTML from the runtime, we can just render it as is - no need to force the output through the notebook renderer infrastructure, which is where all the encoding/decoding happens. This alone fixes the issue reported in the original bug.
- But UTF-8 is still broken in the notebook renderer codepath; fix that by converting the Base64 in the webview into a UTF-8 array that can be read by a `TextDecoder`.

### QA Notes

Note that this affects all HTML widgets. 