### PR TITLE
Send escape sequence `SyntaxWarning` to logs

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -489,12 +489,9 @@ class PositronIPyKernel(IPythonKernel):
             filename = f"<positron-console-cell-{self.execution_count}>"
 
         # send to logs if warning is coming from Positron files
-        # or if it is a SyntaxWarning for escape sequences, which can be noisy
-        if (
-            str(positron_files_path) in str(filename)
-            or "invalid escape sequence" in str(message)
-            and category is SyntaxWarning
-        ):
+        # also send warnings from attempted compiles from IPython to logs
+        # https://github.com/ipython/ipython/blob/8.24.0/IPython/core/async_helpers.py#L151
+        if (str(positron_files_path) in str(filename) or str(filename) == "<>"):
             msg = f"{filename}-{lineno}: {category}: {message}"
             logger.warning(msg)
             return

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -491,7 +491,7 @@ class PositronIPyKernel(IPythonKernel):
         # send to logs if warning is coming from Positron files
         # also send warnings from attempted compiles from IPython to logs
         # https://github.com/ipython/ipython/blob/8.24.0/IPython/core/async_helpers.py#L151
-        if (str(positron_files_path) in str(filename) or str(filename) == "<>"):
+        if str(positron_files_path) in str(filename) or str(filename) == "<>":
             msg = f"{filename}-{lineno}: {category}: {message}"
             logger.warning(msg)
             return

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_jedilsp.py
@@ -671,8 +671,8 @@ def _publish_diagnostics(server: JediLanguageServer, uri: str) -> None:
 
     # --- Start Positron ---
     try:
-        with warnings.catch_warning():
-            warnings.simple_filter("ignore", SyntaxWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", SyntaxWarning)
             diagnostic = jedi_utils.lsp_python_diagnostic(uri, doc.source)
     except Exception:
         logger.exception(f"Failed to publish diagnostics for uri {uri}", exc_info=True)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_jedilsp.py
@@ -672,7 +672,7 @@ def _publish_diagnostics(server: JediLanguageServer, uri: str) -> None:
     # --- Start Positron ---
     try:
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore", SyntaxWarning)
+            warnings.simplefilter("ignore")
             diagnostic = jedi_utils.lsp_python_diagnostic(uri, doc.source)
     except Exception:
         logger.exception(f"Failed to publish diagnostics for uri {uri}", exc_info=True)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_jedilsp.py
@@ -7,6 +7,7 @@ import enum
 import logging
 import re
 import threading
+import warnings
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union, cast
 
@@ -670,7 +671,9 @@ def _publish_diagnostics(server: JediLanguageServer, uri: str) -> None:
 
     # --- Start Positron ---
     try:
-        diagnostic = jedi_utils.lsp_python_diagnostic(uri, doc.source)
+        with warnings.catch_warning():
+            warnings.simple_filter("ignore", SyntaxWarning)
+            diagnostic = jedi_utils.lsp_python_diagnostic(uri, doc.source)
     except Exception:
         logger.exception(f"Failed to publish diagnostics for uri {uri}", exc_info=True)
         diagnostic = None


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

addresses #2615 by sending SyntaxWarnings about escape sequences, that can be populated at compile time, to logs

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

Builds on infrastructure set up in #2776 

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

I've been testing with

```
import warnings
warnings.warn("invalid escape sequence", SyntaxWarning)
```

since the example from #2615 is not reproducible for me.