### PR TITLE
Use self-hosted-production macOS label

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -61,7 +61,7 @@ jobs:
 
   build-archs:
     name: Build macOS
-    runs-on: [self-hosted, macos, arm64]
+    runs-on: [self-hosted-production, macos, arm64]
     needs: [revive_agent]
     timeout-minutes: 60
 


### PR DESCRIPTION
This change ensures that Positron builds only run against the MacInCloud builder until the EC2 builder is able to absorb work.