### PR TITLE
Pass build_number to Linux binary build step

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -72,6 +72,7 @@ jobs:
     needs: version_string
     secrets: inherit
     with:
+      build_number: ${{ needs.version_string.outputs.build_number }}
       short_version: ${{ needs.version_string.outputs.short_version }}
 
   releases:


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/2870.

### Approach

Pass the `build_number` parameter to the Linux binary release step. This parameter was not previously passed and so always had the default value (999). 

### QA Notes

See #2870 for notes.