### PR TITLE
Add Positron-specific Linux package metadata

### DIFF
--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -84,7 +84,14 @@ function prepareDebPackage(arch) {
 			async function () {
 				const that = this;
 				const dependencies = await dependenciesGenerator.getDependencies('deb', binaryDir, product.applicationName, debArch);
-				gulp.src('resources/linux/debian/control.template', { base: '.' })
+				// --- Start Positron ---
+				// VS Code's Debian control file is replaced with Positron's
+				// control file. This file contains metadata about the package,
+				// such as its name and description.
+
+				// gulp.src('resources/linux/debian/control.template', { base: '.' })
+				gulp.src('resources/linux/debian/positron.control.template', { base: '.' })
+					// --- End Positron ---
 					.pipe(replace('@@NAME@@', product.applicationName))
 					// --- Start Positron ---
 					.pipe(replace('@@VERSION@@', product.positronVersion + '-' + linuxPackageRevision))

--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -200,12 +200,12 @@ function prepareRpmPackage(arch) {
 		// --- Start Positron ---
 		// Fixes an upstream bug where the template was generated once per code
 		// source file and overwhelming the build.
-		const spec = gulp.src('resources/linux/rpm/code.spec.template', { base: '.' }).pipe(es.through(
-			function (f) {},
+		const spec = gulp.src('resources/linux/rpm/positron.spec.template', { base: '.' }).pipe(es.through(
+			function (f) { },
 			async function (spec) {
 				const that = this;
 				const dependencies = await dependenciesGenerator.getDependencies('rpm', binaryDir, product.applicationName, rpmArch);
-				gulp.src('resources/linux/rpm/code.spec.template', { base: '.' })
+				gulp.src('resources/linux/rpm/positron.spec.template', { base: '.' })
 					.pipe(replace('@@NAME@@', product.applicationName))
 					.pipe(replace('@@NAME_LONG@@', product.nameLong))
 					.pipe(replace('@@ICON@@', product.linuxIconName))

--- a/resources/linux/debian/positron.control.template
+++ b/resources/linux/debian/positron.control.template
@@ -1,0 +1,16 @@
+Package: @@NAME@@
+Version: @@VERSION@@
+Section: devel
+Depends: @@DEPENDS@@
+Recommends: @@RECOMMENDS@@
+Priority: optional
+Architecture: @@ARCHITECTURE@@
+Maintainer: Posit Software, PBC <info@posit.co>
+Homepage: https://www.posit.co/
+Installed-Size: @@INSTALLEDSIZE@@
+Provides: positron-@@NAME@@
+Conflicts: positron-@@NAME@@
+Replaces: positron-@@NAME@@
+Description: A next-generation data science IDE.
+ Positron is an extensible, polyglot tool for writing code and exploring data
+ in Python, R, and other languages.

--- a/resources/linux/rpm/positron.spec.template
+++ b/resources/linux/rpm/positron.spec.template
@@ -1,0 +1,87 @@
+Name:     @@NAME@@
+Version:  @@VERSION@@
+Release:  @@RELEASE@@.el8
+Summary:  A next-generation data science IDE.
+Group:    Development/Tools
+Vendor:   Posit Software, PBC
+Packager: Positron Development Team <info@posit.co>
+License:  @@LICENSE@@
+URL:      https://www.posit.co/
+Icon:     @@NAME@@.xpm
+Requires: @@DEPENDENCIES@@
+AutoReq:  0
+
+%global __provides_exclude_from ^%{_datadir}/%{name}/.*\\.so.*$
+
+%description
+Positron is an extensible, polyglot tool for writing code and exploring data in Python, R, and other languages.
+
+# Don't generate build_id links to prevent conflicts when installing multiple
+# versions of VS Code alongside each other (e.g. `code` and `code-insiders`)
+%define _build_id_links none
+
+%install
+# Destination directories
+mkdir -p %{buildroot}%{_bindir}
+mkdir -p %{buildroot}%{_datadir}/%{name}
+mkdir -p %{buildroot}%{_datadir}/applications
+mkdir -p %{buildroot}%{_datadir}/appdata
+mkdir -p %{buildroot}%{_datadir}/mime/packages
+mkdir -p %{buildroot}%{_datadir}/pixmaps
+mkdir -p %{buildroot}%{_datadir}/bash-completion/completions
+mkdir -p %{buildroot}%{_datadir}/zsh/site-functions
+# Application
+cp -r usr/share/%{name}/* %{buildroot}%{_datadir}/%{name}
+ln -s %{_datadir}/%{name}/bin/%{name} %{buildroot}%{_bindir}/%{name}
+# Support files
+cp -r usr/share/applications/%{name}.desktop %{buildroot}%{_datadir}/applications
+cp -r usr/share/applications/%{name}-url-handler.desktop %{buildroot}%{_datadir}/applications
+cp -r usr/share/appdata/%{name}.appdata.xml %{buildroot}%{_datadir}/appdata
+cp -r usr/share/mime/packages/%{name}-workspace.xml %{buildroot}%{_datadir}/mime/packages/%{name}-workspace.xml
+cp -r usr/share/pixmaps/@@ICON@@.png %{buildroot}%{_datadir}/pixmaps
+# Shell completions
+cp usr/share/bash-completion/completions/%{name} %{buildroot}%{_datadir}/bash-completion/completions/%{name}
+cp usr/share/zsh/site-functions/_%{name} %{buildroot}%{_datadir}/zsh/site-functions/_%{name}
+
+%post
+# Remove the legacy bin command if this is the stable build
+if [ "%{name}" = "positron" ]; then
+	rm -f /usr/local/bin/positron
+fi
+
+# Register yum repository
+# TODO: #229: Enable once the yum repository is signed
+#if [ "@@NAME@@" != "code-oss" ]; then
+#	if [ -d "/etc/yum.repos.d" ]; then
+#		REPO_FILE=/etc/yum.repos.d/@@NAME@@.repo
+#		rm -f $REPO_FILE
+#		echo -e "[@@NAME@@]\nname=@@NAME_LONG@@\nbaseurl=@@UPDATEURL@@/api/rpm/@@QUALITY@@/@@ARCHITECTURE@@/rpm" > $REPO_FILE
+#	fi
+#fi
+
+# Install the desktop entry
+update-desktop-database &> /dev/null || :
+
+# Update mimetype database to pickup workspace mimetype
+update-mime-database %{_datadir}/mime &> /dev/null || :
+
+%postun
+# Uninstall the desktop entry
+update-desktop-database &> /dev/null || :
+
+# Update mimetype database for removed workspace mimetype
+update-mime-database %{_datadir}/mime &> /dev/null || :
+
+%files
+%defattr(-,root,root)
+%attr(4755, root, root) %{_datadir}/%{name}/chrome-sandbox
+
+%{_bindir}/%{name}
+%{_datadir}/%{name}/
+%{_datadir}/applications/%{name}.desktop
+%{_datadir}/applications/%{name}-url-handler.desktop
+%{_datadir}/appdata/%{name}.appdata.xml
+%{_datadir}/mime/packages/%{name}-workspace.xml
+%{_datadir}/pixmaps/@@ICON@@.png
+%{_datadir}/bash-completion/completions/%{name}
+%{_datadir}/zsh/site-functions/_%{name}


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/2897.

### Approach

- Add Positron-specific Debian and RedHat package metadata, and use it in the build process. 
- Use wholly separate control files rather than editing VS Code's (to help reduce merge conflicts).

### QA Notes

Positron doesn't have an email address, maintainer, or website yet. I've put in generic Posit placeholders for those fields. 

Though #2897 refers specifically to the `.deb` package, the same issue exists for the `.rpm` package, and that's addressed here as well. Both should be verified.