### PR TITLE
Fix R installation logging for not current and not orthogonal

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -82,7 +82,7 @@ export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRun
 		})
 		.filter(r => {
 			if (!(r.current || r.orthogonal)) {
-				console.log(`Filtering out ${r.binpath}: not current and also not orthogonal.`);
+				LOGGER.info(`Filtering out ${r.binpath}: not current and also not orthogonal.`);
 				return false;
 			}
 			return true;

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -74,15 +74,15 @@ export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRun
 			return true;
 		})
 		.filter(r => {
-			if (!r.supported) {
-				LOGGER.info(`Filtering out ${r.binpath}: version is < ${MINIMUM_R_VERSION}`);
+			if (!(r.current || r.orthogonal)) {
+				LOGGER.info(`Filtering out ${r.binpath}: not current and also not orthogonal.`);
 				return false;
 			}
 			return true;
 		})
 		.filter(r => {
-			if (!(r.current || r.orthogonal)) {
-				LOGGER.info(`Filtering out ${r.binpath}: not current and also not orthogonal.`);
+			if (!r.supported) {
+				LOGGER.info(`Filtering out ${r.binpath}: version is < ${MINIMUM_R_VERSION}`);
 				return false;
 			}
 			return true;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

- Address: https://github.com/posit-dev/positron/issues/2960
- Related: https://github.com/posit-dev/positron/issues/2942

#### Before
<img width="1000" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/57ccf333-e226-4574-ba61-d769dbdae692">

#### After
<img width="1000" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/cf13d69b-c321-496c-8e8a-5cd39eb0ea28">

### Approach

- change the `console.log` to `LOGGER.info` so that the message is printed to `Output > Positron R Extension` instead of to the console
- reorder the filtering so that the "...not current and also not orthogonal" message is printed instead of the "...version is < 4.2"

### QA Notes

The above expected output should show in `Output > Positron R Extension`. See repro steps in https://github.com/posit-dev/positron/issues/2960.
