### PR TITLE
Install Pandoc in a subfolder

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -290,9 +290,13 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 		const positronApi = gulp.src('src/positron-dts/positron.d.ts')
 			.pipe(rename('out/positron-dts/positron.d.ts'));
 
-		// Bundled Pandoc binary
+		// Bundled Pandoc binary. Place this in a `pandoc` subfolder of `bin`
+		// since `bin` can be placed in the $PATH, and we don't want to pollute
+		// the $PATH with the Pandoc binary.
 		const pandocExt = process.platform === 'win32' ? '.exe' : '';
-		const binFolder = process.platform === 'darwin' ? 'bin' : path.join('..', '..', 'bin');
+		const binFolder = process.platform === 'darwin' ?
+			path.join('bin', 'pandoc') :
+			path.join('..', '..', 'bin', 'pandoc');
 		const pandoc = getPandocStream()
 			.pipe(rename(path.join(binFolder, `pandoc${pandocExt}`)))
 			.pipe(util.setExecutableBit());

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -679,7 +679,9 @@ export function createJupyterKernelSpec(
 	// On MacOS, the binary path lives alongside the app bundle; on other
 	// platforms, it's a couple of directories up from the app root.
 	const pandocPath = path.join(vscode.env.appRoot,
-		process.platform === 'darwin' ? 'bin' : path.join('..', '..', 'bin'));
+		process.platform === 'darwin' ?
+			path.join('bin', 'pandoc') :
+			path.join('..', '..', 'bin', 'pandoc'));
 	if (existsSync(pandocPath)) {
 		env['RSTUDIO_PANDOC'] = pandocPath;
 	}


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/2921.

### Approach

Instead of installing Pandoc into the same `bin` folder as the main app binary, install it in a subfolder called `pandoc`. 

### QA Notes

In R, Positron sets the environment variable `RSTUDIO_PANDOC` to the location of the bundled Pandoc binary. Make sure this value is still set and points to a working copy of Pandoc. 