### PR TITLE
Try to detect recent RStudio usage on Windows

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -458,14 +458,26 @@ function isRStudioUser(): boolean {
 }
 
 /**
- * Returns the path to RStudio's state folder directory. Doesn't currently work
- * on Windows; see XDG specification for the correct path there.
+ * Returns the path to RStudio's state folder directory. Currently checks only the default for each
+ * OS. A more earnest effort would require fully implementing the logic in RStudio's `userDataDir()`
+ * functions (there are implementations in both C++ and Typescript). That would add logic to
+ * check the variables RSTUDIO_DATA_HOME and XDG_DATA_HOME.
  *
  * @param pathToAppend The path to append, if any
  * @returns The path to RStudio's state folder directory.
  */
 function rstudioStateFolderPath(pathToAppend = ''): string {
-	// TODO: Windows
-	const newPath = path.join(process.env.HOME!, '.local/share/rstudio', pathToAppend);
+	let newPath: string;
+	switch (process.platform) {
+		case 'darwin':
+		case 'linux':
+			newPath = path.join(process.env.HOME!, '.local/share/rstudio', pathToAppend);
+			break;
+		case 'win32':
+			newPath = path.join(process.env.LOCALAPPDATA!, 'RStudio', pathToAppend);
+			break;
+		default:
+			throw new Error('Unsupported platform');
+	}
 	return newPath;
 }

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -448,12 +448,11 @@ function isRStudioUser(): boolean {
 		const filenames = fs.readdirSync(rstudioStateFolderPath());
 		const today = new Date();
 		const thirtyDaysAgo = new Date(new Date().setDate(today.getDate() - 30));
-		const recentlyModified = new Array<boolean>();
-		filenames.forEach(file => {
+		const isRecentlyModified = filenames.some(file => {
 			const stats = fs.statSync(rstudioStateFolderPath(file));
-			recentlyModified.push(stats.mtime > thirtyDaysAgo);
+			return stats.mtime > thirtyDaysAgo;
 		});
-		return recentlyModified.some(bool => bool === true);
+		return isRecentlyModified;
 	} catch { }
 	return false;
 }


### PR DESCRIPTION
Addresses #2518 

### Intent

When the workspace doesn't provide any signals re "is this an R user?", positron-r might still recommend firing up an R runtime if we find evidence of recent RStudio usage on the machine. We should include Windows users in this.

### Approach

We now do this on Windows, with exactly the same level of effort as on *nix. We look in the most likely RStudio state folder, but don't implement the full-blown strategy actually implemented in RStudio, which consults an RStudio-specific environment variable and an XDG directory.

### QA Notes

Be on Windows and make sure you've used RStudio recently (within the past 30 days). Launch Positron and do "New folder" and check "open in new window". Once the new Positron window opens, in this new empty folder, you should see R fire up in the Console.

Also, I have confirmed that R does _not_ fire up in this scenario with, e.g. the release build below. So I've confirmed the before and after.

Positron Version: 2024.04.0 (system setup) build 2024.04.0-1579
Code - OSS Version: 1.88.0
Commit: 2d5b6ee8b11890d5176f25c37588f76354db3992
Date: 2024-05-01T03:15:10.182Z
Electron: 28.2.8
Chromium: 120.0.6099.291
Node.js: 18.18.2
V8: 12.0.267.19-electron.0
OS: Windows_NT x64 10.0.20348
