### PR TITLE
Exclude Positron dev extensions from package stream

### DIFF
--- a/build/gulpfile.reh.js
+++ b/build/gulpfile.reh.js
@@ -259,6 +259,14 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
 				}
 			}
 		};
+		// --- Start Positron ---
+		const excludedExtensions = [
+			'vscode-api-tests',
+			'vscode-test-resolver',
+			'positron-zed',
+			'positron-javascript',
+		];
+		// --- End Positron ---
 		const localWorkspaceExtensions = glob.sync('extensions/*/package.json')
 			.filter((extensionPath) => {
 				if (type === 'reh-web') {
@@ -270,7 +278,11 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
 				const manifest = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, extensionPath)).toString());
 				return !isUIExtension(manifest);
 			}).map((extensionPath) => path.basename(path.dirname(extensionPath)))
-			.filter(name => name !== 'vscode-api-tests' && name !== 'vscode-test-resolver'); // Do not ship the test extensions
+			// --- Start Positron ---
+			// Add Positron dev extensions to the list that we don't ship with the REH
+			// .filter(name => name !== 'vscode-api-tests' && name !== 'vscode-test-resolver'); // Do not ship the test extensions
+			.filter(name => excludedExtensions.indexOf(name) === -1);
+		// --- End Positron ---
 		const marketplaceExtensions = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'product.json'), 'utf8')).builtInExtensions
 			.filter(entry => !entry.platforms || new Set(entry.platforms).has(platform))
 			.filter(entry => !entry.clientOnly)

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -299,8 +299,10 @@ const excludedExtensions = [
 	'vscode-test-resolver',
 	'ms-vscode.node-debug',
 	'ms-vscode.node-debug2',
+	// --- Start Positron ---
 	'positron-zed',
 	'positron-javascript',
+	// --- End Positron ---
 ];
 
 const marketplaceWebExtensionsExclude = new Set([

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -299,6 +299,8 @@ const excludedExtensions = [
 	'vscode-test-resolver',
 	'ms-vscode.node-debug',
 	'ms-vscode.node-debug2',
+	'positron-zed',
+	'positron-javascript',
 ];
 
 const marketplaceWebExtensionsExclude = new Set([


### PR DESCRIPTION
### Intent

Addresses #2923.

### Approach

Use a similar pattern to extensions like `vscode-api-tests` that are compiled in dev builds but aren't part of a release: add our extensions to a set of exclusions that are not included when packaging the set of local extensions.

### QA Notes

You may still see `positron-zed` and `positron-javascript` artifacts in the release bundles. The goal of this change is to prevent them from attempting to activate and causing errors. 