### PR TITLE
`%connection_show` register a variable path

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -158,7 +158,10 @@ class ConnectionsService:
         self.comm_id_to_path: Dict[str, Set[PathKey]] = {}
 
     def register_connection(
-        self, connection: Any, variable_path: Optional[List[str]] = None, display_pane: bool = True
+        self,
+        connection: Any,
+        variable_path: Optional[List[str] | str] = None,
+        display_pane: bool = True,
     ) -> str:
         """
         Opens a connection to the given data source.
@@ -216,9 +219,14 @@ class ConnectionsService:
 
         return comm_id
 
-    def _register_variable_path(self, variable_path: Optional[List[str]], comm_id: str) -> None:
+    def _register_variable_path(
+        self, variable_path: Optional[List[str] | str], comm_id: str
+    ) -> None:
         if variable_path is None:
             return
+
+        if isinstance(variable_path, str):
+            variable_path = [encode_access_key(variable_path)]
 
         if not isinstance(variable_path, list):
             raise ValueError(variable_path)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -23,12 +23,7 @@ from ipykernel.zmqshell import ZMQDisplayPublisher, ZMQInteractiveShell
 from IPython.core import magic_arguments, oinspect, page
 from IPython.core.error import UsageError
 from IPython.core.interactiveshell import ExecutionInfo, InteractiveShell
-from IPython.core.magic import (
-    Magics,
-    MagicsManager,
-    line_magic,
-    magics_class,
-)
+from IPython.core.magic import Magics, MagicsManager, line_magic, magics_class
 from IPython.utils import PyColorize
 
 from .connections import ConnectionsService
@@ -184,7 +179,9 @@ class PositronMagics(Magics):
             raise UsageError(f"name '{args.object}' is not defined")
 
         try:
-            self.shell.kernel.connections_service.register_connection(info.obj)
+            self.shell.kernel.connections_service.register_connection(
+                info.obj, variable_path=args.object
+            )
         except TypeError:
             raise UsageError(f"cannot show object of type '{get_qualname(info.obj)}'")
 


### PR DESCRIPTION
Makes sure connections are then tracked by the variables pane and can be displayed as 'closed' when the connection is closed with eg `conn.close()`.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

Addresses #2977 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

Connections opened with `%connection_show conn` are now tracked in the variables pane, thus they can be m,arket as disconnected when the user calls `connection.close()` on them.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
