### PR TITLE
Remove redundant failover status indicator in the Data Explorer

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.tsx
@@ -119,9 +119,6 @@ export const StatusBar = () => {
 				<span className='counter'>{numColumns.toLocaleString()}</span>
 				<span>&nbsp;</span>
 				<span className='label'>columns</span>
-				<StatusBarActivityIndicator
-					status={clientStatus}
-				/>
 			</div>
 		);
 	} else {


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/2976.

### Approach

Remove backup status indicator.

### QA Notes

It's now necessary to look on the left hand side of the status bar to see the indicator, as the redundant failover status indicator in the right hand side has been removed in this change. 