### PR TITLE
Correctly refer to store key when discarding a connection

### DIFF
--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -393,7 +393,7 @@ export class ConnectionItemsProvider
 		// they key is a combination of the language_id, host and the type, so we can identify the
 		// connection uniquely
 		this.context.workspaceState.update(
-			`language_id-${conn.metadata.language_id}-host-${conn.metadata.host}-type-${conn.metadata.type}`,
+			makeConnectionKey(conn.metadata),
 			conn.metadata
 		);
 
@@ -501,7 +501,7 @@ export class ConnectionItemsProvider
 	 * @param item The connection to remove
 	 */
 	removeFromHistory(item: DisconnectedConnectionItem) {
-		this.context.workspaceState.update(item.name, undefined);
+		this.context.workspaceState.update(makeConnectionKey(item.metadata), undefined);
 		this._connections = this._connections.filter((connection) => {
 			return !compareConnectionsMetadata(connection.metadata, item.metadata);
 		});
@@ -577,4 +577,8 @@ function compareConnectionsMetadata(a: ConnectionMetadata, b: ConnectionMetadata
 	return a.language_id === b.language_id &&
 		a.host === b.host &&
 		a.type === b.type;
+}
+
+function makeConnectionKey(metadata: ConnectionMetadata): string {
+	return `language_id-${metadata.language_id}-host-${metadata.host}-type-${metadata.type}`;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

Address https://github.com/posit-dev/positron/issues/2979

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

The error was caused by incorrecly refering to the name of the connection when discarding it instead of using a combination of metadata attributes tthat was used when registering the connection.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
