### PR TITLE
Project Wizard: allow more than one runtime source filter

### DIFF
--- a/src/vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums.ts
@@ -54,8 +54,8 @@ export enum NewProjectType {
  * PythonRuntimeFilter enum.
  */
 export enum PythonRuntimeFilter {
-	All = 'All',        // Include all runtimes. This is when an existing Python installation is to be used.
-	Global = 'Global',  // Include only global runtimes. This is when a new Venv environment is being created.
+	Global = 'Global',
+	Pyenv = 'Pyenv'
 }
 
 /**

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/interpreterDropDownUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/interpreterDropDownUtils.ts
@@ -39,7 +39,9 @@ const includeRuntimeSource = (
 	filters?: RuntimeFilter[]
 ) => {
 	return (
-		!filters || !filters.length || filters.find((rs) => rs === runtimeSource) !== undefined
+		!filters ||
+		!filters.length ||
+		filters.find((rs) => rs === runtimeSource) !== undefined
 	);
 };
 
@@ -60,33 +62,43 @@ export const getInterpreterDropdownItems = (
 ) => {
 	// Return the DropDownListBoxEntry array.
 	return languageRuntimeService.registeredRuntimes
-		.filter(runtime => runtime.languageId === languageId &&
-			includeRuntimeSource(runtime.runtimeSource, runtimeSourceFilters)
+		.filter(
+			(runtime) =>
+				runtime.languageId === languageId &&
+				includeRuntimeSource(runtime.runtimeSource, runtimeSourceFilters)
 		)
-		.sort((left, right) => left.runtimeSource.localeCompare(right.runtimeSource))
+		.sort((left, right) =>
+			left.runtimeSource.localeCompare(right.runtimeSource)
+		)
 		.reduce<DropDownListBoxEntry<string, InterpreterInfo>[]>(
 			(entries, runtime, index, runtimes) => {
 				// Perform break processing when the runtime source changes.
-				if (index && runtimes[index].runtimeSource !== runtimes[index - 1].runtimeSource) {
+				if (
+					index &&
+					runtimes[index].runtimeSource !== runtimes[index - 1].runtimeSource
+				) {
 					entries.push(new DropDownListBoxSeparator());
 				}
 
 				// Push the DropDownListBoxItem.
-				entries.push(new DropDownListBoxItem<string, InterpreterInfo>({
-					identifier: runtime.runtimeId,
-					value: {
-						preferred: runtime.runtimeId === preferredRuntimeId,
-						runtimeId: runtime.runtimeId,
-						languageName: runtime.languageName,
-						languageVersion: runtime.languageVersion,
-						runtimePath: runtime.runtimePath,
-						runtimeSource: runtime.runtimeSource
-					}
-				}));
+				entries.push(
+					new DropDownListBoxItem<string, InterpreterInfo>({
+						identifier: runtime.runtimeId,
+						value: {
+							preferred: runtime.runtimeId === preferredRuntimeId,
+							runtimeId: runtime.runtimeId,
+							languageName: runtime.languageName,
+							languageVersion: runtime.languageVersion,
+							runtimePath: runtime.runtimePath,
+							runtimeSource: runtime.runtimeSource,
+						},
+					})
+				);
 
 				// Return the entries for the next iteration.
 				return entries;
-			}, []
+			},
+			[]
 		);
 };
 
@@ -96,7 +108,10 @@ export const getInterpreterDropdownItems = (
  * @param languageId The languageId of the runtime to retrieve.
  * @returns The preferred interpreter or undefined if no preferred runtime is found.
  */
-export const getPreferredRuntime = (runtimeStartupService: IRuntimeStartupService, languageId: LanguageIds) => {
+export const getPreferredRuntime = (
+	runtimeStartupService: IRuntimeStartupService,
+	languageId: LanguageIds
+) => {
 	let preferredRuntime;
 	try {
 		preferredRuntime = runtimeStartupService.getPreferredRuntime(languageId);
@@ -120,7 +135,7 @@ const isInterpreterInDropdown = (
 	if (!interpreter || !interpreterEntries.length) {
 		return false;
 	}
-	return interpreterEntries.find(entry => {
+	return interpreterEntries.find((entry) => {
 		if (entry instanceof DropDownListBoxItem) {
 			return entry.options.identifier === interpreter.runtimeId;
 		}
@@ -150,7 +165,10 @@ export const getSelectedInterpreter = (
 	}
 
 	// Return the preferred interpreter if it is in the dropdown list.
-	const preferredInterpreter = getPreferredRuntime(runtimeStartupService, languageId);
+	const preferredInterpreter = getPreferredRuntime(
+		runtimeStartupService,
+		languageId
+	);
 	if (isInterpreterInDropdown(preferredInterpreter, interpreterEntries)) {
 		return preferredInterpreter;
 	}

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/interpreterDropDownUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/interpreterDropDownUtils.ts
@@ -28,24 +28,40 @@ export interface InterpreterInfo {
 }
 
 /**
+ * Determines if the runtime source should be included based on the filters.
+ * @param runtimeSource The runtime source to check.
+ * @param filters The runtime source filters to apply.
+ * @returns True if the runtime source should be included, false otherwise.
+ * If no filters are provided, all runtime sources are included.
+ */
+const includeRuntimeSource = (
+	runtimeSource: string,
+	filters?: RuntimeFilter[]
+) => {
+	return (
+		!filters || !filters.length || filters.find((rs) => rs === runtimeSource) !== undefined
+	);
+};
+
+/**
  * Retrieves the detected interpreters as DropDownListBoxItems, filtering and grouping the list by
  * runtime source if requested.
  * @param languageRuntimeService The language runtime service.
  * @param languageId The language ID of the runtime to retrieve interpreters for.
  * @param preferredRuntimeId The runtime ID of the preferred interpreter.
- * @param runtimeSourceFilter The runtime source filter to apply to the runtimes.
+ * @param runtimeSourceFilters The runtime source filters to apply to the runtimes.
  * @returns An array of DropDownListBoxEntry for the interpreters.
  */
 export const getInterpreterDropdownItems = (
 	languageRuntimeService: ILanguageRuntimeService,
 	languageId: LanguageIds,
 	preferredRuntimeId: string,
-	runtimeSourceFilter?: RuntimeFilter
+	runtimeSourceFilters?: RuntimeFilter[]
 ) => {
 	// Return the DropDownListBoxEntry array.
 	return languageRuntimeService.registeredRuntimes
 		.filter(runtime => runtime.languageId === languageId &&
-			(!runtimeSourceFilter || runtime.runtimeSource === runtimeSourceFilter)
+			includeRuntimeSource(runtime.runtimeSource, runtimeSourceFilters)
 		)
 		.sort((left, right) => left.runtimeSource.localeCompare(right.runtimeSource))
 		.reduce<DropDownListBoxEntry<string, InterpreterInfo>[]>(

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils.ts
@@ -21,13 +21,14 @@ export interface PythonEnvironmentTypeInfo {
  * list by runtime source if requested.
  * @param runtimeStartupService The runtime startup service.
  * @param languageRuntimeService The language runtime service.
- * @param pythonRuntimeFilter The PythonRuntimeFilter to apply to the Python runtimes.
+ * @param pythonRuntimeFilters The PythonRuntimeFilters to apply to the Python runtimes.
  * @returns An array of DropDownListBoxEntry for Python interpreters.
  */
 const getPythonInterpreterDropDownItems = (
 	runtimeStartupService: IRuntimeStartupService,
 	languageRuntimeService: ILanguageRuntimeService,
-	pythonRuntimeFilter = PythonRuntimeFilter.All
+	pythonRuntimeFilters?: PythonRuntimeFilter[]
+
 ) => {
 	const languageId = LanguageIds.Python;
 	const preferredRuntime = runtimeStartupService.getPreferredRuntime(languageId);
@@ -36,7 +37,7 @@ const getPythonInterpreterDropDownItems = (
 		languageRuntimeService,
 		languageId,
 		preferredRuntime?.runtimeId,
-		pythonRuntimeFilter === PythonRuntimeFilter.All ? undefined : PythonRuntimeFilter.Global
+		pythonRuntimeFilters
 	);
 };
 
@@ -86,7 +87,7 @@ export const getPythonInterpreterEntries = (
 					return getPythonInterpreterDropDownItems(
 						runtimeStartupService,
 						languageRuntimeService,
-						PythonRuntimeFilter.Global
+						[PythonRuntimeFilter.Global, PythonRuntimeFilter.Pyenv]
 					);
 				case PythonEnvironmentType.Conda:
 					return createCondaInterpreterDropDownItems();
@@ -94,14 +95,12 @@ export const getPythonInterpreterEntries = (
 					return getPythonInterpreterDropDownItems(
 						runtimeStartupService,
 						languageRuntimeService,
-						PythonRuntimeFilter.All
 					);
 			}
 		case EnvironmentSetupType.ExistingEnvironment:
 			return getPythonInterpreterDropDownItems(
 				runtimeStartupService,
 				languageRuntimeService,
-				PythonRuntimeFilter.All
 			);
 		default:
 			return [];

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils.ts
@@ -28,10 +28,10 @@ const getPythonInterpreterDropDownItems = (
 	runtimeStartupService: IRuntimeStartupService,
 	languageRuntimeService: ILanguageRuntimeService,
 	pythonRuntimeFilters?: PythonRuntimeFilter[]
-
 ) => {
 	const languageId = LanguageIds.Python;
-	const preferredRuntime = runtimeStartupService.getPreferredRuntime(languageId);
+	const preferredRuntime =
+		runtimeStartupService.getPreferredRuntime(languageId);
 
 	return getInterpreterDropdownItems(
 		languageRuntimeService,
@@ -50,18 +50,20 @@ export const createCondaInterpreterDropDownItems = () => {
 	// TODO: we should get the list of Python versions from the Conda service
 	const pythonVersions = ['3.12', '3.11', '3.10', '3.9', '3.8'];
 	const condaRuntimes: DropDownListBoxItem<string, InterpreterInfo>[] = [];
-	pythonVersions.forEach(version => {
-		condaRuntimes.push(new DropDownListBoxItem<string, InterpreterInfo>({
-			identifier: `conda-python-${version}`,
-			value: {
-				preferred: version === '3.12',
-				runtimeId: `conda-python-${version}`,
-				languageName: 'Python',
-				languageVersion: version,
-				runtimePath: '',
-				runtimeSource: 'Conda'
-			}
-		}));
+	pythonVersions.forEach((version) => {
+		condaRuntimes.push(
+			new DropDownListBoxItem<string, InterpreterInfo>({
+				identifier: `conda-python-${version}`,
+				value: {
+					preferred: version === '3.12',
+					runtimeId: `conda-python-${version}`,
+					languageName: 'Python',
+					languageVersion: version,
+					runtimePath: '',
+					runtimeSource: 'Conda',
+				},
+			})
+		);
 	});
 	return condaRuntimes;
 };
@@ -94,13 +96,13 @@ export const getPythonInterpreterEntries = (
 				default:
 					return getPythonInterpreterDropDownItems(
 						runtimeStartupService,
-						languageRuntimeService,
+						languageRuntimeService
 					);
 			}
 		case EnvironmentSetupType.ExistingEnvironment:
 			return getPythonInterpreterDropDownItems(
 				runtimeStartupService,
-				languageRuntimeService,
+				languageRuntimeService
 			);
 		default:
 			return [];
@@ -122,11 +124,12 @@ export const locationForNewEnv = (
 ) => {
 	// TODO: this only works for Venv and Conda environments. We'll need to expand on this to add
 	// support for other environment types.
-	const envDir = envType === PythonEnvironmentType.Venv
-		? '.venv'
-		: envType === PythonEnvironmentType.Conda
-			? '.conda'
-			: '';
+	const envDir =
+		envType === PythonEnvironmentType.Venv
+			? '.venv'
+			: envType === PythonEnvironmentType.Conda
+				? '.conda'
+				: '';
 	return `${parentFolder}/${projectName}/${envDir}`;
 };
 
@@ -142,15 +145,16 @@ export const getEnvTypeEntries = () => {
 			identifier: PythonEnvironmentType.Venv,
 			value: {
 				envType: PythonEnvironmentType.Venv,
-				envDescription: 'Creates a `.venv` virtual environment for your project'
-			}
+				envDescription:
+					'Creates a `.venv` virtual environment for your project',
+			},
 		}),
 		new DropDownListBoxItem<PythonEnvironmentType, PythonEnvironmentTypeInfo>({
 			identifier: PythonEnvironmentType.Conda,
 			value: {
 				envType: PythonEnvironmentType.Conda,
-				envDescription: 'Creates a `.conda` Conda environment for your project'
-			}
-		})
+				envDescription: 'Creates a `.conda` Conda environment for your project',
+			},
+		}),
 	];
 };


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

- Address #2982 

#### Local Testing Preview
<img width="500" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/85972c10-514b-47f7-8633-f90ac473c257">

### Approach

- Refactors the runtime source filtering to allow more than one runtime source type, so that the new `Venv` environment interpreter dropdown can include interpreters from both `Global` and `Pyenv` runtime sources
- Remove the `PythonRuntimeFilter.All` filter and instead handle if `undefined` or `[]` is passed for the filters (no filters means include all)

### QA Notes

For Python/Jupyter, the existing interpreter and new Conda environment interpreter dropdowns should still show the expected interpreters.

The R interpreters dropdown should be unaffected by this change.
