### PR TITLE
Mark positron-r and positron-zed as private; don't bundle

### DIFF
--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -129,20 +129,6 @@ const tasks = compilations.map(function (tsconfigFile) {
 			// --- Start Positron ---
 			// Add '**/*.tsx'.
 			const tsFilter = filter(['**/*.ts', '**/*.tsx', '!**/lib/lib*.d.ts', '!**/node_modules/**'], { restore: true, dot: true });
-			// Check if the extension has defined a bundle-dev task to be run
-			let needsBundling = false;
-			const absoluteExtPath = path.join(root, relativeDirname);
-			const metadataPath = path.join(absoluteExtPath, 'package.json');
-			const webpackConfigPath = path.join(absoluteExtPath, 'extension.webpack.config.js');
-
-			const fs = require('fs');
-			const webpack = require('webpack-stream');
-			const compiler = require('webpack');
-
-			if (fs.existsSync(metadataPath)) {
-				const scripts = JSON.parse(fs.readFileSync(metadataPath).toString('utf8')).scripts;
-				needsBundling = 'bundle-dev' in scripts && process.env.NODE_ENV !== 'production';
-			}
 			// --- End Positron ---
 			const output = input
 				.pipe(plumber({
@@ -169,20 +155,6 @@ const tasks = compilations.map(function (tsconfigFile) {
 				.pipe(build ? nlsDev.bundleMetaDataFiles(headerId, headerOut) : es.through())
 				// Filter out *.nls.json file. We needed them only to bundle meta data file.
 				.pipe(filter(['**', '!**/*.nls.json'], { dot: true }))
-				// --- Start Positron ---
-				.pipe(needsBundling
-					? webpack({
-						...require(webpackConfigPath),
-						mode: 'development',
-						devtool: 'eval-cheap-source-map',
-					}, compiler, function (_err, stats) {
-						// output some info about the compiled assets
-						console.log(stats.toString({ preset: 'minimal', colors: true }));
-						const outputPath = path.join(stats.compilation.options.context, 'out');
-						console.log(`Assets written to ${outputPath}`);
-					})
-					: es.through())
-				// --- End Positron ---
 				.pipe(reporter.end(emitError));
 
 			return es.duplex(input, output);

--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -268,6 +268,10 @@ const excludedExtensions = [
     'vscode-test-resolver',
     'ms-vscode.node-debug',
     'ms-vscode.node-debug2',
+    // --- Start Positron ---
+    'positron-zed',
+    'positron-javascript',
+    // --- End Positron ---
 ];
 const marketplaceWebExtensionsExclude = new Set([
     'ms-vscode.node-debug',
@@ -536,6 +540,11 @@ async function copyExtensionBinaries(outputRoot) {
         // be copied.  The Positron extension metadata lives in the
         // `positron.json` file in the extension's root directory.
         const binaryMetadata = (glob.sync('extensions/*/positron.json')
+            .filter(metadataPath => {
+            // Don't copy binaries for excluded extensions.
+            const extension = path.basename(path.dirname(metadataPath));
+            return excludedExtensions.indexOf(extension) === -1;
+        })
             .map(metadataPath => {
             // Read the metadata file.
             const metadata = JSON.parse(fs.readFileSync(metadataPath).toString('utf8'));

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -624,6 +624,11 @@ export async function copyExtensionBinaries(outputRoot: string) {
 		// `positron.json` file in the extension's root directory.
 		const binaryMetadata = (
 			(<string[]>glob.sync('extensions/*/positron.json'))
+				.filter(metadataPath => {
+					// Don't copy binaries for excluded extensions.
+					const extension = path.basename(path.dirname(metadataPath));
+					return excludedExtensions.indexOf(extension) === -1;
+				})
 				.map(metadataPath => {
 					// Read the metadata file.
 					const metadata = JSON.parse(fs.readFileSync(metadataPath).toString('utf8'));

--- a/extensions/positron-javascript/package.json
+++ b/extensions/positron-javascript/package.json
@@ -10,6 +10,7 @@
   "categories": [
     "Programming Languages"
   ],
+  "private": true,
   "activationEvents": [],
   "main": "./out/extension.js",
   "scripts": {

--- a/extensions/positron-zed/package.json
+++ b/extensions/positron-zed/package.json
@@ -11,6 +11,7 @@
     "Programming Languages"
   ],
   "main": "./out/extension.js",
+  "private": true,
   "activationEvents": [
     "onStartupFinished"
   ],


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/2923.

### Approach

The original problem (and the reason that the original PR did not fully address the issue) was that I hadn't built and committed the `extensions.js` change (files in the `build/` directory have a `.js` counterpart that must be manually built and committed when a change to the `.ts` file is made). However, while I was in there I made a few other tweaks:

- The `bundle-dev` task was only used for the Positron Data Viewer 1.0, now completely removed, so I've also removed the unused bundle-dev task.
- Resources are no longer copied for excluded extensions.

### QA Notes

See notes in #2923 