### PR TITLE
Remove old activation command

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -6,7 +6,6 @@ import * as nls from 'vs/nls';
 import { Emitter } from 'vs/base/common/event';
 import { ILogService } from 'vs/platform/log/common/log';
 import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
-import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { ILanguageRuntimeMetadata, ILanguageRuntimeService, formatLanguageRuntimeMetadata } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { Registry } from 'vs/platform/registry/common/platform';
@@ -119,8 +118,6 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 
 	//#endregion ILanguageRuntimeService Implementation
 }
-
-CommandsRegistry.registerCommand('positron.activateInterpreters', () => true);
 
 // Instantiate the language runtime service "eagerly", meaning as soon as a
 // consumer depdends on it. This fixes an issue where languages are encountered


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

This is the command I made for activating extensions in #1853 but we're not using this anymore so we can take it out.

### Approach

This is now dead code. I noticed it when working on #2944 but that PR was otherwise not the right approach.

### QA Notes

Check that the Python and R extensions come online as expected.