### PR TITLE
Create universal binary on production builder

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -148,7 +148,7 @@ jobs:
   macos-universal:
     name: Create macOS universal binary
     needs: [build-archs]
-    runs-on: [self-hosted, macos, arm64]
+    runs-on: [self-hosted-production, macos, arm64]
     timeout-minutes: 60
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Intent

The macOS universal binary build step is occasionally breaking because it is running on the EC2 builder.

### Approach

Only build the universal binary on the production build instance (MacInCloud)

### QA Notes

