### PR TITLE
remove smoke tests from checkin flow in gh actions

### DIFF
--- a/.github/workflows/positron-ci.yml
+++ b/.github/workflows/positron-ci.yml
@@ -55,9 +55,6 @@ jobs:
       - name: Compile Integration Tests
         run: yarn --cwd test/integration/browser compile
 
-      - name: Compile Smoke Tests
-        run: yarn --cwd test/smoke compile
-
       - name: Run Unit Tests (node.js)
         id: nodejs-unit-tests
         run: yarn test-node
@@ -65,23 +62,3 @@ jobs:
       - name: Run Integration Tests (Electron)
         id: electron-integration-tests
         run: DISPLAY=:10 ./scripts/test-integration.sh
-
-      - name: Add Python 3.10.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.10.12
-          cache: 'pip'
-
-      - name: Run Smoke Tests (Electron)
-        env:
-          POSITRON_PY_VER_SEL: 3.10.12 (Global)
-          POSITRON_R_VER_SEL: R 4.3.3
-        id: electron-smoke-tests
-        run: DISPLAY=:10 yarn smoketest-no-compile --tracing
-
-      - name: Upload smoke test run log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: smoke-test-runner.log
-          path: .build/logs/smoke-tests-electron/smoke-test-runner.log


### PR DESCRIPTION
### Intent

> Remove smoke tests from checkin flow.  There is a flaky test that I need to get worked out.  I will add the smoke tests back once they have successfully passed for some time running nightly.

### Approach

> Minor change to github actions to remove smoke tests for positron-ci.yml

### QA Notes

> Removing flaky QA tests.  No QA required.
