### PR TITLE
Add remote extension host release asset

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -181,3 +181,15 @@ jobs:
           asset_path: Positron-${{ needs.version_string.outputs.short_version }}.rpm
           asset_name: Positron-${{ needs.version_string.outputs.short_version }}.rpm
           asset_content_type: application/octet-stream
+
+      - name: Upload Linux Remote Extension Host release asset
+        uses: actions/upload-release-asset@v1
+        if: github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.releases.outputs.upload_url }}
+          asset_path: positron-reh-linux-x64-${{ needs.version_string.outputs.short_version }}.tar.gz
+          asset_name: positron-reh-linux-x64-${{ needs.version_string.outputs.short_version }}.tar.gz
+          asset_content_type: application/octet-stream
+


### PR DESCRIPTION
### Intent

Adds the Remote Extension Host (REH) to the set of release assets, in order to make the binary URL addressable. 

### Approach

Create a new release asset from the `positron-reh-linux` build work (which is already done).

### QA Notes

Just adds a new binary asset; no QA needed at this time.