### PR TITLE
Make it possible to add "or" filters to the Data Explorer

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -733,6 +733,36 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			onAccept={applyRowFilter}
 		>
 			<div className='add-edit-row-filter-modal-popup-body'>
+				{!props.isFirstFilter &&
+					<DropDownListBox
+						onSelectionChanged={() => { }}
+						keybindingService={props.renderer.keybindingService}
+						layoutService={props.renderer.layoutService}
+						title={(() => localize(
+							'positron.addEditRowFilter.selectCombiningOperator',
+							"Select Combining Operator"
+						))()}
+						entries={[
+							new DropDownListBoxItem({
+								identifier: 'AND',
+								title: localize(
+									'positron.addEditRowFilter.combiningOperatorAnd',
+									"AND"
+								),
+								value: 'AND'
+							}),
+							new DropDownListBoxItem({
+								identifier: 'OR',
+								title: localize(
+									'positron.addEditRowFilter.combiningOperatorOr',
+									"OR"
+								),
+								value: 'OR'
+							})
+						]}
+						selectedIdentifier={selectedFilterType}
+					/>
+				}
 				<DropDownColumnSelector
 					keybindingService={props.renderer.keybindingService}
 					layoutService={props.renderer.layoutService}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -177,8 +177,8 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		props.editRowFilter?.props.errorMessage
 	);
 	const [selectedCondtion, setSelectedCondition] =
-		useState<RowFilterCondition | undefined>(
-			props.editRowFilter?.props.condition
+		useState<RowFilterCondition>(
+			props.editRowFilter?.props.condition ?? RowFilterCondition.And
 		);
 
 	// useEffect for when the selectedFilterType changes.
@@ -775,7 +775,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 								identifier: RowFilterCondition.And,
 								title: localize(
 									'positron.addEditRowFilter.conditionAnd',
-									"AND"
+									"and"
 								),
 								value: RowFilterCondition.And,
 							}),
@@ -783,7 +783,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 								identifier: RowFilterCondition.Or,
 								title: localize(
 									'positron.addEditRowFilter.conditionOr',
-									"OR"
+									"or"
 								),
 								value: RowFilterCondition.Or
 							})

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -135,6 +135,7 @@ interface AddEditRowFilterModalPopupProps {
 	dataExplorerClientInstance: DataExplorerClientInstance;
 	renderer: PositronModalReactRenderer;
 	anchor: HTMLElement;
+	isFirstFilter: boolean;
 	editRowFilter?: RowFilterDescriptor;
 	onApplyRowFilter: (rowFilter: RowFilterDescriptor) => void;
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
@@ -45,6 +45,9 @@ export enum RowFilterDescrType {
  * Common properties for row filters.
  */
 interface RowFilterCommonProps {
+	/** The combining operator  */
+	readonly condition: RowFilterCondition;
+
 	/** The column schema */
 	readonly columnSchema: ColumnSchema;
 
@@ -599,7 +602,8 @@ export function getRowFilterDescriptor(backendFilter: RowFilter): RowFilterDescr
 	const commonProps = {
 		columnSchema: backendFilter.column_schema,
 		isValid: backendFilter.is_valid,
-		errorMessage: backendFilter.error_message
+		errorMessage: backendFilter.error_message,
+		condition: backendFilter.condition
 	};
 	switch (backendFilter.filter_type) {
 		case RowFilterType.Compare: {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
@@ -41,9 +41,17 @@ export enum RowFilterDescrType {
 	IS_NOT_BETWEEN = 'is-not-between'
 }
 
+/**
+ * Common properties for row filters.
+ */
 interface RowFilterCommonProps {
+	/** The column schema */
 	readonly columnSchema: ColumnSchema;
+
+	/** The filter validity, if known */
 	readonly isValid?: boolean;
+
+	/** For an invalid filter, the error message */
 	readonly errorMessage?: string;
 }
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
@@ -90,7 +90,7 @@ abstract class BaseRowFilterDescriptor {
 		return {
 			filter_id: this.identifier,
 			column_schema: this.props.columnSchema,
-			condition: RowFilterCondition.And
+			condition: this.props.condition
 		};
 	}
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget.tsx
@@ -25,13 +25,14 @@ import {
 	RowFilterDescriptorIsTrue,
 	RowFilterDescriptorSearch
 } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
+import { RowFilterCondition } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * RowFilterWidgetProps interface.
  */
 interface RowFilterWidgetProps {
 	rowFilter: RowFilterDescriptor;
-	booleanOperator?: 'and';
+	booleanOperator?: RowFilterCondition;
 	onEdit: () => void;
 	onClear: () => void;
 }
@@ -142,7 +143,10 @@ export const RowFilterWidget = forwardRef<HTMLButtonElement, RowFilterWidgetProp
 		>
 			{props.booleanOperator &&
 				<div className='boolean-operator'>
-					{localize('positron.dataExplorer.rowFilterWidget.and', "and")}
+					{props.rowFilter.props.condition === RowFilterCondition.And ?
+						localize('positron.dataExplorer.rowFilterWidget.and', "and") :
+						localize('positron.dataExplorer.rowFilterWidget.or', "or")
+					}
 				</div>
 			}
 			<div className='title'>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -67,6 +67,8 @@ export const RowFilterBar = () => {
 
 	/**
 	 * Shows the add / edit row filter modal popup.
+	 * @param anchor The anchor element.
+	 * @param isFirstFilter Whether this is the first filter.
 	 * @param editRowFilterDescriptor The row filter to edit, or undefined, to add a row filter.
 	 */
 	const showAddEditRowFilterModalPopup = (
@@ -222,7 +224,7 @@ export const RowFilterBar = () => {
 						}}
 						key={index}
 						rowFilter={rowFilter}
-						booleanOperator={index ? 'and' : undefined}
+						booleanOperator={index === 0 ? undefined : rowFilter.props.condition}
 						onEdit={() => {
 							if (rowFilterWidgetRefs.current[index]) {
 								showAddEditRowFilterModalPopup(
@@ -238,7 +240,9 @@ export const RowFilterBar = () => {
 					ref={addFilterButtonRef}
 					className='add-row-filter-button'
 					ariaLabel={(() => localize('positron.dataExplorer.addFilter', "Add filter"))()}
-					onPressed={() => showAddEditRowFilterModalPopup(addFilterButtonRef.current)}
+					onPressed={() => showAddEditRowFilterModalPopup(addFilterButtonRef.current,
+						rowFilterDescriptors.length === 0
+					)}
 				>
 					<div className='codicon codicon-positron-add-filter' />
 				</Button>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -71,6 +71,7 @@ export const RowFilterBar = () => {
 	 */
 	const showAddEditRowFilterModalPopup = (
 		anchor: HTMLElement,
+		isFirstFilter: boolean = false,
 		editRowFilterDescriptor?: RowFilterDescriptor
 	) => {
 		// Create the renderer.
@@ -120,6 +121,7 @@ export const RowFilterBar = () => {
 				dataExplorerClientInstance={context.instance.dataExplorerClientInstance}
 				renderer={renderer}
 				anchor={anchor}
+				isFirstFilter={isFirstFilter}
 				editRowFilter={editRowFilterDescriptor}
 				onApplyRowFilter={applyRowFilterHandler}
 			/>
@@ -135,7 +137,9 @@ export const RowFilterBar = () => {
 		entries.push(new ContextMenuItem({
 			label: localize('positron.dataExplorer.addFilter', "Add filter"),
 			icon: 'positron-add-filter',
-			onSelected: () => showAddEditRowFilterModalPopup(rowFilterButtonRef.current)
+			onSelected: () => showAddEditRowFilterModalPopup(
+				rowFilterButtonRef.current,
+				rowFilterDescriptors.length === 0)
 		}));
 		entries.push(new ContextMenuSeparator());
 		if (!rowFiltersHidden) {
@@ -223,6 +227,7 @@ export const RowFilterBar = () => {
 							if (rowFilterWidgetRefs.current[index]) {
 								showAddEditRowFilterModalPopup(
 									rowFilterWidgetRefs.current[index],
+									index === 0,
 									rowFilter
 								);
 							}


### PR DESCRIPTION
### Intent

Adds the minimal amount of UI required to drive the "or" filter feature for R and Python.

<img width="563" alt="image" src="https://github.com/posit-dev/positron/assets/470418/5cf73b51-8d8e-496e-bf8c-1a24644bbd2e">

Addresses https://github.com/posit-dev/positron/issues/2984.

### Approach

Pretty straightforward plumbing of the `condition` value through the UI. The first filter is a special case; all other filters will let you pick "and" or "or", using a new drop box.

<img width="298" alt="image" src="https://github.com/posit-dev/positron/assets/470418/3622cdeb-b2ed-4713-a230-e55a55211939">

### QA Notes

- You can modify an existing filter's condition (making an "and" filter an "or" filter, for example)
- Creating an "or" filter introduces a new behavior wherein the order of filters matters, because the "or" can re-select rows that were previously unselected. 
- You should never see any UI that suggests that you can add an and/or condition to the _first_ filter on the table. 