### PR TITLE
Remove DPI from plot saving

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.css
@@ -18,11 +18,10 @@
 .plot-preview-input .plot-input {
 	grid-area: plot-input;
 	display: grid;
-	grid-template-columns: repeat(3, auto);
+	grid-template-columns: repeat(3, 1fr);
 	grid-template-areas:
 		"input input input"
 		"error error error";
-	justify-content: space-between;
 }
 
 .plot-input input {

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -117,6 +117,9 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 		filterEntries.push({ extensions: [filter.toLowerCase()], name: filter.toUpperCase() });
 	}
 
+	// hide DPI as it may be configurable for PDF in the future
+	const enableDPI = false;
+
 	React.useEffect(() => {
 		setUri(props.plotClient.lastRender?.uri ?? '');
 	}, [props.plotClient.lastRender?.uri]);
@@ -306,7 +309,7 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 								min={1}
 								error={!height.valid}
 							/>
-							<LabeledTextInput
+							{enableDPI && <LabeledTextInput
 								label={(() => localize(
 									'positron.savePlotModalDialog.dpi',
 									"DPI"
@@ -317,7 +320,7 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 								min={1}
 								max={300}
 								error={!dpi.valid}
-							/>
+							/>}
 							<div className='error'>
 								<div>
 									{!directory.valid && (() => localize(


### PR DESCRIPTION
### Intent
Address feedback in #2657 

### Approach
Hides DPI and uses the default 100 DPI for saving.

![image](https://github.com/posit-dev/positron/assets/9591545/4fa6359b-e1b0-4130-b43e-578ce7b2af0f)

### QA Notes
Hiding DPI leaves it open to reuse this input in the future for PDF specific saving.