### PR TITLE
Fix default save plot path

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -106,8 +106,12 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	const zoomPlotHandler = (zoomLevel: number) => {
 		props.zoomHandler(zoomLevel);
 	};
-	const savePlotHandler = async () => {
-		positronPlotsContext.positronPlotsService.savePlot();
+	const savePlotHandler = () => {
+		try {
+			positronPlotsContext.positronPlotsService.savePlot();
+		} catch (error) {
+			positronPlotsContext.notificationService.error(localize('positronPlotsServiceSavePlotError', 'Failed to save plot: {0}', error.message));
+		}
 	};
 
 	const copyPlotHandler = () => {


### PR DESCRIPTION
### Intent
Address #2741 

### Approach
Set a better default file path when no workspace is active by using the file dialog service.


### QA Notes
This uses VS Code's preference of picking a file path. It will likely be the active file's location but could be the last active workspace.