### PR TITLE
Only restart runtimes on `RuntimeExitReason.Error`

### DIFF
--- a/extensions/positron-python/src/client/positron/errorHandler.ts
+++ b/extensions/positron-python/src/client/positron/errorHandler.ts
@@ -23,6 +23,7 @@ import { traceWarn } from '../logging';
 // https://github.com/posit-dev/positron/pull/2880
 // https://github.com/microsoft/vscode-languageserver-node/blob/8e625564b531da607859b8cb982abb7cdb2fbe2e/client/src/common/client.ts#L420
 // https://github.com/microsoft/vscode-languageserver-node/blob/8e625564b531da607859b8cb982abb7cdb2fbe2e/client/src/common/client.ts#L1617
+// https://github.com/microsoft/vscode-languageserver-node/blob/4b5f9cf622963dcfbc6129cdc1a570e2bb9f66a4/client/src/common/client.ts#L1639
 export class PythonErrorHandler implements ErrorHandler {
     constructor(private readonly _version: string, private readonly _port: number) {}
 
@@ -30,7 +31,7 @@ export class PythonErrorHandler implements ErrorHandler {
         traceWarn(
             `Python (${this._version}) language client error occurred (port ${this._port}). '${error.name}' with message: ${error.message}. This is error number ${count}.`,
         );
-        return { action: ErrorAction.Shutdown };
+        return { action: ErrorAction.Shutdown, handled: true };
     }
 
     public closed(): CloseHandlerResult {

--- a/extensions/positron-r/src/error-handler.ts
+++ b/extensions/positron-r/src/error-handler.ts
@@ -23,6 +23,7 @@ import { LOGGER } from './extension';
 // https://github.com/posit-dev/positron/pull/2880
 // https://github.com/microsoft/vscode-languageserver-node/blob/8e625564b531da607859b8cb982abb7cdb2fbe2e/client/src/common/client.ts#L420
 // https://github.com/microsoft/vscode-languageserver-node/blob/8e625564b531da607859b8cb982abb7cdb2fbe2e/client/src/common/client.ts#L1617
+// https://github.com/microsoft/vscode-languageserver-node/blob/4b5f9cf622963dcfbc6129cdc1a570e2bb9f66a4/client/src/common/client.ts#L1639
 export class RErrorHandler implements ErrorHandler {
 	constructor(
 		private readonly _version: string,
@@ -32,7 +33,7 @@ export class RErrorHandler implements ErrorHandler {
 
 	public error(error: Error, _message: Message, count: number): ErrorHandlerResult {
 		LOGGER.warn(`ARK (R ${this._version}) language client error occurred (port ${this._port}). '${error.name}' with message: ${error.message}. This is error number ${count}.`);
-		return { action: ErrorAction.Shutdown };
+		return { action: ErrorAction.Shutdown, handled: true };
 	}
 
 	public closed(): CloseHandlerResult {

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -740,7 +740,10 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		}
 
 		// Ignore if the runtime exited for a Good Reason.
-		if (exit.reason !== RuntimeExitReason.Error && exit.reason !== RuntimeExitReason.Unknown) {
+		// If the reason is `Unknown`, then we don't know the reason for the exit, but the
+		// `exit_code` was `0`, so we don't treat it as a crash. If the `exit_code` had not been
+		// `0`, then `onKernelExited()` would have upgraded the crash from `Unknown` to `Error`.
+		if (exit.reason !== RuntimeExitReason.Error) {
 			return;
 		}
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/628

I realized that when `q()` is called in R, we do actually know that the exit code was `0`, and we treat this as an `Unknown` exit reason (by definition, `Unknown` also means an exit code of `0`, otherwise it would have been upgraded to an `Error`).

I think pretty much all of the expected cleanup is already happening on the Positron side when `q()` is called, the only weird thing is that we are treating an `Unknown` exit like a crash and automatically restarting.

It turns out that we can fix that pretty easily by only auto-restarting when the exit reason is `Error`, where previously we restarted if the exit reason is `Error` OR `Unknown`.

I think we should treat `Unknown` as more of an "expected" case where the shutdown was initiated by the kernel. I would be in favor of possibly changing the name of `Unknown` to `BackendShutdown` or something, and then change `Shutdown` to `FrontendShutdown`? i.e. here:
https://github.com/posit-dev/positron/blob/7b71e16e71409f8e5ad0e7af84c35672eb542546/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts#L312-L338



https://github.com/posit-dev/positron/assets/19150088/2e3a6ce1-ef63-4ee8-9e87-ed895c0681ab



