### PR TITLE
Temporary version pin for pip

### DIFF
--- a/extensions/positron-python/python_files/download_get_pip.py
+++ b/extensions/positron-python/python_files/download_get_pip.py
@@ -10,7 +10,12 @@ from packaging.version import parse as version_parser
 EXTENSION_ROOT = pathlib.Path(__file__).parent.parent
 GET_PIP_DEST = EXTENSION_ROOT / "python_files"
 PIP_PACKAGE = "pip"
-PIP_VERSION = "latest"  # Can be "latest", or specific version "23.1.2"
+
+# --- Start Positron ---
+# Temporarily disable "latest" due to upstream break with pre-release version
+# PIP_VERSION = "latest"  # Can be "latest", or specific version "23.1.2"
+PIP_VERSION = "24.0"
+# --- End Positron ---
 
 
 def _get_package_data():


### PR DESCRIPTION
Addresses a build break:

```
[22:15:25] Error: Failed to download get-pip.py using 'python'
    at /Users/user229818/actions-runner/_work/positron/positron/extensions/positron-python/gulpfile.js:332:18
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /Users/user229818/actions-runner/_work/positron/positron/extensions/positron-python/gulpfile.js:327:5
[22:15:25] 'installPythonLibs' errored after 12 s
```

by pinning to pip 24.0. 