### PR TITLE
Reduce log noise by passing all comm data to the main thread

### DIFF
--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -40,7 +40,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$getForegroundSession(): Promise<string | undefined>;
 	$getNotebookSession(notebookUri: URI): Promise<string | undefined>;
 	$restartSession(handle: number): Promise<void>;
-	$emitLanguageRuntimeMessage(handle: number, message: ILanguageRuntimeMessage): void;
+	$emitLanguageRuntimeMessage(handle: number, handled: boolean, message: ILanguageRuntimeMessage): void;
 	$emitLanguageRuntimeState(handle: number, clock: number, state: RuntimeState): void;
 	$emitLanguageRuntimeExit(handle: number, exit: ILanguageRuntimeExit): void;
 }

--- a/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
@@ -121,9 +121,10 @@ export class PositronBaseComm extends Disposable {
 						`${JSON.stringify(payload)} ` +
 						`(Expected an object or an array)`);
 				}
-			} else {
-				// If there are no emitters, this event will get dropped on
-				// the floor. Log a warning.
+			} else if (data.method) {
+				// If there are no emitters but an event type was defined with
+				// the 'method' field, this event will get dropped on the floor.
+				// Log a warning.
 				console.warn(`Dropping event '${data.method}' ` +
 					`on comm ${this.clientInstance.getClientId()}: ` +
 					`${JSON.stringify(data.params)} ` +


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/2972. 

This bug was a regression from https://github.com/posit-dev/positron/pull/2892. We eliminated a bunch of warnings about unhandled messages by not passing messages to the main thread if they were handled in the extension host. This did get rid of the warnings, but in some circumstances it can create a bunch of `INFO` logs, because the main thread's Lamport clocks allow it to detect the missing messages, and it waits for a beat to see if they will arrive.

### Approach

The fix here is to pass *every* message to the main thread, whether we handled it in the extension host or not, so that the main thread's Lamport clocks stay updated. Messages that were handled in the extension host are simply not processed by the main thread. 

As an aside, I am not totally sure we need the Lamport clocks at all; it felt a lot like we had message ordering issues before we added them, but empirically I've never seen any logging that suggests messages actually get delivered out of order. I'm not ready to rip them out, as they are inexpensive, but they may be complicating things more than necessary.

### QA Notes

Checking the INFO logs at startup should be sufficient to validate this change.