### PR TITLE
Fix stack overflow caused by unsafe uint8-base64 conversion of image data

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
@@ -147,18 +147,22 @@ export function parseOutputData(output: ICellOutput['outputs'][number]): ParsedO
 		};
 	}
 
-
 	return { type: 'unknown', contents: message };
 }
 
 
-function uint8ToBase64(u8: Uint8Array): string {
+/**
+ * Convert a Uint8Array to a base64 encoded string.
+ * @param u8 Uint8Array to convert to base64
+ * @returns The base64 encoded string
+ */
+function uint8ToBase64(u8: Uint8Array) {
+	const output = [];
 
-	return btoa(
-		String.fromCharCode.apply(
-			null,
-			// Forgive me for I have sinned
-			u8 as unknown as number[]
-		)
-	);
+	for (let i = 0, length = u8.length; i < length; i++) {
+		output.push(String.fromCharCode(u8[i]));
+	}
+
+	// btoa() is depreciated but there doesn't seem to be a better way to do this
+	return btoa(output.join(''));
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
@@ -157,10 +157,10 @@ export function parseOutputData(output: ICellOutput['outputs'][number]): ParsedO
  * @returns The base64 encoded string
  */
 function uint8ToBase64(u8: Uint8Array) {
-	const output = [];
+	const output = new Array(u8.length);
 
 	for (let i = 0, length = u8.length; i < length; i++) {
-		output.push(String.fromCharCode(u8[i]));
+		output[i] = String.fromCharCode(u8[i]);
 	}
 
 	// btoa() is deprecated but there doesn't seem to be a better way to do this

--- a/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
@@ -163,6 +163,6 @@ function uint8ToBase64(u8: Uint8Array) {
 		output.push(String.fromCharCode(u8[i]));
 	}
 
-	// btoa() is depreciated but there doesn't seem to be a better way to do this
+	// btoa() is deprecated but there doesn't seem to be a better way to do this
 	return btoa(output.join(''));
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Fix bug caused when opening some larger images where we'd run out of stack space while converting image data from `Uint8` to base 64 where it's used to populate data-urls in positron notebooks. 

Partially addresses #3062 

### Approach

Rewrite the `uint8ToBase64()` function to loop over the array rather than attempt to pass in the whole array to `String.fromCharCode()` at once. 


### QA Notes

Images in notebooks should open up as expected. Examples can be found in the notebooks of the fastAi course. The one specifically tested here was `16A_StyleTransfer.ipynb`. Prior to this PR the notebook would just appear blank. 
