### PR TITLE
Preserve whitespaces in data grid cells

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.css
@@ -13,6 +13,7 @@
 	white-space: nowrap;
 	line-height: normal;
 	text-overflow: ellipsis;
+	white-space-collapse: preserve;
 }
 
 .data-grid-row-cell


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

Addresses https://github.com/posit-dev/positron/issues/2865
Whitespace characters are a common source of data problems and we want to be able to visualize them in the UI;

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

Changes the css attribute that controls how whitespace characters are rendered.
While it would be nice if whitespace characters could be displayed as in the text editor with whitespace rendering enabled:

![image](https://github.com/posit-dev/positron/assets/4706822/af5a5a5a-a36b-4117-bf3f-d9196ba4d379)

AFAICT this a monaco editor feature, and not simple to mimick with just HTML/css;

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

```View(data.frame(x = c("a ", "a", " a ")))```

Should show:

![image](https://github.com/posit-dev/positron/assets/4706822/0004f62c-f233-4238-a114-8152c73154b6)

Which is simlar to RStudio

![image](https://github.com/posit-dev/positron/assets/4706822/c510f664-f819-45dd-a41a-14fa7358368e)

