### PR TITLE
Register variable_path when using %view with dataframes

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -26,6 +26,7 @@ from IPython.core.interactiveshell import ExecutionInfo, InteractiveShell
 from IPython.core.magic import Magics, MagicsManager, line_magic, magics_class
 from IPython.utils import PyColorize
 
+from .access_keys import encode_access_key
 from .connections import ConnectionsService
 from .data_explorer import DataExplorerService
 from .help import HelpService, help
@@ -159,7 +160,9 @@ class PositronMagics(Magics):
         # Register a dataset with the data explorer service.
         obj = info.obj
         try:
-            self.shell.kernel.data_explorer_service.register_table(obj, title)
+            self.shell.kernel.data_explorer_service.register_table(
+                obj, title, variable_path=[encode_access_key(args.object)]
+            )
         except TypeError:
             raise UsageError(f"cannot view object of type '{get_qualname(obj)}'")
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

Addresses https://github.com/posit-dev/positron/issues/2896

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

When using `%view df`, the object path wouldn't be tracked, and thus the variables pane (which is responsible for triggering data explorer tables) wouldn't trigger the update for that vairiable.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

https://github.com/posit-dev/positron/assets/4706822/a1000c6b-3d9f-45e6-823e-09fee93d1699



