### PR TITLE
Show the manual restart button in the `Unknown` shutdown case

### DIFF
--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1659,12 +1659,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			const crashedAndNeedRestartButton = exit.reason === RuntimeExitReason.Error &&
 				!this._configurationService.getValue<boolean>('positron.interpreters.restartOnCrash');
 
-			// In the case of a forced quit or normal shutdown, we don't attempt
-			// to automatically start the runtime again. In this case, we add an
-			// activity item that shows a button the user can use to start the
+			// In the case of a forced quit, normal shutdown, or unknown shutdown where the exit
+			// code was `0`, we don't attempt to automatically start the runtime again. In this
+			// case, we add an activity item that shows a button the user can use to start the
 			// runtime manually.
 			if (exit.reason === RuntimeExitReason.ForcedQuit ||
 				exit.reason === RuntimeExitReason.Shutdown ||
+				exit.reason === RuntimeExitReason.Unknown ||
 				crashedAndNeedRestartButton) {
 				const restartButton = new RuntimeItemRestartButton(generateUuid(),
 					this._session.runtimeMetadata.languageName,


### PR DESCRIPTION
Addresses @juliasilge's comment at the end of https://github.com/posit-dev/positron/issues/628#issuecomment-2101015517

`Unknown` shutdowns have an exit code of `0`, i.e. an expected shutdown initiated by the backend, so this seems like a reasonable case to show the manual restart button too.


https://github.com/posit-dev/positron/assets/19150088/0916f188-505d-45d6-9a56-698e79341125

