### PR TITLE
Fix text overflow in row headers

### DIFF
--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.css
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.css
@@ -49,6 +49,7 @@
 
 .data-grid-row-header
 .content {
+	overflow: hidden;
 	grid-row: content / splitter;
 	grid-column: content / splitter;
 }


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

Lengthy row headers are drawn outside of the row headers column, as reported in this issue: https://github.com/posit-dev/positron/issues/2387
 
![image](https://github.com/posit-dev/positron/assets/853239/8b45926b-0e38-4a89-a778-2df1c96670be)

The intent of this PR is to fix this.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

I updated the `DataGridRowHeader` CSS to stop this from happening.

Overflowing row headers now look like:

<img width="1585" alt="image" src="https://github.com/posit-dev/positron/assets/853239/3ec6fbde-6be2-4d84-b607-d3d7625aa0d5">

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

None.
