### PR TITLE
Enforce maximum width of custom folder menu button

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -514,6 +514,7 @@
 		"--vscode-pickerGroup-foreground",
 		"--vscode-ports-iconRunningProcessForeground",
 		"--positronActionBar-foreground",
+		"--positronActionBar-hoverBackground",
 		"--positronActionBar-textInputBackground",
 		"--positronActionBar-textInputSelectionBackground",
 		"--positronActionBar-textInputSelectionForeground",

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCustomFolderMenu.css
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCustomFolderMenu.css
@@ -42,10 +42,10 @@
 	color: var(--positronActionBar-foreground);
 }
 
-.top-action-bar-custom-folder-menu .left .label .icon {
-	width: 16px;
-	height: 16px;
-	margin-right: 6px;
+.top-action-bar-custom-folder-menu .left .label .label-text {
+	overflow: hidden;
+	max-width: 200px;
+	text-overflow: ellipsis;
 }
 
 .top-action-bar-custom-folder-menu .right {

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCustomFolderMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCustomFolderMenu.tsx
@@ -96,11 +96,10 @@ export const TopActionBarCustonFolderMenu = () => {
 				<div className='label'>
 					<div className={'action-bar-button-icon codicon codicon-folder'} />
 					{context.workspaceFolder &&
-						<div className='label'>
+						<div className='label-text'>
 							{context.workspaceFolder ? context.workspaceFolder.name : ''}
 						</div>
 					}
-
 				</div>
 			</div>
 			<div className='right' aria-hidden='true'>


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

As reported in https://github.com/posit-dev/positron/issues/2443, super long folder names blow up the Top Action Bar, as can be seen in this image:

![image](https://github.com/posit-dev/positron/assets/853239/707f80c7-f11a-4085-8b93-6205190c4bc9)

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

I've adjusted the UI for the TopActionBarCustonFolderMenu component so this no longer happens, as can be see in this image:

<img width="1413" alt="image" src="https://github.com/posit-dev/positron/assets/853239/e1825f17-dda8-4a1b-ad48-bd4394cae71e">

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

You can just try to create and open a folder with a super long name, such as:

```
This is a long folder name long folder name long folder name long folder name long folder name long folder name long folder name long folder name
```
