### PR TITLE
Don't render iframes in the Console

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -754,8 +754,9 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 
 		// If there's an HTML representation, use that.
 		if (mimeTypes.includes('text/html')) {
-			// Check to see if there are any <script>, <html>, or <body> tags.
-			if (/<(script|html|body)/.test(message.data['text/html'])) {
+			// Check to see if there are any tags that look like they belong in
+			// a standalone HTML document.
+			if (/<(script|html|body|iframe)/.test(message.data['text/html'])) {
 				// This looks like standalone HTML.
 				if (message.data['text/html'].includes('<table')) {
 					// Tabular data? Probably best in the Viewer pane.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1472,7 +1472,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					const htmlContent = languageRuntimeMessageOutput.data['text/html'].toLowerCase();
 					if (htmlContent.indexOf('<script') >= 0 ||
 						htmlContent.indexOf('<body') >= 0 ||
-						htmlContent.indexOf('<html') >= 0) {
+						htmlContent.indexOf('<html') >= 0 ||
+						htmlContent.indexOf('<iframe') >= 0) {
 						// We only want to render HTML fragments for now; if it has
 						// scripts or looks like it is a self-contained document,
 						// hard pass. In the future, we'll need to render those in a


### PR DESCRIPTION
### Intent

Addresses #3069.

<img width="1548" alt="image" src="https://github.com/posit-dev/positron/assets/470418/0a97af86-93c5-4e48-96d5-0820cd2a9232">

This fixes a problem in which `folium` content doesn't show up in Positron. It turned out that the issue was that folium HTML is a little weird: it generates an `<iframe>` tag and then tries to set its `src` to a long string of HTML. Setting arbitrary HTML is disallowed in Electron for security reasons, so an exception is thrown that breaks the React render of the Console. 

### Approach

Pretty simple: add `<iframe>` to the list of tags that trigger content to render in a safe sandbox (e.g. the Plots or Viewer pane) rather than inline in the Console. 

This is a heuristic and therefore a band-aid. We still have some issues around how we render HTML output from R and Python that we need to address (most notably https://github.com/posit-dev/positron/issues/1719). 

### QA Notes

This fix isn't Python specific; it applies to all HTML output from kernels (but not to widgets like R HTML widgets or IPywidgets). 