### PR TITLE
Adding row filter limit (currently 15)

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronOKModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronOKModalDialog.tsx
@@ -18,9 +18,7 @@ import { PositronModalDialog, PositronModalDialogProps } from 'vs/workbench/brow
  * OKModalDialogProps interface.
  */
 export interface OKModalDialogProps extends PositronModalDialogProps {
-	title: string;
 	okButtonTitle?: string;
-	onAccept: () => void;
 }
 
 /**


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR introduces a limit to the number of row filters that can be added in the Data Explorer. Currently, this limit is set to 15. When a user tries to add a row filter beyond this limit, they are shown the following message box:

<img width="422" alt="image" src="https://github.com/posit-dev/positron/assets/853239/0034ad3d-2ac7-4be1-8162-1afccc9f4b81">

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

Since row filters are loaded from the backend via `backendClient.cachedBackendState.row_filters`, or via the `onDidUpdateBackendState` event, the message box that is shown does not specify what the limit is. It merely informs the user that the maximum number of row filters has been reached. 

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

To test this, try to add 16 row filters.
