### PR TITLE
Project Wizard: use python extension environment providers

### DIFF
--- a/extensions/positron-python/src/client/common/constants.ts
+++ b/extensions/positron-python/src/client/common/constants.ts
@@ -53,6 +53,9 @@ export namespace Commands {
     export const Exec_Selection_In_Django_Shell = 'python.execSelectionInDjangoShell';
     export const Exec_Selection_In_Terminal = 'python.execSelectionInTerminal';
     export const GetSelectedInterpreterPath = 'python.interpreterPath';
+    // --- Start Positron ---
+    export const Get_Create_Environment_Providers = 'python.getCreateEnvironmentProviders';
+    // --- End Positron ---
     export const InstallJupyter = 'python.installJupyter';
     export const InstallPython = 'python.installPython';
     export const InstallPythonOnLinux = 'python.installPythonOnLinux';

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -76,6 +76,20 @@ export function registerCreateEnvironmentFeatures(
                 await executeCommand(Commands.Create_Environment);
             },
         ),
+        // --- Start Positron ---
+        registerCommand(
+            Commands.Get_Create_Environment_Providers,
+            () => {
+                const providers = _createEnvironmentProviders.getAll();
+                const providersForWizard = providers.map((provider) => ({
+                    id: provider.id,
+                    name: provider.name,
+                    description: provider.description,
+                }));
+                return providersForWizard;
+            },
+        ),
+        // --- End Positron ---
         registerCreateEnvironmentProvider(new VenvCreationProvider(interpreterQuickPick)),
         registerCreateEnvironmentProvider(condaCreationProvider()),
         onCreateEnvironmentExited(async (e: EnvironmentDidCreateEvent) => {

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -77,18 +77,15 @@ export function registerCreateEnvironmentFeatures(
             },
         ),
         // --- Start Positron ---
-        registerCommand(
-            Commands.Get_Create_Environment_Providers,
-            () => {
-                const providers = _createEnvironmentProviders.getAll();
-                const providersForWizard = providers.map((provider) => ({
-                    id: provider.id,
-                    name: provider.name,
-                    description: provider.description,
-                }));
-                return providersForWizard;
-            },
-        ),
+        registerCommand(Commands.Get_Create_Environment_Providers, () => {
+            const providers = _createEnvironmentProviders.getAll();
+            const providersForWizard = providers.map((provider) => ({
+                id: provider.id,
+                name: provider.name,
+                description: provider.description,
+            }));
+            return providersForWizard;
+        }),
         // --- End Positron ---
         registerCreateEnvironmentProvider(new VenvCreationProvider(interpreterQuickPick)),
         registerCreateEnvironmentProvider(condaCreationProvider()),

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -143,18 +143,12 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 		envProvider: string | undefined,
 		interpreter: ILanguageRuntimeMetadata | undefined
 	) => {
-		// Update the project configuration with the new environment setup type.
-		setEnvSetupType(envSetupType);
-
-		// Update the project configuration with the new environment type.
-		setEnvProviderId(envProvider);
-
 		// Update the interpreter entries.
 		const entries = getPythonInterpreterEntries(
 			runtimeStartupService,
 			languageRuntimeService,
 			envSetupType,
-			envProviderNameForId(envProviderId, envProviders)
+			envProviderNameForId(envProvider, envProviders)
 		);
 		setInterpreterEntries(entries);
 
@@ -165,6 +159,14 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 		// Update the installIpykernel flag for the selected interpreter.
 		const installIpykernel = await getInstallIpykernel(envSetupType, selectedRuntime);
 		setWillInstallIpykernel(installIpykernel);
+
+		// Update the project configuration with the new environment type.
+		setEnvProviderId(envProvider);
+
+		// Update the project configuration with the new environment setup type.
+		// Set this last so that the above state changes have been applied before changing to the
+		// new env setup type view.
+		setEnvSetupType(envSetupType);
 
 		// Save the changes to the project configuration.
 		setProjectConfig({

--- a/src/vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums.ts
@@ -27,10 +27,8 @@ export enum EnvironmentSetupType {
 }
 
 /**
- * PythonEnvironmentType enum includes the types of Python environments.
- * - Venv: A virtual environment.
- * - Conda: A conda environment.
- * TODO: retrieve these values from the appropriate extensions/services?
+ * PythonEnvironmentType enum includes the types of Python environments that are supported by the
+ * New Project Wizard.
  */
 export enum PythonEnvironmentType {
 	Venv = 'Venv',

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -23,6 +23,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IPositronNewProjectService, NewProjectConfiguration } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
 import { EnvironmentSetupType } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
+import { getEnvProviderInfoList } from 'vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils';
 
 /**
  * Shows the NewProjectModalDialog.
@@ -65,6 +66,7 @@ export const showNewProjectModalDialog = async (
 				runtimeStartupService,
 			}}
 			parentFolder={(await fileDialogService.defaultFolderPath()).fsPath}
+			pythonEnvProviders={await getEnvProviderInfoList(commandService, logService)}
 		>
 			<NewProjectModalDialog
 				renderer={renderer}
@@ -78,7 +80,7 @@ export const showNewProjectModalDialog = async (
 					// The python environment type is only relevant if a new environment is being created.
 					const pythonEnvType =
 						result.pythonEnvSetupType === EnvironmentSetupType.NewEnvironment
-							? result.pythonEnvType
+							? result.pythonEnvProvider
 							: '';
 
 					// Install ipykernel if applicable.
@@ -95,7 +97,7 @@ export const showNewProjectModalDialog = async (
 							// If an error occurs while installing ipykernel, a message will be
 							// logged and once the project is opened, when the chosen runtime is
 							// starting, the user will be prompted again to install ipykernel.
-							
+
 							await commandService.executeCommand(
 								'python.installIpykernel',
 								String(pythonPath)

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.tsx
@@ -2,12 +2,15 @@
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
+// React.
 import { useState } from 'react';
+
+// Other dependencies.
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { ILanguageRuntimeMetadata, ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
-import { EnvironmentSetupType, NewProjectType, NewProjectWizardStep, PythonEnvironmentType } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
+import { EnvironmentSetupType, NewProjectType, NewProjectWizardStep } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ILogService } from 'vs/platform/log/common/log';
@@ -15,6 +18,7 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { IFileService } from 'vs/platform/files/common/files';
 import { ICommandService } from 'vs/platform/commands/common/commands';
+import { PythonEnvironmentProviderInfo } from 'vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils';
 
 /**
  * NewProjectWizardServices interface. Defines the set of services that are required by the New
@@ -41,6 +45,7 @@ interface NewProjectWizardServices {
 export interface NewProjectWizardStateProps {
 	readonly services: NewProjectWizardServices;
 	readonly parentFolder: string;
+	readonly pythonEnvProviders: PythonEnvironmentProviderInfo[];
 }
 
 /**
@@ -55,7 +60,7 @@ export interface NewProjectWizardConfiguration {
 	readonly initGitRepo: boolean;
 	readonly openInNewWindow: boolean;
 	readonly pythonEnvSetupType: EnvironmentSetupType | undefined;
-	readonly pythonEnvType: PythonEnvironmentType | undefined;
+	readonly pythonEnvProvider: string | undefined;
 	readonly installIpykernel: boolean | undefined;
 	readonly useRenv: boolean | undefined;
 }
@@ -67,6 +72,7 @@ export interface NewProjectWizardState extends NewProjectWizardServices {
 	projectConfig: NewProjectWizardConfiguration;
 	wizardSteps: NewProjectWizardStep[]; // TODO: remove: this is for debugging
 	currentStep: NewProjectWizardStep;
+	pythonEnvProviders: PythonEnvironmentProviderInfo[];
 	setProjectConfig(config: NewProjectWizardConfiguration): void;
 	goToNextStep: (step: NewProjectWizardStep) => void;
 	goToPreviousStep: () => void;
@@ -89,7 +95,7 @@ export const useNewProjectWizardState = (
 		initGitRepo: false,
 		openInNewWindow: false,
 		pythonEnvSetupType: undefined,
-		pythonEnvType: undefined,
+		pythonEnvProvider: undefined,
 		installIpykernel: undefined,
 		useRenv: undefined
 	});
@@ -126,6 +132,7 @@ export const useNewProjectWizardState = (
 		projectConfig,
 		wizardSteps, // TODO: remove: this is for debugging
 		currentStep,
+		pythonEnvProviders: props.pythonEnvProviders,
 		setProjectConfig,
 		goToNextStep,
 		goToPreviousStep,

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils.ts
@@ -2,6 +2,8 @@
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
+import { ICommandService } from 'vs/platform/commands/common/commands';
+import { ILogService } from 'vs/platform/log/common/log';
 import { DropDownListBoxItem } from 'vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBoxItem';
 import { EnvironmentSetupType, LanguageIds, PythonEnvironmentType, PythonRuntimeFilter } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
 import { InterpreterInfo, getInterpreterDropdownItems } from 'vs/workbench/browser/positronNewProjectWizard/utilities/interpreterDropDownUtils';
@@ -9,11 +11,12 @@ import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/c
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
 
 /**
- * PythonEnvironmentTypeInfo interface.
+ * PythonEnvironmentProviderInfo interface.
  */
-export interface PythonEnvironmentTypeInfo {
-	envType: PythonEnvironmentType;
-	envDescription: string;
+export interface PythonEnvironmentProviderInfo {
+	id: string;
+	name: string;
+	description: string;
 }
 
 /**
@@ -48,6 +51,8 @@ const getPythonInterpreterDropDownItems = (
  */
 export const createCondaInterpreterDropDownItems = () => {
 	// TODO: we should get the list of Python versions from the Conda service
+	// see extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaUtils.ts
+	// pickPythonVersion function
 	const pythonVersions = ['3.12', '3.11', '3.10', '3.9', '3.8'];
 	const condaRuntimes: DropDownListBoxItem<string, InterpreterInfo>[] = [];
 	pythonVersions.forEach((version) => {
@@ -80,11 +85,11 @@ export const getPythonInterpreterEntries = (
 	runtimeStartupService: IRuntimeStartupService,
 	languageRuntimeService: ILanguageRuntimeService,
 	envSetupType: EnvironmentSetupType,
-	envType: PythonEnvironmentType | undefined
+	envProviderName: string | undefined,
 ) => {
 	switch (envSetupType) {
-		case EnvironmentSetupType.NewEnvironment:
-			switch (envType) {
+		case EnvironmentSetupType.NewEnvironment: {
+			switch (envProviderName) {
 				case PythonEnvironmentType.Venv:
 					return getPythonInterpreterDropDownItems(
 						runtimeStartupService,
@@ -99,6 +104,7 @@ export const getPythonInterpreterEntries = (
 						languageRuntimeService
 					);
 			}
+		}
 		case EnvironmentSetupType.ExistingEnvironment:
 			return getPythonInterpreterDropDownItems(
 				runtimeStartupService,
@@ -120,41 +126,67 @@ export const getPythonInterpreterEntries = (
 export const locationForNewEnv = (
 	parentFolder: string,
 	projectName: string,
-	envType: PythonEnvironmentType | undefined
+	envProviderName: string | undefined,
 ) => {
 	// TODO: this only works for Venv and Conda environments. We'll need to expand on this to add
 	// support for other environment types.
 	const envDir =
-		envType === PythonEnvironmentType.Venv
+		envProviderName === PythonEnvironmentType.Venv
 			? '.venv'
-			: envType === PythonEnvironmentType.Conda
+			: envProviderName === PythonEnvironmentType.Conda
 				? '.conda'
 				: '';
 	return `${parentFolder}/${projectName}/${envDir}`;
 };
 
 /**
- * Constructs and returns the entries for the environment type dropdown box.
- * @returns The entries for the environment type dropdown box.
+ * Constructs and returns the entries for the environment providers dropdown box.
+ * @returns The entries for the environment providers dropdown box.
  */
-export const getEnvTypeEntries = () => {
-	// TODO: retrieve the python environment types from the language runtime service somehow?
-	// TODO: localize these entries
-	return [
-		new DropDownListBoxItem<PythonEnvironmentType, PythonEnvironmentTypeInfo>({
-			identifier: PythonEnvironmentType.Venv,
-			value: {
-				envType: PythonEnvironmentType.Venv,
-				envDescription:
-					'Creates a `.venv` virtual environment for your project',
-			},
-		}),
-		new DropDownListBoxItem<PythonEnvironmentType, PythonEnvironmentTypeInfo>({
-			identifier: PythonEnvironmentType.Conda,
-			value: {
-				envType: PythonEnvironmentType.Conda,
-				envDescription: 'Creates a `.conda` Conda environment for your project',
-			},
-		}),
-	];
+export const getEnvProviderInfoList = async (
+	commandService: ICommandService,
+	logService: ILogService,
+): Promise<PythonEnvironmentProviderInfo[]> => {
+	const envTypes = await commandService.executeCommand(
+		'python.getCreateEnvironmentProviders'
+	);
+	if (!envTypes) {
+		logService.debug('No Python Create Environment Providers found.');
+		return [];
+	}
+	return envTypes;
+};
+
+/**
+ * Converts PythonEnvironmentProviderInfo objects to DropDownListBoxItem objects.
+ * @param providers The PythonEnvironmentProviderInfo objects to convert.
+ * @returns The array of DropDownListBoxItem objects.
+ */
+export const envProviderInfoToDropDownItems = (
+	providers: PythonEnvironmentProviderInfo[]
+): DropDownListBoxItem<string, PythonEnvironmentProviderInfo>[] => {
+	return providers.map(
+		(provider) =>
+			new DropDownListBoxItem<string, PythonEnvironmentProviderInfo>({
+				identifier: provider.id,
+				value: provider,
+			})
+	);
+};
+
+/**
+ * Retrieves the name of the environment provider based on the provider ID.
+ * @param providerId The ID of the environment provider.
+ * @param providers The list of environment providers.
+ * @returns The name of the environment provider or undefined if not found.
+ */
+export const envProviderNameForId = (
+	providerId: string | undefined,
+	providers: PythonEnvironmentProviderInfo[]
+): string | undefined => {
+	if (!providerId) {
+		return undefined;
+	}
+	const provider = providers.find((p) => p.id === providerId);
+	return provider ? provider.name : undefined;
 };


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Scaffolding for https://github.com/posit-dev/positron/issues/2838 and https://github.com/posit-dev/positron/issues/2839 to pull the list of available environment providers from the python extension, instead of the hardcoded list of Venv and Conda.

Currently, it looks like only Venv and Conda are supported via the python extension (at least via the Create Environment quickpick command).

### Approach

- register new command in python extension `python.getCreateEnvironmentProviders`
- rename "envType" to "envProvider" in project wizard code to align better with the python extension (and to avoid confusion between "envType" and "envSetupType")
- retrieve the list of python environment providers and store in the wizard state during project modal initialization

### QA Notes

The Python Environment dropdown and related functionality should look exactly the same. The only difference is that the dropdown is filled with data from the python extension instead of hardcoded text.
