### PR TITLE
Rename 'Clear Console' to 'Clear Debug Console'

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -974,7 +974,11 @@ registerAction2(class extends ViewAction<Repl> {
 		super({
 			id: 'workbench.debug.panel.action.clearReplAction',
 			viewId: REPL_VIEW_ID,
-			title: localize2('clearRepl', 'Clear Console'),
+			// --- Start Positron ---
+			// Rename 'Clear Console' to 'Clear Debgug Console' to differentiate it from Positron's
+			// Clear Console command.
+			title: localize2('clearRepl', 'Clear Debug Console'),
+			// --- End Positron ---
 			metadata: {
 				description: localize2('clearRepl.descriotion', 'Clears all program output from your debug REPL')
 			},

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -975,7 +975,7 @@ registerAction2(class extends ViewAction<Repl> {
 			id: 'workbench.debug.panel.action.clearReplAction',
 			viewId: REPL_VIEW_ID,
 			// --- Start Positron ---
-			// Rename 'Clear Console' to 'Clear Debgug Console' to differentiate it from Positron's
+			// Rename 'Clear Console' to 'Clear Debug Console' to differentiate it from Positron's
 			// Clear Console command.
 			title: localize2('clearRepl', 'Clear Debug Console'),
 			// --- End Positron ---


### PR DESCRIPTION
### Introduction

This PR addresses: https://github.com/posit-dev/positron/issues/2370

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

Visual Studio Code has a command named `Clear Console`. Its metadata says:

`Clears all program output from your debug REPL`.

```
metadata: {
	description: localize2('clearRepl.descriotion', 'Clears all program output from your debug REPL')
},
```

(Note the misspelling of `descriotion`. This is not our mistake.)

Positron has a command named: `Console: Clear Console`. Its purpose is to clear the Positron Console (like pressing Ctrl-L).

These commands conflict with one another. To fix this, we're renaming Visual Studio Code's `Clear Console` command to `Clear Debug Console`. This matches with its metadata description.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

The approach taken was to rename the `Clear Console` command to `Clear Debug Console`.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

The command palette will show `Console: Clear Console` for the command to clear the Positron Console and `Clear Debug Console` for the Visual Studio Code command:

<img width="659" alt="image" src="https://github.com/posit-dev/positron/assets/853239/ff3be0a1-466b-4095-b177-6bc475b51eee">