### PR TITLE
Introduce an LSP `OutputChannel` manager

### DIFF
--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -15,6 +15,7 @@ import { PromiseHandles } from './util';
 import { PythonErrorHandler } from './errorHandler';
 import { PythonHelpTopicProvider } from './help';
 import { PythonStatementRangeProvider } from './statementRange';
+import { PythonLspOutputChannelManager } from './lspOutputChannelManager';
 
 /**
  * The state of the language server.
@@ -45,7 +46,7 @@ export class PythonLsp implements vscode.Disposable {
         private readonly serviceContainer: IServiceContainer,
         private readonly _version: string,
         private readonly _clientOptions: LanguageClientOptions,
-        private readonly _notebookUri: vscode.Uri | undefined,
+        private readonly _metadata: positron.RuntimeSessionMetadata,
     ) {}
 
     /**
@@ -79,11 +80,19 @@ export class PythonLsp implements vscode.Disposable {
             return out.promise;
         };
 
+        const notebookUri = this._metadata.notebookUri;
+
+        // Persistant output channel, used across multiple sessions of the same name + mode combination
+        const outputChannel = PythonLspOutputChannelManager.instance.getOutputChannel(
+            this._metadata.sessionName,
+            this._metadata.sessionMode,
+        );
+
         // If this client belongs to a notebook, set the document selector to only include that notebook.
         // Otherwise, this is the main client for this language, so set the document selector to include
         // untitled Python files, in-memory Python files (e.g. the console), and Python files on disk.
-        this._clientOptions.documentSelector = this._notebookUri
-            ? [{ language: 'python', pattern: this._notebookUri.path }]
+        this._clientOptions.documentSelector = notebookUri
+            ? [{ language: 'python', pattern: notebookUri.path }]
             : [
                   { language: 'python', scheme: 'untitled' },
                   { language: 'python', scheme: 'inmemory' }, // Console
@@ -93,6 +102,9 @@ export class PythonLsp implements vscode.Disposable {
         // Override default error handler with one that doesn't automatically restart the client,
         // and that logs to the appropriate place.
         this._clientOptions.errorHandler = new PythonErrorHandler(this._version, port);
+
+        // Override default output channel with our persistant one that is reused across sessions.
+        this._clientOptions.outputChannel = outputChannel;
 
         traceInfo(`Creating Positron Python ${this._version} language client (port ${port})...`);
         this._client = new LanguageClient(

--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -106,7 +106,10 @@ export class PythonLsp implements vscode.Disposable {
         // Override default output channel with our persistant one that is reused across sessions.
         this._clientOptions.outputChannel = outputChannel;
 
-        traceInfo(`Creating Positron Python ${this._version} language client (port ${port})...`);
+        const message = `Creating Positron Python ${this._version} language client (port ${port})`;
+        traceInfo(message);
+        outputChannel.appendLine(message);
+
         this._client = new LanguageClient(
             PYTHON_LANGUAGE,
             `Positron Python Language Server (${this._version})`,

--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -80,7 +80,7 @@ export class PythonLsp implements vscode.Disposable {
             return out.promise;
         };
 
-        const notebookUri = this._metadata.notebookUri;
+        const {notebookUri} = this._metadata;
 
         // Persistant output channel, used across multiple sessions of the same name + mode combination
         const outputChannel = PythonLspOutputChannelManager.instance.getOutputChannel(

--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -80,7 +80,7 @@ export class PythonLsp implements vscode.Disposable {
             return out.promise;
         };
 
-        const {notebookUri} = this._metadata;
+        const { notebookUri } = this._metadata;
 
         // Persistant output channel, used across multiple sessions of the same name + mode combination
         const outputChannel = PythonLspOutputChannelManager.instance.getOutputChannel(

--- a/extensions/positron-python/src/client/positron/lspOutputChannelManager.ts
+++ b/extensions/positron-python/src/client/positron/lspOutputChannelManager.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+const LSP_OUTPUT_CHANNEL_PREFIX = 'Positron Language Server: ';
+
+/**
+ * Manages all the Python LSP output channels
+ *
+ * Only cleaned up when Positron is closed. Output channels are persistant so they can be reused
+ * between sessions of the same key (session name + session mode), and so you can use them for
+ * debugging after a kernel crashes.
+ */
+export class PythonLspOutputChannelManager {
+    /// Singleton instance
+    private static _instance: PythonLspOutputChannelManager;
+
+    /// Map of keys to OutputChannel instances
+    private _channels: Map<string, vscode.OutputChannel> = new Map();
+
+    /// Constructor; private since we only want one of these
+    private constructor() {}
+
+    /**
+     * Accessor for the singleton instance; creates it if it doesn't exist.
+     */
+    static get instance(): PythonLspOutputChannelManager {
+        if (!PythonLspOutputChannelManager._instance) {
+            PythonLspOutputChannelManager._instance = new PythonLspOutputChannelManager();
+        }
+        return PythonLspOutputChannelManager._instance;
+    }
+
+    /**
+     * Gets the output channel for the given key. Creates one if the key hasn't been provided yet.
+     *
+     * @param sessionName The session name of the session to get the output channel for.
+     * @param sessionMode The session mode of the session to get the output channel for.
+     * @returns An output channel.
+     */
+    getOutputChannel(sessionName: string, sessionMode: string): vscode.OutputChannel {
+        let key = sessionName + '-' + sessionMode;
+        let out = this._channels.get(key);
+
+        if (!out) {
+            let name = `${LSP_OUTPUT_CHANNEL_PREFIX}${sessionName} (${sessionMode})`;
+            out = vscode.window.createOutputChannel(name);
+            this._channels.set(key, out);
+        }
+
+        return out;
+    }
+}

--- a/extensions/positron-python/src/client/positron/lspOutputChannelManager.ts
+++ b/extensions/positron-python/src/client/positron/lspOutputChannelManager.ts
@@ -14,42 +14,43 @@ const LSP_OUTPUT_CHANNEL_PREFIX = 'Positron Language Server: ';
  * debugging after a kernel crashes.
  */
 export class PythonLspOutputChannelManager {
-    /// Singleton instance
-    private static _instance: PythonLspOutputChannelManager;
+	/// Singleton instance
+	private static _instance: PythonLspOutputChannelManager;
 
-    /// Map of keys to OutputChannel instances
-    private _channels: Map<string, vscode.OutputChannel> = new Map();
+	/// Map of keys to OutputChannel instances
+	private _channels: Map<string, vscode.OutputChannel> = new Map();
 
-    /// Constructor; private since we only want one of these
-    private constructor() {}
+	/// Constructor; private since we only want one of these
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	private constructor() { }
 
-    /**
-     * Accessor for the singleton instance; creates it if it doesn't exist.
-     */
-    static get instance(): PythonLspOutputChannelManager {
-        if (!PythonLspOutputChannelManager._instance) {
-            PythonLspOutputChannelManager._instance = new PythonLspOutputChannelManager();
-        }
-        return PythonLspOutputChannelManager._instance;
-    }
+	/**
+	 * Accessor for the singleton instance; creates it if it doesn't exist.
+	 */
+	static get instance(): PythonLspOutputChannelManager {
+		if (!PythonLspOutputChannelManager._instance) {
+			PythonLspOutputChannelManager._instance = new PythonLspOutputChannelManager();
+		}
+		return PythonLspOutputChannelManager._instance;
+	}
 
-    /**
-     * Gets the output channel for the given key. Creates one if the key hasn't been provided yet.
-     *
-     * @param sessionName The session name of the session to get the output channel for.
-     * @param sessionMode The session mode of the session to get the output channel for.
-     * @returns An output channel.
-     */
-    getOutputChannel(sessionName: string, sessionMode: string): vscode.OutputChannel {
-        let key = sessionName + '-' + sessionMode;
-        let out = this._channels.get(key);
+	/**
+	 * Gets the output channel for the given key. Creates one if the key hasn't been provided yet.
+	 *
+	 * @param sessionName The session name of the session to get the output channel for.
+	 * @param sessionMode The session mode of the session to get the output channel for.
+	 * @returns An output channel.
+	 */
+	getOutputChannel(sessionName: string, sessionMode: string): vscode.OutputChannel {
+		const key = `${sessionName}-${sessionMode}`;
+		let out = this._channels.get(key);
 
-        if (!out) {
-            let name = `${LSP_OUTPUT_CHANNEL_PREFIX}${sessionName} (${sessionMode})`;
-            out = vscode.window.createOutputChannel(name);
-            this._channels.set(key, out);
-        }
+		if (!out) {
+			const name = `${LSP_OUTPUT_CHANNEL_PREFIX}${sessionName} (${sessionMode})`;
+			out = vscode.window.createOutputChannel(name);
+			this._channels.set(key, out);
+		}
 
-        return out;
-    }
+		return out;
+	}
 }

--- a/extensions/positron-python/src/client/positron/lspOutputChannelManager.ts
+++ b/extensions/positron-python/src/client/positron/lspOutputChannelManager.ts
@@ -14,43 +14,43 @@ const LSP_OUTPUT_CHANNEL_PREFIX = 'Positron Language Server: ';
  * debugging after a kernel crashes.
  */
 export class PythonLspOutputChannelManager {
-	/// Singleton instance
-	private static _instance: PythonLspOutputChannelManager;
+    /// Singleton instance
+    private static _instance: PythonLspOutputChannelManager;
 
-	/// Map of keys to OutputChannel instances
-	private _channels: Map<string, vscode.OutputChannel> = new Map();
+    /// Map of keys to OutputChannel instances
+    private _channels: Map<string, vscode.OutputChannel> = new Map();
 
-	/// Constructor; private since we only want one of these
-	// eslint-disable-next-line @typescript-eslint/no-empty-function
-	private constructor() { }
+    /// Constructor; private since we only want one of these
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    private constructor() {}
 
-	/**
-	 * Accessor for the singleton instance; creates it if it doesn't exist.
-	 */
-	static get instance(): PythonLspOutputChannelManager {
-		if (!PythonLspOutputChannelManager._instance) {
-			PythonLspOutputChannelManager._instance = new PythonLspOutputChannelManager();
-		}
-		return PythonLspOutputChannelManager._instance;
-	}
+    /**
+     * Accessor for the singleton instance; creates it if it doesn't exist.
+     */
+    static get instance(): PythonLspOutputChannelManager {
+        if (!PythonLspOutputChannelManager._instance) {
+            PythonLspOutputChannelManager._instance = new PythonLspOutputChannelManager();
+        }
+        return PythonLspOutputChannelManager._instance;
+    }
 
-	/**
-	 * Gets the output channel for the given key. Creates one if the key hasn't been provided yet.
-	 *
-	 * @param sessionName The session name of the session to get the output channel for.
-	 * @param sessionMode The session mode of the session to get the output channel for.
-	 * @returns An output channel.
-	 */
-	getOutputChannel(sessionName: string, sessionMode: string): vscode.OutputChannel {
-		const key = `${sessionName}-${sessionMode}`;
-		let out = this._channels.get(key);
+    /**
+     * Gets the output channel for the given key. Creates one if the key hasn't been provided yet.
+     *
+     * @param sessionName The session name of the session to get the output channel for.
+     * @param sessionMode The session mode of the session to get the output channel for.
+     * @returns An output channel.
+     */
+    getOutputChannel(sessionName: string, sessionMode: string): vscode.OutputChannel {
+        const key = `${sessionName}-${sessionMode}`;
+        let out = this._channels.get(key);
 
-		if (!out) {
-			const name = `${LSP_OUTPUT_CHANNEL_PREFIX}${sessionName} (${sessionMode})`;
-			out = vscode.window.createOutputChannel(name);
-			this._channels.set(key, out);
-		}
+        if (!out) {
+            const name = `${LSP_OUTPUT_CHANNEL_PREFIX}${sessionName} (${sessionMode})`;
+            out = vscode.window.createOutputChannel(name);
+            this._channels.set(key, out);
+        }
 
-		return out;
-	}
+        return out;
+    }
 }

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -337,7 +337,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             this.serviceContainer,
             this.runtimeMetadata.languageVersion,
             languageClientOptions,
-            this.metadata.notebookUri,
+            this.metadata,
         );
     }
 

--- a/extensions/positron-r/src/lsp-output-channel-manager.ts
+++ b/extensions/positron-r/src/lsp-output-channel-manager.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+const LSP_OUTPUT_CHANNEL_PREFIX = 'Positron Language Server: ';
+
+/**
+ * Manages all the R LSP output channels
+ *
+ * Only cleaned up when Positron is closed. Output channels are persistant so they can be reused
+ * between sessions of the same key (session name + session mode), and so you can use them for
+ * debugging after a kernel crashes.
+ */
+export class RLspOutputChannelManager {
+	/// Singleton instance
+	private static _instance: RLspOutputChannelManager;
+
+	/// Map of keys to OutputChannel instances
+	private _channels: Map<string, vscode.OutputChannel> = new Map();
+
+	/// Constructor; private since we only want one of these
+	private constructor() { }
+
+	/**
+	 * Accessor for the singleton instance; creates it if it doesn't exist.
+	 */
+	static get instance(): RLspOutputChannelManager {
+		if (!RLspOutputChannelManager._instance) {
+			RLspOutputChannelManager._instance = new RLspOutputChannelManager();
+		}
+		return RLspOutputChannelManager._instance;
+	}
+
+	/**
+	 * Gets the output channel for the given key. Creates one if the key hasn't been provided yet.
+	 *
+	 * @param sessionName The session name of the session to get the output channel for.
+	 * @param sessionMode The session mode of the session to get the output channel for.
+	 * @returns An output channel.
+	 */
+	getOutputChannel(sessionName: string, sessionMode: string): vscode.OutputChannel {
+		let key = sessionName + '-' + sessionMode;
+		let out = this._channels.get(key);
+
+		if (!out) {
+			let name = `${LSP_OUTPUT_CHANNEL_PREFIX}${sessionName} (${sessionMode})`;
+			out = vscode.window.createOutputChannel(name);
+			this._channels.set(key, out);
+		}
+
+		return out;
+	}
+}

--- a/extensions/positron-r/src/lsp-output-channel-manager.ts
+++ b/extensions/positron-r/src/lsp-output-channel-manager.ts
@@ -21,6 +21,7 @@ export class RLspOutputChannelManager {
 	private _channels: Map<string, vscode.OutputChannel> = new Map();
 
 	/// Constructor; private since we only want one of these
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	private constructor() { }
 
 	/**
@@ -41,11 +42,11 @@ export class RLspOutputChannelManager {
 	 * @returns An output channel.
 	 */
 	getOutputChannel(sessionName: string, sessionMode: string): vscode.OutputChannel {
-		let key = sessionName + '-' + sessionMode;
+		const key = `${sessionName}-${sessionMode}`;
 		let out = this._channels.get(key);
 
 		if (!out) {
-			let name = `${LSP_OUTPUT_CHANNEL_PREFIX}${sessionName} (${sessionMode})`;
+			const name = `${LSP_OUTPUT_CHANNEL_PREFIX}${sessionName} (${sessionMode})`;
 			out = vscode.window.createOutputChannel(name);
 			this._channels.set(key, out);
 		}

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -120,7 +120,10 @@ export class ArkLsp implements vscode.Disposable {
 		// With a `.` rather than a `-` so vscode-languageserver can look up related options correctly
 		const id = 'positron.r';
 
-		LOGGER.info(`Creating Positron R ${this._version} language client (port ${port})...`);
+		const message = `Creating Positron R ${this._version} language client (port ${port})`;
+		LOGGER.info(message);
+		outputChannel.appendLine(message);
+
 		this._client = new LanguageClient(id, `Positron R Language Server (${this._version})`, serverOptions, clientOptions);
 
 		const out = new PromiseHandles<void>();

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -87,7 +87,7 @@ export class ArkLsp implements vscode.Disposable {
 			return out.promise;
 		};
 
-		const notebookUri = this._metadata.notebookUri;
+		const { notebookUri } = this._metadata;
 
 		// Persistant output channel, used across multiple sessions of the same name + mode combination
 		const outputChannel = RLspOutputChannelManager.instance.getOutputChannel(

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -84,7 +84,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		readonly kernelSpec?: JupyterKernelSpec,
 		readonly extra?: JupyterKernelExtra,
 	) {
-		this._lsp = new ArkLsp(runtimeMetadata.languageVersion, metadata.notebookUri);
+		this._lsp = new ArkLsp(runtimeMetadata.languageVersion, metadata);
 		this._queue = new PQueue({ concurrency: 1 });
 		this.onDidReceiveRuntimeMessage = this._messageEmitter.event;
 		this.onDidChangeRuntimeState = this._stateEmitter.event;


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/1568
See https://github.com/posit-dev/positron/issues/1568#issuecomment-2077521907 where I fully outlined the issue

This PR introduces an output channel manager for R and Python (same code, duplicated across both). It essentially manages a map of `key -> OutputChannel` so that we can be fully in charge of the output channel that the `LanguageClient` uses.

The hardest part was picking a `key`, but a reasonable one seems to be `sessionName + sessionMode`, as that effectively matches the key used for the kernel log, i.e. `Console: R 4.4.0` and `Notebook: R 4.4.0`. The main case where this falls down is if the user opens multiple notebooks that have the same name, but that seems somewhat rare, and it won't break, you'll just get everything logged to 1 output channel.

It uses a singleton pattern modeled after `RSessionManager`. Notably it never disposes of the output channels, which I think is okay because:
- We reuse the same output channel between restarts of the same `sessionName + sessionMode` combination
- If a kernel crashes and can't start up, you want to be able to look at the output channel for debugging purposes

https://github.com/posit-dev/positron/assets/19150088/f85f79a8-376e-4758-ae85-d6eb4c6332ad

You can now see a `shutdown()` followed by an `initialize()` in that single output channel for R 4.4.0 (console)

<img width="472" alt="Screenshot 2024-05-09 at 3 18 30 PM" src="https://github.com/posit-dev/positron/assets/19150088/a065323c-c68d-4374-b64f-81c9df57282f">


This is what it looks like with a few active LSP output channels

<img width="359" alt="Screenshot 2024-05-09 at 3 05 18 PM" src="https://github.com/posit-dev/positron/assets/19150088/437b65b6-ec60-4a25-8e67-285f27bfbdce">
