### PR TITLE
Fix/windows copy from console

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -318,7 +318,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 						const selection = codeEditorWidgetRef.current.getSelection();
 
 						// If there isn't a selection, the Ctrl-C interrupts the runtime. Otherwise,
-						// Ctrl-C copies the selection to the clipboard and clears the selection.
+						// Ctrl-C copies the selection to the clipboard.
 						if (!selection || selection.isEmpty()) {
 							interruptRuntime();
 						} else {
@@ -331,14 +331,6 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 
 								// Write the selection value to the clipboard.
 								await positronConsoleContext.clipboardService.writeText(value);
-
-								// Clear the selection.
-								codeEditorWidgetRef.current.setSelection({
-									startLineNumber: Number.MAX_VALUE,
-									startColumn: Number.MAX_VALUE,
-									endLineNumber: Number.MAX_VALUE,
-									endColumn: Number.MAX_VALUE
-								});
 							}
 						}
 					}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -317,8 +317,8 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 						// Get the selection.
 						const selection = codeEditorWidgetRef.current.getSelection();
 
-						// If there isn't a selection, the Ctrl-C interrupts the console. Otherwise,
-						// Ctrl-C copies the selection to the clipboard.
+						// If there isn't a selection, the Ctrl-C interrupts the runtime. Otherwise,
+						// Ctrl-C copies the selection to the clipboard and clears the selection.
 						if (!selection || selection.isEmpty()) {
 							interruptRuntime();
 						} else {
@@ -332,7 +332,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 								// Write the selection value to the clipboard.
 								await positronConsoleContext.clipboardService.writeText(value);
 
-								// Unselect the selection.
+								// Clear the selection.
 								codeEditorWidgetRef.current.setSelection({
 									startLineNumber: Number.MAX_VALUE,
 									startColumn: Number.MAX_VALUE,


### PR DESCRIPTION
### Introduction

This PR addresses https://github.com/posit-dev/positron/issues/2126 by adding special processing for Ctrl-C in the Positron Console on Windows and Linux.

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

On Windows and Linux, allow users to copy selected code from the Positron Console CodeEditorWidget using Ctrl-C. Prior to this PR, pressing Ctrl-C always interrupted the runtime.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

With this PR, on Windows and Linux, Ctrl-C now has two possible functions:

1. If there is selected code in the Positron Console CodeEditorWidget, pressing Ctrl-C will copy the selected code to the clipboard.
2. If there isn't selected code in the Positron Console CodeEditorWidget, Ctrl-C will interrupt the runtime.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

This will need to be tested on a real Windows machine as well as on a Windows VM.

Here's a movie.

https://github.com/posit-dev/positron/assets/853239/5fb4b1a4-9c77-43b0-8ce5-2c30bcde9548



