### PR TITLE
Be more cautious about deepcopying mutable objects

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -185,7 +185,7 @@ class PositronInspector(Generic[T]):
 #
 
 
-class NoneInspector(PositronInspector[types.NoneType]):
+class NoneInspector(PositronInspector[type(None)]):
     def is_mutable(self) -> bool:
         return False
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
@@ -4,7 +4,6 @@
 import copy
 import datetime
 import inspect
-import math
 import pprint
 import random
 import string

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
@@ -238,6 +238,17 @@ def test_mpl_multiple_figures(shell: PositronShell, plots_service: PlotsService)
     assert plot_comms[1].messages == [json_rpc_notification("show", {})]
 
 
+def test_mpl_issue_2824(shell: PositronShell, plots_service: PlotsService) -> None:
+    """
+    Creating a mutable collection of figures should not create a duplicate plot.
+    See https://github.com/posit-dev/positron/issues/2824
+    """
+    shell.run_cell("figs = [plt.figure()]")
+    # This step triggers the variables service to create a snapshot, which shouldn't duplicate the plot.
+    shell.run_cell("plt.show()")
+    assert len(plots_service._plots) == 1
+
+
 def test_mpl_shutdown(shell: PositronShell, plots_service: PlotsService) -> None:
     plot_comms = [_create_mpl_plot(shell, plots_service) for _ in range(2)]
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
@@ -62,20 +62,20 @@ def test_comm_open(kernel: PositronIPyKernel) -> None:
         #
         # Same types
         #
-        ("import numpy as np", [f"np.array({x})" for x in [3, [3], [[3]]]]),
-        ("import torch", [f"torch.tensor({x})" for x in [3, [3], [[3]]]]),
+        ("import numpy as np", [f"x = np.array({x})" for x in [3, [3], [[3]]]]),
+        ("import torch", [f"x = torch.tensor({x})" for x in [3, [3], [[3]]]]),
         pytest.param(
             "import pandas as pd",
-            [f"pd.Series({x})" for x in [[], [3], [3, 3], ["3"]]],
+            [f"x = pd.Series({x})" for x in [[], [3], [3, 3], ["3"]]],
         ),
         pytest.param(
             "import polars as pl",
-            [f"pl.Series({x})" for x in [[], [3], [3, 3], ["3"]]],
+            [f"x = pl.Series({x})" for x in [[], [3], [3, 3], ["3"]]],
         ),
         (
             "import pandas as pd",
             [
-                f"pd.DataFrame({x})"
+                f"x = pd.DataFrame({x})"
                 for x in [
                     {"a": []},
                     {"a": [3]},
@@ -87,7 +87,7 @@ def test_comm_open(kernel: PositronIPyKernel) -> None:
         (
             "import polars as pl",
             [
-                f"pl.DataFrame({x})"
+                f"x = pl.DataFrame({x})"
                 for x in [
                     {"a": []},
                     {"a": [3]},
@@ -96,11 +96,9 @@ def test_comm_open(kernel: PositronIPyKernel) -> None:
                 ]
             ],
         ),
-        #
-        # Changing types
-        #
-        ("", ["3", "'3'"]),
-        ("import numpy as np", ["3", "np.array(3)"]),
+        # Nested mutable types
+        ("", ["x = [{}]", "x[0]['a'] = 0"]),
+        ("", ["x = {'a': []}", "x['a'].append(0)"]),
     ],
 )
 def test_change_detection(
@@ -119,7 +117,7 @@ def test_change_detection(
 
 def _assert_assigned(shell: PositronShell, value_code: str, variables_comm: DummyComm):
     # Assign the value to a variable.
-    shell.run_cell(f"x = {value_code}")
+    shell.run_cell(value_code)
 
     # Test that the expected `update` message was sent with the
     # expected `assigned` value.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -11,6 +11,7 @@ over a variety types from popular Python libraries.
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 import time
 import types
@@ -20,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 from comm.base_comm import BaseComm
 
 from .access_keys import decode_access_key, encode_access_key
-from .inspectors import CopyError, get_inspector
+from .inspectors import get_inspector
 from .positron_comm import CommMessage, JsonRpcErrorCode, PositronComm
 from .utils import JsonData, JsonRecord, cancel_tasks, create_task, get_qualname
 from .variables_comm import (
@@ -56,6 +57,7 @@ MAX_ITEMS: int = 10000
 
 # Budget for number of "units" of work to allow for namespace change
 # detection. The costs are defined in inspectors.py
+# Units are rough estimates of the number of bytes copied.
 MAX_SNAPSHOT_COMPARISON_BUDGET: int = 10_000_000
 
 
@@ -295,8 +297,8 @@ class VariablesService:
                 else:
                     comparison_cost += cost
                     try:
-                        mutable_vars_copied[key] = inspector.copy()
-                    except CopyError:
+                        mutable_vars_copied[key] = inspector.deepcopy()
+                    except copy.Error:
                         # when a variable is mutable, but not copiable we can't
                         # detect changes on it
                         mutable_vars_excluded[key] = value


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses #2833 and #2824.

### Approach

The main change is to throw `copy.Error`s when trying to deepcopy inspectors of mutable values, unless a sub-class provides a safe `deepcopy` method. We already catch these errors and notify the frontend that the variable was updated.

I also renamed `copy` to `deepcopy` since that's what we really need for detecting changes of mutable objects.

I also tried a few different ways to hook into the deepcopy mechanism at every level of a nested collection/map but couldn't get it to work. The rough idea was to wrap children in inspectors and call their `deepcopy` method instead of directly deepcopying the parent value. I still think it's possible but don't think it's worth spending more time on so leaving it for future. Alternatively, we might end up changing the way the frontend variable pane interacts with the kernel.

### QA Notes

See #2824. #2833 doesn't correspond to any noticeable difference in the UI.