### PR TITLE
Data Explorer: Normalize pandas boolean type name based on how type was discovered

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -274,6 +274,7 @@ class PandasView(DataExplorerTableView):
         "bytes": "string",
         "string": "string",
     }
+    TYPE_NAME_MAPPING = {"boolean": "bool"}
 
     def __init__(
         self,
@@ -582,6 +583,7 @@ class PandasView(DataExplorerTableView):
         # TODO: time zone for datetimetz datetime64[ns] types
         if dtype == object:
             type_name = get_inferred_dtype()
+            type_name = cls.TYPE_NAME_MAPPING.get(type_name, type_name)
         else:
             # TODO: more sophisticated type mapping
             type_name = str(dtype)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -495,7 +495,7 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
         {
             "column_name": "b",
             "column_index": 1,
-            "type_name": "boolean",
+            "type_name": "bool",
             "type_display": "boolean",
         },
         {


### PR DESCRIPTION
Based on whether there were nulls or not, the type would show up as "bool" vs "boolean", so this normalizes to be "bool". Per #2950