### PR TITLE
Store `__pycache__` folders in the extension's global storage directory for the user

### DIFF
--- a/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
+++ b/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
@@ -32,7 +32,7 @@ export interface JupyterKernelSpec {
 	interrupt_mode?: 'signal' | 'message'; // eslint-disable-line
 
 	/** Environment variables to set when starting the kernel */
-	env?: { [key: string]: string };
+	env?: NodeJS.ProcessEnv;
 }
 
 /**

--- a/extensions/positron-python/src/client/jupyter-adapter.d.ts
+++ b/extensions/positron-python/src/client/jupyter-adapter.d.ts
@@ -32,7 +32,7 @@ export interface JupyterKernelSpec {
     interrupt_mode?: 'signal' | 'message'; // eslint-disable-line
 
     /** Environment variables to set when starting the kernel */
-    env?: { [key: string]: string };
+    env?: NodeJS.ProcessEnv;
 }
 
 /**

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -18,6 +18,7 @@ import { PythonRuntimeSession } from './session';
 import { PythonRuntimeExtraData } from './runtime';
 import { EXTENSION_ROOT_DIR } from '../common/constants';
 import { JupyterKernelSpec } from '../jupyter-adapter.d';
+import { IEnvironmentVariablesProvider } from '../common/variables/types';
 
 /**
  * Provides Python language runtime metadata and sessions to Positron;
@@ -81,6 +82,9 @@ export class PythonRuntimeManager implements positron.LanguageRuntimeManager {
         traceInfo('createPythonSession: getting service instances');
 
         const configService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
+        const environmentVariablesProvider = this.serviceContainer.get<IEnvironmentVariablesProvider>(
+            IEnvironmentVariablesProvider,
+        );
 
         // Extract the extra data from the runtime metadata; it contains the
         // environment ID that was saved when the metadata was created.
@@ -131,10 +135,12 @@ export class PythonRuntimeManager implements positron.LanguageRuntimeManager {
         // Create a kernel spec for this Python installation. The kernel spec is
         // only provided for new sessions; existing (restored) sessions already
         // have one.
+        const env = await environmentVariablesProvider.getEnvironmentVariables();
         const kernelSpec: JupyterKernelSpec = {
             argv: args,
             display_name: `${runtimeMetadata.runtimeName}`,
             language: 'Python',
+            env,
         };
 
         traceInfo(`createPythonSession: kernelSpec argv: ${args}`);

--- a/extensions/positron-python/src/test/common/variables/envVarsProvider.multiroot.test.ts
+++ b/extensions/positron-python/src/test/common/variables/envVarsProvider.multiroot.test.ts
@@ -89,6 +89,7 @@ suite('Multiroot Environment Variables Provider', () => {
             mockProcess,
             // --- Start Positron ---
             instance(context),
+            fs,
             // --- End Positron ---
         );
     }

--- a/extensions/positron-python/src/test/common/variables/envVarsProvider.multiroot.test.ts
+++ b/extensions/positron-python/src/test/common/variables/envVarsProvider.multiroot.test.ts
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+// --- Start Positron ---
+/* eslint-disable import/no-duplicates */
+// --- End Positron ---
 
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
@@ -22,6 +25,9 @@ import { closeActiveWindows, initialize, initializeTest, IS_MULTI_ROOT_TEST } fr
 import { MockAutoSelectionService } from '../../mocks/autoSelector';
 import { MockProcess } from '../../mocks/process';
 import { UnitTestIocContainer } from '../../testing/serviceRegistry';
+// --- Start Positron ---
+import { IExtensionContext } from '../../../client/common/types';
+// --- End Positron ---
 
 use(chaiAsPromised);
 
@@ -72,12 +78,18 @@ suite('Multiroot Environment Variables Provider', () => {
         const disposables = ioc.serviceContainer.get<Disposable[]>(IDisposableRegistry);
         ioc.serviceManager.addSingletonInstance(IInterpreterAutoSelectionService, new MockAutoSelectionService());
         const workspaceService = new WorkspaceService();
+        // --- Start Positron ---
+        const context: IExtensionContext = mock(IExtensionContext);
+        // --- End Positron ---
         return new EnvironmentVariablesProvider(
             variablesService,
             disposables,
             new PlatformService(),
             workspaceService,
             mockProcess,
+            // --- Start Positron ---
+            instance(context),
+            // --- End Positron ---
         );
     }
 

--- a/extensions/positron-python/src/test/common/variables/environmentVariablesProvider.unit.test.ts
+++ b/extensions/positron-python/src/test/common/variables/environmentVariablesProvider.unit.test.ts
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+// --- Start Positron ---
+/* eslint-disable import/no-duplicates */
+// --- End Positron ---
 
 'use strict';
 
@@ -22,6 +25,9 @@ import { EnvironmentVariablesProvider } from '../../../client/common/variables/e
 import { IEnvironmentVariablesService } from '../../../client/common/variables/types';
 import * as EnvFileTelemetry from '../../../client/telemetry/envFileTelemetry';
 import { noop } from '../../core';
+// --- Start Positron ---
+import { IExtensionContext } from '../../../client/common/types';
+// --- End Positron ---
 
 suite('Multiroot Environment Variables Provider', () => {
     let provider: EnvironmentVariablesProvider;
@@ -29,6 +35,9 @@ suite('Multiroot Environment Variables Provider', () => {
     let platform: IPlatformService;
     let workspace: IWorkspaceService;
     let currentProcess: ICurrentProcess;
+    // --- Start Positron ---
+    let context: IExtensionContext;
+    // --- End Positron ---
     let envFile: string;
 
     setup(() => {
@@ -37,6 +46,9 @@ suite('Multiroot Environment Variables Provider', () => {
         platform = mock(PlatformService);
         workspace = mock(WorkspaceService);
         currentProcess = mock(CurrentProcess);
+        // --- Start Positron ---
+        context = mock(IExtensionContext);
+        // --- End Positron ---
 
         when(workspace.onDidChangeConfiguration).thenReturn(noop as any);
         when(workspace.getConfiguration('python', anything())).thenReturn({
@@ -48,6 +60,9 @@ suite('Multiroot Environment Variables Provider', () => {
             instance(platform),
             instance(workspace),
             instance(currentProcess),
+            // --- Start Positron ---
+            instance(context),
+            // --- End Positron ---
         );
 
         sinon.stub(EnvFileTelemetry, 'sendFileCreationTelemetry').returns();
@@ -312,6 +327,9 @@ suite('Multiroot Environment Variables Provider', () => {
                 instance(platform),
                 instance(workspace),
                 instance(currentProcess),
+                // --- Start Positron ---
+                instance(context),
+                // --- End Positron ---
                 100,
             );
             const vars = await provider.getEnvironmentVariables(workspaceUri);

--- a/extensions/positron-python/src/test/common/variables/environmentVariablesProvider.unit.test.ts
+++ b/extensions/positron-python/src/test/common/variables/environmentVariablesProvider.unit.test.ts
@@ -256,7 +256,7 @@ suite('Multiroot Environment Variables Provider', () => {
             verify(envVarsService.mergeVariables(deepEqual(currentProcEnv), deepEqual({}))).once();
             verify(platform.pathVariableName).atLeast(1);
             // --- Start Positron ---
-            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: '/pycache' });
+            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
             // --- End Positron ---
         });
         test(`Getting environment variables (with an envfile, without PATH in current env, without PYTHONPATH in current env) & ${workspaceTitle}`, async () => {
@@ -277,7 +277,7 @@ suite('Multiroot Environment Variables Provider', () => {
             verify(envVarsService.mergeVariables(deepEqual(currentProcEnv), deepEqual(envFileVars))).once();
             verify(platform.pathVariableName).atLeast(1);
             // --- Start Positron ---
-            assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: '/pycache' });
+            assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
             // --- End Positron ---
         });
         test(`Getting environment variables (with an envfile, with PATH in current env, with PYTHONPATH in current env) & ${workspaceTitle}`, async () => {
@@ -300,7 +300,7 @@ suite('Multiroot Environment Variables Provider', () => {
             verify(envVarsService.appendPythonPath(deepEqual(envFileVars), currentProcEnv.PYTHONPATH)).once();
             verify(platform.pathVariableName).atLeast(1);
             // --- Start Positron ---
-            assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: '/pycache' });
+            assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
             // --- End Positron ---
         });
 
@@ -317,7 +317,7 @@ suite('Multiroot Environment Variables Provider', () => {
             const vars = await provider.getEnvironmentVariables(workspaceUri);
 
             // --- Start Positron ---
-            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: '/pycache' });
+            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
             // --- End Positron ---
 
             await provider.getEnvironmentVariables(workspaceUri);
@@ -325,7 +325,7 @@ suite('Multiroot Environment Variables Provider', () => {
             // Verify that the contents of `_getEnvironmentVariables()` method are only invoked once
             verify(workspace.getConfiguration('python', anything())).once();
             // --- Start Positron ---
-            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: '/pycache' });
+            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
             // --- End Positron ---
         });
 
@@ -354,7 +354,7 @@ suite('Multiroot Environment Variables Provider', () => {
             const vars = await provider.getEnvironmentVariables(workspaceUri);
 
             // --- Start Positron ---
-            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: '/pycache' });
+            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
             // --- End Positron ---
 
             await sleep(110);
@@ -363,7 +363,7 @@ suite('Multiroot Environment Variables Provider', () => {
             // Verify that the contents of `_getEnvironmentVariables()` method are invoked twice
             verify(workspace.getConfiguration('python', anything())).twice();
             // --- Start Positron ---
-            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: '/pycache' });
+            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
             // --- End Positron ---
         });
 
@@ -405,17 +405,17 @@ suite('Multiroot Environment Variables Provider', () => {
             async function checkVars() {
                 let vars = await provider.getEnvironmentVariables(undefined);
                 // --- Start Positron ---
-                assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: '/pycache' });
+                assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
                 // --- End Positron ---
 
                 vars = await provider.getEnvironmentVariables(Uri.file(sourceFile));
                 // --- Start Positron ---
-                assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: '/pycache' });
+                assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
                 // --- End Positron ---
 
                 vars = await provider.getEnvironmentVariables(Uri.file(sourceDir));
                 // --- Start Positron ---
-                assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: '/pycache' });
+                assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
                 // --- End Positron ---
             }
 

--- a/extensions/positron-python/src/test/common/variables/environmentVariablesProvider.unit.test.ts
+++ b/extensions/positron-python/src/test/common/variables/environmentVariablesProvider.unit.test.ts
@@ -256,7 +256,7 @@ suite('Multiroot Environment Variables Provider', () => {
             verify(envVarsService.mergeVariables(deepEqual(currentProcEnv), deepEqual({}))).once();
             verify(platform.pathVariableName).atLeast(1);
             // --- Start Positron ---
-            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
+            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: `${path.sep}pycache` });
             // --- End Positron ---
         });
         test(`Getting environment variables (with an envfile, without PATH in current env, without PYTHONPATH in current env) & ${workspaceTitle}`, async () => {
@@ -277,7 +277,7 @@ suite('Multiroot Environment Variables Provider', () => {
             verify(envVarsService.mergeVariables(deepEqual(currentProcEnv), deepEqual(envFileVars))).once();
             verify(platform.pathVariableName).atLeast(1);
             // --- Start Positron ---
-            assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
+            assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: `${path.sep}pycache` });
             // --- End Positron ---
         });
         test(`Getting environment variables (with an envfile, with PATH in current env, with PYTHONPATH in current env) & ${workspaceTitle}`, async () => {
@@ -300,7 +300,7 @@ suite('Multiroot Environment Variables Provider', () => {
             verify(envVarsService.appendPythonPath(deepEqual(envFileVars), currentProcEnv.PYTHONPATH)).once();
             verify(platform.pathVariableName).atLeast(1);
             // --- Start Positron ---
-            assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
+            assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: `${path.sep}pycache` });
             // --- End Positron ---
         });
 
@@ -317,7 +317,7 @@ suite('Multiroot Environment Variables Provider', () => {
             const vars = await provider.getEnvironmentVariables(workspaceUri);
 
             // --- Start Positron ---
-            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
+            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: `${path.sep}pycache` });
             // --- End Positron ---
 
             await provider.getEnvironmentVariables(workspaceUri);
@@ -325,7 +325,7 @@ suite('Multiroot Environment Variables Provider', () => {
             // Verify that the contents of `_getEnvironmentVariables()` method are only invoked once
             verify(workspace.getConfiguration('python', anything())).once();
             // --- Start Positron ---
-            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
+            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: `${path.sep}pycache` });
             // --- End Positron ---
         });
 
@@ -354,7 +354,7 @@ suite('Multiroot Environment Variables Provider', () => {
             const vars = await provider.getEnvironmentVariables(workspaceUri);
 
             // --- Start Positron ---
-            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
+            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: `${path.sep}pycache` });
             // --- End Positron ---
 
             await sleep(110);
@@ -363,7 +363,7 @@ suite('Multiroot Environment Variables Provider', () => {
             // Verify that the contents of `_getEnvironmentVariables()` method are invoked twice
             verify(workspace.getConfiguration('python', anything())).twice();
             // --- Start Positron ---
-            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
+            assert.deepEqual(vars, { PYTHONPYCACHEPREFIX: `${path.sep}pycache` });
             // --- End Positron ---
         });
 
@@ -405,17 +405,17 @@ suite('Multiroot Environment Variables Provider', () => {
             async function checkVars() {
                 let vars = await provider.getEnvironmentVariables(undefined);
                 // --- Start Positron ---
-                assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
+                assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: `${path.sep}pycache` });
                 // --- End Positron ---
 
                 vars = await provider.getEnvironmentVariables(Uri.file(sourceFile));
                 // --- Start Positron ---
-                assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
+                assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: `${path.sep}pycache` });
                 // --- End Positron ---
 
                 vars = await provider.getEnvironmentVariables(Uri.file(sourceDir));
                 // --- Start Positron ---
-                assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: path.join('', 'pycache') });
+                assert.deepEqual(vars, { ...envFileVars, PYTHONPYCACHEPREFIX: `${path.sep}pycache` });
                 // --- End Positron ---
             }
 

--- a/extensions/positron-r/src/jupyter-adapter.d.ts
+++ b/extensions/positron-r/src/jupyter-adapter.d.ts
@@ -32,7 +32,7 @@ export interface JupyterKernelSpec {
 	interrupt_mode?: 'signal' | 'message'; // eslint-disable-line
 
 	/** Environment variables to set when starting the kernel */
-	env?: { [key: string]: string };
+	env?: NodeJS.ProcessEnv;
 }
 
 /**
@@ -99,7 +99,8 @@ export interface JupyterAdapterApi extends vscode.Disposable {
 	 *   start the kernel.
 	 * @param dynState The initial dynamic state of the session.
 	 * @param extra Optional implementations for extra functionality.
-	 * @returns A LanguageRuntimeAdapter that wraps the kernel.
+	 *
+	 * @returns A JupyterLanguageRuntimeSession that wraps the kernel.
 	 */
 	createSession(
 		runtimeMetadata: positron.LanguageRuntimeMetadata,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Address #960.

### Approach

This updates the `EnvironmentVariablesProvider` adding the `PYTHONPYCACHEPREFIX` key which points to a subfolder of `IExtensionContext.globalStorageUri`, and now uses the `EnvironmentVariablesProvider` to get the env vars for the runtime's kernelspec.

Notes:

1. I wondered if passing `environmentVariablesProvider.getEnvironmentVariables` would pass any new environment variables, but that somehow didn't seem to be the case in my testing.
2. My cache dir gets to 135MB. There doesn't seem to be a way to only reroute `__pycache__` folders in the Positron `.app` folder, so _everything_ gets written to the new cache folder.

### QA Notes