### PR TITLE
Plot mouse pan

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/scrollable/Scrollable.tsx
+++ b/src/vs/base/browser/ui/positronComponents/scrollable/Scrollable.tsx
@@ -1,0 +1,105 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from 'react';
+import { PropsWithChildren } from 'react';
+import { DomScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableElement';
+import { ScrollableElementChangeOptions } from 'vs/base/browser/ui/scrollbar/scrollableElementOptions';
+import { positronClassNames } from 'vs/base/common/positronUtilities';
+import { ScrollbarVisibility } from 'vs/base/common/scrollable';
+
+interface ScrollableProps {
+	width: number;
+	height: number;
+	scrollableWidth: number;
+	scrollableHeight: number;
+	mousePan?: boolean;
+}
+
+/**
+ * A scrollable component that wraps child elements and provides scrolling functionality.
+ * The component is composed of the child elements and scrollable controls. The controls are provided
+ * by the DomScrollableElement class.
+ *
+ * Any number of child elements can be wrapped by the Scrollable component. The scrollableWidth and
+ * scrollableHeight properties are used to determine the scrollable extents.
+ *
+ * @param props Scrollable props
+ * @returns The rendered component that scrolls the child element.
+ */
+export const Scrollable = (props: PropsWithChildren<ScrollableProps>) => {
+	const [scrollableElement, setScrollableElement] = React.useState<DomScrollableElement>();
+	const [grabbing, setGrabbing] = React.useState<boolean>(false);
+	const scrollableRef = React.useRef<HTMLDivElement>(null);
+
+	React.useEffect(() => {
+		const scrollableOptions: ScrollableElementChangeOptions = {
+			horizontal: props.width < props.scrollableWidth ? ScrollbarVisibility.Visible : ScrollbarVisibility.Hidden,
+			vertical: props.height < props.scrollableHeight ? ScrollbarVisibility.Visible : ScrollbarVisibility.Hidden,
+		};
+		scrollableRef?.current?.style.setProperty('width', `${props.width}px`);
+		scrollableRef?.current?.style.setProperty('height', `${props.height}px`);
+		scrollableElement?.updateOptions(scrollableOptions);
+		scrollableElement?.scanDomNode();
+	}, [props.children, props.width, props.height, props.scrollableWidth, props.scrollableHeight, scrollableElement]);
+
+	/**
+	 * The scrollable is appended to the parent of the wrapper element. Then the wrapper element is appended to the scrollable.
+	 *
+	 * The DOM will look liks this:
+	 * <div class="parent">
+	 *  <div class="positron-scrollable-element">
+	 *    <div class="scrollable">
+	 * 		<div class="scrollbar horizontal">
+	 * 		<div class="scrollbar vertical">
+	 *    </div>
+	 *  </div>
+	 * </div>
+	 */
+	React.useEffect(() => {
+		if (!scrollableRef.current) {
+			return;
+		}
+		if (!scrollableElement) {
+			const parentElement = scrollableRef.current.parentElement;
+			const scrollable = new DomScrollableElement(scrollableRef.current, {
+				horizontal: ScrollbarVisibility.Auto,
+				vertical: ScrollbarVisibility.Auto,
+				useShadows: false,
+				className: 'positron-scrollable-element',
+			});
+
+			setScrollableElement(scrollable);
+			parentElement?.appendChild(scrollable.getDomNode());
+			scrollable.scanDomNode();
+		}
+		return () => scrollableElement?.dispose();
+	}, [scrollableElement]);
+
+	const updateCursor = (event: React.MouseEvent<HTMLElement>) => {
+		if (props.mousePan) {
+			if (event.type === 'mousedown' && event.buttons === 1) {
+				setGrabbing(true);
+			} else {
+				setGrabbing(false);
+			}
+		}
+	};
+
+	const panImage = (event: React.MouseEvent<HTMLDivElement>) => {
+		event.preventDefault();
+		if (props.mousePan && event.buttons === 1) {
+			scrollableElement?.setScrollPosition({
+				scrollLeft: scrollableElement.getScrollPosition().scrollLeft - event.movementX,
+				scrollTop: scrollableElement.getScrollPosition().scrollTop - event.movementY,
+			});
+		}
+	};
+
+	return (
+		<div className={positronClassNames('scrollable', { 'grab': !grabbing, 'grabbing': grabbing })} ref={scrollableRef} onMouseMoveCapture={panImage} onMouseDown={updateCursor} onMouseUp={updateCursor}>
+			{props.children}
+		</div >
+	);
+};

--- a/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
@@ -513,6 +513,7 @@ export abstract class AbstractScrollableElement extends Widget {
 		if (!this._options.lazyRender) {
 			throw new Error('Please use `lazyRender` together with `renderNow`!');
 		}
+		this._shouldRender = true;
 
 		this._render();
 	}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/panZoomImage.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/panZoomImage.tsx
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from 'react';
+import { isMacintosh } from 'vs/base/common/platform';
+import { ZoomLevel } from 'vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton';
+
+interface PanZoomImageProps {
+	imageUri: string;
+	description: string;
+	zoom: ZoomLevel;
+}
+
+/**
+ * A component to pan the image using mouse drag or wheel
+ * and set the image zoom (scale multiplier).
+ * @param props A PanZoomImageProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const PanZoomImage = (props: PanZoomImageProps) => {
+	const [width, setWidth] = React.useState<number>(1);
+	const [height, setHeight] = React.useState<number>(1);
+	const imageWrapperRef = React.useRef<HTMLDivElement>(null);
+	const [moveX, setMoveX] = React.useState<number>(0);
+	const [moveY, setMoveY] = React.useState<number>(0);
+	const [grabbing, setGrabbing] = React.useState<boolean>(false);
+
+	const reverseScroll = isMacintosh;
+
+	React.useEffect(() => {
+		// centers the image
+		const { clientWidth, clientHeight } = imageWrapperRef.current ?? { clientWidth: 0, clientHeight: 0 };
+		setMoveX((clientWidth - (width * props.zoom)) / 2);
+		setMoveY((clientHeight - (height * props.zoom)) / 2);
+	}, [width, height, props.zoom]);
+
+	const getStyle = (): React.CSSProperties => {
+		let style: React.CSSProperties = {};
+
+		if (props.zoom === ZoomLevel.Fill) {
+			// no translation added and let the entire plot be visible
+			style = {
+				width: '100%',
+				height: '100%',
+				position: 'unset',
+				transform: 'none',
+			};
+		} else {
+			const panMovement = `translateX(${moveX}px) translateY(${moveY}px)`;
+			style = {
+				cursor: grabbing ? 'grabbing' : 'grab',
+				maxWidth: 'none',
+				maxHeight: 'none',
+				top: 0,
+				left: 0,
+				transform: panMovement,
+			};
+		}
+
+		return style;
+	};
+	const onImgLoad = (event: React.SyntheticEvent<HTMLImageElement>) => {
+		const img = event.target as HTMLImageElement;
+		const width = img.naturalWidth;
+		const height = img.naturalHeight;
+		setWidth(width);
+		setHeight(height);
+	};
+
+	const applyZoom = (value: number): string => {
+		if (props.zoom !== ZoomLevel.Fill) {
+			return `${value * props.zoom}px`;
+		}
+
+		return '100%';
+	};
+
+	const panImage = (event: React.MouseEvent<HTMLElement>) => {
+		const { clientWidth, clientHeight } = imageWrapperRef.current ?? { clientWidth: 0, clientHeight: 0 };
+		const adjustedWidth = width * props.zoom;
+		const adjustedHeight = height * props.zoom;
+
+		// Clamp the movement to the parent's boundaries
+		const maxMoveX = adjustedWidth > clientWidth ? 0 : clientWidth - adjustedWidth;
+		const minMoveX = adjustedWidth > clientWidth ? -adjustedWidth + clientWidth : 0;
+		const maxMoveY = adjustedHeight > clientHeight ? 0 : clientHeight - adjustedHeight;
+		const minMoveY = adjustedHeight > clientHeight ? -adjustedHeight + clientHeight : 0;
+
+		let newMoveX = 0, newMoveY = 0;
+
+		if (event.type === 'wheel' && event.buttons === 0) {
+			const wheelEvent = event as React.WheelEvent<HTMLImageElement>;
+
+			// Adds the reverse scroll effect if on Mac
+			newMoveX = moveX + (reverseScroll ? -wheelEvent.deltaX : wheelEvent.deltaX);
+			newMoveY = moveY + (reverseScroll ? -wheelEvent.deltaY : wheelEvent.deltaY);
+		} else if (event.buttons === 1 && props.zoom !== ZoomLevel.Fill) {
+			newMoveX = moveX + event.movementX;
+			newMoveY = moveY + event.movementY;
+		} else {
+			return;
+		}
+
+		const finalMoveX = Math.max(Math.min(newMoveX, maxMoveX), minMoveX);
+		const finalMoveY = Math.max(Math.min(newMoveY, maxMoveY), minMoveY);
+		setMoveX(finalMoveX);
+		setMoveY(finalMoveY);
+	};
+
+	const updateCursor = (event: React.MouseEvent<HTMLElement>) => {
+		setGrabbing(event.type === 'mousedown');
+	};
+
+	return (
+		<div className='image-wrapper'
+			ref={imageWrapperRef}
+			onMouseMoveCapture={panImage}
+			onMouseDown={updateCursor}
+			onMouseUp={updateCursor}
+			onWheel={panImage}
+		>
+			<img src={props.imageUri}
+				alt={props.description}
+				onLoad={onImgLoad}
+				style={getStyle()}
+				width={applyZoom(width)}
+				height={applyZoom(height)}
+				draggable={false}
+			/>
+		</div>
+	);
+};

--- a/src/vs/workbench/contrib/positronPlots/browser/components/panZoomImage.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/panZoomImage.tsx
@@ -75,14 +75,6 @@ export const PanZoomImage = (props: PanZoomImageProps) => {
 		scrollableElement.scanDomNode();
 	}, [width, height, props.zoom, props.width, props.height, scrollableElement]);
 
-	React.useEffect(() => {
-		if (!imageWrapperRef.current || !scrollableElement) {
-			return;
-		}
-
-		scrollableElement.scanDomNode();
-	}, [scrollableElement]);
-
 	// Wrap the image in a scrollable element
 	React.useEffect(() => {
 		if (!imageWrapperRef.current || !imageRef.current) {

--- a/src/vs/workbench/contrib/positronPlots/browser/components/panZoomImage.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/panZoomImage.tsx
@@ -38,14 +38,18 @@ export const PanZoomImage = (props: PanZoomImageProps) => {
 		const adjustedWidth = props.zoom === ZoomLevel.Fill ? width : width * props.zoom;
 		const adjustedHeight = props.zoom === ZoomLevel.Fill ? height : height * props.zoom;
 		if (props.zoom === ZoomLevel.Fill) {
-			if (adjustedWidth < props.width) {
-				imageRef.current.style.height = '100%';
-				imageRef.current.style.width = 'auto';
-			} else if (adjustedHeight < props.height) {
-				imageRef.current.style.width = '100%';
-				imageRef.current.style.height = 'auto';
-			}
+			scrollableElement.updateOptions({
+				horizontal: ScrollbarVisibility.Hidden,
+				vertical: ScrollbarVisibility.Hidden,
+			});
+			imageRef.current.style.width = '100%';
+			imageRef.current.style.height = '100%';
+			imageRef.current.style.objectFit = 'contain';
 		} else {
+			scrollableElement.updateOptions({
+				horizontal: ScrollbarVisibility.Visible,
+				vertical: ScrollbarVisibility.Visible,
+			});
 			imageRef.current.style.width = `${adjustedWidth}px`;
 			imageRef.current.style.height = `${adjustedHeight}px`;
 		}
@@ -155,9 +159,6 @@ export const PanZoomImage = (props: PanZoomImageProps) => {
 				onLoad={onImgLoad}
 				className={grabbing ? 'grabbing' : 'grab'}
 				draggable={false}
-				// style={getStyle()}
-				// width={applyZoom(width)}
-				// height={applyZoom(height)}z
 				ref={imageRef}
 			/>
 		</div>

--- a/src/vs/workbench/contrib/positronPlots/browser/components/panZoomImage.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/panZoomImage.tsx
@@ -103,8 +103,6 @@ export const PanZoomImage = (props: PanZoomImageProps) => {
 			});
 			setScrollableElement(domScrollableElement);
 			imageArea?.appendChild(domScrollableElement.getDomNode());
-		} else {
-			// scrollableElement.scanDomNode();
 		}
 		return () => scrollableElement?.dispose();
 	}, [imageWrapperRef, scrollableElement]);

--- a/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
@@ -3,6 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from 'react';
+import { PanZoomImage } from 'vs/workbench/contrib/positronPlots/browser/components/panZoomImage';
 import { ZoomLevel } from 'vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton';
 import { StaticPlotClient } from 'vs/workbench/services/positronPlots/common/staticPlotClient';
 
@@ -25,114 +26,12 @@ interface StaticPlotInstanceProps {
  * @returns The rendered component.
  */
 export const StaticPlotInstance = (props: StaticPlotInstanceProps) => {
-	const [width, setWidth] = React.useState<number>(1);
-	const [height, setHeight] = React.useState<number>(1);
-	const imageWrapperRef = React.useRef<HTMLDivElement>(null);
-	const [moveX, setMoveX] = React.useState<number>(0);
-	const [moveY, setMoveY] = React.useState<number>(0);
-	const [grabbing, setGrabbing] = React.useState<boolean>(false);
-
-	const onImgLoad = (event: React.SyntheticEvent<HTMLImageElement>) => {
-		const img = event.target as HTMLImageElement;
-		const width = img.naturalWidth;
-		const height = img.naturalHeight;
-		setWidth(width);
-		setHeight(height);
-	};
-
-	React.useEffect(() => {
-		const { clientWidth, clientHeight } = imageWrapperRef.current ?? { clientWidth: 0, clientHeight: 0 };
-		setMoveX((clientWidth - (width * props.zoom)) / 2);
-		setMoveY((clientHeight - (height * props.zoom)) / 2);
-	}, [width, height, props.zoom]);
-
-	React.useLayoutEffect(() => {
-		if (!imageWrapperRef.current || props.zoom === ZoomLevel.Fill) {
-			return;
-		}
-	});
-
-	const getStyle = (): React.CSSProperties => {
-		const panMovement = `translateX(${moveX}px) translateY(${moveY}px)`;
-		let style: React.CSSProperties = {};
-
-		if (props.zoom === ZoomLevel.Fill) {
-			// no centering and let the entire plot be visible
-			style = {
-				width: '100%',
-				height: '100%',
-				position: 'unset',
-				transform: 'none',
-			};
-		} else {
-			style = {
-				cursor: grabbing ? 'grabbing' : 'grab',
-				maxWidth: 'none',
-				maxHeight: 'none',
-				top: 0,
-				left: 0,
-				transform: panMovement,
-			};
-		}
-
-		return style;
-	};
-
-	const applyZoom = (value: number): string => {
-		if (props.zoom !== ZoomLevel.Fill) {
-			return `${value * props.zoom}px`;
-		}
-
-		return '100%';
-	};
-
-	const panImage = (event: React.MouseEvent<HTMLImageElement>) => {
-		const { clientWidth, clientHeight } = imageWrapperRef.current ?? { clientWidth: 0, clientHeight: 0 };
-		const adjustedWidth = width * props.zoom;
-		const adjustedHeight = height * props.zoom;
-		const maxMoveX = adjustedWidth > clientWidth ? 0 : clientWidth - adjustedWidth;
-		const minMoveX = adjustedWidth > clientWidth ? -adjustedWidth + clientWidth : 0;
-		const maxMoveY = adjustedHeight > clientHeight ? 0 : clientHeight - adjustedHeight;
-		const minMoveY = adjustedHeight > clientHeight ? -adjustedHeight + clientHeight : 0;
-
-		let newMoveX = 0, newMoveY = 0;
-
-		if (event.type === 'wheel' && event.buttons === 0) {
-			const wheelEvent = event as React.WheelEvent<HTMLImageElement>;
-			newMoveX = moveX + wheelEvent.deltaX;
-			newMoveY = moveY + wheelEvent.deltaY;
-		} else if (event.buttons === 1 && props.zoom !== ZoomLevel.Fill) {
-			newMoveX = moveX + event.movementX;
-			newMoveY = moveY + event.movementY;
-		} else {
-			return;
-		}
-
-		const finalMoveX = Math.max(Math.min(newMoveX, maxMoveX), minMoveX);
-		const finalMoveY = Math.max(Math.min(newMoveY, maxMoveY), minMoveY);
-		setMoveX(finalMoveX);
-		setMoveY(finalMoveY);
-	};
-
-	const updateCursor = (event: React.MouseEvent<HTMLImageElement>) => {
-		setGrabbing(event.type === 'mousedown');
-	};
-
 	return (
 		<div className='plot-instance static-plot-instance'>
-			<div className='image-wrapper' ref={imageWrapperRef}>
-				<img src={props.plotClient.uri}
-					alt={props.plotClient.code ? props.plotClient.code : 'Plot ' + props.plotClient.id}
-					onLoad={onImgLoad}
-					style={getStyle()}
-					width={applyZoom(width)}
-					height={applyZoom(height)}
-					onMouseMoveCapture={panImage}
-					onMouseDown={updateCursor}
-					onMouseUp={updateCursor}
-					onWheel={panImage}
-					draggable={false}
-				/>
-			</div>
+			<PanZoomImage
+				imageUri={props.plotClient.uri}
+				description={props.plotClient.code ? props.plotClient.code : 'Plot ' + props.plotClient.id}
+				zoom={props.zoom}
+			/>
 		</div>);
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
@@ -29,20 +29,22 @@ export const StaticPlotInstance = (props: StaticPlotInstanceProps) => {
 	const ref = React.useRef<HTMLDivElement>(null);
 	const [width, setWidth] = React.useState<number>(1);
 	const [height, setHeight] = React.useState<number>(1);
+	const resizeObserver = React.useRef<ResizeObserver>();
 
 	React.useEffect(() => {
+		resizeObserver.current = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+			if (entries.length > 0) {
+				const entry = entries[0];
+				const width = entry.contentRect.width;
+				const height = entry.contentRect.height;
+				setWidth(width);
+				setHeight(height);
+			}
+		});
 		if (ref.current) {
-			const resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => {
-				if (entries.length > 0) {
-					const entry = entries[0];
-					const width = entry.contentRect.width;
-					const height = entry.contentRect.height;
-					setWidth(width);
-					setHeight(height);
-				}
-			});
-			resizeObserver.observe(ref.current);
+			resizeObserver.current.observe(ref.current);
 		}
+		return () => resizeObserver.current?.disconnect();
 
 	}, []);
 

--- a/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
@@ -87,19 +87,31 @@ export const StaticPlotInstance = (props: StaticPlotInstanceProps) => {
 	};
 
 	const panImage = (event: React.MouseEvent<HTMLImageElement>) => {
-		if (event.type === 'wheel') {
+		const { clientWidth, clientHeight } = imageWrapperRef.current ?? { clientWidth: 0, clientHeight: 0 };
+		const adjustedWidth = width * props.zoom;
+		const adjustedHeight = height * props.zoom;
+		const maxMoveX = adjustedWidth > clientWidth ? 0 : clientWidth - adjustedWidth;
+		const minMoveX = adjustedWidth > clientWidth ? -adjustedWidth + clientWidth : 0;
+		const maxMoveY = adjustedHeight > clientHeight ? 0 : clientHeight - adjustedHeight;
+		const minMoveY = adjustedHeight > clientHeight ? -adjustedHeight + clientHeight : 0;
+
+		let newMoveX = 0, newMoveY = 0;
+
+		if (event.type === 'wheel' && event.buttons === 0) {
 			const wheelEvent = event as React.WheelEvent<HTMLImageElement>;
-			console.log(`Wheel event: ${wheelEvent.deltaX}, ${wheelEvent.deltaY}`);
-			setMoveX(moveX + wheelEvent.deltaX);
-			setMoveY(moveY + wheelEvent.deltaY);
+			newMoveX = moveX + wheelEvent.deltaX;
+			newMoveY = moveY + wheelEvent.deltaY;
+		} else if (event.buttons === 1 && props.zoom !== ZoomLevel.Fill) {
+			newMoveX = moveX + event.movementX;
+			newMoveY = moveY + event.movementY;
+		} else {
 			return;
 		}
-		if (event.buttons !== 1 || props.zoom === ZoomLevel.Fill) {
-			return;
-		}
-		console.log(`Mouse event: ${event.movementX}, ${event.movementY}`);
-		setMoveX(moveX + event.movementX);
-		setMoveY(moveY + event.movementY);
+
+		const finalMoveX = Math.max(Math.min(newMoveX, maxMoveX), minMoveX);
+		const finalMoveY = Math.max(Math.min(newMoveY, maxMoveY), minMoveY);
+		setMoveX(finalMoveX);
+		setMoveY(finalMoveY);
 	};
 
 	const updateCursor = (event: React.MouseEvent<HTMLImageElement>) => {

--- a/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
@@ -26,12 +26,34 @@ interface StaticPlotInstanceProps {
  * @returns The rendered component.
  */
 export const StaticPlotInstance = (props: StaticPlotInstanceProps) => {
+	const ref = React.useRef<HTMLDivElement>(null);
+	const [width, setWidth] = React.useState<number>(1);
+	const [height, setHeight] = React.useState<number>(1);
+
+	React.useEffect(() => {
+		if (ref.current) {
+			const resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+				if (entries.length > 0) {
+					const entry = entries[0];
+					const width = entry.contentRect.width;
+					const height = entry.contentRect.height;
+					setWidth(width);
+					setHeight(height);
+				}
+			});
+			resizeObserver.observe(ref.current);
+		}
+
+	}, []);
+
 	return (
-		<div className='plot-instance static-plot-instance'>
+		<div className='plot-instance static-plot-instance' ref={ref}>
 			<PanZoomImage
 				imageUri={props.plotClient.uri}
 				description={props.plotClient.code ? props.plotClient.code : 'Plot ' + props.plotClient.id}
 				zoom={props.zoom}
+				width={width}
+				height={height}
 			/>
 		</div>);
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
@@ -154,7 +154,7 @@
 	display: block;
 	object-fit: none;
 	position: absolute;
-	overflow:hidden;
+	overflow: hidden;
 	width: 100%;
 	height: 100%;
 }

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
@@ -151,16 +151,6 @@
 	position: relative;
 }
 
-/* .plot-instance .image-wrapper {
-	display: block;
-	object-fit: none;
-	position: absolute;
-	overflow: hidden;
-	width: 100%;
-	height: 100%;
-}
-
-.plot-instance .image-wrapper img, */
 .plot-thumbnail .image-wrapper img {
 	display: block;
 	max-width: 100%;

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
@@ -64,6 +64,7 @@
 
 .history-bottom .plot-history-scroller {
 	border-top: 1px solid var(--vscode-statusBar-border);
+	min-height: 100px;
 	height: 100px;
 }
 
@@ -150,7 +151,7 @@
 	position: relative;
 }
 
-.plot-instance .image-wrapper {
+/* .plot-instance .image-wrapper {
 	display: block;
 	object-fit: none;
 	position: absolute;
@@ -159,7 +160,7 @@
 	height: 100%;
 }
 
-.plot-instance .image-wrapper img,
+.plot-instance .image-wrapper img, */
 .plot-thumbnail .image-wrapper img {
 	display: block;
 	max-width: 100%;
@@ -198,4 +199,13 @@
 
 .monaco-pane-view .pane .plots-container .monaco-progress-container {
 	top: 0px;
+}
+
+/* image panning */
+.grabbing {
+	cursor: grabbing;
+}
+
+.grab {
+	cursor: grab;
 }

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
@@ -154,7 +154,7 @@
 	display: block;
 	object-fit: none;
 	position: absolute;
-	overflow: scroll;
+	overflow:hidden;
 	width: 100%;
 	height: 100%;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent
Address https://github.com/posit-dev/positron/issues/2508

### Approach
This seemed easier to do than fixing the horizontal scrollbar not showing. Listens to mouse events for scrolling and dragging to update the image position. The disadvantage is setting `overflow: hidden` resulting in the scrollbars not showing at all. While it may not be obvious that scrolling vertically and horizontally is possible, it can be done and it is now easier to see that the image can be grabbed (cursor changes on the image) and panned.

The scroll direction is reversed on Mac. I'm not sure if it's a good idea but there doesn't seem to be a way to detect the OS preference for natural scrolling. We can remove this or add a Positron preference.

https://github.com/posit-dev/positron/assets/9591545/5493416b-cf83-417c-9e5e-84697f0f5440


Move the pan and zoom into a component should allow reusing this if we want to pop up a plot into an editor.



### QA Notes
The removal of the vertical scrollbar