### PR TITLE
create command `r.getMinimumRVersion`

### DIFF
--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -10,6 +10,7 @@ import { getRPackageName } from './contexts';
 import { getRPackageTasks } from './tasks';
 import { randomUUID } from 'crypto';
 import { RSessionManager } from './session-manager';
+import { MINIMUM_R_VERSION } from './constants';
 
 export async function registerCommands(context: vscode.ExtensionContext) {
 
@@ -180,6 +181,9 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 				// https://github.com/posit-dev/positron/issues/780
 			}
 		}),
+
+		// Command used to get the minimum version of R supported by the extension
+		vscode.commands.registerCommand('r.getMinimumRVersion', (): string => MINIMUM_R_VERSION),
 	);
 }
 

--- a/extensions/positron-r/src/constants.ts
+++ b/extensions/positron-r/src/constants.ts
@@ -12,4 +12,4 @@ export const EXTENSION_ROOT_DIR = path.join(__dirname, '..');
 const packageJson = fs.readJSONSync(path.join(EXTENSION_ROOT_DIR, 'package.json'));
 
 // The minimum supported version of R.
-export const MINIMUM_R_VERSION = packageJson.positron.minimumRVersion;
+export const MINIMUM_R_VERSION = packageJson.positron.minimumRVersion as string;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Create a command in the positron-r extension `r.getMinimumRVersion` which is used to retrieve the minimum R version supported, as a string. This minimum version will be displayed in the Project Wizard when no supported R interpreters are found, to inform the user of the minimum version to install.

This is part of https://github.com/posit-dev/positron/issues/3101.

### Approach

- add `string` type assertion to `MINIMUM_R_VERSION` (the value is read as a string from package.json and is considered `any` by default)
- register command `r.getMinimumRVersion`

### QA Notes

This command will be used in a future PR via the Project Wizard.
