### PR TITLE
create command `python.getMinimumPythonVersion`

### DIFF
--- a/extensions/positron-python/src/client/common/constants.ts
+++ b/extensions/positron-python/src/client/common/constants.ts
@@ -1,4 +1,9 @@
 /* eslint-disable camelcase */
+
+// --- Start Positron ---
+import { PythonVersion } from '../pythonEnvironments/info/pythonVersion';
+// --- End Positron ---
+
 /* eslint-disable @typescript-eslint/no-namespace */
 export const PYTHON_LANGUAGE = 'python';
 export const PYTHON_WARNINGS = 'PYTHONWARNINGS';
@@ -124,6 +129,7 @@ export const UseProposedApi = Symbol('USE_VSC_PROPOSED_API');
 
 // --- Start Positron ---
 export const IPYKERNEL_VERSION = '>=6.19.1';
+export const MINIMUM_PYTHON_VERSION = { major: 3, minor: 8, patch: 0, raw: '3.8.0' } as PythonVersion;
 // --- End Positron
 
 export * from '../constants';

--- a/extensions/positron-python/src/client/positron/discoverer.ts
+++ b/extensions/positron-python/src/client/positron/discoverer.ts
@@ -14,6 +14,7 @@ import { PythonEnvironment } from '../pythonEnvironments/info';
 import { PythonVersion } from '../pythonEnvironments/info/pythonVersion';
 import { createPythonRuntimeMetadata } from './runtime';
 import { comparePythonVersionDescending } from '../interpreter/configuration/environmentTypeComparer';
+import { MINIMUM_PYTHON_VERSION } from '../common/constants';
 
 /**
  * Provides Python language runtime metadata to Positron; called during the
@@ -78,10 +79,9 @@ export async function* pythonRuntimeDiscoverer(
         traceInfo(`pythonRuntimeDiscoverer: recommended for workspace: ${recommendedForWorkspace}`);
 
         // Register each interpreter as a language runtime metadata entry
-        const minimumSupportedVersion = { major: 3, minor: 8, patch: 0, raw: '3.8.0' } as PythonVersion;
         for (const interpreter of interpreters) {
             try {
-                if (isVersionSupported(interpreter?.version, minimumSupportedVersion)) {
+                if (isVersionSupported(interpreter?.version, MINIMUM_PYTHON_VERSION)) {
                     const runtime = await createPythonRuntimeMetadata(
                         interpreter,
                         serviceContainer,

--- a/extensions/positron-python/src/client/positron/extension.ts
+++ b/extensions/positron-python/src/client/positron/extension.ts
@@ -122,10 +122,7 @@ export async function activatePositron(
         );
         // Register a command to get the minimum version of python supported by the extension.
         disposables.push(
-            vscode.commands.registerCommand(
-                'python.getMinimumPythonVersion',
-                (): string => MINIMUM_PYTHON_VERSION.raw,
-            ),
+            vscode.commands.registerCommand('python.getMinimumPythonVersion', (): string => MINIMUM_PYTHON_VERSION.raw),
         );
         traceInfo('activatePositron: done!');
     } catch (ex) {

--- a/extensions/positron-python/src/client/positron/extension.ts
+++ b/extensions/positron-python/src/client/positron/extension.ts
@@ -12,7 +12,7 @@ import { IServiceContainer } from '../ioc/types';
 import { traceError, traceInfo } from '../logging';
 import { PythonRuntimeManager } from './manager';
 import { createPythonRuntimeMetadata } from './runtime';
-import { IPYKERNEL_VERSION } from '../common/constants';
+import { IPYKERNEL_VERSION, MINIMUM_PYTHON_VERSION } from '../common/constants';
 import { InstallOptions } from '../common/installer/types';
 
 export async function activatePositron(
@@ -119,6 +119,13 @@ export async function activatePositron(
                     traceError(`Could not install ipykernel due to an invalid interpreter path: ${pythonPath}`);
                 }
             }),
+        );
+        // Register a command to get the minimum version of python supported by the extension.
+        disposables.push(
+            vscode.commands.registerCommand(
+                'python.getMinimumPythonVersion',
+                (): string => MINIMUM_PYTHON_VERSION.raw,
+            ),
         );
         traceInfo('activatePositron: done!');
     } catch (ex) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Create a command in the positron-python extension `python.getMinimumPythonVersion` which is used to retrieve the minimum Python version supported, as a string. This minimum version will be displayed in the Project Wizard when no supported Python interpreters are found, to inform the user of the minimum version to install.

This is part of https://github.com/posit-dev/positron/issues/3101.

### Approach

- create constant `MINIMUM_PYTHON_VERSION` (pull existing local variable `minimumSupportedVersion` into a constant)
- register command `python.getMinimumPythonVersion`

### QA Notes

This command will be used in a future PR via the Project Wizard.
