### PR TITLE
Update ark to 0.1.93

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -541,7 +541,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.92"
+      "ark": "0.1.93"
     },
     "minimumRVersion": "4.2.0"
   }


### PR DESCRIPTION
Updates ark to 0.1.93.

For https://github.com/posit-dev/amalthea/pull/344, https://github.com/posit-dev/amalthea/pull/336.