### PR TITLE
Update 'workbench.action.positronConsole.executeCode' to be used in Quarto

### DIFF
--- a/src/vs/editor/contrib/positronStatementRange/browser/provideStatementRange.ts
+++ b/src/vs/editor/contrib/positronStatementRange/browser/provideStatementRange.ts
@@ -46,9 +46,9 @@ CommandsRegistry.registerCommand('_executeStatementRangeProvider', async (access
 	if (!model) {
 		return undefined;
 	}
-	const { statementRangeProvider } = accessor.get(ILanguageFeaturesService);
+	const languageFeaturesService = accessor.get(ILanguageFeaturesService);
 	const result = await provideStatementRange(
-		statementRangeProvider,
+		languageFeaturesService.statementRangeProvider,
 		model,
 		Position.lift(position),
 		CancellationToken.None

--- a/src/vs/editor/contrib/positronStatementRange/browser/provideStatementRange.ts
+++ b/src/vs/editor/contrib/positronStatementRange/browser/provideStatementRange.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { LanguageFeatureRegistry } from 'vs/editor/common/languageFeatureRegistry';
+import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
+import * as languages from 'vs/editor/common/languages';
+import { onUnexpectedExternalError } from 'vs/base/common/errors';
+import { CommandsRegistry } from 'vs/platform/commands/common/commands';
+import { assertType } from 'vs/base/common/types';
+import { URI } from 'vs/base/common/uri';
+import { IPosition, Position } from 'vs/editor/common/core/position';
+import { ITextModel } from 'vs/editor/common/model';
+import { IModelService } from 'vs/editor/common/services/model';
+import { CancellationToken } from 'vs/base/common/cancellation';
+
+
+async function provideStatementRange(
+	registry: LanguageFeatureRegistry<languages.StatementRangeProvider>,
+	model: ITextModel,
+	position: Position,
+	token: CancellationToken
+): Promise<languages.IStatementRange | undefined> {
+
+	const providers = registry.ordered(model);
+
+	for (const provider of providers) {
+		try {
+			const result = await provider.provideStatementRange(model, position, token);
+			if (result) {
+				return result;
+			}
+		} catch (err) {
+			onUnexpectedExternalError(err);
+		}
+	}
+	return undefined;
+}
+
+CommandsRegistry.registerCommand('_executeStatementRangeProvider', async (accessor, ...args: [URI, IPosition]) => {
+	const [uri, position] = args;
+	assertType(URI.isUri(uri));
+	assertType(Position.isIPosition(position));
+
+	const model = accessor.get(IModelService).getModel(uri);
+	if (!model) {
+		return undefined;
+	}
+	const { statementRangeProvider } = accessor.get(ILanguageFeaturesService);
+	const result = await provideStatementRange(
+		statementRangeProvider,
+		model,
+		Position.lift(position),
+		CancellationToken.None
+	);
+	if (!result) {
+		// there is no provider or it didn't return a statement range
+		return undefined;
+	}
+
+	return result;
+});

--- a/src/vs/editor/contrib/positronStatementRange/browser/provideStatementRange.ts
+++ b/src/vs/editor/contrib/positronStatementRange/browser/provideStatementRange.ts
@@ -47,16 +47,10 @@ CommandsRegistry.registerCommand('_executeStatementRangeProvider', async (access
 		return undefined;
 	}
 	const languageFeaturesService = accessor.get(ILanguageFeaturesService);
-	const result = await provideStatementRange(
+	return await provideStatementRange(
 		languageFeaturesService.statementRangeProvider,
 		model,
 		Position.lift(position),
 		CancellationToken.None
 	);
-	if (!result) {
-		// there is no provider or it didn't return a statement range
-		return undefined;
-	}
-
-	return result;
 });

--- a/src/vs/editor/editor.all.ts
+++ b/src/vs/editor/editor.all.ts
@@ -64,6 +64,7 @@ import 'vs/editor/contrib/diffEditorBreadcrumbs/browser/contribution';
 
 // --- Start Positron ---
 import 'vs/editor/contrib/positronEditorActions/browser/positronEditorActions';
+import 'vs/editor/contrib/positronStatementRange/browser/provideStatementRange';
 // --- End Positron ---
 
 // Load up these strings even in VSCode, even if they are not used

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { StatementRange } from 'positron';
 import { isFalsyOrEmpty } from 'vs/base/common/arrays';
 import { VSBuffer } from 'vs/base/common/buffer';
 import { Schemas, matchesSomeScheme } from 'vs/base/common/network';
@@ -490,9 +491,9 @@ const newCommands: ApiCommand[] = [
 	new ApiCommand(
 		'vscode.executeStatementRangeProvider', '_executeStatementRangeProvider', 'Execute statement range provider.',
 		[ApiCommandArgument.Uri, ApiCommandArgument.Position],
-		new ApiCommandResult<IRange, types.Range>('A promise that resolves to a range.', result => {
+		new ApiCommandResult<languages.IStatementRange, StatementRange>('A promise that resolves to a statement range.', result => {
 			// converter: convert from IRange (API type) to vscode.Range
-			return typeConverters.Range.to(result);
+			return { range: typeConverters.Range.to(result.range) };
 		})
 	),
 	// --- End Positron

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -493,7 +493,7 @@ const newCommands: ApiCommand[] = [
 		[ApiCommandArgument.Uri, ApiCommandArgument.Position],
 		new ApiCommandResult<languages.IStatementRange, StatementRange>('A promise that resolves to a statement range.', result => {
 			// converter: convert from IRange (API type) to vscode.Range
-			return { range: typeConverters.Range.to(result.range) };
+			return { range: typeConverters.Range.to(result.range), code: result.code };
 		})
 	),
 	// --- End Positron

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -489,15 +489,7 @@ const newCommands: ApiCommand[] = [
 	// -- statement range
 	new ApiCommand(
 		'vscode.executeStatementRangeProvider', '_executeStatementRangeProvider', 'Execute statement range provider.',
-		[ApiCommandArgument.Uri,
-		new ApiCommandArgument<types.Position, IPosition>('position',
-			'A position in a text document',
-			// validator: check for a valid position
-			v => types.Position.isPosition(v),
-			// converter: convert from vscode.Position to IPosition (API type)
-			v => {
-				return typeConverters.Position.from(v);
-			})],
+		[ApiCommandArgument.Uri, ApiCommandArgument.Position],
 		new ApiCommandResult<IRange, types.Range>('A promise that resolves to a range.', result => {
 			// converter: convert from IRange (API type) to vscode.Range
 			return typeConverters.Range.to(result);

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -268,6 +268,9 @@ export function registerPositronConsoleActions() {
 		/**
 		 * Runs action.
 		 * @param accessor The services accessor.
+		 * @param opts Options for code execution
+		 *   - allowIncomplete: Optionally, should incomplete statements be accepted? If `undefined`, treated as `false`.
+		 *   - languageId: Optionally, a language override for the code to execute. If `undefined`, the language of the active text editor is used. Useful for notebooks.
 		 */
 		async run(accessor: ServicesAccessor, opts: { allowIncomplete?: boolean; languageId?: string } = {}) {
 			// Access services.

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -315,20 +315,9 @@ export function registerPositronConsoleActions() {
 				return;
 			}
 
-			// If we have a language ID opt (such as from Quarto), temporarily switch to it.
-			const originalLanguageId = model.getLanguageId();
-			if (opts.languageId) {
-				model.setLanguage(opts.languageId);
-			}
-
 			// Get all the statement range providers for the active document.
 			const statementRangeProviders =
 				languageFeaturesService.statementRangeProvider.all(model);
-
-			// If we have a languageId opt (such as from Quarto), put back original languageId.
-			if (opts.languageId) {
-				model.setLanguage(originalLanguageId);
-			}
 
 			// If the user doesn't have an explicit selection, consult a statement range provider,
 			// which can be used to get the code to execute.

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -269,7 +269,7 @@ export function registerPositronConsoleActions() {
 		 * Runs action.
 		 * @param accessor The services accessor.
 		 */
-		async run(accessor: ServicesAccessor, opts: { allowIncomplete?: boolean } = {}) {
+		async run(accessor: ServicesAccessor, opts: { allowIncomplete?: boolean; languageId?: string } = {}) {
 			// Access services.
 			const editorService = accessor.get(IEditorService);
 			const languageFeaturesService = accessor.get(ILanguageFeaturesService);
@@ -315,9 +315,20 @@ export function registerPositronConsoleActions() {
 				return;
 			}
 
+			// If we have a language ID opt (such as from Quarto), temporarily switch to it.
+			const originalLanguageId = model.getLanguageId();
+			if (opts.languageId) {
+				model.setLanguage(opts.languageId);
+			}
+
 			// Get all the statement range providers for the active document.
 			const statementRangeProviders =
 				languageFeaturesService.statementRangeProvider.all(model);
+
+			// If we have a languageId opt (such as from Quarto), put back original languageId.
+			if (opts.languageId) {
+				model.setLanguage(originalLanguageId);
+			}
 
 			// If the user doesn't have an explicit selection, consult a statement range provider,
 			// which can be used to get the code to execute.
@@ -499,7 +510,7 @@ export function registerPositronConsoleActions() {
 			}
 
 			// Now that we've gotten this far, ensure we have a target language.
-			const languageId = editorService.activeTextEditorLanguageId;
+			const languageId = opts.languageId ? opts.languageId : editorService.activeTextEditorLanguageId;
 			if (!languageId) {
 				notificationService.notify({
 					severity: Severity.Info,
@@ -513,7 +524,7 @@ export function registerPositronConsoleActions() {
 			// By default, we don't allow incomplete code to be executed, but the language runtime can override this.
 			// This means that if allowIncomplete is false or undefined, the incomplete code will not be sent to the backend for execution.
 			// The console will continue to wait for more input until the user completes the code, or cancels out of the operation.
-			const { allowIncomplete } = opts;
+			const allowIncomplete = opts.allowIncomplete;
 
 
 			// Ask the Positron console service to execute the code. Do not focus the console as


### PR DESCRIPTION
### Intent

Addresses #1518
Goes together with https://github.com/quarto-dev/quarto/pull/436/


### Approach

I'm putting this up as draft for some discussion, and I'll add some notes to point out the current challenges.

### QA Notes

When we QA this change, we'll want to use the current development version of the Quarto extension (download `.vsix` from https://github.com/quarto-dev/quarto) and check out the statement-by-statement execution in Quarto chunks.