### PR TITLE
Create a notebook controller per interpreter

### DIFF
--- a/extensions/positron-notebook-controllers/src/extension.ts
+++ b/extensions/positron-notebook-controllers/src/extension.ts
@@ -26,16 +26,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(manager);
 
 	// Register notebook controllers for newly registered runtimes.
-	context.subscriptions.push(positron.runtime.onDidRegisterRuntime((runtime) => {
-		if (!manager.controllers.has(runtime.languageId)) {
-			manager.createNotebookController(runtime.languageId);
+	context.subscriptions.push(positron.runtime.onDidRegisterRuntime((runtimeMetadata) => {
+		if (!manager.controllers.has(runtimeMetadata.runtimeId)) {
+			manager.createNotebookController(runtimeMetadata);
 		}
 	}));
 
 	// Register notebook controllers for existing runtimes.
-	for (const runtime of await positron.runtime.getRegisteredRuntimes()) {
-		if (!manager.controllers.has(runtime.languageId)) {
-			manager.createNotebookController(runtime.languageId);
+	for (const runtimeMetadata of await positron.runtime.getRegisteredRuntimes()) {
+		if (!manager.controllers.has(runtimeMetadata.runtimeId)) {
+			manager.createNotebookController(runtimeMetadata);
 		}
 	}
 

--- a/extensions/positron-notebook-controllers/src/notebookControllerManager.ts
+++ b/extensions/positron-notebook-controllers/src/notebookControllerManager.ts
@@ -80,7 +80,14 @@ export class NotebookControllerManager implements vscode.Disposable {
 			?? notebook.getCells()?.[0].document.languageId;
 
 		// Get the preferred controller for the language.
-		const preferredRuntime = await positron.runtime.getPreferredRuntime(languageId);
+		let preferredRuntime: positron.LanguageRuntimeMetadata;
+		try {
+			preferredRuntime = await positron.runtime.getPreferredRuntime(languageId);
+		} catch (ex) {
+			// It may error if there are no registered runtimes for the language, so log and return.
+			log.debug(`Failed to get preferred runtime for language: ${languageId}`, ex);
+			return;
+		}
 		const preferredController = this.controllers.get(preferredRuntime.runtimeId);
 
 		// Set the affinity across all known controllers.

--- a/extensions/positron-notebook-controllers/src/notebookControllerManager.ts
+++ b/extensions/positron-notebook-controllers/src/notebookControllerManager.ts
@@ -2,6 +2,7 @@
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
+import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { log } from './extension';
 import { NotebookController } from './notebookController';
@@ -11,7 +12,7 @@ import { NotebookSessionService } from './notebookSessionService';
  * Manages notebook controllers.
  */
 export class NotebookControllerManager implements vscode.Disposable {
-	/** Notebook controllers keyed by languageId. */
+	/** Notebook controllers keyed by language runtime ID. */
 	public readonly controllers = new Map<string, NotebookController>();
 
 	/**
@@ -21,17 +22,18 @@ export class NotebookControllerManager implements vscode.Disposable {
 	constructor(private readonly _notebookSessionService: NotebookSessionService) { }
 
 	/**
-	 * Create a notebook controller for a language.
+	 * Create a notebook controller for a runtime.
 	 *
-	 * @param languageId The language ID for which to create a notebook controller.
+	 * @param runtimeMetadata The language runtime metadata for which to create a notebook controller.
 	 */
-	public createNotebookController(languageId: string): void {
-		if (this.controllers.has(languageId)) {
-			throw new Error(`Notebook controller already exists for language: ${languageId}`);
+	public createNotebookController(runtimeMetadata: positron.LanguageRuntimeMetadata): void {
+		const { runtimeId } = runtimeMetadata;
+		if (this.controllers.has(runtimeId)) {
+			throw new Error(`Notebook controller already exists for runtime: ${runtimeId}`);
 		}
-		const controller = new NotebookController(languageId, this._notebookSessionService);
-		this.controllers.set(languageId, controller);
-		log.info(`Registered notebook controller for language: ${languageId}`);
+		const controller = new NotebookController(runtimeMetadata, this._notebookSessionService);
+		this.controllers.set(runtimeId, controller);
+		log.info(`Registered notebook controller for runtime: ${runtimeId}`);
 	}
 
 	/**
@@ -78,7 +80,8 @@ export class NotebookControllerManager implements vscode.Disposable {
 			?? notebook.getCells()?.[0].document.languageId;
 
 		// Get the preferred controller for the language.
-		const preferredController = languageId && this.controllers.get(languageId);
+		const preferredRuntime = await positron.runtime.getPreferredRuntime(languageId);
+		const preferredController = this.controllers.get(preferredRuntime.runtimeId);
 
 		// Set the affinity across all known controllers.
 		for (const controller of this.controllers.values()) {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -59,7 +59,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 		rpcProtocol.getRaw(ExtHostContext.ExtHostLanguageFeatures);
 	const extHostEditors: ExtHostEditors = rpcProtocol.getRaw(ExtHostContext.ExtHostEditors);
 	const extHostDocuments: ExtHostDocuments = rpcProtocol.getRaw(ExtHostContext.ExtHostDocuments);
-	const extHostLanguageRuntime = rpcProtocol.set(ExtHostPositronContext.ExtHostLanguageRuntime, new ExtHostLanguageRuntime(rpcProtocol));
+	const extHostLanguageRuntime = rpcProtocol.set(ExtHostPositronContext.ExtHostLanguageRuntime, new ExtHostLanguageRuntime(rpcProtocol, extHostLogService));
 	const extHostPreviewPanels = rpcProtocol.set(ExtHostPositronContext.ExtHostPreviewPanel, new ExtHostPreviewPanels(rpcProtocol, extHostWebviews, extHostWorkspace));
 	const extHostModalDialogs = rpcProtocol.set(ExtHostPositronContext.ExtHostModalDialogs, new ExtHostModalDialogs(rpcProtocol));
 	const extHostConsoleService = rpcProtocol.set(ExtHostPositronContext.ExtHostConsoleService, new ExtHostConsoleService(rpcProtocol, extHostLogService));

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -14,6 +14,7 @@ import { ExtensionIdentifier, IExtensionDescription } from 'vs/platform/extensio
 import { URI } from 'vs/base/common/uri';
 import { DeferredPromise, retry } from 'vs/base/common/async';
 import { IRuntimeSessionMetadata } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
+import { ILogService } from 'vs/platform/log/common/log';
 
 /**
  * A language runtime manager and metadata about the extension that registered it.
@@ -62,7 +63,8 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 	public onDidRegisterRuntime = this._onDidRegisterRuntimeEmitter.event;
 
 	constructor(
-		mainContext: extHostProtocol.IMainPositronContext
+		mainContext: extHostProtocol.IMainPositronContext,
+		private readonly _logService: ILogService,
 	) {
 		// Trigger creation of the proxy
 		this._proxy = mainContext.getProxy(extHostProtocol.MainPositronContext.MainThreadLanguageRuntime);
@@ -543,6 +545,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		return retry(async () => {
 			const runtime = this._registeredRuntimes.find(runtime => runtime.runtimeId === metadata.runtimeId);
 			if (!runtime) {
+				this._logService.warn(`Could not find runtime ${metadata.runtimeId} on extension host. Waiting 2 seconds and retrying.`);
 				throw new Error(`Runtime exists on main thread but not extension host: ${metadata.runtimeId}`);
 			}
 			return runtime;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Address #3096 and #3006.

### Approach

Rewired the `NotebookController` to use a runtime instead of a language.

Addresses #3006 by making `ExtHostLanguageRuntime. _runtimeDiscoveryComplete` a `Barrier` and awaiting it in `getPreferredRuntime`.

### QA Notes

See linked issues for repros.