### PR TITLE
Revert `section` highlighting within comments

### DIFF
--- a/extensions/positron-r/syntaxes/README.md
+++ b/extensions/positron-r/syntaxes/README.md
@@ -1,0 +1,15 @@
+## R TextMate Grammar
+
+To generate `r.tmGrammar.gen.json` from `r.tm.Grammar.src.json`, first navigate to the positron-r extension folder:
+
+```
+cd extensions/positron-r
+```
+
+then run:
+
+```
+yarn compile-syntax
+```
+
+`compile-syntax` is a custom typescript script that performs glue-like interpolation, i.e. `{{ bracket }}` in the `src` file will get interpolated as `keyword.operator` in the `gen` file. The substitutions are based on the `"variables"` field of the `src` file, and are intended to avoid repetition of these style names, and to make it easier to change them all at once if we ever need to.

--- a/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
@@ -30,9 +30,6 @@
 		"basic": {
 			"patterns": [
 				{
-					"include": "#section"
-				},
-				{
 					"include": "#roxygen"
 				},
 				{
@@ -533,20 +530,6 @@
 					"match": "@(?!@)\\w*"
 				}
 			]
-		},
-		"section": {
-			"match": "^\\s*(#+)\\s*(.*?)(={4,}|-{4,}|#{4,})\\s*$",
-			"captures": {
-				"1": {
-					"name": "comment.line"
-				},
-				"2": {
-					"name": "entity.name.section"
-				},
-				"3": {
-					"name": "comment.line"
-				}
-			}
 		}
 	}
 }

--- a/extensions/positron-r/syntaxes/r.tmGrammar.src.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.src.json
@@ -30,9 +30,6 @@
 		"basic": {
 			"patterns": [
 				{
-					"include": "#section"
-				},
-				{
 					"include": "#roxygen"
 				},
 				{
@@ -533,20 +530,6 @@
 					"match": "@(?!@)\\w*"
 				}
 			]
-		},
-		"section": {
-			"match": "^\\s*(#+)\\s*(.*?)(={4,}|-{4,}|#{4,})\\s*$",
-			"captures": {
-				"1": {
-					"name": "comment.line"
-				},
-				"2": {
-					"name": "entity.name.section"
-				},
-				"3": {
-					"name": "comment.line"
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3121

Also added a README for the syntaxes/ folder, as I had no idea how the gen vs src files worked.

<img width="334" alt="Screenshot 2024-05-13 at 2 53 27 PM" src="https://github.com/posit-dev/positron/assets/19150088/0d4a6695-f146-4414-b3b7-6a88d31d7d5c">

Also, a note that we do use the `"entity.name.section"` style name in one other place. When you are inside a roxygen comment and you do a code block (i.e. triple backticks) then whatever you put inside the backticks will be treated as a section name, which minimal/white styling. This seems fine, at least for now!

<img width="276" alt="Screenshot 2024-05-13 at 2 40 45 PM" src="https://github.com/posit-dev/positron/assets/19150088/e1e88835-7471-4a6f-aefe-5fe4b5746217">
