### PR TITLE
Improve on aggravating backtick behavior in (roxygen) comments

### DIFF
--- a/extensions/positron-r/language-configuration/r-language-configuration.json
+++ b/extensions/positron-r/language-configuration/r-language-configuration.json
@@ -13,7 +13,7 @@
 		{ "open": "(", "close": ")" },
 		{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
 		{ "open": "\"", "close": "\"", "notIn": ["string"] },
-		{ "open": "`", "close": "`", "notIn": ["string", "comment"] },
+		{ "open": "`", "close": "`", "notIn": ["string"] },
 		{ "open": "%", "close": "%", "notIn": ["string", "comment"] },
 	],
 	"autoCloseBefore": ";:.,=}])>` \n\t",

--- a/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
@@ -345,13 +345,7 @@
 				},
 				{
 					"name": "markup.quote",
-					"begin": "`",
-					"end": "`",
-					"patterns": [
-						{
-							"match": "\\\\`"
-						}
-					]
+					"match": "(`(?:[^`\\\\]|\\\\.)*`)"
 				},
 				{
 					"name": "markup.underline.link",

--- a/extensions/positron-r/syntaxes/r.tmGrammar.src.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.src.json
@@ -345,13 +345,7 @@
 				},
 				{
 					"name": "markup.quote",
-					"begin": "`",
-					"end": "`",
-					"patterns": [
-						{
-							"match": "\\\\`"
-						}
-					]
+					"match": "(`(?:[^`\\\\]|\\\\.)*`)"
 				},
 				{
 					"name": "markup.underline.link",


### PR DESCRIPTION
Addresses #1776 (mostly, enough to close probably)

Two changes:
- We now auto close backticks in comments (like RStudio). This makes doing a triple backtick to create a code block more annoying, but this is way rarer than backticking a symbol name or function name (it is also annoying in RStudio but not to the point that it is awful)
- I've changed the `markup.quote` TextMate grammar rule to be a `match` rule so that it is single line. As seen in https://github.com/posit-dev/positron/issues/1776#issuecomment-2108684450, matching over multiple lines results in weird highlighting, and I can't think of a case where it is really that useful. More importantly, matching over multiple lines means that ``` `foo ``` without a closing backtick will actually look like a `markup.quote` because it is "waiting" for its closing backtick, at least that seems to be what is happening.

It is not perfect, notably if you happen to delete the closing backtick, then trying to insert another backtick to re-close it will typically insert 2 (b/c of the auto closing). It doesn't typically do this with double quotes, and I can't figure out what the difference is. But in general this is not common to get yourself into this case.

Bad, before:

<img width="208" alt="Screenshot 2024-05-13 at 3 51 09 PM" src="https://github.com/posit-dev/positron/assets/19150088/b4c86d94-098a-4f0d-8aff-9cca8387da17">

After:

<img width="152" alt="Screenshot 2024-05-13 at 4 18 54 PM" src="https://github.com/posit-dev/positron/assets/19150088/aff569b0-5f0c-4c56-b4fc-334ec32160f3">

More edge cases:

<img width="127" alt="Screenshot 2024-05-13 at 4 18 37 PM" src="https://github.com/posit-dev/positron/assets/19150088/fd7d548e-a273-49d9-8518-d56164406f2e">

<img width="169" alt="Screenshot 2024-05-13 at 4 18 18 PM" src="https://github.com/posit-dev/positron/assets/19150088/a5b44500-383d-4da7-a643-ac62668a3c30">


https://github.com/posit-dev/positron/assets/19150088/33caf6f5-acc4-4a88-98a0-f2a1f2529cf2

