### PR TITLE
Make the session's pane its own seperate view container

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -183,6 +183,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/contrib/positronSession",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/contrib/positronHelp",
 			"project": "vscode-workbench"
 		},

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -18,7 +18,7 @@ import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWo
 import { Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
 import { registerAction2 } from 'vs/platform/actions/common/actions';
 import { PlotsRefreshAction } from 'vs/workbench/contrib/positronPlots/browser/positronPlotsActions';
-import { VIEW_CONTAINER } from 'vs/workbench/contrib/positronVariables/browser/positronVariables.contribution';
+import { POSITRON_SESSION_CONTAINER } from 'vs/workbench/contrib/positronSession/browser/positronSessionContainer';
 
 // Register the Positron plots service.
 registerSingleton(IPositronPlotsService, PositronPlotsService, InstantiationType.Delayed);
@@ -48,7 +48,7 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 			}
 		}
 	],
-	VIEW_CONTAINER
+	POSITRON_SESSION_CONTAINER
 );
 
 class PositronPlotsContribution extends Disposable implements IWorkbenchContribution {

--- a/src/vs/workbench/contrib/positronSession/browser/positronSessionContainer.ts
+++ b/src/vs/workbench/contrib/positronSession/browser/positronSessionContainer.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as nls from 'vs/nls';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
+import { ViewPaneContainer } from 'vs/workbench/browser/parts/views/viewPaneContainer';
+import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions } from 'vs/workbench/common/views';
+import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
+import { Codicon } from 'vs/base/common/codicons';
+
+export const POSITRON_SESSION_VIEW_ID = 'workbench.panel.positronSession';
+
+// The Positron variables view icon.
+export const positronSessionViewIcon = registerIcon(
+	'positron-session-view-icon',
+	Codicon.positronVariablesView,
+	nls.localize('positronSessionViewIcon', 'View icon of the Positron session view.')
+);
+
+
+/**
+ * A view container for holding views related to the positron session.
+ * E.g. variables and plots.
+ */
+export const POSITRON_SESSION_CONTAINER: ViewContainer = Registry.as<IViewContainersRegistry>(
+	ViewContainerExtensions.ViewContainersRegistry
+).registerViewContainer(
+	{
+		id: POSITRON_SESSION_VIEW_ID,
+		title: {
+			value: nls.localize('positron.session', "Session"),
+			original: 'Session'
+		},
+		icon: positronSessionViewIcon,
+		order: 1,
+		ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [POSITRON_SESSION_VIEW_ID, { mergeViewWithContainerWhenSingleView: true }]),
+		storageId: POSITRON_SESSION_VIEW_ID,
+		hideIfEmpty: false,
+	},
+	ViewContainerLocation.AuxiliaryBar,
+	{
+		doNotRegisterOpenCommand: true,
+		isDefault: true
+	}
+);

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariables.contribution.ts
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariables.contribution.ts
@@ -3,57 +3,25 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from 'vs/nls';
-import { Codicon } from 'vs/base/common/codicons';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { registerAction2 } from 'vs/platform/actions/common/actions';
-import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 import { PositronVariablesFocused } from 'vs/workbench/common/contextkeys';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { ViewPaneContainer } from 'vs/workbench/browser/parts/views/viewPaneContainer';
 import { PositronVariablesViewPane } from 'vs/workbench/contrib/positronVariables/browser/positronVariablesView';
 import { PositronVariablesRefreshAction } from 'vs/workbench/contrib/positronVariables/browser/positronVariablesActions';
 import { IPositronVariablesService } from 'vs/workbench/services/positronVariables/common/interfaces/positronVariablesService';
 import { ICommandAndKeybindingRule, KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from 'vs/workbench/common/contributions';
-import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
+import { Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
 import { POSITRON_VARIABLES_COLLAPSE, POSITRON_VARIABLES_COPY_AS_HTML, POSITRON_VARIABLES_COPY_AS_TEXT, POSITRON_VARIABLES_EXPAND } from 'vs/workbench/contrib/positronVariables/browser/positronVariablesIdentifiers';
+import { POSITRON_SESSION_CONTAINER, positronSessionViewIcon } from 'vs/workbench/contrib/positronSession/browser/positronSessionContainer';
 
 // The Positron variables view identifier.
 export const POSITRON_VARIABLES_VIEW_ID = 'workbench.panel.positronVariables';
-
-// The Positron variables view icon.
-const positronVariablesViewIcon = registerIcon(
-	'positron-variables-view-icon',
-	Codicon.positronVariablesView,
-	nls.localize('positronVariablesViewIcon', 'View icon of the Positron variables view.')
-);
-
-// Register the Positron variables view container.
-export const VIEW_CONTAINER: ViewContainer = Registry.as<IViewContainersRegistry>(
-	ViewContainerExtensions.ViewContainersRegistry
-).registerViewContainer(
-	{
-		id: POSITRON_VARIABLES_VIEW_ID,
-		title: {
-			value: nls.localize('positron.session', "Session"),
-			original: 'Session'
-		},
-		icon: positronVariablesViewIcon,
-		order: 1,
-		ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [POSITRON_VARIABLES_VIEW_ID, { mergeViewWithContainerWhenSingleView: true }]),
-		storageId: POSITRON_VARIABLES_VIEW_ID,
-		hideIfEmpty: false,
-	},
-	ViewContainerLocation.AuxiliaryBar,
-	{
-		doNotRegisterOpenCommand: true,
-		isDefault: true
-	}
-);
 
 // Register the Positron variables view.
 Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews(
@@ -67,7 +35,7 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 			ctorDescriptor: new SyncDescriptor(PositronVariablesViewPane),
 			canToggleVisibility: false,
 			canMoveView: true,
-			containerIcon: positronVariablesViewIcon,
+			containerIcon: positronSessionViewIcon,
 			openCommandActionDescriptor: {
 				id: 'workbench.action.positron.toggleVariables',
 				mnemonicTitle: nls.localize({ key: 'miToggleVariables', comment: ['&& denotes a mnemonic'] }, "&&Variables"),
@@ -78,7 +46,7 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 			}
 		}
 	],
-	VIEW_CONTAINER
+	POSITRON_SESSION_CONTAINER
 );
 
 /**


### PR DESCRIPTION
### Intent

Rename the previous `workbench.panel.positronVariables` view container to `workbench.panel.positronSession` to reflect its role and clear up confusion about the view container being called "variables" but labeled "session" and used for both variables _and_ plots. 

### Approach

Separated the logic for the view container and the view in the positron variables section, and moved the view container definition to its own new `positronSession` folder. Also renamed the icon. 

### QA Notes

Should just be a code shuffle but we do change the internal names of some things so checking that the plots and variables sections work as expected could be useful?
