### PR TITLE
Data Explorer: address lifecycle issues, add comm-closed UI state and close comm when tab closed

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -515,6 +515,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/services/positronDataExplorer",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/services/positronNewProject",
 			"project": "vscode-workbench"
 		},

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
@@ -38,7 +38,7 @@ export const ColumnSelectorModalPopup = (props: ColumnSelectorModalPopupProps) =
 	// Reference hooks.
 	const positronDataGridRef = useRef<HTMLDivElement>(undefined!);
 
-	// Main use effect.
+	// Main useEffect.
 	useEffect(() => {
 		// Drive focus into the data grid so the user can immediately navigate.
 		positronDataGridRef.current.focus();

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -144,8 +144,6 @@ export const DataExplorer = () => {
 		context.instance.columnsWidthPercent = newColumnsWidth / width;
 	};
 
-	console.log('Rendering data explorer');
-
 	// Render.
 	return (
 		<div ref={dataExplorerRef} className='data-explorer'>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.tsx
@@ -10,7 +10,7 @@ import * as React from 'react';
 import { useEffect, useState } from 'react'; // eslint-disable-line no-duplicate-imports
 
 // Other dependencies.
-import * as nls from 'vs/nls';
+import { localize } from 'vs/nls';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { usePositronDataExplorerContext } from 'vs/workbench/browser/positronDataExplorer/positronDataExplorerContext';
 import { DataExplorerClientStatus } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
@@ -23,13 +23,13 @@ const StatusBarActivityIndicator = (props: ActivityIndicatorProps) => {
 	const getStatusText = () => {
 		switch (props.status) {
 			case DataExplorerClientStatus.Idle:
-				return nls.localize('positron.dataExplorer.idle', 'Idle');
+				return localize('positron.dataExplorer.idle', 'Idle');
 			case DataExplorerClientStatus.Computing:
-				return nls.localize('positron.dataExplorer.computing', 'Computing');
+				return localize('positron.dataExplorer.computing', 'Computing');
 			case DataExplorerClientStatus.Disconnected:
-				return nls.localize('positron.dataExplorer.disconnected', 'Disconnected');
+				return localize('positron.dataExplorer.disconnected', 'Disconnected');
 			case DataExplorerClientStatus.Error:
-				return nls.localize('positron.dataExplorer.error', 'Error');
+				return localize('positron.dataExplorer.error', 'Error');
 		}
 	};
 

--- a/src/vs/workbench/browser/positronDataExplorer/positronDataExplorer.css
+++ b/src/vs/workbench/browser/positronDataExplorer/positronDataExplorer.css
@@ -8,7 +8,53 @@
 	min-width: 0;
 	min-height: 0;
 	display: grid;
+	position: relative;
 	color: var(--vscode-positronDataExplorer-foreground);
 	background-color: var(--vscode-positronDataExplorer-background);
 	grid-template-rows: [action-bar] 32px [data-explorer-panel] 1fr [end];
+}
+
+.positron-data-explorer-overlay {
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 30;
+	display: grid;
+	position: absolute;
+	background-color: transparent;
+	grid-template-rows: [top-gutter] 1fr [message] max-content [bottom-gutter] 1fr [end];
+	grid-template-columns: [left-gutter] 1fr [message] max-content [right-gutter] 1fr [end];
+}
+
+.positron-data-explorer-overlay
+.message {
+	color: white;
+	display: flex;
+	row-gap: 10px;
+	font-size: 16px;
+	cursor: pointer;
+	padding: 25px 50px;
+	border-radius: 6px;
+	flex-direction: column;
+	background-color: #0000001f;
+	background-color: #0000001f;
+	grid-row: message / bottom-gutter;
+	grid-column: message / right-gutter;
+	box-shadow: 0 0 8px 2px var(--vscode-widget-shadow);
+	color: var(--vscode-positronModalDialog-foreground);
+	border: 1px solid var(--vscode-positronModalDialog-border);
+	background-color: var(--vscode-positronModalDialog-background);
+}
+
+.positron-data-explorer-overlay
+.message
+.message-line {
+	text-align: center;
+}
+
+.positron-data-explorer-overlay
+.message
+.message-line.close {
+	text-transform: uppercase;
 }

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -3,13 +3,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { ILocalizedString } from 'vs/platform/action/common/action';
 import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
 import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
-import { IPositronDataExplorerService } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
 
 /**
  * Positron data explorer action category.
@@ -31,33 +28,29 @@ const category: ILocalizedString = {
  * Positron data explorer command ID's.
  */
 const enum PositronDataExplorerCommandId {
-	TestAction = 'workbench.action.positronDataExplorer.open',
+	PlaceholderAction = 'workbench.action.positronDataExplorer.placeholder',
 }
 
 /**
- * OpenPositronDataExplorer action.
+ * PositronDataExplorerPlaceholderAction action.
  */
-class OpenPositronDataExplorer extends Action2 {
+class PositronDataExplorerPlaceholderAction extends Action2 {
 	/**
 	 * Constructor.
 	 */
 	constructor() {
 		super({
-			id: PositronDataExplorerCommandId.TestAction,
+			id: PositronDataExplorerCommandId.PlaceholderAction,
 			title: {
 				value: localize(
-					'workbench.action.positronDataExplorer.openPositronDataExplorer',
-					"Open Positron Data Explorer"
+					'workbench.action.positronDataExplorer.placeholder',
+					"Positron Data Explorer Placeholder"
 				),
-				original: 'Open Positron Data Explorer'
+				original: 'Positron Data Explorer Placeholder'
 			},
 			f1: true,
 			category,
-			precondition: IsDevelopmentContext,
-			keybinding: {
-				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.Shift | KeyMod.WinCtrl | KeyMod.Alt | KeyCode.KeyT
-			},
+			precondition: IsDevelopmentContext
 		});
 	}
 
@@ -66,11 +59,7 @@ class OpenPositronDataExplorer extends Action2 {
 	 * @param accessor The services accessor.
 	 */
 	async run(accessor: ServicesAccessor) {
-		// Access services.
-		const positronDataExplorerService = accessor.get(IPositronDataExplorerService);
-
-		// Test opening a positron data explorer.
-		await positronDataExplorerService.testOpen('b809490e-1801-4f2f-911c-7b9539c78204');
+		// Empty for now.
 	}
 }
 
@@ -78,5 +67,5 @@ class OpenPositronDataExplorer extends Action2 {
  * Registers Positron data explorer actions.
  */
 export function registerPositronDataExplorerActions() {
-	registerAction2(OpenPositronDataExplorer);
+	registerAction2(PositronDataExplorerPlaceholderAction);
 }

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
@@ -21,12 +21,19 @@ import { PositronDataExplorerEditorInput } from 'vs/workbench/contrib/positronDa
  * PositronDataExplorerContribution class.
  */
 class PositronDataExplorerContribution extends Disposable {
+	/**
+	 * Constructor.
+	 * @param editorResolverService The editor resolver service.
+	 * @param instantiationService The instantiation service.
+	 */
 	constructor(
 		@IEditorResolverService editorResolverService: IEditorResolverService,
 		@IInstantiationService instantiationService: IInstantiationService,
 	) {
+		// Call the base class's constructor.
 		super();
 
+		// Register the editor.
 		this._register(editorResolverService.registerEditor(
 			`${Schemas.positronDataExplorer}:**/**`,
 			{
@@ -41,7 +48,13 @@ class PositronDataExplorerContribution extends Disposable {
 			},
 			{
 				createEditorInput: ({ resource, options }) => {
-					return { editor: instantiationService.createInstance(PositronDataExplorerEditorInput, resource), options };
+					return {
+						editor: instantiationService.createInstance(
+							PositronDataExplorerEditorInput,
+							resource
+						),
+						options
+					};
 				}
 			}
 		));

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -274,6 +274,7 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 						keybindingService={this._keybindingService}
 						layoutService={this._layoutService}
 						instance={positronDataExplorerInstance}
+						onClose={() => this._group.closeEditor(this.input)}
 					/>
 				);
 

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -185,7 +185,7 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 	 */
 	constructor(
 		readonly _group: IEditorGroup,
-		@IClipboardService readonly _clipboardService: IClipboardService,
+		@IClipboardService private readonly _clipboardService: IClipboardService,
 		@ICommandService private readonly _commandService: ICommandService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput.ts
@@ -5,6 +5,8 @@
 import { URI } from 'vs/base/common/uri';
 import { IUntypedEditorInput } from 'vs/workbench/common/editor';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
+import { PositronDataExplorerUri } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerUri';
+import { IPositronDataExplorerService } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
 
 /**
  * PositronDataExplorerEditorInput class.
@@ -31,8 +33,12 @@ export class PositronDataExplorerEditorInput extends EditorInput {
 	/**
 	 * Constructor.
 	 * @param resource The resource.
+	 * @param _positronDataExplorerService The Positron data explorer service.
 	 */
-	constructor(readonly resource: URI) {
+	constructor(
+		readonly resource: URI,
+		@IPositronDataExplorerService private readonly _positronDataExplorerService: IPositronDataExplorerService
+	) {
 		// Call the base class's constructor.
 		super();
 	}
@@ -41,6 +47,15 @@ export class PositronDataExplorerEditorInput extends EditorInput {
 	 * dispose override method.
 	 */
 	override dispose(): void {
+		// Dispose of the data explorer client instance.
+		const identifier = PositronDataExplorerUri.parse(this.resource);
+		if (identifier) {
+			const instance = this._positronDataExplorerService.getInstance(identifier);
+			if (instance) {
+				instance.dataExplorerClientInstance.dispose();
+			}
+		}
+
 		// Call the base class's dispose method.
 		super.dispose();
 	}

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -352,7 +352,6 @@ export class DataExplorerClientInstance extends Disposable {
 
 	//#region Public Events
 
-
 	/**
 	 * Event that fires when the data explorer is closed on the runtime side, as a result of
 	 * a dataset being deallocated or overwritten with a non-dataset.

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -2,23 +2,11 @@
  *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
+import { Emitter } from 'vs/base/common/event';
 import { generateUuid } from 'vs/base/common/uuid';
-import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
-import {
-	BackendState,
-	ColumnProfileRequest,
-	ColumnProfileResult,
-	ColumnSchema,
-	ColumnSortKey,
-	FilterResult,
-	PositronDataExplorerComm,
-	RowFilter,
-	SchemaUpdateEvent,
-	TableData,
-	TableSchema
-} from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { BackendState, ColumnProfileRequest, ColumnProfileResult, ColumnSchema, ColumnSortKey, FilterResult, PositronDataExplorerComm, RowFilter, SchemaUpdateEvent, TableData, TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * TableSchemaSearchResult interface. This is here temporarily until searching the tabe schema
@@ -75,6 +63,11 @@ export class DataExplorerClientInstance extends Disposable {
 	private readonly _positronDataExplorerComm: PositronDataExplorerComm;
 
 	/**
+	 * The onDidClose event emitter.
+	 */
+	private readonly _onDidCloseEmitter = this._register(new Emitter<void>());
+
+	/**
 	 * The onDidSchemaUpdate event emitter.
 	 */
 	private readonly _onDidSchemaUpdateEmitter = this._register(new Emitter<SchemaUpdateEvent>());
@@ -82,9 +75,7 @@ export class DataExplorerClientInstance extends Disposable {
 	/**
 	 * The onDidUpdateBackendState event emitter.
 	 */
-	private readonly _onDidUpdateBackendStateEmitter = this._register(
-		new Emitter<BackendState>
-	);
+	private readonly _onDidUpdateBackendStateEmitter = this._register(new Emitter<BackendState>);
 
 	/**
 	 * The onDidDataUpdate event emitter.
@@ -117,21 +108,21 @@ export class DataExplorerClientInstance extends Disposable {
 		this._positronDataExplorerComm = new PositronDataExplorerComm(client);
 		this._register(this._positronDataExplorerComm);
 
-		// Close emitter
-		this.onDidClose = this._positronDataExplorerComm.onDidClose;
+		// Register the onDidClose event handler.
+		this._register(this._positronDataExplorerComm.onDidClose(() => {
+			this.setStatus(DataExplorerClientStatus.Disconnected);
+			this._onDidCloseEmitter.fire();
+		}));
 
+		// Register the onDidSchemaUpdate event handler.
 		this._register(this._positronDataExplorerComm.onDidSchemaUpdate(async (e: SchemaUpdateEvent) => {
-			this.updateBackendState();
+			await this.updateBackendState();
 			this._onDidSchemaUpdateEmitter.fire(e);
 		}));
 
-		this._register(this._positronDataExplorerComm.onDidDataUpdate(async (_evt) => {
+		// Register the onDidDataUpdate event handler.
+		this._register(this._positronDataExplorerComm.onDidDataUpdate(() => {
 			this._onDidDataUpdateEmitter.fire();
-		}));
-
-		this._register(this.onDidClose(() => {
-			this.status = DataExplorerClientStatus.Disconnected;
-			this._onDidStatusUpdateEmitter.fire(this.status);
 		}));
 	}
 
@@ -356,7 +347,7 @@ export class DataExplorerClientInstance extends Disposable {
 	 * Event that fires when the data explorer is closed on the runtime side, as a result of
 	 * a dataset being deallocated or overwritten with a non-dataset.
 	 */
-	onDidClose: Event<void>;
+	onDidClose = this._onDidCloseEmitter.event;
 
 	/**
 	 * Event that fires when the schema has been updated.

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
@@ -15,6 +15,11 @@ export interface IPositronDataExplorerInstance {
 	/**
 	 * Gets the data explorer client instance.
 	 */
+	readonly languageName: string;
+
+	/**
+	 * Gets the data explorer client instance.
+	 */
 	readonly dataExplorerClientInstance: DataExplorerClientInstance;
 
 	/**
@@ -36,6 +41,11 @@ export interface IPositronDataExplorerInstance {
 	 * Gets the TableDataDataGridInstance.
 	 */
 	readonly tableDataDataGridInstance: TableDataDataGridInstance;
+
+	/**
+	 * The onDidClose event.
+	 */
+	readonly onDidClose: Event<void>;
 
 	/**
 	 * The onDidChangeLayout event.

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
@@ -32,12 +32,6 @@ export interface IPositronDataExplorerService {
 	initialize(): void;
 
 	/**
-	 * Test open function.
-	 * @param identifier The identifier.
-	 */
-	testOpen(identifier: string): Promise<void>;
-
-	/**
 	 *
 	 * @param identifier
 	 */

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -22,7 +22,10 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	 */
 	private readonly _dataExplorerClientInstance: DataExplorerClientInstance;
 
-	private readonly _dataCache: DataExplorerCache;
+	/**
+	 * Gets the DataExplorerCache.
+	 */
+	private readonly _dataExplorerCache: DataExplorerCache;
 
 	/**
 	 * Gets or sets the layout.
@@ -75,14 +78,14 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 
 		// Initialize.
 		this._dataExplorerClientInstance = dataExplorerClientInstance;
-		this._dataCache = new DataExplorerCache(dataExplorerClientInstance);
+		this._dataExplorerCache = new DataExplorerCache(dataExplorerClientInstance);
 		this._tableSchemaDataGridInstance = new TableSummaryDataGridInstance(
 			dataExplorerClientInstance,
-			this._dataCache
+			this._dataExplorerCache
 		);
 		this._tableDataDataGridInstance = new TableDataDataGridInstance(
 			dataExplorerClientInstance,
-			this._dataCache
+			this._dataExplorerCache
 		);
 
 		// Add event handlers.

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -10,9 +10,9 @@ import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/
 import { PositronDataExplorerUri } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerUri';
 import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
 import { PositronDataExplorerInstance } from 'vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance';
+import { ILanguageRuntimeSession, IRuntimeSessionService, RuntimeClientType } from '../../runtimeSession/common/runtimeSessionService';
 import { IPositronDataExplorerService } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
 import { IPositronDataExplorerInstance } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance';
-import { ILanguageRuntimeSession, IRuntimeSessionService, RuntimeClientType } from '../../runtimeSession/common/runtimeSessionService';
 
 /**
  * DataExplorerRuntime class.
@@ -47,8 +47,9 @@ class DataExplorerRuntime extends Disposable {
 	//#region Constructor & Dispose
 
 	/**
-	 *
-	 * @param runtime
+	 * Constructor.
+	 * @param _session The session.
+	 * @param _notificationService The notification service.
 	 */
 	constructor(
 		private readonly _session: ILanguageRuntimeSession,

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -38,9 +38,11 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	/**
 	 * Constructor.
 	 * @param dataExplorerClientInstance The DataExplorerClientInstance.
+	 * @param dataExplorerCache The DataExplorerCache.
 	 */
-	constructor(dataExplorerClientInstance: DataExplorerClientInstance,
-		dataCache: DataExplorerCache
+	constructor(
+		dataExplorerClientInstance: DataExplorerClientInstance,
+		dataExplorerCache: DataExplorerCache
 	) {
 		// Call the base class's constructor.
 		super({
@@ -66,8 +68,8 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		// Setup the data explorer client instance.
 		this._dataExplorerClientInstance = dataExplorerClientInstance;
 
-		// Set the shared data cache
-		this._dataExplorerCache = dataCache;
+		// Set the data explorer cache.
+		this._dataExplorerCache = dataExplorerCache;
 
 		// Add the onDidUpdateCache event handler.
 		this._register(this._dataExplorerCache.onDidUpdateCache(() =>

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -7,11 +7,11 @@ import * as React from 'react';
 
 // Other dependencies.
 import { IColumnSortKey } from 'vs/workbench/browser/positronDataGrid/interfaces/columnSortKey';
-import { ColumnSortKeyDescriptor, DataGridInstance } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
 import { DataExplorerCache } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
 import { TableDataCell } from 'vs/workbench/services/positronDataExplorer/browser/components/tableDataCell';
 import { TableDataRowHeader } from 'vs/workbench/services/positronDataExplorer/browser/components/tableDataRowHeader';
 import { PositronDataExplorerColumn } from 'vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn';
+import { ColumnSortKeyDescriptor, DataGridInstance } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
 import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
 import { BackendState, RowFilter, SchemaUpdateEvent } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -9,9 +9,9 @@ import * as React from 'react';
 import { Emitter } from 'vs/base/common/event';
 import { DataGridInstance } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
 import { DataExplorerCache } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
-import { ColumnDisplayType, ColumnSummaryStats } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { ColumnSummaryCell } from 'vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell';
 import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
+import { ColumnDisplayType, ColumnSummaryStats } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * Constants.
@@ -52,9 +52,11 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	/**
 	 * Constructor.
 	 * @param dataExplorerClientInstance The DataExplorerClientInstance.
+	 * @param dataExplorerCache The DataExplorerCache.
 	 */
-	constructor(dataExplorerClientInstance: DataExplorerClientInstance,
-		dataCache: DataExplorerCache
+	constructor(
+		dataExplorerClientInstance: DataExplorerClientInstance,
+		dataExplorerCache: DataExplorerCache
 	) {
 		// Call the base class's constructor.
 		super({
@@ -76,8 +78,8 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		// Set the data explorer client instance.
 		this._dataExplorerClientInstance = dataExplorerClientInstance;
 
-		// Set the shared data cache
-		this._dataExplorerCache = dataCache;
+		// Set the data explorer cache.
+		this._dataExplorerCache = dataExplorerCache;
 
 		// Add the onDidUpdateCache event handler.
 		this._register(this._dataExplorerCache.onDidUpdateCache(() => {
@@ -87,12 +89,12 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 				() => this._onDidUpdateEmitter.fire()
 			);
 		}));
+
 		// Add the onDidSchemaUpdate event handler.
 		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(async () => {
 			this.setScreenPosition(0, 0);
 			this._expandedColumns.clear();
 			this.fetchData();
-
 		}));
 	}
 

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
@@ -4,8 +4,8 @@
 
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
-import { ColumnProfileType, ColumnSchema, ColumnSummaryStats, TableData } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
+import { ColumnProfileType, ColumnSchema, ColumnSummaryStats, TableData } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * Constants.
@@ -417,7 +417,7 @@ export class DataExplorerCache extends Disposable {
 			this._cacheUpdateDescriptor = undefined;
 
 			// Update the cache for the pending cache update descriptor.
-			await this.updateCache(pendingCacheUpdateDescriptor);
+			this.updateCache(pendingCacheUpdateDescriptor);
 		}
 	}
 


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

Improve the Positron Data Explorer lifecycle management.

This PR addresses part 1 of:
https://github.com/posit-dev/positron/issues/636

and 

https://github.com/posit-dev/positron/issues/2297

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

This PR updates the Positron Data Explorer such that:

- When an underlying PositronDataExplorerComm is closed, its PositronDataExplorerEditor is closed.
- When a PositronDataExplorerEditor is closed, its underlying PositronDataExplorerComm is closed.

Here is a screen recording of this PR in action:

https://github.com/posit-dev/positron/assets/853239/b69e2a84-9641-4a6f-ba53-2badbee7de9e

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
