### PR TITLE
Bump ark to 0.1.94

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -541,7 +541,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.93"
+      "ark": "0.1.94"
     },
     "minimumRVersion": "4.2.0"
   }


### PR DESCRIPTION
For https://github.com/posit-dev/amalthea/pull/351 addressing https://github.com/posit-dev/positron/issues/3117 for private beta

Wait for https://github.com/posit-dev/amalthea/actions/runs/9080687934