### PR TITLE
Data Explorer: Give up on using pandas.io.formats for value formatting because of whitespace issues

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -60,7 +60,7 @@ from .data_explorer_comm import (
     TableShape,
 )
 from .positron_comm import CommMessage, PositronComm
-from .third_party import pd_
+from .third_party import pd_, np_
 from .utils import guid
 
 if TYPE_CHECKING:
@@ -225,14 +225,14 @@ class DataExplorerTableView(abc.ABC):
         pass
 
 
-def _pandas_format_values(col):
-    import pandas.io.formats.format as fmt
+def _format_value(x):
+    if isinstance(x, float) and np_.isnan(x):
+        return "NaN"
+    return str(x)
 
-    try:
-        return fmt.format_array(col._values, None, leading_space=False)
-    except Exception:
-        logger.warning(f"Failed to format column '{col.name}'")
-        return col.astype(str).tolist()
+
+def _pandas_format_values(col):
+    return col.map(_format_value).tolist()
 
 
 _FILTER_RANGE_COMPARE_SUPPORTED = {

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -617,10 +617,6 @@ def test_pandas_search_schema(dxf: DataExplorerFixture):
         assert matches == ex_matches
 
 
-def _trim_whitespace(columns):
-    return [[x.strip() for x in column] for column in columns]
-
-
 def test_pandas_get_data_values(dxf: DataExplorerFixture):
     result = dxf.get_data_values(
         "simple",
@@ -629,8 +625,6 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
         column_indices=list(range(6)),
     )
 
-    # TODO: pandas pads all values to fixed width, do we want to do
-    # something different?
     expected_columns = [
         ["1", "2", "3", "4", "5"],
         ["True", "False", "True", "None", "True"],
@@ -646,7 +640,7 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
         ["None", "5", "-1", "None", "None"],
     ]
 
-    assert _trim_whitespace(result["columns"]) == expected_columns
+    assert result["columns"] == expected_columns
 
     assert result["row_labels"] == [["0", "1", "2", "3", "4"]]
 
@@ -659,7 +653,7 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
     response = dxf.get_data_values(
         "simple", row_start_index=0, num_rows=5, column_indices=[2, 3, 4, 5]
     )
-    assert _trim_whitespace(response["columns"]) == expected_columns[2:]
+    assert response["columns"] == expected_columns[2:]
 
     # Edge case: request invalid column index
     # Per issue #2149, until we can align on whether the UI is allowed
@@ -669,6 +663,31 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
     #     dxf.get_data_values(
     #         "simple", row_start_index=0, num_rows=10, column_indices=[4]
     #     )
+
+
+def test_pandas_leading_whitespace(dxf: DataExplorerFixture):
+    # See GH#3138
+    df = pd.DataFrame(
+        {
+            "a": ["   foo", "  bar", " baz", "qux", "potato"],
+            "c": [True, False, True, False, True],
+        }
+    )
+
+    dxf.register_table("ws", df)
+    result = dxf.get_data_values(
+        "ws",
+        row_start_index=0,
+        num_rows=5,
+        column_indices=list(range(6)),
+    )
+
+    expected_columns = [
+        ["   foo", "  bar", " baz", "qux", "potato"],
+        ["True", "False", "True", "False", "True"],
+    ]
+
+    assert result["columns"] == expected_columns
 
 
 def _filter(filter_type, column_schema, condition="and", is_valid=None, **kwargs):


### PR DESCRIPTION
addresses #3138 

pandas's internal formatting modular is useful for rendering console output but does not offer enough control over whitespace to be used for the `get_data_values` RPC, and it cannot be relied upon to work consistently in future versions of pandas (since it is an internal API with no promises of stability). This switches to formatting values ourselves, so we can grow / improve our value formatting to achieve consistency across different versions of pandas. 