### PR TITLE
Data Explorer: do not reset user-edited column widths or row heights after applying a filter

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
@@ -182,7 +182,7 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 	async setSearchText(searchText?: string): Promise<void> {
 		// When the search text changes, perform a soft reset and search.
 		if (searchText !== this._searchText) {
-			// Each search performs a soft
+			// Each search performs a soft reset.
 			this.softReset();
 
 			// Set the search text and fetch data.

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -2058,8 +2058,6 @@ export abstract class DataGridInstance extends Disposable {
 		this._columnSelectionIndexes.clear();
 		this._rowSelectionRange = undefined;
 		this._rowSelectionIndexes.clear();
-		this._columnWidths.clear();
-		this._rowHeights.clear();
 	}
 
 	//#endregion Protected Methods

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -9,11 +9,11 @@ import * as React from 'react';
 import { IColumnSortKey } from 'vs/workbench/browser/positronDataGrid/interfaces/columnSortKey';
 import { DataExplorerCache } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
 import { TableDataCell } from 'vs/workbench/services/positronDataExplorer/browser/components/tableDataCell';
+import { BackendState, RowFilter } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { TableDataRowHeader } from 'vs/workbench/services/positronDataExplorer/browser/components/tableDataRowHeader';
 import { PositronDataExplorerColumn } from 'vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn';
 import { ColumnSortKeyDescriptor, DataGridInstance } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
 import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
-import { BackendState, RowFilter, SchemaUpdateEvent } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * TableDataDataGridInstance class.
@@ -77,13 +77,15 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		));
 
 		// Add the onDidSchemaUpdate event handler.
-		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(async (e: SchemaUpdateEvent) => {
+		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(e => {
+			this._dataExplorerCache.invalidateDataCache();
 			this.softReset();
 			this.fetchData();
 		}));
 
 		// Add the onDidDataUpdate event handler.
-		this._register(this._dataExplorerClientInstance.onDidDataUpdate(async () => {
+		this._register(this._dataExplorerClientInstance.onDidDataUpdate(() => {
+			this._dataExplorerCache.invalidateDataCache();
 			this.fetchData();
 		}));
 


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR addresses https://github.com/posit-dev/positron/issues/2822 by _not_ resetting column widths and row heights when in the `softReset` method of `PositronDataGrid` is invoked.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

I updated the `onDidSchemaUpdate` and `onDidDataUpdate` event handlers in `src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx` to invalidate the data cache before fetching data.

Additionally, I fixed a bad comment in:
src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

To test, resize some columns and change the column sorting on one or more columns. The resized columns should retain their size.
