### PR TITLE
Fix extension host crashes on Intel macOS

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -76,7 +76,12 @@ jobs:
       # Check Python environment. This helps diagnose build issues that are due
       # to Python version and environment problems.
       - name: Check Python
+        env:
+          npm_config_arch: ${{ matrix.arch }}
         run: |
+          export NVM_DIR="$HOME/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          nvm use
           echo "--- PATH ---"
           echo $PATH
           echo "--- Python Path (${{matrix.arch_terminal}}) ---"
@@ -88,6 +93,12 @@ jobs:
           echo "--- library paths---"
           pkg-config --libs libsodium
           pkg-config --libs liblzma
+          echo "--- node environment ---"
+          which node
+          node --version
+          which yarn
+          yarn --version
+
 
       # Install node_modules binaries
       - name: Install dependencies

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -62,16 +62,6 @@ jobs:
           arch -${{matrix.arch_terminal}} /bin/bash -c "${{matrix.homebrew_folder}}/bin/brew install libsodium"
           arch -${{matrix.arch_terminal}} /bin/bash -c "${{matrix.homebrew_folder}}/bin/brew install xz"
 
-      # Zeromq calls whatever pkg-config version is findable on the PATH to be
-      # able to locate libsodium, so we have to ensure the x86_64 version is
-      # first on the PATH when compiling for that architecture, so that it finds
-      # the x86_64 version of libsodium for zeromq to link against.
-      - name: Update PATH to pkg-config for zeromq
-        id: update_path_for_zeromq
-        if: matrix.arch == 'x64'
-        run: |
-          echo "${{matrix.homebrew_folder}}/bin" >> $GITHUB_PATH
-
       # Check Python environment. This helps diagnose build issues that are due
       # to Python version and environment problems.
       - name: Check Python
@@ -82,6 +72,10 @@ jobs:
           which python3
           echo "--- Python Version ---"
           python3 --version
+          echo "--- pkg-config Path ---"
+          which pkg-config
+          echo "--- libsodium path---"
+          pkg-config --libs libsodium
 
       # Install node_modules binaries
       - name: Install dependencies

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -62,6 +62,16 @@ jobs:
           arch -${{matrix.arch_terminal}} /bin/bash -c "${{matrix.homebrew_folder}}/bin/brew install libsodium"
           arch -${{matrix.arch_terminal}} /bin/bash -c "${{matrix.homebrew_folder}}/bin/brew install xz"
 
+      # Zeromq calls whatever pkg-config version is findable on the PATH to be
+      # able to locate libsodium, so we have to ensure the x86_64 version is
+      # first on the PATH when compiling for that architecture, so that it finds
+      # the x86_64 version of libsodium for zeromq to link against.
+      - name: Update PATH to pkg-config for zeromq
+        id: update_path_for_zeromq
+        if: matrix.arch == 'x64'
+        run: |
+          echo "${{matrix.homebrew_folder}}/bin" >> $GITHUB_PATH
+
       # Check Python environment. This helps diagnose build issues that are due
       # to Python version and environment problems.
       - name: Check Python

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -36,12 +36,13 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        arch: [arm64, x64]
+#       arch: [arm64, x64]
+        arch: [x64]
         include:
-          - arch: arm64
-            arch_terminal: arm64
-            homebrew_folder: /opt/homebrew
-            rust_target_prefix: aarch64
+#         - arch: arm64
+#           arch_terminal: arm64
+#           homebrew_folder: /opt/homebrew
+#           rust_target_prefix: aarch64
           - arch: x64
             arch_terminal: x86_64
             homebrew_folder: /usr/local
@@ -84,8 +85,9 @@ jobs:
           python3 --version
           echo "--- pkg-config Path ---"
           which pkg-config
-          echo "--- libsodium path---"
+          echo "--- library paths---"
           pkg-config --libs libsodium
+          pkg-config --libs liblzma
 
       # Install node_modules binaries
       - name: Install dependencies

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -39,12 +39,10 @@ jobs:
         arch: [arm64, x64]
         include:
           - arch: arm64
-            prebuild_arch: arm64
             arch_terminal: arm64
             homebrew_folder: /opt/homebrew
             rust_target_prefix: aarch64
           - arch: x64
-            prebuild_arch: x86
             arch_terminal: x86_64
             homebrew_folder: /usr/local
             rust_target_prefix: x86_64
@@ -66,8 +64,8 @@ jobs:
 
 
       # When running under x86, put x86 homebrew on the $PATH ahead of arm64
-      # homebrew. We also force Python 3.10 since 3.12 is not compatible with
-      # the version of node-gyp currently used by Positron.
+      # homebrew. We also force Python 3.10 (arm64) on x86 since 3.12 is not
+      # compatible with the version of node-gyp currently used by Positron.
       - name: Update PATH for x86_64
         id: update_path_for_zeromq
         if: matrix.arch == 'x64'
@@ -104,7 +102,6 @@ jobs:
       - name: Install dependencies
         env:
           npm_config_arch: ${{ matrix.arch }}
-          PREBUILD_ARCH: ${{ matrix.prebuild_arch }}
           POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
         run: |
           export NVM_DIR="$HOME/.nvm"

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -40,10 +40,12 @@ jobs:
         arch: [x64]
         include:
 #         - arch: arm64
+#           prebuild_arch: arm64
 #           arch_terminal: arm64
 #           homebrew_folder: /opt/homebrew
 #           rust_target_prefix: aarch64
           - arch: x64
+            prebuild_arch: x86
             arch_terminal: x86_64
             homebrew_folder: /usr/local
             rust_target_prefix: x86_64
@@ -104,6 +106,7 @@ jobs:
       - name: Install dependencies
         env:
           npm_config_arch: ${{ matrix.arch }}
+          PREBUILD_ARCH: ${{ matrix.prebuild_arch }}
           POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
         run: |
           export NVM_DIR="$HOME/.nvm"

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -73,7 +73,7 @@ jobs:
         id: update_path_for_zeromq
         if: matrix.arch == 'x64'
         run: |
-          echo "${{matrix.homebrew_folder}}/opt/python@3.10/libexec/bin:${{matrix.homebrew_folder}}/bin" >> $GITHUB_PATH
+          echo "/opt/homebrew/opt/python@3.10/libexec/bin:${{matrix.homebrew_folder}}/bin" >> $GITHUB_PATH
 
       # Check Python environment. This helps diagnose build issues that are due
       # to Python version and environment problems.

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -36,14 +36,13 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-#       arch: [arm64, x64]
-        arch: [x64]
+        arch: [arm64, x64]
         include:
-#         - arch: arm64
-#           prebuild_arch: arm64
-#           arch_terminal: arm64
-#           homebrew_folder: /opt/homebrew
-#           rust_target_prefix: aarch64
+          - arch: arm64
+            prebuild_arch: arm64
+            arch_terminal: arm64
+            homebrew_folder: /opt/homebrew
+            rust_target_prefix: aarch64
           - arch: x64
             prebuild_arch: x86
             arch_terminal: x86_64
@@ -75,9 +74,8 @@ jobs:
         run: |
           echo "/opt/homebrew/opt/python@3.10/libexec/bin:${{matrix.homebrew_folder}}/bin" >> $GITHUB_PATH
 
-      # Check Python environment. This helps diagnose build issues that are due
-      # to Python version and environment problems.
-      - name: Check Python
+      # Check environment. This helps diagnose build issues.
+      - name: Inspect Environment
         env:
           npm_config_arch: ${{ matrix.arch }}
         run: |

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -62,6 +62,16 @@ jobs:
           arch -${{matrix.arch_terminal}} /bin/bash -c "${{matrix.homebrew_folder}}/bin/brew install libsodium"
           arch -${{matrix.arch_terminal}} /bin/bash -c "${{matrix.homebrew_folder}}/bin/brew install xz"
 
+
+      # When running under x86, put x86 homebrew on the $PATH ahead of arm64
+      # homebrew. We also force Python 3.10 since 3.12 is not compatible with
+      # the version of node-gyp currently used by Positron.
+      - name: Update PATH for x86_64
+        id: update_path_for_zeromq
+        if: matrix.arch == 'x64'
+        run: |
+          echo "${{matrix.homebrew_folder}}/opt/python@3.10/libexec/bin:${{matrix.homebrew_folder}}/bin" >> $GITHUB_PATH
+
       # Check Python environment. This helps diagnose build issues that are due
       # to Python version and environment problems.
       - name: Check Python


### PR DESCRIPTION
### Intent

Addresses #3110.

### Approach

The problem is due to a complex interplay between the build machine's configuration and environment, Homebrew x86 and arm64 conflicts, Node and Electron building and linking scripts, ZeroMQ, libsodium, and liblzma native binaries and modules, and a partridge in a pear tree.

What was happening (loosely) was that we weren't getting an x86 copy of `libsodium` statically linked in when building `zeromq` for x86. This resulted in runtime crashes when we tried to call methods in this library.

The fix, as is so often the case with these kinds of issues, is pretty simple:

- When building for x86, we need to put Homebrew x86 on the path. This is necessary so that we get the `pkg-config` from Homebrew x86 on the path, which in turn is necessary to get `libsodium` x86 headers and libraries linked in to zeromq x86. 
- However, Homebrew x86 *also* supplies Python x86 which causes `node-gyp` to think it has to rebuild `liblzma`, which always ends in weeping and gnashing of teeth. So we also need to fix up the path to force the right version of Python to the front.

A couple of followup items: (a) @petetronic pointed out that we should really consider using `actions/setup-python` instead of manually configuring it (a good point), and (b) we should get IT to provision an real Intel mac so these cross-platform entanglements don't keep soaking up engineering time.
 
### QA Notes

If you can boot R or Python on an Intel Mac, this is working.