### PR TITLE
Feature/add Add Filter option to the data grid column header drop down menu

### DIFF
--- a/src/vs/workbench/browser/positronComponents/contextMenu/contextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/contextMenu/contextMenu.tsx
@@ -20,6 +20,11 @@ import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalRe
 import { ContextMenuItem, ContextMenuItemOptions } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenuItem';
 
 /**
+ * ContextMenuEntry type.
+ */
+export type ContextMenuEntry = ContextMenuItem | ContextMenuSeparator;
+
+/**
  * Shows a context menu.
  * @param keybindingService The keybinding service.
  * @param layoutService The layout service.
@@ -34,7 +39,7 @@ export const showContextMenu = async (
 	anchor: HTMLElement,
 	popupAlignment: 'left' | 'right',
 	width: number,
-	entries: (ContextMenuItem | ContextMenuSeparator)[]
+	entries: ContextMenuEntry[]
 ) => {
 	// Create the renderer.
 	const renderer = new PositronModalReactRenderer({
@@ -64,7 +69,7 @@ interface ContextMenuModalPopupProps {
 	anchor: HTMLElement;
 	popupAlignment: 'left' | 'right';
 	width: number;
-	entries: (ContextMenuItem | ContextMenuSeparator)[];
+	entries: ContextMenuEntry[];
 }
 
 /**

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -136,6 +136,7 @@ interface AddEditRowFilterModalPopupProps {
 	renderer: PositronModalReactRenderer;
 	anchor: HTMLElement;
 	isFirstFilter: boolean;
+	schema?: ColumnSchema;
 	editRowFilter?: RowFilterDescriptor;
 	onApplyRowFilter: (rowFilter: RowFilterDescriptor) => void;
 }
@@ -152,7 +153,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 
 	// State hooks.
 	const [selectedColumnSchema, setSelectedColumnSchema] = useState<ColumnSchema | undefined>(
-		props.editRowFilter?.schema
+		props.schema
 	);
 	const [selectedFilterType, setSelectedFilterType] = useState<RowFilterDescrType | undefined>(
 		props.editRowFilter?.descrType

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -7,17 +7,18 @@ import 'vs/css!./rowFilterBar';
 
 // React.
 import * as React from 'react';
-import { useEffect, useRef, useState } from 'react'; // eslint-disable-line no-duplicate-imports
+import { useCallback, useEffect, useRef, useState } from 'react'; // eslint-disable-line no-duplicate-imports
 
 // Other dependencies.
 import { localize } from 'vs/nls';
 import * as DOM from 'vs/base/browser/dom';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { Button } from 'vs/base/browser/ui/positronComponents/button/button';
-import { showContextMenu } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenu';
+import { ColumnSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { ContextMenuItem } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenuItem';
 import { ContextMenuSeparator } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenuSeparator';
 import { OKModalDialog } from 'vs/workbench/browser/positronComponents/positronModalDialog/positronOKModalDialog';
+import { ContextMenuEntry, showContextMenu } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenu';
 import { usePositronDataExplorerContext } from 'vs/workbench/browser/positronDataExplorer/positronDataExplorerContext';
 import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer';
 import { RowFilterWidget } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget';
@@ -51,33 +52,18 @@ export const RowFilterBar = () => {
 	);
 	const [rowFiltersHidden, setRowFiltersHidden] = useState(false);
 
-	// Main useEffect. This is where we set up event handlers.
-	useEffect(() => {
-		// Create the disposable store for cleanup.
-		const disposableStore = new DisposableStore();
-
-		// Set up event handler for backend state sync updating the filter bar
-		disposableStore.add(context.instance.dataExplorerClientInstance.onDidUpdateBackendState(
-			(state) => {
-				const newDescriptors = state.row_filters.map(getRowFilterDescriptor);
-				setRowFilterDescriptors(newDescriptors);
-			})
-		);
-
-		// Return the cleanup function that will dispose of the event handlers.
-		return () => disposableStore.dispose();
-	}, [context.instance]);
-
 	/**
 	 * Add row filter handler.
 	 * @param anchor The anchor element.
 	 * @param isFirstFilter Whether this is the first filter.
+	 * @param schema The column schema to preselect.
 	 * @param editRowFilterDescriptor The row filter to edit, or undefined, to add a row filter.
 	 */
-	const addRowFilterHandler = (
+	const addRowFilterHandler = useCallback((
 		anchor: HTMLElement,
-		isFirstFilter: boolean = false,
-		editRowFilterDescriptor?: RowFilterDescriptor
+		isFirstFilter: boolean,
+		schema?: ColumnSchema,
+		editRowFilterDescriptor?: RowFilterDescriptor,
 	) => {
 		// Create the renderer.
 		const renderer = new PositronModalReactRenderer({
@@ -145,19 +131,26 @@ export const RowFilterBar = () => {
 					renderer={renderer}
 					anchor={anchor}
 					isFirstFilter={isFirstFilter}
+					schema={schema}
 					editRowFilter={editRowFilterDescriptor}
 					onApplyRowFilter={applyRowFilterHandler}
 				/>
 			);
 		}
-	};
+	}, [
+		context.instance.dataExplorerClientInstance,
+		context.instance.tableDataDataGridInstance,
+		context.keybindingService,
+		context.layoutService,
+		rowFilterDescriptors
+	]);
 
 	/**
 	 * Filter button pressed handler.
 	 */
 	const filterButtonPressedHandler = async () => {
 		// Build the context menu entries.
-		const entries: (ContextMenuItem | ContextMenuSeparator)[] = [];
+		const entries: ContextMenuEntry[] = [];
 		entries.push(new ContextMenuItem({
 			label: localize('positron.dataExplorer.addFilter', "Add Filter"),
 			icon: 'positron-add-filter',
@@ -225,6 +218,32 @@ export const RowFilterBar = () => {
 		);
 	};
 
+	// Main useEffect. This is where we set up event handlers.
+	useEffect(() => {
+		// Create the disposable store for cleanup.
+		const disposableStore = new DisposableStore();
+
+		// Add the onAddFilter event handler.
+		disposableStore.add(context.instance.tableDataDataGridInstance.onAddFilter(schema => {
+			addRowFilterHandler(
+				addFilterButtonRef.current,
+				rowFilterDescriptors.length === 0,
+				schema
+			);
+		}));
+
+		// Add the onDidUpdateBackendState event handler.
+		disposableStore.add(context.instance.dataExplorerClientInstance.onDidUpdateBackendState(
+			state => {
+				const newDescriptors = state.row_filters.map(getRowFilterDescriptor);
+				setRowFilterDescriptors(newDescriptors);
+			})
+		);
+
+		// Return the cleanup function that will dispose of the event handlers.
+		return () => disposableStore.dispose();
+	}, [addRowFilterHandler, context.instance, rowFilterDescriptors.length]);
+
 	// Render.
 	return (
 		<div ref={ref} className='row-filter-bar'>
@@ -253,6 +272,7 @@ export const RowFilterBar = () => {
 								addRowFilterHandler(
 									rowFilterWidgetRefs.current[index],
 									index === 0,
+									rowFilter.schema,
 									rowFilter
 								);
 							}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -159,7 +159,7 @@ export const RowFilterBar = () => {
 		// Build the context menu entries.
 		const entries: (ContextMenuItem | ContextMenuSeparator)[] = [];
 		entries.push(new ContextMenuItem({
-			label: localize('positron.dataExplorer.addFilter', "Add filter"),
+			label: localize('positron.dataExplorer.addFilter', "Add Filter"),
 			icon: 'positron-add-filter',
 			onSelected: () => addRowFilterHandler(
 				rowFilterButtonRef.current,
@@ -169,21 +169,21 @@ export const RowFilterBar = () => {
 		entries.push(new ContextMenuSeparator());
 		if (!rowFiltersHidden) {
 			entries.push(new ContextMenuItem({
-				label: localize('positron.dataExplorer.hideFilters', "Hide filters"),
+				label: localize('positron.dataExplorer.hideFilters', "Hide Filters"),
 				icon: 'positron-hide-filters',
 				disabled: rowFilterDescriptors.length === 0,
 				onSelected: () => setRowFiltersHidden(true)
 			}));
 		} else {
 			entries.push(new ContextMenuItem({
-				label: localize('positron.dataExplorer.showFilters', "Show filters"),
+				label: localize('positron.dataExplorer.showFilters', "Show Filters"),
 				icon: 'positron-show-filters',
 				onSelected: () => setRowFiltersHidden(false)
 			}));
 		}
 		entries.push(new ContextMenuSeparator());
 		entries.push(new ContextMenuItem({
-			label: localize('positron.dataExplorer.clearFilters', "Clear filters"),
+			label: localize('positron.dataExplorer.clearFilters', "Clear Filters"),
 			icon: 'positron-clear-row-filters',
 			disabled: rowFilterDescriptors.length === 0,
 			onSelected: async () => {
@@ -262,7 +262,7 @@ export const RowFilterBar = () => {
 				<Button
 					ref={addFilterButtonRef}
 					className='add-row-filter-button'
-					ariaLabel={(() => localize('positron.dataExplorer.addFilter', "Add filter"))()}
+					ariaLabel={(() => localize('positron.dataExplorer.addFilter', "Add Filter"))()}
 					onPressed={() => addRowFilterHandler(
 						addFilterButtonRef.current,
 						rowFilterDescriptors.length === 0

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -6,6 +6,7 @@ import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IDataColumn } from 'vs/workbench/browser/positronDataGrid/interfaces/dataColumn';
 import { IColumnSortKey } from 'vs/workbench/browser/positronDataGrid/interfaces/columnSortKey';
+import { ContextMenuEntry } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenu';
 
 /**
  * ColumnHeaderOptions type.
@@ -946,6 +947,15 @@ export abstract class DataGridInstance extends Disposable {
 
 		// Fire the onDidUpdate event.
 		this._onDidUpdateEmitter.fire();
+	}
+
+	/**
+	 * Returns column context menu entries.
+	 * @param columnIndex The column index.
+	 * @returns The column context menu entries.
+	 */
+	columnContextMenuEntries(columnIndex: number): ContextMenuEntry[] {
+		return [];
 	}
 
 	/**

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -28,7 +28,6 @@ import { ContextMenuSeparator } from 'vs/workbench/browser/positronComponents/co
 const sortAscendingTitle = localize('positron.sortAscending', "Sort Ascending");
 const sortDescendingTitle = localize('positron.sortDescending', "Sort Descending");
 const clearSortingTitle = localize('positron.clearSorting', "Clear Sorting");
-const copyColumnTitle = localize('positron.copyColumn', "Copy Column");
 
 /**
  * DataGridColumnHeaderProps interface.
@@ -108,14 +107,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 					onSelected: async () =>
 						context.instance.removeColumnSortKey(props.columnIndex)
 				}),
-				new ContextMenuSeparator(),
-				new ContextMenuItem({
-					checked: false,
-					label: copyColumnTitle,
-					disabled: false,
-					icon: 'copy',
-					onSelected: () => console.log('Copy')
-				}),
+				...context.instance.columnContextMenuEntries(props.columnIndex)
 			]
 		);
 	};

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -518,8 +518,6 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 		top += context.instance.getRowHeight(rowIndex);
 	}
 
-	console.log(`Rendering waffle ${width}, ${height}`);
-
 	// Render.
 	return (
 		<div

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn.ts
@@ -19,7 +19,7 @@ export class PositronDataExplorerColumn implements IPositronDataExplorerColumn {
 
 	//#endregion Private Properties
 
-	//#region Constructor & Dispose
+	//#region Constructor
 
 	/**
 	 * Constructor.
@@ -30,7 +30,7 @@ export class PositronDataExplorerColumn implements IPositronDataExplorerColumn {
 		this._columnSchema = columnSchema;
 	}
 
-	//#endregion Constructor & Dispose
+	//#endregion Constructor
 
 	//#region IPositronDataExplorerColumn Implementation
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -6,14 +6,24 @@
 import * as React from 'react';
 
 // Other dependencies.
+import { localize } from 'vs/nls';
+import { Emitter } from 'vs/base/common/event';
 import { IColumnSortKey } from 'vs/workbench/browser/positronDataGrid/interfaces/columnSortKey';
+import { ContextMenuEntry } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenu';
+import { ContextMenuItem } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenuItem';
 import { DataExplorerCache } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
 import { TableDataCell } from 'vs/workbench/services/positronDataExplorer/browser/components/tableDataCell';
-import { BackendState, RowFilter } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { ContextMenuSeparator } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenuSeparator';
 import { TableDataRowHeader } from 'vs/workbench/services/positronDataExplorer/browser/components/tableDataRowHeader';
 import { PositronDataExplorerColumn } from 'vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn';
 import { ColumnSortKeyDescriptor, DataGridInstance } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
 import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
+import { BackendState, ColumnSchema, RowFilter } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+
+/**
+ * Localized strings.
+ */
+const addFilterTitle = localize('positron.addFilter', "Add Filter");
 
 /**
  * TableDataDataGridInstance class.
@@ -30,6 +40,11 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * Gets the data explorer cache.
 	 */
 	private readonly _dataExplorerCache: DataExplorerCache;
+
+	/**
+	 * The onAddFilter event emitter.
+	 */
+	private readonly _onAddFilterEmitter = this._register(new Emitter<ColumnSchema>);
 
 	//#endregion Private Properties
 
@@ -127,6 +142,29 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	//#region DataGridInstance Methods
 
 	/**
+	 * Returns column context menu entries.
+	 * @param columnIndex The column index.
+	 * @returns The column context menu entries.
+	 */
+	override columnContextMenuEntries(columnIndex: number): ContextMenuEntry[] {
+		return [
+			new ContextMenuSeparator(),
+			new ContextMenuItem({
+				checked: false,
+				label: addFilterTitle,
+				disabled: false,
+				icon: 'positron-add-filter',
+				onSelected: () => {
+					const columnSchema = this._dataExplorerCache.getColumnSchema(columnIndex);
+					if (columnSchema) {
+						this._onAddFilterEmitter.fire(columnSchema);
+					}
+				}
+			}),
+		];
+	}
+
+	/**
 	 * Sorts the data.
 	 * @returns A Promise<void> that resolves when the data is sorted.
 	 */
@@ -210,6 +248,13 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	}
 
 	//#endregion DataGridInstance Methods
+
+	//#region Public Events
+
+	/**
+	 * The onAddFilter event.
+	 */
+	readonly onAddFilter = this._onAddFilterEmitter.event;
 
 	//#region Public Methods
 


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR addresses https://github.com/posit-dev/positron/issues/2804 by adding an **Add Filter** menu item to the data grid column header drop down menu.

<img width="321" alt="image" src="https://github.com/posit-dev/positron/assets/853239/9e19b3e0-dafc-4306-a3d6-c369198f1b3d">

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

I approached this work from the front.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

Do some stuff like this:

https://github.com/posit-dev/positron/assets/853239/767f971a-1231-433b-9a92-9d49ec71e8ff
