### PR TITLE
Fix build by compiling darwin create-universal-app.ts to js

### DIFF
--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -40,6 +40,9 @@ async function main(buildDir) {
             'electron.napi.node', // ZeroMQ Electron architecture-specific pre-built binary
             'node.napi.node', // ZeroMQ Electron architecture-specific pre-built binary
             'node.napi.glibc.node', // ZeroMQ Electron architecture-specific pre-built binary
+            // Case-sensitivity issues
+            'HTML.icns',
+            'html.icns',
             // Exclusions from Python language pack (positron-python)
             'pydevd', // Cython pre-built binaries for Python debugging
             // Exclusions from R language pack (positron-r)


### PR DESCRIPTION
We have excludes in create-universal-app.ts but they need to be compiled in the build folder to the .js version.

See: 
https://github.com/posit-dev/positron/blob/main/build/darwin/create-universal-app.ts#L47-L49