### PR TITLE
Fix how the Data Explorer's display name is acquired

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/positronDataExplorer.css
+++ b/src/vs/workbench/browser/positronDataExplorer/positronDataExplorer.css
@@ -52,9 +52,3 @@
 .message-line {
 	text-align: center;
 }
-
-.positron-data-explorer-overlay
-.message
-.message-line.close {
-	text-transform: uppercase;
-}

--- a/src/vs/workbench/browser/positronDataExplorer/positronDataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/positronDataExplorer.tsx
@@ -51,6 +51,7 @@ export interface PositronDataExplorerProps extends PositronDataExplorerConfigura
 export const PositronDataExplorer = (props: PropsWithChildren<PositronDataExplorerProps>) => {
 	// State hooks.
 	const [closed, setClosed] = useState(false);
+	const [displayName, setDisplayName] = useState('');
 
 	// Main useEffect.
 	useEffect(() => {
@@ -58,9 +59,18 @@ export const PositronDataExplorer = (props: PropsWithChildren<PositronDataExplor
 		const disposableStore = new DisposableStore();
 
 		// Add the onDidUpdateBackendState event handler.
-		disposableStore.add(props.instance.onDidClose(() => {
-			setClosed(true);
-		}));
+		disposableStore.add(
+			props.instance.dataExplorerClientInstance.onDidUpdateBackendState(backendState => {
+				setDisplayName(backendState.display_name);
+			})
+		);
+
+		// Add the onDidClose event handler.
+		disposableStore.add(
+			props.instance.onDidClose(() => {
+				setClosed(true);
+			})
+		);
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
@@ -75,21 +85,29 @@ export const PositronDataExplorer = (props: PropsWithChildren<PositronDataExplor
 				{closed && (
 					<div className='positron-data-explorer-overlay'>
 						<PositronButton className='message' onPressed={props.onClose}>
-							<div className='message-line'>
-								{localize(
+							<div
+								className='message-line'>
+								{(() => localize(
 									'positron.dataExplorer.dataDisplayName',
 									'{0} Data: {1}',
 									props.instance.languageName,
-									props.instance.dataExplorerClientInstance.cachedBackendState?.display_name
-								)}
+									displayName
+								))()}
 							</div>
-							<div className='message-line'>
-								{localize(
+							<div
+								className='message-line'>
+								{(() => localize(
 									'positron.dataExplorer.isNoLongerAvailable',
-									'is no longer available'
-								)}
+									'Is no longer available'
+								))()}
 							</div>
-							<div className='message-line close'>{(() => localize('positron.dataExplorer.clickToClose', "Click To Close"))()}</div>
+							<div
+								className='message-line'>
+								{(() => localize(
+									'positron.dataExplorer.clickToClose',
+									"Click to close Data Explorer"
+								))()}
+							</div>
 						</PositronButton>
 					</div>
 				)}


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR addresses https://github.com/posit-dev/positron/issues/3160, which was caused by a call to `localize` with an undefined value for `props.instance.dataExplorerClientInstance.cachedBackendState`.

![image](https://github.com/posit-dev/positron/assets/853239/3923f465-3283-4148-884e-4612362ede04)

The undefined value in question was:
`props.instance.dataExplorerClientInstance.cachedBackendState?.display_name`.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

With this fix, the `display_name` is acquired through an event handler for the `onDidUpdateBackendState` event.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

To repro in R, execute each line below one at a time:

```R
foo <- mtcars
View(foo)
foo = 100
```

You should see this after setting `foo` to `100`:

<img width="1690" alt="image" src="https://github.com/posit-dev/positron/assets/853239/dbf0fbf3-f860-4b25-b5b0-3d2b88069d60">
