### PR TITLE
Drive smoke tests via `workbench.action.executeCode.console` command

### DIFF
--- a/test/automation/src/workbench.ts
+++ b/test/automation/src/workbench.ts
@@ -89,7 +89,7 @@ export class Workbench {
 		// --- Start Positron ---
 		this.positronPopups = new PositronPopups(code);
 		this.startInterpreter = new StartInterpreter(code, this.positronPopups);
-		this.positronConsole = new PositronConsole(code);
+		this.positronConsole = new PositronConsole(code, this.quickaccess, this.quickinput);
 		this.positronVariables = new PositronVariables(code);
 		this.positronDataExplorer = new PositronDataExplorer(code);
 		this.positronSideBar = new PositronSideBar(code);

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -6,7 +6,6 @@
 import { expect } from '@playwright/test';
 import { Application, Logger, PositronPythonFixtures, PositronRFixtures } from '../../../../../automation';
 import { installAllHandlers } from '../../../utils';
-import { PositronConsoleFixtures } from '../../../fixtures/positronConsoleFixtures';
 
 
 export function setup(logger: Logger) {
@@ -24,15 +23,11 @@ export function setup(logger: Logger) {
 				const pythonFixtures = new PositronPythonFixtures(app);
 				await pythonFixtures.startPythonInterpreter();
 
-				const consoleFixtures = new PositronConsoleFixtures(app);
-				await consoleFixtures.updateTerminalSettings();
-
 			});
 
 			after(async function () {
 
 				const app = this.app as Application;
-				await app.workbench.settingsEditor.clearUserSettings();
 
 				await app.workbench.positronDataExplorer.closeDataExplorer();
 				await app.workbench.positronVariables.openVariables();
@@ -50,11 +45,7 @@ data = {'Name':['Jai', 'Princi', 'Gaurav', 'Anuj'],
 df = pd.DataFrame(data)`;
 
 				console.log('Sending code to console');
-				await app.workbench.positronConsole.typeToConsole(script);
-				console.log('Sending enter key');
-				await app.workbench.positronConsole.sendEnterKey();
-
-				await app.workbench.positronConsole.waitForReady('>>>');
+				await app.workbench.positronConsole.executeCode('Python', script, '>>>');
 
 				console.log('Opening data grid');
 				await app.workbench.positronVariables.doubleClickVariableRow('df');
@@ -79,15 +70,11 @@ df = pd.DataFrame(data)`;
 				const rFixtures = new PositronRFixtures(app);
 				await rFixtures.startRInterpreter();
 
-				const consoleFixtures = new PositronConsoleFixtures(app);
-				await consoleFixtures.updateTerminalSettings();
-
 			});
 
 			after(async function () {
 
 				const app = this.app as Application;
-				await app.workbench.settingsEditor.clearUserSettings();
 
 				await app.workbench.positronDataExplorer.closeDataExplorer();
 				await app.workbench.positronVariables.openVariables();
@@ -105,10 +92,7 @@ df = pd.DataFrame(data)`;
 )`;
 
 				console.log('Sending code to console');
-				await app.workbench.positronConsole.typeToConsole(script);
-				console.log('Sending enter key');
-				await app.workbench.positronConsole.sendEnterKey();
-				await app.workbench.positronConsole.waitForReady('>');
+				await app.workbench.positronConsole.executeCode('R', script, '>');
 
 				console.log('Opening data grid');
 				await app.workbench.positronVariables.doubleClickVariableRow('Data_Frame');

--- a/test/smoke/src/areas/positron/variables/variablespane.test.ts
+++ b/test/smoke/src/areas/positron/variables/variablespane.test.ts
@@ -24,20 +24,13 @@ export function setup(logger: Logger) {
 			it('Verifies Variables pane basic function with python interpreter', async function () {
 				const app = this.app as Application;
 
-				const varOne = 'x=1';
-				await app.workbench.positronConsole.typeToConsole(varOne);
-				await app.workbench.positronConsole.sendEnterKey();
-				await app.workbench.positronConsole.waitForEndingConsoleText(varOne);
+				const executeCode = async (code: string) => {
+					await app.workbench.positronConsole.executeCode('Python', code, '>>>');
+				};
 
-				const varTwo = 'y=10';
-				await app.workbench.positronConsole.typeToConsole(varTwo);
-				await app.workbench.positronConsole.sendEnterKey();
-				await app.workbench.positronConsole.waitForEndingConsoleText(varTwo);
-
-				const varThree = 'z=100';
-				await app.workbench.positronConsole.typeToConsole(varThree);
-				await app.workbench.positronConsole.sendEnterKey();
-				await app.workbench.positronConsole.waitForEndingConsoleText(varThree);
+				await executeCode('x=1');
+				await executeCode('y=10');
+				await executeCode('z=100');
 
 				console.log('Entered lines in console defining variables');
 
@@ -65,20 +58,13 @@ export function setup(logger: Logger) {
 			it('Verifies Variables pane basic function with R interpreter', async function () {
 				const app = this.app as Application;
 
-				const varOne = 'x=1';
-				await app.workbench.positronConsole.typeToConsole(varOne);
-				await app.workbench.positronConsole.sendEnterKey();
-				await app.workbench.positronConsole.waitForEndingConsoleText(varOne);
+				const executeCode = async (code: string) => {
+					await app.workbench.positronConsole.executeCode('R', code, '>');
+				};
 
-				const varTwo = 'y=10';
-				await app.workbench.positronConsole.typeToConsole(varTwo);
-				await app.workbench.positronConsole.sendEnterKey();
-				await app.workbench.positronConsole.waitForEndingConsoleText(varTwo);
-
-				const varThree = 'z=100';
-				await app.workbench.positronConsole.typeToConsole(varThree);
-				await app.workbench.positronConsole.sendEnterKey();
-				await app.workbench.positronConsole.waitForEndingConsoleText(varThree);
+				await executeCode('x=1');
+				await executeCode('y=10');
+				await executeCode('z=100');
 
 				console.log('Entered lines in console defining variables');
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

We discussed that we needed a more programmatic way to perform actions in Positron during our smoke tests, rather than driving everything through the UI.

This PR introduces one potential approach: perform actions via commands and the quickpick (which we assume to have a stable UI moving forward). This is the same approach taken in the upstream terminal smoke test automation ([source](https://github.com/posit-dev/positron/blob/1a8e4e9b31ab563931be2a9babf3ab11d20c2d2b/test/automation/src/terminal.ts#L108)).

### Approach

This PR updates the `workbench.action.executeCode.console` command to prompt the user for inputs if no args are provided, and supports multiline code by explicitly handling newlines (`\n` or `\r`) as done for terminal tests ([source](https://github.com/posit-dev/positron/blob/1a8e4e9b31ab563931be2a9babf3ab11d20c2d2b/src/vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution.ts#L66)). The quickpick updates as new languages are discovered – we use that fact in the smoke test automation by waiting for the desired language to appear.

_If we prefer, we could create a separate command under the `Developer:` category instead of making the existing command available in the command palette._

(EDIT: Reverted below after discussion with @testlabauto)

~~I removed manual interpreter selection from tests since the underlying `executeCode` call automatically starts an interpreter (an example of the benefit of having more direct programmatic access), but I intend to add a separate "select interpreter" command in #3118 if we need more control.~~

~~I also moved the ipykernel install into the GH workflow. IMO we should test the ipykernel install as a standalone test, and we should create a fresh virtual environment specifically for that test, but that can be handled in a separate PR.~~

There may be some teething issues / initial flakiness with this approach, I'm happy to fix those as we discover them.

### QA Notes

Smoke tests should reliably pass.