### PR TITLE
Refactor console and variables automation to use `waitForElement(s)` instead of locators

### DIFF
--- a/test/automation/src/positron/positronVariables.ts
+++ b/test/automation/src/positron/positronVariables.ts
@@ -12,8 +12,8 @@ interface FlatVariables {
 }
 
 const VARIABLE_ITEMS = '.variables-instance .list .variable-item';
-const VARIABLE_NAMES = '.name-column';
-const VARIABLE_DETAILS = '.details-column';
+const VARIABLE_NAMES = 'name-column';
+const VARIABLE_DETAILS = 'details-column';
 const VARIABLES_NAME_COLUMN = '.variable-item .name-column';
 const VARIABLES_SECTION = '[aria-label="Variables Section"]';
 
@@ -22,27 +22,23 @@ export class PositronVariables {
 	constructor(private code: Code) { }
 
 	async getFlatVariables(): Promise<Map<string, FlatVariables>> {
+		const variables = new Map<string, FlatVariables>();
+		const variableItems = await this.code.waitForElements(VARIABLE_ITEMS, true);
 
-		const variablesLocator = this.code.driver.getLocator(VARIABLE_ITEMS);
-		const nameLocators = variablesLocator.locator(VARIABLE_NAMES);
-		const detailLocators = variablesLocator.locator(VARIABLE_DETAILS);
+		for (const item of variableItems) {
+			const name = item.children.find(child => child.className === VARIABLE_NAMES)?.textContent;
+			const details = item.children.find(child => child.className === VARIABLE_DETAILS);
 
-		const names = await Promise.all(Array.from({ length: await nameLocators.count() }, async (_, i) => {
-			return await nameLocators.nth(i).innerText();
-		}));
+			const value = details?.children[0].textContent;
+			const type = details?.children[1].textContent;
 
-		const details = await Promise.all(Array.from({ length: await detailLocators.count() }, async (_, i) => {
-			return await detailLocators.nth(i).innerText();
-		}));
+			if (!name || !value || !type) {
+				throw new Error('Could not parse variable item');
+			}
 
-		const variablesMap = new Map<string, FlatVariables>();
-		for (let i = 0; i < names.length; i++) {
-			const detailsParts: string[] = details[i].split('\n');
-			variablesMap.set(names[i], { value: detailsParts[0], type: detailsParts[1] });
+			variables.set(name, { value, type });
 		}
-
-		return variablesMap;
-
+		return variables;
 	}
 
 	async doubleClickVariableRow(variableName: string) {


### PR DESCRIPTION
This PR refactors console and variables automation to use `waitForElement(s)` instead of locators.

My personal preference would be to reuse the upstream code here since it also does polling and errors if the element isn't found after 20 seconds.

I suspect similar could be done for the data explorer automation.

If we prefer locators, I think we could write our own polling logic lower down the stack similar to the existing ones.