### PR TITLE
Updates to use the editor font in the Data Grid

### DIFF
--- a/src/vs/workbench/browser/editorFontApplier.ts
+++ b/src/vs/workbench/browser/editorFontApplier.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from 'vs/base/browser/dom';
+import { PixelRatio } from 'vs/base/browser/pixelRatio';
+import { BareFontInfo } from 'vs/editor/common/config/fontInfo';
+import { applyFontInfo } from 'vs/editor/browser/config/domFontInfo';
+import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
+import { FontMeasurements } from 'vs/editor/browser/config/fontMeasurements';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+
+/**
+ * Applies the editor font info to the specified element.
+ * @param configurationService The configuration service.
+ * @param element The element to apply the editor font info to.
+ */
+const applyEditorFontInfoToElement = (
+	configurationService: IConfigurationService,
+	element: HTMLElement,
+) => {
+	// Get the editor options.
+	const editorOptions = configurationService.getValue<IEditorOptions>('editor');
+
+	// Get the window.
+	const window = DOM.getWindow(element);
+
+	// Get the editor font info for the window.
+	const fontInfo = FontMeasurements.readFontInfo(
+		window,
+		BareFontInfo.createFromRawSettings(editorOptions, PixelRatio.getInstance(window).value)
+	);
+
+	// Apply the editor font info to the element.
+	applyFontInfo(element, fontInfo);
+};
+
+/**
+ * Editor font applier.
+ * @param configurationService The configuration service.
+ * @param element The element to apply the editor font to.
+ * @returns A disposable that should be disposed when the editor font applier is no longer needed.
+ */
+export const editorFontApplier = (
+	configurationService: IConfigurationService,
+	element: HTMLElement
+) => {
+	// Apply the initial editor font info to the rows element.
+	applyEditorFontInfoToElement(
+		configurationService,
+		element
+	);
+
+	// Add the onDidChangeConfiguration event handler.
+	return configurationService.onDidChangeConfiguration(configurationChangeEvent => {
+		// When something in the editor changes, determine whether it's font-related and, if it is,
+		// apply the new font info.
+		if (configurationChangeEvent.affectsConfiguration('editor')) {
+			if (configurationChangeEvent.affectedKeys.has('editor.fontFamily') ||
+				configurationChangeEvent.affectedKeys.has('editor.fontWeight') ||
+				configurationChangeEvent.affectedKeys.has('editor.fontSize') ||
+				configurationChangeEvent.affectedKeys.has('editor.fontLigatures') ||
+				configurationChangeEvent.affectedKeys.has('editor.fontVariations') ||
+				configurationChangeEvent.affectedKeys.has('editor.lineHeight') ||
+				configurationChangeEvent.affectedKeys.has('editor.letterSpacing')
+			) {
+				// Apply the updated editor font info to the rows element.
+				applyEditorFontInfoToElement(
+					configurationService,
+					element
+				);
+			}
+		}
+	});
+};

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
@@ -19,6 +19,7 @@ import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
 import { CommandCenter } from 'vs/platform/commandCenter/common/commandCenter';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { PositronActionBar } from 'vs/platform/positronActionBar/browser/positronActionBar';
 import { ActionBarRegion } from 'vs/platform/positronActionBar/browser/components/actionBarRegion';
 import { ActionBarSeparator } from 'vs/platform/positronActionBar/browser/components/actionBarSeparator';
@@ -66,6 +67,7 @@ export interface IPositronTopActionBarContainer {
  * Positron top action bar.
  */
 export interface PositronTopActionBarServices extends PositronActionBarServices {
+	configurationService: IConfigurationService;
 	hostService: IHostService;
 	labelService: ILabelService;
 	languageRuntimeService: ILanguageRuntimeService;

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -12,31 +12,17 @@ import { useEffect, useRef, useState } from 'react'; // eslint-disable-line no-d
 // Other dependencies.
 import { localize } from 'vs/nls';
 import { Button } from 'vs/base/browser/ui/positronComponents/button/button';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { DropDownListBoxItem } from 'vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBoxItem';
 import { PositronModalPopup } from 'vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup';
-import { ColumnSchema, ColumnDisplayType, RowFilterCondition } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer';
 import { DropDownListBoxSeparator } from 'vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBoxSeparator';
 import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
 import { DropDownListBox, DropDownListBoxEntry } from 'vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBox';
+import { ColumnSchema, ColumnDisplayType, RowFilterCondition } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { RowFilterParameter } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/rowFilterParameter';
 import { DropDownColumnSelector } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/dropDownColumnSelector';
-import {
-	RangeRowFilterDescriptor,
-	RowFilterDescriptor,
-	RowFilterDescrType,
-	RowFilterDescriptorComparison,
-	RowFilterDescriptorIsBetween,
-	RowFilterDescriptorIsEmpty,
-	RowFilterDescriptorIsNotBetween,
-	RowFilterDescriptorIsNotEmpty,
-	SingleValueRowFilterDescriptor,
-	RowFilterDescriptorIsNotNull,
-	RowFilterDescriptorIsNull,
-	RowFilterDescriptorSearch,
-	RowFilterDescriptorIsTrue,
-	RowFilterDescriptorIsFalse,
-} from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
+import { RangeRowFilterDescriptor, RowFilterDescriptor, RowFilterDescrType, RowFilterDescriptorComparison, RowFilterDescriptorIsBetween, RowFilterDescriptorIsEmpty, RowFilterDescriptorIsNotBetween, RowFilterDescriptorIsNotEmpty, SingleValueRowFilterDescriptor, RowFilterDescriptorIsNotNull, RowFilterDescriptorIsNull, RowFilterDescriptorSearch, RowFilterDescriptorIsTrue, RowFilterDescriptorIsFalse } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
 
 /**
  * Validates a row filter value.
@@ -132,6 +118,7 @@ const isSingleParam = (filterType: RowFilterDescrType | undefined) => {
  * AddEditRowFilterModalPopupProps interface.
  */
 interface AddEditRowFilterModalPopupProps {
+	configurationService: IConfigurationService;
 	dataExplorerClientInstance: DataExplorerClientInstance;
 	renderer: PositronModalReactRenderer;
 	anchor: HTMLElement;
@@ -793,6 +780,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					/>
 				}
 				<DropDownColumnSelector
+					configurationService={props.configurationService}
 					keybindingService={props.renderer.keybindingService}
 					layoutService={props.renderer.layoutService}
 					dataExplorerClientInstance={props.dataExplorerClientInstance}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
@@ -64,6 +64,7 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 			horizontalScrollbar: false,
 			verticalScrollbar: true,
 			scrollbarWidth: 8,
+			useEditorFont: false,
 			automaticLayout: true,
 			rowsMargin: 4,
 			cellBorders: false,

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef } from 'react'; // eslint-disable-line no-duplicate-i
 
 // Other dependencies.
 import { DisposableStore } from 'vs/base/common/lifecycle';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { PositronDataGrid } from 'vs/workbench/browser/positronDataGrid/positronDataGrid';
 import { ColumnSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { PositronModalPopup } from 'vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup';
@@ -22,6 +23,7 @@ import { ColumnSelectorDataGridInstance } from 'vs/workbench/browser/positronDat
  * ColumnSelectorModalPopupProps interface.
  */
 interface ColumnSelectorModalPopupProps {
+	readonly configurationService: IConfigurationService;
 	readonly renderer: PositronModalReactRenderer;
 	readonly columnSelectorDataGridInstance: ColumnSelectorDataGridInstance;
 	readonly anchor: HTMLElement;
@@ -81,10 +83,11 @@ export const ColumnSelectorModalPopup = (props: ColumnSelectorModalPopupProps) =
 				</div>
 				<div className='view' style={{ height: 400 }}>
 					<PositronDataGrid
-						ref={positronDataGridRef}
-						id='column-positron-data-grid'
+						configurationService={props.configurationService}
 						keybindingService={props.renderer.keybindingService}
 						layoutService={props.renderer.layoutService}
+						ref={positronDataGridRef}
+						id='column-positron-data-grid'
 						instance={props.columnSelectorDataGridInstance}
 					/>
 				</div>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/dropDownColumnSelector.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/dropDownColumnSelector.tsx
@@ -14,6 +14,7 @@ import * as DOM from 'vs/base/browser/dom';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { Button } from 'vs/base/browser/ui/positronComponents/button/button';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ColumnSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer';
 import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
@@ -25,6 +26,7 @@ import { ColumnSelectorDataGridInstance } from 'vs/workbench/browser/positronDat
  * DropDownColumnSelectorProps interface.
  */
 interface DropDownColumnSelectorProps {
+	configurationService: IConfigurationService;
 	keybindingService: IKeybindingService;
 	layoutService: ILayoutService;
 	dataExplorerClientInstance: DataExplorerClientInstance;
@@ -73,6 +75,7 @@ export const DropDownColumnSelector = (props: DropDownColumnSelectorProps) => {
 				// Show the drop down list box modal popup.
 				renderer.render(
 					<ColumnSelectorModalPopup
+						configurationService={props.configurationService}
 						renderer={renderer}
 						columnSelectorDataGridInstance={columnSelectorDataGridInstance}
 						anchor={ref.current}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -149,6 +149,7 @@ export const DataExplorer = () => {
 		<div ref={dataExplorerRef} className='data-explorer'>
 			<div ref={column1Ref} className='column-1'>
 				<PositronDataGrid
+					configurationService={context.configurationService}
 					keybindingService={context.keybindingService}
 					layoutService={context.layoutService}
 					instance={context.instance.tableSchemaDataGridInstance}
@@ -163,6 +164,7 @@ export const DataExplorer = () => {
 			</div>
 			<div ref={column2Ref} className='column-2'>
 				<PositronDataGrid
+					configurationService={context.configurationService}
 					keybindingService={context.keybindingService}
 					layoutService={context.layoutService}
 					instance={context.instance.tableDataDataGridInstance}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -127,6 +127,7 @@ export const RowFilterBar = () => {
 			// Show the add /edit row filter modal popup.
 			renderer.render(
 				<AddEditRowFilterModalPopup
+					configurationService={context.configurationService}
 					dataExplorerClientInstance={context.instance.dataExplorerClientInstance}
 					renderer={renderer}
 					anchor={anchor}
@@ -138,6 +139,7 @@ export const RowFilterBar = () => {
 			);
 		}
 	}, [
+		context.configurationService,
 		context.instance.dataExplorerClientInstance,
 		context.instance.tableDataDataGridInstance,
 		context.keybindingService,

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -87,6 +87,7 @@ type ScrollbarOptions = | {
  * DisplayOptions type.
  */
 type DisplayOptions = | {
+	useEditorFont: boolean;
 	automaticLayout: boolean;
 	rowsMargin?: number;
 	cellBorders?: boolean;
@@ -380,6 +381,11 @@ export abstract class DataGridInstance extends Disposable {
 	private readonly _scrollbarWidth: number;
 
 	/**
+	 * Gets a value which indicates whether to use the editor font to display data.
+	 */
+	private readonly _useEditorFont: boolean;
+
+	/**
 	 * Gets a value which indicates whether to perform automatic layout using a ResizeObserver.
 	 */
 	private readonly _automaticLayout: boolean;
@@ -530,7 +536,8 @@ export abstract class DataGridInstance extends Disposable {
 		this._verticalScrollbar = options.verticalScrollbar || false;
 		this._scrollbarWidth = options.scrollbarWidth ?? 0;
 
-		this._automaticLayout = options.automaticLayout ?? true;
+		this._useEditorFont = options.useEditorFont;
+		this._automaticLayout = options.automaticLayout;
 		this._rowsMargin = options.rowsMargin ?? 0;
 		this._cellBorders = options.cellBorders ?? true;
 
@@ -646,6 +653,13 @@ export abstract class DataGridInstance extends Disposable {
 	 */
 	get scrollbarWidth() {
 		return this._scrollbarWidth;
+	}
+
+	/**
+	 * Gets a value which indicates whether to perform automatic layout using a ResizeObserver.
+	 */
+	get useEditorFont() {
+		return this._useEditorFont;
 	}
 
 	/**

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -10,10 +10,17 @@ import * as React from 'react';
 import { forwardRef, KeyboardEvent, useEffect, useImperativeHandle, useRef, useState, WheelEvent } from 'react'; // eslint-disable-line no-duplicate-imports
 
 // Other dependencies.
+import * as DOM from 'vs/base/browser/dom';
 import { generateUuid } from 'vs/base/common/uuid';
 import { isMacintosh } from 'vs/base/common/platform';
+import { PixelRatio } from 'vs/base/browser/pixelRatio';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { pinToRange } from 'vs/base/common/positronUtilities';
+import { applyFontInfo } from 'vs/editor/browser/config/domFontInfo';
+import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
+import { BareFontInfo, FontInfo } from 'vs/editor/common/config/fontInfo';
+import { FontMeasurements } from 'vs/editor/browser/config/fontMeasurements';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { DataGridRow } from 'vs/workbench/browser/positronDataGrid/components/dataGridRow';
 import { DataGridScrollbar } from 'vs/workbench/browser/positronDataGrid/components/dataGridScrollbar';
 import { DataGridRowHeaders } from 'vs/workbench/browser/positronDataGrid/components/dataGridRowHeaders';
@@ -27,6 +34,33 @@ import { ExtendColumnSelectionBy, ExtendRowSelectionBy } from 'vs/workbench/brow
  * Constants.
  */
 const MOUSE_WHEEL_SENSITIVITY = 50;
+
+/**
+ * Gets the font info for the editor font.
+ *
+ * @param editorContainer The HTML element containing the editor, if known.
+ * @param configurationService The configuration service.
+ *
+ * @returns The font info.
+ */
+const getEditorFontInfo = (
+	editorContainer: HTMLElement | undefined,
+	configurationService: IConfigurationService) => {
+
+	// Get the editor options and read the font info.
+	const editorOptions = configurationService.getValue<IEditorOptions>('editor');
+
+	// Use the editor container to get the window, if it's available. Otherwise, use the active
+	// window.
+	const window = editorContainer ?
+		DOM.getActiveWindow() :
+		DOM.getWindow(editorContainer);
+
+	return FontMeasurements.readFontInfo(
+		window,
+		BareFontInfo.createFromRawSettings(editorOptions, PixelRatio.getInstance(window).value)
+	);
+};
 
 /**
  * DataGridWaffle component.
@@ -46,6 +80,9 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 	// State hooks.
 	const [width, setWidth] = useState(0);
 	const [height, setHeight] = useState(0);
+	const [editorFontInfo, setEditorFontInfo] = useState<FontInfo>(
+		getEditorFontInfo(undefined, context.configurationService)
+	);
 	const [, setRenderMarker] = useState(generateUuid());
 	const [lastWheelEvent, setLastWheelEvent] = useState(0);
 	const [wheelDeltaX, setWheelDeltaX] = useState(0);
@@ -56,6 +93,39 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 		// Create the disposable store for cleanup.
 		const disposableStore = new DisposableStore();
 
+		// Apply the font info to the waffle.
+		applyFontInfo(dataGridWaffleRef.current, editorFontInfo);
+
+		// Add the onDidChangeConfiguration event handler.
+		disposableStore.add(context.configurationService.onDidChangeConfiguration(
+			configurationChangeEvent => {
+				// When something in the editor changes, determine whether it's font-related and, if
+				// it is, apply the new font info to the waffle..
+				if (configurationChangeEvent.affectsConfiguration('editor')) {
+					if (configurationChangeEvent.affectedKeys.has('editor.fontFamily') ||
+						configurationChangeEvent.affectedKeys.has('editor.fontWeight') ||
+						configurationChangeEvent.affectedKeys.has('editor.fontSize') ||
+						configurationChangeEvent.affectedKeys.has('editor.fontLigatures') ||
+						configurationChangeEvent.affectedKeys.has('editor.fontVariations') ||
+						configurationChangeEvent.affectedKeys.has('editor.lineHeight') ||
+						configurationChangeEvent.affectedKeys.has('editor.letterSpacing')
+					) {
+						// Get the font info.
+						const editorFontInfo = getEditorFontInfo(
+							dataGridWaffleRef.current,
+							context.configurationService
+						);
+
+						// Set the editor font info.
+						setEditorFontInfo(editorFontInfo);
+
+						// Apply the font info to the waffle.
+						applyFontInfo(dataGridWaffleRef.current, editorFontInfo);
+					}
+				}
+			}
+		));
+
 		// Add the onDidUpdate event handler.
 		disposableStore.add(context.instance.onDidUpdate(() => {
 			setRenderMarker(generateUuid());
@@ -63,7 +133,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, [context.instance]);
+	}, [context.configurationService, context.instance, editorFontInfo]);
 
 	// Layout useEffect.
 	useEffect(() => {
@@ -145,7 +215,6 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 
 			// Enter key.
 			case 'Enter': {
-				console.log(`User pressed enter on ${context.instance.cursorColumnIndex},${context.instance.cursorRowIndex}`);
 				break;
 			}
 
@@ -526,8 +595,6 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 			className='data-grid-waffle'
 			onKeyDown={keyDownHandler}
 			onWheel={wheelHandler}
-			onFocus={() => console.log('data-grid-waffle focus')}
-			onBlur={() => console.log('data-grid-waffle blur')}
 		>
 			{context.instance.columnHeaders && context.instance.rowHeaders &&
 				<DataGridCornerTopLeft

--- a/src/vs/workbench/browser/positronDataGrid/positronDataGridContext.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/positronDataGridContext.tsx
@@ -10,12 +10,14 @@ import { PropsWithChildren, createContext, useContext, useEffect } from 'react';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { DataGridInstance } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
 
 /**
  * PositronDataGridServices interface.
  */
 export interface PositronDataGridServices {
+	configurationService: IConfigurationService;
 	keybindingService: IKeybindingService;
 	layoutService: ILayoutService;
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/profileNumber.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/profileNumber.tsx
@@ -7,7 +7,11 @@ import 'vs/css!./profileNumber';
 
 // React.
 import * as React from 'react';
+import { useEffect, useRef } from 'react'; // eslint-disable-line no-duplicate-imports
 
+// Other dependencies.
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { editorFontApplier } from 'vs/workbench/browser/editorFontApplier';
 import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
 
 /**
@@ -29,8 +33,30 @@ export const ProfileNumber = (props: ProfileNumberProps) => {
 	if (!stats) {
 		stats = {};
 	}
+
+	// Reference hooks.
+	const ref = useRef<HTMLDivElement>(undefined!);
+
+	// Main useEffect.
+	useEffect(() => {
+		// Create the disposable store for cleanup.
+		const disposableStore = new DisposableStore();
+
+		// Use the editor font.
+		disposableStore.add(
+			editorFontApplier(
+				props.instance.configurationService,
+				ref.current
+			)
+		);
+
+		// Return the cleanup function that will dispose of the disposables.
+		return () => disposableStore.dispose();
+	}, [props.instance.configurationService]);
+
+	// Render.
 	return (
-		<div className='tabular-info'>
+		<div ref={ref} className='tabular-info'>
 			<div className='labels'>
 				<div className='label'>NA</div>
 				<div className='label'>Mean</div>
@@ -48,14 +74,6 @@ export const ProfileNumber = (props: ProfileNumberProps) => {
 					<div className='value'>{stats.min_value}</div>
 					<div className='value'>{stats.max_value}</div>
 				</div>
-				{/* <div className='values-right'>
-					<div className='value'>&nbsp;</div>
-					<div className='value'>.51</div>
-					<div className='value'>.20</div>
-					<div className='value'>.24</div>
-					<div className='value'>&nbsp;</div>
-					<div className='value'>.44</div>
-				</div> */}
 			</div>
 		</div>
 	);

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/profileString.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/profileString.tsx
@@ -7,6 +7,11 @@ import 'vs/css!./profileString';
 
 // React.
 import * as React from 'react';
+import { useEffect, useRef } from 'react'; // eslint-disable-line no-duplicate-imports
+
+// Other dependencies.
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { editorFontApplier } from 'vs/workbench/browser/editorFontApplier';
 import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
 
 /**
@@ -28,8 +33,30 @@ export const ProfileString = (props: ProfileStringProps) => {
 	if (!stats) {
 		stats = {};
 	}
+
+	// Reference hooks.
+	const ref = useRef<HTMLDivElement>(undefined!);
+
+	// Main useEffect.
+	useEffect(() => {
+		// Create the disposable store for cleanup.
+		const disposableStore = new DisposableStore();
+
+		// Use the editor font.
+		disposableStore.add(
+			editorFontApplier(
+				props.instance.configurationService,
+				ref.current
+			)
+		);
+
+		// Return the cleanup function that will dispose of the disposables.
+		return () => disposableStore.dispose();
+	}, [props.instance.configurationService]);
+
+	// Render.
 	return (
-		<div className='tabular-info'>
+		<div ref={ref} className='tabular-info'>
 			<div className='labels'>
 				<div className='label'>NA</div>
 				<div className='label'>Empty</div>
@@ -41,11 +68,6 @@ export const ProfileString = (props: ProfileStringProps) => {
 					<div className='value'>{stats.num_empty}</div>
 					<div className='value'>{stats.num_unique}</div>
 				</div>
-				{/* <div className='values-right'>
-					<div className='value'>&nbsp;</div>
-					<div className='value'>.51</div>
-					<div className='value'>.20</div>
-				</div> */}
 			</div>
 		</div>
 	);

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -10,6 +10,7 @@ import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntim
 import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
 import { PositronDataExplorerLayout } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
 import { IPositronDataExplorerInstance } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 /**
  * PositronDataExplorerInstance class.
@@ -85,12 +86,17 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 
 	/**
 	 * Constructor.
+	 * @param configurationService The configuration service.
 	 * @param languageName The language name.
 	 * @param dataExplorerClientInstance The DataExplorerClientInstance. The
 	 * data explorer takes ownership of the client instance and will dispose it
 	 * when it is disposed.
 	 */
-	constructor(languageName: string, dataExplorerClientInstance: DataExplorerClientInstance) {
+	constructor(
+		configurationService: IConfigurationService,
+		languageName: string,
+		dataExplorerClientInstance: DataExplorerClientInstance
+	) {
 		// Call the base class's constructor.
 		super();
 
@@ -99,6 +105,7 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 		this._dataExplorerClientInstance = dataExplorerClientInstance;
 		this._dataExplorerCache = new DataExplorerCache(dataExplorerClientInstance);
 		this._tableSchemaDataGridInstance = new TableSummaryDataGridInstance(
+			configurationService,
 			dataExplorerClientInstance,
 			this._dataExplorerCache
 		);

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -14,6 +14,7 @@ import { PositronDataExplorerInstance } from 'vs/workbench/services/positronData
 import { ILanguageRuntimeSession, IRuntimeSessionService, RuntimeClientType } from '../../runtimeSession/common/runtimeSessionService';
 import { IPositronDataExplorerService } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
 import { IPositronDataExplorerInstance } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 /**
  * DataExplorerRuntime class.
@@ -116,11 +117,13 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 
 	/**
 	 * Constructor.
+	 * @param _configurationService The configuration service.
 	 * @param _editorService The editor service.
 	 * @param _notificationService The notification service.
 	 * @param _runtimeSessionService The language runtime session service.
 	 */
 	constructor(
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService
@@ -276,7 +279,11 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 		// Set the Positron data explorer client instance.
 		this._positronDataExplorerInstances.set(
 			dataExplorerClientInstance.identifier,
-			new PositronDataExplorerInstance(languageName, dataExplorerClientInstance)
+			new PositronDataExplorerInstance(
+				this._configurationService,
+				languageName,
+				dataExplorerClientInstance
+			)
 		);
 
 		// Open an editor for the Positron data explorer client instance.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -74,6 +74,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			horizontalScrollbar: true,
 			verticalScrollbar: true,
 			scrollbarWidth: 14,
+			useEditorFont: true,
 			automaticLayout: true,
 			cellBorders: true,
 			internalCursor: true,

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 
 // Other dependencies.
 import { Emitter } from 'vs/base/common/event';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { DataGridInstance } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
 import { DataExplorerCache } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
 import { ColumnSummaryCell } from 'vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell';
@@ -26,16 +27,6 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	//#region Private Properties
 
 	/**
-	 * Gets the data explorer client instance.
-	 */
-	private readonly _dataExplorerClientInstance: DataExplorerClientInstance;
-
-	/**
-	 * Gets the data explorer cache.
-	 */
-	private readonly _dataExplorerCache: DataExplorerCache;
-
-	/**
 	 * Gets the expanded columns set.
 	 */
 	private readonly _expandedColumns = new Set<number>();
@@ -51,12 +42,14 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 
 	/**
 	 * Constructor.
-	 * @param dataExplorerClientInstance The DataExplorerClientInstance.
-	 * @param dataExplorerCache The DataExplorerCache.
+	 * @param _configurationService The configuration service.
+	 * @param _dataExplorerClientInstance The DataExplorerClientInstance.
+	 * @param _dataExplorerCache The DataExplorerCache.
 	 */
 	constructor(
-		dataExplorerClientInstance: DataExplorerClientInstance,
-		dataExplorerCache: DataExplorerCache
+		private readonly _configurationService: IConfigurationService,
+		private readonly _dataExplorerClientInstance: DataExplorerClientInstance,
+		private readonly _dataExplorerCache: DataExplorerCache
 	) {
 		// Call the base class's constructor.
 		super({
@@ -69,17 +62,12 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 			horizontalScrollbar: false,
 			verticalScrollbar: true,
 			scrollbarWidth: 14,
+			useEditorFont: false,
 			automaticLayout: true,
 			cellBorders: false,
 			internalCursor: false,
 			selection: false
 		});
-
-		// Set the data explorer client instance.
-		this._dataExplorerClientInstance = dataExplorerClientInstance;
-
-		// Set the data explorer cache.
-		this._dataExplorerCache = dataExplorerCache;
 
 		// Add the onDidUpdateCache event handler.
 		this._register(this._dataExplorerCache.onDidUpdateCache(() => {
@@ -260,6 +248,17 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	readonly onDidSelectColumn = this._onDidSelectColumnEmitter.event;
 
 	//#endregion Public Events
+
+	//#region Public Properties
+
+	/**
+	 * Gets the configuration service.
+	 */
+	get configurationService() {
+		return this._configurationService;
+	}
+
+	//#endregion Public Properties
 
 	//#region Public Methods
 


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

Users want data values to be displayed in a fixed-width font in the `PositronDataExplorer`. This PR adds the capability to use the fixed-width editor font to display values in any `PositronDataGrid`. The `PositronDataExplorer` has been updated to use this capability.

Here's a screenshot:

![image](https://github.com/posit-dev/positron/assets/853239/91e9b246-11ea-4fb3-be58-fe1681ab6cd7)

This capability is enabled by setting `useEditorFont` to `true` in the constructor of a `DataGridInstance`:

<img width="622" alt="image" src="https://github.com/posit-dev/positron/assets/853239/1db87cb9-02e2-4a59-b511-db59bc81c9b5">

Users also want summary information to be displayed in a fixed width font in the `PositronDataExplorer`. This PR adjusts the `ProfileNumber` and `ProfileString` components to use the fixed-width editor font.

Here's a screenshot:

![image](https://github.com/posit-dev/positron/assets/853239/1da24355-3de2-4547-a634-88ce434d9949)

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

I repurposed code from the `Console` component for this work and built a new utility function called `editorFontApplier` that can be used to apply the editor font to any `HTMLElement`. It's very simple to use:

```TypeScript
// Main useEffect.
useEffect(() => {
	// Create the disposable store for cleanup.
	const disposableStore = new DisposableStore();

	// Use the editor font.
	disposableStore.add(
		editorFontApplier(
			props.instance.configurationService,
			ref.current
		)
	);

	// Return the cleanup function that will dispose of the disposables.
	return () => disposableStore.dispose();
}, [props.instance.configurationService]);
```

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

You should see the editor font in the PositronDataExplorer. Also, you should be able to change the editor font and see it change automatically in any open `PositronDataExplorer`.
