### PR TITLE
Re-enable Python integration tests

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -247,9 +247,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-12, windows-latest]
         python: ['3.x']
-        # TODO: Temporarily disable Electron tests since they're failing on GitHub Actions.
-        # test-suite: [ts-unit, venv, single-workspace, debugger, functional, smoke]
-        test-suite: [ts-unit, functional]
+        test-suite: [ts-unit, venv, single-workspace, debugger, functional, smoke]
         # TODO: Add integration tests on windows and ubuntu. This requires updating
         # src/test/positron/testElectron.ts to support installing Positron on these platforms.
         exclude:


### PR DESCRIPTION
Re-enable Python integration tests now that #3110 has been addressed.