### PR TITLE
Adding smoke test python dependencies and maximize console after running code

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pandas
+          python -m pip install pandas matplotlib ipykernel
 
       - name: Run Smoke Tests (Electron)
         env:

--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -11,6 +11,7 @@ import { QuickInput } from '../quickinput';
 const CONSOLE_ITEMS = '.runtime-items span';
 const CONSOLE_INSTANCE = '.console-instance';
 const ACTIVE_CONSOLE_INSTANCE = '.console-instance[style*="z-index: auto"]';
+const MAXIMIZE_CONSOLE = '.bottom .codicon-positron-maximize-panel';
 
 export class PositronConsole {
 
@@ -52,6 +53,7 @@ export class PositronConsole {
 
 		// The console will show the prompt after the code is done executing.
 		await this.waitForReady(prompt);
+		await this.maximizeConsole();
 	}
 
 	async logConsoleContents() {
@@ -120,5 +122,9 @@ export class PositronConsole {
 				lastConsoleLine = await this.getConsoleContents(-1);
 			}
 		}
+	}
+
+	async maximizeConsole() {
+		await this.code.waitAndClick(MAXIMIZE_CONSOLE);
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Minor fixes: include matplotlib and ipykernel as smoke test dependencies and maximize console after running code to make CI debugging easier

### Approach

> pip install relevant packages and maximize console with waitAndClick.

### QA Notes

> All smoke tests pass
