### PR TITLE
Check session existence before disposing log file

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -1162,9 +1162,9 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 	 * Dispose the kernel connection. Note that this does not dispose the
 	 * session or the kernel itself; it remains running in a terminal.
 	 */
-	public async dispose() {
+	public dispose() {
 		// Clean up file watcher for log file
-		await this.disposeLogTail();
+		this.disposeLogTail();
 
 		// Dispose heartbeat timers
 		this.disposeHeartbeatTimers();
@@ -1173,19 +1173,23 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		this.disposeAllSockets();
 	}
 
-	async disposeLogTail() {
+	disposeLogTail() {
 		if (!this._logTail) {
 			return;
 		}
 
 		this._logTail.unwatch();
 
-		const file = this._session!.state.logFile;
+		if (!this._session) {
+			return;
+		}
+
+		const file = this._session.state.logFile;
 		if (!file || !fs.existsSync(file) || !this._logChannel) {
 			return;
 		}
 
-		const lines = fs.readFileSync(this._session!.state.logFile, 'utf8').split('\n');
+		const lines = fs.readFileSync(this._session.state.logFile, 'utf8').split('\n');
 
 		// Push remaining lines in case new line events haven't had time to
 		// fire up before unwatching. We skip lines that we've already seen and
@@ -1421,7 +1425,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			this._terminal = undefined;
 
 			// Dispose the remainder of the connection state
-			await this.dispose();
+			this.dispose();
 		}
 	}
 


### PR DESCRIPTION
This is a fix for this error I noticed while restarting R:

```log
console.ts:137 [Extension Host] stack trace: TypeError: Cannot read properties of undefined (reading 'state')
	at JupyterKernel.disposeLogTail (/Users/lionel/Sync/Projects/Positron/positron/extensions/jupyter-adapter/out/JupyterKernel.js:970:36)
	at JupyterKernel.dispose (/Users/lionel/Sync/Projects/Positron/positron/extensions/jupyter-adapter/out/JupyterKernel.js:959:20)
	at JupyterKernel.onStatusChange (/Users/lionel/Sync/Projects/Positron/positron/extensions/jupyter-adapter/out/JupyterKernel.js:1182:24)
	at JupyterKernel.<anonymous> (/Users/lionel/Sync/Projects/Positron/positron/extensions/jupyter-adapter/out/JupyterKernel.js:81:18)
	at JupyterKernel.emit (node:events:529:35)
	at JupyterKernel.setStatus (/Users/lionel/Sync/Projects/Positron/positron/extensions/jupyter-adapter/out/JupyterKernel.js:1145:14)
	at JupyterKernel.onSocketDisconnected (/Users/lionel/Sync/Projects/Positron/positron/extensions/jupyter-adapter/out/JupyterKernel.js:813:14)
	at UniqueContainer.value (/Users/lionel/Sync/Projects/Positron/positron/extensions/jupyter-adapter/out/JupyterKernel.js:181:48)
	at Emitter._deliver (/Users/lionel/Sync/Projects/Positron/positron/out/vs/base/common/event.js:889:26)
	at Emitter.fire (/Users/lionel/Sync/Projects/Positron/positron/out/vs/base/common/event.js:918:22)
	at JupyterSocket.disconnect (/Users/lionel/Sync/Projects/Positron/positron/extensions/jupyter-adapter/out/JupyterSocket.js:121:33)
	at JupyterSocket.onDisconnectedEvent (/Users/lionel/Sync/Projects/Positron/positron/extensions/jupyter-adapter/out/JupyterSocket.js:140:14)
	at Socket.emit (node:events:517:28)
	at read (/Users/lionel/Sync/Projects/Positron/positron/extensions/jupyter-adapter/node_modules/zeromq/lib/compat.js:461:26) (at console.<anonymous> (/Users/lionel/Sync/Projects/Positron/positron/out/vs/workbench/api/common/extHostConsoleForwarder.js:45:26))
mainThreadExtensionService.ts:81 [vscode.jupyter-adapter]Cannot read properties of undefined (reading 'state')
mainThreadExtensionService.ts:82 TypeError: Cannot read properties of undefined (reading 'state')
```

The error is not easily reproducible and I'm not sure in what cases the session is undefined but this didn't seem worth investigating.