### PR TITLE
Track focus of whole console pane

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -406,7 +406,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			!e.altKey;
 
 		// Shift key is pressed without other modifiers.
-		const onlyShiftKey = e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey;;
+		const onlyShiftKey = e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey;
 
 		// Calculates the page height.
 		const pageHeight = () =>
@@ -598,20 +598,6 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 		}
 	};
 
-	/**
-	 * onFocus event handler.
-	 */
-	const focusHandler = () => {
-		props.reactComponentContainer.focusChanged?.(true);
-	};
-
-	/**
-	 * onBlur event handler.
-	 */
-	const blurHandler = () => {
-		props.reactComponentContainer.focusChanged?.(false);
-	};
-
 	// Calculate the adjusted width (to account for indentation of the entire console instance).
 	const adjustedWidth = props.width - 10;
 
@@ -637,8 +623,6 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 				whiteSpace: wordWrap ? 'pre-wrap' : 'pre',
 				zIndex: props.active ? 'auto' : -1
 			}}
-			onFocus={focusHandler}
-			onBlur={blurHandler}
 			onClick={clickHandler}
 			onKeyDown={keyDownHandler}
 			onMouseDown={mouseDownHandler}

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -127,9 +127,6 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 	}
 
 	focusChanged(focused: boolean) {
-		// NOTE: A blurring event fires up when selecting text in the console
-		// (i.e. the code editor widget is no longer focused). Can/should we do
-		// better? The blurring event also happens with `ViewPane::onDidBlur()`.
 		this._positronConsoleFocusedContextKey.set(focused);
 
 		if (focused) {
@@ -295,6 +292,11 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 				reactComponentContainer={this}
 			/>
 		);
+
+		// Create a focus tracker that updates the PositronConsoleFocused context key.
+		const focusTracker = this._register(DOM.trackFocus(this.element));
+		this._register(focusTracker.onDidFocus(() => this.focusChanged(true)));
+		this._register(focusTracker.onDidBlur(() => this.focusChanged(false)));
 	}
 
 	/**


### PR DESCRIPTION
### Intent

Addresses #3080. The `positronConsoleFocused` context key is not set to `false` when restarting the console with the keyboard shortcut while the console input is focused (only the first time). This causes issues with Cmd+V dispatching.


### Approach

Since #2806, the `positronConsoleFocused` context key tracks focus of the console input. However when the input is re-rendered, the blur event is not triggered (which is expected if the element is simply taken off the DOM, see https://html.spec.whatwg.org/multipage/infrastructure.html#node-remove-focus-fixup).

I considered updating the context key when the console input is unmounted but this is tricky to implement correctly, especially considering that other widgets might have focus (readline input, restart button).

Instead I decided to go back to tracking the whole pane. This also better corresponds to the context key name which is about the console rather than just the input. The context key will now be enabled no matter what is selected inside the pane. I no longer observe the blurring and toggling issues I mentioned in the linked PR, thanks to the pane now having a `tabIndex` making it focusable. Note that the DOM tracker now calls `focusChanged()` instead of just setting the context key as it did before, so that it notifies `onFocused()` handlers as expected.

We could still decide to add a new context key just for the console input in the future. This more specific key would not need to consider other focusable widgets in the console, but it would need to make sure it's disabled on unmount. This can be done by adding a disposable in a `useEffect()`, e.g.:

```ts

useEffect(() => {
	const disposableStore = new DisposableStore();

	// Blur events do not happen when element is unmounted, so update focus key manually
	disposableStore.add({
		dispose() {
			this._myContextKey.set(false);
		}
	});

	return () => disposableStore.dispose();
}, []);
```


### QA Notes

See https://github.com/posit-dev/positron/issues/3080#issuecomment-2119224460 for reprex.