### PR TITLE
Data Explorer: add integer codes to get_data_values backend RPC to return special values to frontend

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections_comm.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import BaseModel, Field
+from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 
 
 class ObjectSchema(BaseModel):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import BaseModel, Field
+from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 
 
 @enum.unique
@@ -650,8 +650,8 @@ class GetColumnProfilesFeatures(BaseModel):
 
 # ColumnValue
 ColumnValue = Union[
-    str,
-    int,
+    StrictInt,
+    StrictStr,
 ]
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -146,21 +146,6 @@ class SearchSchemaResult(BaseModel):
     )
 
 
-class TableData(BaseModel):
-    """
-    Table values formatted as strings
-    """
-
-    columns: List[List[str]] = Field(
-        description="The columns of data",
-    )
-
-    row_labels: Optional[List[List[str]]] = Field(
-        default=None,
-        description="Zero or more arrays of row labels",
-    )
-
-
 class FilterResult(BaseModel):
     """
     The result of applying filters to a table
@@ -255,6 +240,21 @@ class ColumnSchema(BaseModel):
     type_size: Optional[int] = Field(
         default=None,
         description="Size parameter for fixed-size types (list, binary)",
+    )
+
+
+class TableData(BaseModel):
+    """
+    Table values formatted as strings
+    """
+
+    columns: List[List[ColumnValue]] = Field(
+        description="The columns of data",
+    )
+
+    row_labels: Optional[List[List[str]]] = Field(
+        default=None,
+        description="Zero or more arrays of row labels",
     )
 
 
@@ -648,6 +648,13 @@ class GetColumnProfilesFeatures(BaseModel):
     )
 
 
+# ColumnValue
+ColumnValue = Union[
+    str,
+    int,
+]
+
+
 @enum.unique
 class DataExplorerBackendRequest(str, enum.Enum):
     """
@@ -916,13 +923,13 @@ class DataExplorerFrontendEvent(str, enum.Enum):
 
 SearchSchemaResult.update_forward_refs()
 
-TableData.update_forward_refs()
-
 FilterResult.update_forward_refs()
 
 BackendState.update_forward_refs()
 
 ColumnSchema.update_forward_refs()
+
+TableData.update_forward_refs()
 
 TableSchema.update_forward_refs()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/help_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/help_comm.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import BaseModel, Field
+from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 
 
 @enum.unique

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import BaseModel, Field
+from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 
 
 @enum.unique

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui_comm.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import BaseModel, Field
+from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 
 Param = Any
 CallMethodResult = Any

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables_comm.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import BaseModel, Field
+from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 
 
 @enum.unique

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -119,36 +119,8 @@
 			],
 			"result": {
 				"schema": {
-					"type": "object",
-					"name": "table_data",
 					"description": "Table values formatted as strings",
-					"required": [
-						"columns"
-					],
-					"properties": {
-						"columns": {
-							"type": "array",
-							"description": "The columns of data",
-							"items": {
-								"type": "array",
-								"description": "Column values formatted as strings",
-								"items": {
-									"type": "string"
-								}
-							}
-						},
-						"row_labels": {
-							"type": "array",
-							"description": "Zero or more arrays of row labels",
-							"items": {
-								"type": "array",
-								"description": "Column values formatted as strings",
-								"items": {
-									"type": "string"
-								}
-							}
-						}
-					}
+					"$ref": "#/components/schemas/table_data"
 				}
 			}
 		},
@@ -361,6 +333,49 @@
 					"type_size": {
 						"type": "integer",
 						"description": "Size parameter for fixed-size types (list, binary)"
+					}
+				}
+			},
+			"column_value": {
+				"oneOf": [
+					{
+						"type": "string",
+						"name": "formatted_value"
+					},
+					{
+						"type": "integer",
+						"name": "special_value_code"
+					}
+				]
+			},
+			"table_data": {
+				"type": "object",
+				"description": "Table values formatted as strings",
+				"required": [
+					"columns"
+				],
+				"properties": {
+					"columns": {
+						"type": "array",
+						"description": "The columns of data",
+						"items": {
+							"type": "array",
+							"description": "Column values",
+							"items": {
+								"$ref": "#/components/schemas/column_value"
+							}
+						}
+					},
+					"row_labels": {
+						"type": "array",
+						"description": "Zero or more arrays of row labels",
+						"items": {
+							"type": "array",
+							"description": "Column values formatted as strings",
+							"items": {
+								"type": "string"
+							}
+						}
 					}
 				}
 			},

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -339,12 +339,12 @@
 			"column_value": {
 				"oneOf": [
 					{
-						"type": "string",
-						"name": "formatted_value"
-					},
-					{
 						"type": "integer",
 						"name": "special_value_code"
+					},
+					{
+						"type": "string",
+						"name": "formatted_value"
 					}
 				]
 			},

--- a/positron/comms/data_explorer.md
+++ b/positron/comms/data_explorer.md
@@ -1,0 +1,22 @@
+<!---
+  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+-->
+
+# Data Explorer OpenRPC Protocol
+
+## Backend Methods
+
+### get_data_values
+
+Non-special values are returned formatted as strings.
+
+Special values such as `NULL`, `NA`, etc. are encoded with integer codes.
+The currently supported special value codes are:
+
+* NULL: 0
+* NA: 1
+* NaN (Not a number): 2
+* NaT (Not a time): 3
+* None (such as Python None): 4
+* +INF: 10
+* -INF: 11

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -104,6 +104,18 @@ const PythonTypeMap: Record<string, string> = {
 	'object': 'Dict',
 };
 
+// Maps from JSON schema types to strict Python types
+const PythonStrictTypeMap: Record<string, string> = {
+	'boolean': 'StrictBool',
+	'integer': 'StrictInt',
+	'number': 'StrictFloat',
+	'string': 'StrictStr',
+	'null': 'null',
+	'array-begin': 'List[',
+	'array-end': ']',
+	'object': 'Dict',
+};
+
 function resolveComm(s: string) {
 	return s
 		.replace(/\.json$/, '')
@@ -777,7 +789,7 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import BaseModel, Field
+from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 
 `;
 
@@ -896,7 +908,7 @@ from ._vendor.pydantic import BaseModel, Field
 			yield `${name} = Union[`;
 			// Options
 			for (const schema of o.oneOf) {
-				yield deriveType(contracts, PythonTypeMap, [schema.name, ...context], schema);
+				yield deriveType(contracts, PythonStrictTypeMap, [schema.name, ...context], schema);
 				yield ', ';
 			}
 			yield ']\n';

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -171,6 +171,7 @@ function parseRefFromContract(ref: string, contract: any): string | undefined {
  * @returns The name of the object referred to by the ref.
  */
 function parseRef(ref: string, contracts: Array<any>): string {
+	console.log(ref);
 	for (const contract of contracts) {
 		if (!contract) {
 			continue;
@@ -217,6 +218,13 @@ function deriveType(contracts: Array<any>,
 			// An enum field within another type, we add the context prefix
 			return snakeCaseToSentenceCase(context[1]) +
 				snakeCaseToSentenceCase(context[0]);
+		}
+	} else if (schema.oneOf) {
+		// Unions we always extract like objects
+		if (schema.name) {
+			return snakeCaseToSentenceCase(schema.name);
+		} else {
+			return snakeCaseToSentenceCase(context[0]);
 		}
 	} else {
 		if (Object.keys(typeMap).includes(schema.type)) {
@@ -365,6 +373,46 @@ function* objectVisitor(
 }
 
 /**
+ * Visitor function for oneOf/union definitions in an OpenRPC contract. Recursively discovers all
+ * oneOf declarations and invokes the callback for each one.
+ *
+ * @param context The current context stack (names of keys leading to the oneOf)
+ * @param contract The OpenRPC contract to visit
+ * @param callback The callback function to call for each oneOf
+ *
+ * @returns An generator that yields the results of the callback function,
+ * invoked for each oneOf declaration
+ */
+function* oneOfVisitor(
+	context: Array<string>,
+	contract: any,
+	callback: (context: Array<string>, o: Record<string, any>) => Generator<string>
+): Generator<string> {
+	if (contract.oneOf) {
+		// This is a oneOf, so call the callback function and yield
+		// the result. For simplicity's sake, we don't allow nesting of oneOf
+		// values.
+		yield* callback(context, contract);
+	} else if (Array.isArray(contract)) {
+		// If this object is an array, recurse into each item
+		for (const item of contract) {
+			yield* oneOfVisitor(context, item, callback);
+		}
+	} else if (typeof contract === 'object') {
+		// If this object is an object, recurse into each property
+		for (const key of Object.keys(contract)) {
+			if (key === 'schema' || key === 'schemas' || key === 'components') {
+				// In these scenarios, we drop the parent context
+				yield* oneOfVisitor(context, contract[key], callback);
+			} else {
+				yield* oneOfVisitor(
+					[key, ...context], contract[key], callback);
+			}
+		}
+	}
+}
+
+/**
  * Create a Rust comm for a given OpenRPC contract.
  *
  * @param name The name of the comm
@@ -447,7 +495,6 @@ use serde::Serialize;
 			yield '}\n\n';
 		});
 
-
 		// Create enums for all enum types
 		yield* enumVisitor([], source, function* (context: Array<string>, values: Array<string>) {
 			if (context.length === 1) {
@@ -471,6 +518,39 @@ use serde::Serialize;
 				yield `\t#[serde(rename = "${value}")]\n`;
 				yield `\t${snakeCaseToSentenceCase(value)}`;
 				if (i < values.length - 1) {
+					yield ',\n\n';
+				} else {
+					yield '\n';
+				}
+			}
+			yield '}\n\n';
+		});
+
+		// Create enums for all oneOf types for unions
+		yield* oneOfVisitor([], source, function* (context: Array<string>, o: Record<string, any>) {
+			if (context.length === 1) {
+				// Shared oneOf at the components.schemas level
+				yield formatComment(`/// `,
+					`Union type ` +
+					snakeCaseToSentenceCase(context[0]));
+				yield '#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]\n';
+				yield `pub enum ${snakeCaseToSentenceCase(context[0])} {\n`;
+			} else {
+				// Enum field within another interface
+				yield formatComment(`/// `,
+					`Union type ` +
+					snakeCaseToSentenceCase(context[0]) + ` in ` +
+					snakeCaseToSentenceCase(context[1]));
+				yield '#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]\n';
+				yield `pub enum ${snakeCaseToSentenceCase(context[1])}${snakeCaseToSentenceCase(context[0])} {\n`;
+			}
+			// TODO: require that unions be named
+			for (let i = 0; i < o.oneOf.length; i++) {
+				const option = o.oneOf[i];
+				const derivedType = deriveType(contracts, RustTypeMap, [option.name, ...context],
+					option);
+				yield `\t${snakeCaseToSentenceCase(option.name)}(${derivedType})`;
+				if (i < o.oneOf.length - 1) {
 					yield ',\n\n';
 				} else {
 					yield '\n';
@@ -797,6 +877,30 @@ from ._vendor.pydantic import BaseModel, Field
 			}
 			yield '\n\n';
 		});
+
+		// Create declare out-of-line union types
+		yield* oneOfVisitor([], source, function* (
+			context: Array<string>,
+			o: Record<string, any>) {
+
+			let name = o.name ? o.name : context[0] === 'items' ? context[1] : context[0];
+			name = snakeCaseToSentenceCase(name);
+
+			// Document origin of union
+			if (context.length === 1) {
+				yield formatComment('# ', snakeCaseToSentenceCase(context[0]));
+			} else {
+				yield formatComment('# ', snakeCaseToSentenceCase(context[0]) + ' in ' +
+					snakeCaseToSentenceCase(context[1]));
+			}
+			yield `${name} = Union[`;
+			// Options
+			for (const schema of o.oneOf) {
+				yield deriveType(contracts, PythonTypeMap, [schema.name, ...context], schema);
+				yield ', ';
+			}
+			yield ']\n';
+		});
 	}
 
 	if (backend) {
@@ -1040,6 +1144,33 @@ import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/co
 				yield* createTypescriptInterface(contracts, context, name, description, o.properties,
 					o.required ? o.required : [], additionalProperties);
 			});
+
+		// Create declare out-of-line union types
+		yield* oneOfVisitor([], source, function* (
+			context: Array<string>,
+			o: Record<string, any>) {
+
+			let name = o.name ? o.name : context[0] === 'items' ? context[1] : context[0];
+			name = snakeCaseToSentenceCase(name);
+
+			// Document origin of union
+			if (context.length === 1) {
+				yield formatComment('/// ', snakeCaseToSentenceCase(context[0]));
+			} else {
+				yield formatComment('/// ', snakeCaseToSentenceCase(context[0]) + ' in ' +
+					snakeCaseToSentenceCase(context[1]));
+			}
+			yield `export type ${name} = `;
+			// Options
+			for (let i = 0; i < o.oneOf.length; i++) {
+				const schema = o.oneOf[i];
+				yield deriveType(contracts, TypescriptTypeMap, [schema.name, ...context], schema);
+				if (i < o.oneOf.length - 1) {
+					yield ' | ';
+				}
+			}
+			yield ';\n\n';
+		});
 
 		// Create enums for all enum types
 		yield* enumVisitor([], source, function* (context: Array<string>, values: Array<string>) {

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -27,22 +27,6 @@ export interface SearchSchemaResult {
 }
 
 /**
- * Table values formatted as strings
- */
-export interface TableData {
-	/**
-	 * The columns of data
-	 */
-	columns: Array<Array<string>>;
-
-	/**
-	 * Zero or more arrays of row labels
-	 */
-	row_labels?: Array<Array<string>>;
-
-}
-
-/**
  * The result of applying filters to a table
  */
 export interface FilterResult {
@@ -147,6 +131,22 @@ export interface ColumnSchema {
 	 * Size parameter for fixed-size types (list, binary)
 	 */
 	type_size?: number;
+
+}
+
+/**
+ * Table values formatted as strings
+ */
+export interface TableData {
+	/**
+	 * The columns of data
+	 */
+	columns: Array<Array<ColumnValue>>;
+
+	/**
+	 * Zero or more arrays of row labels
+	 */
+	row_labels?: Array<Array<string>>;
 
 }
 
@@ -589,6 +589,9 @@ export interface GetColumnProfilesFeatures {
 	supported_types: Array<ColumnProfileType>;
 
 }
+
+/// ColumnValue
+export type ColumnValue = string | number;
 
 /**
  * Possible values for ColumnDisplayType

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -591,7 +591,7 @@ export interface GetColumnProfilesFeatures {
 }
 
 /// ColumnValue
-export type ColumnValue = string | number;
+export type ColumnValue = number | string;
 
 /**
  * Possible values for ColumnDisplayType

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
@@ -11,13 +11,14 @@ import * as React from 'react';
 // Other dependencies.
 import { positronClassNames } from 'vs/base/common/positronUtilities';
 import { PositronDataExplorerColumn } from 'vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn';
+import { DataCell } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
 
 /**
  * TableDataCellProps interface.
  */
 interface TableDataCellProps {
 	column: PositronDataExplorerColumn;
-	cellValue: string;
+	cellValue: DataCell;
 }
 
 /**
@@ -29,7 +30,7 @@ export const TableDataCell = (props: TableDataCellProps) => {
 	// Render.
 	return (
 		<div className={positronClassNames('text', props.column.alignment)}>
-			{props.cellValue}
+			{props.cellValue.formatted}
 		</div>
 	);
 };

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
@@ -32,6 +32,69 @@ interface CacheUpdateDescriptor {
 }
 
 /**
+ * DataCellKind enum
+ */
+export enum DataCellKind {
+	NON_NULL = '',
+	NULL = 'null',
+	NA = 'na',
+	NaN = 'NaN',
+	NotATime = 'NaT',
+	None = 'None',
+	INFINITY = 'inf',
+	NEG_INFINITY = 'neginf',
+	UNKNOWN = 'unknown'
+}
+
+/**
+ * DataCell interface
+ */
+export interface DataCell {
+	formatted: string;
+	kind: DataCellKind;
+}
+
+function decodeSpecialValue(value: number) {
+	switch (value) {
+		case 0:
+			return {
+				kind: DataCellKind.NULL,
+				formatted: 'NULL'
+			};
+		case 1:
+			return {
+				kind: DataCellKind.NA,
+				formatted: 'NA'
+			};
+		case 2:
+			return {
+				kind: DataCellKind.NaN,
+				formatted: 'NaN'
+			};
+		case 3:
+			return {
+				kind: DataCellKind.NotATime,
+				formatted: 'NaT'
+			};
+		case 10:
+			return {
+				kind: DataCellKind.INFINITY,
+				formatted: 'INF'
+			};
+		case 11:
+			return {
+				kind: DataCellKind.NEG_INFINITY,
+				formatted: '-INF'
+			};
+		default:
+			return {
+				kind: DataCellKind.UNKNOWN,
+				formatted: 'UNKNOWN'
+			};
+	}
+}
+
+/**
  * DataExplorerCache class.
  */
 export class DataExplorerCache extends Disposable {
@@ -85,7 +148,7 @@ export class DataExplorerCache extends Disposable {
 	/**
 	 * Gets the data cell cache.
 	 */
-	private readonly _dataCellCache = new Map<string, string>();
+	private readonly _dataCellCache = new Map<string, DataCell>();
 
 	/**
 	 * The onDidUpdateCache event emitter.
@@ -393,7 +456,16 @@ export class DataExplorerCache extends Disposable {
 						const value = tableData.columns[column][row];
 						const columnIndex = columnIndices[column];
 						const rowIndex = rowIndices[row];
-						this._dataCellCache.set(`${columnIndex},${rowIndex}`, value);
+						if (typeof value === 'number') {
+							this._dataCellCache.set(`${columnIndex},${rowIndex}`,
+								decodeSpecialValue(value)
+							);
+						} else {
+							this._dataCellCache.set(`${columnIndex},${rowIndex}`, {
+								formatted: value,
+								kind: DataCellKind.NON_NULL
+							});
+						}
 					}
 				}
 

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
@@ -46,6 +46,8 @@ export enum DataCellKind {
 	UNKNOWN = 'unknown'
 }
 
+
+
 /**
  * DataCell interface
  */
@@ -54,48 +56,28 @@ export interface DataCell {
 	kind: DataCellKind;
 }
 
+const SpecialValues: Record<number, [DataCellKind, string]> = {
+	0: [DataCellKind.NULL, 'NULL'],
+	1: [DataCellKind.NA, 'NA'],
+	2: [DataCellKind.NaN, 'NaN'],
+	3: [DataCellKind.NotATime, 'NaT'],
+	4: [DataCellKind.None, 'None'],
+	10: [DataCellKind.INFINITY, 'INF'],
+	11: [DataCellKind.NEG_INFINITY, '-INF'],
+};
+
 function decodeSpecialValue(value: number) {
-	switch (value) {
-		case 0:
-			return {
-				kind: DataCellKind.NULL,
-				formatted: 'NULL'
-			};
-		case 1:
-			return {
-				kind: DataCellKind.NA,
-				formatted: 'NA'
-			};
-		case 2:
-			return {
-				kind: DataCellKind.NaN,
-				formatted: 'NaN'
-			};
-		case 3:
-			return {
-				kind: DataCellKind.NotATime,
-				formatted: 'NaT'
-			};
-		case 4:
-			return {
-				kind: DataCellKind.None,
-				formatted: 'None'
-			};
-		case 10:
-			return {
-				kind: DataCellKind.INFINITY,
-				formatted: 'INF'
-			};
-		case 11:
-			return {
-				kind: DataCellKind.NEG_INFINITY,
-				formatted: '-INF'
-			};
-		default:
-			return {
-				kind: DataCellKind.UNKNOWN,
-				formatted: 'UNKNOWN'
-			};
+	if (value in SpecialValues) {
+		const [kind, formatted] = SpecialValues[value];
+		return {
+			kind,
+			formatted
+		};
+	} else {
+		return {
+			kind: DataCellKind.UNKNOWN,
+			formatted: 'UNKNOWN'
+		};
 	}
 }
 

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
@@ -76,6 +76,11 @@ function decodeSpecialValue(value: number) {
 				kind: DataCellKind.NotATime,
 				formatted: 'NaT'
 			};
+		case 4:
+			return {
+				kind: DataCellKind.None,
+				formatted: 'None'
+			};
 		case 10:
 			return {
 				kind: DataCellKind.INFINITY,


### PR DESCRIPTION
### Intent

Addresses #3190 and part of #2860. 

* Uses oneOf union with integer and string to pass special values (NA, NULL, NaN, None, Inf, -Inf, and in principle many others) instead of an ambiguous string formatted representation.
* Adds basic comm code generation support for unions -- may need to be tweaked to make Rust work correctly, haven't done the Amalthea implementation yet
* Adds basic Python support to pass the NaN or None codes (Inf/-Inf will have to be done separately)
* Adds data_explorer.md as a place to add documentation for the protocols (e.g. special codes like these)

This doesn't address CSS changes to make e.g. `None` and `"None"` look different, that will have to come next. 

### Approach

I considered some other approaches and found the `number | string` union to be a simple, compact, and extensible way to do this.

I also took note of #3191 since I had to use StrictInt and StrictStr when creating the union here in Python. 

### QA Notes

Check that in pandas data frames, special values (NaN, None, others) still format the same.