### PR TITLE
Fixes for restoration of minimised panels

### DIFF
--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -481,8 +481,8 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		}
 
 		// --- Start Positron ---
-		// If the panel is minimized, restore it.
-		if (this.layoutService.isPanelMinimized()) {
+		// If we're opening a view in the panel and it is minimized, restore it.
+		if (this.partId === Parts.PANEL_PART && this.layoutService.isPanelMinimized()) {
 			this.layoutService.restorePanel();
 		}
 		// --- End Positron ---

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -23,7 +23,6 @@ import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
-import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { NOTEBOOK_EDITOR_FOCUSED } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
 import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/common/executionHistoryService';
@@ -143,13 +142,10 @@ export function registerPositronConsoleActions() {
 		 * @param accessor The services accessor.
 		 */
 		async run(accessor: ServicesAccessor) {
-
-			const layoutService = accessor.get(IWorkbenchLayoutService);
 			const viewsService = accessor.get(IViewsService);
 
 			// Ensure that the panel and console are visible. This is essentially
 			// equivalent to what `workbench.panel.positronConsole.focus` does.
-			layoutService.restorePanel();
 			await viewsService.openView(POSITRON_CONSOLE_VIEW_ID, true);
 		}
 	});

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -12,7 +12,6 @@ import { ISettableObservable, observableValue } from 'vs/base/common/observableI
 import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { RuntimeItem } from 'vs/workbench/services/positronConsole/browser/classes/runtimeItem';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
@@ -187,7 +186,6 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
 		@ILogService private readonly _logService: ILogService,
 		@IViewsService private readonly _viewsService: IViewsService,
-		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService
 	) {
 		// Call the disposable constrcutor.
 		super();
@@ -367,9 +365,8 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 	 * @returns A value which indicates whether the code could be executed.
 	 */
 	async executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean) {
-		// When code is executed in the console service, ensure that the panel is restored, if it
-		// needs to be, and open the console view.
-		this._layoutService.restorePanel();
+		// When code is executed in the console service, open the console view. This opens
+		// the relevant pane composite if needed.
 		await this._viewsService.openView(POSITRON_CONSOLE_VIEW_ID, false);
 
 		// Get the running runtimes for the language.

--- a/src/vs/workbench/services/views/browser/viewsService.ts
+++ b/src/vs/workbench/services/views/browser/viewsService.ts
@@ -480,6 +480,18 @@ export class ViewsService extends Disposable implements IViewsService {
 					if (focusedViewId === viewDescriptor.id) {
 
 						const viewLocation = viewDescriptorService.getViewLocationById(viewDescriptor.id);
+						// --- Start Positron ---
+						// This deals with an edge case. If we're opening a view
+						// in the panel, and it is minimized, and it is focused
+						// (unlikely but possible, e.g. after clicking the
+						// minimize button), restore it.
+						if (viewLocation === ViewContainerLocation.Panel && layoutService.isPanelMinimized()) {
+							layoutService.restorePanel();
+							// Returning early instead of chaining with `else` to avoid formatter
+							// indenting the other branches
+							return;
+						}
+						// --- End Positron ---
 						if (viewDescriptorService.getViewLocationById(viewDescriptor.id) === ViewContainerLocation.Sidebar) {
 							// focus the editor if the view is focused and in the side bar
 							editorGroupService.activeGroup.focus();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses #2032 and a few related issues.


1. We currently assume that the console is always in the bottom panel. This causes us to incorrectly restore a minimised panel to its original size when the user has the console in the side bar and tries to open a view.

2. In actions such as `executeCode` we restore the panel without checking which pane the console is in.

3. There is an edge case where we don't restore the panel when we ought to: when opening a view in the panel (e.g. with `workbench.action.positronConsole.open`) and the panel is minimised _and_ focused (happens after clicking the minimise button).

### Approach

Make sure the view manager handles minimised panels selectively everywhere needed. And avoid trying to restore the panel from commands and actions, instead rely on our injected code in the view manager.

The three commits fix each of the issues described above:

1. Changes our injected code in `doOpenPaneComposite()` (called when the user opens a viewpane) to only restore a minimised panel if the view being opened is actually in the panel.

2. Removes our `restorePanel()` calls in actions. Calling `openView()` is sufficient since that ends up calling `doOpenPaneComposite()` eventually.

3. Handles the edge case so that opening commands restore a minimised and focused panel.

Following this, if I'm not missing anything, I believe `positron.restorePanel` is redundant with `workbench.action.togglePanel`. Should we remove it?

### QA Notes

The following apply to console views as well as any other views:

A minimised panel (e.g. from clicking on the minimise button, not to be confused with a hidden panel from Cmd/Ctrl + J) should never be restored when opening views in the sidebar.

A minimised panel should be restored on Cmd/Ctrl + J or when opening views in the panel with toggling/focus/open commands such as `workbench.action.positronConsole.open` or `workbench.action.positronConsole.focusConsole`. This should be the case both when focused or not.