### PR TITLE
Enable Welcome screen for release builds

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -48,13 +48,7 @@ registerAction2(class extends Action2 {
 				id: MenuId.MenubarHelpMenu,
 				group: '1_welcome',
 				order: 1,
-				// --- Start Positron ---
-				when: IsDevelopmentContext
-				// --- End Positron ---
 			},
-			// --- Start Positron ---
-			precondition: IsDevelopmentContext,
-			// --- End Positron ---
 			metadata: {
 				description: localize2('minWelcomeDescription', 'Opens a Walkthrough to help you get started in VS Code.')
 			}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -857,7 +857,8 @@ export class GettingStartedPage extends EditorPane {
 		const layoutRecentList = () => {
 			const leftContent = $('div.positron-welcome-left-column');
 			this.positronReactRenderer = createWelcomePageLeft(leftContent, this.openerService, this.keybindingService,
-				this.layoutService, this.commandService, this.runtimeSessionService, this.runtimeStartupService, this.languageRuntimeService);
+				this.layoutService, this.commandService, this.runtimeSessionService, this.runtimeStartupService, this.languageRuntimeService,
+				this.contextService, this.configurationService);
 			reset(leftColumn, leftContent);
 			reset(rightColumn, startList.getDomElement(), recentList.getDomElement());
 			// }

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageLeft.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageLeft.tsx
@@ -18,6 +18,9 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { projectWizardEnabled } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 
 export interface PositronWelcomePageLeftProps {
 	openerService: IOpenerService;
@@ -27,6 +30,7 @@ export interface PositronWelcomePageLeftProps {
 	runtimesSessionService: IRuntimeSessionService;
 	languageRuntimeService: ILanguageRuntimeService;
 	runtimeStartupService: IRuntimeStartupService;
+	projectWizardEnabled: boolean;
 }
 
 export const PositronWelcomePageLeft = (props: PropsWithChildren<PositronWelcomePageLeftProps>) => {
@@ -40,6 +44,7 @@ export const PositronWelcomePageLeft = (props: PropsWithChildren<PositronWelcome
 				runtimeSessionService={props.runtimesSessionService}
 				runtimeStartupService={props.runtimeStartupService}
 				languageRuntimeService={props.languageRuntimeService}
+				projectWizardEnabled={props.projectWizardEnabled}
 			/>
 			<PositronWelcomePageHelp openerService={props.openerService} />
 		</>
@@ -49,7 +54,8 @@ export const PositronWelcomePageLeft = (props: PropsWithChildren<PositronWelcome
 export const createWelcomePageLeft = (container: HTMLElement, openerService: IOpenerService,
 	keybindingService: IKeybindingService, layoutService: ILayoutService, commandService: ICommandService,
 	runtimeSessionService: IRuntimeSessionService, runtimeStartupService: IRuntimeStartupService,
-	languageRuntimeService: ILanguageRuntimeService): PositronReactRenderer => {
+	languageRuntimeService: ILanguageRuntimeService, contextKeyService: IContextKeyService, configurationService: IConfigurationService): PositronReactRenderer => {
+	const enableProjectWizard = projectWizardEnabled(contextKeyService, configurationService);
 	const renderer = new PositronReactRenderer(container);
 	renderer.render(<PositronWelcomePageLeft
 		openerService={openerService}
@@ -59,6 +65,7 @@ export const createWelcomePageLeft = (container: HTMLElement, openerService: IOp
 		runtimesSessionService={runtimeSessionService}
 		runtimeStartupService={runtimeStartupService}
 		languageRuntimeService={languageRuntimeService}
+		projectWizardEnabled={enableProjectWizard}
 	/>);
 	return renderer;
 };

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageStart.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageStart.tsx
@@ -30,6 +30,7 @@ export interface PositronWelcomePageStartProps {
 	runtimeSessionService: IRuntimeSessionService;
 	runtimeStartupService: IRuntimeStartupService;
 	languageRuntimeService: ILanguageRuntimeService;
+	projectWizardEnabled: boolean;
 }
 
 export const PositronWelcomePageStart = (props: PropsWithChildren<PositronWelcomePageStartProps>) => {
@@ -75,12 +76,15 @@ export const PositronWelcomePageStart = (props: PropsWithChildren<PositronWelcom
 					runtimeStartupService={props.runtimeStartupService}
 					commandService={props.commandService}
 				/>
-				<WelcomeButton
-					label={(() => localize('positron.welcome.newProject', "New Project"))()}
-					codicon='positron-new-project'
-					ariaLabel={(() => localize('positron.welcome.newProjectDescription', "Create a new project"))()}
-					onPressed={() => props.commandService.executeCommand(PositronNewProjectAction.ID)}
-				/>
+
+				{
+					props.projectWizardEnabled && <WelcomeButton
+						label={(() => localize('positron.welcome.newProject', "New Project"))()}
+						codicon='positron-new-project'
+						ariaLabel={(() => localize('positron.welcome.newProjectDescription', "Create a new project"))()}
+						onPressed={() => props.commandService.executeCommand(PositronNewProjectAction.ID)}
+					/>
+				}
 			</div>
 		</div>
 	);

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -29,11 +29,6 @@ import { localize } from 'vs/nls';
 import { IEditorResolverService, RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
 import { TerminalCommandId } from 'vs/workbench/contrib/terminal/common/terminal';
 
-// --- Start Positron ---
-import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-// --- End Positron ---
-
 export const restoreWalkthroughsConfigurationKey = 'workbench.welcomePage.restorableWalkthroughs';
 export type RestoreWalkthroughsConfigurationValue = { folder: string; category?: string; step?: string };
 
@@ -80,9 +75,6 @@ export class StartupPageRunnerContribution implements IWorkbenchContribution {
 	static readonly ID = 'workbench.contrib.startupPageRunner';
 
 	constructor(
-		// --- Start Positron ---
-		@IContextKeyService private readonly contextKeyService: IContextKeyService,
-		// --- End Positron ---
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IEditorService private readonly editorService: IEditorService,
 		@IWorkingCopyBackupService private readonly workingCopyBackupService: IWorkingCopyBackupService,
@@ -122,10 +114,7 @@ export class StartupPageRunnerContribution implements IWorkbenchContribution {
 			return;
 		}
 
-		// --- Start Positron ---
-		const enabled = isStartupPageEnabled(this.configurationService, this.contextService, this.environmentService)
-			&& isPositronStartupPageEnabled(this.contextKeyService);
-		// --- End Positron ---
+		const enabled = isStartupPageEnabled(this.configurationService, this.contextService, this.environmentService);
 		if (enabled && this.lifecycleService.startupKind !== StartupKind.ReloadedWindow) {
 			const hasBackups = await this.workingCopyBackupService.hasBackups();
 			if (hasBackups) { return; }
@@ -244,8 +233,3 @@ function isStartupPageEnabled(configurationService: IConfigurationService, conte
 		|| startupEditor.value === 'terminal';
 }
 
-// --- Start Positron ---
-function isPositronStartupPageEnabled(contextKeyService: IContextKeyService): boolean {
-	return IsDevelopmentContext.getValue(contextKeyService) === true;
-}
-// --- End Positron ---


### PR DESCRIPTION
### Intent
#2815 

### Approach
Add a check on the `New Project` button to show only if the new project wizard is enabled. Remove the development context check on welcome.

### QA Notes
The new project wizard preference can be toggled to show the `New Project` button. If it doesn't enable immediately, closing and opening the welcome screen will update the button visibility.