### PR TITLE
Fix "Python: Select Interpreter" when choosing the selected interpreter

### DIFF
--- a/extensions/positron-python/src/client/common/serviceRegistry.ts
+++ b/extensions/positron-python/src/client/common/serviceRegistry.ts
@@ -89,6 +89,9 @@ import { ContextKeyManager } from './application/contextKeyManager';
 import { CreatePythonFileCommandHandler } from './application/commands/createPythonFile';
 import { RequireJupyterPrompt } from '../jupyter/requireJupyterPrompt';
 import { isWindows } from './platform/platformService';
+// --- Start Positron ---
+import { registerPositronTypes } from '../positron/serviceRegistry';
+// --- End Positron ---
 
 export function registerTypes(serviceManager: IServiceManager): void {
     serviceManager.addSingletonInstance<boolean>(IsWindows, isWindows());
@@ -187,4 +190,7 @@ export function registerTypes(serviceManager: IServiceManager): void {
         IExtensionSingleActivationService,
         DebugSessionTelemetry,
     );
+    // --- Start Positron ---
+    registerPositronTypes(serviceManager);
+    // --- End Positron ---
 }

--- a/extensions/positron-python/src/client/extension.ts
+++ b/extensions/positron-python/src/client/extension.ts
@@ -91,7 +91,7 @@ export async function activate(context: IExtensionContext): Promise<PythonExtens
 
     // --- Start Positron ---
 
-    activatePositron(ready, api, serviceContainer)
+    activatePositron(serviceContainer)
         // Run in the background.
         .ignoreErrors();
 

--- a/extensions/positron-python/src/client/interpreter/configuration/pythonPathUpdaterService.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/pythonPathUpdaterService.ts
@@ -9,7 +9,7 @@ import { PythonInterpreterTelemetry } from '../../telemetry/types';
 import { IComponentAdapter } from '../contracts';
 import { IPythonPathUpdaterServiceFactory, IPythonPathUpdaterServiceManager } from './types';
 // --- Start Positron ---
-import { PythonRuntimeManager } from '../../positron/manager';
+import { IPythonRuntimeManager } from '../../positron/manager';
 // --- End Positron ---
 
 @injectable()
@@ -18,7 +18,10 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
         @inject(IPythonPathUpdaterServiceFactory)
         private readonly pythonPathSettingsUpdaterFactory: IPythonPathUpdaterServiceFactory,
         @inject(IComponentAdapter) private readonly pyenvs: IComponentAdapter,
+        // --- Start Positron ---
+        @inject(IPythonRuntimeManager) private readonly pythonRuntimeManager: IPythonRuntimeManager,
     ) {}
+    // --- End Positron ---
 
     public async updatePythonPath(
         pythonPath: string | undefined,
@@ -41,11 +44,9 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
         // --- Start Positron ---
         // If the interpreter path is set, make it the active interpreter in the Positron console.
         if (pythonPath) {
-            PythonRuntimeManager.instance()
-                .selectLanguageRuntimeFromPath(pythonPath)
-                .catch((ex) => {
-                    traceError(`Failed to select language runtime for path ${pythonPath}. ${ex}`);
-                });
+            this.pythonRuntimeManager.selectLanguageRuntimeFromPath(pythonPath).catch((ex) => {
+                traceError(`Failed to select language runtime for path ${pythonPath}. ${ex}`);
+            });
         }
         // --- End Positron ---
         // do not wait for this to complete

--- a/extensions/positron-python/src/client/interpreter/configuration/pythonPathUpdaterService.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/pythonPathUpdaterService.ts
@@ -42,7 +42,7 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
             traceError(reason);
         }
         // --- Start Positron ---
-        // If the interpreter path is set, make it the active interpreter in the Positron console.
+        // If the interpreter path is set, ensure that it's the active interpreter in the Positron console.
         if (pythonPath) {
             this.pythonRuntimeManager.selectLanguageRuntimeFromPath(pythonPath).catch((ex) => {
                 traceError(`Failed to select language runtime for path ${pythonPath}. ${ex}`);

--- a/extensions/positron-python/src/client/interpreter/configuration/pythonPathUpdaterService.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/pythonPathUpdaterService.ts
@@ -43,7 +43,7 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
         }
         // --- Start Positron ---
         // If the interpreter path is set, ensure that it's the active interpreter in the Positron console.
-        if (pythonPath) {
+        if (pythonPath && !failed) {
             this.pythonRuntimeManager.selectLanguageRuntimeFromPath(pythonPath).catch((ex) => {
                 traceError(`Failed to select language runtime for path ${pythonPath}. ${ex}`);
             });

--- a/extensions/positron-python/src/client/positron/discoverer.ts
+++ b/extensions/positron-python/src/client/positron/discoverer.ts
@@ -22,21 +22,14 @@ import { MINIMUM_PYTHON_VERSION } from '../common/constants';
  *
  * @param serviceContainer The Python extension's service container to use for
  * dependency injection.
- * @param runtimes A map from interpreter path to language runtime metadata.
- * @param activatedPromise Resolves when all Python extension components are activated.
  *
  * @returns An async generator that yields Python language runtime metadata.
  */
 export async function* pythonRuntimeDiscoverer(
     serviceContainer: IServiceContainer,
-    activatedPromise: Promise<void>,
 ): AsyncGenerator<positron.LanguageRuntimeMetadata> {
     try {
         traceInfo('pythonRuntimeDiscoverer: Starting Python runtime discoverer');
-
-        // Wait for all extension components to be activated
-        traceInfo('pythonRuntimeDiscoverer: awaiting extension activation');
-        await activatedPromise;
 
         const interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
         const interpreterSelector = serviceContainer.get<IInterpreterSelector>(IInterpreterSelector);

--- a/extensions/positron-python/src/client/positron/extension.ts
+++ b/extensions/positron-python/src/client/positron/extension.ts
@@ -1,57 +1,24 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
 import { ProgressLocation, ProgressOptions } from 'vscode';
 import * as fs from 'fs';
-// eslint-disable-next-line import/no-unresolved
-import * as positron from 'positron';
-import { PythonExtension } from '../api/types';
 import { IDisposableRegistry, IInstaller, InstallerResponse, Product, ProductInstallStatus } from '../common/types';
 import { IInterpreterService } from '../interpreter/contracts';
 import { IServiceContainer } from '../ioc/types';
 import { traceError, traceInfo, traceLog } from '../logging';
-import { PythonRuntimeManager } from './manager';
 import { IPYKERNEL_VERSION, MINIMUM_PYTHON_VERSION, Commands } from '../common/constants';
 import { InstallOptions } from '../common/installer/types';
 import { EnvironmentType } from '../pythonEnvironments/info';
-import { showErrorMessage } from '../common/vscodeApis/windowApis';
 import { isProblematicCondaEnvironment } from '../interpreter/configuration/environmentTypeComparer';
-import { CreateEnv, Interpreters } from '../common/utils/localize';
+import { Interpreters } from '../common/utils/localize';
 import { IApplicationShell } from '../common/application/types';
 
-export async function activatePositron(
-    activatedPromise: Promise<void>,
-    pythonApi: PythonExtension,
-    serviceContainer: IServiceContainer,
-): Promise<void> {
+export async function activatePositron(serviceContainer: IServiceContainer): Promise<void> {
     try {
-        traceInfo('activatePositron: creating runtime manager');
-        const manager = new PythonRuntimeManager(serviceContainer, activatedPromise);
-
-        // Register the Python runtime discoverer (to find all available runtimes) with positron.
-        traceInfo('activatePositron: registering python runtime manager');
-        positron.runtime.registerLanguageRuntimeManager(manager);
-
-        // Wait for all extension components to be activated before registering event listeners
-        traceInfo('activatePositron: awaiting extension activation');
-        await activatedPromise;
-
         const disposables = serviceContainer.get<IDisposableRegistry>(IDisposableRegistry);
-        // If a new runtime is registered via the Python extension, create and register a corresponding language runtime.
-        disposables.push(
-            pythonApi.environments.onDidChangeEnvironments(async (event) => {
-                if (event.type === 'add') {
-                    const interpreterPath = event.env.path;
-                    await checkAndInstallPython(interpreterPath, serviceContainer);
-                    if (!fs.existsSync(interpreterPath)) {
-                        showErrorMessage(`${CreateEnv.pathDoesntExist} ${interpreterPath}`);
-                    }
-                    await manager.registerLanguageRuntimeFromPath(interpreterPath);
-                }
-            }),
-        );
         // Register a command to check if ipykernel is installed for a given interpreter.
         disposables.push(
             vscode.commands.registerCommand('python.isIpykernelInstalled', async (pythonPath: string) => {

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 
 import { Event, EventEmitter } from 'vscode';
-import { inject } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { IServiceContainer } from '../ioc/types';
 import { pythonRuntimeDiscoverer } from './discoverer';
 import { IInterpreterService } from '../interpreter/contracts';
@@ -36,6 +36,7 @@ export interface IPythonRuntimeManager extends positron.LanguageRuntimeManager {
  * Provides Python language runtime metadata and sessions to Positron;
  * implements positron.LanguageRuntimeManager.
  */
+@injectable()
 export class PythonRuntimeManager implements IPythonRuntimeManager {
     /**
      * A map of Python interpreter paths to their language runtime metadata.

--- a/extensions/positron-python/src/client/positron/serviceRegistry.ts
+++ b/extensions/positron-python/src/client/positron/serviceRegistry.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IServiceManager } from '../ioc/types';
+import { IPythonRuntimeManager, PythonRuntimeManager } from './manager';
+
+export function registerPositronTypes(serviceManager: IServiceManager): void {
+    serviceManager.addSingleton<IPythonRuntimeManager>(IPythonRuntimeManager, PythonRuntimeManager);
+}

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -9,7 +9,6 @@
 import * as positron from 'positron';
 import * as vscode from 'vscode';
 import PQueue from 'p-queue';
-import { PythonExtension } from '../api/types';
 import { ProductNames } from '../common/installer/productNames';
 import { InstallOptions } from '../common/installer/types';
 import {
@@ -77,7 +76,6 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         readonly runtimeMetadata: positron.LanguageRuntimeMetadata,
         readonly metadata: positron.RuntimeSessionMetadata,
         readonly serviceContainer: IServiceContainer,
-        private readonly pythonApi: PythonExtension,
         readonly kernelSpec?: JupyterKernelSpec | undefined,
     ) {
         const interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
@@ -266,8 +264,6 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
 
         // Update the active environment in the Python extension.
         this._interpreterPathService.update(undefined, vscode.ConfigurationTarget.Global, this.interpreter.path);
-
-        this.pythonApi.environments.updateActiveEnvironmentPath(this.interpreter.path);
 
         // Register for console width changes, if we haven't already
         if (!this._consoleWidthDisposable) {

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -1,0 +1,156 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import * as assert from 'assert';
+import * as fs from 'fs-extra';
+// eslint-disable-next-line import/no-unresolved
+import * as positron from 'positron';
+import * as sinon from 'sinon';
+import { verify } from 'ts-mockito';
+import * as TypeMoq from 'typemoq';
+import * as runtime from '../../client/positron/runtime';
+import * as session from '../../client/positron/session';
+import { IEnvironmentVariablesProvider } from '../../client/common/variables/types';
+import { IConfigurationService, IDisposable } from '../../client/common/types';
+import { IServiceContainer } from '../../client/ioc/types';
+import { PythonRuntimeManager } from '../../client/positron/manager';
+import { IInterpreterService } from '../../client/interpreter/contracts';
+import { PythonEnvironment } from '../../client/pythonEnvironments/info';
+import { mockedPositronNamespaces } from '../vscode-mock';
+
+suite('Python runtime manager', () => {
+    const pythonPath = 'pythonPath';
+
+    let runtimeMetadata: TypeMoq.IMock<positron.LanguageRuntimeMetadata>;
+    let interpreter: TypeMoq.IMock<PythonEnvironment>;
+    let configService: TypeMoq.IMock<IConfigurationService>;
+    let envVarsProvider: TypeMoq.IMock<IEnvironmentVariablesProvider>;
+    let interpreterService: TypeMoq.IMock<IInterpreterService>;
+    let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+    let pythonRuntimeManager: PythonRuntimeManager;
+    let disposables: IDisposable[];
+
+    setup(() => {
+        runtimeMetadata = TypeMoq.Mock.ofType<positron.LanguageRuntimeMetadata>();
+        interpreter = TypeMoq.Mock.ofType<PythonEnvironment>();
+        configService = TypeMoq.Mock.ofType<IConfigurationService>();
+        envVarsProvider = TypeMoq.Mock.ofType<IEnvironmentVariablesProvider>();
+        interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
+        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+
+        runtimeMetadata.setup((r) => r.runtimeId).returns(() => 'runtimeId');
+        runtimeMetadata
+            .setup((r) => r.extraRuntimeData)
+            .returns(() => ({ pythonPath, pythonEnvironmentId: 'pythonEnvironmentId' }));
+
+        interpreterService
+            .setup((i) => i.getInterpreterDetails(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(interpreter.object));
+
+        serviceContainer.setup((s) => s.get(IConfigurationService)).returns(() => configService.object);
+        serviceContainer.setup((s) => s.get(IEnvironmentVariablesProvider)).returns(() => envVarsProvider.object);
+        serviceContainer.setup((s) => s.get(IInterpreterService)).returns(() => interpreterService.object);
+
+        pythonRuntimeManager = new PythonRuntimeManager(serviceContainer.object, interpreterService.object);
+        disposables = [];
+    });
+
+    teardown(() => {
+        sinon.restore();
+        disposables.forEach((d) => d.dispose());
+    });
+
+    test('constructor', () => {
+        verify(mockedPositronNamespaces.runtime!.registerLanguageRuntimeManager(pythonRuntimeManager)).once();
+    });
+
+    /** Helper function to assert that a language runtime is registered. */
+    async function assertRegisterLanguageRuntime(fn: () => Promise<void>) {
+        // Create a mock listener for onDidDiscoverRuntime, and verify that it's called with the expected runtime metadata.
+        const listener = TypeMoq.Mock.ofType<(e: positron.LanguageRuntimeMetadata) => void>();
+        listener.setup((l) => l(runtimeMetadata.object)).verifiable(TypeMoq.Times.once());
+
+        // Register the mock listener.
+        disposables.push(pythonRuntimeManager.onDidDiscoverRuntime(listener.object));
+
+        // Call the function.
+        await fn();
+
+        // Check that the runtime was registered.
+        assert.strictEqual(pythonRuntimeManager.registeredPythonRuntimes.get(pythonPath), runtimeMetadata.object);
+    }
+
+    test('registerLanguageRuntime: registers a language runtime with Positron', async () => {
+        await assertRegisterLanguageRuntime(async () => {
+            pythonRuntimeManager.registerLanguageRuntime(runtimeMetadata.object);
+        });
+    });
+
+    // TODO: Test createSession
+    // test('createSession', async () => {
+    // });
+
+    test('restoreSession: creates and returns a Python runtime session', async () => {
+        const sessionMetadata = TypeMoq.Mock.ofType<positron.RuntimeSessionMetadata>();
+        const pythonRuntimeSession = sinon.stub(session, 'PythonRuntimeSession');
+
+        const result = await pythonRuntimeManager.restoreSession(runtimeMetadata.object, sessionMetadata.object);
+
+        assert.strictEqual(result, pythonRuntimeSession.returnValues[0]);
+        sinon.assert.calledOnceWithExactly(
+            pythonRuntimeSession,
+            runtimeMetadata.object,
+            sessionMetadata.object,
+            serviceContainer.object,
+        );
+    });
+
+    // TODO: Test discoverRuntimes
+    // test('discoverRuntimes', async () => {
+    // });
+
+    test('validateMetadata: returns the validated metadata', async () => {
+        sinon.stub(fs, 'pathExists').resolves(true);
+
+        const validated = await pythonRuntimeManager.validateMetadata(runtimeMetadata.object);
+
+        assert.deepStrictEqual(validated, runtimeMetadata.object);
+    });
+
+    test('validateMetadata: throws if extra data is missing', async () => {
+        const invalidRuntimeMetadata = TypeMoq.Mock.ofType<positron.LanguageRuntimeMetadata>();
+        assert.rejects(() => pythonRuntimeManager.validateMetadata(invalidRuntimeMetadata.object));
+    });
+
+    test('validateMetadata: throws if interpreter path does not exist', async () => {
+        sinon.stub(fs, 'pathExists').resolves(false);
+        assert.rejects(() => pythonRuntimeManager.validateMetadata(runtimeMetadata.object));
+    });
+
+    test('registerLanguageRuntimeFromPath: registers a runtime with the corresponding runtime metadata', async () => {
+        const createPythonRuntimeMetadata = sinon
+            .stub(runtime, 'createPythonRuntimeMetadata')
+            .resolves(runtimeMetadata.object);
+
+        await assertRegisterLanguageRuntime(async () => {
+            await pythonRuntimeManager.registerLanguageRuntimeFromPath(pythonPath);
+        });
+
+        sinon.assert.calledOnceWithExactly(
+            createPythonRuntimeMetadata,
+            interpreter.object,
+            serviceContainer.object,
+            false,
+        );
+    });
+
+    test('selectLanguageRuntimeFromPath: calls positron.runtime.selectLanguageRuntime with the corresponding runtime ID', async () => {
+        pythonRuntimeManager.registeredPythonRuntimes.set(pythonPath, runtimeMetadata.object);
+
+        await pythonRuntimeManager.selectLanguageRuntimeFromPath(pythonPath);
+
+        verify(mockedPositronNamespaces.runtime!.selectLanguageRuntime(runtimeMetadata.object.runtimeId)).once();
+    });
+});

--- a/extensions/positron-python/src/test/vscode-mock.ts
+++ b/extensions/positron-python/src/test/vscode-mock.ts
@@ -24,10 +24,17 @@ type Positron = typeof positron;
 
 // Create the mocked Positron API; a partial type of Positron (all attributes are optional).
 const mockedPositron: Partial<Positron> = {};
+export const mockedPositronNamespaces: { [P in keyof Positron]?: Positron[P] } = {};
 
 // TODO(seem): mockedPositron is currently empty. We can update it as needed as we add tests.
 
 import { patchMockingLibs } from './positron/initialize';
+
+function generatePositronMock<K extends keyof Positron>(name: K): void {
+    const mockedObj = mock<Positron[K]>();
+    (mockedPositron as any)[name] = instance(mockedObj);
+    mockedPositronNamespaces[name] = mockedObj;
+}
 // --- End Positron ---
 
 function generateMock<K extends keyof VSCode>(name: K): void {
@@ -70,6 +77,15 @@ export function initialize() {
     when(contributes.debuggers).thenReturn([{ aiKey: '' }]);
     when(mockedVSCodeNamespaces.extensions!.getExtension(anything())).thenReturn(instance(extension));
     when(mockedVSCodeNamespaces.extensions!.all).thenReturn([]);
+
+    // --- Start Positron ---
+    generatePositronMock('languages');
+    generatePositronMock('methods');
+    generatePositronMock('runtime');
+    generatePositronMock('window');
+
+    generatePositronMock('RuntimeState');
+    // --- End Positron ---
 
     // When upgrading to npm 9-10, this might have to change, as we could have explicit imports (named imports).
     Module._load = function (request: any, _parent: any) {


### PR DESCRIPTION
### Intent

Address #3169.

### Approach

I moved some code over to the `PythonRuntimeManager` and made it a global singleton accessible via the existing service registry. That way, we can use it to select the runtime in the `PythonPathUpdaterService`.

I also took some more time to try to understand the upstream extension activation logic. I don't think we need to await the `activationPromise` (I initially thought it waits for all services to be instantiated, but it turns out it waits for _some_ service classes that implement an `activate` method that runs after instantiation) so I removed that. We originally added those awaits while trying to debug an issue where Python runtimes weren't being discovered, but it turned out to be an issue in Positron core.

I also added some basic unit tests, but left out some of the more complicated methods for now.
### QA Notes

See the linked issue. This PR changes how we register _and_ select runtimes in Positron based on events in the Python extension, so those are worth testing out again:

- If you create a new venv in the directory, it should ask if you want to activate that venv. If you choose to, it should select the corresponding interpreter in the Positron console.
- The "Python: Select Interpreter" command should work as expected.