### PR TITLE
Fix console inputs keybindings for Home, End, and Ctrl+U

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -351,6 +351,16 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				break;
 			}
 
+			case KeyCode.KeyU: {
+				// Bind Ctrl+U to `deleteAllLeft`
+				if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && !e.altGraphKey) {
+					consumeEvent();
+					positronConsoleContext.commandService.executeCommand('deleteAllLeft');
+					break;
+				}
+				break;
+			}
+
 			// Tab processing.
 			case KeyCode.Tab: {
 				// If the history browser is active, accept the selected history entry and
@@ -452,6 +462,26 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 						// Position the code editor widget.
 						updateCodeEditorWidgetPosition(Position.Last, Position.Last);
 					}
+				}
+				break;
+			}
+
+			// Bind Home key to `cursorLineStart` (same as Ctrl+A)
+			case KeyCode.Home: {
+				if (!e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && !e.altGraphKey) {
+					consumeEvent();
+					positronConsoleContext.commandService.executeCommand('cursorLineStart');
+					break;
+				}
+				break;
+			}
+
+			// Bind End key to `cursorLineEnd` (same as Ctrl+E)
+			case KeyCode.End: {
+				if (!e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && !e.altGraphKey) {
+					consumeEvent();
+					positronConsoleContext.commandService.executeCommand('cursorLineEnd');
+					break;
 				}
 				break;
 			}

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
@@ -21,6 +21,7 @@ import { IPositronConsoleInstance, IPositronConsoleService } from 'vs/workbench/
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 
 /**
  * PositronConsoleServices interface. Defines the set of services that are required by the Positron
@@ -43,6 +44,7 @@ export interface PositronConsoleServices extends PositronActionBarServices {
 	readonly viewsService: IViewsService;
 	readonly workbenchLayoutService: IWorkbenchLayoutService;
 	readonly contextKeyService: IContextKeyService;
+	readonly commandService: ICommandService;
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses #2548 and https://github.com/posit-dev/positron-beta/discussions/138#discussioncomment-9429388. Home, End, and Ctrl+U are now working as in RStudio (go to beginning of line, go to end of line, delete from cursor to beginning of line).

### Approach

I'm invoking existing commands from our key handler. This way we don't have to reimplement behaviour.

### QA Notes
