### PR TITLE
Improve performance of positron_ipykernel test suite

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
 #
 
+from typing import Iterable
 from unittest.mock import MagicMock, Mock
 
 import comm
@@ -67,11 +68,8 @@ def kernel() -> PositronIPyKernel:
 
 
 @pytest.fixture
-def shell() -> PositronShell:
+def shell() -> Iterable[PositronShell]:
     shell = PositronShell.instance()
-
-    # Ensure a clean namespace
-    shell.reset()
 
     # TODO: For some reason these vars are in user_ns but not user_ns_hidden during tests. For now,
     #       manually add them to user_ns_hidden to replicate running in Positron.
@@ -91,7 +89,14 @@ def shell() -> PositronShell:
         }
     )
 
-    return shell
+    user_ns_keys = set(shell.user_ns.keys())
+
+    yield shell
+
+    # Ensure a clean namespace
+    new_user_ns_keys = set(shell.user_ns.keys()) - user_ns_keys
+    for key in new_user_ns_keys:
+        del shell.user_ns[key]
 
 
 @pytest.fixture

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
@@ -39,7 +39,8 @@ BIG_ARRAY_LENGTH = 10_000_001
 TARGET_NAME = "target_name"
 
 
-def test_comm_open(kernel: PositronIPyKernel) -> None:
+# Depend on shell fixture for a clean namespace
+def test_comm_open(kernel: PositronIPyKernel, shell) -> None:
     service = VariablesService(kernel)
 
     # Double-check that comm is not yet open
@@ -390,7 +391,8 @@ def test_handle_inspect_2d(
         _assert_inspect(value[key], ["x", key], variables_comm)
 
 
-def test_handle_inspect_error(variables_comm: DummyComm) -> None:
+# Depend on shell fixture for a clean namespace
+def test_handle_inspect_error(variables_comm: DummyComm, shell) -> None:
     path = [encode_access_key("x")]
     # TODO(pyright): We shouldn't need to cast; may be a pyright bug
     msg = json_rpc_request("inspect", cast(JsonRecord, {"path": path}), comm_id="dummy_comm_id")
@@ -421,7 +423,8 @@ def test_handle_clipboard_format(shell: PositronShell, variables_comm: DummyComm
     assert variables_comm.messages == [json_rpc_response({"content": "3"})]
 
 
-def test_handle_clipboard_format_error(variables_comm: DummyComm) -> None:
+# Depend on shell fixture for a clean namespace
+def test_handle_clipboard_format_error(variables_comm: DummyComm, shell) -> None:
     path = [encode_access_key("x")]
     # TODO(pyright): We shouldn't need to cast; may be a pyright bug
     msg = json_rpc_request(
@@ -456,7 +459,8 @@ def test_handle_view(
     assert_register_table_called(mock_dataexplorer_service, shell.user_ns["x"], "x")
 
 
-def test_handle_view_error(variables_comm: DummyComm) -> None:
+# Depend on shell fixture for a clean namespace
+def test_handle_view_error(variables_comm: DummyComm, shell) -> None:
     path = [encode_access_key("x")]
     # TODO(pyright): We shouldn't need to cast; may be a pyright bug
     msg = json_rpc_request("view", cast(JsonRecord, {"path": path}), comm_id="dummy_comm_id")


### PR DESCRIPTION
### Intent

Address #3205.

### Approach

Ipykernel kernel and shell classes are singletons so the `.instance` calls in our fixtures don't do much. The slow part was the `shell.reset`. Removing `autouse=True` for both took the tests down from ~1min to ~30 seconds on my laptop.

We also don't need a full `shell.reset`, we can just remove the variables added by a test. This took it down to ~20 seconds.

Then there was a particularly slow test `test_update_max_items_plus_one`. I decided to monkey patch the `MAX_ITEMS` variable down to a smaller value for tests, since we're still testing the same logic. This took it down to ~14 seconds.

For reference, here are a few of the slowest tests at this point (via the pytest `--durations=0` flag):

```
2.21s call     positron/positron_ipykernel/tests/test_data_explorer.py::test_pandas_set_sort_columns
1.03s call     positron/positron_ipykernel/tests/test_data_explorer.py::test_pandas_wide_schemas
1.01s teardown positron/positron_ipykernel/tests/test_help.py::test_pydoc_server_styling
0.99s call     positron/positron_ipykernel/tests/test_help.py::test_pydoc_server_starts_and_shuts_down
0.46s call     positron/positron_ipykernel/tests/test_plots.py::test_mpl_update
0.42s call     positron/positron_ipykernel/tests/test_plots.py::test_mpl_multiple_figures
```

### QA Notes

Tests should pass in CI and locally.