### PR TITLE
Additional workaround for phantom cells in data explorer scraping

### DIFF
--- a/test/automation/src/positron/positronDataExplorer.ts
+++ b/test/automation/src/positron/positronDataExplorer.ts
@@ -33,7 +33,7 @@ export class PositronDataExplorer {
 				const innerText = cell.textContent;
 				const headerName = headerNames[columnIndex];
 				// workaround for extra offscreen cells
-				if (headerName === undefined) {
+				if (!headerName) {
 					continue;
 				}
 				rowData[headerName] = innerText;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> After reimplementing the data explorer table scrape, it appears that we need to check for header name "truthiness" instead of just undefined when determining if a "phantom cell" is being processed.

### Approach

> Very simple, just checking headerName falsiness instead of just undefined.

### QA Notes

> All smoke tests should pass
