### PR TITLE
Select interpreter command

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -94,8 +94,8 @@ jobs:
 
       - name: Run Smoke Tests (Electron)
         env:
-          POSITRON_PY_VER_SEL: 3.10.12 (Global)
-          POSITRON_R_VER_SEL: R 4.3.3
+          POSITRON_PY_VER_SEL: Python 3.10.12 64-bit
+          POSITRON_R_VER_SEL: R 4.4.0
         id: electron-smoke-tests
         run: DISPLAY=:10 yarn smoketest-no-compile --tracing
 

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -110,6 +110,11 @@
         "shortTitle": "%r.menu.packageDocument.title%"
       },
       {
+        "command": "r.selectInterpreter",
+        "category": "R",
+        "title": "%r.command.selectInterpreter.title%"
+      },
+      {
         "command": "r.sourceCurrentFile",
         "category": "R",
         "title": "%r.command.sourceCurrentFile.title%",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -15,6 +15,7 @@
 	"r.command.useTest.title": "Add (or visit) a test file",
 	"r.command.packageCheck.title": "Check R Package",
 	"r.command.packageDocument.title": "Document R Package",
+	"r.command.selectInterpreter.title": "Select R Interpreter",
 	"r.menu.createNewFile.title": "R File",
 	"r.menu.insertPipe.title": "Insert the pipe operator",
 	"r.menu.insertLeftAssignment.title": "Insert the \"<-\" assignment operator",

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -135,6 +135,10 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 			executeCodeForCommand('devtools', 'devtools::document()');
 		}),
 
+		vscode.commands.registerCommand('r.selectInterpreter', async () => {
+			vscode.commands.executeCommand('workbench.action.languageRuntime.select', 'r');
+		}),
+
 		// Command used to source the current file
 		vscode.commands.registerCommand('r.sourceCurrentFile', async () => {
 			// Get the active text editor

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -74,7 +74,7 @@ async function selectLanguage(accessor: ServicesAccessor) {
 		];
 
 		input.canSelectMany = false;
-		input.placeholder = 'Select the language to execute code in';
+		input.placeholder = nls.localize('positron.executeCode.selectLanguage', 'Select the language to execute code in');
 
 		for (const runtimeMetadata of languageRuntimeService.registeredRuntimes) {
 			addRuntime(runtimeMetadata);
@@ -178,8 +178,8 @@ const selectLanguageRuntime = async (
 
 		input.canSelectMany = false;
 		const languageName = languageService.getLanguageName(languageId);
-		input.title = `Select ${languageName} Interpreter`;
-		input.placeholder = 'Discovering Interpreters...';
+		input.title = nls.localize('positron.languageRuntime.select.selectInterpreter', 'Select {0} Interpreter', languageName);
+		input.placeholder = nls.localize('positron.languageRuntime.select.discoveringInterpreters', 'Discovering Interpreters...');
 		input.matchOnDescription = true;
 
 		for (const runtimeMetadata of languageRuntimeService.registeredRuntimes) {
@@ -196,7 +196,7 @@ const selectLanguageRuntime = async (
 			// yet registered. Do nothing.
 		}
 		if (preferredRuntime) {
-			input.placeholder = `Selected Interpreter: ${preferredRuntime.runtimeName}`;
+			input.placeholder = nls.localize('positron.languageRuntime.select.selectedInterpreer', 'Selected Interpreter: {0}', preferredRuntime.runtimeName);
 			const activeItem = runtimePicks.get(preferredRuntime.runtimeId);
 			if (activeItem) {
 				input.activeItems = [activeItem];

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -6,18 +6,19 @@ import * as nls from 'vs/nls';
 import { generateUuid } from 'vs/base/common/uuid';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { ILocalizedString } from 'vs/platform/action/common/action';
-import { ICommandService } from 'vs/platform/commands/common/commands';
 import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
-import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
+import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from 'vs/platform/quickinput/common/quickInput';
 import { IKeybindingRule, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { LANGUAGE_RUNTIME_ACTION_CATEGORY } from 'vs/workbench/contrib/languageRuntime/common/languageRuntime';
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
-import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionMode, RuntimeCodeExecutionMode, RuntimeErrorBehavior } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService, RuntimeCodeExecutionMode, RuntimeErrorBehavior } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionService, RuntimeClientType } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { ILanguageService } from 'vs/editor/common/languages/language';
+import { groupBy } from 'vs/base/common/collections';
+import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 import { dispose } from 'vs/base/common/lifecycle';
 
 // The category for language runtime actions.
@@ -119,37 +120,92 @@ export const selectLanguageRuntimeSession = async (
 };
 
 /**
- * Helper function that asks the user to select a registered language runtime from
- * an array of language runtime metadata entries.
+ * Helper function that asks the user to select a registered language runtime for a language.
  *
- * @param quickInputService The quick input service.
- * @param runtimes The language runtime entries the user can select from.
- * @param placeHolder The placeholder for the quick input.
+ * @param accessor The service accessor.
+ * @param languageId The language ID of the language runtimes to select from.
  *
  * @returns The language runtime the user selected, or undefined, if the user canceled the operation.
  */
-export const selectLanguageRuntime = async (
-	quickInputService: IQuickInputService,
-	runtimes: ILanguageRuntimeMetadata[],
-	placeHolder: string): Promise<ILanguageRuntimeMetadata | undefined> => {
+const selectLanguageRuntime = async (
+	accessor: ServicesAccessor,
+	languageId: string): Promise<ILanguageRuntimeMetadata | undefined> => {
 
-	// Build the language runtime quick pick items.
-	const languageRuntimeQuickPickItems = runtimes.map<LanguageRuntimeQuickPickItem>(runtime => ({
-		id: runtime.runtimeId,
-		label: runtime.runtimeName,
-		description: runtime.languageVersion,
-		runtime
-	} satisfies LanguageRuntimeQuickPickItem));
+	const quickInputService = accessor.get(IQuickInputService);
+	const runtimeStartupService = accessor.get(IRuntimeStartupService);
+	const languageRuntimeService = accessor.get(ILanguageRuntimeService);
+	const languageService = accessor.get(ILanguageService);
 
 	// Prompt the user to select a language runtime.
-	const languageRuntimeQuickPickItem = await quickInputService
-		.pick<LanguageRuntimeQuickPickItem>(languageRuntimeQuickPickItems, {
-			canPickMany: false,
-			placeHolder
-		});
+	return new Promise((resolve) => {
+		const input = quickInputService.createQuickPick<LanguageRuntimeQuickPickItem>();
+		const runtimePicks = new Map<string, LanguageRuntimeQuickPickItem>();
 
-	// Done.
-	return languageRuntimeQuickPickItem?.runtime;
+		const addRuntime = (runtimeMetadata: ILanguageRuntimeMetadata) => {
+			runtimePicks.set(runtimeMetadata.runtimeId, {
+				id: runtimeMetadata.runtimeId,
+				label: `${runtimeMetadata.languageName} ${runtimeMetadata.languageVersion}`,
+				description: runtimeMetadata.runtimePath,
+				runtime: runtimeMetadata
+			});
+
+			// Update the quick pick items.
+			const runtimePicksBySource = groupBy(Array.from(runtimePicks.values()), pick => pick.runtime.runtimeSource);
+			const sortedSources = Object.keys(runtimePicksBySource).sort();
+			const picks = new Array<IQuickPickSeparator | LanguageRuntimeQuickPickItem>();
+			for (const source of sortedSources) {
+				picks.push({ label: source, type: 'separator' }, ...runtimePicksBySource[source]);
+			}
+			input.items = picks;
+		};
+
+		const disposables = [
+			input,
+			input.onDidAccept(() => {
+				resolve(input.activeItems[0]?.runtime);
+				input.hide();
+			}),
+			input.onDidHide(() => {
+				dispose(disposables);
+				resolve(undefined);
+			}),
+			languageRuntimeService.onDidRegisterRuntime((runtimeMetadata) => {
+				if (runtimeMetadata.languageId === languageId) {
+					addRuntime(runtimeMetadata);
+				}
+			}),
+		];
+
+		input.canSelectMany = false;
+		const languageName = languageService.getLanguageName(languageId);
+		input.title = `Select ${languageName} Interpreter`;
+		input.placeholder = 'Discovering Interpreters...';
+		input.matchOnDescription = true;
+
+		for (const runtimeMetadata of languageRuntimeService.registeredRuntimes) {
+			if (runtimeMetadata.languageId === languageId) {
+				addRuntime(runtimeMetadata);
+			}
+		}
+
+		let preferredRuntime: ILanguageRuntimeMetadata | undefined;
+		try {
+			preferredRuntime = runtimeStartupService.getPreferredRuntime(languageId);
+		} catch (e) {
+			// getPreferredRuntime can error if a workspace-affiliated runtime is not
+			// yet registered. Do nothing.
+		}
+		if (preferredRuntime) {
+			input.placeholder = `Selected Interpreter: ${preferredRuntime.runtimeName}`;
+			const activeItem = runtimePicks.get(preferredRuntime.runtimeId);
+			if (activeItem) {
+				input.activeItems = [activeItem];
+			}
+		}
+
+		input.show();
+
+	});
 };
 
 /**
@@ -223,36 +279,31 @@ export function registerLanguageRuntimeActions() {
 	};
 
 	// Registers the start language runtime action.
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.start', 'Start Interpreter', async accessor => {
-		// Access services.
-		const commandService = accessor.get(ICommandService);
-		const extensionService = accessor.get(IExtensionService);
-		const languageRuntimeService = accessor.get(ILanguageRuntimeService);
-		const runtimeSessionService = accessor.get(IRuntimeSessionService);
-		const quickInputService = accessor.get(IQuickInputService);
-
-		// Ensure that the python extension is loaded.
-		await extensionService.activateByEvent('onLanguage:python');
-
-		// Get the registered language runtimes.
-		const registeredRuntimes = languageRuntimeService.registeredRuntimes;
-		if (!registeredRuntimes.length) {
-			alert(nls.localize('positronNoInstalledRuntimes', "No interpreters are currently installed."));
-			return;
+	registerAction2(class SelectInterpreterAction extends Action2 {
+		constructor() {
+			super({
+				id: 'workbench.action.languageRuntime.select',
+				title: nls.localize2('positron.command.selectInterpreter', "Select Interpreter"),
+				f1: false,
+				category,
+			});
 		}
 
-		// Ask the user to select the language runtime to start. If they selected one, start it.
-		const languageRuntime = await selectLanguageRuntime(quickInputService, registeredRuntimes, 'Select the interpreter to start');
-		if (languageRuntime) {
-			// Start the language runtime.
-			runtimeSessionService.startNewRuntimeSession(languageRuntime.runtimeId,
-				languageRuntime.runtimeName,
-				LanguageRuntimeSessionMode.Console,
-				undefined, // No notebook URI (console session)
-				`'Start Interpreter' command invoked`);
+		async run(accessor: ServicesAccessor, languageId: string) {
+			// Access services.
+			const commandService = accessor.get(ICommandService);
+			const runtimeSessionService = accessor.get(IRuntimeSessionService);
 
-			// Drive focus into the Positron console.
-			commandService.executeCommand('workbench.panel.positronConsole.focus');
+			// Ask the user to select the language runtime to start. If they selected one, start it.
+			const languageRuntime = await selectLanguageRuntime(accessor, languageId);
+
+			if (languageRuntime) {
+				// Start the language runtime.
+				runtimeSessionService.selectRuntime(languageRuntime.runtimeId, `'Select Interpreter' command invoked`);
+
+				// Drive focus into the Positron console.
+				commandService.executeCommand('workbench.panel.positronConsole.focus');
+			}
 		}
 	});
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -278,8 +278,9 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		if (activeSession) {
 			// Is this, by chance, the runtime that's already running?
 			if (activeSession.runtimeMetadata.runtimeId === runtimeId) {
-				return Promise.reject(
-					new Error(`${formatLanguageRuntimeMetadata(runtime)} is already running.`));
+				// Set it as the foreground session and return.
+				this._foregroundSession = activeSession;
+				return;
 			}
 
 			// We wait for `onDidEndSession()` rather than `RuntimeState.Exited`, because the former

--- a/test/automation/src/positron/fixtures/positronPythonFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronPythonFixtures.ts
@@ -16,7 +16,7 @@ export class PositronPythonFixtures {
 		if (desiredPython === undefined) {
 			fail('Please be sure to set env var POSITRON_PY_VER_SEL to the UI text corresponding to the Python version for the test');
 		}
-		await this.app.workbench.startInterpreter.selectInterpreter(InterpreterType.Python, desiredPython);
+		await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.Python, desiredPython);
 
 		await this.app.workbench.positronConsole.waitForReady('>>>');
 

--- a/test/automation/src/positron/fixtures/positronRFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronRFixtures.ts
@@ -16,7 +16,7 @@ export class PositronRFixtures {
 		if (desiredR === undefined) {
 			fail('Please be sure to set env var POSITRON_R_VER_SEL to the UI text corresponding to the R version for the test');
 		}
-		await this.app.workbench.startInterpreter.selectInterpreter(InterpreterType.R, desiredR);
+		await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.R, desiredR);
 
 		await this.app.workbench.positronConsole.waitForReady('>');
 

--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -33,20 +33,10 @@ export class PositronConsole {
 		await this.quickinput.waitForQuickInputOpened();
 		await this.quickinput.type(desiredInterpreterString);
 
-		// The Python select interpreter command may include additional items above the desired
-		// interpreter string, if the interpreter is registered after the command is run.
-		// In that case, we have to scroll down to select the desired interpreter.
-
-		// Wait until the desired interpreter string appears in the list.
-		await this.quickinput.waitForQuickInputElements(elements =>
-			!!elements && !!elements.find(e => e === desiredInterpreterString)
-		);
-
-		// Select the desired interpreter string.
-		while (await this.quickinput.waitForQuickInputElementFocused() !== desiredInterpreterString) {
-			await this.code.dispatchKeybinding('down');
-		}
-		await this.code.dispatchKeybinding('enter');
+		// Wait until the desired interpreter string appears in the list and select it.
+		// We need to click instead of using 'enter' because the Python select interpreter command
+		// may include additional items above the desired interpreter string.
+		await this.quickinput.selectQuickInputElementContaining(desiredInterpreterString);
 		await this.quickinput.waitForQuickInputClosed();
 	}
 

--- a/test/automation/src/quickinput.ts
+++ b/test/automation/src/quickinput.ts
@@ -25,9 +25,12 @@ export class QuickInput {
 		await this.code.waitForSetValue(QuickInput.QUICK_INPUT_INPUT, value);
 	}
 
-	async waitForQuickInputElementFocused(): Promise<void> {
-		await this.code.waitForTextContent(QuickInput.QUICK_INPUT_FOCUSED_ELEMENT);
+	// --- Start Positron ---
+	// Updated to return the focused element text instead of void.
+	async waitForQuickInputElementFocused(): Promise<string> {
+		return await this.code.waitForTextContent(QuickInput.QUICK_INPUT_FOCUSED_ELEMENT);
 	}
+	// --- End Positron ---
 
 	async waitForQuickInputElementText(): Promise<string> {
 		return this.code.waitForTextContent(QuickInput.QUICK_INPUT_ENTRY_LABEL_SPAN);

--- a/test/automation/src/quickinput.ts
+++ b/test/automation/src/quickinput.ts
@@ -60,7 +60,7 @@ export class QuickInput {
 	async selectQuickInputElementContaining(contains: string): Promise<void> {
 		const selector = `${QuickInput.QUICK_INPUT_ROW}[aria-label*="${contains}"]`;
 		try {
-			await this.code.waitAndClick(selector, undefined, undefined, 1);
+			await this.code.waitAndClick(selector);
 		} catch (ex) {
 			// Show a more helpful error message by clearing the input and logging the list of items
 			await this.type('');

--- a/test/automation/src/quickinput.ts
+++ b/test/automation/src/quickinput.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Code } from './code';
-import { IElement } from './driver';
 
 export class QuickInput {
 
@@ -39,12 +38,9 @@ export class QuickInput {
 		await this.waitForQuickInputClosed();
 	}
 
-	// --- Start Positron ---
-	// Updated to return the elements.
-	async waitForQuickInputElements(accept: (names: string[]) => boolean): Promise<IElement[]> {
-		return await this.code.waitForElements(QuickInput.QUICK_INPUT_ENTRY_LABEL, false, els => accept(els.map(e => e.textContent)));
+	async waitForQuickInputElements(accept: (names: string[]) => boolean): Promise<void> {
+		await this.code.waitForElements(QuickInput.QUICK_INPUT_ENTRY_LABEL, false, els => accept(els.map(e => e.textContent)));
 	}
-	// --- End Positron ---
 
 	async waitForQuickInputClosed(): Promise<void> {
 		await this.code.waitForElement(QuickInput.QUICK_INPUT, r => !!r && r.attributes.style.indexOf('display: none;') !== -1);
@@ -64,13 +60,13 @@ export class QuickInput {
 	async selectQuickInputElementContaining(contains: string): Promise<void> {
 		const selector = `${QuickInput.QUICK_INPUT_ROW}[aria-label*="${contains}"]`;
 		try {
-			await this.code.waitAndClick(selector);
+			await this.code.waitAndClick(selector, undefined, undefined, 1);
 		} catch (ex) {
 			// Show a more helpful error message by clearing the input and logging the list of items
 			await this.type('');
-			const elements = await this.waitForQuickInputElements((e) => !!e);
-			const names = elements.map(e => e.attributes['aria-label']);
-			throw new Error(`Could not find item containing '${contains}' in list: ${names}`);
+			const elements = await this.code.waitForElements(QuickInput.QUICK_INPUT_ROW, false);
+			const ariaLabels = elements.map(e => e.attributes['aria-label']);
+			throw new Error(`Could not find item containing '${contains}' in list:\n${ariaLabels.join('\n')}`);
 		}
 	}
 	// --- End Positron ---

--- a/test/automation/src/quickinput.ts
+++ b/test/automation/src/quickinput.ts
@@ -59,7 +59,16 @@ export class QuickInput {
 	// --- Start Positron ---
 	async selectQuickInputElementContaining(contains: string): Promise<void> {
 		const selector = `${QuickInput.QUICK_INPUT_ROW}[aria-label*="${contains}"]`;
-		await this.code.waitAndClick(selector);
+		try {
+			await this.code.waitAndClick(selector);
+		} catch (ex) {
+			// Show a more helpful error message.
+			await this.waitForQuickInputElements((names) => {
+				console.error(`Could not find item containing '${contains}' in list: ${names}`);
+				return true;
+			});
+			throw ex;
+		}
 	}
 	// --- End Positron ---
 }

--- a/test/automation/src/quickinput.ts
+++ b/test/automation/src/quickinput.ts
@@ -62,7 +62,8 @@ export class QuickInput {
 		try {
 			await this.code.waitAndClick(selector);
 		} catch (ex) {
-			// Show a more helpful error message.
+			// Show a more helpful error message by clearing the input and logging the list of items
+			await this.type('');
 			await this.waitForQuickInputElements((names) => {
 				console.error(`Could not find item containing '${contains}' in list: ${names}`);
 				return true;

--- a/test/automation/src/quickinput.ts
+++ b/test/automation/src/quickinput.ts
@@ -25,12 +25,9 @@ export class QuickInput {
 		await this.code.waitForSetValue(QuickInput.QUICK_INPUT_INPUT, value);
 	}
 
-	// --- Start Positron ---
-	// Updated to return the focused element text instead of void.
-	async waitForQuickInputElementFocused(): Promise<string> {
-		return await this.code.waitForTextContent(QuickInput.QUICK_INPUT_FOCUSED_ELEMENT);
+	async waitForQuickInputElementFocused(): Promise<void> {
+		await this.code.waitForTextContent(QuickInput.QUICK_INPUT_FOCUSED_ELEMENT);
 	}
-	// --- End Positron ---
 
 	async waitForQuickInputElementText(): Promise<string> {
 		return this.code.waitForTextContent(QuickInput.QUICK_INPUT_ENTRY_LABEL_SPAN);
@@ -59,4 +56,10 @@ export class QuickInput {
 			await this.waitForQuickInputClosed();
 		}
 	}
+	// --- Start Positron ---
+	async selectQuickInputElementContaining(contains: string): Promise<void> {
+		const selector = `${QuickInput.QUICK_INPUT_ROW}[aria-label*="${contains}"]`;
+		await this.code.waitAndClick(selector);
+	}
+	// --- End Positron ---
 }

--- a/test/automation/src/quickinput.ts
+++ b/test/automation/src/quickinput.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Code } from './code';
+import { IElement } from './driver';
 
 export class QuickInput {
 
@@ -38,9 +39,12 @@ export class QuickInput {
 		await this.waitForQuickInputClosed();
 	}
 
-	async waitForQuickInputElements(accept: (names: string[]) => boolean): Promise<void> {
-		await this.code.waitForElements(QuickInput.QUICK_INPUT_ENTRY_LABEL, false, els => accept(els.map(e => e.textContent)));
+	// --- Start Positron ---
+	// Updated to return the elements.
+	async waitForQuickInputElements(accept: (names: string[]) => boolean): Promise<IElement[]> {
+		return await this.code.waitForElements(QuickInput.QUICK_INPUT_ENTRY_LABEL, false, els => accept(els.map(e => e.textContent)));
 	}
+	// --- End Positron ---
 
 	async waitForQuickInputClosed(): Promise<void> {
 		await this.code.waitForElement(QuickInput.QUICK_INPUT, r => !!r && r.attributes.style.indexOf('display: none;') !== -1);
@@ -64,11 +68,9 @@ export class QuickInput {
 		} catch (ex) {
 			// Show a more helpful error message by clearing the input and logging the list of items
 			await this.type('');
-			await this.waitForQuickInputElements((names) => {
-				console.error(`Could not find item containing '${contains}' in list: ${names}`);
-				return true;
-			});
-			throw ex;
+			const elements = await this.waitForQuickInputElements((e) => !!e);
+			const names = elements.map(e => e.attributes['aria-label']);
+			throw new Error(`Could not find item containing '${contains}' in list: ${names}`);
 		}
 	}
 	// --- End Positron ---


### PR DESCRIPTION
### Intent

Address #3118.

### Approach

Added the `workbench.action.languageRuntime.select` command with `f1: false`. Language packs can implement their own commands in the command palette that call down to this, with a `languageId`.

I replaced the `workbench.action.languageRuntime.start` command since this feels like it handles all of the same usecases but with a nicer UX. Happy to revert if I missed something.

I also updated smoke tests to use this.

### QA Notes

Smoke tests should pass in CI and locally. Try out the R select interpreter command too.