### PR TITLE
Turn `Enable Preview` back on by default

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -43,10 +43,7 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 	focusRecentEditorAfterClose: true,
 	showIcons: true,
 	hasIcons: true, // 'vs-seti' is our default icon theme
-	// --- Start Positron ---
-	// enablePreview: true,
-	enablePreview: false,
-	// --- End Positron ---
+	enablePreview: true,
 	openPositioning: 'right',
 	openSideBySideDirection: 'right',
 	closeEmptyGroups: true,

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -284,10 +284,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.editor.enablePreview': {
 				'type': 'boolean',
 				'description': localize('enablePreview', "Controls whether opened editors show as preview editors. Preview editors do not stay open, are reused until explicitly set to be kept open (via double-click or editing), and show file names in italics."),
-				// --- Start Positron ---
-				// 'default': true
-				'default': false
-				// --- End Positron ---
+				'default': true
 			},
 			'workbench.editor.enablePreviewFromQuickOpen': {
 				'type': 'boolean',

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -472,11 +472,6 @@ suite('EditorGroupsService', () => {
 
 	test('editor basics', async function () {
 		const [part] = await createPart();
-		// --- Start Positron ---
-		// We default this to `false`, but this test expects it to be `true`
-		assert.strictEqual(part.partOptions.enablePreview, false);
-		const partOptionsListener = part.enforcePartOptions({ enablePreview: true });
-		// --- End Positron ---
 		const group = part.activeGroup;
 		assert.strictEqual(group.isEmpty, true);
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3016
Reverts https://github.com/posit-dev/positron/pull/1029

Still also worth considering https://github.com/posit-dev/positron/issues/3017 for the future