### PR TITLE
Use strict validation for types in generated Python comms

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections_comm.py
@@ -22,11 +22,11 @@ class ObjectSchema(BaseModel):
     ObjectSchema in Schemas
     """
 
-    name: str = Field(
+    name: StrictStr = Field(
         description="Name of the underlying object",
     )
 
-    kind: str = Field(
+    kind: StrictStr = Field(
         description="The object type (table, catalog, schema)",
     )
 
@@ -36,11 +36,11 @@ class FieldSchema(BaseModel):
     FieldSchema in Schemas
     """
 
-    name: str = Field(
+    name: StrictStr = Field(
         description="Name of the field",
     )
 
-    dtype: str = Field(
+    dtype: StrictStr = Field(
         description="The field data type",
     )
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -523,7 +523,7 @@ class ColumnHistogram(BaseModel):
         description="Absolute count of values in each histogram bin",
     )
 
-    bin_width: StrictFloat = Field(
+    bin_width: Union[StrictInt, StrictFloat] = Field(
         description="Absolute floating-point width of a histogram bin",
     )
 
@@ -561,7 +561,7 @@ class ColumnQuantileValue(BaseModel):
     An exact or approximate quantile value from a column
     """
 
-    q: StrictFloat = Field(
+    q: Union[StrictInt, StrictFloat] = Field(
         description="Quantile number (percentile). E.g. 1 for 1%, 50 for median",
     )
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -141,7 +141,7 @@ class SearchSchemaResult(BaseModel):
         description="A schema containing matching columns up to the max_results limit",
     )
 
-    total_num_matches: int = Field(
+    total_num_matches: StrictInt = Field(
         description="The total number of columns matching the search term",
     )
 
@@ -151,11 +151,11 @@ class FilterResult(BaseModel):
     The result of applying filters to a table
     """
 
-    selected_num_rows: int = Field(
+    selected_num_rows: StrictInt = Field(
         description="Number of rows in table after applying filters",
     )
 
-    had_errors: Optional[bool] = Field(
+    had_errors: Optional[StrictBool] = Field(
         default=None,
         description="Flag indicating if there were errors in evaluation",
     )
@@ -166,7 +166,7 @@ class BackendState(BaseModel):
     The current backend state for the data explorer
     """
 
-    display_name: str = Field(
+    display_name: StrictStr = Field(
         description="Variable name or other string to display for tab name in UI",
     )
 
@@ -196,15 +196,15 @@ class ColumnSchema(BaseModel):
     Schema for a column in a table
     """
 
-    column_name: str = Field(
+    column_name: StrictStr = Field(
         description="Name of column as UTF-8 string",
     )
 
-    column_index: int = Field(
+    column_index: StrictInt = Field(
         description="The position of the column within the schema",
     )
 
-    type_name: str = Field(
+    type_name: StrictStr = Field(
         description="Exact name of data type used by underlying table",
     )
 
@@ -212,7 +212,7 @@ class ColumnSchema(BaseModel):
         description="Canonical Positron display name of data type",
     )
 
-    description: Optional[str] = Field(
+    description: Optional[StrictStr] = Field(
         default=None,
         description="Column annotation / description",
     )
@@ -222,22 +222,22 @@ class ColumnSchema(BaseModel):
         description="Schema of nested child types",
     )
 
-    precision: Optional[int] = Field(
+    precision: Optional[StrictInt] = Field(
         default=None,
         description="Precision for decimal types",
     )
 
-    scale: Optional[int] = Field(
+    scale: Optional[StrictInt] = Field(
         default=None,
         description="Scale for decimal types",
     )
 
-    timezone: Optional[str] = Field(
+    timezone: Optional[StrictStr] = Field(
         default=None,
         description="Time zone for timestamp with time zone",
     )
 
-    type_size: Optional[int] = Field(
+    type_size: Optional[StrictInt] = Field(
         default=None,
         description="Size parameter for fixed-size types (list, binary)",
     )
@@ -252,7 +252,7 @@ class TableData(BaseModel):
         description="The columns of data",
     )
 
-    row_labels: Optional[List[List[str]]] = Field(
+    row_labels: Optional[List[List[StrictStr]]] = Field(
         default=None,
         description="Zero or more arrays of row labels",
     )
@@ -273,11 +273,11 @@ class TableShape(BaseModel):
     Provides number of rows and columns in a table
     """
 
-    num_rows: int = Field(
+    num_rows: StrictInt = Field(
         description="Numbers of rows in the table",
     )
 
-    num_columns: int = Field(
+    num_columns: StrictInt = Field(
         description="Number of columns in the table",
     )
 
@@ -287,7 +287,7 @@ class RowFilter(BaseModel):
     Specifies a table row filter based on a single column's values
     """
 
-    filter_id: str = Field(
+    filter_id: StrictStr = Field(
         description="Unique identifier for this filter",
     )
 
@@ -303,12 +303,12 @@ class RowFilter(BaseModel):
         description="The binary condition to use to combine with preceding row filters",
     )
 
-    is_valid: Optional[bool] = Field(
+    is_valid: Optional[StrictBool] = Field(
         default=None,
         description="Whether the filter is valid and supported by the backend, if undefined then true",
     )
 
-    error_message: Optional[str] = Field(
+    error_message: Optional[StrictStr] = Field(
         default=None,
         description="Optional error message when the filter is invalid",
     )
@@ -339,11 +339,11 @@ class BetweenFilterParams(BaseModel):
     Parameters for the 'between' and 'not_between' filter types
     """
 
-    left_value: str = Field(
+    left_value: StrictStr = Field(
         description="The lower limit for filtering",
     )
 
-    right_value: str = Field(
+    right_value: StrictStr = Field(
         description="The upper limit for filtering",
     )
 
@@ -357,7 +357,7 @@ class CompareFilterParams(BaseModel):
         description="String representation of a binary comparison",
     )
 
-    value: str = Field(
+    value: StrictStr = Field(
         description="A stringified column value for a comparison filter",
     )
 
@@ -367,11 +367,11 @@ class SetMembershipFilterParams(BaseModel):
     Parameters for the 'set_membership' filter type
     """
 
-    values: List[str] = Field(
+    values: List[StrictStr] = Field(
         description="Array of column values for a set membership filter",
     )
 
-    inclusive: bool = Field(
+    inclusive: StrictBool = Field(
         description="Filter by including only values passed (true) or excluding (false)",
     )
 
@@ -385,11 +385,11 @@ class SearchFilterParams(BaseModel):
         description="Type of search to perform",
     )
 
-    term: str = Field(
+    term: StrictStr = Field(
         description="String value/regex to search for in stringified data",
     )
 
-    case_sensitive: bool = Field(
+    case_sensitive: StrictBool = Field(
         description="If true, do a case-sensitive search, otherwise case-insensitive",
     )
 
@@ -399,7 +399,7 @@ class ColumnProfileRequest(BaseModel):
     A single column profile request
     """
 
-    column_index: int = Field(
+    column_index: StrictInt = Field(
         description="The ordinal column index to profile",
     )
 
@@ -413,7 +413,7 @@ class ColumnProfileResult(BaseModel):
     Result of computing column profile
     """
 
-    null_count: Optional[int] = Field(
+    null_count: Optional[StrictInt] = Field(
         default=None,
         description="Result from null_count request",
     )
@@ -465,23 +465,23 @@ class SummaryStatsNumber(BaseModel):
     SummaryStatsNumber in Schemas
     """
 
-    min_value: str = Field(
+    min_value: StrictStr = Field(
         description="Minimum value as string",
     )
 
-    max_value: str = Field(
+    max_value: StrictStr = Field(
         description="Maximum value as string",
     )
 
-    mean: str = Field(
+    mean: StrictStr = Field(
         description="Average value as string",
     )
 
-    median: str = Field(
+    median: StrictStr = Field(
         description="Sample median (50% value) value as string",
     )
 
-    stdev: str = Field(
+    stdev: StrictStr = Field(
         description="Sample standard deviation as a string",
     )
 
@@ -491,11 +491,11 @@ class SummaryStatsBoolean(BaseModel):
     SummaryStatsBoolean in Schemas
     """
 
-    true_count: int = Field(
+    true_count: StrictInt = Field(
         description="The number of non-null true values",
     )
 
-    false_count: int = Field(
+    false_count: StrictInt = Field(
         description="The number of non-null false values",
     )
 
@@ -505,11 +505,11 @@ class SummaryStatsString(BaseModel):
     SummaryStatsString in Schemas
     """
 
-    num_empty: int = Field(
+    num_empty: StrictInt = Field(
         description="The number of empty / length-zero values",
     )
 
-    num_unique: int = Field(
+    num_unique: StrictInt = Field(
         description="The exact number of distinct values",
     )
 
@@ -519,11 +519,11 @@ class ColumnHistogram(BaseModel):
     Result from a histogram profile request
     """
 
-    bin_sizes: List[int] = Field(
+    bin_sizes: List[StrictInt] = Field(
         description="Absolute count of values in each histogram bin",
     )
 
-    bin_width: float = Field(
+    bin_width: StrictFloat = Field(
         description="Absolute floating-point width of a histogram bin",
     )
 
@@ -537,7 +537,7 @@ class ColumnFrequencyTable(BaseModel):
         description="Counts of distinct values in column",
     )
 
-    other_count: int = Field(
+    other_count: StrictInt = Field(
         description="Number of other values not accounted for in counts. May be 0",
     )
 
@@ -547,11 +547,11 @@ class ColumnFrequencyTableItem(BaseModel):
     Entry in a column's frequency table
     """
 
-    value: str = Field(
+    value: StrictStr = Field(
         description="Stringified value",
     )
 
-    count: int = Field(
+    count: StrictInt = Field(
         description="Number of occurrences of value",
     )
 
@@ -561,15 +561,15 @@ class ColumnQuantileValue(BaseModel):
     An exact or approximate quantile value from a column
     """
 
-    q: float = Field(
+    q: StrictFloat = Field(
         description="Quantile number (percentile). E.g. 1 for 1%, 50 for median",
     )
 
-    value: str = Field(
+    value: StrictStr = Field(
         description="Stringified quantile value",
     )
 
-    exact: bool = Field(
+    exact: StrictBool = Field(
         description="Whether value is exact or approximate (computed from binned data or sketches)",
     )
 
@@ -579,11 +579,11 @@ class ColumnSortKey(BaseModel):
     Specifies a column to sort by
     """
 
-    column_index: int = Field(
+    column_index: StrictInt = Field(
         description="Column index to sort by",
     )
 
-    ascending: bool = Field(
+    ascending: StrictBool = Field(
         description="Sort order, ascending (true) or descending (false)",
     )
 
@@ -611,7 +611,7 @@ class SearchSchemaFeatures(BaseModel):
     Feature flags for 'search_schema' RPC
     """
 
-    supported: bool = Field(
+    supported: StrictBool = Field(
         description="Whether this RPC method is supported at all",
     )
 
@@ -621,11 +621,11 @@ class SetRowFiltersFeatures(BaseModel):
     Feature flags for 'set_row_filters' RPC
     """
 
-    supported: bool = Field(
+    supported: StrictBool = Field(
         description="Whether this RPC method is supported at all",
     )
 
-    supports_conditions: bool = Field(
+    supports_conditions: StrictBool = Field(
         description="Whether AND/OR filter conditions are supported",
     )
 
@@ -639,7 +639,7 @@ class GetColumnProfilesFeatures(BaseModel):
     Feature flags for 'get_column_profiles' RPC
     """
 
-    supported: bool = Field(
+    supported: StrictBool = Field(
         description="Whether this RPC method is supported at all",
     )
 
@@ -688,11 +688,11 @@ class GetSchemaParams(BaseModel):
     Request full schema for a table-like object
     """
 
-    start_index: int = Field(
+    start_index: StrictInt = Field(
         description="First column schema to fetch (inclusive)",
     )
 
-    num_columns: int = Field(
+    num_columns: StrictInt = Field(
         description="Number of column schemas to fetch from start index. May extend beyond end of table",
     )
 
@@ -721,15 +721,15 @@ class SearchSchemaParams(BaseModel):
     Search schema for column names matching a passed substring
     """
 
-    search_term: str = Field(
+    search_term: StrictStr = Field(
         description="Substring to match for (currently case insensitive)",
     )
 
-    start_index: int = Field(
+    start_index: StrictInt = Field(
         description="Index (starting from zero) of first result to fetch",
     )
 
-    max_results: int = Field(
+    max_results: StrictInt = Field(
         description="Maximum number of resulting column schemas to fetch from the start index",
     )
 
@@ -758,15 +758,15 @@ class GetDataValuesParams(BaseModel):
     Request a rectangular subset of data with values formatted as strings
     """
 
-    row_start_index: int = Field(
+    row_start_index: StrictInt = Field(
         description="First row to fetch (inclusive)",
     )
 
-    num_rows: int = Field(
+    num_rows: StrictInt = Field(
         description="Number of rows to fetch from start index. May extend beyond end of table",
     )
 
-    column_indices: List[int] = Field(
+    column_indices: List[StrictInt] = Field(
         description="Indices to select, which can be a sequential, sparse, or random selection",
     )
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/help_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/help_comm.py
@@ -48,7 +48,7 @@ class ShowHelpTopicParams(BaseModel):
     delivered.
     """
 
-    topic: str = Field(
+    topic: StrictStr = Field(
         description="The help topic to show",
     )
 
@@ -95,7 +95,7 @@ class ShowHelpParams(BaseModel):
     Request to show help in the frontend
     """
 
-    content: str = Field(
+    content: StrictStr = Field(
         description="The help content to show",
     )
 
@@ -103,7 +103,7 @@ class ShowHelpParams(BaseModel):
         description="The type of content to show",
     )
 
-    focus: bool = Field(
+    focus: StrictBool = Field(
         description="Whether to focus the Help pane when the content is displayed.",
     )
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
@@ -37,11 +37,11 @@ class PlotResult(BaseModel):
     A rendered plot
     """
 
-    data: str = Field(
+    data: StrictStr = Field(
         description="The plot data, as a base64-encoded string",
     )
 
-    mime_type: str = Field(
+    mime_type: StrictStr = Field(
         description="The MIME type of the plot data",
     )
 
@@ -62,15 +62,15 @@ class RenderParams(BaseModel):
     data is returned in a base64-encoded string.
     """
 
-    height: int = Field(
+    height: StrictInt = Field(
         description="The requested plot height, in pixels",
     )
 
-    width: int = Field(
+    width: StrictInt = Field(
         description="The requested plot width, in pixels",
     )
 
-    pixel_ratio: float = Field(
+    pixel_ratio: StrictFloat = Field(
         description="The pixel ratio of the display device",
     )
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
@@ -70,7 +70,7 @@ class RenderParams(BaseModel):
         description="The requested plot width, in pixels",
     )
 
-    pixel_ratio: StrictFloat = Field(
+    pixel_ratio: Union[StrictInt, StrictFloat] = Field(
         description="The pixel ratio of the display device",
     )
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
@@ -32,6 +32,19 @@ class DummyComm(comm.base_comm.BaseComm):
         msg["msg_type"] = msg_type
         self.messages.append(msg)
 
+    def handle_msg(self, msg, raise_errors=True):
+        message_count = len(self.messages)
+
+        super().handle_msg(msg)
+
+        # Raise JSON RPC error responses as test failures.
+        if raise_errors:
+            new_messages = self.messages[message_count:]
+            for message in new_messages:
+                error = message.get("data", {}).get("error")
+                if error is not None:
+                    raise AssertionError(error["message"])
+
 
 # Enable autouse so that all comms are created as DummyComms.
 @pytest.fixture(autouse=True)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -313,10 +313,7 @@ class DataExplorerFixture:
         self.de_service.comms[comm_id].comm.handle_msg(request)
         response = get_last_message(self.de_service, comm_id)
         data = response["data"]
-        if "error" in data:
-            raise ValueError(data["error"]["message"])
-        else:
-            return data["result"]
+        return data["result"]
 
     def get_schema(self, table_name, start_index=None, num_columns=None):
         if start_index is None:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
@@ -76,7 +76,7 @@ def _create_mpl_plot(shell: PositronShell, plots_service: PlotsService) -> Dummy
 
 
 def _do_render(
-    plot_comm: DummyComm, width=400, height=300, pixel_ratio=2, format="png"
+    plot_comm: DummyComm, width=400, height=300, pixel_ratio=2.0, format="png"
 ) -> Dict[str, Any]:
     msg = json_rpc_request(
         "render",
@@ -119,7 +119,7 @@ def test_mpl_render(shell: PositronShell, plots_service: PlotsService, images_pa
     # Send a render request to the plot comm. The frontend would send this on comm creation.
     width = 400
     height = 300
-    pixel_ratio = 2
+    pixel_ratio = 2.0
     format = "png"
     response = _do_render(plot_comm, width, height, pixel_ratio, format)
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
@@ -76,11 +76,16 @@ def _create_mpl_plot(shell: PositronShell, plots_service: PlotsService) -> Dummy
 
 
 def _do_render(
-    plot_comm: DummyComm, width=400, height=300, pixel_ratio=2.0, format="png"
+    plot_comm: DummyComm, width=400, height=300, pixel_ratio=2, format="png"
 ) -> Dict[str, Any]:
     msg = json_rpc_request(
         "render",
-        {"width": width, "height": height, "pixel_ratio": pixel_ratio, "format": format},
+        {
+            "width": width,
+            "height": height,
+            "pixel_ratio": pixel_ratio,
+            "format": format,
+        },
         comm_id="dummy_comm_id",
     )
     plot_comm.handle_msg(msg)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
@@ -76,7 +76,7 @@ def _create_mpl_plot(shell: PositronShell, plots_service: PlotsService) -> Dummy
 
 
 def _do_render(
-    plot_comm: DummyComm, width=400, height=300, pixel_ratio=2, format="png"
+    plot_comm: DummyComm, width=400, height=300, pixel_ratio=2.0, format="png"
 ) -> Dict[str, Any]:
     msg = json_rpc_request(
         "render",

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
@@ -405,7 +405,8 @@ def test_handle_inspect_error(variables_comm: DummyComm) -> None:
     path = [encode_access_key("x")]
     # TODO(pyright): We shouldn't need to cast; may be a pyright bug
     msg = json_rpc_request("inspect", cast(JsonRecord, {"path": path}), comm_id="dummy_comm_id")
-    variables_comm.handle_msg(msg)
+
+    variables_comm.handle_msg(msg, raise_errors=False)
 
     # An error message is sent
     assert variables_comm.messages == [
@@ -440,7 +441,7 @@ def test_handle_clipboard_format_error(variables_comm: DummyComm) -> None:
         cast(JsonRecord, {"path": path, "format": "text/plain"}),
         comm_id="dummy_comm_id",
     )
-    variables_comm.handle_msg(msg)
+    variables_comm.handle_msg(msg, raise_errors=False)
 
     # An error message is sent
     assert variables_comm.messages == [
@@ -471,7 +472,7 @@ def test_handle_view_error(variables_comm: DummyComm) -> None:
     path = [encode_access_key("x")]
     # TODO(pyright): We shouldn't need to cast; may be a pyright bug
     msg = json_rpc_request("view", cast(JsonRecord, {"path": path}), comm_id="dummy_comm_id")
-    variables_comm.handle_msg(msg)
+    variables_comm.handle_msg(msg, raise_errors=False)
 
     # An error message is sent
     assert variables_comm.messages == [
@@ -484,7 +485,7 @@ def test_handle_view_error(variables_comm: DummyComm) -> None:
 
 def test_handle_unknown_method(variables_comm: DummyComm) -> None:
     msg = json_rpc_request("unknown_method", comm_id="dummy_comm_id")
-    variables_comm.handle_msg(msg)
+    variables_comm.handle_msg(msg, raise_errors=False)
 
     assert variables_comm.messages == [
         json_rpc_error(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui_comm.py
@@ -336,7 +336,7 @@ class DebugSleepParams(BaseModel):
     Sleep for n seconds
     """
 
-    ms: StrictFloat = Field(
+    ms: Union[StrictInt, StrictFloat] = Field(
         description="Duration in milliseconds",
     )
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui_comm.py
@@ -29,7 +29,7 @@ class EditorContext(BaseModel):
         description="Document metadata",
     )
 
-    contents: List[str] = Field(
+    contents: List[StrictStr] = Field(
         description="Document contents",
     )
 
@@ -47,35 +47,35 @@ class TextDocument(BaseModel):
     Document metadata
     """
 
-    path: str = Field(
+    path: StrictStr = Field(
         description="URI of the resource viewed in the editor",
     )
 
-    eol: str = Field(
+    eol: StrictStr = Field(
         description="End of line sequence",
     )
 
-    is_closed: bool = Field(
+    is_closed: StrictBool = Field(
         description="Whether the document has been closed",
     )
 
-    is_dirty: bool = Field(
+    is_dirty: StrictBool = Field(
         description="Whether the document has been modified",
     )
 
-    is_untitled: bool = Field(
+    is_untitled: StrictBool = Field(
         description="Whether the document is untitled",
     )
 
-    language_id: str = Field(
+    language_id: StrictStr = Field(
         description="Language identifier",
     )
 
-    line_count: int = Field(
+    line_count: StrictInt = Field(
         description="Number of lines in the document",
     )
 
-    version: int = Field(
+    version: StrictInt = Field(
         description="Version number of the document",
     )
 
@@ -85,11 +85,11 @@ class Position(BaseModel):
     A line and character position, such as the position of the cursor.
     """
 
-    character: int = Field(
+    character: StrictInt = Field(
         description="The zero-based character value, as a Unicode code point offset.",
     )
 
-    line: int = Field(
+    line: StrictInt = Field(
         description="The zero-based line value.",
     )
 
@@ -111,7 +111,7 @@ class Selection(BaseModel):
         description="End position of the selection",
     )
 
-    text: str = Field(
+    text: StrictStr = Field(
         description="Text of the selection",
     )
 
@@ -147,7 +147,7 @@ class CallMethodParams(BaseModel):
     an implementation-defined serialization scheme.
     """
 
-    method: str = Field(
+    method: StrictStr = Field(
         description="The method to call inside the interpreter",
     )
 
@@ -224,7 +224,7 @@ class BusyParams(BaseModel):
     Change in backend's busy/idle status
     """
 
-    busy: bool = Field(
+    busy: StrictBool = Field(
         description="Whether the backend is busy",
     )
 
@@ -234,15 +234,15 @@ class OpenEditorParams(BaseModel):
     Open an editor
     """
 
-    file: str = Field(
+    file: StrictStr = Field(
         description="The path of the file to open",
     )
 
-    line: int = Field(
+    line: StrictInt = Field(
         description="The line number to jump to",
     )
 
-    column: int = Field(
+    column: StrictInt = Field(
         description="The column number to jump to",
     )
 
@@ -252,11 +252,11 @@ class NewDocumentParams(BaseModel):
     Create a new document with text contents
     """
 
-    contents: str = Field(
+    contents: StrictStr = Field(
         description="Document contents",
     )
 
-    language_id: str = Field(
+    language_id: StrictStr = Field(
         description="Language identifier",
     )
 
@@ -266,7 +266,7 @@ class ShowMessageParams(BaseModel):
     Show a message
     """
 
-    message: str = Field(
+    message: StrictStr = Field(
         description="The message to show to the user.",
     )
 
@@ -276,19 +276,19 @@ class ShowQuestionParams(BaseModel):
     Show a question
     """
 
-    title: str = Field(
+    title: StrictStr = Field(
         description="The title of the dialog",
     )
 
-    message: str = Field(
+    message: StrictStr = Field(
         description="The message to display in the dialog",
     )
 
-    ok_button_title: str = Field(
+    ok_button_title: StrictStr = Field(
         description="The title of the OK button",
     )
 
-    cancel_button_title: str = Field(
+    cancel_button_title: StrictStr = Field(
         description="The title of the Cancel button",
     )
 
@@ -298,11 +298,11 @@ class ShowDialogParams(BaseModel):
     Show a dialog
     """
 
-    title: str = Field(
+    title: StrictStr = Field(
         description="The title of the dialog",
     )
 
-    message: str = Field(
+    message: StrictStr = Field(
         description="The message to display in the dialog",
     )
 
@@ -312,11 +312,11 @@ class PromptStateParams(BaseModel):
     New state of the primary and secondary prompts
     """
 
-    input_prompt: str = Field(
+    input_prompt: StrictStr = Field(
         description="Prompt for primary input.",
     )
 
-    continuation_prompt: str = Field(
+    continuation_prompt: StrictStr = Field(
         description="Prompt for incomplete input.",
     )
 
@@ -326,7 +326,7 @@ class WorkingDirectoryParams(BaseModel):
     Change the displayed working directory
     """
 
-    directory: str = Field(
+    directory: StrictStr = Field(
         description="The new working directory",
     )
 
@@ -336,7 +336,7 @@ class DebugSleepParams(BaseModel):
     Sleep for n seconds
     """
 
-    ms: float = Field(
+    ms: StrictFloat = Field(
         description="Duration in milliseconds",
     )
 
@@ -346,7 +346,7 @@ class ExecuteCommandParams(BaseModel):
     Execute a Positron command
     """
 
-    command: str = Field(
+    command: StrictStr = Field(
         description="The command to execute",
     )
 
@@ -356,19 +356,19 @@ class ExecuteCodeParams(BaseModel):
     Execute code in a Positron runtime
     """
 
-    language_id: str = Field(
+    language_id: StrictStr = Field(
         description="The language ID of the code to execute",
     )
 
-    code: str = Field(
+    code: StrictStr = Field(
         description="The code to execute",
     )
 
-    focus: bool = Field(
+    focus: StrictBool = Field(
         description="Whether to focus the runtime's console",
     )
 
-    allow_incomplete: bool = Field(
+    allow_incomplete: StrictBool = Field(
         description="Whether to bypass runtime code completeness checks",
     )
 
@@ -378,11 +378,11 @@ class OpenWorkspaceParams(BaseModel):
     Open a workspace
     """
 
-    path: str = Field(
+    path: StrictStr = Field(
         description="The path for the workspace to be opened",
     )
 
-    new_window: bool = Field(
+    new_window: StrictBool = Field(
         description="Should the workspace be opened in a new window?",
     )
 
@@ -406,7 +406,7 @@ class ModifyEditorSelectionsParams(BaseModel):
         description="The selections (really, ranges) to set in the document",
     )
 
-    values: List[str] = Field(
+    values: List[StrictStr] = Field(
         description="The text values to insert at the selections",
     )
 
@@ -416,7 +416,7 @@ class ShowUrlParams(BaseModel):
     Show a URL in Positron's Viewer pane
     """
 
-    url: str = Field(
+    url: StrictStr = Field(
         description="The URL to display",
     )
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables_comm.py
@@ -70,11 +70,11 @@ class VariableList(BaseModel):
         description="A list of variables in the session.",
     )
 
-    length: int = Field(
+    length: StrictInt = Field(
         description="The total number of variables in the session. This may be greater than the number of variables in the 'variables' array if the array is truncated.",
     )
 
-    version: Optional[int] = Field(
+    version: Optional[StrictInt] = Field(
         default=None,
         description="The version of the view (incremented with each update)",
     )
@@ -89,7 +89,7 @@ class InspectedVariable(BaseModel):
         description="The children of the inspected variable.",
     )
 
-    length: int = Field(
+    length: StrictInt = Field(
         description="The total number of children. This may be greater than the number of children in the 'children' array if the array is truncated.",
     )
 
@@ -99,7 +99,7 @@ class FormattedVariable(BaseModel):
     An object formatted for copying to the clipboard.
     """
 
-    content: str = Field(
+    content: StrictStr = Field(
         description="The formatted content of the variable.",
     )
 
@@ -109,27 +109,27 @@ class Variable(BaseModel):
     A single variable in the runtime.
     """
 
-    access_key: str = Field(
+    access_key: StrictStr = Field(
         description="A key that uniquely identifies the variable within the runtime and can be used to access the variable in `inspect` requests",
     )
 
-    display_name: str = Field(
+    display_name: StrictStr = Field(
         description="The name of the variable, formatted for display",
     )
 
-    display_value: str = Field(
+    display_value: StrictStr = Field(
         description="A string representation of the variable's value, formatted for display and possibly truncated",
     )
 
-    display_type: str = Field(
+    display_type: StrictStr = Field(
         description="The variable's type, formatted for display",
     )
 
-    type_info: str = Field(
+    type_info: StrictStr = Field(
         description="Extended information about the variable's type",
     )
 
-    size: int = Field(
+    size: StrictInt = Field(
         description="The size of the variable's value in bytes",
     )
 
@@ -137,19 +137,19 @@ class Variable(BaseModel):
         description="The kind of value the variable represents, such as 'string' or 'number'",
     )
 
-    length: int = Field(
+    length: StrictInt = Field(
         description="The number of elements in the variable, if it is a collection",
     )
 
-    has_children: bool = Field(
+    has_children: StrictBool = Field(
         description="Whether the variable has child variables",
     )
 
-    has_viewer: bool = Field(
+    has_viewer: StrictBool = Field(
         description="True if there is a viewer available for this variable (i.e. the runtime can handle a 'view' request for this variable)",
     )
 
-    is_truncated: bool = Field(
+    is_truncated: StrictBool = Field(
         description="True if the 'value' field is a truncated representation of the variable's value",
     )
 
@@ -199,7 +199,7 @@ class ClearParams(BaseModel):
     Clears (deletes) all variables in the current session.
     """
 
-    include_hidden_objects: bool = Field(
+    include_hidden_objects: StrictBool = Field(
         description="Whether to clear hidden objects in addition to normal variables",
     )
 
@@ -228,7 +228,7 @@ class DeleteParams(BaseModel):
     Deletes the named variables from the current session.
     """
 
-    names: List[str] = Field(
+    names: List[StrictStr] = Field(
         description="The names of the variables to delete.",
     )
 
@@ -257,7 +257,7 @@ class InspectParams(BaseModel):
     Returns the children of a variable, as an array of variables.
     """
 
-    path: List[str] = Field(
+    path: List[StrictStr] = Field(
         description="The path to the variable to inspect, as an array of access keys.",
     )
 
@@ -287,7 +287,7 @@ class ClipboardFormatParams(BaseModel):
     clipboard.
     """
 
-    path: List[str] = Field(
+    path: List[StrictStr] = Field(
         description="The path to the variable to format, as an array of access keys.",
     )
 
@@ -322,7 +322,7 @@ class ViewParams(BaseModel):
     variable.
     """
 
-    path: List[str] = Field(
+    path: List[StrictStr] = Field(
         description="The path to the variable to view, as an array of access keys.",
     )
 
@@ -381,11 +381,11 @@ class UpdateParams(BaseModel):
         description="An array of variables that have been newly assigned.",
     )
 
-    removed: List[str] = Field(
+    removed: List[StrictStr] = Field(
         description="An array of variable names that have been removed.",
     )
 
-    version: int = Field(
+    version: StrictInt = Field(
         description="The version of the view (incremented with each update), or 0 if the backend doesn't track versions.",
     )
 
@@ -399,11 +399,11 @@ class RefreshParams(BaseModel):
         description="An array listing all the variables in the current session.",
     )
 
-    length: int = Field(
+    length: StrictInt = Field(
         description="The number of variables in the current session.",
     )
 
-    version: int = Field(
+    version: StrictInt = Field(
         description="The version of the view (incremented with each update), or 0 if the backend doesn't track versions.",
     )
 

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -96,7 +96,7 @@ const RustTypeMap: Record<string, string> = {
 const PythonTypeMap: Record<string, string> = {
 	'boolean': 'StrictBool',
 	'integer': 'StrictInt',
-	'number': 'StrictFloat',
+	'number': 'Union[StrictInt, StrictFloat]',
 	'string': 'StrictStr',
 	'null': 'null',
 	'array-begin': 'List[',

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -94,18 +94,6 @@ const RustTypeMap: Record<string, string> = {
 
 // Maps from JSON schema types to Python types
 const PythonTypeMap: Record<string, string> = {
-	'boolean': 'bool',
-	'integer': 'int',
-	'number': 'float',
-	'string': 'str',
-	'null': 'null',
-	'array-begin': 'List[',
-	'array-end': ']',
-	'object': 'Dict',
-};
-
-// Maps from JSON schema types to strict Python types
-const PythonStrictTypeMap: Record<string, string> = {
 	'boolean': 'StrictBool',
 	'integer': 'StrictInt',
 	'number': 'StrictFloat',
@@ -908,7 +896,7 @@ from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictI
 			yield `${name} = Union[`;
 			// Options
 			for (const schema of o.oneOf) {
-				yield deriveType(contracts, PythonStrictTypeMap, [schema.name, ...context], schema);
+				yield deriveType(contracts, PythonTypeMap, [schema.name, ...context], schema);
 				yield ', ';
 			}
 			yield ']\n';


### PR DESCRIPTION
Per #3191, we are letting pydantic do silent type coercion in our models, when we should probably be explicitly doing coercions. This may result in there being silent bugs or other issues.

We need to kick the tires on the application to see if this change exposes any JSON validation bugs from messages coming from the front end. It seems the Amalthea should be as strict as this, but we should be careful and check. 