### PR TITLE
Data Explorer: Fix broken pandas view refresh that triggers in variable updates

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
@@ -68,8 +68,8 @@ def kernel() -> PositronIPyKernel:
 
 
 @pytest.fixture
-def shell() -> Iterable[PositronShell]:
-    shell = PositronShell.instance()
+def shell(kernel) -> Iterable[PositronShell]:
+    shell = PositronShell.instance(parent=kernel)
 
     # TODO: For some reason these vars are in user_ns but not user_ns_hidden during tests. For now,
     #       manually add them to user_ns_hidden to replicate running in Positron.


### PR DESCRIPTION
Addresses #3044 where a view refresh was causing the data explorer internals to get into a partial/broken state. The bug in #3044 has been addressed.

Also adds a `kernel` dependency for the `shell` fixture which does not work correctly without this when running a single unit tests with `pytest -k` 