### PR TITLE
Plot actions

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -24,6 +24,7 @@ import { ZoomPlotMenuButton } from 'vs/workbench/contrib/positronPlots/browser/c
 import { PlotClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimePlotClient';
 import { StaticPlotClient } from 'vs/workbench/services/positronPlots/common/staticPlotClient';
 import { INotificationService } from 'vs/platform/notification/common/notification';
+import { PlotsClearAction, PlotsCopyAction, PlotsNextAction, PlotsPreviousAction, PlotsSaveAction } from 'vs/workbench/contrib/positronPlots/browser/positronPlotsActions';
 
 // Constants.
 const kPaddingLeft = 14;
@@ -85,21 +86,21 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	// Clear all the plots from the service.
 	const clearAllPlotsHandler = () => {
 		if (hasPlots) {
-			positronPlotsContext.positronPlotsService.removeAllPlots();
+			props.commandService.executeCommand(PlotsClearAction.ID);
 		}
 	};
 
 	// Navigate to the previous plot in the plot history.
 	const showPreviousPlotHandler = () => {
 		if (!disableLeft) {
-			positronPlotsContext.positronPlotsService.selectPreviousPlot();
+			props.commandService.executeCommand(PlotsPreviousAction.ID);
 		}
 	};
 
 	// Navigate to the next plot in the plot history.
 	const showNextPlotHandler = () => {
 		if (!disableRight) {
-			positronPlotsContext.positronPlotsService.selectNextPlot();
+			props.commandService.executeCommand(PlotsNextAction.ID);
 		}
 	};
 
@@ -107,22 +108,11 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		props.zoomHandler(zoomLevel);
 	};
 	const savePlotHandler = () => {
-		try {
-			positronPlotsContext.positronPlotsService.savePlot();
-		} catch (error) {
-			positronPlotsContext.notificationService.error(localize('positronPlotsServiceSavePlotError', 'Failed to save plot: {0}', error.message));
-		}
+		props.commandService.executeCommand(PlotsSaveAction.ID);
 	};
 
 	const copyPlotHandler = () => {
-		positronPlotsContext.positronPlotsService.copyPlotToClipboard()
-			.then(() => {
-				positronPlotsContext.notificationService.info(localize('positronPlotsServiceCopyToClipboard', 'Plot copied to clipboard'));
-			})
-			.catch((error) => {
-				positronPlotsContext.notificationService.error(localize('positronPlotsServiceCopyToClipboardError', 'Failed to copy plot to clipboard: {0}', error.message));
-			});
-
+		props.commandService.executeCommand(PlotsCopyAction.ID);
 	};
 
 	// Render.

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -17,7 +17,7 @@ import { IPositronPlotsService, POSITRON_PLOTS_VIEW_ID } from 'vs/workbench/serv
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
 import { registerAction2 } from 'vs/platform/actions/common/actions';
-import { PlotsRefreshAction } from 'vs/workbench/contrib/positronPlots/browser/positronPlotsActions';
+import { PlotsClearAction, PlotsCopyAction, PlotsNextAction, PlotsPreviousAction, PlotsRefreshAction, PlotsSaveAction } from 'vs/workbench/contrib/positronPlots/browser/positronPlotsActions';
 import { POSITRON_SESSION_CONTAINER } from 'vs/workbench/contrib/positronSession/browser/positronSessionContainer';
 
 // Register the Positron plots service.
@@ -62,6 +62,11 @@ class PositronPlotsContribution extends Disposable implements IWorkbenchContribu
 
 	private registerActions(): void {
 		registerAction2(PlotsRefreshAction);
+		registerAction2(PlotsSaveAction);
+		registerAction2(PlotsCopyAction);
+		registerAction2(PlotsNextAction);
+		registerAction2(PlotsPreviousAction);
+		registerAction2(PlotsClearAction);
 	}
 }
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -24,7 +24,7 @@ export class PlotsRefreshAction extends Action2 {
 			title: localize2('positronPlots.refreshPlots', 'Refresh Plots'),
 			f1: true,
 			category,
-			precondition: IsDevelopmentContext,
+			precondition: IsDevelopmentContext, // hide this from release until implemented
 		});
 	}
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -3,9 +3,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from 'vs/nls';
+import { localize, localize2 } from 'vs/nls';
 import { ILocalizedString } from 'vs/platform/action/common/action';
 import { Action2 } from 'vs/platform/actions/common/actions';
+import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IPositronPlotsService } from 'vs/workbench/services/positronPlots/common/positronPlots';
 
 export const POSITRON_PLOTS_ACTION_CATEGORY = nls.localize('positronPlotsCategory', "Plots");
 const category: ILocalizedString = { value: POSITRON_PLOTS_ACTION_CATEGORY, original: 'Plots' };
@@ -17,9 +21,10 @@ export class PlotsRefreshAction extends Action2 {
 	constructor() {
 		super({
 			id: PlotsRefreshAction.ID,
-			title: { value: 'Refresh Plots', original: 'Refresh Plots' },
+			title: localize2('positronPlots.refreshPlots', 'Refresh Plots'),
 			f1: true,
-			category
+			category,
+			precondition: IsDevelopmentContext,
 		});
 	}
 
@@ -30,5 +35,141 @@ export class PlotsRefreshAction extends Action2 {
 	 */
 	async run(accessor: ServicesAccessor) {
 		// TODO: Implement a plots service.
+	}
+}
+
+export class PlotsSaveAction extends Action2 {
+	static ID = 'workbench.action.positronPlots.save';
+
+	constructor() {
+		super({
+			id: PlotsSaveAction.ID,
+			title: localize2('positronPlots.savePlots', 'Save Plot'),
+			category,
+			f1: true,
+		});
+	}
+
+	/**
+	 * Runs the action and saves the plots.
+	 *
+	 * @param accessor The service accessor.
+	 */
+	async run(accessor: ServicesAccessor) {
+		const plotsService = accessor.get(IPositronPlotsService);
+		if (plotsService.selectedPlotId) {
+			try {
+				plotsService.savePlot();
+			} catch (error) {
+				accessor.get(INotificationService).error(localize('positronPlotsServiceSavePlotError', 'Failed to save plot: {0}', error.message));
+			}
+		} else {
+			accessor.get(INotificationService).info(localize('positronPlots.noPlotSelected', 'No plot selected.'));
+		}
+	}
+}
+
+export class PlotsCopyAction extends Action2 {
+	static ID = 'workbench.action.positronPlots.copy';
+
+	constructor() {
+		super({
+			id: PlotsCopyAction.ID,
+			title: localize2('positronPlots.copyPlot', 'Copy Plot'),
+			category,
+			f1: true,
+		});
+	}
+
+	/**
+	 * Runs the action and copies the plots.
+	 *
+	 * @param accessor The service accessor.
+	 */
+	async run(accessor: ServicesAccessor) {
+		const plotsService = accessor.get(IPositronPlotsService);
+		const notificationService = accessor.get(INotificationService);
+		if (plotsService.selectedPlotId) {
+			plotsService.copyPlotToClipboard()
+				.then(() => {
+					notificationService.info(localize('positronPlots.plotCopied', 'Plot copied to clipboard.'));
+				}
+				).catch((error) => {
+					notificationService.error(localize('positronPlotsServiceCopyToClipboardError', 'Failed to copy plot to clipboard: {0}', error.message));
+				});
+		} else {
+			notificationService.info(localize('positronPlots.noPlotSelected', 'No plot selected.'));
+		}
+	}
+}
+
+export class PlotsNextAction extends Action2 {
+	static ID = 'workbench.action.positronPlots.next';
+
+	constructor() {
+		super({
+			id: PlotsNextAction.ID,
+			title: localize2('positronPlots.nextPlot', 'Select Next Plot'),
+			category,
+			f1: true,
+		});
+	}
+
+	/**
+	 * Runs the action and selects the next plot.
+	 *
+	 * @param accessor The service accessor.
+	 */
+	async run(accessor: ServicesAccessor) {
+		const plotsService = accessor.get(IPositronPlotsService);
+		plotsService.selectNextPlot();
+	}
+}
+
+export class PlotsPreviousAction extends Action2 {
+	static ID = 'workbench.action.positronPlots.previous';
+
+	constructor() {
+		super({
+			id: PlotsPreviousAction.ID,
+			title: localize2('positronPlots.previousPlot', 'Select Previous Plot'),
+			category,
+			f1: true,
+		});
+	}
+
+	/**
+	 * Runs the action and selects the previous plot.
+	 *
+	 * @param accessor The service accessor.
+	 */
+	async run(accessor: ServicesAccessor) {
+		const plotsService = accessor.get(IPositronPlotsService);
+		plotsService.selectPreviousPlot();
+	}
+}
+
+export class PlotsClearAction extends Action2 {
+	static ID = 'workbench.action.positronPlots.clear';
+
+	constructor() {
+		super({
+			id: PlotsClearAction.ID,
+			title: localize2('positronPlots.clearPlots', 'Clear Plots'),
+			category,
+			f1: true,
+		});
+	}
+
+	/**
+	 * Runs the action and clears the plots.
+	 *
+	 * @param accessor The service accessor.
+	 */
+	async run(accessor: ServicesAccessor) {
+		const plotsService = accessor.get(IPositronPlotsService);
+		if (plotsService.positronPlotInstances.length > 0) {
+			plotsService.removeAllPlots();
+		}
 	}
 }


### PR DESCRIPTION
### Intent
Address #3208 and #3209 

### Approach
Hides refresh plot in release builds and add in actions for save, copy, next, previous, and clear. No action for zooming since that isn't as easy to implement.

### QA Notes
The actions are seen in the command palette when searching 'plot'. No keyboard shortcuts have been added at the moment.