### PR TITLE
Fast-boot for new projects

### DIFF
--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -27,6 +27,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 import { IPositronNewProjectService } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
+import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 
 /**
  * The PositronNewProjectAction.
@@ -89,6 +90,7 @@ export class PositronNewProjectAction extends Action2 {
 			accessor.get(IPositronNewProjectService),
 			accessor.get(IRuntimeSessionService),
 			accessor.get(IRuntimeStartupService),
+			accessor.get(IWorkspaceTrustManagementService)
 		);
 	}
 }

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -24,6 +24,7 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IPositronNewProjectService, NewProjectConfiguration } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
 import { EnvironmentSetupType } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
 import { getEnvProviderInfoList } from 'vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils';
+import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 
 /**
  * Shows the NewProjectModalDialog.
@@ -41,6 +42,7 @@ export const showNewProjectModalDialog = async (
 	positronNewProjectService: IPositronNewProjectService,
 	runtimeSessionService: IRuntimeSessionService,
 	runtimeStartupService: IRuntimeStartupService,
+	workspaceTrustManagementService: IWorkspaceTrustManagementService
 ): Promise<void> => {
 	// Create the renderer.
 	const renderer = new PositronModalReactRenderer({
@@ -107,7 +109,7 @@ export const showNewProjectModalDialog = async (
 
 					// Create the new project configuration.
 					const newProjectConfig: NewProjectConfiguration = {
-						runtimeId: result.selectedRuntime?.runtimeId || '',
+						runtimeMetadata: result.selectedRuntime || undefined,
 						projectType: result.projectType || '',
 						projectFolder: folder.fsPath,
 						initGitRepo: result.initGitRepo,
@@ -123,6 +125,10 @@ export const showNewProjectModalDialog = async (
 
 					// Store the new project configuration.
 					positronNewProjectService.storeNewProjectConfig(newProjectConfig);
+
+					// Pre-trust the new folder so the user isn't prompted to
+					// trust the folder when the project is opened.
+					workspaceTrustManagementService.setUrisTrust([folder], true);
 
 					// Any context-dependent work needs to be done before opening the folder
 					// because the extension host gets destroyed when a new project is opened,

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -75,7 +75,8 @@ export const showNewProjectModalDialog = async (
 				createProject={async result => {
 					// Create the new project folder if it doesn't already exist.
 					const folder = URI.file((await pathService.path).join(result.parentFolder, result.projectName));
-					if (!(await fileService.exists(folder))) {
+					const existingFolder = await fileService.exists(folder);
+					if (!existingFolder) {
 						await fileService.createFolder(folder);
 					}
 
@@ -126,9 +127,10 @@ export const showNewProjectModalDialog = async (
 					// Store the new project configuration.
 					positronNewProjectService.storeNewProjectConfig(newProjectConfig);
 
-					// Pre-trust the new folder so the user isn't prompted to
-					// trust the folder when the project is opened.
-					workspaceTrustManagementService.setUrisTrust([folder], true);
+					// If the folder is new, set its trust state to trusted.
+					if (!existingFolder) {
+						workspaceTrustManagementService.setUrisTrust([folder], true);
+					}
 
 					// Any context-dependent work needs to be done before opening the folder
 					// because the extension host gets destroyed when a new project is opened,

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -4,6 +4,8 @@
 
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { Event } from 'vs/base/common/event';
+import { ILanguageRuntimeMetadata } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { Barrier } from 'vs/base/common/async';
 
 export const POSITRON_NEW_PROJECT_CONFIG_STORAGE_KEY = 'positron.newProjectConfig';
 
@@ -56,7 +58,7 @@ export enum NewProjectTask {
  * NewProjectConfiguration interface. Defines the configuration for a new project.
  */
 export interface NewProjectConfiguration {
-	readonly runtimeId: string;
+	readonly runtimeMetadata: ILanguageRuntimeMetadata | undefined;
 	readonly projectType: string;
 	readonly projectFolder: string;
 	readonly initGitRepo: boolean;
@@ -106,6 +108,16 @@ export interface IPositronNewProjectService {
 	 * @returns Whether the new project was initialized.
 	 */
 	initNewProject(): Promise<void>;
+
+	/**
+	 * Barrier for other services to wait for all project tasks to complete.
+	 */
+	allTasksComplete: Barrier;
+
+	/**
+	 * Returns the metadata for the metadata for the runtime chosen for the new project.
+	 */
+	readonly newProjectRuntimeMetadata: ILanguageRuntimeMetadata | undefined;
 
 	/**
 	 * Stores the new project configuration in the storage service.

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -115,7 +115,8 @@ export interface IPositronNewProjectService {
 	allTasksComplete: Barrier;
 
 	/**
-	 * Returns the metadata for the metadata for the runtime chosen for the new project.
+	 * Returns the metadata for the runtime chosen for the new project, or
+	 * undefined if this isn't a new project.
 	 */
 	readonly newProjectRuntimeMetadata: ILanguageRuntimeMetadata | undefined;
 

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -70,10 +70,12 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 		// Parse the new project configuration from the storage service
 		this._newProjectConfig = this._parseNewProjectConfig();
 
-		// If no new project configuration is found, the new project startup is complete
 		if (this._newProjectConfig === null) {
+			// If no new project configuration is found, the new project startup
+			// is complete
 			this.allTasksComplete.open();
 		} else {
+			// If new project configuration is found, save the runtime metadata
 			this._runtimeMetadata = this._newProjectConfig.runtimeMetadata;
 		}
 

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -70,7 +70,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 		// Parse the new project configuration from the storage service
 		this._newProjectConfig = this._parseNewProjectConfig();
 
-		if (this._newProjectConfig === null) {
+		if (!_isCurrentWindowNewProject()) {
 			// If no new project configuration is found, the new project startup
 			// is complete
 			this.allTasksComplete.open();


### PR DESCRIPTION
### Intent

Makes new projects boot quickly; skips the workspace trust and discovery phases so you're dropped into a workspace with a live interpreter immediately. 

Addresses #3098
Addresses #3124 

### Approach

When creating a project in a new folder, extend trust to the folder before opening it, so that the user isn't asked to trust something that was just created. 

When creating a new project, pause the runtime startup process until all new-project tasks have completed. If the new project's configuration names some runtime metadata, adopt it as the workspace's affiliated runtime, which causes it to start without waiting for all runtimes to be discovered. 

### QA Notes

This change doesn't attempt to make a trust decision based on the location of the workspace but rather on whether or not it is in a wholly new folder, on the rationale that if the folder started out empty and we are responsible for everything added to it, it's safe to extend trust. Creating a project from an existing folder should still trigger a trust prompt (and may also trigger a discovery pass for similar reasons) if the parent folder is untrusted, just like "Open Folder" in VS Code. 