### PR TITLE
Fix bug introduced when we added keybindings to the positron notebooks.

### DIFF
--- a/src/vs/workbench/services/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/ContextKeysManager.ts
@@ -12,9 +12,6 @@ import { IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/cont
  */
 export const POSITRON_NOTEBOOK_EDITOR_FOCUSED = new RawContextKey<boolean>('positronNotebookEditorFocused', false);
 
-// This is a copy of the existing vscode notebook context key. We can't directly import their copy
-// due to import rules
-// const NOTEBOOK_EDITOR_FOCUSED = new RawContextKey<boolean>('notebookEditorFocused', false);
 
 /**
  * Class to handle context keys for positron notebooks
@@ -30,7 +27,6 @@ export class PositronNotebookContextKeyManager extends Disposable {
 
 	//#region Public Properties
 	positronEditorFocus?: IContextKey<boolean>;
-	// editorFocus?: IContextKey<boolean>;
 	//#endregion Public Properties
 
 	//#region Constructor & Dispose
@@ -48,17 +44,14 @@ export class PositronNotebookContextKeyManager extends Disposable {
 		this._scopedContextKeyService = this._contextKeyService.createScoped(this._container);
 
 		this.positronEditorFocus = POSITRON_NOTEBOOK_EDITOR_FOCUSED.bindTo(this._scopedContextKeyService);
-		// this.editorFocus = NOTEBOOK_EDITOR_FOCUSED.bindTo(this._scopedContextKeyService);
 
 		const focusTracker = this._register(DOM.trackFocus(container));
 		this._register(focusTracker.onDidFocus(() => {
 			this.positronEditorFocus?.set(true);
-			// this.editorFocus?.set(true);
 		}));
 
 		this._register(focusTracker.onDidBlur(() => {
 			this.positronEditorFocus?.set(false);
-			// this.editorFocus?.set(false);
 		}));
 	}
 

--- a/src/vs/workbench/services/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/ContextKeysManager.ts
@@ -14,7 +14,7 @@ export const POSITRON_NOTEBOOK_EDITOR_FOCUSED = new RawContextKey<boolean>('posi
 
 // This is a copy of the existing vscode notebook context key. We can't directly import their copy
 // due to import rules
-const NOTEBOOK_EDITOR_FOCUSED = new RawContextKey<boolean>('notebookEditorFocused', false);
+// const NOTEBOOK_EDITOR_FOCUSED = new RawContextKey<boolean>('notebookEditorFocused', false);
 
 /**
  * Class to handle context keys for positron notebooks
@@ -30,7 +30,7 @@ export class PositronNotebookContextKeyManager extends Disposable {
 
 	//#region Public Properties
 	positronEditorFocus?: IContextKey<boolean>;
-	editorFocus?: IContextKey<boolean>;
+	// editorFocus?: IContextKey<boolean>;
 	//#endregion Public Properties
 
 	//#region Constructor & Dispose
@@ -48,17 +48,17 @@ export class PositronNotebookContextKeyManager extends Disposable {
 		this._scopedContextKeyService = this._contextKeyService.createScoped(this._container);
 
 		this.positronEditorFocus = POSITRON_NOTEBOOK_EDITOR_FOCUSED.bindTo(this._scopedContextKeyService);
-		this.editorFocus = NOTEBOOK_EDITOR_FOCUSED.bindTo(this._scopedContextKeyService);
+		// this.editorFocus = NOTEBOOK_EDITOR_FOCUSED.bindTo(this._scopedContextKeyService);
 
 		const focusTracker = this._register(DOM.trackFocus(container));
 		this._register(focusTracker.onDidFocus(() => {
 			this.positronEditorFocus?.set(true);
-			this.editorFocus?.set(true);
+			// this.editorFocus?.set(true);
 		}));
 
 		this._register(focusTracker.onDidBlur(() => {
 			this.positronEditorFocus?.set(false);
-			this.editorFocus?.set(false);
+			// this.editorFocus?.set(false);
 		}));
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

When we added keyboard shortcuts for the positron notebooks we inadvertently broke almost all the keybindings for the vscode notebooks. This PR fixes this. 

### Approach

Previously we reused the existing keybinding action IDs (e.g. we rebound the action/keybinding `notebook.cell.executeAndFocusContainer`.) This caused the original keybinding to not fire even if the context key was not satisfied. 
Here we simply prefix all these actions with a new id of `positronNotebook.*`.  Since this now means the jupyter-keybindings extension won't target our notebooks we copy those keybindings with the `secondary` keybinding field. 
Also we stop faking the existing notebook context key to avoid the same conflict in reverse. 

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
