### PR TITLE
Format the interpreter path as code in the ipykernel install dialog

### DIFF
--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -217,7 +217,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
 
             const product = Product.ipykernel;
             const message = vscode.l10n.t(
-                'To enable Python support, Positron needs to {0} the package "{1}" for the active interpreter {2} at: <code>{3}</code>.',
+                'To enable Python support, Positron needs to {0} the package <code>{1}</code> for the active interpreter {2} at: <code>{3}</code>.',
                 installOrUpgrade,
                 ProductNames.get(product)!,
                 `Python ${this.runtimeMetadata.languageVersion}`,

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -217,7 +217,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
 
             const product = Product.ipykernel;
             const message = vscode.l10n.t(
-                'To enable Python support, Positron needs to {0} the package "{1}" for the active interpreter {2} at: {3}.',
+                'To enable Python support, Positron needs to {0} the package "{1}" for the active interpreter {2} at: <code>{3}</code>.',
                 installOrUpgrade,
                 ProductNames.get(product)!,
                 `Python ${this.runtimeMetadata.languageVersion}`,

--- a/src/vs/workbench/contrib/positronModalDialogs/browser/positronModalDialogs.tsx
+++ b/src/vs/workbench/contrib/positronModalDialogs/browser/positronModalDialogs.tsx
@@ -118,7 +118,14 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 		renderer.render(
 			<PositronModalDialog renderer={renderer} title={title} width={400} height={200} onAccept={acceptHandler} onCancel={cancelHandler}>
 				<ContentArea>
-					{message}
+					{renderHtml(
+						message,
+						{
+							componentOverrides: {
+								a: (props) => <ExternalLink {...props} openerService={this._openerService} />
+							}
+						}
+					)}
 				</ContentArea>
 				<OKCancelActionBar
 					okButtonTitle={okButtonTitle}


### PR DESCRIPTION
I noticed we weren't rendering html for one of the modal types so added that in order to format our modal.

After:

<img width="413" alt="image" src="https://github.com/posit-dev/positron/assets/559360/e7712566-b8bd-4f83-b2f7-031a197ef396">
