### PR TITLE
Address 2254 by using IHoverService to display actual datatype

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorCell.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorCell.css
@@ -58,7 +58,7 @@
 	opacity: 80%;
 	display: flex;
 	align-items: center;
-	justify-content: left;
+	justify-content: center;
 	grid-column: icon / title;
 }
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/dropDownColumnSelector.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/dropDownColumnSelector.css
@@ -40,7 +40,7 @@
 	opacity: 80%;
 	display: flex;
 	align-items: center;
-	justify-content: left;
+	justify-content: center;
 	grid-column: icon / title;
 }
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
@@ -50,7 +50,7 @@
 	display: flex;
 	cursor: pointer;
 	align-items: center;
-	justify-content: center;
+	justify-content: right;
 	grid-column: expand-collapse / icon;
 }
 
@@ -81,7 +81,7 @@
 	opacity: 80%;
 	display: flex;
 	align-items: center;
-	justify-content: left;
+	justify-content: center;
 	grid-column: icon / title;
 }
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -46,7 +46,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			content: `${props.columnSchema.type_name}`,
 			target: dataTypeRef.current,
 			position: {
-				hoverPosition: HoverPosition.LEFT,
+				hoverPosition: HoverPosition.ABOVE,
 			},
 			persistence: {
 				hideOnHover: false

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -7,8 +7,11 @@ import 'vs/css!./columnSummaryCell';
 
 // React.
 import * as React from 'react';
+import { useRef } from 'react'; // eslint-disable-line no-duplicate-imports
 
 // Other dependencies.
+import { IHoverService } from 'vs/platform/hover/browser/hover';
+import { HoverPosition } from 'vs/base/browser/ui/hover/hoverWidget';
 import { ProfileNumber } from 'vs/workbench/services/positronDataExplorer/browser/components/profileNumber';
 import { ProfileString } from 'vs/workbench/services/positronDataExplorer/browser/components/profileString';
 import { ColumnNullPercent } from 'vs/workbench/services/positronDataExplorer/browser/components/columnNullPercent';
@@ -19,6 +22,7 @@ import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronData
  * ColumnSummaryCellProps interface.
  */
 interface ColumnSummaryCellProps {
+	hoverService: IHoverService;
 	instance: TableSummaryDataGridInstance;
 	columnSchema: ColumnSchema;
 	columnIndex: number;
@@ -31,11 +35,38 @@ interface ColumnSummaryCellProps {
  * @returns The rendered component.
  */
 export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
+	// Reference hooks.
+	const dataTypeRef = useRef<HTMLDivElement>(undefined!);
+
 	/**
-	 * Returns the data type icon for the column schema.
-	 * @returns The data type icon.
+	 * onMouseOver event handler.
 	 */
-	const dataTypeIcon = () => {
+	const mouseOverHandler = () => {
+		props.hoverService.showHover({
+			content: `${props.columnSchema.type_name}`,
+			target: dataTypeRef.current,
+			position: {
+				hoverPosition: HoverPosition.LEFT,
+			},
+			persistence: {
+				hideOnHover: false
+			},
+			appearance: {
+				showHoverHint: true,
+				showPointer: true
+			}
+		}, false);
+	};
+
+	/**
+	 * onMouseLeave event handler.
+	 */
+	const mouseLeaveHandler = () => {
+		props.hoverService.hideHover();
+	};
+
+	// Set the data type icon.
+	const dataTypeIcon = (() => {
 		// Determine the alignment based on type.
 		switch (props.columnSchema.type_display) {
 			case ColumnDisplayType.Number:
@@ -69,13 +100,11 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			default:
 				return 'codicon-question';
 		}
-	};
+	})();
 
-	/**
-	 * Returns the profile component for the column.
-	 * @returns The profile component.
-	 */
-	const profile = () => {
+	// Set the profile component for the column.
+	const profile = (() => {
+
 		// Determine the alignment based on type.
 		switch (props.columnSchema.type_display) {
 			case ColumnDisplayType.Number:
@@ -115,7 +144,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			default:
 				return null;
 		}
-	};
+	})();
 
 	// Get the expanded state of the column.
 	const expanded = props.instance.isColumnExpanded(props.columnIndex);
@@ -145,7 +174,12 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 					}
 				</div>
 
-				<div className={`data-type-icon codicon ${dataTypeIcon()}`}></div>
+				<div
+					ref={dataTypeRef}
+					className={`data-type-icon codicon ${dataTypeIcon}`}
+					onMouseOver={mouseOverHandler}
+					onMouseLeave={mouseLeaveHandler}
+				/>
 				<div className='column-name'>
 					{props.columnSchema.column_name}
 				</div>
@@ -156,7 +190,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			</div>
 			{expanded &&
 				<div className='profile-info'>
-					{profile()}
+					{profile}
 				</div>
 			}
 		</div>

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -4,13 +4,14 @@
 
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
+import { IHoverService } from 'vs/platform/hover/browser/hover';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { DataExplorerCache } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
 import { TableDataDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance';
 import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
 import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
 import { PositronDataExplorerLayout } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
 import { IPositronDataExplorerInstance } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 /**
  * PositronDataExplorerInstance class.
@@ -87,13 +88,14 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	/**
 	 * Constructor.
 	 * @param configurationService The configuration service.
+	 * @param hoverService The hover service.
 	 * @param languageName The language name.
-	 * @param dataExplorerClientInstance The DataExplorerClientInstance. The
-	 * data explorer takes ownership of the client instance and will dispose it
-	 * when it is disposed.
+	 * @param dataExplorerClientInstance The DataExplorerClientInstance. The data explorer takes
+	 * ownership of the client instance and will dispose it when it is disposed.
 	 */
 	constructor(
 		configurationService: IConfigurationService,
+		hoverService: IHoverService,
 		languageName: string,
 		dataExplorerClientInstance: DataExplorerClientInstance
 	) {
@@ -106,6 +108,7 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 		this._dataExplorerCache = new DataExplorerCache(dataExplorerClientInstance);
 		this._tableSchemaDataGridInstance = new TableSummaryDataGridInstance(
 			configurationService,
+			hoverService,
 			dataExplorerClientInstance,
 			this._dataExplorerCache
 		);

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -5,8 +5,10 @@
 import { localize } from 'vs/nls';
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
+import { IHoverService } from 'vs/platform/hover/browser/hover';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { PositronDataExplorerUri } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerUri';
 import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
@@ -14,7 +16,6 @@ import { PositronDataExplorerInstance } from 'vs/workbench/services/positronData
 import { ILanguageRuntimeSession, IRuntimeSessionService, RuntimeClientType } from '../../runtimeSession/common/runtimeSessionService';
 import { IPositronDataExplorerService } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
 import { IPositronDataExplorerInstance } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 /**
  * DataExplorerRuntime class.
@@ -119,12 +120,14 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	 * Constructor.
 	 * @param _configurationService The configuration service.
 	 * @param _editorService The editor service.
+	 * @param _hoverService The hover service.
 	 * @param _notificationService The notification service.
 	 * @param _runtimeSessionService The language runtime session service.
 	 */
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IEditorService private readonly _editorService: IEditorService,
+		@IHoverService private readonly _hoverService: IHoverService,
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService
 	) {
@@ -281,6 +284,7 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 			dataExplorerClientInstance.identifier,
 			new PositronDataExplorerInstance(
 				this._configurationService,
+				this._hoverService,
 				languageName,
 				dataExplorerClientInstance
 			)

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 
 // Other dependencies.
 import { Emitter } from 'vs/base/common/event';
+import { IHoverService } from 'vs/platform/hover/browser/hover';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { DataGridInstance } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
 import { DataExplorerCache } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
@@ -43,11 +44,13 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	/**
 	 * Constructor.
 	 * @param _configurationService The configuration service.
+	 * @param _hoverService The hover service.
 	 * @param _dataExplorerClientInstance The DataExplorerClientInstance.
 	 * @param _dataExplorerCache The DataExplorerCache.
 	 */
 	constructor(
 		private readonly _configurationService: IConfigurationService,
+		private readonly _hoverService: IHoverService,
 		private readonly _dataExplorerClientInstance: DataExplorerClientInstance,
 		private readonly _dataExplorerCache: DataExplorerCache
 	) {
@@ -211,6 +214,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		// Return the ColumnSummaryCell.
 		return (
 			<ColumnSummaryCell
+				hoverService={this._hoverService}
 				instance={this}
 				columnSchema={columnSchema}
 				columnIndex={rowIndex}


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

To address https://github.com/posit-dev/positron/issues/2254, this PR uses the `IHoverService` to instantaneously display the data type when a user hovers over a data type icon in a Data Explorer.

<img width="401" alt="image" src="https://github.com/posit-dev/positron/assets/853239/cbd8a73e-d036-47f5-9162-d0382b2abcf4">

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

Some people might not like that the display is instantaneous. We'll see how people react.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
