### PR TITLE
Data Explorer: Update backend state to get new table shape after data update event

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
@@ -209,6 +209,9 @@ export class DataExplorerCache extends Disposable {
 		this._dataCellCache.clear();
 		this._columnNullCountCache.clear();
 		this._columnSummaryStatsCache.clear();
+
+		// On an update event, table shape may have changed
+		this._dataExplorerClientInstance.updateBackendState();
 	}
 
 	/**


### PR DESCRIPTION
This addresses #3218 where removing rows from a table does not update the shape of the waffle. When invalidating the data cache, we also trigger a state update which must process before the next data requests go through.