### PR TITLE
Debounce StatusBarActivityIndicator component

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.css
@@ -2,53 +2,18 @@
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
-.data-explorer-panel .status-bar {
-	display: flex;
+.data-explorer-panel
+.status-bar {
 	padding: 0;
+	display: flex;
 	align-items: center;
 	grid-row: status-bar / end;
 	border-top: 1px solid var(--vscode-positronDataExplorer-border);
 	background-color: var(--vscode-positronDataExplorer-contrastBackground);
 }
 
-.data-explorer-panel .status-bar .label {
+.data-explorer-panel
+.status-bar
+.label {
 	opacity: 80%;
-}
-
-.data-explorer-panel .status-bar .status-bar-indicator {
-	padding: 0 2px;
-	margin-right: 8px;
-	height: 100%;
-	display: flex;
-	align-items: center;
-	padding-left: 2px;
-	border-right: 1px solid var(--vscode-positronDataExplorer-border);
-}
-
-.data-explorer-panel .status-bar .status-bar-indicator .action-bar-separator {
-	margin-left: 4px;
-}
-
-.data-explorer-panel .status-bar .status-bar-indicator .icon {
-	height: 20px;
-	width: 20px;
-}
-
-.data-explorer-panel .status-bar .status-bar-indicator .icon.computing {
-	background-image: url(status-active.svg);
-	animation: status-icon-rotate-computing 1.5s linear infinite;
-}
-
-@keyframes status-icon-rotate-computing {
-	to {
-		transform: rotate(360deg);
-	}
-}
-
-.data-explorer-panel .status-bar .status-bar-indicator .icon.idle {
-	background-image: url(status-idle.svg);
-}
-
-.data-explorer-panel .status-bar .status-bar-indicator .icon.disconnected {
-	background-image: url(status-disconnected.svg);
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.tsx
@@ -10,50 +10,9 @@ import * as React from 'react';
 import { useEffect, useState } from 'react'; // eslint-disable-line no-duplicate-imports
 
 // Other dependencies.
-import { localize } from 'vs/nls';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { usePositronDataExplorerContext } from 'vs/workbench/browser/positronDataExplorer/positronDataExplorerContext';
-import { DataExplorerClientStatus } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
-
-interface ActivityIndicatorProps {
-	status: DataExplorerClientStatus;
-}
-
-const StatusBarActivityIndicator = (props: ActivityIndicatorProps) => {
-	const getStatusText = () => {
-		switch (props.status) {
-			case DataExplorerClientStatus.Idle:
-				return localize('positron.dataExplorer.idle', 'Idle');
-			case DataExplorerClientStatus.Computing:
-				return localize('positron.dataExplorer.computing', 'Computing');
-			case DataExplorerClientStatus.Disconnected:
-				return localize('positron.dataExplorer.disconnected', 'Disconnected');
-			case DataExplorerClientStatus.Error:
-				return localize('positron.dataExplorer.error', 'Error');
-		}
-	};
-
-	const getStatusClass = () => {
-		switch (props.status) {
-			case DataExplorerClientStatus.Idle:
-				return 'idle';
-			case DataExplorerClientStatus.Computing:
-				return 'computing';
-			case DataExplorerClientStatus.Disconnected:
-				return 'disconnected';
-			case DataExplorerClientStatus.Error:
-				return 'error';
-		}
-	};
-
-	return (
-		<div className='status-bar-indicator'>
-			<div className={`icon ${getStatusClass()}`}
-				title={getStatusText()}
-				aria-label={getStatusText()}></div>
-		</div>
-	);
-};
+import { StatusBarActivityIndicator } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBarActivityIndicator';
 
 /**
  * StatusBar component.
@@ -65,10 +24,8 @@ export const StatusBar = () => {
 
 	// State hooks.
 	const [backendState, setBackendState] = useState(
-		context.instance.dataExplorerClientInstance.cachedBackendState);
-
-	const [clientStatus, setClientStatus] = useState(
-		context.instance.dataExplorerClientInstance.status);
+		context.instance.dataExplorerClientInstance.cachedBackendState
+	);
 
 	// Main useEffect.
 	useEffect(() => {
@@ -80,32 +37,29 @@ export const StatusBar = () => {
 			state => setBackendState(state)
 		));
 
-		// Set up onDidStatusUpdate event handler.
-		disposableStore.add(context.instance.dataExplorerClientInstance.onDidStatusUpdate(
-			status => setClientStatus(status)
-		));
-
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
 	}, [context.instance.dataExplorerClientInstance]);
 
-	// Render.
-	let numRows = 0;
-	let numColumns = 0;
-	if (backendState !== undefined) {
+	// Set the number of rows and numbr of columns.
+	let numRows;
+	let numColumns;
+	if (!backendState) {
+		numRows = 0;
+		numColumns = 0;
+	} else {
 		numRows = backendState.table_shape.num_rows;
 		numColumns = backendState?.table_shape.num_columns;
 	}
 
+	// Render.
 	if (backendState && backendState.row_filters.length > 0) {
 		const numUnfilteredRows = backendState.table_unfiltered_shape.num_rows;
 		const pctFiltered = numUnfilteredRows === 0 ? 0 : 100 * numRows / numUnfilteredRows;
 
 		return (
 			<div className='status-bar'>
-				<StatusBarActivityIndicator
-					status={clientStatus}
-				/>
+				<StatusBarActivityIndicator />
 				<span className='label'>Showing</span>
 				<span>&nbsp;</span>
 				<span className='counter'>{numRows.toLocaleString()}</span>
@@ -124,9 +78,7 @@ export const StatusBar = () => {
 	} else {
 		return (
 			<div className='status-bar'>
-				<StatusBarActivityIndicator
-					status={clientStatus}
-				/>
+				<StatusBarActivityIndicator />
 				<span className='counter'>{numRows.toLocaleString()}</span>
 				<span>&nbsp;</span>
 				<span className='label'>rows</span>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBar.tsx
@@ -41,7 +41,7 @@ export const StatusBar = () => {
 		return () => disposableStore.dispose();
 	}, [context.instance.dataExplorerClientInstance]);
 
-	// Set the number of rows and numbr of columns.
+	// Set the number of rows and number of columns.
 	let numRows;
 	let numColumns;
 	if (!backendState) {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBarActivityIndicator.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBarActivityIndicator.css
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+.data-explorer-panel
+.status-bar
+.status-bar-indicator {
+	padding: 0 2px;
+	margin-right: 8px;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	padding-left: 2px;
+	border-right: 1px solid var(--vscode-positronDataExplorer-border);
+}
+
+.data-explorer-panel
+.status-bar
+.status-bar-indicator
+.action-bar-separator {
+	margin-left: 4px;
+}
+
+.data-explorer-panel
+.status-bar
+.status-bar-indicator
+.icon {
+	height: 20px;
+	width: 20px;
+}
+
+.data-explorer-panel
+.status-bar
+.status-bar-indicator
+.icon.computing {
+	background-image: url(status-active.svg);
+	animation: status-icon-rotate-computing 1.5s linear infinite;
+}
+
+@keyframes status-icon-rotate-computing {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.data-explorer-panel
+.status-bar
+.status-bar-indicator
+.icon.idle {
+	background-image: url(status-idle.svg);
+}
+
+.data-explorer-panel
+.status-bar
+.status-bar-indicator
+.icon.disconnected {
+	background-image: url(status-disconnected.svg);
+}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBarActivityIndicator.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBarActivityIndicator.tsx
@@ -1,0 +1,105 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import 'vs/css!./statusBarActivityIndicator';
+
+// React.
+import * as React from 'react';
+import { useEffect, useState } from 'react'; // eslint-disable-line no-duplicate-imports
+
+// Other dependencies.
+import { localize } from 'vs/nls';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { usePositronDataExplorerContext } from 'vs/workbench/browser/positronDataExplorer/positronDataExplorerContext';
+import { DataExplorerClientStatus } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
+
+/**
+ * StatusBarActivityIndicator component.
+ * @returns The rendered component.
+ */
+export const StatusBarActivityIndicator = () => {
+	// Context hooks.
+	const context = usePositronDataExplorerContext();
+
+	// State hooks.
+	const [dataExplorerClientStatus, setDataExplorerClientStatus] = useState(
+		context.instance.dataExplorerClientInstance.status
+	);
+
+	// Main useEffect.
+	useEffect(() => {
+		// Create the disposable store for cleanup.
+		const disposableStore = new DisposableStore();
+
+		// Set up onDidStatusUpdate event handler.
+		let debounceTimeout: NodeJS.Timeout | undefined = undefined;
+		disposableStore.add(context.instance.dataExplorerClientInstance.onDidStatusUpdate(
+			newDataExplorerClientStatus => {
+				// If there is a debounce timeout in flight, clear it.
+				if (debounceTimeout) {
+					clearTimeout(debounceTimeout);
+					debounceTimeout = undefined;
+				}
+
+				// When transitioning from idle to something else, update the data explorer client
+				// status immediately. Otherwise, debounce the status update.
+				if (dataExplorerClientStatus === DataExplorerClientStatus.Idle &&
+					dataExplorerClientStatus !== newDataExplorerClientStatus
+				) {
+					setDataExplorerClientStatus(newDataExplorerClientStatus);
+				} else {
+					debounceTimeout = setTimeout(
+						() => setDataExplorerClientStatus(newDataExplorerClientStatus),
+						250
+					);
+				}
+			}
+		));
+
+		// Return the cleanup function that will dispose of the event handlers.
+		return () => disposableStore.dispose();
+	}, [context.instance.dataExplorerClientInstance, dataExplorerClientStatus]);
+
+	// Set the status text.
+	const statusText = (() => {
+		switch (dataExplorerClientStatus) {
+			case DataExplorerClientStatus.Idle:
+				return localize('positron.dataExplorer.idle', 'Idle');
+
+			case DataExplorerClientStatus.Computing:
+				return localize('positron.dataExplorer.computing', 'Computing');
+
+			case DataExplorerClientStatus.Disconnected:
+				return localize('positron.dataExplorer.disconnected', 'Disconnected');
+
+			case DataExplorerClientStatus.Error:
+				return localize('positron.dataExplorer.error', 'Error');
+		}
+	})();
+
+	// Set the status class name.
+	const statusClassName = (() => {
+		switch (dataExplorerClientStatus) {
+			case DataExplorerClientStatus.Idle:
+				return 'idle';
+
+			case DataExplorerClientStatus.Computing:
+				return 'computing';
+
+			case DataExplorerClientStatus.Disconnected:
+				return 'disconnected';
+
+			case DataExplorerClientStatus.Error:
+				return 'error';
+		}
+	})();
+
+	// Render.
+	return (
+		<div className='status-bar-indicator'>
+			<div className={`icon ${statusClassName}`} title={statusText} aria-label={statusText} />
+		</div>
+	);
+};


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

Addressed https://github.com/posit-dev/positron/issues/2947 by debouncing status updates.

Also, I moved the StatusBarActivityIndicator into its own CSS and TSX files.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

The theory of operation is that when we transition from the `Idle` status to any other status, the status is updated immediately. Otherwise, status changes are debounced at 250ms, which I found was the best timeout.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

See:

https://github.com/posit-dev/positron/assets/853239/54ba434f-06d8-49c0-9167-23dcae0aa201

