### PR TITLE
Wait until data explorer headers are not empty & don't wait for ipykernel install

### DIFF
--- a/test/automation/src/positron/positronDataExplorer.ts
+++ b/test/automation/src/positron/positronDataExplorer.ts
@@ -21,8 +21,10 @@ export class PositronDataExplorer {
 
 	async getDataExplorerTableData(expectedColumns: number, expectedRows: number): Promise<object[]> {
 
-		const headers = await this.code.waitForElements(`${COLUMN_HEADERS} ${HEADER_TITLES}`, false, (elements) => elements.length === expectedColumns);
-		const rows = await this.code.waitForElements(`${DATA_GRID_ROWS} ${DATA_GRID_ROW}`, true, (elements) => elements.length === expectedRows);
+		const headers = await this.code.waitForElements(`${COLUMN_HEADERS} ${HEADER_TITLES}`, false, (elements) =>
+			elements.length === expectedColumns && elements.every((element) => element.textContent !== ''));
+		const rows = await this.code.waitForElements(`${DATA_GRID_ROWS} ${DATA_GRID_ROW}`, true, (elements) =>
+			elements.length === expectedRows);
 		const headerNames = headers.map((header) => header.textContent);
 
 		const tableData: object[] = [];

--- a/test/automation/src/positron/positronStartInterpreter.ts
+++ b/test/automation/src/positron/positronStartInterpreter.ts
@@ -59,7 +59,9 @@ export class StartInterpreter {
 
 		} else {
 			console.log('Primary interpreter matched');
-			await this.code.waitAndClick(`${INTERPRETER_GROUPS}:nth-of-type(${primaryInterpreter.index})`);
+			chosenInterpreter = this.code.driver.getLocator(`${INTERPRETER_GROUPS}:nth-of-type(${primaryInterpreter.index})`);
+			await chosenInterpreter.waitFor({ state: 'visible' });
+			await chosenInterpreter.click();
 		}
 
 		for (let i = 0; i < 10; i++) {

--- a/test/automation/src/positron/positronStartInterpreter.ts
+++ b/test/automation/src/positron/positronStartInterpreter.ts
@@ -4,7 +4,6 @@
 
 
 import { Code } from '../code';
-import { PositronPopups } from './positronPopups';
 
 interface InterpreterGroupLocation {
 	description: string;
@@ -28,7 +27,7 @@ export enum InterpreterType {
 
 export class StartInterpreter {
 
-	constructor(private code: Code, private positronPopups: PositronPopups) { }
+	constructor(private code: Code) { }
 
 	async selectInterpreter(desiredInterpreterType: InterpreterType, desiredInterpreterString: string) {
 
@@ -63,24 +62,18 @@ export class StartInterpreter {
 			await this.code.waitAndClick(`${INTERPRETER_GROUPS}:nth-of-type(${primaryInterpreter.index})`);
 		}
 
-		if (desiredInterpreterType === InterpreterType.Python) {
-			// noop if dialog does not appear
-			await this.positronPopups.installIPyKernel();
-		}
-
 		for (let i = 0; i < 10; i++) {
 			try {
 				const dialog = this.code.driver.getLocator(POSITRON_MODAL_POPUP);
 				await dialog.waitFor({ state: 'detached', timeout: 2000 });
 				break;
-			} catch {
-				console.log('Retrying row click');
+			} catch (e) {
+				console.log(`Error: ${e}, Retrying row click`);
 				try {
 					await chosenInterpreter!.click({ timeout: 1000 });
-					if (desiredInterpreterType === InterpreterType.Python) {
-						await this.positronPopups.installIPyKernel();
-					}
-				} catch { }
+				} catch (f) {
+					console.log(`Inner Error: ${f}}`);
+				}
 			}
 		}
 	}

--- a/test/automation/src/workbench.ts
+++ b/test/automation/src/workbench.ts
@@ -90,7 +90,7 @@ export class Workbench {
 
 		// --- Start Positron ---
 		this.positronPopups = new PositronPopups(code);
-		this.startInterpreter = new StartInterpreter(code, this.positronPopups);
+		this.startInterpreter = new StartInterpreter(code);
 		this.positronConsole = new PositronConsole(code, this.quickaccess, this.quickinput);
 		this.positronVariables = new PositronVariables(code);
 		this.positronDataExplorer = new PositronDataExplorer(code);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Waiting before processing contents of data explorer until the headers are not empty (in addition to waiting for the proper dimensions)
Stop checking for popup related to ipykernel install as it is preinstalled.
Fix for logic that would reclick the interpreter selector (when its used again in a special test case) when the primary selector is the one that matches.

### Approach

These are all various test reliability fixes for CI only.

### QA Notes

All smoke tests pass
