### PR TITLE
Increase plot render timeout; silently cancel pending renders if a plot comm closes

### DIFF
--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -1382,8 +1382,7 @@ import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/co
 					yield ', ';
 				}
 			}
-			yield ']';
-			yield ');\n';
+			yield ']);\n';
 			yield `\t}\n\n`;
 		}
 	}

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -1324,6 +1324,9 @@ import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/co
 				yield formatComment('\t * ',
 					`@param ${snakeCaseToCamelCase(param.name)} ${param.description}`);
 			}
+			yield formatComment('\t * ',
+				'@param timeout Timeout in milliseconds after which to error if the server does ' +
+				'not respond');
 			yield `\t *\n`;
 			if (method.result && method.result.schema) {
 				yield formatComment('\t * ',
@@ -1343,11 +1346,9 @@ import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/co
 				} else {
 					yield deriveType(contracts, TypescriptTypeMap, [method.name, param.name], schema);
 				}
-				if (i < method.params.length - 1) {
-					yield ', ';
-				}
+				yield ', ';
 			}
-			yield '): Promise<';
+			yield 'timeout?: number): Promise<';
 			if (method.result && method.result.schema) {
 				if (method.result.schema.type === 'object') {
 					yield snakeCaseToSentenceCase(method.result.schema.name);
@@ -1372,7 +1373,7 @@ import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/co
 					yield ', ';
 				}
 			}
-			yield ']);\n';
+			yield '], timeout);\n';
 			yield `\t}\n\n`;
 		}
 	}

--- a/positron/comms/plot-backend-openrpc.json
+++ b/positron/comms/plot-backend-openrpc.json
@@ -66,8 +66,7 @@
 						"mime_type"
 					]
 				}
-			},
-			"x-default-timeout": 30000
+			}
 		}
 	]
 }

--- a/positron/comms/plot-backend-openrpc.json
+++ b/positron/comms/plot-backend-openrpc.json
@@ -66,7 +66,8 @@
 						"mime_type"
 					]
 				}
-			}
+			},
+			"x-default-timeout": 30000
 		}
 	]
 }

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance.ts
@@ -73,7 +73,7 @@ export interface IRuntimeClientInstance<Input, Output> extends Disposable {
 	onDidReceiveData: Event<Output>;
 	getClientId(): string;
 	getClientType(): RuntimeClientType;
-	performRpc(request: Input): Promise<Output>;
+	performRpc(request: Input, timeout: number): Promise<Output>;
 	messageCounter: ISettableObservable<number>;
 	clientState: ISettableObservable<RuntimeClientState>;
 }

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -217,6 +217,10 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 		clientStateEvent((state) => {
 			if (state === RuntimeClientState.Closed) {
 				this._closeEmitter.fire();
+
+				// Silently cancel any pending render requests
+				this._currentRender?.cancel();
+				this._queuedRender?.cancel();
 			}
 			this._stateEmitter.fire(PlotClientState.Closed);
 		});

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -209,7 +209,7 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 		public readonly metadata: IPositronPlotMetadata) {
 		super();
 
-		this._comm = new PositronPlotComm(client);
+		this._comm = new PositronPlotComm(client, { render: { timeout: 30_000 } });
 
 		// Connect close emitter event
 		this.onDidClose = this._closeEmitter.event;
@@ -406,8 +406,7 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 		this._comm.render(renderRequest.height,
 			renderRequest.width,
 			renderRequest.pixel_ratio,
-			renderRequest.format,
-			30_000).then((response) => {
+			renderRequest.format).then((response) => {
 
 				// Ignore if the request was cancelled or already fulfilled
 				if (!request.isComplete) {

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -406,7 +406,8 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 		this._comm.render(renderRequest.height,
 			renderRequest.width,
 			renderRequest.pixel_ratio,
-			renderRequest.format).then((response) => {
+			renderRequest.format,
+			30_000).then((response) => {
 
 				// Ignore if the request was cancelled or already fulfilled
 				if (!request.isComplete) {

--- a/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
@@ -48,6 +48,9 @@ export type PositronCommOptions<T extends string> = {
 	[key in T]?: PositronCommRpcOptions;
 };
 
+/**
+ * Options for a specific RPC of a {@link PositronBaseComm}.
+ */
 export interface PositronCommRpcOptions {
 	/**
 	 * Timeout in milliseconds after which to error if the server does not respond.

--- a/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
@@ -181,12 +181,15 @@ export class PositronBaseComm extends Disposable {
 	 * @param rpcName The name of the RPC to perform.
 	 * @param paramNames The parameter names
 	 * @param paramValues The parameter values
+	 * @param timeout Timeout in milliseconds after which to error if the server does not respond,
+	 *   defaults to 5 seconds.
 	 * @returns A promise that resolves to the result of the RPC, or rejects
 	 *  with a PositronCommError.
 	 */
 	protected async performRpc<T>(rpcName: string,
 		paramNames: Array<string>,
-		paramValues: Array<any>): Promise<T> {
+		paramValues: Array<any>,
+		timeout: number = 5000): Promise<T> {
 
 		// Create the RPC arguments from the parameter names and values. This
 		// allows us to pass the parameters as positional parameters, but
@@ -211,7 +214,7 @@ export class PositronBaseComm extends Disposable {
 		// Perform the RPC
 		let response = {} as any;
 		try {
-			response = await this.clientInstance.performRpc(request);
+			response = await this.clientInstance.performRpc(request, timeout);
 		} catch (err) {
 			// Convert the error to a runtime method error. This handles errors
 			// that occur while performing the RPC; if the RPC is successfully

--- a/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
@@ -182,7 +182,7 @@ export class PositronBaseComm extends Disposable {
 	 * @param paramNames The parameter names
 	 * @param paramValues The parameter values
 	 * @param timeout Timeout in milliseconds after which to error if the server does not respond,
-	 *   defaults to 5 seconds.
+	 *   defaults to 5 seconds
 	 * @returns A promise that resolves to the result of the RPC, or rejects
 	 *  with a PositronCommError.
 	 */

--- a/src/vs/workbench/services/languageRuntime/common/positronConnectionsComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronConnectionsComm.ts
@@ -73,11 +73,13 @@ export class PositronConnectionsComm extends PositronBaseComm {
 	 * and views.
 	 *
 	 * @param path The path to object that we want to list children.
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns Array of objects names and their kinds.
 	 */
-	listObjects(path: Array<ObjectSchema>): Promise<Array<ObjectSchema>> {
-		return super.performRpc('list_objects', ['path'], [path]);
+	listObjects(path: Array<ObjectSchema>, timeout?: number): Promise<Array<ObjectSchema>> {
+		return super.performRpc('list_objects', ['path'], [path], timeout);
 	}
 
 	/**
@@ -86,11 +88,13 @@ export class PositronConnectionsComm extends PositronBaseComm {
 	 * List fields of an object, such as columns of a table or view.
 	 *
 	 * @param path The path to object that we want to list fields.
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns Array of field names and data types.
 	 */
-	listFields(path: Array<ObjectSchema>): Promise<Array<FieldSchema>> {
-		return super.performRpc('list_fields', ['path'], [path]);
+	listFields(path: Array<ObjectSchema>, timeout?: number): Promise<Array<FieldSchema>> {
+		return super.performRpc('list_fields', ['path'], [path], timeout);
 	}
 
 	/**
@@ -100,11 +104,13 @@ export class PositronConnectionsComm extends PositronBaseComm {
 	 *
 	 * @param path The path to object that we want to check if it contains
 	 * data.
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns Boolean indicating if the object contains data.
 	 */
-	containsData(path: Array<ObjectSchema>): Promise<boolean> {
-		return super.performRpc('contains_data', ['path'], [path]);
+	containsData(path: Array<ObjectSchema>, timeout?: number): Promise<boolean> {
+		return super.performRpc('contains_data', ['path'], [path], timeout);
 	}
 
 	/**
@@ -113,11 +119,13 @@ export class PositronConnectionsComm extends PositronBaseComm {
 	 * Get icon of an object, such as a table or view.
 	 *
 	 * @param path The path to object that we want to get the icon.
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns The icon of the object.
 	 */
-	getIcon(path: Array<ObjectSchema>): Promise<string> {
-		return super.performRpc('get_icon', ['path'], [path]);
+	getIcon(path: Array<ObjectSchema>, timeout?: number): Promise<string> {
+		return super.performRpc('get_icon', ['path'], [path], timeout);
 	}
 
 	/**
@@ -126,11 +134,13 @@ export class PositronConnectionsComm extends PositronBaseComm {
 	 * Preview object data, such as a table or view.
 	 *
 	 * @param path The path to object that we want to preview.
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns undefined
 	 */
-	previewObject(path: Array<ObjectSchema>): Promise<null> {
-		return super.performRpc('preview_object', ['path'], [path]);
+	previewObject(path: Array<ObjectSchema>, timeout?: number): Promise<null> {
+		return super.performRpc('preview_object', ['path'], [path], timeout);
 	}
 
 

--- a/src/vs/workbench/services/languageRuntime/common/positronConnectionsComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronConnectionsComm.ts
@@ -7,7 +7,7 @@
 //
 
 import { Event } from 'vs/base/common/event';
-import { PositronBaseComm } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
+import { PositronBaseComm, PositronCommOptions } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
 
 /**
@@ -59,9 +59,20 @@ export enum ConnectionsFrontendEvent {
 	Update = 'update'
 }
 
+export enum ConnectionsBackendRequest {
+	ListObjects = 'list_objects',
+	ListFields = 'list_fields',
+	ContainsData = 'contains_data',
+	GetIcon = 'get_icon',
+	PreviewObject = 'preview_object'
+}
+
 export class PositronConnectionsComm extends PositronBaseComm {
-	constructor(instance: IRuntimeClientInstance<any, any>) {
-		super(instance);
+	constructor(
+		instance: IRuntimeClientInstance<any, any>,
+		options?: PositronCommOptions<ConnectionsBackendRequest>,
+	) {
+		super(instance, options);
 		this.onDidFocus = super.createEventEmitter('focus', []);
 		this.onDidUpdate = super.createEventEmitter('update', []);
 	}
@@ -73,13 +84,11 @@ export class PositronConnectionsComm extends PositronBaseComm {
 	 * and views.
 	 *
 	 * @param path The path to object that we want to list children.
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns Array of objects names and their kinds.
 	 */
-	listObjects(path: Array<ObjectSchema>, timeout?: number): Promise<Array<ObjectSchema>> {
-		return super.performRpc('list_objects', ['path'], [path], timeout);
+	listObjects(path: Array<ObjectSchema>): Promise<Array<ObjectSchema>> {
+		return super.performRpc('list_objects', ['path'], [path]);
 	}
 
 	/**
@@ -88,13 +97,11 @@ export class PositronConnectionsComm extends PositronBaseComm {
 	 * List fields of an object, such as columns of a table or view.
 	 *
 	 * @param path The path to object that we want to list fields.
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns Array of field names and data types.
 	 */
-	listFields(path: Array<ObjectSchema>, timeout?: number): Promise<Array<FieldSchema>> {
-		return super.performRpc('list_fields', ['path'], [path], timeout);
+	listFields(path: Array<ObjectSchema>): Promise<Array<FieldSchema>> {
+		return super.performRpc('list_fields', ['path'], [path]);
 	}
 
 	/**
@@ -104,13 +111,11 @@ export class PositronConnectionsComm extends PositronBaseComm {
 	 *
 	 * @param path The path to object that we want to check if it contains
 	 * data.
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns Boolean indicating if the object contains data.
 	 */
-	containsData(path: Array<ObjectSchema>, timeout?: number): Promise<boolean> {
-		return super.performRpc('contains_data', ['path'], [path], timeout);
+	containsData(path: Array<ObjectSchema>): Promise<boolean> {
+		return super.performRpc('contains_data', ['path'], [path]);
 	}
 
 	/**
@@ -119,13 +124,11 @@ export class PositronConnectionsComm extends PositronBaseComm {
 	 * Get icon of an object, such as a table or view.
 	 *
 	 * @param path The path to object that we want to get the icon.
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns The icon of the object.
 	 */
-	getIcon(path: Array<ObjectSchema>, timeout?: number): Promise<string> {
-		return super.performRpc('get_icon', ['path'], [path], timeout);
+	getIcon(path: Array<ObjectSchema>): Promise<string> {
+		return super.performRpc('get_icon', ['path'], [path]);
 	}
 
 	/**
@@ -134,13 +137,11 @@ export class PositronConnectionsComm extends PositronBaseComm {
 	 * Preview object data, such as a table or view.
 	 *
 	 * @param path The path to object that we want to preview.
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns undefined
 	 */
-	previewObject(path: Array<ObjectSchema>, timeout?: number): Promise<null> {
-		return super.performRpc('preview_object', ['path'], [path], timeout);
+	previewObject(path: Array<ObjectSchema>): Promise<null> {
+		return super.performRpc('preview_object', ['path'], [path]);
 	}
 
 

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -7,7 +7,7 @@
 //
 
 import { Event } from 'vs/base/common/event';
-import { PositronBaseComm } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
+import { PositronBaseComm, PositronCommOptions } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
 
 /**
@@ -682,9 +682,22 @@ export enum DataExplorerFrontendEvent {
 	DataUpdate = 'data_update'
 }
 
+export enum DataExplorerBackendRequest {
+	GetSchema = 'get_schema',
+	SearchSchema = 'search_schema',
+	GetDataValues = 'get_data_values',
+	SetRowFilters = 'set_row_filters',
+	SetSortColumns = 'set_sort_columns',
+	GetColumnProfiles = 'get_column_profiles',
+	GetState = 'get_state'
+}
+
 export class PositronDataExplorerComm extends PositronBaseComm {
-	constructor(instance: IRuntimeClientInstance<any, any>) {
-		super(instance);
+	constructor(
+		instance: IRuntimeClientInstance<any, any>,
+		options?: PositronCommOptions<DataExplorerBackendRequest>,
+	) {
+		super(instance, options);
 		this.onDidSchemaUpdate = super.createEventEmitter('schema_update', []);
 		this.onDidDataUpdate = super.createEventEmitter('data_update', []);
 	}
@@ -697,13 +710,11 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * @param startIndex First column schema to fetch (inclusive)
 	 * @param numColumns Number of column schemas to fetch from start index.
 	 * May extend beyond end of table
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns undefined
 	 */
-	getSchema(startIndex: number, numColumns: number, timeout?: number): Promise<TableSchema> {
-		return super.performRpc('get_schema', ['start_index', 'num_columns'], [startIndex, numColumns], timeout);
+	getSchema(startIndex: number, numColumns: number): Promise<TableSchema> {
+		return super.performRpc('get_schema', ['start_index', 'num_columns'], [startIndex, numColumns]);
 	}
 
 	/**
@@ -715,13 +726,11 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * @param startIndex Index (starting from zero) of first result to fetch
 	 * @param maxResults Maximum number of resulting column schemas to fetch
 	 * from the start index
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns undefined
 	 */
-	searchSchema(searchTerm: string, startIndex: number, maxResults: number, timeout?: number): Promise<SearchSchemaResult> {
-		return super.performRpc('search_schema', ['search_term', 'start_index', 'max_results'], [searchTerm, startIndex, maxResults], timeout);
+	searchSchema(searchTerm: string, startIndex: number, maxResults: number): Promise<SearchSchemaResult> {
+		return super.performRpc('search_schema', ['search_term', 'start_index', 'max_results'], [searchTerm, startIndex, maxResults]);
 	}
 
 	/**
@@ -734,13 +743,11 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * beyond end of table
 	 * @param columnIndices Indices to select, which can be a sequential,
 	 * sparse, or random selection
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns Table values formatted as strings
 	 */
-	getDataValues(rowStartIndex: number, numRows: number, columnIndices: Array<number>, timeout?: number): Promise<TableData> {
-		return super.performRpc('get_data_values', ['row_start_index', 'num_rows', 'column_indices'], [rowStartIndex, numRows, columnIndices], timeout);
+	getDataValues(rowStartIndex: number, numRows: number, columnIndices: Array<number>): Promise<TableData> {
+		return super.performRpc('get_data_values', ['row_start_index', 'num_rows', 'column_indices'], [rowStartIndex, numRows, columnIndices]);
 	}
 
 	/**
@@ -749,13 +756,11 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * Set or clear row filters on table, replacing any previous filters
 	 *
 	 * @param filters Zero or more filters to apply
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns The result of applying filters to a table
 	 */
-	setRowFilters(filters: Array<RowFilter>, timeout?: number): Promise<FilterResult> {
-		return super.performRpc('set_row_filters', ['filters'], [filters], timeout);
+	setRowFilters(filters: Array<RowFilter>): Promise<FilterResult> {
+		return super.performRpc('set_row_filters', ['filters'], [filters]);
 	}
 
 	/**
@@ -766,12 +771,10 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 *
 	 * @param sortKeys Pass zero or more keys to sort by. Clears any existing
 	 * keys
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 */
-	setSortColumns(sortKeys: Array<ColumnSortKey>, timeout?: number): Promise<void> {
-		return super.performRpc('set_sort_columns', ['sort_keys'], [sortKeys], timeout);
+	setSortColumns(sortKeys: Array<ColumnSortKey>): Promise<void> {
+		return super.performRpc('set_sort_columns', ['sort_keys'], [sortKeys]);
 	}
 
 	/**
@@ -780,13 +783,11 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * Requests a statistical summary or data profile for batch of columns
 	 *
 	 * @param profiles Array of requested profiles
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns undefined
 	 */
-	getColumnProfiles(profiles: Array<ColumnProfileRequest>, timeout?: number): Promise<Array<ColumnProfileResult>> {
-		return super.performRpc('get_column_profiles', ['profiles'], [profiles], timeout);
+	getColumnProfiles(profiles: Array<ColumnProfileRequest>): Promise<Array<ColumnProfileResult>> {
+		return super.performRpc('get_column_profiles', ['profiles'], [profiles]);
 	}
 
 	/**
@@ -795,13 +796,11 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * Request the current backend state (shape, filters, sort keys,
 	 * features)
 	 *
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns The current backend state for the data explorer
 	 */
-	getState(timeout?: number): Promise<BackendState> {
-		return super.performRpc('get_state', [], [], timeout);
+	getState(): Promise<BackendState> {
+		return super.performRpc('get_state', [], []);
 	}
 
 

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -697,11 +697,13 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * @param startIndex First column schema to fetch (inclusive)
 	 * @param numColumns Number of column schemas to fetch from start index.
 	 * May extend beyond end of table
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns undefined
 	 */
-	getSchema(startIndex: number, numColumns: number): Promise<TableSchema> {
-		return super.performRpc('get_schema', ['start_index', 'num_columns'], [startIndex, numColumns]);
+	getSchema(startIndex: number, numColumns: number, timeout?: number): Promise<TableSchema> {
+		return super.performRpc('get_schema', ['start_index', 'num_columns'], [startIndex, numColumns], timeout);
 	}
 
 	/**
@@ -713,11 +715,13 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * @param startIndex Index (starting from zero) of first result to fetch
 	 * @param maxResults Maximum number of resulting column schemas to fetch
 	 * from the start index
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns undefined
 	 */
-	searchSchema(searchTerm: string, startIndex: number, maxResults: number): Promise<SearchSchemaResult> {
-		return super.performRpc('search_schema', ['search_term', 'start_index', 'max_results'], [searchTerm, startIndex, maxResults]);
+	searchSchema(searchTerm: string, startIndex: number, maxResults: number, timeout?: number): Promise<SearchSchemaResult> {
+		return super.performRpc('search_schema', ['search_term', 'start_index', 'max_results'], [searchTerm, startIndex, maxResults], timeout);
 	}
 
 	/**
@@ -730,11 +734,13 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * beyond end of table
 	 * @param columnIndices Indices to select, which can be a sequential,
 	 * sparse, or random selection
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns Table values formatted as strings
 	 */
-	getDataValues(rowStartIndex: number, numRows: number, columnIndices: Array<number>): Promise<TableData> {
-		return super.performRpc('get_data_values', ['row_start_index', 'num_rows', 'column_indices'], [rowStartIndex, numRows, columnIndices]);
+	getDataValues(rowStartIndex: number, numRows: number, columnIndices: Array<number>, timeout?: number): Promise<TableData> {
+		return super.performRpc('get_data_values', ['row_start_index', 'num_rows', 'column_indices'], [rowStartIndex, numRows, columnIndices], timeout);
 	}
 
 	/**
@@ -743,11 +749,13 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * Set or clear row filters on table, replacing any previous filters
 	 *
 	 * @param filters Zero or more filters to apply
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns The result of applying filters to a table
 	 */
-	setRowFilters(filters: Array<RowFilter>): Promise<FilterResult> {
-		return super.performRpc('set_row_filters', ['filters'], [filters]);
+	setRowFilters(filters: Array<RowFilter>, timeout?: number): Promise<FilterResult> {
+		return super.performRpc('set_row_filters', ['filters'], [filters], timeout);
 	}
 
 	/**
@@ -758,10 +766,12 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 *
 	 * @param sortKeys Pass zero or more keys to sort by. Clears any existing
 	 * keys
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 */
-	setSortColumns(sortKeys: Array<ColumnSortKey>): Promise<void> {
-		return super.performRpc('set_sort_columns', ['sort_keys'], [sortKeys]);
+	setSortColumns(sortKeys: Array<ColumnSortKey>, timeout?: number): Promise<void> {
+		return super.performRpc('set_sort_columns', ['sort_keys'], [sortKeys], timeout);
 	}
 
 	/**
@@ -770,11 +780,13 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * Requests a statistical summary or data profile for batch of columns
 	 *
 	 * @param profiles Array of requested profiles
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns undefined
 	 */
-	getColumnProfiles(profiles: Array<ColumnProfileRequest>): Promise<Array<ColumnProfileResult>> {
-		return super.performRpc('get_column_profiles', ['profiles'], [profiles]);
+	getColumnProfiles(profiles: Array<ColumnProfileRequest>, timeout?: number): Promise<Array<ColumnProfileResult>> {
+		return super.performRpc('get_column_profiles', ['profiles'], [profiles], timeout);
 	}
 
 	/**
@@ -783,11 +795,13 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * Request the current backend state (shape, filters, sort keys,
 	 * features)
 	 *
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns The current backend state for the data explorer
 	 */
-	getState(): Promise<BackendState> {
-		return super.performRpc('get_state', [], []);
+	getState(timeout?: number): Promise<BackendState> {
+		return super.performRpc('get_state', [], [], timeout);
 	}
 
 

--- a/src/vs/workbench/services/languageRuntime/common/positronHelpComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronHelpComm.ts
@@ -59,12 +59,14 @@ export class PositronHelpComm extends PositronBaseComm {
 	 * delivered.
 	 *
 	 * @param topic The help topic to show
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns Whether the topic was found and shown. Topics are shown via a
 	 * Show Help notification.
 	 */
-	showHelpTopic(topic: string): Promise<boolean> {
-		return super.performRpc('show_help_topic', ['topic'], [topic]);
+	showHelpTopic(topic: string, timeout?: number): Promise<boolean> {
+		return super.performRpc('show_help_topic', ['topic'], [topic], timeout);
 	}
 
 

--- a/src/vs/workbench/services/languageRuntime/common/positronHelpComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronHelpComm.ts
@@ -7,7 +7,7 @@
 //
 
 import { Event } from 'vs/base/common/event';
-import { PositronBaseComm } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
+import { PositronBaseComm, PositronCommOptions } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
 
 /**
@@ -44,9 +44,16 @@ export enum HelpFrontendEvent {
 	ShowHelp = 'show_help'
 }
 
+export enum HelpBackendRequest {
+	ShowHelpTopic = 'show_help_topic'
+}
+
 export class PositronHelpComm extends PositronBaseComm {
-	constructor(instance: IRuntimeClientInstance<any, any>) {
-		super(instance);
+	constructor(
+		instance: IRuntimeClientInstance<any, any>,
+		options?: PositronCommOptions<HelpBackendRequest>,
+	) {
+		super(instance, options);
 		this.onDidShowHelp = super.createEventEmitter('show_help', ['content', 'kind', 'focus']);
 	}
 
@@ -59,14 +66,12 @@ export class PositronHelpComm extends PositronBaseComm {
 	 * delivered.
 	 *
 	 * @param topic The help topic to show
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns Whether the topic was found and shown. Topics are shown via a
 	 * Show Help notification.
 	 */
-	showHelpTopic(topic: string, timeout?: number): Promise<boolean> {
-		return super.performRpc('show_help_topic', ['topic'], [topic], timeout);
+	showHelpTopic(topic: string): Promise<boolean> {
+		return super.performRpc('show_help_topic', ['topic'], [topic]);
 	}
 
 

--- a/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
@@ -7,7 +7,7 @@
 //
 
 import { Event } from 'vs/base/common/event';
-import { PositronBaseComm } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
+import { PositronBaseComm, PositronCommOptions } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
 
 /**
@@ -53,9 +53,16 @@ export enum PlotFrontendEvent {
 	Show = 'show'
 }
 
+export enum PlotBackendRequest {
+	Render = 'render'
+}
+
 export class PositronPlotComm extends PositronBaseComm {
-	constructor(instance: IRuntimeClientInstance<any, any>) {
-		super(instance);
+	constructor(
+		instance: IRuntimeClientInstance<any, any>,
+		options?: PositronCommOptions<PlotBackendRequest>,
+	) {
+		super(instance, options);
 		this.onDidUpdate = super.createEventEmitter('update', []);
 		this.onDidShow = super.createEventEmitter('show', []);
 	}
@@ -70,13 +77,11 @@ export class PositronPlotComm extends PositronBaseComm {
 	 * @param width The requested plot width, in pixels
 	 * @param pixelRatio The pixel ratio of the display device
 	 * @param format The requested plot format
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns A rendered plot
 	 */
-	render(height: number, width: number, pixelRatio: number, format: RenderFormat, timeout?: number): Promise<PlotResult> {
-		return super.performRpc('render', ['height', 'width', 'pixel_ratio', 'format'], [height, width, pixelRatio, format], timeout);
+	render(height: number, width: number, pixelRatio: number, format: RenderFormat): Promise<PlotResult> {
+		return super.performRpc('render', ['height', 'width', 'pixel_ratio', 'format'], [height, width, pixelRatio, format]);
 	}
 
 

--- a/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
@@ -70,11 +70,13 @@ export class PositronPlotComm extends PositronBaseComm {
 	 * @param width The requested plot width, in pixels
 	 * @param pixelRatio The pixel ratio of the display device
 	 * @param format The requested plot format
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns A rendered plot
 	 */
-	render(height: number, width: number, pixelRatio: number, format: RenderFormat): Promise<PlotResult> {
-		return super.performRpc('render', ['height', 'width', 'pixel_ratio', 'format'], [height, width, pixelRatio, format], 30_000);
+	render(height: number, width: number, pixelRatio: number, format: RenderFormat, timeout?: number): Promise<PlotResult> {
+		return super.performRpc('render', ['height', 'width', 'pixel_ratio', 'format'], [height, width, pixelRatio, format], timeout);
 	}
 
 

--- a/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
@@ -74,7 +74,7 @@ export class PositronPlotComm extends PositronBaseComm {
 	 * @returns A rendered plot
 	 */
 	render(height: number, width: number, pixelRatio: number, format: RenderFormat): Promise<PlotResult> {
-		return super.performRpc('render', ['height', 'width', 'pixel_ratio', 'format'], [height, width, pixelRatio, format]);
+		return super.performRpc('render', ['height', 'width', 'pixel_ratio', 'format'], [height, width, pixelRatio, format], 30_000);
 	}
 
 

--- a/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
@@ -469,11 +469,13 @@ export class PositronUiComm extends PositronBaseComm {
 	 *
 	 * @param method The method to call inside the interpreter
 	 * @param params The parameters for `method`
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns The method result
 	 */
-	callMethod(method: string, params: Array<Param>): Promise<CallMethodResult> {
-		return super.performRpc('call_method', ['method', 'params'], [method, params]);
+	callMethod(method: string, params: Array<Param>, timeout?: number): Promise<CallMethodResult> {
+		return super.performRpc('call_method', ['method', 'params'], [method, params], timeout);
 	}
 
 

--- a/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
@@ -7,7 +7,7 @@
 //
 
 import { Event } from 'vs/base/common/event';
-import { PositronBaseComm } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
+import { PositronBaseComm, PositronCommOptions } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
 
 /**
@@ -445,9 +445,16 @@ export enum UiFrontendRequest {
 	LastActiveEditorContext = 'last_active_editor_context'
 }
 
+export enum UiBackendRequest {
+	CallMethod = 'call_method'
+}
+
 export class PositronUiComm extends PositronBaseComm {
-	constructor(instance: IRuntimeClientInstance<any, any>) {
-		super(instance);
+	constructor(
+		instance: IRuntimeClientInstance<any, any>,
+		options?: PositronCommOptions<UiBackendRequest>,
+	) {
+		super(instance, options);
 		this.onDidBusy = super.createEventEmitter('busy', ['busy']);
 		this.onDidClearConsole = super.createEventEmitter('clear_console', []);
 		this.onDidOpenEditor = super.createEventEmitter('open_editor', ['file', 'line', 'column']);
@@ -469,13 +476,11 @@ export class PositronUiComm extends PositronBaseComm {
 	 *
 	 * @param method The method to call inside the interpreter
 	 * @param params The parameters for `method`
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns The method result
 	 */
-	callMethod(method: string, params: Array<Param>, timeout?: number): Promise<CallMethodResult> {
-		return super.performRpc('call_method', ['method', 'params'], [method, params], timeout);
+	callMethod(method: string, params: Array<Param>): Promise<CallMethodResult> {
+		return super.performRpc('call_method', ['method', 'params'], [method, params]);
 	}
 
 

--- a/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
@@ -226,11 +226,13 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 *
 	 * Returns a list of all the variables in the current session.
 	 *
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns A view containing a list of variables in the session.
 	 */
-	list(): Promise<VariableList> {
-		return super.performRpc('list', [], []);
+	list(timeout?: number): Promise<VariableList> {
+		return super.performRpc('list', [], [], timeout);
 	}
 
 	/**
@@ -240,10 +242,12 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 *
 	 * @param includeHiddenObjects Whether to clear hidden objects in
 	 * addition to normal variables
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 */
-	clear(includeHiddenObjects: boolean): Promise<void> {
-		return super.performRpc('clear', ['include_hidden_objects'], [includeHiddenObjects]);
+	clear(includeHiddenObjects: boolean, timeout?: number): Promise<void> {
+		return super.performRpc('clear', ['include_hidden_objects'], [includeHiddenObjects], timeout);
 	}
 
 	/**
@@ -252,11 +256,13 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 * Deletes the named variables from the current session.
 	 *
 	 * @param names The names of the variables to delete.
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns The names of the variables that were successfully deleted.
 	 */
-	delete(names: Array<string>): Promise<Array<string>> {
-		return super.performRpc('delete', ['names'], [names]);
+	delete(names: Array<string>, timeout?: number): Promise<Array<string>> {
+		return super.performRpc('delete', ['names'], [names], timeout);
 	}
 
 	/**
@@ -266,11 +272,13 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 *
 	 * @param path The path to the variable to inspect, as an array of access
 	 * keys.
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns An inspected variable.
 	 */
-	inspect(path: Array<string>): Promise<InspectedVariable> {
-		return super.performRpc('inspect', ['path'], [path]);
+	inspect(path: Array<string>, timeout?: number): Promise<InspectedVariable> {
+		return super.performRpc('inspect', ['path'], [path], timeout);
 	}
 
 	/**
@@ -282,11 +290,13 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 * @param path The path to the variable to format, as an array of access
 	 * keys.
 	 * @param format The requested format for the variable, as a MIME type
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns An object formatted for copying to the clipboard.
 	 */
-	clipboardFormat(path: Array<string>, format: ClipboardFormatFormat): Promise<FormattedVariable> {
-		return super.performRpc('clipboard_format', ['path', 'format'], [path, format]);
+	clipboardFormat(path: Array<string>, format: ClipboardFormatFormat, timeout?: number): Promise<FormattedVariable> {
+		return super.performRpc('clipboard_format', ['path', 'format'], [path, format], timeout);
 	}
 
 	/**
@@ -297,11 +307,13 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 *
 	 * @param path The path to the variable to view, as an array of access
 	 * keys.
+	 * @param timeout Timeout in milliseconds after which to error if the
+	 * server does not respond
 	 *
 	 * @returns The ID of the viewer that was opened.
 	 */
-	view(path: Array<string>): Promise<string> {
-		return super.performRpc('view', ['path'], [path]);
+	view(path: Array<string>, timeout?: number): Promise<string> {
+		return super.performRpc('view', ['path'], [path], timeout);
 	}
 
 

--- a/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
@@ -7,7 +7,7 @@
 //
 
 import { Event } from 'vs/base/common/event';
-import { PositronBaseComm } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
+import { PositronBaseComm, PositronCommOptions } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
 
 /**
@@ -214,9 +214,21 @@ export enum VariablesFrontendEvent {
 	Refresh = 'refresh'
 }
 
+export enum VariablesBackendRequest {
+	List = 'list',
+	Clear = 'clear',
+	Delete = 'delete',
+	Inspect = 'inspect',
+	ClipboardFormat = 'clipboard_format',
+	View = 'view'
+}
+
 export class PositronVariablesComm extends PositronBaseComm {
-	constructor(instance: IRuntimeClientInstance<any, any>) {
-		super(instance);
+	constructor(
+		instance: IRuntimeClientInstance<any, any>,
+		options?: PositronCommOptions<VariablesBackendRequest>,
+	) {
+		super(instance, options);
 		this.onDidUpdate = super.createEventEmitter('update', ['assigned', 'unevaluated', 'removed', 'version']);
 		this.onDidRefresh = super.createEventEmitter('refresh', ['variables', 'length', 'version']);
 	}
@@ -226,13 +238,11 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 *
 	 * Returns a list of all the variables in the current session.
 	 *
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns A view containing a list of variables in the session.
 	 */
-	list(timeout?: number): Promise<VariableList> {
-		return super.performRpc('list', [], [], timeout);
+	list(): Promise<VariableList> {
+		return super.performRpc('list', [], []);
 	}
 
 	/**
@@ -242,12 +252,10 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 *
 	 * @param includeHiddenObjects Whether to clear hidden objects in
 	 * addition to normal variables
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 */
-	clear(includeHiddenObjects: boolean, timeout?: number): Promise<void> {
-		return super.performRpc('clear', ['include_hidden_objects'], [includeHiddenObjects], timeout);
+	clear(includeHiddenObjects: boolean): Promise<void> {
+		return super.performRpc('clear', ['include_hidden_objects'], [includeHiddenObjects]);
 	}
 
 	/**
@@ -256,13 +264,11 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 * Deletes the named variables from the current session.
 	 *
 	 * @param names The names of the variables to delete.
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns The names of the variables that were successfully deleted.
 	 */
-	delete(names: Array<string>, timeout?: number): Promise<Array<string>> {
-		return super.performRpc('delete', ['names'], [names], timeout);
+	delete(names: Array<string>): Promise<Array<string>> {
+		return super.performRpc('delete', ['names'], [names]);
 	}
 
 	/**
@@ -272,13 +278,11 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 *
 	 * @param path The path to the variable to inspect, as an array of access
 	 * keys.
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns An inspected variable.
 	 */
-	inspect(path: Array<string>, timeout?: number): Promise<InspectedVariable> {
-		return super.performRpc('inspect', ['path'], [path], timeout);
+	inspect(path: Array<string>): Promise<InspectedVariable> {
+		return super.performRpc('inspect', ['path'], [path]);
 	}
 
 	/**
@@ -290,13 +294,11 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 * @param path The path to the variable to format, as an array of access
 	 * keys.
 	 * @param format The requested format for the variable, as a MIME type
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns An object formatted for copying to the clipboard.
 	 */
-	clipboardFormat(path: Array<string>, format: ClipboardFormatFormat, timeout?: number): Promise<FormattedVariable> {
-		return super.performRpc('clipboard_format', ['path', 'format'], [path, format], timeout);
+	clipboardFormat(path: Array<string>, format: ClipboardFormatFormat): Promise<FormattedVariable> {
+		return super.performRpc('clipboard_format', ['path', 'format'], [path, format]);
 	}
 
 	/**
@@ -307,13 +309,11 @@ export class PositronVariablesComm extends PositronBaseComm {
 	 *
 	 * @param path The path to the variable to view, as an array of access
 	 * keys.
-	 * @param timeout Timeout in milliseconds after which to error if the
-	 * server does not respond
 	 *
 	 * @returns The ID of the viewer that was opened.
 	 */
-	view(path: Array<string>, timeout?: number): Promise<string> {
-		return super.performRpc('view', ['path'], [path], timeout);
+	view(path: Array<string>): Promise<string> {
+		return super.performRpc('view', ['path'], [path]);
 	}
 
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Address #3042 and #3249.

### Approach

Bump the timeout to 30 seconds as discussed in #3042.

I'd like feedback on the approach to #3249. I opted to silently cancel any pending renders, but if we think this should be an error case, we can try to change the Python kernel's behavior on `plt.close()`.

### QA Notes

Repros in issues.