### PR TITLE
Don't tag unions when converting to/from json in generated Rust comms

### DIFF
--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -534,6 +534,7 @@ use serde::Serialize;
 					`Union type ` +
 					snakeCaseToSentenceCase(context[0]));
 				yield '#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]\n';
+				yield '#[serde(untagged)]\n';
 				yield `pub enum ${snakeCaseToSentenceCase(context[0])} {\n`;
 			} else {
 				// Enum field within another interface


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This is related to getting https://github.com/posit-dev/positron/issues/3194 to work with R

### Approach

We mark unions as untagged otherwise serde will add the enum field name to the value eg in:

```
pub enum Foo {
	String,
	i64,
}
let a = Foo::String("hello".to_string());
```

becomes the json:

```
{
	"String": "hello"
}
```

instead of the bare value

```
"hello"
```

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

No user facing changes
