### PR TITLE
fix regression: starting an interpreter doesn't update selected

### DIFF
--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -264,6 +264,11 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
 
         // Update the active environment in the Python extension.
         this._interpreterPathService.update(undefined, vscode.ConfigurationTarget.Global, this.interpreter.path);
+        this._interpreterPathService.update(
+            undefined,
+            vscode.ConfigurationTarget.WorkspaceFolder,
+            this.interpreter.path,
+        );
 
         // Register for console width changes, if we haven't already
         if (!this._consoleWidthDisposable) {


### PR DESCRIPTION
This was a regression introduced here: https://github.com/posit-dev/positron/pull/3197/files#diff-6fd55e1a3bb912e04d350d5ff41ef83b475dc47d88814b9970e19800ecba5e2eL270.

```typescript
        this._interpreterPathService.update(
            undefined,
            vscode.ConfigurationTarget.WorkspaceFolder,
            this.interpreter.path,
        );
```

should be equivalent to the:

```typescript
this.pythonApi.environments.updateActiveEnvironmentPath(this.interpreter.path);
```

that was removed since that's what it ultimately calls down to here:

https://github.com/posit-dev/positron/blob/d569a6d8e954f3a8f84d122caf2fce20fb5d53a6/extensions/positron-python/src/client/environmentApi.ts#L233