### PR TITLE
Bump ark to 0.1.98

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -546,7 +546,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.97"
+      "ark": "0.1.98"
     },
     "minimumRVersion": "4.2.0"
   }


### PR DESCRIPTION
For https://github.com/posit-dev/amalthea/pull/347, which addresses #1025