### PR TITLE
Fix bug where help-pane won't show up if collapsed when loaded. 

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
@@ -573,8 +573,8 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 		// height element and thus the help pane will be empty after expanding.
 		let previousHeight = element.clientHeight;
 		let numberOfChecks = 0;
-		const maxNumberOfChecks = 10;
-		const waitBetweenChecksMs = 25;
+		const maxNumberOfChecks = 12;
+		const waitBetweenChecksMs = 20;
 		const claimAndLayoutWebview = () => {
 			const currentHeight = element.clientHeight;
 

--- a/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
@@ -360,6 +360,12 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 			this._setTitleTimeout = undefined;
 		}
 
+		// Clear the webview claim timeout.
+		if (this._claimTimeout) {
+			clearTimeout(this._claimTimeout);
+			this._claimTimeout = undefined;
+		}
+
 		// Clear the dispose timeout.
 		if (this._disposeTimeout) {
 			clearTimeout(this._disposeTimeout);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

Addresses #2656. 

### Intent

Make sure the help pane shows up when activated while collapsed. 

### Approach

The layout overview is called immediately after the command to expand the view. The webview when claimed looks at the size of the container element, but since the opening is animated, when the claiming is done the view is still at height of zero. This doesn't update after the view has expanded. 

This fixes this in a fairly brute-force way of using a setTimeout when the client height is 0 upon the claim request. There are other ways to accomplish this but I couldnt figure out a way to do them that didn't involve mangling interfaces pretty badly. I'm very open to alternatives, though!

### QA Notes

You should be able to have your help pane docked as a secondary view in the aux-sidebar and collapsed...
<img width="517" alt="image" src="https://github.com/posit-dev/positron/assets/6764693/bfab5d01-0e31-4e22-9f42-7c414e19ac0a">


...and then call something that activates help. Ala `?mtcars` and the help pane will open and actually show something. 