### PR TITLE
Fix keybindings in `PositronConsoleFocused` contexts

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -349,6 +349,10 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			}
 		}));
 
+		disposableStore.add(props.positronConsoleInstance.onDidSelectAll(text => {
+			selectAllRuntimeItems();
+		}));
+
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
 	}, [editorFontInfo, positronConsoleContext.activePositronConsoleInstance?.session, positronConsoleContext.configurationService, positronConsoleContext.positronPlotsService, positronConsoleContext.runtimeSessionService, positronConsoleContext.viewsService, props.positronConsoleInstance, props.reactComponentContainer, scrollToBottom]);

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -46,7 +46,7 @@ import { RuntimeItemPendingInput } from 'vs/workbench/services/positronConsole/b
 import { RuntimeItemRestartButton } from 'vs/workbench/services/positronConsole/browser/classes/runtimeItemRestartButton';
 import { IPositronConsoleInstance, PositronConsoleState } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
 import { RuntimeItemStartupFailure } from 'vs/workbench/services/positronConsole/browser/classes/runtimeItemStartupFailure';
-import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_CUT, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
+import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
 import { disposableTimeout } from 'vs/base/common/async';
 
 // ConsoleInstanceProps interface.
@@ -171,18 +171,6 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 
 		// The actions that are built below.
 		const actions: IAction[] = [];
-
-		// Add the cut action. This action is never enabled here. It exists here so that the user
-		// will see a consistent set of Cut, Copy, Paste actions in this context menu and the code
-		// editor widget's context menu.
-		actions.push({
-			id: POSITRON_CONSOLE_CUT,
-			label: nls.localize('positron.console.cut', "Cut"),
-			tooltip: '',
-			class: undefined,
-			enabled: false,
-			run: () => { }
-		});
 
 		// Add the copy action.
 		actions.push({

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
@@ -63,19 +63,6 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 	}
 }], VIEW_CONTAINER);
 
-// The following is commented out because it prevents `cut` from working in the
-// console input
-// https://github.com/posit-dev/positron/issues/2549
-
-// // Register keybinding rule for cut.
-// KeybindingsRegistry.registerCommandAndKeybindingRule({
-// 	id: POSITRON_CONSOLE_CUT,
-// 	weight: KeybindingWeight.WorkbenchContrib,
-// 	primary: KeyMod.CtrlCmd | KeyCode.KeyX,
-// 	when: PositronConsoleFocused,
-// 	handler: accessor => { }
-// } satisfies ICommandAndKeybindingRule);
-
 // // Register keybinding rule for copy.
 // KeybindingsRegistry.registerCommandAndKeybindingRule({
 // 	id: POSITRON_CONSOLE_COPY,

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
@@ -16,8 +16,8 @@ import { IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/
 import { ICommandAndKeybindingRule, KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
 import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
-import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 
 // The Positron console view icon.
 const positronConsoleViewIcon = registerIcon(
@@ -65,13 +65,20 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 	}
 }], VIEW_CONTAINER);
 
+// Below we define keybindings so we can refer to them in the console context
+// menu and display the keybinding shortcut next to the menu action. We don't
+// necessarily want to handle the keybinding instead of VS Code. In that case,
+// we condition the keybinding handler on this context key that never activates.
+const never = new RawContextKey<boolean>('never', false);
+
 // Register keybinding rule for copy.
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: POSITRON_CONSOLE_COPY,
 	weight: KeybindingWeight.WorkbenchContrib,
 	primary: KeyMod.CtrlCmd | KeyCode.KeyC,
-	when: PositronConsoleFocused,
-	handler: accessor => accessor.get(ICommandService).executeCommand('editor.action.clipboardCopyAction')
+	// We let the default command copy for us
+	when: never,
+	handler: accessor => { }
 } satisfies ICommandAndKeybindingRule);
 
 // Register keybinding rule for paste.

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
@@ -15,7 +15,7 @@ import { registerPositronConsoleActions } from 'vs/workbench/contrib/positronCon
 import { POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
 import { ICommandAndKeybindingRule, KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
-import { POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
+import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
 
 // The Positron console view icon.
 const positronConsoleViewIcon = registerIcon(
@@ -63,14 +63,14 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 	}
 }], VIEW_CONTAINER);
 
-// // Register keybinding rule for copy.
-// KeybindingsRegistry.registerCommandAndKeybindingRule({
-// 	id: POSITRON_CONSOLE_COPY,
-// 	weight: KeybindingWeight.WorkbenchContrib,
-// 	primary: KeyMod.CtrlCmd | KeyCode.KeyC,
-// 	when: PositronConsoleFocused,
-// 	handler: accessor => { }
-// } satisfies ICommandAndKeybindingRule);
+// Register keybinding rule for copy.
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: POSITRON_CONSOLE_COPY,
+	weight: KeybindingWeight.WorkbenchContrib,
+	primary: KeyMod.CtrlCmd | KeyCode.KeyC,
+	when: PositronConsoleFocused,
+	handler: accessor => accessor.get(ICommandService).executeCommand('editor.action.clipboardCopyAction')
+} satisfies ICommandAndKeybindingRule);
 
 // Register keybinding rule for paste.
 KeybindingsRegistry.registerCommandAndKeybindingRule({

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
@@ -15,7 +15,7 @@ import { registerPositronConsoleActions } from 'vs/workbench/contrib/positronCon
 import { POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
 import { ICommandAndKeybindingRule, KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
-import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
+import { POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
 
 // The Positron console view icon.
 const positronConsoleViewIcon = registerIcon(
@@ -76,14 +76,14 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 // 	handler: accessor => { }
 // } satisfies ICommandAndKeybindingRule);
 
-// Register keybinding rule for copy.
-KeybindingsRegistry.registerCommandAndKeybindingRule({
-	id: POSITRON_CONSOLE_COPY,
-	weight: KeybindingWeight.WorkbenchContrib,
-	primary: KeyMod.CtrlCmd | KeyCode.KeyC,
-	when: PositronConsoleFocused,
-	handler: accessor => { }
-} satisfies ICommandAndKeybindingRule);
+// // Register keybinding rule for copy.
+// KeybindingsRegistry.registerCommandAndKeybindingRule({
+// 	id: POSITRON_CONSOLE_COPY,
+// 	weight: KeybindingWeight.WorkbenchContrib,
+// 	primary: KeyMod.CtrlCmd | KeyCode.KeyC,
+// 	when: PositronConsoleFocused,
+// 	handler: accessor => { }
+// } satisfies ICommandAndKeybindingRule);
 
 // Register keybinding rule for paste.
 KeybindingsRegistry.registerCommandAndKeybindingRule({

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
@@ -12,10 +12,12 @@ import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { ViewPaneContainer } from 'vs/workbench/browser/parts/views/viewPaneContainer';
 import { PositronConsoleViewPane } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleView';
 import { registerPositronConsoleActions } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleActions';
-import { POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
+import { IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
 import { ICommandAndKeybindingRule, KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
 import { POSITRON_CONSOLE_COPY, POSITRON_CONSOLE_PASTE, POSITRON_CONSOLE_SELECT_ALL } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleIdentifiers';
+import { ICommandService } from 'vs/platform/commands/common/commands';
+import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 
 // The Positron console view icon.
 const positronConsoleViewIcon = registerIcon(
@@ -78,7 +80,12 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	weight: KeybindingWeight.WorkbenchContrib,
 	primary: KeyMod.CtrlCmd | KeyCode.KeyV,
 	when: PositronConsoleFocused,
-	handler: accessor => { }
+	handler: async accessor => {
+		const clipboardService = accessor.get(IClipboardService);
+		const consoleService = accessor.get(IPositronConsoleService);
+		const text = await clipboardService.readText();
+		return consoleService.activePositronConsoleInstance?.pasteText(text);
+	}
 } satisfies ICommandAndKeybindingRule);
 
 // Register keybinding rule for select all.

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.contribution.ts
@@ -101,7 +101,10 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	weight: KeybindingWeight.WorkbenchContrib,
 	primary: KeyMod.CtrlCmd | KeyCode.KeyA,
 	when: PositronConsoleFocused,
-	handler: accessor => { }
+	handler: async accessor => {
+		const consoleService = accessor.get(IPositronConsoleService);
+		return consoleService.activePositronConsoleInstance?.selectAll();
+	}
 } satisfies ICommandAndKeybindingRule);
 
 // Register all the Positron console actions.

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -188,6 +188,11 @@ export interface IPositronConsoleInstance {
 	readonly onDidPasteText: Event<string>;
 
 	/**
+	 * The onDidSelectAll event.
+	 */
+	readonly onDidSelectAll: Event<void>;
+
+	/**
 	 * The onDidClearConsole event.
 	 */
 	readonly onDidClearConsole: Event<void>;
@@ -263,6 +268,11 @@ export interface IPositronConsoleInstance {
 	 * Pastes text into the console.
 	 */
 	pasteText(text: string): void;
+
+	/**
+	 * Select all text in the console.
+	 */
+	selectAll(): void;
 
 	/**
 	 * Clears the console.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -620,6 +620,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	private readonly _onDidPasteTextEmitter = this._register(new Emitter<string>);
 
 	/**
+	 * The onDidSelectAll event emitter.
+	 */
+	private readonly _onDidSelectAllEmitter = this._register(new Emitter<void>);
+
+	/**
 	 * The onDidClearConsole event emitter.
 	 */
 	private readonly _onDidClearConsoleEmitter = this._register(new Emitter<void>);
@@ -857,6 +862,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	readonly onDidPasteText = this._onDidPasteTextEmitter.event;
 
 	/**
+	 * onDidSelectAll event.
+	 */
+	readonly onDidSelectAll = this._onDidSelectAllEmitter.event;
+
+	/**
 	 * onDidClearConsole event.
 	 */
 	readonly onDidClearConsole = this._onDidClearConsoleEmitter.event;
@@ -928,6 +938,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	pasteText(text: string) {
 		this.focusInput();
 		this._onDidPasteTextEmitter.fire(text);
+	}
+
+	/**
+	 * Select all text in the console.
+	 */
+	selectAll() {
+		this._onDidSelectAllEmitter.fire();
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses #3251. Copying output from the console no longer works.

### Approach

Edit: New approach described in https://github.com/posit-dev/positron/pull/3264#issuecomment-2137795779

~Following a recent fix (https://github.com/posit-dev/positron/pull/3187), the `PositronConsoleFocused` context key is now enabled when output is selected. This causes one of the empty handlers added in https://github.com/posit-dev/positron/commit/ff250114bc6f8b3983380a2fcba78e87f5a865b0 to kick in and override the default command for copy.~

~To fix this, I took the same approach as https://github.com/posit-dev/positron/pull/2864/commits/296b6a5d7c6dbec5aa0632ef04892b197c37f056 which disabled the empty handler preventing Cut from working in the console input. The empty handler for Copy is now commented out as well.~

~@softwarenerd I'm not sure what was the intent behind these handlers. Do we need another approach here?~

### QA Notes

We've now fixed Copy, Paste, and Select All when text is selected in the output. Cut is completely disabled in this case and no longer appears in the context menu. All these commands should still be working in the console input area. Select all has different behaviour in the input (select all input) than in the output (select all output).