### PR TITLE
Plumb the type of output messages through to notebook cell outputs

### DIFF
--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -709,7 +709,6 @@ export class LanguageRuntimeSessionAdapter
 			when: message.when,
 			type: positron.LanguageRuntimeMessageType.Output,
 			data: data.data as any,
-			outputType: positron.LanguageRuntimeOutputType.DisplayData,
 		} as positron.LanguageRuntimeOutput);
 	}
 
@@ -744,10 +743,9 @@ export class LanguageRuntimeSessionAdapter
 			id: message.msgId,
 			parent_id: message.originId,
 			when: message.when,
-			type: positron.LanguageRuntimeMessageType.Output,
+			type: positron.LanguageRuntimeMessageType.Result,
 			data: data.data as any,
-			outputType: positron.LanguageRuntimeOutputType.ExecuteResult,
-		} as positron.LanguageRuntimeOutput);
+		} as positron.LanguageRuntimeResult);
 	}
 
 	/**

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -709,6 +709,7 @@ export class LanguageRuntimeSessionAdapter
 			when: message.when,
 			type: positron.LanguageRuntimeMessageType.Output,
 			data: data.data as any,
+			outputType: positron.LanguageRuntimeOutputType.DisplayData,
 		} as positron.LanguageRuntimeOutput);
 	}
 
@@ -744,7 +745,8 @@ export class LanguageRuntimeSessionAdapter
 			parent_id: message.originId,
 			when: message.when,
 			type: positron.LanguageRuntimeMessageType.Output,
-			data: data.data as any
+			data: data.data as any,
+			outputType: positron.LanguageRuntimeOutputType.ExecuteResult,
 		} as positron.LanguageRuntimeOutput);
 	}
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -34,7 +34,7 @@ declare module 'positron' {
 		/** A message representing a runtime event */
 		Event = 'event',
 
-		/** A message representing a new comm (client instance) being opened from the rutime side */
+		/** A message representing a new comm (client instance) being opened from the runtime side */
 		CommOpen = 'comm_open',
 
 		/** A message representing data received via a comm (to a client instance) */
@@ -42,6 +42,15 @@ declare module 'positron' {
 
 		/** A message indicating that a comm (client instance) was closed from the server side */
 		CommClosed = 'comm_closed',
+	}
+
+	/** The set of possible types of language runtime output messages */
+	export enum LanguageRuntimeOutputType {
+		/** An output message representing data to be displayed in a frontend */
+		DisplayData = 'display_data',
+
+		/** An output message representing the result of an execution */
+		ExecuteResult = 'execute_result'
 	}
 
 	/**
@@ -201,6 +210,9 @@ declare module 'positron' {
 	export interface LanguageRuntimeOutput extends LanguageRuntimeMessage {
 		/** A record of data MIME types to the associated data, e.g. `text/plain` => `'hello world'` */
 		data: Record<string, string>;
+
+		/** The type of output */
+		outputType: LanguageRuntimeOutputType;
 	}
 
 	/**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -16,6 +16,9 @@ declare module 'positron' {
 		/** A message representing output (text, plots, etc.) */
 		Output = 'output',
 
+		/** A message representing the computational result of a runtime execution */
+		Result = 'result',
+
 		/** A message representing output from one of the standard streams (stdout or stderr) */
 		Stream = 'stream',
 
@@ -42,15 +45,6 @@ declare module 'positron' {
 
 		/** A message indicating that a comm (client instance) was closed from the server side */
 		CommClosed = 'comm_closed',
-	}
-
-	/** The set of possible types of language runtime output messages */
-	export enum LanguageRuntimeOutputType {
-		/** An output message representing data to be displayed in a frontend */
-		DisplayData = 'display_data',
-
-		/** An output message representing the result of an execution */
-		ExecuteResult = 'execute_result'
 	}
 
 	/**
@@ -210,9 +204,13 @@ declare module 'positron' {
 	export interface LanguageRuntimeOutput extends LanguageRuntimeMessage {
 		/** A record of data MIME types to the associated data, e.g. `text/plain` => `'hello world'` */
 		data: Record<string, string>;
+	}
 
-		/** The type of output */
-		outputType: LanguageRuntimeOutputType;
+	/**
+	 * LanguageRuntimeResult is a LanguageRuntimeOutput representing the computational result of a
+	 * runtime execution.
+	 */
+	export interface LanguageRuntimeResult extends LanguageRuntimeOutput {
 	}
 
 	/**

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -196,7 +196,6 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			RuntimeExitReason: extHostTypes.RuntimeExitReason,
 			RuntimeMethodErrorCode: extHostTypes.RuntimeMethodErrorCode,
 			LanguageRuntimeMessageType: extHostTypes.LanguageRuntimeMessageType,
-			LanguageRuntimeOutputType: extHostTypes.LanguageRuntimeOutputType,
 			LanguageRuntimeStreamName: extHostTypes.LanguageRuntimeStreamName,
 			LanguageRuntimeSessionMode: extHostTypes.LanguageRuntimeSessionMode,
 			RuntimeCodeExecutionMode: extHostTypes.RuntimeCodeExecutionMode,

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -196,6 +196,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			RuntimeExitReason: extHostTypes.RuntimeExitReason,
 			RuntimeMethodErrorCode: extHostTypes.RuntimeMethodErrorCode,
 			LanguageRuntimeMessageType: extHostTypes.LanguageRuntimeMessageType,
+			LanguageRuntimeOutputType: extHostTypes.LanguageRuntimeOutputType,
 			LanguageRuntimeStreamName: extHostTypes.LanguageRuntimeStreamName,
 			LanguageRuntimeSessionMode: extHostTypes.LanguageRuntimeSessionMode,
 			RuntimeCodeExecutionMode: extHostTypes.RuntimeCodeExecutionMode,

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -58,6 +58,9 @@ export enum LanguageRuntimeMessageType {
 	/** A message representing output (text, plots, etc.) */
 	Output = 'output',
 
+	/** A message representing the computational result of a runtime execution */
+	Result = 'result',
+
 	/** A message representing output from one of the standard streams (stdout or stderr) */
 	Stream = 'stream',
 
@@ -84,15 +87,6 @@ export enum LanguageRuntimeMessageType {
 
 	/** A message indicating that a comm (client instance) was closed from the server side */
 	CommClosed = 'comm_closed',
-}
-
-/** The set of possible types of language runtime output messages */
-export enum LanguageRuntimeOutputType {
-	/** An output message representing data to be displayed in a frontend */
-	DisplayData = 'display_data',
-
-	/** An output message representing the result of an execution */
-	ExecuteResult = 'execute_result'
 }
 
 /**

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -86,6 +86,15 @@ export enum LanguageRuntimeMessageType {
 	CommClosed = 'comm_closed',
 }
 
+/** The set of possible types of language runtime output messages */
+export enum LanguageRuntimeOutputType {
+	/** An output message representing data to be displayed in a frontend */
+	DisplayData = 'display_data',
+
+	/** An output message representing the result of an execution */
+	ExecuteResult = 'execute_result'
+}
+
 /**
  * LanguageRuntimeSessionMode is an enum representing the set of possible
  * modes for a language runtime session.

--- a/src/vs/workbench/contrib/executionHistory/common/runtimeExecutionHistory.ts
+++ b/src/vs/workbench/contrib/executionHistory/common/runtimeExecutionHistory.ts
@@ -6,7 +6,7 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { IExecutionHistoryEntry } from 'vs/workbench/contrib/executionHistory/common/executionHistoryService';
-import { RuntimeOnlineState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeMessageOutput, RuntimeOnlineState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 
 /**
@@ -80,7 +80,7 @@ export class RuntimeExecutionHistory extends Disposable {
 			}
 		}));
 
-		this._register(this._session.onDidReceiveRuntimeMessageOutput(message => {
+		const handleDidReceiveRuntimeMessageOutput = (message: ILanguageRuntimeMessageOutput) => {
 			// Get the output.
 			const output = message.data['text/plain'];
 
@@ -106,7 +106,10 @@ export class RuntimeExecutionHistory extends Disposable {
 				// Add the entry to the pending executions map
 				this._pendingExecutions.set(message.parent_id, entry);
 			}
-		}));
+		};
+
+		this._register(this._session.onDidReceiveRuntimeMessageOutput(handleDidReceiveRuntimeMessageOutput));
+		this._register(this._session.onDidReceiveRuntimeMessageResult(handleDidReceiveRuntimeMessageOutput));
 
 		// When we receive a message indicating that an execution has completed,
 		// we'll move it from the pending executions map to the history entries.

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -449,7 +449,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Console) {
 			// Listen for static plots being emitted, and register each one with
 			// the plots service.
-			this._register(session.onDidReceiveRuntimeMessageOutput(async (message) => {
+			const handleDidReceiveRuntimeMessageOutput = async (message: ILanguageRuntimeMessageOutput) => {
 				// Check to see if we we already have a plot client for this
 				// message ID. If so, we don't need to do anything.
 				if (this.hasPlot(session.sessionId, message.id)) {
@@ -471,7 +471,9 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 					// Raise the Plots pane so the plot is visible.
 					this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
 				}
-			}));
+			};
+			this._register(session.onDidReceiveRuntimeMessageOutput(handleDidReceiveRuntimeMessageOutput));
+			this._register(session.onDidReceiveRuntimeMessageResult(handleDidReceiveRuntimeMessageOutput));
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -9,7 +9,7 @@ import { IWebviewService, WebviewExtensionDescription, WebviewInitInfo } from 'v
 import { PreviewWebview } from 'vs/workbench/contrib/positronPreview/browser/previewWebview';
 import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
 import { POSITRON_PREVIEW_URL_VIEW_TYPE, POSITRON_PREVIEW_VIEW_ID } from 'vs/workbench/contrib/positronPreview/browser/positronPreviewSevice';
-import { LanguageRuntimeSessionMode, RuntimeOutputKind } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeMessageOutput, LanguageRuntimeSessionMode, RuntimeOutputKind } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ILanguageRuntimeSession, IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IPositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
 import { URI } from 'vs/base/common/uri';
@@ -235,7 +235,7 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 			// Don't attach notebook sessions; they display previews inline.
 			return;
 		}
-		this._register(session.onDidReceiveRuntimeMessageOutput(async (e) => {
+		const handleDidReceiveRuntimeMessageOutput = async (e: ILanguageRuntimeMessageOutput) => {
 			if (e.kind === RuntimeOutputKind.ViewerWidget) {
 				const webview = await
 					this._notebookOutputWebviewService.createNotebookOutputWebview(session, e);
@@ -248,7 +248,9 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 					this.openPreviewWebview(preview, false);
 				}
 			}
-		}));
+		};
+		this._register(session.onDidReceiveRuntimeMessageOutput(handleDidReceiveRuntimeMessageOutput));
+		this._register(session.onDidReceiveRuntimeMessageResult(handleDidReceiveRuntimeMessageOutput));
 	}
 
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -125,6 +125,13 @@ export interface ILanguageRuntimeMessageOutput extends ILanguageRuntimeMessage {
 }
 
 /**
+ * LanguageRuntimeResult is a LanguageRuntimeOutput representing the computational result of a
+ * runtime execution.
+ */
+export interface ILanguageRuntimeMessageResult extends ILanguageRuntimeMessageOutput {
+}
+
+/**
  * The set of possible output locations for a LanguageRuntimeWebOutput.
  */
 export enum PositronOutputLocation {
@@ -407,6 +414,9 @@ export enum RuntimeOnlineState {
 export enum LanguageRuntimeMessageType {
 	/** A message representing output (text, plots, etc.) */
 	Output = 'output',
+
+	/** A message representing the computational result of a runtime execution */
+	Result = 'result',
 
 	/** A message representing output from one of the standard streams (stdout or stderr) */
 	Stream = 'stream',

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -35,7 +35,7 @@ import { ActivityItem, RuntimeItemActivity } from 'vs/workbench/services/positro
 import { ActivityItemInput, ActivityItemInputState } from 'vs/workbench/services/positronConsole/browser/classes/activityItemInput';
 import { ActivityItemErrorStream, ActivityItemOutputStream } from 'vs/workbench/services/positronConsole/browser/classes/activityItemStream';
 import { IPositronConsoleInstance, IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID, PositronConsoleState, SessionAttachMode } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
-import { ILanguageRuntimeExit, ILanguageRuntimeMessage, ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeState, formatLanguageRuntimeMetadata, formatLanguageRuntimeSession } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeExit, ILanguageRuntimeMessage, ILanguageRuntimeMessageOutput, ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeState, formatLanguageRuntimeMetadata, formatLanguageRuntimeSession } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../runtimeSession/common/runtimeSessionService';
 import { UiFrontendEvent } from 'vs/workbench/services/languageRuntime/common/positronUiComm';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
@@ -1446,8 +1446,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		}));
 
 		// Add the onDidReceiveRuntimeMessageOutput event handler.
-		this._runtimeDisposableStore.add(this._session.onDidReceiveRuntimeMessageOutput(
-			languageRuntimeMessageOutput => {
+		const handleDidReceiveRuntimeMessageOutput = (
+			(languageRuntimeMessageOutput: ILanguageRuntimeMessageOutput) => {
 				// If trace is enabled, add a trace runtime item.
 				if (this._trace) {
 					this.addRuntimeItemTrace(
@@ -1517,7 +1517,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 						)
 					);
 				}
-			}));
+			});
+		this._runtimeDisposableStore.add(this._session.onDidReceiveRuntimeMessageOutput(handleDidReceiveRuntimeMessageOutput));
+		this._runtimeDisposableStore.add(this._session.onDidReceiveRuntimeMessageResult(handleDidReceiveRuntimeMessageOutput));
 
 		// Add the onDidReceiveRuntimeMessageStream event handler.
 		this._runtimeDisposableStore.add(this._session.onDidReceiveRuntimeMessageStream(

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -5,7 +5,7 @@
 import { Event } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, ILanguageRuntimeSessionState, RuntimeState, ILanguageRuntimeInfo, ILanguageRuntimeStartupFailure, ILanguageRuntimeExit, ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageStream, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageError, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, RuntimeCodeExecutionMode, RuntimeErrorBehavior, RuntimeCodeFragmentStatus, RuntimeExitReason } from '../../languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, ILanguageRuntimeSessionState, RuntimeState, ILanguageRuntimeInfo, ILanguageRuntimeStartupFailure, ILanguageRuntimeExit, ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageStream, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageError, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, RuntimeCodeExecutionMode, RuntimeErrorBehavior, RuntimeCodeFragmentStatus, RuntimeExitReason, ILanguageRuntimeMessageResult } from '../../languageRuntime/common/languageRuntimeService';
 import { RuntimeClientType, IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
 import { IRuntimeClientEvent } from 'vs/workbench/services/languageRuntime/common/languageRuntimeUiClient';
 import { IDisposable } from 'vs/base/common/lifecycle';
@@ -107,6 +107,7 @@ export interface ILanguageRuntimeSession {
 	onDidCreateClientInstance: Event<ILanguageRuntimeClientCreatedEvent>;
 
 	onDidReceiveRuntimeMessageOutput: Event<ILanguageRuntimeMessageOutput>;
+	onDidReceiveRuntimeMessageResult: Event<ILanguageRuntimeMessageResult>;
 	onDidReceiveRuntimeMessageStream: Event<ILanguageRuntimeMessageStream>;
 	onDidReceiveRuntimeMessageInput: Event<ILanguageRuntimeMessageInput>;
 	onDidReceiveRuntimeMessageError: Event<ILanguageRuntimeMessageError>;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Address #3272.

### Approach

I'm not too sure about introducing the `LanguageRuntimeOutputType` enum since this is quite Jupyter-specific, and I think runtimes are somewhat abstracted away from that.