### PR TITLE
Remove disposal of now-extinct part options listener

### DIFF
--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -598,10 +598,6 @@ suite('EditorGroupsService', () => {
 		group.unstickEditor(input);
 		assert.strictEqual(editorStickyCounter, 2);
 
-		// --- Start Positron ---
-		partOptionsListener.dispose();
-		// --- End Positron ---
-
 		editorCloseListener.dispose();
 		editorWillCloseListener.dispose();
 		editorDidCloseListener.dispose();


### PR DESCRIPTION
Build fix; looks like this needs removal now that the variable has been removed (https://github.com/posit-dev/positron/commit/5a20a4e43c91733677aaa72fbbcea2929563f17e). 