### PR TITLE
Git init new project

### DIFF
--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -114,6 +114,7 @@ export const showNewProjectModalDialog = async (
 						runtimeMetadata: result.selectedRuntime || undefined,
 						projectType: result.projectType || '',
 						projectFolder: folder.fsPath,
+						projectName: result.projectName,
 						initGitRepo: result.initGitRepo,
 						pythonEnvType: pythonEnvType || '',
 						installIpykernel: result.installIpykernel || false,

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -61,6 +61,7 @@ export interface NewProjectConfiguration {
 	readonly runtimeMetadata: ILanguageRuntimeMetadata | undefined;
 	readonly projectType: string;
 	readonly projectFolder: string;
+	readonly projectName: string;
 	readonly initGitRepo: boolean;
 	readonly pythonEnvType: string;
 	readonly installIpykernel: boolean;

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -16,8 +16,10 @@ import { ILanguageRuntimeMetadata } from 'vs/workbench/services/languageRuntime/
 import { IFileService } from 'vs/platform/files/common/files';
 import { VSBuffer } from 'vs/base/common/buffer';
 import { joinPath } from 'vs/base/common/resources';
-import { DOT_IGNORE_PYTHON, DOT_IGNORE_R } from 'vs/workbench/services/positronNewProject/common/positronNewProjectTemplates';
+import { DOT_IGNORE_JUPYTER, DOT_IGNORE_PYTHON, DOT_IGNORE_R } from 'vs/workbench/services/positronNewProject/common/positronNewProjectTemplates';
 import { URI } from 'vs/base/common/uri';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { localize } from 'vs/nls';
 
 /**
  * PositronNewProjectService class.
@@ -46,10 +48,11 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	constructor(
 		@IWorkspaceContextService private readonly _contextService: IWorkspaceContextService,
 		@ICommandService private readonly _commandService: ICommandService,
+		@IFileService private readonly _fileService: IFileService,
 		@ILogService private readonly _logService: ILogService,
+		@INotificationService private readonly _notificationService: INotificationService,
 		@IStorageService private readonly _storageService: IStorageService,
-		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
-		@IFileService private readonly _fileService: IFileService
+		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService
 	) {
 		super();
 
@@ -212,26 +215,62 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 		this._removePendingTask(NewProjectTask.R);
 	}
 
+	private _handleGitIgnoreError(error: Error) {
+		const errorMessage = localize('positronNewProjectService.gitIgnoreError', 'Error creating .gitignore {0}', error.message);
+		this._notificationService.error(errorMessage);
+	}
+
 	/**
 	 * Runs the git init command.
 	 * Relies on extension vscode.git
 	 */
 	private async _runGitInit() {
-		this._commandService.executeCommand('git.init', true);
-
 		const projectRoot = URI.file(this._newProjectConfig?.projectFolder!);
+		const gitInitTask = new Promise(() => {
+			this._commandService.executeCommand('git.init', true)
+				.catch((error) => {
+					const errorMessage = localize('positronNewProjectService.gitInitError', 'Error initializing git repository {0}', error);
+					this._notificationService.error(errorMessage);
+				});
+		});
+		const readmeTask = new Promise(() => {
+			this._fileService.createFile(joinPath(projectRoot, 'README.md'), VSBuffer.fromString(`# ${this._newProjectConfig?.projectName}`))
+				.catch((error) => {
+					this._handleGitIgnoreError(error);
+				});
+		});
+		const tasks = [gitInitTask, readmeTask];
+
 		// TODO: use enum values instead of strings
 		switch (this._newProjectConfig?.projectType) {
 			case 'Python Project':
-				this._fileService.createFile(joinPath(projectRoot, '.gitignore'), VSBuffer.fromString(DOT_IGNORE_PYTHON));
+				tasks.push(new Promise(() => {
+					this._fileService.createFile(joinPath(projectRoot, '.gitignore'), VSBuffer.fromString(DOT_IGNORE_PYTHON))
+						.catch((error) => {
+							this._handleGitIgnoreError(error);
+						});
+				}));
 				break;
 			case 'R Project':
-				this._fileService.createFile(joinPath(projectRoot, '.gitignore'), VSBuffer.fromString(DOT_IGNORE_R));
+				tasks.push(new Promise(() => {
+					this._fileService.createFile(joinPath(projectRoot, '.gitignore'), VSBuffer.fromString(DOT_IGNORE_R))
+						.catch((error) => {
+							this._handleGitIgnoreError(error);
+						});
+				}));
+				break;
+			case 'Jupyter Notebook':
+				tasks.push(new Promise(() => {
+					this._fileService.createFile(joinPath(projectRoot, '.gitignore'), VSBuffer.fromString(DOT_IGNORE_JUPYTER))
+						.catch((error) => {
+							this._handleGitIgnoreError(error);
+						});
+				}));
 				break;
 			default:
 		}
 
-		this._fileService.createFile(joinPath(projectRoot, 'README.md'), VSBuffer.fromString(`# ${this._newProjectConfig?.projectName}`));
+		Promise.allSettled(tasks);
 
 		this._removePendingTask(NewProjectTask.Git);
 	}

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -211,8 +211,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	 * Relies on extension vscode.git
 	 */
 	private async _runGitInit() {
-		// TODO: This command works, but requires a quick pick selection
-		// this._commandService.executeCommand('git.init');
+		this._commandService.executeCommand('git.init', true);
 
 		// TODO: create .gitignore and README.md
 		this._removePendingTask(NewProjectTask.Git);

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -227,6 +227,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	private async _runGitInit() {
 		const projectRoot = URI.file(this._newProjectConfig?.projectFolder!);
 		const gitInitTask = new Promise(() => {
+			// true to skip the folder prompt
 			this._commandService.executeCommand('git.init', true)
 				.catch((error) => {
 					const errorMessage = localize('positronNewProjectService.gitInitError', 'Error initializing git repository {0}', error);

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -270,7 +270,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 			default:
 		}
 
-		Promise.allSettled(tasks);
+		await Promise.allSettled(tasks);
 
 		this._removePendingTask(NewProjectTask.Git);
 	}

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectTemplates.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectTemplates.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+export const DOT_IGNORE_PYTHON: string = `*.pyc
+*.pyo
+__pycache__/
+`;
+export const DOT_IGNORE_R: string = `.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+`;

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectTemplates.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectTemplates.ts
@@ -11,3 +11,7 @@ export const DOT_IGNORE_R: string = `.Rproj.user
 .RData
 .Ruserdata
 `;
+
+export const DOT_IGNORE_JUPYTER: string = `.ipynb_checkpoints
+*/.ipynb_checkpoints/*
+`;


### PR DESCRIPTION
### Intent
Address #3126 

### Approach
Calls init git repository command with option to skip the quick pick. Add initial files based on the selected project type.

### QA Notes
The contents of the initial files may change depending on feedback but they should have something in them.