### PR TITLE
Create new Venv for Python-based Project

### DIFF
--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -220,8 +220,11 @@ export class PythonRuntimeManager implements IPythonRuntimeManager {
             throw new Error(`Python interpreter path is missing: ${extraData.pythonPath}`);
         }
 
+        // Replace the metadata if we can find the runtime in the registered runtimes,
+        const registeredMetadata = this.registeredPythonRuntimes.get(extraData.pythonPath);
+
         // Metadata is valid
-        return metadata;
+        return registeredMetadata ?? metadata;
     }
 
     /**

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
@@ -209,7 +209,12 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
             existingEnvStep,
             async (context?: MultiStepAction) => {
                 if (workspace) {
-                    if (
+                    // --- Start Positron ---
+                    if (existingVenvAction === ExistingVenvAction.Create && options?.interpreterPath) {
+                        interpreter = options.interpreterPath;
+                    }
+                    // --- End Positron ---
+                    else if (
                         existingVenvAction === ExistingVenvAction.Recreate ||
                         existingVenvAction === ExistingVenvAction.Create
                     ) {

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/types.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/types.ts
@@ -8,4 +8,7 @@ export interface CreateEnvironmentProgress extends Progress<{ message?: string; 
 export interface CreateEnvironmentOptionsInternal {
     workspaceFolder?: WorkspaceFolder;
     providerId?: string;
+    // --- Start Positron ---
+    interpreterPath?: string;
+    // --- End Positron ---
 }

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -92,14 +92,23 @@ export const showNewProjectModalDialog = async (
 							? result.pythonEnvProviderId
 							: '';
 
-					// Install ipykernel if applicable.
-					if (result.installIpykernel) {
+					// Install ipykernel if applicable for an existing environment.
+					// For new environments, ipykernel will be installed as part of the environment
+					// creation and setup process once the new project is opened.
+					if (
+						result.pythonEnvSetupType ===
+						EnvironmentSetupType.ExistingEnvironment &&
+						result.installIpykernel
+					) {
 						const pythonPath =
-							result.selectedRuntime?.extraRuntimeData?.pythonPath ??
+							result.selectedRuntime?.extraRuntimeData
+								?.pythonPath ??
 							result.selectedRuntime?.runtimePath ??
 							'';
 						if (!pythonPath) {
-							logService.error('Could not determine python path to install ipykernel via Positron Project Wizard');
+							logService.error(
+								'Could not determine python path to install ipykernel via Positron Project Wizard'
+							);
 						} else {
 							// Awaiting the command execution is necessary to ensure ipykernel is
 							// installed before the project is opened.

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -130,6 +130,7 @@ export const showNewProjectModalDialog = async (
 						projectName: result.projectName,
 						initGitRepo: result.initGitRepo,
 						pythonEnvProviderId: pythonEnvProviderId || '',
+						pythonEnvProviderName: result.pythonEnvProviderName || '',
 						installIpykernel: result.installIpykernel || false,
 						useRenv: result.useRenv || false,
 					};

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -25,7 +25,7 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IPositronNewProjectService, NewProjectConfiguration } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
-import { EnvironmentSetupType, NewProjectWizardStep } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
+import { EnvironmentSetupType, NewProjectWizardStep, PythonEnvironmentProvider } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
 import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 
 /**
@@ -83,8 +83,12 @@ export const showNewProjectModalDialog = async (
 					}
 
 					// The python environment type is only relevant if a new environment is being created.
-					const pythonEnvType =
-						result.pythonEnvSetupType === EnvironmentSetupType.NewEnvironment
+					const pythonEnvProviderId =
+						result.pythonEnvSetupType ===
+							EnvironmentSetupType.NewEnvironment &&
+							// TODO: Conda isn't supported yet, so don't set the env provider if it's conda.
+							result.pythonEnvProviderName !==
+							PythonEnvironmentProvider.Conda
 							? result.pythonEnvProviderId
 							: '';
 
@@ -116,7 +120,7 @@ export const showNewProjectModalDialog = async (
 						projectFolder: folder.fsPath,
 						projectName: result.projectName,
 						initGitRepo: result.initGitRepo,
-						pythonEnvType: pythonEnvType || '',
+						pythonEnvProviderId: pythonEnvProviderId || '',
 						installIpykernel: result.installIpykernel || false,
 						useRenv: result.useRenv || false,
 					};

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -61,6 +61,7 @@ export interface NewProjectWizardState {
 	openInNewWindow: boolean;
 	pythonEnvSetupType: EnvironmentSetupType | undefined;
 	pythonEnvProviderId: string | undefined;
+	readonly pythonEnvProviderName: string | undefined;
 	readonly installIpykernel: boolean | undefined;
 	useRenv: boolean | undefined;
 }
@@ -480,6 +481,7 @@ export class NewProjectWizardStateManager
 			openInNewWindow: this._openInNewWindow,
 			pythonEnvSetupType: this._pythonEnvSetupType,
 			pythonEnvProviderId: this._pythonEnvProviderId,
+			pythonEnvProviderName: this._getEnvProviderName(),
 			installIpykernel: this._installIpykernel,
 			useRenv: this._useRenv
 		} satisfies NewProjectWizardState;

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -64,6 +64,7 @@ export interface NewProjectConfiguration {
 	readonly projectName: string;
 	readonly initGitRepo: boolean;
 	readonly pythonEnvProviderId: string;
+	readonly pythonEnvProviderName: string;
 	readonly installIpykernel: boolean;
 	readonly useRenv: boolean;
 }

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -63,7 +63,7 @@ export interface NewProjectConfiguration {
 	readonly projectFolder: string;
 	readonly projectName: string;
 	readonly initGitRepo: boolean;
-	readonly pythonEnvType: string;
+	readonly pythonEnvProviderId: string;
 	readonly installIpykernel: boolean;
 	readonly useRenv: boolean;
 }
@@ -127,3 +127,13 @@ export interface IPositronNewProjectService {
 	 */
 	storeNewProjectConfig(newProjectConfig: NewProjectConfiguration): void;
 }
+
+/**
+ * CreateEnvironmentOptions type.
+ * Used to capture the result of creating a new environment.
+ * Based on extensions/positron-python/src/client/pythonEnvironments/creation/proposed.createEnvApis.ts
+ */
+export type CreateEnvironmentResult = {
+	readonly path?: string;
+	readonly error?: Error;
+};

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -195,11 +195,15 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	 * Relies on extension ms-python.python
 	 */
 	private async _runPythonTasks() {
+		// Create a new Python file
+		await this._commandService.executeCommand('python.createNewFile');
+
+		// Create the Python environment
 		if (this.pendingTasks.has(NewProjectTask.PythonEnvironment)) {
 			await this._createPythonEnvironment();
 		}
 
-		await this._commandService.executeCommand('python.createNewFile');
+		// Complete the Python task
 		this._removePendingTask(NewProjectTask.Python);
 	}
 
@@ -208,6 +212,10 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	 * Relies on extension vscode.ipynb
 	 */
 	private async _runJupyterTasks() {
+		// Create a new untitled Jupyter notebook
+		await this._commandService.executeCommand('ipynb.newUntitledIpynb');
+
+		// Create the Python environment
 		// For now, Jupyter notebooks are always Python based. In the future, we'll need to surface
 		// some UI in the Project Wizard for the user to select the language/kernel and pass that
 		// metadata to the new project configuration.
@@ -215,7 +223,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 			await this._createPythonEnvironment();
 		}
 
-		await this._commandService.executeCommand('ipynb.newUntitledIpynb');
+		// Complete the Jupyter task
 		this._removePendingTask(NewProjectTask.Jupyter);
 	}
 
@@ -224,11 +232,15 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	 * Relies on extension vscode.positron-r
 	 */
 	private async _runRTasks() {
+		// Create a new R file
+		await this._commandService.executeCommand('r.createNewFile');
+
+		// Create the R environment
 		if (this.pendingTasks.has(NewProjectTask.REnvironment)) {
 			await this._createREnvironment();
 		}
 
-		await this._commandService.executeCommand('r.createNewFile');
+		// Complete the R task
 		this._removePendingTask(NewProjectTask.R);
 	}
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -661,17 +661,26 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				//
 				// This isn't unexpected but deserves some logging.
 				if (validated.runtimeId !== metadata.runtimeId) {
-					const existing =
-						this._languageRuntimeService.getRegisteredRuntime(validated.runtimeId);
-					if (existing) {
-						// This should shouldn't happen, but warn if it does.
-						this._logService.warn(
-							`Language runtime ${formatLanguageRuntimeMetadata(validated)} ` +
-							`already registered; re-registering.`);
-					} else {
+					if (!metadata.runtimeId) {
+						// We've leveraged validateMetadata to swap the partially hydrated metadata
+						// for the fully hydrated metadata.
 						this._logService.info(
-							`Replacing runtime ${formatLanguageRuntimeMetadata(metadata)} => `
-							+ `${formatLanguageRuntimeMetadata(validated)}`);
+							`Hydrated metadata for runtime ${formatLanguageRuntimeMetadata(validated)}`
+						);
+					} else {
+						// The runtime ID changed.
+						const existing =
+							this._languageRuntimeService.getRegisteredRuntime(validated.runtimeId);
+						if (existing) {
+							// This should shouldn't happen, but warn if it does.
+							this._logService.warn(
+								`Language runtime ${formatLanguageRuntimeMetadata(validated)} ` +
+								`already registered; re-registering.`);
+						} else {
+							this._logService.info(
+								`Replacing runtime ${formatLanguageRuntimeMetadata(metadata)} => `
+								+ `${formatLanguageRuntimeMetadata(validated)}`);
+						}
 					}
 				}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

- Address https://github.com/posit-dev/positron/issues/2838

#### Demo
https://github.com/posit-dev/positron/assets/25834218/692c5c2d-a236-48aa-903f-52cd4d31be95

### Approach

#### python extension
- add `interpreterPath` to the `CreateEnvironmentOptionsInternal` options so we can skip user input via quickpick, as we'll already have the interpreterPath for a global python installation
- modify `VenvCreationProvider.createEnvironment()` to use `interpreterPath` if provided
- modify `validateMetadata` to return a corresponding registered runtimeMetadata based on the `pythonPath` -- this allows us to pass in a runtimeMetadata object which only contains a `pythonPath` and receive an actual filled-out runtimeMetadata object

#### new project service
- add support for creating a new Python environment using Venv
- install `ipykernel` in the created environment
- autostart the interpreter initialized in the created environment

#### project wizard dialog
- leverage the `pythonEnvProviderName` to omit Conda envs from the project config, since we don't currently support Conda (support will be added via #2839)
- only install `ipykernel` for existing interpreters, since new environments will be handled by the new project service

### QA Notes

Suggested steps
1. Open the New Project Wizard
2. Select Python Project or Jupyter Notebook
3. Project name/location should be inconsequential (defaults are fine)
4. Select New Environment and use Venv as the provider
5. Select any version of Python in the interpreter dropdown
6. Create the Project

Expected outputs
- once the new project window is loaded, a `.venv` directory should be created after a few moments, with `ipykernel` installed
- the Venv interpreter (based on the selected version of Python in the project wizard) should be selected as the active interpreter
- a blank Python/Jupyter file should be open
- the Console should be functional and reflect the Venv interpreter
