### PR TITLE
Contain text in block so text-overflow: ellipsis works

### DIFF
--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.css
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.css
@@ -65,7 +65,6 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	overflow: hidden;
 	position: absolute;
 }
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.css
@@ -4,33 +4,41 @@
 
 .data-grid-row-cell
 .content
-.text {
+.text-container {
 	height: 100%;
 	display: flex;
 	margin: 0 7px;
-	overflow: hidden;
 	align-items: center;
+}
+
+.data-grid-row-cell
+.content
+.text-container
+.text-value {
+	overflow: hidden;
 	white-space: nowrap;
-	line-height: normal;
 	text-overflow: ellipsis;
 	white-space-collapse: preserve;
 }
 
 .data-grid-row-cell
 .content
-.text.left {
+.text-container
+.text-value.left {
 	justify-content: left;
 }
 
 .data-grid-row-cell
 .content
-.text.center {
+.text-container
+.text-value.center {
 	justify-content: center;
 }
 
 .data-grid-row-cell
 .content
-.text.right {
+.text-container
+.text-value.right {
 	justify-content: right;
 	font-variant-numeric: tabular-nums;
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
@@ -29,8 +29,10 @@ interface TableDataCellProps {
 export const TableDataCell = (props: TableDataCellProps) => {
 	// Render.
 	return (
-		<div className={positronClassNames('text', props.column.alignment)}>
-			{props.cellValue.formatted}
+		<div className={positronClassNames('text-container', props.column.alignment)}>
+			<div className='text-value'>
+				{props.cellValue.formatted}
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR adresses https://github.com/posit-dev/positron/issues/3258 by placing `TableDataCell` text in a block `div` with `text-overflow: ellipsis`.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

I adjusted CSS.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

To test, in Python, execute:

```
import pandas as pd
df_long = pd.DataFrame({
    'long': ['aaa' * i for i in range(20)]
})
```

And you should see:

<img width="748" alt="image" src="https://github.com/posit-dev/positron/assets/853239/ec4418f4-55cc-46fa-855b-26a149c295d5">

