### PR TITLE
Allow passing `metadata` on client creation for ipywidgets support

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -767,8 +767,9 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 	 * @param targetName The name of the target comm to create.
 	 * @param id The ID of the comm to create.
 	 * @param data Data to send to the comm.
+	 * @param metadata Metadata to send to the comm.
 	 */
-	public openComm(targetName: string, id: string, data: object): Promise<void> {
+	public openComm(targetName: string, id: string, data: object, metadata?: object): Promise<void> {
 		// Create the message to send to the kernel
 		const msg: JupyterCommOpen = {
 			target_name: targetName,  // eslint-disable-line
@@ -777,7 +778,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		};
 
 		// Dispatch it
-		return this.send(uuidv4(), 'comm_open', this._shell!, msg);
+		return this.send(uuidv4(), 'comm_open', this._shell!, msg, metadata);
 	}
 
 	/**
@@ -1252,9 +1253,10 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 	 * @param type The type of the message
 	 * @param dest The socket to which the message should be sent
 	 * @param message The body of the message
+	 * @param metadata The metadata to send with the message
 	 */
-	private send(id: string, type: string, dest: JupyterSocket, message: JupyterMessageSpec): Promise<void> {
-		return this.sendToSocket(id, type, dest, {} as JupyterMessageHeader, message);
+	private send(id: string, type: string, dest: JupyterSocket, message: JupyterMessageSpec, metadata?: object): Promise<void> {
+		return this.sendToSocket(id, type, dest, {} as JupyterMessageHeader, message, metadata);
 	}
 
 	/**
@@ -1265,14 +1267,15 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 	 * @param dest The socket to which the message should be sent
 	 * @param parent The parent message header (if any, {} if no parent)
 	 * @param message The body of the message
+	 * @param metadata The metadata to send with the message
 	 */
 	private async sendToSocket(id: string, type: string, dest: JupyterSocket,
-		parent: JupyterMessageHeader, message: JupyterMessageSpec) {
+		parent: JupyterMessageHeader, message: JupyterMessageSpec, metadata: object = {}) {
 		const msg: JupyterMessage = {
 			buffers: [],
 			content: message,
 			header: this.generateMessageHeader(id, type),
-			metadata: new Map(),
+			metadata: metadata as Map<any, any>,
 			parent_header: parent
 		};
 		this.log(`SEND ${msg.header.msg_type} to ${dest.title()}: ${JSON.stringify(msg)}`);

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -407,11 +407,14 @@ export class LanguageRuntimeSessionAdapter
 	 * @param type The type of client to create
 	 * @param params The parameters for the client; the format of this object is
 	 *   specific to the client type
+	 * @param metadata The metadata for the client; the format of this object is
+	 *   specific to the client type
 	 */
 	public async createClient(
 		id: string,
 		type: positron.RuntimeClientType,
-		params: object
+		params: object,
+		metadata?: object,
 	) {
 
 		// Ensure the type of client we're being asked to create is a known type that supports
@@ -429,7 +432,7 @@ export class LanguageRuntimeSessionAdapter
 			const server_comm = type === positron.RuntimeClientType.Lsp;
 
 			// Create a new client adapter to wrap the comm channel
-			const adapter = new RuntimeClientAdapter(id, type, params, this._kernel, server_comm);
+			const adapter = new RuntimeClientAdapter(id, type, params, this._kernel, server_comm, metadata);
 
 			// Add the client to the map. Note that we have to do this before opening
 			// the instance, because we may need to process messages from the client

--- a/extensions/jupyter-adapter/src/RuntimeClientAdapter.ts
+++ b/extensions/jupyter-adapter/src/RuntimeClientAdapter.ts
@@ -37,7 +37,8 @@ export class RuntimeClientAdapter {
 		private readonly _type: positron.RuntimeClientType,
 		private readonly _params: object,
 		private readonly _kernel: JupyterKernel,
-		private readonly _server_comm: boolean) {
+		private readonly _server_comm: boolean,
+		private readonly _metadata?: object) {
 
 		// Wire event handlers for state changes
 		this._currentState = positron.RuntimeClientState.Uninitialized;
@@ -73,7 +74,7 @@ export class RuntimeClientAdapter {
 	public async open(): Promise<void> {
 		// Ask the kernel to open a comm channel for us
 		this._state.fire(positron.RuntimeClientState.Opening);
-		await this._kernel.openComm(this._type, this._id, this._params);
+		await this._kernel.openComm(this._type, this._id, this._params, this._metadata);
 
 		// If not a server comm, resolve immediately. If a server
 		// comm, we'll resolve when we get the notification message

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -148,9 +148,9 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    createClient(id: string, type: positron.RuntimeClientType, params: any): Thenable<void> {
+    createClient(id: string, type: positron.RuntimeClientType, params: any, metadata?: any): Thenable<void> {
         if (this._kernel) {
-            return this._kernel.createClient(id, type, params);
+            return this._kernel.createClient(id, type, params, metadata);
         } else {
             throw new Error(`Cannot create client of type '${type}'; kernel not started`);
         }

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -182,9 +182,9 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		}
 	}
 
-	createClient(id: string, type: positron.RuntimeClientType, params: any): Thenable<void> {
+	createClient(id: string, type: positron.RuntimeClientType, params: any, metadata?: any): Thenable<void> {
 		if (this._kernel) {
-			return this._kernel.createClient(id, type, params);
+			return this._kernel.createClient(id, type, params, metadata);
 		} else {
 			throw new Error(`Cannot create client of type '${type}'; kernel not started`);
 		}

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -721,8 +721,9 @@ declare module 'positron' {
 		 *   unique string.
 		 * @param type The type of client to create
 		 * @param params A set of parameters to pass to the client; specific to the client type
+		 * @param metadata A set of metadata to pass to the client; specific to the client type
 		 */
-		createClient(id: string, type: RuntimeClientType, params: any): Thenable<void>;
+		createClient(id: string, type: RuntimeClientType, params: any, metadata?: any): Thenable<void>;
 
 		/**
 		 * List all clients, optionally filtered by type.

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -384,7 +384,7 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 	}
 
 	/** Create a new client inside the runtime */
-	createClient<Input, Output>(type: RuntimeClientType, params: any):
+	createClient<Input, Output>(type: RuntimeClientType, params: any, metadata?: any):
 		Thenable<IRuntimeClientInstance<Input, Output>> {
 		// Create an ID for the client.
 		const id = this.generateClientId(this.runtimeMetadata.languageId, type);
@@ -403,7 +403,7 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 		// If the creation fails on the server, we'll either get an error here
 		// or see the server end get closed immediately via a CommClose message.
 		// In either case we'll let the client know.
-		this._proxy.$createClient(this.handle, id, type, params).then(() => {
+		this._proxy.$createClient(this.handle, id, type, params, metadata).then(() => {
 			// There is no protocol message indicating that the client has been
 			// successfully created, so presume it's connected once the message
 			// has been safely delivered, and handle the close event if it

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -55,7 +55,7 @@ export interface ExtHostLanguageRuntimeShape {
 	$openResource(handle: number, resource: URI | string): Promise<boolean>;
 	$executeCode(handle: number, code: string, id: string, mode: RuntimeCodeExecutionMode, errorBehavior: RuntimeErrorBehavior): void;
 	$isCodeFragmentComplete(handle: number, code: string): Promise<RuntimeCodeFragmentStatus>;
-	$createClient(handle: number, id: string, type: RuntimeClientType, params: any): Promise<void>;
+	$createClient(handle: number, id: string, type: RuntimeClientType, params: any, metadata?: any): Promise<void>;
 	$listClients(handle: number, type?: RuntimeClientType): Promise<Record<string, string>>;
 	$removeClient(handle: number, id: string): void;
 	$sendClientMessage(handle: number, client_id: string, message_id: string, message: any): void;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -382,11 +382,11 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		return Promise.resolve(this._runtimeSessions[handle].isCodeFragmentComplete(code));
 	}
 
-	$createClient(handle: number, id: string, type: RuntimeClientType, params: any): Promise<void> {
+	$createClient(handle: number, id: string, type: RuntimeClientType, params: any, metadata?: any): Promise<void> {
 		if (handle >= this._runtimeSessions.length) {
 			throw new Error(`Cannot create '${type}' client: session handle '${handle}' not found or no longer valid.`);
 		}
-		return Promise.resolve(this._runtimeSessions[handle].createClient(id, type, params));
+		return Promise.resolve(this._runtimeSessions[handle].createClient(id, type, params, metadata));
 	}
 
 	$listClients(handle: number, type?: RuntimeClientType): Promise<Record<string, string>> {

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -148,8 +148,9 @@ export interface ILanguageRuntimeSession {
 	 *
 	 * @param type The type of client to create
 	 * @param params The parameters to pass to the client constructor
+	 * @param metadata The metadata to pass to the client constructor
 	 */
-	createClient<T, U>(type: RuntimeClientType, params: any): Thenable<IRuntimeClientInstance<T, U>>;
+	createClient<T, U>(type: RuntimeClientType, params: any, metadata?: any): Thenable<IRuntimeClientInstance<T, U>>;
 
 	/** Get a list of all known clients */
 	listClients(type?: RuntimeClientType): Thenable<Array<IRuntimeClientInstance<any, any>>>;


### PR DESCRIPTION
**NB: I accidentally merged https://github.com/posit-dev/positron/pull/3277 into another branch instead of `main`. Since that had passed review, I'll merge this without an approval.**

### Intent

A small step toward #3276.

### Approach

This PR allows `metadata` to be passed to `createClient`. This is required by the `ipywidgets` Python kernel implementation which assume that `jupyter.widget` ([source](https://github.com/jupyter-widgets/ipywidgets/blob/b12dae7f55b85250e848e8a94014499aa1e45ce0/python/ipywidgets/ipywidgets/widgets/widget.py#L415)) and `jupyter.widget.control` ([source](https://github.com/jupyter-widgets/ipywidgets/blob/b12dae7f55b85250e848e8a94014499aa1e45ce0/python/ipywidgets/ipywidgets/widgets/widget.py#L373)) comm open messages have `{ metadata: { version: string } }`.

An alternative could be to catch and modify these messages in our kernel, but I feel like we ought to support `metadata` anyway.

### QA Notes

Should be no functional changes.