### PR TITLE
Fix theme for custom plot size dialog

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/setPlotSizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/setPlotSizeModalDialog.tsx
@@ -7,7 +7,7 @@ import 'vs/css!./setPlotSizeModalDialog';
 
 // React.
 import * as React from 'react';
-import { useRef } from 'react'; // eslint-disable-line no-duplicate-imports
+import { useState } from 'react'; // eslint-disable-line no-duplicate-imports
 
 // Other dependencies.
 import { localize } from 'vs/nls';
@@ -17,6 +17,7 @@ import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/la
 import { ContentArea } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/contentArea';
 import { PositronModalDialog } from 'vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog';
 import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer';
+import { LabeledTextInput } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/labeledTextInput';
 
 /**
  * SetPlotSizeResult interface.
@@ -70,19 +71,17 @@ interface SetPlotSizeModalDialogProps {
  * @returns The rendered component.
  */
 const SetPlotSizeModalDialog = (props: SetPlotSizeModalDialogProps) => {
-	// Reference hooks.
-	const widthRef = useRef<HTMLInputElement>(undefined!);
-	const heightRef = useRef<HTMLInputElement>(undefined!);
+	const [width, setWidth] = useState(props.customSize?.width ?? 100);
+	const [height, setHeight] = useState(props.customSize?.height ?? 100);
 
 	// The accept handler.
 	const acceptHandler = () => {
 		let result: SetPlotSizeResult | undefined = undefined;
-		if (widthRef.current && widthRef.current.value.length > 0 &&
-			heightRef.current && heightRef.current.value.length > 0) {
+		if (width && height && width > 0 && height > 0) {
 			result = {
 				size: {
-					width: parseInt(widthRef.current.value),
-					height: parseInt(heightRef.current.value)
+					width: width,
+					height: height
 				}
 			};
 		}
@@ -115,37 +114,15 @@ const SetPlotSizeModalDialog = (props: SetPlotSizeModalDialogProps) => {
 					<tbody>
 						<tr>
 							<td>
-								<label htmlFor='width'>
-									{(() => localize('positronPlotWidth', "Width"))()}
-								</label>
+								<LabeledTextInput label={(() => localize('positronPlotWidth', "Width"))()}
+									value={width} autoFocus={true}
+									type='number' onChange={(el) => { setWidth(el.target.valueAsNumber); }} />
 							</td>
 							<td>
-								<input
-									ref={widthRef}
-									id='width'
-									type='number'
-									placeholder='100'
-									defaultValue={props.customSize ? props.customSize.width : ''}
-								/>
+								<LabeledTextInput label={(() => localize('positronPlotHeight', "Height"))()}
+									value={height}
+									type='number' onChange={(el) => { setHeight(el.target.valueAsNumber); }} />
 							</td>
-							<td>{(() => localize('positronPlotPixelsAbbrev', "px"))()}</td>
-						</tr>
-						<tr>
-							<td>
-								<label htmlFor='height'>
-									{(() => localize('positronPlotHeight', "Height"))()}
-								</label>
-							</td>
-							<td>
-								<input
-									ref={heightRef}
-									id='height'
-									type='number'
-									placeholder='100'
-									defaultValue={props.customSize ? props.customSize.height : ''}
-								/>
-							</td>
-							<td>{(() => localize('positronPlotPixelsAbbrev', "px"))()}</td>
 						</tr>
 					</tbody>
 				</table>

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/setPlotSizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/setPlotSizeModalDialog.tsx
@@ -77,14 +77,12 @@ const SetPlotSizeModalDialog = (props: SetPlotSizeModalDialogProps) => {
 	// The accept handler.
 	const acceptHandler = () => {
 		let result: SetPlotSizeResult | undefined = undefined;
-		if (width && height && width > 0 && height > 0) {
-			result = {
-				size: {
-					width: width,
-					height: height
-				}
-			};
-		}
+		result = {
+			size: {
+				width: width,
+				height: height
+			}
+		};
 		props.renderer.dispose();
 		props.setPlotSize(result);
 	};
@@ -115,13 +113,13 @@ const SetPlotSizeModalDialog = (props: SetPlotSizeModalDialogProps) => {
 						<tr>
 							<td>
 								<LabeledTextInput label={(() => localize('positronPlotWidth', "Width"))()}
-									value={width} autoFocus={true}
-									type='number' onChange={(el) => { setWidth(el.target.valueAsNumber); }} />
+									value={width} autoFocus={true} min={100}
+									type='number' onChange={(el) => setWidth(el.target.valueAsNumber)} />
 							</td>
 							<td>
 								<LabeledTextInput label={(() => localize('positronPlotHeight', "Height"))()}
-									value={height}
-									type='number' onChange={(el) => { setHeight(el.target.valueAsNumber); }} />
+									value={height} min={100}
+									type='number' onChange={(el) => setHeight(el.target.valueAsNumber)} />
 							</td>
 						</tr>
 					</tbody>


### PR DESCRIPTION
### Intent
Address #3238

### Approach
Switch to using `LabeledTextInput`. Instead of adding placeholder support to `LabeledTextInput`, I've removed it and set a default value. The "px" label was also removed. I think this aligns better with the save plot dialog layout.

### QA Notes
No more placeholder or "px" label. This uses the same style as other parts of the UI since it's using a common component now.
