### PR TITLE
Explicitly request the default 'type' command

### DIFF
--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -34,10 +34,13 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 		}),
 
 		// TODO: remove this hack when we can address the Console like an editor
+		// In the meantime, note the use of the command 'default:type' instead of 'type'.
+		// This works around the fact that the vim plugin overrides the 'type' command.
+		// https://github.com/posit-dev/positron/issues/3279
 		vscode.commands.registerCommand('r.insertPipeConsole', () => {
 			const extConfig = vscode.workspace.getConfiguration('positron.r');
 			const pipeString = extConfig.get<string>('pipe') || '|>';
-			vscode.commands.executeCommand('type', { text: ` ${pipeString} ` });
+			vscode.commands.executeCommand('default:type', { text: ` ${pipeString} ` });
 		}),
 
 		vscode.commands.registerCommand('r.insertLeftAssignment', () => {
@@ -46,7 +49,7 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 
 		// TODO: remove this hack when we can address the Console like an editor
 		vscode.commands.registerCommand('r.insertLeftAssignmentConsole', () => {
-			vscode.commands.executeCommand('type', { text: ' <- ' });
+			vscode.commands.executeCommand('default:type', { text: ' <- ' });
 		}),
 
 		// Commands for package development tooling


### PR DESCRIPTION
### Intent

Addresses #3279, where we see R's `<-` (left assignment) and `|>` (pipe) appearing in the source editor, even when the user is working in the console. We've heard of this at least twice and, so far, it's always been a negative interaction with the vim emulation extension (https://open-vsx.org/extension/vscodevim/vim).

### Approach

The vim extension overrides the `'type'` command, globally it appears 😲 

By requesting the `'default:type'` command, we can avoid their override or, presumably, anyone else's.

### QA Notes

Install the vim extension and try to use the keyboard shortcuts to insert `<-` (Opt/Alt + `-`) and `|>` (Cmd/Ctrl + Shift + M) while working in the R console. They should be inserted in the console and not the source editor.