### PR TITLE
Fix "Python: Create Environment" not selecting the corresponding interpreter

### DIFF
--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -68,6 +68,17 @@ export class PythonRuntimeManager implements IPythonRuntimeManager {
                     await this.registerLanguageRuntimeFromPath(interpreterPath);
                 }
             }),
+
+            interpreterService.onDidChangeInterpreter(async (workspaceUri) => {
+                const interpreter = await interpreterService.getActiveInterpreter(workspaceUri);
+                if (!interpreter) {
+                    traceError(
+                        `Interpreter not found; could not select language runtime. Workspace: ${workspaceUri?.fsPath}`,
+                    );
+                    return;
+                }
+                await this.selectLanguageRuntimeFromPath(interpreter.path);
+            }),
         );
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Address #3298.

### Approach

The fix is to listen to `IInterpreterService.onDidChangeInterpreter` and call `selectLanguageRuntime`.

Unfortunately, that makes it possible to do quick consecutive calls to `selectLanguageRuntime` which errors before this PR. The second change is to coalesce `selectLanguageRuntime` – indirectly, by extracting `shutdownRuntimeSession` and coalescing calls to it. That'll also be needed when we bring functionality from positron-notebook-controller into positron core (#2671).

### QA Notes

See the repro in the issue, also worth playing around with the "Python: Select Interpreter" command, and the other ways of shutting down a runtime in the UI.