### PR TITLE
Project Wizard: handle state changes to project directory

### DIFF
--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectTypeStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectTypeStep.tsx
@@ -16,6 +16,7 @@ import { NewProjectWizardStep } from 'vs/workbench/browser/positronNewProjectWiz
 import { NewProjectWizardStepProps } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardStepProps';
 import { OKCancelBackNextActionBar } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelBackNextActionBar';
 import { ProjectTypeGroup } from 'vs/workbench/browser/positronNewProjectWizard/components/projectTypeGroup';
+import { checkProjectName } from 'vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils';
 
 /**
  * The ProjectTypeStep component is the first step in the new project wizard, used to
@@ -32,7 +33,7 @@ export const ProjectTypeStep = (props: PropsWithChildren<NewProjectWizardStepPro
 
 	// Set the projectType and initialize the default project name if applicable,
 	// then navigate to the ProjectNameLocation step.
-	const nextStep = () => {
+	const nextStep = async () => {
 		if (!selectedProjectType) {
 			// If no project type is selected, return. This shouldn't happen since the Next button should
 			// be disabled if no project type is selected.
@@ -51,6 +52,12 @@ export const ProjectTypeStep = (props: PropsWithChildren<NewProjectWizardStepPro
 				) + selectedProjectType.replace(/\s/g, '');
 			context.projectType = selectedProjectType;
 			context.projectName = defaultProjectName;
+			context.projectNameFeedback = await checkProjectName(
+				defaultProjectName,
+				context.parentFolder,
+				context.services.pathService,
+				context.services.fileService
+			);
 		}
 		props.next(NewProjectWizardStep.ProjectNameLocation);
 	};

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
@@ -186,6 +186,7 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 							"Use `renv` to create a reproducible environment"
 						))()}
 						onChanged={checked => context.useRenv = checked}
+						initialChecked={context.useRenv}
 					/>
 					<ExternalLink
 						className='renv-docs-external-link'

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -155,6 +155,9 @@ export const showNewProjectModalDialog = async (
 	);
 };
 
+/**
+ * NewProjectModalDialogProps interface.
+ */
 interface NewProjectModalDialogProps {
 	renderer: PositronModalReactRenderer;
 	createProject: (result: NewProjectWizardState) => Promise<void>;

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -25,7 +25,7 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IPositronNewProjectService, NewProjectConfiguration } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
-import { EnvironmentSetupType, NewProjectWizardStep, PythonEnvironmentProvider } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
+import { EnvironmentSetupType, NewProjectWizardStep } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
 import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 
 /**
@@ -82,16 +82,6 @@ export const showNewProjectModalDialog = async (
 						await fileService.createFolder(folder);
 					}
 
-					// The python environment type is only relevant if a new environment is being created.
-					const pythonEnvProviderId =
-						result.pythonEnvSetupType ===
-							EnvironmentSetupType.NewEnvironment &&
-							// TODO: Conda isn't supported yet, so don't set the env provider if it's conda.
-							result.pythonEnvProviderName !==
-							PythonEnvironmentProvider.Conda
-							? result.pythonEnvProviderId
-							: '';
-
 					// Install ipykernel if applicable for an existing environment.
 					// For new environments, ipykernel will be installed as part of the environment
 					// creation and setup process once the new project is opened.
@@ -104,7 +94,7 @@ export const showNewProjectModalDialog = async (
 							result.selectedRuntime?.extraRuntimeData
 								?.pythonPath ??
 							result.selectedRuntime?.runtimePath ??
-							'';
+							undefined;
 						if (!pythonPath) {
 							logService.error(
 								'Could not determine python path to install ipykernel via Positron Project Wizard'
@@ -129,10 +119,10 @@ export const showNewProjectModalDialog = async (
 						projectFolder: folder.fsPath,
 						projectName: result.projectName,
 						initGitRepo: result.initGitRepo,
-						pythonEnvProviderId: pythonEnvProviderId || '',
-						pythonEnvProviderName: result.pythonEnvProviderName || '',
-						installIpykernel: result.installIpykernel || false,
-						useRenv: result.useRenv || false,
+						pythonEnvProviderId: result.pythonEnvProviderId,
+						pythonEnvProviderName: result.pythonEnvProviderName,
+						installIpykernel: result.installIpykernel,
+						useRenv: result.useRenv,
 					};
 
 					// TODO: we may want to allow the user to select an already existing directory

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -773,6 +773,7 @@ export class NewProjectWizardStateManager
 			this._services.logService.error(
 				'[Project Wizard] Unsupported project type'
 			);
+			return;
 		}
 		if (langId === LanguageIds.Python) {
 			this._useRenv = undefined;

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -18,6 +18,7 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { PythonEnvironmentProviderInfo } from 'vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Emitter, Event } from 'vs/base/common/event';
+import { WizardFormattedTextItem } from 'vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText';
 
 /**
  * NewProjectWizardServices interface.
@@ -98,6 +99,7 @@ export class NewProjectWizardStateManager
 	private _selectedRuntime: ILanguageRuntimeMetadata | undefined;
 	private _projectType: NewProjectType | undefined;
 	private _projectName: string;
+	private _projectNameFeedback: WizardFormattedTextItem | undefined;
 	private _parentFolder: string;
 	private _initGitRepo: boolean;
 	private _openInNewWindow: boolean;
@@ -136,6 +138,7 @@ export class NewProjectWizardStateManager
 		this._selectedRuntime = undefined;
 		this._projectType = undefined;
 		this._projectName = '';
+		this._projectNameFeedback = undefined;
 		this._parentFolder = config.parentFolder ?? '';
 		this._initGitRepo = false;
 		this._openInNewWindow = false;
@@ -261,6 +264,23 @@ export class NewProjectWizardStateManager
 	 */
 	set projectName(value: string) {
 		this._projectName = value;
+		this._onUpdateProjectDirectoryEmitter.fire();
+	}
+
+	/**
+	 * Gets the project name feedback.
+	 * @returns The project name feedback.
+	 */
+	get projectNameFeedback(): WizardFormattedTextItem | undefined {
+		return this._projectNameFeedback;
+	}
+
+	/**
+	 * Sets the project name feedback.
+	 * @param value The project name feedback.
+	 */
+	set projectNameFeedback(value: WizardFormattedTextItem | undefined) {
+		this._projectNameFeedback = value;
 		this._onUpdateProjectDirectoryEmitter.fire();
 	}
 
@@ -741,6 +761,7 @@ export class NewProjectWizardStateManager
 	private _resetProjectConfig() {
 		this._initGitRepo = false;
 		this._useRenv = undefined;
+		this.projectNameFeedback = undefined;
 	}
 
 	/**

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -75,6 +75,7 @@ export interface INewProjectWizardStateManager {
 	readonly goToNextStep: (step: NewProjectWizardStep) => void;
 	readonly goToPreviousStep: () => void;
 	readonly onUpdateInterpreterState: Event<void>;
+	readonly onUpdateProjectDirectory: Event<void>;
 }
 
 /**
@@ -121,6 +122,7 @@ export class NewProjectWizardStateManager
 
 	// Event emitters.
 	private _onUpdateInterpreterStateEmitter = this._register(new Emitter<void>());
+	private _onUpdateProjectDirectoryEmitter = this._register(new Emitter<void>());
 
 	/**
 	 * Constructor for the NewProjectWizardStateManager class.
@@ -238,6 +240,9 @@ export class NewProjectWizardStateManager
 	 * @param value The project type.
 	 */
 	set projectType(value: NewProjectType | undefined) {
+		if (this._projectType !== value) {
+			this._resetProjectConfig();
+		}
 		this._projectType = value;
 		this._updateInterpreterRelatedState();
 	}
@@ -256,6 +261,7 @@ export class NewProjectWizardStateManager
 	 */
 	set projectName(value: string) {
 		this._projectName = value;
+		this._onUpdateProjectDirectoryEmitter.fire();
 	}
 
 	/**
@@ -272,6 +278,7 @@ export class NewProjectWizardStateManager
 	 */
 	set parentFolder(value: string) {
 		this._parentFolder = value;
+		this._onUpdateProjectDirectoryEmitter.fire();
 	}
 
 	/**
@@ -492,6 +499,11 @@ export class NewProjectWizardStateManager
 	 * Event that is fired when the runtime startup is complete.
 	 */
 	readonly onUpdateInterpreterState = this._onUpdateInterpreterStateEmitter.event;
+
+	/**
+	 * Event that is fired when the project directory is updated.
+	 */
+	readonly onUpdateProjectDirectory = this._onUpdateProjectDirectoryEmitter.event;
 
 	/****************************************************************************************
 	 * Private Methods
@@ -720,6 +732,15 @@ export class NewProjectWizardStateManager
 			!filters.length ||
 			filters.find((rs) => rs === runtimeSource) !== undefined
 		);
+	}
+
+	/**
+	 * Resets the properties of the project configuration that should not be persisted when the
+	 * project type changes.
+	 */
+	private _resetProjectConfig() {
+		this._initGitRepo = false;
+		this._useRenv = undefined;
 	}
 
 	/**

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -63,10 +63,10 @@ export interface NewProjectConfiguration {
 	readonly projectFolder: string;
 	readonly projectName: string;
 	readonly initGitRepo: boolean;
-	readonly pythonEnvProviderId: string;
-	readonly pythonEnvProviderName: string;
-	readonly installIpykernel: boolean;
-	readonly useRenv: boolean;
+	readonly pythonEnvProviderId: string | undefined;
+	readonly pythonEnvProviderName: string | undefined;
+	readonly installIpykernel: boolean | undefined;
+	readonly useRenv: boolean | undefined;
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

- Addresses: https://github.com/posit-dev/positron/issues/3291

### Approach

- Ensure the project name and location component is communicating with the state properly
- Add an event which fires when the project name, directory or name feedback is updated, so components can subscribe and update their state
- Use a similar pattern to the #3145 to set/get the project name feedback between the component and the state

_~This branch is currently targeted to `feature/project-wizard-new-venv` so the diff is clear.~ I'm also a bit curious what will happen to this PR when the Venv PR is merged and the branch is deleted. I wonder if this PR will auto-retarget to `main` and if the commits will become weird or if that will be handled 🤔_ 
- _Update: yes, the branch auto-targeted to `main` and because of our squash strategy, the commits from the other branch showed here. But the commits in this PR have been fixed with some resetting and cherry-picking 👍_ 


### QA Notes

A user should once again be able to type more than one or two characters into the project name input box now!