### PR TITLE
Show more informative log and link to logfile on Console crash

### DIFF
--- a/extensions/jupyter-adapter/src/Api.ts
+++ b/extensions/jupyter-adapter/src/Api.ts
@@ -105,5 +105,4 @@ export class JupyterAdapterApiImpl implements JupyterAdapterApi {
 
 	dispose() {
 	}
-
 }

--- a/extensions/jupyter-adapter/src/Api.ts
+++ b/extensions/jupyter-adapter/src/Api.ts
@@ -103,6 +103,14 @@ export class JupyterAdapterApiImpl implements JupyterAdapterApi {
 		return findAvailablePort(excluding, maxTries);
 	}
 
+	/**
+	 * Return logfile path
+	 */
+	getKernelLogFile(): string {
+		return this.getKernelLogFile();
+	}
+
 	dispose() {
 	}
+
 }

--- a/extensions/jupyter-adapter/src/Api.ts
+++ b/extensions/jupyter-adapter/src/Api.ts
@@ -103,13 +103,6 @@ export class JupyterAdapterApiImpl implements JupyterAdapterApi {
 		return findAvailablePort(excluding, maxTries);
 	}
 
-	/**
-	 * Return logfile path
-	 */
-	getKernelLogFile(): string {
-		return this.getKernelLogFile();
-	}
-
 	dispose() {
 	}
 

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -355,8 +355,8 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		return this.establishSocketListeners();
 	}
 
-	public getLogFilePath() {
-		return this._session!.state.logFile;
+	public getKernelLogFilePath() {
+		return this._session!.logFile;
 	}
 
 	private handleIopubMsg(args: any[]) {

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -355,6 +355,10 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		return this.establishSocketListeners();
 	}
 
+	public getLogFilePath() {
+		return this._session!.state.logFile;
+	}
+
 	private handleIopubMsg(args: any[]) {
 		// Deserialize the message
 		const msg = deserializeJupyterMessage(args, this._session!.key, this._channel);
@@ -1468,17 +1472,6 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 							this.log(`Could not parse exit code in last line of log file ` +
 								`${state.logFile}: ${lastLine}`);
 						}
-						// don't surface errors for normal exit status
-						if (exitCode != 0) {
-							const endIndex = lines.findIndex(line => line.startsWith('*** Log ended'));
-
-							const logFileContent = lines.slice(endIndex - 1, endIndex).join('\n');
-							const regex = /^(\w*Error)\b/m;
-							// check to see if there is an error to surface
-							if (regex.test(logFileContent)) {
-								this.showErrorMessage(logFileContent, state.logFile);
-							}
-						}
 					} catch (e) {
 						this.log(`Could not find exit code in last line of log file ` +
 							`${state.logFile}: ${lastLine} (${e}))`);
@@ -1588,17 +1581,6 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 	 */
 	public showOutput() {
 		this._logChannel?.show();
-	}
-
-	/**
-	* Show error from logs in message and give link to logfile
-	*/
-	public async showErrorMessage(errorMessage: string, logfile: string) {
-		const res = await vscode.window.showErrorMessage(errorMessage, vscode.l10n.t('Open logfile'));
-		if (res) {
-			const textDocument = await vscode.workspace.openTextDocument(logfile);
-			await vscode.window.showTextDocument(textDocument);
-		}
 	}
 
 	/**

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -1472,6 +1472,10 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 						this.log(`Could not find exit code in last line of log file ` +
 							`${state.logFile}: ${lastLine} (${e}))`);
 					}
+					// last line before log end is end of traceback
+					const endIndex = lines.findIndex(line => line.startsWith('*** Log ended'));
+					const logFileContent = lines.slice(endIndex - 1, endIndex).join('\n');
+					this.showErrorMessage(logFileContent, state.logFile);
 				}
 			} else {
 				this.log(`Not reading exit code from process ${state.processId}; ` +
@@ -1577,6 +1581,17 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 	 */
 	public showOutput() {
 		this._logChannel?.show();
+	}
+
+	/**
+	* Show error from logs in message and give link to logfile
+	*/
+	public async showErrorMessage(errorMessage: string, logfile: string) {
+		const res = await vscode.window.showErrorMessage(errorMessage, vscode.l10n.t('Open logfile'));
+		if (res) {
+			const textDocument = await vscode.workspace.openTextDocument(logfile);
+			await vscode.window.showTextDocument(textDocument);
+		}
 	}
 
 	/**

--- a/extensions/jupyter-adapter/src/JupyterSession.ts
+++ b/extensions/jupyter-adapter/src/JupyterSession.ts
@@ -56,6 +56,10 @@ export class JupyterSession implements vscode.Disposable {
 		return this.state.sessionId;
 	}
 
+	get logFile(): string {
+		return this.state.logFile;
+	}
+
 	get portsInUse(): Array<number> {
 		return [
 			this.spec.control_port,

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -1019,4 +1019,8 @@ export class LanguageRuntimeSessionAdapter
 		// Tell the kernel to shut down
 		await this._kernel.dispose();
 	}
+
+	public getLogFile(): string {
+		return this._kernel.getLogFilePath()
+	}
 }

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -1021,6 +1021,6 @@ export class LanguageRuntimeSessionAdapter
 	}
 
 	public getKernelLogFile(): string {
-		return this._kernel.getLogFilePath()
+		return this._kernel.getKernelLogFilePath()
 	}
 }

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -1020,7 +1020,7 @@ export class LanguageRuntimeSessionAdapter
 		await this._kernel.dispose();
 	}
 
-	public getLogFile(): string {
+	public getKernelLogFile(): string {
 		return this._kernel.getLogFilePath()
 	}
 }

--- a/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
+++ b/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
@@ -82,6 +82,11 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * response.
 	 */
 	callMethod(method: string, ...args: Array<any>): Promise<any>;
+
+	/**
+	 * Return logfile path
+	 */
+	getKernelLogFile(): string;
 }
 
 /**
@@ -132,11 +137,6 @@ export interface JupyterAdapterApi extends vscode.Disposable {
 	 * @returns An available TCP port
 	 */
 	findAvailablePort(excluding: Array<number>, maxTries: number): Promise<number>;
-
-	/**
-	  * Return logfile path
-	 */
-	getKernelLogFile(): string;
 }
 
 /** Specific functionality implemented by runtimes */

--- a/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
+++ b/extensions/jupyter-adapter/src/jupyter-adapter.d.ts
@@ -132,6 +132,11 @@ export interface JupyterAdapterApi extends vscode.Disposable {
 	 * @returns An available TCP port
 	 */
 	findAvailablePort(excluding: Array<number>, maxTries: number): Promise<number>;
+
+	/**
+	  * Return logfile path
+	 */
+	getKernelLogFile(): string;
 }
 
 /** Specific functionality implemented by runtimes */

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -530,3 +530,9 @@ export namespace CreateEnv {
         );
     }
 }
+
+// --- Start Positron ---
+export namespace Console {
+    export const consoleExit = l10n.t('Console exited unexpectedly. View logs for more info.');
+}
+// --- End Positron ---

--- a/extensions/positron-python/src/client/jupyter-adapter.d.ts
+++ b/extensions/positron-python/src/client/jupyter-adapter.d.ts
@@ -132,6 +132,11 @@ export interface JupyterAdapterApi extends vscode.Disposable {
      * @returns An available TCP port
      */
     findAvailablePort(excluding: Array<number>, maxTries: number): Promise<number>;
+
+    /**
+     * Return logfile path
+     */
+    getKernelLogFile(): string;
 }
 
 /** Specific functionality implemented by runtimes */

--- a/extensions/positron-python/src/client/jupyter-adapter.d.ts
+++ b/extensions/positron-python/src/client/jupyter-adapter.d.ts
@@ -82,7 +82,7 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
     /**
      * Return logfile path
      */
-    getLogFile(): string;
+    getKernelLogFile(): string;
 }
 
 /**

--- a/extensions/positron-python/src/client/jupyter-adapter.d.ts
+++ b/extensions/positron-python/src/client/jupyter-adapter.d.ts
@@ -78,6 +78,11 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
      * response.
      */
     callMethod(method: string, ...args: Array<any>): Promise<any>;
+
+    /**
+     * Return logfile path
+     */
+    getLogFile(): string;
 }
 
 /**

--- a/extensions/positron-python/src/client/jupyter-adapter.d.ts
+++ b/extensions/positron-python/src/client/jupyter-adapter.d.ts
@@ -133,10 +133,6 @@ export interface JupyterAdapterApi extends vscode.Disposable {
      */
     findAvailablePort(excluding: Array<number>, maxTries: number): Promise<number>;
 
-    /**
-     * Return logfile path
-     */
-    getKernelLogFile(): string;
 }
 
 /** Specific functionality implemented by runtimes */

--- a/extensions/positron-python/src/client/jupyter-adapter.d.ts
+++ b/extensions/positron-python/src/client/jupyter-adapter.d.ts
@@ -132,7 +132,6 @@ export interface JupyterAdapterApi extends vscode.Disposable {
      * @returns An available TCP port
      */
     findAvailablePort(excluding: Array<number>, maxTries: number): Promise<number>;
-
 }
 
 /** Specific functionality implemented by runtimes */

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -35,6 +35,7 @@ import { ILanguageServerOutputChannel } from '../activation/types';
 import { IWorkspaceService } from '../common/application/types';
 import { IInterpreterService } from '../interpreter/contracts';
 import { showErrorMessage } from '../common/vscodeApis/windowApis';
+import { Console } from '../common/utils/localize';
 
 /**
  * A Positron language runtime that wraps a Jupyter kernel and a Language Server
@@ -505,8 +506,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         if (fs.existsSync(logFilePath)) {
             const lines = fs.readFileSync(logFilePath, 'utf8').split('\n');
             const lastLine = lines.length - 3;
-            const logFileContent = lines.slice(lastLine - 1, lastLine).join('\n');
-            const res = await showErrorMessage(logFileContent, vscode.l10n.t('Open logs'));
+            let logFileContent = lines.slice(lastLine - 1, lastLine).join('\n');
+            const regex = /^(\w*Error)\b/m;
+            const errortext = regex.test(logFileContent) ? logFileContent : Console.consoleExit;
+            const res = await showErrorMessage(errortext, vscode.l10n.t('Open logs'));
             if (res) {
                 kernel.showOutput();
             }

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -506,7 +506,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             const lines = fs.readFileSync(logFilePath, 'utf8').split('\n');
             const lastLine = lines.length - 3;
             const logFileContent = lines.slice(lastLine - 1, lastLine).join('\n');
-            const res = await showErrorMessage(logFileContent, vscode.l10n.t('Open output'));
+            const res = await showErrorMessage(logFileContent, vscode.l10n.t('Open logs'));
             if (res) {
                 kernel.showOutput();
             }

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -442,7 +442,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         });
         kernel.onDidEndSession(async (exit) => {
             this._exitEmitter.fire(exit);
-            if (exit.exit_code != 0) {
+            if (exit.exit_code !== 0) {
                 await this.showExitMessageWithLogs(kernel);
             }
         });
@@ -498,6 +498,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             }
         }
     }
+
     private async showExitMessageWithLogs(kernel: JupyterLanguageRuntimeSession): Promise<void> {
         const logFilePath = kernel.getLogFile();
 

--- a/extensions/positron-r/src/jupyter-adapter.d.ts
+++ b/extensions/positron-r/src/jupyter-adapter.d.ts
@@ -82,6 +82,11 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	 * response.
 	 */
 	callMethod(method: string, ...args: Array<any>): Promise<any>;
+
+	/**
+	 * Return logfile path
+	 */
+	getKernelLogFile(): string;
 }
 
 /**

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -790,8 +790,6 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			action = 'and was not automatically restarted';
 		}
 
-		//const logfileName = session._editorService?._logService.logger.loggers[0].file.path
-
 		// Let the user know what we did.
 		const msg = nls.localize(
 			'positronConsole.runtimeCrashed',
@@ -805,7 +803,6 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			{
 				label: 'Open logile',
 				run: () => {
-					//const textDocument = await workspace.openTextDocument(logfile);
 					this._commandService.executeCommand('workbench.action.openLogFile');
 				}
 			},

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -274,10 +274,6 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		});
 	}
 
-
-	protected _triggerCommand(handlerId: string, payload: any): void {
-		this._commandService.executeCommand(handlerId, payload);
-	}
 	/**
 	 * The main entry point for the runtime startup service.
 	 */

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -803,7 +803,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 
 		this._notificationService.prompt(Severity.Warning, msg, [
 			{
-				label: 'Find and Replace',
+				label: 'Open logile',
 				run: () => {
 					//const textDocument = await workspace.openTextDocument(logfile);
 					this._commandService.executeCommand('workbench.action.openLogFile');

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -795,7 +795,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 
 		this._notificationService.prompt(Severity.Warning, msg, [
 			{
-				label: nls.localize('openOutputPanel', 'Open Output'),
+				label: nls.localize('openOutputLogs', 'Open logs'),
 				run: () => {
 					session.showOutput()
 				}

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -78,7 +78,6 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 
 	// The current startup phase; an observeable value.
 	private _startupPhase: ISettableObservable<RuntimeStartupPhase>;
-	private readonly _commandService: ICommandService;
 
 	onDidChangeRuntimeStartupPhase: Event<RuntimeStartupPhase>;
 
@@ -257,7 +256,6 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				}
 			}
 		});
-		this._commandService = commandService;
 		// Register a shutdown event handler to clear the workspace sessions to
 		// prepare for a clean start of Positron next time.
 		this._lifecycleService.onBeforeShutdown((e) => {
@@ -797,9 +795,9 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 
 		this._notificationService.prompt(Severity.Warning, msg, [
 			{
-				label: 'Open logile',
+				label: nls.localize('openOutputPanel', 'Open Output'),
 				run: () => {
-					this._commandService.executeCommand('workbench.action.openLogFile');
+					session.showOutput()
 				}
 			},
 		]);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

addresses #2248 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

Adding button to `Go to logs`:
- at RuntimeStartupService -> restart after crash 
- at JupyterKernel exit events

Currently, the `RuntimeStartupService` will give a list of logfile options, and the `JupyterKernel` will give a popup of the error, if is a Python error and will open Runtime logs. The R runtime errors I witnessed were all Rust backtraces that did not generate actionable items, so they are not given a popup (open to changing that if there is some way to detect the error exists in useful way)

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

In Python, an "easy" way to ensure crashes is to delete the `extensions/positron-python/python_files/positron/positron_ipykernel/_vendor` directory if you're running this in Positron dev. On a release build:

Python
```python
import os
os._exit(1)
``` 

R: this seems to USUALLY crash/restart, if it doesn't restart there won't be a popup to click on
```r
rlang::node_car(0) 
```

But please do use your favorite way to break things 😆

Other behaviors to consider:

- there should NOT be a popup for a regular restart, eg, exit status 0