### PR TITLE
Data Explorer: Add preliminary customizable float formatting options for data values, summary stats

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -271,7 +271,8 @@ def _get_float_formatter(options: FormatOptions) -> Callable:
     thousands_sep = options.thousands_sep
 
     if thousands_sep is not None:
-        medium_format = thousands_sep + medium_format
+        # We format with comma then replace later
+        medium_format = "," + medium_format
 
     def base_float_format(x) -> str:
         abs_x = abs(x)
@@ -293,12 +294,15 @@ def _get_float_formatter(options: FormatOptions) -> Callable:
                 return format(x, sci_format)
 
     if thousands_sep is not None:
+        if thousands_sep != ",":
 
-        def float_format(x) -> str:
-            base = base_float_format(x)
-            return base.replace(",", thousands_sep)
+            def float_format(x) -> str:
+                base = base_float_format(x)
+                return base.replace(",", thousands_sep)
 
-        return float_format
+            return float_format
+        else:
+            return base_float_format
     else:
         return base_float_format
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -767,9 +767,9 @@ class PandasView(DataExplorerTableView):
                 return float_format(x)
         elif x is None:
             return _VALUE_NONE
-        elif x is getattr(pd_, "NaT"):
+        elif x is getattr(pd_, "NaT", None):
             return _VALUE_NAT
-        elif x is getattr(pd_, "NA"):
+        elif x is getattr(pd_, "NA", None):
             return _VALUE_NA
         else:
             return str(x)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -282,8 +282,11 @@ def _get_float_formatter(options: FormatOptions) -> Callable:
                 return format(x, medium_format)
             else:
                 return format(x, sci_format)
+        elif abs_x == 0:
+            # Special case 0 to align with other "medium" numbers
+            return format(x, medium_format)
         else:
-            if abs_x == 0 or abs_x >= lower_threshold:
+            if abs_x >= lower_threshold:
                 # Less than 1 but above lower threshold
                 return format(x, small_format)
             else:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -33,10 +33,12 @@ from .data_explorer_comm import (
     ColumnSchema,
     ColumnSortKey,
     ColumnSummaryStats,
+    ColumnValue,
     CompareFilterParamsOp,
     DataExplorerBackendMessageContent,
     DataExplorerFrontendEvent,
     FilterResult,
+    FormatOptions,
     GetColumnProfilesFeatures,
     GetColumnProfilesRequest,
     GetDataValuesRequest,
@@ -134,6 +136,7 @@ class DataExplorerTableView(abc.ABC):
             request.params.row_start_index,
             request.params.num_rows,
             request.params.column_indices,
+            request.params.format_options,
         ).dict()
 
     def set_row_filters(self, request: SetRowFiltersRequest):
@@ -151,7 +154,7 @@ class DataExplorerTableView(abc.ABC):
                 count = self._prof_null_count(req.column_index)
                 result = ColumnProfileResult(null_count=int(count))
             elif req.profile_type == ColumnProfileType.SummaryStats:
-                stats = self._prof_summary_stats(req.column_index)
+                stats = self._prof_summary_stats(req.column_index, request.params.format_options)
                 result = ColumnProfileResult(summary_stats=stats)
             elif req.profile_type == ColumnProfileType.FrequencyTable:
                 freq_table = self._prof_freq_table(req.column_index)
@@ -193,6 +196,7 @@ class DataExplorerTableView(abc.ABC):
         row_start: int,
         num_rows: int,
         column_indices: Sequence[int],
+        format_options: FormatOptions,
     ) -> TableData:
         pass
 
@@ -213,7 +217,7 @@ class DataExplorerTableView(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def _prof_summary_stats(self, column_index: int) -> ColumnSummaryStats:
+    def _prof_summary_stats(self, column_index: int, options: FormatOptions) -> ColumnSummaryStats:
         pass
 
     @abc.abstractmethod
@@ -236,21 +240,64 @@ _VALUE_NAT = 3
 _VALUE_NONE = 4
 
 
-def _format_value(x):
-    if isinstance(x, float) and np_.isnan(x):
-        return _VALUE_NAN
-    elif x is None:
-        return _VALUE_NONE
-    elif x is getattr(pd_, "NaT"):
-        return _VALUE_NAT
-    elif x is getattr(pd_, "NA"):
-        return _VALUE_NA
+if np_ is not None:
+
+    def _is_float_scalar(x):
+        return isinstance(x, (float, np_.floating))
+
+    _isnan = np_.isnan  # type: ignore
+else:
+
+    def _is_float_scalar(x):
+        return isinstance(x, float)
+
+    def _isnan(x: float) -> bool:
+        return x != x
+
+
+def _get_float_formatter(options: FormatOptions) -> Callable:
+    sci_format = f".{options.large_num_digits}E"
+    medium_format = f".{options.large_num_digits}f"
+    small_format = f".{options.small_num_digits}f"
+
+    # The limit for large numbers before switching to scientific
+    # notation
+    upper_threshold = float("1" + "0" * options.max_integral_digits)
+
+    # The limit for small numbers before switching to scientific
+    # notation
+    lower_threshold = float("0." + "0" * (options.small_num_digits - 1) + "1")
+
+    thousands_sep = options.thousands_sep
+
+    if thousands_sep is not None:
+        medium_format = thousands_sep + medium_format
+
+    def base_float_format(x) -> str:
+        abs_x = abs(x)
+
+        if abs_x >= 1:
+            if abs_x < upper_threshold:
+                # Has non-zero integral part but below
+                return format(x, medium_format)
+            else:
+                return format(x, sci_format)
+        else:
+            if abs_x == 0 or abs_x >= lower_threshold:
+                # Less than 1 but above lower threshold
+                return format(x, small_format)
+            else:
+                return format(x, sci_format)
+
+    if thousands_sep is not None:
+
+        def float_format(x) -> str:
+            base = base_float_format(x)
+            return base.replace(",", thousands_sep)
+
+        return float_format
     else:
-        return str(x)
-
-
-def _pandas_format_values(col):
-    return [_format_value(x) for x in col]
+        return base_float_format
 
 
 _FILTER_RANGE_COMPARE_SUPPORTED = {
@@ -653,7 +700,11 @@ class PandasView(DataExplorerTableView):
         )
 
     def _get_data_values(
-        self, row_start: int, num_rows: int, column_indices: Sequence[int]
+        self,
+        row_start: int,
+        num_rows: int,
+        column_indices: Sequence[int],
+        format_options: FormatOptions,
     ) -> TableData:
         formatted_columns = []
 
@@ -685,15 +736,36 @@ class PandasView(DataExplorerTableView):
             indices = self.table.index[row_start : row_start + num_rows]
             columns = [col.iloc[row_start : row_start + num_rows] for col in columns]
 
-        formatted_columns = [_pandas_format_values(col) for col in columns]
+        formatted_columns = [self._format_values(col, format_options) for col in columns]
 
         # Currently, we format MultiIndex in its flat tuple
         # representation. In the future we will return multiple lists
         # of row labels to be formatted more nicely in the UI
         if isinstance(self.table.index, pd_.MultiIndex):
             indices = indices.to_flat_index()
-        row_labels = [_pandas_format_values(indices)]
+        row_labels = [[str(x) for x in indices]]
         return TableData(columns=formatted_columns, row_labels=row_labels)
+
+    @classmethod
+    def _format_values(cls, values, options: FormatOptions) -> List[ColumnValue]:
+        float_format = _get_float_formatter(options)
+        return [cls._format_value(x, float_format) for x in values]
+
+    @staticmethod
+    def _format_value(x, float_format: Callable):
+        if _is_float_scalar(x):
+            if _isnan(x):
+                return _VALUE_NAN
+            else:
+                return float_format(x)
+        elif x is None:
+            return _VALUE_NONE
+        elif x is getattr(pd_, "NaT"):
+            return _VALUE_NAT
+        elif x is getattr(pd_, "NA"):
+            return _VALUE_NA
+        else:
+            return str(x)
 
     def _update_view_indices(self):
         if len(self.sort_keys) == 0:
@@ -942,7 +1014,7 @@ class PandasView(DataExplorerTableView):
     def _prof_null_count(self, column_index: int):
         return self._get_column(column_index).isnull().sum()
 
-    def _prof_summary_stats(self, column_index: int):
+    def _prof_summary_stats(self, column_index: int, options: FormatOptions):
         col_schema = self._get_single_column_schema(column_index)
         col = self._get_column(column_index)
 
@@ -953,31 +1025,31 @@ class PandasView(DataExplorerTableView):
             # Return nothing for types we don't yet know how to summarize
             return ColumnSummaryStats(type_display=ui_type)
         else:
-            return handler(col)
+            return handler(col, options)
 
-    @staticmethod
-    def _summarize_number(col: "pd.Series"):
-        import pandas.io.formats.format as fmt
+    @classmethod
+    def _summarize_number(cls, col: "pd.Series", options: FormatOptions):
+        float_format = _get_float_formatter(options)
 
-        minmax = pd_.Series([col.min(), col.max()], dtype=col.dtype)
-        numeric_stats = pd_.Series([col.mean(), col.median(), col.std()])
-
-        min_value, max_value = fmt.format_array(minmax.to_numpy(), None, leading_space=False)
-        mean, median, stdev = fmt.format_array(numeric_stats.to_numpy(), None, leading_space=False)
+        min_val = col.min()
+        max_val = col.max()
+        mean_val = col.mean()
+        median_val = col.median()
+        std_val = col.std()
 
         return ColumnSummaryStats(
             type_display=ColumnDisplayType.Number,
             number_stats=SummaryStatsNumber(
-                min_value=min_value,
-                max_value=max_value,
-                mean=mean,
-                median=median,
-                stdev=stdev,
+                min_value=float_format(min_val),
+                max_value=float_format(max_val),
+                mean=float_format(mean_val),
+                median=float_format(median_val),
+                stdev=float_format(std_val),
             ),
         )
 
     @staticmethod
-    def _summarize_string(col: "pd.Series"):
+    def _summarize_string(col: "pd.Series", options: FormatOptions):
         num_empty = (col.str.len() == 0).sum()
         num_unique = col.nunique()
 
@@ -987,7 +1059,7 @@ class PandasView(DataExplorerTableView):
         )
 
     @staticmethod
-    def _summarize_boolean(col: "pd.Series"):
+    def _summarize_boolean(col: "pd.Series", options: FormatOptions):
         null_count = col.isnull().sum()
         true_count = col.sum()
         false_count = len(col) - true_count - null_count

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -258,6 +258,29 @@ class TableData(BaseModel):
     )
 
 
+class FormatOptions(BaseModel):
+    """
+    Formatting options for returning data values as strings
+    """
+
+    large_num_digits: StrictInt = Field(
+        description="Fixed number of decimal places to display for numbers over 1, or in scientific notation",
+    )
+
+    small_num_digits: StrictInt = Field(
+        description="Fixed number of decimal places to display for small numbers, and to determine lower threshold for switching to scientific notation",
+    )
+
+    max_integral_digits: StrictInt = Field(
+        description="Maximum number of integral digits to display before switching to scientific notation",
+    )
+
+    thousands_sep: Optional[StrictStr] = Field(
+        default=None,
+        description="Thousands separator string",
+    )
+
+
 class TableSchema(BaseModel):
     """
     The schema for a table-like object
@@ -770,6 +793,10 @@ class GetDataValuesParams(BaseModel):
         description="Indices to select, which can be a sequential, sparse, or random selection",
     )
 
+    format_options: FormatOptions = Field(
+        description="Formatting options for returning data values as strings",
+    )
+
 
 class GetDataValuesRequest(BaseModel):
     """
@@ -859,6 +886,10 @@ class GetColumnProfilesParams(BaseModel):
         description="Array of requested profiles",
     )
 
+    format_options: FormatOptions = Field(
+        description="Formatting options for returning data values as strings",
+    )
+
 
 class GetColumnProfilesRequest(BaseModel):
     """
@@ -930,6 +961,8 @@ BackendState.update_forward_refs()
 ColumnSchema.update_forward_refs()
 
 TableData.update_forward_refs()
+
+FormatOptions.update_forward_refs()
 
 TableSchema.update_forward_refs()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -1706,7 +1706,12 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
     )
     dxf.register_table("df1", df1)
 
-    format_options = DEFAULT_FORMAT
+    format_options = FormatOptions(
+        large_num_digits=4,
+        small_num_digits=6,
+        max_integral_digits=7,
+        thousands_sep="_",
+    )
     _format_float = _get_float_formatter(format_options)
 
     cases = [
@@ -1746,7 +1751,7 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
 
     for table_name, col_index, ex_result in cases:
         profiles = [_get_summary_stats(col_index)]
-        results = dxf.get_column_profiles(table_name, profiles)
+        results = dxf.get_column_profiles(table_name, profiles, format_options=format_options)
 
         stats = results[0]["summary_stats"]
         ui_type = stats["type_display"]

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -655,7 +655,7 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
         ["1", "2", "3", "4", "5"],
         ["True", "False", "True", _VALUE_NONE, "True"],
         ["foo", "bar", _VALUE_NONE, "bar", "None"],
-        ["0.0000", "1.20", "-4.50", "6.00", _VALUE_NAN],
+        ["0.00", "1.20", "-4.50", "6.00", _VALUE_NAN],
         [
             "2024-01-01 00:00:00",
             "2024-01-02 12:34:45",
@@ -695,6 +695,7 @@ def test_pandas_float_formatting(dxf: DataExplorerFixture):
     df = pd.DataFrame(
         {
             "a": [
+                0,
                 1.0,
                 1.01,
                 1.012,
@@ -717,6 +718,7 @@ def test_pandas_float_formatting(dxf: DataExplorerFixture):
         (
             FormatOptions(large_num_digits=2, small_num_digits=4, max_integral_digits=7),
             [
+                "0.00",
                 "1.00",
                 "1.01",
                 "1.01",
@@ -738,6 +740,7 @@ def test_pandas_float_formatting(dxf: DataExplorerFixture):
                 thousands_sep="_",
             ),
             [
+                "0.000",
                 "1.000",
                 "1.010",
                 "1.012",

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -115,6 +115,14 @@
 							"type": "integer"
 						}
 					}
+				},
+				{
+					"name": "format_options",
+					"description": "Formatting options for returning data values as strings",
+					"required": true,
+					"schema": {
+						"$ref": "#/components/schemas/format_options"
+					}
 				}
 			],
 			"result": {
@@ -195,6 +203,14 @@
 						"items": {
 							"$ref": "#/components/schemas/column_profile_request"
 						}
+					}
+				},
+				{
+					"name": "format_options",
+					"description": "Formatting options for returning data values as strings",
+					"required": false,
+					"schema": {
+						"$ref": "#/components/schemas/format_options"
 					}
 				}
 			],
@@ -376,6 +392,33 @@
 								"type": "string"
 							}
 						}
+					}
+				}
+			},
+			"format_options": {
+				"type": "object",
+				"description": "Formatting options for returning data values as strings",
+				"required": [
+					"large_num_digits",
+					"small_num_digits",
+					"max_integral_digits"
+				],
+				"properties": {
+					"large_num_digits": {
+						"type": "integer",
+						"description": "Fixed number of decimal places to display for numbers over 1, or in scientific notation"
+					},
+					"small_num_digits": {
+						"type": "integer",
+						"description": "Fixed number of decimal places to display for small numbers, and to determine lower threshold for switching to scientific notation"
+					},
+					"max_integral_digits": {
+						"type": "integer",
+						"description": "Maximum number of integral digits to display before switching to scientific notation"
+					},
+					"thousands_sep": {
+						"type": "string",
+						"description": "Thousands separator string"
 					}
 				}
 			},

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -171,7 +171,6 @@ function parseRefFromContract(ref: string, contract: any): string | undefined {
  * @returns The name of the object referred to by the ref.
  */
 function parseRef(ref: string, contracts: Array<any>): string {
-	console.log(ref);
 	for (const contract of contracts) {
 		if (!contract) {
 			continue;

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -90,9 +90,14 @@ export class DataExplorerClientInstance extends Disposable {
 	private _numPendingTasks: number = 0;
 
 	/**
-	 * Value formatting properties for backend requests
+	 * Data formatting options for backend requests
 	 */
-	_formatOptions: FormatOptions;
+	_dataFormatOptions: FormatOptions;
+
+	/**
+	 * Profile formatting options for backend requests
+	 */
+	_profileFormatOptions: FormatOptions;
 
 	//#endregion Private Properties
 
@@ -106,9 +111,16 @@ export class DataExplorerClientInstance extends Disposable {
 		// Call the disposable constructor.
 		super();
 
-		this._formatOptions = {
-			large_num_digits: 2,
+		this._dataFormatOptions = {
+			large_num_digits: 6,
 			small_num_digits: 6,
+			max_integral_digits: 7,
+			thousands_sep: ','
+		};
+
+		this._profileFormatOptions = {
+			large_num_digits: 2,
+			small_num_digits: 4,
 			max_integral_digits: 7,
 			thousands_sep: ','
 		};
@@ -286,7 +298,7 @@ export class DataExplorerClientInstance extends Disposable {
 	): Promise<TableData> {
 		return this.runBackendTask(
 			() => this._positronDataExplorerComm.getDataValues(rowStartIndex, numRows, columnIndices,
-				this._formatOptions
+				this._dataFormatOptions
 			),
 			() => {
 				return { columns: [[]] };
@@ -303,7 +315,7 @@ export class DataExplorerClientInstance extends Disposable {
 		profiles: Array<ColumnProfileRequest>
 	): Promise<Array<ColumnProfileResult>> {
 		return this.runBackendTask(
-			() => this._positronDataExplorerComm.getColumnProfiles(profiles, this._formatOptions),
+			() => this._positronDataExplorerComm.getColumnProfiles(profiles, this._profileFormatOptions),
 			() => []
 		);
 	}

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -5,7 +5,7 @@
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
-import { BackendState, ColumnProfileRequest, ColumnProfileResult, ColumnSchema, ColumnSortKey, FilterResult, PositronDataExplorerComm, RowFilter, SchemaUpdateEvent, TableData, TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { BackendState, ColumnProfileRequest, ColumnProfileResult, ColumnSchema, ColumnSortKey, FilterResult, FormatOptions, PositronDataExplorerComm, RowFilter, SchemaUpdateEvent, TableData, TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * TableSchemaSearchResult interface. This is here temporarily until searching the tabe schema
@@ -89,6 +89,11 @@ export class DataExplorerClientInstance extends Disposable {
 	 */
 	private _numPendingTasks: number = 0;
 
+	/**
+	 * Value formatting properties for backend requests
+	 */
+	_formatOptions: FormatOptions;
+
 	//#endregion Private Properties
 
 	//#region Constructor & Dispose
@@ -100,6 +105,13 @@ export class DataExplorerClientInstance extends Disposable {
 	constructor(client: IRuntimeClientInstance<any, any>) {
 		// Call the disposable constructor.
 		super();
+
+		this._formatOptions = {
+			large_num_digits: 2,
+			small_num_digits: 6,
+			max_integral_digits: 7,
+			thousands_sep: ','
+		};
 
 		// Create and register the PositronDataExplorerComm on the client.
 		this._positronDataExplorerComm = new PositronDataExplorerComm(client);
@@ -273,7 +285,9 @@ export class DataExplorerClientInstance extends Disposable {
 		columnIndices: Array<number>
 	): Promise<TableData> {
 		return this.runBackendTask(
-			() => this._positronDataExplorerComm.getDataValues(rowStartIndex, numRows, columnIndices),
+			() => this._positronDataExplorerComm.getDataValues(rowStartIndex, numRows, columnIndices,
+				this._formatOptions
+			),
 			() => {
 				return { columns: [[]] };
 			}
@@ -289,7 +303,7 @@ export class DataExplorerClientInstance extends Disposable {
 		profiles: Array<ColumnProfileRequest>
 	): Promise<Array<ColumnProfileResult>> {
 		return this.runBackendTask(
-			() => this._positronDataExplorerComm.getColumnProfiles(profiles),
+			() => this._positronDataExplorerComm.getColumnProfiles(profiles, this._formatOptions),
 			() => []
 		);
 	}

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -151,6 +151,35 @@ export interface TableData {
 }
 
 /**
+ * Formatting options for returning data values as strings
+ */
+export interface FormatOptions {
+	/**
+	 * Fixed number of decimal places to display for numbers over 1, or in
+	 * scientific notation
+	 */
+	large_num_digits: number;
+
+	/**
+	 * Fixed number of decimal places to display for small numbers, and to
+	 * determine lower threshold for switching to scientific notation
+	 */
+	small_num_digits: number;
+
+	/**
+	 * Maximum number of integral digits to display before switching to
+	 * scientific notation
+	 */
+	max_integral_digits: number;
+
+	/**
+	 * Thousands separator string
+	 */
+	thousands_sep?: string;
+
+}
+
+/**
  * The schema for a table-like object
  */
 export interface TableSchema {
@@ -743,11 +772,13 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * beyond end of table
 	 * @param columnIndices Indices to select, which can be a sequential,
 	 * sparse, or random selection
+	 * @param formatOptions Formatting options for returning data values as
+	 * strings
 	 *
 	 * @returns Table values formatted as strings
 	 */
-	getDataValues(rowStartIndex: number, numRows: number, columnIndices: Array<number>): Promise<TableData> {
-		return super.performRpc('get_data_values', ['row_start_index', 'num_rows', 'column_indices'], [rowStartIndex, numRows, columnIndices]);
+	getDataValues(rowStartIndex: number, numRows: number, columnIndices: Array<number>, formatOptions: FormatOptions): Promise<TableData> {
+		return super.performRpc('get_data_values', ['row_start_index', 'num_rows', 'column_indices', 'format_options'], [rowStartIndex, numRows, columnIndices, formatOptions]);
 	}
 
 	/**
@@ -783,11 +814,13 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * Requests a statistical summary or data profile for batch of columns
 	 *
 	 * @param profiles Array of requested profiles
+	 * @param formatOptions Formatting options for returning data values as
+	 * strings
 	 *
 	 * @returns undefined
 	 */
-	getColumnProfiles(profiles: Array<ColumnProfileRequest>): Promise<Array<ColumnProfileResult>> {
-		return super.performRpc('get_column_profiles', ['profiles'], [profiles]);
+	getColumnProfiles(profiles: Array<ColumnProfileRequest>, formatOptions: FormatOptions): Promise<Array<ColumnProfileResult>> {
+		return super.performRpc('get_column_profiles', ['profiles', 'format_options'], [profiles, formatOptions]);
 	}
 
 	/**


### PR DESCRIPTION
Partly addresses #2339 and #3210, and #3314. Adds a `format_options` parameter in the `get_data_values` and `get_column_profiles` backend methods to allow customized formatting of large, small, and medium-sized numbers. If the value threshold is above or below limits implied by the parameters, scientific notation is used. We've talked about dynamically trimming zero padding from the end of numbers (e.g. if all the floats displayed are integral, then we can trim the trailing zeros off all of them), but this will be a frontend-only change that can be done after. 

e.g. with

```
df2 = pd.DataFrame(
    {
        "a": [
            0,
            1.0,
            1.01,
            1.012,
            0.0123,
            0.01234,
            0.0001,
            0.00000001,
            9999.123,
            9999.999,
            9999999,
            10000000,
            -10000000,
        ]
    }
)
```

![image](https://github.com/posit-dev/positron/assets/329591/39d1a029-56b3-4f2b-bf32-1e4ab1f10bfa)