### PR TITLE
Project Wizard: new project window selection modal

### DIFF
--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -7,7 +7,7 @@ import { ITelemetryData } from 'vs/base/common/actions';
 import { IFileService } from 'vs/platform/files/common/files';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { ICommandService } from 'vs/platform/commands/common/commands';
-import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IDialogService, IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
@@ -79,6 +79,7 @@ export class PositronNewProjectAction extends Action2 {
 		// Show the new project modal dialog.
 		await showNewProjectModalDialog(
 			accessor.get(ICommandService),
+			accessor.get(IDialogService),
 			accessor.get(IFileDialogService),
 			accessor.get(IFileService),
 			accessor.get(IKeybindingService),

--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -7,7 +7,7 @@ import { ITelemetryData } from 'vs/base/common/actions';
 import { IFileService } from 'vs/platform/files/common/files';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { ICommandService } from 'vs/platform/commands/common/commands';
-import { IDialogService, IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
@@ -79,7 +79,6 @@ export class PositronNewProjectAction extends Action2 {
 		// Show the new project modal dialog.
 		await showNewProjectModalDialog(
 			accessor.get(ICommandService),
-			accessor.get(IDialogService),
 			accessor.get(IFileDialogService),
 			accessor.get(IFileService),
 			accessor.get(IKeybindingService),

--- a/src/vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog.css
+++ b/src/vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog.css
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+.positron-modal-dialog-box
+.choose-new-project-window-modal-dialog {
+	top: 32px;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	padding: 16px;
+	position: absolute;
+}
+
+.positron-modal-dialog-box
+.choose-new-project-window-modal-dialog
+code {
+	color: var(--vscode-positronModalDialog-preformattedTextForeground);
+	border-radius: 4px;
+	padding: 0px 3px !important;
+	font-family: var(--monaco-monospace-font);
+	font-size: 11px;
+}
+
+.positron-modal-dialog-box
+.choose-new-project-window-modal-dialog
+.project-window-action-bar {
+	left: 0;
+	right: 0;
+	bottom: 0;
+	gap: 10px;
+	height: 64px;
+	display: flex;
+	margin: 0 16px;
+	padding: 0 0px;
+	position: absolute;
+	align-items: center;
+	justify-content: end;
+}
+
+.positron-modal-dialog-box
+.choose-new-project-window-modal-dialog
+.project-window-action-bar
+.action-bar-button {
+	width: auto;
+	height: 32px;
+	padding: 0 12px;
+}
+
+.positron-modal-dialog-box
+.choose-new-project-window-modal-dialog
+.top-separator {
+	border-top: 1px solid var(--vscode-positronModalDialog-separator);
+}
+
+

--- a/src/vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog.tsx
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// // CSS.
+// import 'vs/css!./chooseNewProjectWindowModalDialog';
+
+// React.
+import * as React from 'react';
+import { useRef } from 'react';  // eslint-disable-line no-duplicate-imports
+
+// Other dependencies.
+import { localize } from 'vs/nls';
+import { VerticalStack } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/verticalStack';
+import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer';
+import { PositronModalDialog } from 'vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog';
+import { Button } from 'vs/base/browser/ui/positronComponents/button/button';
+
+/**
+ * ChooseNewProjectWindowModalDialogProps interface.
+ */
+interface ChooseNewProjectWindowModalDialogProps {
+	renderer: PositronModalReactRenderer;
+	projectName: string;
+	openInNewWindow: boolean;
+	chooseNewProjectWindowAction: (openInNewWindow: boolean) => Promise<void>;
+}
+
+/**
+ * ChooseNewProjectWindowModalDialog component.
+ * @param props The component properties.
+ * @returns The component.
+ */
+export const ChooseNewProjectWindowModalDialog = (props: ChooseNewProjectWindowModalDialogProps) => {
+	// State.
+	const openInNewWindow = useRef(props.openInNewWindow);
+
+	// Button configuration.
+	const newWindowButtonConfig = {
+		title: localize('positron.newProject.whereToOpen.newWindow', "New Window"),
+		onClick: () => setWindowAndAccept(true)
+	};
+	const currentWindowButtonConfig = {
+		title: localize('positron.newProject.whereToOpen.currentWindow', "Current Window"),
+		onClick: () => setWindowAndAccept(false)
+	};
+	const defaultButtonConfig = props.openInNewWindow ? newWindowButtonConfig : currentWindowButtonConfig;
+	const otherButtonConfig = props.openInNewWindow ? currentWindowButtonConfig : newWindowButtonConfig;
+
+	// Handle setting where to open the new project and accept.
+	const setWindowAndAccept = async (newWindow: boolean) => {
+		openInNewWindow.current = newWindow;
+		await accept();
+	};
+
+	// Handle accepting the dialog.
+	const accept = async () => {
+		props.renderer.dispose();
+		await props.chooseNewProjectWindowAction(openInNewWindow.current);
+	};
+
+	// Render.
+	return (
+		<PositronModalDialog
+			renderer={props.renderer}
+			width={375}
+			height={175}
+			title={(() =>
+				localize(
+					'positron.chooseNewProjectWindowModalDialog.title',
+					'New Project Window'
+				))()}
+			onAccept={accept}
+		>
+			<VerticalStack>
+				<div>
+					{(() =>
+						localize(
+							'positron.newProject.whereToOpen.question',
+							"Where would you like to open your new project"
+						))()}
+				</div>
+				<code>{props.projectName}</code>
+				<span>?</span>
+				{/* TODO: add checkbox to save the user's selection to preferences */}
+			</VerticalStack>
+			<div className='ok-cancel-action-bar top-separator'>
+				<Button className='button action-bar-button' onPressed={otherButtonConfig.onClick}>
+					{otherButtonConfig.title}
+				</Button>
+				<Button className='button action-bar-button default' onPressed={defaultButtonConfig.onClick}>
+					{defaultButtonConfig.title}
+				</Button>
+			</div>
+		</PositronModalDialog>
+	);
+};

--- a/src/vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog.tsx
@@ -15,6 +15,46 @@ import { VerticalStack } from 'vs/workbench/browser/positronComponents/positronM
 import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer';
 import { PositronModalDialog } from 'vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog';
 import { Button } from 'vs/base/browser/ui/positronComponents/button/button';
+import { ICommandService } from 'vs/platform/commands/common/commands';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
+import { URI } from 'vs/base/common/uri';
+
+export const showChooseNewProjectWindowModalDialog = (
+	commandService: ICommandService,
+	keybindingService: IKeybindingService,
+	layoutService: IWorkbenchLayoutService,
+	projectName: string,
+	projectFolder: URI,
+	openInNewWindow: boolean,
+) => {
+	// Create the renderer.
+	const renderer = new PositronModalReactRenderer({
+		keybindingService,
+		layoutService,
+		container: layoutService.activeContainer
+	});
+
+	// Show the choose new project window modal dialog.
+	renderer.render(
+		<ChooseNewProjectWindowModalDialog
+			renderer={renderer}
+			projectName={projectName}
+			openInNewWindow={openInNewWindow}
+			chooseNewProjectWindowAction={async (openInNewWindow: boolean) => {
+				// Open the project in the selected window.
+				await commandService.executeCommand(
+					'vscode.openFolder',
+					projectFolder,
+					{
+						forceNewWindow: openInNewWindow,
+						forceReuseWindow: !openInNewWindow
+					}
+				);
+			}}
+		/>
+	);
+};
 
 /**
  * ChooseNewProjectWindowModalDialogProps interface.
@@ -31,7 +71,7 @@ interface ChooseNewProjectWindowModalDialogProps {
  * @param props The component properties.
  * @returns The component.
  */
-export const ChooseNewProjectWindowModalDialog = (props: ChooseNewProjectWindowModalDialogProps) => {
+const ChooseNewProjectWindowModalDialog = (props: ChooseNewProjectWindowModalDialogProps) => {
 	// State.
 	const openInNewWindow = useRef(props.openInNewWindow);
 

--- a/src/vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog.tsx
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // // CSS.
-// import 'vs/css!./chooseNewProjectWindowModalDialog';
+import 'vs/css!./chooseNewProjectWindowModalDialog';
 
 // React.
 import * as React from 'react';
@@ -63,34 +63,34 @@ export const ChooseNewProjectWindowModalDialog = (props: ChooseNewProjectWindowM
 	return (
 		<PositronModalDialog
 			renderer={props.renderer}
-			width={375}
-			height={175}
+			width={320}
+			height={180}
 			title={(() =>
 				localize(
 					'positron.chooseNewProjectWindowModalDialog.title',
-					'New Project Window'
+					'Create New Project'
 				))()}
 			onAccept={accept}
 		>
-			<VerticalStack>
-				<div>
-					{(() =>
-						localize(
-							'positron.newProject.whereToOpen.question',
-							"Where would you like to open your new project"
-						))()}
+			<div className='choose-new-project-window-modal-dialog'>
+				<VerticalStack>
+					<div>
+						{(() =>
+							localize(
+								'positron.newProject.whereToOpen.question',
+								"Where would you like to open your new project "
+							))()}<code>{props.projectName}</code>{'?'}
+					</div>
+					{/* TODO: add checkbox to save the user's selection to preferences */}
+				</VerticalStack>
+				<div className='project-window-action-bar top-separator'>
+					<Button className='button action-bar-button' onPressed={otherButtonConfig.onClick}>
+						{otherButtonConfig.title}
+					</Button>
+					<Button className='button action-bar-button default' onPressed={defaultButtonConfig.onClick}>
+						{defaultButtonConfig.title}
+					</Button>
 				</div>
-				<code>{props.projectName}</code>
-				<span>?</span>
-				{/* TODO: add checkbox to save the user's selection to preferences */}
-			</VerticalStack>
-			<div className='ok-cancel-action-bar top-separator'>
-				<Button className='button action-bar-button' onPressed={otherButtonConfig.onClick}>
-					{otherButtonConfig.title}
-				</Button>
-				<Button className='button action-bar-button default' onPressed={defaultButtonConfig.onClick}>
-					{defaultButtonConfig.title}
-				</Button>
 			</div>
 		</PositronModalDialog>
 	);

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/wizardStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/wizardStep.tsx
@@ -29,10 +29,6 @@ export const PositronWizardStep = (props: PropsWithChildren<PositronWizardStepPr
 				{props.title}
 			</div>
 			<VerticalStack>
-				{/*
-					TODO: based on input validation in children, handle errors/incomplete input
-					by displaying corresponding help text and disable the next/create buttons
-				*/}
 				{props.children}
 			</VerticalStack>
 			<OKCancelBackNextActionBar

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -27,7 +27,7 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IPositronNewProjectService, NewProjectConfiguration } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
 import { EnvironmentSetupType, NewProjectWizardStep } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
 import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
-import { ChooseNewProjectWindowModalDialog } from 'vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog';
+import { showChooseNewProjectWindowModalDialog } from 'vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog';
 
 /**
  * Shows the NewProjectModalDialog.
@@ -139,31 +139,17 @@ export const showNewProjectModalDialog = async (
 						workspaceTrustManagementService.setUrisTrust([folder], true);
 					}
 
-					// Ask the user where to open the new project.
-					const renderer = new PositronModalReactRenderer({
+					// Any context-dependent work needs to be done before opening the folder
+					// because the extension host gets destroyed when a new project is opened,
+					// whether the folder is opened in a new window or in the existing window.
+					// Ask the user where to open the new project and open it.
+					showChooseNewProjectWindowModalDialog(
+						commandService,
 						keybindingService,
 						layoutService,
-						container: layoutService.activeContainer
-					});
-					renderer.render(
-						<ChooseNewProjectWindowModalDialog
-							renderer={renderer}
-							projectName={result.projectName}
-							openInNewWindow={result.openInNewWindow}
-							chooseNewProjectWindowAction={async (openInNewWindow) => {
-								// Any context-dependent work needs to be done before opening the folder
-								// because the extension host gets destroyed when a new project is opened,
-								// whether the folder is opened in a new window or in the existing window.
-								await commandService.executeCommand(
-									'vscode.openFolder',
-									folder,
-									{
-										forceNewWindow: openInNewWindow,
-										forceReuseWindow: !openInNewWindow
-									}
-								);
-							}}
-						/>
+						result.projectName,
+						folder,
+						result.openInNewWindow
 					);
 				}}
 			/>

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 
 // Other dependencies.
 import { localize } from 'vs/nls';
-import { IDialogService, IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { NewProjectWizardContextProvider, useNewProjectWizardContext } from 'vs/workbench/browser/positronNewProjectWizard/newProjectWizardContext';
 import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
@@ -34,7 +34,6 @@ import { ChooseNewProjectWindowModalDialog } from 'vs/workbench/browser/positron
  */
 export const showNewProjectModalDialog = async (
 	commandService: ICommandService,
-	dialogService: IDialogService,
 	fileDialogService: IFileDialogService,
 	fileService: IFileService,
 	keybindingService: IKeybindingService,
@@ -140,21 +139,21 @@ export const showNewProjectModalDialog = async (
 						workspaceTrustManagementService.setUrisTrust([folder], true);
 					}
 
+					// Ask the user where to open the new project.
 					const renderer = new PositronModalReactRenderer({
 						keybindingService,
 						layoutService,
 						container: layoutService.activeContainer
 					});
-
-					console.log('**** result openInNewWindow ', result.openInNewWindow);
-
 					renderer.render(
 						<ChooseNewProjectWindowModalDialog
 							renderer={renderer}
 							projectName={result.projectName}
 							openInNewWindow={result.openInNewWindow}
 							chooseNewProjectWindowAction={async (openInNewWindow) => {
-								console.log('**** chooseNewProjectWindowAction ', openInNewWindow);
+								// Any context-dependent work needs to be done before opening the folder
+								// because the extension host gets destroyed when a new project is opened,
+								// whether the folder is opened in a new window or in the existing window.
 								await commandService.executeCommand(
 									'vscode.openFolder',
 									folder,
@@ -166,41 +165,6 @@ export const showNewProjectModalDialog = async (
 							}}
 						/>
 					);
-
-					// const openInNewWindow = await dialogService.prompt({
-					// 	type: 'question',
-					// 	title: localize('positron.newProject.whereToOpen.title', "Create New Project"),
-					// 	message: localize('positron.newProject.whereToOpen.question', "Where would you like to open your new project {0}?", result.projectName),
-					// 	detail: 'test detail hello hello',
-					// 	buttons: [
-					// 		{
-					// 			label: localize('positron.newProject.whereToOpen.newWindow', "New Window"),
-					// 			run: () => true
-					// 		},
-					// 		{
-					// 			label: localize('positron.newProject.whereToOpen.currentWindow', "Current Window"),
-					// 			run: () => false
-					// 		}
-					// 	],
-					// 	checkbox: {
-					// 		label: localize('positron.newProject.whereToOpen.storePreference', "Remember my choice"),
-					// 		checked: false
-					// 	}
-					// });
-
-					// console.log('openInNewWindow', openInNewWindow);
-
-					// Any context-dependent work needs to be done before opening the folder
-					// because the extension host gets destroyed when a new project is opened,
-					// whether the folder is opened in a new window or in the existing window.
-					// await commandService.executeCommand(
-					// 	'vscode.openFolder',
-					// 	folder,
-					// 	{
-					// 		forceNewWindow: result.openInNewWindow,
-					// 		forceReuseWindow: !result.openInNewWindow
-					// 	}
-					// );
 				}}
 			/>
 		</NewProjectWizardContextProvider>

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -141,7 +141,8 @@ export class NewProjectWizardStateManager
 		this._projectNameFeedback = undefined;
 		this._parentFolder = config.parentFolder ?? '';
 		this._initGitRepo = false;
-		this._openInNewWindow = false;
+		// Default to a new window as the least "destructive" option.
+		this._openInNewWindow = true;
 		this._pythonEnvSetupType = EnvironmentSetupType.NewEnvironment;
 		this._pythonEnvProviderId = undefined;
 		this._installIpykernel = undefined;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

- Addresses: https://github.com/posit-dev/positron/issues/2842

#### Preview

<img width="245" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/e5e3d353-8d39-40fd-a72e-f4af4c509bd4">

#### Demo

https://github.com/posit-dev/positron/assets/25834218/c3301ade-13e2-4430-a459-e67ede42b5f2

### Approach

- create a new modal for the user to select Current Window or New Window
- render the modal upon the user clicking Create in the Project Wizard
- open the new project in the current window or new window depending on user selection

In the future, it'd be great to include a checkbox which saves the user's new/current window preference to settings, so they aren't prompted with the choice.

### QA Notes

- the user should not be able to cancel/escape the modal dialog -- they should only be able to proceed by clicking Current Window or New Window
