### PR TITLE
Fix a variety of new project initialization issues

### DIFF
--- a/src/vs/workbench/browser/positronNewProjectWizard/components/projectType.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/projectType.tsx
@@ -10,11 +10,11 @@ import * as React from 'react';
 import { useRef } from 'react'; // eslint-disable-line no-duplicate-imports
 
 // Other dependencies.
-import { NewProjectType } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
 import { PythonLogo } from 'vs/workbench/browser/positronNewProjectWizard/components/logos/logoPython';
 import { JupyterLogo } from 'vs/workbench/browser/positronNewProjectWizard/components/logos/logoJupyter';
 import { RLogo } from 'vs/workbench/browser/positronNewProjectWizard/components/logos/logoR';
 import { useNewProjectWizardContext } from 'vs/workbench/browser/positronNewProjectWizard/newProjectWizardContext';
+import { NewProjectType } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
 
 /**
  * ProjectTypeProps interface.

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/projectTypeGroup.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/projectTypeGroup.tsx
@@ -11,7 +11,7 @@ import { PropsWithChildren, useState } from 'react'; // eslint-disable-line no-d
 
 // Other dependencies.
 import { ProjectType } from 'vs/workbench/browser/positronNewProjectWizard/components/projectType';
-import { NewProjectType } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
+import { NewProjectType } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
 
 /**
  * ProjectTypeProps interface.

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -10,7 +10,7 @@ import { PropsWithChildren, useEffect, useState } from 'react';  // eslint-disab
 import { localize } from 'vs/nls';
 import { useNewProjectWizardContext } from 'vs/workbench/browser/positronNewProjectWizard/newProjectWizardContext';
 import { URI } from 'vs/base/common/uri';
-import { NewProjectType, NewProjectWizardStep } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
+import { NewProjectWizardStep } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
 import { NewProjectWizardStepProps } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardStepProps';
 import { PositronWizardStep } from 'vs/workbench/browser/positronNewProjectWizard/components/wizardStep';
 import { PositronWizardSubStep } from 'vs/workbench/browser/positronNewProjectWizard/components/wizardSubStep';
@@ -20,6 +20,7 @@ import { Checkbox } from 'vs/workbench/browser/positronComponents/positronModalD
 import { WizardFormattedText, WizardFormattedTextType } from 'vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText';
 import { checkProjectName } from 'vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils';
 import { DisposableStore } from 'vs/base/common/lifecycle';
+import { NewProjectType } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
 
 /**
  * The ProjectNameLocationStep component is the second step in the new project wizard.

--- a/src/vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums.ts
@@ -36,19 +36,6 @@ export enum PythonEnvironmentProvider {
 }
 
 /**
- * NewProjectType enum. Defines the types of projects that can be created.
- * TODO: localize. Since this is an enum, we can't use the localize function
- * because computed values must be numbers (not strings). So we'll probably need to
- * turn this into an object with keys and values, maybe also using something like
- * satisfies Readonly<Record<string, string>>.
- */
-export enum NewProjectType {
-	PythonProject = 'Python Project',
-	RProject = 'R Project',
-	JupyterNotebook = 'Jupyter Notebook'
-}
-
-/**
  * PythonRuntimeFilter enum.
  */
 export enum PythonRuntimeFilter {

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -780,10 +780,14 @@ export class NewProjectWizardStateManager
 		if (langId === LanguageIds.Python) {
 			this._useRenv = undefined;
 			// TODO: Conda isn't supported yet, so don't set the env provider if it's conda.
-			if (
-				this._pythonEnvSetupType === EnvironmentSetupType.NewEnvironment &&
-				this._getEnvProviderName() === PythonEnvironmentProvider.Conda
-			) {
+			const newCondaEnv =
+				this._pythonEnvSetupType ===
+				EnvironmentSetupType.NewEnvironment &&
+				this._getEnvProviderName() === PythonEnvironmentProvider.Conda;
+			const existingEnv =
+				this._pythonEnvSetupType ===
+				EnvironmentSetupType.ExistingEnvironment;
+			if (newCondaEnv || existingEnv) {
 				this._pythonEnvProviderId = undefined;
 			}
 		} else if (langId === LanguageIds.R) {

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -7,7 +7,7 @@ import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { ILanguageRuntimeMetadata, ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IRuntimeStartupService, RuntimeStartupPhase } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
-import { EnvironmentSetupType, LanguageIds, NewProjectType, NewProjectWizardStep, PythonEnvironmentProvider, PythonRuntimeFilter } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
+import { EnvironmentSetupType, LanguageIds, NewProjectWizardStep, PythonEnvironmentProvider, PythonRuntimeFilter } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ILogService } from 'vs/platform/log/common/log';
@@ -19,6 +19,7 @@ import { PythonEnvironmentProviderInfo } from 'vs/workbench/browser/positronNewP
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Emitter, Event } from 'vs/base/common/event';
 import { WizardFormattedTextItem } from 'vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText';
+import { NewProjectType } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
 
 /**
  * NewProjectWizardServices interface.

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -29,6 +29,10 @@ import { localize } from 'vs/nls';
 import { IEditorResolverService, RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
 import { TerminalCommandId } from 'vs/workbench/contrib/terminal/common/terminal';
 
+// --- Start Positron ---
+import { IPositronNewProjectService } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
+// --- End Positron ---
+
 export const restoreWalkthroughsConfigurationKey = 'workbench.welcomePage.restorableWalkthroughs';
 export type RestoreWalkthroughsConfigurationValue = { folder: string; category?: string; step?: string };
 
@@ -87,7 +91,10 @@ export class StartupPageRunnerContribution implements IWorkbenchContribution {
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 		@IStorageService private readonly storageService: IStorageService,
 		@ILogService private readonly logService: ILogService,
-		@INotificationService private readonly notificationService: INotificationService
+		@INotificationService private readonly notificationService: INotificationService,
+		// --- Start Positron ---
+		@IPositronNewProjectService private readonly positronNewProjectService: IPositronNewProjectService,
+		// --- End Positron ---
 	) {
 		this.run().then(undefined, onUnexpectedError);
 	}
@@ -114,7 +121,9 @@ export class StartupPageRunnerContribution implements IWorkbenchContribution {
 			return;
 		}
 
-		const enabled = isStartupPageEnabled(this.configurationService, this.contextService, this.environmentService);
+		// --- Start Positron ---
+		const enabled = isStartupPageEnabled(this.configurationService, this.contextService, this.environmentService, this.positronNewProjectService);
+		// --- End Positron ---
 		if (enabled && this.lifecycleService.startupKind !== StartupKind.ReloadedWindow) {
 			const hasBackups = await this.workingCopyBackupService.hasBackups();
 			if (hasBackups) { return; }
@@ -214,10 +223,18 @@ export class StartupPageRunnerContribution implements IWorkbenchContribution {
 	}
 }
 
-function isStartupPageEnabled(configurationService: IConfigurationService, contextService: IWorkspaceContextService, environmentService: IWorkbenchEnvironmentService) {
+// --- Start Positron ---
+function isStartupPageEnabled(configurationService: IConfigurationService, contextService: IWorkspaceContextService, environmentService: IWorkbenchEnvironmentService, positronNewProjectService: IPositronNewProjectService) {
+	// --- End Positron ---
 	if (environmentService.skipWelcome) {
 		return false;
 	}
+
+	// --- Start Positron ---
+	if (positronNewProjectService.isCurrentWindowNewProject()) {
+		return false;
+	}
+	// --- End Positron ---
 
 	const startupEditor = configurationService.inspect<string>(configurationKey);
 	if (!startupEditor.userValue && !startupEditor.workspaceValue) {

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -64,7 +64,8 @@ export enum NewProjectTask {
 	Jupyter = 'jupyter',
 	Git = 'git',
 	PythonEnvironment = 'pythonEnvironment',
-	REnvironment = 'rEnvironment'
+	REnvironment = 'rEnvironment',
+	CreateNewFile = 'createNewFile',
 }
 
 /**

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -112,6 +112,12 @@ export interface IPositronNewProjectService {
 	initNewProject(): Promise<void>;
 
 	/**
+	 * Determines whether the current window the new project that was just created.
+	 * @returns Whether the current window is the newly created project.
+	 */
+	isCurrentWindowNewProject(): boolean;
+
+	/**
 	 * Barrier for other services to wait for all project tasks to complete.
 	 */
 	allTasksComplete: Barrier;

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -43,6 +43,19 @@ export enum NewProjectStartupPhase {
 }
 
 /**
+ * NewProjectType enum. Defines the types of projects that can be created.
+ * TODO: localize. Since this is an enum, we can't use the localize function
+ * because computed values must be numbers (not strings). So we'll probably need to
+ * turn this into an object with keys and values, maybe also using something like
+ * satisfies Readonly<Record<string, string>>.
+ */
+export enum NewProjectType {
+	PythonProject = 'Python Project',
+	RProject = 'R Project',
+	JupyterNotebook = 'Jupyter Notebook'
+}
+
+/**
  * NewProjectTask enum. Defines the tasks that can be pending during new project initialization.
  */
 export enum NewProjectTask {

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -254,6 +254,10 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 		this._removePendingTask(NewProjectTask.R);
 	}
 
+	/**
+	 * Displays an error notification if there was an error creating the .gitignore file.
+	 * @param error The error that occurred.
+	 */
 	private _handleGitIgnoreError(error: Error) {
 		const errorMessage = localize('positronNewProjectService.gitIgnoreError', 'Error creating .gitignore {0}', error.message);
 		this._notificationService.error(errorMessage);
@@ -274,7 +278,8 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 			});
 		await this._fileService.createFile(joinPath(projectRoot, 'README.md'), VSBuffer.fromString(`# ${this._newProjectConfig?.projectName}`))
 			.catch((error) => {
-				this._handleGitIgnoreError(error);
+				const errorMessage = localize('positronNewProjectService.readmeError', 'Error creating readme {0}', error);
+				this._notificationService.error(errorMessage);
 			});
 
 		switch (this._newProjectConfig?.projectType) {
@@ -297,6 +302,11 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 					});
 				break;
 			default:
+				this._logService.error(
+					'Cannot determine .gitignore content for unknown project type',
+					this._newProjectConfig?.projectType
+				);
+				break;
 		}
 
 		this._removePendingTask(NewProjectTask.Git);

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -324,6 +324,10 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 							workspaceFolder,
 							providerId: provider,
 							interpreterPath,
+							// Do not start the environment after creation. We'll install ipykernel
+							// first, then set the environment as the affiliated runtime, which will
+							// be automatically started by the runtimeStartupService.
+							selectEnvironment: false
 						}
 					);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

- Address issue where selecting an existing interpreter still creates a Venv https://github.com/posit-dev/positron/issues/2838#issuecomment-2140722156 and https://github.com/posit-dev/positron/issues/2840
- Address issue where the newly created Venv starts before we've had a chance to install ipykernel https://github.com/posit-dev/positron/issues/2838#issuecomment-2140722156
- Address hiding the welcome page editor for a new project https://github.com/posit-dev/positron/issues/3329

### Approach

- move `NewProjectType` enum so it can be used in the service (clears out a couple TODOs in the service to use an enum)
- fix up `_cleanupState` in newProjectWizardState.ts so that the python environment provider ID is properly cleared out when an existing interpreter is selected (resolves the issue where a Venv is created anyways)
- add checks to startupPage.ts to skip showing the welcome page if the window is a new project window
- reorder the project initialization tasks so that quicker tasks run first (creating the new, empty file; then running git init if applicable; then running environment creation tasks)
- don't start the new Venv immediately by passing `selectEnvironment: false` in the create environment arguments

### QA Notes

- Both the New Environment - Venv and Existing Interpreter Python/Jupyter flows should be working
- R projects are not impacted by these changes very much
