### PR TITLE
Data Explorer: spec out "export_data_selection" backend method for exporting cells and cell/column/row ranges, and add Python pandas implementation

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -37,6 +37,10 @@ from .data_explorer_comm import (
     CompareFilterParamsOp,
     DataExplorerBackendMessageContent,
     DataExplorerFrontendEvent,
+    DataSelection,
+    ExportDataSelectionRequest,
+    ExportFormat,
+    ExportedData,
     FilterResult,
     FormatOptions,
     GetColumnProfilesFeatures,
@@ -139,6 +143,13 @@ class DataExplorerTableView(abc.ABC):
             request.params.format_options,
         ).dict()
 
+    def export_data_selection(self, request: ExportDataSelectionRequest):
+        self._recompute_if_needed()
+        return self._export_data_selection(
+            request.params.selection,
+            request.params.format,
+        ).dict()
+
     def set_row_filters(self, request: SetRowFiltersRequest):
         return self._set_row_filters(request.params.filters).dict()
 
@@ -198,6 +209,12 @@ class DataExplorerTableView(abc.ABC):
         column_indices: Sequence[int],
         format_options: FormatOptions,
     ) -> TableData:
+        pass
+
+    @abc.abstractmethod
+    def _export_data_selection(
+        self, selection: DataSelection, format: ExportFormat
+    ) -> ExportedData:
         pass
 
     @abc.abstractmethod

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -131,6 +131,38 @@ class ColumnProfileType(str, enum.Enum):
     Histogram = "histogram"
 
 
+@enum.unique
+class DataSelectionKind(str, enum.Enum):
+    """
+    Possible values for Kind in DataSelection
+    """
+
+    SingleCell = "single_cell"
+
+    CellRange = "cell_range"
+
+    ColumnRange = "column_range"
+
+    RowRange = "row_range"
+
+    ColumnIndices = "column_indices"
+
+    RowIndices = "row_indices"
+
+
+@enum.unique
+class ExportFormat(str, enum.Enum):
+    """
+    Possible values for ExportFormat
+    """
+
+    Csv = "csv"
+
+    Tsv = "tsv"
+
+    Html = "html"
+
+
 class SearchSchemaResult(BaseModel):
     """
     Result in Methods
@@ -143,6 +175,20 @@ class SearchSchemaResult(BaseModel):
 
     total_num_matches: StrictInt = Field(
         description="The total number of columns matching the search term",
+    )
+
+
+class ExportedData(BaseModel):
+    """
+    Exported result
+    """
+
+    data: StrictStr = Field(
+        description="Exported data as a string suitable for copy and paste",
+    )
+
+    format: ExportFormat = Field(
+        description="The exported data format",
     )
 
 
@@ -671,10 +717,92 @@ class GetColumnProfilesFeatures(BaseModel):
     )
 
 
+class DataSelection(BaseModel):
+    """
+    A selection on the data grid, for copying to the clipboard or other
+    actions
+    """
+
+    kind: DataSelectionKind = Field(
+        description="Type of selection",
+    )
+
+    selection: Selection = Field(
+        description="A union of selection types",
+    )
+
+
+class DataSelectionSingleCell(BaseModel):
+    """
+    A selection that contains a single data cell
+    """
+
+    row_index: StrictInt = Field(
+        description="The selected row index",
+    )
+
+    column_index: StrictInt = Field(
+        description="The selected column index",
+    )
+
+
+class DataSelectionCellRange(BaseModel):
+    """
+    A selection that contains a rectangular range of data cells
+    """
+
+    first_row_index: StrictInt = Field(
+        description="The starting selected row index (inclusive)",
+    )
+
+    last_row_index: StrictInt = Field(
+        description="The final selected row index (inclusive)",
+    )
+
+    first_column_index: StrictInt = Field(
+        description="The starting selected column index (inclusive)",
+    )
+
+    last_column_index: StrictInt = Field(
+        description="The final selected column index (inclusive)",
+    )
+
+
+class DataSelectionRange(BaseModel):
+    """
+    A contiguous selection bounded by inclusive start and end indices
+    """
+
+    first_index: StrictInt = Field(
+        description="The starting selected index (inclusive)",
+    )
+
+    last_index: StrictInt = Field(
+        description="The final selected index (inclusive)",
+    )
+
+
+class DataSelectionIndices(BaseModel):
+    """
+    A selection defined by a sequence of indices to include
+    """
+
+    indices: List[StrictInt] = Field(
+        description="The selected indices",
+    )
+
+
 # ColumnValue
 ColumnValue = Union[
     StrictInt,
     StrictStr,
+]
+# Selection in Properties
+Selection = Union[
+    DataSelectionSingleCell,
+    DataSelectionCellRange,
+    DataSelectionRange,
+    DataSelectionIndices,
 ]
 
 
@@ -692,6 +820,9 @@ class DataExplorerBackendRequest(str, enum.Enum):
 
     # Get a rectangle of data values
     GetDataValues = "get_data_values"
+
+    # Export data selection as a string in different formats
+    ExportDataSelection = "export_data_selection"
 
     # Set row filters based on column values
     SetRowFilters = "set_row_filters"
@@ -817,6 +948,41 @@ class GetDataValuesRequest(BaseModel):
     )
 
 
+class ExportDataSelectionParams(BaseModel):
+    """
+    Export data selection as a string in different formats like CSV, TSV,
+    HTML
+    """
+
+    selection: DataSelection = Field(
+        description="The data selection",
+    )
+
+    format: ExportFormat = Field(
+        description="Result string format",
+    )
+
+
+class ExportDataSelectionRequest(BaseModel):
+    """
+    Export data selection as a string in different formats like CSV, TSV,
+    HTML
+    """
+
+    params: ExportDataSelectionParams = Field(
+        description="Parameters to the ExportDataSelection method",
+    )
+
+    method: Literal[DataExplorerBackendRequest.ExportDataSelection] = Field(
+        description="The JSON-RPC method name (export_data_selection)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
+
+
 class SetRowFiltersParams(BaseModel):
     """
     Set or clear row filters on table, replacing any previous filters
@@ -932,6 +1098,7 @@ class DataExplorerBackendMessageContent(BaseModel):
         GetSchemaRequest,
         SearchSchemaRequest,
         GetDataValuesRequest,
+        ExportDataSelectionRequest,
         SetRowFiltersRequest,
         SetSortColumnsRequest,
         GetColumnProfilesRequest,
@@ -953,6 +1120,8 @@ class DataExplorerFrontendEvent(str, enum.Enum):
 
 
 SearchSchemaResult.update_forward_refs()
+
+ExportedData.update_forward_refs()
 
 FilterResult.update_forward_refs()
 
@@ -1008,6 +1177,16 @@ SetRowFiltersFeatures.update_forward_refs()
 
 GetColumnProfilesFeatures.update_forward_refs()
 
+DataSelection.update_forward_refs()
+
+DataSelectionSingleCell.update_forward_refs()
+
+DataSelectionCellRange.update_forward_refs()
+
+DataSelectionRange.update_forward_refs()
+
+DataSelectionIndices.update_forward_refs()
+
 GetSchemaParams.update_forward_refs()
 
 GetSchemaRequest.update_forward_refs()
@@ -1019,6 +1198,10 @@ SearchSchemaRequest.update_forward_refs()
 GetDataValuesParams.update_forward_refs()
 
 GetDataValuesRequest.update_forward_refs()
+
+ExportDataSelectionParams.update_forward_refs()
+
+ExportDataSelectionRequest.update_forward_refs()
 
 SetRowFiltersParams.update_forward_refs()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -28,7 +28,6 @@ from ..data_explorer_comm import (
     ColumnProfileResult,
     ColumnSchema,
     ColumnSortKey,
-    DataSelection,
     FilterResult,
     FormatOptions,
     RowFilter,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -4,6 +4,7 @@
 
 # ruff: noqa: E712
 
+from io import StringIO
 from typing import Any, Dict, List, Optional, Type, cast
 
 import numpy as np
@@ -27,6 +28,7 @@ from ..data_explorer_comm import (
     ColumnProfileResult,
     ColumnSchema,
     ColumnSortKey,
+    DataSelection,
     FilterResult,
     FormatOptions,
     RowFilter,
@@ -359,6 +361,14 @@ class DataExplorerFixture:
             "get_data_values",
             format_options=format_options,
             **params,
+        )
+
+    def export_data_selection(self, table_name, selection, format="csv"):
+        return self.do_json_rpc(
+            table_name,
+            "export_data_selection",
+            selection=selection,
+            format=format,
         )
 
     def set_row_filters(self, table_name, filters=None):
@@ -1573,6 +1583,127 @@ def test_pandas_updated_with_sort_keys(dxf: DataExplorerFixture):
     assert schema_updated
     assert new_filt == view.filters
     assert new_sort_keys == view.sort_keys
+
+
+def _select_single_cell(row_index: int, col_index: int):
+    return {
+        "kind": "single_cell",
+        "selection": {"row_index": row_index, "column_index": col_index},
+    }
+
+
+def _select_cell_range(
+    first_row_index: int,
+    last_row_index: int,
+    first_col_index: int,
+    last_col_index: int,
+):
+    return {
+        "kind": "cell_range",
+        "selection": {
+            "first_row_index": first_row_index,
+            "last_row_index": last_row_index,
+            "first_column_index": first_col_index,
+            "last_column_index": last_col_index,
+        },
+    }
+
+
+def _select_range(first_index: int, last_index: int, kind: str):
+    return {
+        "kind": kind,
+        "selection": {"first_index": first_index, "last_index": last_index},
+    }
+
+
+def _select_column_range(first_index: int, last_index: int):
+    return _select_range(first_index, last_index, "column_range")
+
+
+def _select_row_range(first_index: int, last_index: int):
+    return _select_range(first_index, last_index, "row_range")
+
+
+def _select_indices(indices: List[int], kind: str):
+    return {
+        "kind": kind,
+        "selection": {"indices": indices},
+    }
+
+
+def _select_column_indices(indices: List[int]):
+    return _select_indices(indices, "column_indices")
+
+
+def _select_row_indices(indices: List[int]):
+    return _select_indices(indices, "row_indices")
+
+
+def test_pandas_export_data_selection(dxf: DataExplorerFixture):
+    length = 100
+    ncols = 20
+
+    np.random.seed(12345)
+    df = pd.DataFrame({f"a{i}": np.random.standard_normal(length) for i in range(ncols)})
+
+    dxf.register_table("df", df)
+    dxf.register_table("filtered", df)
+
+    schema = dxf.get_schema("filtered")
+    dxf.set_row_filters("filtered", filters=[_compare_filter(schema[0], ">", "0")])
+
+    filtered = df[df.iloc[:, 0] > 0]
+
+    # Test exporting single cells
+    single_cell_cases = [(0, 0), (5, 10), (25, 15), (99, 19)]
+
+    for row_index, col_index in single_cell_cases:
+        selection = _select_single_cell(row_index, col_index)
+        df_result = dxf.export_data_selection("df", selection, "tsv")
+        df_expected = str(df.iat[row_index, col_index])
+        assert df_result["data"] == df_expected
+        assert df_result["format"] == "tsv"
+
+        filt_row_index = min(row_index, len(filtered) - 1)
+        filt_selection = _select_single_cell(filt_row_index, col_index)
+        filt_result = dxf.export_data_selection("filtered", filt_selection, "csv")
+        filt_expected = str(filtered.iat[filt_row_index, col_index])
+        assert filt_result["data"] == filt_expected
+
+    # Test exporting ranges
+    range_cases = [
+        (_select_cell_range(1, 4, 10, 19), (slice(1, 5), slice(10, 20))),
+        (_select_cell_range(1, 1, 4, 4), (slice(1, 2), slice(4, 5))),
+        (_select_column_range(1, 5), (slice(None), slice(1, 6))),
+        (_select_row_range(1, 5), (slice(1, 6), slice(None))),
+        (_select_row_indices([0, 3, 5, 7]), ([0, 3, 5, 7], slice(None))),
+        (_select_column_indices([0, 3, 5, 7]), (slice(None), [0, 3, 5, 7])),
+    ]
+
+    def do_export(x, fmt):
+        buf = StringIO()
+        if fmt == "csv":
+            x.to_csv(buf, index=False)
+        elif fmt == "tsv":
+            x.to_csv(buf, sep="\t", index=False)
+        elif fmt == "html":
+            x.to_html(buf, index=False)
+        return buf.getvalue()
+
+    for rpc_selection, selector in range_cases:
+        df_selected = df.iloc[selector]
+        filtered_selected = filtered.iloc[selector]
+
+        for fmt in ["csv", "tsv", "html"]:
+            df_result = dxf.export_data_selection("df", rpc_selection, fmt)
+            df_expected = do_export(df_selected, fmt)
+
+            assert df_result["data"] == df_expected
+            assert df_result["format"] == fmt
+
+            filt_result = dxf.export_data_selection("filtered", rpc_selection, fmt)
+            filt_expected = do_export(filtered_selected, fmt)
+            assert filt_result["data"] == filt_expected
 
 
 def _profile_request(column_index, profile_type):

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -133,6 +133,50 @@
 			}
 		},
 		{
+			"name": "export_data_selection",
+			"summary": "Export data selection as a string in different formats",
+			"description": "Export data selection as a string in different formats like CSV, TSV, HTML",
+			"params": [
+				{
+					"name": "selection",
+					"description": "The data selection",
+					"required": true,
+					"schema": {
+						"$ref": "#/components/schemas/data_selection"
+					}
+				},
+				{
+					"name": "format",
+					"description": "Result string format",
+					"required": true,
+					"schema": {
+						"$ref": "#/components/schemas/export_format"
+					}
+				}
+			],
+			"result": {
+				"schema": {
+					"name": "exported_data",
+					"type": "object",
+					"description": "Exported result",
+					"required": [
+						"data",
+						"format"
+					],
+					"properties": {
+						"data": {
+							"type": "string",
+							"description": "Exported data as a string suitable for copy and paste"
+						},
+						"format": {
+							"$ref": "#/components/schemas/export_format",
+							"description": "The exported data format"
+						}
+					}
+				}
+			}
+		},
+		{
 			"name": "set_row_filters",
 			"summary": "Set row filters based on column values",
 			"description": "Set or clear row filters on table, replacing any previous filters",
@@ -282,7 +326,6 @@
 		"contentDescriptors": {},
 		"schemas": {
 			"column_display_type": {
-				"name": "column_display_type",
 				"type": "string",
 				"description": "Canonical Positron display name of data type",
 				"enum": [
@@ -951,6 +994,138 @@
 						}
 					}
 				}
+			},
+			"data_selection": {
+				"type": "object",
+				"description": "A selection on the data grid, for copying to the clipboard or other actions",
+				"required": [
+					"kind",
+					"selection"
+				],
+				"properties": {
+					"kind": {
+						"type": "string",
+						"description": "Type of selection",
+						"enum": [
+							"single_cell",
+							"cell_range",
+							"column_range",
+							"row_range",
+							"column_indices",
+							"row_indices"
+						]
+					},
+					"selection": {
+						"description": "A union of selection types",
+						"oneOf": [
+							{
+								"name": "single_cell",
+								"$ref": "#/components/schemas/data_selection_single_cell"
+							},
+							{
+								"name": "cell_range",
+								"$ref": "#/components/schemas/data_selection_cell_range"
+							},
+							{
+								"name": "index_range",
+								"$ref": "#/components/schemas/data_selection_range"
+							},
+							{
+								"name": "indices",
+								"$ref": "#/components/schemas/data_selection_indices"
+							}
+						]
+					}
+				}
+			},
+			"data_selection_single_cell": {
+				"type": "object",
+				"description": "A selection that contains a single data cell",
+				"required": [
+					"row_index",
+					"column_index"
+				],
+				"properties": {
+					"row_index": {
+						"type": "integer",
+						"description": "The selected row index"
+					},
+					"column_index": {
+						"type": "integer",
+						"description": "The selected column index"
+					}
+				}
+			},
+			"data_selection_cell_range": {
+				"type": "object",
+				"description": "A selection that contains a rectangular range of data cells",
+				"required": [
+					"first_row_index",
+					"last_row_index",
+					"first_column_index",
+					"last_column_index"
+				],
+				"properties": {
+					"first_row_index": {
+						"type": "integer",
+						"description": "The starting selected row index (inclusive)"
+					},
+					"last_row_index": {
+						"type": "integer",
+						"description": "The final selected row index (inclusive)"
+					},
+					"first_column_index": {
+						"type": "integer",
+						"description": "The starting selected column index (inclusive)"
+					},
+					"last_column_index": {
+						"type": "integer",
+						"description": "The final selected column index (inclusive)"
+					}
+				}
+			},
+			"data_selection_range": {
+				"type": "object",
+				"description": "A contiguous selection bounded by inclusive start and end indices",
+				"required": [
+					"first_index",
+					"last_index"
+				],
+				"properties": {
+					"first_index": {
+						"type": "integer",
+						"description": "The starting selected index (inclusive)"
+					},
+					"last_index": {
+						"type": "integer",
+						"description": "The final selected index (inclusive)"
+					}
+				}
+			},
+			"data_selection_indices": {
+				"type": "object",
+				"description": "A selection defined by a sequence of indices to include",
+				"required": [
+					"indices"
+				],
+				"properties": {
+					"indices": {
+						"type": "array",
+						"description": "The selected indices",
+						"items": {
+							"type": "integer"
+						}
+					}
+				}
+			},
+			"export_format": {
+				"type": "string",
+				"description": "Exported data format",
+				"enum": [
+					"csv",
+					"tsv",
+					"html"
+				]
 			}
 		}
 	}

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -544,9 +544,11 @@ use serde::Serialize;
 				yield '#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]\n';
 				yield `pub enum ${snakeCaseToSentenceCase(context[1])}${snakeCaseToSentenceCase(context[0])} {\n`;
 			}
-			// TODO: require that unions be named
 			for (let i = 0; i < o.oneOf.length; i++) {
 				const option = o.oneOf[i];
+				if (option.name === undefined) {
+					throw new Error(`No name in option: ${JSON.stringify(option)}`);
+				}
 				const derivedType = deriveType(contracts, RustTypeMap, [option.name, ...context],
 					option);
 				yield `\t${snakeCaseToSentenceCase(option.name)}(${derivedType})`;
@@ -895,8 +897,11 @@ from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictI
 			}
 			yield `${name} = Union[`;
 			// Options
-			for (const schema of o.oneOf) {
-				yield deriveType(contracts, PythonTypeMap, [schema.name, ...context], schema);
+			for (const option of o.oneOf) {
+				if (option.name === undefined) {
+					throw new Error(`No name in option: ${JSON.stringify(option)}`);
+				}
+				yield deriveType(contracts, PythonTypeMap, [option.name, ...context], option);
 				yield ', ';
 			}
 			yield ']\n';
@@ -1163,8 +1168,11 @@ import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/co
 			yield `export type ${name} = `;
 			// Options
 			for (let i = 0; i < o.oneOf.length; i++) {
-				const schema = o.oneOf[i];
-				yield deriveType(contracts, TypescriptTypeMap, [schema.name, ...context], schema);
+				const option = o.oneOf[i];
+				if (option.name === undefined) {
+					throw new Error(`No name in option: ${JSON.stringify(option)}`);
+				}
+				yield deriveType(contracts, TypescriptTypeMap, [option.name, ...context], option);
 				if (i < o.oneOf.length - 1) {
 					yield ' | ';
 				}

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -841,6 +841,7 @@ export enum DataExplorerBackendRequest {
 	GetSchema = 'get_schema',
 	SearchSchema = 'search_schema',
 	GetDataValues = 'get_data_values',
+	ExportDataSelection = 'export_data_selection',
 	SetRowFilters = 'set_row_filters',
 	SetSortColumns = 'set_sort_columns',
 	GetColumnProfiles = 'get_column_profiles',

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -27,6 +27,22 @@ export interface SearchSchemaResult {
 }
 
 /**
+ * Exported result
+ */
+export interface ExportedData {
+	/**
+	 * Exported data as a string suitable for copy and paste
+	 */
+	data: string;
+
+	/**
+	 * The exported data format
+	 */
+	format: ExportFormat;
+
+}
+
+/**
  * The result of applying filters to a table
  */
 export interface FilterResult {
@@ -619,8 +635,97 @@ export interface GetColumnProfilesFeatures {
 
 }
 
+/**
+ * A selection on the data grid, for copying to the clipboard or other
+ * actions
+ */
+export interface DataSelection {
+	/**
+	 * Type of selection
+	 */
+	kind: DataSelectionKind;
+
+	/**
+	 * A union of selection types
+	 */
+	selection: Selection;
+
+}
+
+/**
+ * A selection that contains a single data cell
+ */
+export interface DataSelectionSingleCell {
+	/**
+	 * The selected row index
+	 */
+	row_index: number;
+
+	/**
+	 * The selected column index
+	 */
+	column_index: number;
+
+}
+
+/**
+ * A selection that contains a rectangular range of data cells
+ */
+export interface DataSelectionCellRange {
+	/**
+	 * The starting selected row index (inclusive)
+	 */
+	first_row_index: number;
+
+	/**
+	 * The final selected row index (inclusive)
+	 */
+	last_row_index: number;
+
+	/**
+	 * The starting selected column index (inclusive)
+	 */
+	first_column_index: number;
+
+	/**
+	 * The final selected column index (inclusive)
+	 */
+	last_column_index: number;
+
+}
+
+/**
+ * A contiguous selection bounded by inclusive start and end indices
+ */
+export interface DataSelectionRange {
+	/**
+	 * The starting selected index (inclusive)
+	 */
+	first_index: number;
+
+	/**
+	 * The final selected index (inclusive)
+	 */
+	last_index: number;
+
+}
+
+/**
+ * A selection defined by a sequence of indices to include
+ */
+export interface DataSelectionIndices {
+	/**
+	 * The selected indices
+	 */
+	indices: Array<number>;
+
+}
+
 /// ColumnValue
 export type ColumnValue = number | string;
+
+/// Selection in Properties
+export type Selection = DataSelectionSingleCell | DataSelectionCellRange | DataSelectionRange | DataSelectionIndices;
 
 /**
  * Possible values for ColumnDisplayType
@@ -692,6 +797,27 @@ export enum ColumnProfileType {
 	SummaryStats = 'summary_stats',
 	FrequencyTable = 'frequency_table',
 	Histogram = 'histogram'
+}
+
+/**
+ * Possible values for Kind in DataSelection
+ */
+export enum DataSelectionKind {
+	SingleCell = 'single_cell',
+	CellRange = 'cell_range',
+	ColumnRange = 'column_range',
+	RowRange = 'row_range',
+	ColumnIndices = 'column_indices',
+	RowIndices = 'row_indices'
+}
+
+/**
+ * Possible values for ExportFormat
+ */
+export enum ExportFormat {
+	Csv = 'csv',
+	Tsv = 'tsv',
+	Html = 'html'
 }
 
 /**
@@ -779,6 +905,21 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 */
 	getDataValues(rowStartIndex: number, numRows: number, columnIndices: Array<number>, formatOptions: FormatOptions): Promise<TableData> {
 		return super.performRpc('get_data_values', ['row_start_index', 'num_rows', 'column_indices', 'format_options'], [rowStartIndex, numRows, columnIndices, formatOptions]);
+	}
+
+	/**
+	 * Export data selection as a string in different formats
+	 *
+	 * Export data selection as a string in different formats like CSV, TSV,
+	 * HTML
+	 *
+	 * @param selection The data selection
+	 * @param format Result string format
+	 *
+	 * @returns Exported result
+	 */
+	exportDataSelection(selection: DataSelection, format: ExportFormat): Promise<ExportedData> {
+		return super.performRpc('export_data_selection', ['selection', 'format'], [selection, format]);
 	}
 
 	/**


### PR DESCRIPTION
This addresses #3313 and is a dependency of #2160 / #3288

This adds several selection OpenRPC types to describe single cell, cell range, row range, column range, and selections based on a list of column or row indices and allows the data to be exported to CSV, TSV (tab-separated, what Excel and Google Sheets need for pasting to work properly), and HTML. 

There is currently no error checking to catch requests that may be too large/expensive -- probably easiest to do this on the front end for now. 

pandas row indices are currently not being exported. I figure it's easiest to make this first step and then we can decide under which circumstances (e.g. only in the row-range/row-indices scenarios?) we want to include the row labels. 