### PR TITLE
Data Explorer: Maintain user's current column position after applying row filter

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/actionBar/actionBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/actionBar/actionBar.tsx
@@ -54,8 +54,8 @@ export const ActionBar = () => {
 							text={clearSortButtonTitle}
 							tooltip={clearSortButtonDescription}
 							ariaLabel={clearSortButtonDescription}
-							onPressed={() =>
-								context.instance.tableDataDataGridInstance.clearColumnSortKeys()
+							onPressed={async () =>
+								await context.instance.tableDataDataGridInstance.clearColumnSortKeys()
 							}
 						/>
 					</ActionBarRegion>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
@@ -84,8 +84,7 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 
 		// Add the onDidSchemaUpdate event handler.
 		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(async () => {
-			this.setScreenPosition(0, 0);
-			this.fetchData();
+			await this.setScreenPosition(0, 0);
 		}));
 	}
 
@@ -113,9 +112,10 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 
 	/**
 	 * Fetches data.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	override fetchData() {
-		this._columnSchemaCache.updateCache({
+	override async fetchData() {
+		await this._columnSchemaCache.updateCache({
 			searchText: this._searchText,
 			firstColumnIndex: this.firstRowIndex,
 			visibleColumns: this.screenRows
@@ -188,7 +188,7 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 
 			// Set the search text and fetch data.
 			this._searchText = searchText;
-			this.fetchData();
+			await this.fetchData();
 		}
 	}
 

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
@@ -74,8 +74,8 @@ export const ColumnSelectorModalPopup = (props: ColumnSelectorModalPopupProps) =
 			<div className='column-selector'>
 				<div className='search'>
 					<ColumnSearch
-						onSearchTextChanged={searchText => {
-							props.columnSelectorDataGridInstance.setSearchText(
+						onSearchTextChanged={async searchText => {
+							await props.columnSelectorDataGridInstance.setSearchText(
 								searchText !== '' ? searchText : undefined
 							);
 						}}

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -943,8 +943,9 @@ export abstract class DataGridInstance extends Disposable {
 	 * Sets the width of a column.
 	 * @param columnIndex The column index.
 	 * @param columnWidth The column width.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	setColumnWidth(columnIndex: number, columnWidth: number) {
+	async setColumnWidth(columnIndex: number, columnWidth: number): Promise<void> {
 		// Get the current column width.
 		const currentColumnWidth = this._columnWidths.get(columnIndex);
 		if (currentColumnWidth !== undefined) {
@@ -957,7 +958,7 @@ export abstract class DataGridInstance extends Disposable {
 		this._columnWidths.set(columnIndex, columnWidth);
 
 		// Fetch data.
-		this.fetchData();
+		await this.fetchData();
 
 		// Fire the onDidUpdate event.
 		this._onDidUpdateEmitter.fire();
@@ -989,8 +990,9 @@ export abstract class DataGridInstance extends Disposable {
 	 * Sets the the height of a row.
 	 * @param rowIndex The row index.
 	 * @param rowHeight The row height.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	setRowHeight(rowIndex: number, rowHeight: number) {
+	async setRowHeight(rowIndex: number, rowHeight: number): Promise<void> {
 		// Get the current row height.
 		const currentRowHeight = this._rowHeights.get(rowIndex);
 		if (currentRowHeight !== undefined) {
@@ -1003,7 +1005,7 @@ export abstract class DataGridInstance extends Disposable {
 		this._rowHeights.set(rowIndex, rowHeight);
 
 		// Fetch data.
-		this.fetchData();
+		await this.fetchData();
 
 		// Fire the onDidUpdate event.
 		this._onDidUpdateEmitter.fire();
@@ -1095,15 +1097,16 @@ export abstract class DataGridInstance extends Disposable {
 	/**
 	 * Sets the row headers width.
 	 * @param rowHeadersWidth The row headers width.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	setRowHeadersWidth(rowHeadersWidth: number) {
+	async setRowHeadersWidth(rowHeadersWidth: number): Promise<void> {
 		// If the row headers width has changed, update it.
 		if (rowHeadersWidth !== this._rowHeadersWidth) {
 			// Set the row headers width..
 			this._rowHeadersWidth = rowHeadersWidth;
 
 			// Fetch data.
-			this.fetchData();
+			await this.fetchData();
 
 			// Fire the onDidUpdate event.
 			this._onDidUpdateEmitter.fire();
@@ -1114,8 +1117,9 @@ export abstract class DataGridInstance extends Disposable {
 	 * Sets the screen size.
 	 * @param width The width.
 	 * @param height The height.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	setScreenSize(width: number, height: number) {
+	async setScreenSize(width: number, height: number): Promise<void> {
 		// A flag that is set to true when the screen size changed.
 		let screenSizeChanged = false;
 
@@ -1136,7 +1140,7 @@ export abstract class DataGridInstance extends Disposable {
 		// If the screen size changed, fetch data and fire the onDidUpdate event.
 		if (screenSizeChanged) {
 			// Fetch data.
-			this.fetchData();
+			await this.fetchData();
 
 			// Fire the onDidUpdate event.
 			this._onDidUpdateEmitter.fire();
@@ -1147,15 +1151,16 @@ export abstract class DataGridInstance extends Disposable {
 	 * Sets the screen position.
 	 * @param firstColumnIndex The first column index.
 	 * @param firstRowIndex The first row index.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	setScreenPosition(firstColumnIndex: number, firstRowIndex: number) {
+	async setScreenPosition(firstColumnIndex: number, firstRowIndex: number): Promise<void> {
 		if (firstColumnIndex !== this._firstColumnIndex || firstRowIndex !== this._firstRowIndex) {
 			// Set the screen position.
 			this._firstColumnIndex = firstColumnIndex;
 			this._firstRowIndex = firstRowIndex;
 
 			// Fetch data.
-			this.fetchData();
+			await this.fetchData();
 
 			// Fire the onDidUpdate event.
 			this._onDidUpdateEmitter.fire();
@@ -1165,14 +1170,15 @@ export abstract class DataGridInstance extends Disposable {
 	/**
 	 * Sets the first column.
 	 * @param firstColumnIndex The first column index.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	setFirstColumn(firstColumnIndex: number) {
+	async setFirstColumn(firstColumnIndex: number): Promise<void> {
 		if (firstColumnIndex !== this._firstColumnIndex) {
 			// Set the first column index.
 			this._firstColumnIndex = firstColumnIndex;
 
 			// Fetch data.
-			this.fetchData();
+			await this.fetchData();
 
 			// Fire the onDidUpdate event.
 			this._onDidUpdateEmitter.fire();
@@ -1182,14 +1188,18 @@ export abstract class DataGridInstance extends Disposable {
 	/**
 	 * Sets the first row.
 	 * @param firstRowIndex The first row index.
+	 * @param force A value which indicates whether to force the operation.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	setFirstRow(firstRowIndex: number) {
-		if (firstRowIndex !== this._firstRowIndex) {
+	async setFirstRow(firstRowIndex: number, force: boolean = false): Promise<void> {
+		// If the operation is being forced, or the first row has changed, set the first row and
+		// update the data grid.
+		if (force || firstRowIndex !== this._firstRowIndex) {
 			// Set the first row index.
 			this._firstRowIndex = firstRowIndex;
 
 			// Fetch data.
-			this.fetchData();
+			await this.fetchData();
 
 			// Fire the onDidUpdate event.
 			this._onDidUpdateEmitter.fire();
@@ -1262,13 +1272,14 @@ export abstract class DataGridInstance extends Disposable {
 	/**
 	 * Scrolls tp the specified column.
 	 * @param columnIndex The column index.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	scrollToColumn(columnIndex: number) {
+	async scrollToColumn(columnIndex: number): Promise<void> {
 		if (columnIndex < this._firstColumnIndex) {
-			this.setFirstColumn(columnIndex);
+			await this.setFirstColumn(columnIndex);
 		} else if (columnIndex >= this._firstColumnIndex + this.visibleColumns) {
 			do {
-				this.setFirstColumn(this._firstColumnIndex + 1);
+				await this.setFirstColumn(this._firstColumnIndex + 1);
 			} while (columnIndex >= this._firstColumnIndex + this.visibleColumns);
 		}
 	}
@@ -1373,8 +1384,9 @@ export abstract class DataGridInstance extends Disposable {
 	 * Mouse selects a column.
 	 * @param columnIndex The column index.
 	 * @param selectionType The selection type.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	mouseSelectColumn(columnIndex: number, selectionType: MouseSelectionType) {
+	async mouseSelectColumn(columnIndex: number, selectionType: MouseSelectionType): Promise<void> {
 		// Clear cell selection.
 		this._cellSelectionRange = undefined;
 
@@ -1383,16 +1395,16 @@ export abstract class DataGridInstance extends Disposable {
 		this._rowSelectionIndexes.clear();
 
 		/**
-		 * Adjust the cursor position.
+		 * Adjusts the cursor position.
 		 * @param columnIndex The column index.
 		 */
-		const adjustCursorPosition = (columnIndex: number) => {
+		const adjustCursorPosition = async (columnIndex: number) => {
 			// Adjust the cursor position.
 			this._cursorColumnIndex = columnIndex;
 			this._cursorRowIndex = this._firstRowIndex;
 
 			// Fetch data.
-			this.fetchData();
+			await this.fetchData();
 
 			// Fire the onDidUpdate event.
 			this._onDidUpdateEmitter.fire();
@@ -1403,7 +1415,7 @@ export abstract class DataGridInstance extends Disposable {
 			// Single selection.
 			case MouseSelectionType.Single: {
 				// Adjust the cursor position.
-				adjustCursorPosition(columnIndex);
+				await adjustCursorPosition(columnIndex);
 
 				// Single select the column.
 				this._columnSelectionRange = undefined;
@@ -1428,7 +1440,7 @@ export abstract class DataGridInstance extends Disposable {
 				// Toggle selection of the column index.
 				if (!this._columnSelectionIndexes.has(columnIndex)) {
 					// Adjust the cursor position.
-					adjustCursorPosition(columnIndex);
+					await adjustCursorPosition(columnIndex);
 
 					// Select the column index.
 					this._columnSelectionIndexes.add(columnIndex);
@@ -1439,9 +1451,9 @@ export abstract class DataGridInstance extends Disposable {
 					// Adjust the cursor position, if necessary.
 					if (this._cursorColumnIndex === columnIndex) {
 						if (this._columnSelectionIndexes.size) {
-							adjustCursorPosition(Math.max(...this._columnSelectionIndexes));
+							await adjustCursorPosition(Math.max(...this._columnSelectionIndexes));
 						} else if (this._columnSelectionRange) {
-							adjustCursorPosition(this._columnSelectionRange.lastColumnIndex);
+							await adjustCursorPosition(this._columnSelectionRange.lastColumnIndex);
 						}
 					}
 				}
@@ -1494,8 +1506,9 @@ export abstract class DataGridInstance extends Disposable {
 	 * Selects a row.
 	 * @param rowIndex The row index.
 	 * @param selectionType The selection type.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	mouseSelectRow(rowIndex: number, selectionType: MouseSelectionType) {
+	async mouseSelectRow(rowIndex: number, selectionType: MouseSelectionType): Promise<void> {
 		// Clear cell selection.
 		this._cellSelectionRange = undefined;
 
@@ -1507,13 +1520,13 @@ export abstract class DataGridInstance extends Disposable {
 		 * Adjust the row position.
 		 * @param columnIndex The column index.
 		 */
-		const adjustRowPosition = (rowIndex: number) => {
+		const adjustRowPosition = async (rowIndex: number) => {
 			// Adjust the cursor position.
 			this._cursorColumnIndex = this._firstColumnIndex;
 			this._cursorRowIndex = rowIndex;
 
 			// Fetch data.
-			this.fetchData();
+			await this.fetchData();
 
 			// Fire the onDidUpdate event.
 			this._onDidUpdateEmitter.fire();
@@ -1524,7 +1537,7 @@ export abstract class DataGridInstance extends Disposable {
 			// Single selection.
 			case MouseSelectionType.Single: {
 				// Adjust the cursor position.
-				adjustRowPosition(rowIndex);
+				await adjustRowPosition(rowIndex);
 
 				// Single select the row.
 				this._rowSelectionRange = undefined;
@@ -1549,7 +1562,7 @@ export abstract class DataGridInstance extends Disposable {
 				// Toggle selection of the row index.
 				if (!this._rowSelectionIndexes.has(rowIndex)) {
 					// Adjust the cursor position.
-					adjustRowPosition(rowIndex);
+					await adjustRowPosition(rowIndex);
 
 					// Select the row index.
 					this._rowSelectionIndexes.add(rowIndex);
@@ -1560,9 +1573,9 @@ export abstract class DataGridInstance extends Disposable {
 					// Adjust the cursor position, if necessary.
 					if (this._cursorRowIndex === rowIndex) {
 						if (this._rowSelectionIndexes.size) {
-							adjustRowPosition(Math.max(...this._rowSelectionIndexes));
+							await adjustRowPosition(Math.max(...this._rowSelectionIndexes));
 						} else if (this._rowSelectionRange) {
-							adjustRowPosition(this._rowSelectionRange.lastRowIndex);
+							await adjustRowPosition(this._rowSelectionRange.lastRowIndex);
 						}
 					}
 				}
@@ -2032,7 +2045,7 @@ export abstract class DataGridInstance extends Disposable {
 	/**
 	 * Fetches data.
 	 */
-	abstract fetchData(): void;
+	abstract fetchData(): Promise<void>;
 
 	/**
 	 * Gets a column.
@@ -2065,9 +2078,10 @@ export abstract class DataGridInstance extends Disposable {
 	//#region Protected Methods
 
 	/**
-	 * Performs a soft reset of the data grid.
+	 * Performs a reset of the data grid.
 	 */
 	protected softReset() {
+		// Reset the display.
 		this._firstColumnIndex = 0;
 		this._firstRowIndex = 0;
 		if (this._cursorInitiallyHidden) {
@@ -2077,6 +2091,15 @@ export abstract class DataGridInstance extends Disposable {
 			this._cursorColumnIndex = 0;
 			this._cursorRowIndex = 0;
 		}
+
+		// Reset selection.
+		this.resetSelection();
+	}
+
+	/**
+	 * Resets the selection.
+	 */
+	protected resetSelection() {
 		this._cellSelectionRange = undefined;
 		this._columnSelectionRange = undefined;
 		this._columnSelectionIndexes.clear();

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -53,14 +53,15 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 	/**
 	 * onMouseDown handler.
 	 * @param e A MouseEvent<HTMLElement> that describes a user interaction with the mouse.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	const mouseDownHandler = (e: MouseEvent<HTMLElement>) => {
+	const mouseDownHandler = async (e: MouseEvent<HTMLElement>) => {
 		// Consume the event.
 		e.preventDefault();
 		e.stopPropagation();
 
 		// Mouse select the column.
-		context.instance.mouseSelectColumn(props.columnIndex, selectionType(e));
+		await context.instance.mouseSelectColumn(props.columnIndex, selectionType(e));
 	};
 
 	/**
@@ -84,7 +85,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 					checked: columnSortKey !== undefined && columnSortKey.ascending,
 					label: sortAscendingTitle,
 					icon: 'arrow-up',
-					onSelected: async () => context.instance.setColumnSortKey(
+					onSelected: async () => await context.instance.setColumnSortKey(
 						props.columnIndex,
 						true
 					)
@@ -93,7 +94,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 					checked: columnSortKey !== undefined && !columnSortKey.ascending,
 					label: sortDescendingTitle,
 					icon: 'arrow-down',
-					onSelected: async () => context.instance.setColumnSortKey(
+					onSelected: async () => await context.instance.setColumnSortKey(
 						props.columnIndex,
 						false
 					)
@@ -105,7 +106,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 					disabled: !columnSortKey,
 					icon: 'positron-clear-sorting',
 					onSelected: async () =>
-						context.instance.removeColumnSortKey(props.columnIndex)
+						await context.instance.removeColumnSortKey(props.columnIndex)
 				}),
 				...context.instance.columnContextMenuEntries(props.columnIndex)
 			]
@@ -179,8 +180,8 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 						maximumWidth: 400,
 						startingWidth: context.instance.getColumnWidth(props.columnIndex)
 					})}
-					onResize={width =>
-						context.instance.setColumnWidth(props.columnIndex, width)
+					onResize={async width =>
+						await context.instance.setColumnWidth(props.columnIndex, width)
 					}
 				/>
 			}

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridCornerTopLeft.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridCornerTopLeft.tsx
@@ -37,8 +37,8 @@ export const DataGridCornerTopLeft = (props: DataGridCornerTopLeftProps) => {
 					maximumWidth: 400,
 					startingWidth: context.instance.rowHeadersWidth
 				})}
-				onResize={width =>
-					context.instance.setRowHeadersWidth(width)
+				onResize={async width =>
+					await context.instance.setRowHeadersWidth(width)
 				}
 			/>
 		</div>

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
@@ -116,8 +116,8 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 						maximumWidth: 400,
 						startingWidth: context.instance.getColumnWidth(props.columnIndex)
 					})}
-					onResize={width =>
-						context.instance.setColumnWidth(props.columnIndex, width)
+					onResize={async width =>
+						await context.instance.setColumnWidth(props.columnIndex, width)
 					}
 				/>
 			}
@@ -128,8 +128,8 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 						maximumHeight: 90,
 						startingHeight: context.instance.getRowHeight(props.rowIndex)
 					})}
-					onResize={height =>
-						context.instance.setRowHeight(props.rowIndex, height)
+					onResize={async height =>
+						await context.instance.setRowHeight(props.rowIndex, height)
 					}
 				/>
 			}

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
@@ -37,9 +37,10 @@ export const DataGridRowHeader = (props: DataGridRowHeaderProps) => {
 	/**
 	 * MouseDown handler.
 	 * @param e A MouseEvent<HTMLElement> that describes a user interaction with the mouse.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	const mouseDownHandler = (e: MouseEvent<HTMLElement>) => {
-		context.instance.mouseSelectRow(props.rowIndex, selectionType(e));
+	const mouseDownHandler = async (e: MouseEvent<HTMLElement>) => {
+		await context.instance.mouseSelectRow(props.rowIndex, selectionType(e));
 	};
 
 	// Get the row selection state.
@@ -79,8 +80,8 @@ export const DataGridRowHeader = (props: DataGridRowHeaderProps) => {
 					maximumWidth: 400,
 					startingWidth: context.instance.rowHeadersWidth
 				})}
-				onResize={width =>
-					context.instance.setRowHeadersWidth(width)
+				onResize={async width =>
+					await context.instance.setRowHeadersWidth(width)
 				}
 			/>
 			{context.instance.rowResize &&
@@ -90,8 +91,8 @@ export const DataGridRowHeader = (props: DataGridRowHeaderProps) => {
 						maximumHeight: 90,
 						startingHeight: context.instance.getRowHeight(props.rowIndex)
 					})}
-					onResize={height =>
-						context.instance.setRowHeight(props.rowIndex, height)
+					onResize={async height =>
+						await context.instance.setRowHeight(props.rowIndex, height)
 					}
 				/>
 			}

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -83,8 +83,17 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 		setWidth(dataGridWaffleRef.current.offsetWidth);
 		setHeight(dataGridWaffleRef.current.offsetHeight);
 
+		/**
+		 * Sets the screen size.
+		 * @returns A Promise<void> that resolves when the operation is complete.
+		 */
+		const setScreenSize = async (width: number, height: number) => {
+			// Set the screen size.
+			await context.instance.setScreenSize(width, height);
+		};
+
 		// Set the initial screen size.
-		context.instance.setScreenSize(
+		setScreenSize(
 			dataGridWaffleRef.current.offsetWidth,
 			dataGridWaffleRef.current.offsetHeight
 		);
@@ -95,13 +104,13 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 		}
 
 		// Allocate and initialize the waffle resize observer.
-		const resizeObserver = new ResizeObserver(entries => {
+		const resizeObserver = new ResizeObserver(async entries => {
 			// Set the width and height.
 			setWidth(entries[0].contentRect.width);
 			setHeight(entries[0].contentRect.height);
 
 			// Set the screen size.
-			context.instance.setScreenSize(
+			await setScreenSize(
 				entries[0].contentRect.width,
 				entries[0].contentRect.height
 			);
@@ -185,14 +194,14 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 				// top left.
 				if (isMacintosh ? e.metaKey : e.ctrlKey) {
 					context.instance.clearSelection();
-					context.instance.setScreenPosition(0, 0);
+					await context.instance.setScreenPosition(0, 0);
 					context.instance.setCursorPosition(0, 0);
 					return;
 				}
 
 				// Home clears the selection and positions the screen and cursor to the left.
 				context.instance.clearSelection();
-				context.instance.setFirstColumn(0);
+				await context.instance.setFirstColumn(0);
 				context.instance.setCursorColumn(0);
 				break;
 			}
@@ -222,7 +231,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 				// bottom right.
 				if (isMacintosh ? e.metaKey : e.ctrlKey) {
 					context.instance.clearSelection();
-					context.instance.setScreenPosition(
+					await context.instance.setScreenPosition(
 						context.instance.maximumFirstColumnIndex,
 						context.instance.maximumFirstRowIndex
 					);
@@ -235,7 +244,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 
 				// End clears the selection and positions the screen and cursor to the left.
 				context.instance.clearSelection();
-				context.instance.setFirstColumn(context.instance.maximumFirstColumnIndex);
+				await context.instance.setFirstColumn(context.instance.maximumFirstColumnIndex);
 				context.instance.setCursorColumn(context.instance.columns - 1);
 				break;
 			}
@@ -268,7 +277,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 					context.instance.firstRowIndex - (e.altKey ? context.instance.visibleRows * 10 : context.instance.visibleRows),
 					0
 				);
-				context.instance.setFirstRow(firstRowIndex);
+				await context.instance.setFirstRow(firstRowIndex);
 				context.instance.setCursorRow(firstRowIndex);
 				break;
 			}
@@ -301,7 +310,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 					context.instance.firstRowIndex + (e.altKey ? context.instance.visibleRows * 10 : context.instance.visibleRows),
 					context.instance.maximumFirstRowIndex
 				);
-				context.instance.setFirstRow(firstRowIndex);
+				await context.instance.setFirstRow(firstRowIndex);
 				context.instance.setCursorRow(firstRowIndex);
 				break;
 			}
@@ -452,8 +461,9 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 	/**
 	 * onWheel event handler.
 	 * @param e A WheelEvent<HTMLDivElement> that describes a user interaction with the mouse wheel.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	const wheelHandler = (e: WheelEvent<HTMLDivElement>) => {
+	const wheelHandler = async (e: WheelEvent<HTMLDivElement>) => {
 		// Record the last wheel event.
 		setLastWheelEvent(e.timeStamp);
 
@@ -480,7 +490,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 			if (!rowsToScroll) {
 				setWheelDeltaY(adjustedWheelDeltaY);
 			} else {
-				context.instance.setFirstRow(pinToRange(
+				await context.instance.setFirstRow(pinToRange(
 					context.instance.firstRowIndex + rowsToScroll,
 					0,
 					context.instance.maximumFirstRowIndex
@@ -494,7 +504,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 			// Determine whether there's enough delta X to scroll one or more columns.
 			const columnsToScroll = Math.trunc(adjustedWheelDeltaX / MOUSE_WHEEL_SENSITIVITY);
 			if (columnsToScroll) {
-				context.instance.setFirstColumn(pinToRange(
+				await context.instance.setFirstColumn(pinToRange(
 					context.instance.firstColumnIndex + columnsToScroll,
 					0,
 					context.instance.maximumFirstColumnIndex
@@ -540,8 +550,8 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 		>
 			{context.instance.columnHeaders && context.instance.rowHeaders &&
 				<DataGridCornerTopLeft
-					onClick={() => {
-						context.instance.setScreenPosition(0, 0);
+					onClick={async () => {
+						await context.instance.setScreenPosition(0, 0);
 					}}
 				/>
 			}
@@ -573,8 +583,8 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 					visibleEntries={context.instance.visibleColumns}
 					firstEntry={context.instance.firstColumnIndex}
 					maximumFirstEntry={context.instance.maximumFirstColumnIndex}
-					onDidChangeFirstEntry={firstColumnIndex =>
-						context.instance.setFirstColumn(firstColumnIndex)
+					onDidChangeFirstEntry={async firstColumnIndex =>
+						await context.instance.setFirstColumn(firstColumnIndex)
 					}
 				/>
 			}
@@ -593,16 +603,16 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 					visibleEntries={context.instance.visibleRows}
 					firstEntry={context.instance.firstRowIndex}
 					maximumFirstEntry={context.instance.maximumFirstRowIndex}
-					onDidChangeFirstEntry={firstRowIndex =>
-						context.instance.setFirstRow(firstRowIndex)
+					onDidChangeFirstEntry={async firstRowIndex =>
+						await context.instance.setFirstRow(firstRowIndex)
 					}
 				/>
 			}
 
 			{context.instance.horizontalScrollbar && context.instance.verticalScrollbar &&
 				<DataGridScrollbarCorner
-					onClick={() => {
-						context.instance.setScreenPosition(
+					onClick={async () => {
+						await context.instance.setScreenPosition(
 							context.instance.maximumFirstColumnIndex,
 							context.instance.maximumFirstRowIndex
 						);

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -276,6 +276,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		this._dataExplorerCache.invalidateDataCache();
 		this.resetSelection();
 		this.setFirstRow(0, true);
+		this.setCursorRow(0);
 	}
 
 	//#endregion Public Methods

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -93,16 +93,16 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		));
 
 		// Add the onDidSchemaUpdate event handler.
-		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(e => {
+		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(async e => {
 			this._dataExplorerCache.invalidateDataCache();
 			this.softReset();
-			this.fetchData();
+			await this.fetchData();
 		}));
 
 		// Add the onDidDataUpdate event handler.
-		this._register(this._dataExplorerClientInstance.onDidDataUpdate(() => {
+		this._register(this._dataExplorerClientInstance.onDidDataUpdate(async () => {
 			this._dataExplorerCache.invalidateDataCache();
-			this.fetchData();
+			await this.fetchData();
 		}));
 
 		// Add the onDidUpdateBackendState event handler.
@@ -180,15 +180,16 @@ export class TableDataDataGridInstance extends DataGridInstance {
 
 		// Clear the data cache and fetch new data.
 		this._dataExplorerCache.invalidateDataCache();
-		this.fetchData();
+		await this.fetchData();
 	}
 
 	/**
 	 * Fetches data.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	override fetchData() {
+	override async fetchData() {
 		// Update the cache.
-		this._dataExplorerCache.updateCache({
+		await this._dataExplorerCache.updateCache({
 			firstColumnIndex: this.firstColumnIndex,
 			visibleColumns: this.screenColumns,
 			firstRowIndex: this.firstRowIndex,
@@ -273,8 +274,8 @@ export class TableDataDataGridInstance extends DataGridInstance {
 
 		// Reload the data grid.
 		this._dataExplorerCache.invalidateDataCache();
-		this.softReset();
-		this.fetchData();
+		this.resetSelection();
+		this.setFirstRow(0, true);
 	}
 
 	//#endregion Public Methods

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -83,9 +83,9 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 
 		// Add the onDidSchemaUpdate event handler.
 		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(async () => {
-			this.setScreenPosition(0, 0);
+			await this.setScreenPosition(0, 0);
 			this._expandedColumns.clear();
-			this.fetchData();
+			await this.fetchData();
 		}));
 	}
 
@@ -113,9 +113,10 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 
 	/**
 	 * Fetches data.
+	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	override fetchData() {
-		this._dataExplorerCache.updateCache({
+	override async fetchData() {
+		await this._dataExplorerCache.updateCache({
 			firstColumnIndex: this.firstRowIndex,
 			visibleColumns: this.screenRows
 		});

--- a/src/vs/workbench/services/positronDataExplorer/common/columnSchemaCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/columnSchemaCache.ts
@@ -120,12 +120,14 @@ export class ColumnSchemaCache extends Disposable {
 	/**
 	 * Updates the cache.
 	 * @param cacheUpdateDescriptor The cache update descriptor.
+	 * @returns A Promise<void> that resolves when the update is complete.
 	 */
-	updateCache(cacheUpdateDescriptor: CacheUpdateDescriptor) {
+	async updateCache(cacheUpdateDescriptor: CacheUpdateDescriptor): Promise<void> {
 		// Update the cache.
-		this.doUpdateCache(cacheUpdateDescriptor).catch(error => {
-			this._onDidUpdateCacheEmitter.fire();
-		});
+		await this.doUpdateCache(cacheUpdateDescriptor);
+
+		// Fire the onDidUpdateCache event.
+		this._onDidUpdateCacheEmitter.fire();
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
@@ -219,11 +219,12 @@ export class DataExplorerCache extends Disposable {
 	 * firstRowIndex and visibleRows parameters from the cache update descriptor.
 	 * @param cacheUpdateDescriptor The cache update descriptor.
 	 */
-	updateCache(cacheUpdateDescriptor: CacheUpdateDescriptor) {
+	async updateCache(cacheUpdateDescriptor: CacheUpdateDescriptor): Promise<void> {
 		// Update the cache.
-		this.doUpdateCache(cacheUpdateDescriptor).catch(error => {
-			this._onDidUpdateCacheEmitter.fire();
-		});
+		await this.doUpdateCache(cacheUpdateDescriptor);
+
+		// Fire the onDidUpdateCache event.
+		this._onDidUpdateCacheEmitter.fire();
 	}
 
 	/**
@@ -479,7 +480,7 @@ export class DataExplorerCache extends Disposable {
 			this._cacheUpdateDescriptor = undefined;
 
 			// Update the cache for the pending cache update descriptor.
-			this.updateCache(pendingCacheUpdateDescriptor);
+			await this.updateCache(pendingCacheUpdateDescriptor);
 		}
 	}
 


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR addresses https://github.com/posit-dev/positron/issues/3077 by maintaining the user's horizontal scroll position when Positron Data Explorer filters are added or removed.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

If you are scrolled horizontally in Positron Data Explorer, adding and removing filters will keep you scrolled to the same column.

For example, if the Positron Data Explorer is scrolled all the way to the right and to the bottom:

<img width="1808" alt="image" src="https://github.com/posit-dev/positron/assets/853239/bd4ded18-9c98-431d-bb7e-99a4c855f68a">

And then a filter is added (in this example, `hour = 7`):

<img width="1808" alt="image" src="https://github.com/posit-dev/positron/assets/853239/b1a2bf23-fe6b-4225-9243-516d3121338d">

You will see that the screen remains scrolled all the way to the right.

Because the set of rows may have changed, the top row and the selection are reset when filters are added or removed.