### PR TITLE
Fix select interpreter not updating the console's foreground session and focus

### DIFF
--- a/extensions/positron-python/src/client/common/application/commands.ts
+++ b/extensions/positron-python/src/client/common/application/commands.ts
@@ -101,6 +101,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [Commands.Debug_In_Terminal]: [Uri];
     // --- Start Positron ---
     [Commands.Exec_In_Console]: [];
+    [Commands.Focus_Positron_Console]: [];
     // --- End Positron ---
     [Commands.Tests_Configure]: [undefined, undefined | CommandSource, undefined | Uri];
     [Commands.LaunchTensorBoard]: [TensorBoardEntrypoint, TensorBoardEntrypointTrigger];

--- a/extensions/positron-python/src/client/common/constants.ts
+++ b/extensions/positron-python/src/client/common/constants.ts
@@ -57,6 +57,9 @@ export namespace Commands {
     // --- End Positron ---
     export const Exec_Selection_In_Django_Shell = 'python.execSelectionInDjangoShell';
     export const Exec_Selection_In_Terminal = 'python.execSelectionInTerminal';
+    // --- Start Positron ---
+    export const Focus_Positron_Console = 'workbench.panel.positronConsole.focus';
+    // --- End Positron ---
     export const GetSelectedInterpreterPath = 'python.interpreterPath';
     // --- Start Positron ---
     export const Get_Create_Environment_Providers = 'python.getCreateEnvironmentProviders';

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -48,6 +48,7 @@ import {
 import { BaseInterpreterSelectorCommand } from './base';
 // --- Start Positron ---
 import { IPythonRuntimeManager } from '../../../../positron/manager';
+import { traceError } from '../../../../logging';
 // --- End Positron ---
 
 const untildify = require('untildify');
@@ -589,7 +590,9 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
             await this.pythonPathUpdaterService.updatePythonPath(interpreterState.path, configTarget, 'ui', wkspace);
             // --- Start Positron ---
             // Ensure that the corresponding runtime is selected in the console, and focus the console.
-            this.pythonRuntimeManager.selectLanguageRuntimeFromPath(interpreterState.path);
+            this.pythonRuntimeManager
+                .selectLanguageRuntimeFromPath(interpreterState.path)
+                .catch((error) => traceError(`Failed to select language runtime from path: ${error}`));
             this.commandManager.executeCommand(Commands.Focus_Positron_Console);
             // --- End Positron ---
         }

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -46,6 +46,9 @@ import {
     ISpecialQuickPickItem,
 } from '../../types';
 import { BaseInterpreterSelectorCommand } from './base';
+// --- Start Positron ---
+import { IPythonRuntimeManager } from '../../../../positron/manager';
+// --- End Positron ---
 
 const untildify = require('untildify');
 
@@ -123,7 +126,10 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
         @inject(IInterpreterSelector) private readonly interpreterSelector: IInterpreterSelector,
         @inject(IWorkspaceService) workspaceService: IWorkspaceService,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
+        // --- Start Positron ---
+        @inject(IPythonRuntimeManager) private readonly pythonRuntimeManager: IPythonRuntimeManager,
     ) {
+        // --- End Positron ---
         super(
             pythonPathUpdaterService,
             commandManager,
@@ -581,6 +587,11 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
             // an empty string, in which case we should update.
             // Having the value `undefined` means user cancelled the quickpick, so we update nothing in that case.
             await this.pythonPathUpdaterService.updatePythonPath(interpreterState.path, configTarget, 'ui', wkspace);
+            // --- Start Positron ---
+            // Ensure that the corresponding runtime is selected in the console, and focus the console.
+            this.pythonRuntimeManager.selectLanguageRuntimeFromPath(interpreterState.path);
+            this.commandManager.executeCommand(Commands.Focus_Positron_Console);
+            // --- End Positron ---
         }
     }
 

--- a/extensions/positron-python/src/client/interpreter/configuration/pythonPathUpdaterService.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/pythonPathUpdaterService.ts
@@ -8,9 +8,6 @@ import { EventName } from '../../telemetry/constants';
 import { PythonInterpreterTelemetry } from '../../telemetry/types';
 import { IComponentAdapter } from '../contracts';
 import { IPythonPathUpdaterServiceFactory, IPythonPathUpdaterServiceManager } from './types';
-// --- Start Positron ---
-import { IPythonRuntimeManager } from '../../positron/manager';
-// --- End Positron ---
 
 @injectable()
 export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManager {
@@ -18,10 +15,7 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
         @inject(IPythonPathUpdaterServiceFactory)
         private readonly pythonPathSettingsUpdaterFactory: IPythonPathUpdaterServiceFactory,
         @inject(IComponentAdapter) private readonly pyenvs: IComponentAdapter,
-        // --- Start Positron ---
-        @inject(IPythonRuntimeManager) private readonly pythonRuntimeManager: IPythonRuntimeManager,
     ) {}
-    // --- End Positron ---
 
     public async updatePythonPath(
         pythonPath: string | undefined,
@@ -41,14 +35,6 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
             window.showErrorMessage(l10n.t('Failed to set interpreter path. Error: {0}', message));
             traceError(reason);
         }
-        // --- Start Positron ---
-        // If the interpreter path is set, ensure that it's the active interpreter in the Positron console.
-        if (pythonPath && !failed) {
-            this.pythonRuntimeManager.selectLanguageRuntimeFromPath(pythonPath).catch((ex) => {
-                traceError(`Failed to select language runtime for path ${pythonPath}. ${ex}`);
-            });
-        }
-        // --- End Positron ---
         // do not wait for this to complete
         this.sendTelemetry(stopWatch.elapsedTime, failed, trigger, pythonPath, wkspace).catch((ex) =>
             traceError('Python Extension: sendTelemetry', ex),

--- a/extensions/positron-python/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
+++ b/extensions/positron-python/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
@@ -47,6 +47,9 @@ import { Commands, Octicons } from '../../../../client/common/constants';
 import { IInterpreterService, PythonEnvironmentsChangedEvent } from '../../../../client/interpreter/contracts';
 import { createDeferred, sleep } from '../../../../client/common/utils/async';
 import { SystemVariables } from '../../../../client/common/variables/systemVariables';
+// --- Start Positron ---
+import { IPythonRuntimeManager } from '../../../../client/positron/manager';
+// --- End Positron ---
 
 const untildify = require('untildify');
 
@@ -62,6 +65,9 @@ suite('Set Interpreter Command', () => {
     let pythonSettings: TypeMoq.IMock<IPythonSettings>;
     let platformService: TypeMoq.IMock<IPlatformService>;
     let multiStepInputFactory: TypeMoq.IMock<IMultiStepInputFactory>;
+    // --- Start Positron ---
+    let pythonRuntimeManager: TypeMoq.IMock<IPythonRuntimeManager>;
+    // --- End Positron ---
     let interpreterService: IInterpreterService;
     const folder1 = { name: 'one', uri: Uri.parse('one'), index: 1 };
     const folder2 = { name: 'two', uri: Uri.parse('two'), index: 2 };
@@ -77,6 +83,9 @@ suite('Set Interpreter Command', () => {
         pythonPathUpdater = TypeMoq.Mock.ofType<IPythonPathUpdaterServiceManager>();
         configurationService = TypeMoq.Mock.ofType<IConfigurationService>();
         pythonSettings = TypeMoq.Mock.ofType<IPythonSettings>();
+        // --- Start Positron ---
+        pythonRuntimeManager = TypeMoq.Mock.ofType<IPythonRuntimeManager>();
+        // --- End Positron ---
 
         workspace = TypeMoq.Mock.ofType<IWorkspaceService>();
         interpreterService = mock<IInterpreterService>();
@@ -97,6 +106,9 @@ suite('Set Interpreter Command', () => {
             interpreterSelector.object,
             workspace.object,
             instance(interpreterService),
+            // --- Start Positron ---
+            pythonRuntimeManager.object,
+            // --- End Positron ---
         );
     });
 
@@ -213,6 +225,9 @@ suite('Set Interpreter Command', () => {
                 interpreterSelector.object,
                 workspace.object,
                 instance(interpreterService),
+                // --- Start Positron ---
+                pythonRuntimeManager.object,
+                // --- End Positron ---
             );
         });
         teardown(() => {
@@ -697,6 +712,9 @@ suite('Set Interpreter Command', () => {
                 interpreterSelector.object,
                 workspace.object,
                 instance(interpreterService),
+                // --- Start Positron ---
+                pythonRuntimeManager.object,
+                // --- End Positron ---
             );
 
             // Test info
@@ -946,6 +964,25 @@ suite('Set Interpreter Command', () => {
                 properties: { action: 'selected' },
             });
         });
+        // --- Start Positron ---
+        test('If an item is selected, select the corresponding language runtime and focus the console', async () => {
+            const state: InterpreterStateArgs = { path: 'some path', workspace: undefined };
+            const multiStepInput = TypeMoq.Mock.ofType<IMultiStepInput<InterpreterStateArgs>>();
+            multiStepInput.setup((i) => i.showQuickPick(TypeMoq.It.isAny())).returns(() => Promise.resolve(item));
+            pythonRuntimeManager
+                .setup((p) => p.selectLanguageRuntimeFromPath(state.path!))
+                .returns(() => Promise.resolve())
+                .verifiable(TypeMoq.Times.once());
+            commandManager
+                .setup((c) => c.executeCommand(Commands.Focus_Positron_Console))
+                .verifiable(TypeMoq.Times.once());
+
+            await setInterpreterCommand._pickInterpreter(multiStepInput.object, state);
+
+            pythonRuntimeManager.verifyAll();
+            commandManager.verifyAll();
+        });
+        // --- End Positron ---
 
         test('If the dropdown is dismissed, send SELECT_INTERPRETER_SELECTED telemetry with the "escape" property value', async () => {
             const state: InterpreterStateArgs = { path: 'some path', workspace: undefined };
@@ -1484,6 +1521,9 @@ suite('Set Interpreter Command', () => {
                 interpreterSelector.object,
                 workspace.object,
                 instance(interpreterService),
+                // --- Start Positron ---
+                pythonRuntimeManager.object,
+                // --- End Positron ---
             );
             type InputStepType = () => Promise<InputStep<unknown> | void>;
             let inputStep!: InputStepType;

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -314,7 +314,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			// Is this, by chance, the runtime that's already running?
 			if (activeSession.runtimeMetadata.runtimeId === runtime.runtimeId) {
 				// Set it as the foreground session and return.
-				this._foregroundSession = activeSession;
+				this.foregroundSession = activeSession;
 				return;
 			}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Address #3169. There were some cases not addressed in the previous PR.

### Approach

We now set `foregroundSession` instead of `_foregroundSession` in `selectLanguageRuntime` so that `onDidChangeForegroundSession` is fired and the console is updated.

We also execute the `workbench.panel.positronConsole.focus ` command after selecting the runtime during the "Python: Select Interpreter" command, to match the existing `workbench.action.languageRuntime.select` command. I moved that logic over from `pythonPathUpdaterService` to `setInterpreter` so that we only focus the console if the select interpreter command is called. We still select the corresponding runtime but don't focus the console on interpreter changes due to other interactions via the `onDidChangeInterpreter` event in the `PythonRuntimeManager`.

### QA Notes

Should address #3169. The main goal is that you should be able to alternate between "Python: Select Interpreter" and "R: Select R Interpreter" a bunch of times with the already selected interpreters to switch between languages in the console.

It also should not break runtime selection via other interactions e.g. environment creation, and should not focus the console unexpectedly.