### PR TITLE
Fix "Python: Select Interpreter" resolving symlinks; add the `resolveSymlinks` API proposal

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -25,7 +25,8 @@
         "terminalDataWriteEvent",
         "terminalExecuteCommandEvent",
         "contribIssueReporter",
-        "terminalShellIntegration"
+        "terminalShellIntegration",
+        "resolveSymlinks"
     ],
     "author": {
         "name": "Posit Software, PBC",

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -49,9 +49,8 @@ import { BaseInterpreterSelectorCommand } from './base';
 // --- Start Positron ---
 import { IPythonRuntimeManager } from '../../../../positron/manager';
 import { traceError } from '../../../../logging';
+import { untildify } from '../../../../pythonEnvironments/common/externalDependencies';
 // --- End Positron ---
-
-const untildify = require('untildify');
 
 export type InterpreterStateArgs = { path?: string; workspace: Resource };
 export type QuickPickType = IInterpreterQuickPickItem | ISpecialQuickPickItem | QuickPickItem;
@@ -545,7 +544,9 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
         if (typeof selection === 'string') {
             // User entered text in the filter box to enter path to python, store it
             sendTelemetryEvent(EventName.SELECT_INTERPRETER_ENTER_CHOICE, undefined, { choice: 'enter' });
-            state.path = selection;
+            // --- Start Positron ---
+            state.path = untildify(selection);
+            // --- End Positron ---
             this.sendInterpreterEntryTelemetry(selection, state.workspace);
         } else if (selection && selection.label === InterpreterQuickPickList.browsePath.label) {
             sendTelemetryEvent(EventName.SELECT_INTERPRETER_ENTER_CHOICE, undefined, { choice: 'browse' });

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -557,6 +557,7 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
                 openLabel: InterpreterQuickPickList.browsePath.openButtonLabel,
                 canSelectMany: false,
                 title: InterpreterQuickPickList.browsePath.title,
+                resolveSymlinks: false,
             });
             if (uris && uris.length > 0) {
                 state.path = uris[0].fsPath;

--- a/extensions/positron-python/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
+++ b/extensions/positron-python/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
@@ -1069,6 +1069,9 @@ suite('Set Interpreter Command', () => {
                 openLabel: InterpreterQuickPickList.browsePath.openButtonLabel,
                 canSelectMany: false,
                 title: InterpreterQuickPickList.browsePath.title,
+                // --- Start Positron ---
+                resolveSymlinks: false,
+                // --- End Positron ---
             };
             const multiStepInput = TypeMoq.Mock.ofType<IMultiStepInput<InterpreterStateArgs>>();
             multiStepInput.setup((i) => i.showQuickPick(TypeMoq.It.isAny())).returns(() => Promise.resolve(items[0]));
@@ -1090,6 +1093,9 @@ suite('Set Interpreter Command', () => {
                 openLabel: InterpreterQuickPickList.browsePath.openButtonLabel,
                 canSelectMany: false,
                 title: InterpreterQuickPickList.browsePath.title,
+                // --- Start Positron ---
+                resolveSymlinks: false,
+                // --- End Positron ---
             };
             multiStepInput.setup((i) => i.showQuickPick(TypeMoq.It.isAny())).returns(() => Promise.resolve(items[0]));
             appShell.setup((a) => a.showOpenDialog(expectedParams)).verifiable(TypeMoq.Times.once());
@@ -1143,6 +1149,9 @@ suite('Set Interpreter Command', () => {
                     openLabel: InterpreterQuickPickList.browsePath.openButtonLabel,
                     canSelectMany: false,
                     title: InterpreterQuickPickList.browsePath.title,
+                    // --- Start Positron ---
+                    resolveSymlinks: false,
+                    // --- End Positron ---
                 };
                 multiStepInput
                     .setup((i) => i.showQuickPick(TypeMoq.It.isAny()))

--- a/extensions/positron-python/tsconfig.json
+++ b/extensions/positron-python/tsconfig.json
@@ -51,6 +51,7 @@
         "typings/vscode-proposed/*.d.ts",
         "types/*.d.ts",
         "types/src/vscode-dts/*.d.ts",
+        "../../src/vscode-dts/vscode.proposed.resolveSymlinks.d.ts",
         "../../src/positron-dts/positron.d.ts",
         "../../src/positron-dts/ui-comm.d.ts"
     ]

--- a/product.json
+++ b/product.json
@@ -261,7 +261,8 @@
 			"terminalDataWriteEvent",
 			"terminalExecuteCommandEvent",
 			"contribIssueReporter",
-			"terminalShellIntegration"
+			"terminalShellIntegration",
+			"resolveSymlinks"
 		],
 		"ms-dotnettools.dotnet-interactive-vscode": [
 			"notebookMessaging"

--- a/src/vs/platform/dialogs/common/dialogs.ts
+++ b/src/vs/platform/dialogs/common/dialogs.ts
@@ -268,6 +268,15 @@ export interface IOpenDialogOptions {
 	 * the schema of the current window.
 	 */
 	availableFileSystems?: readonly string[];
+	// --- Start Positron ---
+	/**
+	 * Resolve symlinks to their target paths, defaults to `true`.
+	 *
+	 * Note: The `resolveSymlinks` option is only available on macOS and will be silently
+	 * ignored on other platforms.
+	 */
+	resolveSymlinks?: boolean;
+	// --- End Positron ---
 }
 
 export const IDialogService = createDecorator<IDialogService>('dialogService');

--- a/src/vs/workbench/api/browser/mainThreadDialogs.ts
+++ b/src/vs/workbench/api/browser/mainThreadDialogs.ts
@@ -47,7 +47,10 @@ export class MainThreadDialogs implements MainThreadDiaglogsShape {
 			canSelectMany: options?.canSelectMany,
 			defaultUri: options?.defaultUri ? URI.revive(options.defaultUri) : undefined,
 			title: options?.title || undefined,
-			availableFileSystems: options?.allowUIResources ? [Schemas.vscodeRemote, Schemas.file] : []
+			// --- Start Positron ---
+			availableFileSystems: options?.allowUIResources ? [Schemas.vscodeRemote, Schemas.file] : [],
+			resolveSymlinks: options?.resolveSymlinks ?? true,
+			// --- End Positron ---
 		};
 		if (options?.filters) {
 			result.filters = [];

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -190,6 +190,9 @@ export interface MainThreadDialogOpenOptions {
 	filters?: { [name: string]: string[] };
 	title?: string;
 	allowUIResources?: boolean;
+	// --- Start Positron ---
+	resolveSymlinks?: boolean;
+	// --- End Positron ---
 }
 
 export interface MainThreadDialogSaveOptions {

--- a/src/vs/workbench/api/common/extHostDialogs.ts
+++ b/src/vs/workbench/api/common/extHostDialogs.ts
@@ -21,6 +21,11 @@ export class ExtHostDialogs {
 		if (options?.allowUIResources) {
 			checkProposedApiEnabled(extension, 'showLocal');
 		}
+		// --- Start Positron ---
+		if (typeof options?.resolveSymlinks === 'boolean') {
+			checkProposedApiEnabled(extension, 'resolveSymlinks');
+		}
+		// --- End Positron ---
 		return this._proxy.$showOpenDialog(options).then(filepaths => {
 			return filepaths ? filepaths.map(p => URI.revive(p)) : undefined;
 		});

--- a/src/vs/workbench/services/dialogs/electron-sandbox/fileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/electron-sandbox/fileDialogService.ts
@@ -197,7 +197,11 @@ export class FileDialogService extends AbstractFileDialogService implements IFil
 		if (options.canSelectMany) {
 			newOptions.properties.push('multiSelections');
 		}
-
+		// --- Start Positron ---
+		if (!options.resolveSymlinks) {
+			newOptions.properties.push('noResolveAliases');
+		}
+		// --- End Positron ---
 		const result = await this.nativeHostService.showOpenDialog(newOptions);
 		return result && Array.isArray(result.filePaths) && result.filePaths.length > 0 ? result.filePaths.map(URI.file) : undefined;
 	}

--- a/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
@@ -94,6 +94,9 @@ export const allApiProposals = Object.freeze({
 	quickDiffProvider: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.quickDiffProvider.d.ts',
 	quickPickItemTooltip: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.quickPickItemTooltip.d.ts',
 	quickPickSortByLabel: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.quickPickSortByLabel.d.ts',
+	// --- Start Positron ---
+	resolveSymlinks: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.resolveSymlinks.d.ts',
+	// --- End Positron ---
 	resolvers: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.resolvers.d.ts',
 	scmActionButton: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.scmActionButton.d.ts',
 	scmHistoryProvider: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.scmHistoryProvider.d.ts',

--- a/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
@@ -94,9 +94,7 @@ export const allApiProposals = Object.freeze({
 	quickDiffProvider: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.quickDiffProvider.d.ts',
 	quickPickItemTooltip: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.quickPickItemTooltip.d.ts',
 	quickPickSortByLabel: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.quickPickSortByLabel.d.ts',
-	// --- Start Positron ---
 	resolveSymlinks: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.resolveSymlinks.d.ts',
-	// --- End Positron ---
 	resolvers: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.resolvers.d.ts',
 	scmActionButton: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.scmActionButton.d.ts',
 	scmHistoryProvider: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.scmHistoryProvider.d.ts',

--- a/src/vscode-dts/vscode.proposed.resolveSymlinks.d.ts
+++ b/src/vscode-dts/vscode.proposed.resolveSymlinks.d.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// https://github.com/posit-dev/positron/issues/2938
+
+declare module 'vscode' {
+
+	export interface OpenDialogOptions {
+		/**
+		 * Resolve symlinks to their target paths, defaults to `true`.
+		 *
+		 * Note: The `resolveSymlinks` option is only available on macOS and will be silently
+		 * ignored on other platforms.
+		 */
+		resolveSymlinks?: boolean;
+	}
+}


### PR DESCRIPTION
### Intent

Address #2938.

### Approach

Added the `resolveSymlinks` API proposal, which eventually sets the `'noResolveAliases'` property of Electron's open dialog options. Sets `resolveSymlinks: false` in the Python extension's interpreter path picker.

### QA Notes

We need to test this on all platforms. Also worth double-checking that the default symlink behavior is not affected.