### PR TITLE
Enable project wizard in release builds

### DIFF
--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -19,13 +19,11 @@ import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/la
 import { showNewFolderModalDialog } from 'vs/workbench/browser/positronModalDialogs/newFolderModalDialog';
 import { showNewFolderFromGitModalDialog } from 'vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog';
 import { showNewProjectModalDialog } from 'vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog';
-import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
 import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
-import { USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 import { IPositronNewProjectService } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
 import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 
@@ -42,10 +40,6 @@ export class PositronNewProjectAction extends Action2 {
 	 * Constructor.
 	 */
 	constructor() {
-		// TODO: [New Project] Remove feature flag when New Project action is ready for release
-		// This removes the action in the New menu, the application bar File menu, and the command
-		// palette when the feature flag is not enabled.
-		const projectWizardEnabled = ContextKeyExpr.deserialize(`config.${USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY}`);
 		super({
 			id: PositronNewProjectAction.ID,
 			title: {
@@ -55,15 +49,11 @@ export class PositronNewProjectAction extends Action2 {
 			},
 			category: workspacesCategory,
 			f1: true,
-			precondition: ContextKeyExpr.and(
-				EnterMultiRootWorkspaceSupportContext,
-				ContextKeyExpr.or(projectWizardEnabled, IsDevelopmentContext)
-			),
+			precondition: EnterMultiRootWorkspaceSupportContext,
 			menu: {
 				id: MenuId.MenubarFileMenu,
 				group: '1_newfolder',
 				order: 3,
-				when: ContextKeyExpr.or(projectWizardEnabled, IsDevelopmentContext),
 			},
 		});
 	}

--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -8,7 +8,7 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
-import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
+import { ContextKeyExpr, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { workspacesCategory } from 'vs/workbench/browser/actions/workspaceActions';
@@ -79,6 +79,8 @@ export class PositronNewProjectAction extends Action2 {
 		// Show the new project modal dialog.
 		await showNewProjectModalDialog(
 			accessor.get(ICommandService),
+			accessor.get(IConfigurationService),
+			accessor.get(IContextKeyService),
 			accessor.get(IFileDialogService),
 			accessor.get(IFileService),
 			accessor.get(IKeybindingService),

--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -8,7 +8,7 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
-import { ContextKeyExpr, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { workspacesCategory } from 'vs/workbench/browser/actions/workspaceActions';
@@ -80,7 +80,6 @@ export class PositronNewProjectAction extends Action2 {
 		await showNewProjectModalDialog(
 			accessor.get(ICommandService),
 			accessor.get(IConfigurationService),
-			accessor.get(IContextKeyService),
 			accessor.get(IFileDialogService),
 			accessor.get(IFileService),
 			accessor.get(IKeybindingService),

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
@@ -9,9 +9,6 @@ import { IAction, Separator } from 'vs/base/common/actions';
 import { ActionBarMenuButton } from 'vs/platform/positronActionBar/browser/components/actionBarMenuButton';
 import { usePositronActionBarContext } from 'vs/platform/positronActionBar/browser/positronActionBarContext';
 import { PositronNewFolderAction, PositronNewFolderFromGitAction, PositronNewProjectAction } from 'vs/workbench/browser/actions/positronActions';
-import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
-import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
-import { USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 
 /**
  * Localized strings.
@@ -36,15 +33,8 @@ export const TopActionBarNewMenu = () => {
 			label: positronNewFile
 		});
 		actions.push(new Separator());
-		// TODO: [New Project] Remove feature flag when New Project action is ready for release
-		// This removes the action from the New menu in the action bar when not in a development context
-		const projectWizardEnabled =
-			ContextKeyExpr.deserialize(
-				`config.${USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY}`
-			);
 		positronActionBarContext.appendCommandAction(actions, {
 			id: PositronNewProjectAction.ID,
-			when: ContextKeyExpr.or(projectWizardEnabled, IsDevelopmentContext),
 		});
 		positronActionBarContext.appendCommandAction(actions, {
 			id: PositronNewFolderAction.ID

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
@@ -22,8 +22,6 @@ import { CustomFolderMenuItem } from 'vs/workbench/browser/parts/positronTopActi
 import { CustomFolderMenuSeparator } from 'vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuSeparator';
 import { CustomFolderRecentlyUsedMenuItem } from 'vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderRecentlyUsedMenuItem';
 import { PositronNewFolderAction, PositronNewFolderFromGitAction, PositronNewProjectAction, PositronOpenFolderInNewWindowAction } from 'vs/workbench/browser/actions/positronActions';
-import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
-import { USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 
 /**
  * Constants.
@@ -145,20 +143,10 @@ export const CustomFolderMenuItems = (props: CustomFolderMenuItemsProps) => {
 		);
 	};
 
-	{/* TODO: [New Project] Remove feature flag when New Project action is ready for release */ }
-	{/* This removes the action from the custom folder menu in the action bar when when not in a development context */ }
-	const projectWizardEnabled =
-		ContextKeyExpr.deserialize(
-			`config.${USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY}`
-		);
-
 	// Render.
 	return (
 		<div className='custom-folder-menu-items'>
-			<CommandActionCustomFolderMenuItem
-				id={PositronNewProjectAction.ID}
-				when={ContextKeyExpr.or(projectWizardEnabled, IsDevelopmentContext)}
-			/>
+			<CommandActionCustomFolderMenuItem id={PositronNewProjectAction.ID} />
 			<CommandActionCustomFolderMenuItem id={PositronNewFolderAction.ID} />
 			<CommandActionCustomFolderMenuItem id={PositronNewFolderFromGitAction.ID} />
 			<CustomFolderMenuSeparator />

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -222,7 +222,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 					'positronNewProjectWizard.createButtonTitle',
 					"Create"
 				))(),
-				disable: !selectedInterpreter
+				disable: !selectedInterpreter || isNewEnvForConda()
 			}}
 		>
 			<PositronWizardSubStep

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -78,6 +78,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 		PythonEnvironmentProvider.Conda;
 	const interpretersAvailable = () =>
 		Boolean(interpreters && interpreters.length) || isNewEnvForConda();
+	const interpretersLoading = () => !interpreters;
 
 	// Radio buttons for selecting the environment setup type.
 	const envSetupRadioButtons: RadioButtonItem[] = [
@@ -162,7 +163,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 		}
 
 		// If the interpreters list is empty, show a message that no interpreters were found.
-		if (!interpretersAvailable()) {
+		if (!interpretersLoading() && !interpretersAvailable()) {
 			return (
 				<WizardFormattedText
 					type={WizardFormattedTextType.Warning}

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
@@ -47,6 +47,8 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 	const [selectedInterpreter, setSelectedInterpreter] = useState(context.selectedRuntime);
 	const [preferredInterpreter, setPreferredInterpreter] = useState(context.preferredInterpreter);
 	const [minimumRVersion, setMinimumRVersion] = useState(context.minimumRVersion);
+	// TODO: remove this check when the feature is no longer WIP
+	const [showRenvInit, setShowRenvInit] = useState(context.wipFunctionalityEnabled());
 
 	useEffect(() => {
 		// Create the disposable store for cleanup.
@@ -58,6 +60,7 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 			setSelectedInterpreter(context.selectedRuntime);
 			setPreferredInterpreter(context.preferredInterpreter);
 			setMinimumRVersion(context.minimumRVersion);
+			setShowRenvInit(context.wipFunctionalityEnabled());
 		}));
 
 		// Return the cleanup function that will dispose of the event handlers.
@@ -173,31 +176,35 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 					}
 				/>
 			</PositronWizardSubStep>
-			<PositronWizardSubStep
-				title={(() => localize(
-					'rConfigurationStep.additionalConfigSubStep.title',
-					"Additional Configuration"
-				))()}
-			>
-				<div className='renv-configuration'>
-					<Checkbox
-						label={(() => localize(
-							'rConfigurationStep.additionalConfigSubStep.useRenv.label',
-							"Use `renv` to create a reproducible environment"
+			{showRenvInit ? (
+				<PositronWizardSubStep
+					title={(() =>
+						localize(
+							'rConfigurationStep.additionalConfigSubStep.title',
+							"Additional Configuration"
 						))()}
-						onChanged={checked => context.useRenv = checked}
-						initialChecked={context.useRenv}
-					/>
-					<ExternalLink
-						className='renv-docs-external-link'
-						openerService={openerService}
-						href='https://rstudio.github.io/renv/articles/renv.html'
-						title='https://rstudio.github.io/renv/articles/renv.html'
-					>
-						<div className='codicon codicon-link-external' />
-					</ExternalLink>
-				</div>
-			</PositronWizardSubStep>
+				>
+					<div className='renv-configuration'>
+						<Checkbox
+							label={(() =>
+								localize(
+									'rConfigurationStep.additionalConfigSubStep.useRenv.label',
+									"Use `renv` to create a reproducible environment"
+								))()}
+							onChanged={(checked) => (context.useRenv = checked)}
+							initialChecked={context.useRenv}
+						/>
+						<ExternalLink
+							className='renv-docs-external-link'
+							openerService={openerService}
+							href='https://rstudio.github.io/renv/articles/renv.html'
+							title='https://rstudio.github.io/renv/articles/renv.html'
+						>
+							<div className='codicon codicon-link-external' />
+						</ExternalLink>
+					</div>
+				</PositronWizardSubStep>
+			) : null}
 		</PositronWizardStep>
 	);
 };

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
@@ -69,6 +69,7 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 
 	// Utility functions.
 	const interpretersAvailable = () => Boolean(interpreters && interpreters.length);
+	const interpretersLoading = () => !interpreters;
 
 	// Handler for when the interpreter is selected.
 	const onInterpreterSelected = (identifier: string) => {
@@ -138,7 +139,7 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 						'Select a version of R to launch your project with. You can modify this later if you change your mind.'
 					))()}
 				feedback={
-					interpretersAvailable() ? undefined : (
+					!interpretersLoading() && !interpretersAvailable() ? (
 						<WizardFormattedText
 							type={WizardFormattedTextType.Warning}
 						>
@@ -149,7 +150,7 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 									minimumRVersion
 								))()}
 						</WizardFormattedText>
-					)
+					) : undefined
 				}
 			>
 				<DropDownListBox

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -28,12 +28,16 @@ import { IPositronNewProjectService, NewProjectConfiguration } from 'vs/workbenc
 import { EnvironmentSetupType, NewProjectWizardStep } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
 import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 import { showChooseNewProjectWindowModalDialog } from 'vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 /**
  * Shows the NewProjectModalDialog.
  */
 export const showNewProjectModalDialog = async (
 	commandService: ICommandService,
+	configurationService: IConfigurationService,
+	contextKeyService: IContextKeyService,
 	fileDialogService: IFileDialogService,
 	fileService: IFileService,
 	keybindingService: IKeybindingService,
@@ -59,6 +63,8 @@ export const showNewProjectModalDialog = async (
 		<NewProjectWizardContextProvider
 			services={{
 				commandService,
+				configurationService,
+				contextKeyService,
 				fileDialogService,
 				fileService,
 				keybindingService,

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -29,7 +29,6 @@ import { EnvironmentSetupType, NewProjectWizardStep } from 'vs/workbench/browser
 import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 import { showChooseNewProjectWindowModalDialog } from 'vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 /**
  * Shows the NewProjectModalDialog.
@@ -37,7 +36,6 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 export const showNewProjectModalDialog = async (
 	commandService: ICommandService,
 	configurationService: IConfigurationService,
-	contextKeyService: IContextKeyService,
 	fileDialogService: IFileDialogService,
 	fileService: IFileService,
 	keybindingService: IKeybindingService,
@@ -64,7 +62,6 @@ export const showNewProjectModalDialog = async (
 			services={{
 				commandService,
 				configurationService,
-				contextKeyService,
 				fileDialogService,
 				fileService,
 				keybindingService,

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -21,7 +21,6 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { WizardFormattedTextItem } from 'vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText';
 import { NewProjectType } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { projectWizardWorkInProgressEnabled } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 
 /**
@@ -31,7 +30,6 @@ import { projectWizardWorkInProgressEnabled } from 'vs/workbench/services/positr
 interface NewProjectWizardServices {
 	readonly commandService: ICommandService;
 	readonly configurationService: IConfigurationService;
-	readonly contextKeyService: IContextKeyService;
 	readonly fileDialogService: IFileDialogService;
 	readonly fileService: IFileService;
 	readonly keybindingService: IKeybindingService;
@@ -527,7 +525,7 @@ export class NewProjectWizardStateManager
 	 * @returns Whether work-in-progress project wizard functionality is enabled.
 	 */
 	wipFunctionalityEnabled(): boolean {
-		return projectWizardWorkInProgressEnabled(this._services.contextKeyService, this._services.configurationService);
+		return projectWizardWorkInProgressEnabled(this._services.configurationService);
 	}
 
 	/**

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -680,6 +680,17 @@ export class NewProjectWizardStateManager
 				(await this._services.commandService.executeCommand(
 					'python.getCreateEnvironmentProviders'
 				)) ?? [];
+
+			// TODO: remove this extra check once the Conda provider is enabled by default.
+			// If work-in-progress functionality is disabled, remove the Conda provider.
+			if (!this.wipFunctionalityEnabled()) {
+				const condaIndex = this._pythonEnvProviders.findIndex(
+					(provider) => provider.name === PythonEnvironmentProvider.Conda
+				);
+				if (condaIndex !== -1) {
+					this._pythonEnvProviders.splice(condaIndex, 1);
+				}
+			}
 		}
 
 		if (!this._pythonEnvProviderId) {

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -20,6 +20,9 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { Emitter, Event } from 'vs/base/common/event';
 import { WizardFormattedTextItem } from 'vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText';
 import { NewProjectType } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { projectWizardWorkInProgressEnabled } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 
 /**
  * NewProjectWizardServices interface.
@@ -27,6 +30,8 @@ import { NewProjectType } from 'vs/workbench/services/positronNewProject/common/
  */
 interface NewProjectWizardServices {
 	readonly commandService: ICommandService;
+	readonly configurationService: IConfigurationService;
+	readonly contextKeyService: IContextKeyService;
 	readonly fileDialogService: IFileDialogService;
 	readonly fileService: IFileService;
 	readonly keybindingService: IKeybindingService;
@@ -76,6 +81,7 @@ export interface INewProjectWizardStateManager {
 	readonly getState: () => NewProjectWizardState;
 	readonly goToNextStep: (step: NewProjectWizardStep) => void;
 	readonly goToPreviousStep: () => void;
+	readonly wipFunctionalityEnabled: () => boolean;
 	readonly onUpdateInterpreterState: Event<void>;
 	readonly onUpdateProjectDirectory: Event<void>;
 }
@@ -204,9 +210,7 @@ export class NewProjectWizardStateManager
 		}
 	}
 
-	/****************************************************************************************
-	 * Getters & Setters
-	 ****************************************************************************************/
+	//#region Getters & Setters
 
 	/**
 	 * Gets the selected runtime.
@@ -446,9 +450,9 @@ export class NewProjectWizardStateManager
 		return this._services;
 	}
 
-	/****************************************************************************************
-	 * Public Methods
-	 ****************************************************************************************/
+	//#endregion Getters & Setters
+
+	//#region Public Methods
 
 	/**
 	 * Sets the provided next step as the current step in the New Project Wizard.
@@ -518,6 +522,15 @@ export class NewProjectWizardStateManager
 	}
 
 	/**
+	 * Gets the value of the configuration setting that determines whether work-in-progress project
+	 * wizard functionality is enabled.
+	 * @returns Whether work-in-progress project wizard functionality is enabled.
+	 */
+	wipFunctionalityEnabled(): boolean {
+		return projectWizardWorkInProgressEnabled(this._services.contextKeyService, this._services.configurationService);
+	}
+
+	/**
 	 * Event that is fired when the runtime startup is complete.
 	 */
 	readonly onUpdateInterpreterState = this._onUpdateInterpreterStateEmitter.event;
@@ -527,9 +540,9 @@ export class NewProjectWizardStateManager
 	 */
 	readonly onUpdateProjectDirectory = this._onUpdateProjectDirectoryEmitter.event;
 
-	/****************************************************************************************
-	 * Private Methods
-	 ****************************************************************************************/
+	//#endregion Public Methods
+
+	//#region Private Methods
 
 	/**
 	 * Updates the interpreter-related state such as the interpreters list, the selected interpreter,
@@ -796,4 +809,6 @@ export class NewProjectWizardStateManager
 			this._installIpykernel = undefined;
 		}
 	}
+
+	//#endregion Private Methods
 }

--- a/src/vs/workbench/contrib/positronNewProject/browser/positronNewProject.contribution.ts
+++ b/src/vs/workbench/contrib/positronNewProject/browser/positronNewProject.contribution.ts
@@ -4,12 +4,10 @@
 
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { Disposable } from 'vs/base/common/lifecycle';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from 'vs/workbench/common/contributions';
 import { ILifecycleService, LifecyclePhase, StartupKind } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IPositronNewProjectService } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
-import { projectWizardWorkInProgressEnabled } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 import { PositronNewProjectService } from 'vs/workbench/services/positronNewProject/common/positronNewProjectService';
 
 // Register the Positron New Project service
@@ -23,33 +21,29 @@ class PositronNewProjectContribution extends Disposable implements IWorkbenchCon
 
 	/**
 	 * Create a new instance of the PositronNewProjectContribution.
-	 * @param _contextKeyService The context key service.
-	 * @param _configurationService The configuration service.
 	 * @param _lifecycleService The lifecycle service.
 	 * @param _positronNewProjectService The Positron New Project service.
 	 */
 	constructor(
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ILifecycleService private readonly _lifecycleService: ILifecycleService,
 		@IPositronNewProjectService private readonly _positronNewProjectService: IPositronNewProjectService,
 	) {
 		super();
-		// TODO: [New Project] Remove feature flag when New Project action is ready for release
-		if (projectWizardWorkInProgressEnabled(this._configurationService)) {
-			// Whether the project was opened in a new window or the existing window, the startup kind
-			// will be `StartupKind.NewWindow`.
-			if (
-				this._lifecycleService.startupKind === StartupKind.NewWindow ||
-				this._lifecycleService.startupKind === StartupKind.ReopenedWindow
-			) {
-				this.run().then(undefined, onUnexpectedError);
-			}
+
+		// Whether the new project directory was opened in a new window or the existing window, the
+		// startup kind will be `StartupKind.NewWindow`. However, if the project wizard allowed the
+		// user to select the directory that is currently open in Positron, the startup kind may be
+		// `StartupKind.ReopenedWindow`.
+		if (
+			this._lifecycleService.startupKind === StartupKind.NewWindow ||
+			this._lifecycleService.startupKind === StartupKind.ReopenedWindow
+		) {
+			this.run().then(undefined, onUnexpectedError);
 		}
 	}
 
 	/**
 	 * Run the Positron New Project contribution, which initializes the new project if applicable.
-	 * @returns A promise that resolves to a boolean indicating whether the new project was initialized.
 	 */
 	private async run() {
 		// Wait until after the workbench has been restored

--- a/src/vs/workbench/contrib/positronNewProject/browser/positronNewProject.contribution.ts
+++ b/src/vs/workbench/contrib/positronNewProject/browser/positronNewProject.contribution.ts
@@ -5,7 +5,6 @@
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from 'vs/workbench/common/contributions';
 import { ILifecycleService, LifecyclePhase, StartupKind } from 'vs/workbench/services/lifecycle/common/lifecycle';
@@ -30,14 +29,13 @@ class PositronNewProjectContribution extends Disposable implements IWorkbenchCon
 	 * @param _positronNewProjectService The Positron New Project service.
 	 */
 	constructor(
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ILifecycleService private readonly _lifecycleService: ILifecycleService,
 		@IPositronNewProjectService private readonly _positronNewProjectService: IPositronNewProjectService,
 	) {
 		super();
 		// TODO: [New Project] Remove feature flag when New Project action is ready for release
-		if (projectWizardWorkInProgressEnabled(this._contextKeyService, this._configurationService)) {
+		if (projectWizardWorkInProgressEnabled(this._configurationService)) {
 			// Whether the project was opened in a new window or the existing window, the startup kind
 			// will be `StartupKind.NewWindow`.
 			if (

--- a/src/vs/workbench/contrib/positronNewProject/browser/positronNewProject.contribution.ts
+++ b/src/vs/workbench/contrib/positronNewProject/browser/positronNewProject.contribution.ts
@@ -10,7 +10,7 @@ import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from 'vs/workbench/common/contributions';
 import { ILifecycleService, LifecyclePhase, StartupKind } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IPositronNewProjectService } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
-import { projectWizardEnabled } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
+import { projectWizardWorkInProgressEnabled } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 import { PositronNewProjectService } from 'vs/workbench/services/positronNewProject/common/positronNewProjectService';
 
 // Register the Positron New Project service
@@ -37,7 +37,7 @@ class PositronNewProjectContribution extends Disposable implements IWorkbenchCon
 	) {
 		super();
 		// TODO: [New Project] Remove feature flag when New Project action is ready for release
-		if (projectWizardEnabled(this._contextKeyService, this._configurationService)) {
+		if (projectWizardWorkInProgressEnabled(this._contextKeyService, this._configurationService)) {
 			// Whether the project was opened in a new window or the existing window, the startup kind
 			// will be `StartupKind.NewWindow`.
 			if (

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -858,11 +858,9 @@ export class GettingStartedPage extends EditorPane {
 		const layoutRecentList = () => {
 			const leftContent = $('div.positron-welcome-left-column');
 			this.positronReactRenderer = createWelcomePageLeft(leftContent, this.openerService, this.keybindingService,
-				this.layoutService, this.commandService, this.runtimeSessionService, this.runtimeStartupService, this.languageRuntimeService,
-				this.contextService, this.configurationService);
+				this.layoutService, this.commandService, this.runtimeSessionService, this.runtimeStartupService, this.languageRuntimeService);
 			reset(leftColumn, leftContent);
 			reset(rightColumn, startList.getDomElement(), recentList.getDomElement());
-			// }
 		};
 		layoutRecentList();
 

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageLeft.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageLeft.tsx
@@ -20,7 +20,7 @@ import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/c
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { projectWizardEnabled } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
+import { projectWizardWorkInProgressEnabled } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 
 export interface PositronWelcomePageLeftProps {
 	openerService: IOpenerService;
@@ -55,7 +55,7 @@ export const createWelcomePageLeft = (container: HTMLElement, openerService: IOp
 	keybindingService: IKeybindingService, layoutService: ILayoutService, commandService: ICommandService,
 	runtimeSessionService: IRuntimeSessionService, runtimeStartupService: IRuntimeStartupService,
 	languageRuntimeService: ILanguageRuntimeService, contextKeyService: IContextKeyService, configurationService: IConfigurationService): PositronReactRenderer => {
-	const enableProjectWizard = projectWizardEnabled(contextKeyService, configurationService);
+	const enableProjectWizard = projectWizardWorkInProgressEnabled(contextKeyService, configurationService);
 	const renderer = new PositronReactRenderer(container);
 	renderer.render(<PositronWelcomePageLeft
 		openerService={openerService}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageLeft.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageLeft.tsx
@@ -18,8 +18,6 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { projectWizardWorkInProgressEnabled } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 
 export interface PositronWelcomePageLeftProps {
 	openerService: IOpenerService;
@@ -29,7 +27,6 @@ export interface PositronWelcomePageLeftProps {
 	runtimesSessionService: IRuntimeSessionService;
 	languageRuntimeService: ILanguageRuntimeService;
 	runtimeStartupService: IRuntimeStartupService;
-	projectWizardEnabled: boolean;
 }
 
 export const PositronWelcomePageLeft = (props: PropsWithChildren<PositronWelcomePageLeftProps>) => {
@@ -43,28 +40,33 @@ export const PositronWelcomePageLeft = (props: PropsWithChildren<PositronWelcome
 				runtimeSessionService={props.runtimesSessionService}
 				runtimeStartupService={props.runtimeStartupService}
 				languageRuntimeService={props.languageRuntimeService}
-				projectWizardEnabled={props.projectWizardEnabled}
 			/>
 			<PositronWelcomePageHelp openerService={props.openerService} />
 		</>
 	);
 };
 
-export const createWelcomePageLeft = (container: HTMLElement, openerService: IOpenerService,
-	keybindingService: IKeybindingService, layoutService: ILayoutService, commandService: ICommandService,
-	runtimeSessionService: IRuntimeSessionService, runtimeStartupService: IRuntimeStartupService,
-	languageRuntimeService: ILanguageRuntimeService, configurationService: IConfigurationService): PositronReactRenderer => {
-	const enableProjectWizard = projectWizardWorkInProgressEnabled(configurationService);
+export const createWelcomePageLeft = (
+	container: HTMLElement,
+	openerService: IOpenerService,
+	keybindingService: IKeybindingService,
+	layoutService: ILayoutService,
+	commandService: ICommandService,
+	runtimeSessionService: IRuntimeSessionService,
+	runtimeStartupService: IRuntimeStartupService,
+	languageRuntimeService: ILanguageRuntimeService
+): PositronReactRenderer => {
 	const renderer = new PositronReactRenderer(container);
-	renderer.render(<PositronWelcomePageLeft
-		openerService={openerService}
-		keybindingService={keybindingService}
-		layoutService={layoutService}
-		commandService={commandService}
-		runtimesSessionService={runtimeSessionService}
-		runtimeStartupService={runtimeStartupService}
-		languageRuntimeService={languageRuntimeService}
-		projectWizardEnabled={enableProjectWizard}
-	/>);
+	renderer.render(
+		<PositronWelcomePageLeft
+			openerService={openerService}
+			keybindingService={keybindingService}
+			layoutService={layoutService}
+			commandService={commandService}
+			runtimesSessionService={runtimeSessionService}
+			runtimeStartupService={runtimeStartupService}
+			languageRuntimeService={languageRuntimeService}
+		/>
+	);
 	return renderer;
 };

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageLeft.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageLeft.tsx
@@ -18,7 +18,6 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { projectWizardWorkInProgressEnabled } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 
@@ -54,8 +53,8 @@ export const PositronWelcomePageLeft = (props: PropsWithChildren<PositronWelcome
 export const createWelcomePageLeft = (container: HTMLElement, openerService: IOpenerService,
 	keybindingService: IKeybindingService, layoutService: ILayoutService, commandService: ICommandService,
 	runtimeSessionService: IRuntimeSessionService, runtimeStartupService: IRuntimeStartupService,
-	languageRuntimeService: ILanguageRuntimeService, contextKeyService: IContextKeyService, configurationService: IConfigurationService): PositronReactRenderer => {
-	const enableProjectWizard = projectWizardWorkInProgressEnabled(contextKeyService, configurationService);
+	languageRuntimeService: ILanguageRuntimeService, configurationService: IConfigurationService): PositronReactRenderer => {
+	const enableProjectWizard = projectWizardWorkInProgressEnabled(configurationService);
 	const renderer = new PositronReactRenderer(container);
 	renderer.render(<PositronWelcomePageLeft
 		openerService={openerService}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageStart.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageStart.tsx
@@ -30,7 +30,6 @@ export interface PositronWelcomePageStartProps {
 	runtimeSessionService: IRuntimeSessionService;
 	runtimeStartupService: IRuntimeStartupService;
 	languageRuntimeService: ILanguageRuntimeService;
-	projectWizardEnabled: boolean;
 }
 
 export const PositronWelcomePageStart = (props: PropsWithChildren<PositronWelcomePageStartProps>) => {
@@ -77,14 +76,12 @@ export const PositronWelcomePageStart = (props: PropsWithChildren<PositronWelcom
 					commandService={props.commandService}
 				/>
 
-				{
-					props.projectWizardEnabled && <WelcomeButton
-						label={(() => localize('positron.welcome.newProject', "New Project"))()}
-						codicon='positron-new-project'
-						ariaLabel={(() => localize('positron.welcome.newProjectDescription', "Create a new project"))()}
-						onPressed={() => props.commandService.executeCommand(PositronNewProjectAction.ID)}
-					/>
-				}
+				<WelcomeButton
+					label={(() => localize('positron.welcome.newProject', "New Project"))()}
+					codicon='positron-new-project'
+					ariaLabel={(() => localize('positron.welcome.newProjectDescription', "Create a new project"))()}
+					onPressed={() => props.commandService.executeCommand(PositronNewProjectAction.ID)}
+				/>
 			</div>
 		</div>
 	);

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectEnablement.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectEnablement.ts
@@ -22,7 +22,7 @@ import { positronConfigurationNodeBase } from 'vs/workbench/services/languageRun
 
 // Key for the configuration setting that determines whether to use the Positron Project Wizard
 export const USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY =
-	'positron.projectWizardEnabled';
+	'positron.projectWizardWorkInProgressEnabled';
 
 /**
  * Return true if in a development build, or retrieve the value of the configuration setting that
@@ -31,7 +31,7 @@ export const USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY =
  * @param configurationService The configuration service
  * @returns Whether to enable the Positron Project Wizard
  */
-export function projectWizardEnabled(
+export function projectWizardWorkInProgressEnabled(
 	contextKeyService: IContextKeyService,
 	configurationService: IConfigurationService
 ) {
@@ -55,8 +55,8 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			default: false,
 			markdownDescription: localize(
-				'positron.enablePositronProjectWizard',
-				'Enable the Positron Project Wizard for creating new projects.'
+				'positron.enablePositronProjectWizardWorkInProgress',
+				'Enable work-in-progress Positron Project Wizard functionality.'
 			),
 		},
 	},

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectEnablement.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectEnablement.ts
@@ -12,15 +12,15 @@ import {
 import { Registry } from 'vs/platform/registry/common/platform';
 import { positronConfigurationNodeBase } from 'vs/workbench/services/languageRuntime/common/languageRuntime';
 
-// Key for the configuration setting that determines whether to use the Positron Project Wizard
+// Key for the configuration setting
 export const USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY =
-	'positron.projectWizardWorkInProgressFunctionality';
+	'positron.work-In-ProgressProjectWizardFeatures';
 
 /**
  * Retrieves the value of the configuration setting that determines whether to enable
- * work-in-progress functionalities the Positron Project Wizard.
+ * work-in-progress features in the Positron Project Wizard.
  * @param configurationService The configuration service
- * @returns Whether to enable work-in-progress Positron Project Wizard functionality
+ * @returns Whether to enable work-in-progress Positron Project Wizard features
  */
 export function projectWizardWorkInProgressEnabled(
 	configurationService: IConfigurationService
@@ -30,8 +30,7 @@ export function projectWizardWorkInProgressEnabled(
 	);
 }
 
-// Register the configuration setting that determines whether to enable work-in-progress Positron
-// Project Wizard functionality
+// Register the configuration setting
 const configurationRegistry = Registry.as<IConfigurationRegistry>(
 	Extensions.Configuration
 );
@@ -44,7 +43,7 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			markdownDescription: localize(
 				'positron.enablePositronProjectWizardWorkInProgress',
-				'Enable work-in-progress Positron Project Wizard functionality.'
+				'**CAUTION**: Enable work-in-progress Project Wizard features which may result in unexpected behaviour.'
 			),
 		},
 	},

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectEnablement.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectEnablement.ts
@@ -12,34 +12,26 @@ import {
 import { Registry } from 'vs/platform/registry/common/platform';
 import { positronConfigurationNodeBase } from 'vs/workbench/services/languageRuntime/common/languageRuntime';
 
-/**
- * This config setting is used to determine whether to use the Positron Project Wizard based on the
- * user's selection in Settings. This flag is used while the New Project Wizard is being developed,
- * to manually enable the wizard in release builds.
- */
-
 // Key for the configuration setting that determines whether to use the Positron Project Wizard
 export const USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY =
-	'positron.projectWizardWorkInProgressEnabled';
+	'positron.projectWizardWorkInProgressFunctionality';
 
 /**
- * Return true if in a development build, or retrieve the value of the configuration setting that
- * determines whether to use the Positron Project Wizard.
- * @param contextKeyService The context key service
+ * Retrieves the value of the configuration setting that determines whether to enable
+ * work-in-progress functionalities the Positron Project Wizard.
  * @param configurationService The configuration service
- * @returns Whether to enable the Positron Project Wizard
+ * @returns Whether to enable work-in-progress Positron Project Wizard functionality
  */
 export function projectWizardWorkInProgressEnabled(
 	configurationService: IConfigurationService
 ) {
-	return (
-		Boolean(
-			configurationService.getValue(USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY)
-		)
+	return Boolean(
+		configurationService.getValue(USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY)
 	);
 }
 
-// Register the configuration setting that determines whether to use the Positron Project Wizard
+// Register the configuration setting that determines whether to enable work-in-progress Positron
+// Project Wizard functionality
 const configurationRegistry = Registry.as<IConfigurationRegistry>(
 	Extensions.Configuration
 );

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectEnablement.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectEnablement.ts
@@ -9,8 +9,6 @@ import {
 	Extensions,
 	IConfigurationRegistry,
 } from 'vs/platform/configuration/common/configurationRegistry';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { positronConfigurationNodeBase } from 'vs/workbench/services/languageRuntime/common/languageRuntime';
 
@@ -32,11 +30,9 @@ export const USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY =
  * @returns Whether to enable the Positron Project Wizard
  */
 export function projectWizardWorkInProgressEnabled(
-	contextKeyService: IContextKeyService,
 	configurationService: IConfigurationService
 ) {
 	return (
-		IsDevelopmentContext.getValue(contextKeyService) ||
 		Boolean(
 			configurationService.getValue(USE_POSITRON_PROJECT_WIZARD_CONFIG_KEY)
 		)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

- Address #2878

### Approach

- remove the feature flag code fences, so the project wizard is shown by default in both dev builds and release builds
- repurpose the existing configuration setting to instead feature flag WIP project wizard features
- unrelated fix to hide interpreter dropdown feedback when interpreters are still loading
- since the project wizard will be available in release builds, disable the Create button for a new python-based project with Conda, although the dropdown will show when the configuration setting is enabled
- feature flag Conda and renv::init UI, as these are not yet implemented

### QA Notes

- the Project Wizard should show in a release build in all your favourite places to open the Project Wizard ✨ 
- toggle the work-in-progress project wizard features by looking up the setting `positron.work-In-ProgressProjectWizardFeatures` (looking up "wizard" is probably sufficient)
    <img width="450" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/df0db1ca-8607-4d6c-9dcf-63e885f8b2c1">
- the work-in-progress project wizard features are:
    - running `renv::init` for R projects: https://github.com/posit-dev/positron/issues/3127
    - using `conda` as a python environment provider: https://github.com/posit-dev/positron/issues/2839

#### Local Release Build
For some reason, the updated config setting doesn't always get picked up into the release build. The following steps seem to be necessary:
- ensure you've closed any other instances of Positron
- delete the `out*` directories (maybe you don't need to delete all of them, but just in case!)
    <img width="70" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/e9c8347f-c302-47fd-9c16-a0c72aea7402">
- rebuild the release `yarn gulp vscode`
- your build has the expected changes if you see the setting on the right
    <img width="1000" alt="Untitled" src="https://github.com/posit-dev/positron/assets/25834218/900a7f5f-33de-492f-9a27-3846260302bd">

