### PR TITLE
Add Python & R Console Restart tests

### DIFF
--- a/test/automation/src/index.ts
+++ b/test/automation/src/index.ts
@@ -36,5 +36,6 @@ export * from './positron/positronSideBar';
 export * from './positron/positronPlots';
 export * from './positron/fixtures/positronPythonFixtures';
 export * from './positron/fixtures/positronRFixtures';
+export * from './positron/positronBaseElement';
 // --- End Positron ---
 export { getDevElectronPath, getBuildElectronPath, getBuildVersion } from './electron';

--- a/test/automation/src/positron/positronBaseElement.ts
+++ b/test/automation/src/positron/positronBaseElement.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Code } from '../code';
+
+/*
+ * Base class for Positron elements similar to a PageObject
+ * This uses the Code class to interact with the UI
+ */
+export class PositronBaseElement {
+	myselector: string;
+
+	constructor(myselector: string, private code: Code = this.code) {
+		this.myselector = myselector;
+	}
+
+	async click(): Promise<void> {
+		await this.code.waitAndClick(this.myselector);
+	}
+
+	async isNotVisible(): Promise<void> {
+		await this.code.waitForElement(this.myselector, (result) => !result);
+	}
+}

--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -8,15 +8,29 @@ import { Code } from '../code';
 import { QuickAccess } from '../quickaccess';
 import { QuickInput } from '../quickinput';
 import { InterpreterType } from './positronStartInterpreter';
+import { PositronBaseElement } from './positronBaseElement';
 
 const CONSOLE_ITEMS = '.runtime-items span';
 const CONSOLE_INSTANCE = '.console-instance';
 const ACTIVE_CONSOLE_INSTANCE = '.console-instance[style*="z-index: auto"]';
 const MAXIMIZE_CONSOLE = '.bottom .codicon-positron-maximize-panel';
+const CONSOLE_BAR_POWER_BUTTON = 'div.action-bar-button-icon.codicon.codicon-positron-power-button-thin';
+const CONSOLE_BAR_RESTART_BUTTON = 'div.action-bar-button-icon.codicon.codicon-positron-restart-runtime-thin';
+const CONSOLE_RESTART_BUTTON = 'button.monaco-text-button.runtime-restart-button';
+const CONSOLE_BAR_CLEAR_BUTTON = 'div.action-bar-button-icon.codicon.codicon-clear-all';
 
 export class PositronConsole {
+	barPowerButton: PositronBaseElement;
+	barRestartButton: PositronBaseElement;
+	barClearButton: PositronBaseElement;
+	consoleRestartButton: PositronBaseElement;
 
-	constructor(private code: Code, private quickaccess: QuickAccess, private quickinput: QuickInput) { }
+	constructor(private code: Code, private quickaccess: QuickAccess, private quickinput: QuickInput) {
+		this.barPowerButton = new PositronBaseElement(CONSOLE_BAR_POWER_BUTTON, this.code);
+		this.barRestartButton = new PositronBaseElement(CONSOLE_BAR_RESTART_BUTTON, this.code);
+		this.barClearButton = new PositronBaseElement(CONSOLE_BAR_CLEAR_BUTTON, this.code);
+		this.consoleRestartButton = new PositronBaseElement(CONSOLE_RESTART_BUTTON, this.code);
+	}
 
 	async selectInterpreter(desiredInterpreterType: InterpreterType, desiredInterpreterString: string) {
 		let command: string;

--- a/test/smoke/src/areas/positron/console/python-console.test.ts
+++ b/test/smoke/src/areas/positron/console/python-console.test.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Application, Logger, PositronPythonFixtures } from '../../../../../automation';
+import { installAllHandlers } from '../../../utils';
+
+export function setup(logger: Logger) {
+	describe('Console Pane: Python', () => {
+
+		// Shared before/after handling
+		installAllHandlers(logger);
+
+		describe('Python Console Restart', () => {
+
+			before(async function () {
+
+				const app = this.app as Application;
+				const pythonFixtures = new PositronPythonFixtures(app);
+				await pythonFixtures.startPythonInterpreter();
+
+			});
+
+			it('Verify restart button inside the console', async function () {
+				// TestRail #377918
+				const app = this.app as Application;
+				// Need to make console bigger to see all bar buttons
+				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+				await app.workbench.positronConsole.barClearButton.click();
+				await app.workbench.positronConsole.barPowerButton.click();
+				await app.workbench.positronConsole.consoleRestartButton.click();
+				await app.workbench.positronConsole.waitForReady('>>>');
+				await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
+				await app.workbench.positronConsole.consoleRestartButton.isNotVisible();
+			});
+
+			it('Verify restart button on console bar', async function () {
+				// TestRail #617464
+				const app = this.app as Application;
+				// Need to make console bigger to see all bar buttons
+				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+				await app.workbench.positronConsole.barClearButton.click();
+				await app.workbench.positronConsole.barRestartButton.click();
+				await app.workbench.positronConsole.waitForReady('>>>');
+				await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
+			});
+
+		});
+
+	});
+}

--- a/test/smoke/src/areas/positron/console/r-console.test.ts
+++ b/test/smoke/src/areas/positron/console/r-console.test.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Application, Logger, PositronRFixtures } from '../../../../../automation';
+import { installAllHandlers } from '../../../utils';
+
+export function setup(logger: Logger) {
+	describe('Console Pane: R', () => {
+
+		// Shared before/after handling
+		installAllHandlers(logger);
+
+		describe('R Console Restart', () => {
+
+			before(async function () {
+
+				const app = this.app as Application;
+				const RFixtures = new PositronRFixtures(app);
+				await RFixtures.startRInterpreter();
+
+			});
+
+			it('Verify restart button inside the console', async function () {
+				// TestRail #377917
+				const app = this.app as Application;
+				// Need to make console bigger to see all bar buttons
+				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+				await app.workbench.positronConsole.barClearButton.click();
+				await app.workbench.positronConsole.barPowerButton.click();
+				await app.workbench.positronConsole.consoleRestartButton.click();
+				await app.workbench.positronConsole.waitForReady('>');
+				await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
+				await app.workbench.positronConsole.consoleRestartButton.isNotVisible();
+			});
+
+			it('Verify restart button on console bar', async function () {
+				// TestRail #620636
+				const app = this.app as Application;
+				// Need to make console bigger to see all bar buttons
+				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+				await app.workbench.positronConsole.barClearButton.click();
+				await app.workbench.positronConsole.barRestartButton.click();
+				await app.workbench.positronConsole.waitForReady('>');
+				await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
+			});
+
+		});
+
+	});
+}

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -33,6 +33,7 @@ import { retry, timeout } from './utils';
 import { setup as setupVariablesTest } from './areas/positron/variables/variablespane.test';
 import { setup as setupDataExplorerTest } from './areas/positron/dataexplorer/dataexplorer.test';
 import { setup as setupPlotsTest } from './areas/positron/plots/plots.test';
+import { setup as setupConsoleTest } from './areas/positron/console/python-console.test';
 // --- End Positron ---
 
 const rootPath = path.join(__dirname, '..', '..', '..');
@@ -420,5 +421,6 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	setupVariablesTest(logger);
 	setupDataExplorerTest(logger);
 	setupPlotsTest(logger);
+	setupConsoleTest(logger);
 	// --- End Positron ---
 });

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -33,7 +33,8 @@ import { retry, timeout } from './utils';
 import { setup as setupVariablesTest } from './areas/positron/variables/variablespane.test';
 import { setup as setupDataExplorerTest } from './areas/positron/dataexplorer/dataexplorer.test';
 import { setup as setupPlotsTest } from './areas/positron/plots/plots.test';
-import { setup as setupConsoleTest } from './areas/positron/console/python-console.test';
+import { setup as setupPythonConsoleTest } from './areas/positron/console/python-console.test';
+import { setup as setupRConsoleTest } from './areas/positron/console/r-console.test';
 // --- End Positron ---
 
 const rootPath = path.join(__dirname, '..', '..', '..');
@@ -421,6 +422,7 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	setupVariablesTest(logger);
 	setupDataExplorerTest(logger);
 	setupPlotsTest(logger);
-	setupConsoleTest(logger);
+	setupPythonConsoleTest(logger);
+	setupRConsoleTest(logger);
 	// --- End Positron ---
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

This implements 2 tests for the Python console
* [Test 377918 - Restart Button in console pane](https://posit.testrail.io/index.php?/cases/view/377918)
* [Test 617464 - Restart Button on console menu bar](https://posit.testrail.io/index.php?/cases/view/617464) 

And 2 for R console
* [Test 377917 - Restart Button in console pane](https://posit.testrail.io/index.php?/cases/view/377917)
* [Test 620636 - Restart Button on console menu bar](https://posit.testrail.io/index.php?/cases/view/620636) 


Additionally, this adds a generic `positronBaseElement` class to be used in page objects, such as `positronConsole`. This allows the tests to have a clean interface abstracted out from the underlying api. 

### Approach

The new class wraps methods from the Microsoft provided API.  This allows the ability to quickly add page elements to the page objects. In this case the power/restart/clear buttons on the console.  This then doesn't require a new method be created every time we need to access/click/etc. those elements.

### QA Notes

This runs as part of the smoke suite and passed in CI for the full test workflow.  They don't require any additional test payloads from `positron-content-examples`, nor any additional python packages.
