### PR TITLE
Data Explorer: UI treatment for copy-and-pasting from data grid and wire up with Python implementation, context menu improvements

### DIFF
--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.css
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.css
@@ -2,7 +2,7 @@
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
-.context-menu-items {
+.custom-context-menu-items {
 	width: 100%;
 	margin: 4px;
 	display: flex;
@@ -10,13 +10,13 @@
 	background: var(--vscode-positronContextMenu-background);
 }
 
-.context-menu-separator {
+.custom-context-menu-separator {
 	height: 1px;
-	margin: 4px 10px;
+	margin: 4px 0;
 	background: var(--vscode-positronContextMenu-separatorBackground);
 }
 
-.context-menu-item {
+.custom-context-menu-item {
 	width: 100%;
 	height: 26px;
 	border: none;
@@ -27,35 +27,50 @@
 	align-content: center;
 	background: transparent;
 	color: var(--vscode-positronContextMenu-foreground);
-	grid-template-columns: [check] 20px [title] 1fr [icon] min-content [end];
+	grid-template-columns: [icon] 22px [title] 1fr [shortcut] min-content [end];
 }
 
-.context-menu-item:not(.disabled):hover {
+.custom-context-menu-item.checkable {
+	grid-template-columns: [check] 22px [icon] 22px [title] 1fr [shortcut] min-content [end];
+}
+
+.custom-context-menu-item:not(.disabled):hover {
 	border-radius: 4px;
 	color: var(--vscode-positronContextMenu-hoverForeground);
 	background: var(--vscode-positronContextMenu-hoverBackground);
 }
 
-.context-menu-item:focus {
+.custom-context-menu-item:focus {
 	outline: none !important;
 }
 
-.context-menu-item:focus-visible {
+.custom-context-menu-item:focus-visible {
 	border-radius: 4px;
 	outline: 1px solid var(--vscode-focusBorder) !important;
 }
 
-.context-menu-item:not(.disabled):focus-visible {
+.custom-context-menu-item:not(.disabled):focus-visible {
 	background: var(--vscode-positronContextMenu-hoverBackground);
 }
 
-.context-menu-item
+.custom-context-menu-item
 .check {
-	padding: 10px;
-	grid-column: check / title;
+	text-align: left;
+	grid-column: check / icon;
 }
 
-.context-menu-item
+.custom-context-menu-item
+.icon {
+	text-align: left;
+	grid-column: icon / title;
+}
+
+.custom-context-menu-item
+.icon.disabled {
+	opacity: 50%;
+}
+
+.custom-context-menu-item
 .title {
 	display: block;
 	max-width: 100%;
@@ -63,22 +78,20 @@
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
-	grid-column: title / icon;
-	padding: 10px 5px 10px 10px;
+	grid-column: title / shortcut;
+	padding: 10px 20px 10px 0;
 }
 
-.context-menu-item
+.custom-context-menu-item
 .title.disabled {
 	opacity: 50%;
 }
 
-.context-menu-item
-.icon {
-	padding: 10px;
-	grid-column: icon / end;
-}
-
-.context-menu-item
-.icon.disabled {
-	opacity: 50%;
+.custom-context-menu-item
+.shortcut {
+	/* display: block; */
+	letter-spacing: .2rem;
+	white-space: nowrap;
+	grid-column: shortcut / end;
+	padding: 10px 0 10px 10px;
 }

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -107,15 +107,15 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 	 * @returns The rendered component.
 	 */
 	const MenuItem = (options: CustomContextMenuItemOptions) => {
-
-		let yack = '';
+		// Get the shortcut, if there is a command ID.
+		let shortcut = '';
 		if (options.commandId) {
 			const keybinding = props.keybindingService.lookupKeybinding(options.commandId);
 
 			if (keybinding) {
 				const label = keybinding.getLabel();
 				if (label) {
-					yack = label;
+					shortcut = label;
 				}
 			}
 		}
@@ -165,7 +165,7 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 				>
 					{options.label}
 				</div>
-				<div className='shortcut'>{yack}</div>
+				<div className='shortcut'>{shortcut}</div>
 			</Button>
 		);
 	};

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenuItem.ts
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenuItem.ts
@@ -5,24 +5,25 @@
 import { KeyboardModifiers } from 'vs/base/browser/ui/positronComponents/button/positronButton';
 
 /**
- * ContextMenuItemOptions interface.
+ * CustomContextMenuItemOptions interface.
  */
-export interface ContextMenuItemOptions {
+export interface CustomContextMenuItemOptions {
+	readonly commandId?: string;
 	readonly checked?: boolean;
-	readonly label: string;
 	readonly icon?: string;
+	readonly label: string;
 	readonly disabled?: boolean;
 	readonly onSelected: (e: KeyboardModifiers) => void;
 }
 
 /**
- * ContextMenuItem class.
+ * CustomContextMenuItem class.
  */
-export class ContextMenuItem {
+export class CustomContextMenuItem {
 	/**
 	 * Constructor.
 	 * @param options A ContextMenuItemOptions that contains the context menu item options.
 	 */
-	constructor(readonly options: ContextMenuItemOptions) {
+	constructor(readonly options: CustomContextMenuItemOptions) {
 	}
 }

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenuSeparator.ts
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenuSeparator.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
- * ContextMenuSeparator class.
+ * CustomContextMenuSeparator class.
  */
-export class ContextMenuSeparator {
+export class CustomContextMenuSeparator {
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
@@ -84,7 +84,6 @@ export const ColumnSelectorModalPopup = (props: ColumnSelectorModalPopupProps) =
 				<div className='view' style={{ height: 400 }}>
 					<PositronDataGrid
 						configurationService={props.configurationService}
-						keybindingService={props.renderer.keybindingService}
 						layoutService={props.renderer.layoutService}
 						ref={positronDataGridRef}
 						id='column-positron-data-grid'

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -150,7 +150,6 @@ export const DataExplorer = () => {
 			<div ref={column1Ref} className='column-1'>
 				<PositronDataGrid
 					configurationService={context.configurationService}
-					keybindingService={context.keybindingService}
 					layoutService={context.layoutService}
 					instance={context.instance.tableSchemaDataGridInstance}
 				/>
@@ -165,7 +164,6 @@ export const DataExplorer = () => {
 			<div ref={column2Ref} className='column-2'>
 				<PositronDataGrid
 					configurationService={context.configurationService}
-					keybindingService={context.keybindingService}
 					layoutService={context.layoutService}
 					instance={context.instance.tableDataDataGridInstance}
 				/>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -15,12 +15,12 @@ import * as DOM from 'vs/base/browser/dom';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { Button } from 'vs/base/browser/ui/positronComponents/button/button';
 import { ColumnSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
-import { ContextMenuItem } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenuItem';
-import { ContextMenuSeparator } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenuSeparator';
 import { OKModalDialog } from 'vs/workbench/browser/positronComponents/positronModalDialog/positronOKModalDialog';
-import { ContextMenuEntry, showContextMenu } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenu';
 import { usePositronDataExplorerContext } from 'vs/workbench/browser/positronDataExplorer/positronDataExplorerContext';
 import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer';
+import { CustomContextMenuItem } from 'vs/workbench/browser/positronComponents/customContextMenu/customContextMenuItem';
+import { CustomContextMenuSeparator } from 'vs/workbench/browser/positronComponents/customContextMenu/customContextMenuSeparator';
+import { CustomContextMenuEntry, showCustomContextMenu } from 'vs/workbench/browser/positronComponents/customContextMenu/customContextMenu';
 import { RowFilterWidget } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget';
 import { AddEditRowFilterModalPopup } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup';
 import { getRowFilterDescriptor, RowFilterDescriptor } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
@@ -152,34 +152,34 @@ export const RowFilterBar = () => {
 	 */
 	const filterButtonPressedHandler = async () => {
 		// Build the context menu entries.
-		const entries: ContextMenuEntry[] = [];
-		entries.push(new ContextMenuItem({
-			label: localize('positron.dataExplorer.addFilter', "Add Filter"),
+		const entries: CustomContextMenuEntry[] = [];
+		entries.push(new CustomContextMenuItem({
 			icon: 'positron-add-filter',
+			label: localize('positron.dataExplorer.addFilter', "Add Filter"),
 			onSelected: () => addRowFilterHandler(
 				rowFilterButtonRef.current,
 				rowFilterDescriptors.length === 0
 			)
 		}));
-		entries.push(new ContextMenuSeparator());
+		entries.push(new CustomContextMenuSeparator());
 		if (!rowFiltersHidden) {
-			entries.push(new ContextMenuItem({
-				label: localize('positron.dataExplorer.hideFilters', "Hide Filters"),
+			entries.push(new CustomContextMenuItem({
 				icon: 'positron-hide-filters',
+				label: localize('positron.dataExplorer.hideFilters', "Hide Filters"),
 				disabled: rowFilterDescriptors.length === 0,
 				onSelected: () => setRowFiltersHidden(true)
 			}));
 		} else {
-			entries.push(new ContextMenuItem({
-				label: localize('positron.dataExplorer.showFilters', "Show Filters"),
+			entries.push(new CustomContextMenuItem({
 				icon: 'positron-show-filters',
+				label: localize('positron.dataExplorer.showFilters', "Show Filters"),
 				onSelected: () => setRowFiltersHidden(false)
 			}));
 		}
-		entries.push(new ContextMenuSeparator());
-		entries.push(new ContextMenuItem({
-			label: localize('positron.dataExplorer.clearFilters', "Clear Filters"),
+		entries.push(new CustomContextMenuSeparator());
+		entries.push(new CustomContextMenuItem({
 			icon: 'positron-clear-row-filters',
+			label: localize('positron.dataExplorer.clearFilters', "Clear Filters"),
 			disabled: rowFilterDescriptors.length === 0,
 			onSelected: async () => {
 				// Clear the row filter descriptors.
@@ -191,7 +191,8 @@ export const RowFilterBar = () => {
 		}));
 
 		// Show the context menu.
-		await showContextMenu(
+		await showCustomContextMenu(
+			context.commandService,
 			context.keybindingService,
 			context.layoutService,
 			rowFilterButtonRef.current,

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -193,6 +193,16 @@ export enum MouseSelectionType {
 }
 
 /**
+ * CellSelectionRange interface.
+ */
+interface CellSelectionRange {
+	firstColumnIndex: number;
+	firstRowIndex: number;
+	lastColumnIndex: number;
+	lastRowIndex: number;
+}
+
+/**
  * ColumnSelectionRange interface.
  */
 interface ColumnSelectionRange {
@@ -209,13 +219,63 @@ interface RowSelectionRange {
 }
 
 /**
- * CellSelectionRange interface.
+ * ClipboardCell class.
  */
-interface CellSelectionRange {
-	firstColumnIndex: number;
-	firstRowIndex: number;
-	lastColumnIndex: number;
-	lastRowIndex: number;
+export class ClipboardCell {
+	constructor(
+		readonly columnIndex: number,
+		readonly rowIndex: number
+	) { }
+}
+
+/**
+ * ClipboardCellRange class.
+ */
+export class ClipboardCellRange {
+	constructor(
+		readonly firstColumnIndex: number,
+		readonly firstRowIndex: number,
+		readonly lastColumnIndex: number,
+		readonly lastRowIndex: number
+	) { }
+}
+
+/**
+ * ClipboardColumnRange class.
+ */
+export class ClipboardColumnRange {
+	constructor(
+		readonly firstColumnIndex: number,
+		readonly lastColumnIndex: number,
+	) { }
+}
+
+/**
+ * ClipboardColumnIndexes class.
+ */
+export class ClipboardColumnIndexes {
+	constructor(
+		readonly indexes: number[]
+	) { }
+}
+
+/**
+ * ClipboardRowRange class.
+ */
+export class ClipboardRowRange {
+	constructor(
+		readonly firstRowIndex: number,
+		readonly lastRowIndex: number,
+	) { }
+}
+
+/**
+ * ClipboardRowIndexes class.
+ */
+export class ClipboardRowIndexes {
+	constructor(
+		readonly indexes: number[]
+	) { }
 }
 
 /**
@@ -2013,6 +2073,63 @@ export abstract class DataGridInstance extends Disposable {
 
 		// Fire the onDidUpdate event.
 		this._onDidUpdateEmitter.fire();
+	}
+
+	/**
+	 * Gets the clipboard data.
+	 * @returns The clipboard data.
+	 */
+	getClipboardData() {
+		// Cell selection range.
+		if (this._cellSelectionRange) {
+			return new ClipboardCellRange(
+				this._cellSelectionRange.firstColumnIndex,
+				this._cellSelectionRange.firstRowIndex,
+				this._cellSelectionRange.lastColumnIndex,
+				this._cellSelectionRange.lastRowIndex
+			);
+		}
+
+		// Column selection range.
+		if (this._columnSelectionRange) {
+			return new ClipboardColumnRange(
+				this._columnSelectionRange.firstColumnIndex,
+				this._columnSelectionRange.firstColumnIndex
+			);
+		}
+
+		// Column selection indexes.
+		if (this._columnSelectionIndexes.size) {
+			return new ClipboardColumnIndexes(
+				Array.from(this._columnSelectionIndexes).sort()
+			);
+		}
+
+		// Row selection range.
+		if (this._rowSelectionRange) {
+			return new ClipboardRowRange(
+				this._rowSelectionRange.firstRowIndex,
+				this._rowSelectionRange.firstRowIndex
+			);
+		}
+
+		// Row selection indexes.
+		if (this._rowSelectionIndexes.size) {
+			return new ClipboardRowIndexes(
+				Array.from(this._rowSelectionIndexes).sort()
+			);
+		}
+
+		// Cursor cell.
+		if (this._cursorColumnIndex >= 0 && this._cursorRowIndex >= 0) {
+			return new ClipboardCell(
+				this._cursorColumnIndex,
+				this._cursorRowIndex
+			);
+		}
+
+		// Clipboard data isn't available.
+		return undefined;
 	}
 
 	/**

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -279,6 +279,17 @@ export class ClipboardRowIndexes {
 }
 
 /**
+ * ClipboardData type.
+ */
+export type ClipboardData =
+	ClipboardCell |
+	ClipboardCellRange |
+	ClipboardColumnRange |
+	ClipboardColumnIndexes |
+	ClipboardRowRange |
+	ClipboardRowIndexes;
+
+/**
  * ColumnSortKeyDescriptor class.
  *
  * "Descriptor" added to disambiguate from ColumnSortKey in generated comm.
@@ -2077,9 +2088,9 @@ export abstract class DataGridInstance extends Disposable {
 
 	/**
 	 * Gets the clipboard data.
-	 * @returns The clipboard data.
+	 * @returns The clipboard data, if it's available; otherwise, undefined.
 	 */
-	getClipboardData() {
+	getClipboardData(): ClipboardData | undefined {
 		// Cell selection range.
 		if (this._cellSelectionRange) {
 			return new ClipboardCellRange(
@@ -2094,7 +2105,7 @@ export abstract class DataGridInstance extends Disposable {
 		if (this._columnSelectionRange) {
 			return new ClipboardColumnRange(
 				this._columnSelectionRange.firstColumnIndex,
-				this._columnSelectionRange.firstColumnIndex
+				this._columnSelectionRange.lastColumnIndex
 			);
 		}
 
@@ -2109,7 +2120,7 @@ export abstract class DataGridInstance extends Disposable {
 		if (this._rowSelectionRange) {
 			return new ClipboardRowRange(
 				this._rowSelectionRange.firstRowIndex,
-				this._rowSelectionRange.firstRowIndex
+				this._rowSelectionRange.lastRowIndex
 			);
 		}
 

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -6,7 +6,6 @@ import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IDataColumn } from 'vs/workbench/browser/positronDataGrid/interfaces/dataColumn';
 import { IColumnSortKey } from 'vs/workbench/browser/positronDataGrid/interfaces/columnSortKey';
-import { ContextMenuEntry } from 'vs/workbench/browser/positronComponents/contextMenu/contextMenu';
 
 /**
  * ColumnHeaderOptions type.
@@ -962,15 +961,6 @@ export abstract class DataGridInstance extends Disposable {
 
 		// Fire the onDidUpdate event.
 		this._onDidUpdateEmitter.fire();
-	}
-
-	/**
-	 * Returns column context menu entries.
-	 * @param columnIndex The column index.
-	 * @returns The column context menu entries.
-	 */
-	columnContextMenuEntries(columnIndex: number): ContextMenuEntry[] {
-		return [];
 	}
 
 	/**
@@ -2072,6 +2062,41 @@ export abstract class DataGridInstance extends Disposable {
 	 * @returns The data cell, or, undefined.
 	 */
 	abstract cell(columnIndex: number, rowIndex: number): JSX.Element | undefined;
+
+	/**
+	 * Shows the column context menu.
+	 * @param anchor The anchor element.
+	 * @param columnIndex The column index.
+	 * @returns A Promise<void> that resolves when the context menu is complete.
+	 */
+	async showColumnContextMenu(anchor: HTMLElement, columnIndex: number): Promise<void> {
+		// Do nothing. This method can be overridden in subclasses.
+	}
+
+	/**
+	 * Shows the row context menu.
+	 * @param anchor The anchor element.
+	 * @param rowIndex The row index.
+	 * @returns A Promise<void> that resolves when the context menu is complete.
+	 */
+	async showRowContextMenu(anchor: HTMLElement, rowIndex: number): Promise<void> {
+		// Do nothing. This method can be overridden in subclasses.
+	}
+
+	/**
+	 * Shows the cell context menu.
+	 * @param anchor The anchor element.
+	 * @param columnIndex The column index.
+	 * @param rowIndex The row index.
+	 * @returns A Promise<void> that resolves when the context menu is complete.
+	 */
+	async showCellContextMenu(
+		anchor: HTMLElement,
+		columnIndex: number,
+		rowIndex: number
+	): Promise<void> {
+		// Do nothing. This method can be overridden in subclasses.
+	}
 
 	//#endregion Public Methods
 

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRow.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRow.tsx
@@ -7,8 +7,8 @@ import 'vs/css!./dataGridRow';
 
 // React.
 import * as React from 'react';
-import { usePositronDataGridContext } from 'vs/workbench/browser/positronDataGrid/positronDataGridContext';
 import { DataGridRowCell } from 'vs/workbench/browser/positronDataGrid/components/dataGridRowCell';
+import { usePositronDataGridContext } from 'vs/workbench/browser/positronDataGrid/positronDataGridContext';
 
 // Other dependencies.
 

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
@@ -7,7 +7,7 @@ import 'vs/css!./dataGridRowCell';
 
 // React.
 import * as React from 'react';
-import { MouseEvent } from 'react'; // eslint-disable-line no-duplicate-imports
+import { MouseEvent, useRef } from 'react'; // eslint-disable-line no-duplicate-imports
 
 // Other dependencies.
 import { isMacintosh } from 'vs/base/common/platform';
@@ -35,20 +35,27 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 	// Context hooks.
 	const context = usePositronDataGridContext();
 
+	// Reference hooks.
+	const ref = useRef<HTMLDivElement>(undefined!);
+
 	/**
 	 * onMouseDown handler.
 	 * @param e A MouseEvent<HTMLElement> that describes a user interaction with the mouse.
 	 */
-	const mouseDownHandler = (e: MouseEvent<HTMLElement>) => {
+	const mouseDownHandler = async (e: MouseEvent<HTMLElement>) => {
 		// Ignore mouse events with meta / ctrl key.
 		if (isMacintosh ? e.metaKey : e.ctrlKey) {
 			return;
 		}
 
+		// Consume the event.
+		e.stopPropagation();
+
 		// If selection is enabled, process selection.
 		if (context.instance.selection) {
 			// When the shift key is down, mouse select the cell.
 			if (e.shiftKey) {
+				// Mouse select the cell and return.
 				context.instance.mouseSelectCell(props.columnIndex, props.rowIndex);
 				return;
 			}
@@ -59,6 +66,11 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 
 		// Set the cursor position.
 		context.instance.setCursorPosition(props.columnIndex, props.rowIndex);
+
+		// Show the cell context menu.
+		if (e.button === 2) {
+			context.instance.showCellContextMenu(ref.current, props.columnIndex, props.rowIndex);
+		}
 	};
 
 	// Get the selection states.
@@ -70,6 +82,7 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 	// Render.
 	return (
 		<div
+			ref={ref}
 			className={
 				positronClassNames(
 					'data-grid-row-cell',

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
@@ -36,21 +36,24 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 	const context = usePositronDataGridContext();
 
 	/**
-	 * MouseDown handler..
+	 * onMouseDown handler.
 	 * @param e A MouseEvent<HTMLElement> that describes a user interaction with the mouse.
 	 */
 	const mouseDownHandler = (e: MouseEvent<HTMLElement>) => {
+		// Ignore mouse events with meta / ctrl key.
 		if (isMacintosh ? e.metaKey : e.ctrlKey) {
 			return;
 		}
 
 		// If selection is enabled, process selection.
 		if (context.instance.selection) {
+			// When the shift key is down, mouse select the cell.
 			if (e.shiftKey) {
 				context.instance.mouseSelectCell(props.columnIndex, props.rowIndex);
 				return;
 			}
 
+			// When the shift key is not down, clear the selection.
 			context.instance.clearSelection();
 		}
 

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
@@ -10,6 +10,7 @@ import * as React from 'react';
 import { MouseEvent } from 'react'; // eslint-disable-line no-duplicate-imports
 
 // Other dependencies.
+import { isMacintosh } from 'vs/base/common/platform';
 import { positronClassNames } from 'vs/base/common/positronUtilities';
 import { selectionType } from 'vs/workbench/browser/positronDataGrid/utilities/mouseUtilities';
 import { RowSelectionState } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
@@ -39,8 +40,20 @@ export const DataGridRowHeader = (props: DataGridRowHeaderProps) => {
 	 * @param e A MouseEvent<HTMLElement> that describes a user interaction with the mouse.
 	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	const mouseDownHandler = async (e: MouseEvent<HTMLElement>) => {
-		await context.instance.mouseSelectRow(props.rowIndex, selectionType(e));
+	const mouseDownHandler = (e: MouseEvent<HTMLElement>) => {
+		// Ignore mouse events with meta / ctrl key.
+		if (isMacintosh ? e.metaKey : e.ctrlKey) {
+			return;
+		}
+
+		// Consume the event.
+		e.stopPropagation();
+
+		// If selection is enabled, process selection.
+		if (context.instance.selection) {
+			// Mouse select the row.
+			context.instance.mouseSelectRow(props.rowIndex, selectionType(e));
+		}
 	};
 
 	// Get the row selection state.

--- a/src/vs/workbench/browser/positronDataGrid/positronDataGridContext.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/positronDataGridContext.tsx
@@ -9,7 +9,6 @@ import { PropsWithChildren, createContext, useContext, useEffect } from 'react';
 // Other dependencies.
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
-import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { DataGridInstance } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
 
@@ -18,7 +17,6 @@ import { DataGridInstance } from 'vs/workbench/browser/positronDataGrid/classes/
  */
 export interface PositronDataGridServices {
 	configurationService: IConfigurationService;
-	keybindingService: IKeybindingService;
 	layoutService: ILayoutService;
 }
 

--- a/src/vs/workbench/common/contextkeys.ts
+++ b/src/vs/workbench/common/contextkeys.ts
@@ -119,7 +119,6 @@ export const PositronTopActionBarVisibleContext = new RawContextKey<boolean>('po
 export const PositronConsoleFocused = new RawContextKey<boolean>('positronConsoleFocused', false, localize('positronConsoleFocused', "Whether Positron Console has keyboard focus"));
 export const PositronVariablesFocused = new RawContextKey<boolean>('positronVariablesFocused', false, localize('positronVariablesFocused', "Whether Positron Variables has keyboard focus"));
 export const PositronHelpFocused = new RawContextKey<boolean>('positronHelpFocused', false, localize('positronHelpFocused', "Whether Positron Help has keyboard focus"));
-export const PositronDataExplorerFocused = new RawContextKey<boolean>('positronDataExplorerFocused', false, localize('positronDataExplorerFocused', "Whether Positron Data Explorer has keyboard focus"));
 // --- End Positron ---
 
 //#region < --- Banner --- >

--- a/src/vs/workbench/common/contextkeys.ts
+++ b/src/vs/workbench/common/contextkeys.ts
@@ -119,6 +119,7 @@ export const PositronTopActionBarVisibleContext = new RawContextKey<boolean>('po
 export const PositronConsoleFocused = new RawContextKey<boolean>('positronConsoleFocused', false, localize('positronConsoleFocused', "Whether Positron Console has keyboard focus"));
 export const PositronVariablesFocused = new RawContextKey<boolean>('positronVariablesFocused', false, localize('positronVariablesFocused', "Whether Positron Variables has keyboard focus"));
 export const PositronHelpFocused = new RawContextKey<boolean>('positronHelpFocused', false, localize('positronHelpFocused', "Whether Positron Help has keyboard focus"));
+export const PositronDataExplorerFocused = new RawContextKey<boolean>('positronDataExplorerFocused', false, localize('positronDataExplorerFocused', "Whether Positron Data Explorer has keyboard focus"));
 // --- End Positron ---
 
 //#region < --- Banner --- >

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -140,7 +140,7 @@ class PositronDataExplorerCopyAction extends Action2 {
 		}
 
 		// Copy to the clipboard.
-		positronDataExplorerInstance.copyToClipboard();
+		await positronDataExplorerInstance.copyToClipboard();
 	}
 }
 

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -8,6 +8,7 @@ import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { ILocalizedString } from 'vs/platform/action/common/action';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
+import { PositronDataExplorerFocused } from 'vs/workbench/common/contextkeys';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
@@ -82,7 +83,10 @@ class PositronDataExplorerCopyAction extends Action2 {
 				primary: KeyMod.CtrlCmd | KeyCode.KeyC,
 			},
 			f1: true,
-			precondition: POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR
+			precondition: ContextKeyExpr.and(
+				POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR,
+				PositronDataExplorerFocused
+			)
 		});
 	}
 

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -3,10 +3,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
+import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { ILocalizedString } from 'vs/platform/action/common/action';
 import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
-import { IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
+import { PositronDataExplorerFocused } from 'vs/workbench/common/contextkeys';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 
 /**
  * Positron data explorer action category.
@@ -27,39 +29,37 @@ const category: ILocalizedString = {
 /**
  * Positron data explorer command ID's.
  */
-const enum PositronDataExplorerCommandId {
-	PlaceholderAction = 'workbench.action.positronDataExplorer.placeholder',
+export const enum PositronDataExplorerCommandId {
+	CopyAction = 'workbench.action.positronDataExplorer.copy',
 }
 
 /**
- * PositronDataExplorerPlaceholderAction action.
+ * PositronDataExplorerCopyAction action.
  */
-class PositronDataExplorerPlaceholderAction extends Action2 {
-	/**
-	 * Constructor.
-	 */
+class PositronDataExplorerCopyAction extends Action2 {
 	constructor() {
 		super({
-			id: PositronDataExplorerCommandId.PlaceholderAction,
+			id: PositronDataExplorerCommandId.CopyAction,
 			title: {
-				value: localize(
-					'workbench.action.positronDataExplorer.placeholder',
-					"Positron Data Explorer Placeholder"
-				),
-				original: 'Positron Data Explorer Placeholder'
+				value: localize('positronDataExplorer.copy', 'Copy'),
+				original: 'Copy'
+			},
+			category,
+			keybinding: {
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyMod.CtrlCmd | KeyCode.KeyC,
 			},
 			f1: true,
-			category,
-			precondition: IsDevelopmentContext
+			precondition: PositronDataExplorerFocused
 		});
 	}
 
 	/**
-	 * Runs action.
+	 * Runs the action.
 	 * @param accessor The services accessor.
 	 */
-	async run(accessor: ServicesAccessor) {
-		// Empty for now.
+	async run(accessor: ServicesAccessor): Promise<void> {
+		console.log('positronDataExplorer.copy command run');
 	}
 }
 
@@ -67,5 +67,5 @@ class PositronDataExplorerPlaceholderAction extends Action2 {
  * Registers Positron data explorer actions.
  */
 export function registerPositronDataExplorerActions() {
-	registerAction2(PositronDataExplorerPlaceholderAction);
+	registerAction2(PositronDataExplorerCopyAction);
 }

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -3,12 +3,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
+import { IEditorPane } from 'vs/workbench/common/editor';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { ILocalizedString } from 'vs/platform/action/common/action';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
-import { PositronDataExplorerFocused } from 'vs/workbench/common/contextkeys';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { IPositronDataExplorerEditor } from 'vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor';
+import { IPositronDataExplorerService } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
+import { PositronDataExplorerEditorInput } from 'vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput';
 
 /**
  * Positron data explorer action category.
@@ -34,6 +40,32 @@ export const enum PositronDataExplorerCommandId {
 }
 
 /**
+ * A ContextKeyExpression that is true when the active editor is a Positron data explorer editor.
+ */
+export const POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR = ContextKeyExpr.equals(
+	'activeEditor',
+	PositronDataExplorerEditorInput.EditorID
+);
+
+/**
+ * Gets the IPositronDataExplorerEditor for the specified editor pane.
+ * @param editorPane The editor pane.
+ * @returns The IPositronDataExplorerEditor for the editor pane, or undefined, if the editor pane
+ * is not a Positron data explorer editor.
+ */
+export const getPositronDataExplorerEditorFromEditorPane = (
+	editorPane?: IEditorPane
+): IPositronDataExplorerEditor | undefined => {
+	// If the editor pane is a Positron data explorer editor, return the editor.
+	if (editorPane && editorPane.getId() === PositronDataExplorerEditorInput.EditorID) {
+		return editorPane.getControl() as unknown as IPositronDataExplorerEditor | undefined;
+	}
+
+	// The editor pane is not a Positron data explorer editor.
+	return undefined;
+};
+
+/**
  * PositronDataExplorerCopyAction action.
  */
 class PositronDataExplorerCopyAction extends Action2 {
@@ -50,7 +82,7 @@ class PositronDataExplorerCopyAction extends Action2 {
 				primary: KeyMod.CtrlCmd | KeyCode.KeyC,
 			},
 			f1: true,
-			precondition: PositronDataExplorerFocused
+			precondition: POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR
 		});
 	}
 
@@ -59,7 +91,56 @@ class PositronDataExplorerCopyAction extends Action2 {
 	 * @param accessor The services accessor.
 	 */
 	async run(accessor: ServicesAccessor): Promise<void> {
-		console.log('positronDataExplorer.copy command run');
+		// Access the services we need.
+		const editorService = accessor.get(IEditorService);
+		const notificationService = accessor.get(INotificationService);
+		const positronDataExplorerService = accessor.get(IPositronDataExplorerService);
+
+		// Get the Positron data explorer editor.
+		const positronDataExplorerEditor = getPositronDataExplorerEditorFromEditorPane(
+			editorService.activeEditorPane
+		);
+
+		/**
+		 * Notifies the user that copy operation failed.
+		 */
+		const notifyUserThatCopyFailed = () => {
+			// Notify the user.
+			notificationService.notify({
+				severity: Severity.Error,
+				message: localize('positron.dataExplorer.noActiveEditor', "Cannot copy. A Positron Data Explorer is not active."),
+				sticky: false
+			});
+		};
+
+		// Make sure that the Positron data explorer editor was returned.
+		if (!positronDataExplorerEditor) {
+			notifyUserThatCopyFailed();
+			return;
+		}
+
+		// Get the identifier.
+		const identifier = positronDataExplorerEditor.identifier;
+
+		// Make sure the identifier was returned.
+		if (!identifier) {
+			notifyUserThatCopyFailed();
+			return;
+		}
+
+		// Get the Positron data explorer instance.
+		const positronDataExplorerInstance = positronDataExplorerService.getInstance(
+			identifier
+		);
+
+		// Make sure the Positron data explorer instance was returned.
+		if (!positronDataExplorerInstance) {
+			notifyUserThatCopyFailed();
+			return;
+		}
+
+		// Copy to the clipboard.
+		positronDataExplorerInstance.copyToClipboard();
 	}
 }
 

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
@@ -8,19 +8,23 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { EditorExtensions } from 'vs/workbench/common/editor';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
-import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from 'vs/workbench/browser/editor';
-import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
+import { WorkbenchPhase, registerWorkbenchContribution2 } from 'vs/workbench/common/contributions';
 import { IEditorResolverService, RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
 import { PositronDataExplorerEditor } from 'vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor';
-import { registerPositronDataExplorerActions } from 'vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions';
 import { PositronDataExplorerEditorInput } from 'vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput';
+import { registerPositronDataExplorerActions } from 'vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions';
 
 /**
  * PositronDataExplorerContribution class.
  */
 class PositronDataExplorerContribution extends Disposable {
+	/**
+	 * The identifier.
+	 */
+	static readonly ID = 'workbench.contrib.positronDataExplorer';
+
 	/**
 	 * Constructor.
 	 * @param editorResolverService The editor resolver service.
@@ -73,9 +77,12 @@ Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane
 	]
 );
 
-// Register workbench contributions.
-const workbenchContributionsRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
-workbenchContributionsRegistry.registerWorkbenchContribution(PositronDataExplorerContribution, LifecyclePhase.Restored);
+// Register workbench contribution.
+registerWorkbenchContribution2(
+	PositronDataExplorerContribution.ID,
+	PositronDataExplorerContribution,
+	WorkbenchPhase.BlockRestore
+);
 
 // Register actions.
 registerPositronDataExplorerActions();

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -250,6 +250,27 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 	 * @param parent The parent HTML element.
 	 */
 	protected override createEditor(parent: HTMLElement): void {
+		// Create the focus tracker.
+		const focusTracker = this._register(DOM.trackFocus(parent));
+
+		// Add the onDidFocus event handler.
+		this._register(focusTracker.onDidFocus(() => {
+			// If there is an identifier, meaning there is an input, set the focused Positron data
+			// explorer.
+			if (this._identifier) {
+				this._positronDataExplorerService.setFocusedPositronDataExplorer(this._identifier);
+			}
+		}));
+
+		// Add the onDidBlur event handler.
+		this._register(focusTracker.onDidBlur(() => {
+			// If there is an identifier, meaning there is an input, clear the focused Positron data
+			// explorer.
+			if (this._identifier) {
+				this._positronDataExplorerService.clearFocusedPositronDataExplorer(this._identifier);
+			}
+		}));
+
 		// Append the Positron data explorer container.
 		parent.appendChild(this._positronDataExplorerContainer);
 	}
@@ -320,8 +341,14 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 		// Dispose the PositronReactRenderer.
 		this.disposePositronReactRenderer();
 
-		// Clear the identifier.
-		this._identifier = undefined;
+		// If there is an identifier, clear it.
+		if (this._identifier) {
+			// Clear the focused Positron data explorer.
+			this._positronDataExplorerService.clearFocusedPositronDataExplorer(this._identifier);
+
+			// Clear the identifier.
+			this._identifier = undefined;
+		}
 
 		// Call the base class's method.
 		super.clearInput();

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -24,6 +24,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IEditorGroup } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { PositronDataExplorer } from 'vs/workbench/browser/positronDataExplorer/positronDataExplorer';
@@ -31,10 +32,6 @@ import { IReactComponentContainer, ISize, PositronReactRenderer } from 'vs/base/
 import { PositronDataExplorerUri } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerUri';
 import { IPositronDataExplorerService } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
 import { PositronDataExplorerEditorInput } from 'vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput';
-import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
-
-// Temporary instance counter.
-let instance = 0;
 
 /**
  * IPositronDataExplorerEditorOptions interface.
@@ -49,34 +46,9 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 	//#region Private Properties
 
 	/**
-	 * The onSizeChanged event emitter.
+	 * Gets the container element.
 	 */
-	private _onSizeChangedEmitter = this._register(new Emitter<ISize>());
-
-	/**
-	 * The onVisibilityChanged event emitter.
-	 */
-	private _onVisibilityChangedEmitter = this._register(new Emitter<boolean>());
-
-	/**
-	 * The onSaveScrollPosition event emitter.
-	 */
-	private _onSaveScrollPositionEmitter = this._register(new Emitter<void>());
-
-	/**
-	 * The onRestoreScrollPosition event emitter.
-	 */
-	private _onRestoreScrollPositionEmitter = this._register(new Emitter<void>());
-
-	/**
-	 * The onFocused event emitter.
-	 */
-	private _onFocusedEmitter = this._register(new Emitter<void>());
-
-	/**
-	 * Gets or sets the container element.
-	 */
-	private _positronDataExplorerContainer!: HTMLElement;
+	private readonly _positronDataExplorerContainer: HTMLElement;
 
 	/**
 	 * Gets or sets the PositronReactRenderer for the PositronDataExplorer component.
@@ -96,11 +68,34 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 	private _height = 0;
 
 	/**
-	 * Gets the instance. This is a temporary property.
+	 * Gets or sets the identifier.
 	 */
-	private _instance = `${++instance}`;
-
 	private _identifier?: string;
+
+	/**
+	 * The onSizeChanged event emitter.
+	 */
+	private readonly _onSizeChangedEmitter = this._register(new Emitter<ISize>());
+
+	/**
+	 * The onVisibilityChanged event emitter.
+	 */
+	private readonly _onVisibilityChangedEmitter = this._register(new Emitter<boolean>());
+
+	/**
+	 * The onSaveScrollPosition event emitter.
+	 */
+	private readonly _onSaveScrollPositionEmitter = this._register(new Emitter<void>());
+
+	/**
+	 * The onRestoreScrollPosition event emitter.
+	 */
+	private readonly _onRestoreScrollPositionEmitter = this._register(new Emitter<void>());
+
+	/**
+	 * The onFocused event emitter.
+	 */
+	private readonly _onFocusedEmitter = this._register(new Emitter<void>());
 
 	//#endregion Private Properties
 
@@ -179,6 +174,7 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 	 * @param _contextMenuService The context menu service.
 	 * @param _editorService The editor service.
 	 * @param _keybindingService The keybinding service.
+	 * @param _layoutService The layout service.
 	 * @param _positronDataExplorerService The Positron data explorer service.
 	 * @param storageService The storage service.
 	 * @param telemetryService The telemetry service.
@@ -200,19 +196,48 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 		@IThemeService themeService: IThemeService,
 	) {
 		// Call the base class's constructor.
-		super(PositronDataExplorerEditorInput.EditorID, _group, telemetryService, themeService, storageService);
+		super(
+			PositronDataExplorerEditorInput.EditorID,
+			_group,
+			telemetryService,
+			themeService,
+			storageService
+		);
 
-		// Logging.
-		console.log(`PositronDataExplorerEditor ${this._instance} created`);
+		// Create the Positron data explorer container.
+		this._positronDataExplorerContainer = DOM.$('.positron-data-explorer-container');
+		this._positronDataExplorerContainer.tabIndex = 0;
+
+		// Create a focus tracker that updates the active Positron data explorer instance.
+		const focusTracker = this._register(DOM.trackFocus(this._positronDataExplorerContainer));
+
+		// Add the onDidFocus event handler.
+		this._register(focusTracker.onDidFocus(() => {
+			// If there is an identifier set, set the active Positron data explorer instance.
+			if (this._identifier) {
+				// Clear the active Positron data explorer instance.
+				this._positronDataExplorerService.setActivePositronDataExplorerInstance(
+					this._identifier
+				);
+			}
+		}));
+
+		// Add the onDidBlur event handler.
+		this._register(focusTracker.onDidBlur(() => {
+			// If there is an identifier set, clear the active Positron data explorer instance.
+			if (this._identifier) {
+				// Clear the active Positron data explorer instance.
+				this._positronDataExplorerService.clearActivePositronDataExplorerInstance(
+					this._identifier
+				);
+			}
+		}));
 	}
 
 	/**
 	 * dispose override method.
 	 */
 	public override dispose(): void {
-		// Logging.
-		console.log(`PositronDataExplorerEditor ${this._instance} dispose`);
-
 		// Dispose the PositronReactRenderer for the PositronDataExplorer.
 		this.disposePositronReactRenderer();
 
@@ -222,18 +247,14 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 
 	//#endregion Constructor & Dispose
 
-	//#region Protected Overrides
+	//#region EditorPane Overrides
 
 	/**
 	 * Creates the editor.
 	 * @param parent The parent HTML element.
 	 */
 	protected override createEditor(parent: HTMLElement): void {
-		// Logging.
-		console.log(`PositronDataExplorerEditor ${this._instance} createEditor`);
-
-		// Create and append the Positron data explorer container.
-		this._positronDataExplorerContainer = DOM.$('.positron-data-explorer-container');
+		// Append the Positron data explorer container.
 		parent.appendChild(this._positronDataExplorerContainer);
 	}
 
@@ -250,20 +271,18 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 		context: IEditorOpenContext,
 		token: CancellationToken
 	): Promise<void> {
-		// Logging.
-		console.log(`PositronDataExplorerEditor ${this._instance} setInput ${input.resource}`);
-
 		// Parse the Positron data explorer URI and set the identifier.
 		this._identifier = PositronDataExplorerUri.parse(input.resource);
 
+		// Render the component, if necessary.
 		if (this._identifier && !this._positronReactRenderer) {
 			// Get the Positron data explorer instance.
-			const positronDataExplorerInstance = this._positronDataExplorerService.getInstance(this._identifier);
+			const positronDataExplorerInstance = this._positronDataExplorerService.getInstance(
+				this._identifier
+			);
 
 			// If the Positron data explorer instance was found, render the Positron data explorer.
 			if (positronDataExplorerInstance) {
-				console.log(`PositronDataExplorerEditor ${this._instance} creating PositronReactRenderer and rendering PositronDataExplorer`);
-
 				// Create the PositronReactRenderer for the PositronDataExplorer component and render it.
 				this._positronReactRenderer = new PositronReactRenderer(this._positronDataExplorerContainer);
 				this._positronReactRenderer.render(
@@ -285,9 +304,6 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 					this._editorService.openEditor(input);
 				}));
 
-				// Logging.
-				console.log(`PositronDataExplorerEditor ${this._instance} create PositronReactRenderer`);
-
 				// Hack -- this is usually set by setInput but we're setting it temporarily to be
 				// able to edit the editor tab name
 				this._input = input;
@@ -305,14 +321,19 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 	 * Clears the input.
 	 */
 	override clearInput(): void {
-		// Logging.
-		console.log(`PositronDataExplorerEditor ${this._instance} clearInput`);
-
-		// Dispose the PositronReactRenderer for the PositronDataExplorer.
+		// Dispose the PositronReactRenderer.
 		this.disposePositronReactRenderer();
 
-		// Clear the identifier.
-		this._identifier = undefined;
+		// Clear the active Positron data explorer instance.
+		if (this._identifier) {
+			// Clear the active Positron data explorer instance.
+			this._positronDataExplorerService.clearActivePositronDataExplorerInstance(
+				this._identifier
+			);
+
+			// Clear the identifier.
+			this._identifier = undefined;
+		}
 
 		// Call the base class's method.
 		super.clearInput();
@@ -323,44 +344,53 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 	 * @param visible A value which indicates whether the editor should be visible.
 	 */
 	protected override setEditorVisible(visible: boolean): void {
-		// Logging.
-		console.log(`PositronDataExplorerEditor ${this._instance} setEditorVisible ${visible} group ${this._group?.id}`);
-
 		// Call the base class's method.
 		super.setEditorVisible(visible);
 	}
 
-	//#endregion Protected Overrides
+	//#endregion EditorPane Overrides
 
-	//#region Protected Overrides
+	//#region Composite Overrides
+
+	/**
+	 * Called when this composite should receive keyboard focus.
+	 */
+	override focus(): void {
+		// Call the base class's method.
+		super.focus();
+
+		// Set the active Positron data explorer instance.
+		if (this._identifier) {
+			// Set the active Positron data explorer instance.
+			this._positronDataExplorerService.setActivePositronDataExplorerInstance(
+				this._identifier
+			);
+
+			// Drive focus into the Positron data explorer instance.
+			this._positronDataExplorerContainer?.focus();
+		}
+	}
 
 	/**
 	 * Lays out the editor.
 	 * @param dimension The layout dimension.
 	 */
 	override layout(dimension: DOM.Dimension): void {
-		// Logging.
-		console.log(`PositronDataExplorerEditor ${this._instance} layout ${dimension.width},${dimension.height}`);
-
 		// Size the container.
 		DOM.size(this._positronDataExplorerContainer, dimension.width, dimension.height);
 
+		// Save the width and height.
 		this._width = dimension.width;
 		this._height = dimension.height;
 
+		// Fire the _onSizeChanged event.
 		this._onSizeChangedEmitter.fire({
 			width: this._width,
 			height: this._height
 		});
-
-		if (!this._identifier) {
-			console.log('PositronDataExplorerEditor was asked to layout with no input set');
-			return;
-		}
-
 	}
 
-	//#endregion Protected Overrides
+	//#endregion Composite Overrides
 
 	//#region Private Methods
 
@@ -371,9 +401,6 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 		// If the PositronReactRenderer for the PositronDataExplorer is exists, dispose it. This
 		// removes the PositronDataExplorer from the DOM.
 		if (this._positronReactRenderer) {
-			// Logging.
-			console.log(`PositronDataExplorerEditor ${this._instance} dispose PositronReactRenderer`);
-
 			// Dispose of the PositronReactRenderer for the PositronDataExplorer.
 			this._positronReactRenderer.dispose();
 			this._positronReactRenderer = undefined;

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -40,9 +40,19 @@ export interface IPositronDataExplorerEditorOptions extends IEditorOptions {
 }
 
 /**
+ * IPositronDataExplorerEditor interface.
+ */
+export interface IPositronDataExplorerEditor {
+	/**
+	 * Gets the identifier.
+	 */
+	get identifier(): string | undefined;
+}
+
+/**
  * PositronDataExplorerEditor class.
  */
-export class PositronDataExplorerEditor extends EditorPane implements IReactComponentContainer {
+export class PositronDataExplorerEditor extends EditorPane implements IPositronDataExplorerEditor, IReactComponentContainer {
 	//#region Private Properties
 
 	/**
@@ -98,6 +108,17 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 	private readonly _onFocusedEmitter = this._register(new Emitter<void>());
 
 	//#endregion Private Properties
+
+	//#region IPositronDataExplorerEditor
+
+	/**
+	 * Gets the identifier.
+	 */
+	get identifier(): string | undefined {
+		return this._identifier;
+	}
+
+	//#endregion IPositronDataExplorerEditor
 
 	//#region IReactComponentContainer
 
@@ -207,31 +228,6 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 		// Create the Positron data explorer container.
 		this._positronDataExplorerContainer = DOM.$('.positron-data-explorer-container');
 		this._positronDataExplorerContainer.tabIndex = 0;
-
-		// Create a focus tracker that updates the active Positron data explorer instance.
-		const focusTracker = this._register(DOM.trackFocus(this._positronDataExplorerContainer));
-
-		// Add the onDidFocus event handler.
-		this._register(focusTracker.onDidFocus(() => {
-			// If there is an identifier set, set the active Positron data explorer instance.
-			if (this._identifier) {
-				// Clear the active Positron data explorer instance.
-				this._positronDataExplorerService.setActivePositronDataExplorerInstance(
-					this._identifier
-				);
-			}
-		}));
-
-		// Add the onDidBlur event handler.
-		this._register(focusTracker.onDidBlur(() => {
-			// If there is an identifier set, clear the active Positron data explorer instance.
-			if (this._identifier) {
-				// Clear the active Positron data explorer instance.
-				this._positronDataExplorerService.clearActivePositronDataExplorerInstance(
-					this._identifier
-				);
-			}
-		}));
 	}
 
 	/**
@@ -324,16 +320,8 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 		// Dispose the PositronReactRenderer.
 		this.disposePositronReactRenderer();
 
-		// Clear the active Positron data explorer instance.
-		if (this._identifier) {
-			// Clear the active Positron data explorer instance.
-			this._positronDataExplorerService.clearActivePositronDataExplorerInstance(
-				this._identifier
-			);
-
-			// Clear the identifier.
-			this._identifier = undefined;
-		}
+		// Clear the identifier.
+		this._identifier = undefined;
 
 		// Call the base class's method.
 		super.clearInput();
@@ -353,22 +341,21 @@ export class PositronDataExplorerEditor extends EditorPane implements IReactComp
 	//#region Composite Overrides
 
 	/**
+	 * Returns the underlying composite control or `undefined` if it is not accessible.
+	 */
+	override getControl(): IPositronDataExplorerEditor {
+		return this;
+	}
+
+	/**
 	 * Called when this composite should receive keyboard focus.
 	 */
 	override focus(): void {
 		// Call the base class's method.
 		super.focus();
 
-		// Set the active Positron data explorer instance.
-		if (this._identifier) {
-			// Set the active Positron data explorer instance.
-			this._positronDataExplorerService.setActivePositronDataExplorerInstance(
-				this._identifier
-			);
-
-			// Drive focus into the Positron data explorer instance.
-			this._positronDataExplorerContainer?.focus();
-		}
+		// Drive focus into the Positron data explorer instance.
+		this._positronDataExplorerContainer?.focus();
 	}
 
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -5,7 +5,7 @@
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
-import { BackendState, ColumnProfileRequest, ColumnProfileResult, ColumnSchema, ColumnSortKey, FilterResult, FormatOptions, PositronDataExplorerComm, RowFilter, SchemaUpdateEvent, TableData, TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { BackendState, ColumnProfileRequest, ColumnProfileResult, ColumnSchema, ColumnSortKey, DataSelection, ExportedData, ExportFormat, FilterResult, FormatOptions, PositronDataExplorerComm, RowFilter, SchemaUpdateEvent, TableData, TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * TableSchemaSearchResult interface. This is here temporarily until searching the tabe schema
@@ -317,6 +317,29 @@ export class DataExplorerClientInstance extends Disposable {
 		return this.runBackendTask(
 			() => this._positronDataExplorerComm.getColumnProfiles(profiles, this._profileFormatOptions),
 			() => []
+		);
+	}
+
+	/**
+	 * Export data selection as a string in different formats
+	 *
+	 * Export data selection as a string in different formats like CSV, TSV,
+	 * HTML
+	 *
+	 * @param selection The data selection
+	 * @param format Result string format
+	 *
+	 * @returns Exported result
+	 */
+	async exportDataSelection(selection: DataSelection, format: ExportFormat): Promise<ExportedData> {
+		return this.runBackendTask(
+			() => this._positronDataExplorerComm.exportDataSelection(selection, format),
+			() => {
+				return {
+					data: '',
+					format
+				};
+			}
 		);
 	}
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
@@ -18,7 +18,7 @@ import { DataCell } from 'vs/workbench/services/positronDataExplorer/common/data
  */
 interface TableDataCellProps {
 	column: PositronDataExplorerColumn;
-	cellValue: DataCell;
+	dataCell: DataCell;
 }
 
 /**
@@ -31,7 +31,7 @@ export const TableDataCell = (props: TableDataCellProps) => {
 	return (
 		<div className={positronClassNames('text-container', props.column.alignment)}>
 			<div className='text-value'>
-				{props.cellValue.formatted}
+				{props.dataCell.formatted}
 			</div>
 		</div>
 	);

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
@@ -69,7 +69,7 @@ export interface IPositronDataExplorerInstance extends IDisposable {
 	requestFocus(): void;
 
 	/**
-	 * Copies to the clipboard.
+	 * Copies the selection or cursor cell to the clipboard.
 	 */
-	copyToClipboard(): void;
+	copyToClipboard(): Promise<void>;
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
@@ -3,11 +3,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from 'vs/base/common/event';
+import { IDisposable } from 'vs/base/common/lifecycle';
 import { TableDataDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance';
 import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
 import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
 import { PositronDataExplorerLayout } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
-import { IDisposable } from 'vs/base/common/lifecycle';
 
 /**
  * IPositronDataExplorerInstance interface.

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
@@ -67,4 +67,9 @@ export interface IPositronDataExplorerInstance extends IDisposable {
 	 * Requests focus for the instance.
 	 */
 	requestFocus(): void;
+
+	/**
+	 * Copies to the clipboard.
+	 */
+	copyToClipboard(): void;
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
@@ -27,9 +27,27 @@ export interface IPositronDataExplorerService {
 	readonly _serviceBrand: undefined;
 
 	/**
+	 * Gets or sets the active Positron data explorer instance.
+	 */
+	readonly activePositronDataExplorerInstance?: IPositronDataExplorerInstance;
+
+	/**
 	 * Placeholder that gets called to "initialize" the PositronDataExplorerService.
 	 */
 	initialize(): void;
+
+	/**
+	 * Gets the instance for the specified identifier.
+	 * @param identifier The instance identifier.
+	 */
+	getInstance(identifier: string): IPositronDataExplorerInstance | undefined;
+
+	/**
+	 * Gets the instance for the specified variable.
+	 *
+	 * @param variableId The variable identifier.
+	 */
+	getInstanceForVar(variableId: string): IPositronDataExplorerInstance | undefined;
 
 	/**
 	 * Associates a variable with an instance.
@@ -40,16 +58,14 @@ export interface IPositronDataExplorerService {
 	setInstanceForVar(instanceId: string, variableId: string): void;
 
 	/**
-	 * Gets the instance for the specified variable.
-	 *
-	 * @param variableId The variable identifier.
+	 * Sets the active Positron data explorer instance.
+	 * @param identifier The identifier of the active Positron data explorer instance to set.
 	 */
-	getInstanceForVar(variableId: string): IPositronDataExplorerInstance | undefined;
+	setActivePositronDataExplorerInstance(identifier: string): void;
 
 	/**
-	 * Gets the instance for the specified identifier.
-	 *
-	 * @param identifier
+	 * Clears the active Positron data explorer instance.
+	 * @param identifier The identifier of the active Positron data explorer instance to clear.
 	 */
-	getInstance(identifier: string): IPositronDataExplorerInstance | undefined;
+	clearActivePositronDataExplorerInstance(identifier: string): void;
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
@@ -56,16 +56,4 @@ export interface IPositronDataExplorerService {
 	 * @param variableId The variable identifier.
 	 */
 	setInstanceForVar(instanceId: string, variableId: string): void;
-
-	/**
-	 * Sets the active Positron data explorer instance.
-	 * @param identifier The identifier of the active Positron data explorer instance to set.
-	 */
-	setActivePositronDataExplorerInstance(identifier: string): void;
-
-	/**
-	 * Clears the active Positron data explorer instance.
-	 * @param identifier The identifier of the active Positron data explorer instance to clear.
-	 */
-	clearActivePositronDataExplorerInstance(identifier: string): void;
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
@@ -56,4 +56,16 @@ export interface IPositronDataExplorerService {
 	 * @param variableId The variable identifier.
 	 */
 	setInstanceForVar(instanceId: string, variableId: string): void;
+
+	/**
+	 * Sets the focused Positron data explorer.
+	 * @param identifier The identifier of the focused Positron data explorer to set.
+	 */
+	setFocusedPositronDataExplorer(identifier: string): void;
+
+	/**
+	 * Clears the focused Positron data explorer.
+	 * @param identifier The identifier of the focused Positron data explorer to clear.
+	 */
+	clearFocusedPositronDataExplorer(identifier: string): void;
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -210,6 +210,13 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	}
 
 	/**
+	 * Copies to the clipboard.
+	 */
+	copyToClipboard(): void {
+		console.log('copyToClipboard called!');
+	}
+
+	/**
 	 * onDidClose event.
 	 */
 	readonly onDidClose = this._onDidCloseEmitter.event;

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -18,7 +18,6 @@ import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntim
 import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
 import { PositronDataExplorerLayout } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
 import { IPositronDataExplorerInstance } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance';
-import { ClipboardCell, ClipboardCellRange, ClipboardColumnIndexes, ClipboardColumnRange, ClipboardRowIndexes, ClipboardRowRange } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
 
 /**
  * PositronDataExplorerInstance class.
@@ -239,42 +238,15 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 			return;
 		}
 
-		// Temporary output. This code will be moved to the data explorer cache layer.
-		switch (clipboardData.constructor) {
-			case ClipboardCell:
-				console.log('ClipboardCell clipboard data');
-				break;
-
-			case ClipboardCellRange:
-				console.log('ClipboardCellRange clipboard data');
-				break;
-
-			case ClipboardColumnRange:
-				console.log('ClipboardColumnRange clipboard data');
-				break;
-
-			case ClipboardColumnIndexes:
-				console.log('ClipboardColumnIndexes clipboard data');
-				break;
-
-			case ClipboardRowRange:
-				console.log('ClipboardRowRange clipboard data');
-				break;
-
-			case ClipboardRowIndexes:
-				console.log('ClipboardRowIndexes clipboard data');
-				break;
-
-			default:
-				notifyUser();
-				break;
+		// Copy the clipboard data.
+		const text = await this._tableDataDataGridInstance.copyClipboardData(clipboardData);
+		if (!text) {
+			notifyUser();
+			return;
 		}
 
-		// Get the clipboard data from the data explorer cache.
-		// const clipboardData = await this._dataExplorerCache.getClipboardData(clipboardRange);
-
 		// Write the clipboard data to the clipboard.
-		this._clipboardService.writeText('Column 1\tColumn 2\tColumn 3\r\n1\t2\t3\r\n4\t5\t6\r\n7\t8\t9');
+		this._clipboardService.writeText(text);
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -5,6 +5,9 @@
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IHoverService } from 'vs/platform/hover/browser/hover';
+import { ICommandService } from 'vs/platform/commands/common/commands';
+import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { DataExplorerCache } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
 import { TableDataDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance';
@@ -18,16 +21,6 @@ import { IPositronDataExplorerInstance } from 'vs/workbench/services/positronDat
  */
 export class PositronDataExplorerInstance extends Disposable implements IPositronDataExplorerInstance {
 	//#region Private Properties
-
-	/**
-	 * Gets the language name.
-	 */
-	private readonly _languageName: string;
-
-	/**
-	 * Gets the DataExplorerClientInstance.
-	 */
-	private readonly _dataExplorerClientInstance: DataExplorerClientInstance;
 
 	/**
 	 * Gets the DataExplorerCache.
@@ -87,33 +80,40 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 
 	/**
 	 * Constructor.
-	 * @param configurationService The configuration service.
-	 * @param hoverService The hover service.
-	 * @param languageName The language name.
-	 * @param dataExplorerClientInstance The DataExplorerClientInstance. The data explorer takes
+	 * @param _commandService The command service.
+	 * @param _configurationService The configuration service.
+	 * @param _hoverService The hover service.
+	 * @param _keybindingService The keybinding service.
+	 * @param _layoutService The layout service.
+	 * @param _languageName The language name.
+	 * @param _dataExplorerClientInstance The DataExplorerClientInstance. The data explorer takes
 	 * ownership of the client instance and will dispose it when it is disposed.
 	 */
 	constructor(
-		configurationService: IConfigurationService,
-		hoverService: IHoverService,
-		languageName: string,
-		dataExplorerClientInstance: DataExplorerClientInstance
+		private readonly _commandService: ICommandService,
+		private readonly _configurationService: IConfigurationService,
+		private readonly _hoverService: IHoverService,
+		private readonly _keybindingService: IKeybindingService,
+		private readonly _layoutService: ILayoutService,
+		private readonly _languageName: string,
+		private readonly _dataExplorerClientInstance: DataExplorerClientInstance
 	) {
 		// Call the base class's constructor.
 		super();
 
 		// Initialize.
-		this._languageName = languageName;
-		this._dataExplorerClientInstance = dataExplorerClientInstance;
-		this._dataExplorerCache = new DataExplorerCache(dataExplorerClientInstance);
+		this._dataExplorerCache = new DataExplorerCache(this._dataExplorerClientInstance);
 		this._tableSchemaDataGridInstance = new TableSummaryDataGridInstance(
-			configurationService,
-			hoverService,
-			dataExplorerClientInstance,
+			this._configurationService,
+			this._hoverService,
+			this._dataExplorerClientInstance,
 			this._dataExplorerCache
 		);
 		this._tableDataDataGridInstance = new TableDataDataGridInstance(
-			dataExplorerClientInstance,
+			this._commandService,
+			this._keybindingService,
+			this._layoutService,
+			this._dataExplorerClientInstance,
 			this._dataExplorerCache
 		);
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -242,19 +242,17 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	 * @param identifier The identifier of the active Positron data explorer instance to set.
 	 */
 	setActivePositronDataExplorerInstance(identifier: string) {
-		if (this._activePositronDataExplorerInstance &&
-			this._activePositronDataExplorerInstance.dataExplorerClientInstance.identifier ===
+		if (!this._activePositronDataExplorerInstance ||
+			this._activePositronDataExplorerInstance.dataExplorerClientInstance.identifier !==
 			identifier
 		) {
-			return;
+			const positronDataExplorerInstance = this._positronDataExplorerInstances.get(identifier);
+			if (positronDataExplorerInstance) {
+				this._activePositronDataExplorerInstance = positronDataExplorerInstance;
+				this._positronDataExplorerFocusedContextKey.set(true);
+			}
 		}
 
-		const positronDataExplorerInstance = this._positronDataExplorerInstances.get(identifier);
-		if (positronDataExplorerInstance) {
-			this._activePositronDataExplorerInstance = positronDataExplorerInstance;
-			this._positronDataExplorerFocusedContextKey.set(true);
-			console.log(`++++++++++ PositronDataExplorerFocused TRUE ${identifier}`);
-		}
 	}
 
 	/**
@@ -268,7 +266,6 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 		) {
 			this._activePositronDataExplorerInstance = undefined;
 			this._positronDataExplorerFocusedContextKey.set(false);
-			console.log(`++++++++++ PositronDataExplorerFocused FALSE ${identifier}`);
 		}
 	}
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -9,6 +9,7 @@ import { IHoverService } from 'vs/platform/hover/browser/hover';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -127,6 +128,7 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 
 	/**
 	 * Constructor.
+	 * @param _clipboardService The clipboard service.
 	 * @param _commandService The command service.
 	 * @param _configurationService The configuration service.
 	 * @param _editorService The editor service.
@@ -137,6 +139,7 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	 * @param _runtimeSessionService The language runtime session service.
 	 */
 	constructor(
+		@IClipboardService private readonly _clipboardService: IClipboardService,
 		@ICommandService private readonly _commandService: ICommandService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IEditorService private readonly _editorService: IEditorService,
@@ -297,11 +300,13 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 		this._positronDataExplorerInstances.set(
 			dataExplorerClientInstance.identifier,
 			new PositronDataExplorerInstance(
+				this._clipboardService,
 				this._commandService,
 				this._configurationService,
 				this._hoverService,
 				this._keybindingService,
 				this._layoutService,
+				this._notificationService,
 				languageName,
 				dataExplorerClientInstance
 			)

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -19,8 +19,6 @@ import { PositronDataExplorerInstance } from 'vs/workbench/services/positronData
 import { ILanguageRuntimeSession, IRuntimeSessionService, RuntimeClientType } from '../../runtimeSession/common/runtimeSessionService';
 import { IPositronDataExplorerService } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
 import { IPositronDataExplorerInstance } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance';
-import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { PositronDataExplorerFocused } from 'vs/workbench/common/contextkeys';
 
 /**
  * DataExplorerRuntime class.
@@ -103,11 +101,6 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	//#region Private Properties
 
 	/**
-	 * Gets or sets the PositronDataExplorerFocused context key.
-	 */
-	private _positronDataExplorerFocusedContextKey: IContextKey<boolean>;
-
-	/**
 	 * A map of the data explorer runtimes keyed by session ID.
 	 */
 	private readonly _dataExplorerRuntimes = new Map<string, DataExplorerRuntime>();
@@ -116,11 +109,6 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	 * The Positron data explorer instances keyed by data explorer client instance identifier.
 	 */
 	private _positronDataExplorerInstances = new Map<string, PositronDataExplorerInstance>();
-
-	/**
-	 * Gets or sets the active Positron data explorer instance.
-	 */
-	private _activePositronDataExplorerInstance?: PositronDataExplorerInstance;
 
 	/**
 	 * The Positron data explorer variable-to-instance map.
@@ -141,7 +129,6 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	 * Constructor.
 	 * @param _commandService The command service.
 	 * @param _configurationService The configuration service.
-	 * @param _contextKeyService The context key service.
 	 * @param _editorService The editor service.
 	 * @param _hoverService The hover service.
 	 * @param _keybindingService The keybinding service.
@@ -152,7 +139,6 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	constructor(
 		@ICommandService private readonly _commandService: ICommandService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@IHoverService private readonly _hoverService: IHoverService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
@@ -162,11 +148,6 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	) {
 		// Call the disposable constrcutor.
 		super();
-
-		// Bind the PositronDataExplorerFocused context key.
-		this._positronDataExplorerFocusedContextKey = PositronDataExplorerFocused.bindTo(
-			this._contextKeyService
-		);
 
 		// Add a data explorer runtime for each running runtime.
 		this._runtimeSessionService.activeSessions.forEach(session => {
@@ -235,38 +216,6 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 	 */
 	setInstanceForVar(instanceId: string, variableId: string): void {
 		this._varIdToInstanceIdMap.set(variableId, instanceId);
-	}
-
-	/**
-	 * Sets the active Positron data explorer instance.
-	 * @param identifier The identifier of the active Positron data explorer instance to set.
-	 */
-	setActivePositronDataExplorerInstance(identifier: string) {
-		if (!this._activePositronDataExplorerInstance ||
-			this._activePositronDataExplorerInstance.dataExplorerClientInstance.identifier !==
-			identifier
-		) {
-			const positronDataExplorerInstance = this._positronDataExplorerInstances.get(identifier);
-			if (positronDataExplorerInstance) {
-				this._activePositronDataExplorerInstance = positronDataExplorerInstance;
-				this._positronDataExplorerFocusedContextKey.set(true);
-			}
-		}
-
-	}
-
-	/**
-	 * Clears the active Positron data explorer instance.
-	 * @param identifier The identifier of the active Positron data explorer instance to clear.
-	 */
-	clearActivePositronDataExplorerInstance(identifier: string) {
-		if (this._activePositronDataExplorerInstance &&
-			this._activePositronDataExplorerInstance.dataExplorerClientInstance.identifier ===
-			identifier
-		) {
-			this._activePositronDataExplorerInstance = undefined;
-			this._positronDataExplorerFocusedContextKey.set(false);
-		}
 	}
 
 	//#endregion Constructor & Dispose

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -244,6 +244,14 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			200,
 			[
 				new CustomContextMenuItem({
+					commandId: PositronDataExplorerCommandId.CopyAction,
+					checked: false,
+					icon: 'copy',
+					label: localize('positron.dataExplorer.copy', "Copy"),
+					onSelected: () => console.log('Copy')
+				}),
+				new CustomContextMenuSeparator(),
+				new CustomContextMenuItem({
 					checked: columnSortKey !== undefined && columnSortKey.ascending,
 					icon: 'arrow-up',
 					label: localize('positron.sortAscending', "Sort Ascending"),

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -14,6 +14,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IColumnSortKey } from 'vs/workbench/browser/positronDataGrid/interfaces/columnSortKey';
 import { DataExplorerCache } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
 import { TableDataCell } from 'vs/workbench/services/positronDataExplorer/browser/components/tableDataCell';
+import { showCustomContextMenu } from 'vs/workbench/browser/positronComponents/customContextMenu/customContextMenu';
 import { TableDataRowHeader } from 'vs/workbench/services/positronDataExplorer/browser/components/tableDataRowHeader';
 import { CustomContextMenuItem } from 'vs/workbench/browser/positronComponents/customContextMenu/customContextMenuItem';
 import { PositronDataExplorerColumn } from 'vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn';
@@ -22,7 +23,6 @@ import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntim
 import { BackendState, ColumnSchema, RowFilter } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { CustomContextMenuSeparator } from 'vs/workbench/browser/positronComponents/customContextMenu/customContextMenuSeparator';
 import { PositronDataExplorerCommandId } from 'vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions';
-import { CustomContextMenuEntry, showCustomContextMenu } from 'vs/workbench/browser/positronComponents/customContextMenu/customContextMenu';
 
 /**
  * Localized strings.
@@ -288,6 +288,16 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	}
 
 	/**
+	 * Shows the row context menu.
+	 * @param anchor The anchor element.
+	 * @param rowIndex The row index.
+	 * @returns A Promise<void> that resolves when the context menu is complete.
+	 */
+	override async showRowContextMenu(anchor: HTMLElement, rowIndex: number): Promise<void> {
+		// TODO.
+	}
+
+	/**
 	 * Shows the cell context menu.
 	 * @param anchor The anchor element.
 	 * @param columnIndex The column index.
@@ -298,23 +308,23 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		columnIndex: number,
 		rowIndex: number
 	): Promise<void> {
-		// Build the context menu entries.
-		const entries: CustomContextMenuEntry[] = [];
-		entries.push(new CustomContextMenuItem({
-			label: localize('positron.dataExplorer.selectColumn', "Select Column"),
-			onSelected: () => this.selectColumn(columnIndex)
-		}));
-		entries.push(new CustomContextMenuItem({
-			label: localize('positron.dataExplorer.selectRow', "Select Row"),
-			onSelected: () => this.selectRow(rowIndex)
-		}));
-		entries.push(new CustomContextMenuSeparator());
-		entries.push(new CustomContextMenuItem({
-			commandId: PositronDataExplorerCommandId.CopyAction,
-			icon: 'copy',
-			label: localize('positron.dataExplorer.copy', "Copy"),
-			onSelected: () => console.log('Copy')
-		}));
+		// // Build the context menu entries.
+		// const entries: CustomContextMenuEntry[] = [];
+		// entries.push(new CustomContextMenuItem({
+		// 	commandId: PositronDataExplorerCommandId.CopyAction,
+		// 	icon: 'copy',
+		// 	label: localize('positron.dataExplorer.copy', "Copy"),
+		// 	onSelected: () => console.log('Copy')
+		// }));
+		// entries.push(new CustomContextMenuSeparator());
+		// entries.push(new CustomContextMenuItem({
+		// 	label: localize('positron.dataExplorer.selectColumn', "Select Column"),
+		// 	onSelected: () => this.selectColumn(columnIndex)
+		// }));
+		// entries.push(new CustomContextMenuItem({
+		// 	label: localize('positron.dataExplorer.selectRow', "Select Row"),
+		// 	onSelected: () => this.selectRow(rowIndex)
+		// }));
 
 		// Show the custom context menu.
 		await showCustomContextMenu(
@@ -324,7 +334,23 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			anchor,
 			'left',
 			200,
-			entries
+			[
+				new CustomContextMenuItem({
+					commandId: PositronDataExplorerCommandId.CopyAction,
+					icon: 'copy',
+					label: localize('positron.dataExplorer.copy', "Copy"),
+					onSelected: () => console.log('Copy')
+				}),
+				new CustomContextMenuSeparator(),
+				new CustomContextMenuItem({
+					label: localize('positron.dataExplorer.selectColumn', "Select Column"),
+					onSelected: () => this.selectColumn(columnIndex)
+				}),
+				new CustomContextMenuItem({
+					label: localize('positron.dataExplorer.selectRow', "Select Row"),
+					onSelected: () => this.selectRow(rowIndex)
+				})
+			]
 		);
 	}
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -237,15 +237,15 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			return undefined;
 		}
 
-		// Get the cell value.
-		const cellValue = this._dataExplorerCache.getCellValue(columnIndex, rowIndex);
-		if (!cellValue) {
+		// Get the data cell.
+		const dataCell = this._dataExplorerCache.getDataCell(columnIndex, rowIndex);
+		if (!dataCell) {
 			return undefined;
 		}
 
 		// Return the TableDataCell.
 		return (
-			<TableDataCell column={column} cellValue={cellValue} />
+			<TableDataCell column={column} dataCell={dataCell} />
 		);
 	}
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -297,19 +297,19 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		// Build the context menu entries.
 		const entries: CustomContextMenuEntry[] = [];
 		entries.push(new CustomContextMenuItem({
-			commandId: PositronDataExplorerCommandId.CopyAction,
-			icon: 'copy',
-			label: localize('positron.dataExplorer.copy', "Copy"),
-			onSelected: () => console.log('Copy')
-		}));
-		entries.push(new CustomContextMenuSeparator());
-		entries.push(new CustomContextMenuItem({
 			label: localize('positron.dataExplorer.selectColumn', "Select Column"),
 			onSelected: () => console.log('Select Column')
 		}));
 		entries.push(new CustomContextMenuItem({
 			label: localize('positron.dataExplorer.selectRow', "Select Row"),
 			onSelected: () => console.log('Select Row')
+		}));
+		entries.push(new CustomContextMenuSeparator());
+		entries.push(new CustomContextMenuItem({
+			commandId: PositronDataExplorerCommandId.CopyAction,
+			icon: 'copy',
+			label: localize('positron.dataExplorer.copy', "Copy"),
+			onSelected: () => console.log('Copy')
 		}));
 
 		// Show the custom context menu.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -293,16 +293,20 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * @param columnIndex The column index.
 	 * @param rowIndex The row index.
 	 */
-	override async showCellContextMenu(anchor: HTMLElement): Promise<void> {
+	override async showCellContextMenu(
+		anchor: HTMLElement,
+		columnIndex: number,
+		rowIndex: number
+	): Promise<void> {
 		// Build the context menu entries.
 		const entries: CustomContextMenuEntry[] = [];
 		entries.push(new CustomContextMenuItem({
 			label: localize('positron.dataExplorer.selectColumn', "Select Column"),
-			onSelected: () => console.log('Select Column')
+			onSelected: () => this.selectColumn(columnIndex)
 		}));
 		entries.push(new CustomContextMenuItem({
 			label: localize('positron.dataExplorer.selectRow', "Select Row"),
-			onSelected: () => console.log('Select Row')
+			onSelected: () => this.selectRow(rowIndex)
 		}));
 		entries.push(new CustomContextMenuSeparator());
 		entries.push(new CustomContextMenuItem({

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -308,24 +308,6 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		columnIndex: number,
 		rowIndex: number
 	): Promise<void> {
-		// // Build the context menu entries.
-		// const entries: CustomContextMenuEntry[] = [];
-		// entries.push(new CustomContextMenuItem({
-		// 	commandId: PositronDataExplorerCommandId.CopyAction,
-		// 	icon: 'copy',
-		// 	label: localize('positron.dataExplorer.copy', "Copy"),
-		// 	onSelected: () => console.log('Copy')
-		// }));
-		// entries.push(new CustomContextMenuSeparator());
-		// entries.push(new CustomContextMenuItem({
-		// 	label: localize('positron.dataExplorer.selectColumn', "Select Column"),
-		// 	onSelected: () => this.selectColumn(columnIndex)
-		// }));
-		// entries.push(new CustomContextMenuItem({
-		// 	label: localize('positron.dataExplorer.selectRow', "Select Row"),
-		// 	onSelected: () => this.selectRow(rowIndex)
-		// }));
-
 		// Show the custom context menu.
 		await showCustomContextMenu(
 			this._commandService,

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
@@ -289,12 +289,12 @@ export class DataExplorerCache extends Disposable {
 	}
 
 	/**
-	 * Gets the cell value for the specified column index and row index.
+	 * Gets the data cell for the specified column index and row index.
 	 * @param columnIndex The column index.
 	 * @param rowIndex The row index.
-	 * @returns The cell value for the specified column index and row index.
+	 * @returns The data cell for the specified column index and row index.
 	 */
-	getCellValue(columnIndex: number, rowIndex: number) {
+	getDataCell(columnIndex: number, rowIndex: number) {
 		return this._dataCellCache.get(`${columnIndex},${rowIndex}`);
 	}
 


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR enables copying data from the Positron Data Explorer to the clipboard.

It also contains some other work:

- `showContextMenu` (`ContextMenuEntry`, `ContextMenuItem`, and `ContextMenuSeparator`) has been renamed `showCustomContextMenu` (and `CustomContextMenuEntry`, `CustomContextMenuItem`, and `CustomContextMenuSeparator`).
- Some work has been done on showing column, row, and cell context menus in the Positron Data Explorer.
- Addition of `PositronDataExplorerFocused` context key, which will be true when keyboard focus is inside a Positron Data Explorer.
- Positron Data Explorer actions have been updated. The placeholder action has been removed. A new action, `workbench.action.positronDataExplorer.copy`, has been added.
- `positronDataExplorerEditor.contribution.ts` has been updated to use `registerWorkbenchContribution2`.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

You should be able to copy data out of a Positron Data Explorer using the ⌘ C (macOS) or Ctrl + C (Windows or Linux). Here's a movie:


https://github.com/posit-dev/positron/assets/853239/f6b6eaa2-c55f-4707-874f-2fe706a5ee5a





