### PR TITLE
Do not add context prefix to enum name for union properties in generated Rust comms

### DIFF
--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -542,7 +542,7 @@ use serde::Serialize;
 					snakeCaseToSentenceCase(context[0]) + ` in ` +
 					snakeCaseToSentenceCase(context[1]));
 				yield '#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]\n';
-				yield `pub enum ${snakeCaseToSentenceCase(context[1])}${snakeCaseToSentenceCase(context[0])} {\n`;
+				yield `pub enum ${snakeCaseToSentenceCase(context[0])} {\n`;
 			}
 			for (let i = 0; i < o.oneOf.length; i++) {
 				const option = o.oneOf[i];


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

Allows generating comms that compile for https://github.com/posit-dev/amalthea/pull/376

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

Match the name of the enum which should be just `context[0]`

https://github.com/posit-dev/positron/blob/2ae23cfd2546428a1c4341e710dc848393db64c0/positron/comms/generate-comms.ts#L888-L889

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

NA