### PR TITLE
Tracing support in Ark

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -650,6 +650,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		const session = await createJupyterSession();
 		const connnectionFile = session.state.connectionFile;
 		const logFile = session.state.logFile;
+		const profileFile = session.state.profileFile;
 
 		// Form the command-line arguments to the kernel process
 		const args = this._spec.argv.map((arg, _idx) => {
@@ -665,6 +666,14 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 				// kernel starts writing to it.
 				fs.writeFileSync(logFile, '');
 				return logFile;
+			}
+
+			// Same as `log_file` but for profiling logs
+			if (arg === '{profile_file}') {
+				// Ensure the profile file exists, so we can start streaming it before the
+				// kernel starts writing to it.
+				fs.writeFileSync(profileFile, '');
+				return profileFile;
 			}
 
 			return arg;

--- a/extensions/jupyter-adapter/src/JupyterSession.ts
+++ b/extensions/jupyter-adapter/src/JupyterSession.ts
@@ -21,6 +21,9 @@ export interface JupyterSessionState {
 	/** The log file the kernel is writing to */
 	logFile: string;
 
+	/** The profile file the kernel is writing to */
+	profileFile: string;
+
 	/** The connection file specifying the ZeroMQ ports, signing keys, etc. */
 	connectionFile: string;
 
@@ -91,6 +94,8 @@ export async function createJupyterSession(): Promise<JupyterSession> {
 	const kerneldir = fs.mkdtempSync(`${tempdir}${sep}kernel-`);
 	const connectionFile = path.join(kerneldir, 'connection.json');
 	const logFile = path.join(kerneldir, 'kernel.log');
+	const profileFile = path.join(kerneldir, 'kernel-profile.log');
+
 	return new Promise((resolve, reject) => {
 		fs.writeFile(connectionFile, JSON.stringify(conn), (err) => {
 			if (err) {
@@ -99,6 +104,7 @@ export async function createJupyterSession(): Promise<JupyterSession> {
 				resolve(new JupyterSession({
 					connectionFile,
 					logFile,
+					profileFile,
 					sessionId: crypto.randomBytes(16).toString('hex'),
 					processId: 0
 				}));

--- a/extensions/jupyter-adapter/src/JupyterSession.ts
+++ b/extensions/jupyter-adapter/src/JupyterSession.ts
@@ -22,7 +22,7 @@ export interface JupyterSessionState {
 	logFile: string;
 
 	/** The profile file the kernel is writing to */
-	profileFile: string;
+	profileFile?: string;
 
 	/** The connection file specifying the ZeroMQ ports, signing keys, etc. */
 	connectionFile: string;

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -401,6 +401,13 @@ export class LanguageRuntimeSessionAdapter
 	}
 
 	/**
+	 * Show profiler log in output panel.
+	 */
+	public async showProfile() {
+		await this._kernel.showProfile();
+	}
+
+	/**
 	 * Creates a new client instance.
 	 *
 	 * @param id The client-supplied ID of the client to create

--- a/extensions/jupyter-adapter/src/LogStreamer.ts
+++ b/extensions/jupyter-adapter/src/LogStreamer.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import { Tail } from 'tail';
+
+// Wrapper around Tail that flushes on `dispose()`.
+// Prevents losing output on reload.
+
+export class LogStreamer implements vscode.Disposable {
+	private _tail: Tail;
+	private _linesCounter: number = 0;
+
+	constructor(
+		private _output: vscode.OutputChannel,
+		private _path: string,
+		private _prefix?: string,
+	) {
+		this._tail = new Tail(this._path, { fromBeginning: true, useWatchFile: true });
+
+		// Establish listeners for new lines in the log file
+		this._tail.on('line', (line) => this.appendLine(line));
+		this._tail.on('error', (error) => this.appendLine(error));
+	}
+
+	public watch() {
+		// Initialise number of lines seen, which might not be zero as the
+		// kernel might have already started outputting lines, or we might be
+		// refreshing with an existing log file. This is used for flushing
+		// the tail of the log on disposal. There is a race condition here so
+		// this might be slightly off, causing duplicate lines in the tail of
+		// the log.
+		const lines = fs.readFileSync(this._path, 'utf8').split('\n');
+		this._linesCounter = lines.length;
+
+		// Start watching the log file. This streams output until the streamer is
+		// disposed.
+		this._tail.watch();
+	}
+
+	private appendLine(line: string) {
+		this._linesCounter += 1;
+
+		if (this._prefix) {
+			this._output.appendLine(`[${this._prefix}] ${line}`);
+		} else {
+			this._output.appendLine(line);
+		}
+	}
+
+	public dispose() {
+		this._tail.unwatch();
+
+		if (!fs.existsSync(this._path)) {
+			return;
+		}
+
+		const lines = fs.readFileSync(this._path, 'utf8').split('\n');
+
+		// Push remaining lines in case new line events haven't had time to
+		// fire up before unwatching. We skip lines that we've already seen and
+		// flush the rest.
+		for (let i = this._linesCounter + 1; i < lines.length; ++i) {
+			this.appendLine(lines[i]);
+		}
+	}
+}

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -157,6 +157,12 @@
           "default": "warn",
           "description": "%r.configuration.logLevel.description%"
         },
+        "positron.r.kernel.profile": {
+          "scope": "window",
+          "type": "string",
+          "default": null,
+          "description": "%r.configuration.profile.description%"
+        },
         "positron.r.kernel.env": {
           "scope": "window",
           "type": "object",

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -157,6 +157,13 @@
           "default": "warn",
           "description": "%r.configuration.logLevel.description%"
         },
+        "positron.r.kernel.logLevelExternal": {
+          "scope": "window",
+          "type": "string",
+          "default": "warn",
+          "title": "%r.configuration.logLevelExternal.title%",
+          "description": "%r.configuration.logLevelExternal.description%"
+        },
         "positron.r.kernel.profile": {
           "scope": "window",
           "type": "string",

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -585,7 +585,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.100"
+      "ark": "0.1.101"
     },
     "minimumRVersion": "4.2.0"
   }

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -40,6 +40,8 @@
 	"r.configuration.logLevel.debug.description": "Debug messages",
 	"r.configuration.logLevel.trace.description": "Verbose tracing messages",
 	"r.configuration.logLevel.description": "Log level for the R Kernel (shut down R and start a new R session to apply)",
+	"r.configuration.logLevelExternal.title": "Log level for external dependencies",
+	"r.configuration.logLevelExternal.description": "Log level for the external dependencies of the R kernel. Note that setting this to info or below will result in an enormous amount of log messages. You can also specify the level for specific crates, e.g. `warn,tokio=trace`. (Shut down R and start a new R session to apply.)",
 	"r.configuration.env.description": "Map of environment variables for the Ark kernel",
 	"r.configuration.profile.description": "Whether and how to profile Ark. Set to '*' for everything, '*>50' for all contexts taking more than 50ms, or 'foo>50' for contexts matching 'foo' taking more than 50ms (shut down R and start a new R session to apply).",
 	"r.configuration.packageTesting.description": "Explore and run testthat tests",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -41,7 +41,7 @@
 	"r.configuration.logLevel.trace.description": "Verbose tracing messages",
 	"r.configuration.logLevel.description": "Log level for the R Kernel (shut down R and start a new R session to apply)",
 	"r.configuration.env.description": "Map of environment variables for the Ark kernel",
-	"r.configuration.profile.description": "Whether and how to profile Ark. Set to '*' for everything, '*>50' for all contexts taking more than 50ms, or 'foo>50' for contexts matching 'foo' taking more than 50ms.\n\nFor this variable to take effect you need to shudown and then restart R. Just restarting doesn't work.",
+	"r.configuration.profile.description": "Whether and how to profile Ark. Set to '*' for everything, '*>50' for all contexts taking more than 50ms, or 'foo>50' for contexts matching 'foo' taking more than 50ms (shut down R and start a new R session to apply).",
 	"r.configuration.packageTesting.description": "Explore and run testthat tests",
 	"r.configuration.restoreWorkspace.description": "Restore the workspace from .RData on startup (shut down R and start a new R session to apply)",
 	"r.configuration.extraArguments.description": "Extra command-line arguments for R intialization",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -41,6 +41,7 @@
 	"r.configuration.logLevel.trace.description": "Verbose tracing messages",
 	"r.configuration.logLevel.description": "Log level for the R Kernel (shut down R and start a new R session to apply)",
 	"r.configuration.env.description": "Map of environment variables for the Ark kernel",
+	"r.configuration.profile.description": "Whether and how to profile Ark. Set to '*' for everything, '*>50' for all contexts taking more than 50ms, or 'foo>50' for contexts matching 'foo' taking more than 50ms.\n\nFor this variable to take effect you need to shudown and then restart R. Just restarting doesn't work.",
 	"r.configuration.packageTesting.description": "Explore and run testthat tests",
 	"r.configuration.restoreWorkspace.description": "Restore the workspace from .RData on startup (shut down R and start a new R session to apply)",
 	"r.configuration.extraArguments.description": "Extra command-line arguments for R intialization",

--- a/extensions/positron-r/src/jupyter-adapter.d.ts
+++ b/extensions/positron-r/src/jupyter-adapter.d.ts
@@ -77,6 +77,11 @@ export interface JupyterLanguageRuntimeSession extends positron.LanguageRuntimeS
 	showOutput(): void;
 
 	/**
+	 * Show profiler log if supported.
+	 */
+	showProfile?(): Thenable<void>;
+
+	/**
 	 * A Jupyter kernel is guaranteed to have a `callMethod()` method; it uses
 	 * the frontend comm to send a message to the kernel and wait for a
 	 * response.

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -671,7 +671,7 @@ export function createJupyterKernelSpec(
 	const env = <Record<string, string>>{
 		'POSITRON': '1',
 		'RUST_BACKTRACE': '1',
-		'RUST_LOG': logLevel,
+		'RUST_LOG': 'warn,ark=' + logLevel,
 		'R_HOME': rHomePath,
 		...userEnv
 	};

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -671,6 +671,7 @@ export function createJupyterKernelSpec(
 	// Check the R kernel log level setting
 	const config = vscode.workspace.getConfiguration('positron.r');
 	const logLevel = config.get<string>('kernel.logLevel') ?? 'warn';
+	const logLevelForeign = config.get<string>('kernel.logLevelExternal') ?? 'warn';
 	const userEnv = config.get<object>('kernel.env') ?? {};
 	const profile = config.get<string>('kernel.profile');
 
@@ -679,7 +680,7 @@ export function createJupyterKernelSpec(
 	const env = <Record<string, string>>{
 		'POSITRON': '1',
 		'RUST_BACKTRACE': '1',
-		'RUST_LOG': 'warn,ark=' + logLevel,
+		'RUST_LOG': logLevelForeign + ',ark=' + logLevel,
 		'R_HOME': rHomePath,
 		...userEnv
 	};

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -344,6 +344,13 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	}
 
 	/**
+	 * Show profiler log if supported.
+	 */
+	async showProfile() {
+		await this._kernel?.showProfile?.();
+	}
+
+	/**
 	 * Get the LANG env var and all categories of the locale, in R's Sys.getlocale() sense, from
 	 * the R session.
 	 */

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -797,6 +797,11 @@ declare module 'positron' {
 		 * Show runtime log in output panel.
 		 */
 		showOutput?(): void;
+
+		/**
+		 * Show profiler log if supported.
+		 */
+		showProfile?(): Thenable<void>;
 	}
 
 

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -517,6 +517,10 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 		return this._proxy.$showOutputLanguageRuntime(this.handle);
 	}
 
+	async showProfile(): Promise<void> {
+		return this._proxy.$showProfileLanguageRuntime(this.handle);
+	}
+
 	/**
 	 * Checks to see whether the runtime can be shut down or restarted.
 	 *

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -65,6 +65,7 @@ export interface ExtHostLanguageRuntimeShape {
 	$shutdownLanguageRuntime(handle: number, exitReason: RuntimeExitReason): Promise<void>;
 	$forceQuitLanguageRuntime(handle: number): Promise<void>;
 	$showOutputLanguageRuntime(handle: number): void;
+	$showProfileLanguageRuntime(handle: number): void;
 	$discoverLanguageRuntimes(): void;
 }
 

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -358,6 +358,17 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		return this._runtimeSessions[handle].showOutput!();
 	}
 
+	$showProfileLanguageRuntime(handle: number): Thenable<void> {
+		if (handle >= this._runtimeSessions.length) {
+			throw new Error(`Cannot show output for runtime: language runtime session handle '${handle}' not found or no longer valid.`);
+		}
+		if (!this._runtimeSessions[handle].showOutput) {
+			throw new Error(`Cannot show output for runtime: language runtime session handle '${handle}' does not implement profiling.`);
+		}
+		return this._runtimeSessions[handle].showProfile!();
+	}
+
+
 	$openResource(handle: number, resource: URI | string): Promise<boolean> {
 		if (handle >= this._runtimeSessions.length) {
 			throw new Error(`Cannot open resource: session handle '${handle}' not found or no longer valid.`);

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -360,10 +360,10 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 
 	$showProfileLanguageRuntime(handle: number): Thenable<void> {
 		if (handle >= this._runtimeSessions.length) {
-			throw new Error(`Cannot show output for runtime: language runtime session handle '${handle}' not found or no longer valid.`);
+			throw new Error(`Cannot show profile for runtime: language runtime session handle '${handle}' not found or no longer valid.`);
 		}
-		if (!this._runtimeSessions[handle].showOutput) {
-			throw new Error(`Cannot show output for runtime: language runtime session handle '${handle}' does not implement profiling.`);
+		if (!this._runtimeSessions[handle].showProfile) {
+			throw new Error(`Cannot show profile for runtime: language runtime session handle '${handle}' does not implement profiling.`);
 		}
 		return this._runtimeSessions[handle].showProfile!();
 	}

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -417,11 +417,18 @@ export function registerLanguageRuntimeActions() {
 	});
 
 	// Registers the show output language runtime action.
-	registerLanguageRuntimeAction('workbench.action.languageRuntime.showOutput', 'Show runtime output', async accessor => {
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.showOutput', 'Show interpreter output', async accessor => {
 		(await selectRunningLanguageRuntime(
 			accessor.get(IRuntimeSessionService),
 			accessor.get(IQuickInputService),
 			'Select the interpreter for which to show output'))?.showOutput();
+	});
+
+	registerLanguageRuntimeAction('workbench.action.languageRuntime.showProfile', 'Show interpreter profile report', async accessor => {
+		(await selectRunningLanguageRuntime(
+			accessor.get(IRuntimeSessionService),
+			accessor.get(IQuickInputService),
+			'Select the interpreter for which to show profile output'))?.showProfile();
 	});
 
 	registerLanguageRuntimeAction('workbench.action.language.runtime.openClient', 'Create Runtime Client Widget', async accessor => {

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -177,6 +177,9 @@ export interface ILanguageRuntimeSession {
 
 	/** Show output log of the runtime */
 	showOutput(): void;
+
+	/** Show profiler log of the runtime, if supported */
+	showProfile(): Thenable<void>;
 }
 
 /**


### PR DESCRIPTION
Frontend side of https://github.com/posit-dev/amalthea/pull/375

This PR adds a Profiler output channel for Ark. Users can enable profiling with the new `r.configuration.profile.description` setting which can be:

- `*` to profile everything.
- `*>50` to profile all contexts taking more than 50ms.
- `foo` or `foo>50` to profile contexts matching `foo` exactly.

There is a new command to open the profile report channel for the currently active runtime.

The `RUST_LOG` variable is now set to `warn,ark=*level*` instead of `*level*`. With the switch to the tracing crate, we now have a more flexible way of setting log levels for each crate. For instance `RUST_LOG=info,tokio=trace,ark=trace` sets the general log level to info, and sets the ark and tokio crates to trace. (In reality `ark` stands for Ark and all internal crates though.) If you set it to just `trace`, you get trace logs for everything. @DavisVaughan this is why you ended up with bad performance while reviewing.

The file watcher has been extracted into a new class `LogStreamer` which is now used for both the profiler and the log channels.