### PR TITLE
create `python.getCondaPythonVersions` command

### DIFF
--- a/extensions/positron-python/src/client/common/constants.ts
+++ b/extensions/positron-python/src/client/common/constants.ts
@@ -63,6 +63,7 @@ export namespace Commands {
     export const GetSelectedInterpreterPath = 'python.interpreterPath';
     // --- Start Positron ---
     export const Get_Create_Environment_Providers = 'python.getCreateEnvironmentProviders';
+    export const Get_Conda_Python_Versions = 'python.getCondaPythonVersions';
     // --- End Positron ---
     export const InstallJupyter = 'python.installJupyter';
     export const InstallPython = 'python.installPython';

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -22,6 +22,10 @@ import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { CreateEnvironmentOptionsInternal } from './types';
 
+// --- Start Positron ---
+import { getCondaPythonVersions } from './provider/condaUtils';
+// --- End Positron ---
+
 class CreateEnvironmentProviders {
     private _createEnvProviders: CreateEnvironmentProvider[] = [];
 
@@ -89,6 +93,7 @@ export function registerCreateEnvironmentFeatures(
             }));
             return providersForWizard;
         }),
+        registerCommand(Commands.Get_Conda_Python_Versions, () => getCondaPythonVersions()),
         // --- End Positron ---
         registerCreateEnvironmentProvider(new VenvCreationProvider(interpreterQuickPick)),
         registerCreateEnvironmentProvider(condaCreationProvider()),

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaUtils.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaUtils.ts
@@ -55,7 +55,7 @@ export async function getCondaBaseEnv(): Promise<string | undefined> {
 export async function pickPythonVersion(token?: CancellationToken): Promise<string | undefined> {
     // --- Start Positron ---
     const items: QuickPickItem[] = SUPPORTED_CONDA_PYTHON_VERSIONS.map((v) => ({
-    // --- End Positron ---
+        // --- End Positron ---
         label: v === RECOMMENDED_CONDA_PYTHON ? `${Octicons.Star} Python` : 'Python',
         description: v,
     }));

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaUtils.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaUtils.ts
@@ -20,6 +20,12 @@ import { deleteCondaEnvironment } from './condaDeleteUtils';
 
 const RECOMMENDED_CONDA_PYTHON = '3.11';
 
+// --- Start Positron ---
+// The first element is the recommended version. It is the first element so it gets displayed first in
+// UI that consumes this list.
+const SUPPORTED_CONDA_PYTHON_VERSIONS = [RECOMMENDED_CONDA_PYTHON, '3.12', '3.10', '3.9', '3.8'];
+// --- End Positron ---
+
 export async function getCondaBaseEnv(): Promise<string | undefined> {
     const conda = await Conda.getConda();
 
@@ -47,7 +53,9 @@ export async function getCondaBaseEnv(): Promise<string | undefined> {
 }
 
 export async function pickPythonVersion(token?: CancellationToken): Promise<string | undefined> {
-    const items: QuickPickItem[] = ['3.11', '3.12', '3.10', '3.9', '3.8'].map((v) => ({
+    // --- Start Positron ---
+    const items: QuickPickItem[] = SUPPORTED_CONDA_PYTHON_VERSIONS.map((v) => ({
+    // --- End Positron ---
         label: v === RECOMMENDED_CONDA_PYTHON ? `${Octicons.Star} Python` : 'Python',
         description: v,
     }));
@@ -67,6 +75,15 @@ export async function pickPythonVersion(token?: CancellationToken): Promise<stri
 
     return undefined;
 }
+
+// --- Start Positron ---
+export function getCondaPythonVersions(): { preferred: string; versions: string[] } {
+    return {
+        preferred: RECOMMENDED_CONDA_PYTHON,
+        versions: SUPPORTED_CONDA_PYTHON_VERSIONS,
+    };
+}
+// --- End Positron ---
 
 export function getPathEnvVariableForConda(condaBasePythonPath: string): string {
     const pathEnv = getEnvironmentVariable('PATH') || getEnvironmentVariable('Path') || '';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

- Create a command which allows us to retrieve the preferred version and supported versions of python for Conda environments
- This is for https://github.com/posit-dev/positron/issues/2839

### Approach

- Create a new `python.getCondaPythonVersions` command in the Python extension.
    - This command returns an object which indicates the preferred version of python as well as a list of supported python versions for a Conda environment.
- Tested by running the command and `console.log`ging the output
```ts
// pseudocode-ish local dev
const condaVersions = await commandService.executeCommand(
	'python.getCondaPythonVersions'
);
console.log(condaVersions);

// RESULT
{
    "preferred": "3.11",
    "versions": [
        "3.11",
        "3.12",
        "3.10",
        "3.9",
        "3.8"
    ]
}
```

### QA Notes

This command will be used in a future PR via the project wizard.
