### PR TITLE
Update issue reporter for public beta

### DIFF
--- a/product.json
+++ b/product.json
@@ -31,7 +31,7 @@
 	"darwinBundleIdentifier": "com.rstudio.positron",
 	"linuxIconName": "com.visualstudio.code.oss",
 	"licenseFileName": "LICENSE.txt",
-	"reportIssueUrl": "https://github.com/posit-dev/positron-beta/issues/new",
+	"reportIssueUrl": "https://github.com/posit-dev/positron/issues/new",
 	"nodejsRepository": "https://nodejs.org",
 	"urlProtocol": "positron",
 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/out/vs/workbench/contrib/webview/browser/pre/",

--- a/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
@@ -16,11 +16,15 @@ const reviewGuidanceLabel = localize( // intentionally not escaped because of it
 	{
 		key: 'reviewGuidanceLabel',
 		comment: [
-			'{Locked="<a href=\"https://github.com/posit-dev/positron-beta/wiki/Feedback-and-Issues\" target=\"_blank\">"}',
+			// --- Start Positron ---
+			'{Locked="<a href=\"https://github.com/posit-dev/positron/wiki/Feedback-and-Issues\" target=\"_blank\">"}',
+			// --- End Positron ---
 			'{Locked="</a>"}'
 		]
 	},
-	'Before you report an issue here please <a href="https://github.com/posit-dev/positron-beta/wiki/Feedback-and-Issues" target="_blank">review the guidance we provide</a>.'
+	// --- Start Positron ---
+	'Before you report an issue here please <a href="https://github.com/posit-dev/positron/wiki/Feedback-and-Issues" target="_blank">review the guidance we provide</a>.'
+	// --- End Positron ---
 );
 
 export default (): string => `

--- a/src/vs/code/electron-sandbox/issue/issueReporterService.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterService.ts
@@ -792,7 +792,9 @@ export class IssueReporter extends Disposable {
 
 		sourceSelect.innerText = '';
 		sourceSelect.append(this.makeOption('', localize('selectSource', "Select source"), true));
-		sourceSelect.append(this.makeOption(IssueSource.VSCode, localize('vscode', "Visual Studio Code"), false));
+		// --- Start Positron ---
+		sourceSelect.append(this.makeOption(IssueSource.VSCode, localize('positron', "Positron"), false));
+		// --- End Positron ---
 		sourceSelect.append(this.makeOption(IssueSource.Extension, localize('extension', "A VS Code extension"), false));
 		if (this.configuration.product.reportMarketplaceIssueUrl) {
 			sourceSelect.append(this.makeOption(IssueSource.Marketplace, localize('marketplace', "Extensions Marketplace"), false));
@@ -853,7 +855,9 @@ export class IssueReporter extends Disposable {
 		if (selectedExtension && this.nonGitHubIssueUrl) {
 			hide(titleTextArea);
 			hide(descriptionTextArea);
+			// --- Start Positron ---
 			reset(descriptionTitle, localize('handlesIssuesElsewhere', "This extension handles issues outside of Positron"));
+			// --- End Positron ---
 			reset(descriptionSubtitle, localize('elsewhereDescription', "The '{0}' extension prefers to use an external issue reporter. To be taken to that issue reporting experience, click the button below.", selectedExtension.displayName));
 			this.previewButton.label = localize('openIssueReporter', "Open External Issue Reporter");
 			return;

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -66,7 +66,7 @@ else {
 			applicationName: 'positron',
 			dataFolderName: '.positron',
 			urlProtocol: 'code-oss',
-			reportIssueUrl: 'https://github.com/posit-dev/positron-beta/issues/new',
+			reportIssueUrl: 'https://github.com/posit-dev/positron/issues/new',
 			licenseName: 'Software Evaluation License',
 			licenseUrl: 'https://github.com/posit-dev/positron-beta/tree/main?tab=License-1-ov-file',
 			serverLicenseUrl: 'https://github.com/posit-dev/positron-beta/tree/main?tab=License-1-ov-file'


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses #3226 

### Approach

I did originally fix this in #2454 but I forgot to put in the "Start Positron" fences 🙈 so it was undone in some intervening upstream merge. I also took this opportunity to move the GH URLs to our normal repo, not the private beta repo. Not a single private beta user has used this issue reporter so I think we can merge this now, but if we wanted to be very conservative, we could wait until closer to this repo being open.

### QA Notes

Under "Help" ➡️ "Report Issue", you should see this window:

![issue-reporter](https://github.com/posit-dev/positron/assets/12505835/382d66b4-c1c4-47a1-8ae7-782a3f722af4)

The top link should go the wiki and and previewing will show you an issue preview on our regular repo.
