### PR TITLE
Data Explorer: Add data explorer support for pandas.Series, do not open data explorer for polars for now

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -593,6 +593,44 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
     assert result == _wrap_json(ColumnSchema, bigger_schema[10:20])
 
 
+def test_pandas_series(dxf: DataExplorerFixture):
+    series = SIMPLE_PANDAS_DF["a"]
+    dxf.register_table("series", series)
+    dxf.register_table("expected", pd.DataFrame({"a": series}))
+
+    schema = dxf.get_schema("series")
+    assert schema == _wrap_json(
+        ColumnSchema,
+        [
+            {
+                "column_name": "a",
+                "column_index": 0,
+                "type_name": "int64",
+                "type_display": "number",
+            },
+        ],
+    )
+
+    dxf.compare_tables("series", "expected", (len(series), 1))
+
+    # Test schema when name attribute is None
+    series2 = series.copy()
+    series2.name = None
+    dxf.register_table("series2", series2)
+    schema = dxf.get_schema("series2")
+    assert schema == _wrap_json(
+        ColumnSchema,
+        [
+            {
+                "column_name": "unnamed",
+                "column_index": 0,
+                "type_name": "int64",
+                "type_display": "number",
+            },
+        ],
+    )
+
+
 def test_pandas_wide_schemas(dxf: DataExplorerFixture):
     arr = np.arange(10).astype(object)
 
@@ -1863,7 +1901,14 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="US/Eastern")}
             ),
             pd.DataFrame(
-                {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="Asia/Hong_Kong")}
+                {
+                    "x": pd.date_range(
+                        "2000-01-01",
+                        freq="2h",
+                        periods=50,
+                        tz="Asia/Hong_Kong",
+                    )
+                }
             ),
         ]
     )
@@ -1875,7 +1920,14 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="US/Eastern")}
             ),
             pd.DataFrame(
-                {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="Asia/Hong_Kong")}
+                {
+                    "x": pd.date_range(
+                        "2000-01-01",
+                        freq="2h",
+                        periods=50,
+                        tz="Asia/Hong_Kong",
+                    )
+                }
             ),
         ]
     )

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
@@ -16,7 +16,11 @@ import polars as pl
 import pytest
 from fastcore.foundation import L
 
-from positron_ipykernel.inspectors import PRINT_WIDTH, TRUNCATE_AT, get_inspector
+from positron_ipykernel.inspectors import (
+    PRINT_WIDTH,
+    TRUNCATE_AT,
+    get_inspector,
+)
 from positron_ipykernel.utils import get_qualname
 from positron_ipykernel.variables_comm import VariableKind
 
@@ -673,7 +677,7 @@ def test_inspect_pandas_dataframe() -> None:
 
     verify_inspector(
         value=value,
-        display_value=f"[{rows} rows x {cols} columns] {get_type_as_str(value)}",
+        display_value=f"[{rows} rows x {cols} columns] pandas.DataFrame",
         kind=VariableKind.Table,
         display_type=f"DataFrame [{rows}x{cols}]",
         type_info=get_type_as_str(value),
@@ -720,11 +724,12 @@ def test_inspect_pandas_series() -> None:
 
     verify_inspector(
         value=value,
-        display_value="[0, 1]",
-        kind=VariableKind.Map,
+        display_value="[2 values] pandas.Series",
+        kind=VariableKind.Table,
         display_type=f"int64 [{rows}]",
         type_info=get_type_as_str(value),
         has_children=True,
+        has_viewer=True,
         is_truncated=True,
         length=rows,
         mutable=True,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -23,7 +23,13 @@ from comm.base_comm import BaseComm
 from .access_keys import decode_access_key, encode_access_key
 from .inspectors import get_inspector
 from .positron_comm import CommMessage, JsonRpcErrorCode, PositronComm
-from .utils import JsonData, JsonRecord, cancel_tasks, create_task, get_qualname
+from .utils import (
+    JsonData,
+    JsonRecord,
+    cancel_tasks,
+    create_task,
+    get_qualname,
+)
 from .variables_comm import (
     ClearRequest,
     ClipboardFormatFormat,
@@ -144,7 +150,10 @@ class VariablesService:
             logger.warning(f"Unhandled request: {request}")
 
     def _send_update(
-        self, assigned: Mapping[str, Any], unevaluated: Mapping[str, Any], removed: Set[str]
+        self,
+        assigned: Mapping[str, Any],
+        unevaluated: Mapping[str, Any],
+        removed: Set[str],
     ) -> None:
         """
         Sends the list of variables that have changed in the current
@@ -332,7 +341,9 @@ class VariablesService:
         copied = repr(list(self._snapshot["mutable_copied"].keys()))
         logger.debug(f"Variables copied: {copied}")
 
-    def _compare_user_ns(self) -> Tuple[Dict[str, Any], Dict[str, Any], Set[str]]:
+    def _compare_user_ns(
+        self,
+    ) -> Tuple[Dict[str, Any], Dict[str, Any], Set[str]]:
         """
         Attempts to detect changes to variables in the user's environment.
 
@@ -573,7 +584,7 @@ class VariablesService:
 
         if self.kernel.connections_service.object_is_supported(value):
             self._open_connections_pane(path, value)
-        else:
+        elif self.kernel.data_explorer_service.is_supported(value):
             self._open_data_explorer(path, value)
 
     def _open_data_explorer(self, path: List[str], value: Any) -> None:


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

Addresses #3189 (by not opening a data explorer for polars objects) and #2215 (by treating a pandas.Series as a DataFrame with one column). 

![image](https://github.com/posit-dev/positron/assets/329591/8dfe8a07-ec6e-4f84-a05b-7ef12cda5635)

Series is reclassified as "table" so it shows up as data in the data viewer. 

### QA Notes

You can test this by opening a data explorer for a pandas.Series (e.g. assigning a variable like `series = df[any_column_name]`), and by trying to open a data explorer for polars.DataFrame (no longer possible) 