### PR TITLE
Data Explorer: Fix filtering with DatetimeTZ dtype, also handle TypeError when filter evaluation fails

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -4,6 +4,7 @@
 
 # ruff: noqa: E712
 
+from datetime import datetime
 from io import StringIO
 from typing import Any, Dict, List, Optional, Type, cast
 
@@ -1039,6 +1040,27 @@ def test_pandas_filter_compare(dxf: DataExplorerFixture):
     for op, op_func in COMPARE_OPS.items():
         filt = _compare_filter(schema[0], op, 3)
         expected_df = df[op_func(df[column], 3)]
+        dxf.check_filter_case(df, [filt], expected_df)
+
+
+def test_pandas_filter_datetimetz(dxf: DataExplorerFixture):
+    import pytz
+
+    tz = pytz.timezone("US/Eastern")
+
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2000-01-01", periods=5, tz="US/Eastern"),
+        }
+    )
+    dxf.register_table("dtz", df)
+    schema = dxf.get_schema("dtz")
+
+    val = datetime(2000, 1, 3, tzinfo=tz)
+
+    for op, op_func in COMPARE_OPS.items():
+        filt = _compare_filter(schema[0], op, "2000-01-03")
+        expected_df = df[op_func(df["date"], val)]
         dxf.check_filter_case(df, [filt], expected_df)
 
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://connect.posit.it/positron-wiki/pull-requests.html
* Ensure that the code is up-to-date with the `main` branch.
-->

Addresses #3285. I also noticed that the TypeError that was being raised was not showing up in the filter error message in the UI, so future TypeErrors will show up as red errors as expected.

### QA Notes

The example from the issue report should work correctly now. 