### PR TITLE
Fix image scaling for dynamic plots

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
@@ -151,6 +151,7 @@
 	position: relative;
 }
 
+.plot-instance .image-wrapper img,
 .plot-thumbnail .image-wrapper img {
 	display: block;
 	max-width: 100%;


### PR DESCRIPTION
### Intent
Address #3349 

### Approach
Undo the unnecessary css change from static plot panning.

### QA Notes
It can only be reproduced on a retina or scaled resolution display. It might be possible to reproduce in Windows by setting the display scaling to 200% but the easiest way to reproduce is on a Mac retina display.

Reprex:
```python
# importing the required module 
import matplotlib.pyplot as plt 
	
# x axis values 
x = [1,2,3] 
# corresponding y axis values 
y = [2,4,1] 
	
# plotting the points 
plt.plot(x, y) 
	
# naming the x axis 
plt.xlabel('x - axis') 
# naming the y axis 
plt.ylabel('y - axis') 
	
# giving a title to my graph 
plt.title('My first graph!') 
	
# function to show the plot 
plt.show() 
```