### PR TITLE
Wait for zombie subprocesses so they don't stall the shutdown sequence

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -485,7 +485,9 @@ class PositronIPyKernel(IPythonKernel):
                 try:
                     child.wait(timeout=1)
                 except psutil.TimeoutExpired as exception:
-                    self.log.warning("Timeout waiting for zombie subprocess to terminate %s", exception)
+                    self.log.warning(
+                        "Timeout waiting for zombie subprocess to terminate %s", exception
+                    )
 
         await super()._progressively_terminate_all_children()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -482,7 +482,10 @@ class PositronIPyKernel(IPythonKernel):
         for child in children:
             if child.status() == "zombie":
                 self.log.debug("Waiting 1 second for zombie subprocess to terminate %s", child)
-                child.wait(timeout=1)
+                try:
+                    child.wait(timeout=1)
+                except psutil.TimeoutExpired as exception:
+                    self.log.warning("Timeout waiting for zombie subprocess to terminate %s", exception)
 
         await super()._progressively_terminate_all_children()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -489,7 +489,9 @@ class PositronIPyKernel(IPythonKernel):
                     # raise a TimeoutExpired.
                     child.wait(timeout=0)
                 except psutil.TimeoutExpired as exception:
-                    self.log.warning("Error while reaping zombie subprocess %s: %s", child, exception)
+                    self.log.warning(
+                        "Error while reaping zombie subprocess %s: %s", child, exception
+                    )
 
     # monkey patching warning.showwarning is recommended by the official documentation
     # https://docs.python.org/3/library/warnings.html#warnings.showwarning


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Address https://github.com/posit-dev/positron/issues/3344.