### PR TITLE
Create new Conda env for Python-based Project

### DIFF
--- a/extensions/positron-python/src/client/common/constants.ts
+++ b/extensions/positron-python/src/client/common/constants.ts
@@ -62,6 +62,7 @@ export namespace Commands {
     // --- End Positron ---
     export const GetSelectedInterpreterPath = 'python.interpreterPath';
     // --- Start Positron ---
+    export const Create_Environment_And_Register = 'python.createEnvironmentAndRegister';
     export const Get_Create_Environment_Providers = 'python.getCreateEnvironmentProviders';
     export const Get_Conda_Python_Versions = 'python.getCondaPythonVersions';
     // --- End Positron ---

--- a/extensions/positron-python/src/client/extensionActivation.ts
+++ b/extensions/positron-python/src/client/extensionActivation.ts
@@ -53,6 +53,10 @@ import { logAndNotifyOnLegacySettings } from './logging/settingLogs';
 import { DebuggerTypeName } from './debugger/constants';
 import { StopWatch } from './common/utils/stopWatch';
 
+// --- Start Positron ---
+import { IPythonRuntimeManager } from './positron/manager';
+// --- End Positron ---
+
 export async function activateComponents(
     // `ext` is passed to any extra activation funcs.
     ext: ExtensionState,
@@ -98,12 +102,22 @@ export function activateFeatures(ext: ExtensionState, _components: Components): 
         IInterpreterService,
     );
     const pathUtils = ext.legacyIOC.serviceContainer.get<IPathUtils>(IPathUtils);
+
+    // --- Start Positron ---
+    const pythonRuntimeManager: IPythonRuntimeManager = ext.legacyIOC.serviceContainer.get<IPythonRuntimeManager>(
+        IPythonRuntimeManager,
+    );
+    // --- End Positron ---
+
     registerAllCreateEnvironmentFeatures(
         ext.disposables,
         interpreterQuickPick,
         interpreterPathService,
         interpreterService,
         pathUtils,
+        // --- Start Positron ---
+        pythonRuntimeManager,
+        // --- End Positron ---
     );
 }
 

--- a/extensions/positron-python/src/client/positron/extension.ts
+++ b/extensions/positron-python/src/client/positron/extension.ts
@@ -66,6 +66,22 @@ export async function activatePositron(serviceContainer: IServiceContainer): Pro
                 }
             }),
         );
+        // Register a command to validate the pythonPath of a given interpreter.
+        disposables.push(
+            vscode.commands.registerCommand(
+                'python.validateInterpreterPath',
+                async (pythonPath: string): Promise<string | undefined> => {
+                    const interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
+                    const interpreter = await interpreterService.getInterpreterDetails(pythonPath);
+                    if (!interpreter) {
+                        return undefined;
+                    }
+                    // If the interpreter was found, return the actual path associated with the interpreter.
+                    // It may or may not be the same as the path passed in.
+                    return interpreter.path;
+                },
+            ),
+        );
         // Register a command to get the minimum version of python supported by the extension.
         disposables.push(
             vscode.commands.registerCommand('python.getMinimumPythonVersion', (): string => MINIMUM_PYTHON_VERSION.raw),

--- a/extensions/positron-python/src/client/positron/extension.ts
+++ b/extensions/positron-python/src/client/positron/extension.ts
@@ -66,22 +66,6 @@ export async function activatePositron(serviceContainer: IServiceContainer): Pro
                 }
             }),
         );
-        // Register a command to validate the pythonPath of a given interpreter.
-        disposables.push(
-            vscode.commands.registerCommand(
-                'python.validateInterpreterPath',
-                async (pythonPath: string): Promise<string | undefined> => {
-                    const interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
-                    const interpreter = await interpreterService.getInterpreterDetails(pythonPath);
-                    if (!interpreter) {
-                        return undefined;
-                    }
-                    // If the interpreter was found, return the actual path associated with the interpreter.
-                    // It may or may not be the same as the path passed in.
-                    return interpreter.path;
-                },
-            ),
-        );
         // Register a command to get the minimum version of python supported by the extension.
         disposables.push(
             vscode.commands.registerCommand('python.getMinimumPythonVersion', (): string => MINIMUM_PYTHON_VERSION.raw),

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// --- Start Positron ---
+// eslint-disable-next-line import/no-unresolved
+import { LanguageRuntimeMetadata } from 'positron';
+// --- End Positron ---
+
 import { ConfigurationTarget, Disposable } from 'vscode';
 import { Commands } from '../../common/constants';
 import { IDisposableRegistry, IInterpreterPathService, IPathUtils } from '../../common/types';
@@ -24,6 +29,7 @@ import { CreateEnvironmentOptionsInternal } from './types';
 
 // --- Start Positron ---
 import { getCondaPythonVersions } from './provider/condaUtils';
+import { IPythonRuntimeManager } from '../../positron/manager';
 // --- End Positron ---
 
 class CreateEnvironmentProviders {
@@ -65,6 +71,9 @@ export function registerCreateEnvironmentFeatures(
     interpreterQuickPick: IInterpreterQuickPick,
     interpreterPathService: IInterpreterPathService,
     pathUtils: IPathUtils,
+    // --- Start Positron ---
+    pythonRuntimeManager: IPythonRuntimeManager,
+    // --- End Positron ---
 ): void {
     disposables.push(
         registerCommand(
@@ -93,6 +102,19 @@ export function registerCreateEnvironmentFeatures(
             }));
             return providersForWizard;
         }),
+        registerCommand(Commands.Create_Environment_And_Register,
+            async (
+                options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
+            ): Promise<CreateEnvironmentResult & { metadata?: LanguageRuntimeMetadata } | undefined> => {
+                const providers = _createEnvironmentProviders.getAll();
+                const result = await handleCreateEnvironmentCommand(providers, options);
+                if (result?.path) {
+                    const metadata = await pythonRuntimeManager.registerLanguageRuntimeFromPath(result.path);
+                    return { ...result, metadata };
+                }
+                return result;
+            },
+        ),
         registerCommand(Commands.Get_Conda_Python_Versions, () => getCondaPythonVersions()),
         // --- End Positron ---
         registerCreateEnvironmentProvider(new VenvCreationProvider(interpreterQuickPick)),

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -102,10 +102,11 @@ export function registerCreateEnvironmentFeatures(
             }));
             return providersForWizard;
         }),
-        registerCommand(Commands.Create_Environment_And_Register,
+        registerCommand(
+            Commands.Create_Environment_And_Register,
             async (
                 options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
-            ): Promise<CreateEnvironmentResult & { metadata?: LanguageRuntimeMetadata } | undefined> => {
+            ): Promise<(CreateEnvironmentResult & { metadata?: LanguageRuntimeMetadata }) | undefined> => {
                 const providers = _createEnvironmentProviders.getAll();
                 const result = await handleCreateEnvironmentCommand(providers, options);
                 if (result?.path) {

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaCreationProvider.ts
@@ -205,26 +205,22 @@ async function createEnvironment(
     const versionStep = new MultiStepNode(
         workspaceStep,
         async (context) => {
-            if (
+            // --- Start Positron ---
+            if (existingCondaAction === ExistingCondaAction.Create && options?.condaPythonVersion) {
+                version = options.condaPythonVersion;
+            } else if (
+                // --- End Positron ---
                 existingCondaAction === ExistingCondaAction.Recreate ||
                 existingCondaAction === ExistingCondaAction.Create
             ) {
-                // --- Start Positron ---
-                if (options?.condaPythonVersion) {
-                    version = options.condaPythonVersion;
-                } else {
-                    // --- End Positron ---
-                    try {
-                        version = await pickPythonVersion();
-                    } catch (ex) {
-                        if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-                            return ex;
-                        }
-                        throw ex;
+                try {
+                    version = await pickPythonVersion();
+                } catch (ex) {
+                    if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+                        return ex;
                     }
-                    // --- Start Positron ---
+                    throw ex;
                 }
-                // --- End Positron ---
                 if (version === undefined) {
                     traceError('Python version was not selected for creating conda environment.');
                     return MultiStepAction.Cancel;

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaCreationProvider.ts
@@ -5,7 +5,7 @@ import { CancellationToken, ProgressLocation, WorkspaceFolder } from 'vscode';
 import * as path from 'path';
 import { Commands, PVSC_EXTENSION_ID } from '../../../common/constants';
 import { traceError, traceInfo, traceLog } from '../../../logging';
-import { CreateEnvironmentProgress } from '../types';
+import { CreateEnvironmentOptionsInternal, CreateEnvironmentProgress } from '../types';
 import { pickWorkspaceFolder } from '../common/workspaceSelection';
 import { execObservable } from '../../../common/process/rawProcessApis';
 import { createDeferred } from '../../../common/utils/async';
@@ -145,7 +145,11 @@ function getExecutableCommand(condaBaseEnvPath: string): string {
     return path.join(condaBaseEnvPath, 'bin', 'python');
 }
 
-async function createEnvironment(options?: CreateEnvironmentOptions): Promise<CreateEnvironmentResult | undefined> {
+async function createEnvironment(
+    // --- Start Positron ---
+    options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
+): Promise<CreateEnvironmentResult | undefined> {
+    // --- End Positron ---
     const conda = await getCondaBaseEnv();
     if (!conda) {
         return undefined;
@@ -205,14 +209,22 @@ async function createEnvironment(options?: CreateEnvironmentOptions): Promise<Cr
                 existingCondaAction === ExistingCondaAction.Recreate ||
                 existingCondaAction === ExistingCondaAction.Create
             ) {
-                try {
-                    version = await pickPythonVersion();
-                } catch (ex) {
-                    if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
-                        return ex;
+                // --- Start Positron ---
+                if (options?.condaPythonVersion) {
+                    version = options.condaPythonVersion;
+                } else {
+                    // --- End Positron ---
+                    try {
+                        version = await pickPythonVersion();
+                    } catch (ex) {
+                        if (ex === MultiStepAction.Back || ex === MultiStepAction.Cancel) {
+                            return ex;
+                        }
+                        throw ex;
                     }
-                    throw ex;
+                    // --- Start Positron ---
                 }
+                // --- End Positron ---
                 if (version === undefined) {
                     traceError('Python version was not selected for creating conda environment.');
                     return MultiStepAction.Cancel;

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/venvCreationProvider.ts
@@ -212,9 +212,8 @@ export class VenvCreationProvider implements CreateEnvironmentProvider {
                     // --- Start Positron ---
                     if (existingVenvAction === ExistingVenvAction.Create && options?.interpreterPath) {
                         interpreter = options.interpreterPath;
-                    }
-                    // --- End Positron ---
-                    else if (
+                    } else if (
+                        // --- End Positron ---
                         existingVenvAction === ExistingVenvAction.Recreate ||
                         existingVenvAction === ExistingVenvAction.Create
                     ) {

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/registrations.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/registrations.ts
@@ -21,11 +21,17 @@ export function registerAllCreateEnvironmentFeatures(
     interpreterService: IInterpreterService,
     pathUtils: IPathUtils,
     // --- Start Positron ---
-    pythonRuntimeManager: IPythonRuntimeManager
+    pythonRuntimeManager: IPythonRuntimeManager,
     // --- End Positron ---
 ): void {
     // --- Start Positron ---
-    registerCreateEnvironmentFeatures(disposables, interpreterQuickPick, interpreterPathService, pathUtils, pythonRuntimeManager);
+    registerCreateEnvironmentFeatures(
+        disposables,
+        interpreterQuickPick,
+        interpreterPathService,
+        pathUtils,
+        pythonRuntimeManager,
+    );
     // --- End Positron ---
     registerCreateEnvironmentButtonFeatures(disposables);
     registerPyProjectTomlFeatures(disposables);

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/registrations.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/registrations.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// --- Start Positron ---
+import { IPythonRuntimeManager } from '../../positron/manager';
+// --- End Positron ---
+
 import { IDisposableRegistry, IInterpreterPathService, IPathUtils } from '../../common/types';
 import { IInterpreterQuickPick } from '../../interpreter/configuration/types';
 import { IInterpreterService } from '../../interpreter/contracts';
@@ -16,8 +20,13 @@ export function registerAllCreateEnvironmentFeatures(
     interpreterPathService: IInterpreterPathService,
     interpreterService: IInterpreterService,
     pathUtils: IPathUtils,
+    // --- Start Positron ---
+    pythonRuntimeManager: IPythonRuntimeManager
+    // --- End Positron ---
 ): void {
-    registerCreateEnvironmentFeatures(disposables, interpreterQuickPick, interpreterPathService, pathUtils);
+    // --- Start Positron ---
+    registerCreateEnvironmentFeatures(disposables, interpreterQuickPick, interpreterPathService, pathUtils, pythonRuntimeManager);
+    // --- End Positron ---
     registerCreateEnvironmentButtonFeatures(disposables);
     registerPyProjectTomlFeatures(disposables);
     registerInstalledPackagesDiagnosticsProvider(disposables, interpreterService);

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/types.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/types.ts
@@ -10,5 +10,6 @@ export interface CreateEnvironmentOptionsInternal {
     providerId?: string;
     // --- Start Positron ---
     interpreterPath?: string;
+    condaPythonVersion?: string;
     // --- End Positron ---
 }

--- a/extensions/positron-python/src/test/pythonEnvironments/creation/createEnvApi.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/creation/createEnvApi.unit.test.ts
@@ -59,7 +59,7 @@ suite('Create Environment APIs', () => {
             interpreterPathService.object,
             pathUtils.object,
             // --- Start Positron ---
-            pythonRuntimeManager.object
+            pythonRuntimeManager.object,
             // --- End Positron ---
         );
     });

--- a/extensions/positron-python/src/test/pythonEnvironments/creation/createEnvApi.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/creation/createEnvApi.unit.test.ts
@@ -15,6 +15,10 @@ import * as windowApis from '../../../client/common/vscodeApis/windowApis';
 import { handleCreateEnvironmentCommand } from '../../../client/pythonEnvironments/creation/createEnvironment';
 import { CreateEnvironmentProvider } from '../../../client/pythonEnvironments/creation/proposed.createEnvApis';
 
+// --- Start Positron ---
+import { IPythonRuntimeManager } from '../../../client/positron/manager';
+// --- End Positron ---
+
 chaiUse(chaiAsPromised);
 
 suite('Create Environment APIs', () => {
@@ -25,6 +29,9 @@ suite('Create Environment APIs', () => {
     let interpreterQuickPick: typemoq.IMock<IInterpreterQuickPick>;
     let interpreterPathService: typemoq.IMock<IInterpreterPathService>;
     let pathUtils: typemoq.IMock<IPathUtils>;
+    // --- Start Positron ---
+    let pythonRuntimeManager: typemoq.IMock<IPythonRuntimeManager>;
+    // --- End Positron ---
 
     setup(() => {
         showQuickPickStub = sinon.stub(windowApis, 'showQuickPick');
@@ -34,6 +41,9 @@ suite('Create Environment APIs', () => {
         interpreterQuickPick = typemoq.Mock.ofType<IInterpreterQuickPick>();
         interpreterPathService = typemoq.Mock.ofType<IInterpreterPathService>();
         pathUtils = typemoq.Mock.ofType<IPathUtils>();
+        // --- Start Positron ---
+        pythonRuntimeManager = typemoq.Mock.ofType<IPythonRuntimeManager>();
+        // --- End Positron ---
 
         registerCommandStub.callsFake((_command: string, _callback: (...args: any[]) => any) => ({
             dispose: () => {
@@ -48,6 +58,9 @@ suite('Create Environment APIs', () => {
             interpreterQuickPick.object,
             interpreterPathService.object,
             pathUtils.object,
+            // --- Start Positron ---
+            pythonRuntimeManager.object
+            // --- End Positron ---
         );
     });
     teardown(() => {

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -82,7 +82,8 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 		// Interpreters are always available for Conda because we display the supported versions
 		// that an environment can be created with.
 		Boolean(context.usesCondaEnv && condaPythonVersionInfo);
-	const interpretersLoading = () => !interpreters && !condaPythonVersionInfo;
+	const interpretersLoading = () =>
+		!interpreters || Boolean(context.usesCondaEnv && !condaPythonVersionInfo);
 	const envProvidersAvailable = () => Boolean(envProviders && envProviders.length);
 	const envProvidersLoading = () => !envProviders;
 

--- a/src/vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums.ts
@@ -42,11 +42,3 @@ export enum PythonRuntimeFilter {
 	Global = 'Global',
 	Pyenv = 'Pyenv'
 }
-
-/**
- * LanguageIds enum.
- */
-export enum LanguageIds {
-	Python = 'python',
-	R = 'r'
-}

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -126,6 +126,7 @@ export const showNewProjectModalDialog = async (
 						pythonEnvProviderId: result.pythonEnvProviderId,
 						pythonEnvProviderName: result.pythonEnvProviderName,
 						installIpykernel: result.installIpykernel,
+						condaPythonVersion: result.condaPythonVersion,
 						useRenv: result.useRenv,
 					};
 

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -725,17 +725,6 @@ export class NewProjectWizardStateManager
 				(await this._services.commandService.executeCommand(
 					'python.getCreateEnvironmentProviders'
 				)) ?? [];
-
-			// TODO: remove this extra check once the Conda provider is enabled by default.
-			// If work-in-progress functionality is disabled, remove the Conda provider.
-			if (!this.wipFunctionalityEnabled()) {
-				const condaIndex = this._pythonEnvProviders.findIndex(
-					(provider) => provider.name === PythonEnvironmentProvider.Conda
-				);
-				if (condaIndex !== -1) {
-					this._pythonEnvProviders.splice(condaIndex, 1);
-				}
-			}
 		}
 
 		if (!this._pythonEnvProviderId) {

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -127,7 +127,7 @@ export class NewProjectWizardStateManager
 
 	// Dynamically populated data as the state changes.
 	private _runtimeStartupComplete: boolean;
-	private _pythonEnvProviders: PythonEnvironmentProviderInfo[];
+	private _pythonEnvProviders: PythonEnvironmentProviderInfo[] | undefined;
 	private _interpreters: ILanguageRuntimeMetadata[] | undefined;
 	private _preferredInterpreter: ILanguageRuntimeMetadata | undefined;
 
@@ -158,7 +158,7 @@ export class NewProjectWizardStateManager
 		this._useRenv = undefined;
 		this._steps = config.steps ?? [config.initialStep];
 		this._currentStep = config.initialStep;
-		this._pythonEnvProviders = [];
+		this._pythonEnvProviders = undefined;
 		this._interpreters = undefined;
 		this._preferredInterpreter = undefined;
 		this._runtimeStartupComplete = false;
@@ -421,7 +421,7 @@ export class NewProjectWizardStateManager
 	/**
 	 * Gets the Python environment providers.
 	 */
-	get pythonEnvProviders(): PythonEnvironmentProviderInfo[] {
+	get pythonEnvProviders(): PythonEnvironmentProviderInfo[] | undefined {
 		return this._pythonEnvProviders;
 	}
 
@@ -567,7 +567,7 @@ export class NewProjectWizardStateManager
 	 */
 	private async _initDefaultsFromExtensions() {
 		// Set the Python environment providers.
-		if (!this.pythonEnvProviders.length) {
+		if (!this.pythonEnvProviders?.length) {
 			await this._setPythonEnvProviders();
 		}
 
@@ -677,7 +677,7 @@ export class NewProjectWizardStateManager
 	 * @returns The name of the selected Python environment provider.
 	 */
 	private _getEnvProviderName(): string | undefined {
-		if (!this._pythonEnvProviderId) {
+		if (!this._pythonEnvProviderId || !this._pythonEnvProviders) {
 			return undefined;
 		}
 		return this._pythonEnvProviders.find(
@@ -720,7 +720,7 @@ export class NewProjectWizardStateManager
 	 * Sets the Python environment providers by calling the Python extension.
 	 */
 	private async _setPythonEnvProviders() {
-		if (!this._pythonEnvProviders.length) {
+		if (!this._pythonEnvProviders?.length) {
 			this._pythonEnvProviders =
 				(await this._services.commandService.executeCommand(
 					'python.getCreateEnvironmentProviders'

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -866,7 +866,7 @@ export class NewProjectWizardStateManager
 			if (this._usesCondaEnv()) {
 				this._selectedRuntime = undefined;
 			} else {
-				this._condaPythonVersionInfo = undefined;
+				this._condaPythonVersion = undefined;
 			}
 		} else if (langId === LanguageIds.R) {
 			this._pythonEnvSetupType = undefined;

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -7,7 +7,7 @@ import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { ILanguageRuntimeMetadata, ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IRuntimeStartupService, RuntimeStartupPhase } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
-import { EnvironmentSetupType, LanguageIds, NewProjectWizardStep, PythonEnvironmentProvider, PythonRuntimeFilter } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
+import { EnvironmentSetupType, NewProjectWizardStep, PythonEnvironmentProvider, PythonRuntimeFilter } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ILogService } from 'vs/platform/log/common/log';
@@ -19,7 +19,7 @@ import { PythonEnvironmentProviderInfo } from 'vs/workbench/browser/positronNewP
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Emitter, Event } from 'vs/base/common/event';
 import { WizardFormattedTextItem } from 'vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText';
-import { NewProjectType } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
+import { LanguageIds, NewProjectType } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { projectWizardWorkInProgressEnabled } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 import { CondaPythonVersionInfo } from 'vs/workbench/browser/positronNewProjectWizard/utilities/condaUtils';

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/condaUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/condaUtils.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DropDownListBoxItem } from 'vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBoxItem';
+import { PythonEnvironmentProvider } from 'vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums';
+import { InterpreterInfo } from 'vs/workbench/browser/positronNewProjectWizard/utilities/interpreterDropDownUtils';
+
+/**
+ * CondaPythonVersionInfo interface.
+ */
+export interface CondaPythonVersionInfo {
+	preferred: string;
+	versions: string[];
+}
+
+/**
+ * Converts a CondaPythonVersionInfo object to DropDownListBoxItem objects.
+ * Conda environments have special handling because the Python interpreters exist until the conda
+ * environment is created. As such, we only have the python versions available to us at this point.
+ * @param versionInfo The CondaPythonVersionInfo object to convert.
+ * @returns The array of DropDownListBoxItem objects.
+ */
+export const condaInterpretersToDropdownItems = (
+	versionInfo: CondaPythonVersionInfo | undefined
+) => {
+	if (!versionInfo) {
+		return [];
+	}
+	return versionInfo.versions.map(
+		(version: string) =>
+			new DropDownListBoxItem<string, InterpreterInfo>({
+				identifier: version,
+				value: {
+					preferred: version === versionInfo.preferred,
+					runtimeId: version,
+					languageName: 'Python',
+					languageVersion: version,
+					runtimePath: '',
+					runtimeSource: PythonEnvironmentProvider.Conda,
+				},
+			})
+	);
+};

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/interpreterDropDownUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/interpreterDropDownUtils.ts
@@ -24,39 +24,12 @@ export interface InterpreterInfo {
  * runtime source if requested.
  * @param interpreters The interpreters to convert to DropDownListBoxItems.
  * @param preferredRuntimeId The runtime ID of the preferred interpreter.
- * @param isConda A temporary flag to retrieve hardcoded Conda interpreters.
  * @returns An array of DropDownListBoxEntry for the interpreters.
  */
 export const interpretersToDropdownItems = (
 	interpreters: ILanguageRuntimeMetadata[],
 	preferredRuntimeId?: string,
-	isConda?: boolean
 ) => {
-	if (isConda) {
-		// TODO: we should get the list of Python versions from the Conda service via the new project
-		// wizard state. For now, we'll hardcode the list of Python versions.
-		// see extensions/positron-python/src/client/pythonEnvironments/creation/provider/condaUtils.ts
-		// pickPythonVersion function
-		const pythonVersions = ['3.12', '3.11', '3.10', '3.9', '3.8'];
-		const condaRuntimes: DropDownListBoxItem<string, InterpreterInfo>[] = [];
-		pythonVersions.forEach((version) => {
-			condaRuntimes.push(
-				new DropDownListBoxItem<string, InterpreterInfo>({
-					identifier: `conda-python-${version}`,
-					value: {
-						preferred: version === '3.12',
-						runtimeId: `conda-python-${version}`,
-						languageName: 'Python',
-						languageVersion: version,
-						runtimePath: '',
-						runtimeSource: 'Conda',
-					},
-				})
-			);
-		});
-		return condaRuntimes;
-	}
-
 	// Return the DropDownListBoxEntry array.
 	return interpreters
 		.reduce<DropDownListBoxEntry<string, InterpreterInfo>[]>(

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/pythonEnvironmentStepUtils.ts
@@ -19,7 +19,7 @@ export interface PythonEnvironmentProviderInfo {
  * and environment type.
  * @param parentFolder The parent folder for the new environment.
  * @param projectName The name of the project.
- * @param envType The type of Python environment.
+ * @param envProviderName The name of the Python environment provider.
  * @returns The location for the new Python environment.
  */
 export const locationForNewEnv = (

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -80,6 +80,7 @@ export interface NewProjectConfiguration {
 	readonly pythonEnvProviderId: string | undefined;
 	readonly pythonEnvProviderName: string | undefined;
 	readonly installIpykernel: boolean | undefined;
+	readonly condaPythonVersion: string | undefined;
 	readonly useRenv: boolean | undefined;
 }
 
@@ -158,3 +159,13 @@ export type CreateEnvironmentResult = {
 	readonly path?: string;
 	readonly error?: Error;
 };
+
+/**
+ * LanguageIds enum.
+ */
+export enum LanguageIds {
+	// Defined in extensions/positron-python/src/client/common/constants.ts "PYTHON_LANGUAGE"
+	Python = 'python',
+	// Defined in extensions/positron-r/src/provider.ts makeMetadata()
+	R = 'r'
+}

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -152,12 +152,14 @@ export interface IPositronNewProjectService {
 
 /**
  * CreateEnvironmentOptions type.
- * Used to capture the result of creating a new environment.
- * Based on extensions/positron-python/src/client/pythonEnvironments/creation/proposed.createEnvApis.ts
+ * Used to capture the result of creating a new environment and registering the interpreter.
+ * Based on the result from the Create_Environment_And_Register 'python.createEnvironmentAndRegister'
+ * command defined in extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts.
  */
 export type CreateEnvironmentResult = {
 	readonly path?: string;
 	readonly error?: Error;
+	readonly metadata?: ILanguageRuntimeMetadata;
 };
 
 /**

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -413,7 +413,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 				// Install ipykernel in the new environment
 				await this._commandService.executeCommand(
 					'python.installIpykernel',
-					result.metadata?.runtimePath
+					result.path
 				);
 
 				this._removePendingTask(NewProjectTask.PythonEnvironment);

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -416,7 +416,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			const startingLanguageRuntime = this._startingConsolesByLanguageId.get(
 				languageRuntime.languageId);
 			if (startingLanguageRuntime) {
-				throw new Error(`Session for language runtime ${formatLanguageRuntimeMetadata(languageRuntime)} cannot be started because language runtime ${formatLanguageRuntimeMetadata(startingLanguageRuntime)} is already starting for the language.`);
+				throw new Error(`Session for language runtime ${formatLanguageRuntimeMetadata(languageRuntime)} cannot be started because language runtime ${formatLanguageRuntimeMetadata(startingLanguageRuntime)} is already starting for the language. Request source: ${source}`);
 			}
 
 			// If there is already a runtime running for the language, throw an error.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

- Address https://github.com/posit-dev/positron/issues/2839

#### Demo

https://github.com/posit-dev/positron/assets/25834218/b23ff80d-1f69-494b-a611-47a6eba6d919

### Approach

#### python extension
- add `createEnvironmentAndRegister` command which wraps the `createEnvironment` command and immediately registers the new pythonPath upon successful environment creation
- add `condaPythonVersion` as an optional property for the `createEnvironmentAndRegister` command
- read the `condaPythonVersion` instead of showing a quick pick if it is provided

#### new project service
- pass `condaPythonVersion` to the python `createEnvironmentAndRegister` command, to avoid the python version quickpick
- remove the skeleton runtime metadata since we now have access to the actual runtime metadata object from the result of `createEnvironmentAndRegister`

#### project wizard
- remove a bunch of conda-specific handling and hardcoded values
- run the new command `python.getCondaPythonVersions` to retrieve the supported python versions
- update the wizard to use the python extension's reported conda python versions

### QA Notes

#### Suggested steps

Pre-req: an existing installation of Conda.
- Note: In testing this work locally, we found some inconsistency in behaviour between conda installed via miniconda and conda installed via miniforge. Those issues have been addressed, but it would be great if both installation methods of Conda could be verified!

1. Open the New Project Wizard
2. Select Python Project or Jupyter Notebook
3. Project name/location should be inconsequential (defaults are fine)
4. Select New Environment and use Conda as the provider
5. Select any version of Python in the interpreter dropdown
6. Create the Project

#### Expected behaviour
- the conda functionality should no longer be gated behind the config setting `positron.work-In-ProgressProjectWizardFeatures`
- once the new project window is loaded, a .conda directory should be created after a few moments, with ipykernel installed
- the Conda interpreter (based on the selected version of Python in the project wizard) should be selected as the active interpreter
    - note: there may be a notification toast that says "We noticed a new virtual environment has been created. Do you want to select it for the workspace folder?"
        - this notification is not trivial to remove (it is automatically shown by the python extension) -- mentioned here: https://github.com/posit-dev/positron/issues/3293#issuecomment-2148381553
        - however, interacting with it (or not) should not cause the new project initialization to break
- a blank Python/Jupyter file should be open
- the Console should be functional and reflect the Conda interpreter

Some of the changes in the PR involve codepaths used for the Create Venv functionality as well. Creating a new Venv from the project wizard should not have regressed.