### PR TITLE
Mark Union type as untagged in Rust generated comms

### DIFF
--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -542,6 +542,7 @@ use serde::Serialize;
 					snakeCaseToSentenceCase(context[0]) + ` in ` +
 					snakeCaseToSentenceCase(context[1]));
 				yield '#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]\n';
+				yield '#[serde(untagged)]\n';
 				yield `pub enum ${snakeCaseToSentenceCase(context[0])} {\n`;
 			}
 			for (let i = 0; i < o.oneOf.length; i++) {


### PR DESCRIPTION
Union types are passed to the backend without their type name. We need to mark them as `untagged` for serde to be able to understand that.

Comm diff after this commit:  https://github.com/posit-dev/amalthea/pull/376/commits/301135b000a5a79a5cda4c0fca72b029d5ee0409, required for https://github.com/posit-dev/amalthea/pull/376