### PR TITLE
Fixes data explorer selection issues, fixes clicking away from a Positron modal popup

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -89,13 +89,20 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 		// Compute the popup position.
 		if (props.anchorPoint) {
 			return {
+				// Set the top.
 				top: props.popupPosition === 'top' ?
 					'auto' :
 					props.anchorPoint.clientY,
+
+				// Set the right.
 				right: props.popupAlignment === 'right' ?
-					props.renderer.container.offsetWidth - (props.anchorPoint.clientX) :
+					-props.anchorPoint.clientX :
 					'auto',
+
+				// Set the bottom.
 				bottom: 'auto',
+
+				// Set the left.
 				left: props.popupAlignment === 'left' ?
 					props.anchorPoint.clientX :
 					'auto'
@@ -103,19 +110,26 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 		} else {
 			const topLeftOffset = DOM.getTopLeftOffset(props.anchorElement);
 			return {
+				// Set the top.
 				top: props.popupPosition === 'top' ?
 					'auto' :
 					topLeftOffset.top + props.anchorElement.offsetHeight + 1,
+
+				// Set the right.
 				right: props.popupAlignment === 'right' ?
-					props.renderer.container.offsetWidth - (topLeftOffset.left + props.anchorElement.offsetWidth) :
+					-(topLeftOffset.left + props.anchorElement.offsetWidth) :
 					'auto',
+
+				// Set the bottom.
 				bottom: 'auto',
+
+				// Set the left.
 				left: props.popupAlignment === 'left' ?
 					topLeftOffset.left :
 					'auto'
 			};
 		}
-	}, [props.anchorElement, props.anchorPoint, props.popupAlignment, props.popupPosition, props.renderer.container.offsetWidth]);
+	}, [props.anchorElement, props.anchorPoint, props.popupAlignment, props.popupPosition]);
 
 	// Reference hooks.
 	const popupContainerRef = useRef<HTMLDivElement>(undefined!);

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
@@ -50,18 +50,27 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 		// context menu.
 		const startingRect = ref.current.getBoundingClientRect();
 
-		// Get the cell selection state.
-		const cellSelectionState = context.instance.cellSelectionState(
-			props.columnIndex,
-			props.rowIndex
-		);
+		// If selection is enabled, process selection logic.
+		if (context.instance.selection) {
+			// Get the cell selection state.
+			const cellSelectionState = context.instance.cellSelectionState(
+				props.columnIndex,
+				props.rowIndex
+			);
 
-		// If the cell selection state is None, and selection is enabled, mouse-select the cell.
-		// Otherwise, scroll the cell into view.
-		if (cellSelectionState === CellSelectionState.None && context.instance.selection) {
-			await context.instance.mouseSelectCell(props.columnIndex, props.rowIndex, selectionType(e));
-		} else {
-			await context.instance.scrollToCell(props.columnIndex, props.rowIndex);
+			// If the cell is not selected, or it is and the user is left-clicking, mouse-select
+			// the cell. Otherwise, scroll to the cell.
+			if (cellSelectionState === CellSelectionState.None || e.button === 0) {
+				// Mouse-select the cell.
+				await context.instance.mouseSelectCell(
+					props.columnIndex,
+					props.rowIndex,
+					selectionType(e)
+				);
+			} else {
+				// Scroll to the cell.
+				await context.instance.scrollToCell(props.columnIndex, props.rowIndex);
+			}
 		}
 
 		// If the left mouse button was pressed, show the context menu.

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
@@ -78,9 +78,10 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 			// Get the ending bounding client rect.
 			const endingRect = ref.current.getBoundingClientRect();
 
-			// Show the column context menu.
-			await context.instance.showColumnContextMenu(
+			// Show the cell context menu.
+			await context.instance.showCellContextMenu(
 				props.columnIndex,
+				props.rowIndex,
 				ref.current,
 				{
 					clientX: e.clientX + endingRect.left - startingRect.left,

--- a/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.css
+++ b/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.css
@@ -10,8 +10,8 @@
 .positron-modal-overlay {
 	top: 0;
 	left: 0;
-	width: 100%;
-	height: 100%;
+	width: 0;
+	height: 0;
 	z-index: 20000;
 	display: flex;
 	position: fixed;

--- a/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.tsx
+++ b/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.tsx
@@ -294,14 +294,14 @@ export class PositronModalReactRenderer extends Disposable {
 
 		// Add global keydown, mousedown, and resize event listeners.
 		window.addEventListener(KEYDOWN, keydownHandler, true);
-		window.addEventListener(MOUSEDOWN, mousedownHandler, false);
+		window.addEventListener(MOUSEDOWN, mousedownHandler, true);
 		window.addEventListener(RESIZE, resizeHandler, false);
 
 		// Return the cleanup function that removes our event listeners.
 		PositronModalReactRenderer._unbindCallback = () => {
 			// Remove keydown, mousedown, and resize event listeners.
 			window.removeEventListener(KEYDOWN, keydownHandler, true);
-			window.removeEventListener(MOUSEDOWN, mousedownHandler, false);
+			window.removeEventListener(MOUSEDOWN, mousedownHandler, true);
 			window.removeEventListener(RESIZE, resizeHandler, false);
 		};
 	}

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -368,9 +368,15 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		anchorElement: HTMLElement,
 		anchorPoint: AnchorPoint
 	): Promise<void> {
+		/**
+		 * Get the column sort key for the column.
+		 */
+		const columnSortKey = this.columnSortKey(columnIndex);
+
 		// Build the entries.
 		const entries: CustomContextMenuEntry[] = [];
 		entries.push(new CustomContextMenuItem({
+			checked: false,
 			commandId: PositronDataExplorerCommandId.CopyAction,
 			icon: 'copy',
 			label: localize('positron.dataExplorer.copy', "Copy"),
@@ -378,16 +384,59 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		}));
 		entries.push(new CustomContextMenuSeparator());
 		entries.push(new CustomContextMenuItem({
+			checked: false,
 			icon: 'positron-select-column',
 			label: localize('positron.dataExplorer.selectColumn', "Select Column"),
 			disabled: this.columnSelectionState(columnIndex) !== ColumnSelectionState.None,
 			onSelected: () => this.selectColumn(columnIndex)
 		}));
 		entries.push(new CustomContextMenuItem({
+			checked: false,
 			icon: 'positron-select-row',
 			label: localize('positron.dataExplorer.selectRow', "Select Row"),
 			disabled: this.rowSelectionState(rowIndex) !== RowSelectionState.None,
 			onSelected: () => this.selectRow(rowIndex)
+		}));
+		entries.push(new CustomContextMenuSeparator());
+		entries.push(new CustomContextMenuItem({
+			checked: columnSortKey !== undefined && columnSortKey.ascending,
+			icon: 'arrow-up',
+			label: localize('positron.sortAscending', "Sort Ascending"),
+			onSelected: async () => this.setColumnSortKey(
+				columnIndex,
+				true
+			)
+		}));
+		entries.push(new CustomContextMenuItem({
+			checked: columnSortKey !== undefined && !columnSortKey.ascending,
+			icon: 'arrow-down',
+			label: localize('positron.sortDescending', "Sort Descending"),
+			onSelected: async () => this.setColumnSortKey(
+				columnIndex,
+				false
+			)
+		}));
+		entries.push(new CustomContextMenuSeparator());
+		entries.push(new CustomContextMenuItem({
+			checked: false,
+			icon: 'positron-clear-sorting',
+			label: localize('positron.clearSorting', "Clear Sorting"),
+			disabled: !columnSortKey,
+			onSelected: async () =>
+				this.removeColumnSortKey(columnIndex)
+		}));
+		entries.push(new CustomContextMenuSeparator());
+		entries.push(new CustomContextMenuItem({
+			checked: false,
+			icon: 'positron-add-filter',
+			label: addFilterTitle,
+			disabled: false,
+			onSelected: () => {
+				const columnSchema = this._dataExplorerCache.getColumnSchema(columnIndex);
+				if (columnSchema) {
+					this._onAddFilterEmitter.fire(columnSchema);
+				}
+			}
 		}));
 
 		// Show the context menu.


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR addresses two issues:

1. It addresses https://github.com/posit-dev/positron/issues/3396 (If you have a whole column or row selected, it is not possible to regular-click and select a single cell).
2. When a Positron modal popup is showing, it fixes how clicks away from the modal popup work. Now, you can click away from the modal popup and the click goes to the control you clicked on.

https://github.com/posit-dev/positron/assets/853239/9574ef16-2306-48ac-9e2b-2fbead9511ad

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
