### PR TITLE
Data Explorer: Shower fewer significant digits for numbers with magnitude greater than 1

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -112,8 +112,8 @@ export class DataExplorerClientInstance extends Disposable {
 		super();
 
 		this._dataFormatOptions = {
-			large_num_digits: 6,
-			small_num_digits: 6,
+			large_num_digits: 2,
+			small_num_digits: 4,
 			max_integral_digits: 7,
 			thousands_sep: ','
 		};


### PR DESCRIPTION
In the absence of dynamic zero trimming per #3325, this sets the formatting to use 2 significant digits for numbers with magnitude over 1 and 4 digits for smaller numbers. If we want decimal alignment for large and small numbers, we'll either have to implement the zero trimming or format with the same number of digits for large and small numbers. 