### PR TITLE
Fix console not rerendering after an activity prompt exits via the runtime

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
@@ -95,11 +95,10 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 					// Consume the event.
 					consumeEvent();
 
-					// Upate the prompt state and reply to it.
-					const value = inputRef.current?.value;
-					props.activityItemPrompt.state = ActivityItemPromptState.Answered;
-					props.activityItemPrompt.answer = !props.activityItemPrompt.password ? value : '';
-					props.positronConsoleInstance.replyToPrompt(props.activityItemPrompt.id, value);
+					// Update the prompt state and reply to it.
+					props.positronConsoleInstance.replyToPrompt(
+						props.activityItemPrompt, inputRef.current?.value
+					);
 					return;
 				}
 
@@ -116,8 +115,7 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 					consumeEvent();
 
 					// Update the prompt state and interrupt it.
-					props.activityItemPrompt.state = ActivityItemPromptState.Interrupted;
-					props.positronConsoleInstance.interruptPrompt(props.activityItemPrompt.id);
+					props.positronConsoleInstance.interruptPrompt(props.activityItemPrompt);
 					return;
 				}
 

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -5,6 +5,7 @@
 import { Event } from 'vs/base/common/event';
 import { IEditor } from 'vs/editor/common/editorCommon';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { ActivityItemPrompt } from 'vs/workbench/services/positronConsole/browser/classes/activityItemPrompt';
 import { RuntimeItem } from 'vs/workbench/services/positronConsole/browser/classes/runtimeItem';
 import { ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 
@@ -305,16 +306,16 @@ export interface IPositronConsoleInstance {
 
 	/**
 	 * Replies to a prompt.
-	 * @param id The prompt identifier.
+	 * @param activityItemPrompt The prompt activity item.
 	 * @param value The value.
 	 */
-	replyToPrompt(id: string, value: string): void;
+	replyToPrompt(activityItemPrompt: ActivityItemPrompt, value: string): void;
 
 	/**
 	 * Interrupts prompt.
-	 * @param id The prompt identifier.
+	 * @param activityItemPrompt The prompt activity item.
 	 */
-	interruptPrompt(id: string): void;
+	interruptPrompt(activityItemPrompt: ActivityItemPrompt): void;
 
 	/**
 	 * Sets the currently attached runtime, or undefined if none.


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/2219.

### Approach

Moved state updates from the React component to the Positron console service, and fire an `onDidChangeRuntimeItems` event in those cases. Note that it doesn't scroll to the bottom correctly and that it doesn't refocus the main console prompt, but it does stop the console from getting "stuck" without the main prompt.

### QA Notes

See the issue for a repro.