### PR TITLE
Fix transient newline on execute

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -500,19 +500,20 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				// If the shift key is pressed, do not process the event because the user is
 				// entering multiple lines.
 				if (e.shiftKey) {
-					return;
+					break;
 				}
 
 				// If the console instance isn't ready, ignore the event.
 				if (props.positronConsoleInstance.state !== PositronConsoleState.Ready) {
-					return;
+					break;
 				}
 
 				// Try to execute the code editor widget's code.
-				if (await executeCodeEditorWidgetCodeIfPossible()) {
-					// Only consume the event if the code was executed. Otherwise, let the code
-					// editor widget handle the key event.
-					consumeEvent();
+				// Consume the event before the await to prevent it from being handled concurrently.
+				consumeEvent();
+				if (!await executeCodeEditorWidgetCodeIfPossible()) {
+					// The code was not executed, insert a new line.
+					positronConsoleContext.commandService.executeCommand('editor.action.insertLineAfter');
 				}
 
 				break;


### PR DESCRIPTION
Related to #705, this fixes an issue introduced in https://github.com/posit-dev/positron/pull/1972 where a newline, along with the indentation prefix `...`, appears in the console input for a moment after the user presses enter.

The problem was that we were only consuming the event after the `await`. The approach here is to consume the event before the `await`, and if necessary, execute the `editor.action.insertLineAfter` command to add a new line.

## QA Notes

Pressing enter for a completed statement should execute without any `...` showing e.g.

```python
print("Hello world!")<cursor>
```

Pressing enter for an incomplete statement should add a newline:

```python
for i in range(5):<cursor>
```

Shouldn't break console behavior in either R or Python.