### PR TITLE
Strip newlines in TableDataCell

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
@@ -31,7 +31,7 @@ export const TableDataCell = (props: TableDataCellProps) => {
 	return (
 		<div className={positronClassNames('text-container', props.column.alignment)}>
 			<div className='text-value'>
-				{props.dataCell.formatted}
+				{props.dataCell.formatted.replace(/\n/g, ' ').trimEnd()}
 			</div>
 		</div>
 	);

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
@@ -31,7 +31,8 @@ export const TableDataCell = (props: TableDataCellProps) => {
 	return (
 		<div className={positronClassNames('text-container', props.column.alignment)}>
 			<div className='text-value'>
-				{props.dataCell.formatted.replace(/\n/g, ' ').trimEnd()}
+				{/* allow-any-unicode-next-line */}
+				{props.dataCell.formatted.replace(/\n/g, '↵')}
 			</div>
 		</div>
 	);

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
@@ -31,8 +31,7 @@ export const TableDataCell = (props: TableDataCellProps) => {
 	return (
 		<div className={positronClassNames('text-container', props.column.alignment)}>
 			<div className='text-value'>
-				{/* allow-any-unicode-next-line */}
-				{props.dataCell.formatted.replace(/\n/g, '↵')}
+				{props.dataCell.formatted.replace(/\r/g, '\\r').replace(/\n/g, '\\n')}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

If you run:

```
import pandas as pd
example = pd.DataFrame({'text': ['  oh\n\rwow\nthis is a long bit of text', 'more text - [ ] checkbox']})
```

You will see output that looks like:

<img width="357" alt="image" src="https://github.com/posit-dev/positron/assets/853239/4870c1b2-08ec-4e70-86c1-89d1194c70e7">

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

This PR addresses this issue (https://github.com/posit-dev/positron/issues/3390) by changing the `TableDataCell` component to replace carriage return characters `\r` with `\\r` and newline characters `\n` with `\\n`.

We do this because we need `white-space-collapse: preserve` so that spaces at the start of a data cell are preserved.

With this PR, the code example above now outputs:

<img width="439" alt="image" src="https://github.com/posit-dev/positron/assets/853239/0dfe016e-a43d-4631-8458-3081153a886c">

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
