### PR TITLE
Basic notebook smoke test for Python and R

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Run Smoke Tests (Electron)
         env:
-          POSITRON_PY_VER_SEL: Python 3.10.12 64-bit
+          POSITRON_PY_VER_SEL: Python 3.10.12
           POSITRON_R_VER_SEL: R 4.4.0
         id: electron-smoke-tests
         run: DISPLAY=:10 yarn smoketest-no-compile --tracing

--- a/test/automation/src/index.ts
+++ b/test/automation/src/index.ts
@@ -37,5 +37,6 @@ export * from './positron/positronPlots';
 export * from './positron/fixtures/positronPythonFixtures';
 export * from './positron/fixtures/positronRFixtures';
 export * from './positron/positronBaseElement';
+export * from './positron/positronNotebooks';
 // --- End Positron ---
 export { getDevElectronPath, getBuildElectronPath, getBuildVersion } from './electron';

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -259,5 +259,9 @@ export class PlaywrightDriver {
 	getKeyboard() {
 		return this.page.keyboard;
 	}
+
+	getFrame(frameSelector: string): playwright.FrameLocator {
+		return this.page.frameLocator(frameSelector);
+	}
 	// --- End Positron ---
 }

--- a/test/automation/src/positron/positronNotebooks.ts
+++ b/test/automation/src/positron/positronNotebooks.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { Code } from '../code';
+import { QuickAccess } from '../quickaccess';
+import { QuickInput } from '../quickinput';
+
+const KERNEL_LABEL = '.kernel-label';
+const KERNEL_ACTION = '.kernel-action-view-item';
+const SELECT_KERNEL_TEXT = 'Select Kernel';
+const NEW_NOTEBOOK_COMMAND = 'ipynb.newUntitledIpynb';
+const EDIT_CELL_COMMAND = 'notebook.cell.edit';
+const EXECUTE_CELL_COMMAND = 'notebook.cell.execute';
+const OUTER_FRAME = '.webview';
+const INNER_FRAME = '#active-frame';
+const PYTHON_OUTPUT = '.output-plaintext';
+const R_OUTPUT = '.output_container .output';
+const REVERT_AND_CLOSE = 'workbench.action.revertAndCloseActiveEditor';
+
+export class PositronNotebooks {
+
+	constructor(private code: Code, private quickinput: QuickInput, private quickaccess: QuickAccess) { }
+
+	async selectInterpreter(kernelGroup: string, desiredKernel: string) {
+		await this.code.waitForElement(KERNEL_LABEL, (e) => e!.textContent.includes(desiredKernel) || e!.textContent.includes(SELECT_KERNEL_TEXT));
+
+		const interpreterManagerText = (await this.code.waitForElement(KERNEL_LABEL)).textContent;
+		if (interpreterManagerText === SELECT_KERNEL_TEXT) {
+			await this.code.waitAndClick(KERNEL_ACTION);
+			await this.quickinput.waitForQuickInputOpened();
+			// depending on random timing, it may or may not be necessary to select the kernel group
+			try {
+				await this.quickinput.selectQuickInputElementContaining(kernelGroup);
+			} catch {
+				console.log('Kernel group not found');
+			}
+			await this.quickinput.selectQuickInputElementContaining(desiredKernel);
+			await this.quickinput.waitForQuickInputClosed();
+		}
+	}
+
+	async createNewNotebook() {
+		await this.quickaccess.runCommand(NEW_NOTEBOOK_COMMAND);
+	}
+
+	async executeInFirstCell(code: string) {
+		await this.quickaccess.runCommand(EDIT_CELL_COMMAND);
+		// no locator-less type method in Microsoft base functionality
+		await this.code.driver.getKeyboard().type(code);
+		await this.quickaccess.runCommand(EXECUTE_CELL_COMMAND);
+	}
+
+	async getPythonCellOutput(): Promise<string> {
+		// basic CSS selection doesn't support frames (or nested frames)
+		const notebookFrame = this.code.driver.getFrame(OUTER_FRAME).frameLocator(INNER_FRAME);
+		const outputLocator = notebookFrame.locator(PYTHON_OUTPUT);
+		const outputText = await outputLocator.textContent();
+		return outputText!;
+	}
+
+	async getRCellOutput(): Promise<string> {
+		// basic CSS selection doesn't support frames (or nested frames)
+		const notebookFrame = this.code.driver.getFrame(OUTER_FRAME).frameLocator(INNER_FRAME);
+		const outputLocator = notebookFrame.locator(R_OUTPUT).nth(0);
+		const outputText = await outputLocator.textContent();
+		return outputText!;
+	}
+
+	async closeNotebookWithoutSaving() {
+		await this.quickaccess.runCommand(REVERT_AND_CLOSE);
+	}
+}

--- a/test/automation/src/workbench.ts
+++ b/test/automation/src/workbench.ts
@@ -98,7 +98,7 @@ export class Workbench {
 		this.positronDataExplorer = new PositronDataExplorer(code);
 		this.positronSideBar = new PositronSideBar(code);
 		this.positronPlots = new PositronPlots(code);
-		this.positronNotebooks = new PositronNotebooks(code, this.quickinput, this.quickaccess);
+		this.positronNotebooks = new PositronNotebooks(code, this.quickinput, this.quickaccess, this.notebook);
 		// --- End Positron ---
 	}
 }

--- a/test/automation/src/workbench.ts
+++ b/test/automation/src/workbench.ts
@@ -31,6 +31,7 @@ import { PositronVariables } from './positron/positronVariables';
 import { PositronDataExplorer } from './positron/positronDataExplorer';
 import { PositronSideBar } from './positron/positronSideBar';
 import { PositronPlots } from './positron/positronPlots';
+import { PositronNotebooks } from './positron/positronNotebooks';
 // --- End Positron ---
 
 export interface Commands {
@@ -66,6 +67,7 @@ export class Workbench {
 	readonly positronDataExplorer: PositronDataExplorer;
 	readonly positronSideBar: PositronSideBar;
 	readonly positronPlots: PositronPlots;
+	readonly positronNotebooks: PositronNotebooks;
 	// --- End Positron ---
 
 	constructor(code: Code) {
@@ -96,6 +98,7 @@ export class Workbench {
 		this.positronDataExplorer = new PositronDataExplorer(code);
 		this.positronSideBar = new PositronSideBar(code);
 		this.positronPlots = new PositronPlots(code);
+		this.positronNotebooks = new PositronNotebooks(code, this.quickinput, this.quickaccess);
 		// --- End Positron ---
 	}
 }

--- a/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
+++ b/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
@@ -31,7 +31,7 @@ export function setup(logger: Logger) {
 				await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
 			});
 
-			it('Python - Basic notebook creation and execution', async function () {
+			it('Python - Basic notebook creation and execution (code)', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.positronNotebooks.createNewNotebook();
@@ -43,6 +43,20 @@ export function setup(logger: Logger) {
 				const outputText = await app.workbench.positronNotebooks.getPythonCellOutput();
 
 				expect(outputText).toBe('64');
+
+			});
+
+			it('Python - Basic notebook creation and execution (markdown)', async function () {
+				const app = this.app as Application;
+
+				await app.workbench.notebook.insertNotebookCell('markdown');
+
+				await app.workbench.notebook.waitForTypeInEditor('## hello2! ');
+				await app.workbench.notebook.stopEditingCell();
+
+				const text = await app.workbench.positronNotebooks.getMarkdownText('h2');
+
+				expect(text).toBe('hello2!');
 
 			});
 		});
@@ -70,7 +84,7 @@ export function setup(logger: Logger) {
 				await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
 			});
 
-			it('R - Basic notebook creation and execution', async function () {
+			it('R - Basic notebook creation and execution (code)', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.positronNotebooks.createNewNotebook();
@@ -82,6 +96,20 @@ export function setup(logger: Logger) {
 				const outputText = await app.workbench.positronNotebooks.getRCellOutput();
 
 				expect(outputText).toBe('[1] 64\n');
+
+			});
+
+			it('R - Basic notebook creation and execution (markdown)', async function () {
+				const app = this.app as Application;
+
+				await app.workbench.notebook.insertNotebookCell('markdown');
+
+				await app.workbench.notebook.waitForTypeInEditor('## hello2! ');
+				await app.workbench.notebook.stopEditingCell();
+
+				const text = await app.workbench.positronNotebooks.getMarkdownText('h2');
+
+				expect(text).toBe('hello2!');
 
 			});
 		});

--- a/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
+++ b/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { expect } from '@playwright/test';
+import { Application, Logger, PositronPythonFixtures, PositronRFixtures } from '../../../../../automation';
+import { installAllHandlers } from '../../../utils';
+
+export function setup(logger: Logger) {
+
+	describe('Notebooks', () => {
+
+		// Shared before/after handling
+		installAllHandlers(logger);
+
+		describe('Python Notebooks', () => {
+
+			before(async function () {
+
+				const app = this.app as Application;
+
+				const pythonFixtures = new PositronPythonFixtures(app);
+				await pythonFixtures.startPythonInterpreter();
+
+			});
+
+			it('Python - Basic notebook creation and execution', async function () {
+				const app = this.app as Application;
+
+				await app.workbench.quickaccess.runCommand('ipynb.newUntitledIpynb');
+
+				await app.workbench.quickaccess.runCommand('notebook.cell.edit');
+
+				// no type method in Microsoft base functionality
+				await app.code.driver.getKeyboard().type('eval("8**2")');
+
+				await app.workbench.quickaccess.runCommand('notebook.cell.execute');
+
+				// basic CSS selection doesn't support frames (or nested frames)
+				const notebookFrame = app.code.driver.getFrame('.webview').frameLocator('#active-frame');
+				const outputLocator = notebookFrame.locator('.output-plaintext');
+				const outputText = await outputLocator.textContent();
+
+				expect(outputText).toBe('64');
+
+			});
+		});
+	});
+
+	describe('Notebooks', () => {
+
+		// Shared before/after handling
+		installAllHandlers(logger);
+
+		describe('R Notebooks', () => {
+
+			before(async function () {
+
+				const app = this.app as Application;
+
+				const rFixtures = new PositronRFixtures(app);
+				await rFixtures.startRInterpreter();
+
+			});
+
+			it('R - Basic notebook creation and execution', async function () {
+				const app = this.app as Application;
+
+				await app.workbench.quickaccess.runCommand('ipynb.newUntitledIpynb');
+
+				await app.workbench.quickaccess.runCommand('notebook.cell.edit');
+
+				// no type method in Microsoft base functionality
+				await app.code.driver.getKeyboard().type('eval(parse(text="8**2"))');
+
+				await app.workbench.quickaccess.runCommand('notebook.cell.execute');
+
+				// basic CSS selection doesn't support frames (or nested frames)
+				const notebookFrame = app.code.driver.getFrame('.webview').frameLocator('#active-frame');
+				const outputLocator = notebookFrame.locator('.output_container .output').nth(0);
+				const outputText = await outputLocator.textContent();
+
+				expect(outputText).toBe('[1] 64\n');
+
+			});
+		});
+
+
+	});
+}

--- a/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
+++ b/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
@@ -30,6 +30,14 @@ export function setup(logger: Logger) {
 
 				await app.workbench.quickaccess.runCommand('ipynb.newUntitledIpynb');
 
+				await app.code.waitForElement('.kernel-label', (e) => e!.textContent.includes(process.env.POSITRON_PY_VER_SEL!) || e!.textContent.includes('Select Kernel'));
+
+				const interpreterManagerText = (await app.code.waitForElement('.kernel-label')).textContent;
+				if (interpreterManagerText === 'Select Kernel') {
+					await app.code.waitAndClick('.kernel-action-view-item');
+					await app.workbench.quickinput.selectQuickInputElementContaining(process.env.POSITRON_PY_VER_SEL!);
+				}
+
 				await app.workbench.quickaccess.runCommand('notebook.cell.edit');
 
 				// no type method in Microsoft base functionality
@@ -68,6 +76,14 @@ export function setup(logger: Logger) {
 				const app = this.app as Application;
 
 				await app.workbench.quickaccess.runCommand('ipynb.newUntitledIpynb');
+
+				await app.code.waitForElement('.kernel-label', (e) => e!.textContent.includes(process.env.POSITRON_R_VER_SEL!) || e!.textContent.includes('Select Kernel'));
+
+				const interpreterManagerText = (await app.code.waitForElement('.kernel-label')).textContent;
+				if (interpreterManagerText === 'Select Kernel') {
+					await app.code.waitAndClick('.kernel-action-view-item');
+					await app.workbench.quickinput.selectQuickInputElementContaining(process.env.POSITRON_R_VER_SEL!);
+				}
 
 				await app.workbench.quickaccess.runCommand('notebook.cell.edit');
 

--- a/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
+++ b/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
@@ -35,7 +35,11 @@ export function setup(logger: Logger) {
 				const interpreterManagerText = (await app.code.waitForElement('.kernel-label')).textContent;
 				if (interpreterManagerText === 'Select Kernel') {
 					await app.code.waitAndClick('.kernel-action-view-item');
+
+					await app.workbench.quickinput.waitForQuickInputOpened();
+					await app.workbench.quickinput.selectQuickInputElementContaining('Python Environments');
 					await app.workbench.quickinput.selectQuickInputElementContaining(process.env.POSITRON_PY_VER_SEL!);
+					await app.workbench.quickinput.waitForQuickInputClosed();
 				}
 
 				await app.workbench.quickaccess.runCommand('notebook.cell.edit');
@@ -82,7 +86,11 @@ export function setup(logger: Logger) {
 				const interpreterManagerText = (await app.code.waitForElement('.kernel-label')).textContent;
 				if (interpreterManagerText === 'Select Kernel') {
 					await app.code.waitAndClick('.kernel-action-view-item');
+
+					await app.workbench.quickinput.waitForQuickInputOpened();
+					await app.workbench.quickinput.selectQuickInputElementContaining('R Environments');
 					await app.workbench.quickinput.selectQuickInputElementContaining(process.env.POSITRON_R_VER_SEL!);
+					await app.workbench.quickinput.waitForQuickInputClosed();
 				}
 
 				await app.workbench.quickaccess.runCommand('notebook.cell.edit');

--- a/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
+++ b/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
@@ -25,34 +25,22 @@ export function setup(logger: Logger) {
 
 			});
 
+			after(async function () {
+
+				const app = this.app as Application;
+				await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
+			});
+
 			it('Python - Basic notebook creation and execution', async function () {
 				const app = this.app as Application;
 
-				await app.workbench.quickaccess.runCommand('ipynb.newUntitledIpynb');
+				await app.workbench.positronNotebooks.createNewNotebook();
 
-				await app.code.waitForElement('.kernel-label', (e) => e!.textContent.includes(process.env.POSITRON_PY_VER_SEL!) || e!.textContent.includes('Select Kernel'));
+				await app.workbench.positronNotebooks.selectInterpreter('Python Environments', process.env.POSITRON_PY_VER_SEL!);
 
-				const interpreterManagerText = (await app.code.waitForElement('.kernel-label')).textContent;
-				if (interpreterManagerText === 'Select Kernel') {
-					await app.code.waitAndClick('.kernel-action-view-item');
+				await app.workbench.positronNotebooks.executeInFirstCell('eval("8**2")');
 
-					await app.workbench.quickinput.waitForQuickInputOpened();
-					await app.workbench.quickinput.selectQuickInputElementContaining('Python Environments');
-					await app.workbench.quickinput.selectQuickInputElementContaining(process.env.POSITRON_PY_VER_SEL!);
-					await app.workbench.quickinput.waitForQuickInputClosed();
-				}
-
-				await app.workbench.quickaccess.runCommand('notebook.cell.edit');
-
-				// no type method in Microsoft base functionality
-				await app.code.driver.getKeyboard().type('eval("8**2")');
-
-				await app.workbench.quickaccess.runCommand('notebook.cell.execute');
-
-				// basic CSS selection doesn't support frames (or nested frames)
-				const notebookFrame = app.code.driver.getFrame('.webview').frameLocator('#active-frame');
-				const outputLocator = notebookFrame.locator('.output-plaintext');
-				const outputText = await outputLocator.textContent();
+				const outputText = await app.workbench.positronNotebooks.getPythonCellOutput();
 
 				expect(outputText).toBe('64');
 
@@ -76,40 +64,26 @@ export function setup(logger: Logger) {
 
 			});
 
+			after(async function () {
+
+				const app = this.app as Application;
+				await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
+			});
+
 			it('R - Basic notebook creation and execution', async function () {
 				const app = this.app as Application;
 
-				await app.workbench.quickaccess.runCommand('ipynb.newUntitledIpynb');
+				await app.workbench.positronNotebooks.createNewNotebook();
 
-				await app.code.waitForElement('.kernel-label', (e) => e!.textContent.includes(process.env.POSITRON_R_VER_SEL!) || e!.textContent.includes('Select Kernel'));
+				await app.workbench.positronNotebooks.selectInterpreter('R Environments', process.env.POSITRON_R_VER_SEL!);
 
-				const interpreterManagerText = (await app.code.waitForElement('.kernel-label')).textContent;
-				if (interpreterManagerText === 'Select Kernel') {
-					await app.code.waitAndClick('.kernel-action-view-item');
+				await app.workbench.positronNotebooks.executeInFirstCell('eval(parse(text="8**2"))');
 
-					await app.workbench.quickinput.waitForQuickInputOpened();
-					await app.workbench.quickinput.selectQuickInputElementContaining('R Environments');
-					await app.workbench.quickinput.selectQuickInputElementContaining(process.env.POSITRON_R_VER_SEL!);
-					await app.workbench.quickinput.waitForQuickInputClosed();
-				}
-
-				await app.workbench.quickaccess.runCommand('notebook.cell.edit');
-
-				// no type method in Microsoft base functionality
-				await app.code.driver.getKeyboard().type('eval(parse(text="8**2"))');
-
-				await app.workbench.quickaccess.runCommand('notebook.cell.execute');
-
-				// basic CSS selection doesn't support frames (or nested frames)
-				const notebookFrame = app.code.driver.getFrame('.webview').frameLocator('#active-frame');
-				const outputLocator = notebookFrame.locator('.output_container .output').nth(0);
-				const outputText = await outputLocator.textContent();
+				const outputText = await app.workbench.positronNotebooks.getRCellOutput();
 
 				expect(outputText).toBe('[1] 64\n');
 
 			});
 		});
-
-
 	});
 }

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -36,6 +36,7 @@ import { setup as setupPlotsTest } from './areas/positron/plots/plots.test';
 import { setup as setupPythonConsoleTest } from './areas/positron/console/python-console.test';
 import { setup as setupRConsoleTest } from './areas/positron/console/r-console.test';
 import { setup as setupLargeDataFrameTest } from './areas/positron/dataexplorer/largeDataFrame.test';
+import { setup as setupNotebookCreateTest } from './areas/positron/notebook/notebookCreate.test';
 // --- End Positron ---
 
 const rootPath = path.join(__dirname, '..', '..', '..');
@@ -426,5 +427,6 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	setupPythonConsoleTest(logger);
 	setupRConsoleTest(logger);
 	setupLargeDataFrameTest(logger);
+	setupNotebookCreateTest(logger);
 	// --- End Positron ---
 });


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

This is a basic notebook smoketest for R and Python.  Only a single cell is created and run.  In both the Python and R scripts, this entails running eval on "8**2" and then checking for "64" in the output.  Basic markdown functionality is also verified.

Selection of the interpreter is conditionally performed if its not automatically set to match the current Positron interpreter.

### Approach

For creating the notebook, adding a cell and running a cell, commands are used:
* ipynb.newUntitledIpynb
* notebook.cell.edit
* notebook.cell.execute
* notebook.cell.insertMarkdownCellBelow
* notebook.cell.quitEdit

The cell output is nested two frames deep so Playwright frame selectors are used.

getPythonCellOutput and getRCellOutput are different because the code run output structure differs between interpreters.

### QA Notes

All smoke tests should pass.
