### PR TITLE
Pin Positron Data Explorers so they are not in preview mode

### DIFF
--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
@@ -59,6 +59,7 @@ class PositronDataExplorerContribution extends Disposable {
 						),
 						options: {
 							...options,
+							// Fix for https://github.com/posit-dev/positron/issues/3362.
 							pinned: true
 						}
 					};

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
@@ -57,7 +57,10 @@ class PositronDataExplorerContribution extends Disposable {
 							PositronDataExplorerEditorInput,
 							resource
 						),
-						options
+						options: {
+							...options,
+							pinned: true
+						}
 					};
 				}
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR addresses https://github.com/posit-dev/positron/issues/3362, which was caused by https://github.com/posit-dev/positron/pull/3216, by "pinning" Positron Data Explorer Editors via `IEditorOptions`.

Note that `pinned` in `IEditorOptions` is not the same as pinning an editor in the UI.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

Investigate and fix. This took a few hours to track down.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

Before this PR, opening a Positron Data Explorer Editor would result in that editor being in "preview" mode (as indicated by the italicized title in the editor tab):

<img width="1530" alt="image" src="https://github.com/posit-dev/positron/assets/853239/fd599713-ac1a-42a0-ba52-6e08333ab96b">

After this PR, the Positron Data Explorer Editor will be "pinned":

<img width="1530" alt="image" src="https://github.com/posit-dev/positron/assets/853239/12338093-27fe-4102-b796-f4a99d125cf3">

Which is NOT the same a pinning the Positron Data Explorer Editor in the UI:

<img width="1530" alt="image" src="https://github.com/posit-dev/positron/assets/853239/78f5d3fa-a993-4a42-858a-e5a70f570a53">




