### PR TITLE
Clean-up some third-party licenses and Positron extensions

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -1459,6 +1459,33 @@ THE SOFTWARE.
 ---------------------------------------------------------
 
 ---------------------------------------------------------
+monaco-editor-core
+See: build/monaco/ThirdPartyNotices.txt
+
+The MIT License (MIT)
+
+Copyright (c) 2016 - present Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+---------------------------------------------------------
+
+---------------------------------------------------------
 
 NVIDIA/cuda-cpp-grammar 0.0.0 - MIT
 https://github.com/NVIDIA/cuda-cpp-grammar
@@ -2518,6 +2545,38 @@ SOFTWARE.
 
 ---------------------------------------------------------
 
+vscode-python v2024.6.0 - MIT
+pythonExtensionApi - MIT
+
+https://github.com/microsoft/vscode-python
+
+See: extensions/positron-python/ThirdPartyNotices-Repository.txt
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 vscode-swift 0.0.1 - MIT
 https://github.com/owensd/vscode-swift
 
@@ -2569,6 +2628,36 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+vscodereporter
+See: extensions/positron-r/resources/testing/vscodereporter
+
+# MIT License
+
+Copyright (c) 2021 vscodereporter authors
+
+Copyright (c) 2013-2019 Hadley Wickham; RStudio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ---------------------------------------------------------
 
 ---------------------------------------------------------

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -1459,6 +1459,7 @@ THE SOFTWARE.
 ---------------------------------------------------------
 
 ---------------------------------------------------------
+
 monaco-editor-core
 See: build/monaco/ThirdPartyNotices.txt
 
@@ -2573,6 +2574,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+vscode-r-test-adapter - MIT
+
+See: extensions/positron-r/resources/testing
+
+MIT License
+
+Copyright (c) [2023] [Posit Software, PBC and M. Eren Akbiyik]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 ---------------------------------------------------------
 
 ---------------------------------------------------------

--- a/extensions/positron-r/LICENSE
+++ b/extensions/positron-r/LICENSE
@@ -1,2 +1,0 @@
-Copyright (c) 2022, RStudio PBC. All rights reserved.
-

--- a/extensions/positron-rstudio-keymap/LICENSE
+++ b/extensions/positron-rstudio-keymap/LICENSE
@@ -1,2 +1,0 @@
-
-Copyright (c) 2024 Posit Software, PBC. All rights reserved.

--- a/extensions/positron-viewer/LICENSE
+++ b/extensions/positron-viewer/LICENSE
@@ -1,3 +1,0 @@
-
-Copyright (c) 2024 Posit Software, PBC. All rights reserved.
-


### PR DESCRIPTION
### Intent

Address a question about third-party licenses from Positron extensions from issue #1809.

### Approach

Remove unnecessary LICENSE files that had been added to some positron extensions. These are built-in and covered by Positron's license and copyright.

Added some missing third-party notice information to the top-level ThirdPartyNotices.txt

### QA Notes

No changes are expected beyond an updated ThirdPartyLicense.txt file in releases.