### PR TITLE
Variables: Handle repeated pandas row labels when inspecting 

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -82,7 +82,7 @@ SIMPLER_NAMES = {
 }
 
 
-def _get_display_name(value):
+def _get_class_display(value):
     display_value = get_qualname(value)
     return SIMPLER_NAMES.get(display_value, display_value)
 
@@ -95,7 +95,7 @@ class PositronInspector(Generic[T]):
     def __init__(self, value: T) -> None:
         self.value = value
 
-    def get_display_name(self, key: str) -> str:
+    def get_display_name(self, key: Any) -> str:
         return str(key)
 
     def get_display_value(
@@ -769,12 +769,8 @@ class BaseColumnInspector(_BaseMapInspector[Column], ABC):
 class PandasSeriesInspector(BaseColumnInspector["pd.Series"]):
     CLASS_QNAME = "pandas.core.series.Series"
 
-    # Per #3388: because the index can contain duplicates, we need to
-    # return integers as children for now until we can separate the
-    # access key from what is displayed to the user in the variables
-    # inspection response.
-    # def get_children(self) -> Collection[Any]:
-    #     return self.value.index
+    def get_display_name(self, key: int) -> str:
+        return str(self.value.index[key])
 
     def get_child(self, key: int) -> Any:
         return self.value.iloc[key]
@@ -807,7 +803,7 @@ class PandasSeriesInspector(BaseColumnInspector["pd.Series"]):
         print_width: Optional[int] = PRINT_WIDTH,
         truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
-        display_value = _get_display_name(self.value)
+        display_value = _get_class_display(self.value)
         display_value = f"[{len(self.value)} values] {display_value}"
         return (display_value, True)
 
@@ -923,7 +919,7 @@ class PandasDataFrameInspector(BaseTableInspector["pd.DataFrame", "pd.Series"]):
         print_width: Optional[int] = PRINT_WIDTH,
         truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
-        display_value = _get_display_name(self.value)
+        display_value = _get_class_display(self.value)
         if hasattr(self.value, "shape"):
             shape = self.value.shape
             display_value = f"[{shape[0]} rows x {shape[1]} columns] {display_value}"
@@ -956,7 +952,7 @@ class PolarsDataFrameInspector(BaseTableInspector["pl.DataFrame", "pl.Series"]):
         print_width: Optional[int] = PRINT_WIDTH,
         truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
-        qualname = _get_display_name(self.value)
+        qualname = _get_class_display(self.value)
         shape = self.value.shape
         display_value = f"[{shape[0]} rows x {shape[1]} columns] {qualname}"
         return (display_value, True)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -769,8 +769,15 @@ class BaseColumnInspector(_BaseMapInspector[Column], ABC):
 class PandasSeriesInspector(BaseColumnInspector["pd.Series"]):
     CLASS_QNAME = "pandas.core.series.Series"
 
-    def get_children(self) -> Collection[Any]:
-        return self.value.index
+    # Per #3388: because the index can contain duplicates, we need to
+    # return integers as children for now until we can separate the
+    # access key from what is displayed to the user in the variables
+    # inspection response.
+    # def get_children(self) -> Collection[Any]:
+    #     return self.value.index
+
+    def get_child(self, key: int) -> Any:
+        return self.value.iloc[key]
 
     def get_kind(self) -> str:
         # #2215 -- we are temporarily reclassifying Series as a table

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
@@ -744,9 +744,15 @@ def test_inspect_pandas_series_duplicate_labels() -> None:
     inspector = get_inspector(value)
     assert list(inspector.get_children()) == [0, 1, 2, 3]
     assert inspector.get_child(0) == 0
+    assert inspector.get_display_name(0) == "0"
+
     assert inspector.get_child(1) == 1
+    assert inspector.get_display_name(1) == "1"
+
     assert inspector.get_child(2) == 2
-    assert inspector.get_child(3) == 3
+    assert inspector.get_display_name(2) == "0"
+
+    assert inspector.get_display_name(3) == "1"
 
 
 def test_inspect_polars_dataframe() -> None:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
@@ -737,6 +737,18 @@ def test_inspect_pandas_series() -> None:
     )
 
 
+def test_inspect_pandas_series_duplicate_labels() -> None:
+    # #3388
+    value = pd.Series([0, 1, 2, 3], index=[0, 1, 0, 1])
+
+    inspector = get_inspector(value)
+    assert list(inspector.get_children()) == [0, 1, 2, 3]
+    assert inspector.get_child(0) == 0
+    assert inspector.get_child(1) == 1
+    assert inspector.get_child(2) == 2
+    assert inspector.get_child(3) == 3
+
+
 def test_inspect_polars_dataframe() -> None:
     value = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
     rows, cols = value.shape
@@ -779,8 +791,8 @@ def test_inspect_polars_series() -> None:
 @pytest.mark.parametrize(
     ("data", "expected"),
     [
-        (pd.Series({"a": 0, "b": 1}), ["a", "b"]),
-        (pl.Series([0, 1]), range(0, 2)),
+        (pd.Series({"a": 0, "b": 1}), range(2)),
+        (pl.Series([0, 1]), range(2)),
         (pd.DataFrame({"a": [1, 2], "b": ["3", "4"]}), ["a", "b"]),
         (pl.DataFrame({"a": [1, 2], "b": ["3", "4"]}), ["a", "b"]),
         (pd.Index([0, 1]), range(0, 2)),
@@ -805,7 +817,7 @@ def test_get_children(data: Any, expected: Iterable) -> None:
     ("value", "key", "expected"),
     [
         (helper, "fn_no_args", helper.fn_no_args),
-        (pd.Series({"a": 0, "b": 1}), "a", 0),
+        (pd.Series({"a": 0, "b": 1}), 0, 0),
         (pl.Series([0, 1]), 0, 0),
         (
             pd.DataFrame({"a": [1, 2], "b": ["3", "4"]}),


### PR DESCRIPTION
Addresses #3388. Used `Inspector.get_display_name` method on the parent (Series) to format the child key for display. 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### QA Notes

You can use this setup to check the new fixed behavior

```
import pandas as pd

ab_123 = pd.DataFrame({'a':[1,2,3], 'b': [1,2,3]}, index=['a', 'b', 'c'])
ab_456 = pd.DataFrame({'a':[4,5,6], 'b': [4,5,6]}, index=['a', 'b', 'c'])
ab = pd.concat([ab_123, ab_456])
```

![image](https://github.com/posit-dev/positron/assets/329591/4a8e8354-c11a-4676-bdf4-21b85cc067b1)