### PR TITLE
Data Explorer: Fix alignment CSS regression so that numeric data is back right-aligned

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.css
@@ -13,32 +13,29 @@
 
 .data-grid-row-cell
 .content
+.text-container.left {
+	justify-content: left;
+}
+
+.data-grid-row-cell
+.content
+.text-container.center {
+	justify-content: center;
+}
+
+.data-grid-row-cell
+.content
+.text-container.right {
+	justify-content: right;
+	font-variant-numeric: tabular-nums;
+}
+
+.data-grid-row-cell
+.content
 .text-container
 .text-value {
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	white-space-collapse: preserve;
-}
-
-.data-grid-row-cell
-.content
-.text-container
-.text-value.left {
-	justify-content: left;
-}
-
-.data-grid-row-cell
-.content
-.text-container
-.text-value.center {
-	justify-content: center;
-}
-
-.data-grid-row-cell
-.content
-.text-container
-.text-value.right {
-	justify-content: right;
-	font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR addresses https://github.com/posit-dev/positron/issues/3376 by fixing some broken CSS.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

Numeric columns are now right aligned.

<img width="1708" alt="image" src="https://github.com/posit-dev/positron/assets/853239/ce0d3e97-6d38-49b1-864a-24cd7b95f6b8">
