### PR TITLE
Add validation of basic file paths for appropriate text inputs

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators.ts
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators.ts
@@ -3,6 +3,8 @@
  *--------------------------------------------------------------------------------------------*/
 import { isValidBasename } from 'vs/base/common/extpath';
 import { OS, OperatingSystem } from 'vs/base/common/platform';
+import { basename } from 'vs/base/common/resources';
+import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 
 interface PathValidatorOptions {
@@ -35,14 +37,16 @@ export function checkIfPathValid(path: string | number, opts: PathValidatorOptio
 	// Check for invalid file names
 	// TODO: This may need to be changed to work with remote file systems with `remoteAgentService.getEnvironment()`
 	const isWindows = OS === OperatingSystem.Windows;
-	if (!isValidBasename(path, isWindows)) {
+
+	const pathBase = basename(URI.file(path));
+	if (!isValidBasename(pathBase, isWindows)) {
 		// Make the path cleaner for display
-		let sanitizedPath = path.replace(/\*/g, '\\*'); // CodeQL [SM02383] This only processes filenames which are enforced against having backslashes in them farther up in the stack.
+		let sanitizedPath = pathBase.replace(/\*/g, '\\*'); // CodeQL [SM02383] This only processes filenames which are enforced against having backslashes in them farther up in the stack.
 		if (sanitizedPath.length > 256) {
 			sanitizedPath = `${sanitizedPath.substr(0, 255)}...`;
 		}
 
-		return localize('invalidFileNameError', "The name **{0}** is not valid as a file or folder name. Please choose a different name.", sanitizedPath);
+		return localize('invalidFileNameError', "{0} is not valid as a file or folder name. Please choose a different name.", sanitizedPath);
 	}
 
 	// Check for whitespace

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators.ts
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators.ts
@@ -38,7 +38,15 @@ export function checkIfPathValid(path: string | number, opts: PathValidatorOptio
 	// TODO: This may need to be changed to work with remote file systems with `remoteAgentService.getEnvironment()`
 	const isWindows = OS === OperatingSystem.Windows;
 
-	const pathBase = basename(URI.file(path));
+	// Try and create URI to validate path. Should catch things like improper characters etc..
+	let pathUri: URI;
+	try {
+		pathUri = URI.file(path);
+	} catch (e) {
+		return localize('unableToConvertToUriError', "Can't parse file name. Check for invalid characters.");
+	}
+
+	const pathBase = basename(pathUri);
 	if (!isValidBasename(pathBase, isWindows)) {
 		// Make the path cleaner for display
 		let sanitizedPath = pathBase.replace(/\*/g, '\\*'); // CodeQL [SM02383] This only processes filenames which are enforced against having backslashes in them farther up in the stack.

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators.ts
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+import { isValidBasename } from 'vs/base/common/extpath';
+import { OS, OperatingSystem } from 'vs/base/common/platform';
+import { localize } from 'vs/nls';
+
+interface PathValidatorOptions {
+	// Whether to forbid absolute paths. Defaults to false.
+	noAbsolutePaths?: boolean;
+}
+
+// This is adapted from the `validateFileName` function in `vs/workbench/contrib/files/browser/fileActions.ts`.
+// Returns an error message if the path is invalid, otherwise returns undefined.
+export function checkIfPathValid(path: string | number, opts: PathValidatorOptions = {}): string | undefined {
+	path = path.toString();
+
+	// A series of simple checks we can do without calling out to file service.
+	// This is to avoid unnecessary calls to the file service which may slow things down.
+	if (path === '') {
+		// Dont show an error message if the path is empty. This is just the equivalent to the `.`
+		// path.
+		return undefined;
+	}
+
+	// Relative paths only
+	if (opts.noAbsolutePaths && (path[0] === '/' || path[0] === '\\')) {
+		return localize('fileNameStartsWithSlashError', "A file or folder name cannot start with a slash.");
+	}
+
+	if (path.length > 256) {
+		return localize('fileNameTooLongError', "File path is too long, must be under 256 characters.");
+	}
+
+	// Check for invalid file names
+	// TODO: This may need to be changed to work with remote file systems with `remoteAgentService.getEnvironment()`
+	const isWindows = OS === OperatingSystem.Windows;
+	if (!isValidBasename(path, isWindows)) {
+		// Make the path cleaner for display
+		let sanitizedPath = path.replace(/\*/g, '\\*'); // CodeQL [SM02383] This only processes filenames which are enforced against having backslashes in them farther up in the stack.
+		if (sanitizedPath.length > 256) {
+			sanitizedPath = `${sanitizedPath.substr(0, 255)}...`;
+		}
+
+		return localize('invalidFileNameError', "The name **{0}** is not valid as a file or folder name. Please choose a different name.", sanitizedPath);
+	}
+
+	// Check for whitespace
+	if (/^\s|\s$/.test(path)) {
+		return localize('fileNameWhitespaceWarning', "Leading or trailing whitespace detected in file or folder name.");
+	}
+
+	return undefined;
+}

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/labeledTextInput.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/labeledTextInput.tsx
@@ -9,6 +9,7 @@ import 'vs/css!./labeledTextInput';
 import * as React from 'react';
 import { ChangeEventHandler, forwardRef } from 'react'; // eslint-disable-line no-duplicate-imports
 import { positronClassNames } from 'vs/base/common/positronUtilities';
+import { Delayer } from 'vs/base/common/async';
 
 /**
  * LabeledTextInputProps interface.
@@ -21,6 +22,7 @@ export interface LabeledTextInputProps {
 	min?: number;
 	type?: 'text' | 'number';
 	error?: boolean;
+	validator?: (value: string | number) => string | undefined;
 	onChange: ChangeEventHandler<HTMLInputElement>;
 }
 
@@ -28,6 +30,9 @@ export interface LabeledTextInputProps {
  * LabeledTextInput component.
  */
 export const LabeledTextInput = forwardRef<HTMLInputElement, LabeledTextInputProps>((props, ref) => {
+
+	const errorMsg = useDebouncedValidator(props);
+
 	// Render.
 	return (
 		<div className='labeled-text-input'>
@@ -35,6 +40,7 @@ export const LabeledTextInput = forwardRef<HTMLInputElement, LabeledTextInputPro
 				{props.label}
 				<input className={positronClassNames('text-input', { 'error': props.error })} ref={ref} type={props.type} value={props.value}
 					autoFocus={props.autoFocus} onChange={props.onChange} max={props.max} min={props.min} />
+				{errorMsg ? <span className='error error-msg'>{errorMsg}</span> : null}
 			</label>
 		</div>
 	);
@@ -45,3 +51,38 @@ LabeledTextInput.displayName = 'LabeledTextInput';
 LabeledTextInput.defaultProps = {
 	type: 'text'
 };
+
+
+const DEBOUNCE_DELAY = 100;
+/**
+ * A hook to debounce the validation of input values.
+ *
+ * Is a bit more complicated than a typical debouncer because it needs to handle the async nature of
+ * the validator. Currently the validator is synchronous, but it could be async in the future.
+ */
+function useDebouncedValidator({ validator, value }: Pick<LabeledTextInputProps, 'validator' | 'value'>) {
+	const [errorMsg, setErrorMsg] = React.useState<string | undefined>(undefined);
+
+	// Create a state to store the delayer instance across rerenders.
+	const delayerRef = React.useRef<Delayer<string | undefined>>();
+	React.useEffect(() => {
+		if (!validator) {
+			// Don't unnecessarily create a delayer if we don't have a validator.
+			return;
+		}
+		const delayer = new Delayer<string | undefined>(DEBOUNCE_DELAY);
+		delayerRef.current = delayer;
+		return () => delayer.dispose();
+	}, [validator]);
+
+	React.useEffect(() => {
+		if (!validator || !delayerRef.current) { return; }
+
+		delayerRef.current
+			.trigger(() => validator(value))
+			.then(setErrorMsg);
+	}, [validator, value]);
+
+	return errorMsg;
+}
+

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
@@ -25,6 +25,7 @@ import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalRe
 import { LabeledTextInput } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/labeledTextInput';
 import { OKCancelModalDialog } from 'vs/workbench/browser/positronComponents/positronModalDialog/positronOKCancelModalDialog';
 import { LabeledFolderInput } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/labeledFolderInput';
+import { checkIfPathValid } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators';
 
 /**
  * Shows the new folder modal dialog.
@@ -150,6 +151,7 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 					autoFocus
 					value={result.folder}
 					onChange={e => setResult({ ...result, folder: e.target.value })}
+					validator={checkIfPathValid}
 				/>
 				<LabeledFolderInput
 					label={(() => localize(

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -21,6 +21,7 @@ import { WizardFormattedText, WizardFormattedTextType } from 'vs/workbench/brows
 import { checkProjectName } from 'vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { NewProjectType } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
+import { checkIfPathValid } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators';
 
 /**
  * The ProjectNameLocationStep component is the second step in the new project wizard.
@@ -157,6 +158,7 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 					value={projectName}
 					onChange={(e) => onChangeProjectName(e.target.value)}
 					type='text'
+					validator={checkIfPathValid}
 					error={
 						projectNameFeedback &&
 						projectNameFeedback.type === WizardFormattedTextType.Error


### PR DESCRIPTION
### Intent

Add simple validation for file paths in the `LabeledTextInput`s used in the new folder dialog and the new project dialog. 

Also sets-up foundation for future validation options for text inputs. 

### Approach
The PR does the following:
- Add a new `validator` prop that takes a function that returns an optional error message on every input value change. 
- Add a `checkIfPathValid()` function that fits this `validator` prop type
- Hook up validator with path validator function for the new folder modal and the new project location modal. 
<img width="413" alt="image" src="https://github.com/posit-dev/positron/assets/6764693/f19c78f6-d808-49d2-8163-94dc59df8411">

Future notes:
- Right now the validator is synchronous but the logic has been added for async validators. This may be necessary if we decide to do more complicated validation that requires calling out to external services or other async processes. 

### General notes
- I did not update the other cases mentioned in the issue #2781 because they have existing validation. It should be relatively straightforward to rewrite that logic in the new `validator` prop option. 
- Some errors are not possible to check until the file is attempted to be created. I'll make another PR to deal with those cases (the error doesn't make sense to go on the labeled text input directly there as it can be related to other input's values.)
- Right now the file path validator gets the operating system directly from the environment variable. I am not sure this will work when we enable remote host options. I added a TODO in a comment about this. 

### QA Notes

- The file input paths should error with invalid paths (e.g. longer than 256 chars). 
- Here's a path in case you want one! `very_long_filename_with_multiple_characters_including_numbers_1234567890_and_special_characters_@_!_#_plus_additional_text_to_extend_the_length_even_further_beyond_the_usual_limits_for_testing_purposes_onlyplus_additional_text_to_extend_the_length_even_further_beyond_the_usual_limits_for_testing_purposes_only`

- I have not tested on windows but the os related logic is all from existing vscode os logic (their `isValidBasename()` function) so it _shouldn't_ be an issue, but it deserves the tires being kicked. 

