### PR TITLE
Variables: Handle repeated pandas column labels when inspecting; Rework variables service tests

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -79,6 +79,8 @@ T = TypeVar("T")
 SIMPLER_NAMES = {
     "pandas.core.frame.DataFrame": "pandas.DataFrame",
     "pandas.core.series.Series": "pandas.Series",
+    "polars.dataframe.frame.DataFrame": "polars.DataFrame",
+    "polars.series.series.Series": "polars.Series",
 }
 
 
@@ -761,8 +763,8 @@ class BaseColumnInspector(_BaseMapInspector[Column], ABC):
         print_width: Optional[int] = PRINT_WIDTH,
         truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
-        # TODO(pyright): cast shouldn't be necessary, recheck in a future version of pyright
-        display_value = str(cast(Column, self.value[:100]).to_list())
+        display_value = _get_class_display(self.value)
+        display_value = f"[{len(self.value)} values] {display_value}"
         return (display_value, True)
 
 
@@ -798,15 +800,6 @@ class PandasSeriesInspector(BaseColumnInspector["pd.Series"]):
     def has_viewer(self) -> bool:
         return True
 
-    def get_display_value(
-        self,
-        print_width: Optional[int] = PRINT_WIDTH,
-        truncate_at: int = TRUNCATE_AT,
-    ) -> Tuple[str, bool]:
-        display_value = _get_class_display(self.value)
-        display_value = f"[{len(self.value)} values] {display_value}"
-        return (display_value, True)
-
 
 class PandasIndexInspector(BaseColumnInspector["pd.Index"]):
     CLASS_QNAME = [
@@ -829,7 +822,8 @@ class PandasIndexInspector(BaseColumnInspector["pd.Index"]):
         if isinstance(self.value, not_none(pd_).RangeIndex):
             return str(self.value), False
 
-        return super().get_display_value(print_width, truncate_at)
+        display_value = str(self.value[:100].to_list())
+        return display_value, True
 
     def has_children(self) -> bool:
         # For ranges, we don't visualize the children as they're
@@ -896,23 +890,11 @@ class BaseTableInspector(_BaseMapInspector[Table], Generic[Table, Column], ABC):
         # number of rows per column is handled by ColumnInspector
         return self.value.shape[1]
 
-    def get_children(self) -> Collection[Any]:
-        return self.value.columns
-
     def has_viewer(self) -> bool:
         return True
 
     def is_mutable(self) -> bool:
         return True
-
-
-#
-# Custom inspectors for specific types
-#
-
-
-class PandasDataFrameInspector(BaseTableInspector["pd.DataFrame", "pd.Series"]):
-    CLASS_QNAME = "pandas.core.frame.DataFrame"
 
     def get_display_value(
         self,
@@ -925,6 +907,24 @@ class PandasDataFrameInspector(BaseTableInspector["pd.DataFrame", "pd.Series"]):
             display_value = f"[{shape[0]} rows x {shape[1]} columns] {display_value}"
 
         return (display_value, True)
+
+
+#
+# Custom inspectors for specific types
+#
+
+
+class PandasDataFrameInspector(BaseTableInspector["pd.DataFrame", "pd.Series"]):
+    CLASS_QNAME = "pandas.core.frame.DataFrame"
+
+    def get_display_name(self, key: int) -> str:
+        return str(self.value.columns[key])
+
+    def get_children(self):
+        return range(self.value.shape[1])
+
+    def get_child(self, key: int) -> Any:
+        return self.value.iloc[:, key]
 
     def equals(self, value: pd.DataFrame) -> bool:
         return self.value.equals(value)
@@ -946,6 +946,9 @@ class PolarsDataFrameInspector(BaseTableInspector["pl.DataFrame", "pl.Series"]):
         "polars.dataframe.frame.DataFrame",
         "polars.internals.dataframe.frame.DataFrame",
     ]
+
+    def get_children(self):
+        return self.value.columns
 
     def get_display_value(
         self,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
@@ -760,7 +760,7 @@ def test_inspect_polars_dataframe() -> None:
     rows, cols = value.shape
     verify_inspector(
         value=value,
-        display_value=f"[{rows} rows x {cols} columns] {get_type_as_str(value)}",
+        display_value=f"[{rows} rows x {cols} columns] polars.DataFrame",
         kind=VariableKind.Table,
         display_type=f"DataFrame [{rows}x{cols}]",
         type_info=get_type_as_str(value),
@@ -782,7 +782,7 @@ def test_inspect_polars_series() -> None:
 
     verify_inspector(
         value=value,
-        display_value="[0, 1]",
+        display_value=f"[{rows} values] polars.Series",
         kind=VariableKind.Map,
         display_type=f"Int64 [{rows}]",
         type_info=get_type_as_str(value),
@@ -799,7 +799,7 @@ def test_inspect_polars_series() -> None:
     [
         (pd.Series({"a": 0, "b": 1}), range(2)),
         (pl.Series([0, 1]), range(2)),
-        (pd.DataFrame({"a": [1, 2], "b": ["3", "4"]}), ["a", "b"]),
+        (pd.DataFrame({"a": [1, 2], "b": ["3", "4"]}), range(2)),
         (pl.DataFrame({"a": [1, 2], "b": ["3", "4"]}), ["a", "b"]),
         (pd.Index([0, 1]), range(0, 2)),
         (
@@ -827,7 +827,7 @@ def test_get_children(data: Any, expected: Iterable) -> None:
         (pl.Series([0, 1]), 0, 0),
         (
             pd.DataFrame({"a": [1, 2], "b": ["3", "4"]}),
-            "a",
+            0,
             pd.Series([1, 2], name="a"),
         ),
         (

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
@@ -394,6 +394,7 @@ class TestClass:
     def x_plus_one(self):
         raise AssertionError("Should not be evaluated")
 
+
 _test_obj = TestClass()
 
 
@@ -567,7 +568,9 @@ def variable(display_name: str, display_value: str, children: List[Dict[str, Any
         ),
     ],
 )
-def test_list_and_recursive_inspect(value, expected, shell: PositronShell, variables_comm: DummyComm) -> None:
+def test_list_and_recursive_inspect(
+    value, expected, shell: PositronShell, variables_comm: DummyComm
+) -> None:
     """
     Simulate a user recursively expanding a variable's children in the UI.
     """

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -559,22 +559,13 @@ class VariablesService:
         """
 
         is_known, value = self._find_var(path)
-        if not is_known:
-            return self._send_error(
+        if is_known:
+            self._send_details(path, value)
+        else:
+            self._send_error(
                 JsonRpcErrorCode.INVALID_PARAMS,
                 f"Cannot find variable at '{path}' to inspect",
             )
-
-        inspector = get_inspector(value)
-        if not inspector.has_children():
-            # TODO: Handle scalar objects with a specific message type
-            summary = _summarize_variable("", value)
-            children = [] if summary is None else [summary]
-        else:
-            children = _summarize_children(value)
-
-        msg = InspectedVariable(children=children, length=len(children))
-        self._send_result(msg.dict())
 
     def _perform_view_action(self, path: List[str]) -> None:
         """
@@ -672,6 +663,54 @@ class VariablesService:
                 JsonRpcErrorCode.INVALID_PARAMS,
                 f"Cannot find variable at '{path}' to format",
             )
+
+    def _send_details(self, path: List[str], value: Any = None):
+        """
+        Sends a detailed list of children of the value (or just the value
+        itself, if is a leaf node on the path) as a message through the
+        variables comm to the client.
+
+        For example:
+        {
+            "data": {
+                "result": {
+                    "children": [{
+                        "display_name": "property1",
+                        "display_value": "Hello",
+                        "kind": "string",
+                        "display_type": "str"
+                    },{
+                        "display_name": "property2",
+                        "display_value": "123",
+                        "kind": "number"
+                        "display_type": "int"
+                    }]
+                }
+            }
+            ...
+        }
+
+        Parameters
+        ----------
+        path : List[str]
+            A list of names describing the path to the variable.
+        value : Any
+            The variable's value to summarize.
+        """
+
+        children = []
+        inspector = get_inspector(value)
+        if inspector.has_children():
+            children = _summarize_children(value)
+        else:
+            # Otherwise, treat as a simple value at given path
+            summary = _summarize_variable("", value)
+            if summary is not None:
+                children.append(summary)
+            # TODO: Handle scalar objects with a specific message type
+
+        msg = InspectedVariable(children=children, length=len(children))
+        self._send_result(msg.dict())
 
 
 def _summarize_variable(


### PR DESCRIPTION
### Intent

The main goal is to address #3388 for columns of a dataframe (https://github.com/posit-dev/positron/pull/3414 fixed it for rows of a dataframe). For example:

```python
df = pd.DataFrame([range(4)], columns=["a", "b", "a", "b"])
```

However, the bulk of the changes are to actually to how we test the `list` and `inspect` methods in `test_variables.py`.

### Approach

Here are the changes:

1. Updated `PandasDataFrameInspector` to use integer children to avoid duplicates; `PolarsDataFrameInspector` doesn't support duplicate columns so keeps the old approach.
2. Updated polars dataframe display values to match pandas.
3. The bulk of the code changes are to `test_variables.py`. I removed `test_handle_refresh`, `test_handle_inspect`, and `test_handle_inspect_2d` and replaced it with a single test: `test_list_and_recursive_inspect`.

    The idea is to be able to declare what the frontend should see for a given user namespace, including optionally recursively inspecting children. It currently only checks the display name and display value but that can be easily extended.

    I think this approach will let us very easily add more test cases down the line as new entries in the `pytest.mark.parametrize` list.

### QA Notes

Tests should pass and the variables pane should continue to function as expected.