### PR TITLE
Run renv::init on new project

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -592,6 +592,7 @@
     "binaryDependencies": {
       "ark": "0.1.109"
     },
-    "minimumRVersion": "4.2.0"
+    "minimumRVersion": "4.2.0",
+		"minimumRenvVersion": "1.0.7"
   }
 }

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -190,7 +190,13 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 			const isInstalled = await checkInstalled('renv', MINIMUM_RENV_VERSION);
 			if (isInstalled) {
 				const session = await positron.runtime.getForegroundSession();
-				session?.execute(`renv::init()`, randomUUID(), positron.RuntimeCodeExecutionMode.Transient, positron.RuntimeErrorBehavior.Stop);
+				if (session) {
+					session.execute(`renv::init()`, randomUUID(), positron.RuntimeCodeExecutionMode.Transient, positron.RuntimeErrorBehavior.Stop);
+				} else {
+					console.debug('[r.renvInit] no session available');
+				}
+			} else {
+				console.debug('[r.renvInit] renv is not installed');
 			}
 		}),
 	);

--- a/extensions/positron-r/src/constants.ts
+++ b/extensions/positron-r/src/constants.ts
@@ -13,3 +13,6 @@ const packageJson = fs.readJSONSync(path.join(EXTENSION_ROOT_DIR, 'package.json'
 
 // The minimum supported version of R.
 export const MINIMUM_R_VERSION = packageJson.positron.minimumRVersion as string;
+
+// The minimum supported version of renv.
+export const MINIMUM_RENV_VERSION = packageJson.positron.minimumRenvVersion as string;

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -394,12 +394,10 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		if (!isInstalled) {
 			const message = pkgVersion ? vscode.l10n.t('Package {0} version {1} required but not installed.', pkgName, pkgVersion)
 				: vscode.l10n.t('Package {0} required but not installed.', pkgName);
-			const actionLabel = pkgVersion ? vscode.l10n.t('Upgrade now')
-				: vscode.l10n.t('Install now');
 			const install = await positron.window.showSimpleModalDialogPrompt(
 				vscode.l10n.t('Missing R package'),
 				message,
-				actionLabel
+				vscode.l10n.t('Install now')
 			);
 			if (install) {
 				const id = randomUUID();

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -392,8 +392,8 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		}
 
 		if (!isInstalled) {
-			const message = pkgVersion ? vscode.l10n.t('Package {0} version {1} required but not installed.', pkgName, pkgVersion)
-				: vscode.l10n.t('Package {0} required but not installed.', pkgName);
+			const message = pkgVersion ? vscode.l10n.t('Package `{0}` version `{1}` required but not installed.', pkgName, pkgVersion)
+				: vscode.l10n.t('Package `{0}` required but not installed.', pkgName);
 			const install = await positron.window.showSimpleModalDialogPrompt(
 				vscode.l10n.t('Missing R package'),
 				message,

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -392,10 +392,14 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		}
 
 		if (!isInstalled) {
+			const message = pkgVersion ? vscode.l10n.t('Package {0} version {1} required but not installed.', pkgName, pkgVersion)
+				: vscode.l10n.t('Package {0} required but not installed.', pkgName);
+			const actionLabel = pkgVersion ? vscode.l10n.t('Upgrade now')
+				: vscode.l10n.t('Install now');
 			const install = await positron.window.showSimpleModalDialogPrompt(
 				vscode.l10n.t('Missing R package'),
-				vscode.l10n.t('Package {0} required but not installed.', pkgName),
-				vscode.l10n.t('Install now')
+				message,
+				actionLabel
 			);
 			if (install) {
 				const id = randomUUID();

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
@@ -47,8 +47,6 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 	const [selectedInterpreter, setSelectedInterpreter] = useState(context.selectedRuntime);
 	const [preferredInterpreter, setPreferredInterpreter] = useState(context.preferredInterpreter);
 	const [minimumRVersion, setMinimumRVersion] = useState(context.minimumRVersion);
-	// TODO: remove this check when the feature is no longer WIP
-	const [showRenvInit, setShowRenvInit] = useState(context.wipFunctionalityEnabled());
 
 	useEffect(() => {
 		// Create the disposable store for cleanup.
@@ -60,7 +58,6 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 			setSelectedInterpreter(context.selectedRuntime);
 			setPreferredInterpreter(context.preferredInterpreter);
 			setMinimumRVersion(context.minimumRVersion);
-			setShowRenvInit(context.wipFunctionalityEnabled());
 		}));
 
 		// Return the cleanup function that will dispose of the event handlers.
@@ -177,35 +174,33 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 					}
 				/>
 			</PositronWizardSubStep>
-			{showRenvInit ? (
-				<PositronWizardSubStep
-					title={(() =>
-						localize(
-							'rConfigurationStep.advancedConfigSubStep.title',
-							"Advanced Configuration"
-						))()}
-				>
-					<div className='renv-configuration'>
-						<Checkbox
-							label={(() =>
-								localize(
-									'rConfigurationStep.additionalConfigSubStep.useRenv.label',
-									"Use `renv` to create a reproducible environment"
-								))()}
-							onChanged={(checked) => (context.useRenv = checked)}
-							initialChecked={context.useRenv}
-						/>
-						<ExternalLink
-							className='renv-docs-external-link'
-							openerService={openerService}
-							href='https://rstudio.github.io/renv/articles/renv.html'
-							title='https://rstudio.github.io/renv/articles/renv.html'
-						>
-							<div className='codicon codicon-link-external' />
-						</ExternalLink>
-					</div>
-				</PositronWizardSubStep>
-			) : null}
+			<PositronWizardSubStep
+				title={(() =>
+					localize(
+						'rConfigurationStep.advancedConfigSubStep.title',
+						"Advanced Configuration"
+					))()}
+			>
+				<div className='renv-configuration'>
+					<Checkbox
+						label={(() =>
+							localize(
+								'rConfigurationStep.additionalConfigSubStep.useRenv.label',
+								"Use `renv` to create a reproducible environment"
+							))()}
+						onChanged={(checked) => (context.useRenv = checked)}
+						initialChecked={context.useRenv}
+					/>
+					<ExternalLink
+						className='renv-docs-external-link'
+						openerService={openerService}
+						href='https://rstudio.github.io/renv/articles/renv.html'
+						title='https://rstudio.github.io/renv/articles/renv.html'
+					>
+						<div className='codicon codicon-link-external' />
+					</ExternalLink>
+				</div>
+			</PositronWizardSubStep>
 		</PositronWizardStep>
 	);
 };

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
@@ -181,8 +181,8 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 				<PositronWizardSubStep
 					title={(() =>
 						localize(
-							'rConfigurationStep.additionalConfigSubStep.title',
-							"Additional Configuration"
+							'rConfigurationStep.advancedConfigSubStep.title',
+							"Advanced Configuration"
 						))()}
 				>
 					<div className='renv-configuration'>

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -21,7 +21,6 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { WizardFormattedTextItem } from 'vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText';
 import { LanguageIds, NewProjectType } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { projectWizardWorkInProgressEnabled } from 'vs/workbench/services/positronNewProject/common/positronNewProjectEnablement';
 import { CondaPythonVersionInfo, EMPTY_CONDA_PYTHON_VERSION_INFO } from 'vs/workbench/browser/positronNewProjectWizard/utilities/condaUtils';
 
 /**
@@ -81,7 +80,6 @@ export interface INewProjectWizardStateManager {
 	readonly getState: () => NewProjectWizardState;
 	readonly goToNextStep: (step: NewProjectWizardStep) => void;
 	readonly goToPreviousStep: () => void;
-	readonly wipFunctionalityEnabled: () => boolean;
 	readonly onUpdateInterpreterState: Event<void>;
 	readonly onUpdateProjectDirectory: Event<void>;
 }
@@ -553,15 +551,6 @@ export class NewProjectWizardStateManager
 			condaPythonVersion: this._condaPythonVersion,
 			useRenv: this._useRenv,
 		} satisfies NewProjectWizardState;
-	}
-
-	/**
-	 * Gets the value of the configuration setting that determines whether work-in-progress project
-	 * wizard functionality is enabled.
-	 * @returns Whether work-in-progress project wizard functionality is enabled.
-	 */
-	wipFunctionalityEnabled(): boolean {
-		return projectWizardWorkInProgressEnabled(this._services.configurationService);
 	}
 
 	/**

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -37,7 +37,7 @@ export enum NewProjectStartupPhase {
 	CreatingProject = 'creatingProject',
 
 	/**
-	 * Phase 4: The runtime for the new project has started.
+	 * Phase 4: The affiliated runtime for the new project is starting.
 	 */
 	RuntimeStartup = 'runtimeStartup',
 

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -117,7 +117,7 @@ export interface IPositronNewProjectService {
 	/**
 	 * Event tracking the pending init tasks.
 	 */
-	onDidChangeInitTasks: Event<Set<string>>;
+	onDidChangePendingInitTasks: Event<Set<string>>;
 
 	/**
 	 * Event tracking the pending post-init tasks.

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -115,7 +115,7 @@ export interface IPositronNewProjectService {
 	readonly startupPhase: NewProjectStartupPhase;
 
 	/**
-	 * Event tracking the pending tasks.
+	 * Event tracking the pending init tasks.
 	 */
 	onDidChangePendingInitTasks: Event<Set<string>>;
 

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -33,13 +33,24 @@ export enum NewProjectStartupPhase {
 	 * Phase 3: The new project is running initialization tasks provided by extensions, such as creating
 	 * the appropriate unsaved new file, initializing the git repository, etc., and starting the user-selected
 	 * interpreter.
-	 */
+	*/
 	CreatingProject = 'creatingProject',
 
 	/**
-	 * Phase 4: The new project has been initialized.
+	 * Phase 4: The runtime for the new project has started.
 	 */
-	Complete = 'complete'
+	RuntimeStartup = 'runtimeStartup',
+
+	/**
+	 * Phase 5: The new project is running post-initialization tasks that require the interpreter to be
+	 * ready, such as running renv::init() in R projects.
+	 */
+
+	PostInitialization = 'postInitialization',
+	/**
+	 * Phase 6: The new project has been initialized.
+	 */
+	Complete = 'complete',
 }
 
 /**
@@ -106,12 +117,22 @@ export interface IPositronNewProjectService {
 	/**
 	 * Event tracking the pending tasks.
 	 */
-	onDidChangePendingTasks: Event<Set<string>>;
+	onDidChangePendingInitTasks: Event<Set<string>>;
+
+	/**
+	 * Event tracking the pending post-init tasks.
+	 */
+	onDidChangePostInitTasks: Event<Set<string>>;
 
 	/**
 	 * The pending tasks.
 	 */
 	readonly pendingTasks: Set<string>;
+
+	/**
+	 * The pending post-init tasks.
+	 */
+	readonly pendingPostInitTasks: Set<string>;
 
 	/**
 	 * Clears the new project configuration from the storage service.
@@ -135,7 +156,12 @@ export interface IPositronNewProjectService {
 	/**
 	 * Barrier for other services to wait for all project tasks to complete.
 	 */
-	allTasksComplete: Barrier;
+	initTasksComplete: Barrier;
+
+	/**
+	 * Barrier for other services to wait for all post-init tasks to complete.
+	 */
+	postInitTasksComplete: Barrier;
 
 	/**
 	 * Returns the metadata for the runtime chosen for the new project, or

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -117,7 +117,7 @@ export interface IPositronNewProjectService {
 	/**
 	 * Event tracking the pending init tasks.
 	 */
-	onDidChangePendingInitTasks: Event<Set<string>>;
+	onDidChangeInitTasks: Event<Set<string>>;
 
 	/**
 	 * Event tracking the pending post-init tasks.
@@ -125,9 +125,9 @@ export interface IPositronNewProjectService {
 	onDidChangePostInitTasks: Event<Set<string>>;
 
 	/**
-	 * The pending tasks.
+	 * The pending init tasks.
 	 */
-	readonly pendingTasks: Set<string>;
+	readonly pendingInitTasks: Set<string>;
 
 	/**
 	 * The pending post-init tasks.
@@ -154,7 +154,7 @@ export interface IPositronNewProjectService {
 	isCurrentWindowNewProject(): boolean;
 
 	/**
-	 * Barrier for other services to wait for all project tasks to complete.
+	 * Barrier for other services to wait for all init tasks to complete.
 	 */
 	initTasksComplete: Barrier;
 

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -203,23 +203,23 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 		// TODO: it would be nice to run these tasks in parallel!
 
 		// First, create the new empty file since this is a quick task.
-		if (this.pendingTasks.has(NewProjectTask.CreateNewFile)) {
+		if (this.pendingInitTasks.has(NewProjectTask.CreateNewFile)) {
 			await this._runCreateNewFile();
 		}
 
 		// Next, run git init if needed.
-		if (this.pendingTasks.has(NewProjectTask.Git)) {
+		if (this.pendingInitTasks.has(NewProjectTask.Git)) {
 			await this._runGitInit();
 		}
 
 		// Next, run language-specific tasks which may take a bit more time.
-		if (this.pendingTasks.has(NewProjectTask.Python)) {
+		if (this.pendingInitTasks.has(NewProjectTask.Python)) {
 			await this._runPythonTasks();
 		}
-		if (this.pendingTasks.has(NewProjectTask.Jupyter)) {
+		if (this.pendingInitTasks.has(NewProjectTask.Jupyter)) {
 			await this._runJupyterTasks();
 		}
-		if (this.pendingTasks.has(NewProjectTask.R)) {
+		if (this.pendingInitTasks.has(NewProjectTask.R)) {
 			await this._runRTasks();
 		}
 	}
@@ -254,7 +254,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	 */
 	private async _runPythonTasks() {
 		// Create the Python environment
-		if (this.pendingTasks.has(NewProjectTask.PythonEnvironment)) {
+		if (this.pendingInitTasks.has(NewProjectTask.PythonEnvironment)) {
 			await this._createPythonEnvironment();
 		}
 
@@ -271,7 +271,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 		// For now, Jupyter notebooks are always Python based. In the future, we'll need to surface
 		// some UI in the Project Wizard for the user to select the language/kernel and pass that
 		// metadata to the new project configuration.
-		if (this.pendingTasks.has(NewProjectTask.PythonEnvironment)) {
+		if (this.pendingInitTasks.has(NewProjectTask.PythonEnvironment)) {
 			await this._createPythonEnvironment();
 		}
 
@@ -531,7 +531,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	 * Removes a pending init task.
 	 */
 	private _removePendingInitTask(task: NewProjectTask) {
-		const updatedPendingTasks = new Set(this.pendingTasks);
+		const updatedPendingTasks = new Set(this.pendingInitTasks);
 		updatedPendingTasks.delete(task);
 		this._pendingInitTasks.set(updatedPendingTasks, undefined);
 	}
@@ -704,7 +704,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	/**
 	 * Returns the pending tasks.
 	 */
-	get pendingTasks(): Set<string> {
+	get pendingInitTasks(): Set<string> {
 		return this._pendingInitTasks.get();
 	}
 

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -75,7 +75,6 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 		);
 		this._register(
 			this.onDidChangeNewProjectStartupPhase((phase) => {
-				// Open barrier when all tasks are complete
 				switch (phase) {
 					case NewProjectStartupPhase.RuntimeStartup:
 						this.initTasksComplete.open();
@@ -88,9 +87,6 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 						break;
 					default:
 				}
-
-				// if phase is post-runtime-startup-tasks
-				// run those tasks
 				this._logService.debug(
 					`[New project startup] Phase changed to ${phase}`
 				);
@@ -123,7 +119,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 				this._logService.debug(
 					`[New project startup] Pending tasks changed to: ${tasks}`
 				);
-				// If there are no pending tasks, the new project startup is complete
+				// If there are no pending init tasks, it's time for runtime startup
 				if (tasks.size === 0) {
 					this._startupPhase.set(
 						NewProjectStartupPhase.RuntimeStartup,
@@ -288,7 +284,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	 * Relies on extension vscode.positron-r
 	 */
 	private async _runRTasks() {
-		// no-op for now
+		// no-op for now, since we haven't defined any pre-runtime startup R tasks
 		// Complete the R task
 		this._removePendingInitTask(NewProjectTask.R);
 	}
@@ -532,7 +528,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	//#endregion Extension Tasks
 
 	/**
-	 * Removes a pending task.
+	 * Removes a pending init task.
 	 */
 	private _removePendingInitTask(task: NewProjectTask) {
 		const updatedPendingTasks = new Set(this.pendingTasks);

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -464,7 +464,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 			if (!this._newProjectConfig.runtimeMetadata?.runtimeId) {
 				return;
 			}
-			this._commandService.executeCommand('r.renvInit', this._newProjectConfig.runtimeMetadata.runtimeId, 'renv', '1.0.7');
+			await this._commandService.executeCommand('r.renvInit', this._newProjectConfig.runtimeMetadata.runtimeId, 'renv', '1.0.7');
 		}
 		this._removePendingTask(NewProjectTask.REnvironment);
 	}

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -52,7 +52,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 		@ILogService private readonly _logService: ILogService,
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IStorageService private readonly _storageService: IStorageService,
-		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService
+		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
 	) {
 		super();
 
@@ -460,7 +460,12 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	 * Relies on extension vscode.positron-r
 	 */
 	private async _createREnvironment() {
-		// TODO: run renv::init()
+		if (this._newProjectConfig?.useRenv) {
+			if (!this._newProjectConfig.runtimeMetadata?.runtimeId) {
+				return;
+			}
+			this._commandService.executeCommand('r.renvInit', this._newProjectConfig.runtimeMetadata.runtimeId, 'renv', '1.0.7');
+		}
 		this._removePendingTask(NewProjectTask.REnvironment);
 	}
 

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -591,7 +591,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	}
 
 	/**
-	 *
+	 *Returns the post initialization tasks that need to be performed for the new project.
 	 * @returns Returns the post initialization tasks that need to be performed for the new project.
 	 */
 	private _getPostInitTasks(): Set<NewProjectTask> {

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -287,7 +287,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		// If this is a new project, wait for it to initialize the project
 		// before proceeding, and then store the new project runtime metadata.
 		// as the affiliated runtime for this workspace.
-		await this._newProjectService.allTasksComplete.wait();
+		await this._newProjectService.initTasksComplete.wait();
 		const newRuntime = this._newProjectService.newProjectRuntimeMetadata;
 		if (newRuntime) {
 			this._storageService.store(this.storageKeyForRuntime(newRuntime),


### PR DESCRIPTION
### Intent
Run `renv::init` at new project initialization.

- Address https://github.com/posit-dev/positron/pull/3438 

### Approach
Creates a new command to run `renv::init` and installs/upgrades to it if necessary. It does not run `renv::init` if the necessary `renv` version is not installed.

This does need to wait until the runtime starts and there's a session ready. So listeners were added to respond when the session is ready to execute the package check and `renv::init`. These will be removed whether the init is performed or not.

The new message prompt if the package is not at the required version:
![image](https://github.com/posit-dev/positron/assets/9591545/ad17349d-397f-4fcd-8c23-c5d0b8b48153)

### QA Notes
If R has `renv` at the correct version, no prompts show for the user. It only shows if the R interpreter does not have `renv` at `1.0.7`. This version will change soon (likely to `1.0.8`) as well when the next `renv` version has a change that improves the Positron experience.