### PR TITLE
Allow overrides of keyboard behavior on modal dialogs

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.tsx
@@ -108,12 +108,15 @@ export const PositronModalDialog = (props: PropsWithChildren<PositronModalDialog
 
 			// Handle the event.
 			switch (e.key) {
-				// Enter accepts dialog.
-				case 'Enter': {
-					consumeEvent();
-					props.onAccept();
-					break;
-				}
+				// TODO: Update enter logic to enter into the default button of the dialog if there
+				// is one. This will use `focusableElementSelectors` to find it.
+
+				// Temporarily disable Enter key handling for #3217 fix.
+				// case 'Enter': {
+				// 	consumeEvent();
+				// 	props.onAccept();
+				// 	break;
+				// }
 
 				// Escape cancels dialog.
 				case 'Escape': {


### PR DESCRIPTION
# Addresses #3217 (in a roundabout way)
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent
Add the ability to override the default keypress behavior in modal dialogs so things like enter-to-submit can be disabled when not appropriate. 

### Approach

The original modal dialogs have a big switch statement for handling keypresses. This PR adds an optional prop of a dictionary keyed by key-id with entries that are event handlers. If this prop has an entry for the currently pressed key, it the modal dialog will use that handler instead of passing the key press down its switch statement. 

This addresses #3217 in a brute-force way of simply using this to disable the enter key with the idea that in the future the logic can be expanded here to do something like setting focus on the appropriate element etc.. 

### QA Notes

Opening a new project modal and pressing enter without actually selecting the project type shouldn't do anything. Escape should still work to get out of the modal. All other modal dialogs should not have any changes in their behavior. 