### PR TITLE
Dont allow zero-height expanded positron view panes

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
@@ -577,7 +577,7 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 		// run a few checks to make sure that the pane has time to animate open and finish its
 		// animation before we show content.  Otherwise the webview will try and layout over a 0
 		// height element and thus the help pane will be empty after expanding.
-		let previousHeight = element.clientHeight;
+		let previousHeight: number | undefined;
 		let numberOfChecks = 0;
 		const maxNumberOfChecks = 12;
 		const waitBetweenChecksMs = 20;

--- a/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
@@ -572,37 +572,55 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 		this._element = element;
 		const helpOverlayWebview = this._helpOverlayWebview;
 
-		// If the help pane is currently collapsed, aka has a height of 0, running the layout and
-		// claim logic will result in a 0-height help-pane. Not super useful. To deal with this we
-		// run a few checks to make sure that the pane has time to animate open and finish its
-		// animation before we show content.  Otherwise the webview will try and layout over a 0
-		// height element and thus the help pane will be empty after expanding.
-		let previousHeight: number | undefined;
+		// When nested view panes are expanded or collapsed they are animated to their new size.
+		// Since overlay webviews can't respond to their container's or position this will result in
+		// the help pane sticking to the size or position it was _before_ the animation started.
+		// This causes things like the help pane sitting at size zero when being opened from
+		// collapsed or staying large and overlapping other elements when shrinking down to
+		// accomodate other panes being expanded. To deal with this we run a few checks to make sure
+		// that the pane has time to animate open and finish its animation before we show content.
+		let oldBounds: DOMRect | undefined;
+
 		let numberOfChecks = 0;
 		const maxNumberOfChecks = 12;
-		const waitBetweenChecksMs = 20;
-		const claimAndLayoutWebview = () => {
-			const currentHeight = element.clientHeight;
+		const waitBetweenChecksMs = 25;
+		const ensureWebviewSizeCorrectWhenAnimating = () => {
+			// Getting client bounding rect is a tad bit expensive so we may want to consider a more
+			// efficient way to do this in the future.
+			const currentBounds = element.getBoundingClientRect();
+			const boundsHaveChanged = oldBounds === undefined || (
+				oldBounds.height !== currentBounds.height ||
+				oldBounds.width !== currentBounds.width ||
+				oldBounds.x !== currentBounds.x ||
+				oldBounds.y !== currentBounds.y);
 
-			const finishedAnimating = currentHeight !== 0 && currentHeight === previousHeight;
+			const isCollapsed = currentBounds.height === 0 || currentBounds.width === 0;
+			const finishedAnimating = !isCollapsed && !boundsHaveChanged;
 			const hasExceededMaxChecks = numberOfChecks >= maxNumberOfChecks;
 
 			if (finishedAnimating || hasExceededMaxChecks) {
-				helpOverlayWebview.claim(element, DOM.getWindow(element), undefined);
-				helpOverlayWebview.layoutWebviewOverElement(element);
 				return;
 			}
+			// Run layout to update the webview's position to keep up with latest position.
+			helpOverlayWebview.layoutWebviewOverElement(element);
 
-			previousHeight = currentHeight;
+			oldBounds = currentBounds;
 			numberOfChecks++;
-			this._claimTimeout = setTimeout(claimAndLayoutWebview, waitBetweenChecksMs);
+			this._claimTimeout = setTimeout(ensureWebviewSizeCorrectWhenAnimating, waitBetweenChecksMs);
 		};
+
 		// By clearing this timeout we prevent clashing that could be caused by rapidfire calling of
 		// `this.showHelpOverlayWebview()` that can be caused by resize events like dragging the
 		// sidebar wider etc..
 		clearTimeout(this._claimTimeout);
 
-		claimAndLayoutWebview();
+		// Run layout claim and layout initially. This will help avoid stutters for non-animating
+		// cases like dragging the help window larger or opening in an already expanded view.
+		helpOverlayWebview.claim(element, DOM.getWindow(element), undefined);
+		helpOverlayWebview.layoutWebviewOverElement(element);
+
+		// Run logic for animating cases.
+		ensureWebviewSizeCorrectWhenAnimating();
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
@@ -173,16 +173,10 @@ export class PositronHelpView extends PositronViewPane implements IReactComponen
 		@IThemeService themeService: IThemeService,
 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService
 	) {
-		// Override minimum size option if it isn't already somehow set. There doesn't seem to be a
-		// way to set this in any sort of configuration hence the need to override it here. If this
-		// isn't set, then the help pane will occlude parts of the editor when it is resized to be
-		// very small.
-		// TODO: See about disposing the webview entirely when the size is too small to see.
-		options = { ...options, minimumBodySize: 0 };
 
 		// Call the base class's constructor.
 		super(
-			options,
+			{ ...options, allowZeroMinimumBodySize: true },
 			keybindingService,
 			contextMenuService,
 			configurationService,

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
@@ -88,11 +88,7 @@ export class PositronPreviewViewPane extends PositronViewPane implements IReactC
 		@IPositronPreviewService private readonly positronPreviewService: IPositronPreviewService,
 		@IHoverService hoverService: IHoverService,
 	) {
-		// Override minimum size option if it isn't already somehow set. See `PositronHelpView` for
-		// more context.
-		options = { ...options, minimumBodySize: 0 };
-
-		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService, hoverService);
+		super({ ...options, allowZeroMinimumBodySize: true }, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService, hoverService);
 
 		this._register(this.onDidChangeBodyVisibility(() => this.onDidChangeVisibility(this.isBodyVisible())));
 		this._positronPreviewContainer = DOM.$('.positron-preview-container');


### PR DESCRIPTION
Temporarily retain minimum height logic when expanding a positron vie…w that has been collapsed or hidden so we cant get stuck with a zero-height "expanded" view.

<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Fix bug described in #3253 where the help and view panes can get into a situation where they get expanded but still look collapsed because their height is 0. 

### Approach

This bug was caused by logic put in to prevent spillover of iframe contents where the view pane option of `minimumBodySize` was set to 0 so positron would allow pane content to shrink and not spill over in the case of short windows. The problem was, `minimumBodySize` also is used to set the initial size after expanding a view (if there's no content to guide this already). 

To deal with this we take advantage of the fact that `PaneView.minimumBodySize` is a setter function that has the side effect of making sure the view is correctly sized. So we temporarily set that size on expand to get the nice non-confusing expansion behavior. 

This logic was also moved down into the `PositronViewPane` class instead of being reimplemented in both the help and viewer panes to avoid duplication. 

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### QA Notes

If you have a help pane at zero height and then press the expand chevron it should always expand to at least some height.  (See #3253 for more details._ Same thing with view pane. Expansion logic for all other custom positron views like console should not be changed. 
