### PR TITLE
Data Explorer: Add preliminary support for viewing Python polars data frames, disable most UI features that are not supported 

### DIFF
--- a/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
@@ -10,6 +10,7 @@ pandas==2.0.3; python_version < '3.9'
 pytest==8.0.2
 pytest-asyncio==0.23.5
 pytest-mock==3.12.0
-polars==0.20.13
+polars==0.20.13; python_version >= '3.9'
+polars[timezone]==0.20.13; python_version < '3.9' or sys_platform == 'win32'
 torch==2.1.2; python_version < '3.12'
 sqlalchemy==2.0.28

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -43,6 +43,7 @@ from .data_explorer_comm import (
     DataSelectionKind,
     DataSelectionRange,
     DataSelectionSingleCell,
+    ExportDataSelectionFeatures,
     ExportDataSelectionRequest,
     ExportFormat,
     ExportedData,
@@ -62,6 +63,7 @@ from .data_explorer_comm import (
     SearchSchemaResult,
     SetRowFiltersFeatures,
     SetRowFiltersRequest,
+    SetSortColumnsFeatures,
     SetSortColumnsRequest,
     SummaryStatsBoolean,
     SummaryStatsDate,
@@ -1253,6 +1255,8 @@ class PandasView(DataExplorerTableView):
                 ColumnProfileType.SummaryStats,
             ],
         ),
+        set_sort_columns=SetSortColumnsFeatures(supported=True),
+        export_data_selection=ExportDataSelectionFeatures(supported=True),
     )
 
     def _get_state(self) -> BackendState:
@@ -1541,6 +1545,8 @@ class PolarsView(DataExplorerTableView):
             supported=True,
             supported_types=[ColumnProfileType.NullCount],
         ),
+        export_data_selection=ExportDataSelectionFeatures(supported=False),
+        set_sort_columns=SetSortColumnsFeatures(supported=False),
     )
 
     def _get_state(self) -> BackendState:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -743,6 +743,14 @@ class SupportedFeatures(BaseModel):
         description="Support for 'get_column_profiles' RPC and its features",
     )
 
+    set_sort_columns: SetSortColumnsFeatures = Field(
+        description="Support for 'set_sort_columns' RPC and its features",
+    )
+
+    export_data_selection: ExportDataSelectionFeatures = Field(
+        description="Support for 'export_data_selection' RPC and its features",
+    )
+
 
 class SearchSchemaFeatures(BaseModel):
     """
@@ -783,6 +791,26 @@ class GetColumnProfilesFeatures(BaseModel):
 
     supported_types: List[ColumnProfileType] = Field(
         description="A list of supported types",
+    )
+
+
+class ExportDataSelectionFeatures(BaseModel):
+    """
+    Feature flags for 'export_data_selction' RPC
+    """
+
+    supported: StrictBool = Field(
+        description="Whether this RPC method is supported at all",
+    )
+
+
+class SetSortColumnsFeatures(BaseModel):
+    """
+    Feature flags for 'set_sort_columns' RPC
+    """
+
+    supported: StrictBool = Field(
+        description="Whether this RPC method is supported at all",
     )
 
 
@@ -1249,6 +1277,10 @@ SearchSchemaFeatures.update_forward_refs()
 SetRowFiltersFeatures.update_forward_refs()
 
 GetColumnProfilesFeatures.update_forward_refs()
+
+ExportDataSelectionFeatures.update_forward_refs()
+
+SetSortColumnsFeatures.update_forward_refs()
 
 DataSelection.update_forward_refs()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -2184,7 +2184,15 @@ def example_polars_df():
     full_data = []
     for i, (dtype, data, type_name, type_display) in enumerate(POLARS_TYPE_EXAMPLES):
         name = f"f{i}"
-        full_data.append(pl.Series(name=name, values=data, dtype=dtype))
+        s = pl.Series(name=name, values=data, dtype=dtype)
+        full_data.append(s)
+
+        # The string representation of a Decimal appears to be
+        # unstable for now so we don't trust our hard-coded type_name
+        # above
+        if s.dtype.base_type() is pl.Decimal:
+            type_name = str(s.dtype)
+
         full_schema.append(
             {
                 "column_name": name,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -5,16 +5,19 @@
 # ruff: noqa: E712
 
 from datetime import datetime
+from decimal import Decimal
 from io import StringIO
 from typing import Any, Dict, List, Optional, Type, cast
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 
 from .._vendor.pydantic import BaseModel
 from ..access_keys import encode_access_key
 from ..data_explorer import (
+    _VALUE_NULL,
     _VALUE_NA,
     _VALUE_NAN,
     _VALUE_NAT,
@@ -452,6 +455,10 @@ def _wrap_json(model: Type[BaseModel], data: JsonRecords):
     return [model(**d).dict() for d in data]
 
 
+# ----------------------------------------------------------------------
+# pandas backend functionality tests
+
+
 def test_pandas_get_state(dxf: DataExplorerFixture):
     result = dxf.get_state("simple")
     assert result["display_name"] == "simple"
@@ -519,8 +526,6 @@ def test_pandas_supported_features(dxf: DataExplorerFixture):
 
 
 def test_pandas_get_schema(dxf: DataExplorerFixture):
-    result = dxf.get_schema("simple", 0, 100)
-
     cases = [
         ([1, 2, 3, 4, 5], "int64", "number"),
         ([True, False, True, None, True], "bool", "boolean"),
@@ -2096,3 +2101,201 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             _assert_date_stats_equal(ex_result, stats["date_stats"])
         elif ui_type == ColumnDisplayType.Datetime:
             _assert_datetime_stats_equal(ex_result, stats["datetime_stats"])
+
+
+# ----------------------------------------------------------------------
+# polars backend functionality tests
+
+
+POLARS_TYPE_EXAMPLES = [
+    (pl.Null, [None, None, None, None], "Null", "unknown"),
+    (pl.Boolean, [False, None, True, False], "Boolean", "boolean"),
+    (pl.Int8, [-1, 2, 3, None], "Int8", "number"),
+    (pl.Int16, [-10000, 20000, 30000, None], "Int16", "number"),
+    (pl.Int32, [-10000000, 20000000, 30000000, None], "Int32", "number"),
+    (
+        pl.Int64,
+        [-10000000000, 20000000000, 30000000000, None],
+        "Int64",
+        "number",
+    ),
+    (pl.UInt8, [0, 2, 3, None], "UInt8", "number"),
+    (pl.UInt16, [0, 2000, 3000, None], "UInt16", "number"),
+    (pl.UInt32, [0, 2000000, 3000000, None], "UInt32", "number"),
+    (pl.UInt64, [0, 2000000000, 3000000000, None], "UInt64", "number"),
+    (pl.Float32, [-0.01234, 2.56789, 3.012345, None], "Float32", "number"),
+    (pl.Float64, [-0.01234, 2.56789, 3.012345, None], "Float64", "number"),
+    (
+        pl.Binary,
+        [b"testing", b"some", b"strings", None],
+        "Binary",
+        "string",
+    ),
+    (pl.String, ["tésting", "söme", "strîngs", None], "String", "string"),
+    (pl.Time, [0, 14400000000000, 40271000000000, None], "Time", "time"),
+    (
+        pl.Datetime("ms"),
+        [1704394167126, 946730085000, 0, None],
+        "Datetime(time_unit='ms', time_zone=None)",
+        "datetime",
+    ),
+    (
+        pl.Datetime("us", "America/New_York"),
+        [1704394167126123, 946730085000123, 0, None],
+        "Datetime(time_unit='us', time_zone='America/New_York')",
+        "datetime",
+    ),
+    (pl.Date, [130120, 0, -1, None], "Date", "date"),
+    (
+        pl.Duration("ms"),
+        [0, 1000, 2000, None],
+        "Duration(time_unit='ms')",
+        "unknown",
+    ),
+    (
+        pl.Decimal(12, 4),
+        [
+            Decimal("123.4501"),
+            Decimal("0"),
+            Decimal("12345678.4501"),
+            None,
+        ],
+        "Decimal(precision=12, scale=4)",
+        "number",
+    ),
+    (pl.List(pl.Int32), [[], [1, None, 3], [0], None], "List(Int32)", "array"),
+    (
+        pl.Struct({"a": pl.Int64, "b": pl.List(pl.String)}),
+        [
+            {"a": 8, "b": ["foo", None, "bar"]},
+            {"a": None, "b": ["", "one", "two"]},
+            None,
+            {"a": 0, "b": None},
+        ],
+        "Struct({'a': Int64, 'b': List(String)})",
+        "struct",
+    ),
+    # (pl.Object, ["Hello", True, None, 5], "Object", "object"),
+]
+
+
+def example_polars_df():
+    full_schema = []
+    full_data = []
+    for i, (dtype, data, type_name, type_display) in enumerate(POLARS_TYPE_EXAMPLES):
+        name = f"f{i}"
+        full_data.append(pl.Series(name=name, values=data, dtype=dtype))
+        full_schema.append(
+            {
+                "column_name": name,
+                "column_index": i,
+                "type_name": type_name,
+                "type_display": type_display,
+            }
+        )
+
+    df = pl.DataFrame(full_data)
+
+    return df, full_schema
+
+
+def test_polars_get_schema(dxf: DataExplorerFixture):
+    df, full_schema = example_polars_df()
+    table_name = guid()
+    dxf.register_table(table_name, df)
+    result = dxf.get_schema(table_name, 0, len(df.columns))
+
+    assert result == _wrap_json(ColumnSchema, full_schema)
+
+    # Test partial gets, boundschecking
+    assert dxf.get_schema(table_name, 0, 0) == []
+    assert dxf.get_schema(table_name, 5, 5) == _wrap_json(ColumnSchema, full_schema[5:10])
+    assert dxf.get_schema(table_name, 5, 100) == _wrap_json(ColumnSchema, full_schema[5:])
+
+
+def test_polars_get_state(dxf: DataExplorerFixture):
+    df, _ = example_polars_df()
+    dxf.register_table("df", df)
+
+    state = dxf.get_state("df")
+    ex_shape = {"num_rows": df.shape[0], "num_columns": df.shape[1]}
+
+    assert state["display_name"] == "df"
+    assert state["table_shape"] == ex_shape
+    assert state["table_unfiltered_shape"] == ex_shape
+    assert state["sort_keys"] == []
+    assert state["row_filters"] == []
+
+    features = state["supported_features"]
+    assert not features["search_schema"]["supported"]
+    assert not features["set_row_filters"]["supported"]
+    assert features["get_column_profiles"]["supported"]
+    assert features["get_column_profiles"]["supported_types"] == ["null_count"]
+
+
+def test_polars_get_data_values(dxf: DataExplorerFixture):
+    df, _ = example_polars_df()
+    dxf.register_table("df", df)
+
+    result = dxf.get_data_values(
+        "df",
+        row_start_index=0,
+        num_rows=10,
+        column_indices=list(range(df.shape[1])),
+    )
+
+    expected_columns = [
+        [_VALUE_NULL] * 4,  # Null
+        ["False", _VALUE_NULL, "True", "False"],  # Boolean
+        ["-1", "2", "3", _VALUE_NULL],  # Int8
+        ["-10000", "20000", "30000", _VALUE_NULL],  # Int16
+        ["-10000000", "20000000", "30000000", _VALUE_NULL],  # Int32
+        ["-10000000000", "20000000000", "30000000000", _VALUE_NULL],  # Int64
+        ["0", "2", "3", _VALUE_NULL],  # UInt8
+        ["0", "2000", "3000", _VALUE_NULL],  # UInt16
+        ["0", "2000000", "3000000", _VALUE_NULL],  # UInt32
+        ["0", "2000000000", "3000000000", _VALUE_NULL],  # UInt64
+        ["-0.0123", "2.57", "3.01", _VALUE_NULL],  # Float32
+        ["-0.0123", "2.57", "3.01", _VALUE_NULL],  # Float64
+        ["b'testing'", "b'some'", "b'strings'", _VALUE_NULL],  # Binary
+        ["tésting", "söme", "strîngs", _VALUE_NULL],  # String
+        ["00:00:00", "04:00:00", "11:11:11", _VALUE_NULL],  # Time
+        [
+            "2024-01-04 18:49:27.126000",
+            "2000-01-01 12:34:45",
+            "1970-01-01 00:00:00",
+            _VALUE_NULL,
+        ],  # Datetime(ms)
+        [
+            "2024-01-04 13:49:27.126123-05:00",
+            "2000-01-01 07:34:45.000123-05:00",
+            "1969-12-31 19:00:00-05:00",
+            _VALUE_NULL,
+        ],  # Datetime(us, 'America/New_York')
+        ["2326-04-05", "1970-01-01", "1969-12-31", _VALUE_NULL],  # Date
+        ["0:00:00", "0:00:01", "0:00:02", _VALUE_NULL],  # Duration
+        ["123.4501", "0.0000", "12345678.4501", _VALUE_NULL],  # Decimal(12, 4)
+        ["[]", "[1, null, 3]", "[0]", _VALUE_NULL],  # List(Int32)
+        [
+            "{'a': 8, 'b': ['foo', None, 'bar']}",
+            "{'a': None, 'b': ['', 'one', 'two']}",
+            _VALUE_NULL,
+            "{'a': 0, 'b': None}",
+        ],  # Struct({'a': Int64, 'b': List(String)}),
+        # ["Hello", "True", _VALUE_NULL, "5"],  # Object
+    ]
+
+    assert result["columns"] == expected_columns
+    assert result["row_labels"] is None
+
+    result = dxf.get_data_values(
+        "df",
+        row_start_index=2,
+        num_rows=10,
+        column_indices=list(range(15, df.shape[1])),
+    )
+    assert result["columns"] == [x[2:] for x in expected_columns[15:]]
+
+    result = dxf.get_data_values("df", row_start_index=10, num_rows=10, column_indices=[])
+    assert result["columns"] == []
+    assert result["row_labels"] is None

--- a/extensions/positron-python/python_files/positron/test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/test-requirements.txt
@@ -4,7 +4,7 @@ ipywidgets
 matplotlib
 numpy
 pandas
-polars; python_version > '3.8'
+polars; python_version >= '3.9'
 polars[timezone]; python_version < '3.9' or sys_platform == 'win32'
 pytest<8.1.1
 pytest-asyncio

--- a/extensions/positron-python/python_files/positron/test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/test-requirements.txt
@@ -4,7 +4,7 @@ ipywidgets
 matplotlib
 numpy
 pandas
-polars; python_version > '3.9'
+polars; python_version > '3.8'
 polars[timezone]; python_version < '3.9' or sys_platform == 'win32'
 pytest<8.1.1
 pytest-asyncio

--- a/extensions/positron-python/python_files/positron/test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/test-requirements.txt
@@ -4,7 +4,8 @@ ipywidgets
 matplotlib
 numpy
 pandas
-polars
+polars; python_version > '3.9'
+polars[timezone]; python_version < '3.9' or sys_platform == 'win32'
 pytest<8.1.1
 pytest-asyncio
 pytest-mock

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -995,7 +995,9 @@
 				"required": [
 					"search_schema",
 					"set_row_filters",
-					"get_column_profiles"
+					"get_column_profiles",
+					"set_sort_columns",
+					"export_data_selection"
 				],
 				"properties": {
 					"search_schema": {
@@ -1009,6 +1011,14 @@
 					"get_column_profiles": {
 						"description": "Support for 'get_column_profiles' RPC and its features",
 						"$ref": "#/components/schemas/get_column_profiles_features"
+					},
+					"set_sort_columns": {
+						"description": "Support for 'set_sort_columns' RPC and its features",
+						"$ref": "#/components/schemas/set_sort_columns_features"
+					},
+					"export_data_selection": {
+						"description": "Support for 'export_data_selection' RPC and its features",
+						"$ref": "#/components/schemas/export_data_selection_features"
 					}
 				}
 			},
@@ -1069,6 +1079,32 @@
 						"items": {
 							"$ref": "#/components/schemas/column_profile_type"
 						}
+					}
+				}
+			},
+			"export_data_selection_features": {
+				"type": "object",
+				"description": "Feature flags for 'export_data_selction' RPC",
+				"required": [
+					"supported"
+				],
+				"properties": {
+					"supported": {
+						"type": "boolean",
+						"description": "Whether this RPC method is supported at all"
+					}
+				}
+			},
+			"set_sort_columns_features": {
+				"type": "object",
+				"description": "Feature flags for 'set_sort_columns' RPC",
+				"required": [
+					"supported"
+				],
+				"properties": {
+					"supported": {
+						"type": "boolean",
+						"description": "Whether this RPC method is supported at all"
 					}
 				}
 			},

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.css
@@ -91,6 +91,13 @@
 .data-explorer-panel
 .row-filter-bar
 .filter-entries
+.add-row-filter-button.disabled {
+	opacity: 50%;
+}
+
+.data-explorer-panel
+.row-filter-bar
+.filter-entries
 .add-row-filter-button:focus {
 	outline: none !important;
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -147,6 +147,10 @@ export const RowFilterBar = () => {
 		rowFilterDescriptors
 	]);
 
+	const features = backendClient.getSupportedFeatures();
+
+	const canFilter = features.set_row_filters.supported;
+
 	/**
 	 * Filter button pressed handler.
 	 */
@@ -156,6 +160,7 @@ export const RowFilterBar = () => {
 		entries.push(new CustomContextMenuItem({
 			icon: 'positron-add-filter',
 			label: localize('positron.dataExplorer.addFilter', "Add Filter"),
+			disabled: !canFilter,
 			onSelected: () => addRowFilterHandler(
 				rowFilterButtonRef.current,
 				rowFilterDescriptors.length === 0
@@ -286,6 +291,7 @@ export const RowFilterBar = () => {
 					ref={addFilterButtonRef}
 					className='add-row-filter-button'
 					ariaLabel={(() => localize('positron.dataExplorer.addFilter', "Add Filter"))()}
+					disabled={!canFilter}
 					onPressed={() => addRowFilterHandler(
 						addFilterButtonRef.current,
 						rowFilterDescriptors.length === 0

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -5,7 +5,7 @@
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
-import { BackendState, ColumnProfileRequest, ColumnProfileResult, ColumnSchema, ColumnSortKey, DataSelection, ExportedData, ExportFormat, FilterResult, FormatOptions, PositronDataExplorerComm, RowFilter, SchemaUpdateEvent, TableData, TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { BackendState, ColumnProfileRequest, ColumnProfileResult, ColumnSchema, ColumnSortKey, DataSelection, ExportedData, ExportFormat, FilterResult, FormatOptions, PositronDataExplorerComm, RowFilter, SchemaUpdateEvent, SupportedFeatures, TableData, TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * TableSchemaSearchResult interface. This is here temporarily until searching the tabe schema
@@ -217,7 +217,9 @@ export class DataExplorerClientInstance extends Disposable {
 						get_column_profiles: {
 							supported: false,
 							supported_types: []
-						}
+						},
+						set_sort_columns: { supported: false },
+						export_data_selection: { supported: false }
 					}
 				};
 			});
@@ -367,6 +369,30 @@ export class DataExplorerClientInstance extends Disposable {
 			() => this._positronDataExplorerComm.setSortColumns(sortKeys),
 			() => { }
 		);
+	}
+
+	getSupportedFeatures(): SupportedFeatures {
+		if (this.cachedBackendState === undefined) {
+			// Until the backend state is available, we disable features.
+			return {
+				search_schema: {
+					supported: false
+				},
+				set_row_filters: {
+					supported: false,
+					supports_conditions: false,
+					supported_types: []
+				},
+				get_column_profiles: {
+					supported: false,
+					supported_types: []
+				},
+				set_sort_columns: { supported: false },
+				export_data_selection: { supported: false }
+			};
+		} else {
+			return this.cachedBackendState.supported_features;
+		}
 	}
 
 	//#endregion Public Methods

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -662,6 +662,16 @@ export interface SupportedFeatures {
 	 */
 	get_column_profiles: GetColumnProfilesFeatures;
 
+	/**
+	 * Support for 'set_sort_columns' RPC and its features
+	 */
+	set_sort_columns: SetSortColumnsFeatures;
+
+	/**
+	 * Support for 'export_data_selection' RPC and its features
+	 */
+	export_data_selection: ExportDataSelectionFeatures;
+
 }
 
 /**
@@ -709,6 +719,28 @@ export interface GetColumnProfilesFeatures {
 	 * A list of supported types
 	 */
 	supported_types: Array<ColumnProfileType>;
+
+}
+
+/**
+ * Feature flags for 'export_data_selction' RPC
+ */
+export interface ExportDataSelectionFeatures {
+	/**
+	 * Whether this RPC method is supported at all
+	 */
+	supported: boolean;
+
+}
+
+/**
+ * Feature flags for 'set_sort_columns' RPC
+ */
+export interface SetSortColumnsFeatures {
+	/**
+	 * Whether this RPC method is supported at all
+	 */
+	supported: boolean;
 
 }
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
@@ -58,6 +58,15 @@
 .content
 .column-summary
 .basic-info
+.expand-collapse-button.disabled {
+	opacity: 0%;
+	cursor: default;
+}
+
+.data-grid-row-cell
+.content
+.column-summary
+.basic-info
 .expand-collapse-button:focus {
 	outline: none !important;
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -15,11 +15,12 @@ import { HoverPosition } from 'vs/base/browser/ui/hover/hoverWidget';
 import { ProfileNumber } from 'vs/workbench/services/positronDataExplorer/browser/components/profileNumber';
 import { ProfileString } from 'vs/workbench/services/positronDataExplorer/browser/components/profileString';
 import { ColumnNullPercent } from 'vs/workbench/services/positronDataExplorer/browser/components/columnNullPercent';
-import { ColumnDisplayType, ColumnSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { ColumnDisplayType, ColumnProfileType, ColumnSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
 import { ProfileBoolean } from 'vs/workbench/services/positronDataExplorer/browser/components/profileBoolean';
 import { ProfileDate } from 'vs/workbench/services/positronDataExplorer/browser/components/profileDate';
 import { ProfileDatetime } from 'vs/workbench/services/positronDataExplorer/browser/components/profileDatetime';
+import { positronClassNames } from 'vs/base/common/positronUtilities';
 
 /**
  * ColumnSummaryCellProps interface.
@@ -167,6 +168,13 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 	// Get the column null percent.
 	const columnNullPercent = props.instance.getColumnNullPercent(props.columnIndex);
 
+	const profileFeatures = props.instance.getSupportedFeatures().get_column_profiles;
+	let summarySupported = profileFeatures.supported_types.includes(ColumnProfileType.SummaryStats);
+	if (props.columnSchema.type_display === ColumnDisplayType.Object ||
+		props.columnSchema.type_display === ColumnDisplayType.Unknown) {
+		summarySupported = false;
+	}
+
 	// Render.
 	return (
 		<div
@@ -178,9 +186,10 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			}
 			<div className='basic-info'>
 				<div
-					className='expand-collapse-button'
-					onClick={() =>
-						props.instance.toggleExpandColumn(props.columnIndex)
+					className={positronClassNames('expand-collapse-button',
+						{ 'disabled': !summarySupported })}
+					onClick={summarySupported ? () =>
+						props.instance.toggleExpandColumn(props.columnIndex) : undefined
 					}
 				>
 					{expanded ?

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -240,11 +240,17 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		 */
 		const columnSortKey = this.columnSortKey(columnIndex);
 
+		const features = this._dataExplorerClientInstance.getSupportedFeatures();
+		const copySupported = features.export_data_selection?.supported;
+		const sortSupported = features.set_sort_columns?.supported;
+		const filterSupported = features.set_row_filters.supported;
+
 		// Build the entries.
 		const entries: CustomContextMenuEntry[] = [];
 		entries.push(new CustomContextMenuItem({
 			commandId: PositronDataExplorerCommandId.CopyAction,
 			checked: false,
+			disabled: !copySupported,
 			icon: 'copy',
 			label: localize('positron.dataExplorer.copy', "Copy"),
 			onSelected: () => console.log('Copy')
@@ -261,6 +267,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		entries.push(new CustomContextMenuItem({
 			checked: columnSortKey !== undefined && columnSortKey.ascending,
 			icon: 'arrow-up',
+			disabled: !sortSupported,
 			label: localize('positron.sortAscending', "Sort Ascending"),
 			onSelected: async () => this.setColumnSortKey(
 				columnIndex,
@@ -270,6 +277,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		entries.push(new CustomContextMenuItem({
 			checked: columnSortKey !== undefined && !columnSortKey.ascending,
 			icon: 'arrow-down',
+			disabled: !sortSupported,
 			label: localize('positron.sortDescending', "Sort Descending"),
 			onSelected: async () => this.setColumnSortKey(
 				columnIndex,
@@ -290,7 +298,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			checked: false,
 			icon: 'positron-add-filter',
 			label: addFilterTitle,
-			disabled: false,
+			disabled: !filterSupported,
 			onSelected: () => {
 				const columnSchema = this._dataExplorerCache.getColumnSchema(columnIndex);
 				if (columnSchema) {
@@ -324,11 +332,15 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		anchorElement: HTMLElement,
 		anchorPoint: AnchorPoint
 	): Promise<void> {
+		const features = this._dataExplorerClientInstance.getSupportedFeatures();
+		const copySupported = features.export_data_selection?.supported;
+
 		// Build the entries.
 		const entries: CustomContextMenuEntry[] = [];
 		entries.push(new CustomContextMenuItem({
 			commandId: PositronDataExplorerCommandId.CopyAction,
 			checked: false,
+			disabled: !copySupported,
 			icon: 'copy',
 			label: localize('positron.dataExplorer.copy', "Copy"),
 			onSelected: () => console.log('Copy')
@@ -373,10 +385,16 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		 */
 		const columnSortKey = this.columnSortKey(columnIndex);
 
+		const features = this._dataExplorerClientInstance.getSupportedFeatures();
+		const copySupported = features.export_data_selection?.supported;
+		const sortSupported = features.set_sort_columns?.supported;
+		const filterSupported = features.set_row_filters.supported;
+
 		// Build the entries.
 		const entries: CustomContextMenuEntry[] = [];
 		entries.push(new CustomContextMenuItem({
 			checked: false,
+			disabled: !copySupported,
 			commandId: PositronDataExplorerCommandId.CopyAction,
 			icon: 'copy',
 			label: localize('positron.dataExplorer.copy', "Copy"),
@@ -401,6 +419,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		entries.push(new CustomContextMenuItem({
 			checked: columnSortKey !== undefined && columnSortKey.ascending,
 			icon: 'arrow-up',
+			disabled: !sortSupported,
 			label: localize('positron.sortAscending', "Sort Ascending"),
 			onSelected: async () => this.setColumnSortKey(
 				columnIndex,
@@ -410,6 +429,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		entries.push(new CustomContextMenuItem({
 			checked: columnSortKey !== undefined && !columnSortKey.ascending,
 			icon: 'arrow-down',
+			disabled: !sortSupported,
 			label: localize('positron.sortDescending', "Sort Descending"),
 			onSelected: async () => this.setColumnSortKey(
 				columnIndex,
@@ -430,7 +450,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			checked: false,
 			icon: 'positron-add-filter',
 			label: addFilterTitle,
-			disabled: false,
+			disabled: !filterSupported,
 			onSelected: () => {
 				const columnSchema = this._dataExplorerCache.getColumnSchema(columnIndex);
 				if (columnSchema) {

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -243,6 +243,10 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		return this._dataExplorerCache.getColumnSummaryStats(columnIndex);
 	}
 
+	getSupportedFeatures() {
+		return this._dataExplorerClientInstance.getSupportedFeatures();
+	}
+
 	//#endregion DataGridInstance Methods
 
 	//#region Public Events


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

Start of addressing #2185, will create sub-issues to break down work to implement all of the missing features. I have used the `SupportedFeatures` response to set `disabled` flags in the UI and added some CSS in consultation with Brian to toggle off row filtering, sorting, copy-and-pasting, expanding summary statistics. So basically we can just see the data values and the data types, along with the null percentages. We will be able to then incrementally add support for all of the missing features and communicate their support level via `SupportedFeatures`.

I added a couple of new items to SupportedFeatures for copy-paste and sorting, and added undefined checks so that the R kernel is not broken when this is merged.

### QA Notes

Try loading a Parquet / CSV file and you should be able to look at the data but not use any analytical features other than seeing the raw data and the null counts. 