### PR TITLE
Data Explorer: fix pandas summary statistics for complex numbers and float columns with inf/-inf values, hide undefined statistics, handle inf/-inf special value codes

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -261,6 +261,8 @@ _VALUE_NA = 1
 _VALUE_NAN = 2
 _VALUE_NAT = 3
 _VALUE_NONE = 4
+_VALUE_INF = 10
+_VALUE_NEGINF = 11
 
 
 if np_ is not None:
@@ -1121,20 +1123,30 @@ class PandasView(DataExplorerTableView):
     def _summarize_number(cls, col: "pd.Series", options: FormatOptions):
         float_format = _get_float_formatter(options)
 
-        min_val = col.min()
-        max_val = col.max()
-        mean_val = col.mean()
-        median_val = col.median()
-        std_val = col.std()
+        if "complex" in str(col.dtype):
+            min_val = max_val = std_val = None
+            values = col.to_numpy()
+            non_null_values = values[~np_.isnan(values)]
+            if len(non_null_values) > 0:
+                median_val = float_format(np_.median(non_null_values))
+                mean_val = float_format(np_.mean(non_null_values))
+            else:
+                median_val = mean_val = None
+        else:
+            min_val = float_format(col.min())
+            max_val = float_format(col.max())
+            mean_val = float_format(col.mean())
+            median_val = float_format(col.median())
+            std_val = float_format(col.std())
 
         return ColumnSummaryStats(
             type_display=ColumnDisplayType.Number,
             number_stats=SummaryStatsNumber(
-                min_value=float_format(min_val),
-                max_value=float_format(max_val),
-                mean=float_format(mean_val),
-                median=float_format(median_val),
-                stdev=float_format(std_val),
+                min_value=min_val,
+                max_value=max_val,
+                mean=mean_val,
+                median=median_val,
+                stdev=std_val,
             ),
         )
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -7,6 +7,7 @@
 
 import abc
 import logging
+import math
 import operator
 from datetime import datetime
 from typing import (
@@ -271,6 +272,7 @@ if np_ is not None:
         return isinstance(x, (float, np_.floating))
 
     _isnan = np_.isnan  # type: ignore
+    _isinf = np_.isinf  # type: ignore
 else:
 
     def _is_float_scalar(x):
@@ -278,6 +280,9 @@ else:
 
     def _isnan(x: float) -> bool:
         return x != x
+
+    def _isinf(x: float) -> bool:
+        return math.isinf(x)
 
 
 def _get_float_formatter(options: FormatOptions) -> Callable:
@@ -775,24 +780,28 @@ class PandasView(DataExplorerTableView):
 
     @classmethod
     def _format_values(cls, values, options: FormatOptions) -> List[ColumnValue]:
+        NaT = pd_.NaT
+        NA = pd_.NA
         float_format = _get_float_formatter(options)
-        return [cls._format_value(x, float_format) for x in values]
 
-    @staticmethod
-    def _format_value(x, float_format: Callable):
-        if _is_float_scalar(x):
-            if _isnan(x):
-                return _VALUE_NAN
+        def _format_value(x):
+            if _is_float_scalar(x):
+                if _isnan(x):
+                    return _VALUE_NAN
+                elif _isinf(x):
+                    return _VALUE_INF if x > 0 else _VALUE_NEGINF
+                else:
+                    return float_format(x)
+            elif x is None:
+                return _VALUE_NONE
+            elif x is NaT:
+                return _VALUE_NAT
+            elif x is NA:
+                return _VALUE_NA
             else:
-                return float_format(x)
-        elif x is None:
-            return _VALUE_NONE
-        elif x is getattr(pd_, "NaT", None):
-            return _VALUE_NAT
-        elif x is getattr(pd_, "NA", None):
-            return _VALUE_NA
-        else:
-            return str(x)
+                return str(x)
+
+        return [_format_value(x) for x in values]
 
     def _export_data_selection(self, selection: DataSelection, fmt: ExportFormat) -> ExportedData:
         sel = selection.selection
@@ -1123,21 +1132,29 @@ class PandasView(DataExplorerTableView):
     def _summarize_number(cls, col: "pd.Series", options: FormatOptions):
         float_format = _get_float_formatter(options)
 
+        median_val = mean_val = std_val = None
+
         if "complex" in str(col.dtype):
-            min_val = max_val = std_val = None
+            min_val = max_val = None
             values = col.to_numpy()
             non_null_values = values[~np_.isnan(values)]
             if len(non_null_values) > 0:
                 median_val = float_format(np_.median(non_null_values))
                 mean_val = float_format(np_.mean(non_null_values))
-            else:
-                median_val = mean_val = None
         else:
-            min_val = float_format(col.min())
-            max_val = float_format(col.max())
-            mean_val = float_format(col.mean())
-            median_val = float_format(col.median())
-            std_val = float_format(col.std())
+            min_val = col.min()
+            max_val = col.max()
+
+            if not _isinf(min_val) and not _isinf(max_val):
+                # These stats are not defined when there is an
+                # inf/-inf in the data
+                mean_val = float_format(col.mean())
+                median_val = float_format(col.median())
+                std_val = float_format(col.std())
+
+            # Format the min/max
+            min_val = float_format(min_val)
+            max_val = float_format(max_val)
 
         return ColumnSummaryStats(
             type_display=ColumnDisplayType.Number,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -546,23 +546,28 @@ class SummaryStatsNumber(BaseModel):
     SummaryStatsNumber in Schemas
     """
 
-    min_value: StrictStr = Field(
+    min_value: Optional[StrictStr] = Field(
+        default=None,
         description="Minimum value as string",
     )
 
-    max_value: StrictStr = Field(
+    max_value: Optional[StrictStr] = Field(
+        default=None,
         description="Maximum value as string",
     )
 
-    mean: StrictStr = Field(
+    mean: Optional[StrictStr] = Field(
+        default=None,
         description="Average value as string",
     )
 
-    median: StrictStr = Field(
+    median: Optional[StrictStr] = Field(
+        default=None,
         description="Sample median (50% value) value as string",
     )
 
-    stdev: StrictStr = Field(
+    stdev: Optional[StrictStr] = Field(
+        default=None,
         description="Sample standard deviation as a string",
     )
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -1958,7 +1958,7 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             "f6": pd.date_range(
                 "2000-01-01", freq="2h", periods=100, tz="US/Eastern"
             ),  # datetime single tz
-            "f7": [1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, np.nan + 0j] * 20,  # complex,
+            "f7": [1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, np.nan] * 20,  # complex,
             "f8": [np.nan, np.inf, -np.inf, 0, np.nan] * 20,  # with infinity
         }
     )

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from decimal import Decimal
 from io import StringIO
 from typing import Any, Dict, List, Optional, Type, cast
+import math
 
 import numpy as np
 import pandas as pd
@@ -17,6 +18,8 @@ import pytest
 from .._vendor.pydantic import BaseModel
 from ..access_keys import encode_access_key
 from ..data_explorer import (
+    _VALUE_NEGINF,
+    _VALUE_INF,
     _VALUE_NULL,
     _VALUE_NA,
     _VALUE_NAN,
@@ -105,6 +108,7 @@ SIMPLE_PANDAS_DF = pd.DataFrame(
         ),
         "f": [None, MyData(5), MyData(-1), None, None],
         "g": [True, False, True, False, True],
+        "h": [np.inf, -np.inf, np.nan, 0, 0],
     }
 )
 
@@ -462,7 +466,7 @@ def _wrap_json(model: Type[BaseModel], data: JsonRecords):
 def test_pandas_get_state(dxf: DataExplorerFixture):
     result = dxf.get_state("simple")
     assert result["display_name"] == "simple"
-    ex_shape = {"num_rows": 5, "num_columns": 7}
+    ex_shape = {"num_rows": 5, "num_columns": 8}
     assert result["table_shape"] == ex_shape
     assert result["table_unfiltered_shape"] == ex_shape
 
@@ -482,7 +486,7 @@ def test_pandas_get_state(dxf: DataExplorerFixture):
     result = dxf.get_state("simple")
     assert result["sort_keys"] == sort_keys
 
-    ex_filtered_shape = {"num_rows": 2, "num_columns": 7}
+    ex_filtered_shape = {"num_rows": 2, "num_columns": 8}
     assert result["table_shape"] == ex_filtered_shape
     assert result["table_unfiltered_shape"] == ex_shape
 
@@ -720,7 +724,7 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
         "simple",
         row_start_index=0,
         num_rows=20,
-        column_indices=list(range(6)),
+        column_indices=list(range(8)),
     )
 
     expected_columns = [
@@ -736,6 +740,8 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
             "2024-01-05 00:00:00",
         ],
         [_VALUE_NONE, "5", "-1", _VALUE_NONE, _VALUE_NONE],
+        ["True", "False", "True", "False", "True"],
+        [_VALUE_INF, _VALUE_NEGINF, _VALUE_NAN, "0.00", "0.00"],
     ]
 
     assert result["columns"] == expected_columns
@@ -749,18 +755,12 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
     # Issue #2149 -- return empty result when requesting non-existent
     # column indices
     response = dxf.get_data_values(
-        "simple", row_start_index=0, num_rows=5, column_indices=[2, 3, 4, 5]
+        "simple",
+        row_start_index=0,
+        num_rows=5,
+        column_indices=[2, 3, 4, 5, 6, 7],
     )
     assert response["columns"] == expected_columns[2:]
-
-    # Edge case: request invalid column index
-    # Per issue #2149, until we can align on whether the UI is allowed
-    # to request non-existent column indices, disable this test
-
-    # with pytest.raises(IndexError):
-    #     dxf.get_data_values(
-    #         "simple", row_start_index=0, num_rows=10, column_indices=[4]
-    #     )
 
 
 def test_pandas_float_formatting(dxf: DataExplorerFixture):
@@ -1729,7 +1729,8 @@ def test_pandas_export_data_selection(dxf: DataExplorerFixture):
     np.random.seed(12345)
     df = pd.DataFrame({f"a{i}": np.random.standard_normal(length) for i in range(ncols)})
 
-    dxf.register_table("df", df)
+    name = guid()
+    dxf.register_table(name, df)
     dxf.register_table("filtered", df)
 
     schema = dxf.get_schema("filtered")
@@ -1742,7 +1743,7 @@ def test_pandas_export_data_selection(dxf: DataExplorerFixture):
 
     for row_index, col_index in single_cell_cases:
         selection = _select_single_cell(row_index, col_index)
-        df_result = dxf.export_data_selection("df", selection, "tsv")
+        df_result = dxf.export_data_selection(name, selection, "tsv")
         df_expected = str(df.iat[row_index, col_index])
         assert df_result["data"] == df_expected
         assert df_result["format"] == "tsv"
@@ -1778,7 +1779,7 @@ def test_pandas_export_data_selection(dxf: DataExplorerFixture):
         filtered_selected = filtered.iloc[selector]
 
         for fmt in ["csv", "tsv", "html"]:
-            df_result = dxf.export_data_selection("df", rpc_selection, fmt)
+            df_result = dxf.export_data_selection(name, rpc_selection, fmt)
             df_expected = do_export(df_selected, fmt)
 
             assert df_result["data"] == df_expected
@@ -1878,12 +1879,30 @@ EPSILON = 1e-7
 
 
 def _assert_close(expected, actual):
-    assert np.abs(actual - expected) < EPSILON
+    if isinstance(expected, float) and math.isinf(expected):
+        assert math.isinf(actual)
+        if expected > 0:
+            assert actual > 0
+        else:
+            assert actual < 0
+    else:
+        assert np.abs(actual - expected) < EPSILON
 
 
 def _assert_numeric_stats_equal(expected, actual):
+    all_stats = {"min_value", "max_value", "mean", "median", "stdev"}
     for attr, value in expected.items():
-        _assert_close(float(value), float(actual.get(attr)))
+        all_stats.remove(attr)
+        if "j" in value:
+            # Complex numbers
+            _assert_close(complex(value), complex(actual.get(attr)))
+        else:
+            _assert_close(float(value), float(actual.get(attr)))
+
+    # for stats that weren't expected, check that there isn't an
+    # unexpected value
+    for not_expected_stat in all_stats:
+        assert not_expected_stat not in actual or actual[not_expected_stat] is None
 
 
 def _assert_string_stats_equal(expected, actual):
@@ -1916,10 +1935,10 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
 
     df1 = pd.DataFrame(
         {
-            "a": arr,
-            "b": arr_with_nulls,
-            "c": [False, False, False, True, None] * 20,
-            "d": [
+            "f0": arr,
+            "f1": arr_with_nulls,
+            "f2": [False, False, False, True, None] * 20,
+            "f3": [
                 "foo",
                 "",
                 "baz",
@@ -1932,11 +1951,15 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 "zzz",
             ]
             * 10,
-            "e": getattr(pd.date_range("2000-01-01", freq="D", periods=100), "date"),  # date column
-            "f": pd.date_range("2000-01-01", freq="2h", periods=100),  # datetime no tz
-            "g": pd.date_range(
+            "f4": getattr(
+                pd.date_range("2000-01-01", freq="D", periods=100), "date"
+            ),  # date column
+            "f5": pd.date_range("2000-01-01", freq="2h", periods=100),  # datetime no tz
+            "f6": pd.date_range(
                 "2000-01-01", freq="2h", periods=100, tz="US/Eastern"
             ),  # datetime single tz
+            "f7": [1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, np.nan + 0j] * 20,  # complex,
+            "f8": [np.nan, np.inf, -np.inf, 0, np.nan] * 20,  # with infinity
         }
     )
 
@@ -1997,20 +2020,20 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             {
                 "min_value": _format_float(arr.min()),
                 "max_value": _format_float(arr.max()),
-                "mean": _format_float(df1["a"].mean()),
-                "stdev": _format_float(df1["a"].std()),
-                "median": _format_float(df1["a"].median()),
+                "mean": _format_float(df1["f0"].mean()),
+                "stdev": _format_float(df1["f0"].std()),
+                "median": _format_float(df1["f0"].median()),
             },
         ),
         (
             "df1",
             1,
             {
-                "min_value": _format_float(df1["b"].min()),
-                "max_value": _format_float(df1["b"].max()),
-                "mean": _format_float(df1["b"].mean()),
-                "stdev": _format_float(df1["b"].std()),
-                "median": _format_float(df1["b"].median()),
+                "min_value": _format_float(df1["f1"].min()),
+                "max_value": _format_float(df1["f1"].max()),
+                "mean": _format_float(df1["f1"].mean()),
+                "stdev": _format_float(df1["f1"].std()),
+                "median": _format_float(df1["f1"].median()),
             },
         ),
         (
@@ -2057,6 +2080,16 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 "max_date": "2000-01-09 06:00:00-05:00",
                 "timezone": "US/Eastern",
             },
+        ),
+        (
+            "df1",
+            7,
+            {"mean": "2.50+2.50j", "median": "2.50+2.50j"},
+        ),
+        (
+            "df1",
+            8,
+            {"min_value": "-INF", "max_value": "INF"},
         ),
         (
             "df_mixed_tz1",
@@ -2223,12 +2256,13 @@ def test_polars_get_schema(dxf: DataExplorerFixture):
 
 def test_polars_get_state(dxf: DataExplorerFixture):
     df, _ = example_polars_df()
-    dxf.register_table("df", df)
+    name = guid()
+    dxf.register_table(name, df)
 
-    state = dxf.get_state("df")
+    state = dxf.get_state(name)
     ex_shape = {"num_rows": df.shape[0], "num_columns": df.shape[1]}
 
-    assert state["display_name"] == "df"
+    assert state["display_name"] == name
     assert state["table_shape"] == ex_shape
     assert state["table_unfiltered_shape"] == ex_shape
     assert state["sort_keys"] == []
@@ -2243,10 +2277,11 @@ def test_polars_get_state(dxf: DataExplorerFixture):
 
 def test_polars_get_data_values(dxf: DataExplorerFixture):
     df, _ = example_polars_df()
-    dxf.register_table("df", df)
+    name = guid()
+    dxf.register_table(name, df)
 
     result = dxf.get_data_values(
-        "df",
+        name,
         row_start_index=0,
         num_rows=10,
         column_indices=list(range(df.shape[1])),
@@ -2297,14 +2332,14 @@ def test_polars_get_data_values(dxf: DataExplorerFixture):
     assert result["row_labels"] is None
 
     result = dxf.get_data_values(
-        "df",
+        name,
         row_start_index=2,
         num_rows=10,
         column_indices=list(range(15, df.shape[1])),
     )
     assert result["columns"] == [x[2:] for x in expected_columns[15:]]
 
-    result = dxf.get_data_values("df", row_start_index=10, num_rows=10, column_indices=[])
+    result = dxf.get_data_values(name, row_start_index=10, num_rows=10, column_indices=[])
     assert result["columns"] == []
     assert result["row_labels"] is None
 
@@ -2318,18 +2353,20 @@ def test_polars_profile_null_counts(dxf: DataExplorerFixture):
             "d": [0, 1, 2, 3, 4, 5, 6],
         }
     )
-    dxf.register_table("df", df)
+
+    name = guid()
+    dxf.register_table(name, df)
 
     # tuples like (table_name, [ColumnProfileRequest], [results])
     cases = [
-        ("df", [], []),
+        (name, [], []),
         (
-            "df",
+            name,
             [_get_null_count(3)],
             [0],
         ),
         (
-            "df",
+            name,
             [
                 _get_null_count(0),
                 _get_null_count(1),

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -756,13 +756,7 @@
 			},
 			"summary_stats_number": {
 				"type": "object",
-				"required": [
-					"min_value",
-					"max_value",
-					"mean",
-					"median",
-					"stdev"
-				],
+				"required": [],
 				"properties": {
 					"min_value": {
 						"type": "string",

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -434,27 +434,27 @@ export interface SummaryStatsNumber {
 	/**
 	 * Minimum value as string
 	 */
-	min_value: string;
+	min_value?: string;
 
 	/**
 	 * Maximum value as string
 	 */
-	max_value: string;
+	max_value?: string;
 
 	/**
 	 * Average value as string
 	 */
-	mean: string;
+	mean?: string;
 
 	/**
 	 * Sample median (50% value) value as string
 	 */
-	median: string;
+	median?: string;
 
 	/**
 	 * Sample standard deviation as a string
 	 */
-	stdev: string;
+	stdev?: string;
 
 }
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/profileNumber.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/profileNumber.tsx
@@ -54,25 +54,38 @@ export const ProfileNumber = (props: ProfileNumberProps) => {
 		return () => disposableStore.dispose();
 	}, [props.instance.configurationService]);
 
+	const statsEntries = [
+		['NA', nullCount],
+	];
+	if (stats.mean) {
+		statsEntries.push(['Mean', stats.mean]);
+	}
+	if (stats.median) {
+		statsEntries.push(['Median', stats.median]);
+	}
+	if (stats.stdev) {
+		statsEntries.push(['SD', stats.stdev]);
+	}
+	if (stats.min_value) {
+		statsEntries.push(['Min', stats.min_value]);
+	}
+	if (stats.max_value) {
+		statsEntries.push(['Max', stats.max_value]);
+	}
+
 	// Render.
 	return (
 		<div ref={ref} className='tabular-info'>
 			<div className='labels'>
-				<div className='label'>NA</div>
-				<div className='label'>Mean</div>
-				<div className='label'>Median</div>
-				<div className='label'>SD</div>
-				<div className='label'>Min</div>
-				<div className='label'>Max</div>
+				{statsEntries.map((entry, index) => (
+					<div key={index} className='label'>{entry[0]}</div>
+				))}
 			</div>
 			<div className='values'>
 				<div className='values-left'>
-					<div className='value'>{nullCount}</div>
-					<div className='value'>{stats.mean}</div>
-					<div className='value'>{stats.median}</div>
-					<div className='value'>{stats.stdev}</div>
-					<div className='value'>{stats.min_value}</div>
-					<div className='value'>{stats.max_value}</div>
+					{statsEntries.map((entry, index) => (
+						<div key={index} className='value'>{entry[1]}</div>
+					))}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Addresses #3421 for Python and #3437. 

inf/-inf now no longer displays mean/median values and there are no runtime warnings in the console

![image](https://github.com/posit-dev/positron/assets/329591/693536da-72b1-41c0-ab51-be5b2365db58)

Similarly, complex numbers only show the the null count, mean, and median (because the min and max are not defined)

![image](https://github.com/posit-dev/positron/assets/329591/bb342a24-6fa1-4900-a835-7139ee4560f7)

Lastly, the special value codes for INF/-INF are now being returned in `get_data_values`