### PR TITLE
Default to four pane layout on first startup

### DIFF
--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -51,8 +51,8 @@ import { setProgressAcccessibilitySignalScheduler } from 'vs/base/browser/ui/pro
 
 // --- Start Positron ---
 import { positronFourPaneDsLayout } from 'vs/workbench/browser/positronCustomViews';
+import { IViewDescriptorService } from 'vs/workbench/common/views';
 // --- End Positron ---
-
 export interface IWorkbenchOptions {
 
 	/**
@@ -63,7 +63,7 @@ export interface IWorkbenchOptions {
 
 export class Workbench extends Layout {
 	// --- Start Positron ---
-	private static readonly LAYOUT_INITIALIZED = 'positron.workbench.layoutInitialized';
+	private static readonly LAYOUT_INITIALIZED_STORAGE_KEY = 'positron.workbench.layoutInitialized';
 	// --- End Positron ---
 
 	private readonly _onWillShutdown = this._register(new Emitter<WillShutdownEvent>());
@@ -71,7 +71,6 @@ export class Workbench extends Layout {
 
 	private readonly _onDidShutdown = this._register(new Emitter<void>());
 	readonly onDidShutdown = this._onDidShutdown.event;
-
 
 	constructor(
 		parent: HTMLElement,
@@ -167,6 +166,7 @@ export class Workbench extends Layout {
 				const hoverService = accessor.get(IHoverService);
 				const dialogService = accessor.get(IDialogService);
 				const notificationService = accessor.get(INotificationService) as NotificationService;
+				const viewDescriptorService = accessor.get(IViewDescriptorService);
 
 				// Default Hover Delegate must be registered before creating any workbench/layout components
 				// as these possibly will use the default hover delegate
@@ -197,10 +197,11 @@ export class Workbench extends Layout {
 
 				// --- Start Positron ---
 				// Initialize the layout only on first startup
-				const isLayoutInitialized = storageService.getBoolean(Workbench.LAYOUT_INITIALIZED, StorageScope.PROFILE, false);
+				const isLayoutInitialized = storageService.getBoolean(Workbench.LAYOUT_INITIALIZED_STORAGE_KEY, StorageScope.PROFILE, false);
 				if (!isLayoutInitialized) {
+					viewDescriptorService.loadCustomViewDescriptor(positronFourPaneDsLayout.layoutDescriptor);
 					this.enterCustomLayout(positronFourPaneDsLayout.layoutDescriptor);
-					storageService.store(Workbench.LAYOUT_INITIALIZED, true, StorageScope.PROFILE, StorageTarget.MACHINE);
+					storageService.store(Workbench.LAYOUT_INITIALIZED_STORAGE_KEY, true, StorageScope.PROFILE, StorageTarget.MACHINE);
 				}
 				// --- End Positron ---
 

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -49,6 +49,10 @@ import { setBaseLayerHoverDelegate } from 'vs/base/browser/ui/hover/hoverDelegat
 import { AccessibilityProgressSignalScheduler } from 'vs/platform/accessibilitySignal/browser/progressAccessibilitySignalScheduler';
 import { setProgressAcccessibilitySignalScheduler } from 'vs/base/browser/ui/progressbar/progressAccessibilitySignal';
 
+// --- Start Positron ---
+import { positronFourPaneDsLayout } from 'vs/workbench/browser/positronCustomViews';
+// --- End Positron ---
+
 export interface IWorkbenchOptions {
 
 	/**
@@ -186,6 +190,10 @@ export class Workbench extends Layout {
 
 				// Layout
 				this.layout();
+
+				// --- Start Positron ---
+				this.enterCustomLayout(positronFourPaneDsLayout.layoutDescriptor);
+				// --- End Positron ---
 
 				// Restore
 				this.restore(lifecycleService);

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -69,6 +69,8 @@ export class Workbench extends Layout {
 	private readonly _onDidShutdown = this._register(new Emitter<void>());
 	readonly onDidShutdown = this._onDidShutdown.event;
 
+	private static readonly LAYOUT_INITIALIZED = 'positron.workbench.layoutInitialized';
+
 	constructor(
 		parent: HTMLElement,
 		private readonly options: IWorkbenchOptions | undefined,
@@ -192,7 +194,12 @@ export class Workbench extends Layout {
 				this.layout();
 
 				// --- Start Positron ---
-				this.enterCustomLayout(positronFourPaneDsLayout.layoutDescriptor);
+				// Initialize the layout only on first startup
+				const isLayoutInitialized = storageService.getBoolean(Workbench.LAYOUT_INITIALIZED, StorageScope.PROFILE, false);
+				if (!isLayoutInitialized) {
+					this.enterCustomLayout(positronFourPaneDsLayout.layoutDescriptor);
+					storageService.store(Workbench.LAYOUT_INITIALIZED, true, StorageScope.PROFILE, StorageTarget.MACHINE);
+				}
 				// --- End Positron ---
 
 				// Restore

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -62,6 +62,9 @@ export interface IWorkbenchOptions {
 }
 
 export class Workbench extends Layout {
+	// --- Start Positron ---
+	private static readonly LAYOUT_INITIALIZED = 'positron.workbench.layoutInitialized';
+	// --- End Positron ---
 
 	private readonly _onWillShutdown = this._register(new Emitter<WillShutdownEvent>());
 	readonly onWillShutdown = this._onWillShutdown.event;
@@ -69,7 +72,6 @@ export class Workbench extends Layout {
 	private readonly _onDidShutdown = this._register(new Emitter<void>());
 	readonly onDidShutdown = this._onDidShutdown.event;
 
-	private static readonly LAYOUT_INITIALIZED = 'positron.workbench.layoutInitialized';
 
 	constructor(
 		parent: HTMLElement,

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -58,6 +58,7 @@ export interface IWorkbenchOptions {
 }
 
 export class Workbench extends Layout {
+
 	private readonly _onWillShutdown = this._register(new Emitter<WillShutdownEvent>());
 	readonly onWillShutdown = this._onWillShutdown.event;
 

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -49,10 +49,6 @@ import { setBaseLayerHoverDelegate } from 'vs/base/browser/ui/hover/hoverDelegat
 import { AccessibilityProgressSignalScheduler } from 'vs/platform/accessibilitySignal/browser/progressAccessibilitySignalScheduler';
 import { setProgressAcccessibilitySignalScheduler } from 'vs/base/browser/ui/progressbar/progressAccessibilitySignal';
 
-// --- Start Positron ---
-import { positronFourPaneDsLayout } from 'vs/workbench/browser/positronCustomViews';
-import { IViewDescriptorService } from 'vs/workbench/common/views';
-// --- End Positron ---
 export interface IWorkbenchOptions {
 
 	/**
@@ -62,10 +58,6 @@ export interface IWorkbenchOptions {
 }
 
 export class Workbench extends Layout {
-	// --- Start Positron ---
-	private static readonly LAYOUT_INITIALIZED_STORAGE_KEY = 'positron.workbench.layoutInitialized';
-	// --- End Positron ---
-
 	private readonly _onWillShutdown = this._register(new Emitter<WillShutdownEvent>());
 	readonly onWillShutdown = this._onWillShutdown.event;
 
@@ -166,7 +158,6 @@ export class Workbench extends Layout {
 				const hoverService = accessor.get(IHoverService);
 				const dialogService = accessor.get(IDialogService);
 				const notificationService = accessor.get(INotificationService) as NotificationService;
-				const viewDescriptorService = accessor.get(IViewDescriptorService);
 
 				// Default Hover Delegate must be registered before creating any workbench/layout components
 				// as these possibly will use the default hover delegate
@@ -194,16 +185,6 @@ export class Workbench extends Layout {
 
 				// Layout
 				this.layout();
-
-				// --- Start Positron ---
-				// Initialize the layout only on first startup
-				const isLayoutInitialized = storageService.getBoolean(Workbench.LAYOUT_INITIALIZED_STORAGE_KEY, StorageScope.PROFILE, false);
-				if (!isLayoutInitialized) {
-					viewDescriptorService.loadCustomViewDescriptor(positronFourPaneDsLayout.layoutDescriptor);
-					this.enterCustomLayout(positronFourPaneDsLayout.layoutDescriptor);
-					storageService.store(Workbench.LAYOUT_INITIALIZED_STORAGE_KEY, true, StorageScope.PROFILE, StorageTarget.MACHINE);
-				}
-				// --- End Positron ---
 
 				// Restore
 				this.restore(lifecycleService);

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -31,6 +31,7 @@ import { TerminalCommandId } from 'vs/workbench/contrib/terminal/common/terminal
 
 // --- Start Positron ---
 import { IPositronNewProjectService } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
+import { positronFourPaneDsLayout } from 'vs/workbench/browser/positronCustomViews';
 // --- End Positron ---
 
 export const restoreWalkthroughsConfigurationKey = 'workbench.welcomePage.restorableWalkthroughs';
@@ -75,6 +76,9 @@ export class StartupPageEditorResolverContribution implements IWorkbenchContribu
 }
 
 export class StartupPageRunnerContribution implements IWorkbenchContribution {
+	// --- Start Positron ---
+	public static readonly LAYOUT_INITIALIZED_STORAGE_KEY = 'positron.workbench.layoutInitialized';
+	// --- End Positron ---
 
 	static readonly ID = 'workbench.contrib.startupPageRunner';
 
@@ -148,6 +152,16 @@ export class StartupPageRunnerContribution implements IWorkbenchContribution {
 					await this.openReadme();
 				} else if (startupEditorSetting.value === 'welcomePage' || startupEditorSetting.value === 'welcomePageInEmptyWorkbench') {
 					await this.openGettingStarted();
+					// --- Start Positron ---
+					// On first startup, change to the four-pane layout when showing the welcome page
+					this.lifecycleService.when(LifecyclePhase.Restored).then(() => {
+						const layoutInitialized = this.storageService.getBoolean(StartupPageRunnerContribution.LAYOUT_INITIALIZED_STORAGE_KEY, StorageScope.PROFILE);
+						if (!layoutInitialized) {
+							this.commandService.executeCommand(positronFourPaneDsLayout.id);
+							this.storageService.store(StartupPageRunnerContribution.LAYOUT_INITIALIZED_STORAGE_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
+						}
+					});
+					// --- End Positron ---
 				} else if (startupEditorSetting.value === 'terminal') {
 					this.commandService.executeCommand(TerminalCommandId.CreateTerminalEditor);
 				}


### PR DESCRIPTION
### Intent
Address #3311 

### Approach
Check storage for `positron.workbench.layoutInitialized` and apply the four pane DS layout.

The screenshot below is Positron opened for the first time on the Macbook screen. It's not tall enough with the console showing to be able to display the logo/title area. The sidebars also take up enough space that the Start section buttons are in a 2x2 layout.

Note that the option to turn off the welcome on startup needs to be scrolled into view. The layout might be able to fit this in but we could also set the scrollbars to always show.

<img width="1299" alt="image" src="https://github.com/posit-dev/positron/assets/9591545/bcfb1f05-dd49-41f3-a5ad-fe5fc7251ff9">

### QA Notes
Delete `/Users/<your username>/Library/Application Support/Positron` to reset Positron to a first run state. Dev builds can delete `/Users/<your username>/.vscode-oss-dev`.
