### PR TITLE
Improvements to PositronModalPopup layout

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -19,6 +19,7 @@ import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalRe
 /**
  * Constants.
  */
+const LAYOUT_MARGIN = 4;
 const MIN_SCROLLABLE_HEIGHT = 75;
 
 /**
@@ -154,10 +155,10 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 	// State hooks.
 	const [popupLayout, setPopupLayout] = useState<PopupLayout>(() => {
 		// Initially, position the popup off screen.
-		const newPopupStyle = new PopupLayout();
-		newPopupStyle.left = -10000;
-		newPopupStyle.top = -10000;
-		return newPopupStyle;
+		const newPopupLayout = new PopupLayout();
+		newPopupLayout.left = -10000;
+		newPopupLayout.top = -10000;
+		return newPopupLayout;
 	});
 
 	// Layout.
@@ -197,7 +198,7 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 			// Calculate the ideal right.
 			const idealRight = anchorLayout.anchorX +
 				childrenWidth +
-				4;
+				LAYOUT_MARGIN;
 
 			// Try to position the popup fully at the bottom or fully at the top. If this this isn't
 			// possible, try to position the popup with scrolling at the bottom or at the top. If
@@ -216,7 +217,7 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 		 */
 		const positionBottom = () => {
 			popupLayout.top = anchorLayout.anchorY + anchorLayout.anchorHeight + 1;
-			popupLayout.maxHeight = documentHeight - 4 - popupLayout.top;
+			popupLayout.maxHeight = documentHeight - LAYOUT_MARGIN - popupLayout.top;
 		};
 
 		/**
@@ -224,7 +225,7 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 		 */
 		const positionTop = () => {
 			popupLayout.bottom = -(anchorLayout.anchorY - 1);
-			popupLayout.maxHeight = anchorLayout.anchorY - 4;
+			popupLayout.maxHeight = anchorLayout.anchorY - LAYOUT_MARGIN;
 		};
 
 		// Adjust the popup layout for the popup position.
@@ -243,7 +244,7 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 				anchorLayout.anchorHeight +
 				1 +
 				childrenHeight +
-				4;
+				LAYOUT_MARGIN;
 
 			// Try to position the popup fully at the bottom or fully at the top. If this this
 			// isn't possible, try to position the popup with scrolling at the bottom or at the
@@ -256,17 +257,17 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 			} else {
 				// Calculate the max bottom height.
 				const top = anchorLayout.anchorY + anchorLayout.anchorHeight + 1;
-				const maxBottomHeight = documentHeight - 4 - top;
+				const maxBottomHeight = documentHeight - LAYOUT_MARGIN - top;
 
 				// Position the popup on the bottom with scrolling, if we can.
 				if (maxBottomHeight > MIN_SCROLLABLE_HEIGHT) {
 					positionBottom();
-				} else if (anchorLayout.anchorY - 4 > MIN_SCROLLABLE_HEIGHT) {
+				} else if (anchorLayout.anchorY - LAYOUT_MARGIN > MIN_SCROLLABLE_HEIGHT) {
 					positionTop();
 				} else {
 					// Position the popup at the top of its container.
-					popupLayout.top = 4;
-					popupLayout.maxHeight = documentHeight - 8;
+					popupLayout.top = LAYOUT_MARGIN;
+					popupLayout.maxHeight = documentHeight - (LAYOUT_MARGIN * 2);
 				}
 			}
 		}
@@ -422,19 +423,21 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 				popupRef.current.getBoundingClientRect();
 
 			// When resizing results in the popup being off screen, dispose of it.
-			if (popupRight >= documentWidth - 4 || popupBottom >= documentHeight - 4) {
+			if (popupRight >= documentWidth - LAYOUT_MARGIN ||
+				popupBottom >= documentHeight - LAYOUT_MARGIN
+			) {
 				props.renderer.dispose();
 			} else if (isNumber(popupLayout.maxHeight)) {
 				// Increase the max height, if possible.
 				if (isNumber(popupLayout.top)) {
 					// Bottom alignment.
-					const maxHeight = documentHeight - 4 - popupLayout.top;
+					const maxHeight = documentHeight - LAYOUT_MARGIN - popupLayout.top;
 					if (maxHeight > popupLayout.maxHeight) {
 						setPopupLayout({ ...popupLayout, maxHeight });
 					}
 				} else if (isNumber(popupLayout.bottom)) {
 					// Top alignment.
-					const maxHeight = anchorLayout.anchorY - 4;
+					const maxHeight = anchorLayout.anchorY - LAYOUT_MARGIN;
 					if (maxHeight > popupLayout.maxHeight) {
 						setPopupLayout({ ...popupLayout, maxHeight });
 					}


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR addresses several issues with PositronModalPopup layout:

- When a modal popup is created, its size cannot be obtained until it is rendered for the first time and its `ref` has been set. For this reason, modal popups are initially rendered offscreen (at -10000, -10000).

- After a modal popup has been rendered for the first time, it is laid out based on its `anchorElement`, `anchorPoint`, `popupPosition`, `popupAlignment`, `width`, `minWidth`, `height`, `minHeight` properties and re-rendered. This is the first time a modal popup becomes visible.

- Because it is not possible to track the position and layering of DOM elements well enough, once a modal popup is laid out, it does not move around as its document is resized.

- When necessary, modal popups will be laid out with vertical scrolling:

<img width="1225" alt="image" src="https://github.com/posit-dev/positron/assets/853239/3e1775ba-cbb0-4e74-99b6-17db8d052bac">

- If the user resizes the document to be larger than the extent of a modal popup that was laid out with vertical scrolling, the modal popup is enlarged:
  
https://github.com/posit-dev/positron/assets/853239/5c8f470c-2762-4c3a-b21c-bc7458c71303

- If the user resizes the document to be smaller than the extent of a modal popup, it is closed automatically:
  
https://github.com/posit-dev/positron/assets/853239/e778d9fb-15d8-41ed-8c27-8c7810deb6be

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

It is very difficult to arrange for and test every possible modal popup layout edge case. For this reason, we're going to need to build tests that automate this.
