### PR TITLE
prevent project creation if conda selected but not installed

### DIFF
--- a/extensions/positron-python/src/client/common/constants.ts
+++ b/extensions/positron-python/src/client/common/constants.ts
@@ -64,6 +64,7 @@ export namespace Commands {
     // --- Start Positron ---
     export const Create_Environment_And_Register = 'python.createEnvironmentAndRegister';
     export const Get_Create_Environment_Providers = 'python.getCreateEnvironmentProviders';
+    export const Is_Conda_Installed = 'python.isCondaInstalled';
     export const Get_Conda_Python_Versions = 'python.getCondaPythonVersions';
     // --- End Positron ---
     export const InstallJupyter = 'python.installJupyter';

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -30,6 +30,7 @@ import { CreateEnvironmentOptionsInternal } from './types';
 // --- Start Positron ---
 import { getCondaPythonVersions } from './provider/condaUtils';
 import { IPythonRuntimeManager } from '../../positron/manager';
+import { Conda } from '../common/environmentManagers/conda';
 // --- End Positron ---
 
 class CreateEnvironmentProviders {
@@ -114,6 +115,13 @@ export function registerCreateEnvironmentFeatures(
                     return { ...result, metadata };
                 }
                 return result;
+            },
+        ),
+        registerCommand(
+            Commands.Is_Conda_Installed,
+            async (): Promise<boolean> => {
+                const conda = await Conda.getConda();
+                return conda !== undefined;
             },
         ),
         registerCommand(Commands.Get_Conda_Python_Versions, () => getCondaPythonVersions()),

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -79,7 +79,11 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 	// Utility functions.
 	const interpretersAvailable = () => {
 		if (context.usesCondaEnv) {
-			return Boolean(context.isCondaInstalled && condaPythonVersionInfo);
+			return Boolean(
+				context.isCondaInstalled &&
+				condaPythonVersionInfo &&
+				condaPythonVersionInfo.versions.length
+			);
 		}
 		return Boolean(interpreters && interpreters.length);
 	};

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -77,13 +77,18 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 	}, [context]);
 
 	// Utility functions.
-	const interpretersAvailable = () =>
-		Boolean(interpreters && interpreters.length) ||
-		// Interpreters are always available for Conda because we display the supported versions
-		// that an environment can be created with.
-		Boolean(context.usesCondaEnv && condaPythonVersionInfo);
-	const interpretersLoading = () =>
-		!interpreters || Boolean(context.usesCondaEnv && !condaPythonVersionInfo);
+	const interpretersAvailable = () => {
+		if (context.usesCondaEnv) {
+			return Boolean(context.isCondaInstalled && condaPythonVersionInfo);
+		}
+		return Boolean(interpreters && interpreters.length);
+	};
+	const interpretersLoading = () => {
+		if (context.usesCondaEnv) {
+			return Boolean(context.isCondaInstalled && !condaPythonVersionInfo);
+		}
+		return !interpreters;
+	};
 	const envProvidersAvailable = () => Boolean(envProviders && envProviders.length);
 	const envProvidersLoading = () => !envProviders;
 
@@ -254,6 +259,20 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 						localize(
 							'pythonInterpreterSubStep.feedback.noInterpretersAvailable',
 							"No interpreters available since no environment providers were found."
+						))()}
+				</WizardFormattedText>
+			);
+		}
+
+		if (context.usesCondaEnv && !context.isCondaInstalled) {
+			return (
+				<WizardFormattedText
+					type={WizardFormattedTextType.Warning}
+				>
+					{(() =>
+						localize(
+							'pythonInterpreterSubStep.feedback.condaNotInstalled',
+							"Conda is not installed. Please install Conda to create a Conda environment."
 						))()}
 				</WizardFormattedText>
 			);

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/condaUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/condaUtils.ts
@@ -15,6 +15,14 @@ export interface CondaPythonVersionInfo {
 }
 
 /**
+ * Empty CondaPythonVersionInfo object.
+ */
+export const EMPTY_CONDA_PYTHON_VERSION_INFO: CondaPythonVersionInfo = {
+	preferred: '',
+	versions: [],
+};
+
+/**
  * Converts a CondaPythonVersionInfo object to DropDownListBoxItem objects.
  * Conda environments have special handling because the Python interpreters exist until the conda
  * environment is created. As such, we only have the python versions available to us at this point.


### PR DESCRIPTION


<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

- address https://github.com/posit-dev/positron/issues/3477

#### Preview

<img width="450" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/0f6477a0-8865-413c-85f1-afcd8ef7e7c5">


https://github.com/posit-dev/positron/assets/25834218/c34369f0-21b8-4291-9d9c-9a9076ae57f6



### Approach

- add command `python.isCondaInstalled` to python extension
- store whether conda is installed or not in project wizard state
- only retrieve available conda python versions if conda is installed
- show conda in environment provider dropdown, but show warning that conda is not installed if selected and indicate that interpreters cannot be found
- don't allow project creation if conda is selected as the environment provider, but it is not installed

### QA Notes

See https://github.com/posit-dev/positron/issues/3477 for steps.
