### PR TITLE
Add Jupyter new project test

### DIFF
--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -14,6 +14,7 @@ const PROJECT_WIZARD_NEXT_BUTTON = 'button.positron-button.button.action-bar-but
 const PROJECT_WIZARD_BACK_BUTTON = 'div.left-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]';
 const PROJECT_WIZARD_DISABLED_CREATE_BUTTON = 'button.positron-button.button.action-bar-button.default.disabled[tabindex="0"][disabled][role="button"][aria-disabled="true"]';
 const PROJECT_WIZARD_CURRENT_WINDOW_BUTTON = 'button.positron-button.button.action-bar-button[tabindex="0"][role="button"]';
+const PROJECT_WIZARD_NEW_JUPYTER_PROJECT = '[id="Jupyter Notebook"]';
 
 export class PositronNewProjectWizard {
 	newPythonProjectButton: PositronBaseElement;
@@ -23,6 +24,7 @@ export class PositronNewProjectWizard {
 	projectWizardBackButton: PositronBaseElement;
 	projectWizardDisabledCreateButton: PositronBaseElement;
 	projectWizardCurrentWindowButton: PositronBaseElement;
+	newJupyterProjectButton: PositronBaseElement;
 
 	constructor(private code: Code, private quickaccess: QuickAccess) {
 		this.newPythonProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_PYTHON_PROJECT, this.code);
@@ -32,6 +34,7 @@ export class PositronNewProjectWizard {
 		this.projectWizardBackButton = new PositronBaseElement(PROJECT_WIZARD_BACK_BUTTON, this.code);
 		this.projectWizardDisabledCreateButton = new PositronBaseElement(PROJECT_WIZARD_DISABLED_CREATE_BUTTON, this.code);
 		this.projectWizardCurrentWindowButton = new PositronBaseElement(PROJECT_WIZARD_CURRENT_WINDOW_BUTTON, this.code);
+		this.newJupyterProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_JUPYTER_PROJECT, this.code);
 	}
 
 	async startNewProject() {

--- a/test/smoke/src/areas/positron/new-project-wizard/python-new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/python-new-project.test.ts
@@ -57,5 +57,31 @@ export function setup(logger: Logger) {
 		});
 
 	});
+
+	describe('New Project Wizard', () => {
+		// Shared before/after handling
+		installAllHandlers(logger);
+
+		describe('Python - New Project Wizard', () => {
+			before(async function () {
+
+			});
+
+			it('Jupyter Project Defaults', async function () {
+				// TestRail #629352
+				const app = this.app as Application;
+				await app.workbench.positronNewProjectWizard.startNewProject();
+				await app.workbench.positronNewProjectWizard.newJupyterProjectButton.click();
+				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
+				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
+				await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(); // May need to pass in a retry count > default of 200
+				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
+				await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
+				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myJupyterNotebook');
+			});
+
+		});
+
+	});
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

To support #2820, adding Jupyter Notebook to New Project wizard test suite

### Approach

Simple default golden path

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
