### PR TITLE
Add GHA-based CLA assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,46 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: posit-dev/cla-assistant-github-action@v2.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          # This token is required only if you have configured to store the signatures in a remote repository/organization
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ASSISTANT_PAT }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          # REPLACE ME!!!!
+          path-to-document: 'https://gist.github.com/jcheng5/f97a51e9724099d7149015eae747de99' # e.g. a CLA or a DCO document
+          # branch should not be protected
+          branch: 'main'
+          # allowlist: user1,bot*
+          remote-organization-name: posit-dev # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          remote-repository-name: cla-assistant-signatures # enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+
+         # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
+          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,9 +1,9 @@
-name: "CLA Assistant"
+name: "CLA Signature Assistant"
 on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened,closed,synchronize]
+    types: [opened, closed, synchronize]
 
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
@@ -13,34 +13,7 @@ permissions:
   statuses: write
 
 jobs:
-  CLAAssistant:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: posit-dev/cla-assistant-github-action@v2.4.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          # This token is required only if you have configured to store the signatures in a remote repository/organization
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ASSISTANT_PAT }}
-        with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          # REPLACE ME!!!!
-          path-to-document: 'https://gist.github.com/jcheng5/f97a51e9724099d7149015eae747de99' # e.g. a CLA or a DCO document
-          # branch should not be protected
-          branch: 'main'
-          # allowlist: user1,bot*
-          remote-organization-name: posit-dev # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          remote-repository-name: cla-assistant-signatures # enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
-
-         # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
-          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
-          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
-          #use-dco-flag: true - If you are using DCO instead of CLA
+  RequireCLA:
+    uses: posit-dev/cla-assistant/.github/workflows/posit-cla.yml@v1
+    secrets:
+      CLA_ASSISTANT_PAT: ${{ secrets.CLA_ASSISTANT_PAT }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,3 +17,5 @@ jobs:
     uses: posit-dev/cla-assistant/.github/workflows/posit-cla.yml@v1
     secrets:
       CLA_ASSISTANT_PAT: ${{ secrets.CLA_ASSISTANT_PAT }}
+    with:
+      allowlist: DavisVaughan, dfalbel, isabelizimm, jonvanausdeln, lionel-, nstrayer, petetronic, seeM, sharon-wang, softwarenerd, timtmok, wesm


### PR DESCRIPTION
### Intent

This adds a workflow that requires all committers to a PR have a signed CLA.

TODO
- [ ] Review approach with @juliasilge et al
- [ ] Review CLA Assistant message templates and change as appropriate

### Approach

For other repos in the past, we've used cla-assistant.io, but that has the undesirable requirement of allowing read/write access to all of your public and private repos, to a third party. This uses [CLA Assistant Lite](https://github.com/contributor-assistant/github-action) which is based on the same codebase but designed to run entirely within GHA workflows, with both the workflow code and the signature database all stored with posit-dev repositories.

Upon creation of a pull request, the action will post a comment on the PR indicating whether all committers have signed CLAs on file, and if not, instructions for how to do so (post their own comment with "I have read and agree to the CLA") or something like that. You can also send the comment "recheck" in order to force a recheck.

### QA Notes

Currently the code that reads the comment is extremely fragile--it doesn't tolerate leading/trailing whitespace. @schloerke has ideas of how to fix that.

Also, with PRs that contain changes to workflows, it's a little confusing which workflows apply--the ones in the main branch or the ones in the PR branch (@schloerke told me it's something like code pushes use the PR branch, comments use the main branch). So don't be surprised if _this PR_ exhibits wonky CLA Assistant behavior--the real test would be what happens to PRs after this branch is merged.