### PR TITLE
Temporarily disable supported feature set_row_filters.supports_condit…

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -1274,7 +1274,10 @@ class PandasView(DataExplorerTableView):
         search_schema=SearchSchemaFeatures(supported=True),
         set_row_filters=SetRowFiltersFeatures(
             supported=True,
-            supports_conditions=True,
+            # Temporarily disabled for https://github.com/posit-dev/positron/issues/3489 on
+            # 6/11/2024. This will be enabled again when the UI has been reworked to support
+            # grouping.
+            supports_conditions=False,
             supported_types=list(SUPPORTED_FILTERS),
         ),
         get_column_profiles=GetColumnProfilesFeatures(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -507,7 +507,7 @@ def test_pandas_supported_features(dxf: DataExplorerFixture):
     assert search_schema["supported"]
 
     assert row_filters["supported"]
-    assert row_filters["supports_conditions"]
+    assert row_filters["supports_conditions"] == False
     assert set(row_filters["supported_types"]) == {
         "between",
         "compare",

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -734,6 +734,9 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 		setErrorText(undefined);
 	};
 
+	// Get the supported features.
+	const supportedFeatures = props.dataExplorerClientInstance.getSupportedFeatures();
+
 	// Render.
 	return (
 		<PositronModalPopup
@@ -747,7 +750,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			onAccept={applyRowFilter}
 		>
 			<div className='add-edit-row-filter-modal-popup-body'>
-				{!props.isFirstFilter &&
+				{supportedFeatures.set_row_filters.supports_conditions && !props.isFirstFilter &&
 					<DropDownListBox
 						onSelectionChanged={dropDownListBoxItem => {
 							setSelectedCondition(dropDownListBoxItem.options.identifier);


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR temporarily disables `SupportedFeatures.set_row_filters.supports_conditions` to address https://github.com/posit-dev/positron/issues/3489.

This will be enabled again when the UI has been reworked to support grouping.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

1) Disable `supports_conditions` in Pandas.
2) Check for `supports_conditions` being enabled in the Add / Edit Row Filter modal popup.

Note that the `and` condition is still displayed:

<img width="523" alt="image" src="https://github.com/posit-dev/positron/assets/853239/4e77234e-52bd-4816-bdd4-c8f3579d6add">

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
