### PR TITLE
Temporarily restrict get_column_profiles to only return ColumnProfileType.NullCount

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -1281,7 +1281,10 @@ class PandasView(DataExplorerTableView):
             supported=True,
             supported_types=[
                 ColumnProfileType.NullCount,
-                ColumnProfileType.SummaryStats,
+                # Temporarily disabled for https://github.com/posit-dev/positron/issues/3490
+                # on 6/11/2024. This will be enabled again when the UI has been reworked to
+                # more fully support column profiles.
+                # ColumnProfileType.SummaryStats,
             ],
         ),
         set_sort_columns=SetSortColumnsFeatures(supported=True),
@@ -1572,7 +1575,13 @@ class PolarsView(DataExplorerTableView):
         ),
         get_column_profiles=GetColumnProfilesFeatures(
             supported=True,
-            supported_types=[ColumnProfileType.NullCount],
+            supported_types=[
+                ColumnProfileType.NullCount,
+                # Temporarily disabled for https://github.com/posit-dev/positron/issues/3490
+                # on 6/11/2024. This will be enabled again when the UI has been reworked to
+                # more fully support column profiles.
+                # ColumnProfileType.SummaryStats,
+            ],
         ),
         export_data_selection=ExportDataSelectionFeatures(supported=False),
         set_sort_columns=SetSortColumnsFeatures(supported=False),

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -525,7 +525,10 @@ def test_pandas_supported_features(dxf: DataExplorerFixture):
     assert column_profiles["supported"]
     assert set(column_profiles["supported_types"]) == {
         "null_count",
-        "summary_stats",
+        # Temporarily disabled for https://github.com/posit-dev/positron/issues/3490
+        # on 6/11/2024. This will be enabled again when the UI has been reworked to
+        # more fully support column profiles.
+        # "summary_stats",
     }
 
 


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

In order to address https://github.com/posit-dev/positron/issues/3490, this PR temporarily restricts `get_column_profiles` to only return `ColumnProfileType.NullCount`.

`ColumnProfileType.SummaryStats` will be enabled again when the UI has been reworked to more fully support column profiles.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
