### PR TITLE
Bump ark to 0.1.107

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -590,7 +590,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.104"
+      "ark": "0.1.107"
     },
     "minimumRVersion": "4.2.0"
   }


### PR DESCRIPTION
ark 0.1.05 https://github.com/posit-dev/amalthea/pull/398

- https://github.com/posit-dev/amalthea/pull/392
- https://github.com/posit-dev/amalthea/pull/395
- https://github.com/posit-dev/amalthea/pull/397

ark 0.1.06 https://github.com/posit-dev/amalthea/pull/399

- https://github.com/posit-dev/amalthea/pull/303

ark 0.1.107 is just a release build fix.