### PR TITLE
Bump ark to 0.1.108

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -590,7 +590,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.107"
+      "ark": "0.1.108"
     },
     "minimumRVersion": "4.2.0"
   }


### PR DESCRIPTION
For:

- https://github.com/posit-dev/amalthea/pull/394
- https://github.com/posit-dev/amalthea/pull/382


See https://github.com/posit-dev/amalthea/pull/401

