### PR TITLE
Disable remote integration tests

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -86,11 +86,14 @@ jobs:
         id: electron-integration-tests
         run: DISPLAY=:10 ./scripts/test-integration.sh
 
-      - name: Run Integration Tests (Remote)
-        id: electron-remote-integration-tests
-        timeout-minutes: 15
-        run: DISPLAY=:10 ./scripts/test-remote-integration.sh
-
+#      Remote integration tests currently disabled since licensing is required.
+#      See https://github.com/posit-dev/positron/issues/3514 for details.
+#
+#      - name: Run Integration Tests (Remote)
+#        id: electron-remote-integration-tests
+#        timeout-minutes: 15
+#        run: DISPLAY=:10 ./scripts/test-remote-integration.sh
+#
 #      - name: Run Integration Tests (Browser, Chromium)
 #        id: browser-integration-tests
 #        run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium


### PR DESCRIPTION
### Intent

Temporarily disable remote integration tests. We can re-enable them when we've hooked them up to licensing, or applied a workaround. See https://github.com/posit-dev/positron/issues/3514 for details.

### Approach

Comment out lines from YAML.

### QA Notes

N/A.