### PR TITLE
Disengage history popup with Esc

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -518,6 +518,16 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 
 				break;
 			}
+
+			// Esc processing.
+			case KeyCode.Escape: {
+				// If the history browser is active, dismiss it.
+				if (historyBrowserActiveRef.current) {
+					disengageHistoryBrowser();
+					consumeEvent();
+					break;
+				}
+			}
 		}
 	};
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/3508

### Approach

When <kbd>Esc</kbd> is pressed in the console, dismiss the history popup if it's active.

### QA Notes

You should also be able to dismiss the popup by clicking outside it or making a selection.