### PR TITLE
Bump ark to 0.1.109

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -590,7 +590,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.108"
+      "ark": "0.1.109"
     },
     "minimumRVersion": "4.2.0"
   }

--- a/extensions/positron-r/src/test/indentation.test.ts
+++ b/extensions/positron-r/src/test/indentation.test.ts
@@ -67,7 +67,11 @@ async function regenerateIndentSnapshots() {
 	// Remove documentation snippet
 	snippets.splice(0, 1);
 
-	const snapshots: string[] = ['# File generated from `indentation-cases.R`.\n\n'];
+	const header =
+		'# File generated from `indentation-cases.R`.\n\n' +
+		'declare(ark(diagnostics(enable = FALSE)))\n\n';
+
+	const snapshots: string[] = [header];
 
 	for (const snippet of snippets) {
 		const bareSnippet = snippet.split('\n').slice(0, -1).join('\n');

--- a/extensions/positron-r/src/test/snapshots/indentation-cases.R
+++ b/extensions/positron-r/src/test/snapshots/indentation-cases.R
@@ -212,3 +212,10 @@ function() {
 foo(function() {
     bar"<>"
 })
+
+# ---
+# Indentation of prefixed braces
+# https://github.com/posit-dev/positron/issues/3475
+# https://github.com/posit-dev/positron/issues/3484
+foobar <- function(arg,
+                   arg) {"<>"}

--- a/extensions/positron-r/src/test/snapshots/indentation-cases.R
+++ b/extensions/positron-r/src/test/snapshots/indentation-cases.R
@@ -8,6 +8,8 @@
 # Snippets are separated by `# ---`. This makes it possible to extract them and
 # process them separately to prevent interferences between test cases.
 
+declare(ark(diagnostics(enable = FALSE)))
+
 # ---
 # Starting a pipeline (+ operator)
 1 +"<>"

--- a/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
+++ b/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
@@ -1,5 +1,7 @@
 # File generated from `indentation-cases.R`.
 
+declare(ark(diagnostics(enable = FALSE)))
+
 # ---
 # Starting a pipeline (+ operator)
 1 +"<>"

--- a/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
+++ b/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
@@ -397,8 +397,21 @@ function() {
 foo(function() {
     bar"<>"
 })
+
 # ->
 foo(function() {
     bar
     "<>"
 })
+
+# ---
+# Indentation of prefixed braces
+# https://github.com/posit-dev/positron/issues/3475
+# https://github.com/posit-dev/positron/issues/3484
+foobar <- function(arg,
+                   arg) {"<>"}
+# ->
+foobar <- function(arg,
+                   arg) {
+                       "<>"
+                   }

--- a/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
+++ b/extensions/positron-r/src/test/snapshots/indentation-snapshots.R
@@ -415,5 +415,5 @@ foobar <- function(arg,
 # ->
 foobar <- function(arg,
                    arg) {
-                       "<>"
-                   }
+    "<>"
+}


### PR DESCRIPTION
https://github.com/posit-dev/amalthea/pull/402 for
- https://github.com/posit-dev/amalthea/pull/393

Addresses https://github.com/posit-dev/positron/issues/3475
Addresses https://github.com/posit-dev/positron/issues/3484

Adds frontend-side integration test.

Disable Ark diagnostics in snapshot files using the new `declare()` annotation.