### PR TITLE
Scope console history to workspaces

### DIFF
--- a/src/vs/workbench/contrib/executionHistory/common/languageInputHistory.ts
+++ b/src/vs/workbench/contrib/executionHistory/common/languageInputHistory.ts
@@ -33,6 +33,7 @@ export class LanguageInputHistory extends Disposable {
 	constructor(
 		private readonly _languageId: string,
 		private readonly _storageService: IStorageService,
+		private readonly _storageScope: StorageScope,
 		private readonly _logService: ILogService,
 		private readonly _configurationService: IConfigurationService) {
 		super();
@@ -98,7 +99,7 @@ export class LanguageInputHistory extends Disposable {
 	 */
 	public getInputHistory(): IInputHistoryEntry[] {
 		// Read the existing entries from storage.
-		const entries = this._storageService.get(this._storageKey, StorageScope.PROFILE, '[]');
+		const entries = this._storageService.get(this._storageKey, this._storageScope, '[]');
 		let parsedEntries: IInputHistoryEntry[] = [];
 		try {
 			parsedEntries = JSON.parse(entries);
@@ -122,7 +123,7 @@ export class LanguageInputHistory extends Disposable {
 		this._pendingEntries.splice(0, this._pendingEntries.length);
 
 		// Clear the underlying storage
-		this._storageService.remove(this._storageKey, StorageScope.PROFILE);
+		this._storageService.remove(this._storageKey, this._storageScope);
 	}
 
 	private save(forShutdown: boolean): void {
@@ -136,7 +137,7 @@ export class LanguageInputHistory extends Disposable {
 
 		// Read the existing entries. We do this every time we save because
 		// another instance of the app may have written to the same storage.
-		const entries = this._storageService.get(this._storageKey, StorageScope.PROFILE, '[]');
+		const entries = this._storageService.get(this._storageKey, this._storageScope, '[]');
 		let parsedEntries: IInputHistoryEntry[] = [];
 		try {
 			parsedEntries = JSON.parse(entries);
@@ -177,7 +178,7 @@ export class LanguageInputHistory extends Disposable {
 		// history in this "session"
 		this._storageService.store(this._storageKey,
 			storageState,
-			StorageScope.PROFILE,
+			this._storageScope,
 			StorageTarget.USER);
 
 		// Clear the pending entries now that they've been flushed to storage.


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/3478.

### Approach

The existing behavior was sort of intentional; the idea was to make it possible to access your library of Commands You Frequently Run in any session. However, it violates the more fundamental expectation that a history in the console is scoped to that console in some way, so this change dials it back a little and scopes history to each workspace.

### QA Notes

- History is still shared per language; for example, if you switch Python versions, you can still access commands you ran before the switch.
- If you don't have a workspace open, we revert to the old behavior. That means it is still possible to get into a state wherein two windows are accessing the same history set by opening several windows without an active workspace. That is expected for now (but we could tweak it further). 
- Within a workspace history should still be preserved across sessions; that is, if you close Positron and reopen it, you should still be able to see your history from your last use of Positron. 