### PR TITLE
Restore focus to last active element when PositronModalReactRenderer is disposed

### DIFF
--- a/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.tsx
+++ b/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.tsx
@@ -79,6 +79,11 @@ export class PositronModalReactRenderer extends Disposable {
 	private readonly _options: PositronModalReactRendererOptions;
 
 	/**
+	 * Gets the last focused element.
+	 */
+	private readonly _lastFocusedElement: HTMLElement | undefined;
+
+	/**
 	 * Gets or sets the overlay element.
 	 */
 	private _overlay?: HTMLElement;
@@ -115,6 +120,12 @@ export class PositronModalReactRenderer extends Disposable {
 		// Call the base class's constructor.
 		super();
 
+		// Set the last focused element.
+		const activeElement = DOM.getWindow(options.parent).document.activeElement;
+		if (activeElement instanceof HTMLElement) {
+			this._lastFocusedElement = activeElement;
+		}
+
 		// Set the options.
 		this._options = options;
 	}
@@ -125,6 +136,9 @@ export class PositronModalReactRenderer extends Disposable {
 	public override dispose(): void {
 		// Call the base class's dispose method.
 		super.dispose();
+
+		// Return focus to the last focused element.
+		this._lastFocusedElement?.focus();
 
 		// If this renderer was rendered, dispose it.
 		if (this._overlay && this._root) {


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR addresses https://github.com/posit-dev/positron/issues/3511. This issue was caused by modal React components "stealing focus" when they become the active element.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

`PositronModalReactRenderer` now keeps track of the last active element when it is instantiated and returns focus to that element when it is disposed.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
