### PR TITLE
Limit Data Explorer copy to clipboard to 10,000 cells

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -279,7 +279,7 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 			this._notificationService.error(
 				localize(
 					'positron.dataExplorer.tooMuchDataToCopy',
-					'There is too much data to copy to the clipboard.'
+					'There is too much data selected to copy to the clipboard.'
 				)
 			);
 			return;

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -250,8 +250,8 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 		if (clipboardData instanceof ClipboardCell) {
 			selectedClipboardCells = 1;
 		} else if (clipboardData instanceof ClipboardCellRange) {
-			const columns = clipboardData.lastColumnIndex - clipboardData.firstColumnIndex;
-			const rows = clipboardData.lastRowIndex - clipboardData.firstRowIndex;
+			const columns = Math.max(clipboardData.lastColumnIndex - clipboardData.firstColumnIndex, 1);
+			const rows = Math.max(clipboardData.lastRowIndex - clipboardData.firstRowIndex, 1);
 			selectedClipboardCells = columns * rows;
 		} else if (clipboardData instanceof ClipboardColumnRange) {
 			const columns = clipboardData.lastColumnIndex - clipboardData.firstColumnIndex;


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR addresses https://github.com/posit-dev/positron/issues/3500 for Public Beta by limiting the number of cells that can be copied to the clipboard to 10,000.

**_This is a stopgap measure to prevent users from hanging Positron when they try to copy an enormous amount of data to the clipboard._**

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

This limit is specified, calculated, and enforced entirely in the UI. In the future, we will want each backend to return how many cells can be copied to the clipboard in the `ExportDataSelectionFeatures` result.

We will also want to add a more prominent "indeterminate progress indicator" to Positron Data Explorer when long-running operations like `exportDataSelection` are executed.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
