### PR TITLE
Provide pipe and `<-` keyboard shortcuts in Quarto files, when RStudio Keymap is enabled

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -33,14 +33,14 @@
         "category": "R",
         "title": "%r.command.insertPipe.title%",
         "shortTitle": "%r.menu.insertPipe.title%",
-        "enablement": "editorTextFocus && editorLangId == r || config.rstudio.keymap.enable && editorTextFocus && editorLangId == quarto"
+        "enablement": "editorTextFocus"
       },
       {
         "command": "r.insertPipeConsole",
         "category": "R",
         "title": "%r.command.insertPipe.title%",
         "shortTitle": "%r.menu.insertPipe.title%",
-        "enablement": "editorLangId == r && positronConsoleFocused"
+        "enablement": "positronConsoleFocused"
       },
       {
         "command": "r.insertLeftAssignment",
@@ -325,13 +325,13 @@
         "command": "r.insertPipe",
         "key": "ctrl+shift+m",
         "mac": "cmd+shift+m",
-        "when": "editorTextFocus && editorLangId == r || config.rstudio.keymap.enable && editorTextFocus && editorLangId == quarto"
+        "when": "editorLangId == r"
       },
       {
         "command": "r.insertPipeConsole",
         "key": "ctrl+shift+m",
         "mac": "cmd+shift+m",
-        "when": "editorLangId == r && positronConsoleFocused"
+        "when": "editorLangId == r"
       },
       {
         "command": "r.insertLeftAssignment",
@@ -407,12 +407,12 @@
         {
           "category": "R",
           "command": "r.insertPipe",
-          "when": "editorTextFocus && editorLangId == r || config.rstudio.keymap.enable && editorTextFocus && editorLangId == quarto"
+          "when": "editorLangId == r"
         },
         {
           "category": "R",
           "command": "r.insertPipeConsole",
-          "when": "editorLangId == r && positronConsoleFocused"
+          "when": "editorLangId == r"
         },
         {
           "category": "R",

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -33,7 +33,7 @@
         "category": "R",
         "title": "%r.command.insertPipe.title%",
         "shortTitle": "%r.menu.insertPipe.title%",
-        "enablement": "editorLangId == r && editorTextFocus"
+        "enablement": "editorTextFocus && editorLangId == r || config.rstudio.keymap.enable && editorTextFocus && editorLangId == quarto"
       },
       {
         "command": "r.insertPipeConsole",
@@ -325,7 +325,7 @@
         "command": "r.insertPipe",
         "key": "ctrl+shift+m",
         "mac": "cmd+shift+m",
-        "when": "editorLangId == r && editorTextFocus"
+        "when": "editorTextFocus && editorLangId == r || config.rstudio.keymap.enable && editorTextFocus && editorLangId == quarto"
       },
       {
         "command": "r.insertPipeConsole",
@@ -407,7 +407,7 @@
         {
           "category": "R",
           "command": "r.insertPipe",
-          "when": "editorLangId == r && editorTextFocus"
+          "when": "editorTextFocus && editorLangId == r || config.rstudio.keymap.enable && editorTextFocus && editorLangId == quarto"
         },
         {
           "category": "R",

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -47,14 +47,14 @@
         "category": "R",
         "title": "%r.command.insertLeftAssignment.title%",
         "shortTitle": "%r.menu.insertLeftAssignment.title%",
-        "enablement": "editorLangId == r && editorTextFocus"
+        "enablement": "editorTextFocus"
       },
       {
         "command": "r.insertLeftAssignmentConsole",
         "category": "R",
         "title": "%r.command.insertLeftAssignment.title%",
         "shortTitle": "%r.menu.insertLeftAssignment.title%",
-        "enablement": "editorLangId == r && positronConsoleFocused"
+        "enablement": "positronConsoleFocused"
       },
       {
         "command": "r.insertSection",
@@ -337,13 +337,13 @@
         "command": "r.insertLeftAssignment",
         "key": "alt+-",
         "mac": "alt+-",
-        "when": "editorLangId == r && editorTextFocus"
+        "when": "editorLangId == r"
       },
       {
         "command": "r.insertLeftAssignmentConsole",
         "key": "alt+-",
         "mac": "alt+-",
-        "when": "editorLangId == r && positronConsoleFocused"
+        "when": "editorLangId == r"
       },
       {
         "command": "r.packageLoad",
@@ -417,12 +417,12 @@
         {
           "category": "R",
           "command": "r.insertLeftAssignment",
-          "when": "editorLangId == r && editorTextFocus"
+          "when": "editorLangId == r"
         },
         {
           "category": "R",
           "command": "r.insertLeftAssignmentConsole",
-          "when": "editorLangId == r && positronConsoleFocused"
+          "when": "editorLangId == r"
         },
         {
           "category": "R",

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -154,6 +154,14 @@
         "command": "r.insertSection"
       },
       {
+        "mac": "cmd+shift+m",
+        "win": "ctrl+shift+m",
+        "linux": "ctrl+shift+m",
+        "key": "ctrl+shift+m",
+        "when": "config.rstudio.keymap.enable && editorLangId == quarto",
+        "command": "r.insertPipe"
+      },
+      {
         "mac": "ctrl+alt+left",
         "win": "ctrl+alt+left",
         "linux": "ctrl+alt+left",

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -162,6 +162,14 @@
         "command": "r.insertPipe"
       },
       {
+        "mac": "alt+-",
+        "win": "alt+-",
+        "linux": "alt+-",
+        "key": "alt+-",
+        "when": "config.rstudio.keymap.enable && editorLangId == quarto",
+        "command": "r.insertLeftAssignment"
+      },
+      {
         "mac": "ctrl+alt+left",
         "win": "ctrl+alt+left",
         "linux": "ctrl+alt+left",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses #1955 sort of but only in a half-hearted manner, by putting this in to the RStudio Keymap

### Approach

This feels a little bad because I'm putting the check for `config.rstudio.keymap.enable` in the ***Positron R*** extension rather than the RStudio Keymap extension. I did it this way because when one extension provides a command with a keybinding and a when clause, another extension can provide an additional when clause for that command, but only in an AND manner, not an OR manner. If you try to write out a boolean algebra expression for `editorLangId == r || editorLangId == quarto`, you have to put the check for the config where the command is contributed; otherwise it tries to check for `editorLangId == r && editorLangId == quarto` which of course is never true.

### QA Notes

- When you have the RStudio Keymap enabled, you can use the pipe and left assignment keyboard shortcuts in _both_ R files and Quarto files (including Python ones, unfortunately).
- When you have the RStudio Keymap not enabled, you can use the pipe and left assignment keyboard shortcuts only in R files, not in Quarto files.

None of this handles `.Rmd`