### PR TITLE
Update/improve column summary cell cursor handling

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -151,17 +151,19 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		summarySupported = false;
 	}
 
+	console.log('YAYA');
+
 	// Render.
 	return (
 		<div
 			className='column-summary'
 			onDoubleClick={props.onDoubleClick}
+			onMouseEnter={() => setMouseInside(true)}
+			onMouseLeave={() => setMouseInside(false)}
 			onMouseDown={() => {
 				props.instance.scrollToRow(props.columnIndex);
 				props.instance.setCursorRow(props.columnIndex);
 			}}
-			onMouseOver={() => setMouseInside(true)}
-			onMouseLeave={() => setMouseInside(false)}
 		>
 			{(mouseInside || props.columnIndex === props.instance.cursorRowIndex) &&
 				<div className='cursor-background' />

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -7,20 +7,20 @@ import 'vs/css!./columnSummaryCell';
 
 // React.
 import * as React from 'react';
-import { useRef } from 'react'; // eslint-disable-line no-duplicate-imports
+import { useRef, useState } from 'react'; // eslint-disable-line no-duplicate-imports
 
 // Other dependencies.
 import { IHoverService } from 'vs/platform/hover/browser/hover';
 import { HoverPosition } from 'vs/base/browser/ui/hover/hoverWidget';
+import { positronClassNames } from 'vs/base/common/positronUtilities';
+import { ProfileDate } from 'vs/workbench/services/positronDataExplorer/browser/components/profileDate';
 import { ProfileNumber } from 'vs/workbench/services/positronDataExplorer/browser/components/profileNumber';
 import { ProfileString } from 'vs/workbench/services/positronDataExplorer/browser/components/profileString';
-import { ColumnNullPercent } from 'vs/workbench/services/positronDataExplorer/browser/components/columnNullPercent';
-import { ColumnDisplayType, ColumnProfileType, ColumnSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
-import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
 import { ProfileBoolean } from 'vs/workbench/services/positronDataExplorer/browser/components/profileBoolean';
-import { ProfileDate } from 'vs/workbench/services/positronDataExplorer/browser/components/profileDate';
 import { ProfileDatetime } from 'vs/workbench/services/positronDataExplorer/browser/components/profileDatetime';
-import { positronClassNames } from 'vs/base/common/positronUtilities';
+import { ColumnNullPercent } from 'vs/workbench/services/positronDataExplorer/browser/components/columnNullPercent';
+import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
+import { ColumnDisplayType, ColumnProfileType, ColumnSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * ColumnSummaryCellProps interface.
@@ -42,32 +42,8 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 	// Reference hooks.
 	const dataTypeRef = useRef<HTMLDivElement>(undefined!);
 
-	/**
-	 * onMouseOver event handler.
-	 */
-	const mouseOverHandler = () => {
-		props.hoverService.showHover({
-			content: `${props.columnSchema.type_name}`,
-			target: dataTypeRef.current,
-			position: {
-				hoverPosition: HoverPosition.ABOVE,
-			},
-			persistence: {
-				hideOnHover: false
-			},
-			appearance: {
-				showHoverHint: true,
-				showPointer: true
-			}
-		}, false);
-	};
-
-	/**
-	 * onMouseLeave event handler.
-	 */
-	const mouseLeaveHandler = () => {
-		props.hoverService.hideHover();
-	};
+	// State hooks.
+	const [mouseInside, setMouseInside] = useState(false);
 
 	// Set the data type icon.
 	const dataTypeIcon = (() => {
@@ -180,8 +156,14 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		<div
 			className='column-summary'
 			onDoubleClick={props.onDoubleClick}
+			onMouseDown={() => {
+				props.instance.scrollToRow(props.columnIndex);
+				props.instance.setCursorRow(props.columnIndex);
+			}}
+			onMouseOver={() => setMouseInside(true)}
+			onMouseLeave={() => setMouseInside(false)}
 		>
-			{props.columnIndex === props.instance.cursorRowIndex &&
+			{(mouseInside || props.columnIndex === props.instance.cursorRowIndex) &&
 				<div className='cursor-background' />
 			}
 			<div className='basic-info'>
@@ -201,8 +183,23 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				<div
 					ref={dataTypeRef}
 					className={`data-type-icon codicon ${dataTypeIcon}`}
-					onMouseOver={mouseOverHandler}
-					onMouseLeave={mouseLeaveHandler}
+					onMouseOver={() =>
+						props.hoverService.showHover({
+							content: `${props.columnSchema.type_name}`,
+							target: dataTypeRef.current,
+							position: {
+								hoverPosition: HoverPosition.ABOVE,
+							},
+							persistence: {
+								hideOnHover: false
+							},
+							appearance: {
+								showHoverHint: true,
+								showPointer: true
+							}
+						}, false)
+					}
+					onMouseLeave={() => props.hoverService.hideHover()}
 				/>
 				<div className='column-name'>
 					{props.columnSchema.column_name}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -151,8 +151,6 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		summarySupported = false;
 	}
 
-	console.log('YAYA');
-
 	// Render.
 	return (
 		<div


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR addresses https://github.com/posit-dev/positron/issues/3501 by improving column summary cell cursor handling to now handle mouse enter, mouse leave, and mouse down events.

Watch this:

https://github.com/posit-dev/positron/assets/853239/e1fd1bef-02c6-45ba-9586-acef9e22354f

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
