### PR TITLE
Addresses 3365 by adding 'Data Explorer Is no longer available' UI to the PositronDataExplorerEditor

### DIFF
--- a/src/vs/base/browser/positronReactRenderer.ts
+++ b/src/vs/base/browser/positronReactRenderer.ts
@@ -4,7 +4,7 @@
 
 import { Event } from 'vs/base/common/event';
 import { createRoot, Root } from 'react-dom/client';
-import { Disposable } from 'vs/base/common/lifecycle';
+import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
 
 /**
  * ISize interface.
@@ -136,6 +136,14 @@ export class PositronReactRenderer extends Disposable {
 		if (this.root) {
 			this.root.render(reactElement);
 		}
+	}
+
+	/**
+	 * Registers an IDisposable with the same lifecycle as the PositronReactRenderer.
+	 * @param disposable The IDisposable.
+	 */
+	public register(disposable: IDisposable) {
+		this._register(disposable);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerClosed.css
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerClosed.css
@@ -1,20 +1,8 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
-.positron-data-explorer {
-	width: 100%;
-	height: 100%;
-	min-width: 0;
-	min-height: 0;
-	display: grid;
-	position: relative;
-	color: var(--vscode-positronDataExplorer-foreground);
-	background-color: var(--vscode-positronDataExplorer-background);
-	grid-template-rows: [action-bar] 32px [data-explorer-panel] 1fr [end];
-}
-
-.positron-data-explorer-overlay {
+.positron-data-explorer-closed {
 	top: 0;
 	left: 0;
 	right: 0;
@@ -27,7 +15,7 @@
 	grid-template-columns: [left-gutter] 1fr [message] max-content [right-gutter] 1fr [end];
 }
 
-.positron-data-explorer-overlay
+.positron-data-explorer-closed
 .message {
 	color: white;
 	display: flex;
@@ -45,7 +33,7 @@
 	background-color: var(--vscode-positronModalDialog-background);
 }
 
-.positron-data-explorer-overlay
+.positron-data-explorer-closed
 .message
 .message-line {
 	text-align: center;

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerClosed.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerClosed.tsx
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import 'vs/css!./positronDataExplorerClosed';
+
+// React.
+import * as React from 'react';
+import { PropsWithChildren } from 'react'; // eslint-disable-line no-duplicate-imports
+
+// Other dependencies.
+import { localize } from 'vs/nls';
+import { PositronButton } from 'vs/base/browser/ui/positronComponents/button/positronButton';
+
+/**
+ * PositronDataExplorerClosedProps interface.
+ */
+export interface PositronDataExplorerClosedProps {
+	languageName?: string;
+	displayName?: string;
+	onClose: () => void;
+}
+
+/**
+ * PositronDataExplorerClosed component.
+ * @param props A PositronDataExplorerClosedProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const PositronDataExplorerClosed = (props: PropsWithChildren<PositronDataExplorerClosedProps>) => {
+	// Render.
+	return (
+		<div className='positron-data-explorer-closed'>
+			<PositronButton className='message' onPressed={props.onClose}>
+				{props.languageName && props.displayName && (
+					<>
+						<div
+							className='message-line'>
+							{(() => localize(
+								'positron.dataExplorerEditor.dataDisplayName',
+								'{0} Data: {1}',
+								props.languageName,
+								props.displayName
+							))()}
+						</div>
+						<div
+							className='message-line'>
+							{(() => localize(
+								'positron.dataExplorerEditor.isNoLongerAvailable',
+								'Is no longer available'
+							))()}
+						</div>
+					</>
+				)}
+				<div
+					className='message-line'>
+					{(() => localize(
+						'positron.dataExplorerEditor.clickToClose',
+						"Click to close Data Explorer"
+					))()}
+				</div>
+			</PositronButton>
+		</div>
+	);
+};


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR addresses 3365 by adding 'Data Explorer Is no longer available' UI to the PositronDataExplorerEditor.

Here's a screen recording:

https://github.com/posit-dev/positron/assets/853239/c83a7e89-8f50-4290-8f99-5e4d6e3f4b16

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

For the moment, this UI duplicates the 'Data Explorer Is no longer available' UI in the `PositronDataExplorer` component. I will consolidate this UI when I fix https://github.com/posit-dev/positron/issues/3527.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
