### PR TITLE
Data Explorer: Add 'experimental' option to enable data explorer features.

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -1272,7 +1272,7 @@ class PandasView(DataExplorerTableView):
             # Temporarily disabled for https://github.com/posit-dev/positron/issues/3489 on
             # 6/11/2024. This will be enabled again when the UI has been reworked to support
             # grouping.
-            supports_conditions=False,
+            supports_conditions=SupportStatus.Unsupported,
             supported_types=[
                 RowFilterTypeSupportStatus(
                     row_filter_type=x, support_status=SupportStatus.Supported
@@ -1579,7 +1579,7 @@ class PolarsView(DataExplorerTableView):
         search_schema=SearchSchemaFeatures(support_status=SupportStatus.Unsupported),
         set_row_filters=SetRowFiltersFeatures(
             support_status=SupportStatus.Unsupported,
-            supports_conditions=False,
+            supports_conditions=SupportStatus.Unsupported,
             supported_types=[
                 RowFilterTypeSupportStatus(
                     row_filter_type=x, support_status=SupportStatus.Supported
@@ -1597,7 +1597,10 @@ class PolarsView(DataExplorerTableView):
                 # Temporarily disabled for https://github.com/posit-dev/positron/issues/3490
                 # on 6/11/2024. This will be enabled again when the UI has been reworked to
                 # more fully support column profiles.
-                # ColumnProfileType.SummaryStats,
+                ColumnProfileTypeSupportStatus(
+                    profile_type=ColumnProfileType.SummaryStats,
+                    support_status=SupportStatus.Unsupported,
+                ),
             ],
         ),
         export_data_selection=ExportDataSelectionFeatures(support_status=SupportStatus.Unsupported),

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -165,6 +165,19 @@ class ExportFormat(str, enum.Enum):
     Html = "html"
 
 
+@enum.unique
+class SupportStatus(str, enum.Enum):
+    """
+    Possible values for SupportStatus
+    """
+
+    Unsupported = "unsupported"
+
+    Supported = "supported"
+
+    Experimental = "experimental"
+
+
 class SearchSchemaResult(BaseModel):
     """
     Result in Methods
@@ -405,6 +418,20 @@ class RowFilter(BaseModel):
     )
 
 
+class RowFilterTypeSupportStatus(BaseModel):
+    """
+    Support status for a row filter type
+    """
+
+    row_filter_type: RowFilterType = Field(
+        description="Type of row filter",
+    )
+
+    support_status: SupportStatus = Field(
+        description="The support status for this row filter type",
+    )
+
+
 class BetweenFilterParams(BaseModel):
     """
     Parameters for the 'between' and 'not_between' filter types
@@ -476,6 +503,20 @@ class ColumnProfileRequest(BaseModel):
 
     profile_type: ColumnProfileType = Field(
         description="The type of analytical column profile",
+    )
+
+
+class ColumnProfileTypeSupportStatus(BaseModel):
+    """
+    Support status for a given column profile type
+    """
+
+    profile_type: ColumnProfileType = Field(
+        description="The type of analytical column profile",
+    )
+
+    support_status: SupportStatus = Field(
+        description="The support status for this column profile type",
     )
 
 
@@ -762,8 +803,8 @@ class SearchSchemaFeatures(BaseModel):
     Feature flags for 'search_schema' RPC
     """
 
-    supported: StrictBool = Field(
-        description="Whether this RPC method is supported at all",
+    support_status: SupportStatus = Field(
+        description="The support status for this RPC method",
     )
 
 
@@ -772,15 +813,15 @@ class SetRowFiltersFeatures(BaseModel):
     Feature flags for 'set_row_filters' RPC
     """
 
-    supported: StrictBool = Field(
-        description="Whether this RPC method is supported at all",
+    support_status: SupportStatus = Field(
+        description="The support status for this RPC method",
     )
 
     supports_conditions: StrictBool = Field(
         description="Whether AND/OR filter conditions are supported",
     )
 
-    supported_types: List[RowFilterType] = Field(
+    supported_types: List[RowFilterTypeSupportStatus] = Field(
         description="A list of supported types",
     )
 
@@ -790,11 +831,11 @@ class GetColumnProfilesFeatures(BaseModel):
     Feature flags for 'get_column_profiles' RPC
     """
 
-    supported: StrictBool = Field(
-        description="Whether this RPC method is supported at all",
+    support_status: SupportStatus = Field(
+        description="The support status for this RPC method",
     )
 
-    supported_types: List[ColumnProfileType] = Field(
+    supported_types: List[ColumnProfileTypeSupportStatus] = Field(
         description="A list of supported types",
     )
 
@@ -804,8 +845,8 @@ class ExportDataSelectionFeatures(BaseModel):
     Feature flags for 'export_data_selction' RPC
     """
 
-    supported: StrictBool = Field(
-        description="Whether this RPC method is supported at all",
+    support_status: SupportStatus = Field(
+        description="The support status for this RPC method",
     )
 
 
@@ -814,8 +855,8 @@ class SetSortColumnsFeatures(BaseModel):
     Feature flags for 'set_sort_columns' RPC
     """
 
-    supported: StrictBool = Field(
-        description="Whether this RPC method is supported at all",
+    support_status: SupportStatus = Field(
+        description="The support status for this RPC method",
     )
 
 
@@ -1241,6 +1282,8 @@ TableShape.update_forward_refs()
 
 RowFilter.update_forward_refs()
 
+RowFilterTypeSupportStatus.update_forward_refs()
+
 BetweenFilterParams.update_forward_refs()
 
 CompareFilterParams.update_forward_refs()
@@ -1250,6 +1293,8 @@ SetMembershipFilterParams.update_forward_refs()
 SearchFilterParams.update_forward_refs()
 
 ColumnProfileRequest.update_forward_refs()
+
+ColumnProfileTypeSupportStatus.update_forward_refs()
 
 ColumnProfileResult.update_forward_refs()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -817,7 +817,7 @@ class SetRowFiltersFeatures(BaseModel):
         description="The support status for this RPC method",
     )
 
-    supports_conditions: StrictBool = Field(
+    supports_conditions: SupportStatus = Field(
         description="Whether AND/OR filter conditions are supported",
     )
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -510,7 +510,7 @@ def test_pandas_supported_features(dxf: DataExplorerFixture):
     assert search_schema["support_status"] == SupportStatus.Supported
 
     assert row_filters["support_status"] == SupportStatus.Supported
-    assert not row_filters["supports_conditions"]
+    assert row_filters["supports_conditions"] == SupportStatus.Unsupported
 
     row_filter_types = [
         "between",
@@ -2295,7 +2295,10 @@ def test_polars_get_state(dxf: DataExplorerFixture):
     assert features["get_column_profiles"]["supported_types"] == [
         ColumnProfileTypeSupportStatus(
             profile_type="null_count", support_status=SupportStatus.Supported
-        )
+        ),
+        ColumnProfileTypeSupportStatus(
+            profile_type="summary_stats", support_status=SupportStatus.Unsupported
+        ),
     ]
 
 

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -573,6 +573,24 @@
 					"set_membership"
 				]
 			},
+			"row_filter_type_support_status": {
+				"type": "object",
+				"description": "Support status for a row filter type",
+				"required": [
+					"row_filter_type",
+					"support_status"
+				],
+				"properties": {
+					"row_filter_type": {
+						"description": "Type of row filter",
+						"$ref": "#/components/schemas/row_filter_type"
+					},
+					"support_status": {
+						"description": "The support status for this row filter type",
+						"$ref": "#/components/schemas/support_status"
+					}
+				}
+			},
 			"between_filter_params": {
 				"type": "object",
 				"description": "Parameters for the 'between' and 'not_between' filter types",
@@ -698,6 +716,24 @@
 					"frequency_table",
 					"histogram"
 				]
+			},
+			"column_profile_type_support_status": {
+				"type": "object",
+				"description": "Support status for a given column profile type",
+				"required": [
+					"profile_type",
+					"support_status"
+				],
+				"properties": {
+					"profile_type": {
+						"description": "The type of analytical column profile",
+						"$ref": "#/components/schemas/column_profile_type"
+					},
+					"support_status": {
+						"description": "The support status for this column profile type",
+						"$ref": "#/components/schemas/support_status"
+					}
+				}
 			},
 			"column_profile_result": {
 				"type": "object",
@@ -1020,12 +1056,12 @@
 				"type": "object",
 				"description": "Feature flags for 'search_schema' RPC",
 				"required": [
-					"supported"
+					"support_status"
 				],
 				"properties": {
-					"supported": {
-						"type": "boolean",
-						"description": "Whether this RPC method is supported at all"
+					"support_status": {
+						"$ref": "#/components/schemas/support_status",
+						"description": "The support status for this RPC method"
 					}
 				}
 			},
@@ -1033,14 +1069,14 @@
 				"type": "object",
 				"description": "Feature flags for 'set_row_filters' RPC",
 				"required": [
-					"supported",
+					"support_status",
 					"supports_conditions",
 					"supported_types"
 				],
 				"properties": {
-					"supported": {
-						"type": "boolean",
-						"description": "Whether this RPC method is supported at all"
+					"support_status": {
+						"$ref": "#/components/schemas/support_status",
+						"description": "The support status for this RPC method"
 					},
 					"supports_conditions": {
 						"type": "boolean",
@@ -1050,7 +1086,7 @@
 						"type": "array",
 						"description": "A list of supported types",
 						"items": {
-							"$ref": "#/components/schemas/row_filter_type"
+							"$ref": "#/components/schemas/row_filter_type_support_status"
 						}
 					}
 				}
@@ -1059,19 +1095,19 @@
 				"type": "object",
 				"description": "Feature flags for 'get_column_profiles' RPC",
 				"required": [
-					"supported",
+					"support_status",
 					"supported_types"
 				],
 				"properties": {
-					"supported": {
-						"type": "boolean",
-						"description": "Whether this RPC method is supported at all"
+					"support_status": {
+						"$ref": "#/components/schemas/support_status",
+						"description": "The support status for this RPC method"
 					},
 					"supported_types": {
 						"type": "array",
 						"description": "A list of supported types",
 						"items": {
-							"$ref": "#/components/schemas/column_profile_type"
+							"$ref": "#/components/schemas/column_profile_type_support_status"
 						}
 					}
 				}
@@ -1080,12 +1116,12 @@
 				"type": "object",
 				"description": "Feature flags for 'export_data_selction' RPC",
 				"required": [
-					"supported"
+					"support_status"
 				],
 				"properties": {
-					"supported": {
-						"type": "boolean",
-						"description": "Whether this RPC method is supported at all"
+					"support_status": {
+						"$ref": "#/components/schemas/support_status",
+						"description": "The support status for this RPC method"
 					}
 				}
 			},
@@ -1093,12 +1129,12 @@
 				"type": "object",
 				"description": "Feature flags for 'set_sort_columns' RPC",
 				"required": [
-					"supported"
+					"support_status"
 				],
 				"properties": {
-					"supported": {
-						"type": "boolean",
-						"description": "Whether this RPC method is supported at all"
+					"support_status": {
+						"$ref": "#/components/schemas/support_status",
+						"description": "The support status for this RPC method"
 					}
 				}
 			},
@@ -1232,6 +1268,15 @@
 					"csv",
 					"tsv",
 					"html"
+				]
+			},
+			"support_status": {
+				"type": "string",
+				"description": "The support status of the RPC method",
+				"enum": [
+					"unsupported",
+					"supported",
+					"experimental"
 				]
 			}
 		}

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -1079,7 +1079,7 @@
 						"description": "The support status for this RPC method"
 					},
 					"supports_conditions": {
-						"type": "boolean",
+						"$ref": "#/components/schemas/support_status",
 						"description": "Whether AND/OR filter conditions are supported"
 					},
 					"supported_types": {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -23,6 +23,7 @@ import { ColumnSchema, ColumnDisplayType, RowFilterCondition } from 'vs/workbenc
 import { RowFilterParameter } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/rowFilterParameter';
 import { DropDownColumnSelector } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/dropDownColumnSelector';
 import { RangeRowFilterDescriptor, RowFilterDescriptor, RowFilterDescrType, RowFilterDescriptorComparison, RowFilterDescriptorIsBetween, RowFilterDescriptorIsEmpty, RowFilterDescriptorIsNotBetween, RowFilterDescriptorIsNotEmpty, SingleValueRowFilterDescriptor, RowFilterDescriptorIsNotNull, RowFilterDescriptorIsNull, RowFilterDescriptorSearch, RowFilterDescriptorIsTrue, RowFilterDescriptorIsFalse } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
+import { dataExplorerExperimentalFeatureEnabled } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerExperimentalConfig';
 
 /**
  * Validates a row filter value.
@@ -736,6 +737,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 
 	// Get the supported features.
 	const supportedFeatures = props.dataExplorerClientInstance.getSupportedFeatures();
+	const supportsConditions = dataExplorerExperimentalFeatureEnabled(supportedFeatures.set_row_filters.supports_conditions, props.configurationService);
 
 	// Render.
 	return (
@@ -750,7 +752,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 			onAccept={applyRowFilter}
 		>
 			<div className='add-edit-row-filter-modal-popup-body'>
-				{supportedFeatures.set_row_filters.supports_conditions && !props.isFirstFilter &&
+				{supportsConditions && !props.isFirstFilter &&
 					<DropDownListBox
 						onSelectionChanged={dropDownListBoxItem => {
 							setSelectedCondition(dropDownListBoxItem.options.identifier);

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -24,6 +24,7 @@ import { CustomContextMenuEntry, showCustomContextMenu } from 'vs/workbench/brow
 import { RowFilterWidget } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/components/rowFilterWidget';
 import { AddEditRowFilterModalPopup } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup';
 import { getRowFilterDescriptor, RowFilterDescriptor } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor';
+import { dataExplorerExperimentalFeatureEnabled } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerExperimentalConfig';
 
 /**
  * Constants.
@@ -148,8 +149,7 @@ export const RowFilterBar = () => {
 	]);
 
 	const features = backendClient.getSupportedFeatures();
-
-	const canFilter = features.set_row_filters.supported;
+	const canFilter = dataExplorerExperimentalFeatureEnabled(features.set_row_filters.support_status, context.configurationService);
 
 	/**
 	 * Filter button pressed handler.

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -211,7 +211,7 @@ export class DataExplorerClientInstance extends Disposable {
 						search_schema: { support_status: SupportStatus.Unsupported },
 						set_row_filters: {
 							support_status: SupportStatus.Unsupported,
-							supports_conditions: false,
+							supports_conditions: SupportStatus.Unsupported,
 							supported_types: []
 						},
 						get_column_profiles: {
@@ -380,7 +380,7 @@ export class DataExplorerClientInstance extends Disposable {
 				},
 				set_row_filters: {
 					support_status: SupportStatus.Unsupported,
-					supports_conditions: false,
+					supports_conditions: SupportStatus.Unsupported,
 					supported_types: []
 				},
 				get_column_profiles: {

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -5,7 +5,7 @@
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
-import { BackendState, ColumnProfileRequest, ColumnProfileResult, ColumnSchema, ColumnSortKey, DataSelection, ExportedData, ExportFormat, FilterResult, FormatOptions, PositronDataExplorerComm, RowFilter, SchemaUpdateEvent, SupportedFeatures, TableData, TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { BackendState, ColumnProfileRequest, ColumnProfileResult, ColumnSchema, ColumnSortKey, DataSelection, ExportedData, ExportFormat, FilterResult, FormatOptions, PositronDataExplorerComm, RowFilter, SchemaUpdateEvent, SupportedFeatures, SupportStatus, TableData, TableSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * TableSchemaSearchResult interface. This is here temporarily until searching the tabe schema
@@ -208,18 +208,18 @@ export class DataExplorerClientInstance extends Disposable {
 					row_filters: [],
 					sort_keys: [],
 					supported_features: {
-						search_schema: { supported: false },
+						search_schema: { support_status: SupportStatus.Unsupported },
 						set_row_filters: {
-							supported: false,
+							support_status: SupportStatus.Unsupported,
 							supports_conditions: false,
 							supported_types: []
 						},
 						get_column_profiles: {
-							supported: false,
+							support_status: SupportStatus.Unsupported,
 							supported_types: []
 						},
-						set_sort_columns: { supported: false },
-						export_data_selection: { supported: false }
+						set_sort_columns: { support_status: SupportStatus.Unsupported, },
+						export_data_selection: { support_status: SupportStatus.Unsupported, }
 					}
 				};
 			});
@@ -376,19 +376,19 @@ export class DataExplorerClientInstance extends Disposable {
 			// Until the backend state is available, we disable features.
 			return {
 				search_schema: {
-					supported: false
+					support_status: SupportStatus.Unsupported
 				},
 				set_row_filters: {
-					supported: false,
+					support_status: SupportStatus.Unsupported,
 					supports_conditions: false,
 					supported_types: []
 				},
 				get_column_profiles: {
-					supported: false,
+					support_status: SupportStatus.Unsupported,
 					supported_types: []
 				},
-				set_sort_columns: { supported: false },
-				export_data_selection: { supported: false }
+				set_sort_columns: { support_status: SupportStatus.Unsupported },
+				export_data_selection: { support_status: SupportStatus.Unsupported }
 			};
 		} else {
 			return this.cachedBackendState.supported_features;

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -280,6 +280,22 @@ export interface RowFilter {
 }
 
 /**
+ * Support status for a row filter type
+ */
+export interface RowFilterTypeSupportStatus {
+	/**
+	 * Type of row filter
+	 */
+	row_filter_type: RowFilterType;
+
+	/**
+	 * The support status for this row filter type
+	 */
+	support_status: SupportStatus;
+
+}
+
+/**
  * Parameters for the 'between' and 'not_between' filter types
  */
 export interface BetweenFilterParams {
@@ -361,6 +377,22 @@ export interface ColumnProfileRequest {
 	 * The type of analytical column profile
 	 */
 	profile_type: ColumnProfileType;
+
+}
+
+/**
+ * Support status for a given column profile type
+ */
+export interface ColumnProfileTypeSupportStatus {
+	/**
+	 * The type of analytical column profile
+	 */
+	profile_type: ColumnProfileType;
+
+	/**
+	 * The support status for this column profile type
+	 */
+	support_status: SupportStatus;
 
 }
 
@@ -679,9 +711,9 @@ export interface SupportedFeatures {
  */
 export interface SearchSchemaFeatures {
 	/**
-	 * Whether this RPC method is supported at all
+	 * The support status for this RPC method
 	 */
-	supported: boolean;
+	support_status: SupportStatus;
 
 }
 
@@ -690,9 +722,9 @@ export interface SearchSchemaFeatures {
  */
 export interface SetRowFiltersFeatures {
 	/**
-	 * Whether this RPC method is supported at all
+	 * The support status for this RPC method
 	 */
-	supported: boolean;
+	support_status: SupportStatus;
 
 	/**
 	 * Whether AND/OR filter conditions are supported
@@ -702,7 +734,7 @@ export interface SetRowFiltersFeatures {
 	/**
 	 * A list of supported types
 	 */
-	supported_types: Array<RowFilterType>;
+	supported_types: Array<RowFilterTypeSupportStatus>;
 
 }
 
@@ -711,14 +743,14 @@ export interface SetRowFiltersFeatures {
  */
 export interface GetColumnProfilesFeatures {
 	/**
-	 * Whether this RPC method is supported at all
+	 * The support status for this RPC method
 	 */
-	supported: boolean;
+	support_status: SupportStatus;
 
 	/**
 	 * A list of supported types
 	 */
-	supported_types: Array<ColumnProfileType>;
+	supported_types: Array<ColumnProfileTypeSupportStatus>;
 
 }
 
@@ -727,9 +759,9 @@ export interface GetColumnProfilesFeatures {
  */
 export interface ExportDataSelectionFeatures {
 	/**
-	 * Whether this RPC method is supported at all
+	 * The support status for this RPC method
 	 */
-	supported: boolean;
+	support_status: SupportStatus;
 
 }
 
@@ -738,9 +770,9 @@ export interface ExportDataSelectionFeatures {
  */
 export interface SetSortColumnsFeatures {
 	/**
-	 * Whether this RPC method is supported at all
+	 * The support status for this RPC method
 	 */
-	supported: boolean;
+	support_status: SupportStatus;
 
 }
 
@@ -928,6 +960,15 @@ export enum ExportFormat {
 	Csv = 'csv',
 	Tsv = 'tsv',
 	Html = 'html'
+}
+
+/**
+ * Possible values for SupportStatus
+ */
+export enum SupportStatus {
+	Unsupported = 'unsupported',
+	Supported = 'supported',
+	Experimental = 'experimental'
 }
 
 /**

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -729,7 +729,7 @@ export interface SetRowFiltersFeatures {
 	/**
 	 * Whether AND/OR filter conditions are supported
 	 */
-	supports_conditions: boolean;
+	supports_conditions: SupportStatus;
 
 	/**
 	 * A list of supported types

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -21,6 +21,7 @@ import { ProfileDatetime } from 'vs/workbench/services/positronDataExplorer/brow
 import { ColumnNullPercent } from 'vs/workbench/services/positronDataExplorer/browser/components/columnNullPercent';
 import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
 import { ColumnDisplayType, ColumnProfileType, ColumnSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { dataExplorerExperimentalFeatureEnabled } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerExperimentalConfig';
 
 /**
  * ColumnSummaryCellProps interface.
@@ -144,8 +145,16 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 	// Get the column null percent.
 	const columnNullPercent = props.instance.getColumnNullPercent(props.columnIndex);
 
+	// Check if the summary stats panel is supported.
 	const profileFeatures = props.instance.getSupportedFeatures().get_column_profiles;
-	let summarySupported = profileFeatures.supported_types.includes(ColumnProfileType.SummaryStats);
+	const summaryStatsStatus = profileFeatures.supported_types.filter((status) => {
+		return status.profile_type === ColumnProfileType.SummaryStats;
+	});
+	let summarySupported = false;
+	if (summaryStatsStatus.length === 1) {
+		summarySupported = dataExplorerExperimentalFeatureEnabled(summaryStatsStatus[0].support_status, props.instance.configurationService);
+	}
+
 	if (props.columnSchema.type_display === ColumnDisplayType.Object ||
 		props.columnSchema.type_display === ColumnDisplayType.Unknown) {
 		summarySupported = false;

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -127,7 +127,8 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 			this._keybindingService,
 			this._layoutService,
 			this._dataExplorerClientInstance,
-			this._dataExplorerCache
+			this._dataExplorerCache,
+			this._configurationService
 		);
 
 		// Add the onDidClose event handler.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -337,7 +337,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		anchorPoint: AnchorPoint
 	): Promise<void> {
 		const features = this._dataExplorerClientInstance.getSupportedFeatures();
-		const copySupported = this.isFeatureEnabled(features.export_data_selection?.support_status);
+		const copySupported = this.isFeatureEnabled(features.export_data_selection.support_status);
 
 		// Build the entries.
 		const entries: CustomContextMenuEntry[] = [];
@@ -391,9 +391,9 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		const columnSortKey = this.columnSortKey(columnIndex);
 
 		const features = this._dataExplorerClientInstance.getSupportedFeatures();
-		const copySupported = this.isFeatureEnabled(features.export_data_selection?.support_status);
-		const sortSupported = this.isFeatureEnabled(features.set_sort_columns?.support_status);
-		const filterSupported = this.isFeatureEnabled(features.set_row_filters?.support_status);
+		const copySupported = this.isFeatureEnabled(features.export_data_selection.support_status);
+		const sortSupported = this.isFeatureEnabled(features.set_sort_columns.support_status);
+		const filterSupported = this.isFeatureEnabled(features.set_row_filters.support_status);
 
 		// Build the entries.
 		const entries: CustomContextMenuEntry[] = [];

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -22,8 +22,10 @@ import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntim
 import { CustomContextMenuSeparator } from 'vs/workbench/browser/positronComponents/customContextMenu/customContextMenuSeparator';
 import { PositronDataExplorerCommandId } from 'vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions';
 import { CustomContextMenuEntry, showCustomContextMenu } from 'vs/workbench/browser/positronComponents/customContextMenu/customContextMenu';
-import { BackendState, ColumnSchema, DataSelection, DataSelectionCellRange, DataSelectionIndices, DataSelectionKind, DataSelectionRange, DataSelectionSingleCell, ExportFormat, RowFilter } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { BackendState, ColumnSchema, DataSelection, DataSelectionCellRange, DataSelectionIndices, DataSelectionKind, DataSelectionRange, DataSelectionSingleCell, ExportFormat, RowFilter, SupportStatus } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { ClipboardCell, ClipboardCellRange, ClipboardColumnIndexes, ClipboardColumnRange, ClipboardData, ClipboardRowIndexes, ClipboardRowRange, ColumnSelectionState, ColumnSortKeyDescriptor, DataGridInstance, RowSelectionState } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
+import { dataExplorerExperimentalFeatureEnabled } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerExperimentalConfig';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 /**
  * Localized strings.
@@ -58,7 +60,8 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		private readonly _keybindingService: IKeybindingService,
 		private readonly _layoutService: ILayoutService,
 		private readonly _dataExplorerClientInstance: DataExplorerClientInstance,
-		private readonly _dataExplorerCache: DataExplorerCache
+		private readonly _dataExplorerCache: DataExplorerCache,
+		private readonly _configurationService: IConfigurationService,
 	) {
 		// Call the base class's constructor.
 		super({
@@ -241,9 +244,9 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		const columnSortKey = this.columnSortKey(columnIndex);
 
 		const features = this._dataExplorerClientInstance.getSupportedFeatures();
-		const copySupported = features.export_data_selection?.supported;
-		const sortSupported = features.set_sort_columns?.supported;
-		const filterSupported = features.set_row_filters.supported;
+		const copySupported = this.isFeatureEnabled(features.export_data_selection?.support_status);
+		const sortSupported = this.isFeatureEnabled(features.set_sort_columns?.support_status);
+		const filterSupported = this.isFeatureEnabled(features.set_row_filters?.support_status);
 
 		// Build the entries.
 		const entries: CustomContextMenuEntry[] = [];
@@ -334,7 +337,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		anchorPoint: AnchorPoint
 	): Promise<void> {
 		const features = this._dataExplorerClientInstance.getSupportedFeatures();
-		const copySupported = features.export_data_selection?.supported;
+		const copySupported = this.isFeatureEnabled(features.export_data_selection?.support_status);
 
 		// Build the entries.
 		const entries: CustomContextMenuEntry[] = [];
@@ -388,9 +391,9 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		const columnSortKey = this.columnSortKey(columnIndex);
 
 		const features = this._dataExplorerClientInstance.getSupportedFeatures();
-		const copySupported = features.export_data_selection?.supported;
-		const sortSupported = features.set_sort_columns?.supported;
-		const filterSupported = features.set_row_filters.supported;
+		const copySupported = this.isFeatureEnabled(features.export_data_selection?.support_status);
+		const sortSupported = this.isFeatureEnabled(features.set_sort_columns?.support_status);
+		const filterSupported = this.isFeatureEnabled(features.set_row_filters?.support_status);
 
 		// Build the entries.
 		const entries: CustomContextMenuEntry[] = [];
@@ -580,6 +583,13 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		this.resetSelection();
 		this.setFirstRow(0, true);
 		this.setCursorRow(0);
+	}
+
+	/**
+	 * Given a status check if the feature is enabled.
+	 */
+	isFeatureEnabled(status: SupportStatus): boolean {
+		return dataExplorerExperimentalFeatureEnabled(status, this._configurationService);
 	}
 
 	//#endregion Public Methods

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerExperimentalConfig.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerExperimentalConfig.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from 'vs/nls';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import {
+	ConfigurationScope,
+	Extensions,
+	IConfigurationRegistry,
+} from 'vs/platform/configuration/common/configurationRegistry';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { positronConfigurationNodeBase } from 'vs/workbench/services/languageRuntime/common/languageRuntime';
+import { SupportStatus } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+
+// Key for the configuration setting
+export const USE_POSITRON_DATA_EXPLORER_EXPERIMENTAL_KEY =
+	'positron.dataExplorerExperimental';
+
+/**
+ * Retrieves the value of the configuration setting that determines whether to enable
+ * experimental features in the Positron Data Explorer.
+ * @param configurationService The configuration service
+ * @returns Whether to enable experimental Positron Data Explorer features
+ */
+export function checkDataExplorerExperimentalFeaturesEnabled(
+	configurationService: IConfigurationService
+) {
+	return Boolean(
+		configurationService.getValue(USE_POSITRON_DATA_EXPLORER_EXPERIMENTAL_KEY)
+	);
+}
+
+export function dataExplorerExperimentalFeatureEnabled(
+	status: SupportStatus,
+	configurationService: IConfigurationService
+) {
+	if (status === SupportStatus.Supported) {
+		return true;
+	}
+
+	if (status === SupportStatus.Experimental) {
+		return checkDataExplorerExperimentalFeaturesEnabled(configurationService);
+	}
+
+	return false;
+}
+
+// Register the configuration setting
+const configurationRegistry = Registry.as<IConfigurationRegistry>(
+	Extensions.Configuration
+);
+configurationRegistry.registerConfiguration({
+	...positronConfigurationNodeBase,
+	scope: ConfigurationScope.MACHINE_OVERRIDABLE,
+	properties: {
+		[USE_POSITRON_DATA_EXPLORER_EXPERIMENTAL_KEY]: {
+			type: 'boolean',
+			default: false,
+			markdownDescription: localize(
+				'positron.enablePositronDataExplorerExperimentalFeatures',
+				'**CAUTION**: Enable experimental Positron Data Explorer features which may result in unexpected behaviour.'
+			),
+		},
+	},
+});


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

Addresses #3537
Allows selecting a set of features that are marked as 'experimental' by backends.

For R, make sure to use: https://github.com/posit-dev/amalthea/pull/407

![image](https://github.com/posit-dev/positron/assets/4706822/1d70df43-275f-4c73-bdec-2253ac7fe840)

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

It's heavily inspired on the work from the new project wizard that has some similar infrastrcture to enable features by toggling a positron preference.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

https://github.com/posit-dev/positron/assets/4706822/d52a4866-acb8-4285-a33f-27d56df46ee1
