### PR TITLE
Bigger initial popup size for help

### DIFF
--- a/src/vs/workbench/browser/positronViewPane/positronViewPane.ts
+++ b/src/vs/workbench/browser/positronViewPane/positronViewPane.ts
@@ -91,7 +91,7 @@ export abstract class PositronViewPane extends ViewPane {
 
 	/**
 	 * Helper function to get the openFromCollapsedSize value as a number of pixels.
-	 * @returns
+	 * @returns How large the view should be when it is opened from a collapsed state in pixels.
 	 */
 	private _getOpenFromCollapsedSize(openFromCollapsedSize: PositronViewPaneOptions['openFromCollapsedSize']): number {
 		// If the value is a plain number then it refers to pixels and we don't need to do anything

--- a/src/vs/workbench/browser/positronViewPane/positronViewPane.ts
+++ b/src/vs/workbench/browser/positronViewPane/positronViewPane.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
-
+import * as DOM from 'vs/base/browser/dom';
 import { disposableTimeout } from 'vs/base/common/async';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -17,7 +17,7 @@ import { IViewPaneOptions, ViewPane } from 'vs/workbench/browser/parts/views/vie
 import { IViewDescriptorService } from 'vs/workbench/common/views';
 
 export interface PositronViewPaneOptions extends IViewPaneOptions {
-	allowZeroMinimumBodySize?: boolean;
+	openFromCollapsedSize?: number | `${number}%`;
 }
 
 export abstract class PositronViewPane extends ViewPane {
@@ -60,7 +60,7 @@ export abstract class PositronViewPane extends ViewPane {
 		// way to set this in any sort of configuration hence the need to override it here. If this
 		// isn't set, then the content of panes may occlude other parts of the editor when it is
 		// resized to be very small. See the `onDidChangeBodyVisibility` handler for implications.
-		if (options.allowZeroMinimumBodySize) {
+		if (options.openFromCollapsedSize) {
 			this.minimumBodySize = 0;
 		}
 
@@ -72,7 +72,7 @@ export abstract class PositronViewPane extends ViewPane {
 		// viewpane management state becomes confused on toggle.
 		this.element.tabIndex = 0;
 
-		if (options.allowZeroMinimumBodySize) {
+		if (options.openFromCollapsedSize) {
 			// Register the onDidChangeBodyVisibility event handler.
 			this._register(this.onDidChangeBodyVisibility(visible => {
 
@@ -82,11 +82,38 @@ export abstract class PositronViewPane extends ViewPane {
 					// the element to have some height. We set the minimum body size to 0 first to ensure
 					// that the view can be resized to be very small without spilling over, so we need to
 					// set it back to the original minimum body size after.
-					this.minimumBodySize = options.maximumBodySize ?? 50;
+					this.minimumBodySize = options.minimumBodySize ?? this._getOpenFromCollapsedSize(options.openFromCollapsedSize);
 					this.minimumBodySize = 0;
 				}
 			}));
 		}
+	}
+
+	/**
+	 * Helper function to get the openFromCollapsedSize value as a number of pixels.
+	 * @returns
+	 */
+	private _getOpenFromCollapsedSize(openFromCollapsedSize: PositronViewPaneOptions['openFromCollapsedSize']): number {
+		// If the value is a plain number then it refers to pixels and we don't need to do anything
+		// special to it.
+		if (typeof openFromCollapsedSize === 'number') {
+			return openFromCollapsedSize;
+		}
+
+		// If the number is a string then it must represent a percentage of the window height. Here
+		// we need to convert it to pixels based on the current window height.
+		if (typeof openFromCollapsedSize === 'string') {
+			const popOpenPercent = parseFloat(openFromCollapsedSize);
+
+			if (isNaN(popOpenPercent)) {
+				throw new Error(`Invalid value for openFromCollapsedSize: ${openFromCollapsedSize}`);
+			}
+
+			const windowHeight = DOM.getWindow(this.element).innerHeight;
+			return windowHeight * popOpenPercent / 100;
+		}
+
+		throw new Error(`Invalid value for openFromCollapsedSize: ${openFromCollapsedSize}`);
 	}
 
 	override focus(): void {

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpView.tsx
@@ -176,7 +176,7 @@ export class PositronHelpView extends PositronViewPane implements IReactComponen
 
 		// Call the base class's constructor.
 		super(
-			{ ...options, allowZeroMinimumBodySize: true },
+			{ ...options, openFromCollapsedSize: '50%' },
 			keybindingService,
 			contextMenuService,
 			configurationService,

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
@@ -88,7 +88,7 @@ export class PositronPreviewViewPane extends PositronViewPane implements IReactC
 		@IPositronPreviewService private readonly positronPreviewService: IPositronPreviewService,
 		@IHoverService hoverService: IHoverService,
 	) {
-		super({ ...options, allowZeroMinimumBodySize: true }, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService, hoverService);
+		super({ ...options, openFromCollapsedSize: '50%' }, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService, hoverService);
 
 		this._register(this.onDidChangeBodyVisibility(() => this.onDidChangeVisibility(this.isBodyVisible())));
 		this._positronPreviewContainer = DOM.$('.positron-preview-container');


### PR DESCRIPTION
Addresses #3530 

### Intent
Make the default size of a freshly-expanded help pane larger than the previous 50 pixels. 

Also, improve the logic around this functionality to declare the pop-open-to size as a percentage of editor height like we have in the layout presets. 

### Approach

- Switch how the allow-to-shrink-to-zero functionality is enabled from a boolean parameter to being enabled when a `openFromCollapsedSize` parameter is provided. This forces consideration of the default size on opening. 

- The `openFromCollapsedSize` parameter can either be:
  - a plain number, in which case it is interpreted as a pixel value and the panel is opened to that size, or...
  - a percentage (in the format of `"<foo>%"`). If a percentage is used then the height is taken as that percentage of the total window height. 

- Both users of the shrink-to-zero functionality: the help pane and the viewer pane are set to pop to 50% of the window height so they're nice and visible upon expanding. 


### QA Notes
The logic around the sizing is now a bit more complex so stress testing the expansion from various scenarios will probably be good. I managed to get a panel to not expand once or twice while developing but I couldn't reproduce so it may have been due to weird timing from debug points. 