### PR TITLE
Fix dead console state when IPyKernel installation is cancelled

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -104,8 +104,8 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	const [trace, setTrace] = useState(props.positronConsoleInstance.trace);
 	const [wordWrap, setWordWrap] = useState(props.positronConsoleInstance.wordWrap);
 	const [marker, setMarker] = useState(generateUuid());
+	const [runtimeAttached, setRuntimeAttached] = useState(props.positronConsoleInstance.runtimeAttached);
 	const [, setIgnoreNextScrollEvent, ignoreNextScrollEventRef] = useStateRef(false);
-
 
 	// Determines whether the console is scrollable.
 	const scrollable = () =>
@@ -351,6 +351,10 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 
 		disposableStore.add(props.positronConsoleInstance.onDidSelectAll(text => {
 			selectAllRuntimeItems();
+		}));
+
+		disposableStore.add(props.positronConsoleInstance.onDidAttachRuntime((runtime) => {
+			setRuntimeAttached(!!runtime);
 		}));
 
 		// Return the cleanup function that will dispose of the event handlers.
@@ -640,7 +644,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 					} else if (runtimeItem instanceof RuntimeItemExited) {
 						return <RuntimeExited key={runtimeItem.id} runtimeItemExited={runtimeItem} />;
 					} else if (runtimeItem instanceof RuntimeItemRestartButton) {
-						return <RuntimeRestartButton key={runtimeItem.id} runtimeItemRestartButton={runtimeItem} positronConsoleInstance={props.positronConsoleInstance}/>;
+						return <RuntimeRestartButton key={runtimeItem.id} runtimeItemRestartButton={runtimeItem} positronConsoleInstance={props.positronConsoleInstance} />;
 					} else if (runtimeItem instanceof RuntimeItemStartupFailure) {
 						return <RuntimeStartupFailure key={runtimeItem.id} runtimeItemStartupFailure={runtimeItem} />;
 					} else if (runtimeItem instanceof RuntimeItemTrace) {
@@ -651,7 +655,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 					}
 				})}
 			</div>
-			{!props.positronConsoleInstance.promptActive && props.positronConsoleInstance.runtimeAttached &&
+			{!props.positronConsoleInstance.promptActive && runtimeAttached &&
 				<ConsoleInput
 					width={consoleInputWidth}
 					positronConsoleInstance={props.positronConsoleInstance}

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1417,7 +1417,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			));
 
 			// If we haven't already detached the runtime, do it now.
-			if (this._runtimeState === RuntimeState.Exited && this.runtimeAttached) {
+			if ((this._runtimeState === RuntimeState.Exited ||
+				this._runtimeState === RuntimeState.Uninitialized) && this.runtimeAttached) {
 				this.detachRuntime();
 			}
 		}));

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1337,11 +1337,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				this.clearRestartItems();
 			}
 
-			if (runtimeState === RuntimeState.Exited) {
+			if (runtimeState === RuntimeState.Exited || runtimeState === RuntimeState.Uninitialized) {
 				if (this._runtimeState === RuntimeState.Starting ||
 					this._runtimeState === RuntimeState.Initializing) {
 					// If we moved directly from Starting or Initializing to
-					// Exited, then we probably encountered a startup
+					// Exited or Uninitialized, then we probably encountered a startup
 					// failure, and will be receiving a
 					// `onDidEncounterStartupFailure` event shortly.  In this
 					// case, we don't want to detach the runtime, because we
@@ -1355,7 +1355,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					setTimeout(() => {
 						// If we're still in the Exited state and haven't
 						// disposed, then do it now.
-						if (this._runtimeState === RuntimeState.Exited && this.runtimeAttached) {
+						if ((this._runtimeState === RuntimeState.Exited ||
+							this._runtimeState === RuntimeState.Uninitialized) &&
+							this.runtimeAttached) {
 							this.detachRuntime();
 
 							this.addRuntimeItem(new RuntimeItemExited(


### PR DESCRIPTION
### Intent

Addresses https://github.com/posit-dev/positron/issues/3457. Briefly, if you try to start Python but the installation of IPyKernel is cancelled or fails, the Console feels broken; you have a prompt but it doesn't run any code. The Power and Restart buttons are enabled but clicking on them does nothing.

### Approach

The underlying issue here is that Python goes from `Starting => Uninitialized` in this case. The Console is not prepared for this state transition and generally doesn't know what to do with runtimes that are `Uninitialized` -- after all, the runtime is usually `Starting` by the time a Console gets attached to it. 

One approach to fixing this would be to go upstream and make sure that Python actually gets marked as `Exited` in this workflow. I chose not to do this for a couple of reasons:

1. Arguably `Exited` isn't accurate since Python never actually starts in this case. You can't exit if you didn't start. 
2. The Console should be resilient to this state transition (who knows what third party language packs will do...)

So, the fix here is mostly going through the Console and making sure all the right stuff happens if a runtime happens to return to an `Uninitialized` state from `Starting`. 

A better fix I think would be to add a specific pre-start hook for the runtime so Positron could supervise this part of the process instead of trying to slip it in as part of an ordinary start. But that's probably more ambitious than we want to be with Beta around the corner. 

### QA Notes

The expected behavior is as follows:

<img width="631" alt="image" src="https://github.com/posit-dev/positron/assets/470418/b997c7c7-fad1-4286-a57b-7e9c7fd9949c">

- The Power button should be enabled.  Clicking it should try to start Python again.
- The Restart button should be disabled.
- There should be no Python prompt visible.