### PR TITLE
Add `r.sourceCurrentFile` to RStudio Keymap

### DIFF
--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -154,6 +154,14 @@
         "command": "r.insertSection"
       },
       {
+        "mac": "cmd+shift+s",
+        "win": "ctrl+shift+s",
+        "linux": "ctrl+shift+s",
+        "key": "ctrl+shift+s",
+        "when": "config.rstudio.keymap.enable && editorLangId == r",
+        "command": "r.sourceCurrentFile"
+      },
+      {
         "mac": "cmd+shift+m",
         "win": "ctrl+shift+m",
         "linux": "ctrl+shift+m",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

This PR adds a missing keybinding to the RStudio Keymap for sourcing a current R file. The keybindings we are taking over for here are:

- `workbench.action.files.saveLocalFile` when `remoteFileDialogVisible` (no problem there)
- the generic `workbench.action.files.saveAs` (a bigger deal)

### Approach

Same as all the other keybindings!

### QA Notes

When you are opted in to the RStudio Keymap, the keybinding <kbd>cmd</kbd>+<kbd>shift</kbd>+<kbd>s</kbd> will source a current R file. 