### PR TITLE
New Project Wizard - Extended timeout waiting for "Create" button

### DIFF
--- a/test/smoke/src/areas/positron/new-project-wizard/python-new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/python-new-project.test.ts
@@ -22,7 +22,7 @@ export function setup(logger: Logger) {
 				await app.workbench.positronNewProjectWizard.newPythonProjectButton.click();
 				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
 				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(); // May need to pass in a retry count > default of 200
+				await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
 				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
 				await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myPythonProject');
@@ -48,7 +48,7 @@ export function setup(logger: Logger) {
 				await app.workbench.positronNewProjectWizard.newRProjectButton.click();
 				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
 				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(); // May need to pass in a retry count > default of 200
+				await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
 				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
 				await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myRProject');
@@ -74,7 +74,7 @@ export function setup(logger: Logger) {
 				await app.workbench.positronNewProjectWizard.newJupyterProjectButton.click();
 				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
 				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(); // May need to pass in a retry count > default of 200
+				await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
 				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
 				await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myJupyterNotebook');


### PR DESCRIPTION


### Intent

The `Create` button in the New Project Wizard only lights up after discovering all interpreters.  In both CI and locally, it can take longer than the default 20 seconds timeout.  This should help with stability

### Approach

Extended timeout to 500 retries, roughly 50 seconds. 

### QA Notes

Passes locally.