### PR TITLE
Update Github client ID for Positron

### DIFF
--- a/extensions/github-authentication/src/config.ts
+++ b/extensions/github-authentication/src/config.ts
@@ -11,5 +11,9 @@ export interface IConfig {
 
 // For easy access to mixin client ID and secret
 export const Config: IConfig = {
-	gitHubClientId: '01ab8ac9400c4e429b23'
+	// --- Start Positron ---
+	// Replace the "GitHub for VS Code" client ID with Positron's client ID
+	// gitHubClientId: '01ab8ac9400c4e429b23'
+	gitHubClientId: 'Ov23lilj1d6nFMvW4QfI'
+	// --- End Positron ---
 };


### PR DESCRIPTION
### Intent

Address https://github.com/posit-dev/positron/issues/3355. 

### Approach

Update the client ID in the Github authentication extension so it's associated with Positron. 

### QA Notes

In addition to ensuring we see the correct icon/text when authenticating, we should also check to make sure that extensions that need to authenticate against Github can continue to do so. 