### PR TITLE
Initial layout on first startup

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -140,6 +140,9 @@ export const TITLE_BAR_SETTINGS = [
 
 export abstract class Layout extends Disposable implements IWorkbenchLayoutService {
 
+	// --- Start Positron ---
+	public static readonly LAYOUT_INITIALIZED_STORAGE_KEY = 'positron.workbench.layoutInitialized';
+	// --- End Positron ---
 	declare readonly _serviceBrand: undefined;
 
 	//#region Events
@@ -3009,7 +3012,22 @@ class LayoutStateModel extends Disposable {
 		LayoutStateKeys.AUXILIARYBAR_HIDDEN.defaultValue = false;
 		LayoutStateKeys.PANEL_HIDDEN.defaultValue = false;
 		LayoutStateKeys.PANEL_SIZE.defaultValue = workbenchDimensions.height / 2;
-		// // --- End Positron ---
+
+		// Initialize layout settings for the first startup.
+		// See positronCustomViews.ts -> positronFourPaneDsLayout
+		// Cannot execute the layout action because not enough of the workbench has been initialized
+		// to correctly proportion the views.
+		const layoutInitialized = this.storageService.getBoolean(Layout.LAYOUT_INITIALIZED_STORAGE_KEY, StorageScope.PROFILE);
+		if (!layoutInitialized) {
+			LayoutStateKeys.SIDEBAR_HIDDEN.defaultValue = false;
+			LayoutStateKeys.PANEL_HIDDEN.defaultValue = false;
+			LayoutStateKeys.AUXILIARYBAR_HIDDEN.defaultValue = false;
+			LayoutStateKeys.SIDEBAR_SIZE.defaultValue = Math.round(workbenchDimensions.width * 0.15);
+			LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT.defaultValue = Math.round(workbenchDimensions.height * 0.4);
+			LayoutStateKeys.AUXILIARYBAR_SIZE.defaultValue = Math.round(workbenchDimensions.width * 0.3);
+			this.storageService.store(Layout.LAYOUT_INITIALIZED_STORAGE_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
+		}
+		// --- End Positron ---
 
 		// Apply all defaults
 		for (key in LayoutStateKeys) {

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -81,6 +81,7 @@ import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
 import { ILanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILifecycleService, LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 /*--- End Positron ---*/
 
 const SLIDE_TRANSITION_TIME_MS = 250;
@@ -204,6 +205,7 @@ export class GettingStartedPage extends EditorPane {
 		@IRuntimeSessionService private readonly runtimeSessionService: IRuntimeSessionService,
 		@IRuntimeStartupService private readonly runtimeStartupService: IRuntimeStartupService,
 		@ILanguageRuntimeService private readonly languageRuntimeService: ILanguageRuntimeService,
+		@ILifecycleService private readonly lifecycleService: ILifecycleService,
 		// @IWorkbenchAssignmentService private readonly tasExperimentService: IWorkbenchAssignmentService
 	) {
 
@@ -326,6 +328,12 @@ export class GettingStartedPage extends EditorPane {
 				JSON.stringify(restoreData),
 				StorageScope.PROFILE, StorageTarget.MACHINE);
 		}));
+
+		// Re-layout when the welcome content has fully loaded
+		// Ensures the scroll height is correct since the initial layout is done before the content is loaded
+		this.lifecycleService.when(LifecyclePhase.Eventually).then(() => {
+			this.layout(new Dimension(this.layoutService.mainContainerDimension.width, this.layoutService.mainContainerDimension.height));
+		});
 	}
 
 	//--- End Positron ---
@@ -1012,9 +1020,11 @@ export class GettingStartedPage extends EditorPane {
 
 		this.layoutMarkdown?.();
 
-		this.container.classList.toggle('height-constrained', size.height <= 600);
+		// --- Start Positron ---
+		// Removed the height-constrained class that hides the header so that product name and logo are always visible
 		this.container.classList.toggle('width-constrained', size.width <= 400);
 		this.container.classList.toggle('width-semi-constrained', size.width <= 800);
+		// --- End Positron ---
 
 		this.categoriesPageScrollbar?.scanDomNode();
 		this.detailsPageScrollbar?.scanDomNode();

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/positronGettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/positronGettingStarted.css
@@ -3,9 +3,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 .gettingStartedContainer .header {
-	margin-bottom: 50px;
 	display: flex;
 	column-gap: 24px;
+}
+
+.gettingStartedContainer .gettingStartedSlideCategories > .gettingStartedCategoriesContainer {
+	row-gap: 50px;
 }
 
 .gettingStartedContainer .product-logo.welcome-positron-logo {

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -31,7 +31,6 @@ import { TerminalCommandId } from 'vs/workbench/contrib/terminal/common/terminal
 
 // --- Start Positron ---
 import { IPositronNewProjectService } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
-import { positronFourPaneDsLayout } from 'vs/workbench/browser/positronCustomViews';
 // --- End Positron ---
 
 export const restoreWalkthroughsConfigurationKey = 'workbench.welcomePage.restorableWalkthroughs';
@@ -76,9 +75,6 @@ export class StartupPageEditorResolverContribution implements IWorkbenchContribu
 }
 
 export class StartupPageRunnerContribution implements IWorkbenchContribution {
-	// --- Start Positron ---
-	public static readonly LAYOUT_INITIALIZED_STORAGE_KEY = 'positron.workbench.layoutInitialized';
-	// --- End Positron ---
 
 	static readonly ID = 'workbench.contrib.startupPageRunner';
 
@@ -152,16 +148,6 @@ export class StartupPageRunnerContribution implements IWorkbenchContribution {
 					await this.openReadme();
 				} else if (startupEditorSetting.value === 'welcomePage' || startupEditorSetting.value === 'welcomePageInEmptyWorkbench') {
 					await this.openGettingStarted();
-					// --- Start Positron ---
-					// On first startup, change to the four-pane layout when showing the welcome page
-					this.lifecycleService.when(LifecyclePhase.Restored).then(() => {
-						const layoutInitialized = this.storageService.getBoolean(StartupPageRunnerContribution.LAYOUT_INITIALIZED_STORAGE_KEY, StorageScope.PROFILE);
-						if (!layoutInitialized) {
-							this.commandService.executeCommand(positronFourPaneDsLayout.id);
-							this.storageService.store(StartupPageRunnerContribution.LAYOUT_INITIALIZED_STORAGE_KEY, true, StorageScope.PROFILE, StorageTarget.USER);
-						}
-					});
-					// --- End Positron ---
 				} else if (startupEditorSetting.value === 'terminal') {
 					this.commandService.executeCommand(TerminalCommandId.CreateTerminalEditor);
 				}


### PR DESCRIPTION
### Intent
Address #3311 

Sets the sidebar and panel sizes when initially creating the workbench layout. This ensures a flicker-free layout with the correct part sizing on first startup.

3840 x 2160
![image](https://github.com/posit-dev/positron/assets/9591545/b13db1ab-e24c-4ac1-aa01-f8d0e91fd384)

2560 x 1440
![image](https://github.com/posit-dev/positron/assets/9591545/ce9aa412-a2ee-43c7-a1ed-f3ade69e3da0)

1728 x 1117 (Macbook M1 screen)
<img width="1299" alt="image" src="https://github.com/posit-dev/positron/assets/9591545/14526e3b-42ca-4620-ac42-c8deab8f6d42">

### Approach
Moves the layout state initialization into the workbench layout. Having access to the workbench dimensions helps set the correct sizes as well as override any defaults. Using the custom layout action wasn't consistent with setting the sizes since the workbench `restore()` would override sizes with hardcoded defaults.

There was a scrolling bug with the Welcome content as it initializes the scroll dimensions before the content is loaded, which made it impossible to scroll all the content. It needed another layout after content loaded so that it can calculate the proper scroll height. The CSS change also contributed to the incorrect scroll height.

The product title and logo are always visible now and small screens will have to deal with scrolling to see all of the Welcome content.

### QA Notes
Delete `/Users/<your username>/Library/Application Support/Positron` to reset to first startup state.


