### PR TITLE
Add baseline for detect-secrets for Positron

### DIFF
--- a/scripts/git_hooks/secrets/.secrets.baseline
+++ b/scripts/git_hooks/secrets/.secrets.baseline
@@ -1,0 +1,964 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": "scripts/git_hooks/secrets/.secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "scripts/git_hooks/secrets/.secrets.baseline.*",
+        ".*cgmanifest.json",
+        ".*/html-manager/dist/embed-amd.js",
+        "src/vs/base/test/common/filters.perf.data.js",
+        ".*/test/browser/recordings/windows11.*"
+      ]
+    }
+  ],
+  "results": {
+    ".github/workflows/build-release.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/build-release.yml",
+        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
+        "is_verified": false,
+        "line_number": 58,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/alpine/product-build-alpine.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/alpine/product-build-alpine.yml",
+        "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
+        "is_verified": false,
+        "line_number": 23,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/cli/cli-darwin-sign.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/cli/cli-darwin-sign.yml",
+        "hashed_secret": "70519fad4f6f57675a71ca41a152d4acb087bd21",
+        "is_verified": false,
+        "line_number": 12,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/cli/cli-win32-sign.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/cli/cli-win32-sign.yml",
+        "hashed_secret": "70519fad4f6f57675a71ca41a152d4acb087bd21",
+        "is_verified": false,
+        "line_number": 12,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/darwin/product-build-darwin-sign.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/darwin/product-build-darwin-sign.yml",
+        "hashed_secret": "70519fad4f6f57675a71ca41a152d4acb087bd21",
+        "is_verified": false,
+        "line_number": 21,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/darwin/product-build-darwin-universal.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/darwin/product-build-darwin-universal.yml",
+        "hashed_secret": "d8368fc8fec27a14a70083cc2cd6d959085086a9",
+        "is_verified": false,
+        "line_number": 15,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/darwin/product-build-darwin.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/darwin/product-build-darwin.yml",
+        "hashed_secret": "d8368fc8fec27a14a70083cc2cd6d959085086a9",
+        "is_verified": false,
+        "line_number": 33,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/distro/download-distro.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/distro/download-distro.yml",
+        "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
+        "is_verified": false,
+        "line_number": 7,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/linux/product-build-linux-legacy-server.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/linux/product-build-linux-legacy-server.yml",
+        "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
+        "is_verified": false,
+        "line_number": 23,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/linux/product-build-linux.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/linux/product-build-linux.yml",
+        "hashed_secret": "256e334e9cc8b59bb08501110e1c729c9b2edec4",
+        "is_verified": false,
+        "line_number": 35,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/product-compile.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/product-compile.yml",
+        "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
+        "is_verified": false,
+        "line_number": 20,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/product-publish.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/product-publish.yml",
+        "hashed_secret": "76f5d6eed49e94461f8e5f88ad74dc253578d3ac",
+        "is_verified": false,
+        "line_number": 16,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/sdl-scan.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/sdl-scan.yml",
+        "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
+        "is_verified": false,
+        "line_number": 67,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/web/product-build-web.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/web/product-build-web.yml",
+        "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
+        "is_verified": false,
+        "line_number": 15,
+        "is_secret": false
+      }
+    ],
+    "build/azure-pipelines/win32/product-build-win32.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "build/azure-pipelines/win32/product-build-win32.yml",
+        "hashed_secret": "256e334e9cc8b59bb08501110e1c729c9b2edec4",
+        "is_verified": false,
+        "line_number": 40,
+        "is_secret": false
+      }
+    ],
+    "cli/src/auth.rs": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "cli/src/auth.rs",
+        "hashed_secret": "b1ca527b736010b3f3125ce314832b9d92311cb2",
+        "is_verified": false,
+        "line_number": 72,
+        "is_secret": false
+      }
+    ],
+    "cli/src/desktop/version_manager.rs": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "cli/src/desktop/version_manager.rs",
+        "hashed_secret": "4f29d0426d3ecc42e70ac2127ee3d7fd9d23f5c7",
+        "is_verified": false,
+        "line_number": 332,
+        "is_secret": false
+      }
+    ],
+    "cli/src/tunnels/socket_signal.rs": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "cli/src/tunnels/socket_signal.rs",
+        "hashed_secret": "9d594c96ec4c8eb6d9ec54efd05ceca6052a8259",
+        "is_verified": false,
+        "line_number": 353,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "cli/src/tunnels/socket_signal.rs",
+        "hashed_secret": "ede64ff4b2c5d298f40c0639b8dffeb241596cca",
+        "is_verified": false,
+        "line_number": 354,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "cli/src/tunnels/socket_signal.rs",
+        "hashed_secret": "8758646166da378eb67718f0780b967bd1b0d5d2",
+        "is_verified": false,
+        "line_number": 355,
+        "is_secret": false
+      }
+    ],
+    "extensions/cpp/syntaxes/platform.tmLanguage.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "extensions/cpp/syntaxes/platform.tmLanguage.json",
+        "hashed_secret": "f4f4522002ae0895566ebbc726b9ebc6064b5003",
+        "is_verified": false,
+        "line_number": 213,
+        "is_secret": false
+      }
+    ],
+    "extensions/git/src/test/git.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "3100a15f2a0660239142c51a09a9860091a57eb6",
+        "is_verified": false,
+        "line_number": 284,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "b3820b8646425e7ce86d52a14f0545675f5a0fb8",
+        "is_verified": false,
+        "line_number": 286,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "1bba808164c2bd2606270fd338b1bcfcbfb9972c",
+        "is_verified": false,
+        "line_number": 310,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "0026ab5726869f2f8d8d2b1e8c4ab07e66f75a98",
+        "is_verified": false,
+        "line_number": 463,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "15b70898ca2a438c30384441f139b460590fbe8a",
+        "is_verified": false,
+        "line_number": 465,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "4f4330cffae54a0d08fb33b66c533b2ee961accb",
+        "is_verified": false,
+        "line_number": 546,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "a3da0860baf4244389064b16f6788dafcf030d1f",
+        "is_verified": false,
+        "line_number": 547,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "30140192774a074079e5307bf65630ac4308a503",
+        "is_verified": false,
+        "line_number": 548,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "f339565b20b0740f51b54166570867fbcf37da8b",
+        "is_verified": false,
+        "line_number": 549,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "26bbee0ec44b5cb456171b8032b8494002b536d1",
+        "is_verified": false,
+        "line_number": 550,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "8cc5973678f7bed6507ba5440f0f7c132626affe",
+        "is_verified": false,
+        "line_number": 551,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "eafa4b025ed67291f5076bb171668e801c36b20e",
+        "is_verified": false,
+        "line_number": 552,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "2a0c0db2b79ee31c56309a893c2360be13f79f28",
+        "is_verified": false,
+        "line_number": 553,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "832e7e6717a35ffb092345019499f9c9c1db2eef",
+        "is_verified": false,
+        "line_number": 555,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "9b93e1d1a6c8e61ec6243d19841b85e081edc956",
+        "is_verified": false,
+        "line_number": 556,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/git/src/test/git.test.ts",
+        "hashed_secret": "1d744d5f622cf01c4cb6d97dae876e634dc9b065",
+        "is_verified": false,
+        "line_number": 578,
+        "is_secret": false
+      }
+    ],
+    "extensions/github-authentication/src/config.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/github-authentication/src/config.ts",
+        "hashed_secret": "b1ca527b736010b3f3125ce314832b9d92311cb2",
+        "is_verified": false,
+        "line_number": 14,
+        "is_secret": false
+      }
+    ],
+    "extensions/github-authentication/src/test/flows.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/github-authentication/src/test/flows.test.ts",
+        "hashed_secret": "3da541559918a808c2402bba5012f6c60b27661c",
+        "is_verified": false,
+        "line_number": 21,
+        "is_secret": false
+      }
+    ],
+    "extensions/ipynb/src/notebookImagePaste.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "extensions/ipynb/src/notebookImagePaste.ts",
+        "hashed_secret": "e582429052cdb908833560f6f7582d232de37c4d",
+        "is_verified": false,
+        "line_number": 213,
+        "is_secret": false
+      }
+    ],
+    "extensions/npm/src/features/bowerJSONContribution.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/npm/src/features/bowerJSONContribution.ts",
+        "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
+        "is_verified": false,
+        "line_number": 16,
+        "is_secret": false
+      }
+    ],
+    "extensions/positron-python/python_files/Notebooks intro.ipynb": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/positron-python/python_files/Notebooks intro.ipynb",
+        "hashed_secret": "c2e045c525442c9c56408ece0a534e0d48b30edd",
+        "is_verified": false,
+        "line_number": 142,
+        "is_secret": false
+      }
+    ],
+    "extensions/vscode-api-tests/testWorkspace/test.ipynb": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/vscode-api-tests/testWorkspace/test.ipynb",
+        "hashed_secret": "536dce5e06e6a83a5ba6163a3859935316485e8e",
+        "is_verified": false,
+        "line_number": 32,
+        "is_secret": false
+      }
+    ],
+    "package.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "package.json",
+        "hashed_secret": "95b9187121d85faed7de90dc42b3036dd6bb3f9e",
+        "is_verified": false,
+        "line_number": 4,
+        "is_secret": false
+      }
+    ],
+    "product.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "product.json",
+        "hashed_secret": "e0d0f85d294f44b67db5f07ff234d143a2db7862",
+        "is_verified": false,
+        "line_number": 42,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "product.json",
+        "hashed_secret": "ba99905cb696b65a9547f0649bbecf3d808df947",
+        "is_verified": false,
+        "line_number": 58,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "product.json",
+        "hashed_secret": "ef77c8ceb4ee9293470dfd0c995a7841dad5d8f4",
+        "is_verified": false,
+        "line_number": 74,
+        "is_secret": false
+      }
+    ],
+    "scripts/git_hooks/secrets/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "scripts/git_hooks/secrets/README.md",
+        "hashed_secret": "7585d1f7ceb90fd0b1ab42d0a6ca39fcf55065c7",
+        "is_verified": false,
+        "line_number": 22,
+        "is_secret": false
+      }
+    ],
+    "scripts/playground-server.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "scripts/playground-server.ts",
+        "hashed_secret": "1d278d3c888d1a2fa7eed622bfc02927ce4049af",
+        "is_verified": false,
+        "line_number": 693,
+        "is_secret": false
+      }
+    ],
+    "src/vs/base/common/buffer.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/vs/base/common/buffer.ts",
+        "hashed_secret": "e582429052cdb908833560f6f7582d232de37c4d",
+        "is_verified": false,
+        "line_number": 405,
+        "is_secret": false
+      }
+    ],
+    "src/vs/base/common/extpath.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/vs/base/common/extpath.ts",
+        "hashed_secret": "3ce1fc6461a712abb4ae6a9eafd66264cc3b3b18",
+        "is_verified": false,
+        "line_number": 389,
+        "is_secret": false
+      }
+    ],
+    "src/vs/base/test/browser/hash.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/base/test/browser/hash.test.ts",
+        "hashed_secret": "66b60e6a2bcec249f7467e10476123722475d77f",
+        "is_verified": false,
+        "line_number": 91,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/base/test/browser/hash.test.ts",
+        "hashed_secret": "80b90c522083cd51a34e3f10ded8ff5f8a9897ad",
+        "is_verified": false,
+        "line_number": 99,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/base/test/browser/hash.test.ts",
+        "hashed_secret": "9cf5caf6c36f5cccde8c73fad8894c958f4983da",
+        "is_verified": false,
+        "line_number": 103,
+        "is_secret": false
+      }
+    ],
+    "src/vs/base/test/common/uri.test.ts": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/vs/base/test/common/uri.test.ts",
+        "hashed_secret": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
+        "is_verified": false,
+        "line_number": 346,
+        "is_secret": false
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/vs/base/test/common/uri.test.ts",
+        "hashed_secret": "114838b44bb42c2832324bac6d42b6b693e15f60",
+        "is_verified": false,
+        "line_number": 352,
+        "is_secret": false
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/vs/base/test/common/uri.test.ts",
+        "hashed_secret": "dde57062d0392ed551b4f21bb937d6f7f199a594",
+        "is_verified": false,
+        "line_number": 358,
+        "is_secret": false
+      }
+    ],
+    "src/vs/base/test/node/crypto.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/base/test/node/crypto.test.ts",
+        "hashed_secret": "9010fe091ace30090c9db33165cf7e7ee08c0cfb",
+        "is_verified": false,
+        "line_number": 33,
+        "is_secret": false
+      }
+    ],
+    "src/vs/code/electron-main/auth.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/vs/code/electron-main/auth.ts",
+        "hashed_secret": "1552ab4cda3b3f85ebbe13ab82fddd1071a00904",
+        "is_verified": false,
+        "line_number": 59,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/vs/code/electron-main/auth.ts",
+        "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
+        "is_verified": false,
+        "line_number": 169,
+        "is_secret": false
+      }
+    ],
+    "src/vs/editor/browser/viewParts/minimap/minimapPreBaked.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/editor/browser/viewParts/minimap/minimapPreBaked.ts",
+        "hashed_secret": "be2768cb6754de2aa14a7eb7fb67e5db0abd8890",
+        "is_verified": false,
+        "line_number": 55,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/editor/browser/viewParts/minimap/minimapPreBaked.ts",
+        "hashed_secret": "7a15525cc2aa0af7747d53b65242a277dc582026",
+        "is_verified": false,
+        "line_number": 60,
+        "is_secret": false
+      }
+    ],
+    "src/vs/editor/contrib/suggest/test/browser/suggestController.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/editor/contrib/suggest/test/browser/suggestController.test.ts",
+        "hashed_secret": "e4e7bced229a170690fb933633e903876e75ee07",
+        "is_verified": false,
+        "line_number": 651,
+        "is_secret": false
+      }
+    ],
+    "src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts",
+        "hashed_secret": "2fbed46209c70d10fc62ec9c23e4a5b4969c4838",
+        "is_verified": false,
+        "line_number": 19,
+        "is_secret": false
+      }
+    ],
+    "src/vs/platform/backup/test/electron-main/backupMainService.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/platform/backup/test/electron-main/backupMainService.test.ts",
+        "hashed_secret": "df85aee71ccafa1974bb0fab73f86de85f89eb52",
+        "is_verified": false,
+        "line_number": 595,
+        "is_secret": false
+      }
+    ],
+    "src/vs/platform/checksum/test/node/checksumService.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/vs/platform/checksum/test/node/checksumService.test.ts",
+        "hashed_secret": "4a211cacf9cf46abb61d97cd30f8927f8ff68949",
+        "is_verified": false,
+        "line_number": 38,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/vs/platform/checksum/test/node/checksumService.test.ts",
+        "hashed_secret": "8b3419d93a3815bab365c9148edef39d80e7c8de",
+        "is_verified": false,
+        "line_number": 38,
+        "is_secret": false
+      }
+    ],
+    "src/vs/platform/encryption/common/encryptionService.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/vs/platform/encryption/common/encryptionService.ts",
+        "hashed_secret": "2164a98794e6e6f7a8c1862ca735183450643ab8",
+        "is_verified": false,
+        "line_number": 34,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/vs/platform/encryption/common/encryptionService.ts",
+        "hashed_secret": "27941be9e491ea754419893f64b724450376db52",
+        "is_verified": false,
+        "line_number": 45,
+        "is_secret": false
+      }
+    ],
+    "src/vs/platform/extensionManagement/test/common/configRemotes.test.ts": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/vs/platform/extensionManagement/test/common/configRemotes.test.ts",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 29,
+        "is_secret": false
+      }
+    ],
+    "src/vs/platform/telemetry/node/telemetryUtils.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/platform/telemetry/node/telemetryUtils.ts",
+        "hashed_secret": "def4e2deaa6e984c6eaa63b1f8ed02574aaa4bda",
+        "is_verified": false,
+        "line_number": 17,
+        "is_secret": false
+      }
+    ],
+    "src/vs/platform/telemetry/test/browser/1dsAppender.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/vs/platform/telemetry/test/browser/1dsAppender.test.ts",
+        "hashed_secret": "da43a8ebe3e071eb9f612ac529369068983ed590",
+        "is_verified": false,
+        "line_number": 70,
+        "is_secret": false
+      }
+    ],
+    "src/vs/platform/windows/test/electron-main/windowsStateHandler.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/platform/windows/test/electron-main/windowsStateHandler.test.ts",
+        "hashed_secret": "81902f90c165b5b742afc5a3be5180bb20fd6fa9",
+        "is_verified": false,
+        "line_number": 125,
+        "is_secret": false
+      }
+    ],
+    "src/vs/platform/workspaces/test/electron-main/workspaces.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/platform/workspaces/test/electron-main/workspaces.test.ts",
+        "hashed_secret": "80186838ad46c9ff7e226d081a5289b4b6dc9a3c",
+        "is_verified": false,
+        "line_number": 52,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/platform/workspaces/test/electron-main/workspaces.test.ts",
+        "hashed_secret": "db8ab9b302acd24863d9f8b173ce760e876452c7",
+        "is_verified": false,
+        "line_number": 52,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/platform/workspaces/test/electron-main/workspaces.test.ts",
+        "hashed_secret": "2d7b6bcb2710e7af54714bf26aa6df65d7d96bc9",
+        "is_verified": false,
+        "line_number": 60,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/platform/workspaces/test/electron-main/workspaces.test.ts",
+        "hashed_secret": "fc8e06e896a2fca7d730591b367221b493df4677",
+        "is_verified": false,
+        "line_number": 60,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/platform/workspaces/test/electron-main/workspaces.test.ts",
+        "hashed_secret": "11f36d26f88c98fc21501757dcaf1d189054b459",
+        "is_verified": false,
+        "line_number": 63,
+        "is_secret": false
+      }
+    ],
+    "src/vs/platform/workspaces/test/electron-main/workspacesHistoryStorage.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/platform/workspaces/test/electron-main/workspacesHistoryStorage.test.ts",
+        "hashed_secret": "81902f90c165b5b742afc5a3be5180bb20fd6fa9",
+        "is_verified": false,
+        "line_number": 120,
+        "is_secret": false
+      }
+    ],
+    "src/vs/server/node/webClientServer.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/vs/server/node/webClientServer.ts",
+        "hashed_secret": "82fe946af002a1d490d8735ecaa1ed209e65f238",
+        "is_verified": false,
+        "line_number": 382,
+        "is_secret": false
+      }
+    ],
+    "src/vs/workbench/api/test/browser/extHostTelemetry.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/vs/workbench/api/test/browser/extHostTelemetry.test.ts",
+        "hashed_secret": "7fe54a7b420126077bba3453c0f9d31430735c5e",
+        "is_verified": false,
+        "line_number": 255,
+        "is_secret": false
+      }
+    ],
+    "src/vs/workbench/contrib/tags/test/node/workspaceTags.test.ts": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/vs/workbench/contrib/tags/test/node/workspaceTags.test.ts",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 26,
+        "is_secret": false
+      }
+    ],
+    "src/vs/workbench/contrib/webview/browser/pre/index.html": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/vs/workbench/contrib/webview/browser/pre/index.html",
+        "hashed_secret": "558f38f9b8037c0fd72537287a216a3853c97872",
+        "is_verified": false,
+        "line_number": 8,
+        "is_secret": false
+      }
+    ],
+    "src/vs/workbench/services/environment/browser/environmentService.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/vs/workbench/services/environment/browser/environmentService.ts",
+        "hashed_secret": "3a8f125da17a2c187d430daf0045e0fdfa707bdd",
+        "is_verified": false,
+        "line_number": 234,
+        "is_secret": false
+      }
+    ],
+    "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts": [
+      {
+        "type": "IBM Cloud IAM Key",
+        "filename": "src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts",
+        "hashed_secret": "0d43d6e259826e4ecbda1644424b26de54faa665",
+        "is_verified": false,
+        "line_number": 95,
+        "is_secret": false
+      }
+    ],
+    "src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html",
+        "hashed_secret": "82fe946af002a1d490d8735ecaa1ed209e65f238",
+        "is_verified": false,
+        "line_number": 7,
+        "is_secret": false
+      }
+    ],
+    "src/vs/workbench/test/browser/webview.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/vs/workbench/test/browser/webview.test.ts",
+        "hashed_secret": "bd86be67e83058d60b6ae73f8264b0e0f4a53faf",
+        "is_verified": false,
+        "line_number": 14,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/vs/workbench/test/browser/webview.test.ts",
+        "hashed_secret": "2cb6f8318e394386a6a2b875eca55c07e2af7045",
+        "is_verified": false,
+        "line_number": 19,
+        "is_secret": false
+      }
+    ],
+    "test/integration/browser/src/index.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/integration/browser/src/index.ts",
+        "hashed_secret": "3a8f125da17a2c187d430daf0045e0fdfa707bdd",
+        "is_verified": false,
+        "line_number": 130,
+        "is_secret": false
+      }
+    ]
+  },
+  "generated_at": "2024-06-14T17:37:51Z"
+}

--- a/scripts/git_hooks/secrets/README.md
+++ b/scripts/git_hooks/secrets/README.md
@@ -1,0 +1,78 @@
+# Secrets Scanning
+
+We use [detect-secrets](https://github.com/Yelp/detect-secrets) to scan for possible secrets in staged files.
+
+For more information on how to use detect-secrets, see the [detect-secrets documentation](https://github.com/Yelp/detect-secrets).
+
+A wrapper script [run-detect-secrets](./run-detect-secrets) is used to run detect-secrets with the appropriate configuration and baseline secrets file.
+
+## Installation
+1. Install detect-secrets via `pip install detect-secrets` (Python and pip installed already) or `brew install detect-secrets` (MacOS).
+2. Install the pre-commit hook via the instructions in the [hooks README](../README.md#install-hooks).
+
+## Pre-commit hook
+The pre-commit hook will run `detect-secrets-hook` on staged files and fail if any secrets are found (if the secrets are not already in the baseline secrets file).
+
+If you're committing changes that modify the line number of a previously detected secret (false positive or otherwise) in the baseline file, `detect-secrets` will automatically update the baseline file with the new line number and fail the commit so you can add the updated baseline file to your commit.
+
+### Example
+`my_secret` on line 2 is already captured in the baseline secrets file.
+```js
+const hello = "hello";         // line 1
+const my_secret = "my_secret"  // line 2
+```
+
+If `puppies` is inserted at line 2, `detect-secrets` will fail the commit and update the baseline secrets file to list `my_secret` on line 3. You can then add the updated baseline secrets file to your commit.
+```diff
+const hello = "hello";         // line 1
++ const puppies = "puppies";   // line 2
+const my_secret = "my_secret"  // line 3
+```
+
+## False positives
+If you are receiving false positives from the pre-commit hook, you can update the baseline secrets file to mark the detected "secrets" as okay to commit.
+
+First, update the baseline secrets file to include the new strings. Then, run the audit command to mark the new strings as false positives. Once complete, commit the updated baseline secrets file.
+
+### Updating the baseline secrets file
+From the root of the project:
+1. Run `./scripts/git_hooks/secrets/run-detect-secrets update-baseline` to scan for new secrets and update the baseline secrets file
+2. See [Auditing the baseline secrets file](#auditing-the-baseline-secrets-file) below to audit the baseline secrets file
+3. Commit the updated baseline secrets file
+
+See [detect-secrets documentation](https://github.com/Yelp/detect-secrets/tree/master?tab=readme-ov-file#adding-new-secrets-to-baseline) for more details.
+
+### Auditing the baseline secrets file
+From the root of the project:
+1. Run `./scripts/git_hooks/secrets/run-detect-secrets audit-baseline` to audit the baseline secrets file (flag each secret as either true or false positive).
+    - If there are new secrets in the baseline file that are unrelated to your changes, notify the team. You can skip them in the audit as you assess the other detected secrets, but they should be addressed before committing the updated baseline file.
+    - If you see the error `ERROR: Secret not found on line <LINE_NUMBER>! Try recreating your baseline to fix this issue.`, **_do not_** recreate the baseline file (i.e., **don't** run `./scripts/git_hooks/secrets/run-detect-secrets init-baseline`, as the marked false and true positives metadata may be lost). Instead, follow the instructions on [updating the baseline secrets file](#updating-the-baseline-secrets-file), which should automatically remove outdated secrets (i.e., if the secret no longer exists or the line number has changed).
+
+## Report of secrets found
+From the root of the project:
+1. Run `./scripts/git_hooks/secrets/run-detect-secrets generate-report`.
+    - The output is similar to the output of `./scripts/git_hooks/secrets/run-detect-secrets audit-baseline` but in JSON format.
+    - `secrets_report[_pro].json` will not be committed as it is `.gitignore`-d
+
+## Filtering secrets
+We currently only use the built-in filtering mechanism `--exclude-files` to filter out secrets in specific files, file name patterns and directories. These directories contain third-party code that we do not want to scan for secrets.
+
+See the `exclude_files` variable in the [run-detect-secrets script](./run-detect-secrets) for the list of files, file name patterns and directories that are excluded.
+
+For some external files which may only include a couple of false positive secrets, we may have included them in the baseline secrets file.
+
+For more on filters, see the [detect-secrets README](https://github.com/Yelp/detect-secrets/tree/master?tab=readme-ov-file#filters) or further details on writing [custom filters](https://github.com/Yelp/detect-secrets/blob/master/docs/filters.md#Using-Your-Own-Filters).
+
+---
+
+<details>
+<summary>Initial Setup (only needed once)</summary>
+
+It's best to refer to [detect-secrets](https://github.com/Yelp/detect-secrets) for the most up-to-date instructions, but here are the steps that were used to set up the initial baseline secrets file.
+
+From the root of the project:
+1. Run `./scripts/git_hooks/secrets/run-detect-secrets init-baseline` to generate the initial baseline secrets file
+2. Run `./scripts/git_hooks/secrets/run-detect-secrets audit-baseline` to audit the baseline secrets file (flag each secret as either true or false positive)
+3. Commit the baseline secrets file
+
+</details>

--- a/scripts/git_hooks/secrets/run-detect-secrets
+++ b/scripts/git_hooks/secrets/run-detect-secrets
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# This is a wrapper script for detect-secrets.
+# Run this script from the root of the repository without any arguments to see usage.
+#   - i.e. ./scripts/git_hooks/secrets/run-detect-secrets
+# This script is used by the pre-commit hook in git_hooks/hooks/pre-commit.
+
+color_highlight='\033[1;95m'
+color_none='\033[0m'
+
+# if this script is not run from the root of the repository, exit
+if [ ! -f "./scripts/git_hooks/secrets/run-detect-secrets" ]; then
+  echo >&2 "This script must be run from the root of the repository."
+  exit 1
+fi
+
+command=$1
+# if no arguments provided or if help is the command, print usage
+if [ $# -eq 0 ] || [ "$command" = "help" ]; then
+  echo -e "Usage: run-detect-secrets ${color_highlight}[command]${color_none}"
+  echo -e "Commands:"
+  echo -e "  ${color_highlight}init-baseline${color_none}: create a baseline file with all secrets in the repo"
+  echo -e "  ${color_highlight}audit-baseline${color_none}: audit the baseline file to mark false positives"
+  echo -e "  ${color_highlight}update-baseline${color_none}: update the baseline file with all secrets in the repo"
+  echo -e "  ${color_highlight}generate-report${color_none}: generate a JSON report of all secrets in the repo"
+  echo -e "  ${color_highlight}run-hook${color_none}: run the detect-secrets-hook on staged files"
+  echo -e "  ${color_highlight}help${color_none}: print this help message"
+  exit 0
+fi
+
+# check that detect-secrets is installed
+if ! command -v detect-secrets &> /dev/null
+then
+  echo >&2 "detect-secrets is not installed. Install detect-secrets with 'pip install detect-secrets' or 'brew install detect-secrets'."
+  exit 1
+fi
+
+baseline_file="scripts/git_hooks/secrets/.secrets.baseline"
+baseline_file_pattern="${baseline_file}.*"
+# Use the pro baseline file if the repo is rstudio-pro
+if git remote -v | grep -q rstudio-pro; then
+  is_pro=true
+  baseline_file="${baseline_file}_pro"
+fi
+
+check_baseline_file_exists() {
+  if [ ! -f "$baseline_file" ]; then
+    echo >&2 "Baseline file ${baseline_file} does not exist. Run 'run-detect-secrets init-baseline' to create it."
+    exit 1
+  fi
+}
+
+# --no-verify is used to skip additional secret verification via a network call
+# If it is specified for creating the baseline file, it should also be specified for updating the baseline file
+no_verify="--no-verify"
+
+# Exclude external files (third-party libraries, etc.) from the baseline file
+#   - https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-files
+# The baseline file needs to be excluded explicitly. This seems like a bug in detect-secrets since
+# the default filter `detect_secrets.filters.common.is_baseline_file` should exclude the baseline file.
+exclude_files=(--exclude-files ${baseline_file_pattern} --exclude-files '.*cgmanifest.json' --exclude-files '.*/html-manager/dist/embed-amd.js' --exclude-files 'src/vs/base/test/common/filters.perf.data.js' --exclude-files '.*/test/browser/recordings/windows11.*')
+
+if [ "$command" = "init-baseline" ]; then
+  echo "Initializing detect-secrets baseline file ${baseline_file}"
+  if [ -f "$baseline_file" ]; then
+    read -p $'\tBaseline file already exists. Would you like to overwrite it? You will lose any marked false positives. (y/n): ' -r
+    if [[ $REPLY =~ ^[Yy]$ ]]
+    then
+      echo -e "\tOverwriting existing baseline file."
+    else
+      echo -e "\tNot overwriting existing baseline file."
+      exit 0
+    fi
+  fi
+  echo -e "\tSecret scanning in progress...this should take less than a minute."
+  detect-secrets scan ${no_verify} "${exclude_files[@]}" > ${baseline_file}
+elif [ "$command" = "audit-baseline" ]; then
+  echo "Auditing detect-secrets baseline file ${baseline_file}"
+  check_baseline_file_exists
+  detect-secrets audit ${baseline_file}
+elif [ "$command" = "update-baseline" ]; then
+  echo "Updating detect-secrets baseline file ${baseline_file}"
+  check_baseline_file_exists
+  echo -e "\tSecret scanning in progress...this should take less than a minute."
+  detect-secrets scan ${no_verify} "${exclude_files[@]}" --baseline ${baseline_file}
+elif [ "$command" = "generate-report" ]; then
+  report_file="./scripts/git_hooks/secrets/secrets_report"
+  if [ "$is_pro" = true ]; then
+    report_file="${report_file}_pro"
+  fi
+  report_file="${report_file}.json"
+  echo "Generating detect-secrets report to ${report_file}"
+  check_baseline_file_exists
+  detect-secrets audit --report ${baseline_file} > ${report_file}
+elif [ "$command" = "run-hook" ]; then
+  check_baseline_file_exists
+  git diff --staged --name-only -z | xargs -0 detect-secrets-hook ${no_verify} --baseline ${baseline_file} "${exclude_files[@]}"
+else
+  echo "Invalid command: ${command}. Run 'run-detect-secrets help' for a list of valid commands."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
### Intent
Address #3413


### Approach

Ran `detect-secrets scan` to establish a baseline. 

Reviewed excludes with team members:
```
        "scripts/git_hooks/secrets/.secrets.baseline.*",
        ".*cgmanifest.json",
        ".*/html-manager/dist/embed-amd.js",
        "src/vs/base/test/common/filters.perf.data.js",
        ".*/test/browser/recordings/windows11.*"
```

Reviewed remaining flagged secrets with team members, all marked not a real secret.

TODO: Define pre-commit hook to run detect-secrets audit

### QA Notes

