### PR TITLE
Set Positron's license as Elastic 2.0

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,12 +1,11 @@
-Posit Software, PBC ("licensor") is making Positron (the "software") available
-to you pursuant to the terms of the Elastic License 2.0, which follow below.
-BY DOWNLOADING, USING OR INSTALLING THE SOFTWARE, YOU ARE AGREEING THAT YOU AND
-YOUR COMPANY (IF APPLICABLE) ACCEPT THE TERMS OF THE ELASTIC LICENSE 2.0. DO
-NOT USE THE SOFTWARE IF YOU DO NOT ACCEPT THESE LICENSE TERMS.
+POSITRON - Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
 
-                                   POSITRON
-
-Copyright (C) 2022-2024 Posit Software, PBC ("Licensor"). All rights reserved.
+BEFORE DOWNLOADING OR USING POSITRON (THE “SOFTWARE”), YOU SHOULD CAREFULLY
+READ THE FOLLOWING LICENSE AGREEMENT THAT APPLIES TO YOUR USE OF THE SOFTWARE.
+DOWNLOADING OR USING POSITRON ESTABLISHES A BINDING AGREEMENT BETWEEN POSIT
+SOFTWARE, PBC ("LICENSOR") AND YOU (INCLUDING YOUR COMPANY, IF APPLICABLE).
+YOUR ACCEPTANCE OF THIS LICENSE AGREEMENT IS REQUIRED AS A CONDITION TO
+PROCEEDING WITH YOUR DOWNLOAD OR USE OF THE SOFTWARE.
 
 
 Elastic License 2.0
@@ -15,12 +14,14 @@ Acceptance
 
 By using the software, you agree to all of the terms and conditions below.
 
+
 Copyright License
 
 The licensor grants you a non-exclusive, royalty-free, worldwide,
 non-sublicensable, non-transferable license to use, copy, distribute, make
 available, and prepare derivative works of the software, in each case subject to
 the limitations and conditions below.
+
 
 Limitations
 
@@ -36,6 +37,7 @@ You may not alter, remove, or obscure any licensing, copyright, or other notices
 of the licensor in the software. Any use of the licensor’s trademarks is subject
 to applicable law.
 
+
 Patents
 
 The licensor grants you a license, under any patent claims the licensor can
@@ -49,6 +51,7 @@ the software granted under these terms ends immediately. If your company makes
 such a claim, your patent license ends immediately for work on behalf of your
 company.
 
+
 Notices
 
 You must ensure that anyone who gets a copy of any part of the software from you
@@ -57,10 +60,12 @@ also gets a copy of these terms.
 If you modify the software, you must include in any modified copies of the
 software prominent notices stating that you have modified the software.
 
+
 No Other Rights
 
 These terms do not imply any licenses other than those expressly granted in
 these terms.
+
 
 Termination
 
@@ -71,6 +76,7 @@ later than 30 days after you receive that notice, your licenses will be
 reinstated retroactively. However, if you violate these terms after such
 reinstatement, any additional violation of these terms will cause your licenses
 to terminate automatically and permanently.
+
 
 No Liability
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,154 +1,103 @@
-BEFORE DOWNLOADING OR USING POSITRON, YOU SHOULD CAREFULLY READ THE FOLLOWING
-LICENSE AGREEMENT THAT APPLIES TO YOUR USE OF THE SOFTWARE. DOWNLOADING OR
-USING POSITRON ESTABLISHES A BINDING AGREEMENT BETWEEN YOU AS THE PERSON
-ACQUIRING THE SOFTWARE ("YOU") AND POSIT SOFTWARE, PBC, ("LICENSOR").
-ACCEPTANCE OF THIS LICENSE AGREEMENT IS REQUIRED AS A CONDITION TO PROCEEDING
-WITH THE DOWNLOAD OR USE OF THE SOFTWARE.
+Posit Software, PBC ("licensor") is making Positron (the "software") available
+to you pursuant to the terms of the Elastic License 2.0, which follow below.
+BY DOWNLOADING, USING OR INSTALLING THE SOFTWARE, YOU ARE AGREEING THAT YOU AND
+YOUR COMPANY (IF APPLICABLE) ACCEPT THE TERMS OF THE ELASTIC LICENSE 2.0. DO
+NOT USE THE SOFTWARE IF YOU DO NOT ACCEPT THESE LICENSE TERMS.
 
                                    POSITRON
 
-       Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+Copyright (C) 2022-2024 Posit Software, PBC ("Licensor"). All rights reserved.
 
 
-                    SOFTWARE EVALUATION LICENSE AGREEMENT
+Elastic License 2.0
 
-This Software Evaluation License Agreement ("Agreement") is by and between
-Posit Software, PBC, ("Licensor") and you.  This Agreement contemplates the
-licensing for evaluation purposes only of a beta version of a software product
-developed by Licensor and referred to as "Positron" that has not been generally
-released for commercial use.  Licensor is willing to provide a copy of such
-software product and related documentation to you for the sole purpose of
-permitting you to conduct an evaluation thereof on the terms and conditions set
-forth in this Agreement.
+Acceptance
 
-1.  License to Use.  Licensor grants you a non-exclusive and non-transferable
-license (the "License") to use Positron and its accompanying documentation in
-machine readable form (collectively, the "Software") on a single computer
-system.  The License governs any releases, revisions or enhancements to the
-Software which Licensor may furnish to you.
+By using the software, you agree to all of the terms and conditions below.
 
-2.  Restrictions.  The Software is copyrighted and contains proprietary
-information and trade secrets belonging to Licensor or its licensors.  Title to
-the Software and all copies thereof is retained by Licensor or its licensors.
-You will not use the Software except for non-revenue generating, testing
-purposes only (the "evaluation purpose") on your own internal computer
-networks.  You may make copies of the Software in connection with the
-evaluation purpose.  You may print copies of the electronic documentation
-solely for your internal use in connection with the evaluation purpose.  You
-will reproduce all proprietary rights notices on these copies.  You may not
-modify, decompile, disassemble, decrypt, extract, or otherwise reverse engineer
-the Software, or create derivative works based upon all or part of the
-Software.  You may not transfer, lease, assign, make available for timesharing,
-or sublicense, in whole or in part, the Software.  Neither Licensor nor its
-licensors grant any license or title to any trademarks or trade names under
-this Agreement.
+Copyright License
 
-3.  Exclusion of Warranty.  You expressly acknowledge that the Software may
-have defects or deficiencies which cannot or may not be corrected by Licensor.
-The Software is provided "AS IS" without any warranty of any kind.  LICENSOR
-DISCLAIMS ALL EXPRESS OR IMPLIED REPRESENTATIONS AND WARRANTIES, INCLUDING ANY
-IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, TITLE
-OR NONINFRINGEMENT.  The Licensor takes no responsibility for the effects of
-the installation or operation of the Software on your software, hardware,
-network or related equipment.
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
 
-4.  Evaluation Support.  You will install and use the Software in accordance
-with the specifications provided by Licensor.  You agree to cooperate and
-consult with Licensor in your evaluation of the Software, including your
-evaluation of its features, performance, functionality and useability.  You
-will make reasonable efforts to provide oral or written evaluations of the
-Software to Licensor. You hereby assign and will assign to Licensor all rights
-and title in the evaluations and the subject matter of the evaluations,
-including, but not limited to, all intellectual property rights in or covering
-the evaluations and the subject matter of the evaluations.  You understand
-that you are exclusively responsible for the supervision, management and
-control of your computer systems and network and the use of the Software,
-including but not limited to: (a) assuring proper machine configuration,
-program installation, audit controls and operating methods, (b) establishing
-adequate backup plans, (c) implementing sufficient procedures to satisfy your
-requirements for security and accuracy of input and output as well as restart
-and recovery in the event of a malfunction; and (d) detecting unauthorized
-access and viruses and preventing any loss or damage to data or other software.
+Limitations
 
-5. Confidentiality.  You agree that you will not (a) disclose the Software or
-any information relating to the Software including without limitation any
-ideas, techniques and concepts contained in or relating to the Software, or
-any of the evaluations, to any third party without the prior written consent
-of Licensor, (b) copy the Software or any portion thereof beyond what is
-explicitly permitted by this Agreement, or (c) use the Software for any
-purpose except for the evaluation purpose.  You agree to hold the Software in
-confidence, to maintain the Software in a secure environment and take all
-reasonable precautions to maintain security in order to prevent unauthorized
-use or disclosure.  You will inform your employees having access to the
-Software of your limitations, duties and obligations regarding nondisclosure
-and copying of the Software.  Prior to disposing of any media, you will erase
-or otherwise destroy the Software contained on that media.  In addition, you
-may not disclose to any third party the terms of this Agreement without the
-prior written consent of Licensor.
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
 
-6. Limitation of Liability.  LICENSOR AND YOU AGREE THAT LICENSOR WOULD NOT
-PROVIDE THE SOFTWARE WITHOUT INCLUSION OF THIS SECTION 6. IN NO EVENT WILL
-LICENSOR OR ITS LICENSORS BE LIABLE FOR ANY DAMAGES INCLUDING WITHOUT
-LIMITATION ANY LOST REVENUE, PROFIT, DATA, OR OTHER SOFTWARE OR ANY DIRECT,
-INDIRECT, CONSEQUENTIAL, SPECIAL, INCIDENTAL, OR PUNITIVE DAMAGES HOWEVER
-CAUSED AND REGARDLESS OF THEORY OF LIABILITY (INCLUDING NEGLIGENCE) ARISING
-OUT OF THE USE OR INABILITY TO USE THE SOFTWARE, EVEN IF LICENSOR KNOWS OR HAS
-BEEN ADVISED OF THE POSSIBILITY OF THOSE DAMAGES.  You acknowledge that:
-(a) other than Licensor and you, no party has obligations under this Agreement;
-(b) during and after the term of this Agreement, you may not seek any remedy
-for any obligations or breaches under this Agreement from any party other than
-Licensor; and (c) you may not sue or seek any remedy on any cause of action
-relating to any Software or the rights in any Software from any party other
-than Licensor.
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
 
-7.  Termination.  The License is effective until terminated by either party or
-at the end of the evaluation period, whichever occurs first.  You may terminate
-the License at any time by destroying all copies of the Software including
-associated documentation.  The License will terminate immediately, without
-prior notice from Licensor, if you fail to comply with any provision of this
-Agreement.  Licensor may also terminate the License upon written notice to you.
-Upon termination, you must destroy all copies of the Software.
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
 
-8.  Export Regulations.  The Software, including technical data, is subject to
-U.S. export control laws, including the U.S. Export Administration Act and its
-associated regulations, and may be subject to export or import regulations in
-other countries.  You agree to comply strictly with all those regulations and
-acknowledge your responsibility to obtain all necessary and appropriate
-licenses to export, re-export or import the Software.
+Patents
 
-9.  No Further Commitment.  Nothing in this Agreement, including without
-limitation the provision of the License, implies that you have any rights in
-any commercially issued software produced by Licensor, including without
-limitation a commercial variation or release of the Software.  In the event
-that you and Licensor are able to reach an agreement on the terms and
-conditions of a license for the Software (or a version thereof) when it is made
-commercially available by Licensor, such license will be subject to the terms
-and conditions of that agreement.
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
 
-10.  Related Software.  You are responsible for providing any commercially
-available software, equipment or services that are required to operate the
-Software.
+Notices
 
-11.  Miscellaneous.  This Agreement and your use of the Software is governed
-under the laws of the Commonwealth of Massachusetts, U.S.A., excluding its
-choice of law provisions.  You and Licensor agree to submit to the exclusive
-jurisdiction of the federal and state courts in the Commonwealth of
-Massachusetts.  The provisions of this Agreement regarding confidentiality,
-disclaimer of warranty, limitation of liability, and all other provisions
-which, as indicated by their sense and content, are intended to survive and
-will survive any termination of this Agreement or the evaluation. This
-Agreement is the entire agreement between you and Licensor relating to the
-Software and: (i) supersedes all prior or contemporaneous oral or written
-communications, proposals, and representations with respect to its subject
-matter; and (ii) prevails over any conflicting or additional terms of any
-quote, order, acknowledgment, or similar communication between the parties.
-If any provision of this Agreement is held invalid, all other provisions will
-remain valid.  No modification to this Agreement is binding, unless in writing
-and signed by a duly authorized representative of each party.  All of
-Licensor's licensors are direct and intended third-party beneficiaries of this
-Agreement and may enforce it against you.  This Agreement and the License
-granted hereunder may not be assigned or in any way transferred by you without
-the prior written consent of Licensor.  Any attempted assignment, delegation or
-transfer in violation hereof shall be null and void.  Subject to the foregoing,
-this Agreement shall be binding on the parties and their successors and
-assigns.
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+No Liability
+
+As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.
+
+
+Definitions
+
+The 'licensor' is the entity offering these terms, and the 'software' is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+'you' refers to the individual or entity agreeing to these terms.
+
+'your company' is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. 'control' means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+'your licenses' are all the licenses granted to you for the software under
+these terms.
+
+'use' means anything you do with the software requiring one of your licenses.
+
+'trademark' means trademarks, service marks, and similar rights.


### PR DESCRIPTION
Establishes Positron source code and distributions under the Elastic 2.0 license.
