### PR TITLE
Fix path for Positron icon

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,4 +1,4 @@
-# Positron  <a href="https://github.com/posit-dev/positron"><img src="positron-product-icons/positron.png" align="right" height="138" alt="Positron" /></a>
+# Positron  <a href="https://github.com/posit-dev/positron"><img src="../positron-product-icons/positron.png" align="right" height="138" alt="Positron" /></a>
 
 What is Positron?
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Fix the path for the Positron icon in the README

### Approach

I forgot that this README is in the `.github` folder! 🙈 

### QA Notes

Positron icon should show up in the README