### PR TITLE
Bump ark to 0.1.110

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -590,7 +590,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.109"
+      "ark": "0.1.110"
     },
     "minimumRVersion": "4.2.0",
 		"minimumRenvVersion": "1.0.7"


### PR DESCRIPTION
- https://github.com/posit-dev/amalthea/pull/406
- https://github.com/posit-dev/amalthea/pull/405
- https://github.com/posit-dev/amalthea/pull/364
- https://github.com/posit-dev/amalthea/pull/400

A few helpful Jupyter compat fixes, a help stability fix, and an environment related variables pane fix