### PR TITLE
Fix/ok cancel modal dialog has incorrect button layout in Delete All Variables

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -585,6 +585,7 @@
 		"--vscode-positronModalDialog-buttonDisabledBackground",
 		"--vscode-positronModalDialog-buttonDisabledBorder",
 		"--vscode-positronModalDialog-buttonDisabledForeground",
+		"--vscode-positronModalDialog-buttonDestructiveForeground",
 		"--vscode-positronModalDialog-buttonForeground",
 		"--vscode-positronModalDialog-buttonHoverBackground",
 		"--vscode-positronModalDialog-checkboxBackground",

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/confirmationModalDialog.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/confirmationModalDialog.css
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+.positron-modal-dialog-box
+.action-bar {
+	left: 0;
+	right: 0;
+	bottom: 0;
+	gap: 10px;
+	height: 64px;
+	display: flex;
+	margin: 0 16px;
+	padding: 0 0px;
+	position: absolute;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.positron-modal-dialog-box
+.action-bar.top-separator {
+	border-top: 1px solid var(--vscode-positronModalDialog-separator);
+}
+
+.positron-modal-dialog-box
+.action-bar
+.left-actions {
+	gap: 10px;
+	align-items: start;
+	flex-direction: row;
+	display: inline-flex;
+	justify-content: space-between;
+}
+
+.positron-modal-dialog-box
+.action-bar
+.right-actions {
+	gap: 10px;
+	align-items: end;
+	flex-direction: row;
+	display: inline-flex;
+	justify-content: space-between;
+}
+
+.positron-modal-dialog-box
+.action-bar
+.action-bar-button {
+	height: 32px;
+	width: 80px;
+	padding: 0 10px;
+}

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/confirmationModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/confirmationModalDialog.tsx
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import 'vs/css!./positronModalDialog';
+import 'vs/css!./confirmationModalDialog';
+
+// React.
+import * as React from 'react';
+import { PropsWithChildren } from 'react'; // eslint-disable-line no-duplicate-imports
+
+// Other dependencies.
+import { positronClassNames } from 'vs/base/common/positronUtilities';
+import { Button } from 'vs/base/browser/ui/positronComponents/button/button';
+import { ContentArea } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/contentArea';
+import { PositronModalDialog, PositronModalDialogProps } from 'vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog';
+
+/**
+ * ConfirmationModalDialogProps interface.
+ */
+export interface ConfirmationModalDialogProps extends PositronModalDialogProps {
+	title: string;
+	secondaryActionTitle?: string;
+	secondaryActionDestructive?: boolean;
+	primaryActionTitle: string;
+	onSecondaryAction: () => (void | Promise<void>);
+	onPrimaryAction: () => (void | Promise<void>);
+}
+
+/**
+ * ConfirmationModalDialog component.
+ * @param props A PropsWithChildren<ConfirmationModalDialogProps> that contains the component
+ * properties.
+ * @returns The rendered component.
+ */
+export const ConfirmationModalDialog = (props: PropsWithChildren<ConfirmationModalDialogProps>) => {
+	// Render.
+	return (
+		<PositronModalDialog {...props}>
+			<ContentArea>
+				{props.children}
+			</ContentArea>
+			<div className='action-bar top-separator'>
+				<div className='left-actions'>
+				</div>
+				<div className='right-actions'>
+					{props.secondaryActionTitle &&
+						<Button
+							className={positronClassNames(
+								'action-bar-button',
+								{ 'destructive': props.secondaryActionDestructive }
+							)}
+							onPressed={async () => await props.onSecondaryAction()}
+						>
+							{props.secondaryActionTitle}
+						</Button>
+					}
+					<Button
+						className='action-bar-button default'
+						onPressed={async () => await props.onPrimaryAction()}
+					>
+						{props.primaryActionTitle}
+					</Button>
+				</div>
+			</div>
+		</PositronModalDialog>
+	);
+};

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.css
@@ -60,7 +60,6 @@
 	background: var(--vscode-positronModalDialog-buttonHoverBackground);
 }
 
-
 .positron-modal-dialog-box .action-bar-button.default {
 	color: var(--vscode-positronModalDialog-defaultButtonForeground);
 	background: var(--vscode-positronModalDialog-defaultButtonBackground);
@@ -68,6 +67,10 @@
 
 .positron-modal-dialog-box .action-bar-button.default:hover {
 	background: var(--vscode-positronModalDialog-defaultButtonHoverBackground);
+}
+
+.positron-modal-dialog-box .action-bar-button.destructive {
+	color: var(--vscode-positronModalDialog-buttonDestructiveForeground);
 }
 
 .positron-modal-dialog-box .action-bar-button:focus {

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.tsx
@@ -41,6 +41,7 @@ export interface PositronModalDialogProps {
 	title: string;
 	width: number;
 	height: number;
+	enterAccepts?: boolean;
 	onAccept: () => void;
 	onCancel?: () => void;
 }
@@ -73,9 +74,11 @@ const kInitialDialogBoxState: DialogBoxState = {
  * @returns The rendered component.
  */
 export const PositronModalDialog = (props: PropsWithChildren<PositronModalDialogProps>) => {
-	// Hooks.
+	// Reference hooks.
 	const dialogContainerRef = useRef<HTMLDivElement>(undefined!);
 	const dialogBoxRef = useRef<HTMLDivElement>(undefined!);
+
+	// State hooks.
 	const [dialogBoxState, setDialogBoxState] = useState(kInitialDialogBoxState);
 
 	// Initialization.
@@ -108,15 +111,14 @@ export const PositronModalDialog = (props: PropsWithChildren<PositronModalDialog
 
 			// Handle the event.
 			switch (e.key) {
-				// TODO: Update enter logic to enter into the default button of the dialog if there
-				// is one. This will use `focusableElementSelectors` to find it.
-
-				// Temporarily disable Enter key handling for #3217 fix.
-				// case 'Enter': {
-				// 	consumeEvent();
-				// 	props.onAccept();
-				// 	break;
-				// }
+				// Enter accepts dialog, if configured to.
+				case 'Enter': {
+					consumeEvent();
+					if (props.enterAccepts && props.onAccept) {
+						props.onAccept();
+					}
+					break;
+				}
 
 				// Escape cancels dialog.
 				case 'Escape': {

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1651,6 +1651,14 @@ export const POSITRON_MODAL_DIALOG_DEFAULT_BUTTON_FOREGROUND = registerColor('po
 	hcLight: buttonForeground
 }, localize('positronModalDialog.defaultButtonForeground', "Positron modal dialog default button foreground color."));
 
+// Positron modal dialog button destructive foreground color.
+export const POSITRON_MODAL_DIALOG_BUTTON_DESTRUCTIVE_FOREGROUND = registerColor('positronModalDialog.buttonDestructiveForeground', {
+	dark: errorForeground,
+	light: errorForeground,
+	hcDark: errorForeground,
+	hcLight: errorForeground
+}, localize('positronModalDialog.buttonDestructiveForeground', "Positron modal dialog button destructive foreground color."));
+
 // Positron modal dialog button disabled foreground color.
 export const POSITRON_MODAL_DIALOG_BUTTON_DISABLED_FOREGROUND = registerColor('positronModalDialog.buttonDisabledForeground', {
 	dark: disabledForeground,

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1654,7 +1654,7 @@ export const POSITRON_MODAL_DIALOG_DEFAULT_BUTTON_FOREGROUND = registerColor('po
 // Positron modal dialog button destructive foreground color.
 export const POSITRON_MODAL_DIALOG_BUTTON_DESTRUCTIVE_FOREGROUND = registerColor('positronModalDialog.buttonDestructiveForeground', {
 	dark: errorForeground,
-	light: errorForeground,
+	light: '#B30600',
 	hcDark: errorForeground,
 	hcLight: errorForeground
 }, localize('positronModalDialog.buttonDestructiveForeground', "Positron modal dialog button destructive foreground color."));

--- a/src/vs/workbench/contrib/positronVariables/browser/modalDialogs/deleteAllVariablesModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/modalDialogs/deleteAllVariablesModalDialog.tsx
@@ -12,7 +12,7 @@ import * as React from 'react';
 import { localize } from 'vs/nls';
 import { VerticalStack } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/verticalStack';
 import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer';
-import { OKCancelModalDialog } from 'vs/workbench/browser/positronComponents/positronModalDialog/positronOKCancelModalDialog';
+import { ConfirmationModalDialog } from 'vs/workbench/browser/positronComponents/positronModalDialog/confirmationModalDialog';
 
 /**
  * DeleteAllVariablesResult interface.
@@ -35,25 +35,40 @@ interface DeleteAllVariablesModalDialogProps {
  * @returns The component.
  */
 export const DeleteAllVariablesModalDialog = (props: DeleteAllVariablesModalDialogProps) => {
-	// Render.
+	/**
+	 * Accept handler.
+	 */
+	const acceptHandler = async (): Promise<void> => {
+		props.renderer.dispose();
+		await props.deleteAllVariablesAction({
+			includeHiddenObjects: false
+		});
+	};
+
+	/**
+	 * Cancel handler.
+	 */
+	const cancelHandler = () => {
+		props.renderer.dispose();
+	};
+
 	return (
-		<OKCancelModalDialog
+		<ConfirmationModalDialog
 			renderer={props.renderer}
 			width={375}
 			height={175}
+			enterAccepts={true}
 			title={(() => localize(
 				'positron.deleteAllVariablesModalDialogTitle',
 				"Delete All Variables"
 			))()}
-			okButtonTitle={(() => localize('positron.yes', "Yes"))()}
-			cancelButtonTitle={(() => localize('positron.no', "No"))()}
-			onAccept={async () => {
-				props.renderer.dispose();
-				await props.deleteAllVariablesAction({
-					includeHiddenObjects: false
-				});
-			}}
-			onCancel={() => props.renderer.dispose()}
+			secondaryActionTitle={(() => localize('positron.delete', "Delete"))()}
+			secondaryActionDestructive={true}
+			primaryActionTitle={(() => localize('positron.cancel', "Cancel"))()}
+			onAccept={cancelHandler}
+			onCancel={cancelHandler}
+			onSecondaryAction={acceptHandler}
+			onPrimaryAction={cancelHandler}
 		>
 			<VerticalStack>
 				<div>
@@ -65,6 +80,6 @@ export const DeleteAllVariablesModalDialog = (props: DeleteAllVariablesModalDial
 				{/* Disabled for Private Alpha. */}
 				{/* <Checkbox label='Include hidden objects' onChanged={checked => setResult({ ...result, includeHiddenObjects: checked })} /> */}
 			</VerticalStack>
-		</OKCancelModalDialog>
+		</ConfirmationModalDialog>
 	);
 };


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

This PR addresses https://github.com/posit-dev/positron/issues/3551.

Over time, changes that were made to the `OKCancelModalDialog` resulted in the button layout of that dialog being incorrect. Here's a screenshot of the incorrect button layout:

![image](https://github.com/posit-dev/positron/assets/853239/6c30d87e-53e1-45b4-8766-3938a15fa07e)

The `OKCancelModalDialog` was one of the first React modal dialog boxes. I was meant to be a simple confirmation dialog that we could use when we needed to ask the user a Yes / No (OK / Cancel) question. Over time, this simple dialog box was changed so that it could be used in other scenarios which resulted in the incorrect layout

This PR introduces a new React modal dialog called `ConfirmationModalDialog` that will be adapted to replace all of the uses of the `OKCancelModalDialog`. For the moment, we're using the new `ConfirmationModalDialog` in the `DeleteAllVariablesModalDialog` for Public Beta.

Here's a screenshot of the `DeleteAllVariablesModalDialog` with this PR:

![image](https://github.com/posit-dev/positron/assets/853239/11267f43-39c6-49a9-bbea-4b1e5692ef4a)

Some changes that were made in the `ConfirmationModalDialog`:

- `ConfirmationModalDialog` is more abstract than `OKCancelModalDialog`.
- The OK and Cancel buttons are replaced by secondary and primary actions.
- The secondary action is optional.
- `secondaryActionDestructive` can be set when the secondary action is considered to be destructive. This results in red text on the button.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

For Public Beta, it seemed too risky to change every use of `OKCancelModalDialog` to `ConfirmationModalDialog`. We will tackle this after Public Beta is done.

One important thing to node is that in `PositronModalDialog`, the `Enter` key must ALWAYS consumed. This is necessary because otherwise, the `Enter` key gets processed outside of the dialog (often resulting in a second instance of the dialog being displayed):

So this code:
```
// TODO: Update enter logic to enter into the default button of the dialog if there
// is one. This will use `focusableElementSelectors` to find it.

// Temporarily disable Enter key handling for #3217 fix.
// case 'Enter': {
// 	consumeEvent();
// 	props.onAccept();
// 	break;
// }
```

Had to be changed to:

```
case 'Enter': {
	consumeEvent();
	if (props.enterAccepts && props.onAccept) {
		props.onAccept();
	}
	break;
}
```

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

Use the "Delete All Objects" button in Variables to test this out:

<img width="49" alt="image" src="https://github.com/posit-dev/positron/assets/853239/af37b0fa-85da-4b50-bbfd-c6b5f0ee67b4">

