### PR TITLE
Fix variable pane updates for zed

### DIFF
--- a/extensions/positron-zed/src/positronZedVariables.ts
+++ b/extensions/positron-zed/src/positronZedVariables.ts
@@ -18,6 +18,7 @@ class ZedVariable {
 	public readonly has_children;
 	public readonly has_viewer;
 	public readonly access_key;
+	public readonly updated_time = Date.now();
 
 	constructor(
 		readonly display_name: string,
@@ -425,6 +426,7 @@ export class ZedVariables {
 	private emitUpdate(assigned?: Array<ZedVariable>, removed?: Array<string>) {
 		this.emitEvent('update', {
 			assigned: assigned || [],
+			unevaluated: [],
 			removed: removed || []
 		});
 	}


### PR DESCRIPTION
### Intent

The changes in PR #3199 made some Zed commands stop working since they didn't supply the new data needed to render updates in the pane. 

This change supplies the new data so Zed variable updates are once again rendered in the Variables pane.

### Approach

Add missing fields.

### QA Notes

N/A, only impact is on the Zed test language.