### PR TITLE
Make Viewer pane URL readable in dark themes

### DIFF
--- a/src/vs/workbench/contrib/positronPreview/browser/components/actionBars.css
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/actionBars.css
@@ -23,6 +23,7 @@ bar to fill the center of the toolbar.
 
 .preview-action-bar .url-bar {
 	border: 1px solid var(--vscode-input-border);
+	background-color: var(--vscode-input-background);
 	border-radius: 4px;
 	margin-left: 10px;
 	padding-left: 10px;

--- a/src/vs/workbench/contrib/positronPreview/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/actionBars.tsx
@@ -189,7 +189,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 					<ActionBarRegion location='center'>
 						<form onSubmit={navigateToHandler}>
 							<input
-								className='url-bar'
+								className='text-input url-bar'
 								aria-label={currentUrl}
 								name={kUrlBarInputName}
 								type='text'


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

Addresses https://github.com/posit-dev/positron/issues/3569.

<img width="592" alt="image" src="https://github.com/posit-dev/positron/assets/470418/9e50cdb3-24a4-460c-83d5-ed73a8225b39">

### Approach

Include the background theme color in the textbox. 

### QA Notes

Style/CSS change only.