### PR TITLE
Make restart button spin in same direction as other restart button

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeRestartButton.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeRestartButton.css
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 .runtime-restart-button {
@@ -9,4 +9,10 @@
 	width: fit-content;
 	padding-left: 10px;
 	padding-right: 10px;
+	background-color: var(--vscode-button-background);
+	color: var(--vscode-button-foreground);
+}
+
+.runtime-restart-button:hover {
+	background-color: var(--vscode-button-hoverBackground);
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeRestartButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeRestartButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./runtimeRestartButton';
@@ -37,7 +37,7 @@ export const RuntimeRestartButton = (props: RuntimeRestartButtonProps) => {
 		}));
 
 		return () => disposableStore.dispose();
-        },[props.positronConsoleInstance]);
+	}, [props.positronConsoleInstance]);
 
 	const handleRestart = () => {
 		// Invoke the restart callback.
@@ -54,7 +54,7 @@ export const RuntimeRestartButton = (props: RuntimeRestartButtonProps) => {
 		<button ref={restartRef}
 			className='monaco-text-button runtime-restart-button'
 			onClick={handleRestart}>
-			<span className='codicon codicon-debug-restart'></span>
+			<span className='codicon codicon-positron-restart-runtime'></span>
 			<span className='label'>{restartLabel}</span>
 		</button>
 	);


### PR DESCRIPTION
### Intent

Make the restart button spin the same direction as the other restart button. Addresses https://github.com/posit-dev/positron/issues/3587.

### Approach

Use the Positron codicon instead of the VS Code codicon. (We might also eventually want to make these match up, too.)

While I was in there I gave this button themed colors so that it looks nicer with the rest of the UI, too.

<img width="556" alt="image" src="https://github.com/posit-dev/positron/assets/470418/aaa56e55-63b0-47e4-9f3a-4226600831fe">

### QA Notes

Visual/style change only.