### PR TITLE
use GitHub app to generate access tokens

### DIFF
--- a/.github/workflows/build-push-beta.yml
+++ b/.github/workflows/build-push-beta.yml
@@ -36,10 +36,18 @@ jobs:
           file: Positron-${{ env.RELEASE_TAG }}.deb
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Create access token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
+          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Create Release to Private Beta
         uses: softprops/action-gh-release@v2
         with:
-          token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: posit-dev/positron-beta
           tag_name: ${{ env.RELEASE_TAG }}
           prerelease: true

--- a/.github/workflows/build-release-linux.yml
+++ b/.github/workflows/build-release-linux.yml
@@ -52,11 +52,22 @@ jobs:
         with:
           node-version: 20
 
+      # Generate an access token. We'll need it for following steps. Note that
+      # we don't generate this until right before we need it since it only
+      # lasts an hour.
+      - name: Create access token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
+          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Execute yarn
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
-          POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+          POSITRON_GITHUB_PAT: ${{ steps.app-token.outputs.token }}
           npm_config_arch: ${{ matrix.arch }}
         run: |
           # Install Yarn

--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -71,13 +71,24 @@ jobs:
         run: |
           echo "/opt/homebrew/opt/python@3.10/libexec/bin:${{matrix.homebrew_folder}}/bin" >> $GITHUB_PATH
 
+      # Generate an access token. We'll need it for following steps. Note that
+      # we don't generate this until right before we need it since it only
+      # lasts an hour.
+      - name: Create access token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
+          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       # Install node itself. Also enables corepack to install modern yarn. Most
       # of the time these will be no-ops, but this allows us to auto-update the
       # node version when it changes upstream.
       - name: Install Node and Yarn
         env:
           npm_config_arch: ${{ matrix.arch }}
-          POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+          POSITRON_GITHUB_PAT: ${{ steps.app-token.outputs.token }}
         run: |
           export NVM_DIR="$HOME/.nvm"
           [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
@@ -113,7 +124,7 @@ jobs:
       - name: Install dependencies
         env:
           npm_config_arch: ${{ matrix.arch }}
-          POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+          POSITRON_GITHUB_PAT: ${{ steps.app-token.outputs.token }}
         run: |
           export NVM_DIR="$HOME/.nvm"
           [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
@@ -163,10 +174,18 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
+      - name: Create access token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
+          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       # Install node_modules binaries
       - name: Install dependencies
         env:
-          POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+          POSITRON_GITHUB_PAT: ${{ steps.app-token.outputs.token }}
         run: |
           export NVM_DIR="$HOME/.nvm"
           [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"

--- a/.github/workflows/build-release-windows.yml
+++ b/.github/workflows/build-release-windows.yml
@@ -49,10 +49,18 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Create access token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
+          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Install node dependencies with yarn
         env:
           npm_config_arch: ${{ matrix.arch }}
-          POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+          POSITRON_GITHUB_PAT: ${{ steps.app-token.outputs.token }}
         shell: pwsh
         # nvm on windows does not see .nvmrc
         run: |

--- a/.github/workflows/positron-ci.yml
+++ b/.github/workflows/positron-ci.yml
@@ -32,11 +32,19 @@ jobs:
         with:
           node-version: 20
 
+      - name: Create access token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
+          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Execute yarn
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
-          POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+          POSITRON_GITHUB_PAT: ${{ steps.app-token.outputs.token }}
         run: |
           # Install Yarn
           npm install -g yarn

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -37,11 +37,19 @@ jobs:
         with:
           node-version: 20
 
+      - name: Create access token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
+          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Execute yarn
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
-          POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+          POSITRON_GITHUB_PAT: ${{ steps.app-token.outputs.token }}
         run: |
           # Install Yarn
           npm install -g yarn

--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -362,6 +362,14 @@ jobs:
         run: yarn test:unittests
         if: matrix.test-suite == 'ts-unit' && startsWith(matrix.python, 3.)
 
+      - name: Create access token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
+          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       # The virtual environment based tests use the `testSingleWorkspace` set of tests
       # with the environment variable `TEST_FILES_SUFFIX` set to `testvirtualenvs`,
       # which is set in the "Prepare environment for venv tests" step.
@@ -372,7 +380,7 @@ jobs:
         env:
           TEST_FILES_SUFFIX: testvirtualenvs
           CI_PYTHON_VERSION: ${{ matrix.python }}
-          POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+          POSITRON_GITHUB_PAT: ${{ steps.app-token.outputs.token }}
         uses: GabrielBB/xvfb-action@v1.6
         with:
           run: yarn testSingleWorkspace
@@ -382,7 +390,7 @@ jobs:
       - name: Run single-workspace tests
         env:
           CI_PYTHON_VERSION: ${{ matrix.python }}
-          POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+          POSITRON_GITHUB_PAT: ${{ steps.app-token.outputs.token }}
         uses: GabrielBB/xvfb-action@v1.6
         with:
           run: yarn testSingleWorkspace
@@ -392,7 +400,7 @@ jobs:
       - name: Run debugger tests
         env:
           CI_PYTHON_VERSION: ${{ matrix.python }}
-          POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+          POSITRON_GITHUB_PAT: ${{ steps.app-token.outputs.token }}
         uses: GabrielBB/xvfb-action@v1.6
         with:
           run: yarn testDebugger
@@ -405,6 +413,6 @@ jobs:
 
       - name: Run smoke tests
         env:
-          POSITRON_GITHUB_PAT: ${{ secrets.POSITRON_GITHUB_PAT }}
+          POSITRON_GITHUB_PAT: ${{ steps.app-token.outputs.token }}
         run: yarn tsc && node ./out/test/smokeTest.js
         if: matrix.test-suite == 'smoke'


### PR DESCRIPTION
### Intent

This change removes all references to the `POSITRON_GITHUB_PAT` secret. This secret was used in a lot of places to perform authenticated Github actions; it is owned and maintained by one of the engineers on the dev team (me). 

### Approach

Instead of a PAT, we now use the new Positron Bot app's credentials by asking it to issue an access token whenever one is needed. 

Once all the jobs I've changed have been run successfully with this new method, I'll remove the obsolete secret from the repository. 

Here's a job run from this branch that demonstrates the credentials being used successfully to fetch amalthea during the build (I canceled it to conserve resources once confirming that access was successful):

https://github.com/posit-dev/positron/actions/runs/9602786991

### QA Notes

This change affects tests since they also use the PAT to access repositories. I've updated the tests, too.