### PR TITLE
Console Smoke Test: Added retries for stability

### DIFF
--- a/test/smoke/src/areas/positron/console/python-console.test.ts
+++ b/test/smoke/src/areas/positron/console/python-console.test.ts
@@ -13,7 +13,7 @@ export function setup(logger: Logger) {
 
 		describe('Python Console Restart', () => {
 
-			before(async function () {
+			beforeEach(async function () {
 
 				const app = this.app as Application;
 				const pythonFixtures = new PositronPythonFixtures(app);
@@ -23,6 +23,7 @@ export function setup(logger: Logger) {
 
 			it('Verify restart button inside the console', async function () {
 				// TestRail #377918
+				this.retries(1);
 				const app = this.app as Application;
 				// Need to make console bigger to see all bar buttons
 				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
@@ -36,6 +37,7 @@ export function setup(logger: Logger) {
 
 			it('Verify restart button on console bar', async function () {
 				// TestRail #617464
+				this.retries(1);
 				const app = this.app as Application;
 				// Need to make console bigger to see all bar buttons
 				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');

--- a/test/smoke/src/areas/positron/console/r-console.test.ts
+++ b/test/smoke/src/areas/positron/console/r-console.test.ts
@@ -13,7 +13,7 @@ export function setup(logger: Logger) {
 
 		describe('R Console Restart', () => {
 
-			before(async function () {
+			beforeEach(async function () {
 
 				const app = this.app as Application;
 				const RFixtures = new PositronRFixtures(app);
@@ -23,6 +23,7 @@ export function setup(logger: Logger) {
 
 			it('Verify restart button inside the console', async function () {
 				// TestRail #377917
+				this.retries(1);
 				const app = this.app as Application;
 				// Need to make console bigger to see all bar buttons
 				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
@@ -36,6 +37,7 @@ export function setup(logger: Logger) {
 
 			it('Verify restart button on console bar', async function () {
 				// TestRail #620636
+				this.retries(1);
 				const app = this.app as Application;
 				// Need to make console bigger to see all bar buttons
 				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');


### PR DESCRIPTION
### Intent
To resolve https://github.com/posit-dev/positron/issues/3536

There can occasionally be a race condition where Python starts up after R and can steal focus of the console unexpectedly in the R test.

### Approach
Added a 1 retry, and changed the before block to `beforeEach` as only the `beforeEach` will get re-run on a retry. So if python steals focus, it will retry and run the `selectInterpreter` again, switching back to the R console.

I also added the same retry to the Python tests as a precaution.

### QA Notes
Passed on Windows and MacOS