### PR TITLE
[python] support numpy==2.X numbers in Variables pane

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -381,7 +381,7 @@ class NumberInspector(PositronInspector[NT], ABC):
         return super().value_to_json()
 
     @classmethod
-    def value_from_json(cls, type_name: str, data: JsonData):
+    def value_from_json(cls, type_name: str, data: JsonData) -> Union[NT, numbers.Number]:
         if type_name == "int":
             if not isinstance(data, numbers.Integral):
                 raise ValueError(f"Expected data to be int, got {data}")

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -351,6 +351,15 @@ NT = TypeVar("NT", numbers.Number, "np.number")
 
 
 class NumberInspector(PositronInspector[NT], ABC):
+    def get_display_type(self) -> str:
+        ty = type(self.value)
+        mod = ty.__module__
+        name = ty.__name__
+        if mod == "builtins":
+            return name
+        else:
+            return f"{mod}.{name}"
+
     def is_mutable(self) -> bool:
         return False
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_help.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_help.py
@@ -100,7 +100,7 @@ def test_pydoc_server_styling(running_help_service: HelpService):
         # Numpy ufuncs
         (np.abs, "numpy.absolute"),
         # getset_descriptors
-        (np.float_.base, "numpy.generic.base"),
+        (np.float32.base, "numpy.generic.base"),
         # Keywords should resolve even though they aren't objects.
         ("async", "async"),
         # The overrided help function should resolve.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
@@ -200,7 +200,7 @@ def test_inspect_numpy_scalars(value: np.integer) -> None:
         is_truncated=False,
         display_value=str(value),
         kind=VariableKind.Number,
-        display_type=str(dtype),
+        display_type=f"numpy.{dtype}",
         type_info=f"numpy.{dtype}",
     )
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
@@ -349,3 +349,38 @@ def positron_ipykernel_usage():
 
     """
     pass
+
+
+numpy_numeric_scalars = [
+    "numpy.int8",
+    "numpy.uint8",
+    "numpy.int16",
+    "numpy.uint16",
+    "numpy.int32",
+    "numpy.uint32",
+    "numpy.int64",
+    "numpy.uint64",
+    "numpy.intp",
+    "numpy.uintp",
+    "numpy.float16",
+    "numpy.float32",
+    "numpy.float64",
+    "numpy.float96",
+    "numpy.complex64",
+    "numpy.complex128",
+    "numpy.short",
+    "numpy.ushort",
+    "numpy.intc",
+    "numpy.uintc",
+    "numpy.long",
+    "numpy.ulong",
+    "numpy.longlong",
+    "numpy.ulonglong",
+    "numpy.half",
+    "numpy.single",
+    "numpy.double",
+    "numpy.longdouble",
+    "numpy.csingle",
+    "numpy.cdouble",
+    "numpy.clongdouble",
+]


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
Please ensure that the code is up-to-date with the `main` branch.
-->

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.

related to https://github.com/posit-dev/positron/issues/3582

The main issue here is that 

```python
x = np.int32(3.5)
x
```

prints out `3` in `numpy==1.X` and `np.int32(3)` in `numpy==2.X`, so we need some sort of handling to make sure the right display goes into our variables pane.

An alternative is making a small inspector for just numpy numbers.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

I checked across numpy 1.X and 2.X, these are used in both major versions. Base Python numbers do NOT have the `value.item()` method, so they should pass through untouched.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.

reopened #3591 