### PR TITLE
Update positron modal dialog styles

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/contentArea.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/contentArea.css
@@ -12,3 +12,11 @@
 	/* Allow overflow of extra long content */
 	overflow: auto;
 }
+
+.positron-modal-dialog-box .content-area code {
+	color: inherit;
+	font-family: var(--monaco-monospace-font);
+	font-size: 11px;
+	/* Wrap extra long words e.g file paths */
+	overflow-wrap: break-word;
+}


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3319, by allowing long code words to break and wrap. Also noticed that the simple modal code style was not pretty so used the style from the project wizard.

Recreated #3507 