### PR TITLE
Add unit test for the language runtime service

### DIFF
--- a/src/vs/workbench/services/languageRuntime/test/common/languageRuntime.test.ts
+++ b/src/vs/workbench/services/languageRuntime/test/common/languageRuntime.test.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { timeout } from 'vs/base/common/async';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { ILogService, NullLogger } from 'vs/platform/log/common/log';
+import { LanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntime';
+import { ILanguageRuntimeMetadata } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+
+suite('LanguageRuntimeService', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+	let instantiationService: TestInstantiationService;
+
+	setup(async () => {
+		instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.stub(ILogService, new NullLogger());
+	});
+
+	test('register and unregister a runtime', async () => {
+		const languageRuntimeService = disposables.add(instantiationService.createInstance(LanguageRuntimeService));
+
+		// No runtimes registered initially.
+		assert.strictEqual(languageRuntimeService.registeredRuntimes.length, 0);
+
+		// Mock runtime metadata.
+		const metadata = <ILanguageRuntimeMetadata>{
+			runtimeId: 'testRuntimeId',
+		};
+
+		// Promise that resolves when the onDidRegisterRuntime event is fired with the expected runtimeId.
+		const didRegisterRuntime = new Promise<void>((resolve) => {
+			const disposable = languageRuntimeService.onDidRegisterRuntime((e) => {
+				if (e.runtimeId === metadata.runtimeId) {
+					disposable.dispose();
+					resolve();
+				}
+			});
+		});
+
+		// Register the runtime.
+		const runtimeDisposable = languageRuntimeService.registerRuntime(metadata);
+
+		// Check that the onDidRegisterRuntime event was fired.
+		let to;
+		const race = await Promise.race([
+			didRegisterRuntime.then(() => 'success'),
+			(to = timeout(10)).then(() => 'timeout')
+		]);
+		assert.strictEqual(race, 'success', 'Awaiting onDidRegisterRuntime event timed out');
+		to.cancel();
+
+		// Check that the runtime was registered.
+		assert.deepStrictEqual(languageRuntimeService.registeredRuntimes, [metadata]);
+
+		// Unregister the runtime.
+		languageRuntimeService.unregisterRuntime(metadata.runtimeId);
+
+		// Check that the runtime was unregistered.
+		assert.strictEqual(languageRuntimeService.registeredRuntimes.length, 0);
+
+		// No-op since we already unregistered the runtime.
+		runtimeDisposable.dispose();
+	});
+});


### PR DESCRIPTION
Similar to https://github.com/posit-dev/positron/pull/3505 which added a Positron extension API test, this PR adds a single unit test for the language runtime service. 

We can decide whether we're happy with this approach before investing too much in writing these tests.

This test will run as part of the existing unit tests via `scripts/test.sh`. You can also run it individually with:

```sh
./scripts/test.sh -g LanguageRuntimeService
```

from the root directory.

Reopened #3506 