### PR TITLE
Add ability to account for length of parent path in file validation

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators.ts
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators.ts
@@ -10,8 +10,14 @@ import { localize } from 'vs/nls';
 import { IFileService } from 'vs/platform/files/common/files';
 
 interface PathValidatorOptions {
-	// Whether to forbid absolute paths. Defaults to false.
+	/**
+	 * Whether to forbid absolute paths. Defaults to false.
+	 */
 	noAbsolutePaths?: boolean;
+	/**
+	 * Parent of the path if it exists.
+	 */
+	parentPath?: string;
 }
 
 // This is adapted from the `validateFileName` function in `vs/workbench/contrib/files/browser/fileActions.ts`.
@@ -32,7 +38,9 @@ export function checkIfPathValid(path: string | number, opts: PathValidatorOptio
 		return localize('fileNameStartsWithSlashError', "A file or folder name cannot start with a slash.");
 	}
 
-	if (path.length > 256) {
+	// Combine path with parent path to check for length. Add 1 for separator.
+	const pathLength = path.length + (opts.parentPath ? opts.parentPath.length + 1 : 0);
+	if (pathLength > 256) {
 		return localize('fileNameTooLongError', "File path is too long, must be under 256 characters.");
 	}
 

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
@@ -152,7 +152,7 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 					autoFocus
 					value={result.folder}
 					onChange={e => setResult({ ...result, folder: e.target.value })}
-					validator={checkIfPathValid}
+					validator={x => checkIfPathValid(x, { parentPath: result.parentFolder })}
 				/>
 				<LabeledFolderInput
 					label={(() => localize(

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -43,7 +43,7 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 	const [projectNameFeedback, setProjectNameFeedback] = useState(context.projectNameFeedback);
 	const nameValidationErrorMsg = useDebouncedValidator({
 		value: projectName,
-		validator: checkIfPathValid
+		validator: x => checkIfPathValid(x, { parentPath: parentFolder })
 	});
 	const isInvalidName = nameValidationErrorMsg !== undefined;
 	const parentPathErrorMsg = useDebouncedValidator({

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -177,8 +177,8 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 					value={projectName}
 					onChange={(e) => onChangeProjectName(e.target.value)}
 					type='text'
-					// Don't let the user create a project with a name that is too long.
-					maxLength={255}
+					// Don't let the user create a project with a location that is too long.
+					maxLength={255 - parentFolder.length}
 					error={
 						(projectNameFeedback &&
 							projectNameFeedback.type === WizardFormattedTextType.Error) ||

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -41,6 +41,8 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 	const [projectName, setProjectName] = useState(context.projectName);
 	const [parentFolder, setParentFolder] = useState(context.parentFolder);
 	const [projectNameFeedback, setProjectNameFeedback] = useState(context.projectNameFeedback);
+	// TODO: Merge `nameValidationErrorMsg` and `parentPathErrorMsg` with the `checkProjectName()`
+	// function.
 	const nameValidationErrorMsg = useDebouncedValidator({
 		value: projectName,
 		validator: x => checkIfPathValid(x, { parentPath: parentFolder })


### PR DESCRIPTION
Addresses #3561 

### Intent

Take into account the parent of a path/ file name when deciding if it is too long or not. 
Previously we would make sure the file path directly was not over 256 characters, but we didnt account for the fact that we may be tacking that onto the end of a parent path which would cause the path to go over 256 once combined. 

### Approach

Add a new optional parameter for the file path validator function that contains the parent path and use that to decide if the length of the path is acceptable. 

The entire path is passed rather than just the length so if in the future we do something more complicated than taking the length we don't need to change the api. Also is simpler to call. 

### QA Notes
I tested by making the longest allowed combination of project name/ parent path and the new project was successfully created. I'm not sure though if there's other more diabolical ways to mess with things. 