### PR TITLE
Streamline PR template and add CONTRIBUTING.md link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,22 @@
 <!-- Thank you for submitting a pull request.
-Please ensure that the code is up-to-date with the `main` branch.
+If this is your first pull request you can find information about
+contributing here:
+  * [Contributing to Positron](https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md)
 -->
 
-### Intent
-
-> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any GitHub issues that are related.
-
-### Approach
-
-> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.
+<!--
+  Describe briefly what problem this pull request resolves, or what
+  new feature it introduces. Include screenshots of any new or altered
+  UI. Link to any GitHub issues that are related. If there are any
+  details about your approach that are unintuitive or you want to draw
+  attention to, please describe them here.
+-->
 
 ### QA Notes
 
-> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.
+<!--
+  Add additional information for QA on how to validate the change,
+  paying special attention to the level of risk, adjacent areas that
+  could be affected by the change, and any important contextual
+  information not present in the linked issues.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,9 @@
 If this is your first pull request you can find information about
 contributing here:
   * [Contributing to Positron](https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md)
+
+We recommend synchronizing your branch with the latest changes in the
+main branch by either pulling or rebasing.
 -->
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,9 +7,10 @@ contributing here:
 <!--
   Describe briefly what problem this pull request resolves, or what
   new feature it introduces. Include screenshots of any new or altered
-  UI. Link to any GitHub issues that are related. If there are any
-  details about your approach that are unintuitive or you want to draw
-  attention to, please describe them here.
+  UI. Link to any GitHub issues but avoid "magic" keywords that will 
+  automatically close the issue. If there are any details about your 
+  approach that are unintuitive or you want to draw attention to, please 
+  describe them here.
 -->
 
 ### QA Notes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!-- Thank you for submitting a pull request.
 If this is your first pull request you can find information about
 contributing here:
-  * [Contributing to Positron](https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md)
+  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md
 
 We recommend synchronizing your branch with the latest changes in the
 main branch by either pulling or rebasing.


### PR DESCRIPTION
Empirically, many of the sections of the current PR template are being left empty. I wanted to propose a more minimal template that also points to CONTRIBUTING.md (which needs to be worked on to add a new contributor guide). It also puts the "instructions" in Markdown comments (so they are hidden in the UI if the contributor does not delete them) to make rendered PR descriptions easier to read. I also question whether the QA notes section is needed, since QA is usually looking at issues when doing verification rather than pull requests. So QA notes may be better off there. 