### PR TITLE
Rename 'amalthea' repository to 'ark' repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Positron is a highly extensible IDE. Its foundation is implemented in [`src`](..
 Positron provides the following built-in extensions:
 
 - [**Jupyter Adapter**](../extensions/jupyter-adapter), the interface between the front end and language extensions described below
-- [**Positron R**](../extensions/positron-r), the Positron extension for the R programming language powered by [ARK](https://github.com/posit-dev/amalthea/tree/main/crates/ark) (the Amalthea R kernel -- our Rust-based kernel for R) which is built on top of our [Amalthea](https://github.com/posit-dev/amalthea) Jupyter kernel framework and the open source [tower-lsp](https://github.com/ebkalderon/tower-lsp) LSP framework
+- [**Positron R**](../extensions/positron-r), the Positron extension for the R programming language powered by [ARK](https://github.com/posit-dev/ark/tree/main/crates/ark) (an R kernel -- our Rust-based kernel for R) which is built on top of our [Amalthea](https://github.com/posit-dev/ark/tree/main/crates/amalthea) Jupyter kernel framework and the open source [tower-lsp](https://github.com/ebkalderon/tower-lsp) LSP framework
 - [**Positron Python**](../extensions/positron-python), the Positron extension for the Python programming language, a fork of [Microsoft's Python VSCode extension](https://github.com/microsoft/vscode-python) built on top of the open source Python-based kernel [IPyKernel](https://github.com/ipython/ipykernel) and [Jedi Language Server](https://github.com/pappasam/jedi-language-server)
 - [**Positron Zed**](../extensions/positron-zed), the Positron extension for a test-bed language, intended for fast simulations primarily to aid UI development
 

--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -46,7 +46,7 @@ async function main(buildDir) {
             // Exclusions from Python language pack (positron-python)
             'pydevd', // Cython pre-built binaries for Python debugging
             // Exclusions from R language pack (positron-r)
-            'amalthea', // R backend sources
+            'ark', // R backend sources
             'ark' // Compiled R kernel and LSP
             // --- End Positron ---
         ],

--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -46,7 +46,6 @@ async function main(buildDir) {
             // Exclusions from Python language pack (positron-python)
             'pydevd', // Cython pre-built binaries for Python debugging
             // Exclusions from R language pack (positron-r)
-            'ark', // R backend sources
             'ark' // Compiled R kernel and LSP
             // --- End Positron ---
         ],

--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -50,7 +50,6 @@ async function main(buildDir?: string) {
 			// Exclusions from Python language pack (positron-python)
 			'pydevd',             // Cython pre-built binaries for Python debugging
 			// Exclusions from R language pack (positron-r)
-			'ark',           // R backend sources
 			'ark'                 // Compiled R kernel and LSP
 			// --- End Positron ---
 		],

--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -50,7 +50,7 @@ async function main(buildDir?: string) {
 			// Exclusions from Python language pack (positron-python)
 			'pydevd',             // Cython pre-built binaries for Python debugging
 			// Exclusions from R language pack (positron-r)
-			'amalthea',           // R backend sources
+			'ark',           // R backend sources
 			'ark'                 // Compiled R kernel and LSP
 			// --- End Positron ---
 		],

--- a/build/filters.js
+++ b/build/filters.js
@@ -28,7 +28,6 @@ module.exports.all = [
 	'!**/node_modules/**',
 
 	// --- Start Positron ---
-	'!**/amalthea/**/*',
 	'!extensions/positron-python/**/*',
 	'!test/smoke/test-repo/**/*'
 	// --- End Positron ---
@@ -67,7 +66,6 @@ module.exports.unicodeFilter = [
 	'!src/vs/workbench/services/keybinding/browser/keyboardLayouts/**',
 
 	// --- Start Positron ---
-	'!**/amalthea/**/*',
 	'!scripts/positron/**/*',
 	// --- End Positron ---
 ];
@@ -152,7 +150,6 @@ module.exports.indentationFilter = [
 	// --- End Positron ---
 
 	// --- Start Positron ---
-	'!**/amalthea/**/*',
 	'!extensions/positron-r/resources/scripts/*.R',
 	'!extensions/positron-r/resources/testing/**',
 	'!scripts/positron/**/*',
@@ -199,7 +196,6 @@ module.exports.copyrightFilter = [
 	'!src/vs/editor/test/node/classification/typescript-test.ts',
 
 	// --- Start Positron ---
-	'!**/amalthea/**/*',
 	'!extensions/positron-r/resources/testing/**',
 	// --- End Positron ---
 ];
@@ -222,10 +218,6 @@ module.exports.tsFormattingFilter = [
 	'!extensions/vscode-api-tests/testWorkspace2/**',
 	'!extensions/**/*.test.ts',
 	'!extensions/html-language-features/server/lib/jquery.d.ts',
-
-	// --- Start Positron ---
-	'!**/amalthea/**/*',
-	// --- End Positron ---
 ];
 
 module.exports.eslintFilter = [

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -551,8 +551,7 @@
     "pretest": "yarn run compile && yarn run lint",
     "postinstall": "ts-node scripts/post-install.ts",
     "lint": "eslint src --ext ts",
-    "test": "node ./out/test/runTest.js",
-    "test-amalthea": "cd amalthea && cargo test"
+    "test": "node ./out/test/runTest.js"
   },
   "extensionDependencies": [
     "vscode.jupyter-adapter"
@@ -586,7 +585,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/posit-dev/amalthea"
+    "url": "https://github.com/posit-dev/positron"
   },
   "positron": {
     "binaryDependencies": {

--- a/extensions/positron-r/scripts/install-kernel.ts
+++ b/extensions/positron-r/scripts/install-kernel.ts
@@ -107,7 +107,7 @@ async function downloadAndReplaceArk(version: string,
 			method: 'GET',
 			protocol: 'https:',
 			hostname: 'api.github.com',
-			path: `/repos/posit-dev/amalthea/releases`
+			path: `/repos/posit-dev/ark/releases`
 		};
 
 		const response = await httpsGetAsync(requestOptions as any) as any;
@@ -122,7 +122,7 @@ async function downloadAndReplaceArk(version: string,
 				await executeCommand('git credential approve',
 					`protocol=https\n` +
 					`host=github.com\n` +
-					`path=/repos/posit-dev/amalthea/releases\n` +
+					`path=/repos/posit-dev/ark/releases\n` +
 					`username=\n` +
 					`password=${githubPat}\n`);
 			console.log(stdout);
@@ -139,7 +139,7 @@ async function downloadAndReplaceArk(version: string,
 				await executeCommand('git credential reject',
 					`protocol=https\n` +
 					`host=github.com\n` +
-					`path=/repos/posit-dev/amalthea/releases\n` +
+					`path=/repos/posit-dev/ark/releases\n` +
 					`username=\n` +
 					`password=${githubPat}\n`);
 			console.log(stdout);
@@ -252,12 +252,13 @@ async function downloadAndReplaceArk(version: string,
 async function main() {
 	const kernelName = platform() === 'win32' ? 'ark.exe' : 'ark';
 
-	// Before we do any work, check to see if there is a locally built copy of Amalthea in the
-	// `amalthea / target` directory. If so, we'll assume that the user is a kernel developer
-	// and skip the download; this version will take precedence over any downloaded version.
+	// Before we do any work, check to see if there is a locally built copy of
+	// the Ark R Kernel in the `ark / target` directory. If so, we'll assume
+	// that the user is a kernel developer and skip the download; this version
+	// will take precedence over any downloaded version.
 	const positronParent = path.dirname(path.dirname(path.dirname(path.dirname(__dirname))));
-	const amaltheaFolder = path.join(positronParent, 'amalthea');
-	const targetFolder = path.join(amaltheaFolder, 'target');
+	const arkFolder = path.join(positronParent, 'ark');
+	const targetFolder = path.join(arkFolder, 'target');
 	const debugBinary = path.join(targetFolder, 'debug', kernelName);
 	const releaseBinary = path.join(targetFolder, 'release', kernelName);
 	if (fs.existsSync(debugBinary) || fs.existsSync(releaseBinary)) {
@@ -265,15 +266,14 @@ async function main() {
 		console.log(`Using locally built Ark in ${binary}.`);
 
 		// Copy the locally built ark to the resources/ark directory. It won't
-		// be read from this directory at runtime, but we need to put it here so
-		// that `yarn gulp vscode` will package it up (the packaging step
-		// doesn't look for a sideloaded ark from an adjacent `amalthea`
-		// directory).
+		// be read from this directory at runtime, but we need to put it here
+		// so that `yarn gulp vscode` will package it up (the packaging step
+		// doesn't look for a sideloaded ark from an adjacent `ark` directory).
 		fs.mkdirSync(path.join('resources', 'ark'), { recursive: true });
 		fs.copyFileSync(binary, path.join('resources', 'ark', kernelName));
 		return;
 	} else {
-		console.log(`No locally built Ark found in ${path.join(positronParent, 'amalthea')}; ` +
+		console.log(`No locally built Ark found in ${path.join(positronParent, 'ark')}; ` +
 			`checking downloaded version.`);
 	}
 
@@ -350,7 +350,7 @@ async function main() {
 			await executeCommand('git credential fill',
 				`protocol=https\n` +
 				`host=github.com\n` +
-				`path=/repos/posit-dev/amalthea/releases\n`);
+				`path=/repos/posit-dev/ark/releases\n`);
 
 		gitCredential = true;
 		// Extract the `password = ` line from the output.

--- a/extensions/positron-r/src/kernel.ts
+++ b/extensions/positron-r/src/kernel.ts
@@ -34,11 +34,11 @@ export function getArkKernelPath(): string | undefined {
 
 	// Look for locally built Debug or Release kernels. If both exist, we'll use
 	// whichever is newest. This is the location where the kernel is typically built
-	// by developers, who have `positron` and `amalthea` directories side-by-side.
+	// by developers, who have `positron` and `ark` directories side-by-side.
 	let devKernel = undefined;
 	const positronParent = path.dirname(path.dirname(path.dirname(EXTENSION_ROOT_DIR)));
-	const devDebugKernel = path.join(positronParent, 'amalthea', 'target', 'debug', kernelName);
-	const devReleaseKernel = path.join(positronParent, 'amalthea', 'target', 'release', kernelName);
+	const devDebugKernel = path.join(positronParent, 'ark', 'target', 'debug', kernelName);
+	const devReleaseKernel = path.join(positronParent, 'ark', 'target', 'release', kernelName);
 	const debugModified = fs.statSync(devDebugKernel, { throwIfNoEntry: false })?.mtime;
 	const releaseModified = fs.statSync(devReleaseKernel, { throwIfNoEntry: false })?.mtime;
 

--- a/positron/comms/README.md
+++ b/positron/comms/README.md
@@ -50,7 +50,7 @@ If you're making changes to these contracts, you will need to coordinate your ch
 
 The code generator presumes that you have the `ark` repository set up as a sibling folder to `positron`. If you haven't already, clone `ark` alongside Positron.
 
-The code generator also places files in `extensions/positron-python`. Prepare the `positron-python` submodule folder for changes by discarding local changes that might conflict and syncing the submodule to `main`.
+The code generator also places files in `extensions/positron-python`.
 
 ### Step 2: Change the Contract
 
@@ -95,8 +95,8 @@ Build `ark`, restart Positron, and thoroughly test your changes against both R a
 
 ### Step 5: Prepare Branches
 
-Create new branches in all three repositories (`positron`, `positron-python`, and `ark`). Commit your changes to each branch.
+Create new branches in both repositories (`positron` and `ark`). Commit your changes to each branch.
 
 ### Step 6: Merge
 
-Once PRs have been approved on each branch, coordinate a merge of all three branches together. A convenient way to do this is to include the submodule bump (`positron-python`) and ark version bump (`amalthea`) as changes in your `positron` PR, so that all the changes land in Positron at the same time.
+Once PRs have been approved on each branch, coordinate a merge of both branches. A convenient way to do this is to include the ark version bump in your `positron` PR, so that all the changes land in Positron at the same time.

--- a/positron/comms/README.md
+++ b/positron/comms/README.md
@@ -48,7 +48,7 @@ If you're making changes to these contracts, you will need to coordinate your ch
 
 ### Step 1: Set Up Repositories
 
-The code generator presumes that you have the `amalthea` repository set up as a sibling folder to `positron`. If you haven't already, clone `amalthea` alongside Positron.
+The code generator presumes that you have the `ark` repository set up as a sibling folder to `positron`. If you haven't already, clone `ark` alongside Positron.
 
 The code generator also places files in `extensions/positron-python`. Prepare the `positron-python` submodule folder for changes by discarding local changes that might conflict and syncing the submodule to `main`.
 
@@ -95,7 +95,7 @@ Build `ark`, restart Positron, and thoroughly test your changes against both R a
 
 ### Step 5: Prepare Branches
 
-Create new branches in all three repositories (`positron`, `positron-python`, and `amalthea`). Commit your changes to each branch.
+Create new branches in all three repositories (`positron`, `positron-python`, and `ark`). Commit your changes to each branch.
 
 ### Step 6: Merge
 


### PR DESCRIPTION
### Intent

We need to rename the 'amalthea' repository to 'ark' in advance of opening it up. 

### Approach

This change performs the Positron side of the rename by updating build scripts, dev scripts, and documentation as appropriate. It also removes some cruft left over from the days when `amalthea` was nested inside `positron-r` (those are the purely deleted lines).

Sequencing the rename will performed as follows:

- When this PR is approved, I'll perform the rename of the `amalthea` repository to `ark`
- CI re-run against this PR to verify the changes (ensures we can download the kernel from the new URL)
- Merge this PR to Positron

### QA Notes

This only changes how the R kernel is acquired, so it shouldn't have any impact on product functionality -- as long as you can start R, everything worked.