### PR TITLE
Update README and CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+### Code of Conduct
+
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
+By participating in this project you agree to abide by its terms.
+
+### CLA
+
+We ask that you sign our
+[Contributor License Agreement](https://posit.co/individual-contributor-agreement/) before we accept
+a contribution, such as via a pull request. When you open a PR, you will automatically be asked to
+sign the CLA via a [GitHub Action](workflows/cla.yml).

--- a/.github/README.md
+++ b/.github/README.md
@@ -24,3 +24,13 @@ Currently, Positron is producing pre-release builds from a continuous integratio
 ## Share your feedback about Positron
 
 We invite you to join us on [GitHub Discussions](https://github.com/posit-dev/positron/discussions) to ask questions and share feedback. [Read more](https://github.com/posit-dev/positron/wiki/Feedback-and-Issues) about giving feedback and reporting bugs.
+
+## Code of conduct
+
+Please note that this project is released with a [Contributor Code of
+Conduct](https://github.com/posit-dev/positron/?tab=coc-ov-file#readme). By participating
+in this project you agree to abide by its terms.
+
+## License
+
+Positron is licensed under the [Elastic License 2.0](https://github.com/posit-dev/positron?tab=License-1-ov-file#readme), a source-available license. [Read more](https://github.com/posit-dev/positron/wiki/Licensing) about what this license means and our decision to use it.


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3029

- [x] Update README for positron with license info
- [x] CONTRIBUTING.md including CLA details on positron repo

This PR is not ready to go until we have the licensing page in the Wiki. cc @jthomasmock 