### PR TITLE
Updates for Data Explorer focus management.

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -38,6 +38,7 @@ export interface KeyboardModifiers {
 interface ButtonProps {
 	readonly hoverManager?: IHoverManager;
 	readonly className?: string;
+	readonly tabIndex?: number;
 	readonly disabled?: boolean;
 	readonly ariaLabel?: string;
 	readonly tooltip?: string | (() => string | undefined);
@@ -175,7 +176,7 @@ export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProp
 				props.className,
 				{ 'disabled': props.disabled }
 			)}
-			tabIndex={0}
+			tabIndex={props.tabIndex ?? 0}
 			disabled={props.disabled}
 			role='button'
 			aria-label={props.ariaLabel}

--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -55,6 +55,8 @@ interface ButtonProps {
 export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProps>>((props, ref) => {
 	// Reference hooks.
 	const buttonRef = useRef<HTMLButtonElement>(undefined!);
+
+	// Customize the ref handle that is exposed.
 	useImperativeHandle(ref, () => buttonRef.current, []);
 
 	/**

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
@@ -87,6 +87,7 @@ export const ColumnSelectorModalPopup = (props: ColumnSelectorModalPopupProps) =
 						layoutService={props.renderer.layoutService}
 						ref={positronDataGridRef}
 						id='column-positron-data-grid'
+						tabIndex={0}
 						instance={props.columnSelectorDataGridInstance}
 					/>
 				</div>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -152,6 +152,7 @@ export const DataExplorer = () => {
 					configurationService={context.configurationService}
 					layoutService={context.layoutService}
 					instance={context.instance.tableSchemaDataGridInstance}
+					tabIndex={0}
 				/>
 			</div>
 			<div ref={splitterRef} className='splitter'>
@@ -166,6 +167,7 @@ export const DataExplorer = () => {
 					configurationService={context.configurationService}
 					layoutService={context.layoutService}
 					instance={context.instance.tableDataDataGridInstance}
+					tabIndex={1}
 				/>
 			</div>
 		</div>

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -897,7 +897,7 @@ export abstract class DataGridInstance extends Disposable {
 	//#region Public Properties
 
 	/**
-	 * Gets the number of columns.
+	 * Gets a value which indicates whether the data explorer is focused.
 	 */
 	get focused() {
 		return this._focused;

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -487,7 +487,7 @@ export class ColumnSortKeyDescriptor implements IColumnSortKey {
  * DataGridInstance class.
  */
 export abstract class DataGridInstance extends Disposable {
-	//#region Private Properties
+	//#region Private Properties - Settings
 
 	/**
 	 * Gets a value which indicates whether to show column headers.
@@ -598,6 +598,15 @@ export abstract class DataGridInstance extends Disposable {
 	 * Gets a value which indicates whether selection is enabled.
 	 */
 	private readonly _selection: boolean;
+
+	//#endregion Private Properties - Settings
+
+	//#region Private Properties
+
+	/**
+	 * Gets or sets a value which indicates whether the data grid is focused.
+	 */
+	private _focused = false;
 
 	/**
 	 * Gets or sets the width.
@@ -734,7 +743,7 @@ export abstract class DataGridInstance extends Disposable {
 
 	//#endregion Constructor & Dispose
 
-	//#region Public Properties
+	//#region Public Properties - Settings
 
 	/**
 	 * Gets a value which indicates whether to display column headers.
@@ -881,6 +890,17 @@ export abstract class DataGridInstance extends Disposable {
 	 */
 	get selection() {
 		return this._selection;
+	}
+
+	//#endregion Public Properties - Settings
+
+	//#region Public Properties
+
+	/**
+	 * Gets the number of columns.
+	 */
+	get focused() {
+		return this._focused;
 	}
 
 	/**
@@ -1087,6 +1107,21 @@ export abstract class DataGridInstance extends Disposable {
 	//#endregion Public Events
 
 	//#region Public Methods
+
+	/**
+	 * Sets the focused state of the data grid.
+	 * @param focused A value which indicates whether the data grid is focused.
+	 */
+	setFocused(focused: boolean) {
+		// Set the focused flag, if it changed.
+		if (this._focused !== focused) {
+			// Set the focused flag.
+			this._focused = focused;
+
+			// Fire the onDidUpdate event.
+			this._onDidUpdateEmitter.fire();
+		}
+	}
 
 	/**
 	 * Shows the cursor, if it was initially hidden.

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.css
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.css
@@ -6,14 +6,9 @@
 	top: 0;
 	bottom: 0;
 	display: grid;
-	/* overflow: hidden; */
 	position: absolute;
-	background-color: var(--vscode-positronDataGrid-contrastBackground);
 	grid-template-columns: [content] 1fr [right-gutter] 1px [end];
-}
-
-.data-grid-column-header.selected {
-	background-color: var(--vscode-positronDataGrid-selectionBackground);
+	background-color: var(--vscode-positronDataGrid-contrastBackground);
 }
 
 .data-grid-column-header
@@ -29,25 +24,42 @@
 }
 
 .data-grid-column-header
-.border-overlay.selected {
+.selection-overlay {
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	position: absolute;
+	box-sizing: border-box;
+	background-color: var(--vscode-positronDataGrid-selectionBackground);
 	border-top: 1px solid var(--vscode-positronDataGrid-selectionBorder);
-	border-right: 1px solid var(--vscode-positronDataGrid-selectionInnerBorder);
 	border-bottom: 1px solid var(--vscode-positronDataGrid-selectionInnerBorder);
 }
 
 .data-grid-column-header
-.border-overlay.selected-left {
+.selection-overlay:not(.focused) {
+	opacity: 50%;
+}
+
+.data-grid-column-header
+.selection-overlay.selected-left {
 	border-left: 1px solid var(--vscode-positronDataGrid-selectionBorder);
 }
 
 .data-grid-column-header
-.border-overlay.selected-right {
+.selection-overlay.selected-right {
 	border-right: 1px solid var(--vscode-positronDataGrid-selectionBorder);
+}
+
+.data-grid-column-header
+.selection-overlay:not(.selected-right) {
+	border-right: 1px solid var(--vscode-positronDataGrid-selectionInnerBorder);
 }
 
 .data-grid-column-header
 .content {
 	display: grid;
+	position: relative;
 	align-items: center;
 	grid-column: content / right-gutter;
 	grid-template-columns: [left-margin] 7px [title-description] minmax(0, 1fr) [sort-indicator] min-content [button] 20px [right-margin] 7px [end];

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -95,6 +95,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 	// Get the column selection state.
 	const columnSelectionState = context.instance.columnSelectionState(props.columnIndex);
 
+	// Determine whether the column is selected.
 	const selected = (columnSelectionState & ColumnSelectionState.Selected) !== 0;
 
 	// Render.

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -149,6 +149,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 				<Button
 					ref={sortingButtonRef}
 					className='sort-button'
+					tabIndex={-1}
 					mouseTrigger={MouseTrigger.MouseDown}
 					onPressed={dropdownPressed}
 				>

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -95,29 +95,34 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 	// Get the column selection state.
 	const columnSelectionState = context.instance.columnSelectionState(props.columnIndex);
 
+	const selected = (columnSelectionState & ColumnSelectionState.Selected) !== 0;
+
 	// Render.
 	return (
 		<div
 			ref={ref}
-			className={
-				positronClassNames(
-					'data-grid-column-header',
-					{ 'selected': columnSelectionState & ColumnSelectionState.Selected }
-				)}
+			className='data-grid-column-header'
 			style={{
 				left: props.left,
 				width: context.instance.getColumnWidth(props.columnIndex)
 			}}
 			onMouseDown={mouseDownHandler}
 		>
-			<div className={
-				positronClassNames(
-					'border-overlay',
-					{ 'selected': columnSelectionState & ColumnSelectionState.Selected },
-					{ 'selected-left': columnSelectionState & ColumnSelectionState.SelectedLeft },
-					{ 'selected-right': columnSelectionState & ColumnSelectionState.SelectedRight }
-				)}
-			/>
+			{context.instance.cellBorder &&
+				<>
+					<div className='border-overlay' />
+					{selected &&
+						<div
+							className={positronClassNames(
+								'selection-overlay',
+								{ 'focused': context.instance.focused },
+								{ 'selected-left': columnSelectionState & ColumnSelectionState.SelectedLeft },
+								{ 'selected-right': columnSelectionState & ColumnSelectionState.SelectedRight }
+							)}
+						/>
+					}
+				</>
+			}
 			<div className='content'>
 				<div className='title-description'>
 					<div className='title'>{props.column?.name}</div>

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.css
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.css
@@ -6,50 +6,62 @@
 	position: absolute;
 }
 
-.data-grid-row-cell.selected {
-	background-color: var(--vscode-positronDataGrid-selectionBackground);
-}
-
 .data-grid-row-cell
-.data-grid-row-cell-border-overlay {
+.border-overlay {
 	top: 0;
 	right: 0;
 	bottom: 0;
 	left: 0;
 	position: absolute;
 	box-sizing: border-box;
-}
-
-.data-grid-row-cell
-.data-grid-row-cell-border-overlay.bordered {
 	border-right: 1px solid var(--vscode-positronDataGrid-border);
 	border-bottom: 1px solid var(--vscode-positronDataGrid-border);
 }
 
 .data-grid-row-cell
-.data-grid-row-cell-border-overlay.selected {
-	border-right: 1px solid var(--vscode-positronDataGrid-selectionInnerBorder);
-	border-bottom: 1px solid var(--vscode-positronDataGrid-selectionInnerBorder);
+.selection-overlay {
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	position: absolute;
+	box-sizing: border-box;
+	background-color: var(--vscode-positronDataGrid-selectionBackground);
 }
 
 .data-grid-row-cell
-.data-grid-row-cell-border-overlay.selected-top {
+.selection-overlay:not(.focused) {
+	opacity: 50%;
+}
+
+.data-grid-row-cell
+.selection-overlay.selected-top {
 	border-top: 1px solid var(--vscode-positronDataGrid-selectionBorder);
 }
 
 .data-grid-row-cell
-.data-grid-row-cell-border-overlay.selected-bottom {
+.selection-overlay.selected-right {
+	border-right: 1px solid var(--vscode-positronDataGrid-selectionBorder);
+}
+
+.data-grid-row-cell
+.selection-overlay:not(.selected-right) {
+	border-right: 1px solid var(--vscode-positronDataGrid-selectionInnerBorder);
+}
+
+.data-grid-row-cell
+.selection-overlay.selected-bottom {
 	border-bottom: 1px solid var(--vscode-positronDataGrid-selectionBorder);
 }
 
 .data-grid-row-cell
-.data-grid-row-cell-border-overlay.selected-left {
-	border-left: 1px solid var(--vscode-positronDataGrid-selectionBorder);
+.selection-overlay:not(.selected-bottom) {
+	border-bottom: 1px solid var(--vscode-positronDataGrid-selectionInnerBorder);
 }
 
 .data-grid-row-cell
-.data-grid-row-cell-border-overlay.selected-right {
-	border-right: 1px solid var(--vscode-positronDataGrid-selectionBorder);
+.selection-overlay.selected-left {
+	border-left: 1px solid var(--vscode-positronDataGrid-selectionBorder);
 }
 
 .data-grid-row-cell
@@ -57,6 +69,11 @@
 	position: absolute;
 	box-sizing: border-box;
 	border: 1.5px solid var(--vscode-positronDataGrid-cursorBorder);
+}
+
+.data-grid-row-cell
+.cursor-border.dimmed {
+	opacity: 50%;
 }
 
 .data-grid-row-cell

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
@@ -97,15 +97,42 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 		props.rowIndex
 	);
 
+	// Determine whether this cell is selected.
+	const selected = (cellSelectionState & CellSelectionState.Selected) !== 0;
+
+	// Determine whether this cell is the cursor cell.
+	const isCursorCell = context.instance.internalCursor &&
+		props.columnIndex === context.instance.cursorColumnIndex &&
+		props.rowIndex === context.instance.cursorRowIndex;
+
+
+	/**
+	 * Cursor component.
+	 * @param dimmed A value which indicates whether the cursor component should be dimmed.
+	 * @returns The rendered component.
+	 */
+	const Cursor = ({ dimmed }: { dimmed?: boolean }) => {
+		return (
+			<div
+				className={positronClassNames(
+					'cursor-border',
+					{ dimmed }
+				)}
+				style={{
+					top: context.instance.cursorOffset,
+					right: context.instance.cursorOffset,
+					bottom: context.instance.cursorOffset,
+					left: context.instance.cursorOffset,
+				}}
+			/>
+		);
+	};
+
 	// Render.
 	return (
 		<div
 			ref={ref}
-			className={
-				positronClassNames(
-					'data-grid-row-cell',
-					{ 'selected': cellSelectionState & CellSelectionState.Selected },
-				)}
+			className='data-grid-row-cell'
 			style={{
 				left: props.left,
 				width: context.instance.getColumnWidth(props.columnIndex),
@@ -113,33 +140,27 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 			}}
 			onMouseDown={mouseDownHandler}
 		>
-			<div
-				className={
-					positronClassNames(
-						'data-grid-row-cell-border-overlay',
-						{ 'bordered': context.instance.cellBorder },
-						{ 'selected': cellSelectionState & CellSelectionState.Selected },
-						{ 'selected-top': cellSelectionState & CellSelectionState.SelectedTop },
-						{ 'selected-bottom': cellSelectionState & CellSelectionState.SelectedBottom },
-						{ 'selected-left': cellSelectionState & CellSelectionState.SelectedLeft },
-						{ 'selected-right': cellSelectionState & CellSelectionState.SelectedRight },
-					)}
-			>
-				{
-					context.instance.internalCursor &&
-					props.columnIndex === context.instance.cursorColumnIndex &&
-					props.rowIndex === context.instance.cursorRowIndex &&
-					<div
-						className='cursor-border'
-						style={{
-							top: context.instance.cursorOffset,
-							right: context.instance.cursorOffset,
-							bottom: context.instance.cursorOffset,
-							left: context.instance.cursorOffset
-						}}
-					/>
-				}
-			</div>
+			{context.instance.cellBorder &&
+				<>
+					<div className='border-overlay'>
+						{!selected && isCursorCell && <Cursor dimmed={!context.instance.focused} />}
+					</div>
+					{selected &&
+						<div
+							className={positronClassNames(
+								'selection-overlay',
+								{ 'focused': context.instance.focused },
+								{ 'selected-top': cellSelectionState & CellSelectionState.SelectedTop },
+								{ 'selected-bottom': cellSelectionState & CellSelectionState.SelectedBottom },
+								{ 'selected-left': cellSelectionState & CellSelectionState.SelectedLeft },
+								{ 'selected-right': cellSelectionState & CellSelectionState.SelectedRight },
+							)}
+						>
+							{isCursorCell && <Cursor />}
+						</div>
+					}
+				</>
+			}
 			<div className='content'>
 				{context.instance.cell(props.columnIndex, props.rowIndex)}
 			</div>

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.css
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.css
@@ -14,12 +14,8 @@
 	background-color: var(--vscode-positronDataGrid-contrastBackground);
 }
 
-.data-grid-row-header.selected {
-	background-color: var(--vscode-positronDataGrid-selectionBackground);
-}
-
 .data-grid-row-header
-.data-grid-row-header-border-overlay {
+.border-overlay {
 	top: 0;
 	right: 0;
 	bottom: 0;
@@ -31,25 +27,42 @@
 }
 
 .data-grid-row-header
-.data-grid-row-header-border-overlay.selected {
+.selection-overlay {
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	position: absolute;
+	box-sizing: border-box;
+	background-color: var(--vscode-positronDataGrid-selectionBackground);
 	border-left: 1px solid var(--vscode-positronDataGrid-selectionBorder);
 	border-right: 1px solid var(--vscode-positronDataGrid-selectionInnerBorder);
-	border-bottom: 1px solid var(--vscode-positronDataGrid-selectionInnerBorder);
 }
 
 .data-grid-row-header
-.data-grid-row-header-border-overlay.selected-top {
+.selection-overlay:not(.focused) {
+	opacity: 50%;
+}
+
+.data-grid-row-header
+.selection-overlay.selected-top {
 	border-top: 1px solid var(--vscode-positronDataGrid-selectionBorder);
 }
 
 .data-grid-row-header
-.data-grid-row-header-border-overlay.selected-bottom {
+.selection-overlay.selected-bottom {
 	border-bottom: 1px solid var(--vscode-positronDataGrid-selectionBorder);
+}
+
+.data-grid-row-header
+.selection-overlay:not(.selected-bottom) {
+	border-bottom: 1px solid var(--vscode-positronDataGrid-selectionInnerBorder);
 }
 
 .data-grid-row-header
 .content {
 	overflow: hidden;
+	position: relative;
 	grid-row: content / splitter;
 	grid-column: content / splitter;
 }

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
@@ -81,32 +81,35 @@ export const DataGridRowHeader = (props: DataGridRowHeaderProps) => {
 	// Get the row selection state.
 	const rowSelectionState = context.instance.rowSelectionState(props.rowIndex);
 
+	// Determine whether this row is selected.
+	const selected = (rowSelectionState & RowSelectionState.Selected) !== 0;
+
 	// Render.
 	return (
 		<div
 			ref={ref}
-			className={
-				positronClassNames(
-					'data-grid-row-header',
-					{ 'selected': rowSelectionState & RowSelectionState.Selected }
-				)
-			}
+			className='data-grid-row-header'
 			style={{
 				top: props.top,
 				height: context.instance.getRowHeight(props.rowIndex)
 			}}
 			onMouseDown={mouseDownHandler}
 		>
-			<div
-				className={
-					positronClassNames(
-						'data-grid-row-header-border-overlay',
-						{ 'selected': rowSelectionState & RowSelectionState.Selected },
-						{ 'selected-top': rowSelectionState & RowSelectionState.SelectedTop },
-						{ 'selected-bottom': rowSelectionState & RowSelectionState.SelectedBottom }
-					)
-				}
-			/>
+			{context.instance.cellBorder &&
+				<>
+					<div className='border-overlay' />
+					{selected &&
+						<div
+							className={positronClassNames(
+								'selection-overlay',
+								{ 'focused': context.instance.focused },
+								{ 'selected-top': rowSelectionState & RowSelectionState.SelectedTop },
+								{ 'selected-bottom': rowSelectionState & RowSelectionState.SelectedBottom }
+							)}
+						/>
+					}
+				</>
+			}
 			<div className='content'>
 				{context.instance.rowHeader(props.rowIndex)}
 			</div>

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -547,6 +547,8 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 			className='data-grid-waffle'
 			onKeyDown={keyDownHandler}
 			onWheel={wheelHandler}
+			onBlur={() => context.instance.setFocused(false)}
+			onFocus={() => context.instance.setFocused(true)}
 		>
 			{context.instance.columnHeaders && context.instance.rowHeaders &&
 				<DataGridCornerTopLeft

--- a/src/vs/workbench/browser/positronDataGrid/positronDataGrid.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/positronDataGrid.tsx
@@ -33,16 +33,7 @@ export const PositronDataGrid = forwardRef<HTMLDivElement, PositronDataGridProps
 	// Render.
 	return (
 		<PositronDataGridContextProvider {...props}>
-			<div
-				ref={ref}
-				id={props.id}
-				tabIndex={props.tabIndex}
-				className='data-grid'
-				onFocus={() =>
-					// Drive focus into the waffle.
-					dataGridWaffleRef.current.focus()
-				}
-			>
+			<div ref={ref} id={props.id} className='data-grid'>
 				<DataGridWaffle ref={dataGridWaffleRef} />
 			</div>
 		</PositronDataGridContextProvider>

--- a/src/vs/workbench/browser/positronDataGrid/positronDataGrid.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/positronDataGrid.tsx
@@ -18,6 +18,7 @@ import { PositronDataGridConfiguration, PositronDataGridContextProvider } from '
  */
 interface PositronDataGridProps extends PositronDataGridConfiguration {
 	id?: string;
+	tabIndex: number;
 }
 
 /**
@@ -35,7 +36,7 @@ export const PositronDataGrid = forwardRef<HTMLDivElement, PositronDataGridProps
 			<div
 				ref={ref}
 				id={props.id}
-				tabIndex={0}
+				tabIndex={props.tabIndex}
 				className='data-grid'
 				onFocus={() =>
 					// Drive focus into the waffle.

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -2197,8 +2197,8 @@ export const POSITRON_DATA_EXPLORER_STATUS_INDICATOR_DISCONNECTED = registerColo
 
 // Positron data explorer selection background color.
 export const POSITRON_DATA_EXPLORER_SELECTION_BACKGROUND_COLOR = registerColor('positronDataExplorer.selectionBackground', {
-	dark: lighten(editorBackground, 0.2),
-	light: darken(editorBackground, 0.05),
+	dark: lighten(editorBackground, 0.5),
+	light: darken(editorBackground, 0.075),
 	hcDark: editorBackground,
 	hcLight: editorBackground
 }, localize('positronDataExplorer.selectionBackground', "Positron data explorer selection background color."));

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
@@ -19,7 +19,7 @@
 .data-grid-row-cell
 .content
 .column-summary
-.cursor-background {
+.cursor {
 	top: 2px;
 	right: 2px;
 	bottom: 2px;
@@ -27,7 +27,14 @@
 	z-index: -1;
 	position: absolute;
 	border-radius: 4px;
-	background-color: var(--vscode-positronDataExplorer-selectionBackground);
+	background-color: var(--vscode-positronDataGrid-selectionBackground);
+}
+
+.data-grid-row-cell
+.content
+.column-summary
+.cursor:not(.focused) {
+	opacity: 50%;
 }
 
 .data-grid-row-cell

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -14,6 +14,7 @@ import { IHoverService } from 'vs/platform/hover/browser/hover';
 import { HoverPosition } from 'vs/base/browser/ui/hover/hoverWidget';
 import { positronClassNames } from 'vs/base/common/positronUtilities';
 import { ProfileDate } from 'vs/workbench/services/positronDataExplorer/browser/components/profileDate';
+import { usePositronDataGridContext } from 'vs/workbench/browser/positronDataGrid/positronDataGridContext';
 import { ProfileNumber } from 'vs/workbench/services/positronDataExplorer/browser/components/profileNumber';
 import { ProfileString } from 'vs/workbench/services/positronDataExplorer/browser/components/profileString';
 import { ProfileBoolean } from 'vs/workbench/services/positronDataExplorer/browser/components/profileBoolean';
@@ -40,6 +41,9 @@ interface ColumnSummaryCellProps {
  * @returns The rendered component.
  */
 export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
+	// Context hooks.
+	const context = usePositronDataGridContext();
+
 	// Reference hooks.
 	const dataTypeRef = useRef<HTMLDivElement>(undefined!);
 
@@ -88,7 +92,6 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 
 	// Set the profile component for the column.
 	const profile = (() => {
-
 		// Determine the alignment based on type.
 		switch (props.columnSchema.type_display) {
 			case ColumnDisplayType.Number:
@@ -160,6 +163,9 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		summarySupported = false;
 	}
 
+	// Determine whether this is the cursor.
+	const cursor = props.columnIndex === props.instance.cursorRowIndex;
+
 	// Render.
 	return (
 		<div
@@ -172,8 +178,13 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				props.instance.setCursorRow(props.columnIndex);
 			}}
 		>
-			{(mouseInside || props.columnIndex === props.instance.cursorRowIndex) &&
-				<div className='cursor-background' />
+			{(mouseInside || cursor) &&
+				<div
+					className={positronClassNames(
+						'cursor',
+						{ 'focused': context.instance.focused && cursor }
+					)}
+				/>
 			}
 			<div className='basic-info'>
 				<div


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR addresses focus management shortcomings in the Data Explorer component. 

https://github.com/posit-dev/positron/issues/3634

Prior to this PR, the Data Explorer component was not aware of where focus was inside the component and a user could not use Tab / Shift Tab (or mouse clicks) to move focus between the table summary and table data data grid instances.

Here's a screen capture of the focus management this PR adds:

https://github.com/posit-dev/positron/assets/853239/e94920f9-d3bc-43b5-9c49-e95d88433d62

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
