### PR TITLE
Run the yarn step with retry on Windows

### DIFF
--- a/.github/workflows/build-release-windows.yml
+++ b/.github/workflows/build-release-windows.yml
@@ -63,8 +63,14 @@ jobs:
           POSITRON_GITHUB_PAT: ${{ steps.app-token.outputs.token }}
         shell: pwsh
         # nvm on windows does not see .nvmrc
+        #
+        # the installation of the npm package windows-process-tree is known to fail
+        # intermittently in the Github Actions build environment, so we retry
+        # this step a few times if necessary.
+        #
+        # see https://github.com/posit-dev/positron/issues/3481
         run: |
-          yarn --network-timeout 120000
+          .\scripts\run-with-retry.ps1 -maxAttempts 3 -command "yarn --network-timeout 120000"
 
       - name: Build Positron
         env:

--- a/scripts/run-with-retry.ps1
+++ b/scripts/run-with-retry.ps1
@@ -1,0 +1,38 @@
+#---------------------------------------------------------------------------------------------
+#  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+#  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+#---------------------------------------------------------------------------------------------
+
+# Runs a command repeatedly until it succeeds, until a maximum number of attempts (default 3).
+
+param (
+    [int]$maxAttempts = 3,
+    [string]$command
+)
+
+if (-not $command) {
+    Write-Host "Error: You must specify a command to run."
+    exit 1
+}
+
+$attempt = 0
+$success = $false
+
+while ($attempt -lt $maxAttempts -and -not $success) {
+    try {
+        $attempt++
+
+        Invoke-Expression $command
+        $success = $true
+    }
+    catch {
+        # If the command fails, output an error message
+        Write-Host "Command '$command' failed on attempt $attempt of $maxAttempts"
+    }
+}
+
+# Check if the command was successful after the maximum attempts
+if (-not $success) {
+    Write-Host "Command '$command' failed after $maxAttempts attempts"
+}
+


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3481 with some duct tape: since we know that installing dependencies with `yarn` fails intermittently, we now retry this step up to three times before actually failing the build.

This isn't ideal, but it ought to be better than having to manually dig into Windows build failures, discover this problem, and replay the build by hand.

### QA Notes

N/A, this change is internal to the build system and doesn't affect the built release binaries. 