### PR TITLE
Fix icon colors as per Paul

### DIFF
--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1456,9 +1456,9 @@ export const POSITRON_SIDE_ACTION_BAR_BACKGROUND = registerColor('positronSideAc
 // Positron side action bar foreground color.
 export const POSITRON_SIDE_ACTION_BAR_FOREGROUND = registerColor('positronSideActionBar.foreground', {
 	dark: foreground,
-	light: '#75828D',
-	hcDark: '#ffffff',
-	hcLight: editorForeground
+	light: foreground,
+	hcDark: foreground,
+	hcLight: foreground
 }, localize('positronSideActionBar.foreground', "Positron side action bar foreground color."));
 
 // Positron side action bar disabled foreground color.


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

As described in https://github.com/posit-dev/positron/issues/3642, action bar icons were not the same color throughout the application. This resulted in:

![image](https://github.com/posit-dev/positron/assets/853239/384f63f2-a76e-41b2-a164-8d9751409b95)

With this PR, icons should match throughout the application.

<img width="266" alt="icons" src="https://github.com/posit-dev/positron/assets/853239/932243dc-dd71-4590-81f8-88286a81b799">
