### PR TITLE
Fix copyright headers to match new format in recently added tests

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/positron/runtime.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/positron/runtime.test.ts
@@ -1,5 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import * as positron from 'positron';

--- a/src/vs/workbench/services/languageRuntime/test/common/languageRuntime.test.ts
+++ b/src/vs/workbench/services/languageRuntime/test/common/languageRuntime.test.ts
@@ -1,5 +1,6 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';


### PR DESCRIPTION
This should pass the eslint rules for copyright headers.