### PR TITLE
Fix path comparison and include additional guidance when secrets detected

### DIFF
--- a/build/detect-secrets.js
+++ b/build/detect-secrets.js
@@ -94,6 +94,7 @@ const detectSecrets = (args, stdio) => {
 		printDebug(result);
 	} catch (error) {
 		printDebug(error);
+		throw error;
 	}
 };
 

--- a/build/detect-secrets.js
+++ b/build/detect-secrets.js
@@ -174,6 +174,9 @@ const runDetectSecretsHook = () => {
 		if (secretsFound) {
 			printDebug('detect-secrets-hook found secrets in the staged files or there was an issue with the .secrets.baseline file.');
 			console.error(error.stdout.toString().red);
+			console.error('Uh oh! If have secrets in your code, please remove them before committing.'.magenta);
+			console.error(`If you are certain that these are false positives, see ${'build/secrets/README.md'.underline} for instructions on how to mark them as such.`.magenta);
+			console.error(); // print newline
 			process.exit(ExitCodes.FOUND_SECRETS_OR_BASELINE_ISSUE);
 		}
 		printDebug(`An error occurred while running detect-secrets-hook: ${error.status}`);

--- a/build/detect-secrets.js
+++ b/build/detect-secrets.js
@@ -79,8 +79,7 @@ const argCount = process.argv.length - (debugFlag ? 1 : 0);
 const tooManyArgs = argCount > 3;
 if (tooManyArgs) {
 	console.error(`${'Error:'.red} Too many arguments. Please only specify one command.`);
-	console.log(); // print newline
-	console.log(usage);
+	console.log(`\n${usage}`);
 	process.exit(ExitCodes.DETECT_SECRETS_WRAPPER_ERROR);
 }
 
@@ -98,9 +97,7 @@ const detectSecrets = (args, stdio, throwIfError = false) => {
 			throw error;
 		} else {
 			// print error and exit with the error code
-			console.error(); // print newline
-			console.error(error.toString().red);
-			console.error(); // print newline
+			console.error(`\n${error.toString().red}\n`);
 			process.exit(`${ExitCodes.DETECT_SECRETS_ERROR}${error.status}`);
 		}
 	}
@@ -122,9 +119,7 @@ try {
 	detectSecrets('--version', stdio = 'pipe', throwIfError = true);
 } catch (error) {
 	printDebug(error);
-	console.error(); // print newline
-	console.error(`${'Error:'.red} detect-secrets is not installed. Install detect-secrets with ${'pip install detect-secrets'.magenta} or ${'brew install detect-secrets'.magenta}.`);
-	console.error(); // print newline
+	console.error(`\n${'Error:'.red} detect-secrets is not installed. Install detect-secrets with ${'pip install detect-secrets'.magenta} or ${'brew install detect-secrets'.magenta}.\n`);
 	process.exit(ExitCodes.DETECT_SECRETS_WRAPPER_ERROR);
 }
 
@@ -145,10 +140,10 @@ const baselineFileExists = () => {
 // Ensure that the baseline file exists and exit if it does not
 const ensureBaselineFileExists = () => {
 	if (!baselineFileExists()) {
-		console.error(); // print newline
-		console.error(`Error: Baseline file ${baselineFile.underline} does not exist.`.red);
-		console.error(`Run ${'node build/detect-secrets.js init-baseline'.magenta} to create it.`);
-		console.error(); // print newline
+		console.error(
+			`\nError: Baseline file ${baselineFile.underline} does not exist.\n`.red +
+			`Run ${'node build/detect-secrets.js init-baseline'.magenta} to create it.\n`
+		);
 		process.exit(ExitCodes.DETECT_SECRETS_WRAPPER_ERROR);
 	}
 	return;
@@ -181,21 +176,21 @@ const runDetectSecretsHook = () => {
 		}
 		const hookCommand = `detect-secrets-hook ${noVerify} --baseline ${baselineFile} ${excludeFilesOption} ${stagedFiles}`;
 		printDebug(hookCommand, true);
+		// pipe the stdio so we can handle the output in case of an error
 		const result = execSync(hookCommand, stdio = 'pipe');
 		printDebug(result);
 	} catch (error) {
 		const secretsFound = error.status === 1;
 		if (secretsFound) {
 			printDebug('detect-secrets-hook found secrets in the staged files or there was an issue with the .secrets.baseline file.');
-			console.error(); // print newline
 			// prints the secret detection output from detect-secrets-hook
 			if (error.stdout) {
-				console.error(error.stdout.toString().red);
+				console.error(`\n${error.stdout.toString().red}`);
 			}
 			// print guidance on how to manage the possible secrets
-			console.error('Uh oh! If you have secrets in your code, please remove them before committing.'.magenta);
-			console.error(`If you are certain that these are false positives, see ${'build/secrets/README.md'.underline} for instructions on how to mark them as such.`.magenta);
-			console.error(); // print newline
+			console.error(
+				'\nUh oh! If you have secrets in your code, please remove them before committing.\n'.magenta +
+				`If you are certain that these are false positives, see ${'build/secrets/README.md'.underline} for instructions on how to mark them as such.\n`.magenta);
 			process.exit(ExitCodes.FOUND_SECRETS_OR_BASELINE_ISSUE);
 		}
 		printDebug(`An error occurred while running detect-secrets-hook: ${error.status}`);

--- a/build/detect-secrets.js
+++ b/build/detect-secrets.js
@@ -41,10 +41,12 @@ const execSync = (command, stdio = ['inherit', 'pipe', 'inherit']) => {
 try {
 	const gitCommand = 'git rev-parse --show-toplevel';
 	printDebug(gitCommand, true);
-	const gitRepoRoot = execSync(gitCommand);
+	const gitRepoRoot = execSync(gitCommand).trim();
 	printDebug(gitRepoRoot);
 	printDebug('current working directory: ' + process.cwd());
-	if (process.cwd().trim() !== gitRepoRoot.trim()) {
+	// check if two paths are the same
+	const currentDir = process.cwd().trim();
+	if (path.resolve(currentDir) !== path.resolve(gitRepoRoot)) {
 		console.error(`${'Error:'.red} Please run this script from the root of the git repository.`);
 		process.exit(ExitCodes.DETECT_SECRETS_WRAPPER_ERROR);
 	}

--- a/build/detect-secrets.js
+++ b/build/detect-secrets.js
@@ -46,7 +46,9 @@ try {
 	const currentDir = process.cwd().trim();
 	printDebug('current working directory: ' + currentDir);
 	if (path.resolve(currentDir) !== path.resolve(gitRepoRoot)) {
-		console.error(`${'Error:'.red} Please run this script from the root of the git repository.`);
+		console.error(
+			`${'Error:'.red} Please run this script from the root of the git repository.`
+		);
 		process.exit(ExitCodes.DETECT_SECRETS_WRAPPER_ERROR);
 	}
 } catch (error) {
@@ -116,10 +118,13 @@ const detectSecretsScan = (args, stdio) => {
 // Ensure that detect-secrets is installed
 try {
 	// pipe the stdio so we print our own error message if detect-secrets is not installed
-	detectSecrets('--version', stdio = 'pipe', throwIfError = true);
+	detectSecrets('--version', (stdio = 'pipe'), (throwIfError = true));
 } catch (error) {
 	printDebug(error);
-	console.error(`\n${'Error:'.red} detect-secrets is not installed. Install detect-secrets with ${'pip install detect-secrets'.magenta} or ${'brew install detect-secrets'.magenta}.\n`);
+	console.error(
+		`\n${'Error:'.red} detect-secrets is not installed. Install detect-secrets with ${'pip install detect-secrets'.magenta
+		} or ${'brew install detect-secrets'.magenta}.\n`
+	);
 	process.exit(ExitCodes.DETECT_SECRETS_WRAPPER_ERROR);
 }
 
@@ -157,7 +162,10 @@ const getStagedFiles = () => {
 		printDebug(diffCommand, true);
 		// Split the output by null characters and remove empty strings, then join the files with a
 		// space so that they can be passed as arguments to detect-secrets-hook
-		const diffOutput = execSync(diffCommand).split('\0').filter(x => !!x).join(' ');
+		const diffOutput = execSync(diffCommand)
+			.split('\0')
+			.filter((x) => !!x)
+			.join(' ');
 		printDebug(diffOutput);
 		return diffOutput;
 	} catch (error) {
@@ -177,20 +185,25 @@ const runDetectSecretsHook = () => {
 		const hookCommand = `detect-secrets-hook ${noVerify} --baseline ${baselineFile} ${excludeFilesOption} ${stagedFiles}`;
 		printDebug(hookCommand, true);
 		// pipe the stdio so we can handle the output in case of an error
-		const result = execSync(hookCommand, stdio = 'pipe');
+		const result = execSync(hookCommand, (stdio = 'pipe'));
 		printDebug(result);
 	} catch (error) {
 		const secretsFound = error.status === 1;
 		if (secretsFound) {
-			printDebug('detect-secrets-hook found secrets in the staged files or there was an issue with the .secrets.baseline file.');
+			printDebug(
+				'detect-secrets-hook found secrets in the staged files or there was an issue with the .secrets.baseline file.'
+			);
 			// prints the secret detection output from detect-secrets-hook
 			if (error.stdout) {
 				console.error(`\n${error.stdout.toString().red}`);
 			}
 			// print guidance on how to manage the possible secrets
 			console.error(
-				'\nUh oh! If you have secrets in your code, please remove them before committing.\n'.magenta +
-				`If you are certain that these are false positives, see ${'build/secrets/README.md'.underline} for instructions on how to mark them as such.\n`.magenta);
+				'\nUh oh! If you have secrets in your code, please remove them before committing.\n'
+					.magenta +
+				`If you are certain that these are false positives, see ${'build/secrets/README.md'.underline
+					} for instructions on how to mark them as such.\n`.magenta
+			);
 			process.exit(ExitCodes.FOUND_SECRETS_OR_BASELINE_ISSUE);
 		}
 		printDebug(`An error occurred while running detect-secrets-hook: ${error.status}`);
@@ -218,9 +231,9 @@ const excludeFiles = [
 	'.*cgmanifest.json',
 	'.*/html-manager/dist/embed-amd.js',
 	'src/vs/base/test/common/filters.perf.data.js',
-	'.*/test/browser/recordings/windows11.*'
+	'.*/test/browser/recordings/windows11.*',
 ];
-const excludeFilesOption = excludeFiles.map(file => `--exclude-files '${file}'`).join(' ');
+const excludeFilesOption = excludeFiles.map((file) => `--exclude-files '${file}'`).join(' ');
 printDebug(`Excluding files: ${excludeFilesOption}`);
 
 // Run the appropriate command
@@ -231,17 +244,19 @@ switch (command) {
 			// notify the user that the file already exists and ask if they want to overwrite it
 			const rl = readline.createInterface({
 				input: process.stdin,
-				output: process.stdout
+				output: process.stdout,
 			});
 			rl.question(
-				`${'Warning:'.yellow
-				} Baseline file ${baselineFile.underline} already exists.\nWould you like to overwrite it? ${'You will lose any marked false positives'.yellow
+				`${'Warning:'.yellow} Baseline file ${baselineFile.underline
+				} already exists.\nWould you like to overwrite it? ${'You will lose any marked false positives'.yellow
 				}. (y/n): `,
 				(answer) => {
 					rl.close();
 					if (answer.toLowerCase() === 'y') {
 						console.log('\tOverwriting existing baseline file...');
-						const scanTime = detectSecretsScan(`${noVerify} ${excludeFilesOption} > ${baselineFile}`);
+						const scanTime = detectSecretsScan(
+							`${noVerify} ${excludeFilesOption} > ${baselineFile}`
+						);
 						console.log(`\tBaseline file initialized in ${scanTime} seconds.`);
 					} else {
 						console.log('\tNot overwriting baseline file. Exiting.');
@@ -250,7 +265,9 @@ switch (command) {
 				}
 			);
 		} else {
-			const scanTime = detectSecretsScan(`${noVerify} ${excludeFilesOption} > ${baselineFile}`);
+			const scanTime = detectSecretsScan(
+				`${noVerify} ${excludeFilesOption} > ${baselineFile}`
+			);
 			console.log(`\tBaseline file initialized in ${scanTime} seconds.`);
 		}
 		break;
@@ -259,13 +276,15 @@ switch (command) {
 		console.log(`Auditing detect-secrets baseline file ${baselineFile.underline}...`);
 		ensureBaselineFileExists();
 		// inherit the stdio so that the user can interact with the audit process
-		detectSecrets(`audit ${baselineFile}`, stdio = 'inherit');
+		detectSecrets(`audit ${baselineFile}`, (stdio = 'inherit'));
 		break;
 	case 'update-baseline': {
 		console.log(`Updating detect-secrets baseline file ${baselineFile.underline}...`);
 		ensureBaselineFileExists();
 		// --force-use-all-plugins ensures that new plugins are picked up and used to update the baseline file
-		const scanTime = detectSecretsScan(`${noVerify} ${excludeFilesOption} --baseline ${baselineFile} --force-use-all-plugins`);
+		const scanTime = detectSecretsScan(
+			`${noVerify} ${excludeFilesOption} --baseline ${baselineFile} --force-use-all-plugins`
+		);
 		console.log(`\tBaseline file updated in ${scanTime} seconds.`);
 		break;
 	}
@@ -280,6 +299,9 @@ switch (command) {
 		runDetectSecretsHook();
 		break;
 	default:
-		console.error(`${'Error:'.red} Invalid command ${command}. Run ${'node build/detect-secrets.js help'.magenta} for a list of commands.`);
+		console.error(
+			`${'Error:'.red} Invalid command ${command}. Run ${'node build/detect-secrets.js help'.magenta
+			} for a list of commands.`
+		);
 		break;
 }

--- a/build/detect-secrets.js
+++ b/build/detect-secrets.js
@@ -94,7 +94,7 @@ const detectSecrets = (args, stdio, throwIfError = false) => {
 	} catch (error) {
 		printDebug(error);
 		if (throwIfError) {
-		// throw error to handle it in the calling function
+			// throw error to handle it in the calling function
 			throw error;
 		} else {
 			// print error and exit with the error code
@@ -118,6 +118,7 @@ const detectSecretsScan = (args, stdio) => {
 
 // Ensure that detect-secrets is installed
 try {
+	// pipe the stdio so we print our own error message if detect-secrets is not installed
 	detectSecrets('--version', stdio = 'pipe', throwIfError = true);
 } catch (error) {
 	printDebug(error);
@@ -209,7 +210,8 @@ const runDetectSecretsHook = () => {
 };
 
 // --no-verify is used to skip additional secret verification via a network call
-// If it is specified for creating the baseline file, it should also be specified for updating the baseline file
+// (it is not related to the similarly named git option to skip hooks)
+// If it is specified for creating the baseline file, it should also be specified for updating the baseline file and running the hook
 const noVerify = '--no-verify';
 
 // Exclude external files (third-party libraries, etc.) from the baseline file
@@ -261,6 +263,7 @@ switch (command) {
 	case 'audit-baseline':
 		console.log(`Auditing detect-secrets baseline file ${baselineFile.underline}...`);
 		ensureBaselineFileExists();
+		// inherit the stdio so that the user can interact with the audit process
 		detectSecrets(`audit ${baselineFile}`, stdio = 'inherit');
 		break;
 	case 'update-baseline': {

--- a/build/detect-secrets.js
+++ b/build/detect-secrets.js
@@ -112,7 +112,9 @@ const detectSecretsScan = (args, stdio) => {
 try {
 	detectSecrets('--version');
 } catch (error) {
+	console.error(); // print newline
 	console.error(`${'Error:'.red} detect-secrets is not installed. Install detect-secrets with ${'pip install detect-secrets'.magenta} or ${'brew install detect-secrets'.magenta}.`);
+	console.error(); // print newline
 	process.exit(ExitCodes.DETECT_SECRETS_WRAPPER_ERROR);
 }
 

--- a/build/detect-secrets.js
+++ b/build/detect-secrets.js
@@ -20,7 +20,7 @@ const ExitCodes = {
 	SUCCESS: 0,                         // success
 	FOUND_SECRETS_OR_BASELINE_ISSUE: 1, // detect-secrets-hook found secrets or encountered a baseline file issue
 	DETECT_SECRETS_WRAPPER_ERROR: 2,    // an error occurred in this script
-	DETECT_SECRETS_ERROR: 999,          // an error occurred in detect-secrets (detect-secrets status code is appended)
+	DETECT_SECRETS_ERROR: 3,            // an error occurred in detect-secrets
 };
 
 // Debug print handling
@@ -100,7 +100,7 @@ const detectSecrets = (args, stdio, throwIfError = false) => {
 		} else {
 			// print error and exit with the error code
 			console.error(`\n${error.toString().red}\n`);
-			process.exit(`${ExitCodes.DETECT_SECRETS_ERROR}${error.status}`);
+			process.exit(ExitCodes.DETECT_SECRETS_ERROR);
 		}
 	}
 };
@@ -213,7 +213,7 @@ const runDetectSecretsHook = () => {
 		if (error.stderr) {
 			console.error(error.stderr.toString().red);
 		}
-		process.exit(`${ExitCodes.DETECT_SECRETS_ERROR}${error.status}`);
+		process.exit(ExitCodes.DETECT_SECRETS_ERROR);
 	}
 };
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

- Addresses: https://github.com/posit-dev/positron/issues/3413#issuecomment-2195084061

### Fixes in this PR

- Fix path comparison issue on Windows
- Note in console output that `detect-secrets` should be installed if it isn't already
    <img width="887" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/76241822-ed7e-4d75-a8ed-902198133175">

- Add some guidance on what actions to take when secrets are detected
    <img width="879" alt="image" src="https://github.com/posit-dev/positron/assets/25834218/8e80c8e9-199d-40fd-96e9-ce376718fd3c">

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

See https://github.com/posit-dev/positron/pull/3618 for more detail on testing and some example secrets to try.

#### Suggested tests
- test the hook on Windows
- test the hook without detect-secrets installed
- some new output should show when secrets are detected, which guide the user to remove the secrets / mark them as false positives / consult the secrets README
