### PR TITLE
Data Explorer: Add polars sorting and row filtering speed up get_data_values, process schema changes to invalidate filters and sort columns

### DIFF
--- a/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
@@ -7,6 +7,7 @@ numpy==1.26.3; python_version >= '3.9'
 numpy==1.24.4; python_version < '3.9'
 pandas==2.2.0; python_version >= '3.9'
 pandas==2.0.3; python_version < '3.9'
+pyarrow==16.1.0
 pytest==8.0.2
 pytest-asyncio==0.23.5
 pytest-mock==3.12.0

--- a/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
@@ -12,6 +12,6 @@ pytest==8.0.2
 pytest-asyncio==0.23.5
 pytest-mock==3.12.0
 polars==0.20.31; python_version >= '3.9'
-polars[timezone]==0.20.13; python_version < '3.9' or sys_platform == 'win32'
+polars[timezone]==0.20.31; python_version < '3.9' or sys_platform == 'win32'
 torch==2.1.2; python_version < '3.12'
 sqlalchemy==2.0.28

--- a/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
@@ -11,7 +11,7 @@ pyarrow==16.1.0
 pytest==8.0.2
 pytest-asyncio==0.23.5
 pytest-mock==3.12.0
-polars==0.20.13; python_version >= '3.9'
+polars==0.20.31; python_version >= '3.9'
 polars[timezone]==0.20.13; python_version < '3.9' or sys_platform == 'win32'
 torch==2.1.2; python_version < '3.12'
 sqlalchemy==2.0.28

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -792,7 +792,7 @@ class PandasView(DataExplorerTableView):
 
         # TODO: pandas MultiIndex columns
         # TODO: time zone for datetimetz datetime64[ns] types
-        if dtype == object:
+        if dtype == object:  # noqa: E721
             type_name = get_inferred_dtype()
             type_name = cls.TYPE_NAME_MAPPING.get(type_name, type_name)
         else:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -1781,7 +1781,7 @@ class PolarsView(DataExplorerTableView):
             ],
         ),
         export_data_selection=ExportDataSelectionFeatures(support_status=SupportStatus.Unsupported),
-        set_sort_columns=SetSortColumnsFeatures(support_status=SupportStatus.Unsupported),
+        set_sort_columns=SetSortColumnsFeatures(support_status=SupportStatus.Supported),
     )
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -23,7 +23,6 @@ from typing import (
 )
 
 import comm
-import pytz
 
 from .access_keys import decode_access_key
 from .data_explorer_comm import (
@@ -1432,6 +1431,8 @@ _ISO_8601_FORMATS = [
 
 
 def _parse_iso8601_like(x, tz=None):
+    import pytz
+
     for fmt in _ISO_8601_FORMATS:
         try:
             result = datetime.strptime(x, fmt)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -1720,9 +1720,14 @@ class PolarsView(DataExplorerTableView):
                 num_rows = len(self.table)
 
             # Do a stable sort of the indices using the columns as sort keys
-            to_sort = pl_.DataFrame({indexer_name: pl_.arange(num_rows, eager=True)}).sort(
-                cols_to_sort, descending=directions, maintain_order=True
-            )
+            to_sort = pl_.DataFrame({indexer_name: pl_.arange(num_rows, eager=True)})
+
+            try:
+                to_sort = to_sort.sort(cols_to_sort, descending=directions, maintain_order=True)
+            except TypeError:
+                # Older versions of polars do not have maintain_order
+                to_sort = to_sort.sort(cols_to_sort, descending=directions)
+
             sort_indexer = to_sort[indexer_name]
             if self.filtered_indices is not None:
                 # Create the filtered, sorted virtual view indices

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/matplotlib_backend.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/matplotlib_backend.py
@@ -166,7 +166,6 @@ class FigureCanvasPositron(FigureCanvasAgg):
         self.figure.set_size_inches(width_in, height_in, forward=False)
 
         # Render the canvas.
-        figure_buffer = io.BytesIO()
         with io.BytesIO() as figure_buffer:
             self.print_figure(
                 figure_buffer,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -491,7 +491,9 @@ class PositronIPyKernel(IPythonKernel):
                     child.wait(timeout=0)
                 except psutil.TimeoutExpired as exception:
                     self.log.warning(
-                        "Error while reaping zombie subprocess %s: %s", child, exception
+                        "Error while reaping zombie subprocess %s: %s",
+                        child,
+                        exception,
                     )
 
     # monkey patching warning.showwarning is recommended by the official documentation

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
@@ -18,6 +18,9 @@ from positron_ipykernel.positron_ipkernel import (
 )
 from positron_ipykernel.session_mode import SessionMode
 from positron_ipykernel.variables import VariablesService
+import positron_ipykernel.utils as utils
+
+utils.TESTING = True
 
 
 class DummyComm(comm.base_comm.BaseComm):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -2329,6 +2329,7 @@ def test_polars_get_state(dxf: DataExplorerFixture):
     features = state["supported_features"]
     assert features["search_schema"]["support_status"] == SupportStatus.Unsupported
     assert features["set_row_filters"]["support_status"] == SupportStatus.Supported
+    assert features["set_sort_columns"]["support_status"] == SupportStatus.Supported
     assert features["get_column_profiles"]["support_status"] == SupportStatus.Supported
     assert features["get_column_profiles"]["supported_types"] == [
         ColumnProfileTypeSupportStatus(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
@@ -33,6 +33,9 @@ JsonRecord = Dict[str, JsonData]
 T = TypeVar("T")
 
 
+TESTING = False
+
+
 def get_qualname(value: Any) -> str:
     """
     Utility to manually construct a qualified type name as

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -49,7 +49,6 @@ from .variables_comm import (
     VariablesFrontendEvent,
     ViewRequest,
 )
-from . import utils
 
 if TYPE_CHECKING:
     from .positron_ipkernel import PositronIPyKernel
@@ -150,8 +149,6 @@ class VariablesService:
 
         else:
             logger.warning(f"Unhandled request: {request}")
-            if utils.TESTING:
-                raise NotImplementedError(request)
 
     def _send_update(
         self,
@@ -277,8 +274,6 @@ class VariablesService:
             self._send_update(assigned, unevaluated, removed)
         except Exception as err:
             logger.warning(err, exc_info=True)
-            if utils.TESTING:
-                raise
 
     def snapshot_user_ns(self) -> None:
         """

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -49,6 +49,7 @@ from .variables_comm import (
     VariablesFrontendEvent,
     ViewRequest,
 )
+from . import utils
 
 if TYPE_CHECKING:
     from .positron_ipkernel import PositronIPyKernel
@@ -149,6 +150,8 @@ class VariablesService:
 
         else:
             logger.warning(f"Unhandled request: {request}")
+            if utils.TESTING:
+                raise NotImplementedError(request)
 
     def _send_update(
         self,
@@ -274,6 +277,8 @@ class VariablesService:
             self._send_update(assigned, unevaluated, removed)
         except Exception as err:
             logger.warning(err, exc_info=True)
+            if utils.TESTING:
+                raise
 
     def snapshot_user_ns(self) -> None:
         """

--- a/extensions/positron-python/python_files/positron/test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/test-requirements.txt
@@ -6,6 +6,7 @@ numpy
 pandas
 polars; python_version >= '3.9'
 polars[timezone]; python_version < '3.9' or sys_platform == 'win32'
+pyarrow
 pytest<8.1.1
 pytest-asyncio
 pytest-mock


### PR DESCRIPTION
Addresses polars support items #3451, #3452, #3761 and did some refactoring for better code reuse. 

I also realized that pydantic validation (and subsequent conversion back to a raw dict for going over the comm interface) of `get_data_values` requests was adding extra overhead that is not so useful in practice, so I have bypassed this validation to make these requests a lot faster. 

### QA Notes

Run same sorting and filter workflows that you would with pandas. 