### PR TITLE
Guard against potential quotes surrounding `R_HOME_DIR` path

### DIFF
--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -6,7 +6,7 @@
 import * as semver from 'semver';
 import * as path from 'path';
 import * as fs from 'fs';
-import { extractValue, readLines } from './util';
+import { extractValue, readLines, removeSurroundingQuotes } from './util';
 import { LOGGER } from './extension';
 import { MINIMUM_R_VERSION } from './constants';
 
@@ -161,7 +161,8 @@ function getRHomePathNotWindows(binPath: string): string | undefined {
 	// macOS: R_HOME_DIR=/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
 	// macOS non-orthogonal: R_HOME_DIR=/Library/Frameworks/R.framework/Resources
 	// linux: R_HOME_DIR=/opt/R/4.2.3/lib/R
-	const R_HOME_DIR = extractValue(targetLine, 'R_HOME_DIR');
+	// On linux we have seen the path surrounded with double quotes, which must be removed (#3696).
+	const R_HOME_DIR = removeSurroundingQuotes(extractValue(targetLine, 'R_HOME_DIR'));
 	const homepath = R_HOME_DIR;
 	if (homepath === '') {
 		LOGGER.info(`Can\'t determine R_HOME_DIR from the binary: ${binPath}`);

--- a/extensions/positron-r/src/util.ts
+++ b/extensions/positron-r/src/util.ts
@@ -64,3 +64,15 @@ export function removeLeadingLines(x: string, pattern: RegExp): string {
 
 	return output.join('\n');
 }
+
+export function removeSurroundingQuotes(x: string): string {
+	const hasQuotes =
+		(x.startsWith('"') && x.endsWith('"')) ||
+		(x.startsWith('\'') && x.endsWith('\''));
+
+	if (hasQuotes) {
+		x = x.slice(1, x.length - 1);
+	}
+
+	return x;
+}


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3696

We aren't sure why, but that particular custom install of R on Linux had `R_HOME_DIR="<path>"` with literal `"` double quotes. We haven't seen that elsewhere, normally its just a "bare" path. That causes our downstream path generation to break.

I can't seem to figure out why R would generate it this way (from looking at the sources here: https://github.com/wch/r-source/blob/9d01d16b4cda7b53b9a2c94a1e3f078faf1b9eaa/src/scripts/Makefile.in#L79), but I figure it is best for us to guard against the possibility of it by removing them.

Tested this myself by manually adjusting my R shell script to include `"` quotes in the `R_HOME_DIR` path, noted that it did break Positron, applied the patch and retested and it worked.