### PR TITLE
Remove PAT from PR CI now that ark repo is public

### DIFF
--- a/.github/workflows/positron-ci.yml
+++ b/.github/workflows/positron-ci.yml
@@ -32,19 +32,10 @@ jobs:
         with:
           node-version: 20
 
-      - name: Create access token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
-          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: Execute yarn
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
-          POSITRON_GITHUB_PAT: ${{ steps.app-token.outputs.token }}
         run: |
           # Install Yarn
           npm install -g yarn

--- a/extensions/positron-r/scripts/install-kernel.ts
+++ b/extensions/positron-r/scripts/install-kernel.ts
@@ -62,47 +62,16 @@ async function getLocalArkVersion(): Promise<string | null> {
 }
 
 /**
- * Helper to execute a command and return the stdout and stderr.
- *
- * @param command The command to execute.
- * @param stdin Optional stdin to pass to the command.
- * @returns A promise that resolves with the stdout and stderr of the command.
- */
-async function executeCommand(command: string, stdin?: string):
-	Promise<{ stdout: string; stderr: string }> {
-	const { exec } = require('child_process');
-	return new Promise((resolve, reject) => {
-		const process = exec(command, (error: any, stdout: string, stderr: string) => {
-			if (error) {
-				reject(error);
-			} else {
-				resolve({ stdout, stderr });
-			}
-		});
-		if (stdin) {
-			process.stdin.write(stdin);
-			process.stdin.end();
-		}
-	});
-}
-
-/**
  * Downloads the specified version of Ark and replaces the local binary.
  *
  * @param version The version of Ark to download.
- * @param githubPat A Github Personal Access Token with the appropriate rights
- *  to download the release.
- * @param gitCredential Whether the PAT originated from the `git credential` command.
  */
-async function downloadAndReplaceArk(version: string,
-	githubPat: string,
-	gitCredential: boolean): Promise<void> {
+async function downloadAndReplaceArk(version: string): Promise<void> {
 
 	try {
 		const requestOptions: https.RequestOptions = {
 			headers: {
 				'Accept': 'application/vnd.github.v3.raw', // eslint-disable-line
-				'Authorization': `token ${githubPat}`,     // eslint-disable-line
 				'User-Agent': 'positron-ark-downloader'    // eslint-disable-line
 			},
 			method: 'GET',
@@ -112,52 +81,6 @@ async function downloadAndReplaceArk(version: string,
 		};
 
 		const response = await httpsGetAsync(requestOptions as any) as any;
-
-		// Special handling for PATs originating from `git credential`.
-		if (gitCredential && response.statusCode === 200) {
-			// If the PAT hasn't been approved yet, do so now. This stores the credential in
-			// the system credential store (or whatever `git credential` uses on the system).
-			// Without this step, the user will be prompted for a username and password the
-			// next time they try to download Ark.
-			const { stdout, stderr } =
-				await executeCommand('git credential approve',
-					`protocol=https\n` +
-					`host=github.com\n` +
-					`path=/repos/posit-dev/ark/releases\n` +
-					`username=\n` +
-					`password=${githubPat}\n`);
-			console.log(stdout);
-			if (stderr) {
-				console.warn(`Unable to approve PAT. You may be prompted for a username and ` +
-					`password the next time you download Ark.`);
-				console.error(stderr);
-			}
-		} else if (gitCredential && response.statusCode > 400 && response.statusCode < 500) {
-			// This handles the case wherein we got an invalid PAT from `git credential`. In this
-			// case we need to clean up the PAT from the credential store, so that we don't
-			// continue to use it.
-			const { stdout, stderr } =
-				await executeCommand('git credential reject',
-					`protocol=https\n` +
-					`host=github.com\n` +
-					`path=/repos/posit-dev/ark/releases\n` +
-					`username=\n` +
-					`password=${githubPat}\n`);
-			console.log(stdout);
-			if (stderr) {
-				console.error(stderr);
-				throw new Error(`The stored PAT returned by 'git credential' is invalid, but\n` +
-					`could not be removed. Please manually remove the PAT from 'git credential'\n` +
-					`for the host 'github.com'`);
-			}
-			throw new Error(`The PAT returned by 'git credential' is invalid. Ark cannot be\n` +
-				`downloaded.\n\n` +
-				`Check to be sure that your Personal Access Token:\n` +
-				'- Has the `repo` scope\n' +
-				'- Is not expired\n' +
-				'- Has been authorized for the "posit-dev" organization on Github (Configure SSO)\n');
-		}
-
 		let responseBody = '';
 
 		response.on('data', (chunk: any) => {
@@ -202,7 +125,6 @@ async function downloadAndReplaceArk(version: string,
 			const requestOptions: https.RequestOptions = {
 				headers: {
 					'Accept': 'application/octet-stream',    // eslint-disable-line
-					'Authorization': `token ${githubPat}`,   // eslint-disable-line
 					'User-Agent': 'positron-ark-downloader'  // eslint-disable-line
 				},
 				method: 'GET',
@@ -294,82 +216,7 @@ async function main() {
 		return;
 	}
 
-	// We need a Github Personal Access Token (PAT) to download Ark. Because this is sensitive
-	// information, there are a lot of ways to set it. We try the following in order:
-
-	// (1) The GITHUB_PAT environment variable.
-	// (2) The POSITRON_GITHUB_PAT environment variable.
-	// (3) The git config setting 'credential.https://api.github.com.token'.
-	// (4) The git credential store.
-
-	// (1) Get the GITHUB_PAT from the environment.
-	let githubPat = process.env.GITHUB_PAT;
-	let gitCredential = false;
-	if (githubPat) {
-		console.log('Using Github PAT from environment variable GITHUB_PAT.');
-	} else {
-		// (2) Try POSITRON_GITHUB_PAT (it's what the build script sets)
-		githubPat = process.env.POSITRON_GITHUB_PAT;
-		if (githubPat) {
-			console.log('Using Github PAT from environment variable POSITRON_GITHUB_PAT.');
-		}
-	}
-
-	// (3) If no GITHUB_PAT is set, try to get it from git config. This provides a
-	// convenient non-interactive way to set the PAT.
-	if (!githubPat) {
-		try {
-			const { stdout, stderr } =
-				await executeCommand('git config --get credential.https://api.github.com.token');
-			githubPat = stdout.trim();
-			if (githubPat) {
-				console.log(`Using Github PAT from git config setting ` +
-					`'credential.https://api.github.com.token'.`);
-			}
-		} catch (error) {
-			// We don't care if this fails; we'll try `git credential` next.
-		}
-	}
-
-	// (4) If no GITHUB_PAT is set, try to get it from git credential.
-	if (!githubPat) {
-		// Explain to the user what's about to happen.
-		console.log(`Attempting to retrieve a Github Personal Access Token from git in order\n` +
-			`to download Ark ${packageJsonVersion}. If you are prompted for a username and\n` +
-			`password, enter your Github username and a Personal Access Token with the\n` +
-			`'repo' scope. You can read about how to create a Personal Access Token here: \n` +
-			`\n` +
-			`https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens\n` +
-			`\n` +
-			`If you don't want to set up a Personal Access Token now, just press Enter twice to set \n` +
-			`a blank value for the password. Ark will not be downloaded, but you will still be\n` +
-			`able to run Positron without R support.\n` +
-			`\n` +
-			`You can set a PAT later by running yarn again and supplying the PAT at this prompt,\n` +
-			`or by running 'git config credential.https://api.github.com.token YOUR_GITHUB_PAT'\n`);
-		const { stdout, stderr } =
-			await executeCommand('git credential fill',
-				`protocol=https\n` +
-				`host=github.com\n` +
-				`path=/repos/posit-dev/ark/releases\n`);
-
-		gitCredential = true;
-		// Extract the `password = ` line from the output.
-		const passwordLine = stdout.split('\n').find(
-			(line: string) => line.startsWith('password='));
-		if (passwordLine) {
-			githubPat = passwordLine.split('=')[1];
-			console.log(`Using Github PAT returned from 'git credential'.`);
-		}
-	}
-
-	if (!githubPat) {
-		console.log(`No Github PAT was found. Unable to download Ark ${packageJsonVersion}.\n` +
-			`You can still run Positron without R support.`);
-		return;
-	}
-
-	await downloadAndReplaceArk(packageJsonVersion, githubPat, gitCredential);
+	await downloadAndReplaceArk(packageJsonVersion);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
When building the positron-r extension, we can download releases of ARK without an auth token now that the repo is public.

By not needing a token, our CI workflows for PRs should be possible to run on those made from forks too.

Addresses #3739

### QA Notes

If the CI workflow for this PR passes, we should be good to go.