### PR TITLE
Use more portable paths in R formatter

### DIFF
--- a/extensions/positron-r/src/formatting.ts
+++ b/extensions/positron-r/src/formatting.ts
@@ -61,7 +61,7 @@ class FormatterProvider implements vscode.DocumentFormattingEditProvider {
 		const originalSource = document.getText(range);
 		const tempdir = os.tmpdir();
 		const fileToStyle = 'styler-' + randomUUID() + '.R';
-		const stylerPath = path.join(tempdir, fileToStyle);
+		const stylerPath = path.join(tempdir, fileToStyle).replace(/\\/g, '/');
 		fs.writeFileSync(stylerPath, originalSource);
 
 		// A promise that resolves when the runtime is idle:


### PR DESCRIPTION
Addresses #3690 in the same manner as we did #2194

### QA Notes

This needs to be checked/tested on Windows.

Take some malformed R code like so:

```r
fn <- function() {
  x <- 1
y <- 2
  x + y
}
```

And then use "Format Document" or (if selected) "Format Selection" from the command palette.