### PR TITLE
Re-enable weekday cron schedule for releases

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -2,9 +2,8 @@ name: "Positron: Build Release"
 
 # Run builds daily at 2am UTC (10p EST) on weekdays for now, or manually
 on:
-  # Daily builds temporarily disabled
-  # schedule:
-  #   - cron: "0 2 * * 1-5"
+  schedule:
+    - cron: "0 2 * * 1-5"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Resumes building Positron each weekday at 2am UTC. Manual builds are also still possible.
