### PR TITLE
Update R language config for Quarto 🚮 and Plumber ➕

### DIFF
--- a/extensions/positron-r/language-configuration/r-language-configuration.json
+++ b/extensions/positron-r/language-configuration/r-language-configuration.json
@@ -49,6 +49,12 @@
 			"action": { "indent": "none", "appendText": "#' " }
 		},
 
+		// Plumber comments.
+		{
+			"beforeText": "^\\s*#+\\*",
+			"action": { "indent": "none", "appendText": "#* " }
+		},
+
 		// A line ending with an operator, preceded by a blank line.
 		{
 			"previousLineText": "^\\s*(?:#|$)",

--- a/extensions/positron-r/language-configuration/r-language-configuration.json
+++ b/extensions/positron-r/language-configuration/r-language-configuration.json
@@ -49,12 +49,6 @@
 			"action": { "indent": "none", "appendText": "#' " }
 		},
 
-		// Quarto comments.
-		{
-			"beforeText": "^\\s*#+\\|",
-			"action": { "indent": "none", "appendText": "#| " }
-		},
-
 		// A line ending with an operator, preceded by a blank line.
 		{
 			"previousLineText": "^\\s*(?:#|$)",


### PR DESCRIPTION
Addresses #3595 
Addresses #3661 

This PR *removes* our `onEnterRules` for Quarto hash pipe comments since the Quarto extension has nicer behavior than is possible with straightforward language config and we now bundle it. It also *adds* `onEnterRules` for special Plumber comments. This means that Quarto comments will have nicer behavior than roxygen and plumber, but in the longer run we can take the same kind of behavior that Quarto uses for these other types of comments.

### QA Notes

After this change:

- when you press enter a couple of times with hash pipe comments `#|`, it will switch to an empty line after you don't add any content
- you will get continuation (FOREVER) for special Plumber comments `#*`
