### PR TITLE
Make maximized layouts available to use in smoke tests

### DIFF
--- a/src/vs/workbench/services/positronLayout/browser/layouts/maximizedPartLayouts.ts
+++ b/src/vs/workbench/services/positronLayout/browser/layouts/maximizedPartLayouts.ts
@@ -24,7 +24,7 @@ registerAction2(class extends PositronLayoutAction {
 		super({
 			id: 'workbench.action.fullSizedSidebar',
 			label: localize2('chooseLayout.fullSizedSidebarLayout', 'Maximized Sidebar Layout'),
-			hideFromPalette: true,
+			hideFromPalette: false,
 			layoutDescriptor: makeMaximizedPartLayout(Parts.SIDEBAR_PART),
 		});
 	}
@@ -35,7 +35,7 @@ registerAction2(class extends PositronLayoutAction {
 		super({
 			id: 'workbench.action.fullSizedPanel',
 			label: localize2('chooseLayout.fullSizedPanelLayout', 'Maximized Panel Layout'),
-			hideFromPalette: true,
+			hideFromPalette: false,
 			layoutDescriptor: makeMaximizedPartLayout(Parts.PANEL_PART),
 		});
 	}
@@ -46,7 +46,7 @@ registerAction2(class extends PositronLayoutAction {
 		super({
 			id: 'workbench.action.fullSizedAuxiliaryBar',
 			label: localize2('chooseLayout.fullSizedAuxiliaryBarLayout', 'Maximized Auxiliary Bar Layout'),
-			hideFromPalette: true,
+			hideFromPalette: false,
 			layoutDescriptor: makeMaximizedPartLayout(Parts.AUXILIARYBAR_PART),
 		});
 	}


### PR DESCRIPTION
Fixes issue where the maximized part layouts introduced in #3616, made specifically for testing, were not available to be used in the tests due to being hidden from the palette. 

I was mistaken in thinking that the method `app.workbench.quickaccess.runCommand()` used some other method of running commands than the command palette. Hence, I hide the maximized layouts to not clutter the user's palette. 

This PR just sets the maximized layouts: `workbench.action.fullSizedPanel`, `workbench.action.fullSizedSidebar`, and `Maximized Auxiliary Bar Layout` to be available in the command palette. 

### QA Notes
Hopefully will make life easier for smoke test users. 