### PR TITLE
Data Explorer: Implement export_data_selection for polars to enable copy-and-paste

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -850,6 +850,10 @@ class ExportDataSelectionFeatures(BaseModel):
         description="The support status for this RPC method",
     )
 
+    supported_formats: List[ExportFormat] = Field(
+        description="Export formats supported",
+    )
+
 
 class SetSortColumnsFeatures(BaseModel):
     """

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -1116,12 +1116,20 @@
 				"type": "object",
 				"description": "Feature flags for 'export_data_selction' RPC",
 				"required": [
-					"support_status"
+					"support_status",
+					"supported_formats"
 				],
 				"properties": {
 					"support_status": {
 						"$ref": "#/components/schemas/support_status",
 						"description": "The support status for this RPC method"
+					},
+					"supported_formats": {
+						"type": "array",
+						"description": "Export formats supported",
+						"items": {
+							"$ref": "#/components/schemas/export_format"
+						}
 					}
 				}
 			},

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -426,7 +426,8 @@ function* createRustComm(name: string, frontend: any, backend: any): Generator<s
 
 /*---------------------------------------------------------------------------------------------
  *  Copyright (C) ${year} Posit Software, PBC. All rights reserved.
- *--------------------------------------------------------------------------------------------*/
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+*--------------------------------------------------------------------------------------------*/
 
 //
 // AUTO-GENERATED from ${name}.json; do not edit.
@@ -767,6 +768,7 @@ function* createPythonComm(name: string,
 	backend: any): Generator<string> {
 	yield `#
 # Copyright (C) ${year} Posit Software, PBC. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
 #
@@ -1118,6 +1120,7 @@ function* createTypescriptComm(name: string, frontend: any, backend: any): Gener
 		readFileSync(path.join(commsDir, `${name}.json`), { encoding: 'utf-8' }));
 	yield `/*---------------------------------------------------------------------------------------------
  *  Copyright (C) ${year} Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 //

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -220,7 +220,10 @@ export class DataExplorerClientInstance extends Disposable {
 							supported_types: []
 						},
 						set_sort_columns: { support_status: SupportStatus.Unsupported, },
-						export_data_selection: { support_status: SupportStatus.Unsupported, }
+						export_data_selection: {
+							support_status: SupportStatus.Unsupported,
+							supported_formats: []
+						}
 					}
 				};
 			});
@@ -389,7 +392,10 @@ export class DataExplorerClientInstance extends Disposable {
 					supported_types: []
 				},
 				set_sort_columns: { support_status: SupportStatus.Unsupported },
-				export_data_selection: { support_status: SupportStatus.Unsupported }
+				export_data_selection: {
+					support_status: SupportStatus.Unsupported,
+					supported_formats: []
+				}
 			};
 		} else {
 			return this.cachedBackendState.supported_features;

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -764,6 +764,11 @@ export interface ExportDataSelectionFeatures {
 	 */
 	support_status: SupportStatus;
 
+	/**
+	 * Export formats supported
+	 */
+	supported_formats: Array<ExportFormat>;
+
 }
 
 /**


### PR DESCRIPTION
Addresses #3454. I also added a `supported_formats` field in `SupportedFeatures.export_data_selection` that will have to be added to Ark in the next iteration. It isn't currently used anywhere in the UI so its absence will not affect anything for now. 

Note that polars does not seem to have HTML export out of the box so only CSV and TSV is supported for now.

### QA Notes

Try copy-and-pasting single cells, rectangular ranges, whole columns or rows, or a random selection of columns or rows. 
