### PR TITLE
Upload Smoke results to TestRail

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Set TestRail Run Title
         id: set-testrail-run-title
-        run: echo "TESTRAIL_TITLE='$(date +'%Y-%m-%d') Smoke Tests'" >> $GITHUB_ENV
+        run: echo "TESTRAIL_TITLE=$(date +'%Y-%m-%d') Smoke Tests" >> $GITHUB_ENV
 
       - name: Upload Test Results to TestRail
         id: testrail-upload

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Upload Test Results to TestRail
         id: testrail-upload
         if: always()
-        run: trcli --host "https://posit.testrail.io/" --project Positron --username jon.vanausdeln@posit.co --key ${{ secrets.TESTRAIL_API_KEY}} parse_junit --file ".build/logs/smoke-tests-electron/test-results/results.xml" --case-matcher name --title $TESTRAIL_TITLE --close-run
+        run: trcli --host "https://posit.testrail.io/" --project Positron --username jon.vanausdeln@posit.co --key ${{ secrets.TESTRAIL_API_KEY}} parse_junit --file ".build/logs/smoke-tests-electron/test-results/results.xml" --case-matcher name --title "$TESTRAIL_TITLE" --close-run
 
       - name: Upload run artifacts
         if: always()

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -117,12 +117,12 @@ jobs:
 
       - name: Set TestRail Run Title
         id: set-testrail-run-title
-        run: echo "::set-output name=title::$(date +'%Y-%m-%d') Nightly Smoke Run"
+        run: echo "TESTRAIL_TITLE='$(date +'%Y-%m-%d') Smoke Tests'" >> $GITHUB_ENV
 
       - name: Upload Test Results to TestRail
         id: testrail-upload
         if: always()
-        run: trcli --host "https://posit.testrail.io/" --project Positron --username jon.vanausdeln@posit.co --key ${{ secrets.TESTRAIL_API_KEY}} parse_junit --file ".build/logs/smoke-tests-electron/test-results/results.xml" --case-matcher name --title ${{ steps.set-testrail-run-title.output.title }} --close-run
+        run: trcli --host "https://posit.testrail.io/" --project Positron --username jon.vanausdeln@posit.co --key ${{ secrets.TESTRAIL_API_KEY}} parse_junit --file ".build/logs/smoke-tests-electron/test-results/results.xml" --case-matcher name --title $TESTRAIL_TITLE --close-run
 
       - name: Upload run artifacts
         if: always()

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pandas matplotlib ipykernel pyarrow openpyxl
+          python -m pip install pandas matplotlib ipykernel pyarrow openpyxl trcli
 
       - name: Run Smoke Tests (Electron)
         env:
@@ -114,6 +114,15 @@ jobs:
         if: success() || failure() # always run even if the previous step fails
         with:
           report_paths: '**/.build/logs/smoke-tests-electron/test-results/*results.xml'
+
+      - name: Set TestRail Run Title
+        id: set-testrail-run-title
+        run: echo "::set-output name=title::$(date +'%Y-%m-%d') Nightly Smoke Run"
+
+      - name: Upload Test Results to TestRail
+        id: testrail-upload
+        if: always()
+        run: trcli --host "https://posit.testrail.io/" --project Positron --username jon.vanausdeln@posit.co --key ${{ secrets.TESTRAIL_API_KEY}} parse_junit --file ".build/logs/smoke-tests-electron/test-results/results.xml" --case-matcher name --title ${{ steps.set-testrail-run-title.output.title }} --close-run
 
       - name: Upload run artifacts
         if: always()

--- a/test/smoke/src/areas/positron/connections/dbConnections.test.ts
+++ b/test/smoke/src/areas/positron/connections/dbConnections.test.ts
@@ -40,7 +40,7 @@ export function setup(logger: Logger) {
 			});
 
 
-			it('Python - SQLite DB Connection [628636]', async function () {
+			it('Python - SQLite DB Connection [C628636]', async function () {
 
 
 				const app = this.app as Application;

--- a/test/smoke/src/areas/positron/connections/dbConnections.test.ts
+++ b/test/smoke/src/areas/positron/connections/dbConnections.test.ts
@@ -40,9 +40,8 @@ export function setup(logger: Logger) {
 			});
 
 
-			it('Python - SQLite DB Connection', async function () {
+			it('Python - SQLite DB Connection [628636]', async function () {
 
-				// TestRail 628636
 
 				const app = this.app as Application;
 				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'chinook-db-py', 'sqlite.py'));
@@ -91,9 +90,7 @@ export function setup(logger: Logger) {
 			});
 
 
-			it('R - SQLite DB Connection', async function () {
-
-				// TestRail 628637
+			it('R - SQLite DB Connection [C628637]', async function () {
 
 				const app = this.app as Application;
 				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'chinook-db-r', 'sqlite.r'));

--- a/test/smoke/src/areas/positron/console/python-console.test.ts
+++ b/test/smoke/src/areas/positron/console/python-console.test.ts
@@ -25,8 +25,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it.only('Verify restart button inside the console [C377918]', async function () {
-				// TestRail #377918
+			it('Verify restart button inside the console [C377918]', async function () {
 				this.retries(1);
 				const app = this.app as Application;
 				// Need to make console bigger to see all bar buttons
@@ -39,8 +38,7 @@ export function setup(logger: Logger) {
 				await app.workbench.positronConsole.consoleRestartButton.isNotVisible();
 			});
 
-			it.only('Verify restart button on console bar [C617464]', async function () {
-				// TestRail #617464
+			it('Verify restart button on console bar [C617464]', async function () {
 				this.retries(1);
 				const app = this.app as Application;
 				// Need to make console bigger to see all bar buttons

--- a/test/smoke/src/areas/positron/console/python-console.test.ts
+++ b/test/smoke/src/areas/positron/console/python-console.test.ts
@@ -25,7 +25,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Verify restart button inside the console', async function () {
+			it.only('Verify restart button inside the console [C377918]', async function () {
 				// TestRail #377918
 				this.retries(1);
 				const app = this.app as Application;
@@ -39,7 +39,7 @@ export function setup(logger: Logger) {
 				await app.workbench.positronConsole.consoleRestartButton.isNotVisible();
 			});
 
-			it('Verify restart button on console bar', async function () {
+			it.only('Verify restart button on console bar [C617464]', async function () {
 				// TestRail #617464
 				this.retries(1);
 				const app = this.app as Application;

--- a/test/smoke/src/areas/positron/console/r-console.test.ts
+++ b/test/smoke/src/areas/positron/console/r-console.test.ts
@@ -25,8 +25,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Verify restart button inside the console', async function () {
-				// TestRail #377917
+			it('Verify restart button inside the console [C377917]', async function () {
 				this.retries(1);
 				const app = this.app as Application;
 				// Need to make console bigger to see all bar buttons
@@ -39,8 +38,7 @@ export function setup(logger: Logger) {
 				await app.workbench.positronConsole.consoleRestartButton.isNotVisible();
 			});
 
-			it('Verify restart button on console bar', async function () {
-				// TestRail #620636
+			it('Verify restart button on console bar [C620636]', async function () {
 				this.retries(1);
 				const app = this.app as Application;
 				// Need to make console bigger to see all bar buttons

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -37,8 +37,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Python - Verifies basic data explorer functionality', async function () {
-				// TestRail #557556
+			it('Python - Verifies basic data explorer functionality [C557556]', async function () {
 				const app = this.app as Application;
 
 				// modified snippet from https://www.geeksforgeeks.org/python-pandas-dataframe/
@@ -89,8 +88,7 @@ df = pd.DataFrame(data)`;
 
 			});
 
-			it('R - Verifies basic data explorer functionality', async function () {
-				// TestRail #609620
+			it('R - Verifies basic data explorer functionality [C609620]', async function () {
 				const app = this.app as Application;
 
 				// snippet from https://www.w3schools.com/r/r_data_frames.asp

--- a/test/smoke/src/areas/positron/dataexplorer/largeDataFrame.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/largeDataFrame.test.ts
@@ -44,8 +44,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Python - Verifies data explorer functionality with large data frame', async function () {
-				//TestRail #557555
+			it('Python - Verifies data explorer functionality with large data frame [C557555]', async function () {
 				const app = this.app as Application;
 				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'nyc-flights-data-py', 'flights-data-frame.py'));
 				await app.workbench.quickaccess.runCommand('python.execInConsole');
@@ -100,8 +99,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('R - Verifies data explorer functionality with large data frame', async function () {
-				// TestRail #557554
+			it('R - Verifies data explorer functionality with large data frame [C557554]', async function () {
 				const app = this.app as Application;
 				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'nyc-flights-data-r', 'flights-data-frame.r'));
 				await app.workbench.quickaccess.runCommand('r.sourceCurrentFile');

--- a/test/smoke/src/areas/positron/dataexplorer/xlsxDataFrame.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/xlsxDataFrame.test.ts
@@ -39,9 +39,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Python - Verifies data explorer functionality with XLSX input', async function () {
-
-				//TestRail 632940
+			it('Python - Verifies data explorer functionality with XLSX input [C632940]', async function () {
 
 				const app = this.app as Application;
 				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'read-xlsx-py', 'supermarket-sales.py'));
@@ -85,9 +83,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('R - Verifies data explorer functionality with XLSX input', async function () {
-
-				//TestRail 632941
+			it('R - Verifies data explorer functionality with XLSX input [C632941]', async function () {
 
 				const app = this.app as Application;
 				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'read-xlsx-r', 'supermarket-sales.r'));

--- a/test/smoke/src/areas/positron/example.test.ts
+++ b/test/smoke/src/areas/positron/example.test.ts
@@ -23,15 +23,13 @@ export function setup(logger: Logger) {
 				await pythonFixtures.startPythonInterpreter();
 			});
 
-			it('Sample Test Case A', async function () {
-				// TestRail #
+			it('Sample Test Case A [TESTRAIL_ID]', async function () {
 				const app = this.app as Application; //Get handle to application
 				await app.workbench.positronConsole.barPowerButton.waitforVisible();
 				this.code.logger.log("Waiting for Power button.");
 			});
 
-			it('Sample Test Case B', async function () {
-				// TestRail #
+			it('Sample Test Case B [TESTRAIL_ID]', async function () {
 				const app = this.app as Application; //Get handle to application
 				await app.workbench.positronConsole.barRestartButton.waitforVisible();
 				this.code.logger.log("Waiting for Power button.");

--- a/test/smoke/src/areas/positron/help/help.test.ts
+++ b/test/smoke/src/areas/positron/help/help.test.ts
@@ -28,9 +28,8 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Python - Verifies basic help functionality', async function () {
+			it('Python - Verifies basic help functionality [C633814]', async function () {
 
-				// TestRail 633814
 				const app = this.app as Application;
 				await app.workbench.positronConsole.executeCode('Python', `?load`, '>>>');
 
@@ -53,9 +52,8 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('R - Verifies basic help functionality', async function () {
+			it('R - Verifies basic help functionality [C633813]', async function () {
 
-				// TestRail 633813
 				const app = this.app as Application;
 				await app.workbench.positronConsole.executeCode('R', `?load()`, '>');
 
@@ -69,8 +67,7 @@ export function setup(logger: Logger) {
 
 		describe('Collapse behavior', () => {
 
-			it('Verifies help panel can be opened when empty and also can be resized smaller and remember resize height', async function () {
-				// TestRail #640934
+			it('Verifies help panel can be opened when empty and also can be resized smaller and remember resize height [C640934]', async function () {
 
 				const app = this.app as Application;
 				const positronHelp = app.workbench.positronHelp;

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -19,8 +19,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Python Project Defaults', async function () {
-				// TestRail #627912
+			it('Python Project Defaults [C627912]', async function () {
 				const app = this.app as Application;
 				await app.workbench.positronNewProjectWizard.startNewProject();
 				await app.workbench.positronNewProjectWizard.newPythonProjectButton.click();
@@ -45,8 +44,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('R Project Defaults', async function () {
-				// TestRail #627913
+			it('R Project Defaults [C627913]', async function () {
 				const app = this.app as Application;
 				await app.workbench.positronNewProjectWizard.startNewProject();
 				await app.workbench.positronNewProjectWizard.newRProjectButton.click();

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -69,8 +69,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Jupyter Project Defaults', async function () {
-				// TestRail #629352
+			it('Jupyter Project Defaults [C629352]', async function () {
 				const app = this.app as Application;
 				await app.workbench.positronNewProjectWizard.startNewProject();
 				await app.workbench.positronNewProjectWizard.newJupyterProjectButton.click();

--- a/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
+++ b/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
@@ -35,8 +35,7 @@ export function setup(logger: Logger) {
 				await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
 			});
 
-			it('Python - Basic notebook creation and execution (code)', async function () {
-				// TestRail #628631
+			it('Python - Basic notebook creation and execution (code) [C628631]', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.positronNotebooks.createNewNotebook();
@@ -50,8 +49,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Python - Basic notebook creation and execution (markdown)', async function () {
-				// TestRail #628632
+			it('Python - Basic notebook creation and execution (markdown) [C628632]', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.notebook.insertNotebookCell('markdown');
@@ -87,8 +85,7 @@ export function setup(logger: Logger) {
 				await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
 			});
 
-			it('R - Basic notebook creation and execution (code)', async function () {
-				// TestRail #628629
+			it('R - Basic notebook creation and execution (code) [C628629]', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.positronNotebooks.createNewNotebook();
@@ -102,8 +99,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('R - Basic notebook creation and execution (markdown)', async function () {
-				// TestRail #628630
+			it('R - Basic notebook creation and execution (markdown) [C628630]', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.notebook.insertNotebookCell('markdown');

--- a/test/smoke/src/areas/positron/plots/plots.test.ts
+++ b/test/smoke/src/areas/positron/plots/plots.test.ts
@@ -28,8 +28,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Python - Verifies basic plot functionality - Dynamic Plot', async function () {
-				// TestRail #608114
+			it('Python - Verifies basic plot functionality - Dynamic Plot [C608114]', async function () {
 				const app = this.app as Application;
 
 				// modified snippet from https://www.geeksforgeeks.org/python-pandas-dataframe/
@@ -74,8 +73,7 @@ plt.show()`;
 
 			});
 
-			it('R - Verifies basic plot functionality', async function () {
-				// TestRail #628633
+			it('R - Verifies basic plot functionality [C628633]', async function () {
 				const app = this.app as Application;
 
 				const script = `cars <- c(1, 3, 6, 4, 9)

--- a/test/smoke/src/areas/positron/variables/variablespane.test.ts
+++ b/test/smoke/src/areas/positron/variables/variablespane.test.ts
@@ -25,8 +25,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Verifies Variables pane basic function with python interpreter', async function () {
-				// TestRail #628634
+			it('Verifies Variables pane basic function with python interpreter [C628634]', async function () {
 				const app = this.app as Application;
 
 				const executeCode = async (code: string) => {
@@ -66,8 +65,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Verifies Variables pane basic function with R interpreter', async function () {
-				// TestRail #628635
+			it('Verifies Variables pane basic function with R interpreter [C628635]', async function () {
 				const app = this.app as Application;
 
 				const executeCode = async (code: string) => {

--- a/test/smoke/test/index.js
+++ b/test/smoke/test/index.js
@@ -31,7 +31,7 @@ if (process.env.BUILD_ARTIFACTSTAGINGDIRECTORY) {
 		reporterEnabled: 'spec, mocha-junit-reporter',
 		mochaJunitReporterReporterOptions: {
 			testsuitesTitle: `${suite} ${process.platform}`,
-			mochaFile: join(process.env.BUILD_ARTIFACTSTAGINGDIRECTORY, `test-results/${process.platform}-${process.arch}-${suite.toLowerCase().replace(/[^\w]/g, '-')}-results.xml`)
+			mochaFile: join(process.env.BUILD_ARTIFACTSTAGINGDIRECTORY, `test-results/results.xml`)
 		}
 	};
 }


### PR DESCRIPTION
### Intent

Addresses #3821 and provides for Automated Smoke test results to be uploaded into Testrail

### Approach

The TestRail API will parse the junit xml results file and send results for each test with a TestRail ID in the name.  The tests Run is immediately closed after results are added.  Currently, there is no milestone associated, but we could add one later if needed (perhaps when we start using release branches, etc)

* Added TestCase ID to each test `it` block
* Changed the Junit results file name to be consistent (results.xml)
* Updated the workflow yml file
  - pip install the TestRail CLI package
  - Added step to generate at Test Run title using the current Date. This is linux specific for now. When we add more platforms, this will need to be update for the new platforms.
  - Added step to upload the results via the TestRail CLI

Note, the currently uses an API key for my TestRail account.  We don't have a service account at this time, but could in the future and switch to that account.

### QA Notes
Test on full smoke run, see:
Full Test Workflow Run: https://github.com/posit-dev/positron/actions/runs/9771103109
TestRail Test Run: https://posit.testrail.io/index.php?/runs/view/2832

It won't do anything for locally run tests as the upload step is only in the GitHub Action workflow.  You an run that command locally if you want to upload your locally run results (you'll need your own TestRail API Key) 