### PR TITLE
Data Explorer: Pass comparator function to correctly sort row/column indexes when exporting to clipboard

### DIFF
--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -324,7 +324,7 @@ class SelectionIndexes {
 	 * @returns The selection indexes as a sorted array.
 	 */
 	sortedArray() {
-		return Array.from(this.indexes).sort();
+		return Array.from(this.indexes).sort((a, b) => a - b);
 	}
 }
 


### PR DESCRIPTION
Addresses #3819. `Array.sort` called without a comparator function results in the values being sorted lexically based on their string representation.

### QA Notes

Use Command-click (on macOS) or Control-click (Windows/Linux) to select a subset of rows or columns in the data explorer and copy-paste into a spreadsheet. The values should appear in the visible order as in the data grid rather than in the selection order. 