### PR TITLE
Enable source maps for smoke tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -525,6 +525,13 @@
 			"outFiles": [
 				"${cwd}/out/**/*.js"
 			],
+			//---- Start Positron
+			"sourceMaps": true,
+			"resolveSourceMapLocations": [
+				"${workspaceFolder}/**",
+				"!**/node_modules/**"
+			],
+			//--- End Positron
 			"env": {
 				"NODE_ENV": "development",
 				"VSCODE_DEV": "1",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes
Resolves the source map locations when debugging smoke tests. Breakpoints can be set directly in the source file before transpilation.

Here's the result showing the breakpoint triggering in the source file. The breakpoints pane on the right has the source location, not the `out` location.
![image](https://github.com/posit-dev/positron/assets/9591545/b7bb886b-3f8b-4c6b-9b91-53be7b6da5ea)

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
