### PR TITLE
Add python requirements to smoke tests

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -99,8 +99,10 @@ jobs:
 
       - name: Install dependencies
         run: |
+          curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
           python -m pip install --upgrade pip
-          python -m pip install pandas matplotlib ipykernel pyarrow openpyxl trcli
+          python -m pip install -r requirements.txt
+          python -m pip install matplotlib ipykernel trcli
 
       - name: Run Smoke Tests (Electron)
         env:

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -124,6 +124,23 @@ Make sure you actually have the version you chose installed. Easiest way is to o
 
 _Note: If you forgot to do this before trying to run the tests, you'll need to restart VSCode or whatever editor you're using before they will take effect._
 
+Several tests use [QA Content Examples](https://github.com/posit-dev/qa-example-content). You will need to install the dependencies for those projects.  A few current tests also use additional packages. You can look in the [positron-full-test.yml](https://github.com/posit-dev/positron/blob/39a01b71064e2ef3ef5822c95691a034b7e0194f/.github/workflows/positron-full-test.yml) Github action for the full list.
+
+The current commands for Python packages:
+
+```
+curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python -m pip install matplotlib ipykernel
+```
+
+The current commands for R packages:
+
+```
+Rscript -e "install.packages(c('arrow', 'connections', 'RSQLite', 'readxl', 'lubridate'))"
+```
+
 ## Build step
 
 The tests are written in typescript, but unlike the main Positron typescript, the files are not transpiled by the build daemons. So when running tests you'll need to navigate into the smoke tests location and run the build watcher:
@@ -138,6 +155,8 @@ _You may see errors in test files before you run this builder step once, as it's
 ## Test Project
 
 Before any of the tests start executing the test framework clones down the [QA Content Examples](https://github.com/posit-dev/qa-example-content) repo.  This repo contains R and Python files that are run by the automated tests and also includes data files (such as Excel, SQLite, & parquet) that support the test scripts.  If you make additions to QA Content Examples for a test, please be sure that the data files are free to use in a public repository.
+
+For Python, add any package requirements to the `requirements.txt` file in the root of the [QA Content Examples](https://github.com/posit-dev/qa-example-content) repo.  We generally do NOT pin them to a specific version, as test can be run against different versions of python and conflicts could arise.  If this becomes a problem, we can revisit this mechanism.
 
 ## Running tests
 


### PR DESCRIPTION
### Intent
Addresses #3580 
Add installation of python dependencies from single source of truch

### Approach

The [QA Content Examples](https://github.com/posit-dev/qa-example-content) repository now has a python `requirements.txt` file.  Full test workflow should now use that as single source of truth for needed packages.
Also update README to specify that for local setup.  Unfortunately, there isn't a good way to do this inside the tests themselves as it's a pretty big performance hit.
 
### QA Notes

All smoke test passed using the requirements.txt file.

We might want to consider moving the few tests that don't use the qa-examples repo into it.. so their dependencies will be part of that as well. I think maybe plots is the only one at the moment