### PR TITLE
Fix leaking commands from the connections extension to the command pallete

### DIFF
--- a/extensions/positron-connections/package.json
+++ b/extensions/positron-connections/package.json
@@ -47,36 +47,47 @@
         "command": "positron.connections.previewTable",
         "title": "%commands.previewTable.title%",
         "category": "%commands.previewTable.category%",
-        "icon": "$(eye)"
+        "icon": "$(eye)",
+        "enablement": "view == connections"
       },
       {
         "command": "positron.connections.closeConnection",
         "title": "%commands.closeConnection.title%",
-        "icon": "$(debug-disconnect)"
+        "icon": "$(debug-disconnect)",
+        "enablement": "view == connections"
       },
       {
         "command": "positron.connections.refresh",
         "title": "%commands.refresh.title%",
-        "icon": "$(refresh)"
+        "icon": "$(refresh)",
+        "enablement": "view == connections"
       },
       {
         "command": "positron.connections.removeFromHistory",
         "title": "%commands.removeFromHistory.title%",
-        "icon": "$(trash)"
+        "icon": "$(trash)",
+        "enablement": "view == connections"
       },
       {
         "command": "positron.connections.reopenConnection",
         "title": "%commands.reopenConnection.title%",
-        "icon": "$(open-preview)"
+        "icon": "$(open-preview)",
+        "enablement": "view == connections"
       },
       {
         "command": "positron.connections.copyCodeToClipboard",
         "title": "%commands.copyCodeToClipboard.title%",
-        "icon": "$(clippy)"
+        "icon": "$(clippy)",
+        "enablement": "view == connections"
       },
       {
         "command": "positron.connections.clearConnectionsHistory",
         "title": "%commands.clearConnectionsHistory.title%",
+        "icon": "$(clear-all)"
+      },
+      {
+        "command": "positron.connections.expandAll",
+        "title": "%commands.expandAll.title%",
         "icon": "$(clear-all)"
       }
     ],

--- a/extensions/positron-connections/package.nls.json
+++ b/extensions/positron-connections/package.nls.json
@@ -11,5 +11,6 @@
 	"commands.removeFromHistory.title": "Remove connection from history",
 	"commands.reopenConnection.title": "Execute connection code in the console",
 	"commands.copyCodeToClipboard.title": "Copy connection code to clipboard",
-	"commands.clearConnectionsHistory.title": "Clear connections history"
+	"commands.clearConnectionsHistory.title": "Clear connections history",
+	"commands.expandAll.title": "Connections: Expand All"
 }

--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -502,6 +502,8 @@ export class ConnectionItemsProvider
 			return null;
 		}
 
+		// We are currently only interested in expanding the root connection nodes,
+		// thus we don't need to further implement this for now.
 		throw new Error(`Can't find the parent of this item`);
 	}
 

--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -496,6 +496,15 @@ export class ConnectionItemsProvider
 		});
 	}
 
+	//* getParent is required for `reveal` to work
+	async getParent(item: ConnectionItem): Promise<ConnectionItem | null> {
+		if (isDisconnectedConnectionItem(item) || isDatabaseConnectionItem(item)) {
+			return null;
+		}
+
+		throw new Error(`Can't find the parent of this item`);
+	}
+
 	public refresh() {
 		this.fireOnDidChangeTreeData();
 	}
@@ -524,6 +533,17 @@ export class ConnectionItemsProvider
 			return !isDisconnectedConnectionItem(connection);
 		});
 		this.fireOnDidChangeTreeData();
+	}
+
+
+	/**
+	 * Expand all connection nodes
+	 * The maximum depth is 3 due to limitations in the TreeView API
+	 */
+	expandConnectionNodes(treeView: vscode.TreeView<ConnectionItem>) {
+		this._connections.forEach((connection) => {
+			treeView.reveal(connection, { expand: 3 });
+		});
 	}
 
 	fireOnDidChangeTreeData() {

--- a/extensions/positron-connections/src/extension.ts
+++ b/extensions/positron-connections/src/extension.ts
@@ -16,10 +16,7 @@ import { PositronConnectionsComm } from './comms/ConnectionsComms';
 export function activate(context: vscode.ExtensionContext) {
 	const viewId = 'connections';
 	const connectionProvider = new ConnectionItemsProvider(context);
-
-	// Register the tree data provider that will provide the connections
-	context.subscriptions.push(
-		vscode.window.registerTreeDataProvider(viewId, connectionProvider));
+	const connectionTreeView = vscode.window.createTreeView(viewId, { treeDataProvider: connectionProvider });
 
 	// Register a handler for the positron.connection client type. This client
 	// represents an active, queryable database connection.
@@ -96,5 +93,12 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('positron.connections.refresh',
 			() => {
 				connectionProvider.refresh();
+			}));
+
+	/* This is mostly used for testing purposes, to avoid requiring clicks in the UI */
+	context.subscriptions.push(
+		vscode.commands.registerCommand('positron.connections.expandAll',
+			() => {
+				connectionProvider.expandConnectionNodes(connectionTreeView);
 			}));
 }


### PR DESCRIPTION
This PR makes a few commands that are internal to the connections pane extension to not appear in the command pallete. Which addresses #3841

Also adds command to expand connections, which will make testing easier. We shouldn' need to rely on specifics of the TreeView API for smoke testing the connections pane. Addresses #3840 
