### PR TITLE
Use expand all command when testing the connections pane

### DIFF
--- a/test/automation/src/positron/positronConnections.ts
+++ b/test/automation/src/positron/positronConnections.ts
@@ -5,16 +5,11 @@
 
 
 import { Code } from '../code';
+import { QuickAccess } from '../quickaccess';
 import { PositronBaseElement } from './positronBaseElement';
 
 const REMOVE_CONNECTION_BUTTON = 'a[aria-label="Remove connection from history"]';
 const DISCONNECT_BUTON = '.codicon-debug-disconnect';
-const PYTHON_SQLITE_CONNECTION = 'div[aria-label="SQLite Connection"]';
-const PYTHON_ROOT_NODE = 'div[aria-label="main"]';
-
-const R_SQLITE_CONNECTION = 'a:has-text("SQLiteConnection")';
-const R_ROOT_NODE_1 = 'div[aria-label="SQLiteConnection"]:last-child';
-const R_ROOT_NODE_2 = 'div[aria-label="Default"]';
 
 const PYTHON_CONNECTION_OPEN_STATE = 'div[aria-label="SQLite Connection"]';
 const R_CONNECTION_OPEN_STATE = 'div[aria-label="SQLiteConnection"]:first-child';
@@ -34,7 +29,7 @@ export class PositronConnections {
 	reconnectButton: PositronBaseElement;
 	connectionsTabLink: PositronBaseElement;
 
-	constructor(private code: Code) {
+	constructor(private code: Code, private quickaccess: QuickAccess) {
 
 		this.removeConnectionButton = new PositronBaseElement(REMOVE_CONNECTION_BUTTON, this.code);
 		this.disconnectButton = new PositronBaseElement(DISCONNECT_BUTON, this.code);
@@ -42,14 +37,19 @@ export class PositronConnections {
 		this.pythonConnectionOpenState = new PositronBaseElement(PYTHON_CONNECTION_OPEN_STATE, this.code);
 		this.reconnectButton = new PositronBaseElement(RECONNECT_BUTTON, this.code);
 		this.connectionsTabLink = new PositronBaseElement(CONNECTIONS_TAB_LINK, this.code);
-
 	}
 
 	async openConnectionsNodes(nodes: string[]) {
-
 		for (const node of nodes) {
 			await this.code.waitAndClick(`div[aria-label="${node}"]`);
 		}
+	}
+
+	async hasConnectionNodes(nodes: string[]) {
+		const waits = nodes.map(async node => {
+			return await this.code.waitForElement(`div[aria-label="${node}"]`);
+		});
+		await Promise.all(waits);
 	}
 
 	async hasConnectionNode(node: string) {
@@ -57,19 +57,16 @@ export class PositronConnections {
 		return x !== undefined;
 	}
 
-	async openPythonTree() {
-		await this.code.waitAndClick(PYTHON_SQLITE_CONNECTION);
-		await this.code.waitAndClick(PYTHON_ROOT_NODE);
+	async openConnectionPane() {
+		await this.quickaccess.runCommand('connections.focus');
+		this.connectionPaneIsOpen(); // waiting for the pane to open
 	}
 
-	async openRTree() {
+	async connectionPaneIsOpen() {
+		this.code.wait(500);
+	}
 
-		// not working due to timing:
-		// await app.code.waitAndClick('div[aria-label="SQLiteConnection"]');
-		// workaround for above:
-		await this.code.driver.getLocator(R_SQLITE_CONNECTION).click();
-
-		await this.code.waitAndClick(R_ROOT_NODE_1);
-		await this.code.waitAndClick(R_ROOT_NODE_2);
+	async openTree() {
+		await this.quickaccess.runCommand('positron.connections.expandAll');
 	}
 }

--- a/test/automation/src/positron/positronConnections.ts
+++ b/test/automation/src/positron/positronConnections.ts
@@ -59,11 +59,11 @@ export class PositronConnections {
 
 	async openConnectionPane() {
 		await this.quickaccess.runCommand('connections.focus');
-		this.connectionPaneIsOpen(); // waiting for the pane to open
+		await this.connectionPaneIsOpen(); // waiting for the pane to open
 	}
 
 	async connectionPaneIsOpen() {
-		this.code.wait(500);
+		await this.code.wait(500);
 	}
 
 	async openTree() {

--- a/test/automation/src/workbench.ts
+++ b/test/automation/src/workbench.ts
@@ -109,7 +109,7 @@ export class Workbench {
 		this.positronNotebooks = new PositronNotebooks(code, this.quickinput, this.quickaccess, this.notebook);
 		this.positronNewProjectWizard = new PositronNewProjectWizard(code, this.quickaccess);
 		this.positronExplorer = new PositronExplorer(code);
-		this.positronConnections = new PositronConnections(code);
+		this.positronConnections = new PositronConnections(code, this.quickaccess);
 		this.positronHelp = new PositronHelp(code);
 		// --- End Positron ---
 	}

--- a/test/smoke/src/areas/positron/connections/dbConnections.test.ts
+++ b/test/smoke/src/areas/positron/connections/dbConnections.test.ts
@@ -53,7 +53,7 @@ export function setup(logger: Logger) {
 				await app.workbench.positronConnections.openTree();
 
 				// click in reverse order to avoid scrolling issues
-				await app.workbench.positronConnections.hasConnectionNodes(["albums"]);
+				await app.workbench.positronConnections.hasConnectionNodes(['albums']);
 
 				// disconnect icon appearance requires hover
 				await app.workbench.positronConnections.pythonConnectionOpenState.hover();
@@ -94,14 +94,16 @@ export function setup(logger: Logger) {
 				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'chinook-db-r', 'sqlite.r'));
 				await app.workbench.quickaccess.runCommand('r.sourceCurrentFile');
 
-				logger.log('Opening connections pane');
-				await app.workbench.positronConnections.openConnectionPane();
-				await app.workbench.positronConnections.openTree();
+				await expect(async () => {
+					logger.log('Opening connections pane');
+					await app.workbench.positronConnections.openConnectionPane();
+					await app.workbench.positronConnections.openTree();
 
-				// click in reverse order to avoid scrolling issues
-				// in R, the opneTree command only shows all tables, we click to also
-				// display fields
-				await app.workbench.positronConnections.openConnectionsNodes(tables);
+					// click in reverse order to avoid scrolling issues
+					// in R, the opneTree command only shows all tables, we click to also
+					// display fields
+					await app.workbench.positronConnections.openConnectionsNodes(tables);
+				}).toPass();
 
 				// disconnect icon appearance requires hover
 				await app.workbench.positronConnections.rConnectionOpenState.hover();
@@ -124,24 +126,24 @@ export function setup(logger: Logger) {
 				logger.log('Opening connections pane');
 				await app.workbench.positronConnections.connectionsTabLink.click();
 
-				await expect(async () => {
-					await app.workbench.positronConnections.openTree();
-				}).toPass();
+				await app.workbench.positronConnections.openTree();
 
 				const visible = await app.workbench.positronConnections.hasConnectionNode("mtcars");
 				if (visible) {
 					throw new Error("mtcars should not be visible");
 				}
 
+				await expect(async () => {
 				// now we add a dataframe to that connection
-				await app.workbench.positronConsole.executeCode(
-					'R',
-					`DBI::dbWriteTable(con, "mtcars", mtcars)`,
-					'>'
-				);
-				// the panel should be automatically updated and we should be able to see
-				// that table and click on it
-				await app.workbench.positronConnections.openConnectionsNodes(["mtcars"]);
+					await app.workbench.positronConsole.executeCode(
+						'R',
+						`DBI::dbWriteTable(con, "mtcars", mtcars)`,
+						'>'
+					);
+					// the panel should be automatically updated and we should be able to see
+					// that table and click on it
+					await app.workbench.positronConnections.openConnectionsNodes(["mtcars"]);
+				}).toPass();
 
 			});
 

--- a/test/smoke/src/areas/positron/connections/dbConnections.test.ts
+++ b/test/smoke/src/areas/positron/connections/dbConnections.test.ts
@@ -49,13 +49,11 @@ export function setup(logger: Logger) {
 
 				logger.log('Opening connections pane');
 				await app.workbench.positronVariables.doubleClickVariableRow('conn');
-
-				await expect(async () => {
-					await app.workbench.positronConnections.openPythonTree();
-				}).toPass();
+				// in Python this will open all table connections, so should be fine.
+				await app.workbench.positronConnections.openTree();
 
 				// click in reverse order to avoid scrolling issues
-				await app.workbench.positronConnections.openConnectionsNodes(tables);
+				await app.workbench.positronConnections.hasConnectionNodes(["albums"]);
 
 				// disconnect icon appearance requires hover
 				await app.workbench.positronConnections.pythonConnectionOpenState.hover();
@@ -97,13 +95,12 @@ export function setup(logger: Logger) {
 				await app.workbench.quickaccess.runCommand('r.sourceCurrentFile');
 
 				logger.log('Opening connections pane');
-				await app.workbench.positronConnections.connectionsTabLink.click();
-
-				await expect(async () => {
-					await app.workbench.positronConnections.openRTree();
-				}).toPass();
+				await app.workbench.positronConnections.openConnectionPane();
+				await app.workbench.positronConnections.openTree();
 
 				// click in reverse order to avoid scrolling issues
+				// in R, the opneTree command only shows all tables, we click to also
+				// display fields
 				await app.workbench.positronConnections.openConnectionsNodes(tables);
 
 				// disconnect icon appearance requires hover
@@ -128,7 +125,7 @@ export function setup(logger: Logger) {
 				await app.workbench.positronConnections.connectionsTabLink.click();
 
 				await expect(async () => {
-					await app.workbench.positronConnections.openRTree();
+					await app.workbench.positronConnections.openTree();
 				}).toPass();
 
 				const visible = await app.workbench.positronConnections.hasConnectionNode("mtcars");


### PR DESCRIPTION
This PR simplifies the connections pane smoke tests by using the `Expand all` command introduced in #3853.