### PR TITLE
Supply RSTUDIO_PANDOC to packaging tasks, including R Markdown render

### DIFF
--- a/extensions/positron-r/src/pandoc.ts
+++ b/extensions/positron-r/src/pandoc.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { existsSync } from 'fs';
+import * as path from 'path';
+
+/**
+ * Discovers the path to the pandoc executable that ships with Positron.
+ *
+ * @returns The path to the pandoc executable, if it exists.
+ */
+export function getPandocPath(): string | undefined {
+	const pandocPath = path.join(vscode.env.appRoot,
+		process.platform === 'darwin' ?
+			path.join('bin', 'pandoc') :
+			path.join('..', '..', 'bin', 'pandoc'));
+	if (existsSync(pandocPath)) {
+		return pandocPath;
+	}
+}

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -18,7 +18,7 @@ import { randomUUID } from 'crypto';
 import { handleRCode } from './hyperlink';
 import { RSessionManager } from './session-manager';
 import { EXTENSION_ROOT_DIR } from './constants';
-import { existsSync } from 'fs';
+import { getPandocPath } from './pandoc';
 
 interface RPackageInstallation {
 	packageName: string;
@@ -704,11 +704,8 @@ export function createJupyterKernelSpec(
 	//
 	// On MacOS, the binary path lives alongside the app bundle; on other
 	// platforms, it's a couple of directories up from the app root.
-	const pandocPath = path.join(vscode.env.appRoot,
-		process.platform === 'darwin' ?
-			path.join('bin', 'pandoc') :
-			path.join('..', '..', 'bin', 'pandoc'));
-	if (existsSync(pandocPath)) {
+	const pandocPath = getPandocPath();
+	if (pandocPath) {
 		env['RSTUDIO_PANDOC'] = pandocPath;
 	}
 


### PR DESCRIPTION
Several beta users have already reported trouble rendering documents with Positron because the render tasks can't find Pandoc, even though it ships with Positron. 

This change supplies the`RSTUDIO_PANDOC` environment variable when running packaging tasks and R Markdown rendering jobs. It's done using the same logic we use to supply `RSTUDIO_PANDOC` to the main R session.

Addresses #3776.

### QA Notes

The embedded Pandoc is only used when there's no other Pandoc on the `$PATH`. To test this, uninstall all your Pandocies (make sure `which pandoc` returns nothing) first so that only the bundled Pandoc is available.

This also touches the code that injects Pandoc into the main R session, so make sure e.g. `rmarkdown::pandoc_version()` still works there.