### PR TITLE
Fix R code cell parser and add `# %%` support (#3709)

### DIFF
--- a/extensions/positron-code-cells/src/parser.ts
+++ b/extensions/positron-code-cells/src/parser.ts
@@ -67,7 +67,7 @@ function getJupyterMarkdownCellText(cell: Cell, document: vscode.TextDocument): 
 // Spaces can not occur before #
 const pythonIsCellStartRegExp = new RegExp(/^#\s*%%/);
 const pythonMarkdownRegExp = new RegExp(/^#\s*%%[^[]*\[markdown\]/);
-const rIsCellStartRegExp = new RegExp(/^#[\s*%%|+]/);
+const rIsCellStartRegExp = new RegExp(/^#(\s*%%|+)/);
 
 // TODO: Expose an API to let extensions register parsers
 const pythonCellParser: CellParser = {

--- a/extensions/positron-code-cells/src/parser.ts
+++ b/extensions/positron-code-cells/src/parser.ts
@@ -64,8 +64,10 @@ function getJupyterMarkdownCellText(cell: Cell, document: vscode.TextDocument): 
 	return `%%markdown\n${text}\n\n`;
 }
 
-const pythonIsCellStartRegExp = new RegExp(/^\s*#\s*%%/);
-const pythonMarkdownRegExp = new RegExp(/^\s*#\s*%%[^[]*\[markdown\]/);
+// Spaces can not occur before #
+const pythonIsCellStartRegExp = new RegExp(/^#\s*%%/);
+const pythonMarkdownRegExp = new RegExp(/^#\s*%%[^[]*\[markdown\]/);
+const rIsCellStartRegExp = new RegExp(/^#[\s*%%|+]/);
 
 // TODO: Expose an API to let extensions register parsers
 const pythonCellParser: CellParser = {
@@ -81,12 +83,12 @@ const pythonCellParser: CellParser = {
 };
 
 const rCellParser: CellParser = {
-	isCellStart: (line) => line.startsWith('#+'),
-	isCellEnd: (line) => line.trim() === '',
+	isCellStart: (line) => rIsCellStartRegExp.test(line),
+	isCellEnd: (_line) => false,
 	getCellType: (_line) => CellType.Code,
 	getCellText: getCellText,
-	newCell: () => '\n\n#+',
-	cellDecorationSetting: () => CellDecorationSetting.All,
+	newCell: () => '\n#+\n',
+	cellDecorationSetting: () => CellDecorationSetting.Current,
 };
 
 const parsers: Map<string, CellParser> = new Map([

--- a/extensions/positron-code-cells/src/parser.ts
+++ b/extensions/positron-code-cells/src/parser.ts
@@ -67,7 +67,7 @@ function getJupyterMarkdownCellText(cell: Cell, document: vscode.TextDocument): 
 // Spaces can not occur before #
 const pythonIsCellStartRegExp = new RegExp(/^#\s*%%/);
 const pythonMarkdownRegExp = new RegExp(/^#\s*%%[^[]*\[markdown\]/);
-const rIsCellStartRegExp = new RegExp(/^#(\s*%%|+)/);
+const rIsCellStartRegExp = new RegExp(/^#(\s*%%|\s*\+|\s*-)/);
 
 // TODO: Expose an API to let extensions register parsers
 const pythonCellParser: CellParser = {

--- a/extensions/positron-code-cells/src/parser.ts
+++ b/extensions/positron-code-cells/src/parser.ts
@@ -67,7 +67,7 @@ function getJupyterMarkdownCellText(cell: Cell, document: vscode.TextDocument): 
 // Spaces can not occur before #
 const pythonIsCellStartRegExp = new RegExp(/^#\s*%%/);
 const pythonMarkdownRegExp = new RegExp(/^#\s*%%[^[]*\[markdown\]/);
-const rIsCellStartRegExp = new RegExp(/^#(\s*%%|\s*\+|\s*-)/);
+const rIsCellStartRegExp = new RegExp(/^#\s+(%%|\+)/);
 
 // TODO: Expose an API to let extensions register parsers
 const pythonCellParser: CellParser = {

--- a/extensions/positron-code-cells/src/parser.ts
+++ b/extensions/positron-code-cells/src/parser.ts
@@ -67,7 +67,7 @@ function getJupyterMarkdownCellText(cell: Cell, document: vscode.TextDocument): 
 // Spaces can not occur before #
 const pythonIsCellStartRegExp = new RegExp(/^#\s*%%/);
 const pythonMarkdownRegExp = new RegExp(/^#\s*%%[^[]*\[markdown\]/);
-const rIsCellStartRegExp = new RegExp(/^#\s+(%%|\+)/);
+const rIsCellStartRegExp = new RegExp(/^#\s*(%%|\+)/);
 
 // TODO: Expose an API to let extensions register parsers
 const pythonCellParser: CellParser = {

--- a/extensions/positron-code-cells/src/test/codeLenses.test.ts
+++ b/extensions/positron-code-cells/src/test/codeLenses.test.ts
@@ -11,45 +11,55 @@ import { closeAllEditors } from './utils';
 suite('CodeLenses', () => {
 	teardown(closeAllEditors);
 
-	test('Provides Python cell code lenses', async () => {
-		const language = 'python';
-		const content = `#%%
+	const content = `# %%
 testing1
-#%%
+
 testing2
-#%%
-testing3`;
-		const document = await vscode.workspace.openTextDocument({ language, content });
+
+# %%
+testing3
+
+# %%
+testing4`;
+	const content_with_plus = content.replaceAll("# %%", "#+");
+
+	test('Provides Python cell code lenses', async () => {
 		const provider = new CellCodeLensProvider();
 
+		const language = 'python';
+		const document = await vscode.workspace.openTextDocument({ language: language, content: content });
 		const codeLenses = await provider.provideCodeLenses(document);
 
 		assert.ok(codeLenses, 'No code lenses provided');
 		verifyCodeLenses(codeLenses, [
-			new vscode.Range(0, 0, 1, 8),
-			new vscode.Range(2, 0, 3, 8),
-			new vscode.Range(4, 0, 5, 8)
+			new vscode.Range(0, 0, 4, 0),
+			new vscode.Range(5, 0, 7, 0),
+			new vscode.Range(8, 0, 9, 8)
 		]);
 	});
 
 	test('Provides R cell code lenses', async () => {
-		const language = 'r';
-		const content = `#+
-testing1
-#+
-testing2
-#+
-testing3`;
-		const document = await vscode.workspace.openTextDocument({ language, content });
 		const provider = new CellCodeLensProvider();
 
+		const language = 'r';
+		const document = await vscode.workspace.openTextDocument({ language: language, content: content });
 		const codeLenses = await provider.provideCodeLenses(document);
 
 		assert.ok(codeLenses, 'No code lenses provided');
 		verifyCodeLenses(codeLenses, [
-			new vscode.Range(0, 0, 1, 8),
-			new vscode.Range(2, 0, 3, 8),
-			new vscode.Range(4, 0, 5, 8)
+			new vscode.Range(0, 0, 4, 0),
+			new vscode.Range(5, 0, 7, 0),
+			new vscode.Range(8, 0, 9, 8)
+		]);
+
+		const document2 = await vscode.workspace.openTextDocument({ language: language, content: content_with_plus });
+		const codeLenses2 = await provider.provideCodeLenses(document2);
+
+		assert.ok(codeLenses2, 'No code lenses provided');
+		verifyCodeLenses(codeLenses2, [
+			new vscode.Range(0, 0, 4, 0),
+			new vscode.Range(5, 0, 7, 0),
+			new vscode.Range(8, 0, 9, 8)
 		]);
 	});
 });

--- a/extensions/positron-code-cells/src/test/folding.test.ts
+++ b/extensions/positron-code-cells/src/test/folding.test.ts
@@ -11,45 +11,56 @@ import { closeAllEditors } from './utils';
 suite('Folding', () => {
 	teardown(closeAllEditors);
 
-	test('Provides Python cell folding ranges', async () => {
-		const language = 'python';
-		const content = `#%%
+	const content = `# %%
 testing1
-#%%
+
 testing2
-#%%
-testing3`;
-		const document = await vscode.workspace.openTextDocument({ language, content });
+
+# %%
+testing3
+
+# %%
+testing4`;
+	const content_with_plus = content.replaceAll("# %%", "#+");
+
+
+	test('Provides Python cell folding ranges', async () => {
 		const provider = new CellFoldingRangeProvider();
 
+		const language = 'python';
+		const document = await vscode.workspace.openTextDocument({ language, content });
 		const foldingRanges = await provider.provideFoldingRanges(document);
 
 		assert.ok(foldingRanges, 'No folding ranges provided');
 		assert.deepStrictEqual(foldingRanges, [
-			new vscode.FoldingRange(0, 1),
-			new vscode.FoldingRange(2, 3),
-			new vscode.FoldingRange(4, 5),
+			new vscode.FoldingRange(0, 4),
+			new vscode.FoldingRange(5, 7),
+			new vscode.FoldingRange(8, 9),
 		], 'Incorrect folding ranges');
 	});
 
 	test('Provides R cell folding ranges', async () => {
-		const language = 'r';
-		const content = `#+
-testing1
-#+
-testing2
-#+
-testing3`;
-		const document = await vscode.workspace.openTextDocument({ language, content });
 		const provider = new CellFoldingRangeProvider();
 
+		const language = 'r';
+		const document = await vscode.workspace.openTextDocument({ language: language, content: content });
 		const foldingRanges = await provider.provideFoldingRanges(document);
 
 		assert.ok(foldingRanges, 'No folding ranges provided');
 		assert.deepStrictEqual(foldingRanges, [
-			new vscode.FoldingRange(0, 1),
-			new vscode.FoldingRange(2, 3),
-			new vscode.FoldingRange(4, 5),
+			new vscode.FoldingRange(0, 4),
+			new vscode.FoldingRange(5, 7),
+			new vscode.FoldingRange(8, 9),
+		], 'Incorrect folding ranges');
+
+		const document2 = await vscode.workspace.openTextDocument({ language: language, content: content_with_plus });
+		const foldingRanges2 = await provider.provideFoldingRanges(document2);
+
+		assert.ok(foldingRanges2, 'No folding ranges provided');
+		assert.deepStrictEqual(foldingRanges2, [
+			new vscode.FoldingRange(0, 4),
+			new vscode.FoldingRange(5, 7),
+			new vscode.FoldingRange(8, 9),
 		], 'Incorrect folding ranges');
 	});
 });

--- a/extensions/positron-code-cells/src/test/parser.test.ts
+++ b/extensions/positron-code-cells/src/test/parser.test.ts
@@ -99,9 +99,9 @@ And a [link](target)`;
 
 	suite('R Parser', () => {
 		const language = 'r';
-		const codeCellBody = '123\n456';
+		const codeCellBody = '\n123\n456';
 		const codeCell1 = `#+\n${codeCellBody}`;
-		const codeCell2 = `#+\n789\n012`;
+		const codeCell2 = `# %%\n789\n\n012`;
 
 		const parser = getParser(language);
 
@@ -123,8 +123,8 @@ And a [link](target)`;
 			const content = [codeCell1, codeCell2].join('\n\n');
 			const document = await vscode.workspace.openTextDocument({ language, content });
 			assert.deepStrictEqual(parseCells(document), [
-				{ range: new vscode.Range(0, 0, 2, 3), type: CellType.Code },
-				{ range: new vscode.Range(4, 0, 6, 3), type: CellType.Code }
+				{ range: new vscode.Range(0, 0, 4, 0), type: CellType.Code },
+				{ range: new vscode.Range(5, 0, 8, 3), type: CellType.Code }
 			]);
 		});
 
@@ -150,11 +150,11 @@ And a [link](target)`;
 		});
 
 		test('New cell', async () => {
-			assert.strictEqual(parser?.newCell(), '\n\n#+');
+			assert.strictEqual(parser?.newCell(), '\n#+\n');
 		});
 
 		test('Cell decoration setting', async () => {
-			assert.strictEqual(parser?.cellDecorationSetting(), CellDecorationSetting.All);
+			assert.strictEqual(parser?.cellDecorationSetting(), CellDecorationSetting.Current);
 		});
 	});
 });


### PR DESCRIPTION
Changes:
- R parser would end cells after first blank line; this is now removed
- `# %%` is now recognized as a valid cell demarcation in R
- cellDecorationSetting now matches python (only highlights currently active cell). Note that before the whole program is highlighted a gray color, so the information was meaningless.
- Tests added to test for these changes

Remaining enhancement:
Complete R support would recognize `#'` as markdown cells. This feature is fully supported in [`knitr::spin`](https://bookdown.org/yihui/rmarkdown-cookbook/spin.html) and [`quarto render` for a script](https://quarto.org/docs/prerelease/1.4/script.html). 

This would be require more substantial changes (that I would be happy to implement). For example: 
``` r
# %% 
#| output: false
1 + 1 

#' Markdown comment

2 + 2
```
This example has three cells: code cell, markdown, and code cell. But the latter one requires seeing the markdown comment, ending the first code cell, and starting the second. 

The `knitr::spin`/`quarto render` treat anything after a markdown comment as a new cell, so this behavior should probably be matched. In this example `output: false` does not apply to 2 + 2, but might seem like it will because running the code would run both 1 + 1 and 2 + 2. 

The main reason this would be a substantial change is that the R parser would have to be specialized and the parser would no longer be "generic" as it seems like is currently planned for it.