### PR TITLE
Smoke Test: Add R dependencies

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -31,7 +31,8 @@ jobs:
         run: |
           curl -Ls https://github.com/r-lib/rig/releases/download/latest/rig-linux-"$(arch)"-latest.tar.gz | $(which sudo) tar xz -C /usr/local
           rig add 4.4.0
-          Rscript -e "install.packages(c('arrow', 'connections', 'RSQLite', 'readxl', 'lubridate'))"
+          curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/DESCRIPTION --output DESCRIPTION
+          Rscript -e "pak::local_install_dev_deps(ask = FALSE)"
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -120,6 +120,7 @@ jobs:
 
       - name: Set TestRail Run Title
         id: set-testrail-run-title
+        if: always()
         run: echo "TESTRAIL_TITLE=$(date +'%Y-%m-%d') Smoke Tests" >> $GITHUB_ENV
 
       - name: Upload Test Results to TestRail

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -138,7 +138,8 @@ python -m pip install matplotlib ipykernel
 The current commands for R packages:
 
 ```
-Rscript -e "install.packages(c('arrow', 'connections', 'RSQLite', 'readxl', 'lubridate'))"
+curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/DESCRIPTION --output DESCRIPTION
+Rscript -e "pak::local_install_dev_deps(ask = FALSE)"
 ```
 
 ## Build step
@@ -157,6 +158,8 @@ _You may see errors in test files before you run this builder step once, as it's
 Before any of the tests start executing the test framework clones down the [QA Content Examples](https://github.com/posit-dev/qa-example-content) repo.  This repo contains R and Python files that are run by the automated tests and also includes data files (such as Excel, SQLite, & parquet) that support the test scripts.  If you make additions to QA Content Examples for a test, please be sure that the data files are free to use in a public repository.
 
 For Python, add any package requirements to the `requirements.txt` file in the root of the [QA Content Examples](https://github.com/posit-dev/qa-example-content) repo.  We generally do NOT pin them to a specific version, as test can be run against different versions of python and conflicts could arise.  If this becomes a problem, we can revisit this mechanism.
+
+For R, add any package requirements to the "imports" section of the `DESCRIPTION` file in the root of the [QA Content Examples](https://github.com/posit-dev/qa-example-content) repo.
 
 ## Running tests
 


### PR DESCRIPTION
### Intent

Addresses #3844 

Switches workflow to use a single source of truth for R dependencies from the qa-example-content repo.

### Approach

Updated Github action to install R dependencies from DESCRIPTION file.

Updated README with new instructions.

### QA Notes

Smoke tests pass using new method.
