### PR TITLE
Project Wizard Smoke Tests: R Project with Renv Environment

### DIFF
--- a/test/automation/src/positron/positronBaseElement.ts
+++ b/test/automation/src/positron/positronBaseElement.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Page } from '@playwright/test';
 import { Code } from '../code';
 
 /*
@@ -38,6 +39,10 @@ export class PositronBaseElement {
 
 	async isEnabled(): Promise<boolean> {
 		return await this.code.driver.getLocator(this.myselector).isEnabled();
+	}
+
+	getPage(): Page {
+		return this.code.driver.getLocator(this.myselector).page();
 	}
 }
 

--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -115,6 +115,29 @@ export class PositronConsole {
 		return elements.map(e => e.textContent);
 	}
 
+	/**
+	 * Waits for the console to show the given text in the last console line.
+	 * @param text The text to wait for in the console.
+	 * @param matchAsSubstring If true, the text is considered a substring of the console text. If
+	 * false, the text must match the console text exactly.
+	 */
+	async waitForEndingConsoleText(text: string, matchAsSubstring = false) {
+
+		let lastConsoleLine = await this.getConsoleContents(-1);
+
+		for (let i = 0; i < 30; i++) {
+			if (
+				lastConsoleLine[0] === text ||
+				(matchAsSubstring && lastConsoleLine[0].includes(text))
+			) {
+				break;
+			} else {
+				await this.code.wait(100);
+				lastConsoleLine = await this.getConsoleContents(-1);
+			}
+		}
+	}
+
 	async maximizeConsole() {
 		await this.code.waitAndClick(MAXIMIZE_CONSOLE);
 	}

--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -115,29 +115,6 @@ export class PositronConsole {
 		return elements.map(e => e.textContent);
 	}
 
-	/**
-	 * Waits for the console to show the given text in the last console line.
-	 * @param text The text to wait for in the console.
-	 * @param matchAsSubstring If true, the text is considered a substring of the console text. If
-	 * false, the text must match the console text exactly.
-	 */
-	async waitForEndingConsoleText(text: string, matchAsSubstring = false) {
-
-		let lastConsoleLine = await this.getConsoleContents(-1);
-
-		for (let i = 0; i < 30; i++) {
-			if (
-				lastConsoleLine[0] === text ||
-				(matchAsSubstring && lastConsoleLine[0].includes(text))
-			) {
-				break;
-			} else {
-				await this.code.wait(100);
-				lastConsoleLine = await this.getConsoleContents(-1);
-			}
-		}
-	}
-
 	async maximizeConsole() {
 		await this.code.waitAndClick(MAXIMIZE_CONSOLE);
 	}

--- a/test/automation/src/positron/positronExplorer.ts
+++ b/test/automation/src/positron/positronExplorer.ts
@@ -9,6 +9,7 @@ import { Code } from '../code';
 import { PositronTextElement } from './positronBaseElement';
 
 const POSITRON_EXPLORER_PROJECT_TITLE = 'div[id="workbench.view.explorer"] h3.title';
+const POSITRON_EXPLORER_PROJECT_FILES = 'div[id="workbench.view.explorer"] span[class="monaco-highlighted-label"]';
 
 
 /*
@@ -17,10 +18,21 @@ const POSITRON_EXPLORER_PROJECT_TITLE = 'div[id="workbench.view.explorer"] h3.ti
 export class PositronExplorer {
 	explorerProjectTitle: PositronTextElement;
 
-
 	constructor(private code: Code) {
 		this.explorerProjectTitle = new PositronTextElement(POSITRON_EXPLORER_PROJECT_TITLE, this.code);
-
 	}
 
+	/**
+	 * Returns a string array of the top-level project files/directories in the explorer.
+	 * @returns Promise<string[]>
+	 */
+	async getExplorerProjectFiles() {
+		const explorerProjectFiles = this.code.driver.getLocator(POSITRON_EXPLORER_PROJECT_FILES);
+		const filesList = await explorerProjectFiles.all();
+		const fileNames = filesList.map(async file => {
+			const fileText = await file.textContent();
+			return fileText || '';
+		});
+		return await Promise.all(fileNames);
+	}
 }

--- a/test/automation/src/positron/positronExplorer.ts
+++ b/test/automation/src/positron/positronExplorer.ts
@@ -23,8 +23,8 @@ export class PositronExplorer {
 	}
 
 	/**
-	 * Returns a string array of the top-level project files/directories in the explorer.
-	 * @returns Promise<string[]>
+	 * Constructs a string array of the top-level project files/directories in the explorer.
+	 * @returns Promise<string[]> Array of strings representing the top-level project files/directories in the explorer.
 	 */
 	async getExplorerProjectFiles() {
 		const explorerProjectFiles = this.code.driver.getLocator(POSITRON_EXPLORER_PROJECT_FILES);

--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -17,6 +17,7 @@ const PROJECT_WIZARD_DISABLED_CREATE_BUTTON = 'button.positron-button.button.act
 const PROJECT_WIZARD_CURRENT_WINDOW_BUTTON = 'button.positron-button.button.action-bar-button[tabindex="0"][role="button"]';
 const PROJECT_WIZARD_NEW_JUPYTER_PROJECT = '[id="Jupyter Notebook"]';
 const PROJECT_WIZARD_RENV_CHECKBOX = 'div.renv-configuration > div.checkbox';
+const PROJECT_WIZARD_PROJECT_NAME_INPUT = 'div.wizard-sub-step-input input.text-input';
 
 /*
  *  Reuseable Positron new project wizard functionality for tests to leverage.
@@ -31,6 +32,7 @@ export class PositronNewProjectWizard {
 	projectWizardCurrentWindowButton: PositronBaseElement;
 	newJupyterProjectButton: PositronBaseElement;
 	projectWizardRenvCheckbox: PositronBaseElement;
+	projectWizardProjectNameInput: PositronBaseElement;
 
 	constructor(private code: Code, private quickaccess: QuickAccess) {
 		this.newPythonProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_PYTHON_PROJECT, this.code);
@@ -42,6 +44,7 @@ export class PositronNewProjectWizard {
 		this.projectWizardCurrentWindowButton = new PositronBaseElement(PROJECT_WIZARD_CURRENT_WINDOW_BUTTON, this.code);
 		this.newJupyterProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_JUPYTER_PROJECT, this.code);
 		this.projectWizardRenvCheckbox = new PositronBaseElement(PROJECT_WIZARD_RENV_CHECKBOX, this.code);
+		this.projectWizardProjectNameInput = new PositronBaseElement(PROJECT_WIZARD_PROJECT_NAME_INPUT, this.code);
 	}
 
 	async startNewProject() {

--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -16,6 +16,7 @@ const PROJECT_WIZARD_BACK_BUTTON = 'div.left-actions > button.positron-button.bu
 const PROJECT_WIZARD_DISABLED_CREATE_BUTTON = 'button.positron-button.button.action-bar-button.default.disabled[tabindex="0"][disabled][role="button"][aria-disabled="true"]';
 const PROJECT_WIZARD_CURRENT_WINDOW_BUTTON = 'button.positron-button.button.action-bar-button[tabindex="0"][role="button"]';
 const PROJECT_WIZARD_NEW_JUPYTER_PROJECT = '[id="Jupyter Notebook"]';
+const PROJECT_WIZARD_RENV_CHECKBOX = 'div.renv-configuration > div.checkbox';
 
 /*
  *  Reuseable Positron new project wizard functionality for tests to leverage.
@@ -29,6 +30,7 @@ export class PositronNewProjectWizard {
 	projectWizardDisabledCreateButton: PositronBaseElement;
 	projectWizardCurrentWindowButton: PositronBaseElement;
 	newJupyterProjectButton: PositronBaseElement;
+	projectWizardRenvCheckbox: PositronBaseElement;
 
 	constructor(private code: Code, private quickaccess: QuickAccess) {
 		this.newPythonProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_PYTHON_PROJECT, this.code);
@@ -39,6 +41,7 @@ export class PositronNewProjectWizard {
 		this.projectWizardDisabledCreateButton = new PositronBaseElement(PROJECT_WIZARD_DISABLED_CREATE_BUTTON, this.code);
 		this.projectWizardCurrentWindowButton = new PositronBaseElement(PROJECT_WIZARD_CURRENT_WINDOW_BUTTON, this.code);
 		this.newJupyterProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_JUPYTER_PROJECT, this.code);
+		this.projectWizardRenvCheckbox = new PositronBaseElement(PROJECT_WIZARD_RENV_CHECKBOX, this.code);
 	}
 
 	async startNewProject() {

--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -50,4 +50,9 @@ export class PositronNewProjectWizard {
 	async startNewProject() {
 		await this.quickaccess.runCommand('positron.workbench.action.newProject', { keepOpen: false });
 	}
+
+	async appendToProjectName(text: string) {
+		await this.code.waitForActiveElement(PROJECT_WIZARD_PROJECT_NAME_INPUT);
+		await this.projectWizardProjectNameInput.getPage().keyboard.type(text);
+	}
 }

--- a/test/automation/src/positron/positronPopups.ts
+++ b/test/automation/src/positron/positronPopups.ts
@@ -8,6 +8,8 @@ import { Code } from '../code';
 
 const POSITRON_MODAL_DIALOG_BOX = '.positron-modal-dialog-box';
 const POSITRON_MODAL_DIALOG_BOX_OK = '.positron-modal-dialog-box .ok-cancel-action-bar .positron-button.action-bar-button.default';
+const POSITRON_MODAL_DIALOG_BOX_CANCEL = '.positron-modal-dialog-box .ok-cancel-action-bar .positron-button.action-bar-button:not(.default)';
+const POSITRON_MODAL_DIALOG_BOX_MISSING_R_PACKAGE_TITLE = '.positron-modal-dialog-box .simple-title-bar-title';
 const NOTIFICATION_TOAST = '.notification-toast';
 
 /*
@@ -36,21 +38,33 @@ export class PositronPopups {
 		}
 	}
 
-	async installRenv() {
+	/**
+	 * Interacts with the Renv install modal dialog box. This dialog box appears when a user opts to
+	 * use Renv in the Project Wizard and creates a new project, but Renv is not installed.
+	 * @param install Whether to install Renv or not. Default is true.
+	 */
+	async installRenv(install: boolean = true) {
 		try {
 			this.code.logger.log('Checking for install Renv modal dialog box');
 			// fail fast if the renv install modal is not present
-			await this.code.waitForTextContent(POSITRON_MODAL_DIALOG_BOX, 'Missing R package', undefined, 50);
-			await this.code.waitAndClick(POSITRON_MODAL_DIALOG_BOX_OK);
-			this.code.logger.log('Installing Renv');
-			await this.waitForToastToAppear();
-			await this.waitForToastToDisappear();
-			this.code.logger.log('Installed Renv');
+			await this.code.waitForTextContent(
+				POSITRON_MODAL_DIALOG_BOX_MISSING_R_PACKAGE_TITLE,
+				'Missing R package',
+				undefined,
+				50
+			);
+			if (install) {
+				this.code.logger.log('Installing Renv');
+				await this.code.waitAndClick(POSITRON_MODAL_DIALOG_BOX_OK);
+				this.code.logger.log('Installed Renv');
+			} else {
+				this.code.logger.log('Skipping Renv installation');
+				await this.code.waitAndClick(POSITRON_MODAL_DIALOG_BOX_CANCEL);
+			}
 		} catch {
 			this.code.logger.log('Did not find install Renv modal dialog box');
 		}
 	}
-
 	async waitForToastToDisappear() {
 		this.code.logger.log('Waiting for toast to be detacted');
 		const toastLocator = this.code.driver.getLocator(NOTIFICATION_TOAST);

--- a/test/automation/src/positron/positronPopups.ts
+++ b/test/automation/src/positron/positronPopups.ts
@@ -36,6 +36,21 @@ export class PositronPopups {
 		}
 	}
 
+	async installRenv() {
+		try {
+			this.code.logger.log('Checking for install Renv modal dialog box');
+			// fail fast if the renv install modal is not present
+			await this.code.waitForTextContent(POSITRON_MODAL_DIALOG_BOX, 'Missing R package', undefined, 50);
+			await this.code.waitAndClick(POSITRON_MODAL_DIALOG_BOX_OK);
+			this.code.logger.log('Installing Renv');
+			await this.waitForToastToAppear();
+			await this.waitForToastToDisappear();
+			this.code.logger.log('Installed Renv');
+		} catch {
+			this.code.logger.log('Did not find install Renv modal dialog box');
+		}
+	}
+
 	async waitForToastToDisappear() {
 		this.code.logger.log('Waiting for toast to be detacted');
 		const toastLocator = this.code.driver.getLocator(NOTIFICATION_TOAST);

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -36,7 +36,7 @@ export function setup(logger: Logger) {
 
 	});
 
-	describe.only('New Project Wizard', () => {
+	describe('New Project Wizard', () => {
 		// Shared before/after handling
 		installAllHandlers(logger);
 

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -134,7 +134,7 @@ export function setup(logger: Logger) {
 				);
 				});
 
-				it('Cancel Renv install [C......]', async function () {
+				it('Cancel Renv install [C656252]', async function () {
 					const projSuffix = '_cancelRenvInstall';
 					const app = this.app as Application;
 					// Remove renv package so we are prompted to install it again

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -95,7 +95,7 @@ export function setup(logger: Logger) {
 						expect(projectFiles).toContain('renv');
 						expect(projectFiles).toContain('.Rprofile');
 						expect(projectFiles).toContain('renv.lock');
-					}).toPass();
+					}).toPass({timeout: 10000});
 					// Verify that renv output in the console confirms no issues occurred
 					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
 						contents.some((line) => line.includes('renv activated'))
@@ -127,7 +127,7 @@ export function setup(logger: Logger) {
 						expect(projectFiles).toContain('renv');
 						expect(projectFiles).toContain('.Rprofile');
 						expect(projectFiles).toContain('renv.lock');
-					}).toPass();
+					}).toPass({timeout: 10000});
 					// Verify that renv output in the console confirms no issues occurred
 					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
 						contents.some((line) => line.includes('renv activated'))
@@ -166,7 +166,7 @@ export function setup(logger: Logger) {
 						expect(projectFiles).not.toContain('renv');
 						expect(projectFiles).not.toContain('.Rprofile');
 						expect(projectFiles).not.toContain('renv.lock');
-					}).toPass();
+					}).toPass({timeout: 10000});
 				});
 			});
 		});

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -57,35 +57,109 @@ export function setup(logger: Logger) {
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myRProject');
 			});
 
-			it.only('R Project with Renv Environment [C633...]', async function () {
-				const app = this.app as Application;
-				await app.workbench.positronNewProjectWizard.startNewProject();
-				await app.workbench.positronNewProjectWizard.newRProjectButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
-				// Select the renv checkbox
-				await app.workbench.positronNewProjectWizard.projectWizardRenvCheckbox.click();
-				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
-				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myRProject');
-				await app.workbench.positronPopups.installRenv();
-				// Verify renv files are present
-				const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();
-				expect(projectFiles).toContain('renv');
-				expect(projectFiles).toContain('.Rprofile');
-				expect(projectFiles).toContain('renv.lock');
-				// Verify that renv output in the console confirms no issues occurred
-				await app.workbench.positronConsole.waitForConsoleContents((contents) =>
-					contents.some((line) => line.includes('renv activated -- please restart the R session.'))
+			describe('R Project with Renv Environment', () => {
+				it('Accept Renv install [C......]', async function () {
+					const projSuffix = '_installRenv';
+					const app = this.app as Application;
+					// Create a new R project - select Renv and install
+					await app.workbench.positronNewProjectWizard.startNewProject();
+					await app.workbench.positronNewProjectWizard.newRProjectButton.click();
+					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
+					await app.workbench.positronNewProjectWizard.projectWizardProjectNameInput
+						.getPage()
+						.keyboard.insertText(projSuffix);
+					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
+					await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+					// Select the renv checkbox
+					await app.workbench.positronNewProjectWizard.projectWizardRenvCheckbox.click();
+					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
+					await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
+					await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
+						`myRProject${projSuffix}`
+					);
+					// Interact with the modal to install renv
+					await app.workbench.positronPopups.installRenv();
+					// Verify renv files are present
+					expect(async () => {
+						const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();
+						expect(projectFiles).toContain('renv');
+						expect(projectFiles).toContain('.Rprofile');
+						expect(projectFiles).toContain('renv.lock');
+					}).toPass();
+					// Verify that renv output in the console confirms no issues occurred
+					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
+						contents.some((line) => line.includes('renv activated'))
+					);
+				});
+
+				it('Renv already installed [C......]', async function () {
+					// Renv will already be installed from the previous test
+					const projSuffix = '_renvAlreadyInstalled';
+					const app = this.app as Application;
+					await app.workbench.positronNewProjectWizard.startNewProject();
+					await app.workbench.positronNewProjectWizard.newRProjectButton.click();
+					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
+					await app.workbench.positronNewProjectWizard.projectWizardProjectNameInput
+						.getPage()
+						.keyboard.insertText(projSuffix);
+					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
+					await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+					// Select the renv checkbox
+					await app.workbench.positronNewProjectWizard.projectWizardRenvCheckbox.click();
+					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
+					await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
+					await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
+						`myRProject${projSuffix}`
+					);
+					// Verify renv files are present
+					expect(async () => {
+						const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();
+						expect(projectFiles).toContain('renv');
+						expect(projectFiles).toContain('.Rprofile');
+						expect(projectFiles).toContain('renv.lock');
+					}).toPass();
+					// Verify that renv output in the console confirms no issues occurred
+					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
+						contents.some((line) => line.includes('renv activated'))
 				);
-				await app.workbench.positronConsole.executeCode('R', 'renv::status()', '>');
-				await app.workbench.positronConsole.waitForConsoleContents((contents) =>
-					contents.some((line) => line.includes('No issues found -- the project is in a consistent state.'))
-				);
+				});
+
+				it('Cancel Renv install [C......]', async function () {
+					const projSuffix = '_cancelRenvInstall';
+					const app = this.app as Application;
+					// Remove renv package so we are prompted to install it again
+					await app.workbench.positronConsole.executeCode('R', 'remove.packages("renv")', '>');
+					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
+						contents.some((line) => line.includes(`Removing package`))
+					);
+					// Create a new R project - select Renv but opt out of installing
+					await app.workbench.positronNewProjectWizard.startNewProject();
+					await app.workbench.positronNewProjectWizard.newRProjectButton.click();
+					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
+					await app.workbench.positronNewProjectWizard.projectWizardProjectNameInput
+						.getPage()
+						.keyboard.insertText(projSuffix);
+					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
+					await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+					// Select the renv checkbox
+					await app.workbench.positronNewProjectWizard.projectWizardRenvCheckbox.click();
+					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
+					await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
+					await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
+						`myRProject${projSuffix}`
+					);
+					// Interact with the modal to skip installing renv
+					await app.workbench.positronPopups.installRenv(false);
+					// Verify renv files are **not** present
+					expect(async () => {
+						const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();
+						expect(projectFiles).not.toContain('renv');
+						expect(projectFiles).not.toContain('.Rprofile');
+						expect(projectFiles).not.toContain('renv.lock');
+					}).toPass();
+				});
 			});
 		});
-
 	});
 
 	describe('New Project Wizard', () => {

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -79,6 +79,16 @@ export function setup(logger: Logger) {
 					);
 					// Interact with the modal to install renv
 					await app.workbench.positronPopups.installRenv();
+					// If the test is running on Windows, we need to interact with the Console to
+					// allow the renv installation to complete. For some reason, we don't need to do
+					// this on Mac or Linux.
+					if (process.platform === 'win32') {
+						await app.workbench.positronConsole.waitForConsoleContents((contents) =>
+							contents.some((line) => line.includes('Do you want to proceed?'))
+						);
+						await app.workbench.positronConsole.typeToConsole('y');
+						await app.workbench.positronConsole.sendEnterKey();
+					}
 					// Verify renv files are present
 					expect(async () => {
 						const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -36,7 +36,7 @@ export function setup(logger: Logger) {
 
 	});
 
-	describe('New Project Wizard', () => {
+	describe.only('New Project Wizard', () => {
 		// Shared before/after handling
 		installAllHandlers(logger);
 
@@ -65,9 +65,7 @@ export function setup(logger: Logger) {
 					await app.workbench.positronNewProjectWizard.startNewProject();
 					await app.workbench.positronNewProjectWizard.newRProjectButton.click();
 					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-					await app.workbench.positronNewProjectWizard.projectWizardProjectNameInput
-						.getPage()
-						.keyboard.insertText(projSuffix);
+					await app.workbench.positronNewProjectWizard.appendToProjectName(projSuffix);
 					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
 					await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
 					// Select the renv checkbox
@@ -114,9 +112,7 @@ export function setup(logger: Logger) {
 					await app.workbench.positronNewProjectWizard.startNewProject();
 					await app.workbench.positronNewProjectWizard.newRProjectButton.click();
 					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-					await app.workbench.positronNewProjectWizard.projectWizardProjectNameInput
-						.getPage()
-						.keyboard.insertText(projSuffix);
+					await app.workbench.positronNewProjectWizard.appendToProjectName(projSuffix);
 					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
 					await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
 					// Select the renv checkbox
@@ -151,9 +147,7 @@ export function setup(logger: Logger) {
 					await app.workbench.positronNewProjectWizard.startNewProject();
 					await app.workbench.positronNewProjectWizard.newRProjectButton.click();
 					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-					await app.workbench.positronNewProjectWizard.projectWizardProjectNameInput
-						.getPage()
-						.keyboard.insertText(projSuffix);
+					await app.workbench.positronNewProjectWizard.appendToProjectName(projSuffix);
 					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
 					await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
 					// Select the renv checkbox

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -79,16 +79,21 @@ export function setup(logger: Logger) {
 					);
 					// Interact with the modal to install renv
 					await app.workbench.positronPopups.installRenv();
-					// If the test is running on Windows, we need to interact with the Console to
-					// allow the renv installation to complete. For some reason, we don't need to do
-					// this on Mac or Linux.
-					if (process.platform === 'win32') {
-						await app.workbench.positronConsole.waitForConsoleContents((contents) =>
-							contents.some((line) => line.includes('Do you want to proceed?'))
-						);
-						await app.workbench.positronConsole.typeToConsole('y');
-						await app.workbench.positronConsole.sendEnterKey();
-					}
+
+					// If the test is running on Windows, we may need to interact with the
+					// Console to allow the renv installation to complete. It doesn't always happen,
+					// so for now this code is commented out. We've seen it once, but not again:
+					// https://github.com/posit-dev/positron/pull/3881#issuecomment-2211123610.
+					// For some reason, we don't need to do this on Mac or Linux -- or at least we
+					// haven't seen it yet!
+					// if (process.platform === 'win32') {
+					// 	await app.workbench.positronConsole.waitForConsoleContents((contents) =>
+					// 		contents.some((line) => line.includes('Do you want to proceed?'))
+					// 	);
+					// 	await app.workbench.positronConsole.typeToConsole('y');
+					// 	await app.workbench.positronConsole.sendEnterKey();
+					// }
+
 					// Verify renv files are present
 					expect(async () => {
 						const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -57,15 +57,14 @@ export function setup(logger: Logger) {
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myRProject');
 			});
 
-			it.only('R Project with Renv Environment', async function () {
-				// TestRail #633...
+			it.only('R Project with Renv Environment [C633...]', async function () {
 				const app = this.app as Application;
 				await app.workbench.positronNewProjectWizard.startNewProject();
 				await app.workbench.positronNewProjectWizard.newRProjectButton.click();
 				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
 				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
 				await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
-				// Select the Renv checkbox
+				// Select the renv checkbox
 				await app.workbench.positronNewProjectWizard.projectWizardRenvCheckbox.click();
 				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
 				await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
@@ -76,10 +75,14 @@ export function setup(logger: Logger) {
 				expect(projectFiles).toContain('renv');
 				expect(projectFiles).toContain('.Rprofile');
 				expect(projectFiles).toContain('renv.lock');
-				// Run `renv::status()` in the console to confirm no issues
+				// Verify that renv output in the console confirms no issues occurred
+				await app.workbench.positronConsole.waitForConsoleContents((contents) =>
+					contents.some((line) => line.includes('renv activated -- please restart the R session.'))
+				);
 				await app.workbench.positronConsole.executeCode('R', 'renv::status()', '>');
-				await app.workbench.positronConsole.waitForEndingConsoleText('No issues found', true);
-				await app.workbench.positronConsole.logConsoleContents();
+				await app.workbench.positronConsole.waitForConsoleContents((contents) =>
+					contents.some((line) => line.includes('No issues found -- the project is in a consistent state.'))
+				);
 			});
 		});
 

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -58,7 +58,7 @@ export function setup(logger: Logger) {
 			});
 
 			describe('R Project with Renv Environment', () => {
-				it('Accept Renv install [C......]', async function () {
+				it('Accept Renv install [C633084]', async function () {
 					const projSuffix = '_installRenv';
 					const app = this.app as Application;
 					// Create a new R project - select Renv and install
@@ -102,7 +102,7 @@ export function setup(logger: Logger) {
 					);
 				});
 
-				it('Renv already installed [C......]', async function () {
+				it('Renv already installed [C656251]', async function () {
 					// Renv will already be installed from the previous test
 					const projSuffix = '_renvAlreadyInstalled';
 					const app = this.app as Application;


### PR DESCRIPTION
## Description

- Addresses the "R Project with Renv Environment" part of https://github.com/posit-dev/positron/issues/3879

### Adds the following test cases for "R Project with Renv Environment":
- **Accept Renv install**: the user does not have renv installed, creates a new R Project with renv init selected and accepts to install it upon project creation
- **Renv already installed**: the user already has renv installed and creates a new R Project with renv init selected
- **Cancel Renv install**: the user does not have renv installed, creates a new R Project with renv init selected, but declines to install it upon project creation

### Introduces the following:
- adds `getPage()` to `PositronBaseElement`, which can be used to insert keyboard text to the page
- adds `getExplorerProjectFiles()` to `PositronExplorer`, which returns the top-level list of file and directory names showing in the explorer

## QA Notes

- Please fill in corresponding Test Ids :)
