### PR TITLE
Adds an integration test for the connections pane.

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -56,6 +56,11 @@ const extensions = [
 		label: 'positron-r',
 		workspaceFolder: path.join(os.tmpdir(), `positron-r-${Math.floor(Math.random() * 100000)}`),
 		mocha: { timeout: 60_000 }
+	},
+	{
+		label: 'positron-connections',
+		workspaceFolder: path.join(os.tmpdir(), `positron-connections-${Math.floor(Math.random() * 100000)}`),
+		mocha: { timeout: 60_000 }
 	}
 	// --- End Positron ---
 ];

--- a/extensions/positron-connections/src/connection.ts
+++ b/extensions/positron-connections/src/connection.ts
@@ -552,6 +552,14 @@ export class ConnectionItemsProvider
 		this._onDidChangeTreeData.fire(undefined);
 		this.treeItemDecorationProvider.updateFileDecorations([]);
 	}
+
+	/**
+	 * List all connections
+	 * Currently only used for testing purposes.
+	 */
+	listConnections() {
+		return this._connections;
+	}
 }
 
 /**

--- a/extensions/positron-connections/src/extension.ts
+++ b/extensions/positron-connections/src/extension.ts
@@ -101,4 +101,8 @@ export function activate(context: vscode.ExtensionContext) {
 			() => {
 				connectionProvider.expandConnectionNodes(connectionTreeView);
 			}));
+
+	// this allows vscode.extensions.getExtension('vscode.positron-connections').exports
+	// to acccess the ConnectionItemsProvider instance
+	return connectionProvider;
 }

--- a/extensions/positron-connections/src/test/README.md
+++ b/extensions/positron-connections/src/test/README.md
@@ -1,0 +1,5 @@
+Launch tests by running this from the repository root:
+
+```sh
+yarn test-extension -l positron-connections
+```

--- a/extensions/positron-connections/src/test/connection.test.ts
+++ b/extensions/positron-connections/src/test/connection.test.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+import { ConnectionItemsProvider } from '../connection';
+import * as mocha from 'mocha';
+import { randomUUID } from 'crypto';
+
+suite('Connections pane works for R', () => {
+	suiteTeardown(() => {
+		vscode.window.showInformationMessage('All tests done!');
+	});
+
+	test('Can list tabeles and fields from R connections', async () => {
+
+		// This is copied from the R extension.
+		// Just waits
+		const info = await assert_or_timeout(async () => {
+			return await positron.runtime.getPreferredRuntime('r');
+		});
+
+		const session = await positron.runtime.startLanguageRuntime(info!.runtimeId, 'Test connections pane!');
+		executeRCode(
+			session,
+			'con <- connections::connection_open(RSQLite::SQLite(), tempfile())',
+		);
+
+		const ext = vscode.extensions.getExtension<ConnectionItemsProvider>('vscode.positron-connections');
+		const provider = ext?.exports;
+		assert(provider !== undefined);
+
+		// There's some delay between the connection being registered in R, the comm opened with
+		// positron and the extension being able to get the message. We wait up to 1 second for
+		// this to happen.
+		const sqlite = await assert_or_timeout(() => {
+			const connections = provider.listConnections();
+			assert(connections !== undefined);
+			assert(connections[0].name === "SQLiteConnection");
+			return connections[0];
+		});
+
+		// Add a table to the connection
+		executeRCode(
+			session,
+			'DBI::dbWriteTable(con, "mtcars", mtcars)'
+		);
+
+		const catalog = await provider.getChildren(sqlite);
+		assert(catalog.length === 1);
+
+		const schema = await provider.getChildren(catalog[0]);
+		assert(schema.length === 1);
+
+		const tables = await provider.getChildren(schema[0]);
+		assert(tables.length === 1);
+		const mtcars = tables[0];
+		assert(mtcars.name === "mtcars");
+
+		const fields = await provider.getChildren(mtcars);
+		assert(fields.length === 11);
+		assert.notStrictEqual(
+			fields.map(f => f.name),
+			['mpg', 'cyl', 'disp', 'hp', 'drat', 'wt', 'qsec', 'vs', 'am', 'gear', 'carb']
+		);
+	});
+});
+
+async function sleep(time: number) {
+	return new Promise((resolve) => setTimeout(resolve, time));
+}
+
+async function assert_or_timeout<T>(fn: () => T, timeout: number = 1000): Promise<T> {
+	const start = Date.now();
+	while (Date.now() - start < timeout) {
+		try {
+			return await fn();
+		} catch (_) {
+			await sleep(50);
+		}
+	}
+	throw new Error('Assert failed');
+}
+
+function executeRCode(session: positron.LanguageRuntimeSession, code: string) {
+	session.execute(
+		code,
+		randomUUID(),
+		positron.RuntimeCodeExecutionMode.Interactive,
+		positron.RuntimeErrorBehavior.Stop
+	);
+}

--- a/extensions/positron-connections/src/test/connection.test.ts
+++ b/extensions/positron-connections/src/test/connection.test.ts
@@ -17,8 +17,7 @@ suite('Connections pane works for R', () => {
 
 	test('Can list tabeles and fields from R connections', async () => {
 
-		// This is copied from the R extension.
-		// Just waits
+		// Waits until positron is ready to start a runtime
 		const info = await assert_or_timeout(async () => {
 			return await positron.runtime.getPreferredRuntime('r');
 		});

--- a/extensions/positron-connections/src/test/connection.test.ts
+++ b/extensions/positron-connections/src/test/connection.test.ts
@@ -15,7 +15,7 @@ suite('Connections pane works for R', () => {
 		vscode.window.showInformationMessage('All tests done!');
 	});
 
-	test('Can list tabeles and fields from R connections', async () => {
+	test('Can list tables and fields from R connections', async () => {
 
 		// Waits until positron is ready to start a runtime
 		const info = await assert_or_timeout(async () => {

--- a/extensions/positron-connections/src/test/connection.test.ts
+++ b/extensions/positron-connections/src/test/connection.test.ts
@@ -72,7 +72,7 @@ async function sleep(time: number) {
 	return new Promise((resolve) => setTimeout(resolve, time));
 }
 
-async function assert_or_timeout<T>(fn: () => T, timeout: number = 1000): Promise<T> {
+async function assert_or_timeout<T>(fn: () => T, timeout: number = 5000): Promise<T> {
 	const start = Date.now();
 	while (Date.now() - start < timeout) {
 		try {

--- a/extensions/positron-connections/src/test/connection.test.ts
+++ b/extensions/positron-connections/src/test/connection.test.ts
@@ -74,14 +74,17 @@ async function sleep(time: number) {
 
 async function assert_or_timeout<T>(fn: () => T, timeout: number = 5000): Promise<T> {
 	const start = Date.now();
+	let error;
 	while (Date.now() - start < timeout) {
 		try {
 			return await fn();
-		} catch (_) {
+		} catch (err) {
+			error = err;
 			await sleep(50);
 		}
 	}
-	throw new Error('Assert failed');
+	// We throw the last error that happened before the timeout
+	throw error;
 }
 
 function executeRCode(session: positron.LanguageRuntimeSession, code: string) {


### PR DESCRIPTION
This PR adds an integration test for the connections pane.
At this level of abstraction, we are not testing individual clicks (like in the smoke tests), but testing the internal logic in the extension that is used by the TreeView API to render the values.

They will not run on CI, as we are not listing those here (and we don't install R/dependencies for running those anyway):

https://github.com/posit-dev/positron/blob/b1afed1bc1b1b59cb8a3a567d858073fee821b06/scripts/test-integration.sh#L130-L137

We could either add R to our default CI pipelines or, only enable them in positron-full-ci, but I'm not sure what would be best.