### PR TITLE
Test static plots and plot actions

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -103,7 +103,7 @@ jobs:
           curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install matplotlib ipykernel trcli
+          python -m pip install matplotlib ipykernel trcli graphviz
 
       - name: Run Smoke Tests (Electron)
         env:

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -98,6 +98,9 @@ jobs:
           which python
           python -m pip --version
 
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2.0.2
+
       - name: Install dependencies
         run: |
           curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt

--- a/test/automation/src/positron/positronBaseElement.ts
+++ b/test/automation/src/positron/positronBaseElement.ts
@@ -31,6 +31,11 @@ export class PositronBaseElement {
 	async hover(): Promise<void> {
 		await this.code.driver.getLocator(this.myselector).hover();
 	}
+
+	async getAttribute(attribute: string): Promise<string | undefined> {
+		const element = await this.code.getElement(this.myselector);
+		return element?.attributes[attribute] ?? undefined;
+	}
 }
 
 export class PositronTextElement extends PositronBaseElement {

--- a/test/automation/src/positron/positronBaseElement.ts
+++ b/test/automation/src/positron/positronBaseElement.ts
@@ -31,11 +31,6 @@ export class PositronBaseElement {
 	async hover(): Promise<void> {
 		await this.code.driver.getLocator(this.myselector).hover();
 	}
-
-	async getAttribute(attribute: string): Promise<string | undefined> {
-		const element = await this.code.getElement(this.myselector);
-		return element?.attributes[attribute] ?? undefined;
-	}
 }
 
 export class PositronTextElement extends PositronBaseElement {

--- a/test/automation/src/positron/positronPlots.ts
+++ b/test/automation/src/positron/positronPlots.ts
@@ -4,14 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 
+import { Locator } from '@playwright/test';
 import { Code } from '../code';
-import { PositronBaseElement } from './positronBaseElement';
 
 const CURRENT_PLOT = '.plot-instance .image-wrapper img';
 const CURRENT_STATIC_PLOT = '.plot-instance.static-plot-instance img';
 const CLEAR_PLOTS = '.positron-plots-container .positron-action-bar .codicon-clear-all';
-const NEXT_PLOT = '.positron-plots-container .positron-action-bar .codicon-positron-right-arrow';
-const PREVIOUS_PLOT = '.positron-plots-container .positron-action-bar .codicon-positron-left-arrow';
 
 
 /*
@@ -19,22 +17,22 @@ const PREVIOUS_PLOT = '.positron-plots-container .positron-action-bar .codicon-p
  */
 export class PositronPlots {
 
-	nextPlotButton: PositronBaseElement;
-	previousPlotButton: PositronBaseElement;
-	clearPlotsButton: PositronBaseElement;
-	plotSizeButton: PositronBaseElement;
-	savePlotButton: PositronBaseElement;
-	copyPlotButton: PositronBaseElement;
-	zoomPlotButton: PositronBaseElement;
+	nextPlotButton: Locator;
+	previousPlotButton: Locator;
+	clearPlotsButton: Locator;
+	plotSizeButton: Locator;
+	savePlotButton: Locator;
+	copyPlotButton: Locator;
+	zoomPlotButton: Locator;
 
 	constructor(private code: Code) {
-		this.nextPlotButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Show next plot"]', this.code);
-		this.previousPlotButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Show previous plot"]', this.code);
-		this.clearPlotsButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Clear all plots"]', this.code);
-		this.plotSizeButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Auto"]', this.code);
-		this.savePlotButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Save plot"]', this.code);
-		this.copyPlotButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Copy plot to clipboard"]', this.code);
-		this.zoomPlotButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Fill"]', this.code);
+		this.nextPlotButton = this.code.driver.getLocator('.positron-plots-container .positron-action-bar .positron-button[aria-label="Show next plot"]');
+		this.previousPlotButton = this.code.driver.getLocator('.positron-plots-container .positron-action-bar .positron-button[aria-label="Show previous plot"]');
+		this.clearPlotsButton = this.code.driver.getLocator('.positron-plots-container .positron-action-bar .positron-button[aria-label="Clear all plots"]');
+		this.plotSizeButton = this.code.driver.getLocator('.positron-plots-container .positron-action-bar .positron-button[aria-label="Auto"]');
+		this.savePlotButton = this.code.driver.getLocator('.positron-plots-container .positron-action-bar .positron-button[aria-label="Save plot"]');
+		this.copyPlotButton = this.code.driver.getLocator('.positron-plots-container .positron-action-bar .positron-button[aria-label="Copy plot to clipboard"]';
+		this.zoomPlotButton = this.code.driver.getLocator('.positron-plots-container .positron-action-bar .positron-button[aria-label="Fill"]');
 	}
 
 	async waitForCurrentPlot() {
@@ -47,14 +45,6 @@ export class PositronPlots {
 
 	async clearPlots() {
 		await this.code.waitAndClick(CLEAR_PLOTS);
-	}
-
-	async nextPlot() {
-		await this.code.waitAndClick(NEXT_PLOT);
-	}
-
-	async previousPlot() {
-		await this.code.waitAndClick(PREVIOUS_PLOT);
 	}
 
 	async waitForNoPlots() {

--- a/test/automation/src/positron/positronPlots.ts
+++ b/test/automation/src/positron/positronPlots.ts
@@ -5,9 +5,13 @@
 
 
 import { Code } from '../code';
+import { PositronBaseElement } from './positronBaseElement';
 
 const CURRENT_PLOT = '.plot-instance .image-wrapper img';
+const CURRENT_STATIC_PLOT = '.plot-instance.static-plot-instance img';
 const CLEAR_PLOTS = '.positron-plots-container .positron-action-bar .codicon-clear-all';
+const NEXT_PLOT = '.positron-plots-container .positron-action-bar .codicon-positron-right-arrow';
+const PREVIOUS_PLOT = '.positron-plots-container .positron-action-bar .codicon-positron-left-arrow';
 
 
 /*
@@ -15,14 +19,34 @@ const CLEAR_PLOTS = '.positron-plots-container .positron-action-bar .codicon-cle
  */
 export class PositronPlots {
 
-	constructor(private code: Code) { }
+	nextPlotButton: PositronBaseElement;
+	previousPlotButton: PositronBaseElement;
+	clearPlotsButton: PositronBaseElement;
+
+	constructor(private code: Code) {
+		this.nextPlotButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Show next plot"]', this.code);
+		this.previousPlotButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Show previous plot"]', this.code);
+		this.clearPlotsButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Clear all plots"]', this.code);
+	}
 
 	async waitForCurrentPlot() {
 		await this.code.waitForElement(CURRENT_PLOT);
 	}
 
+	async waitForCurrentStaticPlot() {
+		await this.code.waitForElement(CURRENT_STATIC_PLOT);
+	}
+
 	async clearPlots() {
 		await this.code.waitAndClick(CLEAR_PLOTS);
+	}
+
+	async nextPlot() {
+		await this.code.waitAndClick(NEXT_PLOT);
+	}
+
+	async previousPlot() {
+		await this.code.waitAndClick(PREVIOUS_PLOT);
 	}
 
 	async waitForNoPlots() {

--- a/test/automation/src/positron/positronPlots.ts
+++ b/test/automation/src/positron/positronPlots.ts
@@ -31,7 +31,7 @@ export class PositronPlots {
 		this.clearPlotsButton = this.code.driver.getLocator('.positron-plots-container .positron-action-bar .positron-button[aria-label="Clear all plots"]');
 		this.plotSizeButton = this.code.driver.getLocator('.positron-plots-container .positron-action-bar .positron-button[aria-label="Auto"]');
 		this.savePlotButton = this.code.driver.getLocator('.positron-plots-container .positron-action-bar .positron-button[aria-label="Save plot"]');
-		this.copyPlotButton = this.code.driver.getLocator('.positron-plots-container .positron-action-bar .positron-button[aria-label="Copy plot to clipboard"]';
+		this.copyPlotButton = this.code.driver.getLocator('.positron-plots-container .positron-action-bar .positron-button[aria-label="Copy plot to clipboard"]');
 		this.zoomPlotButton = this.code.driver.getLocator('.positron-plots-container .positron-action-bar .positron-button[aria-label="Fill"]');
 	}
 

--- a/test/automation/src/positron/positronPlots.ts
+++ b/test/automation/src/positron/positronPlots.ts
@@ -22,11 +22,19 @@ export class PositronPlots {
 	nextPlotButton: PositronBaseElement;
 	previousPlotButton: PositronBaseElement;
 	clearPlotsButton: PositronBaseElement;
+	plotSizeButton: PositronBaseElement;
+	savePlotButton: PositronBaseElement;
+	copyPlotButton: PositronBaseElement;
+	zoomPlotButton: PositronBaseElement;
 
 	constructor(private code: Code) {
 		this.nextPlotButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Show next plot"]', this.code);
 		this.previousPlotButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Show previous plot"]', this.code);
 		this.clearPlotsButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Clear all plots"]', this.code);
+		this.plotSizeButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Auto"]', this.code);
+		this.savePlotButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Save plot"]', this.code);
+		this.copyPlotButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Copy plot to clipboard"]', this.code);
+		this.zoomPlotButton = new PositronBaseElement('.positron-plots-container .positron-action-bar .positron-button[aria-label="Fill"]', this.code);
 	}
 
 	async waitForCurrentPlot() {

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -132,7 +132,7 @@ The current commands for Python packages:
 curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
-python -m pip install matplotlib ipykernel
+python -m pip install matplotlib ipykernel trcli graphviz
 ```
 
 The current commands for R packages:
@@ -141,6 +141,12 @@ The current commands for R packages:
 curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/DESCRIPTION --output DESCRIPTION
 Rscript -e "pak::local_install_dev_deps(ask = FALSE)"
 ```
+
+Graphviz is external software that has a Python package to render graphs. Install for your OS:
+* **Debian/Ubuntu** - `apt install graphviz`
+* **Fedora** - `dnf install graphviz`
+* **Windows** - `choco install graphviz`
+* **Mac** - `brew install graphviz`
 
 ## Build step
 

--- a/test/smoke/src/areas/positron/plots/plots.test.ts
+++ b/test/smoke/src/areas/positron/plots/plots.test.ts
@@ -91,10 +91,10 @@ IPython.display.display_png(h)`;
 				await app.workbench.positronPlots.waitForNoPlots();
 			});
 
-			it('Python - Verifies navigating between plots - Next/Previous Plot', async function () {
+			it('Python - Verifies the plots pane action bar - Plot actions', async function () {
 				const app = this.app as Application;
 
-				const script = `import graphviz as gv
+				const scriptPlot1 = `import graphviz as gv
 import IPython
 
 h = gv.Digraph(format="svg")
@@ -110,7 +110,7 @@ h.edge("A", "C")
 
 IPython.display.display_png(h)`;
 
-				const script2 = `import matplotlib.pyplot as plt
+				const scriptPlot2 = `import matplotlib.pyplot as plt
 
 # x axis values
 x = [1,2,3]
@@ -134,34 +134,51 @@ plt.show()`;
 				const clearPlotsButton = app.workbench.positronPlots.clearPlotsButton;
 				const nextPlotButton = app.workbench.positronPlots.nextPlotButton;
 				const previousPlotButton = app.workbench.positronPlots.previousPlotButton;
+				const plotSizeButton = app.workbench.positronPlots.plotSizeButton;
+				const savePlotButton = app.workbench.positronPlots.savePlotButton;
+				const copyPlotButton = app.workbench.positronPlots.copyPlotButton;
+				const zoomPlotButton = app.workbench.positronPlots.zoomPlotButton;
 
-				expect(await clearPlotsButton.getAttribute('disabled'), 'Clear plots button should be disabled').toBeDefined();
-				expect(await nextPlotButton.getAttribute('disabled'), 'Next plot button should be disabled').toBeDefined();
-				expect(await previousPlotButton.getAttribute('disabled'), 'Previous plot button should be disabled').toBeDefined();
+				// default plot pane state for action bar
+				await plotSizeButton.isNotVisible();
+				await savePlotButton.isNotVisible();
+				await copyPlotButton.isNotVisible();
+				await zoomPlotButton.isNotVisible();
 
-				await app.workbench.positronConsole.executeCode('Python', script, '>>>');
+				// create plots separately so that the order is known
+				await app.workbench.positronConsole.executeCode('Python', scriptPlot1, '>>>');
 				await app.workbench.positronPlots.waitForCurrentStaticPlot();
-
-				await app.workbench.positronConsole.executeCode('Python', script2, '>>>');
+				await app.workbench.positronConsole.executeCode('Python', scriptPlot2, '>>>');
 				await app.workbench.positronPlots.waitForCurrentPlot();
 
 				expect(await clearPlotsButton.getAttribute('disabled'), 'Clear plots button should not be disabled').toBeUndefined();
 				expect(await nextPlotButton.getAttribute('disabled'), 'Next plot button should be disabled').toBeDefined();
 				expect(await previousPlotButton.getAttribute('disabled'), 'Previous plot button should not be disabled').toBeUndefined();
+				expect(await plotSizeButton.getAttribute('disabled'), 'Plot size button should not be disabled').toBeUndefined();
+				expect(await savePlotButton.getAttribute('disabled'), 'Save plot button should not be disabled').toBeUndefined();
+				expect(await copyPlotButton.getAttribute('disabled'), 'Copy plot button should not be disabled').toBeUndefined();
 
 				await app.workbench.positronPlots.previousPlot();
-				await app.workbench.positronPlots.waitForCurrentStaticPlot();
+
+				// switching to fized size plot changes action bar
+				await zoomPlotButton.waitforVisible();
+				await plotSizeButton.isNotVisible();
 
 				expect(await clearPlotsButton.getAttribute('disabled'), 'Clear plots button should not be disabled').toBeUndefined();
 				expect(await nextPlotButton.getAttribute('disabled'), 'Next plot button should not be disabled').toBeUndefined();
 				expect(await previousPlotButton.getAttribute('disabled'), 'Previous plot button should be disabled').toBeDefined();
+				expect(await zoomPlotButton.getAttribute('disabled'), 'Zoom plot button should not be disabled').toBeUndefined();
 
 				await app.workbench.positronPlots.nextPlot();
 				await app.workbench.positronPlots.waitForCurrentPlot();
 
+				await zoomPlotButton.isNotVisible();
+				await plotSizeButton.waitforVisible();
+
 				expect(await clearPlotsButton.getAttribute('disabled'), 'Clear plots button should not be disabled').toBeUndefined();
 				expect(await nextPlotButton.getAttribute('disabled'), 'Next plot button should be disabled').toBeDefined();
 				expect(await previousPlotButton.getAttribute('disabled'), 'Previous plot button should not be disabled').toBeUndefined();
+				expect(await plotSizeButton.getAttribute('disabled'), 'Plot size button should not be disabled').toBeUndefined();
 
 				await app.workbench.positronPlots.clearPlots();
 

--- a/test/smoke/src/areas/positron/plots/plots.test.ts
+++ b/test/smoke/src/areas/positron/plots/plots.test.ts
@@ -131,19 +131,12 @@ plt.title('My first graph!')
 # function to show the plot
 plt.show()`;
 				logger.log('Sending code to console');
-				const clearPlotsButton = app.workbench.positronPlots.clearPlotsButton;
-				const nextPlotButton = app.workbench.positronPlots.nextPlotButton;
-				const previousPlotButton = app.workbench.positronPlots.previousPlotButton;
-				const plotSizeButton = app.workbench.positronPlots.plotSizeButton;
-				const savePlotButton = app.workbench.positronPlots.savePlotButton;
-				const copyPlotButton = app.workbench.positronPlots.copyPlotButton;
-				const zoomPlotButton = app.workbench.positronPlots.zoomPlotButton;
 
 				// default plot pane state for action bar
-				await plotSizeButton.isNotVisible();
-				await savePlotButton.isNotVisible();
-				await copyPlotButton.isNotVisible();
-				await zoomPlotButton.isNotVisible();
+				await expect(app.workbench.positronPlots.plotSizeButton).not.toBeVisible();
+				await expect(app.workbench.positronPlots.savePlotButton).not.toBeVisible();
+				await expect(app.workbench.positronPlots.copyPlotButton).not.toBeVisible();
+				await expect(app.workbench.positronPlots.zoomPlotButton).not.toBeVisible();
 
 				// create plots separately so that the order is known
 				await app.workbench.positronConsole.executeCode('Python', scriptPlot1, '>>>');
@@ -151,34 +144,37 @@ plt.show()`;
 				await app.workbench.positronConsole.executeCode('Python', scriptPlot2, '>>>');
 				await app.workbench.positronPlots.waitForCurrentPlot();
 
-				expect(await clearPlotsButton.getAttribute('disabled'), 'Clear plots button should not be disabled').toBeUndefined();
-				expect(await nextPlotButton.getAttribute('disabled'), 'Next plot button should be disabled').toBeDefined();
-				expect(await previousPlotButton.getAttribute('disabled'), 'Previous plot button should not be disabled').toBeUndefined();
-				expect(await plotSizeButton.getAttribute('disabled'), 'Plot size button should not be disabled').toBeUndefined();
-				expect(await savePlotButton.getAttribute('disabled'), 'Save plot button should not be disabled').toBeUndefined();
-				expect(await copyPlotButton.getAttribute('disabled'), 'Copy plot button should not be disabled').toBeUndefined();
+				await expect(app.workbench.positronPlots.clearPlotsButton).not.toBeDisabled();
+				await expect(app.workbench.positronPlots.nextPlotButton).toBeDisabled();
+				await expect(app.workbench.positronPlots.previousPlotButton).not.toBeDisabled();
+				await expect(app.workbench.positronPlots.plotSizeButton).not.toBeDisabled();
+				await expect(app.workbench.positronPlots.savePlotButton).not.toBeDisabled();
+				await expect(app.workbench.positronPlots.copyPlotButton).not.toBeDisabled();
 
-				await app.workbench.positronPlots.previousPlot();
+				// switch to fixed size plot
+				await app.workbench.positronPlots.previousPlotButton.click();
+				await app.workbench.positronPlots.waitForCurrentStaticPlot();
 
 				// switching to fized size plot changes action bar
-				await zoomPlotButton.waitforVisible();
-				await plotSizeButton.isNotVisible();
+				await expect(app.workbench.positronPlots.zoomPlotButton).toBeVisible();
+				await expect(app.workbench.positronPlots.plotSizeButton).not.toBeVisible();
 
-				expect(await clearPlotsButton.getAttribute('disabled'), 'Clear plots button should not be disabled').toBeUndefined();
-				expect(await nextPlotButton.getAttribute('disabled'), 'Next plot button should not be disabled').toBeUndefined();
-				expect(await previousPlotButton.getAttribute('disabled'), 'Previous plot button should be disabled').toBeDefined();
-				expect(await zoomPlotButton.getAttribute('disabled'), 'Zoom plot button should not be disabled').toBeUndefined();
+				await expect(app.workbench.positronPlots.clearPlotsButton).not.toBeDisabled();
+				await expect(app.workbench.positronPlots.nextPlotButton).not.toBeDisabled();
+				await expect(app.workbench.positronPlots.previousPlotButton).toBeDisabled();
+				await expect(app.workbench.positronPlots.zoomPlotButton).not.toBeDisabled();
 
-				await app.workbench.positronPlots.nextPlot();
+				// switch back to dynamic plot
+				await app.workbench.positronPlots.nextPlotButton.click();
 				await app.workbench.positronPlots.waitForCurrentPlot();
 
-				await zoomPlotButton.isNotVisible();
-				await plotSizeButton.waitforVisible();
+				await expect(app.workbench.positronPlots.zoomPlotButton).not.toBeVisible();
+				await expect(app.workbench.positronPlots.plotSizeButton).toBeVisible();
 
-				expect(await clearPlotsButton.getAttribute('disabled'), 'Clear plots button should not be disabled').toBeUndefined();
-				expect(await nextPlotButton.getAttribute('disabled'), 'Next plot button should be disabled').toBeDefined();
-				expect(await previousPlotButton.getAttribute('disabled'), 'Previous plot button should not be disabled').toBeUndefined();
-				expect(await plotSizeButton.getAttribute('disabled'), 'Plot size button should not be disabled').toBeUndefined();
+				await expect(app.workbench.positronPlots.clearPlotsButton).not.toBeDisabled();
+				await expect(app.workbench.positronPlots.nextPlotButton).toBeDisabled();
+				await expect(app.workbench.positronPlots.previousPlotButton).not.toBeDisabled();
+				await expect(app.workbench.positronPlots.plotSizeButton).not.toBeDisabled();
 
 				await app.workbench.positronPlots.clearPlots();
 

--- a/test/smoke/src/areas/positron/plots/plots.test.ts
+++ b/test/smoke/src/areas/positron/plots/plots.test.ts
@@ -62,7 +62,7 @@ plt.show()`;
 				await app.workbench.positronPlots.waitForNoPlots();
 			});
 
-			it('Python - Verifies basic plot functionality - Static Plot', async function () {
+			it('Python - Verifies basic plot functionality - Static Plot [C654401]', async function () {
 				const app = this.app as Application;
 
 				const script = `import graphviz as gv
@@ -91,7 +91,7 @@ IPython.display.display_png(h)`;
 				await app.workbench.positronPlots.waitForNoPlots();
 			});
 
-			it('Python - Verifies the plots pane action bar - Plot actions', async function () {
+			it('Python - Verifies the plots pane action bar - Plot actions [C656297]', async function () {
 				const app = this.app as Application;
 
 				const scriptPlot1 = `import graphviz as gv

--- a/test/smoke/src/areas/positron/plots/plots.test.ts
+++ b/test/smoke/src/areas/positron/plots/plots.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 
+import { expect } from '@playwright/test';
 import { Application, Logger, PositronPythonFixtures, PositronRFixtures } from '../../../../../automation';
 import { installAllHandlers } from '../../../utils';
 
@@ -55,6 +56,112 @@ plt.show()`;
 				await app.workbench.positronConsole.executeCode('Python', script, '>>>');
 
 				await app.workbench.positronPlots.waitForCurrentPlot();
+
+				await app.workbench.positronPlots.clearPlots();
+
+				await app.workbench.positronPlots.waitForNoPlots();
+			});
+
+			it('Python - Verifies basic plot functionality - Static Plot', async function () {
+				const app = this.app as Application;
+
+				const script = `import graphviz as gv
+import IPython
+
+h = gv.Digraph(format="svg")
+names = [
+    "A",
+    "B",
+    "C",
+]
+
+# Specify edges
+h.edge("A", "B")
+h.edge("A", "C")
+
+IPython.display.display_png(h)`;
+
+				logger.log('Sending code to console');
+				await app.workbench.positronConsole.executeCode('Python', script, '>>>');
+
+				await app.workbench.positronPlots.waitForCurrentStaticPlot();
+
+				await app.workbench.positronPlots.clearPlots();
+
+				await app.workbench.positronPlots.waitForNoPlots();
+			});
+
+			it('Python - Verifies navigating between plots - Next/Previous Plot', async function () {
+				const app = this.app as Application;
+
+				const script = `import graphviz as gv
+import IPython
+
+h = gv.Digraph(format="svg")
+names = [
+    "A",
+    "B",
+    "C",
+]
+
+# Specify edges
+h.edge("A", "B")
+h.edge("A", "C")
+
+IPython.display.display_png(h)`;
+
+				const script2 = `import matplotlib.pyplot as plt
+
+# x axis values
+x = [1,2,3]
+# corresponding y axis values
+y = [2,4,1]
+
+# plotting the points
+plt.plot(x, y)
+
+# naming the x axis
+plt.xlabel('x - axis')
+# naming the y axis
+plt.ylabel('y - axis')
+
+# giving a title to my graph
+plt.title('My first graph!')
+
+# function to show the plot
+plt.show()`;
+				logger.log('Sending code to console');
+				const clearPlotsButton = app.workbench.positronPlots.clearPlotsButton;
+				const nextPlotButton = app.workbench.positronPlots.nextPlotButton;
+				const previousPlotButton = app.workbench.positronPlots.previousPlotButton;
+
+				expect(await clearPlotsButton.getAttribute('disabled'), 'Clear plots button should be disabled').toBeDefined();
+				expect(await nextPlotButton.getAttribute('disabled'), 'Next plot button should be disabled').toBeDefined();
+				expect(await previousPlotButton.getAttribute('disabled'), 'Previous plot button should be disabled').toBeDefined();
+
+				await app.workbench.positronConsole.executeCode('Python', script, '>>>');
+				await app.workbench.positronPlots.waitForCurrentStaticPlot();
+
+				await app.workbench.positronConsole.executeCode('Python', script2, '>>>');
+				await app.workbench.positronPlots.waitForCurrentPlot();
+
+				expect(await clearPlotsButton.getAttribute('disabled'), 'Clear plots button should not be disabled').toBeUndefined();
+				expect(await nextPlotButton.getAttribute('disabled'), 'Next plot button should be disabled').toBeDefined();
+				expect(await previousPlotButton.getAttribute('disabled'), 'Previous plot button should not be disabled').toBeUndefined();
+
+				await app.workbench.positronPlots.previousPlot();
+				await app.workbench.positronPlots.waitForCurrentStaticPlot();
+
+				expect(await clearPlotsButton.getAttribute('disabled'), 'Clear plots button should not be disabled').toBeUndefined();
+				expect(await nextPlotButton.getAttribute('disabled'), 'Next plot button should not be disabled').toBeUndefined();
+				expect(await previousPlotButton.getAttribute('disabled'), 'Previous plot button should be disabled').toBeDefined();
+
+				await app.workbench.positronPlots.nextPlot();
+				await app.workbench.positronPlots.waitForCurrentPlot();
+
+				expect(await clearPlotsButton.getAttribute('disabled'), 'Clear plots button should not be disabled').toBeUndefined();
+				expect(await nextPlotButton.getAttribute('disabled'), 'Next plot button should be disabled').toBeDefined();
+				expect(await previousPlotButton.getAttribute('disabled'), 'Previous plot button should not be disabled').toBeUndefined();
 
 				await app.workbench.positronPlots.clearPlots();
 


### PR DESCRIPTION
Added `graphviz` for Python to create a fixed size plot. Tests visibility and enablement for the plot action bar.

The button matching for the plot size and zoom is based on the default. It'll need some extra handling in the future if switching the values is tested.

### QA Notes
The Python environment will need `graphviz`.