### PR TITLE
Data Explorer: Add "search_schema" support for polars, add 'match data types' support, introduce "column filter" RPC type, refactor row filters a bit

### DIFF
--- a/extensions/positron-python/.vscode/launch.json
+++ b/extensions/positron-python/.vscode/launch.json
@@ -5,7 +5,7 @@
         // --- Start Positron ---
         {
             "name": "Positron: Remote Attach",
-            "type": "debugpy",
+            "type": "python",
             "request": "attach",
             "connect": {
                 "host": "localhost",

--- a/extensions/positron-python/.vscode/launch.json
+++ b/extensions/positron-python/.vscode/launch.json
@@ -5,7 +5,7 @@
         // --- Start Positron ---
         {
             "name": "Positron: Remote Attach",
-            "type": "python",
+            "type": "debugpy",
             "request": "attach",
             "connect": {
                 "host": "localhost",

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -229,19 +229,11 @@ class DataExplorerTableView(abc.ABC):
                     return schema
 
         schema_memo = SchemaMemo()
-        matches = []
-        for column_index in range(self.table.shape[1]):
-            # All filters must match
-            no_match = False
-            for matcher in matchers:
-                if not matcher(column_index, schema_memo):
-                    no_match = True
-                    break
-
-            if no_match:
-                continue
-            col_schema = self._get_single_column_schema(column_index)
-            matches.append(col_schema)
+        matches = [
+            self._get_single_column_schema(column_index)
+            for column_index in range(self.table.shape[1])
+            if all(matcher(column_index, schema_memo) for matcher in matchers)
+        ]
 
         return matches
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -145,9 +145,9 @@ class DataExplorerTableView(abc.ABC):
         # without having to recompute the search. If the search term
         # changes, we discard the last search result. We might add an
         # LRU cache here or something if it helps performance.
-        self._search_schema_last_result: Optional[
-            Tuple[List[ColumnFilter], List[ColumnSchema]]
-        ] = None
+        self._search_schema_last_result: Optional[Tuple[List[ColumnFilter], List[ColumnSchema]]] = (
+            None
+        )
 
     def _set_sort_keys(self, sort_keys):
         self.sort_keys = sort_keys if sort_keys is not None else []
@@ -155,8 +155,7 @@ class DataExplorerTableView(abc.ABC):
         # We store the column schemas for each sort key to help with
         # eviction later during updates
         self._sort_key_schemas = [
-            self._get_single_column_schema(key.column_index)
-            for key in self.sort_keys
+            self._get_single_column_schema(key.column_index) for key in self.sort_keys
         ]
 
     def _recompute_if_needed(self) -> bool:
@@ -212,9 +211,7 @@ class DataExplorerTableView(abc.ABC):
             total_num_matches=len(matches),
         ).dict()
 
-    def _search_schema_get_matches(
-        self, filters: List[ColumnFilter]
-    ) -> List[ColumnSchema]:
+    def _search_schema_get_matches(self, filters: List[ColumnFilter]) -> List[ColumnSchema]:
         matchers = self._get_column_filter_functions(filters)
 
         parent = self
@@ -339,14 +336,10 @@ class DataExplorerTableView(abc.ABC):
         else:
             raise NotImplementedError(f"Unknown data export: {kind}")
 
-    def _export_cell(
-        self, row_index: int, column_index: int, fmt: ExportFormat
-    ):
+    def _export_cell(self, row_index: int, column_index: int, fmt: ExportFormat):
         raise NotImplementedError
 
-    def _export_tabular(
-        self, row_selector, column_selector, fmt: ExportFormat
-    ):
+    def _export_tabular(self, row_selector, column_selector, fmt: ExportFormat):
         raise NotImplementedError
 
     def set_row_filters(self, request: SetRowFiltersRequest):
@@ -364,9 +357,7 @@ class DataExplorerTableView(abc.ABC):
             # Simply reset if empty filter set passed
             self.filtered_indices = None
             self._update_view_indices()
-            return FilterResult(
-                selected_num_rows=len(self.table), had_errors=False
-            )
+            return FilterResult(selected_num_rows=len(self.table), had_errors=False)
 
         # Evaluate all the filters and combine them using the
         # indicated conditions
@@ -401,16 +392,12 @@ class DataExplorerTableView(abc.ABC):
 
         self.filtered_indices = self._mask_to_indices(combined_mask)
         selected_num_rows = (
-            len(self.table)
-            if self.filtered_indices is None
-            else len(self.filtered_indices)
+            len(self.table) if self.filtered_indices is None else len(self.filtered_indices)
         )
 
         # Update the view indices, re-sorting if needed
         self._update_view_indices()
-        return FilterResult(
-            selected_num_rows=selected_num_rows, had_errors=had_errors
-        )
+        return FilterResult(selected_num_rows=selected_num_rows, had_errors=had_errors)
 
     def _mask_to_indices(self, mask):
         raise NotImplementedError
@@ -438,9 +425,7 @@ class DataExplorerTableView(abc.ABC):
                 count = self._prof_null_count(req.column_index)
                 result = ColumnProfileResult(null_count=int(count))
             elif req.profile_type == ColumnProfileType.SummaryStats:
-                stats = self._prof_summary_stats(
-                    req.column_index, request.params.format_options
-                )
+                stats = self._prof_summary_stats(req.column_index, request.params.format_options)
                 result = ColumnProfileResult(summary_stats=stats)
             elif req.profile_type == ColumnProfileType.FrequencyTable:
                 freq_table = self._prof_freq_table(req.column_index)
@@ -553,9 +538,7 @@ class DataExplorerTableView(abc.ABC):
                     continue
             elif column_index in shifted_columns:
                 key.column_index = shifted_columns[column_index]
-            elif column_index in deleted_columns or prior_name != str(
-                new_columns[column_index]
-            ):
+            elif column_index in deleted_columns or prior_name != str(new_columns[column_index]):
                 # Column deleted
                 continue
 
@@ -619,9 +602,7 @@ class DataExplorerTableView(abc.ABC):
     def _prof_null_count(self, column_index: int) -> int:
         raise NotImplementedError
 
-    def _prof_summary_stats(
-        self, column_index: int, options: FormatOptions
-    ) -> ColumnSummaryStats:
+    def _prof_summary_stats(self, column_index: int, options: FormatOptions) -> ColumnSummaryStats:
         raise NotImplementedError
 
     def _prof_freq_table(self, column_index: int) -> ColumnFrequencyTable:
@@ -797,8 +778,7 @@ class PandasView(DataExplorerTableView):
         from pandas.api.types import infer_dtype
 
         filtered_columns = {
-            filt.column_schema.column_index: filt.column_schema
-            for filt in self.filters
+            filt.column_schema.column_index: filt.column_schema for filt in self.filters
         }
 
         # self.table may have been modified in place, so we cannot
@@ -832,9 +812,7 @@ class PandasView(DataExplorerTableView):
         def _get_column_schema(column, column_name, column_index):
             # We only use infer_dtype for columns that are involved in
             # a filter
-            type_name, type_display = self._get_type(
-                column.dtype, lambda: infer_dtype(column)
-            )
+            type_name, type_display = self._get_type(column.dtype, lambda: infer_dtype(column))
 
             return ColumnSchema(
                 column_name=column_name,
@@ -883,9 +861,7 @@ class PandasView(DataExplorerTableView):
                 # If it was an in place modification, as a last ditch
                 # effort we check if we remember the data type because
                 # of a prior filter
-                if filtered_columns[old_index].type_name == str(
-                    new_column.dtype
-                ):
+                if filtered_columns[old_index].type_name == str(new_column.dtype):
                     # Type is the same and not object dtype
                     continue
 
@@ -898,14 +874,10 @@ class PandasView(DataExplorerTableView):
                 # unnecessary
                 continue
 
-            schema_changes[old_index] = _get_column_schema(
-                new_column, str(column_name), new_index
-            )
+            schema_changes[old_index] = _get_column_schema(new_column, str(column_name), new_index)
 
         def schema_getter(column_name, column_index):
-            return _get_column_schema(
-                new_table.iloc[:, column_index], column_name, column_index
-            )
+            return _get_column_schema(new_table.iloc[:, column_index], column_name, column_index)
 
         new_filters = self._get_adjusted_filters(
             new_table.columns,
@@ -925,9 +897,7 @@ class PandasView(DataExplorerTableView):
         from pandas.api.types import infer_dtype
 
         if column_index not in self._inferred_dtypes:
-            self._inferred_dtypes[column_index] = infer_dtype(
-                self.table.iloc[:, column_index]
-            )
+            self._inferred_dtypes[column_index] = infer_dtype(self.table.iloc[:, column_index])
         return self._inferred_dtypes[column_index]
 
     @classmethod
@@ -1049,13 +1019,9 @@ class PandasView(DataExplorerTableView):
         else:
             # No filtering or sorting, just slice directly
             indices = self.table.index[row_start : row_start + num_rows]
-            columns = [
-                col.iloc[row_start : row_start + num_rows] for col in columns
-            ]
+            columns = [col.iloc[row_start : row_start + num_rows] for col in columns]
 
-        formatted_columns = [
-            self._format_values(col, format_options) for col in columns
-        ]
+        formatted_columns = [self._format_values(col, format_options) for col in columns]
 
         # Currently, we format MultiIndex in its flat tuple
         # representation. In the future we will return multiple lists
@@ -1067,9 +1033,7 @@ class PandasView(DataExplorerTableView):
         return {"columns": formatted_columns, "row_labels": row_labels}
 
     @classmethod
-    def _format_values(
-        cls, values, options: FormatOptions
-    ) -> List[ColumnValue]:
+    def _format_values(cls, values, options: FormatOptions) -> List[ColumnValue]:
         NaT = pd_.NaT
         NA = pd_.NA
         float_format = _get_float_formatter(options)
@@ -1093,9 +1057,7 @@ class PandasView(DataExplorerTableView):
 
         return [_format_value(x) for x in values]
 
-    def _export_tabular(
-        self, row_selector, column_selector, fmt: ExportFormat
-    ):
+    def _export_tabular(self, row_selector, column_selector, fmt: ExportFormat):
         from io import StringIO
 
         if self.view_indices is not None:
@@ -1122,12 +1084,8 @@ class PandasView(DataExplorerTableView):
 
         return ExportedData(data=result, format=fmt).dict()
 
-    def _export_cell(
-        self, row_index: int, column_index: int, fmt: ExportFormat
-    ):
-        return ExportedData(
-            data=str(self.table.iat[row_index, column_index]), format=fmt
-        ).dict()
+    def _export_cell(self, row_index: int, column_index: int, fmt: ExportFormat):
+        return ExportedData(data=str(self.table.iat[row_index, column_index]), format=fmt).dict()
 
     def _mask_to_indices(self, mask):
         if mask is not None:
@@ -1147,12 +1105,8 @@ class PandasView(DataExplorerTableView):
         ):
             params = filt.params
             assert isinstance(params, FilterBetween)
-            left_value = self._coerce_value(
-                params.left_value, dtype, inferred_type
-            )
-            right_value = self._coerce_value(
-                params.right_value, dtype, inferred_type
-            )
+            left_value = self._coerce_value(params.left_value, dtype, inferred_type)
+            right_value = self._coerce_value(params.right_value, dtype, inferred_type)
             if filt.filter_type == RowFilterType.Between:
                 mask = (col >= left_value) & (col <= right_value)
             else:
@@ -1166,9 +1120,7 @@ class PandasView(DataExplorerTableView):
                 raise ValueError(f"Unsupported filter type: {params.op}")
             op = COMPARE_OPS[params.op]
             # pandas comparison filters return False for null values
-            mask = op(
-                col, self._coerce_value(params.value, dtype, inferred_type)
-            )
+            mask = op(col, self._coerce_value(params.value, dtype, inferred_type))
         elif filt.filter_type == RowFilterType.IsEmpty:
             mask = col.str.len() == 0
         elif filt.filter_type == RowFilterType.IsNull:
@@ -1185,10 +1137,7 @@ class PandasView(DataExplorerTableView):
             params = filt.params
             assert isinstance(params, FilterSetMembership)
             boxed_values = pd_.Series(
-                [
-                    self._coerce_value(val, dtype, inferred_type)
-                    for val in params.values
-                ]
+                [self._coerce_value(val, dtype, inferred_type) for val in params.values]
             )
             # IN
             mask = col.isin(boxed_values)
@@ -1278,9 +1227,7 @@ class PandasView(DataExplorerTableView):
                 self.view_indices = self.filtered_indices.take(sort_indexer)
             else:
                 # Data is not filtered
-                self.view_indices = nargsort(
-                    column, kind="mergesort", ascending=key.ascending
-                )
+                self.view_indices = nargsort(column, kind="mergesort", ascending=key.ascending)
         elif len(self.sort_keys) > 1:
             # Multiple sorting keys
             cols_to_sort = []
@@ -1369,9 +1316,7 @@ class PandasView(DataExplorerTableView):
 
         return ColumnSummaryStats(
             type_display=ColumnDisplayType.String,
-            string_stats=SummaryStatsString(
-                num_empty=int(num_empty), num_unique=int(num_unique)
-            ),
+            string_stats=SummaryStatsString(num_empty=int(num_empty), num_unique=int(num_unique)),
         )
 
     @staticmethod
@@ -1512,9 +1457,7 @@ class PandasView(DataExplorerTableView):
                 ),
             ],
         ),
-        set_sort_columns=SetSortColumnsFeatures(
-            support_status=SupportStatus.Supported
-        ),
+        set_sort_columns=SetSortColumnsFeatures(support_status=SupportStatus.Supported),
         export_data_selection=ExportDataSelectionFeatures(
             support_status=SupportStatus.Supported,
             supported_formats=[
@@ -1598,8 +1541,7 @@ class PolarsView(DataExplorerTableView):
 
     def get_updated_state(self, new_table) -> StateUpdate:
         filtered_columns = {
-            filt.column_schema.column_index: filt.column_schema
-            for filt in self.filters
+            filt.column_schema.column_index: filt.column_schema for filt in self.filters
         }
 
         # As of June 2024, polars seems to be really slow for
@@ -1684,9 +1626,7 @@ class PolarsView(DataExplorerTableView):
                 # If it was an in place modification, as a last ditch
                 # effort we check if we remember the data type because
                 # of a prior filter
-                if filtered_columns[old_index].type_name == str(
-                    new_column.dtype
-                ):
+                if filtered_columns[old_index].type_name == str(new_column.dtype):
                     # Type is the same and not object dtype
                     continue
 
@@ -1705,9 +1645,7 @@ class PolarsView(DataExplorerTableView):
             )
 
         def schema_getter(column_name, column_index):
-            return self._construct_schema(
-                new_table[:, column_index], column_name, column_index
-            )
+            return self._construct_schema(new_table[:, column_index], column_name, column_index)
 
         new_filters = self._get_adjusted_filters(
             new_columns,
@@ -1730,9 +1668,7 @@ class PolarsView(DataExplorerTableView):
     def _get_column_name(self, column_index: int) -> str:
         return self.table[:, column_index].name
 
-    def _construct_schema(
-        self, column: "pl.Series", column_index: int, name=None
-    ):
+    def _construct_schema(self, column: "pl.Series", column_index: int, name=None):
         type_display = self._get_type_display(column.dtype)
 
         return ColumnSchema(
@@ -1807,21 +1743,15 @@ class PolarsView(DataExplorerTableView):
             columns = [col.gather(view_slice) for col in columns]
         else:
             # No filtering or sorting, just slice
-            columns = [
-                col[row_start : row_start + num_rows] for col in columns
-            ]
+            columns = [col[row_start : row_start + num_rows] for col in columns]
 
-        formatted_columns = [
-            self._format_values(col, format_options) for col in columns
-        ]
+        formatted_columns = [self._format_values(col, format_options) for col in columns]
 
         # Bypass pydantic model for speed
         return {"columns": formatted_columns, "row_labels": None}
 
     @classmethod
-    def _format_values(
-        cls, values, options: FormatOptions
-    ) -> List[ColumnValue]:
+    def _format_values(cls, values, options: FormatOptions) -> List[ColumnValue]:
         float_format = _get_float_formatter(options)
 
         def _format_scalar(x):
@@ -1842,11 +1772,7 @@ class PolarsView(DataExplorerTableView):
                     if is_valid_mask[i]:
                         inner_values = _format_series(v)
                         result.append(
-                            "["
-                            + ", ".join(
-                                "null" if v == 0 else v for v in inner_values
-                            )
-                            + "]"
+                            "[" + ", ".join("null" if v == 0 else v for v in inner_values) + "]"
                         )
                     else:
                         result.append(_VALUE_NULL)
@@ -1860,9 +1786,7 @@ class PolarsView(DataExplorerTableView):
 
         return _format_series(values)
 
-    def _export_tabular(
-        self, row_selector, column_selector, fmt: ExportFormat
-    ):
+    def _export_tabular(self, row_selector, column_selector, fmt: ExportFormat):
         if self.view_indices is not None:
             row_selector = self.view_indices[row_selector]
 
@@ -1877,12 +1801,8 @@ class PolarsView(DataExplorerTableView):
 
         return ExportedData(data=result, format=fmt).dict()
 
-    def _export_cell(
-        self, row_index: int, column_index: int, fmt: ExportFormat
-    ):
-        return ExportedData(
-            data=str(self.table[row_index, column_index]), format=fmt
-        ).dict()
+    def _export_cell(self, row_index: int, column_index: int, fmt: ExportFormat):
+        return ExportedData(data=str(self.table[row_index, column_index]), format=fmt).dict()
 
     SUPPORTED_FILTERS = {
         RowFilterType.Between,
@@ -1917,12 +1837,8 @@ class PolarsView(DataExplorerTableView):
         ):
             params = filt.params
             assert isinstance(params, FilterBetween)
-            left_value = self._coerce_value(
-                params.left_value, dtype, display_type
-            )
-            right_value = self._coerce_value(
-                params.right_value, dtype, display_type
-            )
+            left_value = self._coerce_value(params.left_value, dtype, display_type)
+            right_value = self._coerce_value(params.right_value, dtype, display_type)
             mask = col.is_between(left_value, right_value)
             if filt.filter_type == RowFilterType.NotBetween:
                 mask = ~mask
@@ -1934,9 +1850,7 @@ class PolarsView(DataExplorerTableView):
                 raise ValueError(f"Unsupported filter type: {params.op}")
             op = COMPARE_OPS[params.op]
             # pandas comparison filters return False for null values
-            mask = op(
-                col, self._coerce_value(params.value, dtype, display_type)
-            )
+            mask = op(col, self._coerce_value(params.value, dtype, display_type))
         elif filt.filter_type == RowFilterType.IsEmpty:
             if col.dtype.is_(pl_.String):
                 mask = col.str.len_chars() == 0
@@ -1966,10 +1880,7 @@ class PolarsView(DataExplorerTableView):
             assert isinstance(params, FilterSetMembership)
 
             boxed_values = pl_.Series(
-                [
-                    self._coerce_value(val, dtype, display_type)
-                    for val in params.values
-                ]
+                [self._coerce_value(val, dtype, display_type) for val in params.values]
             )
             mask = col.is_in(boxed_values)
             if not params.inclusive:
@@ -2053,14 +1964,10 @@ class PolarsView(DataExplorerTableView):
                 num_rows = len(self.table)
 
             # Do a stable sort of the indices using the columns as sort keys
-            to_sort = pl_.DataFrame(
-                {indexer_name: pl_.arange(num_rows, eager=True)}
-            )
+            to_sort = pl_.DataFrame({indexer_name: pl_.arange(num_rows, eager=True)})
 
             try:
-                to_sort = to_sort.sort(
-                    cols_to_sort, descending=directions, maintain_order=True
-                )
+                to_sort = to_sort.sort(cols_to_sort, descending=directions, maintain_order=True)
             except TypeError:
                 # Older versions of polars do not have maintain_order
                 to_sort = to_sort.sort(cols_to_sort, descending=directions)
@@ -2085,9 +1992,7 @@ class PolarsView(DataExplorerTableView):
             column = column.gather(self.filtered_indices)
         return column
 
-    def _prof_summary_stats(
-        self, column_index: int, options: FormatOptions
-    ) -> ColumnSummaryStats:
+    def _prof_summary_stats(self, column_index: int, options: FormatOptions) -> ColumnSummaryStats:
         raise NotImplementedError
 
     def _prof_freq_table(self, column_index: int) -> ColumnFrequencyTable:
@@ -2130,9 +2035,7 @@ class PolarsView(DataExplorerTableView):
             support_status=SupportStatus.Supported,
             supported_formats=[ExportFormat.Csv, ExportFormat.Tsv],
         ),
-        set_sort_columns=SetSortColumnsFeatures(
-            support_status=SupportStatus.Supported
-        ),
+        set_sort_columns=SetSortColumnsFeatures(support_status=SupportStatus.Supported),
     )
 
 
@@ -2231,9 +2134,7 @@ class DataExplorerService:
             comm_id = guid()
 
         if variable_path is not None:
-            full_title = ", ".join(
-                [str(decode_access_key(k)) for k in variable_path]
-            )
+            full_title = ", ".join([str(decode_access_key(k)) for k in variable_path])
         else:
             full_title = title
 
@@ -2327,9 +2228,7 @@ class DataExplorerService:
             for comm_id in list(self.path_to_comm_ids[path]):
                 self._update_explorer_for_comm(comm_id, path, new_variable)
 
-    def _update_explorer_for_comm(
-        self, comm_id: str, path: PathKey, new_variable
-    ):
+    def _update_explorer_for_comm(self, comm_id: str, path: PathKey, new_variable):
         """
         If a variable is updated, we have to handle the different scenarios:
 
@@ -2365,9 +2264,7 @@ class DataExplorerService:
         # data explorer open for a nested value, then we need to use
         # the same variables inspection logic to resolve it here.
         if len(path) > 1:
-            is_found, new_table = _resolve_value_from_path(
-                new_variable, path[1:]
-            )
+            is_found, new_table = _resolve_value_from_path(new_variable, path[1:])
             if not is_found:
                 raise KeyError(f"Path {full_title} not found in value")
         else:
@@ -2390,9 +2287,7 @@ class DataExplorerService:
             new_filters = []
             new_sort_keys = []
         else:
-            (schema_updated, new_filters, new_sort_keys) = (
-                table_view.get_updated_state(new_table)
-            )
+            (schema_updated, new_filters, new_sort_keys) = table_view.get_updated_state(new_table)
 
         self.table_views[comm_id] = _get_table_view(
             new_table,
@@ -2406,9 +2301,7 @@ class DataExplorerService:
         else:
             comm.send_event(DataExplorerFrontendEvent.DataUpdate.value, {})
 
-    def handle_msg(
-        self, msg: CommMessage[DataExplorerBackendMessageContent], raw_msg
-    ):
+    def handle_msg(self, msg: CommMessage[DataExplorerBackendMessageContent], raw_msg):
         """
         Handle messages received from the client via the
         positron.data_explorer comm.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -572,7 +572,7 @@ class DataExplorerTableView(abc.ABC):
             return display_type == ColumnDisplayType.String
         elif filt.filter_type == RowFilterType.Compare:
             params = filt.params
-            assert isinstance(params, FilterComparison)
+            assert isinstance(params, FilterComparison), str(params)
             if params.op in [
                 FilterComparisonOp.Eq,
                 FilterComparisonOp.NotEq,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -127,7 +127,7 @@ class ColumnFilterType(str, enum.Enum):
 
     TextSearch = "text_search"
 
-    MatchDataType = "match_data_type"
+    MatchDataTypes = "match_data_types"
 
 
 @enum.unique
@@ -514,6 +514,20 @@ class ColumnFilter(BaseModel):
     )
 
 
+class ColumnFilterTypeSupportStatus(BaseModel):
+    """
+    Support status for a column filter type
+    """
+
+    column_filter_type: ColumnFilterType = Field(
+        description="Type of column filter",
+    )
+
+    support_status: SupportStatus = Field(
+        description="The support status for this column filter type",
+    )
+
+
 class ColumnProfileRequest(BaseModel):
     """
     A single column profile request
@@ -827,6 +841,10 @@ class SearchSchemaFeatures(BaseModel):
 
     support_status: SupportStatus = Field(
         description="The support status for this RPC method",
+    )
+
+    supported_types: List[ColumnFilterTypeSupportStatus] = Field(
+        description="A list of supported types",
     )
 
 
@@ -1333,6 +1351,8 @@ FilterTextSearch.update_forward_refs()
 FilterMatchDataTypes.update_forward_refs()
 
 ColumnFilter.update_forward_refs()
+
+ColumnFilterTypeSupportStatus.update_forward_refs()
 
 ColumnProfileRequest.update_forward_refs()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -86,9 +86,9 @@ class RowFilterType(str, enum.Enum):
 
 
 @enum.unique
-class CompareFilterParamsOp(str, enum.Enum):
+class FilterComparisonOp(str, enum.Enum):
     """
-    Possible values for Op in CompareFilterParams
+    Possible values for Op in FilterComparison
     """
 
     Eq = "="
@@ -105,9 +105,9 @@ class CompareFilterParamsOp(str, enum.Enum):
 
 
 @enum.unique
-class SearchFilterType(str, enum.Enum):
+class TextSearchType(str, enum.Enum):
     """
-    Possible values for SearchFilterType
+    Possible values for TextSearchType
     """
 
     Contains = "contains"
@@ -117,6 +117,17 @@ class SearchFilterType(str, enum.Enum):
     EndsWith = "ends_with"
 
     RegexMatch = "regex_match"
+
+
+@enum.unique
+class ColumnFilterType(str, enum.Enum):
+    """
+    Possible values for ColumnFilterType
+    """
+
+    TextSearch = "text_search"
+
+    MatchDataType = "match_data_type"
 
 
 @enum.unique
@@ -190,7 +201,7 @@ class SearchSchemaResult(BaseModel):
     )
 
     total_num_matches: StrictInt = Field(
-        description="The total number of columns matching the search term",
+        description="The total number of columns matching the filter",
     )
 
 
@@ -398,24 +409,9 @@ class RowFilter(BaseModel):
         description="Optional error message when the filter is invalid",
     )
 
-    between_params: Optional[BetweenFilterParams] = Field(
+    params: Optional[RowFilterParams] = Field(
         default=None,
-        description="Parameters for the 'between' and 'not_between' filter types",
-    )
-
-    compare_params: Optional[CompareFilterParams] = Field(
-        default=None,
-        description="Parameters for the 'compare' filter type",
-    )
-
-    search_params: Optional[SearchFilterParams] = Field(
-        default=None,
-        description="Parameters for the 'search' filter type",
-    )
-
-    set_membership_params: Optional[SetMembershipFilterParams] = Field(
-        default=None,
-        description="Parameters for the 'set_membership' filter type",
+        description="The row filter type-specific parameters",
     )
 
 
@@ -433,7 +429,7 @@ class RowFilterTypeSupportStatus(BaseModel):
     )
 
 
-class BetweenFilterParams(BaseModel):
+class FilterBetween(BaseModel):
     """
     Parameters for the 'between' and 'not_between' filter types
     """
@@ -447,12 +443,12 @@ class BetweenFilterParams(BaseModel):
     )
 
 
-class CompareFilterParams(BaseModel):
+class FilterComparison(BaseModel):
     """
     Parameters for the 'compare' filter type
     """
 
-    op: CompareFilterParamsOp = Field(
+    op: FilterComparisonOp = Field(
         description="String representation of a binary comparison",
     )
 
@@ -461,13 +457,13 @@ class CompareFilterParams(BaseModel):
     )
 
 
-class SetMembershipFilterParams(BaseModel):
+class FilterSetMembership(BaseModel):
     """
     Parameters for the 'set_membership' filter type
     """
 
     values: List[StrictStr] = Field(
-        description="Array of column values for a set membership filter",
+        description="Array of values for a set membership filter",
     )
 
     inclusive: StrictBool = Field(
@@ -475,21 +471,46 @@ class SetMembershipFilterParams(BaseModel):
     )
 
 
-class SearchFilterParams(BaseModel):
+class FilterTextSearch(BaseModel):
     """
     Parameters for the 'search' filter type
     """
 
-    search_type: SearchFilterType = Field(
+    search_type: TextSearchType = Field(
         description="Type of search to perform",
     )
 
     term: StrictStr = Field(
-        description="String value/regex to search for in stringified data",
+        description="String value/regex to search for",
     )
 
     case_sensitive: StrictBool = Field(
         description="If true, do a case-sensitive search, otherwise case-insensitive",
+    )
+
+
+class FilterMatchDataTypes(BaseModel):
+    """
+    Parameters for the 'match_data_types' filter type
+    """
+
+    display_types: List[ColumnDisplayType] = Field(
+        description="Column display types to match",
+    )
+
+
+class ColumnFilter(BaseModel):
+    """
+    A filter that selects a subset of columns by name, type, or other
+    criteria
+    """
+
+    filter_type: ColumnFilterType = Field(
+        description="Type of column filter to apply",
+    )
+
+    params: ColumnFilterParams = Field(
+        description="Parameters for column filter",
     )
 
 
@@ -945,7 +966,19 @@ ColumnValue = Union[
     StrictInt,
     StrictStr,
 ]
-# Selection in Properties
+# Union of row filter parameters
+RowFilterParams = Union[
+    FilterBetween,
+    FilterComparison,
+    FilterTextSearch,
+    FilterSetMembership,
+]
+# Union of column filter type-specific parameters
+ColumnFilterParams = Union[
+    FilterTextSearch,
+    FilterMatchDataTypes,
+]
+# A union of selection types
 Selection = Union[
     DataSelectionSingleCell,
     DataSelectionCellRange,
@@ -963,7 +996,7 @@ class DataExplorerBackendRequest(str, enum.Enum):
     # Request schema
     GetSchema = "get_schema"
 
-    # Search schema by column name
+    # Search schema with column filters
     SearchSchema = "search_schema"
 
     # Get a rectangle of data values
@@ -1023,12 +1056,12 @@ class SearchSchemaParams(BaseModel):
     Search schema for column names matching a passed substring
     """
 
-    search_term: StrictStr = Field(
-        description="Substring to match for (currently case insensitive)",
+    filters: List[ColumnFilter] = Field(
+        description="Column filters to apply when searching",
     )
 
     start_index: StrictInt = Field(
-        description="Index (starting from zero) of first result to fetch",
+        description="Index (starting from zero) of first result to fetch (for paging)",
     )
 
     max_results: StrictInt = Field(
@@ -1289,13 +1322,17 @@ RowFilter.update_forward_refs()
 
 RowFilterTypeSupportStatus.update_forward_refs()
 
-BetweenFilterParams.update_forward_refs()
+FilterBetween.update_forward_refs()
 
-CompareFilterParams.update_forward_refs()
+FilterComparison.update_forward_refs()
 
-SetMembershipFilterParams.update_forward_refs()
+FilterSetMembership.update_forward_refs()
 
-SearchFilterParams.update_forward_refs()
+FilterTextSearch.update_forward_refs()
+
+FilterMatchDataTypes.update_forward_refs()
+
+ColumnFilter.update_forward_refs()
 
 ColumnProfileRequest.update_forward_refs()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -178,9 +178,7 @@ def test_explorer_open_close_delete(
     assert len(de_service.table_views) == 0
 
 
-def _assign_variables(
-    shell: PositronShell, variables_comm: DummyComm, **variables
-):
+def _assign_variables(shell: PositronShell, variables_comm: DummyComm, **variables):
     # A hack to make sure that change events are fired when we
     # manipulate user_ns
     shell.kernel.variables_service.snapshot_user_ns()
@@ -221,9 +219,7 @@ def test_explorer_delete_variable(
         assert len(paths) > 0
 
         comms = [
-            de_service.comms[comm_id]
-            for p in paths
-            for comm_id in de_service.path_to_comm_ids[p]
+            de_service.comms[comm_id] for p in paths for comm_id in de_service.path_to_comm_ids[p]
         ]
         variables_comm.handle_msg(msg)
 
@@ -243,11 +239,7 @@ def _check_update_variable(de_service, name, update_type="schema"):
     paths = de_service.get_paths_for_variable(name)
     assert len(paths) > 0
 
-    comms = [
-        de_service.comms[comm_id]
-        for p in paths
-        for comm_id in de_service.path_to_comm_ids[p]
-    ]
+    comms = [de_service.comms[comm_id] for p in paths for comm_id in de_service.path_to_comm_ids[p]]
 
     if update_type == "schema":
         expected_msg = json_rpc_notification("schema_update", {})
@@ -390,9 +382,7 @@ class DataExplorerFixture:
     def get_state(self, table_name):
         return self.do_json_rpc(table_name, "get_state")
 
-    def get_data_values(
-        self, table_name, format_options=DEFAULT_FORMAT, **params
-    ):
+    def get_data_values(self, table_name, format_options=DEFAULT_FORMAT, **params):
         return self.do_json_rpc(
             table_name,
             "get_data_values",
@@ -412,13 +402,9 @@ class DataExplorerFixture:
         return self.do_json_rpc(table_name, "set_row_filters", filters=filters)
 
     def set_sort_columns(self, table_name, sort_keys=None):
-        return self.do_json_rpc(
-            table_name, "set_sort_columns", sort_keys=sort_keys
-        )
+        return self.do_json_rpc(table_name, "set_sort_columns", sort_keys=sort_keys)
 
-    def get_column_profiles(
-        self, table_name, profiles, format_options=DEFAULT_FORMAT
-    ):
+    def get_column_profiles(self, table_name, profiles, format_options=DEFAULT_FORMAT):
         return self.do_json_rpc(
             table_name,
             "get_column_profiles",
@@ -437,9 +423,7 @@ class DataExplorerFixture:
 
         ex_num_rows = len(expected_table)
         try:
-            assert response == FilterResult(
-                selected_num_rows=ex_num_rows, had_errors=False
-            )
+            assert response == FilterResult(selected_num_rows=ex_num_rows, had_errors=False)
         except Exception:
             pprint.pprint(state["row_filters"])
             raise
@@ -476,9 +460,7 @@ class DataExplorerFixture:
         assert response is None
         self.compare_tables(table_id, ex_unsorted_id, table.shape)
 
-    def compare_tables(
-        self, table_id: str, expected_id: str, table_shape: tuple
-    ):
+    def compare_tables(self, table_id: str, expected_id: str, table_shape: tuple):
         state = self.get_state(table_id)
         ex_state = self.get_state(expected_id)
 
@@ -506,9 +488,7 @@ class DataExplorerFixture:
             mask = left == right
             different_indices = (~mask).nonzero()[0]
             if len(different_indices) > 0:
-                raise AssertionError(
-                    f"Indices differ at {str(different_indices)}"
-                )
+                raise AssertionError(f"Indices differ at {str(different_indices)}")
 
 
 @pytest.fixture
@@ -589,9 +569,7 @@ def test_pandas_supported_features(dxf: DataExplorerFixture):
     ]
     for tp in row_filter_types:
         assert (
-            RowFilterTypeSupportStatus(
-                row_filter_type=tp, support_status=SupportStatus.Supported
-            )
+            RowFilterTypeSupportStatus(row_filter_type=tp, support_status=SupportStatus.Supported)
             in row_filters["supported_types"]
         )
     assert len(row_filter_types) == len(row_filters["supported_types"])
@@ -645,9 +623,7 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
         ),
         ([None, MyData(5), MyData(-1), None, None], "mixed", "object"),
         (
-            np.array(
-                [1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, 5 + 5j], dtype="complex64"
-            ),
+            np.array([1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, 5 + 5j], dtype="complex64"),
             "complex64",
             "number",
         ),
@@ -785,9 +761,7 @@ def _text_search_filter(term, match="contains", case_sensitive=False):
 def _match_types_filter(data_types):
     return {
         "filter_type": "match_data_types",
-        "params": {
-            "display_types": [getattr(x, "value", x) for x in data_types]
-        },
+        "params": {"display_types": [getattr(x, "value", x) for x in data_types]},
     }
 
 
@@ -816,8 +790,7 @@ def test_search_schema(dxf: DataExplorerFixture):
     }
 
     frame_data = {
-        name: data_examples[i % len(data_examples)]
-        for i, name in enumerate(column_names)
+        name: data_examples[i % len(data_examples)] for i, name in enumerate(column_names)
     }
 
     # Make a data frame with those column names
@@ -848,18 +821,12 @@ def test_search_schema(dxf: DataExplorerFixture):
             (
                 [
                     aaa_filter,
-                    _match_types_filter(
-                        [ColumnDisplayType.Boolean, ColumnDisplayType.Number]
-                    ),
+                    _match_types_filter([ColumnDisplayType.Boolean, ColumnDisplayType.Number]),
                 ],
                 0,
                 120,
                 600,
-                [
-                    x
-                    for i, x in enumerate(full_schema[:200])
-                    if i % 5 in (0, 2, 3)
-                ],
+                [x for i, x in enumerate(full_schema[:200]) if i % 5 in (0, 2, 3)],
             ),
             ([aaa_filter], 100, 100, 1000, full_schema[100:200]),
             ([aaa_filter], 950, 100, 1000, full_schema[950:1000]),
@@ -913,9 +880,7 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
     assert result["row_labels"] == [["0", "1", "2", "3", "4"]]
 
     # Edge cases: request beyond end of table
-    response = dxf.get_data_values(
-        "simple", row_start_index=5, num_rows=10, column_indices=[0]
-    )
+    response = dxf.get_data_values("simple", row_start_index=5, num_rows=10, column_indices=[0])
     assert response["columns"] == [[]]
 
     # Issue #2149 -- return empty result when requesting non-existent
@@ -954,9 +919,7 @@ def test_pandas_float_formatting(dxf: DataExplorerFixture):
     # (FormatOptions, expected results)
     cases = [
         (
-            FormatOptions(
-                large_num_digits=2, small_num_digits=4, max_integral_digits=7
-            ),
+            FormatOptions(large_num_digits=2, small_num_digits=4, max_integral_digits=7),
             [
                 "0.00",
                 "1.00",
@@ -1011,12 +974,8 @@ def test_pandas_float_formatting(dxf: DataExplorerFixture):
 def test_pandas_extension_dtypes(dxf: DataExplorerFixture):
     df = pd.DataFrame(
         {
-            "datetime_tz": pd.date_range(
-                "2000-01-01", periods=5, tz="US/Eastern"
-            ),
-            "arrow_bools": pd.Series(
-                [False, None, True, False, None], dtype=pd.BooleanDtype()
-            ),
+            "datetime_tz": pd.date_range("2000-01-01", periods=5, tz="US/Eastern"),
+            "arrow_bools": pd.Series([False, None, True, False, None], dtype=pd.BooleanDtype()),
             "arrow_strings": pd.Series(
                 ["foo", "bar", "baz", None, "quuuux"], dtype=pd.StringDtype()
             ),
@@ -1096,9 +1055,7 @@ def test_pandas_leading_whitespace(dxf: DataExplorerFixture):
     assert result["columns"] == expected_columns
 
 
-def _filter(
-    filter_type, column_schema, condition="and", is_valid=None, **kwargs
-):
+def _filter(filter_type, column_schema, condition="and", is_valid=None, **kwargs):
     kwargs.update(
         {
             "filter_id": guid(),
@@ -1121,9 +1078,7 @@ def _compare_filter(column_schema, op, value, condition="and", is_valid=None):
     )
 
 
-def _between_filter(
-    column_schema, left_value, right_value, op="between", condition="and"
-):
+def _between_filter(column_schema, left_value, right_value, op="between", condition="and"):
     return _filter(
         op,
         column_schema,
@@ -1135,9 +1090,7 @@ def _between_filter(
     )
 
 
-def _not_between_filter(
-    column_schema, left_value, right_value, condition="and"
-):
+def _not_between_filter(column_schema, left_value, right_value, condition="and"):
     return _between_filter(
         column_schema,
         left_value,
@@ -1200,20 +1153,12 @@ def test_pandas_filter_between(dxf: DataExplorerFixture):
 
         dxf.check_filter_case(
             df,
-            [
-                _between_filter(
-                    column_schema, str(left_value), str(right_value)
-                )
-            ],
+            [_between_filter(column_schema, str(left_value), str(right_value))],
             ex_between,
         )
         dxf.check_filter_case(
             df,
-            [
-                _not_between_filter(
-                    column_schema, str(left_value), str(right_value)
-                )
-            ],
+            [_not_between_filter(column_schema, str(left_value), str(right_value))],
             ex_not_between,
         )
 
@@ -1293,9 +1238,7 @@ def test_pandas_filter_reset(dxf: DataExplorerFixture):
     filt = _compare_filter(schema[0], "<", 3)
     _ = dxf.set_row_filters(table_name, filters=[filt])
     response = dxf.set_row_filters(table_name, filters=[])
-    assert response == FilterResult(
-        selected_num_rows=len(df), had_errors=False
-    )
+    assert response == FilterResult(selected_num_rows=len(df), had_errors=False)
 
     # register the whole table to make sure the filters are really cleared
     ex_id = guid()
@@ -1366,18 +1309,10 @@ def test_pandas_filter_empty(dxf: DataExplorerFixture):
 
     schema = dxf.get_schema_for(df)
 
-    dxf.check_filter_case(
-        df, [_filter("is_empty", schema[0])], df[df["a"].str.len() == 0]
-    )
-    dxf.check_filter_case(
-        df, [_filter("not_empty", schema[0])], df[df["a"].str.len() != 0]
-    )
-    dxf.check_filter_case(
-        df, [_filter("is_empty", schema[1])], df[df["b"].str.len() == 0]
-    )
-    dxf.check_filter_case(
-        df, [_filter("not_empty", schema[1])], df[df["b"].str.len() != 0]
-    )
+    dxf.check_filter_case(df, [_filter("is_empty", schema[0])], df[df["a"].str.len() == 0])
+    dxf.check_filter_case(df, [_filter("not_empty", schema[0])], df[df["a"].str.len() != 0])
+    dxf.check_filter_case(df, [_filter("is_empty", schema[1])], df[df["b"].str.len() == 0])
+    dxf.check_filter_case(df, [_filter("not_empty", schema[1])], df[df["b"].str.len() != 0])
 
 
 def test_pandas_filter_boolean(dxf: DataExplorerFixture):
@@ -1389,12 +1324,8 @@ def test_pandas_filter_boolean(dxf: DataExplorerFixture):
 
     schema = dxf.get_schema_for(df)
 
-    dxf.check_filter_case(
-        df, [_filter("is_true", schema[0])], df[df["a"] == True]
-    )  # noqa: E712
-    dxf.check_filter_case(
-        df, [_filter("is_false", schema[0])], df[df["a"] == False]
-    )  # noqa: E712
+    dxf.check_filter_case(df, [_filter("is_true", schema[0])], df[df["a"] == True])  # noqa: E712
+    dxf.check_filter_case(df, [_filter("is_false", schema[0])], df[df["a"] == False])  # noqa: E712
 
 
 def test_pandas_filter_is_null_not_null(dxf: DataExplorerFixture):
@@ -1576,9 +1507,7 @@ def test_variable_updates(
         assert new_state["display_name"] == name
         assert new_state["table_shape"]["num_rows"] == 5
         assert new_state["table_shape"]["num_columns"] == 1
-        assert new_state["sort_keys"] == [
-            ColumnSortKey(**k) for k in x_sort_keys
-        ]
+        assert new_state["sort_keys"] == [ColumnSortKey(**k) for k in x_sort_keys]
 
     # Execute code that triggers an update event for big_x because it's large
     shell.run_cell("None")
@@ -1638,14 +1567,10 @@ class SchemaChangeFixture:
         filter_spec = scenario.get("filters", [])
 
         if "sort_keys" in scenario:
-            self.dxf.set_sort_columns(
-                table_id, sort_keys=scenario["sort_keys"]
-            )
+            self.dxf.set_sort_columns(table_id, sort_keys=scenario["sort_keys"])
 
         if len(filter_spec) > 0:
-            self.dxf.set_row_filters(
-                table_id, filters=list(zip(*filter_spec))[0]
-            )
+            self.dxf.set_row_filters(table_id, filters=list(zip(*filter_spec))[0])
 
         self.dxf.execute_code(code)
 
@@ -1735,9 +1660,7 @@ def test_schema_change_scenario2(ssf: SchemaChangeFixture):
     ssf.check_scenario("df", scenario2, "df['a'] = df['a'].astype('int16')")
 
     # polars
-    ssf.check_scenario(
-        "dfp", scenario2, "dfp = dfp.with_columns(pl.col('a').cast(pl.Int16))"
-    )
+    ssf.check_scenario("dfp", scenario2, "dfp = dfp.with_columns(pl.col('a').cast(pl.Int16))")
 
 
 def test_schema_change_scenario3(ssf: SchemaChangeFixture):
@@ -1814,14 +1737,10 @@ def test_schema_change_scenario6(ssf: SchemaChangeFixture):
     ssf.check_scenario("df", scenario6, "df['b2'] = df['b']")
 
     # polars
-    ssf.check_scenario(
-        "dfp", scenario6, "dfp = dfp.with_columns(dfp['b'].alias('b2'))"
-    )
+    ssf.check_scenario("dfp", scenario6, "dfp = dfp.with_columns(dfp['b'].alias('b2'))")
 
 
-def test_schema_change_scenario7(
-    ssf: SchemaChangeFixture, dxf: DataExplorerFixture
-):
+def test_schema_change_scenario7(ssf: SchemaChangeFixture, dxf: DataExplorerFixture):
     # Scenario 7: delete column, then restore it and check that the
     def scenario7(fixture: DataExplorerFixture, table_id):
         schema = fixture.get_schema(table_id)
@@ -1906,17 +1825,12 @@ def test_pandas_set_sort_columns(dxf: DataExplorerFixture):
     ]
 
     # Test sort AND filter
-    filter_cases = {
-        "df2": [
-            (lambda x: x[x["a"] > 0], [_compare_filter(df2_schema[0], ">", 0)])
-        ]
-    }
+    filter_cases = {"df2": [(lambda x: x[x["a"] > 0], [_compare_filter(df2_schema[0], ">", 0)])]}
 
     for df_name, sort_keys, expected_params in cases:
         df = tables[df_name]
         wrapped_keys = [
-            {"column_index": index, "ascending": ascending}
-            for index, ascending in sort_keys
+            {"column_index": index, "ascending": ascending} for index, ascending in sort_keys
         ]
 
         expected_params["kind"] = "mergesort"
@@ -1927,9 +1841,7 @@ def test_pandas_set_sort_columns(dxf: DataExplorerFixture):
 
         for filter_f, filters in filter_cases.get(df_name, []):
             expected_filtered = filter_f(df).sort_values(**expected_params)
-            dxf.check_sort_case(
-                df, wrapped_keys, expected_filtered, filters=filters
-            )
+            dxf.check_sort_case(df, wrapped_keys, expected_filtered, filters=filters)
 
 
 def test_pandas_change_schema_after_sort(
@@ -1972,9 +1884,7 @@ def test_pandas_change_schema_after_sort(
 
     # Check that the out of bounds column index was evicted, and the
     # shift was correct
-    dxf.get_state("df")["sort_keys"] = [
-        {"column_index": 1, "ascending": False}
-    ]
+    dxf.get_state("df")["sort_keys"] = [{"column_index": 1, "ascending": False}]
 
 
 def test_pandas_updated_with_sort_keys(dxf: DataExplorerFixture):
@@ -2062,13 +1972,9 @@ def test_export_data_selection(dxf: DataExplorerFixture):
     ncols = 20
 
     np.random.seed(12345)
-    df = pd.DataFrame(
-        {f"a{i}": np.random.standard_normal(length) for i in range(ncols)}
-    )
+    df = pd.DataFrame({f"a{i}": np.random.standard_normal(length) for i in range(ncols)})
 
-    dfp = pl.DataFrame(
-        {f"a{i}": np.random.standard_normal(length) for i in range(ncols)}
-    )
+    dfp = pl.DataFrame({f"a{i}": np.random.standard_normal(length) for i in range(ncols)})
 
     pandas_name = "df"
     polars_name = "dfp"
@@ -2080,9 +1986,7 @@ def test_export_data_selection(dxf: DataExplorerFixture):
 
     for name in ["df_filtered", "dfp_filtered"]:
         schema = dxf.get_schema(name)
-        dxf.set_row_filters(
-            name, filters=[_compare_filter(schema[0], ">", "0")]
-        )
+        dxf.set_row_filters(name, filters=[_compare_filter(schema[0], ">", "0")])
 
     # Test exporting single cells
     single_cell_cases = [(0, 0), (5, 10), (25, 15), (99, 19)]
@@ -2153,9 +2057,7 @@ def test_export_data_selection(dxf: DataExplorerFixture):
 
             filt_row_index = min(row_index, len(filtered) - 1)
             filt_selection = _select_single_cell(filt_row_index, col_index)
-            filt_result = dxf.export_data_selection(
-                f"{name}_filtered", filt_selection, "csv"
-            )
+            filt_result = dxf.export_data_selection(f"{name}_filtered", filt_selection, "csv")
             filt_expected = export_cell(filtered, filt_row_index, col_index)
             assert filt_result["data"] == filt_expected
 
@@ -2174,9 +2076,7 @@ def test_export_data_selection(dxf: DataExplorerFixture):
                 assert df_result["data"] == df_expected
                 assert df_result["format"] == fmt
 
-                filt_result = dxf.export_data_selection(
-                    f"{name}_filtered", rpc_selection, fmt
-                )
+                filt_result = dxf.export_data_selection(f"{name}_filtered", rpc_selection, fmt)
                 filt_expected = export_table(filtered_selected, fmt)
                 assert filt_result["data"] == filt_expected
 
@@ -2236,9 +2136,7 @@ def test_pandas_profile_null_counts(dxf: DataExplorerFixture):
     for table_name, profiles, ex_results in cases:
         results = dxf.get_column_profiles(table_name, profiles)
 
-        ex_results = [
-            ColumnProfileResult(null_count=count) for count in ex_results
-        ]
+        ex_results = [ColumnProfileResult(null_count=count) for count in ex_results]
 
         assert results == ex_results
 
@@ -2295,10 +2193,7 @@ def _assert_numeric_stats_equal(expected, actual):
     # for stats that weren't expected, check that there isn't an
     # unexpected value
     for not_expected_stat in all_stats:
-        assert (
-            not_expected_stat not in actual
-            or actual[not_expected_stat] is None
-        )
+        assert not_expected_stat not in actual or actual[not_expected_stat] is None
 
 
 def _assert_string_stats_equal(expected, actual):
@@ -2350,9 +2245,7 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             "f4": getattr(
                 pd.date_range("2000-01-01", freq="D", periods=100), "date"
             ),  # date column
-            "f5": pd.date_range(
-                "2000-01-01", freq="2h", periods=100
-            ),  # datetime no tz
+            "f5": pd.date_range("2000-01-01", freq="2h", periods=100),  # datetime no tz
             "f6": pd.date_range(
                 "2000-01-01", freq="2h", periods=100, tz="US/Eastern"
             ),  # datetime single tz
@@ -2363,15 +2256,9 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
 
     df_mixed_tz1 = pd.concat(
         [
+            pd.DataFrame({"x": pd.date_range("2000-01-01", freq="2h", periods=50)}),
             pd.DataFrame(
-                {"x": pd.date_range("2000-01-01", freq="2h", periods=50)}
-            ),
-            pd.DataFrame(
-                {
-                    "x": pd.date_range(
-                        "2000-01-01", freq="2h", periods=50, tz="US/Eastern"
-                    )
-                }
+                {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="US/Eastern")}
             ),
             pd.DataFrame(
                 {
@@ -2390,11 +2277,7 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
     df_mixed_tz2 = pd.concat(
         [
             pd.DataFrame(
-                {
-                    "x": pd.date_range(
-                        "2000-01-01", freq="2h", periods=50, tz="US/Eastern"
-                    )
-                }
+                {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="US/Eastern")}
             ),
             pd.DataFrame(
                 {
@@ -2527,9 +2410,7 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
 
     for table_name, col_index, ex_result in cases:
         profiles = [_get_summary_stats(col_index)]
-        results = dxf.get_column_profiles(
-            table_name, profiles, format_options=format_options
-        )
+        results = dxf.get_column_profiles(table_name, profiles, format_options=format_options)
 
         stats = results[0]["summary_stats"]
         ui_type = stats["type_display"]
@@ -2625,9 +2506,7 @@ POLARS_TYPE_EXAMPLES = [
 def example_polars_df():
     full_schema = []
     full_data = []
-    for i, (dtype, data, type_name, type_display) in enumerate(
-        POLARS_TYPE_EXAMPLES
-    ):
+    for i, (dtype, data, type_name, type_display) in enumerate(POLARS_TYPE_EXAMPLES):
         name = f"f{i}"
         s = pl.Series(name=name, values=data, dtype=dtype)
         full_data.append(s)
@@ -2662,12 +2541,8 @@ def test_polars_get_schema(dxf: DataExplorerFixture):
 
     # Test partial gets, boundschecking
     assert dxf.get_schema(table_name, 0, 0) == []
-    assert dxf.get_schema(table_name, 5, 5) == _wrap_json(
-        ColumnSchema, full_schema[5:10]
-    )
-    assert dxf.get_schema(table_name, 5, 100) == _wrap_json(
-        ColumnSchema, full_schema[5:]
-    )
+    assert dxf.get_schema(table_name, 5, 5) == _wrap_json(ColumnSchema, full_schema[5:10])
+    assert dxf.get_schema(table_name, 5, 100) == _wrap_json(ColumnSchema, full_schema[5:])
 
 
 def test_polars_get_state(dxf: DataExplorerFixture):
@@ -2685,22 +2560,10 @@ def test_polars_get_state(dxf: DataExplorerFixture):
     assert state["row_filters"] == []
 
     features = state["supported_features"]
-    assert (
-        features["search_schema"]["support_status"]
-        == SupportStatus.Unsupported
-    )
-    assert (
-        features["set_row_filters"]["support_status"]
-        == SupportStatus.Supported
-    )
-    assert (
-        features["set_sort_columns"]["support_status"]
-        == SupportStatus.Supported
-    )
-    assert (
-        features["get_column_profiles"]["support_status"]
-        == SupportStatus.Supported
-    )
+    assert features["search_schema"]["support_status"] == SupportStatus.Unsupported
+    assert features["set_row_filters"]["support_status"] == SupportStatus.Supported
+    assert features["set_sort_columns"]["support_status"] == SupportStatus.Supported
+    assert features["get_column_profiles"]["support_status"] == SupportStatus.Supported
     export_data = features["export_data_selection"]
     assert export_data["support_status"] == SupportStatus.Supported
     assert export_data["supported_formats"] == ["csv", "tsv"]
@@ -2779,9 +2642,7 @@ def test_polars_get_data_values(dxf: DataExplorerFixture):
     )
     assert result["columns"] == [x[2:] for x in expected_columns[15:]]
 
-    result = dxf.get_data_values(
-        name, row_start_index=10, num_rows=10, column_indices=[]
-    )
+    result = dxf.get_data_values(name, row_start_index=10, num_rows=10, column_indices=[])
     assert result["columns"] == []
     assert result["row_labels"] is None
 
@@ -2802,20 +2663,12 @@ def test_polars_filter_between(dxf: DataExplorerFixture):
 
         dxf.check_filter_case(
             df,
-            [
-                _between_filter(
-                    column_schema, str(left_value), str(right_value)
-                )
-            ],
+            [_between_filter(column_schema, str(left_value), str(right_value))],
             ex_between,
         )
         dxf.check_filter_case(
             df,
-            [
-                _not_between_filter(
-                    column_schema, str(left_value), str(right_value)
-                )
-            ],
+            [_not_between_filter(column_schema, str(left_value), str(right_value))],
             ex_not_between,
         )
 
@@ -2908,23 +2761,15 @@ def test_polars_filter_boolean(dxf: DataExplorerFixture):
 
     schema = dxf.get_schema_for(df)
 
-    dxf.check_filter_case(
-        df, [_filter("is_true", schema[0])], df.filter(df["a"])
-    )
-    dxf.check_filter_case(
-        df, [_filter("is_false", schema[0])], df.filter(~df["a"])
-    )
+    dxf.check_filter_case(df, [_filter("is_true", schema[0])], df.filter(df["a"]))
+    dxf.check_filter_case(df, [_filter("is_false", schema[0])], df.filter(~df["a"]))
 
 
 def test_polars_filter_is_null_not_null(dxf: DataExplorerFixture):
     df, schema = example_polars_df()
     for i, col in enumerate(schema):
-        dxf.check_filter_case(
-            df, [_filter("is_null", col)], df.filter(df[:, i].is_null())
-        )
-        dxf.check_filter_case(
-            df, [_filter("not_null", col)], df.filter(~df[:, i].is_null())
-        )
+        dxf.check_filter_case(df, [_filter("is_null", col)], df.filter(df[:, i].is_null()))
+        dxf.check_filter_case(df, [_filter("not_null", col)], df.filter(~df[:, i].is_null()))
 
 
 def test_polars_filter_reset(dxf: DataExplorerFixture):
@@ -2937,9 +2782,7 @@ def test_polars_filter_reset(dxf: DataExplorerFixture):
     filt = _compare_filter(schema[4], "<", 0)
     dxf.set_row_filters(table_id, filters=[filt])
     response = dxf.set_row_filters(table_id, filters=[])
-    assert response == FilterResult(
-        selected_num_rows=len(df), had_errors=False
-    )
+    assert response == FilterResult(selected_num_rows=len(df), had_errors=False)
 
     # register the whole table to make sure the filters are really cleared
     ex_id = guid()
@@ -3114,8 +2957,7 @@ def test_polars_set_sort_columns(dxf: DataExplorerFixture):
     for df_name, sort_keys, expected_params in cases:
         df = tables[df_name]
         wrapped_keys = [
-            {"column_index": index, "ascending": ascending}
-            for index, ascending in sort_keys
+            {"column_index": index, "ascending": ascending} for index, ascending in sort_keys
         ]
 
         args = (expected_params["by"],)
@@ -3129,9 +2971,7 @@ def test_polars_set_sort_columns(dxf: DataExplorerFixture):
 
         for filter_f, filters in filter_cases.get(df_name, []):
             expected_filtered = filter_f(df).sort(*args, **kwds)
-            dxf.check_sort_case(
-                df, wrapped_keys, expected_filtered, filters=filters
-            )
+            dxf.check_sort_case(df, wrapped_keys, expected_filtered, filters=filters)
 
 
 def test_polars_profile_null_counts(dxf: DataExplorerFixture):
@@ -3170,8 +3010,6 @@ def test_polars_profile_null_counts(dxf: DataExplorerFixture):
     for table_name, profiles, ex_results in cases:
         results = dxf.get_column_profiles(table_name, profiles)
 
-        ex_results = [
-            ColumnProfileResult(null_count=count) for count in ex_results
-        ]
+        ex_results = [ColumnProfileResult(null_count=count) for count in ex_results]
 
         assert results == ex_results

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -35,20 +35,23 @@
 		},
 		{
 			"name": "search_schema",
-			"summary": "Search schema by column name",
+			"summary": "Search schema with column filters",
 			"description": "Search schema for column names matching a passed substring",
 			"params": [
 				{
-					"name": "search_term",
-					"description": "Substring to match for (currently case insensitive)",
+					"name": "filters",
+					"description": "Column filters to apply when searching",
 					"required": true,
 					"schema": {
-						"type": "string"
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/column_filter"
+						}
 					}
 				},
 				{
 					"name": "start_index",
-					"description": "Index (starting from zero) of first result to fetch",
+					"description": "Index (starting from zero) of first result to fetch (for paging)",
 					"required": false,
 					"schema": {
 						"type": "integer"
@@ -77,7 +80,7 @@
 							"$ref": "#/components/schemas/table_schema"
 						},
 						"total_num_matches": {
-							"description": "The total number of columns matching the search term",
+							"description": "The total number of columns matching the filter",
 							"type": "integer"
 						}
 					}
@@ -538,23 +541,32 @@
 						"type": "string",
 						"description": "Optional error message when the filter is invalid"
 					},
-					"between_params": {
-						"description": "Parameters for the 'between' and 'not_between' filter types",
-						"$ref": "#/components/schemas/between_filter_params"
-					},
-					"compare_params": {
-						"description": "Parameters for the 'compare' filter type",
-						"$ref": "#/components/schemas/compare_filter_params"
-					},
-					"search_params": {
-						"description": "Parameters for the 'search' filter type",
-						"$ref": "#/components/schemas/search_filter_params"
-					},
-					"set_membership_params": {
-						"description": "Parameters for the 'set_membership' filter type",
-						"$ref": "#/components/schemas/set_membership_filter_params"
+					"params": {
+						"description": "The row filter type-specific parameters",
+						"$ref": "#/components/schemas/row_filter_params"
 					}
 				}
+			},
+			"row_filter_params": {
+				"description": "Union of row filter parameters",
+				"oneOf": [
+					{
+						"name": "between",
+						"$ref": "#/components/schemas/filter_between"
+					},
+					{
+						"name": "comparison",
+						"$ref": "#/components/schemas/filter_comparison"
+					},
+					{
+						"name": "text_search",
+						"$ref": "#/components/schemas/filter_text_search"
+					},
+					{
+						"name": "set_membership",
+						"$ref": "#/components/schemas/filter_set_membership"
+					}
+				]
 			},
 			"row_filter_type": {
 				"type": "string",
@@ -591,7 +603,7 @@
 					}
 				}
 			},
-			"between_filter_params": {
+			"filter_between": {
 				"type": "object",
 				"description": "Parameters for the 'between' and 'not_between' filter types",
 				"required": [
@@ -609,7 +621,7 @@
 					}
 				}
 			},
-			"compare_filter_params": {
+			"filter_comparison": {
 				"type": "object",
 				"description": "Parameters for the 'compare' filter type",
 				"required": [
@@ -635,7 +647,7 @@
 					}
 				}
 			},
-			"set_membership_filter_params": {
+			"filter_set_membership": {
 				"type": "object",
 				"description": "Parameters for the 'set_membership' filter type",
 				"required": [
@@ -645,7 +657,7 @@
 				"properties": {
 					"values": {
 						"type": "array",
-						"description": "Array of column values for a set membership filter",
+						"description": "Array of values for a set membership filter",
 						"items": {
 							"type": "string"
 						}
@@ -656,7 +668,7 @@
 					}
 				}
 			},
-			"search_filter_params": {
+			"filter_text_search": {
 				"type": "object",
 				"description": "Parameters for the 'search' filter type",
 				"required": [
@@ -666,12 +678,12 @@
 				],
 				"properties": {
 					"search_type": {
-						"$ref": "#/components/schemas/search_filter_type",
+						"$ref": "#/components/schemas/text_search_type",
 						"description": "Type of search to perform"
 					},
 					"term": {
 						"type": "string",
-						"description": "String value/regex to search for in stringified data"
+						"description": "String value/regex to search for"
 					},
 					"case_sensitive": {
 						"type": "boolean",
@@ -679,14 +691,69 @@
 					}
 				}
 			},
-			"search_filter_type": {
+			"text_search_type": {
 				"type": "string",
-				"description": "Type of string search filter to perform",
+				"description": "Type of string text search filter to perform",
 				"enum": [
 					"contains",
 					"starts_with",
 					"ends_with",
 					"regex_match"
+				]
+			},
+			"filter_match_data_types": {
+				"type": "object",
+				"description": "Parameters for the 'match_data_types' filter type",
+				"required": [
+					"display_types"
+				],
+				"properties": {
+					"display_types": {
+						"type": "array",
+						"description": "Column display types to match",
+						"items": {
+							"$ref": "#/components/schemas/column_display_type"
+						}
+					}
+				}
+			},
+			"column_filter": {
+				"type": "object",
+				"description": "A filter that selects a subset of columns by name, type, or other criteria",
+				"required": [
+					"filter_type",
+					"params"
+				],
+				"properties": {
+					"filter_type": {
+						"description": "Type of column filter to apply",
+						"$ref": "#/components/schemas/column_filter_type"
+					},
+					"params": {
+						"description": "Parameters for column filter",
+						"$ref": "#/components/schemas/column_filter_params"
+					}
+				}
+			},
+			"column_filter_params": {
+				"description": "Union of column filter type-specific parameters",
+				"oneOf": [
+					{
+						"name": "text_search",
+						"$ref": "#/components/schemas/filter_text_search"
+					},
+					{
+						"name": "match_data_types",
+						"$ref": "#/components/schemas/filter_match_data_types"
+					}
+				]
+			},
+			"column_filter_type": {
+				"type": "string",
+				"description": "Type of column filter",
+				"enum": [
+					"text_search",
+					"match_data_type"
 				]
 			},
 			"column_profile_request": {

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -753,8 +753,26 @@
 				"description": "Type of column filter",
 				"enum": [
 					"text_search",
-					"match_data_type"
+					"match_data_types"
 				]
+			},
+			"column_filter_type_support_status": {
+				"type": "object",
+				"description": "Support status for a column filter type",
+				"required": [
+					"column_filter_type",
+					"support_status"
+				],
+				"properties": {
+					"column_filter_type": {
+						"description": "Type of column filter",
+						"$ref": "#/components/schemas/column_filter_type"
+					},
+					"support_status": {
+						"description": "The support status for this column filter type",
+						"$ref": "#/components/schemas/support_status"
+					}
+				}
 			},
 			"column_profile_request": {
 				"type": "object",
@@ -1123,12 +1141,20 @@
 				"type": "object",
 				"description": "Feature flags for 'search_schema' RPC",
 				"required": [
-					"support_status"
+					"support_status",
+					"supported_types"
 				],
 				"properties": {
 					"support_status": {
 						"$ref": "#/components/schemas/support_status",
 						"description": "The support status for this RPC method"
+					},
+					"supported_types": {
+						"type": "array",
+						"description": "A list of supported types",
+						"items": {
+							"$ref": "#/components/schemas/column_filter_type_support_status"
+						}
 					}
 				}
 			},

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -533,6 +533,9 @@ use serde::Serialize;
 				yield formatComment(`/// `,
 					`Union type ` +
 					snakeCaseToSentenceCase(context[0]));
+				if (o.description) {
+					yield formatComment(`/// `, o.description);
+				}
 				yield '#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]\n';
 				yield '#[serde(untagged)]\n';
 				yield `pub enum ${snakeCaseToSentenceCase(context[0])} {\n`;
@@ -892,12 +895,16 @@ from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictI
 			name = snakeCaseToSentenceCase(name);
 
 			// Document origin of union
-			if (context.length === 1) {
+
+			if (o.description) {
+				yield formatComment('# ', o.description);
+			} else if (context.length === 1) {
 				yield formatComment('# ', snakeCaseToSentenceCase(context[0]));
 			} else {
 				yield formatComment('# ', snakeCaseToSentenceCase(context[0]) + ' in ' +
 					snakeCaseToSentenceCase(context[1]));
 			}
+
 			yield `${name} = Union[`;
 			// Options
 			for (const option of o.oneOf) {
@@ -1163,7 +1170,9 @@ import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/co
 			name = snakeCaseToSentenceCase(name);
 
 			// Document origin of union
-			if (context.length === 1) {
+			if (o.description) {
+				yield formatComment('/// ', o.description);
+			} else if (context.length === 1) {
 				yield formatComment('/// ', snakeCaseToSentenceCase(context[0]));
 			} else {
 				yield formatComment('/// ', snakeCaseToSentenceCase(context[0]) + ' in ' +

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
@@ -6,11 +6,15 @@
 import { generateUuid } from 'vs/base/common/uuid';
 import {
 	ColumnSchema,
-	CompareFilterParamsOp,
+	FilterBetween,
+	FilterComparison,
+	FilterComparisonOp,
+	FilterSetMembership,
+	FilterTextSearch,
 	RowFilter,
 	RowFilterCondition,
 	RowFilterType,
-	SearchFilterType
+	TextSearchType
 } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
@@ -334,18 +338,18 @@ export class RowFilterDescriptorComparison extends SingleValueRowFilterDescripto
 		const getCompareOp = () => {
 			switch (this.descrType) {
 				case RowFilterDescrType.IS_EQUAL_TO:
-					return CompareFilterParamsOp.Eq;
+					return FilterComparisonOp.Eq;
 				case RowFilterDescrType.IS_GREATER_OR_EQUAL:
-					return CompareFilterParamsOp.GtEq;
+					return FilterComparisonOp.GtEq;
 				case RowFilterDescrType.IS_GREATER_THAN:
-					return CompareFilterParamsOp.Gt;
+					return FilterComparisonOp.Gt;
 				case RowFilterDescrType.IS_LESS_OR_EQUAL:
-					return CompareFilterParamsOp.LtEq;
+					return FilterComparisonOp.LtEq;
 				case RowFilterDescrType.IS_LESS_THAN:
-					return CompareFilterParamsOp.Lt;
+					return FilterComparisonOp.Lt;
 				default:
 					// IS_NOT_EQUAL_TO
-					return CompareFilterParamsOp.NotEq;
+					return FilterComparisonOp.NotEq;
 			}
 		};
 		return {
@@ -412,14 +416,14 @@ export class RowFilterDescriptorSearch extends SingleValueRowFilterDescriptor {
 		const getSearchOp = () => {
 			switch (this._descrType) {
 				case RowFilterDescrType.SEARCH_CONTAINS:
-					return SearchFilterType.Contains;
+					return TextSearchType.Contains;
 				case RowFilterDescrType.SEARCH_STARTS_WITH:
-					return SearchFilterType.StartsWith;
+					return TextSearchType.StartsWith;
 				case RowFilterDescrType.SEARCH_ENDS_WITH:
-					return SearchFilterType.EndsWith;
+					return TextSearchType.EndsWith;
 				default:
 					// SEARCH_REGEX_MATCHES
-					return SearchFilterType.RegexMatch;
+					return TextSearchType.RegexMatch;
 			}
 		};
 
@@ -569,32 +573,32 @@ export class RowFilterDescriptorIsNotBetween extends RangeRowFilterDescriptor {
 	}
 }
 
-function getCompareDescrType(op: CompareFilterParamsOp) {
+function getCompareDescrType(op: FilterComparisonOp) {
 	switch (op) {
-		case CompareFilterParamsOp.Eq:
+		case FilterComparisonOp.Eq:
 			return RowFilterDescrType.IS_EQUAL_TO;
-		case CompareFilterParamsOp.NotEq:
+		case FilterComparisonOp.NotEq:
 			return RowFilterDescrType.IS_NOT_EQUAL_TO;
-		case CompareFilterParamsOp.Lt:
+		case FilterComparisonOp.Lt:
 			return RowFilterDescrType.IS_LESS_THAN;
-		case CompareFilterParamsOp.LtEq:
+		case FilterComparisonOp.LtEq:
 			return RowFilterDescrType.IS_LESS_OR_EQUAL;
-		case CompareFilterParamsOp.Gt:
+		case FilterComparisonOp.Gt:
 			return RowFilterDescrType.IS_GREATER_THAN;
-		case CompareFilterParamsOp.GtEq:
+		case FilterComparisonOp.GtEq:
 			return RowFilterDescrType.IS_GREATER_OR_EQUAL;
 	}
 }
 
-function getSearchDescrType(searchType: SearchFilterType) {
+function getSearchDescrType(searchType: TextSearchType) {
 	switch (searchType) {
-		case SearchFilterType.Contains:
+		case TextSearchType.Contains:
 			return RowFilterDescrType.SEARCH_CONTAINS;
-		case SearchFilterType.EndsWith:
+		case TextSearchType.EndsWith:
 			return RowFilterDescrType.SEARCH_ENDS_WITH;
-		case SearchFilterType.StartsWith:
+		case TextSearchType.StartsWith:
 			return RowFilterDescrType.SEARCH_STARTS_WITH;
-		case SearchFilterType.RegexMatch:
+		case TextSearchType.RegexMatch:
 			return RowFilterDescrType.SEARCH_REGEX_MATCHES;
 	}
 }
@@ -608,19 +612,19 @@ export function getRowFilterDescriptor(backendFilter: RowFilter): RowFilterDescr
 	};
 	switch (backendFilter.filter_type) {
 		case RowFilterType.Compare: {
-			const params = backendFilter.compare_params!;
+			const params = backendFilter.params as FilterComparison;
 			return new RowFilterDescriptorComparison(commonProps,
 				params.value, getCompareDescrType(params.op),
 			);
 		}
 		case RowFilterType.Between: {
-			const params = backendFilter.between_params!;
+			const params = backendFilter.params as FilterBetween;
 			return new RowFilterDescriptorIsBetween(commonProps,
 				params.left_value, params.right_value
 			);
 		}
 		case RowFilterType.NotBetween: {
-			const params = backendFilter.between_params!;
+			const params = backendFilter.params as FilterBetween;
 			return new RowFilterDescriptorIsNotBetween(commonProps,
 				params.left_value, params.right_value
 			);
@@ -638,12 +642,12 @@ export function getRowFilterDescriptor(backendFilter: RowFilter): RowFilterDescr
 		case RowFilterType.IsFalse:
 			return new RowFilterDescriptorIsFalse(commonProps);
 		case RowFilterType.Search: {
-			const params = backendFilter.search_params!;
+			const params = backendFilter.params as FilterTextSearch;
 			return new RowFilterDescriptorSearch(commonProps,
 				params.term, getSearchDescrType(params.search_type));
 		}
 		case RowFilterType.SetMembership: {
-			const params = backendFilter.set_membership_params!;
+			const params = backendFilter.params as FilterSetMembership;
 			return new RowFilterDescriptorSetMembership(commonProps,
 				params.values
 			);

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
@@ -122,7 +122,7 @@ export class RowFilterDescriptorIsEmpty extends BaseRowFilterDescriptor {
 	/**
 	 * Get the backend OpenRPC type.
 	 */
-	get backendFilter() {
+	get backendFilter(): RowFilter {
 		return {
 			filter_type: RowFilterType.IsEmpty,
 			...this._sharedBackendParams()
@@ -334,7 +334,7 @@ export class RowFilterDescriptorComparison extends SingleValueRowFilterDescripto
 	/**
 	 * Get the backend OpenRPC type.
 	 */
-	get backendFilter() {
+	get backendFilter(): RowFilter {
 		const getCompareOp = () => {
 			switch (this.descrType) {
 				case RowFilterDescrType.IS_EQUAL_TO:
@@ -354,7 +354,7 @@ export class RowFilterDescriptorComparison extends SingleValueRowFilterDescripto
 		};
 		return {
 			filter_type: RowFilterType.Compare,
-			compare_params: {
+			params: {
 				op: getCompareOp(),
 				value: this.value
 			},
@@ -412,7 +412,7 @@ export class RowFilterDescriptorSearch extends SingleValueRowFilterDescriptor {
 	/**
 	 * Get the backend OpenRPC type.
 	 */
-	get backendFilter() {
+	get backendFilter(): RowFilter {
 		const getSearchOp = () => {
 			switch (this._descrType) {
 				case RowFilterDescrType.SEARCH_CONTAINS:
@@ -429,7 +429,7 @@ export class RowFilterDescriptorSearch extends SingleValueRowFilterDescriptor {
 
 		return {
 			filter_type: RowFilterType.Search,
-			search_params: {
+			params: {
 				search_type: getSearchOp(),
 				term: this.value,
 				case_sensitive: false
@@ -470,10 +470,10 @@ export class RowFilterDescriptorSetMembership extends BaseRowFilterDescriptor {
 	/**
 	 * Get the backend OpenRPC type.
 	 */
-	get backendFilter() {
+	get backendFilter(): RowFilter {
 		return {
 			filter_type: RowFilterType.SetMembership,
-			set_membership_filter_params: {
+			params: {
 				values: this.values,
 				inclusive: true
 			},
@@ -525,10 +525,10 @@ export class RowFilterDescriptorIsBetween extends RangeRowFilterDescriptor {
 	/**
 	 * Get the backend OpenRPC type.
 	 */
-	get backendFilter() {
+	get backendFilter(): RowFilter {
 		return {
 			filter_type: RowFilterType.Between,
-			between_params: {
+			params: {
 				left_value: this.lowerLimit,
 				right_value: this.upperLimit
 			},
@@ -561,10 +561,10 @@ export class RowFilterDescriptorIsNotBetween extends RangeRowFilterDescriptor {
 	/**
 	 * Get the backend OpenRPC type.
 	 */
-	get backendFilter() {
+	get backendFilter(): RowFilter {
 		return {
 			filter_type: RowFilterType.NotBetween,
-			between_params: {
+			params: {
 				left_value: this.lowerLimit,
 				right_value: this.upperLimit
 			},

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -209,7 +209,10 @@ export class DataExplorerClientInstance extends Disposable {
 					row_filters: [],
 					sort_keys: [],
 					supported_features: {
-						search_schema: { support_status: SupportStatus.Unsupported },
+						search_schema: {
+							support_status: SupportStatus.Unsupported,
+							supported_types: []
+						},
 						set_row_filters: {
 							support_status: SupportStatus.Unsupported,
 							supports_conditions: SupportStatus.Unsupported,
@@ -380,7 +383,8 @@ export class DataExplorerClientInstance extends Disposable {
 			// Until the backend state is available, we disable features.
 			return {
 				search_schema: {
-					support_status: SupportStatus.Unsupported
+					support_status: SupportStatus.Unsupported,
+					supported_types: []
 				},
 				set_row_filters: {
 					support_status: SupportStatus.Unsupported,

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -379,6 +379,22 @@ export interface ColumnFilter {
 }
 
 /**
+ * Support status for a column filter type
+ */
+export interface ColumnFilterTypeSupportStatus {
+	/**
+	 * Type of column filter
+	 */
+	column_filter_type: ColumnFilterType;
+
+	/**
+	 * The support status for this column filter type
+	 */
+	support_status: SupportStatus;
+
+}
+
+/**
  * A single column profile request
  */
 export interface ColumnProfileRequest {
@@ -729,6 +745,11 @@ export interface SearchSchemaFeatures {
 	 */
 	support_status: SupportStatus;
 
+	/**
+	 * A list of supported types
+	 */
+	supported_types: Array<ColumnFilterTypeSupportStatus>;
+
 }
 
 /**
@@ -961,7 +982,7 @@ export enum TextSearchType {
  */
 export enum ColumnFilterType {
 	TextSearch = 'text_search',
-	MatchDataType = 'match_data_type'
+	MatchDataTypes = 'match_data_types'
 }
 
 /**

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -21,7 +21,7 @@ export interface SearchSchemaResult {
 	matches?: TableSchema;
 
 	/**
-	 * The total number of columns matching the search term
+	 * The total number of columns matching the filter
 	 */
 	total_num_matches: number;
 
@@ -259,24 +259,9 @@ export interface RowFilter {
 	error_message?: string;
 
 	/**
-	 * Parameters for the 'between' and 'not_between' filter types
+	 * The row filter type-specific parameters
 	 */
-	between_params?: BetweenFilterParams;
-
-	/**
-	 * Parameters for the 'compare' filter type
-	 */
-	compare_params?: CompareFilterParams;
-
-	/**
-	 * Parameters for the 'search' filter type
-	 */
-	search_params?: SearchFilterParams;
-
-	/**
-	 * Parameters for the 'set_membership' filter type
-	 */
-	set_membership_params?: SetMembershipFilterParams;
+	params?: RowFilterParams;
 
 }
 
@@ -299,7 +284,7 @@ export interface RowFilterTypeSupportStatus {
 /**
  * Parameters for the 'between' and 'not_between' filter types
  */
-export interface BetweenFilterParams {
+export interface FilterBetween {
 	/**
 	 * The lower limit for filtering
 	 */
@@ -315,11 +300,11 @@ export interface BetweenFilterParams {
 /**
  * Parameters for the 'compare' filter type
  */
-export interface CompareFilterParams {
+export interface FilterComparison {
 	/**
 	 * String representation of a binary comparison
 	 */
-	op: CompareFilterParamsOp;
+	op: FilterComparisonOp;
 
 	/**
 	 * A stringified column value for a comparison filter
@@ -331,9 +316,9 @@ export interface CompareFilterParams {
 /**
  * Parameters for the 'set_membership' filter type
  */
-export interface SetMembershipFilterParams {
+export interface FilterSetMembership {
 	/**
-	 * Array of column values for a set membership filter
+	 * Array of values for a set membership filter
 	 */
 	values: Array<string>;
 
@@ -347,14 +332,14 @@ export interface SetMembershipFilterParams {
 /**
  * Parameters for the 'search' filter type
  */
-export interface SearchFilterParams {
+export interface FilterTextSearch {
 	/**
 	 * Type of search to perform
 	 */
-	search_type: SearchFilterType;
+	search_type: TextSearchType;
 
 	/**
-	 * String value/regex to search for in stringified data
+	 * String value/regex to search for
 	 */
 	term: string;
 
@@ -362,6 +347,34 @@ export interface SearchFilterParams {
 	 * If true, do a case-sensitive search, otherwise case-insensitive
 	 */
 	case_sensitive: boolean;
+
+}
+
+/**
+ * Parameters for the 'match_data_types' filter type
+ */
+export interface FilterMatchDataTypes {
+	/**
+	 * Column display types to match
+	 */
+	display_types: Array<ColumnDisplayType>;
+
+}
+
+/**
+ * A filter that selects a subset of columns by name, type, or other
+ * criteria
+ */
+export interface ColumnFilter {
+	/**
+	 * Type of column filter to apply
+	 */
+	filter_type: ColumnFilterType;
+
+	/**
+	 * Parameters for column filter
+	 */
+	params: ColumnFilterParams;
 
 }
 
@@ -871,7 +884,13 @@ export interface DataSelectionIndices {
 /// ColumnValue
 export type ColumnValue = number | string;
 
-/// Selection in Properties
+/// Union of row filter parameters
+export type RowFilterParams = FilterBetween | FilterComparison | FilterTextSearch | FilterSetMembership;
+
+/// Union of column filter type-specific parameters
+export type ColumnFilterParams = FilterTextSearch | FilterMatchDataTypes;
+
+/// A union of selection types
 export type Selection = DataSelectionSingleCell | DataSelectionCellRange | DataSelectionRange | DataSelectionIndices;
 
 /**
@@ -916,9 +935,9 @@ export enum RowFilterType {
 }
 
 /**
- * Possible values for Op in CompareFilterParams
+ * Possible values for Op in FilterComparison
  */
-export enum CompareFilterParamsOp {
+export enum FilterComparisonOp {
 	Eq = '=',
 	NotEq = '!=',
 	Lt = '<',
@@ -928,13 +947,21 @@ export enum CompareFilterParamsOp {
 }
 
 /**
- * Possible values for SearchFilterType
+ * Possible values for TextSearchType
  */
-export enum SearchFilterType {
+export enum TextSearchType {
 	Contains = 'contains',
 	StartsWith = 'starts_with',
 	EndsWith = 'ends_with',
 	RegexMatch = 'regex_match'
+}
+
+/**
+ * Possible values for ColumnFilterType
+ */
+export enum ColumnFilterType {
+	TextSearch = 'text_search',
+	MatchDataType = 'match_data_type'
 }
 
 /**
@@ -1031,19 +1058,20 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	}
 
 	/**
-	 * Search schema by column name
+	 * Search schema with column filters
 	 *
 	 * Search schema for column names matching a passed substring
 	 *
-	 * @param searchTerm Substring to match for (currently case insensitive)
+	 * @param filters Column filters to apply when searching
 	 * @param startIndex Index (starting from zero) of first result to fetch
+	 * (for paging)
 	 * @param maxResults Maximum number of resulting column schemas to fetch
 	 * from the start index
 	 *
 	 * @returns undefined
 	 */
-	searchSchema(searchTerm: string, startIndex: number, maxResults: number): Promise<SearchSchemaResult> {
-		return super.performRpc('search_schema', ['search_term', 'start_index', 'max_results'], [searchTerm, startIndex, maxResults]);
+	searchSchema(filters: Array<ColumnFilter>, startIndex: number, maxResults: number): Promise<SearchSchemaResult> {
+		return super.performRpc('search_schema', ['filters', 'start_index', 'max_results'], [filters, startIndex, maxResults]);
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
@@ -5,8 +5,7 @@
 
 import { generateUuid } from 'vs/base/common/uuid';
 import {
-	CompareFilterParamsOp,
-	SearchFilterType,
+	TextSearchType,
 	ColumnSchema,
 	ColumnProfileResult,
 	RowFilter,
@@ -14,7 +13,8 @@ import {
 	TableData,
 	TableSchema,
 	RowFilterCondition,
-	ColumnDisplayType
+	ColumnDisplayType,
+	FilterComparisonOp
 } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 const exampleTypes: [string, ColumnDisplayType, object][] = [
@@ -133,11 +133,11 @@ function _getCommonFilterProps(column_schema: ColumnSchema, filter_type: RowFilt
 	};
 }
 
-export function getCompareFilter(columnSchema: ColumnSchema, op: CompareFilterParamsOp,
+export function getCompareFilter(columnSchema: ColumnSchema, op: FilterComparisonOp,
 	value: string): RowFilter {
 	return {
 		..._getCommonFilterProps(columnSchema, RowFilterType.Compare),
-		compare_params: {
+		params: {
 			op, value
 		}
 	};
@@ -159,17 +159,17 @@ export function getSetMemberFilter(columnSchema: ColumnSchema, values: string[],
 	inclusive: boolean): RowFilter {
 	return {
 		..._getCommonFilterProps(columnSchema, RowFilterType.SetMembership),
-		set_membership_params: {
+		params: {
 			values, inclusive
 		}
 	};
 }
 
 export function getTextSearchFilter(columnSchema: ColumnSchema, searchTerm: string,
-	searchType: SearchFilterType, caseSensitive: boolean): RowFilter {
+	searchType: TextSearchType, caseSensitive: boolean): RowFilter {
 	return {
 		..._getCommonFilterProps(columnSchema, RowFilterType.Search),
-		search_params: {
+		params: {
 			term: searchTerm, search_type: searchType, case_sensitive: caseSensitive
 		}
 	};

--- a/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
+++ b/src/vs/workbench/services/positronDataExplorer/test/common/positronDataExplorerMocks.test.ts
@@ -6,9 +6,12 @@
 import * as assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import {
-	CompareFilterParamsOp,
+	FilterComparison,
+	FilterComparisonOp,
+	FilterSetMembership,
+	FilterTextSearch,
 	RowFilterType,
-	SearchFilterType
+	TextSearchType
 } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import * as mocks from "vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks";
 
@@ -42,13 +45,13 @@ suite('DataExplorerMocks', () => {
 	test('Test getCompareFilter', () => {
 		const schema = mocks.getTableSchema(1000, 10);
 
-		const filter = mocks.getCompareFilter(schema.columns[2], CompareFilterParamsOp.Gt, '1234');
+		const filter = mocks.getCompareFilter(schema.columns[2], FilterComparisonOp.Gt, '1234');
 		assert.equal(filter.filter_type, RowFilterType.Compare);
 		assert.equal(filter.column_schema.column_index, 2);
 
-		const params = filter.compare_params!;
+		const params = filter.params as FilterComparison;
 
-		assert.equal(params.op, CompareFilterParamsOp.Gt);
+		assert.equal(params.op, FilterComparisonOp.Gt);
 		assert.equal(params.value, '1234');
 	});
 
@@ -65,14 +68,14 @@ suite('DataExplorerMocks', () => {
 	test('Test getTextSearchFilter', () => {
 		const schema = mocks.getTableSchema(1000, 10);
 		const filter = mocks.getTextSearchFilter(schema.columns[5], 'needle',
-			SearchFilterType.Contains, false);
+			TextSearchType.Contains, false);
 		assert.equal(filter.column_schema.column_index, 5);
 		assert.equal(filter.filter_type, RowFilterType.Search);
 
-		const params = filter.search_params!;
+		const params = filter.params as FilterTextSearch;
 
 		assert.equal(params.term, 'needle');
-		assert.equal(params.search_type, SearchFilterType.Contains);
+		assert.equal(params.search_type, TextSearchType.Contains);
 		assert.equal(params.case_sensitive, false);
 	});
 
@@ -83,7 +86,7 @@ suite('DataExplorerMocks', () => {
 		assert.equal(filter.column_schema.column_index, 6);
 		assert.equal(filter.filter_type, RowFilterType.SetMembership);
 
-		const params = filter.set_membership_params!;
+		const params = filter.params as FilterSetMembership;
 
 		assert.equal(params.values, set_values);
 		assert.equal(params.inclusive, true);


### PR DESCRIPTION
This adds a `match_data_types` filter type in the `search_schema` RPC to support column selection and filtering workflows. This is implemented/tested for both pandas and polars -- no user-visible capabilities in this change. 

I also refactored the row filter RPC types a bit to support extensibility and code reuse. We will need to coordinate with Ark when merging this. 

Related Ark PR: https://github.com/posit-dev/ark/pull/424