### PR TITLE
Add Data Explorer Python Polars Smoke Test

### DIFF
--- a/test/automation/src/positron/positronDataExplorer.ts
+++ b/test/automation/src/positron/positronDataExplorer.ts
@@ -6,6 +6,7 @@
 
 import { expect } from '@playwright/test';
 import { Code } from '../code';
+import { PositronBaseElement } from './positronBaseElement';
 
 const COLUMN_HEADERS = '.data-explorer-panel .column-2 .data-grid-column-headers';
 const HEADER_TITLES = '.data-grid-column-header .title-description .title';
@@ -24,6 +25,7 @@ const FILTER_SELECTOR = '.positron-modal-overlay .row-filter-parameter-input .te
 const APPLY_FILTER = '.positron-modal-overlay .button-apply-row-filter';
 const STATUS_BAR = '.positron-data-explorer .status-bar';
 const OVERLAY_BUTTON = '.positron-modal-overlay .positron-button';
+const CLEAR_SORTING_BUTTON = '.codicon-positron-clear-sorting';
 
 export interface CellData {
 	[key: string]: string;
@@ -34,7 +36,11 @@ export interface CellData {
  */
 export class PositronDataExplorer {
 
-	constructor(private code: Code) { }
+	clearSortingButton: PositronBaseElement;
+
+	constructor(private code: Code) {
+		this.clearSortingButton = new PositronBaseElement(CLEAR_SORTING_BUTTON, this.code);
+	}
 
 	/*
 	 * Get the currently visible data explorer table data
@@ -101,7 +107,7 @@ export class PositronDataExplorer {
 			await this.code.waitAndClick(COLUMN_SELECTOR_CELL);
 			const checkValue = (await this.code.waitForElement(COLUMN_SELECTOR)).textContent;
 			expect(checkValue).toBe(columnName);
-		}).toPass();
+		}).toPass({timeout: 10000});
 
 
 		await this.code.waitAndClick(FUNCTION_SELECTOR);

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -157,8 +157,12 @@ df = pd.DataFrame(data)`;
 
 				tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
 
-				expect(tableData[0]).toStrictEqual({ 'foo': '2', 'bar': '7.00', 'ham': '2021-03-04' });
-				expect(tableData[1]).toStrictEqual({ 'foo': '3', 'bar': '8.00', 'ham': '2022-05-06' });
+				expect(tableData[0]['foo']).toBe('2');
+				expect(tableData[1]['foo']).toBe('3');
+				expect(tableData[0]['bar']).toBe('7.00');
+				expect(tableData[1]['bar']).toBe('8.00');
+				expect(tableData[0]['ham']).toBe('2021-03-04');
+				expect(tableData[1]['ham']).toBe('2022-05-06');
 				expect(tableData.length).toBe(2);
 
 			});

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -110,9 +110,15 @@ df = pd.DataFrame(data)`;
 
 				const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
 
-				expect(tableData[0]).toStrictEqual({ 'foo': '1', 'bar': '6.00', 'ham': '2020-01-02' });
-				expect(tableData[1]).toStrictEqual({ 'foo': '2', 'bar': '7.00', 'ham': '2021-03-04' });
-				expect(tableData[2]).toStrictEqual({ 'foo': '3', 'bar': '8.00', 'ham': '2022-05-06' });
+				expect(tableData[0]['foo']).toBe('1');
+				expect(tableData[1]['foo']).toBe('2');
+				expect(tableData[2]['foo']).toBe('3');
+				expect(tableData[0]['bar']).toBe('6.00');
+				expect(tableData[1]['bar']).toBe('7.00');
+				expect(tableData[2]['bar']).toBe('8.00');
+				expect(tableData[0]['ham']).toBe('2020-01-02');
+				expect(tableData[1]['ham']).toBe('2021-03-04');
+				expect(tableData[2]['ham']).toBe('2022-05-06');
 				expect(tableData.length).toBe(3);
 
 			});
@@ -124,8 +130,12 @@ df = pd.DataFrame(data)`;
 
 				const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
 
-				expect(tableData[0]).toStrictEqual({ 'foo': '2', 'bar': '7.00', 'ham': '2021-03-04' });
-				expect(tableData[1]).toStrictEqual({ 'foo': '3', 'bar': '8.00', 'ham': '2022-05-06' });
+				expect(tableData[0]['foo']).toBe('2');
+				expect(tableData[1]['foo']).toBe('3');
+				expect(tableData[0]['bar']).toBe('7.00');
+				expect(tableData[1]['bar']).toBe('8.00');
+				expect(tableData[0]['ham']).toBe('2021-03-04');
+				expect(tableData[1]['ham']).toBe('2022-05-06');
 				expect(tableData.length).toBe(2);
 			});
 
@@ -135,8 +145,12 @@ df = pd.DataFrame(data)`;
 
 				let tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
 
-				expect(tableData[0]).toStrictEqual({ 'foo': '3', 'bar': '8.00', 'ham': '2022-05-06' });
-				expect(tableData[1]).toStrictEqual({ 'foo': '2', 'bar': '7.00', 'ham': '2021-03-04' });
+				expect(tableData[0]['foo']).toBe('3');
+				expect(tableData[1]['foo']).toBe('2');
+				expect(tableData[0]['bar']).toBe('8.00');
+				expect(tableData[1]['bar']).toBe('7.00');
+				expect(tableData[0]['ham']).toBe('2022-05-06');
+				expect(tableData[1]['ham']).toBe('2021-03-04');
 				expect(tableData.length).toBe(2);
 
 				await app.workbench.positronDataExplorer.clearSortingButton.click();


### PR DESCRIPTION
### Intent

Add Smoke test for Data Explorer using Python Polars

### Approach

* Added new section to existing data explorer test.  The new section is broken up into several `it()` blocks to cover multiple TestRail test cases.  
* Added a console/runtime restart after the pandas test as the polars test uses the same variable names
* Added timeout to expect block in `addFilter` as it defaults to no timeout and could get stuck in loop.

### QA Notes

Passes in [Smoke CI](https://github.com/posit-dev/positron/actions/runs/9824943969)