### PR TITLE
Set `DYLD_LIBRARY_PATH` on macOS

### DIFF
--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -698,6 +698,8 @@ export function createJupyterKernelSpec(
 		// https://github.com/posit-dev/positron/issues/1619#issuecomment-1971552522
 		env['LD_LIBRARY_PATH'] = rHomePath + '/lib';
 	} else if (process.platform === 'darwin') {
+	        // Workaround for
+	        // https://github.com/posit-dev/positron/issues/3732
 		env['DYLD_LIBRARY_PATH'] = rHomePath + '/lib';
 	}
 

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -697,6 +697,8 @@ export function createJupyterKernelSpec(
 		// Workaround for
 		// https://github.com/posit-dev/positron/issues/1619#issuecomment-1971552522
 		env['LD_LIBRARY_PATH'] = rHomePath + '/lib';
+	} else if (process.platform === 'darwin') {
+		env['DYLD_LIBRARY_PATH'] = rHomePath + '/lib';
 	}
 
 	// Inject the path to the Pandoc executable into the environment; R packages


### PR DESCRIPTION
Addresses #3732.

Same approach as in https://github.com/posit-dev/positron/pull/2809.

- The `libR.dylib` library might link to internal deps with relative paths
- The package libraries might link to R with a relative path
- The package libraries might link to R with an absolute path to a library that no longer exists

All these cases should be fixed by allowing ark to link against the target `libR.dylib` if needed (even though in principle we shouldn't need to since we load the library with dlopen and expose all of the symbols to subsequently loaded libraries).

I opted for the non-fallback envvar to prevent linking against any outdated or wrong libs. The linked issue shows that the library paths in some setups might not always be as expected. We still have the relevant entitlement from before our switch to `dlopen()` so it should work out of the box https://github.com/posit-dev/positron/blob/203958161106d234eaa85556293c1be8f8b395b3/build/azure-pipelines/darwin/app-entitlements.plist#L18.

### QA Notes

It's not easy to set up an environment to reproduce the linked issues. I verified that it solved mine (https://github.com/posit-dev/positron/issues/3732#issuecomment-2212473315) and we can ask the issues reporters to check they can now load R once the fix is in a release.