### PR TITLE
Bump ark to 0.1.115

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -589,7 +589,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.114"
+      "ark": "0.1.115"
     },
     "minimumRVersion": "4.2.0",
 		"minimumRenvVersion": "1.0.7"

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -589,7 +589,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.113"
+      "ark": "0.1.114"
     },
     "minimumRVersion": "4.2.0",
 		"minimumRenvVersion": "1.0.7"


### PR DESCRIPTION
For https://github.com/posit-dev/ark/pull/429 from @yutannihilation: Workaround to silence error notifications of https://github.com/posit-dev/positron/issues/3467

And for https://github.com/posit-dev/ark/pull/424: Update data explorer comm and adapt to RPC protocol changes related to filtering