### PR TITLE
Add tests for positron layouts

### DIFF
--- a/test/automation/src/positron/positronLayouts.ts
+++ b/test/automation/src/positron/positronLayouts.ts
@@ -8,6 +8,7 @@ import { Code } from '../code';
 import { Workbench } from '../workbench';
 
 const FULL_APP = 'body';
+const CUSTOMIZE_LAYOUT_BUTTON_LABEL = 'Customize Layout';
 const AUX_BAR = '.part.auxiliarybar';
 const PANEL = '.part.panel';
 const SIDEBAR = '.part.sidebar';
@@ -35,6 +36,11 @@ export class PositronLayouts {
 	 * Locator for the entire IDE. This is the "body" of the root page.
 	 */
 	fullApp = this.code.driver.getLocator(FULL_APP);
+
+	/**
+	 * Button in upper right of IDE for customizing layout.
+	 */
+	customizeLayoutButton = this.fullApp.getByLabel(CUSTOMIZE_LAYOUT_BUTTON_LABEL);
 
 	/**
 	 * Locator for the panel part of the IDE.

--- a/test/automation/src/positron/positronLayouts.ts
+++ b/test/automation/src/positron/positronLayouts.ts
@@ -92,7 +92,7 @@ export class PositronLayouts {
 	 * @param layout Known layout to enter.
 	 */
 	async enterLayout(layout: keyof typeof positronLayoutPresets): Promise<void> {
-		await this.workbench.quickaccess.runCommand(positronLayoutPresets[layout]);
+		await this.workbench.quickaccess.runCommand(positronLayoutPresets[layout], { keepOpen: true });
 	}
 
 	/**

--- a/test/automation/src/positron/positronLayouts.ts
+++ b/test/automation/src/positron/positronLayouts.ts
@@ -8,10 +8,13 @@ import { Code } from '../code';
 import { Workbench } from '../workbench';
 
 const FULL_APP = 'body';
-const CUSTOMIZE_LAYOUT_BUTTON_LABEL = 'Customize Layout';
 const AUX_BAR = '.part.auxiliarybar';
 const PANEL = '.part.panel';
 const SIDEBAR = '.part.sidebar';
+
+const CUSTOMIZE_LAYOUT_BUTTON_LABEL = /customize layout/i;
+const PANEL_EXPAND_BUTTON_LABEL = /restore panel/i;
+const VIEW_TABS_LABEL = /active view switcher/i;
 
 // Known layouts in Positron.
 const positronLayoutPresets = {
@@ -50,7 +53,7 @@ export class PositronLayouts {
 	/**
 	 * Locator for the tabs in the panel used to navigate to different views.
 	 */
-	panelViewsTab = this.panel.getByLabel(`Active View Switcher`).getByRole('tab');
+	panelViewsTab = getPaneViewTabs(this.panel);
 
 	/**
 	 * The content of the panel. This is what should be tested if visible etc because
@@ -62,7 +65,7 @@ export class PositronLayouts {
 	/**
 	 * Locator for the button to expand the panel.
 	 */
-	panelExpandButton = this.panel.getByLabel(/restore panel/i);
+	panelExpandButton = this.panel.getByLabel(PANEL_EXPAND_BUTTON_LABEL);
 
 	/**
 	 * Locator for the auxiliary bar part of the IDE.
@@ -72,7 +75,7 @@ export class PositronLayouts {
 	/**
 	 * Locator for the tabs in the auxiliary bar used to navigate to different views.
 	 */
-	auxBarViewsTab = this.auxBar.getByLabel(`Active View Switcher`).getByRole('tab');
+	auxBarViewsTab = getPaneViewTabs(this.auxBar);
 
 	/**
 	 * Locator for the sidebar part of the IDE.
@@ -117,4 +120,8 @@ export class PositronLayouts {
 		const boundingBox = await this.boundingBox(locator);
 		return boundingBox[property];
 	}
+}
+
+function getPaneViewTabs(locator: Locator) {
+	return locator.getByLabel(VIEW_TABS_LABEL).getByRole('tab');
 }

--- a/test/automation/src/positron/positronLayouts.ts
+++ b/test/automation/src/positron/positronLayouts.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Locator } from '@playwright/test';
+import { Code } from '../code';
+import { Workbench } from '../workbench';
+
+const FULL_APP = 'body';
+const AUX_BAR = '.part.auxiliarybar';
+const PANEL = '.part.panel';
+const SIDEBAR = '.part.sidebar';
+
+// Known layouts in Positron.
+const positronLayoutPresets = {
+	stacked: 'workbench.action.positronFourPaneDataScienceLayout',
+	side_by_side: 'workbench.action.positronTwoPaneDataScienceLayout',
+	notebook: 'workbench.action.positronNotebookLayout',
+	dockedHelp: 'workbench.action.positronHelpPaneDocked',
+	fullSizedAuxBar: 'workbench.action.fullSizedAuxiliaryBar',
+	fullSizedSidebar: 'workbench.action.fullSizedSidebar',
+	fullSizedPanel: 'workbench.action.fullSizedPanel',
+};
+
+/**
+ * Helper class for testing Positron layouts.
+ *
+ * Allows for things like getting various locators for parts of the IDE and entering different
+ * layouts.
+ */
+export class PositronLayouts {
+
+	/**
+	 * Locator for the entire IDE. This is the "body" of the root page.
+	 */
+	fullApp = this.code.driver.getLocator(FULL_APP);
+
+	/**
+	 * Locator for the panel part of the IDE.
+	 */
+	panel = this.code.driver.getLocator(PANEL);
+
+	/**
+	 * Locator for the tabs in the panel used to navigate to different views.
+	 */
+	panelViewsTab = this.panel.getByLabel(`Active View Switcher`).getByRole('tab');
+
+	/**
+	 * The content of the panel. This is what should be tested if visible etc because
+	 * the panel never is hidden, just collapsed.
+	 * E.g. `await expect(positronLayouts.panelContent).not.toBeVisible();`
+	 */
+	panelContent = this.panel.locator('.content');
+
+	/**
+	 * Locator for the button to expand the panel.
+	 */
+	panelExpandButton = this.panel.getByLabel(/restore panel/i);
+
+	/**
+	 * Locator for the auxiliary bar part of the IDE.
+	 */
+	auxBar = this.code.driver.getLocator(AUX_BAR);
+
+	/**
+	 * Locator for the tabs in the auxiliary bar used to navigate to different views.
+	 */
+	auxBarViewsTab = this.auxBar.getByLabel(`Active View Switcher`).getByRole('tab');
+
+	/**
+	 * Locator for the sidebar part of the IDE.
+	 */
+	sidebar = this.code.driver.getLocator(SIDEBAR);
+
+	constructor(private code: Code, private workbench: Workbench) { }
+
+	/**
+	 * Enter a known positron layout.
+	 *
+	 * Works by calling the command that sets the layout.
+	 *
+	 * @param layout Known layout to enter.
+	 */
+	async enterLayout(layout: keyof typeof positronLayoutPresets): Promise<void> {
+		await this.workbench.quickaccess.runCommand(positronLayoutPresets[layout]);
+	}
+
+	/**
+	 * A bounding box getting that errors if the element is not found rather than returning null.
+	 * @param locator Element locator to get bounding box of. E.g. `this.panelContent`.
+	 * @returns Bounding box object
+	 */
+	async boundingBox(locator: Locator) {
+		const boundingBox = await locator.boundingBox();
+
+		if (!boundingBox) {
+			throw new Error(`Error finding bounding box of element: element not found`);
+		}
+
+		return boundingBox;
+	}
+
+	/**
+	 * Get just a specific property of the bounding box. Errors if the element is not found.
+	 * @param locator Element locator to get bounding box of. E.g. `this.panelContent`.
+	 * @param property Which property of the bounding box to return.
+	 * @returns A number representing the property of the bounding box.
+	 */
+	async boundingBoxProperty(locator: Locator, property: 'x' | 'y' | 'width' | 'height') {
+		const boundingBox = await this.boundingBox(locator);
+		return boundingBox[property];
+	}
+}

--- a/test/automation/src/workbench.ts
+++ b/test/automation/src/workbench.ts
@@ -37,6 +37,7 @@ import { PositronExplorer } from './positron/positronExplorer';
 import { PositronConnections } from './positron/positronConnections';
 import { PositronHelp } from './positron/positronHelp';
 import { PositronTopActionBar } from './positron/positronTopActionBar';
+import { PositronLayouts } from './positron/positronLayouts';
 // --- End Positron ---
 
 export interface Commands {
@@ -78,6 +79,7 @@ export class Workbench {
 	readonly positronConnections: PositronConnections;
 	readonly positronHelp: PositronHelp;
 	readonly positronTopActionBar: PositronTopActionBar;
+	readonly positronLayouts: PositronLayouts;
 	// --- End Positron ---
 
 	constructor(code: Code) {
@@ -114,6 +116,7 @@ export class Workbench {
 		this.positronConnections = new PositronConnections(code, this.quickaccess);
 		this.positronHelp = new PositronHelp(code);
 		this.positronTopActionBar = new PositronTopActionBar(code);
+		this.positronLayouts = new PositronLayouts(code, this);
 		// --- End Positron ---
 	}
 }

--- a/test/smoke/src/areas/positron/help/help.test.ts
+++ b/test/smoke/src/areas/positron/help/help.test.ts
@@ -85,7 +85,7 @@ export function setup(logger: Logger) {
 				await app.workbench.settingsEditor.addUserSetting('workbench.reduceMotion', '"on"');
 
 				// Enter layout with help pane docked in session panel
-				await app.workbench.quickaccess.runCommand('workbench.action.positronHelpPaneDocked');
+				await app.workbench.positronLayouts.enterLayout('dockedHelp');
 
 				// Help panel starts collapsed thanks to the above command
 				await expect(helpContainerLocator).not.toBeVisible();

--- a/test/smoke/src/areas/positron/layouts/layouts.test.ts
+++ b/test/smoke/src/areas/positron/layouts/layouts.test.ts
@@ -17,29 +17,6 @@ export function setup(logger: Logger) {
 		// Shared before/after handling
 		installAllHandlers(logger);
 
-		describe('Layouts appear in the customize layouts dropdown', () => {
-
-			it('Verify the stacked layout appears in the customize layouts dropdown', async function () {
-
-				const app = this.app as Application;
-				const layouts = app.workbench.positronLayouts;
-				const quickPick = layouts.fullApp.locator('.quick-input-widget');
-				const quickPickRows = quickPick.getByRole('option');
-
-				// Open the customize layout dropdown
-				await layouts.customizeLayoutButton.click();
-
-				// Make sure dropdown is open before continuing
-				await expect(quickPick.getByText('Customize Layout')).toBeVisible();
-
-				// Make sure all the layouts are visible
-				await expect(quickPickRows.getByText(/stacked layout/i)).toBeVisible();
-				await expect(quickPickRows.getByText(/side-by-side layout/i)).toBeVisible();
-				await expect(quickPickRows.getByText(/notebook layout/i)).toBeVisible();
-			});
-		});
-
-
 		describe('Stacked Layout', () => {
 
 			it('Verify stacked layout puts stuff in appropriate places', async function () {

--- a/test/smoke/src/areas/positron/layouts/layouts.test.ts
+++ b/test/smoke/src/areas/positron/layouts/layouts.test.ts
@@ -158,9 +158,13 @@ export function setup(logger: Logger) {
 				// If the sidebar is collapsed is dependent upon the size of the window. If it
 				// is _not_ collapsed, then it needs to be wider than 180px.
 				// TODO: Test this after resizing the window to make sure behavior is correct.
-				const sidebarWidth = await layouts.boundingBoxProperty(layouts.sidebar, 'width');
-				if (sidebarWidth) {
-					expect(sidebarWidth).toBeGreaterThan(180);
+				try {
+					const sidebarWidth = await layouts.boundingBoxProperty(layouts.sidebar, 'width');
+					if (sidebarWidth) {
+						expect(sidebarWidth).toBeGreaterThan(180);
+					}
+				} catch (e) {
+					// No op if the sidebar isn't visible
 				}
 
 				// ------ Auxiliary Bar -------

--- a/test/smoke/src/areas/positron/layouts/layouts.test.ts
+++ b/test/smoke/src/areas/positron/layouts/layouts.test.ts
@@ -130,7 +130,7 @@ export function setup(logger: Logger) {
 
 		describe('Notebook Layout', () => {
 
-			it.only('Verify notebook layout puts stuff in appropriate places', async function () {
+			it('Verify notebook layout puts stuff in appropriate places', async function () {
 
 				const app = this.app as Application;
 				const layouts = app.workbench.positronLayouts;

--- a/test/smoke/src/areas/positron/layouts/layouts.test.ts
+++ b/test/smoke/src/areas/positron/layouts/layouts.test.ts
@@ -1,0 +1,149 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { expect } from '@playwright/test';
+import { Application, Logger } from '../../../../../automation';
+import { installAllHandlers } from '../../../utils';
+
+/*
+ * Test cases for Positron layouts
+ */
+export function setup(logger: Logger) {
+	describe('Layouts', () => {
+
+		// Shared before/after handling
+		installAllHandlers(logger);
+
+		describe('Stacked Layout', () => {
+
+			it('Verify stacked layout puts stuff in appropriate places', async function () {
+
+				const app = this.app as Application;
+				const layouts = app.workbench.positronLayouts;
+
+				// Enter layout with help pane docked in session panel
+				await layouts.enterLayout('stacked');
+
+				// ------ Sidebar -------
+				await expect(layouts.sidebar).toBeVisible();
+
+				// ------ Panel -------
+				await expect(layouts.panelContent).toBeVisible();
+
+				// The console tab should be in the panel at the first position followed by the
+				// terminal tab
+				await expect(layouts.panelViewsTab.nth(0)).toHaveText('Console');
+				await expect(layouts.panelViewsTab.nth(1)).toHaveText('Terminal');
+
+				// ------ Auxiliary Bar -------
+				await expect(layouts.auxBar).toBeVisible();
+
+				// First view should be the session view
+				await expect(layouts.auxBarViewsTab.nth(0)).toHaveText('Session');
+
+				const variablesSection = layouts.auxBar.getByLabel('Variables Section');
+				const plotsSection = layouts.auxBar.getByLabel('Plots Section');
+				await expect(variablesSection).toBeVisible();
+				await expect(plotsSection).toBeVisible();
+
+				// Neither section should be collapsed
+				await expect(variablesSection).toHaveAttribute('aria-expanded', 'true');
+				await expect(plotsSection).toHaveAttribute('aria-expanded', 'true');
+
+				// Variables section should sit above the plots section
+				const variablesSectionY = await layouts.boundingBoxProperty(variablesSection, 'y');
+				const plotsSectionY = await layouts.boundingBoxProperty(plotsSection, 'y');
+				expect(variablesSectionY).toBeLessThan(plotsSectionY);
+
+				await expect(layouts.auxBar).toBeVisible();
+			});
+		});
+
+		describe('Side-by-side Layout', () => {
+
+			it('Verify Side-by-side layout puts stuff in appropriate places', async function () {
+
+				const app = this.app as Application;
+				const layouts = app.workbench.positronLayouts;
+
+				// Enter layout with help pane docked in session panel
+				await layouts.enterLayout('side_by_side');
+
+				// ------ Panel and Sidebar -------
+				// Both should be collapsed.
+				await expect(layouts.panelContent).not.toBeVisible();
+				await expect(layouts.sidebar).not.toBeVisible();
+
+				// ------ Auxiliary Bar -------
+				await expect(layouts.auxBar).toBeVisible();
+
+				// First view should be the session view, second should be terminal
+				await expect(layouts.auxBarViewsTab.nth(0)).toHaveText('Session');
+				await expect(layouts.auxBarViewsTab.nth(1)).toHaveText('Terminal');
+
+				const consoleSection = layouts.auxBar.getByLabel(/console section/i);
+				const variablesSection = layouts.auxBar.getByLabel(/variables section/i);
+				const plotsSection = layouts.auxBar.getByLabel(/plots section/i);
+				await expect(consoleSection).toBeVisible();
+				await expect(variablesSection).toBeVisible();
+				await expect(plotsSection).toBeVisible();
+
+				// Only the console section should be expanded
+				await expect(consoleSection).toHaveAttribute('aria-expanded', 'true');
+				await expect(variablesSection).toHaveAttribute('aria-expanded', 'false');
+				await expect(plotsSection).toHaveAttribute('aria-expanded', 'false');
+
+				// Should be in vertical order of console, variables, plots
+				const consoleY = await layouts.boundingBoxProperty(consoleSection, 'y');
+				const variablesY = await layouts.boundingBoxProperty(variablesSection, 'y');
+				const plotsY = await layouts.boundingBoxProperty(plotsSection, 'y');
+				expect(consoleY).toBeLessThan(variablesY);
+				expect(variablesY).toBeLessThan(plotsY);
+			});
+		});
+
+		describe('Notebook Layout', () => {
+
+			it.only('Verify notebook layout puts stuff in appropriate places', async function () {
+
+				const app = this.app as Application;
+				const layouts = app.workbench.positronLayouts;
+
+				// Enter layout with help pane docked in session panel
+				await layouts.enterLayout('notebook');
+
+				// ------ Panel -------
+				// Panel should be collapsed
+				await expect(layouts.panelContent).not.toBeVisible();
+
+				// In the collapsed layout, the first tab should be the console and the second
+				// should be the terminal
+				await expect(layouts.panelViewsTab.nth(0)).toHaveText('Console');
+				await expect(layouts.panelViewsTab.nth(1)).toHaveText('Terminal');
+
+				// When expanding the panel it should go to roughly 40% the height of the window
+				await layouts.panelExpandButton.click();
+				const fullAppHeight = await layouts.boundingBoxProperty(layouts.fullApp, 'height');
+				const panelHeight = await layouts.boundingBoxProperty(layouts.panel, 'height');
+				expect(panelHeight).toBeGreaterThan(fullAppHeight * 0.3);
+
+
+				// ------ Sidebar -------
+				// If the sidebar is collapsed is dependent upon the size of the window. If it
+				// is _not_ collapsed, then it needs to be wider than 180px.
+				// TODO: Test this after resizing the window to make sure behavior is correct.
+				const sidebarWidth = await layouts.boundingBoxProperty(layouts.sidebar, 'width');
+				if (sidebarWidth) {
+					expect(sidebarWidth).toBeGreaterThan(180);
+				}
+
+				// ------ Auxiliary Bar -------
+				// Should be collapsed
+				await expect(layouts.auxBar).not.toBeVisible();
+			});
+		});
+	});
+}

--- a/test/smoke/src/areas/positron/layouts/layouts.test.ts
+++ b/test/smoke/src/areas/positron/layouts/layouts.test.ts
@@ -19,7 +19,7 @@ export function setup(logger: Logger) {
 
 		describe('Layouts appear in the customize layouts dropdown', () => {
 
-			it.only('Verify the stacked layout appears in the customize layouts dropdown', async function () {
+			it('Verify the stacked layout appears in the customize layouts dropdown', async function () {
 
 				const app = this.app as Application;
 				const layouts = app.workbench.positronLayouts;

--- a/test/smoke/src/areas/positron/layouts/layouts.test.ts
+++ b/test/smoke/src/areas/positron/layouts/layouts.test.ts
@@ -17,6 +17,29 @@ export function setup(logger: Logger) {
 		// Shared before/after handling
 		installAllHandlers(logger);
 
+		describe('Layouts appear in the customize layouts dropdown', () => {
+
+			it.only('Verify the stacked layout appears in the customize layouts dropdown', async function () {
+
+				const app = this.app as Application;
+				const layouts = app.workbench.positronLayouts;
+				const quickPick = layouts.fullApp.locator('.quick-input-widget');
+				const quickPickRows = quickPick.getByRole('option');
+
+				// Open the customize layout dropdown
+				await layouts.customizeLayoutButton.click();
+
+				// Make sure dropdown is open before continuing
+				await expect(quickPick.getByText('Customize Layout')).toBeVisible();
+
+				// Make sure all the layouts are visible
+				await expect(quickPickRows.getByText(/stacked layout/i)).toBeVisible();
+				await expect(quickPickRows.getByText(/side-by-side layout/i)).toBeVisible();
+				await expect(quickPickRows.getByText(/notebook layout/i)).toBeVisible();
+			});
+		});
+
+
 		describe('Stacked Layout', () => {
 
 			it('Verify stacked layout puts stuff in appropriate places', async function () {

--- a/test/smoke/src/areas/positron/variables/variablespane.test.ts
+++ b/test/smoke/src/areas/positron/variables/variablespane.test.ts
@@ -27,7 +27,7 @@ export function setup(logger: Logger) {
 
 			it('Verifies Variables pane basic function with python interpreter [C628634]', async function () {
 				const app = this.app as Application;
-				await app.workbench.quickaccess.runCommand('workbench.action.fullSizedAuxiliaryBar');
+				await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
 
 				const executeCode = async (code: string) => {
 					await app.workbench.positronConsole.executeCode('Python', code, '>>>');
@@ -62,7 +62,7 @@ export function setup(logger: Logger) {
 
 			it('Verifies Variables pane basic function with R interpreter [C628635]', async function () {
 				const app = this.app as Application;
-				await app.workbench.quickaccess.runCommand('workbench.action.fullSizedAuxiliaryBar');
+				await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
 
 				const executeCode = async (code: string) => {
 					await app.workbench.positronConsole.executeCode('R', code, '>');

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -41,7 +41,8 @@ import { setup as setupConnectionsTest } from './areas/positron/connections/dbCo
 import { setup as setupNewProjectWizardTest } from './areas/positron/new-project-wizard/new-project.test';
 import { setup as setupXLSXDataFrameTest } from './areas/positron/dataexplorer/xlsxDataFrame.test';
 import { setup as setupHelpTest } from './areas/positron/help/help.test';
-import { setup as setupClipboardTest} from './areas/positron/console/consoleClipboard.test'
+import { setup as setupClipboardTest } from './areas/positron/console/consoleClipboard.test';
+import { setup as setupLayoutTest } from './areas/positron/layouts/layouts.test';
 import { setup as setupTopActionBarTest } from './areas/positron/top-action-bar/top-action-bar.test';
 // --- End Positron ---
 
@@ -442,5 +443,6 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	setupHelpTest(logger);
 	setupClipboardTest(logger);
 	setupTopActionBarTest(logger);
+	setupLayoutTest(logger);
 	// --- End Positron ---
 });


### PR DESCRIPTION
Addresses #3929

Adds a series of smoke-tests that
- Check to make sure positron layouts are visible in the customize layout dropdown
- Test the main three layouts by checking that the assumptions of the layout are satisfied. 

Adds a new `positronLayouts` attribute onto the workbench that... 
- Helps find various parts of the ide pertinent to layouts
- Has a method `enterLayout()` for entering any existing positron layouts. 

(Also updated existing tests that entered layouts via the manual `runCommand(...)` method to use the  `workbench.positronLayouts.enterLayout()` method instead. 

### QA Notes
Since these are just looking for elements and positions they should run nice and fast. 
