### PR TITLE
Add the `POSITRON` env var to all consoles (R and Python) plus Positron terminal sessions

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -725,7 +725,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		const command = args.join(' ');
 
 		// Create environment.
-		const env = { POSITRON_VERSION: positron.version };
+		const env = { POSITRON: '1', POSITRON_VERSION: positron.version };
 		Object.assign(env, process.env, this._spec.env);
 
 		// We are now starting the kernel

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -681,7 +681,6 @@ export function createJupyterKernelSpec(
 
 	/* eslint-disable */
 	const env = <Record<string, string>>{
-		'POSITRON': '1',
 		'RUST_BACKTRACE': '1',
 		'RUST_LOG': logLevelForeign + ',ark=' + logLevel,
 		'R_HOME': rHomePath,

--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -137,7 +137,11 @@ export function getShellIntegrationInjection(
 	const appRoot = path.dirname(FileAccess.asFileUri('').fsPath);
 	let newArgs: string[] | undefined;
 	const envMixin: IProcessEnvironment = {
-		'VSCODE_INJECTION': '1'
+		// --- Start Positron ---
+		// 'VSCODE_INJECTION': '1'
+		'VSCODE_INJECTION': '1',
+		'POSITRON': '1'
+		// --- End Positron ---
 	};
 
 	if (options.shellIntegration.nonce) {

--- a/src/vs/platform/terminal/test/node/terminalEnvironment.test.ts
+++ b/src/vs/platform/terminal/test/node/terminalEnvironment.test.ts
@@ -50,6 +50,9 @@ suite('platform - terminalEnvironment', () => {
 						expectedPs1
 					],
 					envMixin: {
+						// --- Start Positron ---
+						POSITRON: '1',
+						// --- End Positron ---
 						VSCODE_INJECTION: '1'
 					}
 				});
@@ -81,6 +84,9 @@ suite('platform - terminalEnvironment', () => {
 						expectedPs1
 					],
 					envMixin: {
+						// --- Start Positron ---
+						POSITRON: '1',
+						// --- End Positron ---
 						VSCODE_INJECTION: '1'
 					}
 				});
@@ -125,10 +131,16 @@ suite('platform - terminalEnvironment', () => {
 						/.+\/out\/vs\/workbench\/contrib\/terminal\/browser\/media\/shellIntegration-login.zsh/
 					];
 					function assertIsEnabled(result: IShellIntegrationConfigInjection, globalZdotdir = homedir()) {
-						strictEqual(Object.keys(result.envMixin!).length, 3);
+						// --- Start Positron ---
+						// strictEqual(Object.keys(result.envMixin!).length, 3);
+						strictEqual(Object.keys(result.envMixin!).length, 4);
+						// --- End Positron ---
 						ok(result.envMixin!['ZDOTDIR']?.match(expectedDir));
 						strictEqual(result.envMixin!['USER_ZDOTDIR'], globalZdotdir);
 						ok(result.envMixin!['VSCODE_INJECTION']?.match('1'));
+						// --- Start Positron ---
+						ok(result.envMixin!['POSITRON']?.match('1'));
+						// --- End Positron ---
 						strictEqual(result.filesToCopy?.length, 4);
 						ok(result.filesToCopy[0].dest.match(expectedDests[0]));
 						ok(result.filesToCopy[1].dest.match(expectedDests[1]));
@@ -186,6 +198,9 @@ suite('platform - terminalEnvironment', () => {
 								`${repoRoot}/out/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh`
 							],
 							envMixin: {
+								// --- Start Positron ---
+								POSITRON: '1',
+								// --- End Positron ---
 								VSCODE_INJECTION: '1'
 							}
 						});
@@ -200,6 +215,9 @@ suite('platform - terminalEnvironment', () => {
 								`${repoRoot}/out/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh`
 							],
 							envMixin: {
+								// --- Start Positron ---
+								POSITRON: '1',
+								// --- End Positron ---
 								VSCODE_INJECTION: '1',
 								VSCODE_SHELL_LOGIN: '1'
 							}


### PR DESCRIPTION
Addresses #3842 

This undoes #2467 with a better approach.

### QA Notes

With this PR, you can find the `POSITRON` env var set in:

- the R console

```r
Sys.getenv("POSITRON")
```

- the Python console

```python
import os
print(os.environ['POSITRON'])
```

- terminals in Positron

```bash
echo "$POSITRON"
```
