### PR TITLE
Use a short name for the temporary build dir while building releases

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -506,7 +506,7 @@ BUILD_TARGETS.forEach(buildTarget => {
 
 	const [vscode, vscodeMin] = ['', 'min'].map(minified => {
 		const sourceFolderName = `out-vscode${dashed(minified)}`;
-		const destinationFolderName = `VSCode${dashed(platform)}${dashed(arch)}`;
+		const destinationFolderName = `p${arch}`;
 
 		const tasks = [
 			util.rimraf(path.join(buildRoot, destinationFolderName)),

--- a/build/gulpfile.vscode.win32.js
+++ b/build/gulpfile.vscode.win32.js
@@ -19,7 +19,7 @@ const rcedit = require('rcedit');
 const mkdirp = require('mkdirp');
 
 const repoPath = path.dirname(__dirname);
-const buildPath = (/** @type {string} */ arch) => path.join(path.dirname(repoPath), `VSCode-win32-${arch}`);
+const buildPath = (/** @type {string} */ arch) => path.join(path.dirname(repoPath), `p${arch}`);
 const setupDir = (/** @type {string} */ arch, /** @type {string} */ target) => path.join(repoPath, '.build', `win32-${arch}`, `${target}-setup`);
 // --- Start Positron ---
 const issPath = path.join(__dirname, 'win32', 'positron.iss');


### PR DESCRIPTION
Positron uses this directory to stage release artifacts while building WIndows releases, and doesn't need as long a name. This will help with long file path limitations in the short term for Inno Setup.
