### PR TITLE
Add method for updating size of the window for smoke tests

### DIFF
--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -265,6 +265,15 @@ export class PlaywrightDriver {
 	}
 
 	/**
+	 * Set the size of the browser window, for more predicable test results.
+	 * @param width Width in pixels
+	 * @param height Height in pixels
+	 */
+	async setViewportSize(opts: { width: number; height: number }) {
+		await this.page.setViewportSize(opts);
+	}
+
+	/**
 	 * Click and drag from one point to another.
 	 * @param opts.from The starting point of the drag as x-y coordinates
 	 * @param opts.to The ending point of the drag as x-y coordinates

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -265,9 +265,9 @@ export class PlaywrightDriver {
 	}
 
 	/**
-	 * Set the size of the browser window, for more predicable test results.
-	 * @param width Width in pixels
-	 * @param height Height in pixels
+	 * Set the size of the browser window for more predicable test results.
+	 * @param opts.width Width in pixels
+	 * @param opts.height Height in pixels
 	 */
 	async setViewportSize(opts: { width: number; height: number }) {
 		await this.page.setViewportSize(opts);

--- a/test/smoke/src/areas/positron/layouts/layouts.test.ts
+++ b/test/smoke/src/areas/positron/layouts/layouts.test.ts
@@ -24,6 +24,8 @@ export function setup(logger: Logger) {
 				const app = this.app as Application;
 				const layouts = app.workbench.positronLayouts;
 
+				app.code.driver.setViewportSize({ width: 1400, height: 1000 });
+
 				// Enter layout with help pane docked in session panel
 				await layouts.enterLayout('stacked');
 


### PR DESCRIPTION

### QA Notes

I only added one usage of this now, but perhaps in the future, we should start enforcing a standard size for our smoke tests to have consistent results. 

You can check that it's "working" by watching the app as the resizing is happening. (Use debug stepping if it happens too fast!) Note that it won't actually resize the app window, but will simply clip. In a headless instance, it will behave as expected. 


