### PR TITLE
This PR adds a Data Explorer smoke test that loads a 100 column x 100 row data frame from a Parquet file and verifies that three rows in the file (the first, the middle, and the last) render correctly in Pandas, Polars, and R.

### DIFF
--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
@@ -162,7 +162,7 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 					}
 				</>
 			}
-			<div className='content'>
+			<div id={`data-grid-row-cell-content-${props.columnIndex}-${props.rowIndex}`} className='content'>
 				{context.instance.cell(props.columnIndex, props.rowIndex)}
 			</div>
 			{context.instance.columnResize &&

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
@@ -73,4 +73,9 @@ export interface IPositronDataExplorerInstance extends IDisposable {
 	 * Copies the selection or cursor cell to the clipboard.
 	 */
 	copyToClipboard(): Promise<void>;
+
+	/**
+	 * Copies the table data to the clipboard.
+	 */
+	copyTableDataToClipboard(): Promise<void>;
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -125,11 +125,11 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 		);
 		this._tableDataDataGridInstance = new TableDataDataGridInstance(
 			this._commandService,
+			this._configurationService,
 			this._keybindingService,
 			this._layoutService,
 			this._dataExplorerClientInstance,
-			this._dataExplorerCache,
-			this._configurationService
+			this._dataExplorerCache
 		);
 
 		// Add the onDidClose event handler.
@@ -296,6 +296,13 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 
 		// Write the clipboard data to the clipboard.
 		this._clipboardService.writeText(text);
+	}
+
+	/**
+	 * Copies the table data to the clipboard.
+	 */
+	async copyTableDataToClipboard(): Promise<void> {
+		this._clipboardService.writeText(await this._dataExplorerCache.getTableData());
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -12,6 +12,7 @@ import { Emitter } from 'vs/base/common/event';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IColumnSortKey } from 'vs/workbench/browser/positronDataGrid/interfaces/columnSortKey';
 import { DataExplorerCache } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
 import { TableDataCell } from 'vs/workbench/services/positronDataExplorer/browser/components/tableDataCell';
@@ -23,10 +24,9 @@ import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntim
 import { CustomContextMenuSeparator } from 'vs/workbench/browser/positronComponents/customContextMenu/customContextMenuSeparator';
 import { PositronDataExplorerCommandId } from 'vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions';
 import { CustomContextMenuEntry, showCustomContextMenu } from 'vs/workbench/browser/positronComponents/customContextMenu/customContextMenu';
+import { dataExplorerExperimentalFeatureEnabled } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerExperimentalConfig';
 import { BackendState, ColumnSchema, DataSelection, DataSelectionCellRange, DataSelectionIndices, DataSelectionKind, DataSelectionRange, DataSelectionSingleCell, ExportFormat, RowFilter, SupportStatus } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { ClipboardCell, ClipboardCellRange, ClipboardColumnIndexes, ClipboardColumnRange, ClipboardData, ClipboardRowIndexes, ClipboardRowRange, ColumnSelectionState, ColumnSortKeyDescriptor, DataGridInstance, RowSelectionState } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
-import { dataExplorerExperimentalFeatureEnabled } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerExperimentalConfig';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 /**
  * Localized strings.
@@ -51,6 +51,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	/**
 	 * Constructor.
 	 * @param _commandService The command service.
+	 * @param _configurationService The configuration service.
 	 * @param _keybindingService The keybinding service.
 	 * @param _layoutService The layout service.
 	 * @param _dataExplorerClientInstance The DataExplorerClientInstance.
@@ -58,11 +59,11 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	constructor(
 		private readonly _commandService: ICommandService,
+		private readonly _configurationService: IConfigurationService,
 		private readonly _keybindingService: IKeybindingService,
 		private readonly _layoutService: ILayoutService,
 		private readonly _dataExplorerClientInstance: DataExplorerClientInstance,
 		private readonly _dataExplorerCache: DataExplorerCache,
-		private readonly _configurationService: IConfigurationService,
 	) {
 		// Call the base class's constructor.
 		super({

--- a/test/automation/src/positron/positronDataExplorer.ts
+++ b/test/automation/src/positron/positronDataExplorer.ts
@@ -133,4 +133,32 @@ export class PositronDataExplorer {
 		await this.code.driver.getLocator(`.positron-modal-overlay div.title:has-text("${menuItem}")`).click();
 
 	}
+
+	async home(): Promise<void> {
+		await this.code.dispatchKeybinding('home');
+	}
+
+	async cmdCtrlHome(): Promise<void> {
+		if (process.platform === 'darwin') {
+			await this.code.dispatchKeybinding('cmd+home');
+		} else {
+			await this.code.dispatchKeybinding('ctrl+home');
+		}
+	}
+
+	async arrowDown(): Promise<void> {
+		await this.code.dispatchKeybinding('ArrowDown');
+	}
+
+	async arrowRight(): Promise<void> {
+		await this.code.dispatchKeybinding('ArrowRight');
+	}
+
+	async arrowUp(): Promise<void> {
+		await this.code.dispatchKeybinding('ArrowUp');
+	}
+
+	async arrowLeft(): Promise<void> {
+		await this.code.dispatchKeybinding('ArrowLeft');
+	}
 }

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -17,7 +17,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 	/**
 	 * Data Explorer 100x100.
 	 */
-	describe('Data Explorer 100x100', function () {
+	describe.only('Data Explorer 100x100', function () {
 		// Shared before/after handling.
 		installAllHandlers(logger);
 

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -85,8 +85,21 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 					// Get the cell.
 					const cell = await app.code.waitForElement(`#data-grid-row-cell-content-${columnIndex}-${rowIndex} .text-container .text-value`);
 
-					// Test the cell.
-					expect(row[columnIndex]).toStrictEqual(cell.textContent);
+					// On Linux, R will conjure up different date values from time to time.
+					let tested = false;
+					if (language === 'R' && process.platform === 'linux') {
+						const expectDate = Date.parse(row[columnIndex]);
+						const cellDate = Date.parse(cell.textContent);
+						if (!isNaN(expectDate) && !isNaN(cellDate)) {
+							expect(Math.round(expectDate / 60000)).toStrictEqual(Math.round(cellDate / 60000));
+							tested = true;
+						}
+					}
+
+					// Test the cell, if it wasn't tested above.
+					if (!tested) {
+						expect(row[columnIndex]).toStrictEqual(cell.textContent);
+					}
 
 					// Move to the next cell.
 					await app.workbench.positronDataExplorer.arrowRight();

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -10,14 +10,14 @@ import { installAllHandlers } from '../../../utils';
 import { Application, Logger, PositronPythonFixtures, PositronRFixtures } from '../../../../../automation';
 
 /**
- * Sets up the 100x100 test.
+ * Sets up the Data Explorer 100x100 smoke test.
  * @param logger The logger.
  */
 export function setupDataExplorer100x100Test(logger: Logger) {
 	/**
 	 * Data Explorer 100x100.
 	 */
-	describe.only('Data Explorer 100x100', function () {
+	describe('Data Explorer 100x100', function () {
 		// Shared before/after handling.
 		installAllHandlers(logger);
 

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -93,7 +93,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 					const cell = await app.code.waitForElement(`#data-grid-row-cell-content-${columnIndex}-${rowIndex} .text-container .text-value`);
 
 					// Test the cell.
-					expect(row[columnIndex]).toStrictEqual(cell.textContent);
+					expect(cell.textContent).toStrictEqual(row[columnIndex]);
 
 					// Move to the next cell.
 					await app.workbench.positronDataExplorer.arrowRight();

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -93,10 +93,10 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 					// On Linux, R will conjure up different date values from time to time.
 					let tested = false;
 					if (!tested && language === 'R' && process.platform === 'linux') {
-						const expectDate = Date.parse(row[columnIndex]);
+						const expectedDate = Date.parse(row[columnIndex]);
 						const cellDate = Date.parse(cell.textContent);
-						if (!isNaN(expectDate) && !isNaN(cellDate)) {
-							expect(Math.round(expectDate / 60000)).toStrictEqual(Math.round(cellDate / 60000));
+						if (!isNaN(expectedDate) && !isNaN(cellDate)) {
+							expect(Math.round(expectedDate / 60000)).toStrictEqual(Math.round(cellDate / 60000));
 							tested = true;
 						}
 					}
@@ -106,7 +106,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 						const expectedValue = parseFloat(row[columnIndex]);
 						const cellValue = parseFloat(cell.textContent);
 						if (!isNaN(expectedValue) && !isNaN(cellValue)) {
-							expect(expectedValue).toBeCloseTo(cellValue, 0);
+							// expect(expectedValue).toBeCloseTo(cellValue, 0);
 							tested = true;
 						}
 					}

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -17,7 +17,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 	/**
 	 * Data Explorer 100x100.
 	 */
-	describe.only('Data Explorer 100x100', function () {
+	describe('Data Explorer 100x100', function () {
 		// Shared before/after handling.
 		installAllHandlers(logger);
 
@@ -90,31 +90,8 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 					// Get the cell.
 					const cell = await app.code.waitForElement(`#data-grid-row-cell-content-${columnIndex}-${rowIndex} .text-container .text-value`);
 
-					// On Linux, R will conjure up different date values from time to time.
-					let tested = false;
-					if (!tested && language === 'R' && process.platform === 'linux') {
-						const expectedDate = Date.parse(row[columnIndex]);
-						const cellDate = Date.parse(cell.textContent);
-						if (!isNaN(expectedDate) && !isNaN(cellDate)) {
-							expect(Math.round(expectedDate / 60000)).toStrictEqual(Math.round(cellDate / 60000));
-							tested = true;
-						}
-					}
-
-					// On Linux, R will conjure up different time values from time to time.
-					if (!tested && language === 'R' && process.platform === 'linux' && row[columnIndex].endsWith(' secs')) {
-						const expectedValue = parseFloat(row[columnIndex]);
-						const cellValue = parseFloat(cell.textContent);
-						if (!isNaN(expectedValue) && !isNaN(cellValue)) {
-							// expect(expectedValue).toBeCloseTo(cellValue, 0);
-							tested = true;
-						}
-					}
-
-					// Test the cell, if it wasn't tested above.
-					if (!tested) {
-						expect(row[columnIndex]).toStrictEqual(cell.textContent);
-					}
+					// Test the cell.
+					expect(row[columnIndex]).toStrictEqual(cell.textContent);
 
 					// Move to the next cell.
 					await app.workbench.positronDataExplorer.arrowRight();
@@ -218,7 +195,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 			/**
 			 * R - Data Explorer 100x100 test case.
 			 */
-			it('R - Data Explorer 100x100', async function () {
+			it.only('R - Data Explorer 100x100', async function () {
 				// Get the app.
 				const app = this.app as Application;
 
@@ -233,7 +210,12 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 						`${dataFrameName} <- read_parquet("${parquetFilePath(app)}")`,
 					],
 					dataFrameName,
-					join(app.workspacePathOrFolder, 'data-files', '100x100', 'r-100x100.tsv')
+					join(
+						app.workspacePathOrFolder,
+						'data-files',
+						'100x100',
+						process.platform === 'linux' ? 'r-100x100-linux.tsv' : 'r-100x100.tsv'
+					)
 				);
 			});
 		});

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -17,7 +17,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 	/**
 	 * Data Explorer 100x100.
 	 */
-	describe.only('Data Explorer 100x100', function () {
+	describe('Data Explorer 100x100', function () {
 		// Shared before/after handling.
 		installAllHandlers(logger);
 

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -1,0 +1,190 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import { join } from 'path';
+import { expect } from '@playwright/test';
+import { installAllHandlers } from '../../../utils';
+import { Application, Logger, PositronPythonFixtures } from '../../../../../automation';
+
+/**
+ * Sets up the 100x100 test.
+ * @param logger The logger.
+ */
+export function setupDataExplorer100x100Test(logger: Logger) {
+	/**
+	 * Data Explorer 100x100.
+	 */
+	describe.only('Data Explorer 100x100', function () {
+		// Shared before/after handling.
+		installAllHandlers(logger);
+
+		/**
+		 * Tests the data explorer.
+		 * @param app The application.
+		 * @param language The language.
+		 * @param prompt The prompt.
+		 * @param commands Commands to run to set up the test.
+		 * @param dataFrameName The data frame name.
+		 * @param tsvFilePath The TSV file path.
+		 */
+		const testDataExplorer = async (
+			app: Application,
+			language: 'Python' | 'R',
+			prompt: string,
+			commands: string[],
+			dataFrameName: string,
+			tsvFilePath: string
+		): Promise<void> => {
+			// Execute commands.
+			for (let i = 0; i < commands.length; i++) {
+				await app.workbench.positronConsole.executeCode(
+					language,
+					commands[i],
+					prompt
+				);
+			}
+
+			// Open the data frame.
+			await expect(async () => {
+				await app.workbench.positronVariables.doubleClickVariableRow(dataFrameName);
+				await app.code.driver.getLocator(`.label-name:has-text("Data: ${dataFrameName}")`).innerText();
+			}).toPass();
+
+			// Drive focus into the data explorer.
+			await app.workbench.positronDataExplorer.clickUpperLeftCorner();
+
+			// Load the TSV file that is used to verify the data and split it into lines.
+			const tsvFile = fs.readFileSync(tsvFilePath, { encoding: 'utf8' });
+			const lines = tsvFile.split('\n');
+
+			// Get the TSV values.
+			const tsvValues: string[][] = [];
+			for (let rowIndex = 0; rowIndex < lines.length; rowIndex++) {
+				tsvValues.push(lines[rowIndex].split('\t'));
+			}
+
+			/**
+			 * Tests the row at the specified row index.
+			 * @param rowIndex The row index of the row under test.
+			 */
+			const testRow = async (rowIndex: number) => {
+				// Scroll to home and put the cursor there.
+				await app.workbench.positronDataExplorer.cmdCtrlHome();
+
+				// Navigate to the row under test.
+				for (let i = 0; i < rowIndex; i++) {
+					await app.workbench.positronDataExplorer.arrowDown();
+				}
+
+				// Test each cell in the row under test.
+				const row = tsvValues[rowIndex];
+				for (let columnIndex = 0; columnIndex < row.length; columnIndex++) {
+					// Get the cell.
+					const cell = await app.code.waitForElement(`#data-grid-row-cell-content-${columnIndex}-${rowIndex} .text-container .text-value`);
+
+					// Test the cell.
+					expect(row[columnIndex]).toStrictEqual(cell.textContent);
+
+					// Move to the next cell.
+					await app.workbench.positronDataExplorer.arrowRight();
+				}
+			};
+
+			// Check the first row, the middle row, and the last row.
+			await testRow(0);
+			await testRow(Math.trunc(tsvValues.length / 2));
+			await testRow(tsvValues.length - 1);
+		};
+
+		/**
+		 * Python - Pandas - Data Explorer 100x100.
+		 */
+		describe('Python - Pandas - Data Explorer 100x100', () => {
+			/**
+			 * Before hook.
+			 */
+			before(async function () {
+				const app = this.app as Application;
+				const pythonFixtures = new PositronPythonFixtures(app);
+				await pythonFixtures.startPythonInterpreter();
+			});
+
+			/**
+			 * After hook.
+			 */
+			after(async function () {
+				const app = this.app as Application;
+				await app.workbench.positronDataExplorer.closeDataExplorer();
+			});
+
+			/**
+			 * Python - Pandas - Data Explorer 100x100 test case.
+			 */
+			it('Python - Pandas - Data Explorer 100x100', async function () {
+				// Get the app.
+				const app = this.app as Application;
+
+				// Test the data explorer.
+				const dataFrameName = 'pandas100x100';
+				await testDataExplorer(
+					app,
+					'Python',
+					'>>>',
+					[
+						'import pandas as pd',
+						`${dataFrameName} = pd.read_parquet("${join(app.workspacePathOrFolder, 'data-files', '100x100', '100x100.parquet')}")`,
+					],
+					dataFrameName,
+					join(app.workspacePathOrFolder, 'data-files', '100x100', 'pandas-100x100.tsv')
+				);
+			});
+
+			/**
+			 * Python - Polars - Data Explorer 100x100 test case.
+			 */
+			it('Python - Polars - Data Explorer 100x100', async function () {
+				// Get the app.
+				const app = this.app as Application;
+
+				// Test the data explorer.
+				const dataFrameName = 'polars100x100';
+				await testDataExplorer(
+					app,
+					'Python',
+					'>>>',
+					[
+						'import polars',
+						`${dataFrameName} = polars.read_parquet("${join(app.workspacePathOrFolder, 'data-files', '100x100', '100x100.parquet')}")`,
+					],
+					dataFrameName,
+					join(app.workspacePathOrFolder, 'data-files', '100x100', 'polars-100x100.tsv')
+				);
+			});
+
+			/**
+			 * R - Data Explorer 100x100 test case.
+			 */
+			it('R - Data Explorer 100x100', async function () {
+				// Get the app.
+				const app = this.app as Application;
+
+				// Test the data explorer.
+				const dataFrameName = 'r100x100';
+				await testDataExplorer(
+					app,
+					'R',
+					'>',
+					[
+						'library(arrow)',
+						`${dataFrameName} <- read_parquet("${join(app.workspacePathOrFolder, 'data-files', '100x100', '100x100.parquet')}")`,
+					],
+					dataFrameName,
+					join(app.workspacePathOrFolder, 'data-files', '100x100', 'r-100x100.tsv')
+				);
+			});
+		});
+	});
+}

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -92,11 +92,21 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 
 					// On Linux, R will conjure up different date values from time to time.
 					let tested = false;
-					if (language === 'R' && process.platform === 'linux') {
+					if (!tested && language === 'R' && process.platform === 'linux') {
 						const expectDate = Date.parse(row[columnIndex]);
 						const cellDate = Date.parse(cell.textContent);
 						if (!isNaN(expectDate) && !isNaN(cellDate)) {
 							expect(Math.round(expectDate / 60000)).toStrictEqual(Math.round(cellDate / 60000));
+							tested = true;
+						}
+					}
+
+					// On Linux, R will conjure up different time values from time to time.
+					if (!tested && language === 'R' && process.platform === 'linux' && row[columnIndex].endsWith(' secs')) {
+						const expectedValue = parseFloat(row[columnIndex]);
+						const cellValue = parseFloat(cell.textContent);
+						if (!isNaN(expectedValue) && !isNaN(cellValue)) {
+							expect(expectedValue).toBeCloseTo(cellValue, 0);
 							tested = true;
 						}
 					}

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -58,7 +58,12 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 
 			// Load the TSV file that is used to verify the data and split it into lines.
 			const tsvFile = fs.readFileSync(tsvFilePath, { encoding: 'utf8' });
-			const lines = tsvFile.split('\n');
+			let lines;
+			if (process.platform === 'win32') {
+				lines = tsvFile.split('\r\n');
+			} else {
+				lines = tsvFile.split('\n');
+			}
 
 			// Get the TSV values.
 			const tsvValues: string[][] = [];
@@ -134,6 +139,29 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 			});
 
 			/**
+			 * Constructs the Parquet file path.
+			 * @param app The application.
+			 * @returns The Parquet file path.
+			 */
+			const parquetFilePath = (app: Application) => {
+				// Set the path to the Parquet file.
+				let parquetFilePath = join(
+					app.workspacePathOrFolder,
+					'data-files',
+					'100x100',
+					'100x100.parquet'
+				);
+
+				// On Windows, double escape the path.
+				if (process.platform === 'win32') {
+					parquetFilePath = parquetFilePath.replaceAll('\\', '\\\\');
+				}
+
+				// Return the path to the Parquet file.
+				return parquetFilePath;
+			};
+
+			/**
 			 * Python - Pandas - Data Explorer 100x100 test case.
 			 */
 			it('Python - Pandas - Data Explorer 100x100', async function () {
@@ -148,7 +176,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 					'>>>',
 					[
 						'import pandas as pd',
-						`${dataFrameName} = pd.read_parquet("${join(app.workspacePathOrFolder, 'data-files', '100x100', '100x100.parquet')}")`,
+						`${dataFrameName} = pd.read_parquet("${parquetFilePath(app)}")`,
 					],
 					dataFrameName,
 					join(app.workspacePathOrFolder, 'data-files', '100x100', 'pandas-100x100.tsv')
@@ -170,7 +198,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 					'>>>',
 					[
 						'import polars',
-						`${dataFrameName} = polars.read_parquet("${join(app.workspacePathOrFolder, 'data-files', '100x100', '100x100.parquet')}")`,
+						`${dataFrameName} = polars.read_parquet("${parquetFilePath(app)}")`,
 					],
 					dataFrameName,
 					join(app.workspacePathOrFolder, 'data-files', '100x100', 'polars-100x100.tsv')
@@ -192,7 +220,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 					'>',
 					[
 						'library(arrow)',
-						`${dataFrameName} <- read_parquet("${join(app.workspacePathOrFolder, 'data-files', '100x100', '100x100.parquet')}")`,
+						`${dataFrameName} <- read_parquet("${parquetFilePath(app)}")`,
 					],
 					dataFrameName,
 					join(app.workspacePathOrFolder, 'data-files', '100x100', 'r-100x100.tsv')

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 import { join } from 'path';
 import { expect } from '@playwright/test';
 import { installAllHandlers } from '../../../utils';
-import { Application, Logger, PositronPythonFixtures } from '../../../../../automation';
+import { Application, Logger, PositronPythonFixtures, PositronRFixtures } from '../../../../../automation';
 
 /**
  * Sets up the 100x100 test.
@@ -17,26 +17,9 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 	/**
 	 * Data Explorer 100x100.
 	 */
-	describe('Data Explorer 100x100', function () {
+	describe.only('Data Explorer 100x100', function () {
 		// Shared before/after handling.
 		installAllHandlers(logger);
-
-		/**
-		 * Before hook.
-		 */
-		before(async function () {
-			const app = this.app as Application;
-			const pythonFixtures = new PositronPythonFixtures(app);
-			await pythonFixtures.startPythonInterpreter();
-		});
-
-		/**
-		 * After hook.
-		 */
-		after(async function () {
-			const app = this.app as Application;
-			// await app.workbench.positronDataExplorer.closeDataExplorer();
-		});
 
 
 		/**
@@ -65,8 +48,6 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 				);
 			}
 
-			console.log(`The TSV file is ${tsvFilePath}`);
-
 			// Open the data frame.
 			await expect(async () => {
 				await app.workbench.positronVariables.doubleClickVariableRow(dataFrameName);
@@ -78,7 +59,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 
 			// Load the TSV file that is used to verify the data and split it into lines.
 			const tsvFile = fs.readFileSync(tsvFilePath, { encoding: 'utf8' });
-			let lines;
+			let lines: string[];
 			if (process.platform === 'win32') {
 				lines = tsvFile.split('\r\n');
 			} else {
@@ -147,76 +128,141 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 			return parquetFilePath;
 		};
 
-
 		/**
-		 * Python - Pandas - Data Explorer 100x100 test case.
+		 * Data Explorer 100x100 - Python - Pandas.
 		 */
-		it('Python - Pandas - Data Explorer 100x100', async function () {
-			// Get the app.
-			const app = this.app as Application;
+		describe('Data Explorer 100x100 - Python - Pandas', function () {
+			/**
+			 * Before hook.
+			 */
+			before(async function () {
+				const app = this.app as Application;
+				const pythonFixtures = new PositronPythonFixtures(app);
+				await pythonFixtures.startPythonInterpreter();
+			});
 
-			// Test the data explorer.
-			const dataFrameName = 'pandas100x100';
-			await testDataExplorer(
-				app,
-				'Python',
-				'>>>',
-				[
-					'import pandas as pd',
-					`${dataFrameName} = pd.read_parquet("${parquetFilePath(app)}")`,
-				],
-				dataFrameName,
-				join(app.workspacePathOrFolder, 'data-files', '100x100', 'pandas-100x100.tsv')
-			);
+			/**
+			 * After hook.
+			 */
+			after(async function () {
+				const app = this.app as Application;
+				await app.workbench.positronDataExplorer.closeDataExplorer();
+			});
+
+			/**
+			 * Data Explorer 100x100 - Python - Pandas - Smoke Test.
+			 */
+			it('Data Explorer 100x100 - Python - Pandas - Smoke Test', async function () {
+				// Get the app.
+				const app = this.app as Application;
+
+				// Test the data explorer.
+				const dataFrameName = 'pandas100x100';
+				await testDataExplorer(
+					app,
+					'Python',
+					'>>>',
+					[
+						'import pandas as pd',
+						`${dataFrameName} = pd.read_parquet("${parquetFilePath(app)}")`,
+					],
+					dataFrameName,
+					join(app.workspacePathOrFolder, 'data-files', '100x100', 'pandas-100x100.tsv')
+				);
+			});
 		});
 
 		/**
-		 * Python - Polars - Data Explorer 100x100 test case.
+		 * Data Explorer 100x100 - Python - Polars.
 		 */
-		it('Python - Polars - Data Explorer 100x100', async function () {
-			// Get the app.
-			const app = this.app as Application;
+		describe('Data Explorer 100x100 - Python - Polars', function () {
+			/**
+			 * Before hook.
+			 */
+			before(async function () {
+				const app = this.app as Application;
+				const pythonFixtures = new PositronPythonFixtures(app);
+				await pythonFixtures.startPythonInterpreter();
+			});
 
-			// Test the data explorer.
-			const dataFrameName = 'polars100x100';
-			await testDataExplorer(
-				app,
-				'Python',
-				'>>>',
-				[
-					'import polars',
-					`${dataFrameName} = polars.read_parquet("${parquetFilePath(app)}")`,
-				],
-				dataFrameName,
-				join(app.workspacePathOrFolder, 'data-files', '100x100', 'polars-100x100.tsv')
-			);
+			/**
+			 * After hook.
+			 */
+			after(async function () {
+				const app = this.app as Application;
+				await app.workbench.positronDataExplorer.closeDataExplorer();
+			});
+
+			/**
+			 * Data Explorer 100x100 - Python - Polars - Smoke Test.
+			 */
+			it('Data Explorer 100x100 - Python - Polars - Smoke Test', async function () {
+				// Get the app.
+				const app = this.app as Application;
+
+				// Test the data explorer.
+				const dataFrameName = 'polars100x100';
+				await testDataExplorer(
+					app,
+					'Python',
+					'>>>',
+					[
+						'import polars',
+						`${dataFrameName} = polars.read_parquet("${parquetFilePath(app)}")`,
+					],
+					dataFrameName,
+					join(app.workspacePathOrFolder, 'data-files', '100x100', 'polars-100x100.tsv')
+				);
+			});
 		});
 
 		/**
-		 * R - Data Explorer 100x100 test case.
+		 * Data Explorer 100x100 - R.
 		 */
-		it('R - Data Explorer 100x100', async function () {
-			// Get the app.
-			const app = this.app as Application;
+		describe('Data Explorer 100x100 - R', function () {
+			/**
+			 * Before hook.
+			 */
+			before(async function () {
+				const app = this.app as Application;
+				const rFixtures = new PositronRFixtures(app);
+				await rFixtures.startRInterpreter();
+			});
 
-			// Test the data explorer.
-			const dataFrameName = 'r100x100';
-			await testDataExplorer(
-				app,
-				'R',
-				'>',
-				[
-					'library(arrow)',
-					`${dataFrameName} <- read_parquet("${parquetFilePath(app)}")`,
-				],
-				dataFrameName,
-				join(
-					app.workspacePathOrFolder,
-					'data-files',
-					'100x100',
-					process.platform === 'linux' ? 'r-100x100-linux.tsv' : 'r-100x100.tsv'
-				)
-			);
+			/**
+			 * After hook.
+			 */
+			after(async function () {
+				const app = this.app as Application;
+				await app.workbench.positronDataExplorer.closeDataExplorer();
+			});
+
+			/**
+			 * Data Explorer 100x100 - R - Smoke Test.
+			 */
+			it('Data Explorer 100x100 - R - Smoke Test', async function () {
+				// Get the app.
+				const app = this.app as Application;
+
+				// Test the data explorer.
+				const dataFrameName = 'r100x100';
+				await testDataExplorer(
+					app,
+					'R',
+					'>',
+					[
+						'library(arrow)',
+						`${dataFrameName} <- read_parquet("${parquetFilePath(app)}")`,
+					],
+					dataFrameName,
+					join(
+						app.workspacePathOrFolder,
+						'data-files',
+						'100x100',
+						process.platform === 'linux' ? 'r-100x100-linux.tsv' : 'r-100x100.tsv'
+					)
+				);
+			});
 		});
 	});
 }

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -47,6 +47,8 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 				);
 			}
 
+			console.log(`The TSV file is ${tsvFilePath}`);
+
 			// Open the data frame.
 			await expect(async () => {
 				await app.workbench.positronVariables.doubleClickVariableRow(dataFrameName);

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -35,7 +35,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 		 */
 		after(async function () {
 			const app = this.app as Application;
-			await app.workbench.positronDataExplorer.closeDataExplorer();
+			// await app.workbench.positronDataExplorer.closeDataExplorer();
 		});
 
 

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -31,6 +31,7 @@ import { retry, timeout } from './utils';
 // import { setup as setupTerminalTests } from './areas/terminal/terminal.test';
 // import { setup as setupTaskTests } from './areas/task/task.test';
 import { setup as setupVariablesTest } from './areas/positron/variables/variablespane.test';
+import { setupDataExplorer100x100Test } from './areas/positron/dataexplorer/data-explorer-100x100.test';
 import { setup as setupDataExplorerTest } from './areas/positron/dataexplorer/dataexplorer.test';
 import { setup as setupPlotsTest } from './areas/positron/plots/plots.test';
 import { setup as setupPythonConsoleTest } from './areas/positron/console/python-console.test';
@@ -432,6 +433,7 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	// if (!opts.web && !opts.remote) { setupLaunchTests(logger); }
 	setupVariablesTest(logger);
 	setupDataExplorerTest(logger);
+	setupDataExplorer100x100Test(logger);
 	setupPlotsTest(logger);
 	setupPythonConsoleTest(logger);
 	setupRConsoleTest(logger);


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR adds a Data Explorer smoke test that loads a 100 column x 100 row data frame from a Parquet file and verifies that three rows in the file (the first, the middle, and the last) render correctly in Pandas, Polars, and R. The data for this smoke test is loaded from the `qa-example-content` repo. 

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
