### PR TITLE
Add basic variables and data explorer support for geopandas Series/DataFrame

### DIFF
--- a/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
@@ -1,4 +1,5 @@
 fastcore==1.5.29
+geopandas==1.0.1
 ipykernel==6.29.3
 ipywidgets==8.1.2
 matplotlib==3.8.2; python_version >= '3.9'

--- a/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
@@ -1,5 +1,6 @@
 fastcore==1.5.29
-geopandas==1.0.1
+geopandas==0.13.2; python_version < '3.9'
+geopandas==1.0.1; python_version >= '3.9'
 ipykernel==6.29.3
 ipywidgets==8.1.2
 matplotlib==3.8.2; python_version >= '3.9'

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -79,6 +79,8 @@ T = TypeVar("T")
 
 
 SIMPLER_NAMES = {
+    "geopandas.geoseries.GeoSeries": "geopandas.GeoSeries",
+    "geopandas.geodataframe.GeoDataFrame": "geopandas.GeoDataFrame",
     "pandas.core.frame.DataFrame": "pandas.DataFrame",
     "pandas.core.series.Series": "pandas.Series",
     "polars.dataframe.frame.DataFrame": "polars.DataFrame",
@@ -800,7 +802,10 @@ class BaseColumnInspector(_BaseMapInspector[Column], ABC):
 
 
 class PandasSeriesInspector(BaseColumnInspector["pd.Series"]):
-    CLASS_QNAME = "pandas.core.series.Series"
+    CLASS_QNAME = [
+        "pandas.core.series.Series",
+        "geopandas.geoseries.GeoSeries",
+    ]
 
     def get_display_name(self, key: int) -> str:
         return str(self.value.index[key])
@@ -946,7 +951,10 @@ class BaseTableInspector(_BaseMapInspector[Table], Generic[Table, Column], ABC):
 
 
 class PandasDataFrameInspector(BaseTableInspector["pd.DataFrame", "pd.Series"]):
-    CLASS_QNAME = "pandas.core.frame.DataFrame"
+    CLASS_QNAME = [
+        "pandas.core.frame.DataFrame",
+        "geopandas.geodataframe.GeoDataFrame",
+    ]
 
     def get_display_name(self, key: int) -> str:
         return str(self.value.columns[key])
@@ -1053,8 +1061,8 @@ class SQLAlchemyEngineInspector(BaseConnectionInspector):
 
 
 INSPECTOR_CLASSES: Dict[str, Type[PositronInspector]] = {
-    PandasDataFrameInspector.CLASS_QNAME: PandasDataFrameInspector,
-    PandasSeriesInspector.CLASS_QNAME: PandasSeriesInspector,
+    **dict.fromkeys(PandasDataFrameInspector.CLASS_QNAME, PandasDataFrameInspector),
+    **dict.fromkeys(PandasSeriesInspector.CLASS_QNAME, PandasSeriesInspector),
     **dict.fromkeys(PandasIndexInspector.CLASS_QNAME, PandasIndexInspector),
     PandasTimestampInspector.CLASS_QNAME: PandasTimestampInspector,
     **dict.fromkeys(NumpyNumberInspector.CLASS_QNAME, NumpyNumberInspector),

--- a/extensions/positron-python/python_files/positron/test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/test-requirements.txt
@@ -1,4 +1,5 @@
 fastcore
+geopandas
 ipykernel
 ipywidgets
 matplotlib


### PR DESCRIPTION
Addresses #3870. These types weren't being inspected correctly (their methods were showing up as children), and couldn't be opened in the data explorer. 

geopandas geometry types show up as unknown in the data explorer, but at least they work!

### QA Notes

Create geopandas GeoSeries or GeoDataFrame and inspect them in the variables pane and open them in the data explorer. 