### PR TITLE
Split R settings in two sections

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -127,117 +127,134 @@
         "icon": "$(play)"
       }
     ],
-    "configuration": {
-      "type": "object",
-      "title": "%r.configuration.title%",
-      "properties": {
-        "positron.r.kernel.path": {
-          "scope": "window",
-          "type": "string",
-          "default": "",
-          "description": "%r.configuration.kernelPath.description%"
-        },
-        "positron.r.kernel.logLevel": {
-          "scope": "window",
-          "type": "string",
-          "enum": [
-            "error",
-            "warn",
-            "info",
-            "debug",
-            "trace"
-          ],
-          "enumDescriptions": [
-            "%r.configuration.logLevel.error.description%",
-            "%r.configuration.logLevel.warn.description%",
-            "%r.configuration.logLevel.info.description%",
-            "%r.configuration.logLevel.debug.description%",
-            "%r.configuration.logLevel.trace.description%"
-          ],
-          "default": "warn",
-          "description": "%r.configuration.logLevel.description%"
-        },
-        "positron.r.kernel.logLevelExternal": {
-          "scope": "window",
-          "type": "string",
-          "default": "warn",
-          "title": "%r.configuration.logLevelExternal.title%",
-          "description": "%r.configuration.logLevelExternal.description%"
-        },
-        "positron.r.kernel.profile": {
-          "scope": "window",
-          "type": "string",
-          "default": null,
-          "description": "%r.configuration.profile.description%"
-        },
-        "positron.r.kernel.env": {
-          "scope": "window",
-          "type": "object",
-          "default": {},
-          "description": "%r.configuration.env.description%"
-        },
-        "positron.r.trace.server": {
-          "scope": "window",
-          "type": "string",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
-          "enumDescriptions": [
-            "%r.configuration.tracing.off.description%",
-            "%r.configuration.tracing.messages.description%",
-            "%r.configuration.tracing.verbose.description%"
-          ],
-          "default": "off",
-          "description": "%r.configuration.tracing.description%"
-        },
-        "positron.r.testing": {
-          "type": "boolean",
-          "default": true,
-          "description": "%r.configuration.packageTesting.description%"
-        },
-        "positron.r.restoreWorkspace": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "description": "%r.configuration.restoreWorkspace.description%"
-        },
-        "positron.r.extraArguments": {
-          "scope": "window",
-          "type": "array",
-          "items": {
-            "type": "string"
+    "configuration": [
+      {
+        "type": "object",
+        "title": "%r.configuration.title%",
+        "properties": {
+          "positron.r.testing": {
+            "type": "boolean",
+            "default": true,
+            "description": "%r.configuration.packageTesting.description%"
           },
-          "default": [],
-          "description": "%r.configuration.extraArguments.description%"
-        },
-        "positron.r.quietMode": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "description": "%r.configuration.quietMode.description%"
-        },
-        "positron.r.pipe": {
-          "type": "string",
-          "default": "%r.configuration.pipe.native.token%",
-          "enum": [
-            "%r.configuration.pipe.native.token%",
-            "%r.configuration.pipe.magrittr.token%"
-          ],
-          "enumDescriptions": [
-            "%r.configuration.pipe.native.description%",
-            "%r.configuration.pipe.magrittr.description%"
-          ],
-          "description": "%r.configuration.pipe%"
-        },
-        "positron.r.diagnostics.enable": {
-          "type": "boolean",
-          "default": true,
-          "description": "%r.configuration.diagnostics.enable.description%"
+          "positron.r.restoreWorkspace": {
+            "scope": "window",
+            "type": "boolean",
+            "default": false,
+            "description": "%r.configuration.restoreWorkspace.description%"
+          },
+          "positron.r.extraArguments": {
+            "scope": "window",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "%r.configuration.extraArguments.description%"
+          },
+          "positron.r.quietMode": {
+            "scope": "window",
+            "type": "boolean",
+            "default": false,
+            "description": "%r.configuration.quietMode.description%"
+          },
+          "positron.r.pipe": {
+            "type": "string",
+            "default": "%r.configuration.pipe.native.token%",
+            "enum": [
+              "%r.configuration.pipe.native.token%",
+              "%r.configuration.pipe.magrittr.token%"
+            ],
+            "enumDescriptions": [
+              "%r.configuration.pipe.native.description%",
+              "%r.configuration.pipe.magrittr.description%"
+            ],
+            "description": "%r.configuration.pipe%"
+          },
+          "positron.r.diagnostics.enable": {
+            "type": "boolean",
+            "default": true,
+            "description": "%r.configuration.diagnostics.enable.description%"
+          }
+        }
+      },
+      {
+        "type": "object",
+        "title": "%r.configuration.title-dev%",
+        "properties": {
+          "positron.r.kernel.path": {
+            "scope": "window",
+            "type": "string",
+            "default": "",
+            "description": "%r.configuration.kernelPath.description%"
+          },
+          "positron.r.kernel.logLevel": {
+            "scope": "window",
+            "type": "string",
+            "enum": [
+              "error",
+              "warn",
+              "info",
+              "debug",
+              "trace"
+            ],
+            "enumDescriptions": [
+              "%r.configuration.logLevel.error.description%",
+              "%r.configuration.logLevel.warn.description%",
+              "%r.configuration.logLevel.info.description%",
+              "%r.configuration.logLevel.debug.description%",
+              "%r.configuration.logLevel.trace.description%"
+            ],
+            "default": "warn",
+            "description": "%r.configuration.logLevel.description%"
+          },
+          "positron.r.kernel.logLevelExternal": {
+            "scope": "window",
+            "type": "string",
+            "default": "warn",
+            "title": "%r.configuration.logLevelExternal.title%",
+            "description": "%r.configuration.logLevelExternal.description%"
+          },
+          "positron.r.kernel.profile": {
+            "scope": "window",
+            "type": "string",
+            "default": null,
+            "description": "%r.configuration.profile.description%"
+          },
+          "positron.r.kernel.env": {
+            "scope": "window",
+            "type": "object",
+            "default": {},
+            "description": "%r.configuration.env.description%"
+          },
+          "positron.r.trace.server": {
+            "scope": "window",
+            "type": "string",
+            "enum": [
+              "off",
+              "messages",
+              "verbose"
+            ],
+            "enumDescriptions": [
+              "%r.configuration.tracing.off.description%",
+              "%r.configuration.tracing.messages.description%",
+              "%r.configuration.tracing.verbose.description%"
+            ],
+            "default": "off",
+            "description": "%r.configuration.tracing.description%"
+          },
+          "positron.r.extraArguments": {
+            "scope": "window",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "%r.configuration.extraArguments.description%"
+          }
         }
       }
-    },
+    ],
     "configurationDefaults": {
       "[r]": {
         "editor.formatOnType": true,
@@ -592,6 +609,6 @@
       "ark": "0.1.115"
     },
     "minimumRVersion": "4.2.0",
-		"minimumRenvVersion": "1.0.7"
+    "minimumRenvVersion": "1.0.7"
   }
 }

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -29,6 +29,7 @@
 	"r.menu.packageDocument.title": "Document R Package",
 	"r.menu.rmarkdownRender.title": "Render Document With R Markdown",
 	"r.configuration.title": "Positron R Language Pack",
+	"r.configuration.title-dev": "Positron R Language Pack (advanced)",
 	"r.configuration.kernelPath.description": "Path on disk to the ARK kernel executable; use this to override the default (embedded) kernel.",
 	"r.configuration.tracing.description": "Traces the communication between VS Code and the language server",
 	"r.configuration.tracing.off.description": "No tracing.",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -54,5 +54,5 @@
 	"r.configuration.pipe.magrittr.token": "%>%",
 	"r.configuration.pipe.native.description": "Native pipe available in R >= 4.1",
 	"r.configuration.pipe.magrittr.description": "Pipe operator from the magrittr package, re-exported by many other packages",
-	"r.configuration.diagnostics.enable.description": "Whether to enable R diagnostics globally"
+	"r.configuration.diagnostics.enable.description": "Enable R diagnostics globally"
 }

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -30,7 +30,7 @@
 	"r.menu.rmarkdownRender.title": "Render Document With R Markdown",
 	"r.configuration.title": "Positron R Language Pack",
 	"r.configuration.title-dev": "Positron R Language Pack (advanced)",
-	"r.configuration.kernelPath.description": "Path on disk to the ARK kernel executable; use this to override the default (embedded) kernel.",
+	"r.configuration.kernelPath.description": "Path on disk to the ARK kernel executable; use this to override the default (embedded) kernel. Note that this is not the path to R.",
 	"r.configuration.tracing.description": "Traces the communication between VS Code and the language server",
 	"r.configuration.tracing.off.description": "No tracing.",
 	"r.configuration.tracing.messages.description": "Log messages from the server to the output panel.",


### PR DESCRIPTION
Intent: Avoid confusion such as in https://github.com/posit-dev/positron/issues/3832 where a user thought the path for Ark was the path for R.

- Add a note that path to Ark is not path to R

- Split advanced settings into a separate section. This way the most useful user settings are separated from the dev or debug settings and are easier for users to skim through. It might also give pause before trying adanced settings like the path to Ark.


https://github.com/posit-dev/positron/assets/4465050/669161e2-3d54-4e9e-8a36-9c25fe39781a

