### PR TITLE
Project Wizard Smoke Tests: Python Project existing interpreter ipykernel tests

### DIFF
--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -226,7 +226,9 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 					onChange={(e) => onChangeParentFolder(e.target.value)}
 				/>
 			</PositronWizardSubStep>
-			<PositronWizardSubStep>
+			<PositronWizardSubStep
+				titleId='misc-proj-options'
+			>
 				{/* TODO: display a warning/message if the user doesn't have git set up */}
 				<Checkbox
 					label={(() =>

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/wizardStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/wizardStep.tsx
@@ -22,16 +22,17 @@ export interface PositronWizardStepProps extends OKCancelBackNextActionBarProps 
  * @returns The rendered component.
  */
 export const PositronWizardStep = (props: PropsWithChildren<PositronWizardStepProps>) => {
+	// The step ID is based on the title, with non-letter or non-number characters replaced with hyphens.
+	const stepId = props.title.toLowerCase().replace(/[^a-z0-9]/g, '-') || '';
 	// Render.
 	return (
 		// QUESTION: should each wizard step be a form element?
-		<div className='wizard-step'>
-			<div className='wizard-step-title'>
-				{props.title}
-			</div>
-			<VerticalStack>
-				{props.children}
-			</VerticalStack>
+		<div
+			className='wizard-step'
+			id={stepId.length ? `wizard-step-${stepId}` : ''}
+		>
+			<div className='wizard-step-title'>{props.title}</div>
+			<VerticalStack>{props.children}</VerticalStack>
 			<OKCancelBackNextActionBar
 				okButtonConfig={props.okButtonConfig}
 				cancelButtonConfig={props.cancelButtonConfig}

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/wizardSubStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/wizardSubStep.tsx
@@ -27,9 +27,17 @@ export interface PositronWizardSubStepProps {
  * @returns The rendered component.
  */
 export const PositronWizardSubStep = (props: PropsWithChildren<PositronWizardSubStepProps>) => {
+	// The sub step ID is based on the title, with non-letter or non-number characters replaced with hyphens.
+	// Try using the titleId before the title, which may be shorter.
+	const subStepTitleId = props.titleId || props.title;
+	const subStepId = subStepTitleId?.toLowerCase().replace(/[^a-z0-9]/g, '-') || '';
+
 	// Render.
 	return (
-		<div className='wizard-sub-step'>
+		<div
+			className='wizard-sub-step'
+			id={subStepId.length ? `wizard-sub-step-${subStepId}` : ''}
+		>
 			{props.title ?
 				<div className='wizard-sub-step-title' id={props.titleId}>
 					{props.title}

--- a/test/automation/src/positron/fixtures/positronPythonFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronPythonFixtures.ts
@@ -5,8 +5,7 @@
 
 import { fail } from 'assert';
 import { Application } from '../../application';
-import { InterpreterType } from '../positronStartInterpreter';
-import { InterpreterInfo } from '../positronConsole';
+import { InterpreterInfo, InterpreterType } from '../utils/positronInterpreterInfo';
 
 /*
  *  Reuseable Positron Python fixture tests can leverage to get a Python interpreter selected.

--- a/test/automation/src/positron/fixtures/positronPythonFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronPythonFixtures.ts
@@ -6,6 +6,7 @@
 import { fail } from 'assert';
 import { Application } from '../../application';
 import { InterpreterType } from '../positronStartInterpreter';
+import { InterpreterInfo } from '../positronConsole';
 
 /*
  *  Reuseable Positron Python fixture tests can leverage to get a Python interpreter selected.
@@ -19,13 +20,13 @@ export class PositronPythonFixtures {
 		await fixtures.startPythonInterpreter();
 	}
 
-	async startPythonInterpreter(installIPyKernelIfPrompted: boolean = false) {
+	async startPythonInterpreter(installIPyKernelIfPrompted: boolean = false): Promise<InterpreterInfo | undefined> {
 
 		const desiredPython = process.env.POSITRON_PY_VER_SEL;
 		if (desiredPython === undefined) {
 			fail('Please be sure to set env var POSITRON_PY_VER_SEL to the UI text corresponding to the Python version for the test');
 		}
-		await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.Python, desiredPython);
+		const interpreterInfo = await this.app.workbench.positronConsole.selectAndGetInterpreter(InterpreterType.Python, desiredPython);
 
 		if (
 			installIPyKernelIfPrompted &&
@@ -37,6 +38,8 @@ export class PositronPythonFixtures {
 		await this.app.workbench.positronConsole.waitForReady('>>>');
 
 		await this.app.workbench.positronConsole.logConsoleContents();
+
+		return interpreterInfo;
 	}
 
 }

--- a/test/automation/src/positron/fixtures/positronPythonFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronPythonFixtures.ts
@@ -20,8 +20,20 @@ export class PositronPythonFixtures {
 		await fixtures.startPythonInterpreter();
 	}
 
-	async startPythonInterpreter(installIPyKernelIfPrompted: boolean = false): Promise<InterpreterInfo | undefined> {
+	async startPythonInterpreter() {
 
+		const desiredPython = process.env.POSITRON_PY_VER_SEL;
+		if (desiredPython === undefined) {
+			fail('Please be sure to set env var POSITRON_PY_VER_SEL to the UI text corresponding to the Python version for the test');
+		}
+		await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.Python, desiredPython);
+
+		await this.app.workbench.positronConsole.waitForReady('>>>');
+
+		await this.app.workbench.positronConsole.logConsoleContents();
+	}
+
+	async startAndGetPythonInterpreter(installIPyKernelIfPrompted: boolean = false): Promise<InterpreterInfo | undefined> {
 		const desiredPython = process.env.POSITRON_PY_VER_SEL;
 		if (desiredPython === undefined) {
 			fail('Please be sure to set env var POSITRON_PY_VER_SEL to the UI text corresponding to the Python version for the test');

--- a/test/automation/src/positron/fixtures/positronPythonFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronPythonFixtures.ts
@@ -19,13 +19,21 @@ export class PositronPythonFixtures {
 		await fixtures.startPythonInterpreter();
 	}
 
-	async startPythonInterpreter() {
+	async startPythonInterpreter(installIPyKernelIfPrompted: boolean = false) {
 
 		const desiredPython = process.env.POSITRON_PY_VER_SEL;
 		if (desiredPython === undefined) {
 			fail('Please be sure to set env var POSITRON_PY_VER_SEL to the UI text corresponding to the Python version for the test');
 		}
 		await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.Python, desiredPython);
+
+		if (await this.app.workbench.positronPopups.popupCurrentlyOpen()) {
+			if (installIPyKernelIfPrompted) {
+				await this.app.workbench.positronPopups.installIPyKernel();
+			} else {
+				fail('The ipykernel popup was opened, but the test was not configured to install it.')
+			}
+		}
 
 		await this.app.workbench.positronConsole.waitForReady('>>>');
 

--- a/test/automation/src/positron/fixtures/positronPythonFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronPythonFixtures.ts
@@ -27,12 +27,11 @@ export class PositronPythonFixtures {
 		}
 		await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.Python, desiredPython);
 
-		if (await this.app.workbench.positronPopups.popupCurrentlyOpen()) {
-			if (installIPyKernelIfPrompted) {
-				await this.app.workbench.positronPopups.installIPyKernel();
-			} else {
-				fail('The ipykernel popup was opened, but the test was not configured to install it.')
-			}
+		if (
+			installIPyKernelIfPrompted &&
+			(await this.app.workbench.positronPopups.popupCurrentlyOpen())
+		) {
+			await this.app.workbench.positronPopups.installIPyKernel();
 		}
 
 		await this.app.workbench.positronConsole.waitForReady('>>>');

--- a/test/automation/src/positron/fixtures/positronRFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronRFixtures.ts
@@ -6,6 +6,7 @@
 import { fail } from 'assert';
 import { Application } from '../../application';
 import { InterpreterType } from '../positronStartInterpreter';
+import { InterpreterInfo } from '../positronConsole';
 
 /*
  *  Reuseable Positron R fixture tests can leverage to get an R interpreter selected.
@@ -19,19 +20,19 @@ export class PositronRFixtures {
 		await fixtures.startRInterpreter();
 	}
 
-	async startRInterpreter() {
+	async startRInterpreter(): Promise<InterpreterInfo | undefined> {
 
 		const desiredR = process.env.POSITRON_R_VER_SEL;
 		if (desiredR === undefined) {
 			fail('Please be sure to set env var POSITRON_R_VER_SEL to the UI text corresponding to the R version for the test');
 		}
-		await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.R, desiredR);
+		const interpreterInfo = await this.app.workbench.positronConsole.selectAndGetInterpreter(InterpreterType.R, desiredR);
 
 		await this.app.workbench.positronConsole.waitForReady('>');
 
 		await this.app.workbench.positronConsole.logConsoleContents();
 
-
+		return interpreterInfo;
 	}
 
 }

--- a/test/automation/src/positron/fixtures/positronRFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronRFixtures.ts
@@ -6,7 +6,6 @@
 import { fail } from 'assert';
 import { Application } from '../../application';
 import { InterpreterType } from '../positronStartInterpreter';
-import { InterpreterInfo } from '../positronConsole';
 
 /*
  *  Reuseable Positron R fixture tests can leverage to get an R interpreter selected.
@@ -20,19 +19,19 @@ export class PositronRFixtures {
 		await fixtures.startRInterpreter();
 	}
 
-	async startRInterpreter(): Promise<InterpreterInfo | undefined> {
+	async startRInterpreter() {
 
 		const desiredR = process.env.POSITRON_R_VER_SEL;
 		if (desiredR === undefined) {
 			fail('Please be sure to set env var POSITRON_R_VER_SEL to the UI text corresponding to the R version for the test');
 		}
-		const interpreterInfo = await this.app.workbench.positronConsole.selectAndGetInterpreter(InterpreterType.R, desiredR);
+		await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.R, desiredR);
 
 		await this.app.workbench.positronConsole.waitForReady('>');
 
 		await this.app.workbench.positronConsole.logConsoleContents();
 
-		return interpreterInfo;
+
 	}
 
 }

--- a/test/automation/src/positron/fixtures/positronRFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronRFixtures.ts
@@ -5,7 +5,7 @@
 
 import { fail } from 'assert';
 import { Application } from '../../application';
-import { InterpreterType } from '../positronStartInterpreter';
+import { InterpreterType } from '../utils/positronInterpreterInfo';
 
 /*
  *  Reuseable Positron R fixture tests can leverage to get an R interpreter selected.

--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -8,7 +8,7 @@ import { Locator } from '@playwright/test';
 import { Code } from '../code';
 import { QuickAccess } from '../quickaccess';
 import { QuickInput } from '../quickinput';
-import { InterpreterType } from './positronStartInterpreter';
+import { InterpreterInfo, InterpreterType } from './utils/positronInterpreterInfo';
 import { PositronBaseElement } from './positronBaseElement';
 import { IElement } from '../driver';
 
@@ -20,13 +20,6 @@ const CONSOLE_BAR_POWER_BUTTON = 'div.action-bar-button-icon.codicon.codicon-pos
 const CONSOLE_BAR_RESTART_BUTTON = 'div.action-bar-button-icon.codicon.codicon-positron-restart-runtime-thin';
 const CONSOLE_RESTART_BUTTON = 'button.monaco-text-button.runtime-restart-button';
 const CONSOLE_BAR_CLEAR_BUTTON = 'div.action-bar-button-icon.codicon.codicon-clear-all';
-
-export interface InterpreterInfo {
-	type: InterpreterType;
-	version: string;
-	path: string;
-	source?: string;
-}
 
 /*
  *  Reuseable Positron console functionality for tests to leverage.  Includes the ability to select an interpreter and execute code which
@@ -81,7 +74,7 @@ export class PositronConsole {
 				version: rawInfo[0].trim(),
 				path: rawInfo[1].trim(),
 				source: hasSource ? rawInfo[2].trim() : ''
-			};
+			} satisfies InterpreterInfo;
 		}
 
 		return undefined;

--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -123,9 +123,14 @@ export class PositronConsole {
 		await this.code.driver.getKeyboard().press('Enter');
 	}
 
-	async waitForReady(prompt: string) {
+	getActiveConsole(): Locator | undefined {
+		const activeConsole = this.code.driver.getLocator(ACTIVE_CONSOLE_INSTANCE);
+		return activeConsole;
+	}
+
+	async waitForReady(prompt: string, retryCount: number = 500) {
 		// Wait for the prompt to show up.
-		await this.code.waitForTextContent(`${ACTIVE_CONSOLE_INSTANCE} .active-line-number`, prompt);
+		await this.code.waitForTextContent(`${ACTIVE_CONSOLE_INSTANCE} .active-line-number`, prompt, undefined, retryCount);
 
 		// Wait for the interpreter to start.
 		await this.waitForConsoleContents((contents) => contents.some((line) => line.includes('started')));

--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -63,17 +63,24 @@ export class PositronConsole {
 		return interpreterElem;
 	}
 
-	async selectAndGetInterpreter(desiredInterpreterType: InterpreterType, desiredInterpreterString: string): Promise<InterpreterInfo | undefined> {
-		const interpreterElem = await this.selectInterpreter(desiredInterpreterType, desiredInterpreterString);
+	async selectAndGetInterpreter(
+		desiredInterpreterType: InterpreterType,
+		desiredInterpreter: string
+	): Promise<InterpreterInfo | undefined> {
+		const interpreterElem = await this.selectInterpreter(
+			desiredInterpreterType,
+			desiredInterpreter
+		);
 
 		if (interpreterElem) {
+			// The aria-label looks something like: Python 3.10.4 64-bit ('3.10.4'), ~/.pyenv/versions/3.10.4/bin/python, Pyenv
 			const rawInfo = interpreterElem.attributes['aria-label'].split(',');
 			const hasSource = rawInfo.length > 2;
 			return {
-				type: desiredInterpreterType,
-				version: rawInfo[0].trim(),
-				path: rawInfo[1].trim(),
-				source: hasSource ? rawInfo[2].trim() : ''
+				type: desiredInterpreterType, // e.g. InterpreterType.Python
+				version: rawInfo[0].trim(), // e.g. Python 3.10.4 64-bit ('3.10.4')
+				path: rawInfo[1].trim(), // e.g. ~/.pyenv/versions/3.10.4/bin/python
+				source: hasSource ? rawInfo[2].trim() : '', // e.g. Pyenv
 			} satisfies InterpreterInfo;
 		}
 

--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -121,7 +121,7 @@ class ProjectWizardRConfigurationStep {
 class ProjectWizardPythonConfigurationStep {
 	newEnvRadioButton: PositronBaseElement;
 	existingEnvRadioButton: PositronBaseElement;
-	selectedInterpreterTitle: PositronTextElement;
+	selectedInterpreterPath: PositronTextElement;
 	interpreterFeedback: PositronTextElement;
 	interpreterDropdown: Locator;
 
@@ -134,8 +134,8 @@ class ProjectWizardPythonConfigurationStep {
 			'div[id="wizard-step-set-up-python-environment"] div[id="wizard-sub-step-pythonenvironment-howtosetupenv"] .radio-button-input[id="existingEnvironment"]',
 			this.code
 		);
-		this.selectedInterpreterTitle = new PositronTextElement(
-			'div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-input button.drop-down-list-box .dropdown-entry-title',
+		this.selectedInterpreterPath = new PositronTextElement(
+			'div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-input button.drop-down-list-box .dropdown-entry-subtitle',
 			this.code
 		);
 		this.interpreterFeedback = new PositronTextElement(
@@ -147,14 +147,14 @@ class ProjectWizardPythonConfigurationStep {
 		);
 	}
 
-	async selectInterpreter(version: string) {
+	async selectInterpreterByPath(interpreterPath: string) {
 		await this.interpreterDropdown.click();
 		await this.code.waitForElement(
 			PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS
 		);
 		await this.code.driver
 			.getLocator(
-				`${PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS} div.dropdown-entry:has-text("${version}")`
+				`${PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS} div.dropdown-entry-subtitle:text-is("${interpreterPath}")`
 			)
 			.click();
 	}

--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -25,7 +25,8 @@ const PROJECT_WIZARD_PROJECT_NAME_INPUT = 'div.wizard-sub-step-input input.text-
 const PROJECT_WIZARD_DISABLED_CREATE_BUTTON = 'button.positron-button.button.action-bar-button.default.disabled[tabindex="0"][disabled][role="button"][aria-disabled="true"]';
 
 // Configuration Step: Python Project & Jupyter Notebook
-
+const PROJECT_WIZARD_EXISTING_ENV_RADIO_BUTTON = '.radio-button-input[id="existingEnvironment"]';
+const PROJECT_WIZARD_NEW_ENV_RADIO_BUTTON = 'radio-button-input.[id="newEnvironment"]';
 
 // Configuration Step: R Project
 const PROJECT_WIZARD_RENV_CHECKBOX = 'div.renv-configuration > div.checkbox';
@@ -37,36 +38,85 @@ const PROJECT_WIZARD_CURRENT_WINDOW_BUTTON = 'button.positron-button.button.acti
  *  Reuseable Positron new project wizard functionality for tests to leverage.
  */
 export class PositronNewProjectWizard {
-	newPythonProjectButton: PositronBaseElement;
-	newRProjectButton: PositronBaseElement;
-	projectWizardCancelButton: PositronBaseElement;
-	projectWizardNextButton: PositronBaseElement;
-	projectWizardBackButton: PositronBaseElement;
-	projectWizardDisabledCreateButton: PositronBaseElement;
-	projectWizardCurrentWindowButton: PositronBaseElement;
-	newJupyterProjectButton: PositronBaseElement;
-	projectWizardRenvCheckbox: PositronBaseElement;
-	projectWizardProjectNameInput: PositronBaseElement;
+	projectTypeStep: ProjectWizardProjectTypeStep;
+	projectNameLocationStep: ProjectWizardProjectNameLocationStep;
+	rConfigurationStep: ProjectWizardRConfigurationStep;
+	pythonConfigurationStep: ProjectWizardPythonConfigurationStep;
+	currentOrNewWindowSelectionModal: CurrentOrNewWindowSelectionModal;
+
+	cancelButton: PositronBaseElement;
+	nextButton: PositronBaseElement;
+	backButton: PositronBaseElement;
+	disabledCreateButton: PositronBaseElement;
 
 	constructor(private code: Code, private quickaccess: QuickAccess) {
-		this.newPythonProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_PYTHON_PROJECT, this.code);
-		this.newRProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_R_PROJECT, this.code);
-		this.projectWizardCancelButton = new PositronBaseElement(PROJECT_WIZARD_CANCEL_BUTTON, this.code);
-		this.projectWizardNextButton = new PositronBaseElement(PROJECT_WIZARD_NEXT_BUTTON, this.code);
-		this.projectWizardBackButton = new PositronBaseElement(PROJECT_WIZARD_BACK_BUTTON, this.code);
-		this.projectWizardDisabledCreateButton = new PositronBaseElement(PROJECT_WIZARD_DISABLED_CREATE_BUTTON, this.code);
-		this.projectWizardCurrentWindowButton = new PositronBaseElement(PROJECT_WIZARD_CURRENT_WINDOW_BUTTON, this.code);
-		this.newJupyterProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_JUPYTER_PROJECT, this.code);
-		this.projectWizardRenvCheckbox = new PositronBaseElement(PROJECT_WIZARD_RENV_CHECKBOX, this.code);
-		this.projectWizardProjectNameInput = new PositronBaseElement(PROJECT_WIZARD_PROJECT_NAME_INPUT, this.code);
+		this.projectTypeStep = new ProjectWizardProjectTypeStep(this.code);
+		this.projectNameLocationStep = new ProjectWizardProjectNameLocationStep(this.code);
+		this.rConfigurationStep = new ProjectWizardRConfigurationStep(this.code);
+		this.pythonConfigurationStep = new ProjectWizardPythonConfigurationStep(this.code);
+		this.currentOrNewWindowSelectionModal = new CurrentOrNewWindowSelectionModal(this.code);
+
+		this.cancelButton = new PositronBaseElement(PROJECT_WIZARD_CANCEL_BUTTON, this.code);
+		this.nextButton = new PositronBaseElement(PROJECT_WIZARD_NEXT_BUTTON, this.code);
+		this.backButton = new PositronBaseElement(PROJECT_WIZARD_BACK_BUTTON, this.code);
+		this.disabledCreateButton = new PositronBaseElement(PROJECT_WIZARD_DISABLED_CREATE_BUTTON, this.code);
 	}
 
 	async startNewProject() {
 		await this.quickaccess.runCommand('positron.workbench.action.newProject', { keepOpen: false });
 	}
+}
+
+class ProjectWizardProjectTypeStep {
+	newPythonProjectButton: PositronBaseElement;
+	newRProjectButton: PositronBaseElement;
+	newJupyterProjectButton: PositronBaseElement;
+
+	constructor(private code: Code) {
+		this.newPythonProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_PYTHON_PROJECT, this.code);
+		this.newRProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_R_PROJECT, this.code);
+		this.newJupyterProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_JUPYTER_PROJECT, this.code);
+	}
+}
+
+class ProjectWizardProjectNameLocationStep {
+	projectNameInput: PositronBaseElement;
+
+	constructor(private code: Code) {
+		this.projectNameInput = new PositronBaseElement(PROJECT_WIZARD_PROJECT_NAME_INPUT, this.code);
+	}
 
 	async appendToProjectName(text: string) {
 		await this.code.waitForActiveElement(PROJECT_WIZARD_PROJECT_NAME_INPUT);
-		await this.projectWizardProjectNameInput.getPage().keyboard.type(text);
+		await this.projectNameInput.getPage().keyboard.type(text);
+	}
+}
+
+class ProjectWizardRConfigurationStep {
+	renvCheckbox: PositronBaseElement;
+
+	constructor(private code: Code) {
+		this.renvCheckbox = new PositronBaseElement(PROJECT_WIZARD_RENV_CHECKBOX, this.code);
+	}
+}
+
+class ProjectWizardPythonConfigurationStep {
+	newEnvRadioButton: PositronBaseElement;
+	existingEnvRadioButton: PositronBaseElement;
+	// TO ADD:
+	// env provider selection
+	// interpreter selection
+	// interpreter feedback text
+	constructor(private code: Code) {
+		this.newEnvRadioButton = new PositronBaseElement(PROJECT_WIZARD_NEW_ENV_RADIO_BUTTON, this.code);
+		this.existingEnvRadioButton = new PositronBaseElement(PROJECT_WIZARD_EXISTING_ENV_RADIO_BUTTON, this.code);
+	}
+}
+
+class CurrentOrNewWindowSelectionModal {
+	currentWindowButton: PositronBaseElement;
+
+	constructor(private code: Code) {
+		this.currentWindowButton = new PositronBaseElement(PROJECT_WIZARD_CURRENT_WINDOW_BUTTON, this.code);
 	}
 }

--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -8,16 +8,30 @@ import { Code } from '../code';
 import { QuickAccess } from '../quickaccess';
 import { PositronBaseElement } from './positronBaseElement';
 
-const PROJECT_WIZARD_NEW_PYTHON_PROJECT = '[id="Python Project"]';
-const PROJECT_WIZARD_NEW_R_PROJECT = '[id="R Project"]';
+// Project Wizard General Modal Elements
 const PROJECT_WIZARD_CANCEL_BUTTON = 'div.right-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]';
 const PROJECT_WIZARD_NEXT_BUTTON = 'button.positron-button.button.action-bar-button.default[tabindex="0"][role="button"]';
 const PROJECT_WIZARD_BACK_BUTTON = 'div.left-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]';
-const PROJECT_WIZARD_DISABLED_CREATE_BUTTON = 'button.positron-button.button.action-bar-button.default.disabled[tabindex="0"][disabled][role="button"][aria-disabled="true"]';
-const PROJECT_WIZARD_CURRENT_WINDOW_BUTTON = 'button.positron-button.button.action-bar-button[tabindex="0"][role="button"]';
+
+// Project Type Selection Step
+const PROJECT_WIZARD_NEW_PYTHON_PROJECT = '[id="Python Project"]';
+const PROJECT_WIZARD_NEW_R_PROJECT = '[id="R Project"]';
 const PROJECT_WIZARD_NEW_JUPYTER_PROJECT = '[id="Jupyter Notebook"]';
-const PROJECT_WIZARD_RENV_CHECKBOX = 'div.renv-configuration > div.checkbox';
+
+// Project Name & Location Step
 const PROJECT_WIZARD_PROJECT_NAME_INPUT = 'div.wizard-sub-step-input input.text-input';
+
+// Configuration Step: General
+const PROJECT_WIZARD_DISABLED_CREATE_BUTTON = 'button.positron-button.button.action-bar-button.default.disabled[tabindex="0"][disabled][role="button"][aria-disabled="true"]';
+
+// Configuration Step: Python Project & Jupyter Notebook
+
+
+// Configuration Step: R Project
+const PROJECT_WIZARD_RENV_CHECKBOX = 'div.renv-configuration > div.checkbox';
+
+// Current or New Window Selection Modal
+const PROJECT_WIZARD_CURRENT_WINDOW_BUTTON = 'button.positron-button.button.action-bar-button[tabindex="0"][role="button"]';
 
 /*
  *  Reuseable Positron new project wizard functionality for tests to leverage.

--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -6,7 +6,7 @@
 
 import { Code } from '../code';
 import { QuickAccess } from '../quickaccess';
-import { PositronBaseElement } from './positronBaseElement';
+import { PositronBaseElement, PositronTextElement } from './positronBaseElement';
 
 // Project Wizard General Modal Elements
 const PROJECT_WIZARD_CANCEL_BUTTON = 'div.right-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]';
@@ -19,14 +19,18 @@ const PROJECT_WIZARD_NEW_R_PROJECT = '[id="R Project"]';
 const PROJECT_WIZARD_NEW_JUPYTER_PROJECT = '[id="Jupyter Notebook"]';
 
 // Project Name & Location Step
-const PROJECT_WIZARD_PROJECT_NAME_INPUT = 'div.wizard-sub-step-input input.text-input';
+const PROJECT_WIZARD_PROJECT_NAME_INPUT = 'div[id="wizard-sub-step-project-name"] .wizard-sub-step-input input.text-input';
 
 // Configuration Step: General
 const PROJECT_WIZARD_DISABLED_CREATE_BUTTON = 'button.positron-button.button.action-bar-button.default.disabled[tabindex="0"][disabled][role="button"][aria-disabled="true"]';
 
 // Configuration Step: Python Project & Jupyter Notebook
-const PROJECT_WIZARD_EXISTING_ENV_RADIO_BUTTON = '.radio-button-input[id="existingEnvironment"]';
-const PROJECT_WIZARD_NEW_ENV_RADIO_BUTTON = 'radio-button-input.[id="newEnvironment"]';
+const PROJECT_WIZARD_EXISTING_ENV_RADIO_BUTTON = 'div[id="wizard-step-set-up-python-environment"] div[id="wizard-sub-step-pythonenvironment-howtosetupenv"] .radio-button-input[id="existingEnvironment"]';
+const PROJECT_WIZARD_NEW_ENV_RADIO_BUTTON = 'div[id="wizard-step-set-up-python-environment"] div[id="wizard-sub-step-pythonenvironment-howtosetupenv"] radio-button-input.[id="newEnvironment"]';
+const PROJECT_WIZARD_INTERPRETER_DROPDOWN = 'div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-input button.drop-down-list-box';
+const PROJECT_WIZARD_INTERPRETER_DROPDOWN_SELECTED_TITLE = 'div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-input button.drop-down-list-box .dropdown-entry-title';
+const PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS = 'div.positron-modal-popup-children button.positron-button.item';
+const PROJECT_WIZARD_PYTHON_INTERPRETER_FEEDBACK = 'div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-feedback .wizard-formatted-text';
 
 // Configuration Step: R Project
 const PROJECT_WIZARD_RENV_CHECKBOX = 'div.renv-configuration > div.checkbox';
@@ -103,13 +107,20 @@ class ProjectWizardRConfigurationStep {
 class ProjectWizardPythonConfigurationStep {
 	newEnvRadioButton: PositronBaseElement;
 	existingEnvRadioButton: PositronBaseElement;
-	// TO ADD:
-	// env provider selection
-	// interpreter selection
-	// interpreter feedback text
+	selectedInterpreterTitle: PositronTextElement;
+	interpreterFeedback: PositronTextElement;
+
 	constructor(private code: Code) {
 		this.newEnvRadioButton = new PositronBaseElement(PROJECT_WIZARD_NEW_ENV_RADIO_BUTTON, this.code);
 		this.existingEnvRadioButton = new PositronBaseElement(PROJECT_WIZARD_EXISTING_ENV_RADIO_BUTTON, this.code);
+		this.selectedInterpreterTitle = new PositronTextElement(PROJECT_WIZARD_INTERPRETER_DROPDOWN_SELECTED_TITLE, this.code);
+		this.interpreterFeedback = new PositronTextElement(PROJECT_WIZARD_PYTHON_INTERPRETER_FEEDBACK, this.code);
+	}
+
+	async selectInterpreter(version: string) {
+		await this.code.driver.getLocator(PROJECT_WIZARD_INTERPRETER_DROPDOWN).click();
+		await this.code.waitForElement(PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS);
+		await this.code.driver.getLocator(`${PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS} div.dropdown-entry:has-text("${version}")`).click();
 	}
 }
 

--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -68,14 +68,14 @@ export class PositronNewProjectWizard {
 }
 
 class ProjectWizardProjectTypeStep {
-	newPythonProjectButton: PositronBaseElement;
-	newRProjectButton: PositronBaseElement;
-	newJupyterProjectButton: PositronBaseElement;
+	pythonProjectButton: PositronBaseElement;
+	rProjectButton: PositronBaseElement;
+	jupyterNotebookButton: PositronBaseElement;
 
 	constructor(private code: Code) {
-		this.newPythonProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_PYTHON_PROJECT, this.code);
-		this.newRProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_R_PROJECT, this.code);
-		this.newJupyterProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_JUPYTER_PROJECT, this.code);
+		this.pythonProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_PYTHON_PROJECT, this.code);
+		this.rProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_R_PROJECT, this.code);
+		this.jupyterNotebookButton = new PositronBaseElement(PROJECT_WIZARD_NEW_JUPYTER_PROJECT, this.code);
 	}
 }
 

--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -4,39 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 
+import { Locator } from '@playwright/test';
 import { Code } from '../code';
 import { QuickAccess } from '../quickaccess';
 import { PositronBaseElement, PositronTextElement } from './positronBaseElement';
 
-// Project Wizard General Modal Elements
-const PROJECT_WIZARD_CANCEL_BUTTON = 'div.right-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]';
-const PROJECT_WIZARD_NEXT_BUTTON = 'button.positron-button.button.action-bar-button.default[tabindex="0"][role="button"]';
-const PROJECT_WIZARD_BACK_BUTTON = 'div.left-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]';
-
-// Project Type Selection Step
-const PROJECT_WIZARD_NEW_PYTHON_PROJECT = '[id="Python Project"]';
-const PROJECT_WIZARD_NEW_R_PROJECT = '[id="R Project"]';
-const PROJECT_WIZARD_NEW_JUPYTER_PROJECT = '[id="Jupyter Notebook"]';
-
 // Project Name & Location Step
 const PROJECT_WIZARD_PROJECT_NAME_INPUT = 'div[id="wizard-sub-step-project-name"] .wizard-sub-step-input input.text-input';
 
-// Configuration Step: General
-const PROJECT_WIZARD_DISABLED_CREATE_BUTTON = 'button.positron-button.button.action-bar-button.default.disabled[tabindex="0"][disabled][role="button"][aria-disabled="true"]';
-
 // Configuration Step: Python Project & Jupyter Notebook
-const PROJECT_WIZARD_EXISTING_ENV_RADIO_BUTTON = 'div[id="wizard-step-set-up-python-environment"] div[id="wizard-sub-step-pythonenvironment-howtosetupenv"] .radio-button-input[id="existingEnvironment"]';
-const PROJECT_WIZARD_NEW_ENV_RADIO_BUTTON = 'div[id="wizard-step-set-up-python-environment"] div[id="wizard-sub-step-pythonenvironment-howtosetupenv"] radio-button-input.[id="newEnvironment"]';
-const PROJECT_WIZARD_INTERPRETER_DROPDOWN = 'div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-input button.drop-down-list-box';
-const PROJECT_WIZARD_INTERPRETER_DROPDOWN_SELECTED_TITLE = 'div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-input button.drop-down-list-box .dropdown-entry-title';
 const PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS = 'div.positron-modal-popup-children button.positron-button.item';
-const PROJECT_WIZARD_PYTHON_INTERPRETER_FEEDBACK = 'div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-feedback .wizard-formatted-text';
-
-// Configuration Step: R Project
-const PROJECT_WIZARD_RENV_CHECKBOX = 'div.renv-configuration > div.checkbox';
-
-// Current or New Window Selection Modal
-const PROJECT_WIZARD_CURRENT_WINDOW_BUTTON = 'button.positron-button.button.action-bar-button[tabindex="0"][role="button"]';
 
 /*
  *  Reuseable Positron new project wizard functionality for tests to leverage.
@@ -60,10 +37,10 @@ export class PositronNewProjectWizard {
 		this.pythonConfigurationStep = new ProjectWizardPythonConfigurationStep(this.code);
 		this.currentOrNewWindowSelectionModal = new CurrentOrNewWindowSelectionModal(this.code);
 
-		this.cancelButton = new PositronBaseElement(PROJECT_WIZARD_CANCEL_BUTTON, this.code);
-		this.nextButton = new PositronBaseElement(PROJECT_WIZARD_NEXT_BUTTON, this.code);
-		this.backButton = new PositronBaseElement(PROJECT_WIZARD_BACK_BUTTON, this.code);
-		this.disabledCreateButton = new PositronBaseElement(PROJECT_WIZARD_DISABLED_CREATE_BUTTON, this.code);
+		this.cancelButton = new PositronBaseElement('div.right-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]', this.code);
+		this.nextButton = new PositronBaseElement('button.positron-button.button.action-bar-button.default[tabindex="0"][role="button"]', this.code);
+		this.backButton = new PositronBaseElement('div.left-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]', this.code);
+		this.disabledCreateButton = new PositronBaseElement('button.positron-button.button.action-bar-button.default.disabled[tabindex="0"][disabled][role="button"][aria-disabled="true"]', this.code);
 	}
 
 	async startNewProject() {
@@ -77,22 +54,22 @@ class ProjectWizardProjectTypeStep {
 	jupyterNotebookButton: PositronBaseElement;
 
 	constructor(private code: Code) {
-		this.pythonProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_PYTHON_PROJECT, this.code);
-		this.rProjectButton = new PositronBaseElement(PROJECT_WIZARD_NEW_R_PROJECT, this.code);
-		this.jupyterNotebookButton = new PositronBaseElement(PROJECT_WIZARD_NEW_JUPYTER_PROJECT, this.code);
+		this.pythonProjectButton = new PositronBaseElement('[id="Python Project"]', this.code);
+		this.rProjectButton = new PositronBaseElement('[id="R Project"]', this.code);
+		this.jupyterNotebookButton = new PositronBaseElement('[id="Jupyter Notebook"]', this.code);
 	}
 }
 
 class ProjectWizardProjectNameLocationStep {
-	projectNameInput: PositronBaseElement;
+	projectNameInput: Locator;
 
 	constructor(private code: Code) {
-		this.projectNameInput = new PositronBaseElement(PROJECT_WIZARD_PROJECT_NAME_INPUT, this.code);
+		this.projectNameInput = this.code.driver.getLocator(PROJECT_WIZARD_PROJECT_NAME_INPUT);
 	}
 
 	async appendToProjectName(text: string) {
 		await this.code.waitForActiveElement(PROJECT_WIZARD_PROJECT_NAME_INPUT);
-		await this.projectNameInput.getPage().keyboard.type(text);
+		await this.projectNameInput.page().keyboard.type(text);
 	}
 }
 
@@ -100,7 +77,7 @@ class ProjectWizardRConfigurationStep {
 	renvCheckbox: PositronBaseElement;
 
 	constructor(private code: Code) {
-		this.renvCheckbox = new PositronBaseElement(PROJECT_WIZARD_RENV_CHECKBOX, this.code);
+		this.renvCheckbox = new PositronBaseElement('div.renv-configuration > div.checkbox', this.code);
 	}
 }
 
@@ -109,16 +86,18 @@ class ProjectWizardPythonConfigurationStep {
 	existingEnvRadioButton: PositronBaseElement;
 	selectedInterpreterTitle: PositronTextElement;
 	interpreterFeedback: PositronTextElement;
+	interpreterDropdown: Locator;
 
 	constructor(private code: Code) {
-		this.newEnvRadioButton = new PositronBaseElement(PROJECT_WIZARD_NEW_ENV_RADIO_BUTTON, this.code);
-		this.existingEnvRadioButton = new PositronBaseElement(PROJECT_WIZARD_EXISTING_ENV_RADIO_BUTTON, this.code);
-		this.selectedInterpreterTitle = new PositronTextElement(PROJECT_WIZARD_INTERPRETER_DROPDOWN_SELECTED_TITLE, this.code);
-		this.interpreterFeedback = new PositronTextElement(PROJECT_WIZARD_PYTHON_INTERPRETER_FEEDBACK, this.code);
+		this.newEnvRadioButton = new PositronBaseElement('div[id="wizard-step-set-up-python-environment"] div[id="wizard-sub-step-pythonenvironment-howtosetupenv"] radio-button-input.[id="newEnvironment"]', this.code);
+		this.existingEnvRadioButton = new PositronBaseElement('div[id="wizard-step-set-up-python-environment"] div[id="wizard-sub-step-pythonenvironment-howtosetupenv"] .radio-button-input[id="existingEnvironment"]', this.code);
+		this.selectedInterpreterTitle = new PositronTextElement('div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-input button.drop-down-list-box .dropdown-entry-title', this.code);
+		this.interpreterFeedback = new PositronTextElement('div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-feedback .wizard-formatted-text', this.code);
+		this.interpreterDropdown = this.code.driver.getLocator('div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-input button.drop-down-list-box');
 	}
 
 	async selectInterpreter(version: string) {
-		await this.code.driver.getLocator(PROJECT_WIZARD_INTERPRETER_DROPDOWN).click();
+		await this.interpreterDropdown.click();
 		await this.code.waitForElement(PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS);
 		await this.code.driver.getLocator(`${PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS} div.dropdown-entry:has-text("${version}")`).click();
 	}
@@ -128,6 +107,6 @@ class CurrentOrNewWindowSelectionModal {
 	currentWindowButton: PositronBaseElement;
 
 	constructor(private code: Code) {
-		this.currentWindowButton = new PositronBaseElement(PROJECT_WIZARD_CURRENT_WINDOW_BUTTON, this.code);
+		this.currentWindowButton = new PositronBaseElement('button.positron-button.button.action-bar-button[tabindex="0"][role="button"]', this.code);
 	}
 }

--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -7,7 +7,6 @@ import { Locator } from '@playwright/test';
 import { Code } from '../code';
 import { QuickAccess } from '../quickaccess';
 import { PositronBaseElement, PositronTextElement } from './positronBaseElement';
-import path = require('path');
 
 // Project Name & Location Step
 const PROJECT_WIZARD_PROJECT_NAME_INPUT =
@@ -150,42 +149,31 @@ class ProjectWizardPythonConfigurationStep {
 
 	/**
 	 * Selects the interpreter corresponding to the given path in the project wizard interpreter
-	 * dropdown. If a relative path is provided, both the relative and absolute paths are tried.
-	 * @param interpreterPath The path of the interpreter to select.
+	 * dropdown.
+	 * @param interpreterPath The path of the interpreter to select in the dropdown.
 	 * @returns A promise that resolves once the interpreter is selected, or rejects if the interpreter is not found.
 	 */
 	async selectInterpreterByPath(interpreterPath: string) {
-		const absInterpreterPath = path.isAbsolute(interpreterPath)
-			? undefined
-			: path.resolve(interpreterPath);
-		const pathsToTry = absInterpreterPath
-			? [interpreterPath, absInterpreterPath]
-			: [interpreterPath];
-
 		// Open the dropdown
 		await this.interpreterDropdown.click();
 
 		// Try to find the interpreterPath in the dropdown and click the entry if found
-		for (let i = 0; i < pathsToTry.length; i++) {
-			try {
-				await this.code.waitForElement(
-					PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS
-				);
-				await this.code.driver
-					.getLocator(
-						`${PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS} div.dropdown-entry-subtitle:text-is("${pathsToTry[i]}")`
-					)
-					.click();
-				return Promise.resolve();
-			} catch (error) {
-				// Couldn't find the interpreterPath in the dropdown, try the next path
-			}
+		try {
+			await this.code.waitForElement(
+				PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS
+			);
+			await this.code.driver
+				.getLocator(
+					`${PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS} div.dropdown-entry-subtitle:text-is("${interpreterPath}")`
+				)
+				.click();
+			return Promise.resolve();
+		} catch (error) {
+			// Couldn't find the relative or absolute path of the interpreter in the dropdown
+			return Promise.reject(
+				`Could not find interpreter path in project wizard dropdown: ${error}`
+			);
 		}
-
-		// Couldn't find the relative or absolute path of the interpreter in the dropdown
-		return Promise.reject(
-			`Could not find interpreter path in project wizard dropdown. Tried: ${pathsToTry.join(', ')}`
-		);
 	}
 }
 

--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -3,17 +3,18 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-
 import { Locator } from '@playwright/test';
 import { Code } from '../code';
 import { QuickAccess } from '../quickaccess';
 import { PositronBaseElement, PositronTextElement } from './positronBaseElement';
 
 // Project Name & Location Step
-const PROJECT_WIZARD_PROJECT_NAME_INPUT = 'div[id="wizard-sub-step-project-name"] .wizard-sub-step-input input.text-input';
+const PROJECT_WIZARD_PROJECT_NAME_INPUT =
+	'div[id="wizard-sub-step-project-name"] .wizard-sub-step-input input.text-input';
 
 // Configuration Step: Python Project & Jupyter Notebook
-const PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS = 'div.positron-modal-popup-children button.positron-button.item';
+const PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS =
+	'div.positron-modal-popup-children button.positron-button.item';
 
 /*
  *  Reuseable Positron new project wizard functionality for tests to leverage.
@@ -32,19 +33,41 @@ export class PositronNewProjectWizard {
 
 	constructor(private code: Code, private quickaccess: QuickAccess) {
 		this.projectTypeStep = new ProjectWizardProjectTypeStep(this.code);
-		this.projectNameLocationStep = new ProjectWizardProjectNameLocationStep(this.code);
-		this.rConfigurationStep = new ProjectWizardRConfigurationStep(this.code);
-		this.pythonConfigurationStep = new ProjectWizardPythonConfigurationStep(this.code);
-		this.currentOrNewWindowSelectionModal = new CurrentOrNewWindowSelectionModal(this.code);
+		this.projectNameLocationStep = new ProjectWizardProjectNameLocationStep(
+			this.code
+		);
+		this.rConfigurationStep = new ProjectWizardRConfigurationStep(
+			this.code
+		);
+		this.pythonConfigurationStep = new ProjectWizardPythonConfigurationStep(
+			this.code
+		);
+		this.currentOrNewWindowSelectionModal =
+			new CurrentOrNewWindowSelectionModal(this.code);
 
-		this.cancelButton = new PositronBaseElement('div.right-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]', this.code);
-		this.nextButton = new PositronBaseElement('button.positron-button.button.action-bar-button.default[tabindex="0"][role="button"]', this.code);
-		this.backButton = new PositronBaseElement('div.left-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]', this.code);
-		this.disabledCreateButton = new PositronBaseElement('button.positron-button.button.action-bar-button.default.disabled[tabindex="0"][disabled][role="button"][aria-disabled="true"]', this.code);
+		this.cancelButton = new PositronBaseElement(
+			'div.right-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]',
+			this.code
+		);
+		this.nextButton = new PositronBaseElement(
+			'button.positron-button.button.action-bar-button.default[tabindex="0"][role="button"]',
+			this.code
+		);
+		this.backButton = new PositronBaseElement(
+			'div.left-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]',
+			this.code
+		);
+		this.disabledCreateButton = new PositronBaseElement(
+			'button.positron-button.button.action-bar-button.default.disabled[tabindex="0"][disabled][role="button"][aria-disabled="true"]',
+			this.code
+		);
 	}
 
 	async startNewProject() {
-		await this.quickaccess.runCommand('positron.workbench.action.newProject', { keepOpen: false });
+		await this.quickaccess.runCommand(
+			'positron.workbench.action.newProject',
+			{ keepOpen: false }
+		);
 	}
 }
 
@@ -54,9 +77,18 @@ class ProjectWizardProjectTypeStep {
 	jupyterNotebookButton: PositronBaseElement;
 
 	constructor(private code: Code) {
-		this.pythonProjectButton = new PositronBaseElement('[id="Python Project"]', this.code);
-		this.rProjectButton = new PositronBaseElement('[id="R Project"]', this.code);
-		this.jupyterNotebookButton = new PositronBaseElement('[id="Jupyter Notebook"]', this.code);
+		this.pythonProjectButton = new PositronBaseElement(
+			'[id="Python Project"]',
+			this.code
+		);
+		this.rProjectButton = new PositronBaseElement(
+			'[id="R Project"]',
+			this.code
+		);
+		this.jupyterNotebookButton = new PositronBaseElement(
+			'[id="Jupyter Notebook"]',
+			this.code
+		);
 	}
 }
 
@@ -64,7 +96,9 @@ class ProjectWizardProjectNameLocationStep {
 	projectNameInput: Locator;
 
 	constructor(private code: Code) {
-		this.projectNameInput = this.code.driver.getLocator(PROJECT_WIZARD_PROJECT_NAME_INPUT);
+		this.projectNameInput = this.code.driver.getLocator(
+			PROJECT_WIZARD_PROJECT_NAME_INPUT
+		);
 	}
 
 	async appendToProjectName(text: string) {
@@ -77,7 +111,10 @@ class ProjectWizardRConfigurationStep {
 	renvCheckbox: PositronBaseElement;
 
 	constructor(private code: Code) {
-		this.renvCheckbox = new PositronBaseElement('div.renv-configuration > div.checkbox', this.code);
+		this.renvCheckbox = new PositronBaseElement(
+			'div.renv-configuration > div.checkbox',
+			this.code
+		);
 	}
 }
 
@@ -89,17 +126,37 @@ class ProjectWizardPythonConfigurationStep {
 	interpreterDropdown: Locator;
 
 	constructor(private code: Code) {
-		this.newEnvRadioButton = new PositronBaseElement('div[id="wizard-step-set-up-python-environment"] div[id="wizard-sub-step-pythonenvironment-howtosetupenv"] radio-button-input.[id="newEnvironment"]', this.code);
-		this.existingEnvRadioButton = new PositronBaseElement('div[id="wizard-step-set-up-python-environment"] div[id="wizard-sub-step-pythonenvironment-howtosetupenv"] .radio-button-input[id="existingEnvironment"]', this.code);
-		this.selectedInterpreterTitle = new PositronTextElement('div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-input button.drop-down-list-box .dropdown-entry-title', this.code);
-		this.interpreterFeedback = new PositronTextElement('div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-feedback .wizard-formatted-text', this.code);
-		this.interpreterDropdown = this.code.driver.getLocator('div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-input button.drop-down-list-box');
+		this.newEnvRadioButton = new PositronBaseElement(
+			'div[id="wizard-step-set-up-python-environment"] div[id="wizard-sub-step-pythonenvironment-howtosetupenv"] radio-button-input.[id="newEnvironment"]',
+			this.code
+		);
+		this.existingEnvRadioButton = new PositronBaseElement(
+			'div[id="wizard-step-set-up-python-environment"] div[id="wizard-sub-step-pythonenvironment-howtosetupenv"] .radio-button-input[id="existingEnvironment"]',
+			this.code
+		);
+		this.selectedInterpreterTitle = new PositronTextElement(
+			'div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-input button.drop-down-list-box .dropdown-entry-title',
+			this.code
+		);
+		this.interpreterFeedback = new PositronTextElement(
+			'div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-feedback .wizard-formatted-text',
+			this.code
+		);
+		this.interpreterDropdown = this.code.driver.getLocator(
+			'div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-input button.drop-down-list-box'
+		);
 	}
 
 	async selectInterpreter(version: string) {
 		await this.interpreterDropdown.click();
-		await this.code.waitForElement(PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS);
-		await this.code.driver.getLocator(`${PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS} div.dropdown-entry:has-text("${version}")`).click();
+		await this.code.waitForElement(
+			PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS
+		);
+		await this.code.driver
+			.getLocator(
+				`${PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS} div.dropdown-entry:has-text("${version}")`
+			)
+			.click();
 	}
 }
 
@@ -107,6 +164,9 @@ class CurrentOrNewWindowSelectionModal {
 	currentWindowButton: PositronBaseElement;
 
 	constructor(private code: Code) {
-		this.currentWindowButton = new PositronBaseElement('button.positron-button.button.action-bar-button[tabindex="0"][role="button"]', this.code);
+		this.currentWindowButton = new PositronBaseElement(
+			'button.positron-button.button.action-bar-button[tabindex="0"][role="button"]',
+			this.code
+		);
 	}
 }

--- a/test/automation/src/positron/positronPopups.ts
+++ b/test/automation/src/positron/positronPopups.ts
@@ -19,6 +19,15 @@ export class PositronPopups {
 
 	constructor(private code: Code) { }
 
+	async popupCurrentlyOpen() {
+		try {
+			await this.code.waitForElement(POSITRON_MODAL_DIALOG_BOX, undefined, 50);
+			return true;
+		} catch (error) {
+			this.code.logger.log('No modal dialog box found');
+		}
+	}
+
 	async installIPyKernel() {
 
 		try {

--- a/test/automation/src/positron/utils/positronInterpreterInfo.ts
+++ b/test/automation/src/positron/utils/positronInterpreterInfo.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export enum InterpreterType {
+	Python = 'Python',
+	R = 'R'
+}
+
+export interface InterpreterInfo {
+	type: InterpreterType;
+	version: string;
+	path: string;
+	source?: string;
+}
+

--- a/test/automation/src/positron/utils/positronInterpreterInfo.ts
+++ b/test/automation/src/positron/utils/positronInterpreterInfo.ts
@@ -10,8 +10,23 @@ export enum InterpreterType {
 
 export interface InterpreterInfo {
 	type: InterpreterType;
-	version: string;
-	path: string;
-	source?: string;
+	version: string; // e.g. Python 3.12.4 64-bit or Python 3.9.19 64-bit ('3.9.19') or R 4.4.0
+	path: string; // e.g. /usr/local/bin/python3 or ~/.pyenv/versions/3.9.19/bin/python or /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/bin/R
+	source?: string; // e.g. Pyenv or Global or Conda or System
 }
 
+/**
+ * Determines the interpreter type based on an interpreter version string.
+ * @param version The version string to extract the interpreter type from.
+ * @returns The corresponding known interpreter type or undefined if unknown.
+ */
+export const getInterpreterType = (version: string): InterpreterType | undefined => {
+	for (const [key, value] of Object.entries(InterpreterType)) {
+		// Check if the versions starts with the interpreter type followed by a space
+		// e.g. version = Python 3.10.4 (Pyenv) would result in InterpreterType.Python
+		if (version.startsWith(`${key} `)) {
+			return value;
+		}
+	}
+	return undefined;
+};

--- a/test/automation/src/quickinput.ts
+++ b/test/automation/src/quickinput.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Code } from './code';
+import { IElement } from './driver';
 
 export class QuickInput {
 
@@ -57,10 +58,12 @@ export class QuickInput {
 		}
 	}
 	// --- Start Positron ---
-	async selectQuickInputElementContaining(contains: string): Promise<void> {
+	async selectQuickInputElementContaining(contains: string): Promise<IElement | undefined> {
 		const selector = `${QuickInput.QUICK_INPUT_ROW}[aria-label*="${contains}"]`;
 		try {
+			const element = this.code.getElement(selector);
 			await this.code.waitAndClick(selector);
+			return element;
 		} catch (ex) {
 			// Show a more helpful error message by clearing the input and logging the list of items
 			await this.type('');

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -23,7 +23,7 @@ export function setup(logger: Logger) {
 				const app = this.app as Application;
 				const pw = app.workbench.positronNewProjectWizard;
 				await pw.startNewProject();
-				await pw.projectTypeStep.newPythonProjectButton.click();
+				await pw.projectTypeStep.pythonProjectButton.click();
 				await pw.nextButton.click();
 				await pw.nextButton.click();
 				await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
@@ -44,7 +44,7 @@ export function setup(logger: Logger) {
 				const app = this.app as Application;
 				const pw = app.workbench.positronNewProjectWizard;
 				await pw.startNewProject();
-				await pw.projectTypeStep.newRProjectButton.click();
+				await pw.projectTypeStep.rProjectButton.click();
 				await pw.nextButton.click();
 				await pw.nextButton.click();
 				await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
@@ -60,7 +60,7 @@ export function setup(logger: Logger) {
 					const pw = app.workbench.positronNewProjectWizard;
 					// Create a new R project - select Renv and install
 					await pw.startNewProject();
-					await pw.projectTypeStep.newRProjectButton.click();
+					await pw.projectTypeStep.rProjectButton.click();
 					await pw.nextButton.click();
 					await pw.projectNameLocationStep.appendToProjectName(projSuffix);
 					await pw.nextButton.click();
@@ -108,7 +108,7 @@ export function setup(logger: Logger) {
 					const app = this.app as Application;
 					const pw = app.workbench.positronNewProjectWizard;
 					await pw.startNewProject();
-					await pw.projectTypeStep.newRProjectButton.click();
+					await pw.projectTypeStep.rProjectButton.click();
 					await pw.nextButton.click();
 					await pw.projectNameLocationStep.appendToProjectName(projSuffix);
 					await pw.nextButton.click();
@@ -144,7 +144,7 @@ export function setup(logger: Logger) {
 					);
 					// Create a new R project - select Renv but opt out of installing
 					await pw.startNewProject();
-					await pw.projectTypeStep.newRProjectButton.click();
+					await pw.projectTypeStep.rProjectButton.click();
 					await pw.nextButton.click();
 					await pw.projectNameLocationStep.appendToProjectName(projSuffix);
 					await pw.nextButton.click();
@@ -180,7 +180,7 @@ export function setup(logger: Logger) {
 				const app = this.app as Application;
 				const pw = app.workbench.positronNewProjectWizard;
 				await pw.startNewProject();
-				await pw.projectTypeStep.newJupyterProjectButton.click();
+				await pw.projectTypeStep.jupyterNotebookButton.click();
 				await pw.nextButton.click();
 				await pw.nextButton.click();
 				await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -36,12 +36,13 @@ export function setup(logger: Logger) {
 			describe('Python Project with existing interpreter', () => {
 				it('With ipykernel already installed [C609619]', async function () {
 					const projSuffix = '_ipykernelInstalled';
-					const selectedPython = process.env.POSITRON_PY_VER_SEL!;
 					const app = this.app as Application;
 					const pw = app.workbench.positronNewProjectWizard;
 					const pythonFixtures = new PositronPythonFixtures(app);
 					// Start the Python interpreter and ensure ipykernel is installed
-					await pythonFixtures.startPythonInterpreter(true);
+					const interpreterInfo = await pythonFixtures.startPythonInterpreter(true);
+					expect(interpreterInfo).toBeDefined();
+					const interpreterPath = interpreterInfo?.path!;
 					// Create a new Python project and use the selected python interpreter
 					await pw.startNewProject();
 					await pw.projectTypeStep.pythonProjectButton.click();
@@ -50,13 +51,13 @@ export function setup(logger: Logger) {
 					await pw.nextButton.click();
 					await pw.pythonConfigurationStep.existingEnvRadioButton.click();
 					try {
-						await pw.pythonConfigurationStep.selectedInterpreterTitle.waitForText(
-							`Python ${selectedPython}`
+						await pw.pythonConfigurationStep.selectedInterpreterPath.waitForText(
+							interpreterPath
 						);
 					} catch (error) {
 						// Since we didn't see the expected interpreter, we'll need to interact with
 						// the dropdown to select the specific interpreter
-						await pw.pythonConfigurationStep.selectInterpreter(selectedPython);
+						await pw.pythonConfigurationStep.selectInterpreterByPath(interpreterPath);
 					}
 					await pw.pythonConfigurationStep.interpreterFeedback.isNotVisible();
 					await pw.disabledCreateButton.isNotVisible(500);
@@ -70,12 +71,13 @@ export function setup(logger: Logger) {
 				});
 				it('With ipykernel not already installed [C609617]', async function () {
 					const projSuffix = '_noIpykernel';
-					const selectedPython = process.env.POSITRON_PY_VER_SEL!;
 					const app = this.app as Application;
 					const pw = app.workbench.positronNewProjectWizard;
 					const pythonFixtures = new PositronPythonFixtures(app);
 					// Start the Python interpreter and uninstall ipykernel
-					await pythonFixtures.startPythonInterpreter(true);
+					const interpreterInfo = await pythonFixtures.startPythonInterpreter(true);
+					expect(interpreterInfo).toBeDefined();
+					const interpreterPath = interpreterInfo?.path!;
 					await app.workbench.positronConsole.typeToConsole('pip uninstall -y ipykernel');
 					await app.workbench.positronConsole.sendEnterKey();
 					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
@@ -90,13 +92,13 @@ export function setup(logger: Logger) {
 					// Choose the existing environment which does not have ipykernel
 					await pw.pythonConfigurationStep.existingEnvRadioButton.click();
 					try {
-						await pw.pythonConfigurationStep.selectedInterpreterTitle.waitForText(
-							`Python ${selectedPython}`
+						await pw.pythonConfigurationStep.selectedInterpreterPath.waitForText(
+							interpreterPath
 						);
 					} catch (error) {
 						// Since we didn't see the expected interpreter, we'll need to interact with
 						// the dropdown to select the specific interpreter
-						await pw.pythonConfigurationStep.selectInterpreter(selectedPython);
+						await pw.pythonConfigurationStep.selectInterpreterByPath(interpreterPath);
 					}
 					await pw.pythonConfigurationStep.interpreterFeedback.waitForText(
 						'ipykernel will be installed for Python language support.'

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -11,7 +11,7 @@ import { installAllHandlers } from '../../../utils';
  * New Project Wizard test cases
  */
 export function setup(logger: Logger) {
-	describe.only('New Project Wizard', () => {
+	describe('New Project Wizard', () => {
 		describe('Python - New Project Wizard', () => {
 			// Shared before/after handling
 			installAllHandlers(logger);
@@ -34,7 +34,7 @@ export function setup(logger: Logger) {
 			});
 
 			describe('Python Project with existing interpreter', () => {
-				it('With ipykernel already installed [.......]', async function () {
+				it('With ipykernel already installed [C609619]', async function () {
 					const projSuffix = '_ipykernelInstalled';
 					const selectedPython = process.env.POSITRON_PY_VER_SEL!;
 					const app = this.app as Application;
@@ -68,7 +68,7 @@ export function setup(logger: Logger) {
 					// The console should initialize without any prompts to install ipykernel
 					await app.workbench.positronConsole.waitForReady('>>>');
 				});
-				it('With ipykernel not already installed [.......]', async function () {
+				it('With ipykernel not already installed [C609617]', async function () {
 					const projSuffix = '_noIpykernel';
 					const selectedPython = process.env.POSITRON_PY_VER_SEL!;
 					const app = this.app as Application;

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -31,6 +31,7 @@ export function setup(logger: Logger) {
 				await pw.nextButton.click();
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myPythonProject');
+				await app.workbench.positronConsole.waitForReady('>>>');
 			});
 
 			describe('Python Project with existing interpreter', () => {
@@ -135,6 +136,7 @@ export function setup(logger: Logger) {
 				await pw.nextButton.click();
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myRProject');
+				await app.workbench.positronConsole.waitForReady('>');
 			});
 
 			describe('R Project with Renv Environment', () => {
@@ -272,6 +274,7 @@ export function setup(logger: Logger) {
 				await pw.nextButton.click();
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myJupyterNotebook');
+				await app.workbench.positronConsole.waitForReady('>>>');
 			});
 
 		});

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -31,7 +31,7 @@ export function setup(logger: Logger) {
 				await pw.nextButton.click();
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myPythonProject');
-				await app.workbench.positronConsole.waitForReady('>>>');
+				await app.workbench.positronConsole.waitForReady('>>>', 10000);
 			});
 
 			describe('Python Project with existing interpreter', () => {
@@ -60,7 +60,7 @@ export function setup(logger: Logger) {
 						`myPythonProject${projSuffix}`
 					);
 					// The console should initialize without any prompts to install ipykernel
-					await app.workbench.positronConsole.waitForReady('>>>');
+					await app.workbench.positronConsole.waitForReady('>>>', 10000);
 				});
 				it('With ipykernel not already installed [C609617]', async function () {
 					const projSuffix = '_noIpykernel';
@@ -96,7 +96,7 @@ export function setup(logger: Logger) {
 					);
 					// If ipykernel was successfully installed during the new project initialization,
 					// the console should be ready without any prompts to install ipykernel
-					await app.workbench.positronConsole.waitForReady('>>>');
+					await app.workbench.positronConsole.waitForReady('>>>', 10000);
 				});
 			});
 		});
@@ -120,7 +120,7 @@ export function setup(logger: Logger) {
 				await pw.nextButton.click();
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myRProject');
-				await app.workbench.positronConsole.waitForReady('>');
+				await app.workbench.positronConsole.waitForReady('>', 10000);
 			});
 
 			describe('R Project with Renv Environment', () => {
@@ -258,7 +258,7 @@ export function setup(logger: Logger) {
 				await pw.nextButton.click();
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myJupyterNotebook');
-				await app.workbench.positronConsole.waitForReady('>>>');
+				await app.workbench.positronConsole.waitForReady('>>>', 10000);
 			});
 
 		});

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -17,7 +17,11 @@ export function setup(logger: Logger) {
 			installAllHandlers(logger);
 
 			before(async function () {
-
+				// Ensure a python interpreter is started before running the tests, otherwise we
+				// sometimes run into issues with selecting an interpreter in the nested tests
+				const app = this.app as Application;
+				const pythonFixtures = new PositronPythonFixtures(app);
+				await pythonFixtures.startPythonInterpreter(true);
 			});
 
 			it('Python Project Defaults [C627912]', async function () {

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -40,8 +40,8 @@ export function setup(logger: Logger) {
 					const pw = app.workbench.positronNewProjectWizard;
 					const pythonFixtures = new PositronPythonFixtures(app);
 					// Start the Python interpreter and ensure ipykernel is installed
-					const interpreterInfo = await pythonFixtures.startPythonInterpreter(true);
-					expect(interpreterInfo).toBeDefined();
+					const interpreterInfo = await pythonFixtures.startAndGetPythonInterpreter(true);
+					expect(interpreterInfo?.path).toBeDefined();
 					const interpreterPath = interpreterInfo?.path!;
 					// Create a new Python project and use the selected python interpreter
 					await pw.startNewProject();
@@ -75,8 +75,8 @@ export function setup(logger: Logger) {
 					const pw = app.workbench.positronNewProjectWizard;
 					const pythonFixtures = new PositronPythonFixtures(app);
 					// Start the Python interpreter and uninstall ipykernel
-					const interpreterInfo = await pythonFixtures.startPythonInterpreter(true);
-					expect(interpreterInfo).toBeDefined();
+					const interpreterInfo = await pythonFixtures.startAndGetPythonInterpreter(true);
+					expect(interpreterInfo?.path).toBeDefined();
 					const interpreterPath = interpreterInfo?.path!;
 					await app.workbench.positronConsole.typeToConsole('pip uninstall -y ipykernel');
 					await app.workbench.positronConsole.sendEnterKey();

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -75,7 +75,7 @@ export function setup(logger: Logger) {
 					const pw = app.workbench.positronNewProjectWizard;
 					const pythonFixtures = new PositronPythonFixtures(app);
 					// Start the Python interpreter and uninstall ipykernel
-					await pythonFixtures.startPythonInterpreter();
+					await pythonFixtures.startPythonInterpreter(true);
 					await app.workbench.positronConsole.typeToConsole('pip uninstall -y ipykernel');
 					await app.workbench.positronConsole.sendEnterKey();
 					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
@@ -177,7 +177,7 @@ export function setup(logger: Logger) {
 						expect(projectFiles).toContain('renv');
 						expect(projectFiles).toContain('.Rprofile');
 						expect(projectFiles).toContain('renv.lock');
-					}).toPass({timeout: 10000});
+					}).toPass({ timeout: 10000 });
 					// Verify that renv output in the console confirms no issues occurred
 					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
 						contents.some((line) => line.includes('renv activated'))
@@ -208,11 +208,11 @@ export function setup(logger: Logger) {
 						expect(projectFiles).toContain('renv');
 						expect(projectFiles).toContain('.Rprofile');
 						expect(projectFiles).toContain('renv.lock');
-					}).toPass({timeout: 10000});
+					}).toPass({ timeout: 10000 });
 					// Verify that renv output in the console confirms no issues occurred
 					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
 						contents.some((line) => line.includes('renv activated'))
-				);
+					);
 				});
 
 				it('Cancel Renv install [C656252]', async function () {
@@ -246,7 +246,7 @@ export function setup(logger: Logger) {
 						expect(projectFiles).not.toContain('renv');
 						expect(projectFiles).not.toContain('.Rprofile');
 						expect(projectFiles).not.toContain('renv.lock');
-					}).toPass({timeout: 10000});
+					}).toPass({ timeout: 10000 });
 				});
 			});
 		});

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -41,7 +41,8 @@ export function setup(logger: Logger) {
 					const pw = app.workbench.positronNewProjectWizard;
 					const pythonFixtures = new PositronPythonFixtures(app);
 					// Start the Python interpreter and ensure ipykernel is installed
-					const interpreterInfo = await pythonFixtures.startAndGetPythonInterpreter(true);
+					await pythonFixtures.startAndGetPythonInterpreter(true);
+					const interpreterInfo = await app.workbench.startInterpreter.getSelectedInterpreterInfo();
 					expect(interpreterInfo?.path).toBeDefined();
 					// Create a new Python project and use the selected python interpreter
 					await pw.startNewProject();
@@ -68,7 +69,8 @@ export function setup(logger: Logger) {
 					const pw = app.workbench.positronNewProjectWizard;
 					const pythonFixtures = new PositronPythonFixtures(app);
 					// Start the Python interpreter and uninstall ipykernel
-					const interpreterInfo = await pythonFixtures.startAndGetPythonInterpreter(true);
+					await pythonFixtures.startAndGetPythonInterpreter(true);
+					const interpreterInfo = await app.workbench.startInterpreter.getSelectedInterpreterInfo();
 					expect(interpreterInfo?.path).toBeDefined();
 					await app.workbench.positronConsole.typeToConsole('pip uninstall -y ipykernel');
 					await app.workbench.positronConsole.sendEnterKey();

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -43,7 +43,6 @@ export function setup(logger: Logger) {
 					// Start the Python interpreter and ensure ipykernel is installed
 					const interpreterInfo = await pythonFixtures.startAndGetPythonInterpreter(true);
 					expect(interpreterInfo?.path).toBeDefined();
-					const interpreterPath = interpreterInfo?.path!;
 					// Create a new Python project and use the selected python interpreter
 					await pw.startNewProject();
 					await pw.projectTypeStep.pythonProjectButton.click();
@@ -51,15 +50,8 @@ export function setup(logger: Logger) {
 					await pw.projectNameLocationStep.appendToProjectName(projSuffix);
 					await pw.nextButton.click();
 					await pw.pythonConfigurationStep.existingEnvRadioButton.click();
-					try {
-						await pw.pythonConfigurationStep.selectedInterpreterPath.waitForText(
-							interpreterPath
-						);
-					} catch (error) {
-						// Since we didn't see the expected interpreter, we'll need to interact with
-						// the dropdown to select the specific interpreter
-						await pw.pythonConfigurationStep.selectInterpreterByPath(interpreterPath);
-					}
+					// Select the interpreter that was started above
+					await pw.pythonConfigurationStep.selectInterpreterByPath(interpreterInfo!.path);
 					await pw.pythonConfigurationStep.interpreterFeedback.isNotVisible();
 					await pw.disabledCreateButton.isNotVisible(500);
 					await pw.nextButton.click();
@@ -78,7 +70,6 @@ export function setup(logger: Logger) {
 					// Start the Python interpreter and uninstall ipykernel
 					const interpreterInfo = await pythonFixtures.startAndGetPythonInterpreter(true);
 					expect(interpreterInfo?.path).toBeDefined();
-					const interpreterPath = interpreterInfo?.path!;
 					await app.workbench.positronConsole.typeToConsole('pip uninstall -y ipykernel');
 					await app.workbench.positronConsole.sendEnterKey();
 					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
@@ -92,15 +83,8 @@ export function setup(logger: Logger) {
 					await pw.nextButton.click();
 					// Choose the existing environment which does not have ipykernel
 					await pw.pythonConfigurationStep.existingEnvRadioButton.click();
-					try {
-						await pw.pythonConfigurationStep.selectedInterpreterPath.waitForText(
-							interpreterPath
-						);
-					} catch (error) {
-						// Since we didn't see the expected interpreter, we'll need to interact with
-						// the dropdown to select the specific interpreter
-						await pw.pythonConfigurationStep.selectInterpreterByPath(interpreterPath);
-					}
+					// Select the interpreter that was started above
+					await pw.pythonConfigurationStep.selectInterpreterByPath(interpreterInfo!.path);
 					await pw.pythonConfigurationStep.interpreterFeedback.waitForText(
 						'ipykernel will be installed for Python language support.'
 					);

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -11,10 +11,11 @@ import { installAllHandlers } from '../../../utils';
  * New Project Wizard test cases
  */
 export function setup(logger: Logger) {
-	describe('New Project Wizard', () => {
+	describe.only('New Project Wizard', () => {
 		describe('Python - New Project Wizard', () => {
 			// Shared before/after handling
 			installAllHandlers(logger);
+
 			before(async function () {
 
 			});
@@ -26,13 +27,13 @@ export function setup(logger: Logger) {
 				await pw.projectTypeStep.pythonProjectButton.click();
 				await pw.nextButton.click();
 				await pw.nextButton.click();
-				await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+				await pw.disabledCreateButton.isNotVisible(500);
 				await pw.nextButton.click();
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myPythonProject');
 			});
-			// Likely to not work well if multiple pythons are installed
-			describe.only('Python Project with existing interpreter', () => {
+
+			describe('Python Project with existing interpreter', () => {
 				it('With ipykernel already installed [.......]', async function () {
 					const projSuffix = '_ipykernelInstalled';
 					const selectedPython = process.env.POSITRON_PY_VER_SEL!;
@@ -41,6 +42,7 @@ export function setup(logger: Logger) {
 					const pythonFixtures = new PositronPythonFixtures(app);
 					// Start the Python interpreter and ensure ipykernel is installed
 					await pythonFixtures.startPythonInterpreter(true);
+					// Create a new Python project and use the selected python interpreter
 					await pw.startNewProject();
 					await pw.projectTypeStep.pythonProjectButton.click();
 					await pw.nextButton.click();
@@ -48,14 +50,16 @@ export function setup(logger: Logger) {
 					await pw.nextButton.click();
 					await pw.pythonConfigurationStep.existingEnvRadioButton.click();
 					try {
-						await pw.pythonConfigurationStep.selectedInterpreterTitle.waitForText(`Python ${selectedPython}`);
+						await pw.pythonConfigurationStep.selectedInterpreterTitle.waitForText(
+							`Python ${selectedPython}`
+						);
 					} catch (error) {
 						// Since we didn't see the expected interpreter, we'll need to interact with
 						// the dropdown to select the specific interpreter
 						await pw.pythonConfigurationStep.selectInterpreter(selectedPython);
 					}
 					await pw.pythonConfigurationStep.interpreterFeedback.isNotVisible();
-					await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+					await pw.disabledCreateButton.isNotVisible(500);
 					await pw.nextButton.click();
 					await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 					await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
@@ -77,7 +81,7 @@ export function setup(logger: Logger) {
 					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
 						contents.some((line) => line.includes('Successfully uninstalled ipykernel'))
 					);
-					// Create a project and select that same python version
+					// Create a new Python project and use the selected python interpreter
 					await pw.startNewProject();
 					await pw.projectTypeStep.pythonProjectButton.click();
 					await pw.nextButton.click();
@@ -86,21 +90,25 @@ export function setup(logger: Logger) {
 					// Choose the existing environment which does not have ipykernel
 					await pw.pythonConfigurationStep.existingEnvRadioButton.click();
 					try {
-						await pw.pythonConfigurationStep.selectedInterpreterTitle.waitForText(`Python ${selectedPython}`);
+						await pw.pythonConfigurationStep.selectedInterpreterTitle.waitForText(
+							`Python ${selectedPython}`
+						);
 					} catch (error) {
 						// Since we didn't see the expected interpreter, we'll need to interact with
 						// the dropdown to select the specific interpreter
 						await pw.pythonConfigurationStep.selectInterpreter(selectedPython);
 					}
-					await pw.pythonConfigurationStep.interpreterFeedback.waitForText('ipykernel will be installed for Python language support.');
-					await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+					await pw.pythonConfigurationStep.interpreterFeedback.waitForText(
+						'ipykernel will be installed for Python language support.'
+					);
+					await pw.disabledCreateButton.isNotVisible(500);
 					await pw.nextButton.click();
 					await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 					await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
 						`myPythonProject${projSuffix}`
 					);
-					// If ipykernel was successfully installed, the console should initialize without
-					// any prompts to install ipykernel
+					// If ipykernel was successfully installed during the new project initialization,
+					// the console should be ready without any prompts to install ipykernel
 					await app.workbench.positronConsole.waitForReady('>>>');
 				});
 			});
@@ -109,6 +117,7 @@ export function setup(logger: Logger) {
 		describe('R - New Project Wizard', () => {
 			// Shared before/after handling
 			installAllHandlers(logger);
+
 			before(async function () {
 
 			});
@@ -120,7 +129,7 @@ export function setup(logger: Logger) {
 				await pw.projectTypeStep.rProjectButton.click();
 				await pw.nextButton.click();
 				await pw.nextButton.click();
-				await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+				await pw.disabledCreateButton.isNotVisible(500);
 				await pw.nextButton.click();
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myRProject');
@@ -137,7 +146,7 @@ export function setup(logger: Logger) {
 					await pw.nextButton.click();
 					await pw.projectNameLocationStep.appendToProjectName(projSuffix);
 					await pw.nextButton.click();
-					await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+					await pw.disabledCreateButton.isNotVisible(500);
 					// Select the renv checkbox
 					await pw.rConfigurationStep.renvCheckbox.click();
 					await pw.nextButton.click();
@@ -185,7 +194,7 @@ export function setup(logger: Logger) {
 					await pw.nextButton.click();
 					await pw.projectNameLocationStep.appendToProjectName(projSuffix);
 					await pw.nextButton.click();
-					await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+					await pw.disabledCreateButton.isNotVisible(500);
 					// Select the renv checkbox
 					await pw.rConfigurationStep.renvCheckbox.click();
 					await pw.nextButton.click();
@@ -221,7 +230,7 @@ export function setup(logger: Logger) {
 					await pw.nextButton.click();
 					await pw.projectNameLocationStep.appendToProjectName(projSuffix);
 					await pw.nextButton.click();
-					await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+					await pw.disabledCreateButton.isNotVisible(500);
 					// Select the renv checkbox
 					await pw.rConfigurationStep.renvCheckbox.click();
 					await pw.nextButton.click();
@@ -245,6 +254,7 @@ export function setup(logger: Logger) {
 		describe('Jupyter - New Project Wizard', () => {
 			// Shared before/after handling
 			installAllHandlers(logger);
+
 			before(async function () {
 
 			});
@@ -256,7 +266,7 @@ export function setup(logger: Logger) {
 				await pw.projectTypeStep.jupyterNotebookButton.click();
 				await pw.nextButton.click();
 				await pw.nextButton.click();
-				await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+				await pw.disabledCreateButton.isNotVisible(500);
 				await pw.nextButton.click();
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myJupyterNotebook');

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -11,49 +11,45 @@ import { installAllHandlers } from '../../../utils';
  * New Project Wizard test cases
  */
 export function setup(logger: Logger) {
-	describe('New Project Wizard', () => {
-		// Shared before/after handling
-		installAllHandlers(logger);
-
+	describe.only('New Project Wizard', () => {
 		describe('Python - New Project Wizard', () => {
+			// Shared before/after handling
+			installAllHandlers(logger);
 			before(async function () {
 
 			});
 
 			it('Python Project Defaults [C627912]', async function () {
 				const app = this.app as Application;
-				await app.workbench.positronNewProjectWizard.startNewProject();
-				await app.workbench.positronNewProjectWizard.newPythonProjectButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
-				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
+				const pw = app.workbench.positronNewProjectWizard;
+				await pw.startNewProject();
+				await pw.projectTypeStep.newPythonProjectButton.click();
+				await pw.nextButton.click();
+				await pw.nextButton.click();
+				await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+				await pw.nextButton.click();
+				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myPythonProject');
 			});
-
 		});
 
-	});
-
-	describe('New Project Wizard', () => {
-		// Shared before/after handling
-		installAllHandlers(logger);
-
 		describe('R - New Project Wizard', () => {
+			// Shared before/after handling
+			installAllHandlers(logger);
 			before(async function () {
 
 			});
 
 			it('R Project Defaults [C627913]', async function () {
 				const app = this.app as Application;
-				await app.workbench.positronNewProjectWizard.startNewProject();
-				await app.workbench.positronNewProjectWizard.newRProjectButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
-				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
+				const pw = app.workbench.positronNewProjectWizard;
+				await pw.startNewProject();
+				await pw.projectTypeStep.newRProjectButton.click();
+				await pw.nextButton.click();
+				await pw.nextButton.click();
+				await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+				await pw.nextButton.click();
+				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myRProject');
 			});
 
@@ -61,17 +57,18 @@ export function setup(logger: Logger) {
 				it('Accept Renv install [C633084]', async function () {
 					const projSuffix = '_installRenv';
 					const app = this.app as Application;
+					const pw = app.workbench.positronNewProjectWizard;
 					// Create a new R project - select Renv and install
-					await app.workbench.positronNewProjectWizard.startNewProject();
-					await app.workbench.positronNewProjectWizard.newRProjectButton.click();
-					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-					await app.workbench.positronNewProjectWizard.appendToProjectName(projSuffix);
-					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-					await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+					await pw.startNewProject();
+					await pw.projectTypeStep.newRProjectButton.click();
+					await pw.nextButton.click();
+					await pw.projectNameLocationStep.appendToProjectName(projSuffix);
+					await pw.nextButton.click();
+					await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
 					// Select the renv checkbox
-					await app.workbench.positronNewProjectWizard.projectWizardRenvCheckbox.click();
-					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-					await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
+					await pw.rConfigurationStep.renvCheckbox.click();
+					await pw.nextButton.click();
+					await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 					await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
 						`myRProject${projSuffix}`
 					);
@@ -109,16 +106,17 @@ export function setup(logger: Logger) {
 					// Renv will already be installed from the previous test
 					const projSuffix = '_renvAlreadyInstalled';
 					const app = this.app as Application;
-					await app.workbench.positronNewProjectWizard.startNewProject();
-					await app.workbench.positronNewProjectWizard.newRProjectButton.click();
-					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-					await app.workbench.positronNewProjectWizard.appendToProjectName(projSuffix);
-					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-					await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+					const pw = app.workbench.positronNewProjectWizard;
+					await pw.startNewProject();
+					await pw.projectTypeStep.newRProjectButton.click();
+					await pw.nextButton.click();
+					await pw.projectNameLocationStep.appendToProjectName(projSuffix);
+					await pw.nextButton.click();
+					await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
 					// Select the renv checkbox
-					await app.workbench.positronNewProjectWizard.projectWizardRenvCheckbox.click();
-					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-					await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
+					await pw.rConfigurationStep.renvCheckbox.click();
+					await pw.nextButton.click();
+					await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 					await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
 						`myRProject${projSuffix}`
 					);
@@ -138,22 +136,23 @@ export function setup(logger: Logger) {
 				it('Cancel Renv install [C656252]', async function () {
 					const projSuffix = '_cancelRenvInstall';
 					const app = this.app as Application;
+					const pw = app.workbench.positronNewProjectWizard;
 					// Remove renv package so we are prompted to install it again
 					await app.workbench.positronConsole.executeCode('R', 'remove.packages("renv")', '>');
 					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
 						contents.some((line) => line.includes(`Removing package`))
 					);
 					// Create a new R project - select Renv but opt out of installing
-					await app.workbench.positronNewProjectWizard.startNewProject();
-					await app.workbench.positronNewProjectWizard.newRProjectButton.click();
-					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-					await app.workbench.positronNewProjectWizard.appendToProjectName(projSuffix);
-					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-					await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+					await pw.startNewProject();
+					await pw.projectTypeStep.newRProjectButton.click();
+					await pw.nextButton.click();
+					await pw.projectNameLocationStep.appendToProjectName(projSuffix);
+					await pw.nextButton.click();
+					await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
 					// Select the renv checkbox
-					await app.workbench.positronNewProjectWizard.projectWizardRenvCheckbox.click();
-					await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-					await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
+					await pw.rConfigurationStep.renvCheckbox.click();
+					await pw.nextButton.click();
+					await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 					await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
 						`myRProject${projSuffix}`
 					);
@@ -169,26 +168,24 @@ export function setup(logger: Logger) {
 				});
 			});
 		});
-	});
 
-	describe('New Project Wizard', () => {
-		// Shared before/after handling
-		installAllHandlers(logger);
-
-		describe('Python - New Project Wizard', () => {
+		describe('Jupyter - New Project Wizard', () => {
+			// Shared before/after handling
+			installAllHandlers(logger);
 			before(async function () {
 
 			});
 
 			it('Jupyter Project Defaults [C629352]', async function () {
 				const app = this.app as Application;
-				await app.workbench.positronNewProjectWizard.startNewProject();
-				await app.workbench.positronNewProjectWizard.newJupyterProjectButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardDisabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
-				await app.workbench.positronNewProjectWizard.projectWizardNextButton.click();
-				await app.workbench.positronNewProjectWizard.projectWizardCurrentWindowButton.click();
+				const pw = app.workbench.positronNewProjectWizard;
+				await pw.startNewProject();
+				await pw.projectTypeStep.newJupyterProjectButton.click();
+				await pw.nextButton.click();
+				await pw.nextButton.click();
+				await pw.disabledCreateButton.isNotVisible(500); // May need to pass in a retry count > default of 200
+				await pw.nextButton.click();
+				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myJupyterNotebook');
 			});
 

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -17,11 +17,7 @@ export function setup(logger: Logger) {
 			installAllHandlers(logger);
 
 			before(async function () {
-				// Ensure a python interpreter is started before running the tests, otherwise we
-				// sometimes run into issues with selecting an interpreter in the nested tests
-				const app = this.app as Application;
-				const pythonFixtures = new PositronPythonFixtures(app);
-				await pythonFixtures.startPythonInterpreter(true);
+
 			});
 
 			it('Python Project Defaults [C627912]', async function () {

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -120,7 +120,8 @@ export function setup(logger: Logger) {
 				await pw.nextButton.click();
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myRProject');
-				await app.workbench.positronConsole.waitForReady('>', 10000);
+				// NOTE: For completeness, we probably want to await app.workbench.positronConsole.waitForReady('>', 10000);
+				// here, but it's timing out in CI, so it is not included for now.
 			});
 
 			describe('R Project with Renv Environment', () => {
@@ -258,7 +259,8 @@ export function setup(logger: Logger) {
 				await pw.nextButton.click();
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myJupyterNotebook');
-				await app.workbench.positronConsole.waitForReady('>>>', 10000);
+				// NOTE: For completeness, we probably want to await app.workbench.positronConsole.waitForReady('>>>', 10000);
+				// here, but it's timing out in CI, so it is not included for now.
 			});
 
 		});


### PR DESCRIPTION
## Description

- Addresses the Python Project ipykernel tests part of #3879

### Summary
- Reorganizes the automation class for Project Wizard
    - Each step now has a class which is contained in the Project Wizard class
    - Selectors are scoped to the class constructors whenever possible
    - Opting for usage of the `Locator` class when reasonable (sometimes waiting for elements and clicking on them still works better with the BaseElement class)
- Adds a couple ipykernel project wizard tests
- Reorganize Project Wizard smoke tests so all of the Project Wizard tests can be run with one `only`
- Modify the frontend components for the Project Wizard so that wizard steps and substeps have an easily referenceable ID, making constructing selectors easier
    <img width="1470" alt="proj_wiz_set_up_py_env_ids" src="https://github.com/posit-dev/positron/assets/25834218/c6b9028e-3a5a-456f-8062-cc59843fced8">
- Add option to `PositronPythonFixtures` to install ipykernel as part of selecting the interpreter
- Add new method `popupCurrentlyOpen()` to `PositronPopups` to check if a popup is currently open
- Support retrieving the active interpreter path from the Interpreter Dropdown
- Modify `StartInterpreter` methods to support returning the interpreter path
   - NOTE: `StartInterpreter` methods don't seem to be used elsewhere, so we should add some tests to confirm the class methods are working. Possibly in test/smoke/src/areas/positron/top-action-bar/top-action-bar.test.ts?

### 🆕 Smoke Tests
#### Python Project with existing interpreter:
- With ipykernel already installed
- With ipykernel not already installed

## QA Notes

Please add new test IDs and validate on Windows. Thank you :)
