### PR TITLE
Add strum to comms generator for enums

### DIFF
--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -502,7 +502,7 @@ use serde::Serialize;
 				yield formatComment(`/// `,
 					`Possible values for ` +
 					snakeCaseToSentenceCase(context[0]));
-				yield '#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]\n';
+				yield '#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]\n';
 				yield `pub enum ${snakeCaseToSentenceCase(context[0])} {\n`;
 			} else {
 				// Enum field within another interface
@@ -510,7 +510,7 @@ use serde::Serialize;
 					`Possible values for ` +
 					snakeCaseToSentenceCase(context[0]) + ` in ` +
 					snakeCaseToSentenceCase(context[1]));
-				yield '#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]\n';
+				yield '#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]\n';
 				yield `pub enum ${snakeCaseToSentenceCase(context[1])}${snakeCaseToSentenceCase(context[0])} {\n`;
 			}
 			for (let i = 0; i < values.length; i++) {

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -516,6 +516,7 @@ use serde::Serialize;
 			for (let i = 0; i < values.length; i++) {
 				const value = values[i];
 				yield `\t#[serde(rename = "${value}")]\n`;
+				yield `\t#[strum(to_string = "${value}")]\n`;
 				yield `\t${snakeCaseToSentenceCase(value)}`;
 				if (i < values.length - 1) {
 					yield ',\n\n';


### PR DESCRIPTION
Address #3852 

Adds the `strum` derivation and implments `to_string` for Rust. This addresses the manual edit in the generated file but requires an update in `ark` to use this change since the `to_string` is new.

The enum is generated like this:
```rs
/// Possible values for Format in Render
#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, strum_macros::Display)]
pub enum RenderFormat {
	#[serde(rename = "png")]
	#[strum(to_string = "png")]
	Png,

	#[serde(rename = "jpeg")]
	#[strum(to_string = "jpeg")]
	Jpeg,

	#[serde(rename = "svg")]
	#[strum(to_string = "svg")]
	Svg,

	#[serde(rename = "pdf")]
	#[strum(to_string = "pdf")]
	Pdf
}
```

and using `to_string`:
```rs
let image_path = r_task(|| unsafe {
    RFunction::from(".ps.graphics.renderPlot")
        .param("id", plot_id)
        .param("width", RObject::try_from(width)?)
        .param("height", RObject::try_from(height)?)
        .param("dpr", pixel_ratio)
        .param("format", format.to_string())
        .call()?
        .to::<String>()
});
```

### QA Notes
This is a tool for code generation