### PR TITLE
Add new interactive kernel chooser for positron notebooks

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -132,15 +132,24 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 	private _receivedInitialStatus = false;
 	private _receivedInitialReply = false;
 
+	/** The URI of the notebook that owns this kernel, if any */
+	private readonly _notebookUri?: vscode.Uri;
+
 	constructor(
 		private readonly _context: vscode.ExtensionContext,
 		spec: JupyterKernelSpec,
 		private readonly _runtimeId: string,
 		private readonly _channel: vscode.OutputChannel,
-		private readonly _notebookUri?: vscode.Uri,
+		readonly notebookUri?: vscode.Uri,
 		readonly extra?: JupyterKernelExtra,
 	) {
 		super();
+
+		if (notebookUri) {
+			// Sometimes this uri comes in only partially formed, so we need to make sure its a full
+			// uri before we store it.
+			this._notebookUri = vscode.Uri.parse(notebookUri.toString());
+		}
 		this._spec = spec;
 		this._extra = extra;
 		this._control = null;

--- a/src/vs/workbench/contrib/positronNotebook/browser/KernelStatusBadge.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/KernelStatusBadge.css
@@ -4,25 +4,28 @@
  *--------------------------------------------------------------------------------------------*/
 
 .positron-notebook-kernel-status-badge {
-	padding-inline: 0.5rem;
+	font-size: 12px;
+	cursor: pointer;
+	color: var(--vscode-positronNotebook-deemphasized-foreground);
 
-	& > .kernel-status {
+	& span.kernel-status {
+		cursor: pointer;
 		font-weight: bold;
 	}
 
-	& > .Uninitialized {
+	& .Uninitialized {
 		color: grey;
 	}
 
-	& > .Connected {
+	& .Connected {
 		color: forestgreen;
 	}
 
-	& > .Disconnected {
+	& .Disconnected {
 		color: red;
 	}
 
-	& > .Connecting {
+	& .Connecting {
 		color: orange;
 	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/KernelStatusBadge.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/KernelStatusBadge.tsx
@@ -7,15 +7,24 @@ import 'vs/css!./KernelStatusBadge';
 import * as React from 'react';
 import { useNotebookInstance } from 'vs/workbench/contrib/positronNotebook/browser/NotebookInstanceProvider';
 import { useObservedValue } from './useObservedValue';
+import { ActionButton } from 'vs/workbench/contrib/positronNotebook/browser/utilityComponents/ActionButton';
+import { useServices } from 'vs/workbench/contrib/positronNotebook/browser/ServicesProvider';
+import { SELECT_KERNEL_ID_POSITRON } from 'vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction';
 
 // This component will eventually be much more complicated and used to
 // control the kernel choice etc. For now, it just displays the kernel status.
 export function KernelStatusBadge() {
 	const notebookInstance = useNotebookInstance();
 	const kernelStatus = useObservedValue(notebookInstance.kernelStatus);
+	const services = useServices();
 
-	return <div className='positron-notebook-kernel-status-badge'>
-		Kernel
-		<span className={`kernel-status ${kernelStatus}`}>{' ' + kernelStatus}</span>
-	</div>;
+	return <ActionButton
+		onPressed={() => services.commandService.executeCommand(SELECT_KERNEL_ID_POSITRON, { forceDropdown: true })}
+		className='positron-notebook-kernel-status-badge'
+	>
+		<div>
+			Kernel
+			<span className={`kernel-status ${kernelStatus}`}>{' ' + kernelStatus}</span>
+		</div>
+	</ActionButton>;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
@@ -1,0 +1,109 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize2, localize } from 'vs/nls';
+import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
+import { selectKernelIcon } from 'vs/workbench/contrib/notebook/browser/notebookIcons';
+import { INotebookKernelService, INotebookKernel } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
+import { PositronNotebookInstance } from 'vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance';
+import { IPositronNotebookService } from 'vs/workbench/services/positronNotebook/browser/positronNotebookService';
+
+export const SELECT_KERNEL_ID_POSITRON = 'positronNotebook.selectKernel';
+const NOTEBOOK_ACTIONS_CATEGORY_POSITRON = localize2('positronNotebookActions.category', 'Positron Notebook');
+const NOTEBOOK_IS_ACTIVE_EDITOR = ContextKeyExpr.equals('activeEditor', 'workbench.editor.positronNotebook');
+
+export interface SelectPositronNotebookKernelContext {
+	forceDropdown: boolean;
+}
+
+class SelectPositronNotebookKernelAction extends Action2 {
+
+	constructor() {
+		super({
+			id: SELECT_KERNEL_ID_POSITRON,
+			category: NOTEBOOK_ACTIONS_CATEGORY_POSITRON,
+			title: localize2('positronNotebookActions.selectKernel', 'Select Positron Notebook Kernel'),
+			icon: selectKernelIcon,
+			f1: true,
+			precondition: NOTEBOOK_IS_ACTIVE_EDITOR,
+		});
+	}
+
+	async run(accessor: ServicesAccessor, context?: SelectPositronNotebookKernelContext): Promise<boolean> {
+		const { forceDropdown } = context || { forceDropdown: false };
+		const notebookKernelService = accessor.get(INotebookKernelService);
+		const notebookService = accessor.get(IPositronNotebookService);
+		const activeNotebook = notebookService.getActiveInstance();
+		const quickInputService = accessor.get(IQuickInputService);
+
+		if (!activeNotebook) {
+			return false;
+		}
+
+		const notebook = (activeNotebook as PositronNotebookInstance).textModel;
+		if (!notebook) {
+			return false;
+		}
+
+		const kernelMatches = notebookKernelService.getMatchingKernel(notebook);
+
+		if (!forceDropdown && kernelMatches.selected) {
+			// current kernel is wanted kernel -> done
+			return true;
+		}
+
+		// Show quick-pick with all kernels that match notebook, aka positronKernels
+		const quickPick = quickInputService.createQuickPick<IQuickPickItem & { kernel?: INotebookKernel }>();
+		quickPick.title = localize('positronNotebookActions.selectKernel.title', 'Select Positron Notebook Kernel');
+
+		const gatherKernelPicks = () => {
+			const kernelMatches = notebookKernelService.getMatchingKernel(notebook);
+			const positronKernels = kernelMatches.all.filter(k => k.extension.value === 'vscode.positron-notebook-controllers');
+			if (positronKernels.length === 0) {
+				quickPick.busy = true;
+				quickPick.items = [{ label: localize('positronNotebookActions.selectKernel.noKernel', 'No Positron Notebook Kernel found'), picked: true }];
+			} else {
+				quickPick.busy = false;
+				quickPick.items = positronKernels.map(kernel => ({
+					label: kernel.label,
+					description: kernel.description,
+					kernel,
+					picked: kernelMatches.selected?.id === kernel.id
+				}));
+			}
+		};
+
+		// Watch for new kernels being added so we can update the quick-pick
+		notebookKernelService.onDidAddKernel(gatherKernelPicks);
+
+		gatherKernelPicks();
+
+		return new Promise<boolean>(resolve => {
+			let didSelectKernel: boolean = false;
+			quickPick.onDidAccept(() => {
+				const selectedKernel = quickPick.selectedItems[0].kernel;
+				if (selectedKernel) {
+					// Link kernel with notebook
+					notebookKernelService.selectKernelForNotebook(selectedKernel, notebook);
+					didSelectKernel = true;
+				}
+				quickPick.hide();
+				quickPick.dispose();
+				resolve(true);
+			});
+
+			quickPick.show();
+
+			quickPick.onDidHide(() => {
+				quickPick.dispose();
+				resolve(didSelectKernel);
+			});
+		});
+	}
+}
+registerAction2(SelectPositronNotebookKernelAction);


### PR DESCRIPTION
Addresses #2355 

_This one is a bit larger and less focused than I would like. Sorry!_

Prior to this positron notebooks just blindly grasped for an available positron notebook kernel and used the first one it found. This obviously isn't ideal. 

This PR now makes it so notebooks will remember preferred kernels from previous runs and provide a dropdown quick-pick interface for selecting available kernels (like the existing notebooks.)

The functionality is exposed via the kernel status badge being turned into a button. The quick pick for kernels was not reused from the vscode notebooks because of reliance on the existence of their editor class.

_New kernel status badge-as-button_
<img width="731" alt="image" src="https://github.com/posit-dev/positron/assets/6764693/601cca4a-73bc-42cd-ae9d-a9a0c56564fd">

_Quick pick menu for selecting available kernels_
<img width="717" alt="image" src="https://github.com/posit-dev/positron/assets/6764693/434c7e3e-144a-43d8-a261-4f772bd3cec4">

There's one small fix in here that's semi-related: the addition of a URI messaging step in the `jupyter-adapter` extension's `JupyterKernel` class. For some reason, there was a regression of the kernel being started properly for positron notebooks due to the URI missing the `fspath` attribute. By reparsing here, we ensure it exists. Otherwise, positron notebook kernels fail to get past the `starting` lifecycle phase. 

### QA Notes

You should be able to click the kernel badge and select a new kernel. You can test that the kernel actually switched by running a cell with the following:
```python
import sys
sys.version
```



