### PR TITLE
Only use short dir name on windows builds

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -506,8 +506,8 @@ BUILD_TARGETS.forEach(buildTarget => {
 
 	const [vscode, vscodeMin] = ['', 'min'].map(minified => {
 		const sourceFolderName = `out-vscode${dashed(minified)}`;
-		let destinationFolderName = `VSCode${dashed(platform)}${dashed(arch)}`;
 		// --- Start Positron ---
+		let destinationFolderName = `VSCode${dashed(platform)}${dashed(arch)}`;
 		if (platform === 'win32') {
 			// Use short folder names for Windows builds
 			destinationFolderName = `p${arch}`;

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -506,7 +506,13 @@ BUILD_TARGETS.forEach(buildTarget => {
 
 	const [vscode, vscodeMin] = ['', 'min'].map(minified => {
 		const sourceFolderName = `out-vscode${dashed(minified)}`;
-		const destinationFolderName = `p${arch}`;
+		let destinationFolderName = `VSCode${dashed(platform)}${dashed(arch)}`;
+		// --- Start Positron ---
+		if (platform === 'win32') {
+			// Use short folder names for Windows builds
+			destinationFolderName = `p${arch}`;
+		}
+		// --- End Positron ---
 
 		const tasks = [
 			util.rimraf(path.join(buildRoot, destinationFolderName)),


### PR DESCRIPTION
Restoring default build staging dir for other platforms, we'll only use this short dir form on windows builds.