### PR TITLE
Fix webview plot contents being recreated on pane resize

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
@@ -103,6 +103,7 @@ export const PlotsContainer = (props: PlotContainerProps) => {
 				key={plotInstance.id}
 				width={plotWidth}
 				height={plotHeight}
+				visible={props.visible}
 				plotClient={plotInstance} />;
 		}
 		return null;

--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
@@ -103,7 +103,6 @@ export const PlotsContainer = (props: PlotContainerProps) => {
 				key={plotInstance.id}
 				width={plotWidth}
 				height={plotHeight}
-				visible={props.visible}
 				plotClient={plotInstance} />;
 		}
 		return null;

--- a/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotInstance.tsx
@@ -14,6 +14,7 @@ interface WebviewPlotInstanceProps {
 	width: number;
 	height: number;
 	plotClient: WebviewPlotClient;
+	visible: boolean;
 }
 
 /**
@@ -29,13 +30,16 @@ export const WebviewPlotInstance = (props: WebviewPlotInstanceProps) => {
 	useEffect(() => {
 		const client = props.plotClient;
 		client.claim(this);
-		if (webviewRef.current) {
-			client.layoutWebviewOverElement(webviewRef.current);
-		}
 		return () => {
 			client.release(this);
 		};
-	});
+	}, [props.plotClient]);
+
+	useEffect(() => {
+		if (webviewRef.current) {
+			props.plotClient.layoutWebviewOverElement(webviewRef.current);
+		}
+	}, [props.plotClient, props.width, props.height, props.visible]);
 
 	const style = {
 		width: `${props.width}px`,

--- a/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotInstance.tsx
@@ -14,7 +14,6 @@ interface WebviewPlotInstanceProps {
 	width: number;
 	height: number;
 	plotClient: WebviewPlotClient;
-	visible: boolean;
 }
 
 /**
@@ -39,7 +38,7 @@ export const WebviewPlotInstance = (props: WebviewPlotInstanceProps) => {
 		if (webviewRef.current) {
 			props.plotClient.layoutWebviewOverElement(webviewRef.current);
 		}
-	}, [props.plotClient, props.width, props.height, props.visible]);
+	});
 
 	const style = {
 		width: `${props.width}px`,


### PR DESCRIPTION
Address #3961, which becomes a much bigger problem as the widgets become more complex and load more JS/CSS resources.

Here's what it looks like after (compared to the video in the issue):

https://github.com/posit-dev/positron/assets/559360/a4b63505-e816-4397-be5b-737282683ea3

The console logs also show that the webview is not claimed/released at all during the above resizing.

One question is whether we should release/reclaim after the widget is hidden (when the pane is hidden) or is it fine as is?