### PR TITLE
Language runtime changes required for IPyWidgets

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -957,6 +957,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		const packet: JupyterMessagePacket = {
 			type: 'jupyter-message',
 			message: msg.content,
+			metadata: msg.metadata,
 			msgId: msg.header.msg_id,
 			msgType: msg.header.msg_type,
 			when: msg.header.date,
@@ -1196,7 +1197,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			return;
 		}
 
-		this.send(packet.msgId, packet.msgType, socket, packet.message);
+		this.send(packet.msgId, packet.msgType, socket, packet.message, packet.metadata);
 	}
 
 	/**

--- a/extensions/jupyter-adapter/src/JupyterMessagePacket.ts
+++ b/extensions/jupyter-adapter/src/JupyterMessagePacket.ts
@@ -33,4 +33,7 @@ export interface JupyterMessagePacket {
 
 	/** The socket on which the message was received, or is to be sent */
 	socket: JupyterSockets;
+
+	/** Additional metadata, if any */
+	metadata?: Map<any, any>;
 }

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -666,6 +666,7 @@ export class LanguageRuntimeSessionAdapter
 			comm_id: msg.comm_id,
 			target_name: msg.target_name,
 			data: msg.data,
+			metadata: message.metadata,
 		} as positron.LanguageRuntimeCommOpen);
 	}
 
@@ -683,6 +684,7 @@ export class LanguageRuntimeSessionAdapter
 			type: positron.LanguageRuntimeMessageType.CommData,
 			comm_id: msg.comm_id,
 			data: msg.data,
+			metadata: message.metadata,
 		} as positron.LanguageRuntimeCommMessage);
 	}
 
@@ -700,6 +702,7 @@ export class LanguageRuntimeSessionAdapter
 			type: positron.LanguageRuntimeMessageType.CommClosed,
 			comm_id: msg.comm_id,
 			data: msg.data,
+			metadata: message.metadata,
 		} as positron.LanguageRuntimeCommClosed);
 	}
 
@@ -717,6 +720,7 @@ export class LanguageRuntimeSessionAdapter
 			when: message.when,
 			type: positron.LanguageRuntimeMessageType.Output,
 			data: data.data as any,
+			metadata: message.metadata,
 		} as positron.LanguageRuntimeOutput);
 	}
 
@@ -735,7 +739,8 @@ export class LanguageRuntimeSessionAdapter
 			type: positron.LanguageRuntimeMessageType.Error,
 			name: data.ename,
 			message: data.evalue,
-			traceback: data.traceback
+			traceback: data.traceback,
+			metadata: message.metadata,
 		} as positron.LanguageRuntimeError);
 	}
 
@@ -753,6 +758,7 @@ export class LanguageRuntimeSessionAdapter
 			when: message.when,
 			type: positron.LanguageRuntimeMessageType.Result,
 			data: data.data as any,
+			metadata: message.metadata,
 		} as positron.LanguageRuntimeResult);
 	}
 
@@ -782,7 +788,8 @@ export class LanguageRuntimeSessionAdapter
 			when: message.when,
 			type: positron.LanguageRuntimeMessageType.Stream,
 			name: data.name,
-			text: data.text
+			text: data.text,
+			metadata: message.metadata,
 		} as positron.LanguageRuntimeStream);
 	}
 
@@ -800,7 +807,8 @@ export class LanguageRuntimeSessionAdapter
 			when: message.when,
 			type: positron.LanguageRuntimeMessageType.Input,
 			code: data.code,
-			execution_count: data.execution_count
+			execution_count: data.execution_count,
+			metadata: message.metadata,
 		} as positron.LanguageRuntimeInput);
 	}
 
@@ -817,7 +825,8 @@ export class LanguageRuntimeSessionAdapter
 			parent_id: message.originId,
 			when: message.when,
 			type: positron.LanguageRuntimeMessageType.State,
-			state: data.execution_state
+			state: data.execution_state,
+			metadata: message.metadata,
 		} as positron.LanguageRuntimeState);
 	}
 
@@ -1032,6 +1041,6 @@ export class LanguageRuntimeSessionAdapter
 	}
 
 	public getKernelLogFile(): string {
-		return this._kernel.getKernelLogFilePath()
+		return this._kernel.getKernelLogFilePath();
 	}
 }

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -431,7 +431,8 @@ export class LanguageRuntimeSessionAdapter
 			type === positron.RuntimeClientType.Lsp ||
 			type === positron.RuntimeClientType.Dap ||
 			type === positron.RuntimeClientType.Ui ||
-			type === positron.RuntimeClientType.Help) {
+			type === positron.RuntimeClientType.Help ||
+			type === positron.RuntimeClientType.IPyWidgetControl) {
 			this._kernel.log(`Creating '${type}' client for ${this.runtimeMetadata.languageName}`);
 
 			// Does the comm wrap a server? In that case the

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -199,6 +199,9 @@ declare module 'positron' {
 
 		/** The type of event */
 		type: LanguageRuntimeMessageType;
+
+		/** Additional metadata, if any */
+		metadata?: Map<any, any>;
 	}
 
 	/** LanguageRuntimeOutput is a LanguageRuntimeMessage representing output (text, plots, etc.) */

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -509,6 +509,7 @@ declare module 'positron' {
 		Help = 'positron.help',
 		Connection = 'positron.connection',
 		IPyWidget = 'jupyter.widget',
+		IPyWidgetControl = 'jupyter.widget.control',
 
 		// Future client types may include:
 		// - Watch window/variable explorer

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -391,10 +391,10 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 	}
 
 	/** Create a new client inside the runtime */
-	createClient<Input, Output>(type: RuntimeClientType, params: any, metadata?: any):
+	createClient<Input, Output>(type: RuntimeClientType, params: any, metadata?: any, id?: string):
 		Thenable<IRuntimeClientInstance<Input, Output>> {
-		// Create an ID for the client.
-		const id = this.generateClientId(this.runtimeMetadata.languageId, type);
+		// Create an ID for the client if not provided.
+		id = id ?? this.generateClientId(this.runtimeMetadata.languageId, type);
 
 		// Create the new instance and add it to the map.
 		const client = new ExtHostRuntimeClientInstance<Input, Output>(id, type, this.handle, this._proxy);

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -163,6 +163,7 @@ export enum RuntimeClientType {
 	Help = 'positron.help',
 	Connection = 'positron.connection',
 	IPyWidget = 'jupyter.widget',
+	IPyWidgetControl = 'jupyter.widget.control',
 
 	// Future client types may include:
 	// - Watch window/variable explorer

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance.ts
@@ -42,8 +42,9 @@ export enum RuntimeClientType {
 	DataExplorer = 'positron.dataExplorer',
 	Ui = 'positron.ui',
 	Help = 'positron.help',
-	IPyWidget = 'jupyter.widget',
 	Connection = 'positron.connection',
+	IPyWidget = 'jupyter.widget',
+	IPyWidgetControl = 'jupyter.widget.control',
 
 	// Future client types may include:
 	// - Watch window/variable explorer

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance.ts
@@ -75,6 +75,7 @@ export interface IRuntimeClientInstance<Input, Output> extends Disposable {
 	getClientId(): string;
 	getClientType(): RuntimeClientType;
 	performRpc(request: Input, timeout: number): Promise<Output>;
+	sendMessage(message: any): void;
 	messageCounter: ISettableObservable<number>;
 	clientState: ISettableObservable<RuntimeClientState>;
 }

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -56,6 +56,9 @@ export interface ILanguageRuntimeMessage {
 
 	/** The message's date and time, in ISO 8601 format */
 	when: string;
+
+	/** Additional metadata, if any */
+	metadata?: Map<any, any>;
 }
 
 /**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -151,8 +151,9 @@ export interface ILanguageRuntimeSession {
 	 * @param type The type of client to create
 	 * @param params The parameters to pass to the client constructor
 	 * @param metadata The metadata to pass to the client constructor
+	 * @param id The unique identifier for the client instance. Defaults to a randomly generated ID.
 	 */
-	createClient<T, U>(type: RuntimeClientType, params: any, metadata?: any): Thenable<IRuntimeClientInstance<T, U>>;
+	createClient<T, U>(type: RuntimeClientType, params: any, metadata?: any, id?: string): Thenable<IRuntimeClientInstance<T, U>>;
 
 	/** Get a list of all known clients */
 	listClients(type?: RuntimeClientType): Thenable<Array<IRuntimeClientInstance<any, any>>>;


### PR DESCRIPTION
A few more tiny steps toward #3276 trying to avoid One Massive PR. Commits are self-contained:

1. Include `metadata` in language runtime messages. IPyWidgets JS libs assume comm open messages include `metadata['version']` specifying the widget protocol version.
2. Add optional `id` param to `session.createClient`. We'll need to create comms with a given UUID.
3. Make runtime client `sendMessage` method public. We'll need to send fire-and-forget messages to widget comms.
4. Allow creating `jupyter.widget.control` comms. We'll use them to fetch widget state from the kernel.

### QA Notes

No functional changes. Nothing should break!