### PR TITLE
Bump ark to 0.1.116

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -589,7 +589,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.115"
+      "ark": "0.1.116"
     },
     "minimumRVersion": "4.2.0",
 		"minimumRenvVersion": "1.0.7"


### PR DESCRIPTION
For #3852 to generate `to_string` with `strum` for enums.