### PR TITLE
Use the correct notebook cell output item type for widgets

### DIFF
--- a/extensions/positron-notebook-controllers/src/notebookController.ts
+++ b/extensions/positron-notebook-controllers/src/notebookController.ts
@@ -321,8 +321,22 @@ function handleRuntimeMessageOutput(
 			case 'image/jpeg':
 				cellOutputItems.push(new vscode.NotebookCellOutputItem(Buffer.from(data, 'base64'), mimeType));
 				break;
+			// This list is a subset of src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.JUPYTER_RENDERER_MIMETYPES
+			case 'application/geo+json':
+			case 'application/vdom.v1+json':
+			case 'application/vnd.dataresource+json':
 			case 'application/vnd.jupyter.widget-view+json':
+			case 'application/vnd.plotly.v1+json':
 			case 'application/vnd.r.htmlwidget':
+			case 'application/vnd.vega.v2+json':
+			case 'application/vnd.vega.v3+json':
+			case 'application/vnd.vega.v4+json':
+			case 'application/vnd.vega.v5+json':
+			case 'application/vnd.vegalite.v1+json':
+			case 'application/vnd.vegalite.v2+json':
+			case 'application/vnd.vegalite.v3+json':
+			case 'application/vnd.vegalite.v4+json':
+			case 'application/x-nteract-model-debug+json':
 				// The JSON cell output item will be rendered using the appropriate notebook renderer.
 				cellOutputItems.push(vscode.NotebookCellOutputItem.json(data, mimeType));
 				break;

--- a/extensions/positron-notebook-controllers/src/notebookController.ts
+++ b/extensions/positron-notebook-controllers/src/notebookController.ts
@@ -315,15 +315,21 @@ function handleRuntimeMessageOutput(
 	outputType: NotebookCellOutputType,
 ): vscode.NotebookCellOutput {
 	const cellOutputItems: vscode.NotebookCellOutputItem[] = [];
-	const mimeTypes = Object.keys(message.data);
-	mimeTypes.map(mimeType => {
-		const data = message.data[mimeType];
-		if (mimeType === 'image/png' || mimeType === 'image/jpeg') {
-			cellOutputItems.push(new vscode.NotebookCellOutputItem(Buffer.from(data, 'base64'), mimeType));
-		} else {
-			cellOutputItems.push(vscode.NotebookCellOutputItem.text(data, mimeType));
+	for (const [mimeType, data] of Object.entries(message.data)) {
+		switch (mimeType) {
+			case 'image/png':
+			case 'image/jpeg':
+				cellOutputItems.push(new vscode.NotebookCellOutputItem(Buffer.from(data, 'base64'), mimeType));
+				break;
+			case 'application/vnd.jupyter.widget-view+json':
+			case 'application/vnd.r.htmlwidget':
+				// The JSON cell output item will be rendered using the appropriate notebook renderer.
+				cellOutputItems.push(vscode.NotebookCellOutputItem.json(data, mimeType));
+				break;
+			default:
+				cellOutputItems.push(vscode.NotebookCellOutputItem.text(data, mimeType));
 		}
-	});
+	}
 	return new vscode.NotebookCellOutput(cellOutputItems, { outputType });
 }
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3972.

Partially addresses https://github.com/posit-dev/positron/issues/3969.

We were trying to use the "text" type which lead to errors like:

```
Error rendering output item using 'positron.r.htmlwidget'
"[object Object]" is not valid JSON
```

Note that this won't actually fix some widget types in notebook. The full fixes are quite a bit more involved, see https://github.com/posit-dev/positron/issues/3969#issuecomment-2223046413.