### PR TITLE
Block incompatible notebook preloads and renderers

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -538,6 +538,13 @@ export class NotebookService extends Disposable implements INotebookService {
 			this._notebookRenderersInfoStore.clear();
 
 			for (const extension of renderers) {
+				// --- Start Positron ---
+				// Don't add renderers from the Jupyter extension since they don't work with our runtimes.
+				// TODO(seem): We can remove this if we eventually decide to unbundle vscode-jupyter.
+				if (extension.description.identifier.value === 'ms-toolsai.jupyter') {
+					continue;
+				}
+				// --- End Positron ---
 				for (const notebookContribution of extension.value) {
 					if (!notebookContribution.entrypoint) { // avoid crashing
 						extension.collector.error(`Notebook renderer does not specify entry point`);
@@ -573,8 +580,24 @@ export class NotebookService extends Disposable implements INotebookService {
 				if (!isProposedApiEnabled(extension.description, 'contribNotebookStaticPreloads')) {
 					continue;
 				}
+				// --- Start Positron ---
+				// Don't add preloads from the Jupyter extension since they don't work with our runtimes.
+				// TODO(seem): We can remove this if we eventually decide to unbundle vscode-jupyter.
+				if (extension.description.identifier.value === 'ms-toolsai.jupyter') {
+					continue;
+				}
+				// --- End Positron ---
 
 				for (const notebookContribution of extension.value) {
+					// --- Start Positron ---
+					// Don't add the preload from the Jupyter extension that bundles ipywidgets JS libraries,
+					// since they don't work with our runtimes.
+					// TODO(seem): We can remove this if we eventually decide to unbundle vscode-jupyter.
+					if (extension.description.identifier.value === 'ms-toolsai.jupyter-renderers' &&
+						notebookContribution.entrypoint.endsWith('ipywidgets.js')) {
+						continue;
+					}
+					// --- End Positron ---
 					if (!notebookContribution.entrypoint) { // avoid crashing
 						extension.collector.error(`Notebook preload does not specify entry point`);
 						continue;


### PR DESCRIPTION
A few of the notebook preloads and notebook renderers contributed by the `ms-toolsai.jupyter` and `ms-toolsai.jupyter-renderers` extensions are incompatible with Positron's language runtimes. This PR stops them from being contributed.

Another step toward #3276. In a follow-up PR, I'll contribute our own preloads/renderers.

Note that the blocked preloads/renderers didn't work in Positron anyway, so this PR should have no effect.

#### QA Notes

- IPyWidgets should work as before with the same limitations (no communication with runtimes)
- R HTMLWidgets should continue to work
- Python Plotly widgets should continue to work
- Notebooks should be able to render most output types, as before