### PR TITLE
Add method for hiding views and use to hide jupyter tab

### DIFF
--- a/src/vs/workbench/services/views/browser/viewDescriptorService.ts
+++ b/src/vs/workbench/services/views/browser/viewDescriptorService.ts
@@ -27,6 +27,11 @@ import { layoutDescriptionToViewInfo } from 'vs/workbench/services/positronLayou
 import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
 import { PaneCompositeBar } from 'vs/workbench/browser/parts/paneCompositeBar';
 import { CustomPositronLayoutDescription } from 'vs/workbench/services/positronLayout/common/positronCustomViews';
+
+// A list of views we don't want shown in the UI. This will be for situations where we reimplement
+// the logic that the view would show in our own custom views or other parts of the UI. The matching
+// for these is done via the `String.includes` method, to enable sub-views to be hidden as well.
+const positronHiddenViews = ['workbench.view.extension.jupyter'];
 // --- End Positron ---
 
 interface IViewsCustomizations {
@@ -112,6 +117,10 @@ export class ViewDescriptorService extends Disposable implements IViewDescriptor
 
 		this._register(this.viewContainersRegistry.onDidRegister(({ viewContainer }) => {
 			this.onDidRegisterViewContainer(viewContainer);
+			// ---- Start Positron ----
+			// Check if view is on the list of ones we want hidden and don't add it if it is.
+			if (positronHiddenViews.some(viewId => viewContainer.id.includes(viewId))) { return; }
+			// ---- End Positron ----
 			this._onDidChangeViewContainers.fire({ added: [{ container: viewContainer, location: this.getViewContainerLocation(viewContainer) }], removed: [] });
 		}));
 


### PR DESCRIPTION
Addresses #3901

This PR hooks into the view descriptor service and adds a way to register views we don't want to show up in the UI. This is useful for instances where an extension we don't control contributes the view but our UI duplicates the functionality. 

The specific instance implemented here is to hide the jupyter tab that was showing up even though our own variables tab replicates the behavior (in a superior manner if I do say so). 

## Implementation notes
This is done in the view descriptor service with the goal of having the smallest blast radius. Basically, the view registration is allowed to run to completion and it's just never added to the UI. There's always a chance though that some logic within the view's UI could be important, but I doubt it. Also, we already mess with the view descriptor service for the layouts so we can keep the modification of non-positron scripts to a minimum. 

We _could_ do this by utilizing the dynamically created `${viewDescriptor.id}.removeView` command that's used for the right-click -> hide interface, but it's not clear if that could be accomplished without flashing the non-desired view for a second (also we'd have to add logic for detecting the registration of the view.)

### QA Notes

Everything should operate exactly as before with the exception of, when a jupyter notebook is open (the original VSCode notebooks, not the positron notebooks) the jupyter tab should never appear. 