### PR TITLE
Retry on Windows with LASTEXITCODE

### DIFF
--- a/scripts/run-with-retry.ps1
+++ b/scripts/run-with-retry.ps1
@@ -22,8 +22,18 @@ while ($attempt -lt $maxAttempts -and -not $success) {
     try {
         $attempt++
 
+        # Reset the exit code to 0 before running the command
+        $global:LASTEXITCODE = 0
+
         Invoke-Expression $command
-        $success = $true
+
+        # Check the return value of the command and set $success to $true if it is successful
+        if ($LASTEXITCODE -eq 0) {
+            $success = $true
+            Write-Host "Command '$command' succeeded"
+        } else {
+            Write-Host "Command '$command' had exit code $LASTEXITCODE on attempt $attempt of $maxAttempts"
+        }
     }
     catch {
         # If the command fails, output an error message


### PR DESCRIPTION
A few recent Windows builds have failed with an intermittent error, even though we have retry logic that is _supposed_ to prevent this exact situation.

```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppBuild.targets(382,5): error MSB3491: Could not write lines to file "Release\obj\node_addon_api_except\node_add.5778BCDE.tlog\node_addon_api_except.lastbuildstate". The process cannot access the file 'C:\a\positron\positron\node_modules\@vscode\node-addon-api\Release\obj\node_addon_api_except\node_add.5778BCDE.tlog\node_addon_api_except.lastbuildstate' because it is being used by another process. [C:\a\positron\positron\node_modules\@vscode\node-addon-api\node_addon_api_except.vcxproj]
```

I did some research and discovered that `Invoke-Expression` can succeed even if the command it wraps returns a non-zero exit code.

The fix here is to amend the try-catch with a test that also looks at the exit code; only in the case of a successful exit code do we stop retrying.

Windows job showing that this results in a successful build: https://github.com/posit-dev/positron/actions/runs/9898975499

(unfortunately the intermittent error did not show up so this doesn't prove the retry case)

### QA Notes

N/A, build change only
