### PR TITLE
Use just-in-time access token for checking CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,6 +14,19 @@ permissions:
 
 jobs:
   RequireCLA:
-    uses: posit-dev/cla-assistant/.github/workflows/posit-cla.yml@v1
-    secrets:
-      CLA_ASSISTANT_PAT: ${{ secrets.CLA_ASSISTANT_PAT }}
+    steps:
+      # Generate an access token; used to access the repository hosting the set
+      # of known CLA signatures
+      - name: Create access token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
+          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      # Validate that the CLA has been signed by the author(s)
+      - name: Validate CLA signatures
+        uses: posit-dev/cla-assistant/.github/workflows/posit-cla.yml@v1
+        secrets:
+          CLA_ASSISTANT_PAT: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This is a speculative fix intended to address the frequent 403 access errors we're seeing with the CLA assistant. Instead of using a PAT provided as a secret to the Github Action, we generate an access token intended for one-time use and supply that to the upstream action. 

### QA Notes

N/A, build change only.