### PR TITLE
Address 403 errors in CLA validation job (Take 2)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -13,20 +13,23 @@ permissions:
   statuses: write
 
 jobs:
-  RequireCLA:
+  AccessToken:
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.access-token.outputs.token }}
     steps:
-      # Generate an access token; used to access the repository hosting the set
-      # of known CLA signatures
-      - name: Create access token
+      - name: Generate access token
+        # Generate an access token; used to access the repository hosting the
+        # set of known CLA signatures
+        id: access-token
         uses: actions/create-github-app-token@v1
-        id: app-token
         with:
           app-id: ${{ vars.POSITRON_BOT_APP_ID }}
           private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
-      # Validate that the CLA has been signed by the author(s)
-      - name: Validate CLA signatures
-        uses: posit-dev/cla-assistant/.github/workflows/posit-cla.yml@v1
-        secrets:
-          CLA_ASSISTANT_PAT: ${{ steps.app-token.outputs.token }}
+  RequireCLA:
+    needs: AccessToken
+    uses: posit-dev/cla-assistant/.github/workflows/posit-cla.yml@v1
+    secrets:
+      CLA_ASSISTANT_PAT: ${{ needs.AccessToken.outputs.token }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,6 +14,19 @@ permissions:
 
 jobs:
   RequireCLA:
-    uses: posit-dev/cla-assistant/.github/workflows/posit-cla.yml@v1
-    secrets:
-      CLA_ASSISTANT_PAT: ${{ secrets.CLA_ASSISTANT_PAT }}
+    steps:
+      # Generate an access token; used to access the repository hosting the set
+      # of known CLA signatures
+      - name: Create access token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
+          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      # Validate that the CLA has been signed by the author(s)
+      - name: Validate CLA signatures
+        uses: posit-dev/cla-assistant/.github/workflows/posit-cla.yml@v1
+        secrets:
+          CLA_ASSISTANT_PAT: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This is a second attempt at addressing the sporadic 403 errors emitted by the CLA assistant. 

It turns out that the kind of reusable workflow exposed by the assistant is not callable from a job step (i.e. it's not a composite step). So in order to get a secret into it, we need create the secret from a separate job, promote it to an output, and _then_ we can use it in the reusable workflow.

### QA Notes

No QA needed, CI change only.