### PR TITLE
Address CLA token issue in latest PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,6 +27,8 @@ jobs:
           app-id: ${{ vars.POSITRON_BOT_APP_ID }}
           private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          # We have to skip revocation here to share the token with the next job
+          skip-token-revoke: true
 
   RequireCLA:
     needs: AccessToken


### PR DESCRIPTION
If we need to pass the token to another job, we need to skip immediate revocation.

if this addresses the issue, we can add a later job to revoke the token manually.
