### PR TITLE
Add issue template for Ark

### DIFF
--- a/.github/ISSUE_TEMPLATE/generic_issue_ark.md
+++ b/.github/ISSUE_TEMPLATE/generic_issue_ark.md
@@ -1,0 +1,5 @@
+---
+name: File an issue for Ark
+about: Create a new issue for the Ark kernel (https://github.com/posit-dev/ark).
+labels: ["lang: r", "area: kernels"]
+---


### PR DESCRIPTION
Addresses #3960.

This template is for a generic issue as I thought adding an Ark variant for every kind of issues would excessively clutter the "New Issue" page. This means triagers will have to add the `bug` or `enhancement` labels (if applicable) themselves.
