### PR TITLE
Move notebook runtime URI fixing to the main-thread. 

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -145,11 +145,6 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 	) {
 		super();
 
-		if (notebookUri) {
-			// Sometimes this uri comes in only partially formed, so we need to make sure its a full
-			// uri before we store it.
-			this._notebookUri = vscode.Uri.parse(notebookUri.toString());
-		}
 		this._spec = spec;
 		this._extra = extra;
 		this._control = null;

--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -132,15 +132,12 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 	private _receivedInitialStatus = false;
 	private _receivedInitialReply = false;
 
-	/** The URI of the notebook that owns this kernel, if any */
-	private readonly _notebookUri?: vscode.Uri;
-
 	constructor(
 		private readonly _context: vscode.ExtensionContext,
 		spec: JupyterKernelSpec,
 		private readonly _runtimeId: string,
 		private readonly _channel: vscode.OutputChannel,
-		readonly notebookUri?: vscode.Uri,
+		private readonly _notebookUri?: vscode.Uri,
 		readonly extra?: JupyterKernelExtra,
 	) {
 		super();

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -84,6 +84,16 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		sessionMetadata: IRuntimeSessionMetadata): Promise<extHostProtocol.RuntimeInitialState> {
 		// Look up the session manager responsible for restoring this session
 		const sessionManager = await this.runtimeManagerForRuntime(runtimeMetadata, true);
+
+		if (sessionMetadata.notebookUri) {
+			// Sometimes the full URI doesn't make it across the serialization boundary.
+			// By reviving the URI here we make sure we're operating with a full URI
+			// rather than a serialized one that may be missing parameters.
+			sessionMetadata = {
+				...sessionMetadata,
+				notebookUri: URI.revive(sessionMetadata.notebookUri)
+			};
+		}
 		if (sessionManager) {
 			const session =
 				await sessionManager.manager.createSession(runtimeMetadata, sessionMetadata);

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -782,15 +782,16 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			this._startingConsolesByLanguageId.set(runtimeMetadata.languageId, runtimeMetadata);
 		}
 
+		if (notebookUri) {
+			// Revive the notebook URI if it's a resource just incase it's not fully formed.
+			notebookUri = URI.revive(notebookUri);
+		}
+
 		// Create a promise that resolves when the runtime is ready to use.
 		const startPromise = new DeferredPromise<string>();
 		const sessionMapKey = getSessionMapKey(sessionMode, runtimeMetadata.runtimeId, notebookUri);
 		this._startingSessionsBySessionMapKey.set(sessionMapKey, startPromise);
 
-		if (notebookUri) {
-			// Revive the notebook URI if it's a resource just incase it's not fully formed.
-			notebookUri = URI.revive(notebookUri);
-		}
 		const sessionManager = await this.getManagerForRuntime(runtimeMetadata);
 		const sessionId = this.generateNewSessionId(runtimeMetadata);
 		const sessionMetadata: IRuntimeSessionMetadata = {

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -782,11 +782,6 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			this._startingConsolesByLanguageId.set(runtimeMetadata.languageId, runtimeMetadata);
 		}
 
-		if (notebookUri) {
-			// Revive the notebook URI if it's a resource just incase it's not fully formed.
-			notebookUri = URI.revive(notebookUri);
-		}
-
 		// Create a promise that resolves when the runtime is ready to use.
 		const startPromise = new DeferredPromise<string>();
 		const sessionMapKey = getSessionMapKey(sessionMode, runtimeMetadata.runtimeId, notebookUri);

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -787,6 +787,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		const sessionMapKey = getSessionMapKey(sessionMode, runtimeMetadata.runtimeId, notebookUri);
 		this._startingSessionsBySessionMapKey.set(sessionMapKey, startPromise);
 
+		if (notebookUri) {
+			// Revive the notebook URI if it's a resource just incase it's not fully formed.
+			notebookUri = URI.revive(notebookUri);
+		}
 		const sessionManager = await this.getManagerForRuntime(runtimeMetadata);
 		const sessionId = this.generateNewSessionId(runtimeMetadata);
 		const sessionMetadata: IRuntimeSessionMetadata = {


### PR DESCRIPTION
Addresses #4016. 

Move the reviving of a URI to the main thread when starting a runtime. Fixes problem where sometimes the URI would get silently blown away by bad to-string conversion and then the runtime would not know where it was supposed to be running.

Previously I added a URI "revival" step on the extension-host side of the RPC to deal with the fact that positron notebooks sometimes provide non-fully-formed URIs. This worked fine for positron notebooks but not normal notebooks, which provided a URI-like object that didn't have a `.toString()` method implemented. This caused the notebook to start from the vaunted `[Object object]` path. 

Now we run `URI.revive()` on the main thread before starting the runtime as we should have from the begining. 

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes
The normal VSCode notebooks should be able to open resources relative to themselves. Like a csv with `pd.read_csv()`
