### PR TITLE
Better guidance for output / devtools location

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,5 +16,10 @@ labels: ['bug']
 ## What did you expect to happen?
 
 
-## Were there any error messages in the output or Developer Tools console?
+## Were there any error messages in the Output panel or Developer Tools console?
+
+<!--
+Open the Developer Tools console by running the Developer: Toggle Developer Tools command from the Command Palette.
+A guide to locating the correct Output channel can be found here: https://github.com/posit-dev/positron/wiki/Troubleshooting
+-->
 


### PR DESCRIPTION
This change addresses some feedback we've been getting that people who report issues don't know what the Developer Tools console is or how to access it.

The "output" can also be unclear but is a more nuanced topic so I've linked it to our troubleshooting page.

### QA Notes

N/A, issue template change only
