### PR TITLE
Fix webview plots not hiding when the plots pane is collapsed

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
@@ -103,6 +103,7 @@ export const PlotsContainer = (props: PlotContainerProps) => {
 				key={plotInstance.id}
 				width={plotWidth}
 				height={plotHeight}
+				visible={props.visible}
 				plotClient={plotInstance} />;
 		}
 		return null;

--- a/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotInstance.tsx
@@ -13,6 +13,7 @@ import { WebviewPlotClient } from 'vs/workbench/contrib/positronPlots/browser/we
 interface WebviewPlotInstanceProps {
 	width: number;
 	height: number;
+	visible: boolean;
 	plotClient: WebviewPlotClient;
 }
 
@@ -28,11 +29,15 @@ export const WebviewPlotInstance = (props: WebviewPlotInstanceProps) => {
 
 	useEffect(() => {
 		const client = props.plotClient;
-		client.claim(this);
+		// Only claim if the plot is visible to avoid rendering the webview when
+		// the parent view pane is collapsed.
+		if (props.visible) {
+			client.claim(this);
+		}
 		return () => {
 			client.release(this);
 		};
-	}, [props.plotClient]);
+	}, [props.plotClient, props.visible]);
 
 	useEffect(() => {
 		if (webviewRef.current) {

--- a/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotThumbnail.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotThumbnail.tsx
@@ -35,10 +35,13 @@ export const WebviewPlotThumbnail = (props: WebviewPlotThumbnailProps) => {
 
 		// When the plot is rendered, update the URI. This can happen multiple times if the plot
 		// is resized.
-		props.plotClient.onDidRenderThumbnail((result) => {
+		const disposable = props.plotClient.onDidRenderThumbnail((result) => {
 			setUri(result);
 		});
-	});
+		return () => {
+			disposable.dispose();
+		};
+	}, [props.plotClient]);
 
 	// If the plot is not yet rendered yet (no URI), show a placeholder;
 	// otherwise, show the rendered thumbnail.


### PR DESCRIPTION
Addresses #2170.

I also noticed a warning in the console about leaked listeners for the `onDidRenderThumbnail` event so cleaned that up too.