### PR TITLE
Improvements to debouncing console execution indicators

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-@keyframes fade-in {
+@keyframes positronActionBarButton-fadeIn {
 	0% {
 		opacity: 0;
 	}
@@ -36,7 +36,7 @@
 
 .action-bar-button.fade-in {
 	opacity: 0;
-	animation: fade-in 0.25s ease-in 0.25s 1 forwards;
+	animation: positronActionBarButton-fadeIn 0.25s ease-in 0.25s 1 forwards;
 }
 
 .action-bar-button:focus {

--- a/src/vs/platform/positronActionBar/browser/components/actionBarFilter.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFilter.css
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-@keyframes fadeIn {
+@keyframes positronActionBarFilter-fadeIn {
 	from { opacity: 0; }
 	to { opacity: 1; }
 }
@@ -57,7 +57,7 @@
 	cursor: pointer;
 	margin: 0 4px 0 0;
 	background: transparent;
-	animation: fadeIn 150ms ease-out;
+	animation: positronActionBarFilter-fadeIn 150ms ease-out;
 }
 
 .action-bar-filter-input .clear-button:focus-visible {

--- a/src/vs/platform/positronActionBar/browser/components/actionBarFind.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFind.css
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-@keyframes fadeIn {
+@keyframes positronActionBarFind-fadeIn {
 	from { opacity: 0; }
 	to { opacity: 1; }
 }
@@ -57,7 +57,7 @@
 	cursor: pointer;
 	margin: 0 4px 0 0;
 	background: transparent;
-	animation: fadeIn 150ms ease-out;
+	animation: positronActionBarFind-fadeIn 150ms ease-out;
 }
 
 .action-bar-find-input .clear-button:focus-visible {

--- a/src/vs/platform/positronActionBar/browser/components/actionBarSeparator.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarSeparator.css
@@ -3,11 +3,26 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+@keyframes positronActionBarSeparator-fadeIn {
+	0% {
+		opacity: 0;
+	}
+
+	100% {
+		opacity: 1;
+	}
+}
+
 .action-bar-separator {
 	width: 7px;
 	align-items: center;
 	justify-content: center;
 	display: flex !important;
+}
+
+.action-bar-separator.fade-in {
+	opacity: 0;
+	animation: positronActionBarSeparator-fadeIn 0.25s ease-in 0.25s 1 forwards;
 }
 
 .action-bar-separator-icon {

--- a/src/vs/platform/positronActionBar/browser/components/actionBarSeparator.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarSeparator.tsx
@@ -5,15 +5,28 @@
 
 import 'vs/css!./actionBarSeparator';
 import * as React from 'react';
+import { optionalBoolean, positronClassNames } from 'vs/base/common/positronUtilities';
+
+/**
+ * ActionBarSeparatorProps interface.
+ */
+export interface ActionBarSeparatorProps {
+	fadeIn?: boolean;
+}
 
 /**
  * ActionBarSeparator component.
  * @returns The component.
  */
-export const ActionBarSeparator = () => {
+export const ActionBarSeparator = (props: ActionBarSeparatorProps) => {
 	// Render.
 	return (
-		<div className='action-bar-separator' aria-hidden='true' >
+		<div
+			className={positronClassNames(
+				'action-bar-separator',
+				{ 'fade-in': optionalBoolean(props.fadeIn) }
+			)}
+			aria-hidden='true' >
 			<div className='action-bar-separator-icon codicon codicon-positron-separator' />
 		</div>
 	);

--- a/src/vs/workbench/browser/positronAnsiRenderer/outputRun.css
+++ b/src/vs/workbench/browser/positronAnsiRenderer/outputRun.css
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-@keyframes output-run-blink {
+@keyframes positronOutputRun-blink {
 	50% {
 		opacity: 0;
 	}

--- a/src/vs/workbench/browser/positronAnsiRenderer/outputRun.tsx
+++ b/src/vs/workbench/browser/positronAnsiRenderer/outputRun.tsx
@@ -203,7 +203,7 @@ export const OutputRun = (props: OutputRunProps) => {
 						cssProperties = {
 							...cssProperties,
 							...{
-								animation: 'output-run-blink 1s linear infinite'
+								animation: 'positronOutputRun-blink 1s linear infinite'
 							}
 						};
 						break;
@@ -214,7 +214,7 @@ export const OutputRun = (props: OutputRunProps) => {
 						cssProperties = {
 							...cssProperties,
 							...{
-								animation: 'output-run-blink 0.5s linear infinite'
+								animation: 'positronOutputRun-blink 0.5s linear infinite'
 							}
 						};
 						break;

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.css
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-@keyframes fade-in {
+@keyframes positronModalDialog-fadeIn {
 	0% { opacity: 0; }
 	100% { opacity: 1; }
 }
@@ -18,19 +18,19 @@
 	position: fixed;
 	align-items: center;
 	justify-content: center;
-	animation: fade-in 0.25s;
+	animation: positronModalDialog-fadeIn 0.25s;
 	background: rgba(0, 0, 0, 0.2);
 }
 
 .positron-modal-dialog-container {
-	animation: fade-in 0.25s;
+	animation: positronModalDialog-fadeIn 0.25s;
 	top: 0;
 	left: 0;
 	width: 100%;
 	height: 100%;
 	position: absolute;
 	outline: none !important;
-	animation: fade-in 0.25s;
+	animation: positronModalDialog-fadeIn 0.25s;
 	/* Makes some devices run their hardware acceleration. */
 	transform: translate3d(0px, 0px, 0px);
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSearch.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSearch.css
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-@keyframes fadeIn {
+@keyframes positronDataExplorerColumnSearch-fadeIn {
 	from { opacity: 0; }
 	to { opacity: 1; }
 }
@@ -58,7 +58,7 @@
 	cursor: pointer;
 	margin: 0 4px 0 0;
 	background: transparent;
-	animation: fadeIn 150ms ease-out;
+	animation: positronDataExplorerColumnSearch-fadeIn 150ms ease-out;
 }
 
 .column-search-input .clear-button:focus-visible {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBarActivityIndicator.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBarActivityIndicator.css
@@ -35,10 +35,10 @@
 .status-bar-indicator
 .icon.computing {
 	background-image: url(status-active.svg);
-	animation: status-icon-rotate-computing 1.5s linear infinite;
+	animation: positronDataExplorerStatusBarActivityIndicator-rotate 1.5s linear infinite;
 }
 
-@keyframes status-icon-rotate-computing {
+@keyframes positronDataExplorerStatusBarActivityIndicator-rotate {
 	to {
 		transform: rotate(360deg);
 	}

--- a/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.css
+++ b/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.css
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-@keyframes fade-in {
+@keyframes positronModalReactRenderer-fadeIn {
 	0% { opacity: 0; }
 	100% { opacity: 1; }
 }
@@ -18,5 +18,5 @@
 	position: fixed;
 	align-items: center;
 	justify-content: center;
-	animation: fade-in 0.25s;
+	animation: positronModalReactRenderer-fadeIn 0.25s;
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -358,7 +358,7 @@ export const ActionBar = (props: ActionBarProps) => {
 							</ActionBarButton>
 						}
 						{interruptible &&
-							<ActionBarSeparator />
+							<ActionBarSeparator fadeIn={true} />
 						}
 						<ActionBarButton
 							iconId='positron-power-button-thin'

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.css
@@ -15,24 +15,15 @@
 	left: -10px;
 }
 
-@keyframes pulseAnimation {
-	0% {
-		opacity: 0;
-	}
-
-	50% {
-		opacity: 0;
-	}
-
-	100% {
-		opacity: 1;
-	}
+@keyframes positronActivityInput-fadeIn {
+	0% { opacity: 0; }
+	100% { opacity: 1; }
 }
 
 .activity-input.executing .progress-bar {
 	background-color: var(--vscode-positronConsole-ansiGreen);
-	animation-name: pulseAnimation;
-	animation-duration: 1s;
+	opacity: 0;
+	animation: positronActivityInput-fadeIn 0.25s ease-in 0.25s 1 forwards;
 }
 
 .activity-input .prompt {

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
@@ -31,10 +31,10 @@
 }
 
 .variable-item.recent {
-	animation: pulseUpdate 2s;
+	animation: positronVariableItem-pulseUpdate 2s;
 }
 
-@keyframes pulseUpdate {
+@keyframes positronVariableItem-pulseUpdate {
 	0% {
 		background-color: var(--vscode-positronVariables-activeSelectionBackground);
 	}
@@ -45,10 +45,10 @@
 }
 
 .variable-item.recent.selected {
-	animation: pulseUpdateSelected 2s;
+	animation: positronVariableItem-pulseUpdateSelected 2s;
 }
 
-@keyframes pulseUpdateSelected {
+@keyframes positronVariableItem-pulseUpdateSelected {
 	0% {
 		background-color: var(--vscode-positronVariables-activeSelectionBackground);
 	}


### PR DESCRIPTION
Addresses #3752.

As [discussed on Slack](https://positpbc.slack.com/archives/C04FPQK3H9C/p1719497121007899), I've also given all of our `@keyframes` unique names to avoid unintentionally overwriting keyframes across components, which broke debouncing the activity item to begin with.

I also made the activity item indicator animation timing the same as the interrupt button, which I think feels better.

Lastly, I added the same fade in to the action bar separator. Before this PR, it would show immediately even though the interrupt button next to it faded in.

https://github.com/user-attachments/assets/1c24e135-1910-4f0d-907d-06dab8dbf142

#### QA Notes

It's worth playing around with different Positron components that animate to make sure the renames didn't break anything.