### PR TITLE
Run show-version scripts in node explicitly

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -253,7 +253,7 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 		const positronBuildNumber =
 			process.env.POSITRON_BUILD_NUMBER ??
 			child_process.execSync(
-				`${path.dirname(__dirname)}/versions/show-version.js --build`).toString().trim();
+				`node ${path.dirname(__dirname)}/versions/show-version.js --build`).toString().trim();
 
 		// --- End Positron ---
 

--- a/build/gulpfile.vscode.web.js
+++ b/build/gulpfile.vscode.web.js
@@ -88,7 +88,7 @@ const buildDate = new Date().toISOString();
 // Use the POSITRON_BUILD_NUMBER var if it's set; otherwise, call show-version to compute it.
 const buildNumber =
 	process.env.POSITRON_BUILD_NUMBER ??
-	child_process.execSync(`${REPO_ROOT}/versions/show-version.js --build`).toString().trim();
+	child_process.execSync(`node ${REPO_ROOT}/versions/show-version.js --build`).toString().trim();
 // --- End Positron ---
 
 /**


### PR DESCRIPTION
This change fixes an annoying issue in Windows dev environments that can cause Visual Studio to open during the incremental build. 

The problem is that Gulp is invoking `show-version.js`. On Unix-alikes, the shebang comment in this file causes it to run under Node, but on Windows, invoking the file opens it in the default editor for `.js` files. 

The fix is to use Node explicitly instead of relying on the shebang. 

### QA Notes

N/A, build change only.