### PR TITLE
Project Wizard Smoke Tests: Python Project with Conda environment

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -34,6 +34,13 @@ jobs:
           curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/DESCRIPTION --output DESCRIPTION
           Rscript -e "pak::local_install_dev_deps(ask = FALSE)"
 
+      # Instructions from: https://github.com/conda-forge/miniforge/?tab=readme-ov-file#downloading-the-installer-as-part-of-a-ci-pipeline
+      - name: Install Conda (Miniforge3)
+        run: |
+          wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+          sudo bash Miniforge3.sh -b -p "${HOME}/conda"
+          source "${HOME}/conda/etc/profile.d/conda.sh"
+
       - uses: actions/setup-node@v3
         with:
           node-version: 20

--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -12,8 +12,8 @@ import { PositronBaseElement, PositronTextElement } from './positronBaseElement'
 const PROJECT_WIZARD_PROJECT_NAME_INPUT =
 	'div[id="wizard-sub-step-project-name"] .wizard-sub-step-input input.text-input';
 
-// Configuration Step: Python Project & Jupyter Notebook
-const PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS =
+// Selector for the currently open dropdown popup items in the project wizard
+const PROJECT_WIZARD_DROPDOWN_POPUP_ITEMS =
 	'div.positron-modal-popup-children button.positron-button.item';
 
 /*
@@ -121,6 +121,7 @@ class ProjectWizardRConfigurationStep {
 class ProjectWizardPythonConfigurationStep {
 	newEnvRadioButton: PositronBaseElement;
 	existingEnvRadioButton: PositronBaseElement;
+	envProviderDropdown: Locator;
 	selectedInterpreterPath: PositronTextElement;
 	interpreterFeedback: PositronTextElement;
 	interpreterDropdown: Locator;
@@ -133,6 +134,9 @@ class ProjectWizardPythonConfigurationStep {
 		this.existingEnvRadioButton = new PositronBaseElement(
 			'div[id="wizard-step-set-up-python-environment"] div[id="wizard-sub-step-pythonenvironment-howtosetupenv"] .radio-button-input[id="existingEnvironment"]',
 			this.code
+		);
+		this.envProviderDropdown = this.code.driver.getLocator(
+			'div[id="wizard-sub-step-python-environment"] .wizard-sub-step-input button.drop-down-list-box'
 		);
 		this.selectedInterpreterPath = new PositronTextElement(
 			'div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-input button.drop-down-list-box .dropdown-entry-subtitle',
@@ -148,6 +152,32 @@ class ProjectWizardPythonConfigurationStep {
 	}
 
 	/**
+	 * Selects the specified environment provider in the project wizard environment provider dropdown.
+	 * @param provider The environment provider to select.
+	 */
+	async selectEnvProvider(provider: string) {
+		// Open the dropdown
+		await this.envProviderDropdown.click();
+
+		// Try to find the env provider in the dropdown
+		try {
+			await this.code.waitForElement(
+				PROJECT_WIZARD_DROPDOWN_POPUP_ITEMS
+			);
+			await this.code.driver
+				.getLocator(
+					`${PROJECT_WIZARD_DROPDOWN_POPUP_ITEMS} div.dropdown-entry-title:text-is("${provider}")`
+				)
+				.click();
+			return Promise.resolve();
+		} catch (error) {
+			return Promise.reject(
+				`Could not find env provider in project wizard dropdown: ${error}`
+			);
+		}
+	}
+
+	/**
 	 * Selects the interpreter corresponding to the given path in the project wizard interpreter
 	 * dropdown.
 	 * @param interpreterPath The path of the interpreter to select in the dropdown.
@@ -160,16 +190,16 @@ class ProjectWizardPythonConfigurationStep {
 		// Try to find the interpreterPath in the dropdown and click the entry if found
 		try {
 			await this.code.waitForElement(
-				PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS
+				PROJECT_WIZARD_DROPDOWN_POPUP_ITEMS
 			);
 			await this.code.driver
 				.getLocator(
-					`${PROJECT_WIZARD_INTERPRETER_DROPDOWN_POPUP_ITEMS} div.dropdown-entry-subtitle:text-is("${interpreterPath}")`
+					`${PROJECT_WIZARD_DROPDOWN_POPUP_ITEMS} div.dropdown-entry-subtitle:text-is("${interpreterPath}")`
 				)
 				.click();
 			return Promise.resolve();
 		} catch (error) {
-			// Couldn't find the relative or absolute path of the interpreter in the dropdown
+			// Couldn't find the path of the interpreter in the dropdown
 			return Promise.reject(
 				`Could not find interpreter path in project wizard dropdown: ${error}`
 			);

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -12,7 +12,7 @@ import { installAllHandlers } from '../../../utils';
  */
 export function setup(logger: Logger) {
 	describe('New Project Wizard', () => {
-		describe.only('Python - New Project Wizard', () => {
+		describe('Python - New Project Wizard', () => {
 			// Shared before/after handling
 			installAllHandlers(logger);
 

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -12,7 +12,7 @@ import { installAllHandlers } from '../../../utils';
  */
 export function setup(logger: Logger) {
 	describe('New Project Wizard', () => {
-		describe('Python - New Project Wizard', () => {
+		describe.only('Python - New Project Wizard', () => {
 			// Shared before/after handling
 			installAllHandlers(logger);
 
@@ -20,18 +20,46 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Python Project Defaults [C627912]', async function () {
-				const app = this.app as Application;
-				const pw = app.workbench.positronNewProjectWizard;
-				await pw.startNewProject();
-				await pw.projectTypeStep.pythonProjectButton.click();
-				await pw.nextButton.click();
-				await pw.nextButton.click();
-				await pw.disabledCreateButton.isNotVisible(500);
-				await pw.nextButton.click();
-				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
-				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myPythonProject');
-				await app.workbench.positronConsole.waitForReady('>>>', 10000);
+			describe('Python Project with new environment', () => {
+				it('Create a new Venv environment [C627912]', async function () {
+					// This is the default behaviour for a new Python Project in the Project Wizard
+					const app = this.app as Application;
+					const pw = app.workbench.positronNewProjectWizard;
+					await pw.startNewProject();
+					await pw.projectTypeStep.pythonProjectButton.click();
+					await pw.nextButton.click();
+					await pw.nextButton.click();
+					await pw.disabledCreateButton.isNotVisible(500);
+					await pw.nextButton.click();
+					await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
+					await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myPythonProject');
+					await app.workbench.positronConsole.waitForReady('>>>', 10000);
+				});
+				it('Create a new Conda environment [.......]', async function () {
+					// This test relies on Conda already being installed on the machine
+					const projSuffix = '_condaInstalled';
+					const app = this.app as Application;
+					const pw = app.workbench.positronNewProjectWizard;
+					await pw.startNewProject();
+					await pw.projectTypeStep.pythonProjectButton.click();
+					await pw.nextButton.click();
+					await pw.projectNameLocationStep.appendToProjectName(projSuffix);
+					await pw.nextButton.click();
+					// Select 'Conda' as the environment provider
+					await pw.pythonConfigurationStep.selectEnvProvider('Conda');
+					await pw.nextButton.click();
+					await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
+					await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
+						`myPythonProject${projSuffix}`
+					);
+					// Check that the `.conda` folder gets created in the project
+					expect(async () => {
+						const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();
+						expect(projectFiles).toContain('.conda');
+					}).toPass({ timeout: 10000 });
+					// The console should initialize without any prompts to install ipykernel
+					await app.workbench.positronConsole.waitForReady('>>>', 10000);
+				});
 			});
 
 			describe('Python Project with existing interpreter', () => {
@@ -42,6 +70,8 @@ export function setup(logger: Logger) {
 					const pythonFixtures = new PositronPythonFixtures(app);
 					// Start the Python interpreter and ensure ipykernel is installed
 					await pythonFixtures.startAndGetPythonInterpreter(true);
+					// Ensure the console is ready with the selected interpreter
+					await app.workbench.positronConsole.waitForReady('>>>', 10000);
 					const interpreterInfo = await app.workbench.startInterpreter.getSelectedInterpreterInfo();
 					expect(interpreterInfo?.path).toBeDefined();
 					// Create a new Python project and use the selected python interpreter
@@ -70,6 +100,8 @@ export function setup(logger: Logger) {
 					const pythonFixtures = new PositronPythonFixtures(app);
 					// Start the Python interpreter and uninstall ipykernel
 					await pythonFixtures.startAndGetPythonInterpreter(true);
+					// Ensure the console is ready with the selected interpreter
+					await app.workbench.positronConsole.waitForReady('>>>', 10000);
 					const interpreterInfo = await app.workbench.startInterpreter.getSelectedInterpreterInfo();
 					expect(interpreterInfo?.path).toBeDefined();
 					await app.workbench.positronConsole.typeToConsole('pip uninstall -y ipykernel');


### PR DESCRIPTION
## Description

- Addresses the Python Project conda env part of #3879

### Summary
- Add installation of conda to CI script `.github/workflows/positron-full-test.yml`
- Add handling for selecting the environment provider in the Project Wizard Python env provider dropdown
- Add new smoke test for creating a new Python project with a new Conda environment in the Project Wizard

### 🆕 Smoke Test
#### Python Project with new environment:
- Create a new Conda environment

### QA Notes

If you're testing this locally, make sure you have Conda installed! Either of the following are lighter-weight options than installing Anaconda:
- miniforge3: https://github.com/conda-forge/miniforge?tab=readme-ov-file#install
- miniconda: https://docs.anaconda.com/miniconda/#quick-command-line-install

Please add new test ID and verify this works on Windows too. Thank you!
