### PR TITLE
Provide context to notebook output webview renderers

### DIFF
--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -207,7 +207,7 @@ declare module 'positron' {
 	/** LanguageRuntimeOutput is a LanguageRuntimeMessage representing output (text, plots, etc.) */
 	export interface LanguageRuntimeOutput extends LanguageRuntimeMessage {
 		/** A record of data MIME types to the associated data, e.g. `text/plain` => `'hello world'` */
-		data: Record<string, string>;
+		data: Record<string, any>;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -44,7 +44,6 @@ import { MergeEditorInput } from 'vs/workbench/contrib/mergeEditor/browser/merge
 import type { EditorInputWithOptions, IResourceMergeEditorInput } from 'vs/workbench/common/editor';
 
 // --- Start Positron ---
-import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { PositronNotebookEditorInput } from 'vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput';
 import { getShouldUsePositronEditor } from 'vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution';
 // --- End Positron ---
@@ -791,26 +790,6 @@ export class NotebookService extends Disposable implements INotebookService {
 			return undefined;
 		}
 		return this._notebookRenderersInfoStore.get(renderers[0].rendererId);
-	}
-
-	/**
-	 * Gets the static notebook preloads associated with the given extension.
-	 *
-	 * @param extensionId The ID of the extension to get static preloads for
-	 * @returns The static preloads for the extension
-	 */
-	async getStaticPreloadsForExt(extensionId: ExtensionIdentifier):
-		Promise<INotebookStaticPreloadInfo[]> {
-
-		const extInfo = await this._extensionService.getExtension(extensionId.value);
-
-		const results: INotebookStaticPreloadInfo[] = [];
-		for (const preload of this._notebookStaticPreloadInfoStore) {
-			if (preload.extensionLocation === extInfo?.extensionLocation) {
-				results.push(preload);
-			}
-		}
-		return results;
 	}
 	// --- End Positron ---
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -488,9 +488,34 @@ export interface IPerformanceMessage extends BaseToWebviewMessage {
 	readonly outputSize?: number;
 	readonly mimeType?: string;
 }
+// --- Start Positron ---
+/**
+ * Request the webview to render an output to an element.
+ */
+export interface IPositronRenderMessage {
+	readonly type: 'positronRender';
+	readonly outputId: string;
+	readonly elementId: string;
+	readonly rendererId: string;
+	readonly mimeType: string;
+	readonly metadata: unknown;
+	readonly valueBytes: Uint8Array;
+}
+
+/**
+ * Message sent by the webview when the widget has finished rendering; used to
+ * coordinate thumbnail generation.
+ */
+export interface IPositronRenderCompleteMessage extends BaseToWebviewMessage {
+	readonly type: 'positronRenderComplete';
+}
+// --- End Positron ---
 
 
 export type FromWebviewMessage = WebviewInitialized |
+	// --- Start Positron ---
+	IPositronRenderCompleteMessage |
+	// --- End Positron ---
 	IDimensionMessage |
 	IMouseEnterMessage |
 	IMouseLeaveMessage |
@@ -525,6 +550,9 @@ export type FromWebviewMessage = WebviewInitialized |
 	IPerformanceMessage;
 
 export type ToWebviewMessage = IClearMessage |
+	// --- Start Positron ---
+	IPositronRenderMessage |
+	// --- End Positron ---
 	IFocusOutputMessage |
 	IBlurOutputMessage |
 	IAckOutputHeightMessage |

--- a/src/vs/workbench/contrib/notebook/common/notebookService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookService.ts
@@ -19,9 +19,6 @@ import { ITextQuery } from 'vs/workbench/services/search/common/search';
 import { NotebookPriorityInfo } from 'vs/workbench/contrib/search/common/search';
 import { INotebookFileMatchNoModel } from 'vs/workbench/contrib/search/common/searchNotebookHelpers';
 
-// --- Start Positron ---
-import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
-// --- End Positron ---
 
 export const INotebookService = createDecorator<INotebookService>('notebookService');
 
@@ -78,7 +75,6 @@ export interface INotebookService {
 
 	// --- Start Positron ---
 	getPreferredRenderer(mimeType: string): INotebookRendererInfo | undefined;
-	getStaticPreloadsForExt(extensionId: ExtensionIdentifier): Promise<INotebookStaticPreloadInfo[]>;
 	// --- End Positron ---
 
 	getStaticPreloads(viewType: string): Iterable<INotebookStaticPreloadInfo>;

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
@@ -5,7 +5,6 @@
 
 import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
-import { INotebookWebviewMessage } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { FromWebviewMessage } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages';
 import { INotebookOutputWebview } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
 import { IOverlayWebview, } from 'vs/workbench/contrib/webview/browser/webview';
@@ -17,7 +16,6 @@ import { IOverlayWebview, } from 'vs/workbench/contrib/webview/browser/webview';
 export class NotebookOutputWebview extends Disposable implements INotebookOutputWebview {
 
 	private readonly _onDidRender = new Emitter<void>;
-	private readonly _onDidReceiveMessage = new Emitter<INotebookWebviewMessage>();
 
 	/**
 	 * Create a new notebook output webview.
@@ -36,9 +34,7 @@ export class NotebookOutputWebview extends Disposable implements INotebookOutput
 		super();
 
 		this.onDidRender = this._onDidRender.event;
-		this.onDidReceiveMessage = this._onDidReceiveMessage.event;
 		this._register(this._onDidRender);
-		this._register(this._onDidReceiveMessage);
 
 		this._register(webview.onMessage(e => {
 			const data: FromWebviewMessage | { readonly __vscode_notebook_message: undefined } = e.message;
@@ -51,24 +47,12 @@ export class NotebookOutputWebview extends Disposable implements INotebookOutput
 				case 'positronRenderComplete':
 					this._onDidRender.fire();
 					break;
-				case 'customKernelMessage':
-					this._onDidReceiveMessage.fire({ message: data.message });
-					break;
 			}
 
 		}));
 	}
 
 	onDidRender: Event<void>;
-	onDidReceiveMessage: Event<INotebookWebviewMessage>;
-
-	postMessage(message: unknown): void {
-		this.webview.postMessage({
-			__vscode_notebook_message: true,
-			type: 'customKernelMessage',
-			message
-		});
-	}
 
 	public override dispose(): void {
 		this.webview.dispose();

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
@@ -30,7 +30,9 @@ export class NotebookOutputWebview extends Disposable implements INotebookOutput
 	constructor(
 		readonly id: string,
 		readonly sessionId: string,
-		readonly webview: IOverlayWebview) {
+		readonly webview: IOverlayWebview,
+		readonly render?: () => void,
+	) {
 		super();
 
 		this.onDidRender = this._onDidRender.event;

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
@@ -5,12 +5,10 @@
 
 import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
+import { INotebookWebviewMessage } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { FromWebviewMessage } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages';
 import { INotebookOutputWebview } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
 import { IOverlayWebview, } from 'vs/workbench/contrib/webview/browser/webview';
-
-// Message sent by the webview when the widget has finished rendering; used to
-// coordinate thumbnail generation.
-export const RENDER_COMPLETE = 'render_complete';
 
 /**
  * A notebook output webview wraps a webview that contains rendered HTML content
@@ -19,13 +17,14 @@ export const RENDER_COMPLETE = 'render_complete';
 export class NotebookOutputWebview extends Disposable implements INotebookOutputWebview {
 
 	private readonly _onDidRender = new Emitter<void>;
+	private readonly _onDidReceiveMessage = new Emitter<INotebookWebviewMessage>();
 
 	/**
 	 * Create a new notebook output webview.
 	 *
 	 * @param id A unique ID for this webview; typically the ID of the message
 	 *   that created it.
-	 * @param runtimeId The ID of the runtime that owns this webview.
+	 * @param sessionId The ID of the runtime that owns this webview.
 	 * @param webview The underlying webview.
 	 */
 	constructor(
@@ -35,16 +34,39 @@ export class NotebookOutputWebview extends Disposable implements INotebookOutput
 		super();
 
 		this.onDidRender = this._onDidRender.event;
+		this.onDidReceiveMessage = this._onDidReceiveMessage.event;
 		this._register(this._onDidRender);
+		this._register(this._onDidReceiveMessage);
 
 		this._register(webview.onMessage(e => {
-			if (e.message === RENDER_COMPLETE) {
-				this._onDidRender.fire();
+			const data: FromWebviewMessage | { readonly __vscode_notebook_message: undefined } = e.message;
+
+			if (!data.__vscode_notebook_message) {
+				return;
 			}
+
+			switch (data.type) {
+				case 'positronRenderComplete':
+					this._onDidRender.fire();
+					break;
+				case 'customKernelMessage':
+					this._onDidReceiveMessage.fire({ message: data.message });
+					break;
+			}
+
 		}));
 	}
 
 	onDidRender: Event<void>;
+	onDidReceiveMessage: Event<INotebookWebviewMessage>;
+
+	postMessage(message: unknown): void {
+		this.webview.postMessage({
+			__vscode_notebook_message: true,
+			type: 'customKernelMessage',
+			message
+		});
+	}
 
 	public override dispose(): void {
 		this.webview.dispose();

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -8,6 +8,7 @@ import { IOverlayWebview } from 'vs/workbench/contrib/webview/browser/webview';
 import { ILanguageRuntimeMessageOutput } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { Event } from 'vs/base/common/event';
+import { INotebookWebviewMessage } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 
 export const POSITRON_NOTEBOOK_OUTPUT_WEBVIEW_SERVICE_ID = 'positronNotebookOutputWebview';
 
@@ -27,6 +28,12 @@ export interface INotebookOutputWebview {
 
 	/** Fired when the content completes rendering */
 	onDidRender: Event<void>;
+
+	/** Fired when a message has been received from the webview */
+	onDidReceiveMessage: Event<INotebookWebviewMessage>;
+
+	/** Send a message to the webview */
+	postMessage(message: unknown): void;
 }
 
 export interface IPositronNotebookOutputWebviewService {
@@ -39,12 +46,15 @@ export interface IPositronNotebookOutputWebviewService {
 	 *
 	 * @param runtime The runtime that emitted the output
 	 * @param output The message containing the contents to be rendered in the webview.
+	 * @param viewType The view type of the notebook e.g 'jupyter-notebook', if known. Used to
+	 *  select the required notebook preload scripts for the webview.
 	 * @returns A promise that resolves to the new webview, or undefined if the
 	 *   output does not have a suitable renderer.
 	 */
 	createNotebookOutputWebview(
 		runtime: ILanguageRuntimeSession,
-		output: ILanguageRuntimeMessageOutput
+		output: ILanguageRuntimeMessageOutput,
+		viewType?: string,
 	): Promise<INotebookOutputWebview | undefined>;
 }
 

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -34,6 +34,8 @@ export interface INotebookOutputWebview {
 
 	/** Send a message to the webview */
 	postMessage(message: unknown): void;
+
+	render?(): void;
 }
 
 export interface IPositronNotebookOutputWebviewService {

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -8,7 +8,6 @@ import { IOverlayWebview } from 'vs/workbench/contrib/webview/browser/webview';
 import { ILanguageRuntimeMessageOutput } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { Event } from 'vs/base/common/event';
-import { INotebookWebviewMessage } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 
 export const POSITRON_NOTEBOOK_OUTPUT_WEBVIEW_SERVICE_ID = 'positronNotebookOutputWebview';
 
@@ -29,12 +28,10 @@ export interface INotebookOutputWebview {
 	/** Fired when the content completes rendering */
 	onDidRender: Event<void>;
 
-	/** Fired when a message has been received from the webview */
-	onDidReceiveMessage: Event<INotebookWebviewMessage>;
-
-	/** Send a message to the webview */
-	postMessage(message: unknown): void;
-
+	/**
+	 * Optional method to render the output in the webview rather than doing so
+	 * directly in the HTML content
+	 */
 	render?(): void;
 }
 

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -3,16 +3,15 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { VSBuffer, encodeBase64 } from 'vs/base/common/buffer';
+import { VSBuffer } from 'vs/base/common/buffer';
 import { Schemas } from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
-import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
-import { RendererMetadata, StaticPreloadMetadata } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages';
+import { IPositronRenderMessage, RendererMetadata, StaticPreloadMetadata } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages';
 import { preloadsScriptStr } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads';
 import { INotebookRendererInfo, RendererMessagingSpec } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
-import { NotebookOutputWebview, RENDER_COMPLETE } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview';
+import { NotebookOutputWebview } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview';
 import { INotebookOutputWebview, IPositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
 import { IWebviewService, WebviewInitInfo } from 'vs/workbench/contrib/webview/browser/webview';
 import { asWebviewUri } from 'vs/workbench/contrib/webview/common/webview';
@@ -20,6 +19,7 @@ import { IExtensionService } from 'vs/workbench/services/extensions/common/exten
 import { ILanguageRuntimeMessageWebOutput } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { MIME_TYPE_WIDGET_STATE, MIME_TYPE_WIDGET_VIEW, IPyWidgetViewSpec } from 'vs/workbench/services/positronIPyWidgets/common/positronIPyWidgetsService';
+import { dirname } from 'vs/base/common/resources';
 
 export class PositronNotebookOutputWebviewService implements IPositronNotebookOutputWebviewService {
 
@@ -37,7 +37,8 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 
 	async createNotebookOutputWebview(
 		runtime: ILanguageRuntimeSession,
-		output: ILanguageRuntimeMessageWebOutput
+		output: ILanguageRuntimeMessageWebOutput,
+		viewType?: string,
 	): Promise<INotebookOutputWebview | undefined> {
 		// Check to see if any of the MIME types have a renderer associated with
 		// them. If they do, prefer the renderer.
@@ -58,7 +59,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 			const renderer = this._notebookService.getPreferredRenderer(mimeType);
 			if (renderer) {
 				return this.createNotebookRenderOutput(output.id, runtime,
-					renderer, mimeType, output);
+					renderer, mimeType, output, viewType);
 			}
 		}
 
@@ -109,9 +110,12 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 	/**
 	 * Gets the static preloads for a given extension.
 	 */
-	private async getStaticPreloadsData(ext: ExtensionIdentifier):
+	private async getStaticPreloadsData(viewType: string | undefined):
 		Promise<StaticPreloadMetadata[]> {
-		const preloads = await this._notebookService.getStaticPreloadsForExt(ext);
+		if (!viewType) {
+			return [];
+		}
+		const preloads = this._notebookService.getStaticPreloads(viewType);
 		return Array.from(preloads, preload => {
 			return {
 				entrypoint: this.asWebviewUri(preload.entrypoint, preload.extensionLocation)
@@ -121,17 +125,47 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 		});
 	}
 
+	private getResourceRoots(
+		message: ILanguageRuntimeMessageWebOutput,
+		renderer: INotebookRendererInfo,
+		viewType: string | undefined,
+	): URI[] {
+
+		const resourceRoots = new Array<URI>();
+
+		// Ensure that the renderer can load local resources from
+		// the extension that provides it
+		resourceRoots.push(renderer.extensionLocation);
+
+		if (viewType) {
+			for (const preload of this._notebookService.getStaticPreloads(viewType)) {
+				// Add each preload's parent folder
+				resourceRoots.push(dirname(preload.entrypoint));
+
+				// Add each preload's local resource roots
+				resourceRoots.push(...preload.localResourceRoots);
+			}
+		}
+
+		// Add auxiliary resource roots contained in the runtime message
+		// These are currently used by positron-r's htmlwidgets renderer
+		if (message.resource_roots) {
+			for (const root of message.resource_roots) {
+				resourceRoots.push(URI.revive(root));
+			}
+		}
+		return resourceRoots;
+	}
+
 	private async createNotebookRenderOutput(id: string,
 		runtime: ILanguageRuntimeSession,
 		renderer: INotebookRendererInfo,
 		mimeType: string,
-		message: ILanguageRuntimeMessageWebOutput
+		message: ILanguageRuntimeMessageWebOutput,
+		viewType?: string,
 	): Promise<INotebookOutputWebview> {
 
 		const data = message.data[mimeType] as any;
-
-		// Get the renderer's entrypoint and convert it to a webview URI
-		const rendererPath = asWebviewUri(renderer.entrypoint.path);
 
 		// Create the preload script contents. This is a simplified version of the
 		// preloads script that the notebook renderer API creates.
@@ -151,18 +185,9 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 			minimalError: false,
 		},
 			this.getRendererData(mimeType),
-			await this.getStaticPreloadsData(renderer.extensionId),
+			await this.getStaticPreloadsData(viewType),
 			this._workspaceTrustManagementService.isWorkspaceTrusted(),
 			id);
-
-		// Get auxiliary resource roots from the runtime service and convert
-		// them to webview URIs
-		const resourceRoots = new Array<URI>();
-		if (message.resource_roots) {
-			for (const root of message.resource_roots) {
-				resourceRoots.push(URI.revive(root));
-			}
-		}
 
 		// Create the metadata for the webview
 		const webviewInitInfo: WebviewInitInfo = {
@@ -171,12 +196,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 				// Needed since we use the API ourselves, and it's also used by
 				// preload scripts
 				allowMultipleAPIAcquire: true,
-				localResourceRoots: [
-					// Ensure that the renderer can load local resources from
-					// the extension that provides it
-					renderer.extensionLocation,
-					...resourceRoots
-				],
+				localResourceRoots: this.getResourceRoots(message, renderer, viewType),
 			},
 			extension: {
 				id: renderer.extensionId,
@@ -188,20 +208,8 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 		// Create the webview itself
 		const webview = this._webviewService.createWebviewOverlay(webviewInitInfo);
 
-		// Encode the data as base64, as either a raw string or JSON object
-		const rawData = encodeBase64(
-			typeof (data) === 'string' ? VSBuffer.fromString(data) :
-				VSBuffer.fromString(JSON.stringify(data)));
-
 		// Form the HTML to send to the webview. Currently, this is a very simplified version
 		// of the HTML that the notebook renderer API creates, but it works for many renderers.
-		//
-		// Some features known to be NYI:
-		// - Message passing between the renderer and the host (RenderContext)
-		// - Extending another renderer (RenderContext)
-		// - State management (RenderContext)
-		// - Raw Uint8Array data and blobs
-
 		webview.setHtml(`
 <head>
 	<style nonce="${id}">
@@ -214,44 +222,26 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 <body>
 <div id='container'></div>
 <div id="_defaultColorPalatte"></div>
-<script type="module">
-	const vscode = acquireVsCodeApi();
-	import { activate } from "${rendererPath.toString()}"
-
-	// A stub implementation of RendererContext
-	var ctx = {
-		workspace: {
-			isTrusted: ${this._workspaceTrustManagementService.isWorkspaceTrusted()}
-		}
-	}
-
-	// Activate the renderer and create the data object
-	var renderer = activate(ctx);
-	var utf8bytes = Uint8Array.from(atob('${rawData}'), (m) => m.codePointAt(0));
-	var rawData = new TextDecoder().decode(utf8bytes);
-	var data = {
-		id: '${id}',
-		mime: '${mimeType}',
-		text: () => { return rawData },
-		json: () => { return JSON.parse(rawData) },
-		data: () => { return new Uint8Array() /* NYI */ },
-		blob: () => { return new Blob(); /* NYI */ },
-	};
-
-	const controller = new AbortController();
-	const signal = controller.signal;
-
-	// Render the widget when the page is loaded, then post a message to the
-	// host letting it know that render is complete.
-	window.onload = function() {
-		let container = document.getElementById('container');
-		renderer.renderOutputItem(data, container, signal);
-		vscode.postMessage('${RENDER_COMPLETE}');
-	};
-</script>
 <script type="module">${preloads}</script>
 </body>
 `);
+
+		// Send a message to the webview to render the output.
+		const valueBytes = typeof (data) === 'string' ? VSBuffer.fromString(data) :
+			VSBuffer.fromString(JSON.stringify(data));
+		// TODO: We may need to pass valueBytes.buffer (or some version of it) as the `transfer`
+		//   argument to postMessage.
+		const transfer: ArrayBuffer[] = [];
+		const webviewMessage: IPositronRenderMessage = {
+			type: 'positronRender',
+			outputId: id,
+			elementId: 'container',
+			rendererId: renderer.id,
+			mimeType,
+			metadata: message.metadata,
+			valueBytes: valueBytes.buffer,
+		};
+		webview.postMessage(webviewMessage, transfer);
 
 		return new NotebookOutputWebview(id, runtime.runtimeMetadata.runtimeId, webview);
 	}
@@ -302,7 +292,10 @@ ${html}
 <script>
 const vscode = acquireVsCodeApi();
 window.onload = function() {
-	vscode.postMessage('${RENDER_COMPLETE}');
+	vscode.postMessage({
+		__vscode_notebook_message: true,
+		type: 'positronRenderComplete',
+	});
 };
 </script>`);
 		return new NotebookOutputWebview(id, runtime.runtimeMetadata.runtimeId, webview);
@@ -399,8 +392,11 @@ ${managerState}
 <script>
 	const vscode = acquireVsCodeApi();
 	window.onload = function() {
-		vscode.postMessage('${RENDER_COMPLETE}');
-};
+		vscode.postMessage({
+			__vscode_notebook_message: true,
+			type: 'positronRenderComplete',
+		});
+	};
 </script>
 </html>
 		`);

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -127,15 +127,15 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 
 	private getResourceRoots(
 		message: ILanguageRuntimeMessageWebOutput,
-		renderer: INotebookRendererInfo,
 		viewType: string | undefined,
 	): URI[] {
 
 		const resourceRoots = new Array<URI>();
 
-		// Ensure that the renderer can load local resources from
-		// the extension that provides it
-		resourceRoots.push(renderer.extensionLocation);
+		for (const renderer of this._notebookService.getRenderers()) {
+			// Add each renderer's parent folder
+			resourceRoots.push(dirname(renderer.entrypoint.path));
+		}
 
 		if (viewType) {
 			for (const preload of this._notebookService.getStaticPreloads(viewType)) {
@@ -194,7 +194,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 				// Needed since we use the API ourselves, and it's also used by
 				// preload scripts
 				allowMultipleAPIAcquire: true,
-				localResourceRoots: this.getResourceRoots(message, renderer, viewType),
+				localResourceRoots: this.getResourceRoots(message, viewType),
 			},
 			extension: {
 				id: renderer.extensionId,

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -108,7 +108,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 	}
 
 	/**
-	 * Gets the static preloads for a given extension.
+	 * Gets the static preloads for a given view type.
 	 */
 	private async getStaticPreloadsData(viewType: string | undefined):
 		Promise<StaticPreloadMetadata[]> {
@@ -125,6 +125,9 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 		});
 	}
 
+	/**
+	 * Gets the resource roots for a given message and view type.
+	 */
 	private getResourceRoots(
 		message: ILanguageRuntimeMessageWebOutput,
 		viewType: string | undefined,

--- a/src/vs/workbench/contrib/positronPlots/browser/webviewPlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/webviewPlotClient.ts
@@ -84,6 +84,7 @@ export class WebviewPlotClient extends Disposable implements IPositronPlotClient
 	 */
 	public claim(claimant: any) {
 		this.webview.webview.claim(claimant, DOM.getWindow(this._element), undefined);
+		this.webview.render?.();
 		this._claimed = true;
 	}
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -125,7 +125,7 @@ export interface ILanguageRuntimeMessageOutput extends ILanguageRuntimeMessage {
 	readonly kind: RuntimeOutputKind;
 
 	/** A record of data MIME types to the associated data, e.g. `text/plain` => `'hello world'` */
-	readonly data: Record<string, string>;
+	readonly data: Record<string, any>;
 }
 
 /**


### PR DESCRIPTION
Another step toward #3276.

This PR moves the rendering of our notebook output webview service to inside the webview, giving the notebook renderer access to features which previously did not work, including (from the code):

> Some features known to be NYI:
> - Message passing between the renderer and the host (RenderContext)
> - Extending another renderer (RenderContext)
> - State management (RenderContext)
> - Raw Uint8Array data and blobs

We do this by listening for a new `positronRender` message inside the webview. I also changed our `render_complete` message to `positronRenderComplete` and added it to the known message types.

I also made some changes to how we determine the required preloads and resource roots to bring it more in line with the backlayer webview:

1. **Preloads:** We get preloads by view type instead of by extension.
2. **Resource roots:**
    1. Removed the renderer's extension folder.
    2. Added each renderer's parent folder.
    3. Added each preload's parent folder.
    4. Added each preload's specified `localResourceRoots`.

### QA Notes

This should not break any existing widgets/plots/HTML outputs. Here are some tests for different code paths:

1. R html content: `gt::gt(mtcars)`
2. Python notebook renderer: `import plotly.express as px; px.bar(x=["a", "b", "c"], y=[1, 3, 2])`
3. R notebook renderer: `library(plotly); plot_ly(data = iris, x = ~Sepal.Length, y = ~Petal.Length)`
4. Python custom ipywidgets webview: `from ipyleaflet import Map; display(Map(center=(52.204793, 360.121558), zoom=12))`