### PR TITLE
Fix welcome logo

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -20,7 +20,7 @@ import { splitRecentLabel } from 'vs/base/common/labels';
 import { DisposableStore, toDisposable } from 'vs/base/common/lifecycle';
 import { ILink, LinkedText } from 'vs/base/common/linkedText';
 import { parse } from 'vs/base/common/marshalling';
-import { FileAccess, Schemas, matchesScheme } from 'vs/base/common/network';
+import { Schemas, matchesScheme } from 'vs/base/common/network';
 import { isMacintosh } from 'vs/base/common/platform';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { assertIsDefined } from 'vs/base/common/types';
@@ -832,9 +832,8 @@ export class GettingStartedPage extends EditorPane {
 			$('h1.product-name.positron.caption', {}, this.productService.nameLong),
 			$('p.subtitle.positron.description', {}, localize({ key: 'gettingStarted.editingEvolved', comment: ['Shown as subtitle on the Welcome page.'] }, "an IDE for data science"))
 		);
-		const logoPath = FileAccess.asBrowserUri('vs/workbench/browser/media/positron-icon.svg');
 		const header = $('.header', {},
-			$('img.product-logo.welcome-positron-logo', { src: logoPath }),
+			$('div.product-logo.welcome-positron-logo.'),
 			headerText
 		);
 

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/positronGettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/positronGettingStarted.css
@@ -12,9 +12,12 @@
 	row-gap: 50px;
 }
 
-.gettingStartedContainer .product-logo.welcome-positron-logo {
+.gettingStartedContainer .product-logo.welcome-positron-logo::before {
 	width: 6em;
 	height: 6em;
+	content: ' ';
+	background-image: url('../../../../browser/media/positron-icon.svg');
+	display: block;
 }
 
 .gettingStartedContainer .welcome-page-section {


### PR DESCRIPTION
Address the image referencing problem revealed from #3996

Reference SVG in style sheet so optimizer handles it correctly

### QA Notes
The welcome screen should show the Positron logo.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
