### PR TITLE
Add improved logging for Data Explorer 100x100 test

### DIFF
--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -92,7 +92,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 					const cell = await app.code.waitForElement(`#data-grid-row-cell-content-${columnIndex}-${rowIndex} .text-container .text-value`);
 
 					// Test the cell.
-					expect(cell.textContent).toStrictEqual(row[columnIndex]);
+					expect(cell.textContent, `${rowIndex},${columnIndex}`).toStrictEqual(row[columnIndex]);
 
 					// Move to the next cell.
 					await app.workbench.positronDataExplorer.arrowRight();


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR improves the logging for the Data Explorer 100x100 test by outputting row and column information in the `expect` test case.

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
