### PR TITLE
Differentiate special values in Data Explorer with opacity

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.css
@@ -3,40 +3,33 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.data-grid-row-cell
-.content
-.text-container {
+.data-grid-row-cell .content .text-container {
 	height: 100%;
 	display: flex;
 	margin: 0 7px;
 	align-items: center;
 }
 
-.data-grid-row-cell
-.content
-.text-container.left {
+.data-grid-row-cell .content .text-container.left {
 	justify-content: left;
 }
 
-.data-grid-row-cell
-.content
-.text-container.center {
+.data-grid-row-cell .content .text-container.center {
 	justify-content: center;
 }
 
-.data-grid-row-cell
-.content
-.text-container.right {
+.data-grid-row-cell .content .text-container.right {
 	justify-content: right;
 	font-variant-numeric: tabular-nums;
 }
 
-.data-grid-row-cell
-.content
-.text-container
-.text-value {
+.data-grid-row-cell .content .text-container .text-value {
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	white-space-collapse: preserve;
+}
+
+.data-grid-row-cell .content .text-container .text-value.special-value {
+	opacity: 0.60;
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
@@ -11,8 +11,8 @@ import * as React from 'react';
 
 // Other dependencies.
 import { positronClassNames } from 'vs/base/common/positronUtilities';
+import { DataCell, DataCellKind } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
 import { PositronDataExplorerColumn } from 'vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn';
-import { DataCell } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
 
 /**
  * TableDataCellProps interface.
@@ -28,10 +28,16 @@ interface TableDataCellProps {
  * @returns The rendered component.
  */
 export const TableDataCell = (props: TableDataCellProps) => {
+	// Set the class names.
+	const classNames = positronClassNames(
+		'text-value',
+		{ 'special-value': props.dataCell.kind !== DataCellKind.NON_NULL }
+	);
+
 	// Render.
 	return (
 		<div className={positronClassNames('text-container', props.column.alignment)}>
-			<div className='text-value'>
+			<div className={classNames}>
 				{props.dataCell.formatted.replace(/\r/g, '\\r').replace(/\n/g, '\\n')}
 			</div>
 		</div>


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

See: https://github.com/posit-dev/positron/issues/2860

This PR differentiates special values in Data Explorer by rendering them at 65% opacity.

For example, execute the following code:

```
import pandas as pd
df = pd.DataFrame([['ant', 'bee', None, float('nan')], ['None', None, 'fly', float('nan')]])
```

And open the resulting data frame in Data Explorer.

And you will notice that the cells containing `None` and `float('nan')` are rendered at 65% opacity to differentiate them from normal, non-null values (like 'ant', 'bee', 'None', and 'fly').

<img width="1240" alt="image" src="https://github.com/user-attachments/assets/c4b2a9e5-cadb-40a0-9e0c-0189142f02f5">

This applies to data cell values of the following kinds:

NULL
NA
NaN
NotATime
None
INFINITY
NEG_INFINITY
UNKNOWN

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

I'd like to generate some example of these values in the `qa-example-content` repo. I will do this soon.
