### PR TITLE
Fix typo in polars test

### DIFF
--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -75,7 +75,7 @@ df = pd.DataFrame(data)`;
 		describe('Python Polars Data Explorer', () => {
 			before(async function () {
 
-				await PositronRFixtures.SetupFixtures(this.app as Application);
+				await PositronPythonFixtures.SetupFixtures(this.app as Application);
 
 			});
 
@@ -165,10 +165,7 @@ df = pd.DataFrame(data)`;
 		describe('R Data Explorer', () => {
 
 			before(async function () {
-				const app = this.app as Application;
-
-				const rFixtures = new PositronRFixtures(app);
-				await rFixtures.startRInterpreter();
+				await PositronRFixtures.SetupFixtures(this.app as Application);
 
 			});
 


### PR DESCRIPTION
Just a minor typo fix and another cleanup.  The polars test was using the R fixture.

### QA Notes

All smoke tests should pass.