### PR TITLE
Skipping failing DataExplorer Column sort test

### DIFF
--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -133,7 +133,8 @@ df = pd.DataFrame(data)`;
 				expect(tableData.length).toBe(2);
 			});
 
-			it('Python Polars - Add Simple Column Sort [C557561]', async function () {
+			// Skip due to issue https://github.com/posit-dev/positron/issues/4070
+			it.skip('Python Polars - Add Simple Column Sort [C557561]', async function () {
 				const app = this.app as Application;
 				await app.workbench.positronDataExplorer.selectColumnMenuItem(1, 'Sort Descending');
 


### PR DESCRIPTION
### Intent

Due to https://github.com/posit-dev/positron/issues/4070 this test needs to be skipped for run stability


### QA Notes

Test should be enabled once issue is resolved.