### PR TITLE
Add non-overlay webview creation to notebook webview service and use for rendering html in positron notebooks

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -56,6 +56,7 @@ import { IWebviewService } from 'vs/workbench/contrib/webview/browser/webview';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IPositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
 
 
 interface NotebookLayoutInfo {
@@ -117,6 +118,7 @@ export class PositronNotebookEditor extends EditorPane {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ITextModelService private readonly _textModelResolverService: ITextModelService,
 		@IWebviewService private readonly _webviewService: IWebviewService,
+		@IPositronNotebookOutputWebviewService private readonly _notebookWebviewService: IPositronNotebookOutputWebviewService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@ILogService private readonly _logService: ILogService,
 		@ICommandService private readonly _commandService: ICommandService,
@@ -454,6 +456,7 @@ export class PositronNotebookEditor extends EditorPane {
 					instantiationService: this._instantiationService,
 					textModelResolverService: this._textModelResolverService,
 					webviewService: this._webviewService,
+					notebookWebviewService: this._notebookWebviewService,
 					commandService: this._commandService,
 					logService: this._logService,
 					openerService: this._openerService,

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -146,7 +146,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	// =============================================================================================
 	// #region Public Properties
 
-	identifier: string = `positron.notebook.instance.${PositronNotebookInstance._count++}`;
+	id: string = `positron.notebook.instance.${PositronNotebookInstance._count++}`;
 
 	/**
 	 * User facing cells wrapped in an observerable for the UI to react to changes
@@ -214,7 +214,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		if (this._notebookOptions) {
 			return this._notebookOptions;
 		}
-		this._logService.info(this.identifier, 'Generating new notebook options');
+		this._logService.info(this.id, 'Generating new notebook options');
 
 		this._notebookOptions = this._creationOptions?.options ?? new NotebookOptions(
 			DOM.getActiveWindow(),
@@ -294,7 +294,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 					return;
 				}
 
-				this._logService.info(this.identifier, `Selecting kernel ${kernel.id} for notebook`);
+				this._logService.info(this.id, `Selecting kernel ${kernel.id} for notebook`);
 				this.notebookKernelService.selectKernelForNotebook(kernel, this.textModel);
 			})
 		);
@@ -314,12 +314,12 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			})
 		);
 
-		this._logService.info(this.identifier, 'constructor');
+		this._logService.info(this.id, 'constructor');
 	}
 
 	override dispose() {
 
-		this._logService.info(this.identifier, 'dispose');
+		this._logService.info(this.id, 'dispose');
 		this._positronNotebookService.unregisterInstance(this);
 
 		super.dispose();
@@ -453,7 +453,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 		this._setupKeyboardNavigation(container);
 
-		this._logService.info(this.identifier, 'attachView');
+		this._logService.info(this.id, 'attachView');
 	}
 
 	/**
@@ -496,7 +496,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 	detachView(): void {
 		this._container = undefined;
-		this._logService.info(this.identifier, 'detachView');
+		this._logService.info(this.id, 'detachView');
 		this._clearKeyboardNavigation?.();
 		this._notebookOptions?.dispose();
 		this._detachModel();
@@ -622,13 +622,13 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	private async _runCells(cells: IPositronNotebookCell[]): Promise<void> {
 		// Filter so we're only working with code cells.
 		const codeCells = cells;
-		this._logService.info(this.identifier, '_runCells');
+		this._logService.info(this.id, '_runCells');
 
 		this._assertTextModel();
 
 		// Make sure we have a kernel to run the cells.
 		if (this.kernelStatus.get() !== KernelStatus.Connected) {
-			this._logService.info(this.identifier, 'No kernel connected, attempting to connect');
+			this._logService.info(this.id, 'No kernel connected, attempting to connect');
 			// Attempt to connect to the kernel
 			await this._commandService.executeCommand(
 				SELECT_KERNEL_ID_POSITRON,
@@ -685,7 +685,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Remove and cleanup the current model for notebook.
 	 */
 	private _detachModel() {
-		this._logService.info(this.identifier, 'detachModel');
+		this._logService.info(this.id, 'detachModel');
 		// Clear store of disposables
 		this._modelStore.clear();
 		this._viewModel?.dispose();

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -36,6 +36,7 @@ import { SELECT_KERNEL_ID_POSITRON, SelectPositronNotebookKernelContext } from '
 import { INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
 import { ILanguageRuntimeSession, IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
+import { isEqual } from 'vs/base/common/resources';
 
 interface IPositronNotebookInstanceRequiredViewModel extends IPositronNotebookInstance {
 	viewModel: NotebookViewModel;
@@ -526,7 +527,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @returns True if the uri is the same as the notebook's uri, false otherwise.
 	 */
 	private _isThisNotebook(uri: URI): boolean {
-		return uri.path === this._input.resource.path;
+		return isEqual(uri, this._input.resource);
 	}
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -90,8 +90,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	// =============================================================================================
 	// #region Private Properties
 
-	private _identifier: string = `Positron Notebook | NotebookInstance(${PositronNotebookInstance._count++}) |`;
-
 	/**
 	 * Internal cells that we use to manage the state of the notebook
 	 */
@@ -147,6 +145,8 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 	// =============================================================================================
 	// #region Public Properties
+
+	identifier: string = `positron.notebook.instance.${PositronNotebookInstance._count++}`;
 
 	/**
 	 * User facing cells wrapped in an observerable for the UI to react to changes
@@ -214,7 +214,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		if (this._notebookOptions) {
 			return this._notebookOptions;
 		}
-		this._logService.info(this._identifier, 'Generating new notebook options');
+		this._logService.info(this.identifier, 'Generating new notebook options');
 
 		this._notebookOptions = this._creationOptions?.options ?? new NotebookOptions(
 			DOM.getActiveWindow(),
@@ -294,7 +294,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 					return;
 				}
 
-				this._logService.info(this._identifier, `Selecting kernel ${kernel.id} for notebook`);
+				this._logService.info(this.identifier, `Selecting kernel ${kernel.id} for notebook`);
 				this.notebookKernelService.selectKernelForNotebook(kernel, this.textModel);
 			})
 		);
@@ -314,12 +314,12 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			})
 		);
 
-		this._logService.info(this._identifier, 'constructor');
+		this._logService.info(this.identifier, 'constructor');
 	}
 
 	override dispose() {
 
-		this._logService.info(this._identifier, 'dispose');
+		this._logService.info(this.identifier, 'dispose');
 		this._positronNotebookService.unregisterInstance(this);
 
 		super.dispose();
@@ -453,7 +453,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 		this._setupKeyboardNavigation(container);
 
-		this._logService.info(this._identifier, 'attachView');
+		this._logService.info(this.identifier, 'attachView');
 	}
 
 	/**
@@ -496,7 +496,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 	detachView(): void {
 		this._container = undefined;
-		this._logService.info(this._identifier, 'detachView');
+		this._logService.info(this.identifier, 'detachView');
 		this._clearKeyboardNavigation?.();
 		this._notebookOptions?.dispose();
 		this._detachModel();
@@ -622,13 +622,13 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	private async _runCells(cells: IPositronNotebookCell[]): Promise<void> {
 		// Filter so we're only working with code cells.
 		const codeCells = cells;
-		this._logService.info(this._identifier, '_runCells');
+		this._logService.info(this.identifier, '_runCells');
 
 		this._assertTextModel();
 
 		// Make sure we have a kernel to run the cells.
 		if (this.kernelStatus.get() !== KernelStatus.Connected) {
-			this._logService.info(this._identifier, 'No kernel connected, attempting to connect');
+			this._logService.info(this.identifier, 'No kernel connected, attempting to connect');
 			// Attempt to connect to the kernel
 			await this._commandService.executeCommand(
 				SELECT_KERNEL_ID_POSITRON,
@@ -685,7 +685,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Remove and cleanup the current model for notebook.
 	 */
 	private _detachModel() {
-		this._logService.info(this._identifier, 'detachModel');
+		this._logService.info(this.identifier, 'detachModel');
 		// Clear store of disposables
 		this._modelStore.clear();
 		this._viewModel?.dispose();

--- a/src/vs/workbench/contrib/positronNotebook/browser/ServicesProvider.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ServicesProvider.tsx
@@ -14,6 +14,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ILogService } from 'vs/platform/log/common/log';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { IPositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
 import { IWebviewService } from 'vs/workbench/contrib/webview/browser/webview';
 
 
@@ -47,6 +48,11 @@ interface ServiceBundle {
 	 * Service for creating webviews
 	 */
 	webviewService: IWebviewService;
+
+	/**
+	 * Service for creating webviews for notebook outputs
+	 */
+	notebookWebviewService: IPositronNotebookOutputWebviewService;
 
 	/**
 	 * Servicer for opening external links

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -36,7 +36,7 @@ export function NotebookCodeCell({ cell }: { cell: PositronNotebookCodeCell }) {
 			<CellEditorMonacoWidget cell={cell} />
 			<div className='positron-notebook-cell-outputs'>
 				{outputContents?.map(({ outputs, outputId }) =>
-					<CellOutput key={outputId} outputs={outputs} />
+					<CellOutput key={outputId} outputs={outputs} outputId={outputId} />
 				)}
 			</div>
 		</div>
@@ -44,7 +44,7 @@ export function NotebookCodeCell({ cell }: { cell: PositronNotebookCodeCell }) {
 
 }
 
-function CellOutput({ outputs }: Pick<NotebookCellOutputs, 'outputs'>) {
+function CellOutput({ outputs, outputId }: NotebookCellOutputs) {
 	const services = useServices();
 	const preferredOutput = pickPreferredOutputItem(outputs, services.logService.warn);
 
@@ -66,7 +66,7 @@ function CellOutput({ outputs }: Pick<NotebookCellOutputs, 'outputs'>) {
 		case 'image':
 			return <img src={parsed.dataUrl} alt='output image' />;
 		case 'html':
-			return <NotebookHTMLContent content={parsed.content} />;
+			return <NotebookHTMLContent content={parsed.content} outputId={outputId} />;
 		case 'unknown':
 			return <div className='unknown-mime-type'>
 				{localize('cellExecutionUnknownMimeType', 'Cant handle mime type "{0}" yet', preferredOutput.mime)}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookHTMLOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookHTMLOutput.tsx
@@ -71,7 +71,7 @@ function acquireVsCodeApi(): { postMessage: (message: HTMLOutputWebviewMessage) 
 }
 
 
-export function NotebookHTMLContent({ content }: { content: string }) {
+export function NotebookHTMLContent({ content, outputId }: { content: string; outputId: string }) {
 	const containerRef = React.useRef<HTMLDivElement>(null);
 	const { notebookWebviewService } = useServices();
 	const instance = useNotebookInstance();
@@ -90,8 +90,8 @@ export function NotebookHTMLContent({ content }: { content: string }) {
 
 		const buildWebview = async () => {
 			const webviewElement = await notebookWebviewService.createRawHtmlOutput({
-				id: 'notebook-html-output',
-				runtimeOrSessionId: notebookRuntime ?? 'positron.notebooks.output.render',
+				id: outputId,
+				runtimeOrSessionId: notebookRuntime ?? instance.identifier,
 				html: buildWebviewHTML({
 					content,
 					styles: htmlOutputStyles,
@@ -121,7 +121,7 @@ export function NotebookHTMLContent({ content }: { content: string }) {
 		buildWebview();
 
 		return cleanup;
-	}, [content, notebookRuntime, notebookWebviewService]);
+	}, [content, instance.identifier, notebookRuntime, notebookWebviewService, outputId]);
 
 	return <div className='positron-notebook-html-output' ref={containerRef}></div>;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookHTMLOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookHTMLOutput.tsx
@@ -91,7 +91,7 @@ export function NotebookHTMLContent({ content }: { content: string }) {
 		const buildWebview = async () => {
 			const webviewElement = await notebookWebviewService.createRawHtmlOutput({
 				id: 'notebook-html-output',
-				runtime: notebookRuntime,
+				runtimeOrSessionId: notebookRuntime ?? 'positron.notebooks.output.render',
 				html: buildWebviewHTML({
 					content,
 					styles: htmlOutputStyles,

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookHTMLOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookHTMLOutput.tsx
@@ -101,7 +101,10 @@ export function NotebookHTMLContent({ content }: { content: string }) {
 			});
 
 			// If the container has been disposed, don't mount the webview
-			if (disposed) { return; }
+			if (disposed) {
+				webviewElement.webview.dispose();
+				return;
+			}
 
 			webviewElement.webview.onMessage(({ message }) => {
 				if (!isHTMLOutputWebviewMessage(message) || !containerRef.current) { return; }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookHTMLOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookHTMLOutput.tsx
@@ -91,7 +91,7 @@ export function NotebookHTMLContent({ content, outputId }: { content: string; ou
 		const buildWebview = async () => {
 			const webviewElement = await notebookWebviewService.createRawHtmlOutput({
 				id: outputId,
-				runtimeOrSessionId: notebookRuntime ?? instance.identifier,
+				runtimeOrSessionId: notebookRuntime ?? instance.id,
 				html: buildWebviewHTML({
 					content,
 					styles: htmlOutputStyles,
@@ -121,7 +121,7 @@ export function NotebookHTMLContent({ content, outputId }: { content: string; ou
 		buildWebview();
 
 		return cleanup;
-	}, [content, instance.identifier, notebookRuntime, notebookWebviewService, outputId]);
+	}, [content, instance.id, notebookRuntime, notebookWebviewService, outputId]);
 
 	return <div className='positron-notebook-html-output' ref={containerRef}></div>;
 }

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
@@ -7,13 +7,13 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { FromWebviewMessage } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages';
 import { INotebookOutputWebview } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
-import { IOverlayWebview, } from 'vs/workbench/contrib/webview/browser/webview';
+import { IOverlayWebview, IWebviewElement } from 'vs/workbench/contrib/webview/browser/webview';
 
 /**
  * A notebook output webview wraps a webview that contains rendered HTML content
  * from notebooks (including raw HTML or the Notebook Renderer API).
  */
-export class NotebookOutputWebview extends Disposable implements INotebookOutputWebview {
+export class NotebookOutputWebview<WType extends IOverlayWebview | IWebviewElement = IOverlayWebview> extends Disposable implements INotebookOutputWebview<WType> {
 
 	private readonly _onDidRender = new Emitter<void>;
 
@@ -28,7 +28,7 @@ export class NotebookOutputWebview extends Disposable implements INotebookOutput
 	constructor(
 		readonly id: string,
 		readonly sessionId: string,
-		readonly webview: IOverlayWebview,
+		readonly webview: WType,
 		readonly render?: () => void,
 	) {
 		super();

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -67,12 +67,17 @@ export interface IPositronNotebookOutputWebviewService {
 	 * @param opts The options for the webview
 	 * @param opts.id A unique ID for this webview; typically the ID of the message
 	 *  that created it.
-	 * @param opts.runtime The runtime that owns this webview.
+	 * @param opts.runtimeOrSessionId The runtime that owns this webview. Can also be a string of the ID of the runtime.
 	 * @param opts.html The HTML content to render in the webview.
 	 * @param opts.webviewType The type of webview to create.
 	 * @returns A promise that resolves to the new webview of the desired type.
 	 */
-	createRawHtmlOutput<WType extends WebviewType>(opts: { id: string; runtime?: ILanguageRuntimeSession; html: string; webviewType: WType }): Promise<
+	createRawHtmlOutput<WType extends WebviewType>(opts: {
+		id: string;
+		html: string;
+		webviewType: WType;
+		runtimeOrSessionId: ILanguageRuntimeSession | string;
+	}): Promise<
 		INotebookOutputWebview<WType extends WebviewType.Overlay ? IOverlayWebview : IWebviewElement>
 	>;
 }

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { IOverlayWebview } from 'vs/workbench/contrib/webview/browser/webview';
+import { IOverlayWebview, IWebviewElement } from 'vs/workbench/contrib/webview/browser/webview';
 import { ILanguageRuntimeMessageOutput } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { Event } from 'vs/base/common/event';
@@ -15,7 +15,7 @@ export const IPositronNotebookOutputWebviewService =
 	createDecorator<IPositronNotebookOutputWebviewService>(
 		POSITRON_NOTEBOOK_OUTPUT_WEBVIEW_SERVICE_ID);
 
-export interface INotebookOutputWebview {
+export interface INotebookOutputWebview<WType extends IOverlayWebview | IWebviewElement = IOverlayWebview> {
 	/** The ID of the notebook output */
 	id: string;
 
@@ -23,7 +23,7 @@ export interface INotebookOutputWebview {
 	sessionId: string;
 
 	/** The webview containing the output's content */
-	webview: IOverlayWebview;
+	webview: WType;
 
 	/** Fired when the content completes rendering */
 	onDidRender: Event<void>;
@@ -33,6 +33,11 @@ export interface INotebookOutputWebview {
 	 * directly in the HTML content
 	 */
 	render?(): void;
+}
+
+export enum WebviewType {
+	Overlay,
+	Standard
 }
 
 export interface IPositronNotebookOutputWebviewService {
@@ -55,5 +60,20 @@ export interface IPositronNotebookOutputWebviewService {
 		output: ILanguageRuntimeMessageOutput,
 		viewType?: string,
 	): Promise<INotebookOutputWebview | undefined>;
+
+	/**
+	 * Create a new raw HTML output webview.
+	 *
+	 * @param opts The options for the webview
+	 * @param opts.id A unique ID for this webview; typically the ID of the message
+	 *  that created it.
+	 * @param opts.runtime The runtime that owns this webview.
+	 * @param opts.html The HTML content to render in the webview.
+	 * @param opts.webviewType The type of webview to create.
+	 * @returns A promise that resolves to the new webview of the desired type.
+	 */
+	createRawHtmlOutput<WType extends WebviewType>(opts: { id: string; runtime?: ILanguageRuntimeSession; html: string; webviewType: WType }): Promise<
+		INotebookOutputWebview<WType extends WebviewType.Overlay ? IOverlayWebview : IWebviewElement>
+	>;
 }
 

--- a/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -30,7 +30,7 @@ export interface IPositronNotebookInstance {
 	 * Identifier for the notebook instance. Used for debugging and claiming ownership of various
 	 * resources.
 	 */
-	identifier: string;
+	id: string;
 
 	/**
 	 * URI of the notebook file being edited

--- a/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -7,6 +7,7 @@ import { ISettableObservable } from 'vs/base/common/observableInternal/base';
 import { URI } from 'vs/base/common/uri';
 import { CellKind, IPositronNotebookCell } from 'vs/workbench/services/positronNotebook/browser/IPositronNotebookCell';
 import { SelectionStateMachine } from 'vs/workbench/services/positronNotebook/browser/selectionMachine';
+import { ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 
 export enum KernelStatus {
 	Uninitialized = 'Uninitialized',
@@ -44,6 +45,11 @@ export interface IPositronNotebookInstance {
 	 * Status of kernel for the notebook.
 	 */
 	kernelStatus: ISettableObservable<KernelStatus>;
+
+	/**
+	 * Current runtime for notebook
+	 */
+	currentRuntime: ISettableObservable<ILanguageRuntimeSession | undefined>;
 
 	/**
 	 * Selection state machine object.

--- a/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -27,6 +27,12 @@ export enum KernelStatus {
 export interface IPositronNotebookInstance {
 
 	/**
+	 * Identifier for the notebook instance. Used for debugging and claiming ownership of various
+	 * resources.
+	 */
+	identifier: string;
+
+	/**
 	 * URI of the notebook file being edited
 	 */
 	get uri(): URI;


### PR DESCRIPTION
This PR has three main parts to it as told by the (first) three commits:

1. Update the `IPositronNotebookWebviewService` to expose the `.createRawHtmlOutput()` method and allow that method to create standard `WebviewElement`s in addition to `OverlayWebview`s.  (Also adds the ability to create the webview without an active runtime due to runtime requirements preventing notebooks from showing html content until the kernel is connected.)
2. Add knowledge of the current language runtime attached to a notebook to the `PositronNotebookInstance` class.  (Also uses that knowledge to make the kernel badge more accurate)
3. Replace the existing rendering of HTML content in notebooks with the `IPositronNotebookWebviewService.createRawHtmlOutput()` and all the goodies that we get (and will get in the future) from that. 

### QA Notes

This should be a simple under-the-hood swap; nothing should look or work differently. 
