### PR TITLE
Hide the actions menu on altair/vega plots

### DIFF
--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -292,6 +292,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 
 		webview.setHtml(`
 <script src='${jQueryPath}'></script>
+${PositronNotebookOutputWebviewService.CssAddons}
 ${html}
 <script>
 const vscode = acquireVsCodeApi();
@@ -304,6 +305,17 @@ window.onload = function() {
 </script>`);
 		return new NotebookOutputWebview(id, runtime.runtimeMetadata.runtimeId, webview);
 	}
+
+	/**
+	 * A set of CSS addons to inject into the HTML of the webview. Used to do things like
+	 * hide elements that are not functional in the context of positron such as links to
+	 * pages that can't be opened.
+	 */
+	static readonly CssAddons = `
+<style>
+	/* Hide actions button that does things like opening source code etc.. (See #2829) */
+	.vega-embed details {display: none;}
+</style>`;
 
 	/**
 	 * Renders widget HTML in a webview.

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -314,7 +314,7 @@ window.onload = function() {
 	static readonly CssAddons = `
 <style>
 	/* Hide actions button that does things like opening source code etc.. (See #2829) */
-	.vega-embed details {display: none;}
+	.vega-embed details[title="Click to view actions"] {display: none;}
 </style>`;
 
 	/**


### PR DESCRIPTION
Addresses #2829 

This is a brute-force solution to the confusing actions menu in altair plots. 

We hide the menu by selecting it via css (with the path `.vega-embed details[title="Click to view actions"]`)

Also adds a static property to the `PositronNotebookOutputWebviewService` service to store these addon css properties in case we need to do more of them in the future for other plotting libraries etc.. 

Ultimately the solution should probably be more robust then this and involve stubbing in functions for opening new pages etc that the actions menu tries to use, but that's a lot more work and this gets the job done at the moment. (See #4087)

### Before
_Altair plot with action menu that is unusable_
![image](https://github.com/user-attachments/assets/78f05113-da7b-4cdf-bcf7-26b36bdc5419)


### After
_Altair plot sans actions menu_
<img width="341" alt="image" src="https://github.com/user-attachments/assets/a7d00b80-4f19-4b3a-9851-7c29a6e48689">

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
