### PR TITLE
Welcome page smoke tests

### DIFF
--- a/test/automation/src/editors.ts
+++ b/test/automation/src/editors.ts
@@ -5,9 +5,22 @@
 
 import { Code } from './code';
 
-export class Editors {
+// --- Start Positron ---
+import { Locator } from '@playwright/test';
+// --- End Positron ---
 
-	constructor(private code: Code) { }
+export class Editors {
+	// --- Start Positron ---
+	activeEditorLocator: Locator;
+	editorIconLocator: Locator;
+	editorPartLocator: Locator;
+
+	constructor(private code: Code) {
+		this.activeEditorLocator = this.code.driver.getLocator('div.tab.tab-actions-right.active.selected');
+		this.editorIconLocator = this.code.driver.getLocator('.monaco-icon-label.file-icon');
+		this.editorPartLocator = this.code.driver.getLocator('.split-view-view .part.editor');
+	}
+	// --- End Positron ---
 
 	async saveOpenedFile(): Promise<any> {
 		if (process.platform === 'darwin') {

--- a/test/automation/src/editors.ts
+++ b/test/automation/src/editors.ts
@@ -11,9 +11,9 @@ import { Locator } from '@playwright/test';
 
 export class Editors {
 	// --- Start Positron ---
-	activeEditorLocator: Locator;
-	editorIconLocator: Locator;
-	editorPartLocator: Locator;
+	activeEditorLocator = this.code.driver.getLocator('div.tab.tab-actions-right.active.selected');
+	editorIconLocator = this.code.driver.getLocator('.monaco-icon-label.file-icon');
+	editorPartLocator = this.code.driver.getLocator('.split-view-view .part.editor');
 
 	constructor(private code: Code) {
 		this.activeEditorLocator = this.code.driver.getLocator('div.tab.tab-actions-right.active.selected');

--- a/test/automation/src/editors.ts
+++ b/test/automation/src/editors.ts
@@ -5,22 +5,14 @@
 
 import { Code } from './code';
 
-// --- Start Positron ---
-import { Locator } from '@playwright/test';
-// --- End Positron ---
-
 export class Editors {
 	// --- Start Positron ---
 	activeEditorLocator = this.code.driver.getLocator('div.tab.tab-actions-right.active.selected');
 	editorIconLocator = this.code.driver.getLocator('.monaco-icon-label.file-icon');
 	editorPartLocator = this.code.driver.getLocator('.split-view-view .part.editor');
-
-	constructor(private code: Code) {
-		this.activeEditorLocator = this.code.driver.getLocator('div.tab.tab-actions-right.active.selected');
-		this.editorIconLocator = this.code.driver.getLocator('.monaco-icon-label.file-icon');
-		this.editorPartLocator = this.code.driver.getLocator('.split-view-view .part.editor');
-	}
 	// --- End Positron ---
+
+	constructor(private code: Code) { }
 
 	async saveOpenedFile(): Promise<any> {
 		if (process.platform === 'darwin') {

--- a/test/automation/src/editors.ts
+++ b/test/automation/src/editors.ts
@@ -7,9 +7,9 @@ import { Code } from './code';
 
 export class Editors {
 	// --- Start Positron ---
-	activeEditorLocator = this.code.driver.getLocator('div.tab.tab-actions-right.active.selected');
-	editorIconLocator = this.code.driver.getLocator('.monaco-icon-label.file-icon');
-	editorPartLocator = this.code.driver.getLocator('.split-view-view .part.editor');
+	activeEditor = this.code.driver.getLocator('div.tab.tab-actions-right.active.selected');
+	editorIcon = this.code.driver.getLocator('.monaco-icon-label.file-icon');
+	editorPart = this.code.driver.getLocator('.split-view-view .part.editor');
 	// --- End Positron ---
 
 	constructor(private code: Code) { }

--- a/test/automation/src/positron/positronNotebooks.ts
+++ b/test/automation/src/positron/positronNotebooks.ts
@@ -27,7 +27,7 @@ const MARKDOWN_TEXT = '#preview';
  *  Reuseable Positron notebook functionality for tests to leverage.  Includes selecting the notebook's interpreter.
  */
 export class PositronNotebooks {
-	kernelLabelLocator: Locator;
+	kernelLabelLocator = this.code.driver.getLocator(KERNEL_LABEL);
 
 	constructor(private code: Code, private quickinput: QuickInput, private quickaccess: QuickAccess, private notebook: Notebook) {
 		this.kernelLabelLocator = this.code.driver.getLocator(KERNEL_LABEL);

--- a/test/automation/src/positron/positronNotebooks.ts
+++ b/test/automation/src/positron/positronNotebooks.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { expect } from '@playwright/test';
+import { expect, Locator } from '@playwright/test';
 import { Code } from '../code';
 import { Notebook } from '../notebook';
 import { QuickAccess } from '../quickaccess';
@@ -27,8 +27,11 @@ const MARKDOWN_TEXT = '#preview';
  *  Reuseable Positron notebook functionality for tests to leverage.  Includes selecting the notebook's interpreter.
  */
 export class PositronNotebooks {
+	kernelLabelLocator: Locator;
 
-	constructor(private code: Code, private quickinput: QuickInput, private quickaccess: QuickAccess, private notebook: Notebook) { }
+	constructor(private code: Code, private quickinput: QuickInput, private quickaccess: QuickAccess, private notebook: Notebook) {
+		this.kernelLabelLocator = this.code.driver.getLocator(KERNEL_LABEL);
+	}
 
 	async selectInterpreter(kernelGroup: string, desiredKernel: string) {
 		await this.code.waitForElement(KERNEL_LABEL, (e) => e!.textContent.includes(desiredKernel) || e!.textContent.includes(SELECT_KERNEL_TEXT));

--- a/test/automation/src/positron/positronNotebooks.ts
+++ b/test/automation/src/positron/positronNotebooks.ts
@@ -29,9 +29,7 @@ const MARKDOWN_TEXT = '#preview';
 export class PositronNotebooks {
 	kernelLabel = this.code.driver.getLocator(KERNEL_LABEL);
 
-	constructor(private code: Code, private quickinput: QuickInput, private quickaccess: QuickAccess, private notebook: Notebook) {
-		this.kernelLabel = this.code.driver.getLocator(KERNEL_LABEL);
-	}
+	constructor(private code: Code, private quickinput: QuickInput, private quickaccess: QuickAccess, private notebook: Notebook) { }
 
 	async selectInterpreter(kernelGroup: string, desiredKernel: string) {
 		await this.code.waitForElement(KERNEL_LABEL, (e) => e!.textContent.includes(desiredKernel) || e!.textContent.includes(SELECT_KERNEL_TEXT));

--- a/test/automation/src/positron/positronNotebooks.ts
+++ b/test/automation/src/positron/positronNotebooks.ts
@@ -27,10 +27,10 @@ const MARKDOWN_TEXT = '#preview';
  *  Reuseable Positron notebook functionality for tests to leverage.  Includes selecting the notebook's interpreter.
  */
 export class PositronNotebooks {
-	kernelLabelLocator = this.code.driver.getLocator(KERNEL_LABEL);
+	kernelLabel = this.code.driver.getLocator(KERNEL_LABEL);
 
 	constructor(private code: Code, private quickinput: QuickInput, private quickaccess: QuickAccess, private notebook: Notebook) {
-		this.kernelLabelLocator = this.code.driver.getLocator(KERNEL_LABEL);
+		this.kernelLabel = this.code.driver.getLocator(KERNEL_LABEL);
 	}
 
 	async selectInterpreter(kernelGroup: string, desiredKernel: string) {

--- a/test/automation/src/positron/positronNotebooks.ts
+++ b/test/automation/src/positron/positronNotebooks.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { expect, Locator } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { Code } from '../code';
 import { Notebook } from '../notebook';
 import { QuickAccess } from '../quickaccess';

--- a/test/automation/src/positron/positronPopups.ts
+++ b/test/automation/src/positron/positronPopups.ts
@@ -10,6 +10,7 @@ const POSITRON_MODAL_DIALOG_BOX = '.positron-modal-dialog-box';
 const POSITRON_MODAL_DIALOG_BOX_OK = '.positron-modal-dialog-box .ok-cancel-action-bar .positron-button.action-bar-button.default';
 const POSITRON_MODAL_DIALOG_BOX_CANCEL = '.positron-modal-dialog-box .ok-cancel-action-bar .positron-button.action-bar-button:not(.default)';
 const POSITRON_MODAL_DIALOG_BOX_TITLE = '.positron-modal-dialog-box .simple-title-bar-title';
+const POSITRON_MODAL_DIALOG_POPUP_OPTION = '.positron-modal-popup .positron-modal-popup-children';
 const NOTIFICATION_TOAST = '.notification-toast';
 
 /*
@@ -103,7 +104,7 @@ export class PositronPopups {
 	 * @param label The label of the option to select.
 	 */
 	async clickOnModalDialogPopupOption(label: string | RegExp) {
-		const el = this.code.driver.getLocator('.positron-modal-popup .positron-modal-popup-children').getByText(label);
+		const el = this.code.driver.getLocator(POSITRON_MODAL_DIALOG_POPUP_OPTION).getByText(label);
 		await el.click();
 	}
 

--- a/test/automation/src/positron/positronPopups.ts
+++ b/test/automation/src/positron/positronPopups.ts
@@ -9,7 +9,7 @@ import { Code } from '../code';
 const POSITRON_MODAL_DIALOG_BOX = '.positron-modal-dialog-box';
 const POSITRON_MODAL_DIALOG_BOX_OK = '.positron-modal-dialog-box .ok-cancel-action-bar .positron-button.action-bar-button.default';
 const POSITRON_MODAL_DIALOG_BOX_CANCEL = '.positron-modal-dialog-box .ok-cancel-action-bar .positron-button.action-bar-button:not(.default)';
-const POSITRON_MODAL_DIALOG_BOX_MISSING_R_PACKAGE_TITLE = '.positron-modal-dialog-box .simple-title-bar-title';
+const POSITRON_MODAL_DIALOG_BOX_TITLE = '.positron-modal-dialog-box .simple-title-bar-title';
 const NOTIFICATION_TOAST = '.notification-toast';
 
 /*
@@ -57,7 +57,7 @@ export class PositronPopups {
 			this.code.logger.log('Checking for install Renv modal dialog box');
 			// fail fast if the renv install modal is not present
 			await this.code.waitForTextContent(
-				POSITRON_MODAL_DIALOG_BOX_MISSING_R_PACKAGE_TITLE,
+				POSITRON_MODAL_DIALOG_BOX_TITLE,
 				'Missing R package',
 				undefined,
 				50
@@ -102,8 +102,16 @@ export class PositronPopups {
 	 * Can be called after a DropDownListBox is clicked. Selects the option with the given label.
 	 * @param label The label of the option to select.
 	 */
-	async clickOnModalDialogPopupOption(label: string) {
-		const el = this.code.driver.getLocator('.positron-modal-popup .positron-button .title').filter({ hasText: label });
+	async clickOnModalDialogPopupOption(label: string | RegExp) {
+		const el = this.code.driver.getLocator('.positron-modal-popup .positron-modal-popup-children').getByText(label);
 		await el.click();
+	}
+
+	/**
+	 * Waits for the modal dialog box title to match the given title.
+	 * @param title The title to wait for.
+	 */
+	async waitForModalDialogTitle(title: string) {
+		await this.code.waitForTextContent(POSITRON_MODAL_DIALOG_BOX_TITLE, title);
 	}
 }

--- a/test/automation/src/positron/positronWelcome.ts
+++ b/test/automation/src/positron/positronWelcome.ts
@@ -6,9 +6,9 @@
 
 import { Code } from '../code';
 
-const LOGO_LOCATOR = '.product-logo';
-const TITLE_LOCATOR = '.gettingStartedCategoriesContainer div.header div .positron';
-const FOOTER_LOCATOR = '.gettingStartedCategoriesContainer div.footer';
+const LOGO = '.product-logo';
+const TITLE = '.gettingStartedCategoriesContainer div.header div .positron';
+const FOOTER = '.gettingStartedCategoriesContainer div.footer';
 const START_SECTION = '.positron-welcome-page-open';
 const HELP_TITLE = '.positron-welcome-page-help';
 const OPEN_SECTION = '.categories-column.categories-column-right .index-list.start-container';
@@ -20,9 +20,9 @@ const LINK_ROLE = 'link';
 
 export class PositronWelcome {
 
-	logoLocator = this.code.driver.getLocator(LOGO_LOCATOR);
-	titleLocator = this.code.driver.getLocator(TITLE_LOCATOR);
-	footerLocator = this.code.driver.getLocator(FOOTER_LOCATOR);
+	logo = this.code.driver.getLocator(LOGO);
+	title = this.code.driver.getLocator(TITLE);
+	footer = this.code.driver.getLocator(FOOTER);
 	startSection = this.code.driver.getLocator(START_SECTION);
 	startTitle = this.startSection.getByRole(HEADING_ROLE);
 	startButtons = this.startSection.getByRole(BUTTON_ROLE);

--- a/test/automation/src/positron/positronWelcome.ts
+++ b/test/automation/src/positron/positronWelcome.ts
@@ -10,9 +10,32 @@ import { Code } from '../code';
 export class PositronWelcome {
 
 	startSection: Locator;
+	startTitle: Locator;
+	startButtons: Locator;
+	helpSection: Locator;
+	helpTitle: Locator;
+	helpLinks: Locator;
+	openSection: Locator;
+	openTitle: Locator;
+	openButtons: Locator;
+	recentSection: Locator;
+	recentTitle: Locator;
 
 	constructor(private code: Code) {
 		this.startSection = this.code.driver.getLocator('.positron-welcome-page-open');
+		this.startTitle = this.startSection.getByRole('heading');
+		this.startButtons = this.startSection.getByRole('button');
+
+		this.helpSection = this.code.driver.getLocator('.positron-welcome-page-help');
+		this.helpTitle = this.helpSection.getByRole('heading');
+		this.helpLinks = this.helpSection.getByRole('link');
+
+		this.openSection = this.code.driver.getLocator('.categories-column.categories-column-right .index-list.start-container');
+		this.openTitle = this.openSection.getByRole('heading');
+		this.openButtons = this.openSection.getByRole('button');
+
+		this.recentSection = this.code.driver.getLocator('.categories-column.categories-column-right .index-list.recently-opened');
+		this.recentTitle = this.recentSection.getByRole('heading');
 	}
 
 	async clickNewNotebook() {

--- a/test/automation/src/positron/positronWelcome.ts
+++ b/test/automation/src/positron/positronWelcome.ts
@@ -4,61 +4,40 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { Locator } from '@playwright/test';
 import { Code } from '../code';
+
+const LOGO_LOCATOR = '.product-logo';
+const TITLE_LOCATOR = '.gettingStartedCategoriesContainer div.header div .positron';
+const FOOTER_LOCATOR = '.gettingStartedCategoriesContainer div.footer';
+const START_SECTION = '.positron-welcome-page-open';
+const HELP_TITLE = '.positron-welcome-page-help';
+const OPEN_SECTION = '.categories-column.categories-column-right .index-list.start-container';
+const RECENT_SECTION = '.categories-column.categories-column-right .index-list.recently-opened';
+
+const HEADING_ROLE = 'heading';
+const BUTTON_ROLE = 'button';
+const LINK_ROLE = 'link';
 
 export class PositronWelcome {
 
-	startSection: Locator;
-	startTitle: Locator;
-	startButtons: Locator;
-	helpSection: Locator;
-	helpTitle: Locator;
-	helpLinks: Locator;
-	openSection: Locator;
-	openTitle: Locator;
-	openButtons: Locator;
-	recentSection: Locator;
-	recentTitle: Locator;
+	logoLocator = this.code.driver.getLocator(LOGO_LOCATOR);
+	titleLocator = this.code.driver.getLocator(TITLE_LOCATOR);
+	footerLocator = this.code.driver.getLocator(FOOTER_LOCATOR);
+	startSection = this.code.driver.getLocator(START_SECTION);
+	startTitle = this.startSection.getByRole(HEADING_ROLE);
+	startButtons = this.startSection.getByRole(BUTTON_ROLE);
+	helpSection = this.code.driver.getLocator(HELP_TITLE);
+	helpTitle = this.helpSection.getByRole(HEADING_ROLE);
+	helpLinks = this.helpSection.getByRole(LINK_ROLE);
+	openSection = this.code.driver.getLocator(OPEN_SECTION);
+	openTitle = this.openSection.getByRole(HEADING_ROLE);
+	openButtons = this.openSection.getByRole(BUTTON_ROLE);
+	recentSection = this.code.driver.getLocator(RECENT_SECTION);
+	recentTitle = this.recentSection.getByRole(HEADING_ROLE);
+	newNotebookButton = this.startButtons.getByText('New Notebook');
+	newFileButton = this.startButtons.getByText('New File');
+	newConsoleButton = this.startButtons.getByText('New Console');
+	newProjectButton = this.startButtons.getByText('New Project');
 
-	constructor(private code: Code) {
-		this.startSection = this.code.driver.getLocator('.positron-welcome-page-open');
-		this.startTitle = this.startSection.getByRole('heading');
-		this.startButtons = this.startSection.getByRole('button');
-
-		this.helpSection = this.code.driver.getLocator('.positron-welcome-page-help');
-		this.helpTitle = this.helpSection.getByRole('heading');
-		this.helpLinks = this.helpSection.getByRole('link');
-
-		this.openSection = this.code.driver.getLocator('.categories-column.categories-column-right .index-list.start-container');
-		this.openTitle = this.openSection.getByRole('heading');
-		this.openButtons = this.openSection.getByRole('button');
-
-		this.recentSection = this.code.driver.getLocator('.categories-column.categories-column-right .index-list.recently-opened');
-		this.recentTitle = this.recentSection.getByRole('heading');
-	}
-
-	async clickNewNotebook() {
-		await this.startSection.locator('button').filter({
-			has: this.code.driver.getLocator('.codicon-positron-new-notebook')
-		}).click();
-	}
-
-	async clickNewFile() {
-		await this.startSection.locator('button').filter({
-			has: this.code.driver.getLocator('.codicon-positron-new-file')
-		}).click();
-	}
-
-	async clickNewConsole() {
-		await this.startSection.locator('button').filter({
-			has: this.code.driver.getLocator('.codicon-positron-new-console')
-		}).click();
-	}
-
-	async clickNewProject() {
-		await this.startSection.locator('button').filter({
-			has: this.code.driver.getLocator('.codicon-positron-new-project')
-		}).click();
-	}
+	constructor(private code: Code) { }
 }

--- a/test/automation/src/positron/positronWelcome.ts
+++ b/test/automation/src/positron/positronWelcome.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { Locator } from '@playwright/test';
+import { Code } from '../code';
+
+export class PositronWelcome {
+
+	startSection: Locator;
+
+	constructor(private code: Code) {
+		this.startSection = this.code.driver.getLocator('.positron-welcome-page-open');
+	}
+
+	async clickNewNotebook() {
+		await this.startSection.locator('button').filter({
+			has: this.code.driver.getLocator('.codicon-positron-new-notebook')
+		}).click();
+	}
+
+	async clickNewFile() {
+		await this.startSection.locator('button').filter({
+			has: this.code.driver.getLocator('.codicon-positron-new-file')
+		}).click();
+	}
+
+	async clickNewConsole() {
+		await this.startSection.locator('button').filter({
+			has: this.code.driver.getLocator('.codicon-positron-new-console')
+		}).click();
+	}
+
+	async clickNewProject() {
+		await this.startSection.locator('button').filter({
+			has: this.code.driver.getLocator('.codicon-positron-new-project')
+		}).click();
+	}
+}

--- a/test/automation/src/workbench.ts
+++ b/test/automation/src/workbench.ts
@@ -39,6 +39,7 @@ import { PositronHelp } from './positron/positronHelp';
 import { PositronTopActionBar } from './positron/positronTopActionBar';
 import { PositronLayouts } from './positron/positronLayouts';
 import { PositronOutput } from './positron/positronOutput';
+import { PositronWelcome } from './positron/positronWelcome';
 // --- End Positron ---
 
 export interface Commands {
@@ -82,6 +83,7 @@ export class Workbench {
 	readonly positronTopActionBar: PositronTopActionBar;
 	readonly positronLayouts: PositronLayouts;
 	readonly positronOutput: PositronOutput;
+	readonly positronWelcome: PositronWelcome;
 	// --- End Positron ---
 
 	constructor(code: Code) {
@@ -120,6 +122,7 @@ export class Workbench {
 		this.positronTopActionBar = new PositronTopActionBar(code);
 		this.positronLayouts = new PositronLayouts(code, this);
 		this.positronOutput = new PositronOutput(code, this.quickaccess, this.quickinput);
+		this.positronWelcome = new PositronWelcome(code);
 		// --- End Positron ---
 	}
 }

--- a/test/smoke/src/areas/positron/welcome/welcome.test.ts
+++ b/test/smoke/src/areas/positron/welcome/welcome.test.ts
@@ -31,38 +31,30 @@ export function setup(logger: Logger) {
 		it('Verify Welcome page header and footer', async function () {
 			const app = this.app as Application;
 
-			await expect(app.workbench.positronWelcome.logoLocator).toBeVisible();
-			const logoBox = await (await app.workbench.positronWelcome.logoLocator.elementHandle())?.boundingBox();
-
-			expect(logoBox?.height).toBeGreaterThan(0);
-			expect(logoBox?.width).toBeGreaterThan(0);
+			await expect(app.workbench.positronWelcome.logo).toBeVisible();
 
 			// product name in release is 'Positron' and in dev is 'Positron Dev'
-			await expect(app.workbench.positronWelcome.titleLocator).toHaveText([/(Positron)|(Positron Dev)/, 'an IDE for data science']);
+			await expect(app.workbench.positronWelcome.title).toHaveText([/(Positron)|(Positron Dev)/, 'an IDE for data science']);
 
-			await expect(app.workbench.positronWelcome.footerLocator).toHaveText('Show welcome page on startup');
+			await expect(app.workbench.positronWelcome.footer).toHaveText('Show welcome page on startup');
 		});
 
 		it('Verify Welcome page content', async function () {
 			const app = this.app as Application;
-			const OPEN_BUTTONS_COUNT = process.platform === 'darwin' ? 3 : 4;
 			const OPEN_BUTTONS_LABELS = process.platform === 'darwin' ?
 				['Open...', 'New Folder...', 'New Folder from Git...']
 				: ['Open File...', 'Open Folder...', 'New Folder...', 'New Folder from Git...'];
 
 			await expect(app.workbench.positronWelcome.startTitle).toHaveText('Start');
 
-			await expect(app.workbench.positronWelcome.startButtons).toHaveCount(4);
 			await expect(app.workbench.positronWelcome.startButtons).toHaveText(['New Notebook', 'New File', 'New Console', 'New Project']);
 
 			await expect(app.workbench.positronWelcome.helpTitle).toHaveText('Help');
 
-			await expect(app.workbench.positronWelcome.helpLinks).toHaveCount(3);
 			await expect(app.workbench.positronWelcome.helpLinks).toHaveText(['Positron Documentation', 'Positron Community', 'Report a bug']);
 
 			await expect(app.workbench.positronWelcome.openTitle).toHaveText('Open');
 
-			await expect(app.workbench.positronWelcome.openButtons).toHaveCount(OPEN_BUTTONS_COUNT);
 			await expect(app.workbench.positronWelcome.openButtons).toHaveText(OPEN_BUTTONS_LABELS);
 
 			await app.workbench.quickaccess.runCommand('File: Clear Recently Opened...');
@@ -99,7 +91,7 @@ export function setup(logger: Logger) {
 
 				await app.workbench.quickinput.selectQuickInputElementContaining('Python File');
 
-				await expect(app.workbench.editors.activeEditorLocator.locator(app.workbench.editors.editorIconLocator)).toHaveClass(/python-lang-file-icon/);
+				await expect(app.workbench.editors.activeEditor.locator(app.workbench.editors.editorIcon)).toHaveClass(/python-lang-file-icon/);
 
 				await app.workbench.quickaccess.runCommand('View: Close Editor');
 			});
@@ -111,10 +103,10 @@ export function setup(logger: Logger) {
 
 				await app.workbench.positronPopups.clickOnModalDialogPopupOption('Python Notebook');
 
-				await expect(app.workbench.editors.activeEditorLocator.locator(app.workbench.editors.editorIconLocator)).toHaveClass(/ipynb-ext-file-icon/);
+				await expect(app.workbench.editors.activeEditor.locator(app.workbench.editors.editorIcon)).toHaveClass(/ipynb-ext-file-icon/);
 
 				const expectedInterpreterVersion = new RegExp(`Python ${process.env.POSITRON_PY_VER_SEL}`, 'i');
-				await expect(app.workbench.positronNotebooks.kernelLabelLocator).toHaveText(expectedInterpreterVersion);
+				await expect(app.workbench.positronNotebooks.kernelLabel).toHaveText(expectedInterpreterVersion);
 			});
 
 			it('Click on Python console from the Welcome page', async function () {
@@ -127,7 +119,7 @@ export function setup(logger: Logger) {
 				await app.workbench.positronPopups.clickOnModalDialogPopupOption(expectedInterpreterVersion);
 
 				// editor is hidden because bottom panel is maximized
-				await expect(app.workbench.editors.editorPartLocator).not.toBeVisible();
+				await expect(app.workbench.editors.editorPart).not.toBeVisible();
 
 				// console is the active view in the bottom panel
 				await expect(app.workbench.positronLayouts.panelViewsTab).toHaveCount(6);
@@ -147,7 +139,7 @@ export function setup(logger: Logger) {
 
 				await app.workbench.quickinput.selectQuickInputElementContaining('R File');
 
-				await expect(app.workbench.editors.activeEditorLocator.locator(app.workbench.editors.editorIconLocator)).toHaveClass(/r-lang-file-icon/);
+				await expect(app.workbench.editors.activeEditor.locator(app.workbench.editors.editorIcon)).toHaveClass(/r-lang-file-icon/);
 			});
 
 			it('Click on R console from the Welcome page', async function () {
@@ -160,7 +152,7 @@ export function setup(logger: Logger) {
 				await app.workbench.positronPopups.clickOnModalDialogPopupOption(expectedInterpreterVersion);
 
 				// editor is hidden because bottom panel is maximized
-				await expect(app.workbench.editors.editorPartLocator).not.toBeVisible();
+				await expect(app.workbench.editors.editorPart).not.toBeVisible();
 
 				// console is the active view in the bottom panel
 				await expect(app.workbench.positronLayouts.panelViewsTab.and(app.code.driver.getLocator('.checked'))).toHaveText('Console');
@@ -173,10 +165,10 @@ export function setup(logger: Logger) {
 
 				await app.workbench.positronPopups.clickOnModalDialogPopupOption('R Notebook');
 
-				await expect(app.workbench.editors.activeEditorLocator.locator(app.workbench.editors.editorIconLocator)).toHaveClass(/ipynb-ext-file-icon/);
+				await expect(app.workbench.editors.activeEditor.locator(app.workbench.editors.editorIcon)).toHaveClass(/ipynb-ext-file-icon/);
 
 				const expectedInterpreterVersion = new RegExp(`R ${process.env.POSITRON_R_VER_SEL}`, 'i');
-				await expect(app.workbench.positronNotebooks.kernelLabelLocator).toHaveText(expectedInterpreterVersion);
+				await expect(app.workbench.positronNotebooks.kernelLabel).toHaveText(expectedInterpreterVersion);
 			});
 		});
 	});

--- a/test/smoke/src/areas/positron/welcome/welcome.test.ts
+++ b/test/smoke/src/areas/positron/welcome/welcome.test.ts
@@ -48,7 +48,7 @@ export function setup(logger: Logger) {
 			const OPEN_BUTTONS_COUNT = process.platform === 'darwin' ? 3 : 4;
 			const OPEN_BUTTONS_LABELS = process.platform === 'darwin' ?
 				['Open...', 'New Folder...', 'New Folder from Git...']
-				: ['Open...', 'Open File...', 'New Folder...', 'New Folder from Git...'];
+				: ['Open File...', 'Open Folder...', 'New Folder...', 'New Folder from Git...'];
 
 			await expect(app.workbench.positronWelcome.startTitle).toHaveText('Start');
 

--- a/test/smoke/src/areas/positron/welcome/welcome.test.ts
+++ b/test/smoke/src/areas/positron/welcome/welcome.test.ts
@@ -15,11 +15,11 @@ import { installAllHandlers } from '../../../utils';
 export function setup(logger: Logger) {
 	describe('Welcome Page', () => {
 		installAllHandlers(logger);
-		
+
 		before(async function () {
 			await PositronPythonFixtures.SetupFixtures(this.app as Application);
 		});
-		
+
 		beforeEach(async function () {
 			const app = this.app as Application;
 
@@ -32,7 +32,7 @@ export function setup(logger: Logger) {
 			await app.workbench.quickaccess.runCommand('View: Close All Editors');
 		});
 
-		it('Verify Welcome page header and footer', async function () {
+		it('Verify Welcome page header and footer [C684750]', async function () {
 			const app = this.app as Application;
 
 			await expect(app.workbench.positronWelcome.logo).toBeVisible();
@@ -43,7 +43,7 @@ export function setup(logger: Logger) {
 			await expect(app.workbench.positronWelcome.footer).toHaveText('Show welcome page on startup');
 		});
 
-		it('Verify Welcome page content', async function () {
+		it('Verify Welcome page content [C610960]', async function () {
 			const app = this.app as Application;
 			const OPEN_BUTTONS_LABELS = process.platform === 'darwin' ?
 				['Open...', 'New Folder...', 'New Folder from Git...']
@@ -69,7 +69,7 @@ export function setup(logger: Logger) {
 			await expect(app.workbench.positronWelcome.recentSection.locator('.empty-recent')).toHaveText('You have no recent folders,open a folderto start.');
 		});
 
-		it('Click on new project from the Welcome page', async function () {
+		it('Click on new project from the Welcome page [C684751]', async function () {
 			const app = this.app as Application;
 
 			await app.workbench.positronWelcome.newProjectButton.click();
@@ -88,7 +88,7 @@ export function setup(logger: Logger) {
 				await PositronPythonFixtures.SetupFixtures(this.app as Application);
 			});
 
-			it('Create a new Python file from the Welcome page', async function () {
+			it('Create a new Python file from the Welcome page [C684752]', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.positronWelcome.newFileButton.click();
@@ -100,7 +100,7 @@ export function setup(logger: Logger) {
 				await app.workbench.quickaccess.runCommand('View: Close Editor');
 			});
 
-			it('Create a new Python notebook from the Welcome page', async function () {
+			it('Create a new Python notebook from the Welcome page [C684753]', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.positronWelcome.newNotebookButton.click();
@@ -113,7 +113,7 @@ export function setup(logger: Logger) {
 				await expect(app.workbench.positronNotebooks.kernelLabel).toHaveText(expectedInterpreterVersion);
 			});
 
-			it('Click on Python console from the Welcome page', async function () {
+			it('Click on Python console from the Welcome page [C684754]', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.positronWelcome.newConsoleButton.click();
@@ -135,7 +135,7 @@ export function setup(logger: Logger) {
 				await PositronRFixtures.SetupFixtures(this.app as Application);
 			});
 
-			it('Create a new R file from the Welcome page', async function () {
+			it('Create a new R file from the Welcome page [C684755]', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.positronWelcome.newFileButton.click();
@@ -145,7 +145,7 @@ export function setup(logger: Logger) {
 				await expect(app.workbench.editors.activeEditor.locator(app.workbench.editors.editorIcon)).toHaveClass(/r-lang-file-icon/);
 			});
 
-			it('Click on R console from the Welcome page', async function () {
+			it('Click on R console from the Welcome page [C684756]', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.positronWelcome.newConsoleButton.click();
@@ -161,7 +161,7 @@ export function setup(logger: Logger) {
 				await expect(app.workbench.positronLayouts.panelViewsTab.and(app.code.driver.getLocator('.checked'))).toHaveText('Console');
 			});
 
-			it('Create a new R notebook from the Welcome page', async function () {
+			it('Create a new R notebook from the Welcome page [C684757]', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.positronWelcome.newNotebookButton.click();

--- a/test/smoke/src/areas/positron/welcome/welcome.test.ts
+++ b/test/smoke/src/areas/positron/welcome/welcome.test.ts
@@ -1,0 +1,210 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { expect } from '@playwright/test';
+import { Application, Logger, PositronPythonFixtures, PositronRFixtures } from '../../../../../automation';
+import { installAllHandlers } from '../../../utils';
+
+/*
+ *  Welcome test cases.
+ */
+
+export function setup(logger: Logger) {
+	describe('Welcome Page', () => {
+		installAllHandlers(logger);
+
+		beforeEach(async function () {
+			const app = this.app as Application;
+
+			await app.workbench.quickaccess.runCommand('Help: Welcome');
+			app.workbench.editors.waitForActiveEditor('Welcome');
+		});
+
+		afterEach(async function () {
+			const app = this.app as Application;
+			await app.workbench.quickaccess.runCommand('View: Close All Editors');
+		});
+
+		it('Verify Welcome page header and footer', async function () {
+			const app = this.app as Application;
+			const logoLocator = '.product-logo';
+			const titleLocator = '.gettingStartedCategoriesContainer div.header div .positron';
+			const footerLocator = '.gettingStartedCategoriesContainer div.footer';
+
+			const footer = app.code.driver.getLocator(footerLocator);
+
+			const logo = app.code.driver.getLocator(logoLocator);
+
+			await expect(logo).toBeVisible();
+			const logoBox = await (await logo.elementHandle())?.boundingBox();
+
+			expect(logoBox?.height).toBeGreaterThan(0);
+			expect(logoBox?.width).toBeGreaterThan(0);
+
+			const title = app.code.driver.getLocator(titleLocator);
+
+			// product name in release is 'Positron' and in dev is 'Positron Dev'
+			await expect(title).toHaveText([/(Positron)|(Positron Dev)/, 'an IDE for data science']);
+
+			await expect(footer).toHaveText('Show welcome page on startup');
+		});
+
+		it('Verify Welcome page content', async function () {
+			const app = this.app as Application;
+
+			const startTitle = app.workbench.positronWelcome.startSection.getByRole('heading');
+			const startButtons = app.workbench.positronWelcome.startSection.getByRole('button');
+
+			const helpSection = app.code.driver.getLocator('.positron-welcome-page-help');
+			const helpTitle = helpSection.getByRole('heading');
+			const helpLinks = helpSection.getByRole('link');
+
+			const openSection = app.code.driver.getLocator('.categories-column.categories-column-right .index-list.start-container');
+			const openTitle = openSection.getByRole('heading');
+			const openButtons = openSection.getByRole('button');
+
+			const recentSection = app.code.driver.getLocator('.categories-column.categories-column-right .index-list.recently-opened');
+			const recentTitle = recentSection.getByRole('heading');
+
+			await expect(startTitle).toHaveText('Start');
+
+			await expect(startButtons).toHaveCount(4);
+			await expect(startButtons).toHaveText(['New Notebook', 'New File', 'New Console', 'New Project']);
+
+			await expect(helpTitle).toHaveText('Help');
+
+			await expect(helpLinks).toHaveCount(3);
+			await expect(helpLinks).toHaveText(['Positron Documentation', 'Positron Community', 'Report a bug']);
+
+			await expect(openTitle).toHaveText('Open');
+
+			await expect(openButtons).toHaveCount(3);
+			await expect(openButtons).toHaveText(['Open...', 'New Folder...', 'New Folder from Git...']);
+
+			await app.workbench.quickaccess.runCommand('File: Clear Recently Opened...');
+
+			await expect(recentTitle).toHaveText('Recent');
+
+			// 'open a folder' is a button so there is no character space because of its padding
+			await expect(recentSection.locator('.empty-recent')).toHaveText('You have no recent folders,open a folderto start.');
+		});
+
+		it('Click on new project from the Welcome page', async function () {
+			const app = this.app as Application;
+
+			await app.workbench.positronWelcome.clickNewProject();
+			await app.workbench.positronPopups.popupCurrentlyOpen();
+
+			await app.workbench.positronPopups.waitForModalDialogBox();
+
+			// confirm New Project dialog box is open
+			await app.workbench.positronPopups.waitForModalDialogTitle('Create New Project');
+
+			await app.workbench.positronPopups.clickCancelOnModalDialogBox();
+		});
+
+		describe('Python', () => {
+			before(async function () {
+				await PositronPythonFixtures.SetupFixtures(this.app as Application);
+			});
+
+			it('Create a new Python file from the Welcome page', async function () {
+				const app = this.app as Application;
+
+				const editorTabLocator = app.code.driver.getLocator('div.tab.tab-actions-right.active.selected');
+
+				await app.workbench.positronWelcome.clickNewFile();
+
+				await app.workbench.quickinput.selectQuickInputElementContaining('Python File');
+
+				await expect(editorTabLocator.locator('.monaco-icon-label.file-icon')).toHaveClass(/python-lang-file-icon/);
+
+				await app.workbench.quickaccess.runCommand('View: Close Editor');
+			});
+
+			it('Create a new Python notebook from the Welcome page', async function () {
+				const app = this.app as Application;
+
+				const editorTabLocator = app.code.driver.getLocator('div.tab.tab-actions-right.active.selected');
+
+				await app.workbench.positronWelcome.clickNewNotebook();
+
+				await app.workbench.positronPopups.clickOnModalDialogPopupOption('Python Notebook');
+
+				await expect(editorTabLocator.locator('.monaco-icon-label.file-icon')).toHaveClass(/ipynb-ext-file-icon/);
+
+				const expectedInterpreterVersion = new RegExp(`Python ${process.env.POSITRON_PY_VER_SEL}`, 'i');
+				await expect(app.code.driver.getLocator('div.notebook-toolbar-container > div.notebook-toolbar-right a.kernel-label')).toHaveText(expectedInterpreterVersion);
+			});
+
+			it('Click on Python console from the Welcome page', async function () {
+				const app = this.app as Application;
+
+				await app.workbench.positronWelcome.clickNewConsole();
+				await app.workbench.positronPopups.popupCurrentlyOpen();
+
+				const expectedInterpreterVersion = new RegExp(`Python ${process.env.POSITRON_PY_VER_SEL}`, 'i');
+				await app.workbench.positronPopups.clickOnModalDialogPopupOption(expectedInterpreterVersion);
+
+				// editor is hidden because bottom panel is maximized
+				await expect(app.code.driver.getLocator('.split-view-view .part.editor')).not.toBeVisible();
+
+				// console is the active view in the bottom panel
+				await expect(app.code.driver.getLocator('.part.panel [aria-label="Active View Switcher"] li.action-item.checked')).toHaveText('Console');
+			});
+		});
+
+		describe('R', () => {
+			before(async function () {
+				await PositronRFixtures.SetupFixtures(this.app as Application);
+			});
+
+			it('Create a new R file from the Welcome page', async function () {
+				const app = this.app as Application;
+
+				const editorTabLocator = app.code.driver.getLocator('div.tab.tab-actions-right.active.selected');
+
+				await app.workbench.positronWelcome.clickNewFile();
+
+				await app.workbench.quickinput.selectQuickInputElementContaining('R File');
+
+				await expect(editorTabLocator.locator('.monaco-icon-label.file-icon')).toHaveClass(/r-lang-file-icon/);
+			});
+
+			it('Click on R console from the Welcome page', async function () {
+				const app = this.app as Application;
+
+				await app.workbench.positronWelcome.clickNewConsole();
+				await app.workbench.positronPopups.popupCurrentlyOpen();
+
+				const expectedInterpreterVersion = new RegExp(`R ${process.env.POSITRON_R_VER_SEL}`, 'i');
+				await app.workbench.positronPopups.clickOnModalDialogPopupOption(expectedInterpreterVersion);
+
+				// editor is hidden because bottom panel is maximized
+				await expect(app.code.driver.getLocator('.split-view-view .part.editor')).not.toBeVisible();
+
+				// console is the active view in the bottom panel
+				await expect(app.code.driver.getLocator('.part.panel [aria-label="Active View Switcher"] li.action-item.checked')).toHaveText('Console');
+			});
+
+			it('Create a new R notebook from the Welcome page', async function () {
+				const app = this.app as Application;
+
+				const editorTabLocator = app.code.driver.getLocator('div.tab.tab-actions-right.active.selected');
+
+				await app.workbench.positronWelcome.clickNewNotebook();
+
+				await app.workbench.positronPopups.clickOnModalDialogPopupOption('R Notebook');
+
+				await expect(editorTabLocator.locator('.monaco-icon-label.file-icon')).toHaveClass(/ipynb-ext-file-icon/);
+
+				const expectedInterpreterVersion = new RegExp(`R ${process.env.POSITRON_R_VER_SEL}`, 'i');
+				await expect(app.code.driver.getLocator('div.notebook-toolbar-container > div.notebook-toolbar-right a.kernel-label')).toHaveText(expectedInterpreterVersion);
+			});
+		});
+	});
+
+}

--- a/test/smoke/src/areas/positron/welcome/welcome.test.ts
+++ b/test/smoke/src/areas/positron/welcome/welcome.test.ts
@@ -30,26 +30,17 @@ export function setup(logger: Logger) {
 
 		it('Verify Welcome page header and footer', async function () {
 			const app = this.app as Application;
-			const logoLocator = '.product-logo';
-			const titleLocator = '.gettingStartedCategoriesContainer div.header div .positron';
-			const footerLocator = '.gettingStartedCategoriesContainer div.footer';
 
-			const footer = app.code.driver.getLocator(footerLocator);
-
-			const logo = app.code.driver.getLocator(logoLocator);
-
-			await expect(logo).toBeVisible();
-			const logoBox = await (await logo.elementHandle())?.boundingBox();
+			await expect(app.workbench.positronWelcome.logoLocator).toBeVisible();
+			const logoBox = await (await app.workbench.positronWelcome.logoLocator.elementHandle())?.boundingBox();
 
 			expect(logoBox?.height).toBeGreaterThan(0);
 			expect(logoBox?.width).toBeGreaterThan(0);
 
-			const title = app.code.driver.getLocator(titleLocator);
-
 			// product name in release is 'Positron' and in dev is 'Positron Dev'
-			await expect(title).toHaveText([/(Positron)|(Positron Dev)/, 'an IDE for data science']);
+			await expect(app.workbench.positronWelcome.titleLocator).toHaveText([/(Positron)|(Positron Dev)/, 'an IDE for data science']);
 
-			await expect(footer).toHaveText('Show welcome page on startup');
+			await expect(app.workbench.positronWelcome.footerLocator).toHaveText('Show welcome page on startup');
 		});
 
 		it('Verify Welcome page content', async function () {
@@ -81,7 +72,7 @@ export function setup(logger: Logger) {
 		it('Click on new project from the Welcome page', async function () {
 			const app = this.app as Application;
 
-			await app.workbench.positronWelcome.clickNewProject();
+			await app.workbench.positronWelcome.newProjectButton.click();
 			await app.workbench.positronPopups.popupCurrentlyOpen();
 
 			await app.workbench.positronPopups.waitForModalDialogBox();
@@ -100,7 +91,7 @@ export function setup(logger: Logger) {
 			it('Create a new Python file from the Welcome page', async function () {
 				const app = this.app as Application;
 
-				await app.workbench.positronWelcome.clickNewFile();
+				await app.workbench.positronWelcome.newFileButton.click();
 
 				await app.workbench.quickinput.selectQuickInputElementContaining('Python File');
 
@@ -112,7 +103,7 @@ export function setup(logger: Logger) {
 			it('Create a new Python notebook from the Welcome page', async function () {
 				const app = this.app as Application;
 
-				await app.workbench.positronWelcome.clickNewNotebook();
+				await app.workbench.positronWelcome.newNotebookButton.click();
 
 				await app.workbench.positronPopups.clickOnModalDialogPopupOption('Python Notebook');
 
@@ -125,7 +116,7 @@ export function setup(logger: Logger) {
 			it('Click on Python console from the Welcome page', async function () {
 				const app = this.app as Application;
 
-				await app.workbench.positronWelcome.clickNewConsole();
+				await app.workbench.positronWelcome.newConsoleButton.click();
 				await app.workbench.positronPopups.popupCurrentlyOpen();
 
 				const expectedInterpreterVersion = new RegExp(`Python ${process.env.POSITRON_PY_VER_SEL}`, 'i');
@@ -148,7 +139,7 @@ export function setup(logger: Logger) {
 			it('Create a new R file from the Welcome page', async function () {
 				const app = this.app as Application;
 
-				await app.workbench.positronWelcome.clickNewFile();
+				await app.workbench.positronWelcome.newFileButton.click();
 
 				await app.workbench.quickinput.selectQuickInputElementContaining('R File');
 
@@ -158,7 +149,7 @@ export function setup(logger: Logger) {
 			it('Click on R console from the Welcome page', async function () {
 				const app = this.app as Application;
 
-				await app.workbench.positronWelcome.clickNewConsole();
+				await app.workbench.positronWelcome.newConsoleButton.click();
 				await app.workbench.positronPopups.popupCurrentlyOpen();
 
 				const expectedInterpreterVersion = new RegExp(`R ${process.env.POSITRON_R_VER_SEL}`, 'i');
@@ -174,7 +165,7 @@ export function setup(logger: Logger) {
 			it('Create a new R notebook from the Welcome page', async function () {
 				const app = this.app as Application;
 
-				await app.workbench.positronWelcome.clickNewNotebook();
+				await app.workbench.positronWelcome.newNotebookButton.click();
 
 				await app.workbench.positronPopups.clickOnModalDialogPopupOption('R Notebook');
 

--- a/test/smoke/src/areas/positron/welcome/welcome.test.ts
+++ b/test/smoke/src/areas/positron/welcome/welcome.test.ts
@@ -55,41 +55,27 @@ export function setup(logger: Logger) {
 		it('Verify Welcome page content', async function () {
 			const app = this.app as Application;
 
-			const startTitle = app.workbench.positronWelcome.startSection.getByRole('heading');
-			const startButtons = app.workbench.positronWelcome.startSection.getByRole('button');
+			await expect(app.workbench.positronWelcome.startTitle).toHaveText('Start');
 
-			const helpSection = app.code.driver.getLocator('.positron-welcome-page-help');
-			const helpTitle = helpSection.getByRole('heading');
-			const helpLinks = helpSection.getByRole('link');
+			await expect(app.workbench.positronWelcome.startButtons).toHaveCount(4);
+			await expect(app.workbench.positronWelcome.startButtons).toHaveText(['New Notebook', 'New File', 'New Console', 'New Project']);
 
-			const openSection = app.code.driver.getLocator('.categories-column.categories-column-right .index-list.start-container');
-			const openTitle = openSection.getByRole('heading');
-			const openButtons = openSection.getByRole('button');
+			await expect(app.workbench.positronWelcome.helpTitle).toHaveText('Help');
 
-			const recentSection = app.code.driver.getLocator('.categories-column.categories-column-right .index-list.recently-opened');
-			const recentTitle = recentSection.getByRole('heading');
+			await expect(app.workbench.positronWelcome.helpLinks).toHaveCount(3);
+			await expect(app.workbench.positronWelcome.helpLinks).toHaveText(['Positron Documentation', 'Positron Community', 'Report a bug']);
 
-			await expect(startTitle).toHaveText('Start');
+			await expect(app.workbench.positronWelcome.openTitle).toHaveText('Open');
 
-			await expect(startButtons).toHaveCount(4);
-			await expect(startButtons).toHaveText(['New Notebook', 'New File', 'New Console', 'New Project']);
-
-			await expect(helpTitle).toHaveText('Help');
-
-			await expect(helpLinks).toHaveCount(3);
-			await expect(helpLinks).toHaveText(['Positron Documentation', 'Positron Community', 'Report a bug']);
-
-			await expect(openTitle).toHaveText('Open');
-
-			await expect(openButtons).toHaveCount(3);
-			await expect(openButtons).toHaveText(['Open...', 'New Folder...', 'New Folder from Git...']);
+			await expect(app.workbench.positronWelcome.openButtons).toHaveCount(3);
+			await expect(app.workbench.positronWelcome.openButtons).toHaveText(['Open...', 'New Folder...', 'New Folder from Git...']);
 
 			await app.workbench.quickaccess.runCommand('File: Clear Recently Opened...');
 
-			await expect(recentTitle).toHaveText('Recent');
+			await expect(app.workbench.positronWelcome.recentTitle).toHaveText('Recent');
 
 			// 'open a folder' is a button so there is no character space because of its padding
-			await expect(recentSection.locator('.empty-recent')).toHaveText('You have no recent folders,open a folderto start.');
+			await expect(app.workbench.positronWelcome.recentSection.locator('.empty-recent')).toHaveText('You have no recent folders,open a folderto start.');
 		});
 
 		it('Click on new project from the Welcome page', async function () {
@@ -114,13 +100,11 @@ export function setup(logger: Logger) {
 			it('Create a new Python file from the Welcome page', async function () {
 				const app = this.app as Application;
 
-				const editorTabLocator = app.code.driver.getLocator('div.tab.tab-actions-right.active.selected');
-
 				await app.workbench.positronWelcome.clickNewFile();
 
 				await app.workbench.quickinput.selectQuickInputElementContaining('Python File');
 
-				await expect(editorTabLocator.locator('.monaco-icon-label.file-icon')).toHaveClass(/python-lang-file-icon/);
+				await expect(app.workbench.editors.activeEditorLocator.locator(app.workbench.editors.editorIconLocator)).toHaveClass(/python-lang-file-icon/);
 
 				await app.workbench.quickaccess.runCommand('View: Close Editor');
 			});
@@ -128,16 +112,14 @@ export function setup(logger: Logger) {
 			it('Create a new Python notebook from the Welcome page', async function () {
 				const app = this.app as Application;
 
-				const editorTabLocator = app.code.driver.getLocator('div.tab.tab-actions-right.active.selected');
-
 				await app.workbench.positronWelcome.clickNewNotebook();
 
 				await app.workbench.positronPopups.clickOnModalDialogPopupOption('Python Notebook');
 
-				await expect(editorTabLocator.locator('.monaco-icon-label.file-icon')).toHaveClass(/ipynb-ext-file-icon/);
+				await expect(app.workbench.editors.activeEditorLocator.locator(app.workbench.editors.editorIconLocator)).toHaveClass(/ipynb-ext-file-icon/);
 
 				const expectedInterpreterVersion = new RegExp(`Python ${process.env.POSITRON_PY_VER_SEL}`, 'i');
-				await expect(app.code.driver.getLocator('div.notebook-toolbar-container > div.notebook-toolbar-right a.kernel-label')).toHaveText(expectedInterpreterVersion);
+				await expect(app.workbench.positronNotebooks.kernelLabelLocator).toHaveText(expectedInterpreterVersion);
 			});
 
 			it('Click on Python console from the Welcome page', async function () {
@@ -150,10 +132,11 @@ export function setup(logger: Logger) {
 				await app.workbench.positronPopups.clickOnModalDialogPopupOption(expectedInterpreterVersion);
 
 				// editor is hidden because bottom panel is maximized
-				await expect(app.code.driver.getLocator('.split-view-view .part.editor')).not.toBeVisible();
+				await expect(app.workbench.editors.editorPartLocator).not.toBeVisible();
 
 				// console is the active view in the bottom panel
-				await expect(app.code.driver.getLocator('.part.panel [aria-label="Active View Switcher"] li.action-item.checked')).toHaveText('Console');
+				await expect(app.workbench.positronLayouts.panelViewsTab).toHaveCount(6);
+				await expect(app.workbench.positronLayouts.panelViewsTab.and(app.code.driver.getLocator('.checked'))).toHaveText('Console');
 			});
 		});
 
@@ -165,13 +148,11 @@ export function setup(logger: Logger) {
 			it('Create a new R file from the Welcome page', async function () {
 				const app = this.app as Application;
 
-				const editorTabLocator = app.code.driver.getLocator('div.tab.tab-actions-right.active.selected');
-
 				await app.workbench.positronWelcome.clickNewFile();
 
 				await app.workbench.quickinput.selectQuickInputElementContaining('R File');
 
-				await expect(editorTabLocator.locator('.monaco-icon-label.file-icon')).toHaveClass(/r-lang-file-icon/);
+				await expect(app.workbench.editors.activeEditorLocator.locator(app.workbench.editors.editorIconLocator)).toHaveClass(/r-lang-file-icon/);
 			});
 
 			it('Click on R console from the Welcome page', async function () {
@@ -184,25 +165,23 @@ export function setup(logger: Logger) {
 				await app.workbench.positronPopups.clickOnModalDialogPopupOption(expectedInterpreterVersion);
 
 				// editor is hidden because bottom panel is maximized
-				await expect(app.code.driver.getLocator('.split-view-view .part.editor')).not.toBeVisible();
+				await expect(app.workbench.editors.editorPartLocator).not.toBeVisible();
 
 				// console is the active view in the bottom panel
-				await expect(app.code.driver.getLocator('.part.panel [aria-label="Active View Switcher"] li.action-item.checked')).toHaveText('Console');
+				await expect(app.workbench.positronLayouts.panelViewsTab.and(app.code.driver.getLocator('.checked'))).toHaveText('Console');
 			});
 
 			it('Create a new R notebook from the Welcome page', async function () {
 				const app = this.app as Application;
 
-				const editorTabLocator = app.code.driver.getLocator('div.tab.tab-actions-right.active.selected');
-
 				await app.workbench.positronWelcome.clickNewNotebook();
 
 				await app.workbench.positronPopups.clickOnModalDialogPopupOption('R Notebook');
 
-				await expect(editorTabLocator.locator('.monaco-icon-label.file-icon')).toHaveClass(/ipynb-ext-file-icon/);
+				await expect(app.workbench.editors.activeEditorLocator.locator(app.workbench.editors.editorIconLocator)).toHaveClass(/ipynb-ext-file-icon/);
 
 				const expectedInterpreterVersion = new RegExp(`R ${process.env.POSITRON_R_VER_SEL}`, 'i');
-				await expect(app.code.driver.getLocator('div.notebook-toolbar-container > div.notebook-toolbar-right a.kernel-label')).toHaveText(expectedInterpreterVersion);
+				await expect(app.workbench.positronNotebooks.kernelLabelLocator).toHaveText(expectedInterpreterVersion);
 			});
 		});
 	});

--- a/test/smoke/src/areas/positron/welcome/welcome.test.ts
+++ b/test/smoke/src/areas/positron/welcome/welcome.test.ts
@@ -15,7 +15,11 @@ import { installAllHandlers } from '../../../utils';
 export function setup(logger: Logger) {
 	describe('Welcome Page', () => {
 		installAllHandlers(logger);
-
+		
+		before(async function () {
+			await PositronPythonFixtures.SetupFixtures(this.app as Application);
+		});
+		
 		beforeEach(async function () {
 			const app = this.app as Application;
 

--- a/test/smoke/src/areas/positron/welcome/welcome.test.ts
+++ b/test/smoke/src/areas/positron/welcome/welcome.test.ts
@@ -122,7 +122,6 @@ export function setup(logger: Logger) {
 				await expect(app.workbench.editors.editorPart).not.toBeVisible();
 
 				// console is the active view in the bottom panel
-				await expect(app.workbench.positronLayouts.panelViewsTab).toHaveCount(6);
 				await expect(app.workbench.positronLayouts.panelViewsTab.and(app.code.driver.getLocator('.checked'))).toHaveText('Console');
 			});
 		});

--- a/test/smoke/src/areas/positron/welcome/welcome.test.ts
+++ b/test/smoke/src/areas/positron/welcome/welcome.test.ts
@@ -45,6 +45,10 @@ export function setup(logger: Logger) {
 
 		it('Verify Welcome page content', async function () {
 			const app = this.app as Application;
+			const OPEN_BUTTONS_COUNT = process.platform === 'darwin' ? 3 : 4;
+			const OPEN_BUTTONS_LABELS = process.platform === 'darwin' ?
+				['Open...', 'New Folder...', 'New Folder from Git...']
+				: ['Open...', 'Open File...', 'New Folder...', 'New Folder from Git...'];
 
 			await expect(app.workbench.positronWelcome.startTitle).toHaveText('Start');
 
@@ -58,8 +62,8 @@ export function setup(logger: Logger) {
 
 			await expect(app.workbench.positronWelcome.openTitle).toHaveText('Open');
 
-			await expect(app.workbench.positronWelcome.openButtons).toHaveCount(3);
-			await expect(app.workbench.positronWelcome.openButtons).toHaveText(['Open...', 'New Folder...', 'New Folder from Git...']);
+			await expect(app.workbench.positronWelcome.openButtons).toHaveCount(OPEN_BUTTONS_COUNT);
+			await expect(app.workbench.positronWelcome.openButtons).toHaveText(OPEN_BUTTONS_LABELS);
 
 			await app.workbench.quickaccess.runCommand('File: Clear Recently Opened...');
 

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -50,6 +50,7 @@ import { setup as setupConsoleInputTest } from './areas/positron/console/console
 import { setup as setupConsoleANSITest } from './areas/positron/console/consoleANSI.test';
 import { setup as setupConsoleOutputLogTest } from './areas/positron/output/consoleOutputLog.test';
 import { setup as setupBasicRMarkdownTest } from './areas/positron/rmarkdown/rmarkdown.test';
+import { setup as setupWelcomeTest } from './areas/positron/welcome/welcome.test';
 // --- End Positron ---
 
 const rootPath = path.join(__dirname, '..', '..', '..');
@@ -456,5 +457,6 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	setupConsoleANSITest(logger);
 	setupConsoleOutputLogTest(logger);
 	setupBasicRMarkdownTest(logger);
+	setupWelcomeTest(logger);
 	// --- End Positron ---
 });


### PR DESCRIPTION
Adds smoke tests for verifying the Welcome page content and that the Start section buttons work.

Changed the `PositronPopup` to allow reusing the modal dialog title locator.

Fixed the modal popup clicking on an option. It wasn't reliable with plot tests and needed to support regex to locate the primary interpreter.

### QA Notes
Suite runs in about 39s on my machine. There's a distinct pause when choosing the interpreter for the console. I think it's from using the regex and it's slower than using a selector. We can consider adding more unique id's to speed up execution.