### PR TITLE
[python] use interpreter to check ipykernel version

### DIFF
--- a/extensions/positron-python/src/client/common/installer/condaInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/condaInstaller.ts
@@ -103,7 +103,10 @@ export class CondaInstaller extends ModuleInstaller {
         if (flags & ModuleInstallFlags.updateDependencies) {
             args.push('--update-deps');
         }
-        if (flags & ModuleInstallFlags.reInstall) {
+        if (
+            flags & ModuleInstallFlags.reInstall ||
+            [Product.ipykernel].map(translateProductToModule).includes(moduleName)
+        ) {
             args.push('--force-reinstall');
         }
         args.push(moduleName);

--- a/extensions/positron-python/src/client/common/installer/condaInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/condaInstaller.ts
@@ -103,10 +103,14 @@ export class CondaInstaller extends ModuleInstaller {
         if (flags & ModuleInstallFlags.updateDependencies) {
             args.push('--update-deps');
         }
+        // --- Start Positron ---
+        // force reinstall ipykernel, to avoid unexpected behavior
+        // if it was uninstalled via pip
         if (
             flags & ModuleInstallFlags.reInstall ||
-            [Product.ipykernel].map(translateProductToModule).includes(moduleName)
+            ([Product.ipykernel].map(translateProductToModule).includes(moduleName) && args[0] === 'install')
         ) {
+            // --- End Positron ---
             args.push('--force-reinstall');
         }
         args.push(moduleName);

--- a/extensions/positron-python/src/client/common/process/pythonEnvironment.ts
+++ b/extensions/positron-python/src/client/common/process/pythonEnvironment.ts
@@ -83,9 +83,10 @@ class PythonEnvironment implements IPythonEnvironment {
     public async isModuleInstalled(moduleName: string): Promise<boolean> {
         // prettier-ignore
         const [args,] = internalPython.isModuleInstalled(moduleName);
-        const info = this.getExecutionInfo(args);
+        // --- Start Positron ---
         try {
-            await this.deps.exec(info.command, info.args);
+            await this.deps.exec(this.pythonPath, args);
+            // --- End Positron ---
         } catch (ex) {
             traceVerbose(`Error when checking if module is installed ${moduleName}`, ex);
             return false;

--- a/extensions/positron-python/src/client/common/process/pythonEnvironment.ts
+++ b/extensions/positron-python/src/client/common/process/pythonEnvironment.ts
@@ -66,10 +66,13 @@ class PythonEnvironment implements IPythonEnvironment {
 
     public async getModuleVersion(moduleName: string): Promise<string | undefined> {
         const [args, parse] = internalPython.getModuleVersion(moduleName);
-        const info = this.getExecutionInfo(args);
+        // --- Start Positron ---
         let data: ExecutionResult<string>;
         try {
-            data = await this.deps.exec(info.command, info.args);
+            // using `conda run ...` fails in some scenarios
+            // use interpreter directly to get module version
+            data = await this.deps.exec(this.pythonPath, args);
+            // --- End Positron ---
         } catch (ex) {
             traceVerbose(`Error when getting version of module ${moduleName}`, ex);
             return undefined;

--- a/extensions/positron-python/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -569,7 +569,11 @@ suite('Module Installer', () => {
                                                 expectedArgs.push(
                                                     condaEnvInfo.path.fileToCommandArgumentForPythonExt(),
                                                 );
+                                                // --- Start Positron ---
+                                            } else if (!isUpgrade && moduleName == 'ipykernel') {
+                                                expectedArgs.push('--force-reinstall');
                                             }
+                                            // --- End Positron ---
                                             expectedArgs.push(moduleName);
                                             expectedArgs.push('-y');
                                             await installModuleAndVerifyCommand(

--- a/extensions/positron-python/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -569,8 +569,9 @@ suite('Module Installer', () => {
                                                 expectedArgs.push(
                                                     condaEnvInfo.path.fileToCommandArgumentForPythonExt(),
                                                 );
-                                                // --- Start Positron ---
-                                            } else if (!isUpgrade && moduleName == 'ipykernel') {
+                                            }
+                                            // --- Start Positron ---
+                                            if (!isUpgrade && moduleName === 'ipykernel') {
                                                 expectedArgs.push('--force-reinstall');
                                             }
                                             // --- End Positron ---


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

addresses #2504 

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

If you would like to reproduce the problem, follow steps outlined in one or more scenarios and then try to start a conda environment.

----

Okay, after diving into this for a bit, I have a few reasons why `conda` environments may be causing troubles. There are a few flavors of scenarios to outline and how you might have gotten there.

### The "wrong conda is executing when trying to find the ipykernel version" scenario

- You have installed multiple versions of conda (eg, miniconda3 and miniforge3) as well as pyenv and have pyenv activating _after_ conda in your `~/.bashrc` or maybe `~/.zshrc` file (see: https://github.com/conda/conda/issues/10401)
- You have installed and then partially uninstalled multiple versions of conda (eg, miniconda3 and miniforge3) and only partially uninstalled one (adjacent problem: https://github.com/ipython/ipython/issues/10986)
- potentially other similar scenarios, primarily stemming from multiple installations/uninstallations of conda

These situations all cause `conda run -n CondaEnvName python PATH_TO_POSITRON_EXT/positron-python/python_files/get_output_via_markers.py -c 'import ipykernel; print(ipykernel.__version__` [to check the version of `ipykernel`](https://github.com/posit-dev/positron/blob/af322f25da6da36c9d9e3c2bcd9b14f87950330f/extensions/positron-python/src/client/common/process/pythonEnvironment.ts#L68) to use the wrong python, even if the correct conda is activated. There are a few linked issues as to why this can be the case. We can use the interpreter directly without side effects AFAIK, this is what was currently being done for all non-conda interpreters.

### The "conda is reporting ipykernel is installed, but it really isn't" scenario

- `conda install ipykernel` in an interpreter, and then `pip uninstall ipykernel` at a later point in time. Then, you click "install" at the Positron ipykernel prompt.

When this occurs, the conda interpreter reports that ipykernel is installed, even though it is not. In this case, a `--force-reinstall` will create the ideal behavior. Forcing a reinstall has no different behavior if a package has not been previously installed.

### The "conda inside a different environment manager" scenario 

- You are using conda-forge or otherwise to install python + packages inside a different package manager, eg, pyenv.
 
For this, a conda installer is used but it should be a pip installer. I think this is a smaller use case, to be fixed in a later PR.