### PR TITLE
Fix smoke tests - selector change in console

### DIFF
--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -132,7 +132,7 @@ export class PositronConsole {
 	}
 
 	async waitForConsoleContents(accept?: (contents: string[]) => boolean) {
-		const elements = await this.code.waitForElements(`${ACTIVE_CONSOLE_INSTANCE} .runtime-items span`,
+		const elements = await this.code.waitForElements(`${ACTIVE_CONSOLE_INSTANCE} div span`,
 			false,
 			(elements) => accept ? (!!elements && accept(elements.map(e => e.textContent))) : true);
 		return elements.map(e => e.textContent);


### PR DESCRIPTION
Minor selector change.  Looks like the class runtime-items went away in the console.

### QA Notes

All smoke tests pass
