### PR TITLE
Data Explorer: work around errors caused by upgrading from polars 0.20.x to 1.2.x

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -890,7 +890,7 @@ class PolarsSeriesInspector(BaseColumnInspector["pl.Series"]):
         try:
             return self.value.equals(value)
         except AttributeError:  # polars.Series.equals was introduced in v0.19.16
-            return self.value.series_equal(value)
+            return self.value.series_equal(value)  # type: ignore
 
     def deepcopy(self) -> pl.Series:
         # Polars produces a shallow clone and does not copy any memory
@@ -1003,7 +1003,7 @@ class PolarsDataFrameInspector(BaseTableInspector["pl.DataFrame", "pl.Series"]):
         try:
             return self.value.equals(value)
         except AttributeError:  # polars.DataFrame.equals was introduced in v0.19.16
-            return self.value.frame_equal(value)
+            return self.value.frame_equal(value)  # type: ignore
 
     def deepcopy(self) -> pl.DataFrame:
         # Polars produces a shallow clone and does not copy any memory

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -3026,8 +3026,6 @@ def test_polars_profile_summary_stats(dxf: DataExplorerFixture):
     arr_with_nulls[::10] = None
     arr_with_nulls = list(arr_with_nulls)
 
-    us_eastern = pytz.timezone("US/Eastern")
-
     df1 = pl.DataFrame(
         {
             "f0": arr,
@@ -3056,10 +3054,10 @@ def test_polars_profile_summary_stats(dxf: DataExplorerFixture):
             ),  # datetime no tz
             "f6": pl.Series(
                 [
-                    x.replace(tzinfo=us_eastern)
+                    x.replace(tzinfo=pytz.utc)
                     for x in pd.date_range("2000-01-01", freq="2h", periods=100)
                 ],
-                dtype=pl.Datetime("ms", time_zone="US/Eastern"),
+                dtype=pl.Datetime("ms", time_zone="UTC"),
             ),  # datetime single tz
             "f7": [np.nan, np.inf, -np.inf, 0, np.nan] * 20,  # with infinity
         }
@@ -3136,11 +3134,11 @@ def test_polars_profile_summary_stats(dxf: DataExplorerFixture):
             6,
             {
                 "num_unique": 100,
-                "min_date": "2000-01-01 00:00:00-05:00",
-                "mean_date": "2000-01-05 03:00:00-05:00",
-                "median_date": "2000-01-05 03:00:00-05:00",
-                "max_date": "2000-01-09 06:00:00-05:00",
-                "timezone": "US/Eastern",
+                "min_date": "2000-01-01 00:00:00+00:00",
+                "mean_date": "2000-01-05 03:00:00+00:00",
+                "median_date": "2000-01-05 03:00:00+00:00",
+                "max_date": "2000-01-09 06:00:00+00:00",
+                "timezone": "UTC",
             },
         ),
         (

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -133,8 +133,7 @@ df = pd.DataFrame(data)`;
 				expect(tableData.length).toBe(2);
 			});
 
-			// Skip due to issue https://github.com/posit-dev/positron/issues/4070
-			it.skip('Python Polars - Add Simple Column Sort [C557561]', async function () {
+			it('Python Polars - Add Simple Column Sort [C557561]', async function () {
 				const app = this.app as Application;
 				await app.workbench.positronDataExplorer.selectColumnMenuItem(1, 'Sort Descending');
 


### PR DESCRIPTION
polars 1.2.x contains various behavior changes that had to be worked around, causing errors like #4070. I reported some of the issues as bugs upstream in polars (they may or may not be considered bugs in polars -- they look like bugs to me or at minimum unpleasant sharp edges). I was able to get the unit tests working on both 0.20.x and 1.2.x but we have a blind spot in our CI right now in that we do not test > polars 1.0 yet. 

### QA Notes

These failures arose because the polars version in the smoke test CI setup wasn't pinned -- it would have been sufficient to run the unit test suite for both 0.20.x and 1.2.x to find these issues.