### PR TITLE
Lint for Mocha `.only` included in `.test.ts` in precommit and hygiene

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,8 @@
 		"jsdoc",
 		"header",
 		"local",
-		"react"
+		"react",
+		"mocha"
 	],
 	"extends": [
 		"plugin:react/recommended",
@@ -116,7 +117,8 @@
 					"pattern": "-{93}\r?\n [*] {2}((Copyright [(]c[)] Microsoft Corporation. All rights reserved.\r?\n [*] {2}Licensed under the MIT License. See License.txt in the project root for license information.)|(Copyright [(][cC]{1}[)]\\s?(20\\d{2})?(-20\\d{2})? Posit Software, PBC\\.( All rights reserved\\.)?\r?\n [*] {2}Licensed under the Elastic License 2\\.0\\. See LICENSE\\.txt for license information\\.))\r?\n [*]-{92}"
 				}
 			]
-		]
+		],
+		"mocha/no-exclusive-tests": "error"
 	},
 	"overrides": [
 		{

--- a/build/detect-secrets-hook.js
+++ b/build/detect-secrets-hook.js
@@ -26,7 +26,6 @@ function detectSecretsHook(reporter) {
 				break;
 		}
 		reporter(message, true);
-		throw new Error(message);
 	}
 	return es.through(function () { /* noop, important for the stream to end */ });
 }

--- a/build/detect-secrets-hook.js
+++ b/build/detect-secrets-hook.js
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 const es = require('event-stream');
-const vfs = require('vinyl-fs');
 const child_process = require('child_process');
 
 module.exports = detectSecretsHook;

--- a/build/eslint-mocha-only-hook.js
+++ b/build/eslint-mocha-only-hook.js
@@ -8,7 +8,7 @@ const child_process = require('child_process');
 
 const eslintMochaOnlyHook = (reporter) => {
 	try {
-		const result = child_process.execSync('node build/eslint-mocha-only.js', { encoding: 'utf8', stdio: 'inherit' });
+		const result = child_process.execSync('node build/eslint-mocha-only.js', { encoding: 'utf8' });
 	} catch (error) {
 		let message = '';
 		let shouldFail;

--- a/build/eslint-mocha-only-hook.js
+++ b/build/eslint-mocha-only-hook.js
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const es = require('event-stream');
+const child_process = require('child_process');
+
+const eslintMochaOnlyHook = (reporter) => {
+	try {
+		const result = child_process.execSync('node build/eslint-mocha-only.js', { encoding: 'utf8', stdio: 'inherit' });
+	} catch (error) {
+		let message = '';
+		let shouldFail;
+		// See ExitCodes in build/eslint-mocha-only.js
+		switch (error.status) {
+			case 1:
+				message = '`.only` was included in the staged test files. Please remove \`.only\` before committing, or commit with \`--no-verify\` to bypass, but this will skip all pre-commit hooks.';
+				shouldFail = true;
+				break;
+			default:
+				message = 'Something went wrong while running the eslint-mocha-only hook.';
+				shouldFail = true;
+				break;
+		}
+		reporter(message, shouldFail);
+		if (shouldFail) {
+			throw new Error(message);
+		}
+	}
+	return es.through(function () {
+		/* noop, important for the stream to end */
+	});
+};
+
+module.exports = eslintMochaOnlyHook;

--- a/build/eslint-mocha-only-hook.js
+++ b/build/eslint-mocha-only-hook.js
@@ -14,7 +14,7 @@ const eslintMochaOnlyHook = (reporter) => {
 		// See ExitCodes in build/eslint-mocha-only.js
 		switch (error.status) {
 			case 1:
-				message = '`.only` was included in the staged test files. Please remove \`.only\` before committing, or commit with \`--no-verify\` to bypass, but this will skip all pre-commit hooks.';
+				message = 'If you end up committing with \`.only\`: please remove `.only` from your tests before merging to `main` :)';
 				break;
 			case 2:
 				message = 'eslint-mocha-only wrapper script encountered an error while running the hook.';
@@ -23,7 +23,7 @@ const eslintMochaOnlyHook = (reporter) => {
 				message = 'eslint-mocha-only encountered an error while running the hook';
 				break;
 		}
-		reporter(message, true);
+		reporter(message + '\n', true);
 	}
 	return es.through(function () {
 		/* noop, important for the stream to end */

--- a/build/eslint-mocha-only-hook.js
+++ b/build/eslint-mocha-only-hook.js
@@ -11,22 +11,19 @@ const eslintMochaOnlyHook = (reporter) => {
 		const result = child_process.execSync('node build/eslint-mocha-only.js', { encoding: 'utf8' });
 	} catch (error) {
 		let message = '';
-		let shouldFail;
 		// See ExitCodes in build/eslint-mocha-only.js
 		switch (error.status) {
 			case 1:
 				message = '`.only` was included in the staged test files. Please remove \`.only\` before committing, or commit with \`--no-verify\` to bypass, but this will skip all pre-commit hooks.';
-				shouldFail = true;
+				break;
+			case 2:
+				message = 'eslint-mocha-only wrapper script encountered an error while running the hook.';
 				break;
 			default:
-				message = 'Something went wrong while running the eslint-mocha-only hook.';
-				shouldFail = true;
+				message = 'eslint-mocha-only encountered an error while running the hook';
 				break;
 		}
-		reporter(message, shouldFail);
-		if (shouldFail) {
-			throw new Error(message);
-		}
+		reporter(message, true);
 	}
 	return es.through(function () {
 		/* noop, important for the stream to end */

--- a/build/eslint-mocha-only.js
+++ b/build/eslint-mocha-only.js
@@ -46,17 +46,16 @@ try {
 		console.log('No staged test files found. Skipping eslint-mocha-only hook.'.cyan);
 		process.exit(ExitCodes.SUCCESS);
 	}
-	// Non-ideal way to fail on `only` being used in mocha tests
+	// Non-ideal way to fail on `only` being used in mocha tests without triggering other linting rules.
 	const result = child_process.execSync(
-		`npx eslint --rule 'mocha/no-exclusive-tests: error' ${files}`,
+		`npx eslint --no-eslintrc --parser '@typescript-eslint/parser' --plugin 'mocha' --rule 'mocha/no-exclusive-tests: error' ${files}`,
 		{ encoding: 'utf8' }
 	);
 	process.exit(ExitCodes.SUCCESS);
 } catch (error) {
 	console.error(
-		`It looks like you've included \`.only\` in your test(s):\n`.cyan +
-		`${error.stdout}` +
-		'If you end up committing with \`.only\`: just a friendly reminder to remove `.only` from your tests before merging to `main` :)'.magenta
+		`It looks like you've included \`.only\` in your test(s):\n`.magenta +
+		`${error.stdout}`
 	);
 	process.exit(ExitCodes.ONLY_COMMITTED_FAIL_HOOK);
 }

--- a/build/eslint-mocha-only.js
+++ b/build/eslint-mocha-only.js
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const child_process = require('child_process');
+const colors = require('colors');
+const readline = require('readline/promises');
+
+// Enum for exit codes
+const ExitCodes = {
+	SUCCESS: 0,                  // success
+	ONLY_COMMITTED_FAIL_HOOK: 1, // fail since `.only` was found in the staged test files
+	ERROR: 2,                    // something else went wrong
+};
+
+// git -z option is used to separate file names with null characters
+// Split the output by null characters and remove empty strings, then join the files with a
+// space so that they can be passed as arguments
+const getStagedTestFiles = () => {
+	try {
+		return (
+			child_process
+				.execSync('git diff --cached --name-only -z', {
+					encoding: 'utf8',
+				})
+				.split('\0')
+				.filter((x) => !!x)
+				// Non-ideal way to filter for test files
+				.filter((x) => x.endsWith('.test.ts'))
+				.join(' ')
+		);
+	} catch (error) {
+		console.error(`Error: Could not get staged files: ${error}`.red);
+		process.exit(ExitCodes.ERROR);
+	}
+};
+
+try {
+	const files = getStagedTestFiles();
+	if (!files) {
+		process.exit(ExitCodes.SUCCESS);
+	}
+	// Non-ideal way to fail on `only` being used in mocha tests
+	const result = child_process.execSync(
+		`npx eslint --rule 'mocha/no-exclusive-tests: error' ${files}`,
+		{ encoding: 'utf8' }
+	);
+	process.exit(ExitCodes.SUCCESS);
+} catch (error) {
+	console.error(
+		`It looks like you've included \`.only\` in your test(s):\n`.cyan +
+		`${error.stdout}` +
+		'If you end up committing with \`.only\`: just a friendly reminder to remove `.only` from your tests before merging to `main` :)'.magenta
+	);
+	process.exit(ExitCodes.ONLY_COMMITTED_FAIL_HOOK);
+}

--- a/build/eslint-mocha-only.js
+++ b/build/eslint-mocha-only.js
@@ -3,6 +3,10 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// This script can be run standalone from the root of the project to check for `.only` in staged
+// test files with `node build/eslint-mocha-only.js`.
+// It is also run in the pre-commit/hygiene tasks to check for `.only` in staged test files.
+
 const child_process = require('child_process');
 const colors = require('colors');
 const readline = require('readline/promises');
@@ -39,6 +43,7 @@ const getStagedTestFiles = () => {
 try {
 	const files = getStagedTestFiles();
 	if (!files) {
+		console.log('No staged test files found. Skipping eslint-mocha-only hook.'.cyan);
 		process.exit(ExitCodes.SUCCESS);
 	}
 	// Non-ideal way to fail on `only` being used in mocha tests

--- a/build/filters.js
+++ b/build/filters.js
@@ -236,3 +236,14 @@ module.exports.eslintFilter = [
 module.exports.stylelintFilter = [
 	'src/**/*.css'
 ];
+
+// --- Start Positron ---
+module.exports.eslintMochaFilter = [
+	'test/**/*.ts',
+	...readFileSync(join(__dirname, '../.eslintignore'))
+		.toString().split(/\r\n|\n/)
+		.filter(line => !line.startsWith('#'))
+		.filter(line => !!line)
+		.map(line => `!${line}`)
+];
+// --- End Positron ---

--- a/build/filters.js
+++ b/build/filters.js
@@ -236,14 +236,3 @@ module.exports.eslintFilter = [
 module.exports.stylelintFilter = [
 	'src/**/*.css'
 ];
-
-// --- Start Positron ---
-module.exports.eslintMochaFilter = [
-	'test/**/*.ts',
-	...readFileSync(join(__dirname, '../.eslintignore'))
-		.toString().split(/\r\n|\n/)
-		.filter(line => !line.startsWith('#'))
-		.filter(line => !!line)
-		.map(line => `!${line}`)
-];
-// --- End Positron ---

--- a/build/hygiene.js
+++ b/build/hygiene.js
@@ -15,7 +15,7 @@ const pall = require('p-all');
 const colors = require('colors');
 // --- End Positron ---
 
-const { all, copyrightFilter, unicodeFilter, indentationFilter, tsFormattingFilter, eslintFilter, stylelintFilter, eslintMochaFilter } = require('./filters');
+const { all, copyrightFilter, unicodeFilter, indentationFilter, tsFormattingFilter, eslintFilter, stylelintFilter } = require('./filters');
 
 const copyrightHeaderLines = [
 	'/*---------------------------------------------------------------------------------------------',

--- a/build/hygiene.js
+++ b/build/hygiene.js
@@ -250,30 +250,10 @@ function hygiene(some, linting = true, secrets = true) {
 					errorCount++;
 				} else {
 					console.warn(message);
+					warningCount++;
 				}
 			}))
 		);
-		// It would be nice to get something like this working, so we don't need to recalculate the
-		// staged files and filter them again for eslintMocha...but the eslint errors don't seem to be
-		// getting caught by the reporter. It seems like no errors are being reported?
-		// Even the eslint linting above doesn't seem to error? I tried committing code that has
-		// eslint errors, but the pre-commit hygiene check passed.
-		// streams.push(
-		// 	result
-		// 		.pipe(filter(eslintMochaFilter))
-		// 		.pipe(
-		// 			gulpeslint({
-		// 				configFile: '.eslintrc.json'
-		// 			})
-		// 		)
-		// 		.pipe(gulpeslint.formatEach('compact'))
-		// 		.pipe(
-		// 			gulpeslint.results((results) => {
-		// 				errorCount += results.warningCount;
-		// 				errorCount += results.errorCount;
-		// 			})
-		// 		)
-		// );
 		// --- End Positron ---
 	}
 
@@ -286,6 +266,7 @@ function hygiene(some, linting = true, secrets = true) {
 					errorCount++;
 				} else {
 					console.warn(message);
+					warningCount++;
 				}
 			}))
 		);

--- a/build/hygiene.js
+++ b/build/hygiene.js
@@ -280,6 +280,12 @@ function hygiene(some, linting = true, secrets = true) {
 					process.stdout.write('.');
 				}
 				this.emit('data', data);
+
+				// --- Start Positron ---
+				if (errorCount > 0) {
+					this.emit('error', 'Hygiene failed with ' + errorCount + ' errors');
+				}
+				// --- End Positron ---
 			},
 			function () {
 				process.stdout.write('\n');

--- a/build/hygiene.js
+++ b/build/hygiene.js
@@ -11,6 +11,10 @@ const path = require('path');
 const fs = require('fs');
 const pall = require('p-all');
 
+// --- Start Positron ---
+const colors = require('colors');
+// --- End Positron ---
+
 const { all, copyrightFilter, unicodeFilter, indentationFilter, tsFormattingFilter, eslintFilter, stylelintFilter, eslintMochaFilter } = require('./filters');
 
 const copyrightHeaderLines = [
@@ -101,9 +105,11 @@ function hygiene(some, linting = true, secrets = true) {
 			} else if (/^[\t]* \*/.test(line)) {
 				// block comment using an extra space
 			} else {
+				// --- Start Positron ---
 				console.error(
-					file.relative + '(' + (i + 1) + ',1): Bad whitespace indentation'
+					file.relative + '(' + (i + 1) + ',1): ' + 'Bad whitespace indentation'.magenta
 				);
+				// --- End Positron ---
 				errorCount++;
 			}
 		});
@@ -152,7 +158,7 @@ function hygiene(some, linting = true, secrets = true) {
 		if (!(matchHeaderLines(copyrightHeaderLines) ||
 			regexMatchHeaderLines(positCopyrightHeaderLines) ||
 			regexMatchHeaderLines(positCopyrightHeaderLinesHash))) {
-			console.error(file.relative + ': Missing or bad copyright statement');
+			console.error(file.relative + ': ' + 'Missing or bad copyright statement'.magenta);
 			errorCount++;
 		}
 
@@ -168,10 +174,12 @@ function hygiene(some, linting = true, secrets = true) {
 			const original = rawInput.replace(/\r\n/gm, '\n');
 			const formatted = rawOutput.replace(/\r\n/gm, '\n');
 			if (original !== formatted) {
+				// --- Start Positron ---
 				console.error(
-					`File not formatted. Run the 'Format Document' command to fix it:`,
-					file.relative
+					file.relative + ': ' +
+					`File not formatted. Run the 'Format Document' command to fix it`.magenta
 				);
+				// --- End Positron ---
 				errorCount++;
 			}
 			cb(null, file);
@@ -283,7 +291,7 @@ function hygiene(some, linting = true, secrets = true) {
 
 				// --- Start Positron ---
 				if (errorCount > 0) {
-					this.emit('error', 'Hygiene failed with ' + errorCount + ' errors');
+					this.emit('error', `Hygiene failed with ${errorCount} errors`.red);
 				}
 				// --- End Positron ---
 			},

--- a/build/hygiene.js
+++ b/build/hygiene.js
@@ -250,7 +250,6 @@ function hygiene(some, linting = true, secrets = true) {
 					errorCount++;
 				} else {
 					console.warn(message);
-					warningCount++;
 				}
 			}))
 		);
@@ -266,7 +265,6 @@ function hygiene(some, linting = true, secrets = true) {
 					errorCount++;
 				} else {
 					console.warn(message);
-					warningCount++;
 				}
 			}))
 		);

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-jsdoc": "^46.5.0",
     "eslint-plugin-local": "^1.0.0",
+    "eslint-plugin-mocha": "^10.4.3",
     "eslint-plugin-react": "^7.34.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "event-stream": "3.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4425,6 +4425,15 @@ eslint-plugin-local@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-local/-/eslint-plugin-local-1.0.0.tgz#f0c07011c95fec42bfb4d909debb6ea035f3b2a4"
   integrity sha512-bcwcQnKL/Iw5Vi/F2lG1he5oKD2OGjhsLmrcctkWrWq5TujgiaYb0cj3pZgr3XI54inNVnneOFdAx1daLoYLJQ==
 
+eslint-plugin-mocha@^10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-10.4.3.tgz#bf641379d9f1c7d6a84646a3fc1a0baa50da8bfd"
+  integrity sha512-emc4TVjq5Ht0/upR+psftuz6IBG5q279p+1dSRDeHf+NS9aaerBi3lXKo1SEzwC29hFIW21gO89CEWSvRsi8IQ==
+  dependencies:
+    eslint-utils "^3.0.0"
+    globals "^13.24.0"
+    rambda "^7.4.0"
+
 eslint-plugin-react-hooks@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
@@ -4485,10 +4494,22 @@ eslint-utils@^1.3.1:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
+
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+
+eslint-visitor-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
 eslint-visitor-keys@^3.3.0:
   version "3.3.0"
@@ -5478,6 +5499,13 @@ globals@^13.19.0:
   version "13.20.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
   integrity sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==
+  dependencies:
+    type-fest "^0.20.2"
+
+globals@^13.24.0:
+  version "13.24.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.24.0.tgz#8432a19d78ce0c1e833949c36adb345400bb1171"
+  integrity sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==
   dependencies:
     type-fest "^0.20.2"
 
@@ -9132,6 +9160,11 @@ quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
+rambda@^7.4.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/rambda/-/rambda-7.5.0.tgz#1865044c59bc0b16f63026c6e5a97e4b1bbe98fe"
+  integrity sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA==
 
 randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Description

- Addresses https://github.com/posit-dev/positron/issues/4110
- Adds `eslint-plugin-mocha` to `package.json` (devs will likely need to `yarn` after this goes in)
- Introduces `build/eslint-mocha-only.js` and `build/eslint-mocha-only-hook.js`, which follows the similar `detect-secrets` scripts closely, to run `npx eslint --no-eslintrc --parser '@typescript-eslint/parser' --plugin 'mocha' --rule 'mocha/no-exclusive-tests: error' ${files}` on staged test files
- Adds a bit more colour to precommit/hygiene output
- If the ESLint extension is installed, usages of `.only` will be red-squiggly-underlined
- This also makes it so hygiene will always fail the commit if any errors were detected. It currently seems like there is some inconsistency in whether the precommit/hygiene fails in local dev when committing, when an error occurs.

### Preview

#### ESList highlighting of `.only` as an error in the editor

https://github.com/user-attachments/assets/74e73b5e-4b9d-4b8f-947f-c2e5f3396b31

#### Committing with `.only`

https://github.com/user-attachments/assets/4281e4cc-b2fe-455f-9548-1f4af9ffa1ec

#### Committing with `.only` and missing copyright header

https://github.com/user-attachments/assets/bfbe1156-133c-40e0-a865-3ba8aef59d21

### QA Notes

- These changes should play nicely with any existing precommit/hygiene checks like `detect-secrets`, typescript file formatting, proper copyright headers in any file, etc.
- There shouldn't be any issues on Windows 🤞 
