### PR TITLE
Update ark to 0.1.118

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -606,7 +606,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.117"
+      "ark": "0.1.118"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.7"


### PR DESCRIPTION
Updates Ark to 0.1.118; for https://github.com/posit-dev/positron/issues/3846.
