### PR TITLE
Truncate data explorer tab title to avoid large names

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -363,7 +363,17 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 		this._register(dataExplorerClientInstance.onDidUpdateBackendState(backendState => {
 			const dxInput = editorPane?.input as any;
 			if (dxInput !== undefined && backendState.display_name !== undefined) {
-				dxInput.setName?.(`Data: ${backendState.display_name}`);
+				// We truncate the `display_name` to a reasonable length as
+				// the editor tab title has limited space.
+
+				// -6 because of 'Data: ' prefix;
+				const maxTabSize = this._configurationService.getValue<number>('workbench.editor.tabSizingFixedMinWidth') - 6;
+				let display_name = backendState.display_name;
+				if (backendState.display_name.length > maxTabSize) {
+					display_name = backendState.display_name.substring(0, maxTabSize - 3) + '...';
+				}
+
+				dxInput.setName?.(`Data: ${display_name}`);
 			}
 		}));
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -365,11 +365,9 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 			if (dxInput !== undefined && backendState.display_name !== undefined) {
 				// We truncate the `display_name` to a reasonable length as
 				// the editor tab title has limited space.
-
-				// -6 because of 'Data: ' prefix;
-				const maxTabSize = this._configurationService.getValue<number>('workbench.editor.tabSizingFixedMinWidth') - 6;
+				const maxTabSize = 30;
 				let display_name = backendState.display_name;
-				if (backendState.display_name.length > maxTabSize && maxTabSize > 3) {
+				if (backendState.display_name.length > maxTabSize) {
 					display_name = backendState.display_name.substring(0, maxTabSize - 3) + '...';
 				}
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -369,7 +369,7 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 				// -6 because of 'Data: ' prefix;
 				const maxTabSize = this._configurationService.getValue<number>('workbench.editor.tabSizingFixedMinWidth') - 6;
 				let display_name = backendState.display_name;
-				if (backendState.display_name.length > maxTabSize) {
+				if (backendState.display_name.length > maxTabSize && maxTabSize > 3) {
 					display_name = backendState.display_name.substring(0, maxTabSize - 3) + '...';
 				}
 


### PR DESCRIPTION
The new max size of the display name is now hard coded to a maximum length of 30 characters. Which seems like a reasonable default. See sccreenshot below:

![image](https://github.com/user-attachments/assets/6867063a-d3da-40a5-acd2-b5cb30ddb370)

This PR addresses https://github.com/posit-dev/positron/issues/4085

Note that by default VSCode allows arbitrary tab sizes, but users could also set the option `workbench.editor.tabSizing` to `shrink` or `fixed` to adapt to their own preferences.

![image](https://github.com/user-attachments/assets/33218c0b-2e1b-448a-bc4f-7aa9f1f5d7bb)

### QA Notes

Executing the following should produce a truncated name. When it's truncated, you'll see `...` at the end of the name.

```r
View(mtcars, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
```

![image](https://github.com/user-attachments/assets/6867063a-d3da-40a5-acd2-b5cb30ddb370)
