### PR TITLE
Data Explorer: Add formatting option to truncate large strings, default to 1000 characters, implement for pandas/polars

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -903,6 +903,13 @@ def _pandas_summarize_datetime(col: "pd.Series", options: FormatOptions):
     return _box_datetime_stats(num_unique, min_date, mean_date, median_date, max_date, timezone)
 
 
+def _safe_stringify(x, max_length: int):
+    formatted = str(x)
+    if len(formatted) > max_length:
+        formatted = formatted[:max_length]
+    return formatted
+
+
 class PandasView(DataExplorerTableView):
     TYPE_NAME_MAPPING = {"boolean": "bool"}
 
@@ -1194,6 +1201,7 @@ class PandasView(DataExplorerTableView):
         NaT = pd_.NaT
         NA = pd_.NA
         float_format = _get_float_formatter(options)
+        max_length = options.max_value_length
 
         def _format_value(x):
             if _is_float_scalar(x):
@@ -1210,7 +1218,7 @@ class PandasView(DataExplorerTableView):
             elif x is NA:
                 return _VALUE_NA
             else:
-                return str(x)
+                return _safe_stringify(x, max_length)
 
         return [_format_value(x) for x in values]
 
@@ -1846,6 +1854,7 @@ class PolarsView(DataExplorerTableView):
     @classmethod
     def _format_values(cls, values, options: FormatOptions) -> List[ColumnValue]:
         float_format = _get_float_formatter(options)
+        max_length = options.max_value_length
 
         def _format_scalar(x):
             if _is_float_scalar(x):
@@ -1854,7 +1863,7 @@ class PolarsView(DataExplorerTableView):
                 else:
                     return float_format(x)
             else:
-                return str(x)
+                return _safe_stringify(x, max_length)
 
         def _format_series(s):
             result = []

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -348,6 +348,10 @@ class FormatOptions(BaseModel):
         description="Maximum number of integral digits to display before switching to scientific notation",
     )
 
+    max_value_length: StrictInt = Field(
+        description="Maximum size of formatted value, for truncating large strings or other large formatted values",
+    )
+
     thousands_sep: Optional[StrictStr] = Field(
         default=None,
         description="Thousands separator string",

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -448,7 +448,8 @@
 				"required": [
 					"large_num_digits",
 					"small_num_digits",
-					"max_integral_digits"
+					"max_integral_digits",
+					"max_value_length"
 				],
 				"properties": {
 					"large_num_digits": {
@@ -462,6 +463,10 @@
 					"max_integral_digits": {
 						"type": "integer",
 						"description": "Maximum number of integral digits to display before switching to scientific notation"
+					},
+					"max_value_length": {
+						"type": "integer",
+						"description": "Maximum size of formatted value, for truncating large strings or other large formatted values"
 					},
 					"thousands_sep": {
 						"type": "string",

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -116,7 +116,7 @@ export class DataExplorerClientInstance extends Disposable {
 			large_num_digits: 2,
 			small_num_digits: 4,
 			max_integral_digits: 7,
-			max_value_length: 32,
+			max_value_length: 1000,
 			thousands_sep: '',
 		};
 
@@ -124,7 +124,7 @@ export class DataExplorerClientInstance extends Disposable {
 			large_num_digits: 2,
 			small_num_digits: 4,
 			max_integral_digits: 7,
-			max_value_length: 32,
+			max_value_length: 1000,
 			thousands_sep: ','
 		};
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -116,13 +116,15 @@ export class DataExplorerClientInstance extends Disposable {
 			large_num_digits: 2,
 			small_num_digits: 4,
 			max_integral_digits: 7,
-			thousands_sep: ''
+			max_value_length: 32,
+			thousands_sep: '',
 		};
 
 		this._profileFormatOptions = {
 			large_num_digits: 2,
 			small_num_digits: 4,
 			max_integral_digits: 7,
+			max_value_length: 32,
 			thousands_sep: ','
 		};
 

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -190,6 +190,12 @@ export interface FormatOptions {
 	max_integral_digits: number;
 
 	/**
+	 * Maximum size of formatted value, for truncating large strings or other
+	 * large formatted values
+	 */
+	max_value_length: number;
+
+	/**
 	 * Thousands separator string
 	 */
 	thousands_sep?: string;


### PR DESCRIPTION
Addresses #3823. This adds `FormatOptions.max_value_length` to truncate stringified values at some number of characters. There's currently no indication that the value has been truncated (but getting to the end of a 1000-character string in the UI would be hard). If you copy-paste a cell, you will get the entire value, not the truncated version. 

### QA Notes

Tricky to test -- I temporarily modified the TypeScript code to use some small number (like 32) to inspect that things are truncating correctly. If you load a data frame with a lot of large string values (think like 1-megabyte strings), then the UI should remain responsive. Here's an example that would put a hurt on the current version of Positron:

```
x = 'aahrealmonsters' * 100000
chunky_df = pd.DataFrame({'a': [x] * 1000})
```