### PR TITLE
Forward errors when performing View actions

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -588,6 +588,11 @@ class VariablesService:
                 self._open_connections_pane(path, value)
             elif self.kernel.data_explorer_service.is_supported(value):
                 self._open_data_explorer(path, value)
+            else:
+                self._send_error(
+                    JsonRpcErrorCode.INTERNAL_ERROR,
+                    f"Error opening viewer for variable at '{path}'. Object nor supported.",
+                )
         except Exception as err:
             self._send_error(
                 JsonRpcErrorCode.INTERNAL_ERROR,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -591,12 +591,12 @@ class VariablesService:
             else:
                 self._send_error(
                     JsonRpcErrorCode.INTERNAL_ERROR,
-                    f"Error opening viewer for variable at '{path}'. Object nor supported.",
+                    f"Error opening viewer for variable at '{path}'. Object not supported. Try restarting the session.",
                 )
         except Exception as err:
             self._send_error(
                 JsonRpcErrorCode.INTERNAL_ERROR,
-                f"Error opening viewer for variable at '{path}'",
+                f"Error opening viewer for variable at '{path}'. Try restarting the session.",
             )
             logger.error(err, exc_info=True)
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -583,10 +583,17 @@ class VariablesService:
                 f"Cannot find variable at '{path}' to view",
             )
 
-        if self.kernel.connections_service.object_is_supported(value):
-            self._open_connections_pane(path, value)
-        elif self.kernel.data_explorer_service.is_supported(value):
-            self._open_data_explorer(path, value)
+        try:
+            if self.kernel.connections_service.object_is_supported(value):
+                self._open_connections_pane(path, value)
+            elif self.kernel.data_explorer_service.is_supported(value):
+                self._open_data_explorer(path, value)
+        except Exception as err:
+            self._send_error(
+                JsonRpcErrorCode.INTERNAL_ERROR,
+                f"Error opening viewer for variable at '{path}'",
+            )
+            logger.error(err, exc_info=True)
 
     def _open_data_explorer(self, path: List[str], value: Any) -> None:
         """Opens a DataExplorer comm for the variable at the requested

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
@@ -123,7 +123,15 @@ export const VariableItem = (props: VariableItemProps) => {
 			instance.requestFocus();
 		} else {
 			// Open a viewer for the variable item.
-			const viewerId = await item.view();
+			let viewerId: string | undefined;
+			try {
+				viewerId = await item.view();
+			} catch (err) {
+				positronVariablesContext.notificationService.error(localize(
+					'positron.variables.viewerError',
+					"An error occurred while opening the viewer. Try restarting your session."
+				));
+			}
 
 			// If a binding was returned, save the binding between the viewer and the variable item.
 			if (viewerId) {

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariablesState.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariablesState.tsx
@@ -13,6 +13,7 @@ import { IPositronVariablesInstance } from 'vs/workbench/services/positronVariab
 import { PositronActionBarServices } from 'vs/platform/positronActionBar/browser/positronActionBarState';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { IPositronDataExplorerService } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
+import { INotificationService } from 'vs/platform/notification/common/notification';
 
 /**
  * PositronVariablesServices interface.
@@ -24,6 +25,7 @@ export interface PositronVariablesServices extends PositronActionBarServices {
 	readonly positronVariablesService: IPositronVariablesService;
 	readonly reactComponentContainer: IReactComponentContainer;
 	readonly dataExplorerService: IPositronDataExplorerService;
+	readonly notificationService: INotificationService;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
@@ -29,6 +29,7 @@ import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/com
 import { PositronViewPane } from 'vs/workbench/browser/positronViewPane/positronViewPane';
 import { IHoverService } from 'vs/platform/hover/browser/hover';
 import { IPositronDataExplorerService } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
+import { INotificationService } from 'vs/platform/notification/common/notification';
 
 /**
  * PositronVariablesViewPane class.
@@ -198,7 +199,8 @@ export class PositronVariablesViewPane extends PositronViewPane implements IReac
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IThemeService themeService: IThemeService,
 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
-		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService
+		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
+		@INotificationService private readonly _notificationService: INotificationService
 	) {
 		// Call the base class's constructor.
 		super(
@@ -268,6 +270,7 @@ export class PositronVariablesViewPane extends PositronViewPane implements IReac
 				contextKeyService={this.contextKeyService}
 				contextMenuService={this.contextMenuService}
 				dataExplorerService={this._dataExplorerService}
+				notificationService={this._notificationService}
 				hoverService={this.hoverService}
 				keybindingService={this.keybindingService}
 				runtimeSessionService={this._runtimeSessionService}


### PR DESCRIPTION
This PR addresses https://github.com/posit-dev/positron/issues/3653 by forwarding the error when opening the Viewer to the user (using a notification) and suggesting to restart the session. It will also forward possible errors when performing `view` on Connections objects.

### QA Notes

It's a little complicated to reproduce the problem:

- Start the Python console within an environment that dioesn't have pandas installed
- install pandas with `%pip install pandas`
- Try to open a pandas data frame by clicking the data icon the variables pane.

You should now see a notification showing that something failed when opening the dataset.
If you are in a dev build, you can also add some code to raise an error anywhere in the registration method:

https://github.com/posit-dev/positron/blob/07060acd646249b7d3daf86a507d741218052836/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py#L2257