### PR TITLE
Update issue reporter for changes from recent upstream merges

### DIFF
--- a/src/vs/workbench/contrib/issue/browser/issue.ts
+++ b/src/vs/workbench/contrib/issue/browser/issue.ts
@@ -645,7 +645,9 @@ export class BaseIssueReporterService extends Disposable {
 
 		sourceSelect.innerText = '';
 		sourceSelect.append(this.makeOption('', localize('selectSource', "Select source"), true));
-		sourceSelect.append(this.makeOption(IssueSource.VSCode, localize('vscode', "Visual Studio Code"), false));
+		// --- Start Positron ---
+		sourceSelect.append(this.makeOption(IssueSource.VSCode, localize('positron', "Positron"), false));
+		// --- End Positron ---
 		sourceSelect.append(this.makeOption(IssueSource.Extension, localize('extension', "A VS Code extension"), false));
 		if (this.product.reportMarketplaceIssueUrl) {
 			sourceSelect.append(this.makeOption(IssueSource.Marketplace, localize('marketplace', "Extensions Marketplace"), false));


### PR DESCRIPTION
Addresses #4123 

### QA Notes

With this change, we should be back to having Positron in the issue reporter:

![Screenshot 2024-07-23 at 10 53 02 AM](https://github.com/user-attachments/assets/fcabfaf5-6fcd-4605-b372-aee008c73299)


If you click "Preview" it will open an issue draft on our real/regular repo.
