### PR TITLE
Smoke Test: Render RMarkdown

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Build Environment
         run: |
           sudo apt-get update
-          sudo apt-get install -y vim curl build-essential clang make cmake git python3-pip python-is-python3 libsodium-dev libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0 libgbm1 libnss3 libnspr4 libasound2 libkrb5-dev libcairo-dev libsdl-pango-dev libjpeg-dev libgif-dev
+          sudo apt-get install -y vim curl build-essential clang make cmake git python3-pip python-is-python3 libsodium-dev libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0 libgbm1 libnss3 libnspr4 libasound2 libkrb5-dev libcairo-dev libsdl-pango-dev libjpeg-dev libgif-dev pandoc
           sudo cp build/azure-pipelines/linux/xvfb.init /etc/init.d/xvfb
           sudo chmod +x /etc/init.d/xvfb
           sudo update-rc.d xvfb defaults

--- a/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
+++ b/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Note - these paths will need to change for your specific test location
+import { Application, Logger, PositronRFixtures } from '../../../../../automation';
+import { installAllHandlers } from '../../../utils';
+import { join } from 'path';
+import { expect } from '@playwright/test';
+
+export function setup(logger: Logger) {
+	describe('RMarkdown', () => {
+		// All Tests blocks inside this 'describe' block will use the same app instance
+		// Shared before/after handling
+		installAllHandlers(logger);
+
+
+			before(async function () {
+				// Executes once before executing all tests.
+				await PositronRFixtures.SetupFixtures(this.app as Application);
+			});
+
+			it('Render RMarkdown [C680618] #nightly', async function () {
+				const app = this.app as Application; //Get handle to application
+				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'basic-rmd-file', 'basicRmd.rmd'));
+				await app.workbench.quickaccess.runCommand('r.rmarkdownRender');
+				// Wait for the file to be created. We don't currently have any terminal tests.
+				// Therefore instead of checking terminal output, just check the project files.
+				// TODO: Add a terminal page object to check output.
+				expect(async () => {
+					const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();
+					expect(projectFiles).toContain('basicRnd.html');
+				}).toPass({ timeout: 10000 });
+
+		});
+
+
+	});
+}

--- a/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
+++ b/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
@@ -21,7 +21,7 @@ export function setup(logger: Logger) {
 			await PositronRFixtures.SetupFixtures(this.app as Application);
 		});
 
-		it('Render RMarkdown [C680618] #nightly', async function () {
+		it('Render RMarkdown [C680618]', async function () {
 			const app = this.app as Application; //Get handle to application
 			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'basic-rmd-file', 'basicRmd.rmd'));
 

--- a/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
+++ b/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
@@ -10,7 +10,7 @@ import { join } from 'path';
 import { expect } from '@playwright/test';
 
 export function setup(logger: Logger) {
-	describe('RMarkdown', () => {
+	describe.only('RMarkdown', () => {
 		// All Tests blocks inside this 'describe' block will use the same app instance
 		// Shared before/after handling
 		installAllHandlers(logger);
@@ -30,7 +30,7 @@ export function setup(logger: Logger) {
 				// TODO: Add a terminal page object to check output.
 				expect(async () => {
 					const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();
-					expect(projectFiles).toContain('basicRnd.html');
+					expect(projectFiles).toContain('basicRmd.html');
 				}).toPass({ timeout: 10000 });
 
 		});

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -48,6 +48,7 @@ import { setup as setupTopActionBarTest } from './areas/positron/top-action-bar/
 import { setup as setupNotebookVariablesTest} from './areas/positron/variables/notebookVariables.test';
 import { setup as setupConsoleInputTest } from './areas/positron/console/consoleInput.test';
 import { setup as setupConsoleOutputLogTest } from './areas/positron/output/consoleOutputLog.test';
+import { setup as setupBasicRMarkdownTest } from './areas/positron/rmarkdown/rmarkdown.test';
 // --- End Positron ---
 
 const rootPath = path.join(__dirname, '..', '..', '..');
@@ -452,5 +453,6 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	setupNotebookVariablesTest(logger);
 	setupConsoleInputTest(logger);
 	setupConsoleOutputLogTest(logger);
+	setupBasicRMarkdownTest(logger);
 	// --- End Positron ---
 });


### PR DESCRIPTION
### Intent

Add a simple test to render an RMarkdown file, in support of testing https://github.com/posit-dev/positron/issues/3816

### Approach

Added jsut 1 test to render using the command palette command. Of note, this is our first use of the ms provided terminal object. 

Update full test ci to install pandoc

### QA Notes

Passes in CI. Not added to PR workflow.

_note_ - to run locally, you need to install pandoc. It is bundled into a release build, but it's not bundled with dev builds.

https://pandoc.org/installing.html
