### PR TITLE
Fix LSP document selectors for notebooks on Windows

### DIFF
--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -93,7 +93,7 @@ export class PythonLsp implements vscode.Disposable {
         // Otherwise, this is the main client for this language, so set the document selector to include
         // untitled Python files, in-memory Python files (e.g. the console), and Python files on disk.
         this._clientOptions.documentSelector = notebookUri
-            ? [{ language: 'python', pattern: notebookUri.path }]
+            ? [{ language: 'python', pattern: notebookUri.fsPath }]
             : [
                   { language: 'python', scheme: 'untitled' },
                   { language: 'python', scheme: 'inmemory' }, // Console

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -110,7 +110,7 @@ export class ArkLsp implements vscode.Disposable {
 			// Otherwise, this is the main client for this language, so set the document selector to include
 			// untitled R files, in-memory R files (e.g. the console), and R / Quarto / R Markdown files on disk.
 			documentSelector: notebookUri ?
-				[{ language: 'r', pattern: notebookUri.path }] :
+				[{ language: 'r', pattern: notebookUri.fsPath }] :
 				R_DOCUMENT_SELECTORS,
 			synchronize: notebookUri ?
 				undefined :


### PR DESCRIPTION
Attempts to address #4006 where completions are empty for notebooks.

I haven't been able to validate the fix, but we did discover in https://github.com/posit-dev/positron/issues/3006#issuecomment-2124800883 that on Windows, the `Uri.path` attribute is not a valid _file_ path e.g. `/c:/Users/foo` and that we should use `Uri.fsPath` instead. I also confirmed from the user's logs that the LSP server is starting up and the client is connecting correctly, so this seems promising.