### PR TITLE
Dont try and show viewer-widget output in the console

### DIFF
--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -36,7 +36,7 @@ import { ActivityItem, RuntimeItemActivity } from 'vs/workbench/services/positro
 import { ActivityItemInput, ActivityItemInputState } from 'vs/workbench/services/positronConsole/browser/classes/activityItemInput';
 import { ActivityItemErrorStream, ActivityItemOutputStream } from 'vs/workbench/services/positronConsole/browser/classes/activityItemStream';
 import { IPositronConsoleInstance, IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID, PositronConsoleState, SessionAttachMode } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
-import { ILanguageRuntimeExit, ILanguageRuntimeMessage, ILanguageRuntimeMessageOutput, ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeState, formatLanguageRuntimeMetadata, formatLanguageRuntimeSession } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeExit, ILanguageRuntimeMessage, ILanguageRuntimeMessageOutput, ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeOutputKind, RuntimeState, formatLanguageRuntimeMetadata, formatLanguageRuntimeSession } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../runtimeSession/common/runtimeSessionService';
 import { UiFrontendEvent } from 'vs/workbench/services/languageRuntime/common/positronUiComm';
 import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
@@ -1486,6 +1486,12 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 						formatCallbackTrace('onDidReceiveRuntimeMessageOutput', languageRuntimeMessageOutput) +
 						formatOutputData(languageRuntimeMessageOutput.data)
 					);
+				}
+
+				if (languageRuntimeMessageOutput.kind === RuntimeOutputKind.ViewerWidget) {
+					// If it's a viewer widget type it's already being shown in the viewer pane so
+					// we don't want to double display it in the console as well.
+					return;
 				}
 
 				// Check to see if the data contains an image by checking the record for the


### PR DESCRIPTION
Addresses #2079


Currently when a runtime message is sent out with the type `RuntimeOutputKind.ViewerWidget` it is both captured by the viewer pane _and_ the console. This manifests in some confusing behavior as seen when trying to print out a great tables table. In this case the html for the table is rendered as one would hope in the viewer pane but also the `text/plain` data is also shown in the console. This can cause some very polluted console output. 

This PR adds a condition to the positron console service's message handler callback that exits early if the message received is of the viewer-widget type. 
<img width="600" alt="Screenshot 2024-07-24 at 11 38 07 AM" src="https://github.com/user-attachments/assets/13729c99-a718-4eb3-ba7d-9558b0d2ae73">

## Potential changes
- Right now the console simply shows nothing. This is clean but maybe is confusing for the user? We could alternatively show something like `<output in viewer pane>` or the like.
- There may be a more appropriate place to do the filtering of message destinations other than the respective subscriber callbacks. 

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->



### QA Notes
Printing a great tables table (or any other viewer-widget type outputs) should not also show output in the console. 

