### PR TITLE
Data Explorer: Relax comparison costs by returning number of data cells for DataFrame instead of estimated number of bytes

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -1,10 +1,3 @@
-"""
-Inspectors are totally decoupled from the variables pane and
-all other Positron (and even non-Positron) components.
-They solve the general problem of providing a consistent interface
-over a variety types from popular Python libraries.
-"""
-
 #
 # Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.


### PR DESCRIPTION
Addresses concern in #4145 -- for large enough data, each time a code cell is executed, a `schema_update` event will be fired. This change relaxes the size limit so that we won't trigger this "always refresh the data explorer" logic unless there are more than 10 million data cells. 

There is now some inconsistency with the `Inspector.get_size` method -- since getting a precise size can be tricky (since Python objects are 8 bytes and may point to something much larger), we might consider nixing this and just using `Inspector.get_num_cells` or something similar. I didn't invest much energy into trying to make this consistent until we decide what we need to support the UI and are comfortable maintaining.