### PR TITLE
Add missing awaits to async expects in proj wizard tests

### DIFF
--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -110,11 +110,12 @@ export function setup(logger: Logger) {
 					const pw = app.workbench.positronNewProjectWizard;
 					const pythonFixtures = new PositronPythonFixtures(app);
 					// Start the Python interpreter and uninstall ipykernel
-					await pythonFixtures.startAndGetPythonInterpreter(true);
+					const firstInfo = await pythonFixtures.startAndGetPythonInterpreter(true);
 					// Ensure the console is ready with the selected interpreter
 					await app.workbench.positronConsole.waitForReady('>>>', 10000);
-					const interpreterInfo = await app.workbench.startInterpreter.getSelectedInterpreterInfo();
-					expect(interpreterInfo?.path).toBeDefined();
+					// seems like the selected interpreter is the one from the prev case
+					//const interpreterInfo = await app.workbench.startInterpreter.getSelectedInterpreterInfo();
+					expect(firstInfo?.path).toBeDefined();
 					await app.workbench.positronConsole.typeToConsole('pip uninstall -y ipykernel');
 					await app.workbench.positronConsole.sendEnterKey();
 					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
@@ -133,7 +134,7 @@ export function setup(logger: Logger) {
 					await expect(
 						async () =>
 							await pw.pythonConfigurationStep.selectInterpreterByPath(
-								interpreterInfo!.path
+								firstInfo!.path
 							)
 					).toPass({ timeout: 50000 });
 					await pw.pythonConfigurationStep.interpreterFeedback.waitForText(

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -52,10 +52,10 @@ export function setup(logger: Logger) {
 						`myPythonProject${projSuffix}`
 					);
 					// Check that the `.conda` folder gets created in the project
-					expect(async () => {
+					await expect(async () => {
 						const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();
 						expect(projectFiles).toContain('.conda');
-					}).toPass({ timeout: 10000 });
+					}).toPass({ timeout: 50000 });
 					// The console should initialize without any prompts to install ipykernel
 					await app.workbench.positronConsole.waitForReady('>>>', 10000);
 				});
@@ -82,12 +82,12 @@ export function setup(logger: Logger) {
 					await pw.pythonConfigurationStep.existingEnvRadioButton.click();
 					// Select the interpreter that was started above. It's possible that this needs
 					// to be attempted a few times to ensure the interpreters are properly loaded.
-					expect(
+					await expect(
 						async () =>
 							await pw.pythonConfigurationStep.selectInterpreterByPath(
 								interpreterInfo!.path
 							)
-					).toPass({ timeout: 10000 });
+					).toPass({ timeout: 50000 });
 					await pw.pythonConfigurationStep.interpreterFeedback.isNotVisible();
 					await pw.navigate(ProjectWizardNavigateAction.CREATE);
 					await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
@@ -123,12 +123,12 @@ export function setup(logger: Logger) {
 					await pw.pythonConfigurationStep.existingEnvRadioButton.click();
 					// Select the interpreter that was started above. It's possible that this needs
 					// to be attempted a few times to ensure the interpreters are properly loaded.
-					expect(
+					await expect(
 						async () =>
 							await pw.pythonConfigurationStep.selectInterpreterByPath(
 								interpreterInfo!.path
 							)
-					).toPass({ timeout: 10000 });
+					).toPass({ timeout: 50000 });
 					await pw.pythonConfigurationStep.interpreterFeedback.waitForText(
 						'ipykernel will be installed for Python language support.'
 					);
@@ -166,13 +166,13 @@ export function setup(logger: Logger) {
 				await app.workbench.positronConsole.waitForReady('>>>', 10000);
 
 				// Verify git-related files are present
-				expect(async () => {
+				await expect(async () => {
 					const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();
 					expect(projectFiles).toContain('.gitignore');
 					expect(projectFiles).toContain('README.md');
 					// Ideally, we'd check for the .git folder, but it's not visible in the Explorer
 					// by default due to the default `files.exclude` setting in the workspace.
-				}).toPass({ timeout: 10000 });
+				}).toPass({ timeout: 50000 });
 
 				// Git status should show that we're on the main branch
 				await app.workbench.terminal.createTerminal();
@@ -237,12 +237,12 @@ export function setup(logger: Logger) {
 					// await app.workbench.positronConsole.sendEnterKey();
 
 					// Verify renv files are present
-					expect(async () => {
+					await expect(async () => {
 						const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();
 						expect(projectFiles).toContain('renv');
 						expect(projectFiles).toContain('.Rprofile');
 						expect(projectFiles).toContain('renv.lock');
-					}).toPass({ timeout: 10000 });
+					}).toPass({ timeout: 50000 });
 					// Verify that renv output in the console confirms no issues occurred
 					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
 						contents.some((line) => line.includes('renv activated'))
@@ -267,12 +267,12 @@ export function setup(logger: Logger) {
 						`myRProject${projSuffix}`
 					);
 					// Verify renv files are present
-					expect(async () => {
+					await expect(async () => {
 						const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();
 						expect(projectFiles).toContain('renv');
 						expect(projectFiles).toContain('.Rprofile');
 						expect(projectFiles).toContain('renv.lock');
-					}).toPass({ timeout: 10000 });
+					}).toPass({ timeout: 50000 });
 					// Verify that renv output in the console confirms no issues occurred
 					await app.workbench.positronConsole.waitForConsoleContents((contents) =>
 						contents.some((line) => line.includes('renv activated'))
@@ -304,12 +304,12 @@ export function setup(logger: Logger) {
 					// Interact with the modal to skip installing renv
 					await app.workbench.positronPopups.installRenv(false);
 					// Verify renv files are **not** present
-					expect(async () => {
+					await expect(async () => {
 						const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();
 						expect(projectFiles).not.toContain('renv');
 						expect(projectFiles).not.toContain('.Rprofile');
 						expect(projectFiles).not.toContain('renv.lock');
-					}).toPass({ timeout: 10000 });
+					}).toPass({ timeout: 50000 });
 				});
 			});
 		});

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -33,6 +33,7 @@ export function setup(logger: Logger) {
 					await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 					await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myPythonProject');
 					await app.workbench.positronConsole.waitForReady('>>>', 10000);
+					await app.workbench.positronConsole.barClearButton.click();
 				});
 				it('Create a new Conda environment [C628628]', async function () {
 					// This test relies on Conda already being installed on the machine
@@ -58,6 +59,7 @@ export function setup(logger: Logger) {
 					}).toPass({ timeout: 50000 });
 					// The console should initialize without any prompts to install ipykernel
 					await app.workbench.positronConsole.waitForReady('>>>', 10000);
+					await app.workbench.positronConsole.barClearButton.click();
 				});
 			});
 
@@ -96,6 +98,7 @@ export function setup(logger: Logger) {
 					);
 					// The console should initialize without any prompts to install ipykernel
 					await app.workbench.positronConsole.waitForReady('>>>', 10000);
+					await app.workbench.positronConsole.barClearButton.click();
 				});
 				it('With ipykernel not already installed [C609617]', async function () {
 					const projSuffix = '_noIpykernel';
@@ -140,6 +143,7 @@ export function setup(logger: Logger) {
 					// If ipykernel was successfully installed during the new project initialization,
 					// the console should be ready without any prompts to install ipykernel
 					await app.workbench.positronConsole.waitForReady('>>>', 10000);
+					await app.workbench.positronConsole.barClearButton.click();
 				});
 			});
 

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -113,8 +113,6 @@ export function setup(logger: Logger) {
 					const firstInfo = await pythonFixtures.startAndGetPythonInterpreter(true);
 					// Ensure the console is ready with the selected interpreter
 					await app.workbench.positronConsole.waitForReady('>>>', 10000);
-					// seems like the selected interpreter is the one from the prev case
-					//const interpreterInfo = await app.workbench.startInterpreter.getSelectedInterpreterInfo();
 					expect(firstInfo?.path).toBeDefined();
 					await app.workbench.positronConsole.typeToConsole('pip uninstall -y ipykernel');
 					await app.workbench.positronConsole.sendEnterKey();
@@ -129,14 +127,7 @@ export function setup(logger: Logger) {
 					await pw.navigate(ProjectWizardNavigateAction.NEXT);
 					// Choose the existing environment which does not have ipykernel
 					await pw.pythonConfigurationStep.existingEnvRadioButton.click();
-					// Select the interpreter that was started above. It's possible that this needs
-					// to be attempted a few times to ensure the interpreters are properly loaded.
-					await expect(
-						async () =>
-							await pw.pythonConfigurationStep.selectInterpreterByPath(
-								firstInfo!.path
-							)
-					).toPass({ timeout: 50000 });
+
 					await pw.pythonConfigurationStep.interpreterFeedback.waitForText(
 						'ipykernel will be installed for Python language support.'
 					);

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -33,7 +33,9 @@ export function setup(logger: Logger) {
 					await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 					await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myPythonProject');
 					await app.workbench.positronConsole.waitForReady('>>>', 10000);
+					await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 					await app.workbench.positronConsole.barClearButton.click();
+					await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 				});
 				it('Create a new Conda environment [C628628]', async function () {
 					// This test relies on Conda already being installed on the machine
@@ -59,7 +61,9 @@ export function setup(logger: Logger) {
 					}).toPass({ timeout: 50000 });
 					// The console should initialize without any prompts to install ipykernel
 					await app.workbench.positronConsole.waitForReady('>>>', 10000);
+					await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 					await app.workbench.positronConsole.barClearButton.click();
+					await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 				});
 			});
 
@@ -98,8 +102,8 @@ export function setup(logger: Logger) {
 					);
 					// The console should initialize without any prompts to install ipykernel
 					await app.workbench.positronConsole.waitForReady('>>>', 10000);
-					await app.workbench.positronConsole.barClearButton.click();
 				});
+
 				it('With ipykernel not already installed [C609617]', async function () {
 					const projSuffix = '_noIpykernel';
 					const app = this.app as Application;
@@ -143,7 +147,9 @@ export function setup(logger: Logger) {
 					// If ipykernel was successfully installed during the new project initialization,
 					// the console should be ready without any prompts to install ipykernel
 					await app.workbench.positronConsole.waitForReady('>>>', 10000);
+					await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 					await app.workbench.positronConsole.barClearButton.click();
+					await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 				});
 			});
 


### PR DESCRIPTION
NOTE: this PR is waiting on input from @sharon-wang.  We have one case that doesn't pass once the awaits were added and want to get her thoughts on it.


This PR simply adds awaits where they were missing on the project wizard tests.  Just to be safe, the timeouts for the async blocks in question were also bumped significantly.

No change in execution functionality was observed on a fast Mac.  Problems were encountered, however, in CI.
### QA Notes

All smoke tests should pass.
