### PR TITLE
Add OpenRPC method for evaluating a `when` clause

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui_comm.py
@@ -352,6 +352,16 @@ class ExecuteCommandParams(BaseModel):
     )
 
 
+class EvaluateWhenClauseParams(BaseModel):
+    """
+    Get a logical for a `when` clause (a set of context keys)
+    """
+
+    when_clause: StrictStr = Field(
+        description="The values for context keys, as a `when` clause",
+    )
+
+
 class ExecuteCodeParams(BaseModel):
     """
     Execute code in a Positron runtime
@@ -455,6 +465,8 @@ WorkingDirectoryParams.update_forward_refs()
 DebugSleepParams.update_forward_refs()
 
 ExecuteCommandParams.update_forward_refs()
+
+EvaluateWhenClauseParams.update_forward_refs()
 
 ExecuteCodeParams.update_forward_refs()
 

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -606,7 +606,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.118"
+      "ark": "0.1.120"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.7"

--- a/positron/comms/ui-frontend-openrpc.json
+++ b/positron/comms/ui-frontend-openrpc.json
@@ -217,6 +217,26 @@
 			]
 		},
 		{
+			"name": "evaluate_when_clause",
+			"summary": "Get a logical for a `when` clause (a set of context keys)",
+			"description": "Use this to evaluate a `when` clause of context keys in the frontend",
+			"params": [
+				{
+					"name": "when_clause",
+					"description": "The values for context keys, as a `when` clause",
+					"schema": {
+						"type": "string"
+					}
+				}
+			],
+			"result": {
+				"schema": {
+					"type": "boolean",
+					"description": "Whether the `when` clause evaluates as true or false"
+				}
+			}
+		},
+		{
 			"name": "execute_code",
 			"summary": "Execute code in a Positron runtime",
 			"description": "Use this to execute code in a Positron runtime",

--- a/src/vs/workbench/api/browser/extensionHost.contribution.ts
+++ b/src/vs/workbench/api/browser/extensionHost.contribution.ts
@@ -94,6 +94,7 @@ import './positron/mainThreadLanguageRuntime';
 import './positron/mainThreadPreviewPanel';
 import './positron/mainThreadModalDialogs';
 import './positron/mainThreadConsoleService';
+import './positron/mainThreadContextKeyService';
 // --- End Positron ---
 
 export class ExtensionPoints implements IWorkbenchContribution {

--- a/src/vs/workbench/api/browser/positron/mainThreadContextKeyService.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadContextKeyService.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
+import { MainPositronContext, MainThreadContextKeyServiceShape } from '../../common/positron/extHost.positron.protocol';
+import { ContextKeyExpr, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+
+@extHostNamedCustomer(MainPositronContext.MainThreadContextKeyService)
+export class MainThreadContextKeyService implements MainThreadContextKeyServiceShape {
+
+	private readonly _disposables = new DisposableStore();
+
+	constructor(
+		extHostContext: IExtHostContext,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService
+	) {
+	}
+
+	$evaluateWhenClause(whenClause: string): Promise<boolean> {
+		const precondition = ContextKeyExpr.deserialize(whenClause);
+		return Promise.resolve(this.contextKeyService.contextMatchesRules(precondition));
+	}
+
+	public dispose(): void {
+		this._disposables.dispose();
+	}
+
+}

--- a/src/vs/workbench/api/browser/positron/mainThreadContextKeyService.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadContextKeyService.ts
@@ -21,6 +21,9 @@ export class MainThreadContextKeyService implements MainThreadContextKeyServiceS
 
 	$evaluateWhenClause(whenClause: string): Promise<boolean> {
 		const precondition = ContextKeyExpr.deserialize(whenClause);
+		if (precondition === undefined) {
+			throw new Error(`Cannot evaluate when clause '${whenClause}'`);
+		}
 		return Promise.resolve(this.contextKeyService.contextMatchesRules(precondition));
 	}
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -17,6 +17,7 @@ import * as extHostTypes from 'vs/workbench/api/common/positron/extHostTypes.pos
 import { IExtHostInitDataService } from 'vs/workbench/api/common/extHostInitDataService';
 import { ExtHostPreviewPanels } from 'vs/workbench/api/common/positron/extHostPreviewPanels';
 import { ExtHostModalDialogs } from 'vs/workbench/api/common/positron/extHostModalDialogs';
+import { ExtHostContextKeyService } from 'vs/workbench/api/common/positron/extHostContextKeyService';
 import { ExtHostDocuments } from 'vs/workbench/api/common/extHostDocuments';
 import { ExtHostContext } from 'vs/workbench/api/common/extHost.protocol';
 import { IExtHostWorkspace } from 'vs/workbench/api/common/extHostWorkspace';
@@ -63,8 +64,10 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 	const extHostLanguageRuntime = rpcProtocol.set(ExtHostPositronContext.ExtHostLanguageRuntime, new ExtHostLanguageRuntime(rpcProtocol, extHostLogService));
 	const extHostPreviewPanels = rpcProtocol.set(ExtHostPositronContext.ExtHostPreviewPanel, new ExtHostPreviewPanels(rpcProtocol, extHostWebviews, extHostWorkspace));
 	const extHostModalDialogs = rpcProtocol.set(ExtHostPositronContext.ExtHostModalDialogs, new ExtHostModalDialogs(rpcProtocol));
+	const extHostContextKeyService = rpcProtocol.set(ExtHostPositronContext.ExtHostContextKeyService, new ExtHostContextKeyService(rpcProtocol));
 	const extHostConsoleService = rpcProtocol.set(ExtHostPositronContext.ExtHostConsoleService, new ExtHostConsoleService(rpcProtocol, extHostLogService));
-	const extHostMethods = rpcProtocol.set(ExtHostPositronContext.ExtHostMethods, new ExtHostMethods(rpcProtocol, extHostEditors, extHostDocuments, extHostModalDialogs, extHostLanguageRuntime, extHostWorkspace));
+	const extHostMethods = rpcProtocol.set(ExtHostPositronContext.ExtHostMethods,
+		new ExtHostMethods(rpcProtocol, extHostEditors, extHostDocuments, extHostModalDialogs, extHostLanguageRuntime, extHostWorkspace, extHostContextKeyService));
 
 	return function (extension: IExtensionDescription, extensionInfo: IExtensionRegistries, configProvider: ExtHostConfigProvider): typeof positron {
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -79,6 +79,14 @@ export interface MainThreadModalDialogsShape extends IDisposable {
 // The interface to the main thread exposed by the extension host
 export interface ExtHostModalDialogsShape { }
 
+// Interface that the main process exposes to the extension host
+export interface MainThreadContextKeyServiceShape {
+	$evaluateWhenClause(whenClause: string): Promise<boolean>;
+}
+
+// Interface to the main thread exposed by the extension host
+export interface ExtHostContextKeyServiceShape { }
+
 export interface MainThreadConsoleServiceShape {
 	$getConsoleWidth(): Promise<number>;
 	$tryPasteText(id: string, text: string): void;
@@ -163,6 +171,7 @@ export const ExtHostPositronContext = {
 	ExtHostPreviewPanel: createProxyIdentifier<ExtHostPreviewPanelShape>('ExtHostPreviewPanel'),
 	ExtHostModalDialogs: createProxyIdentifier<ExtHostModalDialogsShape>('ExtHostModalDialogs'),
 	ExtHostConsoleService: createProxyIdentifier<ExtHostConsoleServiceShape>('ExtHostConsoleService'),
+	ExtHostContextKeyService: createProxyIdentifier<ExtHostContextKeyServiceShape>('ExtHostContextKeyService'),
 	ExtHostMethods: createProxyIdentifier<ExtHostMethodsShape>('ExtHostMethods'),
 };
 
@@ -171,5 +180,6 @@ export const MainPositronContext = {
 	MainThreadPreviewPanel: createProxyIdentifier<MainThreadPreviewPanelShape>('MainThreadPreviewPanel'),
 	MainThreadModalDialogs: createProxyIdentifier<MainThreadModalDialogsShape>('MainThreadModalDialogs'),
 	MainThreadConsoleService: createProxyIdentifier<MainThreadConsoleServiceShape>('MainThreadConsoleService'),
+	MainThreadContextKeyService: createProxyIdentifier<MainThreadContextKeyServiceShape>('MainThreadContextKeyService'),
 	MainThreadMethods: createProxyIdentifier<MainThreadMethodsShape>('MainThreadMethods'),
 };

--- a/src/vs/workbench/api/common/positron/extHostContextKeyService.ts
+++ b/src/vs/workbench/api/common/positron/extHostContextKeyService.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as extHostProtocol from './extHost.positron.protocol';
+
+export class ExtHostContextKeyService implements extHostProtocol.ExtHostContextKeyServiceShape {
+
+	private readonly _proxy: extHostProtocol.MainThreadContextKeyServiceShape;
+
+	constructor(
+		mainContext: extHostProtocol.IMainPositronContext,
+	) {
+		// Trigger creation of the proxy
+		this._proxy = mainContext.getProxy(extHostProtocol.MainPositronContext.MainThreadContextKeyService);
+	}
+
+	/**
+	 * Queries the main thread with a `when` clause.
+	 *
+	 * @returns If the `when` clause evaluates to true or false.
+	 */
+	public evaluateWhenClause(whenClause: string): Promise<boolean> {
+		return this._proxy.$evaluateWhenClause(whenClause);
+	}
+
+}
+

--- a/src/vs/workbench/api/common/positron/extHostMethods.ts
+++ b/src/vs/workbench/api/common/positron/extHostMethods.ts
@@ -8,6 +8,7 @@ import { ExtHostEditors } from '../extHostTextEditors';
 import { ExtHostDocuments } from '../extHostDocuments';
 import { ExtHostWorkspace } from '../extHostWorkspace';
 import { ExtHostModalDialogs } from '../positron/extHostModalDialogs';
+import { ExtHostContextKeyService } from '../positron/extHostContextKeyService';
 import { ExtHostLanguageRuntime } from '../positron/extHostLanguageRuntime';
 import { UiFrontendRequest, EditorContext, Range as UIRange } from 'vs/workbench/services/languageRuntime/common/positronUiComm';
 import { JsonRpcErrorCode } from 'vs/workbench/services/languageRuntime/common/positronBaseComm';
@@ -41,7 +42,8 @@ export class ExtHostMethods implements extHostProtocol.ExtHostMethodsShape {
 		private readonly documents: ExtHostDocuments,
 		private readonly dialogs: ExtHostModalDialogs,
 		private readonly runtime: ExtHostLanguageRuntime,
-		private readonly workspace: ExtHostWorkspace
+		private readonly workspace: ExtHostWorkspace,
+		private readonly contextKeys: ExtHostContextKeyService
 	) {
 	}
 
@@ -135,6 +137,13 @@ export class ExtHostMethods implements extHostProtocol.ExtHostMethodsShape {
 						params.code as string,
 						params.focus as boolean,
 						params.allow_incomplete as boolean);
+					break;
+				}
+				case UiFrontendRequest.EvaluateWhenClause: {
+					if (!params || !Object.keys(params).includes('when_clause')) {
+						return newInvalidParamsError(method);
+					}
+					result = await this.evaluateWhenClause(params.when_clause as string);
 					break;
 				}
 				case UiFrontendRequest.DebugSleep: {
@@ -268,6 +277,10 @@ export class ExtHostMethods implements extHostProtocol.ExtHostMethodsShape {
 
 	async executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean): Promise<boolean> {
 		return this.runtime.executeCode(languageId, code, focus, allowIncomplete);
+	}
+
+	async evaluateWhenClause(whenClause: string): Promise<boolean> {
+		return this.contextKeys.evaluateWhenClause(whenClause);
 	}
 
 	async debugSleep(ms: number): Promise<null> {

--- a/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
@@ -359,6 +359,19 @@ export interface DebugSleepRequest {
 }
 
 /**
+ * Request: Get a logical for a `when` clause (a set of context keys)
+ *
+ * Use this to evaluate a `when` clause of context keys in the frontend
+ */
+export interface EvaluateWhenClauseRequest {
+	/**
+	 * The values for context keys, as a `when` clause
+	 */
+	when_clause: string;
+
+}
+
+/**
  * Request: Execute code in a Positron runtime
  *
  * Use this to execute code in a Positron runtime
@@ -440,6 +453,7 @@ export enum UiFrontendRequest {
 	ShowQuestion = 'show_question',
 	ShowDialog = 'show_dialog',
 	DebugSleep = 'debug_sleep',
+	EvaluateWhenClause = 'evaluate_when_clause',
 	ExecuteCode = 'execute_code',
 	WorkspaceFolder = 'workspace_folder',
 	ModifyEditorSelections = 'modify_editor_selections',


### PR DESCRIPTION
Goes along with https://github.com/posit-dev/ark/pull/449

I was thinking about how to address https://github.com/posit-dev/positron/issues/2697 and have a proposed approach in this PR plus the accompanying PR for ark. I looked at how various extensions (like the git extension, etc) check for whether we are in a git repo in the workspace and all that checking is typically based on context keys. In an extension specifically, you can check those keys with a ["when" clause](https://code.visualstudio.com/api/references/when-clause-contexts) and I realized that approach (i.e. a string) could work well as an OpenRPC method and would be flexible for other context keys we will need to check when we are not in the main thread. 

Alternatively, we could add methods to return more specific info (are we in a git repo? etc etc etc) but I like the idea of using "when" clauses for this, like an extension could directly for commands, etc.

### QA Notes

Evaluating code like this in R should show the correct results for your situation:

```r
.ps.ui.evaluateWhenClause("isLinux || isWindows")
.ps.ui.evaluateWhenClause("isMac")
.ps.ui.evaluateWhenClause("gitOpenRepositoryCount >= 1")
```
