### PR TITLE
only check python interpreter paths when manually entered

### DIFF
--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -3,6 +3,9 @@
 
 'use strict';
 
+// --- Start Positron ---
+import * as fs from 'fs-extra';
+// --- End Positron --
 import { inject, injectable } from 'inversify';
 import { cloneDeep } from 'lodash';
 import * as path from 'path';
@@ -20,7 +23,10 @@ import { Commands, Octicons, ThemeIcons } from '../../../../common/constants';
 import { isParentPath } from '../../../../common/platform/fs-paths';
 import { IPlatformService } from '../../../../common/platform/types';
 import { IConfigurationService, IPathUtils, Resource } from '../../../../common/types';
-import { Common, InterpreterQuickPickList } from '../../../../common/utils/localize';
+// --- Start Positron ---
+// add CreateEnv
+import { Common, InterpreterQuickPickList, CreateEnv } from '../../../../common/utils/localize';
+// --- End Positron ---
 import { noop } from '../../../../common/utils/misc';
 import {
     IMultiStepInput,
@@ -47,13 +53,10 @@ import {
 } from '../../types';
 import { BaseInterpreterSelectorCommand } from './base';
 // --- Start Positron ---
-import * as fs from 'fs-extra';
-
 import { IPythonRuntimeManager } from '../../../../positron/manager';
 import { traceError } from '../../../../logging';
 import { untildify } from '../../../../pythonEnvironments/common/externalDependencies';
 import { showErrorMessage } from '../../../../common/vscodeApis/windowApis';
-import { CreateEnv } from '../../../../common/utils/localize';
 // --- End Positron ---
 
 export type InterpreterStateArgs = { path?: string; workspace: Resource };

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -3,9 +3,6 @@
 
 'use strict';
 
-// --- Start Positron ---
-import * as fs from 'fs-extra';
-// --- End Positron --
 import { inject, injectable } from 'inversify';
 import { cloneDeep } from 'lodash';
 import * as path from 'path';
@@ -23,10 +20,8 @@ import { Commands, Octicons, ThemeIcons } from '../../../../common/constants';
 import { isParentPath } from '../../../../common/platform/fs-paths';
 import { IPlatformService } from '../../../../common/platform/types';
 import { IConfigurationService, IPathUtils, Resource } from '../../../../common/types';
-// --- Start Positron ---
-// add CreateEnv
-import { Common, InterpreterQuickPickList, CreateEnv } from '../../../../common/utils/localize';
-// --- End Positron ---
+// eslint-disable-next-line import/no-duplicates
+import { Common, InterpreterQuickPickList } from '../../../../common/utils/localize';
 import { noop } from '../../../../common/utils/misc';
 import {
     IMultiStepInput,
@@ -53,10 +48,14 @@ import {
 } from '../../types';
 import { BaseInterpreterSelectorCommand } from './base';
 // --- Start Positron ---
+// eslint-disable-next-line import/order
+import * as fs from 'fs-extra';
+// eslint-disable-next-line import/no-duplicates
+import { CreateEnv } from '../../../../common/utils/localize';
 import { IPythonRuntimeManager } from '../../../../positron/manager';
+import { showErrorMessage } from '../../../../common/vscodeApis/windowApis';
 import { traceError } from '../../../../logging';
 import { untildify } from '../../../../pythonEnvironments/common/externalDependencies';
-import { showErrorMessage } from '../../../../common/vscodeApis/windowApis';
 // --- End Positron ---
 
 export type InterpreterStateArgs = { path?: string; workspace: Resource };

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -47,9 +47,13 @@ import {
 } from '../../types';
 import { BaseInterpreterSelectorCommand } from './base';
 // --- Start Positron ---
+import * as fs from 'fs-extra';
+
 import { IPythonRuntimeManager } from '../../../../positron/manager';
 import { traceError } from '../../../../logging';
 import { untildify } from '../../../../pythonEnvironments/common/externalDependencies';
+import { showErrorMessage } from '../../../../common/vscodeApis/windowApis';
+import { CreateEnv } from '../../../../common/utils/localize';
 // --- End Positron ---
 
 export type InterpreterStateArgs = { path?: string; workspace: Resource };
@@ -547,6 +551,9 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
             sendTelemetryEvent(EventName.SELECT_INTERPRETER_ENTER_CHOICE, undefined, { choice: 'enter' });
             // --- Start Positron ---
             state.path = untildify(selection);
+            if (!fs.existsSync(state.path)) {
+                showErrorMessage(`${CreateEnv.pathDoesntExist} ${state.path}`);
+            }
             // --- End Positron ---
             this.sendInterpreterEntryTelemetry(selection, state.workspace);
         } else if (selection && selection.label === InterpreterQuickPickList.browsePath.label) {

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -23,8 +23,6 @@ import { EXTENSION_ROOT_DIR } from '../common/constants';
 import { JupyterKernelSpec } from '../jupyter-adapter.d';
 import { IEnvironmentVariablesProvider } from '../common/variables/types';
 import { checkAndInstallPython } from './extension';
-import { showErrorMessage } from '../common/vscodeApis/windowApis';
-import { CreateEnv } from '../common/utils/localize';
 
 export const IPythonRuntimeManager = Symbol('IPythonRuntimeManager');
 
@@ -63,9 +61,6 @@ export class PythonRuntimeManager implements IPythonRuntimeManager {
                     // An interpreter was added.
                     const interpreterPath = event.new.path;
                     await checkAndInstallPython(interpreterPath, serviceContainer);
-                    if (!fs.existsSync(interpreterPath)) {
-                        showErrorMessage(`${CreateEnv.pathDoesntExist} ${interpreterPath}`);
-                    }
                     await this.registerLanguageRuntimeFromPath(interpreterPath);
                 }
             }),

--- a/extensions/positron-python/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
+++ b/extensions/positron-python/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
@@ -48,6 +48,7 @@ import { IInterpreterService, PythonEnvironmentsChangedEvent } from '../../../..
 import { createDeferred, sleep } from '../../../../client/common/utils/async';
 import { SystemVariables } from '../../../../client/common/variables/systemVariables';
 // --- Start Positron ---
+import * as windowApis from '../../../../client/common/vscodeApis/windowApis';
 import { IPythonRuntimeManager } from '../../../../client/positron/manager';
 // --- End Positron ---
 
@@ -1105,6 +1106,22 @@ suite('Set Interpreter Command', () => {
 
             appShell.verifyAll();
         });
+
+        // --- Start Positron ---
+        test('should show error message if path does not exist', async () => {
+            const state: InterpreterStateArgs = { path: undefined, workspace: undefined };
+            const multiStepInput = TypeMoq.Mock.ofType<IMultiStepInput<InterpreterStateArgs>>();
+            const showErrorMessageStub = sinon.stub(windowApis, 'showErrorMessage');
+
+            multiStepInput
+                .setup((i) => i.showQuickPick(TypeMoq.It.isAny()))
+                .returns(() => Promise.resolve('enteredPath'));
+
+            await setInterpreterCommand._enterOrBrowseInterpreterPath(multiStepInput.object, state).ignoreErrors();
+
+            sinon.assert.calledOnce(showErrorMessageStub);
+        });
+        // --- End Positron ---
 
         suite('SELECT_INTERPRETER_ENTERED_EXISTS telemetry', async () => {
             let sendTelemetryStub: sinon.SinonStub;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

related to #3339 

Moving `Entered path does not exists` popup from when paths are changed/registered to only when they are entered by the user

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

use `cmd+shift+p` -> `Python Select Interpreter` -> `Enter interpreter path...` -> enter some nonsense path and see popup