### PR TITLE
Console history test reliability fixes

### DIFF
--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -21,6 +21,7 @@ const CONSOLE_BAR_RESTART_BUTTON = 'div.action-bar-button-icon.codicon.codicon-p
 const CONSOLE_RESTART_BUTTON = 'button.monaco-text-button.runtime-restart-button';
 const CONSOLE_BAR_CLEAR_BUTTON = 'div.action-bar-button-icon.codicon.codicon-clear-all';
 const HISTORY_COMPLETION_ITEM = '.history-completion-item';
+const PREVIOUS_CONSOLE_LINES = '.runtime-activity .activity-input div';
 
 /*
  *  Reuseable Positron console functionality for tests to leverage.  Includes the ability to select an interpreter and execute code which
@@ -147,6 +148,13 @@ export class PositronConsole {
 		const element = await this.code.waitForElement(`${ACTIVE_CONSOLE_INSTANCE} .view-line`,
 			(e) => accept ? (!!e && accept(e.textContent)) : true);
 		return element.textContent;
+	}
+
+	async waitForPreviousConsoleLineContents(accept?: (contents: string[]) => boolean) {
+		const elements = await this.code.waitForElements(PREVIOUS_CONSOLE_LINES,
+			false,
+			(elements) => accept ? (!!elements && accept(elements.map(e => e.textContent))) : true);
+		return elements.map(e => e.textContent);
 	}
 
 	async waitForHistoryContents(accept?: (contents: string[]) => boolean) {

--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -151,7 +151,7 @@ export class PositronConsole {
 	}
 
 	async waitForPreviousConsoleLineContents(accept?: (contents: string[]) => boolean) {
-		const elements = await this.code.waitForElements(PREVIOUS_CONSOLE_LINES,
+		const elements = await this.code.waitForElements(`${ACTIVE_CONSOLE_INSTANCE} ${PREVIOUS_CONSOLE_LINES}`,
 			false,
 			(elements) => accept ? (!!elements && accept(elements.map(e => e.textContent))) : true);
 		return elements.map(e => e.textContent);

--- a/test/smoke/src/areas/positron/console/consoleHistory.test.ts
+++ b/test/smoke/src/areas/positron/console/consoleHistory.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 
+import { expect } from '@playwright/test';
 import { Application, Logger, PositronPythonFixtures, PositronRFixtures } from '../../../../../automation';
 import { installAllHandlers } from '../../../utils';
 
@@ -24,14 +25,31 @@ export function setup(logger: Logger) {
 			it('Python - Verify Console History [C685945]', async function () {
 				const app = this.app as Application;
 
-				await app.workbench.positronConsole.typeToConsole('a = 1');
-				await app.workbench.positronConsole.sendEnterKey();
+				await expect(async () => {
+					await app.workbench.positronConsole.typeToConsole('a = 1');
+					await app.workbench.positronConsole.sendEnterKey();
 
-				await app.workbench.positronConsole.typeToConsole('b = 2');
-				await app.workbench.positronConsole.sendEnterKey();
+					await app.code.wait(200);
 
-				await app.workbench.positronConsole.typeToConsole('c = 3');
-				await app.workbench.positronConsole.sendEnterKey();
+					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
+						(lines) => lines.some((line) => line.includes('a = 1')));
+
+					await app.workbench.positronConsole.typeToConsole('b = 2');
+					await app.workbench.positronConsole.sendEnterKey();
+
+					await app.code.wait(200);
+
+					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
+						(lines) => lines.some((line) => line.includes('b = 2')));
+
+					await app.workbench.positronConsole.typeToConsole('c = 3');
+					await app.workbench.positronConsole.sendEnterKey();
+
+					await app.code.wait(200);
+
+					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
+						(lines) => lines.some((line) => line.includes('c = 3')));
+				}).toPass({ timeout: 40000 });
 
 				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 				await app.workbench.positronConsole.barClearButton.click();
@@ -69,14 +87,32 @@ export function setup(logger: Logger) {
 			it('R - Verify Console History [C685946]]', async function () {
 				const app = this.app as Application;
 
-				await app.workbench.positronConsole.typeToConsole('a <- 1');
-				await app.workbench.positronConsole.sendEnterKey();
+				await expect(async () => {
+					await app.workbench.positronConsole.typeToConsole('a <- 1');
+					await app.workbench.positronConsole.sendEnterKey();
 
-				await app.workbench.positronConsole.typeToConsole('b <- 2');
-				await app.workbench.positronConsole.sendEnterKey();
+					await app.code.wait(200);
 
-				await app.workbench.positronConsole.typeToConsole('c <- 3');
-				await app.workbench.positronConsole.sendEnterKey();
+					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
+						(lines) => lines.some((line) => line.includes('a <- 1')));
+
+					await app.workbench.positronConsole.typeToConsole('b <- 2');
+					await app.workbench.positronConsole.sendEnterKey();
+
+					await app.code.wait(200);
+
+					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
+						(lines) => lines.some((line) => line.includes('b <- 2')));
+
+					await app.workbench.positronConsole.typeToConsole('c <- 3');
+					await app.workbench.positronConsole.sendEnterKey();
+
+					await app.code.wait(200);
+
+					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
+						(lines) => lines.some((line) => line.includes('c <- 3')));
+
+				}).toPass({ timeout: 40000 });
 
 				await app.code.wait(500);
 

--- a/test/smoke/src/areas/positron/console/consoleHistory.test.ts
+++ b/test/smoke/src/areas/positron/console/consoleHistory.test.ts
@@ -32,23 +32,17 @@ export function setup(logger: Logger) {
 					await app.workbench.positronConsole.typeToConsole(lineOne);
 					await app.workbench.positronConsole.sendEnterKey();
 
-					await app.code.wait(200);
-
 					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
 						(lines) => lines.some((line) => line.includes(lineOne)));
 
 					await app.workbench.positronConsole.typeToConsole(lineTwo);
 					await app.workbench.positronConsole.sendEnterKey();
 
-					await app.code.wait(200);
-
 					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
 						(lines) => lines.some((line) => line.includes(lineTwo)));
 
 					await app.workbench.positronConsole.typeToConsole(lineThree);
 					await app.workbench.positronConsole.sendEnterKey();
-
-					await app.code.wait(200);
 
 					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
 						(lines) => lines.some((line) => line.includes(lineThree)));
@@ -97,23 +91,17 @@ export function setup(logger: Logger) {
 					await app.workbench.positronConsole.typeToConsole(lineOne);
 					await app.workbench.positronConsole.sendEnterKey();
 
-					await app.code.wait(200);
-
 					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
 						(lines) => lines.some((line) => line.includes(lineOne)));
 
 					await app.workbench.positronConsole.typeToConsole(lineTwo);
 					await app.workbench.positronConsole.sendEnterKey();
 
-					await app.code.wait(200);
-
 					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
 						(lines) => lines.some((line) => line.includes(lineTwo)));
 
 					await app.workbench.positronConsole.typeToConsole(lineThree);
 					await app.workbench.positronConsole.sendEnterKey();
-
-					await app.code.wait(200);
 
 					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
 						(lines) => lines.some((line) => line.includes(lineThree)));

--- a/test/smoke/src/areas/positron/console/consoleHistory.test.ts
+++ b/test/smoke/src/areas/positron/console/consoleHistory.test.ts
@@ -22,33 +22,36 @@ export function setup(logger: Logger) {
 				this.app.workbench.positronConsole.sendKeyboardKey('Escape');
 			});
 
+			const lineOne = 'a = 1';
+			const lineTwo = 'b = 2';
+			const lineThree = 'c = 3';
 			it('Python - Verify Console History [C685945]', async function () {
 				const app = this.app as Application;
 
 				await expect(async () => {
-					await app.workbench.positronConsole.typeToConsole('a = 1');
+					await app.workbench.positronConsole.typeToConsole(lineOne);
 					await app.workbench.positronConsole.sendEnterKey();
 
 					await app.code.wait(200);
 
 					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
-						(lines) => lines.some((line) => line.includes('a = 1')));
+						(lines) => lines.some((line) => line.includes(lineOne)));
 
-					await app.workbench.positronConsole.typeToConsole('b = 2');
+					await app.workbench.positronConsole.typeToConsole(lineTwo);
 					await app.workbench.positronConsole.sendEnterKey();
 
 					await app.code.wait(200);
 
 					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
-						(lines) => lines.some((line) => line.includes('b = 2')));
+						(lines) => lines.some((line) => line.includes(lineTwo)));
 
-					await app.workbench.positronConsole.typeToConsole('c = 3');
+					await app.workbench.positronConsole.typeToConsole(lineThree);
 					await app.workbench.positronConsole.sendEnterKey();
 
 					await app.code.wait(200);
 
 					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
-						(lines) => lines.some((line) => line.includes('c = 3')));
+						(lines) => lines.some((line) => line.includes(lineThree)));
 				}).toPass({ timeout: 40000 });
 
 				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
@@ -66,9 +69,9 @@ export function setup(logger: Logger) {
 				await app.workbench.positronConsole.sendKeyboardKey('Control+R');
 
 				await app.workbench.positronConsole.waitForHistoryContents((contents) =>
-					contents.some((line) => line.includes('a = 1')) &&
-					contents.some((line) => line.includes('b = 2')) &&
-					contents.some((line) => line.includes('c = 3')));
+					contents.some((line) => line.includes(lineOne)) &&
+					contents.some((line) => line.includes(lineTwo)) &&
+					contents.some((line) => line.includes(lineThree)));
 
 				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 
@@ -87,30 +90,33 @@ export function setup(logger: Logger) {
 			it('R - Verify Console History [C685946]]', async function () {
 				const app = this.app as Application;
 
+				const lineOne = 'a <- 1';
+				const lineTwo = 'b <- 2';
+				const lineThree = 'c <- 3';
 				await expect(async () => {
-					await app.workbench.positronConsole.typeToConsole('a <- 1');
+					await app.workbench.positronConsole.typeToConsole(lineOne);
 					await app.workbench.positronConsole.sendEnterKey();
 
 					await app.code.wait(200);
 
 					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
-						(lines) => lines.some((line) => line.includes('a <- 1')));
+						(lines) => lines.some((line) => line.includes(lineOne)));
 
-					await app.workbench.positronConsole.typeToConsole('b <- 2');
+					await app.workbench.positronConsole.typeToConsole(lineTwo);
 					await app.workbench.positronConsole.sendEnterKey();
 
 					await app.code.wait(200);
 
 					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
-						(lines) => lines.some((line) => line.includes('b <- 2')));
+						(lines) => lines.some((line) => line.includes(lineTwo)));
 
-					await app.workbench.positronConsole.typeToConsole('c <- 3');
+					await app.workbench.positronConsole.typeToConsole(lineThree);
 					await app.workbench.positronConsole.sendEnterKey();
 
 					await app.code.wait(200);
 
 					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
-						(lines) => lines.some((line) => line.includes('c <- 3')));
+						(lines) => lines.some((line) => line.includes(lineThree)));
 
 				}).toPass({ timeout: 40000 });
 
@@ -131,9 +137,9 @@ export function setup(logger: Logger) {
 				await app.workbench.positronConsole.sendKeyboardKey('Control+R');
 
 				await app.workbench.positronConsole.waitForHistoryContents((contents) =>
-					contents.some((line) => line.includes('a <- 1')) &&
-					contents.some((line) => line.includes('b <- 2')) &&
-					contents.some((line) => line.includes('c <- 3')));
+					contents.some((line) => line.includes(lineOne)) &&
+					contents.some((line) => line.includes(lineTwo)) &&
+					contents.some((line) => line.includes(lineThree)));
 
 				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 


### PR DESCRIPTION
Fixes for occasional failures with console history tests.  We were seeing occasional test failures whereby the lines being typed into the console to check the history functionality were being truncated, likely because the test was running too quickly.

Remediated this by adding functionality to await the proper lines in the "previous console lines" displayed after an entry is made.  If any of these awaits fails, the entire block that writes out lines to be used for history evaluation will be repeated, up until a 40 second timeout.

### QA Notes

All smoke tests should pass.
