### PR TITLE
Test reliability fixes - console tests

### DIFF
--- a/test/automation/src/positron/fixtures/positronPythonFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronPythonFixtures.ts
@@ -27,7 +27,7 @@ export class PositronPythonFixtures {
 		}
 		await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.Python, desiredPython);
 
-		await this.app.workbench.positronConsole.waitForReady('>>>');
+		await this.app.workbench.positronConsole.waitForReady('>>>', 2000);
 
 		await this.app.workbench.positronConsole.logConsoleContents();
 	}
@@ -46,7 +46,7 @@ export class PositronPythonFixtures {
 			await this.app.workbench.positronPopups.installIPyKernel();
 		}
 
-		await this.app.workbench.positronConsole.waitForReady('>>>');
+		await this.app.workbench.positronConsole.waitForReady('>>>', 2000);
 
 		await this.app.workbench.positronConsole.logConsoleContents();
 

--- a/test/automation/src/positron/fixtures/positronRFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronRFixtures.ts
@@ -27,7 +27,7 @@ export class PositronRFixtures {
 		}
 		await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.R, desiredR);
 
-		await this.app.workbench.positronConsole.waitForReady('>');
+		await this.app.workbench.positronConsole.waitForReady('>', 2000);
 
 		await this.app.workbench.positronConsole.logConsoleContents();
 

--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -21,7 +21,6 @@ const CONSOLE_BAR_RESTART_BUTTON = 'div.action-bar-button-icon.codicon.codicon-p
 const CONSOLE_RESTART_BUTTON = 'button.monaco-text-button.runtime-restart-button';
 const CONSOLE_BAR_CLEAR_BUTTON = 'div.action-bar-button-icon.codicon.codicon-clear-all';
 const HISTORY_COMPLETION_ITEM = '.history-completion-item';
-const PREVIOUS_CONSOLE_LINES = '.runtime-activity .activity-input div';
 
 /*
  *  Reuseable Positron console functionality for tests to leverage.  Includes the ability to select an interpreter and execute code which
@@ -148,13 +147,6 @@ export class PositronConsole {
 		const element = await this.code.waitForElement(`${ACTIVE_CONSOLE_INSTANCE} .view-line`,
 			(e) => accept ? (!!e && accept(e.textContent)) : true);
 		return element.textContent;
-	}
-
-	async waitForPreviousConsoleLineContents(accept?: (contents: string[]) => boolean) {
-		const elements = await this.code.waitForElements(`${ACTIVE_CONSOLE_INSTANCE} ${PREVIOUS_CONSOLE_LINES}`,
-			false,
-			(elements) => accept ? (!!elements && accept(elements.map(e => e.textContent))) : true);
-		return elements.map(e => e.textContent);
 	}
 
 	async waitForHistoryContents(accept?: (contents: string[]) => boolean) {

--- a/test/smoke/src/areas/positron/console/consoleClipboard.test.ts
+++ b/test/smoke/src/areas/positron/console/consoleClipboard.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 
+import { expect } from '@playwright/test';
 import { Application, Logger, PositronPythonFixtures, PositronRFixtures } from '../../../../../automation';
 import { installAllHandlers } from '../../../utils';
 import * as os from 'os';
@@ -17,35 +18,50 @@ export function setup(logger: Logger) {
 		const modifier = isMac ? 'Meta' : 'Control';
 
 		async function testBody(app: Application) {
-				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+			await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 
-				const activeConsole = app.workbench.positronConsole.activeConsole;
-				await activeConsole.click();
+			const activeConsole = app.workbench.positronConsole.activeConsole;
+			await activeConsole.click();
+			const page = activeConsole!.page();
 
-				await app.workbench.positronConsole.typeToConsole('a = 1');
+			const testLine = 'a = 1';
 
-				const page = activeConsole!.page();
-				await page.keyboard.press(`${modifier}+A`);
-				await page.keyboard.press(`${modifier}+C`);
-
+			await expect(async () => {
+				// Ensure nothing is in the current line and clear the console
 				await app.workbench.positronConsole.sendEnterKey();
-
-				await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('a = 1')));
-
 				await app.workbench.positronConsole.barClearButton.click();
 
+				// Send test line to console
+				await app.workbench.positronConsole.typeToConsole(testLine);
+
+				// copy the test line and send enter key
+				await page.keyboard.press(`${modifier}+A`);
+				await page.keyboard.press(`${modifier}+C`);
+				await app.workbench.positronConsole.sendEnterKey();
+
+				// ensure the console previous lines contain the test line
+				await app.workbench.positronConsole.waitForConsoleContents(
+					(lines) => lines.some((line) => line.includes(testLine)));
+
+				// clear the console and ensure the clear succeeded
+				await app.workbench.positronConsole.barClearButton.click();
 				await app.workbench.positronConsole.waitForConsoleContents((contents) => {
 					return !contents.some(Boolean);
 				});
+			}).toPass({ timeout: 40000 });
 
-				await page.keyboard.press(`${modifier}+V`);
-				await app.workbench.positronConsole.sendEnterKey();
+			// paste the copied test line twice so that if the previous toPass
+			// block failed, we won't think the test passed due to the original typing
+			await page.keyboard.press(`${modifier}+V`);
+			await page.keyboard.press(`${modifier}+V`);
+			await app.workbench.positronConsole.sendEnterKey();
 
-				await app.workbench.positronConsole.waitForConsoleContents((contents) =>
-					contents.some((line) => line.includes('a = 1'))
-				);
+			// check for two instances of the test line in a row (invalid)
+			await app.workbench.positronConsole.waitForConsoleContents((contents) =>
+				contents.some((line) => line.includes(`${testLine}${testLine}`))
+			);
 
-				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+			await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 		}
 
 		describe('Console Clipboard - Python', () => {

--- a/test/smoke/src/areas/positron/console/consoleHistory.test.ts
+++ b/test/smoke/src/areas/positron/console/consoleHistory.test.ts
@@ -32,19 +32,19 @@ export function setup(logger: Logger) {
 					await app.workbench.positronConsole.typeToConsole(lineOne);
 					await app.workbench.positronConsole.sendEnterKey();
 
-					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
+					await app.workbench.positronConsole.waitForConsoleContents(
 						(lines) => lines.some((line) => line.includes(lineOne)));
 
 					await app.workbench.positronConsole.typeToConsole(lineTwo);
 					await app.workbench.positronConsole.sendEnterKey();
 
-					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
+					await app.workbench.positronConsole.waitForConsoleContents(
 						(lines) => lines.some((line) => line.includes(lineTwo)));
 
 					await app.workbench.positronConsole.typeToConsole(lineThree);
 					await app.workbench.positronConsole.sendEnterKey();
 
-					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
+					await app.workbench.positronConsole.waitForConsoleContents(
 						(lines) => lines.some((line) => line.includes(lineThree)));
 				}).toPass({ timeout: 40000 });
 
@@ -88,27 +88,28 @@ export function setup(logger: Logger) {
 				const lineTwo = 'b <- 2';
 				const lineThree = 'c <- 3';
 				await expect(async () => {
+					// send test line one and the enter key, then expect it in the previous console
+					// lines
 					await app.workbench.positronConsole.typeToConsole(lineOne);
 					await app.workbench.positronConsole.sendEnterKey();
-
-					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
+					await app.workbench.positronConsole.waitForConsoleContents(
 						(lines) => lines.some((line) => line.includes(lineOne)));
 
+					// send test line two and the enter key, then expect it in the previous console
+					// lines
 					await app.workbench.positronConsole.typeToConsole(lineTwo);
 					await app.workbench.positronConsole.sendEnterKey();
-
-					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
+					await app.workbench.positronConsole.waitForConsoleContents(
 						(lines) => lines.some((line) => line.includes(lineTwo)));
 
+					// send test line three and the enter key, then expect it in the previous console
+					// lines
 					await app.workbench.positronConsole.typeToConsole(lineThree);
 					await app.workbench.positronConsole.sendEnterKey();
-
-					await app.workbench.positronConsole.waitForPreviousConsoleLineContents(
+					await app.workbench.positronConsole.waitForConsoleContents(
 						(lines) => lines.some((line) => line.includes(lineThree)));
 
 				}).toPass({ timeout: 40000 });
-
-				await app.code.wait(500);
 
 				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 				await app.workbench.positronConsole.barClearButton.click();


### PR DESCRIPTION
Test reliability fixes for the console. 

* waiting for the "ready prompt" in fixtures was not waiting long enough (500 -> 2000)
* waitForPreviousConsoleLineContents was a duplicate of waitForConsoleContents using a different selector
* console clipboard tests would occasionally drop the enter key - tests made robust in this regard with a retry loop; retry loop requires satisfying retry precondition of a clear console
* console clipboard tests now paste twice in a row to ensure verification of pasted line doesn't just pick up original line post failure of first half of test by timeout

### QA Notes

All smoke tests should pass
