### PR TITLE
Data Explorer: Request multiple column profiles at once, flesh out histogram and frequency table parameters, add simple implementations for pandas and polars

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -1610,7 +1610,11 @@ class PandasView(DataExplorerTableView):
 
         formatted_edges = self._format_values(bin_edges, format_options)
 
-        return ColumnHistogram(bin_edges=formatted_edges, bin_counts=[int(x) for x in bin_counts])
+        return ColumnHistogram(
+            bin_edges=formatted_edges,
+            bin_counts=[int(x) for x in bin_counts],
+            quantiles=[],
+        )
 
     SUPPORTED_FILTERS = {
         RowFilterType.Between,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -33,7 +33,6 @@ from .data_explorer_comm import (
     ColumnFilterType,
     ColumnFilterTypeSupportStatus,
     ColumnFrequencyTable,
-    ColumnFrequencyTableItem,
     ColumnFrequencyTableParams,
     ColumnHistogram,
     ColumnHistogramParams,
@@ -1576,14 +1575,13 @@ class PandasView(DataExplorerTableView):
         top_counts = counts.iloc[: params.limit]
         other_group = counts.iloc[params.limit :]
 
-        formatted_groups = self._format_values(top_counts, format_options)
+        formatted_groups = self._format_values(top_counts.index, format_options)
 
-        freq_items = [
-            ColumnFrequencyTableItem(value=group, count=count)
-            for group, count in zip(formatted_groups, top_counts)
-        ]
-
-        return ColumnFrequencyTable(counts=freq_items, other_count=int(other_group.sum()))
+        return ColumnFrequencyTable(
+            values=formatted_groups,
+            counts=[int(x) for x in top_counts],
+            other_count=int(other_group.sum()),
+        )
 
     def _prof_histogram(
         self,
@@ -1669,6 +1667,14 @@ class PandasView(DataExplorerTableView):
                 # profiles.
                 ColumnProfileTypeSupportStatus(
                     profile_type=ColumnProfileType.SummaryStats,
+                    support_status=SupportStatus.Experimental,
+                ),
+                ColumnProfileTypeSupportStatus(
+                    profile_type=ColumnProfileType.Histogram,
+                    support_status=SupportStatus.Experimental,
+                ),
+                ColumnProfileTypeSupportStatus(
+                    profile_type=ColumnProfileType.FrequencyTable,
                     support_status=SupportStatus.Experimental,
                 ),
             ],

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -781,6 +781,10 @@ class ColumnHistogram(BaseModel):
         description="Absolute count of values in each histogram bin",
     )
 
+    quantiles: List[ColumnQuantileValue] = Field(
+        description="Sample quantiles that were also requested",
+    )
+
 
 class ColumnFrequencyTableParams(BaseModel):
     """
@@ -807,7 +811,7 @@ class ColumnFrequencyTable(BaseModel):
 
     other_count: Optional[StrictInt] = Field(
         default=None,
-        description="Number of other values not accounted for in counts. May be omitted",
+        description="Number of other values not accounted for in counts, excluding nulls/NA values. May be omitted",
     )
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -541,8 +541,23 @@ class ColumnProfileRequest(BaseModel):
         description="The ordinal column index to profile",
     )
 
+    profiles: List[ColumnProfileSpec] = Field(
+        description="Column profiles needed",
+    )
+
+
+class ColumnProfileSpec(BaseModel):
+    """
+    Parameters for a single column profile for a request for profiles
+    """
+
     profile_type: ColumnProfileType = Field(
-        description="The type of analytical column profile",
+        description="Type of column profile",
+    )
+
+    params: Optional[ColumnProfileParams] = Field(
+        default=None,
+        description="Extra parameters for different profile types",
     )
 
 
@@ -738,17 +753,47 @@ class SummaryStatsDatetime(BaseModel):
     )
 
 
+class ColumnHistogramParams(BaseModel):
+    """
+    Parameters for a column histogram profile request
+    """
+
+    num_bins: StrictInt = Field(
+        description="Number of bins in the computed histogram",
+    )
+
+    quantiles: Optional[List[Union[StrictInt, StrictFloat]]] = Field(
+        default=None,
+        description="Sample quantiles (numbers between 0 and 1) to compute along with the histogram",
+    )
+
+
 class ColumnHistogram(BaseModel):
     """
     Result from a histogram profile request
     """
 
-    bin_sizes: List[StrictInt] = Field(
+    bin_edges: List[StrictStr] = Field(
+        description="String-formatted versions of the bin edges, there are N + 1 where N is the number of bins",
+    )
+
+    bin_counts: List[StrictInt] = Field(
         description="Absolute count of values in each histogram bin",
     )
 
-    bin_width: Union[StrictInt, StrictFloat] = Field(
-        description="Absolute floating-point width of a histogram bin",
+
+class ColumnFrequencyTableParams(BaseModel):
+    """
+    Parameters for a frequency_table profile request
+    """
+
+    limit: StrictInt = Field(
+        description="Number of most frequently-occurring values to return. The K in TopK",
+    )
+
+    include_other_count: Optional[StrictBool] = Field(
+        default=None,
+        description="Whether to also return the total number of 'other' values outside of the most frequent values",
     )
 
 
@@ -761,8 +806,9 @@ class ColumnFrequencyTable(BaseModel):
         description="Counts of distinct values in column",
     )
 
-    other_count: StrictInt = Field(
-        description="Number of other values not accounted for in counts. May be 0",
+    other_count: Optional[StrictInt] = Field(
+        default=None,
+        description="Number of other values not accounted for in counts. May be omitted",
     )
 
 
@@ -786,7 +832,7 @@ class ColumnQuantileValue(BaseModel):
     """
 
     q: Union[StrictInt, StrictFloat] = Field(
-        description="Quantile number (percentile). E.g. 1 for 1%, 50 for median",
+        description="Quantile number; a number between 0 and 1",
     )
 
     value: StrictStr = Field(
@@ -999,6 +1045,11 @@ RowFilterParams = Union[
 ColumnFilterParams = Union[
     FilterTextSearch,
     FilterMatchDataTypes,
+]
+# Extra parameters for different profile types
+ColumnProfileParams = Union[
+    ColumnHistogramParams,
+    ColumnFrequencyTableParams,
 ]
 # A union of selection types
 Selection = Union[
@@ -1356,6 +1407,8 @@ ColumnFilterTypeSupportStatus.update_forward_refs()
 
 ColumnProfileRequest.update_forward_refs()
 
+ColumnProfileSpec.update_forward_refs()
+
 ColumnProfileTypeSupportStatus.update_forward_refs()
 
 ColumnProfileResult.update_forward_refs()
@@ -1372,7 +1425,11 @@ SummaryStatsDate.update_forward_refs()
 
 SummaryStatsDatetime.update_forward_refs()
 
+ColumnHistogramParams.update_forward_refs()
+
 ColumnHistogram.update_forward_refs()
+
+ColumnFrequencyTableParams.update_forward_refs()
 
 ColumnFrequencyTable.update_forward_refs()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -791,38 +791,23 @@ class ColumnFrequencyTableParams(BaseModel):
         description="Number of most frequently-occurring values to return. The K in TopK",
     )
 
-    include_other_count: Optional[StrictBool] = Field(
-        default=None,
-        description="Whether to also return the total number of 'other' values outside of the most frequent values",
-    )
-
 
 class ColumnFrequencyTable(BaseModel):
     """
     Result from a frequency_table profile request
     """
 
-    counts: List[ColumnFrequencyTableItem] = Field(
-        description="Counts of distinct values in column",
+    values: List[StrictStr] = Field(
+        description="The formatted top values",
+    )
+
+    counts: List[StrictInt] = Field(
+        description="Counts of top values",
     )
 
     other_count: Optional[StrictInt] = Field(
         default=None,
         description="Number of other values not accounted for in counts. May be omitted",
-    )
-
-
-class ColumnFrequencyTableItem(BaseModel):
-    """
-    Entry in a column's frequency table
-    """
-
-    value: StrictStr = Field(
-        description="Stringified value",
-    )
-
-    count: StrictInt = Field(
-        description="Number of occurrences of value",
     )
 
 
@@ -1432,8 +1417,6 @@ ColumnHistogram.update_forward_refs()
 ColumnFrequencyTableParams.update_forward_refs()
 
 ColumnFrequencyTable.update_forward_refs()
-
-ColumnFrequencyTableItem.update_forward_refs()
 
 ColumnQuantileValue.update_forward_refs()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -2554,6 +2554,7 @@ def test_pandas_profile_histogram(dxf: DataExplorerFixture):
             {
                 "bin_edges": ["0.00", "2.50", "5.00", "7.50", "10.00"],
                 "bin_counts": [3, 2, 3, 3],
+                "quantiles": [],
             },
         ),
         (
@@ -2567,6 +2568,7 @@ def test_pandas_profile_histogram(dxf: DataExplorerFixture):
                     "2000-01-11 00:00:00",
                 ],
                 "bin_counts": [3, 2, 3, 3],
+                "quantiles": [],
             },
         ),
         (
@@ -2582,6 +2584,7 @@ def test_pandas_profile_histogram(dxf: DataExplorerFixture):
                     "10.00",
                 ],
                 "bin_counts": [1, 1, 1, 3, 2, 1],
+                "quantiles": [],
             },
         ),
     ]

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -2166,16 +2166,16 @@ def test_export_data_selection(dxf: DataExplorerFixture):
                 assert filt_result["data"] == filt_expected
 
 
-def _profile_request(column_index, profile_type):
-    return {"column_index": column_index, "profile_type": profile_type}
+def _profile_request(column_index, profiles):
+    return {"column_index": column_index, "profiles": profiles}
 
 
 def _get_null_count(column_index):
-    return _profile_request(column_index, "null_count")
+    return _profile_request(column_index, [{"profile_type": "null_count"}])
 
 
 def _get_summary_stats(column_index):
-    return _profile_request(column_index, "summary_stats")
+    return _profile_request(column_index, [{"profile_type": "summary_stats"}])
 
 
 def test_pandas_profile_null_counts(dxf: DataExplorerFixture):

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -606,7 +606,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.121"
+      "ark": "0.1.122"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.7"

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -1084,17 +1084,12 @@
 				"type": "object",
 				"description": "Parameters for a frequency_table profile request",
 				"required": [
-					"limit",
-					"include_other_group"
+					"limit"
 				],
 				"properties": {
 					"limit": {
 						"type": "integer",
 						"description": "Number of most frequently-occurring values to return. The K in TopK"
-					},
-					"include_other_count": {
-						"type": "boolean",
-						"description": "Whether to also return the total number of 'other' values outside of the most frequent values"
 					}
 				}
 			},
@@ -1102,37 +1097,27 @@
 				"type": "object",
 				"description": "Result from a frequency_table profile request",
 				"required": [
+					"values",
 					"counts"
 				],
 				"properties": {
+					"values": {
+						"type": "array",
+						"description": "The formatted top values",
+						"items": {
+							"type": "string"
+						}
+					},
 					"counts": {
 						"type": "array",
-						"description": "Counts of distinct values in column",
+						"description": "Counts of top values",
 						"items": {
-							"$ref": "#/components/schemas/column_frequency_table_item"
+							"type": "integer"
 						}
 					},
 					"other_count": {
 						"type": "integer",
 						"description": "Number of other values not accounted for in counts. May be omitted"
-					}
-				}
-			},
-			"column_frequency_table_item": {
-				"type": "object",
-				"description": "Entry in a column's frequency table",
-				"required": [
-					"value",
-					"count"
-				],
-				"properties": {
-					"value": {
-						"type": "string",
-						"description": "Stringified value"
-					},
-					"count": {
-						"type": "integer",
-						"description": "Number of occurrences of value"
 					}
 				}
 			},

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -779,18 +779,51 @@
 				"description": "A single column profile request",
 				"required": [
 					"column_index",
-					"profile_type"
+					"profiles"
 				],
 				"properties": {
 					"column_index": {
 						"type": "integer",
 						"description": "The ordinal column index to profile"
 					},
-					"profile_type": {
-						"description": "The type of analytical column profile",
-						"$ref": "#/components/schemas/column_profile_type"
+					"profiles": {
+						"type": "array",
+						"description": "Column profiles needed",
+						"items": {
+							"$ref": "#/components/schemas/column_profile_spec"
+						}
 					}
 				}
+			},
+			"column_profile_spec": {
+				"type": "object",
+				"description": "Parameters for a single column profile for a request for profiles",
+				"required": [
+					"profile_type"
+				],
+				"properties": {
+					"profile_type": {
+						"description": "Type of column profile",
+						"$ref": "#/components/schemas/column_profile_type"
+					},
+					"params": {
+						"description": "Extra parameters for different profile types",
+						"$ref": "#/components/schemas/column_profile_params"
+					}
+				}
+			},
+			"column_profile_params": {
+				"description": "Extra parameters for different profile types",
+				"oneOf": [
+					{
+						"name": "histogram",
+						"$ref": "#/components/schemas/column_histogram_params"
+					},
+					{
+						"name": "frequency_table",
+						"$ref": "#/components/schemas/column_frequency_table_params"
+					}
+				]
 			},
 			"column_profile_type": {
 				"type": "string",
@@ -1003,24 +1036,65 @@
 					}
 				}
 			},
+			"column_histogram_params": {
+				"type": "object",
+				"description": "Parameters for a column histogram profile request",
+				"required": [
+					"num_bins"
+				],
+				"properties": {
+					"num_bins": {
+						"type": "integer",
+						"description": "Number of bins in the computed histogram"
+					},
+					"quantiles": {
+						"type": "array",
+						"description": "Sample quantiles (numbers between 0 and 1) to compute along with the histogram",
+						"items": {
+							"type": "number"
+						}
+					}
+				}
+			},
 			"column_histogram": {
 				"type": "object",
 				"description": "Result from a histogram profile request",
 				"required": [
-					"bin_sizes",
-					"bin_width"
+					"bin_edges",
+					"bin_counts"
 				],
 				"properties": {
-					"bin_sizes": {
+					"bin_edges": {
+						"type": "array",
+						"description": "String-formatted versions of the bin edges, there are N + 1 where N is the number of bins",
+						"items": {
+							"type": "string"
+						}
+					},
+					"bin_counts": {
 						"type": "array",
 						"description": "Absolute count of values in each histogram bin",
 						"items": {
 							"type": "integer"
 						}
+					}
+				}
+			},
+			"column_frequency_table_params": {
+				"type": "object",
+				"description": "Parameters for a frequency_table profile request",
+				"required": [
+					"limit",
+					"include_other_group"
+				],
+				"properties": {
+					"limit": {
+						"type": "integer",
+						"description": "Number of most frequently-occurring values to return. The K in TopK"
 					},
-					"bin_width": {
-						"type": "number",
-						"description": "Absolute floating-point width of a histogram bin"
+					"include_other_count": {
+						"type": "boolean",
+						"description": "Whether to also return the total number of 'other' values outside of the most frequent values"
 					}
 				}
 			},
@@ -1028,8 +1102,7 @@
 				"type": "object",
 				"description": "Result from a frequency_table profile request",
 				"required": [
-					"counts",
-					"other_count"
+					"counts"
 				],
 				"properties": {
 					"counts": {
@@ -1041,7 +1114,7 @@
 					},
 					"other_count": {
 						"type": "integer",
-						"description": "Number of other values not accounted for in counts. May be 0"
+						"description": "Number of other values not accounted for in counts. May be omitted"
 					}
 				}
 			},
@@ -1074,7 +1147,7 @@
 				"properties": {
 					"q": {
 						"type": "number",
-						"description": "Quantile number (percentile). E.g. 1 for 1%, 50 for median"
+						"description": "Quantile number; a number between 0 and 1"
 					},
 					"value": {
 						"type": "string",

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -1061,7 +1061,8 @@
 				"description": "Result from a histogram profile request",
 				"required": [
 					"bin_edges",
-					"bin_counts"
+					"bin_counts",
+					"quantiles"
 				],
 				"properties": {
 					"bin_edges": {
@@ -1076,6 +1077,13 @@
 						"description": "Absolute count of values in each histogram bin",
 						"items": {
 							"type": "integer"
+						}
+					},
+					"quantiles": {
+						"type": "array",
+						"description": "Sample quantiles that were also requested",
+						"items": {
+							"$ref": "#/components/schemas/column_quantile_value"
 						}
 					}
 				}
@@ -1117,7 +1125,7 @@
 					},
 					"other_count": {
 						"type": "integer",
-						"description": "Number of other values not accounted for in counts. May be omitted"
+						"description": "Number of other values not accounted for in counts, excluding nulls/NA values. May be omitted"
 					}
 				}
 			},

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -410,9 +410,25 @@ export interface ColumnProfileRequest {
 	column_index: number;
 
 	/**
-	 * The type of analytical column profile
+	 * Column profiles needed
+	 */
+	profiles: Array<ColumnProfileSpec>;
+
+}
+
+/**
+ * Parameters for a single column profile for a request for profiles
+ */
+export interface ColumnProfileSpec {
+	/**
+	 * Type of column profile
 	 */
 	profile_type: ColumnProfileType;
+
+	/**
+	 * Extra parameters for different profile types
+	 */
+	params?: ColumnProfileParams;
 
 }
 
@@ -626,18 +642,53 @@ export interface SummaryStatsDatetime {
 }
 
 /**
+ * Parameters for a column histogram profile request
+ */
+export interface ColumnHistogramParams {
+	/**
+	 * Number of bins in the computed histogram
+	 */
+	num_bins: number;
+
+	/**
+	 * Sample quantiles (numbers between 0 and 1) to compute along with the
+	 * histogram
+	 */
+	quantiles?: Array<number>;
+
+}
+
+/**
  * Result from a histogram profile request
  */
 export interface ColumnHistogram {
 	/**
-	 * Absolute count of values in each histogram bin
+	 * String-formatted versions of the bin edges, there are N + 1 where N is
+	 * the number of bins
 	 */
-	bin_sizes: Array<number>;
+	bin_edges: Array<string>;
 
 	/**
-	 * Absolute floating-point width of a histogram bin
+	 * Absolute count of values in each histogram bin
 	 */
-	bin_width: number;
+	bin_counts: Array<number>;
+
+}
+
+/**
+ * Parameters for a frequency_table profile request
+ */
+export interface ColumnFrequencyTableParams {
+	/**
+	 * Number of most frequently-occurring values to return. The K in TopK
+	 */
+	limit: number;
+
+	/**
+	 * Whether to also return the total number of 'other' values outside of
+	 * the most frequent values
+	 */
+	include_other_count?: boolean;
 
 }
 
@@ -651,9 +702,9 @@ export interface ColumnFrequencyTable {
 	counts: Array<ColumnFrequencyTableItem>;
 
 	/**
-	 * Number of other values not accounted for in counts. May be 0
+	 * Number of other values not accounted for in counts. May be omitted
 	 */
-	other_count: number;
+	other_count?: number;
 
 }
 
@@ -678,7 +729,7 @@ export interface ColumnFrequencyTableItem {
  */
 export interface ColumnQuantileValue {
 	/**
-	 * Quantile number (percentile). E.g. 1 for 1%, 50 for median
+	 * Quantile number; a number between 0 and 1
 	 */
 	q: number;
 
@@ -916,6 +967,9 @@ export type RowFilterParams = FilterBetween | FilterComparison | FilterTextSearc
 
 /// Union of column filter type-specific parameters
 export type ColumnFilterParams = FilterTextSearch | FilterMatchDataTypes;
+
+/// Extra parameters for different profile types
+export type ColumnProfileParams = ColumnHistogramParams | ColumnFrequencyTableParams;
 
 /// A union of selection types
 export type Selection = DataSelectionSingleCell | DataSelectionCellRange | DataSelectionRange | DataSelectionIndices;

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -673,6 +673,11 @@ export interface ColumnHistogram {
 	 */
 	bin_counts: Array<number>;
 
+	/**
+	 * Sample quantiles that were also requested
+	 */
+	quantiles: Array<ColumnQuantileValue>;
+
 }
 
 /**
@@ -701,7 +706,8 @@ export interface ColumnFrequencyTable {
 	counts: Array<number>;
 
 	/**
-	 * Number of other values not accounted for in counts. May be omitted
+	 * Number of other values not accounted for in counts, excluding nulls/NA
+	 * values. May be omitted
 	 */
 	other_count?: number;
 

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -684,12 +684,6 @@ export interface ColumnFrequencyTableParams {
 	 */
 	limit: number;
 
-	/**
-	 * Whether to also return the total number of 'other' values outside of
-	 * the most frequent values
-	 */
-	include_other_count?: boolean;
-
 }
 
 /**
@@ -697,30 +691,19 @@ export interface ColumnFrequencyTableParams {
  */
 export interface ColumnFrequencyTable {
 	/**
-	 * Counts of distinct values in column
+	 * The formatted top values
 	 */
-	counts: Array<ColumnFrequencyTableItem>;
+	values: Array<string>;
+
+	/**
+	 * Counts of top values
+	 */
+	counts: Array<number>;
 
 	/**
 	 * Number of other values not accounted for in counts. May be omitted
 	 */
 	other_count?: number;
-
-}
-
-/**
- * Entry in a column's frequency table
- */
-export interface ColumnFrequencyTableItem {
-	/**
-	 * Stringified value
-	 */
-	value: string;
-
-	/**
-	 * Number of occurrences of value
-	 */
-	count: number;
 
 }
 

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
@@ -265,7 +265,9 @@ export class DataExplorerCache extends Disposable {
 			columnIndices.map(column_index => {
 				return {
 					column_index,
-					profile_type: ColumnProfileType.SummaryStats
+					profiles: [
+						{ profile_type: ColumnProfileType.SummaryStats }
+					]
 				};
 			})
 		);
@@ -446,7 +448,9 @@ export class DataExplorerCache extends Disposable {
 				columnNullCountIndices.map(column_index => {
 					return {
 						column_index,
-						profile_type: ColumnProfileType.NullCount
+						profiles: [
+							{ profile_type: ColumnProfileType.NullCount }
+						]
 					};
 				})
 			);


### PR DESCRIPTION
This is work helping put the pieces in place for #4061. A few things here:

* get_column_profiles receives an array of profile specs (a "spec" is what I'm calling a profile type + its params), presumably no duplicates of the same time, and the results are returned in the ColumnProfileResult type
* Added simple parameters for histograms and frequency tables
* Add basic implementation and some unit tests for pandas. These will need to be fleshed out to support more cases and handle exceptional scenarios

This can't be merged in its current state until the corresponding Ark PR is landed but putting this up for review in the meantime. 

### QA Notes

There is nothing visible in the UI yet. 