### PR TITLE
Capture screenshots when fixtures fail; handle "detecting kernels" during notebook open

### DIFF
--- a/test/automation/src/positron/fixtures/positronPythonFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronPythonFixtures.ts
@@ -25,10 +25,15 @@ export class PositronPythonFixtures {
 		if (desiredPython === undefined) {
 			fail('Please be sure to set env var POSITRON_PY_VER_SEL to the UI text corresponding to the Python version for the test');
 		}
-		await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.Python, desiredPython);
 
-		await this.app.workbench.positronConsole.waitForReady('>>>', 2000);
-
+		// We currently don't capture fixtures in the Playwright trace, so take a screenshot on failure
+		try {
+			await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.Python, desiredPython);
+			await this.app.workbench.positronConsole.waitForReady('>>>', 2000);
+		} catch (e) {
+			this.app.code.driver.takeScreenshot('startPythonInterpreter');
+			throw e;
+		}
 		await this.app.workbench.positronConsole.logConsoleContents();
 	}
 

--- a/test/automation/src/positron/fixtures/positronRFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronRFixtures.ts
@@ -25,9 +25,16 @@ export class PositronRFixtures {
 		if (desiredR === undefined) {
 			fail('Please be sure to set env var POSITRON_R_VER_SEL to the UI text corresponding to the R version for the test');
 		}
-		await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.R, desiredR);
 
-		await this.app.workbench.positronConsole.waitForReady('>', 2000);
+
+		// We currently don't capture fixtures in the Playwright trace, so take a screenshot on failure
+		try {
+			await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.R, desiredR);
+			await this.app.workbench.positronConsole.waitForReady('>', 2000);
+		} catch (e) {
+			this.app.code.driver.takeScreenshot('startRInterpreter');
+			throw e;
+		}
 
 		await this.app.workbench.positronConsole.logConsoleContents();
 

--- a/test/automation/src/positron/positronNotebooks.ts
+++ b/test/automation/src/positron/positronNotebooks.ts
@@ -13,6 +13,7 @@ import { QuickInput } from '../quickinput';
 const KERNEL_LABEL = '.kernel-label';
 const KERNEL_ACTION = '.kernel-action-view-item';
 const SELECT_KERNEL_TEXT = 'Select Kernel';
+const DETECTING_KERNELS_TEXT = 'Detecting Kernels';
 const NEW_NOTEBOOK_COMMAND = 'ipynb.newUntitledIpynb';
 const EDIT_CELL_COMMAND = 'notebook.cell.edit';
 const EXECUTE_CELL_COMMAND = 'notebook.cell.execute';
@@ -32,9 +33,19 @@ export class PositronNotebooks {
 	constructor(private code: Code, private quickinput: QuickInput, private quickaccess: QuickAccess, private notebook: Notebook) { }
 
 	async selectInterpreter(kernelGroup: string, desiredKernel: string) {
-		await this.code.waitForElement(KERNEL_LABEL, (e) => e!.textContent.includes(desiredKernel) || e!.textContent.includes(SELECT_KERNEL_TEXT));
 
-		const interpreterManagerText = (await this.code.waitForElement(KERNEL_LABEL)).textContent;
+		// get the kernel label text
+		let interpreterManagerText = (await this.code.waitForElement(KERNEL_LABEL)).textContent;
+
+		// if we are still detecting kernels, wait extra time for the correct kernel or for the
+		// "Select Kernel" option to appear
+		if (interpreterManagerText === DETECTING_KERNELS_TEXT) {
+			interpreterManagerText = (await this.code.waitForElement(KERNEL_LABEL, (e) =>
+				e!.textContent.includes(desiredKernel) ||
+				e!.textContent.includes(SELECT_KERNEL_TEXT), 600)).textContent;
+		}
+
+		// if select kernel appears, select the proper kernel
 		if (interpreterManagerText === SELECT_KERNEL_TEXT) {
 			await this.code.waitAndClick(KERNEL_ACTION);
 			await this.quickinput.waitForQuickInputOpened();


### PR DESCRIPTION
Two fixes:
* Screenshot the application if the Python or R startup fixture fails.  This has happened recently in cases where the test cannot detect "started" in the console to know when to move forward.  We need to get a look at the full app when this happens to debug further.
* Allow the notebook startup process to show "Detecting kernels" in kernel selector.  This has rarely happened, but we should be able to handle it by waiting for "Select Kernel" or the valid kernel name when "Detecting kernels" shows up.  Previously we only expected a valid kernel or "Select Kernel"

### QA Notes

All smoke tests should pass.  If a startup fixture randomly fails to detect "started" kernel, screenshot the application before exit.
