### PR TITLE
Positron ipywidgets listen to results messages and show plots pane

### DIFF
--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 import { Disposable, DisposableStore, toDisposable } from 'vs/base/common/lifecycle';
-import { LanguageRuntimeSessionMode, RuntimeOutputKind, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeMessageOutput, LanguageRuntimeSessionMode, RuntimeOutputKind, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionService, RuntimeClientType } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { Emitter, Event } from 'vs/base/common/event';
 import { IPositronIPyWidgetsService } from 'vs/workbench/services/positronIPyWidgets/common/positronIPyWidgetsService';
@@ -66,23 +66,39 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 			this._consoleInstancesByMessageId.has(id);
 	}
 
+	/**
+	 * Map to disposeable stores for each session. Used to preventing memory leaks caused by
+	 * repeatedly attaching to the same session which can happen in the case of the application
+	 * closing before the session ends
+	 */
+	static SessionToDisposablesMap = new Map<ILanguageRuntimeSession, DisposableStore>();
+
 	private attachSession(session: ILanguageRuntimeSession) {
+		// Check if we're already attached here
+		const existingSessionDisposables = PositronIPyWidgetsService.SessionToDisposablesMap.get(session);
+		if (existingSessionDisposables && !existingSessionDisposables.isDisposed) {
+			this._logService.warn(`Already attached to session, disposing existing listeners before reattaching: ${session.metadata.sessionId}`);
+			existingSessionDisposables.dispose();
+		}
+		const disposables = new DisposableStore();
+		PositronIPyWidgetsService.SessionToDisposablesMap.set(session, disposables);
+
 		switch (session.metadata.sessionMode) {
 			case LanguageRuntimeSessionMode.Console:
-				this.attachConsoleSession(session);
+				this.attachConsoleSession(session, disposables);
 				break;
 			case LanguageRuntimeSessionMode.Notebook:
-				this.attachNotebookSession(session);
+				this.attachNotebookSession(session, disposables);
 				break;
+			default:
+				this._logService.error(`Unexpected session mode: ${session.metadata.sessionMode}`);
+				disposables.dispose();
+				PositronIPyWidgetsService.SessionToDisposablesMap.delete(session);
 		}
 	}
 
-	private attachConsoleSession(session: ILanguageRuntimeSession) {
-		// TODO: Currently, if the application closes before the session ends, this will not be
-		//       disposed.
-		const disposables = new DisposableStore();
-
-		disposables.add(session.onDidReceiveRuntimeMessageOutput(async (message) => {
+	private attachConsoleSession(session: ILanguageRuntimeSession, disposables: DisposableStore) {
+		const handleMessageOutput = async (message: ILanguageRuntimeMessageOutput) => {
 			// Only handle IPyWidget output messages.
 			if (message.kind !== RuntimeOutputKind.IPyWidget) {
 				return;
@@ -117,7 +133,10 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 			// Fire the onDidCreatePlot event.
 			const client = disposables.add(new NotebookOutputPlotClient(webview, message));
 			this._onDidCreatePlot.fire(client);
-		}));
+		};
+
+		disposables.add(session.onDidReceiveRuntimeMessageResult(handleMessageOutput));
+		disposables.add(session.onDidReceiveRuntimeMessageOutput(handleMessageOutput));
 
 		// Dispose when the session ends.
 		disposables.add(session.onDidEndSession((e) => {
@@ -125,7 +144,7 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 		}));
 	}
 
-	private attachNotebookSession(session: ILanguageRuntimeSession) {
+	private attachNotebookSession(session: ILanguageRuntimeSession, disposables: DisposableStore) {
 		// Find the session's notebook editor by its notebook URI.
 		const notebookEditor = this._notebookEditorService.listNotebookEditors().find(
 			(editor) => isEqual(session.metadata.notebookUri, editor.textModel?.uri));
@@ -136,10 +155,6 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 		}
 
 		this._logService.debug(`Found an existing notebook editor for session '${session.sessionId}, starting ipywidgets instance`);
-
-		// TODO: Currently, if the application closes before the session ends, this will not be
-		// 	     disposed.
-		const disposables = new DisposableStore();
 
 		// We found a matching notebook editor, create an ipywidgets instance.
 		const messaging = disposables.add(new IPyWidgetsWebviewMessaging(

--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -77,19 +77,19 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 	 * repeatedly attaching to the same session which can happen in the case of the application
 	 * closing before the session ends
 	 */
-	private _sessionToDisposablesMap = new Map<ILanguageRuntimeSession, DisposableStore>();
+	private _sessionToDisposablesMap = new Map<string, DisposableStore>();
 
 	private attachSession(session: ILanguageRuntimeSession) {
 		// Check if we're already attached here
-		const existingSessionDisposables = this._sessionToDisposablesMap.get(session);
+		const existingSessionDisposables = this._sessionToDisposablesMap.get(session.sessionId);
 		if (existingSessionDisposables && !existingSessionDisposables.isDisposed) {
 			this._logService.warn(`Already attached to session, disposing existing listeners before reattaching: ${session.metadata.sessionId}`);
 			existingSessionDisposables.dispose();
 		}
 		const disposables = new DisposableStore();
-		this._sessionToDisposablesMap.set(session, disposables);
+		this._sessionToDisposablesMap.set(session.sessionId, disposables);
 		// Cleanup from map when disposed.
-		disposables.add(toDisposable(() => this._sessionToDisposablesMap.delete(session)));
+		disposables.add(toDisposable(() => this._sessionToDisposablesMap.delete(session.sessionId)));
 
 		switch (session.metadata.sessionMode) {
 			case LanguageRuntimeSessionMode.Console:

--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -88,6 +88,8 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 		}
 		const disposables = new DisposableStore();
 		this._sessionToDisposablesMap.set(session, disposables);
+		// Cleanup from map when disposed.
+		disposables.add(toDisposable(() => this._sessionToDisposablesMap.delete(session)));
 
 		switch (session.metadata.sessionMode) {
 			case LanguageRuntimeSessionMode.Console:
@@ -99,7 +101,6 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 			default:
 				this._logService.error(`Unexpected session mode: ${session.metadata.sessionMode}`);
 				disposables.dispose();
-				this._sessionToDisposablesMap.delete(session);
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.test.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.test.ts
@@ -138,6 +138,26 @@ suite('Positron - PositronIPyWidgetsService', () => {
 		await timeout(0);
 
 		assert(positronIpywidgetsService.hasInstance(message.id));
+		// Note that we don't end the session here. This helps us check for memory leaks caused by
+		// improper disposal of listeners
+	});
+
+	test('notebook session: respond to result message type', async () => {
+		const { session } = await createNotebookSession();
+
+		// Simulate the runtime sending a result message.
+		const message = session.receiveResultMessage({
+			kind: RuntimeOutputKind.IPyWidget,
+			data: {
+				'application/vnd.jupyter.widget-view+json': {},
+			},
+		});
+
+		await timeout(0);
+
+		assert(positronIpywidgetsService.hasInstance(message.id));
+		// Note that we don't end the session here. This helps us check for memory leaks caused by
+		// improper disposal of listeners
 	});
 
 	async function createNotebookSession() {

--- a/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.test.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.test.ts
@@ -124,7 +124,7 @@ suite('Positron - PositronIPyWidgetsService', () => {
 		assert(!positronIpywidgetsService.hasInstance(plotClient.id));
 	});
 
-	test('console session: respond to result message type', async () => {
+	test('console session: respond to result message type and check for memory leaks', async () => {
 		const { session } = await createConsoleSession();
 
 		// Simulate the runtime sending a result message.
@@ -142,20 +142,12 @@ suite('Positron - PositronIPyWidgetsService', () => {
 		// improper disposal of listeners
 	});
 
-	test('notebook session: respond to result message type', async () => {
+	test('notebook session: check for memory leaks', async () => {
 		const { session } = await createNotebookSession();
-
-		// Simulate the runtime sending a result message.
-		const message = session.receiveResultMessage({
-			kind: RuntimeOutputKind.IPyWidget,
-			data: {
-				'application/vnd.jupyter.widget-view+json': {},
-			},
-		});
 
 		await timeout(0);
 
-		assert(positronIpywidgetsService.hasInstance(message.id));
+		assert(positronIpywidgetsService.hasInstance(session.sessionId));
 		// Note that we don't end the session here. This helps us check for memory leaks caused by
 		// improper disposal of listeners
 	});

--- a/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.test.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.test.ts
@@ -124,6 +124,22 @@ suite('Positron - PositronIPyWidgetsService', () => {
 		assert(!positronIpywidgetsService.hasInstance(plotClient.id));
 	});
 
+	test('console session: respond to result message type', async () => {
+		const { session } = await createConsoleSession();
+
+		// Simulate the runtime sending a result message.
+		const message = session.receiveResultMessage({
+			kind: RuntimeOutputKind.IPyWidget,
+			data: {
+				'application/vnd.jupyter.widget-view+json': {},
+			},
+		});
+
+		await timeout(0);
+
+		assert(positronIpywidgetsService.hasInstance(message.id));
+	});
+
 	async function createNotebookSession() {
 		const notebookUri = URI.file('notebook.ipynb');
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -257,6 +257,10 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		}
 	}
 
+	private _showPlotsPane() {
+		this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+	}
+
 	openPlotInNewWindow(): void {
 
 		if (!this._selectedPlotId) {
@@ -508,7 +512,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 				this.registerPlotClient(plotClient, true);
 
 				// Raise the Plots pane so the plot is visible.
-				this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+				this._showPlotsPane();
 			}
 		}));
 
@@ -530,13 +534,13 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 					this.registerStaticPlot(session.sessionId, message, code);
 
 					// Raise the Plots pane so the plot is visible.
-					this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+					this._showPlotsPane();
 				} else if (message.kind === RuntimeOutputKind.PlotWidget) {
 					// Create a new webview plot client instance and register it with the service.
 					await this.registerNotebookOutputPlot(session, message, code);
 
 					// Raise the Plots pane so the plot is visible.
-					this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+					this._showPlotsPane();
 				}
 			};
 			this._register(session.onDidReceiveRuntimeMessageOutput(handleDidReceiveRuntimeMessageOutput));
@@ -576,7 +580,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 
 		const selectPlot = () => {
 			// Raise the Plots pane so the user can see the updated plot
-			this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+			this._showPlotsPane();
 
 			// Select the plot to bring it into view within the history; it's
 			// possible that it is not the most recently created plot
@@ -880,7 +884,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		this.registerNewPlotClient(new HtmlPlotClient(webview));
 
 		// Raise the Plots pane so the plot is visible.
-		this._viewsService.openView(POSITRON_PLOTS_VIEW_ID, false);
+		this._showPlotsPane();
 	}
 
 	/**
@@ -894,6 +898,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		this._onDidEmitPlot.fire(client);
 		this._onDidSelectPlot.fire(client.id);
 		this._register(client);
+		this._showPlotsPane();
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1488,9 +1488,12 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					);
 				}
 
-				if (languageRuntimeMessageOutput.kind === RuntimeOutputKind.ViewerWidget) {
-					// If it's a viewer widget type it's already being shown in the viewer pane so
-					// we don't want to double display it in the console as well.
+				if (
+					languageRuntimeMessageOutput.kind === RuntimeOutputKind.ViewerWidget ||
+					languageRuntimeMessageOutput.kind === RuntimeOutputKind.IPyWidget
+				) {
+					// If this message will be handled by the viewer or plots pane, we can break
+					// early to avoid displaying potentially long output in the console.
 					return;
 				}
 


### PR DESCRIPTION
Addresses #4181 


This PR does three things

1. Listens to `LanguageRuntimeMessageType.Result` messages in addition to (the existing) `LanguageRuntimeMessageType.Output` messages. jupyter messages with widgets attached can come over both (e.g. leaflet plots come across on `.Result`. 
2. Adds some extra steps for cleaning up disposables related to the `PositronIPyWidgetsService` listening to a given session. Now we check if there are existing listeners for the given session and make sure to dispose them, where previously it was possible to leak when the application was reloaded. 
3. Makes sure the plots pane is shown when an iPyWidget is rendered. Previously if the plots pane was not visible the user might not see if the plot was shown. 

<img width="1002" alt="image" src="https://github.com/user-attachments/assets/bf1f4bc3-aa0f-4343-9031-5900c9cf41b3">


### Notes
- If we want to remove the work for 2, I'm fine with that. It's defensive but maybe it complicates the diff. 

### QA Notes

Running the following leaflet code in a Python script should open the viewer pane (even if it was hidden) and show a map. 


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
