### PR TITLE
Bring focus to Data Explorer after second click

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -20,6 +20,8 @@ import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronData
 import { PositronDataExplorerLayout } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
 import { IPositronDataExplorerInstance } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance';
 import { ClipboardCell, ClipboardCellRange, ClipboardColumnIndexes, ClipboardColumnRange, ClipboardRowIndexes, ClipboardRowRange } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { PositronDataExplorerUri } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerUri';
 
 /**
  * Constants.
@@ -109,6 +111,7 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 		private readonly _keybindingService: IKeybindingService,
 		private readonly _layoutService: ILayoutService,
 		private readonly _notificationService: INotificationService,
+		private readonly _editorService: IEditorService,
 		private readonly _languageName: string,
 		private readonly _dataExplorerClientInstance: DataExplorerClientInstance
 	) {
@@ -141,6 +144,11 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 		this._register(this._tableSchemaDataGridInstance.onDidSelectColumn(columnIndex => {
 			this._tableDataDataGridInstance.selectColumn(columnIndex);
 			this._tableDataDataGridInstance.scrollToColumn(columnIndex);
+		}));
+
+		this._register(this.onDidRequestFocus(() => {
+			const uri = PositronDataExplorerUri.generate(this._dataExplorerClientInstance.identifier);
+			this._editorService.openEditor({ resource: uri });
 		}));
 	}
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -340,6 +340,7 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 				this._keybindingService,
 				this._layoutService,
 				this._notificationService,
+				this._editorService,
 				languageName,
 				dataExplorerClientInstance
 			)

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -208,6 +208,7 @@ df = pd.DataFrame(data)`;
 			});
 
 			it('R - Open Data Explorer for the second time brings focus back', async function () {
+				// Regression test for https://github.com/posit-dev/positron/issues/4197
 				const app = this.app as Application;
 
 				const script = `Data_Frame <- mtcars`;

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -169,12 +169,11 @@ df = pd.DataFrame(data)`;
 
 			});
 
-			after(async function () {
-
+			afterEach(async function () {
 				const app = this.app as Application;
 
 				await app.workbench.positronDataExplorer.closeDataExplorer();
-				await app.workbench.positronVariables.openVariables();
+				await app.workbench.quickaccess.runCommand('workbench.panel.positronVariables.focus');
 
 			});
 
@@ -205,6 +204,29 @@ df = pd.DataFrame(data)`;
 				expect(tableData[1]).toStrictEqual({ 'Training': 'Stamina', 'Pulse': '150.00', 'Duration': '30.00' });
 				expect(tableData[2]).toStrictEqual({ 'Training': 'Other', 'Pulse': '120.00', 'Duration': '45.00' });
 				expect(tableData.length).toBe(3);
+
+			});
+
+			it('R - Open Data Explorer for the second time brings focus back', async function () {
+				const app = this.app as Application;
+
+				const script = `Data_Frame <- mtcars`;
+				await app.workbench.positronConsole.executeCode('R', script, '>');
+				await app.workbench.quickaccess.runCommand('workbench.panel.positronVariables.focus');
+
+				await expect(async () => {
+					await app.workbench.positronVariables.doubleClickVariableRow('Data_Frame');
+					await app.code.driver.getLocator('.label-name:has-text("Data: Data_Frame")').innerText();
+				}).toPass();
+
+				// Now move focus out of the the data explorer pane
+				await app.workbench.editors.newUntitledFile();
+				await app.workbench.quickaccess.runCommand('workbench.panel.positronVariables.focus');
+				await app.workbench.positronVariables.doubleClickVariableRow('Data_Frame');
+
+				await expect(async () => {
+					await app.code.driver.getLocator('.label-name:has-text("Data: Data_Frame")').innerText();
+				}).toPass();
 
 			});
 		});

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -207,7 +207,7 @@ df = pd.DataFrame(data)`;
 
 			});
 
-			it('R - Open Data Explorer for the second time brings focus back', async function () {
+			it('R - Open Data Explorer for the second time brings focus back [C701143]', async function () {
 				// Regression test for https://github.com/posit-dev/positron/issues/4197
 				const app = this.app as Application;
 


### PR DESCRIPTION
Added an event listener to `positronDataExplorerInstance` that listens to the `onRequestFocus` event and correctly regain focus via the editor service.

Also added a regression test for this behavior.


Addresses: https://github.com/posit-dev/positron/issues/4197

### QA Notes

@testlabauto @jonvanausdeln  Can you take a look at the regression test and add test rail ids?