### PR TITLE
On build-release-macos.yml, update PATH for both archs

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -69,12 +69,11 @@ jobs:
           arch -${{matrix.arch_terminal}} /bin/bash -c "${{matrix.homebrew_folder}}/bin/brew install libsodium"
           arch -${{matrix.arch_terminal}} /bin/bash -c "${{matrix.homebrew_folder}}/bin/brew install xz"
 
-      # When running under x86, put x86 homebrew on the $PATH ahead of arm64
-      # homebrew. We also force Python 3.10 (arm64) on x86 since 3.12 is not
+      # Put arch homebrew on the $PATH ahead of arm64. 
+      # We also force Python 3.10 (arm64) on both archs since 3.12 is not
       # compatible with the version of node-gyp currently used by Positron.
-      - name: Update PATH for x86_64
+      - name: Update PATH
         id: update_path_for_zeromq
-        if: matrix.arch == 'x64'
         run: |
           echo "/opt/homebrew/opt/python@3.10/libexec/bin:${{matrix.homebrew_folder}}/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
Unfortunately this workaround seems needed for both archs. If confirmed, I will document all my findings.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
