### PR TITLE
Forgot test case references for Shiny tests

### DIFF
--- a/test/smoke/src/areas/positron/apps/shiny.test.ts
+++ b/test/smoke/src/areas/positron/apps/shiny.test.ts
@@ -25,7 +25,7 @@ export function setup(logger: Logger) {
 				await PositronPythonFixtures.SetupFixtures(this.app as Application);
 			});
 
-			it('Python - Verify Basic Shiny App [...]', async function () {
+			it('Python - Verify Basic Shiny App [C699099]', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'shiny-py-example', 'app.py'));
@@ -52,7 +52,7 @@ export function setup(logger: Logger) {
 				await PositronRFixtures.SetupFixtures(this.app as Application);
 			});
 
-			it('R - Verify Basic Shiny App [...]', async function () {
+			it('R - Verify Basic Shiny App [C699100]', async function () {
 				const app = this.app as Application;
 
 				const code = `library(shiny)


### PR DESCRIPTION
This simply adds the TestRail references for the new Shiny app smoke tests.

### QA Notes

All smoke tests should pass
