### PR TITLE
Add new lock GH action

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -12,8 +12,3 @@ jobs:
         with:
           process-only: 'issues'
           issue-inactive-days: '14'
-          issue-comment: >
-            This issue has been automatically locked. If you believe you have
-            found a related problem, please read our guide on feedback
-            (https://github.com/posit-dev/positron/wiki/Feedback-and-Issues)
-            and open a new issue, linking to this issue.

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,19 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v5
+        with:
+          process-only: 'issues'
+          issue-inactive-days: '14'
+          issue-comment: >
+            This issue has been automatically locked. If you believe you have
+            found a related problem, please read our guide on feedback
+            (https://github.com/posit-dev/positron/wiki/Feedback-and-Issues)
+            and open a new issue, linking to this issue.


### PR DESCRIPTION
Addresses #4143 

This PR uses [this very broadly used GH action](https://github.com/dessant/lock-threads) to lock _closed_ issues that have had no activity for 14 days.

It does not change the behavior around locking merged/deleted PRs, which [is discussed more here](https://github.com/posit-dev/positron/issues/4143#issuecomment-2265832815).

### QA Notes

This GH action will help us keep folks from commenting on old, closed issues.

> [!CAUTION]
> We have a lot (I mean, tons and tons) of old, closed issues. This action will make a comment on _every single one of these_ and generate a notification. It will process a bunch each day until it makes it through the whole backlog of closed issues. I've gone through this on a few other large repos and if you have notifications turned on, it is extremely annoying for the first several days while it works through all of them.

### Option 1

We leave this as is and just deal with the onslaught of notifications, with the goal of getting to a better stage eventually. The disadvantage here is pretty clear. 😩 

### Option 2

We take _out_ the comment and only lock, which I believe does not notify, possibly adding the comment in later, like next month sometime, after the backlog is worked through. The disadvantage is that people can feel quite put off when they find an old, locked issue that they feel is relevant to their problem; the comment can help them know what to do.
