### PR TITLE
Add `vsda` config feature

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -82,3 +82,7 @@ codegen-units = 1
 [features]
 default = []
 vscode-encrypt = []
+# --- Start Positron ---
+# Adding in config feature for https://github.com/posit-dev/positron/issues/4225
+vsda = []
+# --- End Positron ---


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4225 to silence warnings when updating to Rust 1.80