### PR TITLE
Data Explorer: Revamped get_data_values RPC and stub out as-yet-unsupported set_column_filters RPC 

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -76,6 +76,7 @@ from .data_explorer_comm import (
     SearchSchemaFeatures,
     SearchSchemaRequest,
     SearchSchemaResult,
+    SetColumnFiltersFeatures,
     SetColumnFiltersRequest,
     SetRowFiltersFeatures,
     SetRowFiltersRequest,
@@ -402,8 +403,10 @@ class DataExplorerTableView(abc.ABC):
         raise NotImplementedError
 
     def set_column_filters(self, request: SetColumnFiltersRequest):
-        # filters = request.params.filters
-        pass
+        return self._set_column_filters(request.params.filters)
+
+    def _set_column_filters(self, filters: List[ColumnFilter]):
+        raise NotImplementedError
 
     def set_row_filters(self, request: SetRowFiltersRequest):
         return self._set_row_filters(request.params.filters)
@@ -743,6 +746,9 @@ class DataExplorerTableView(abc.ABC):
         search_schema=SearchSchemaFeatures(
             support_status=SupportStatus.Unsupported,
             supported_types=[],
+        ),
+        set_column_filters=SetColumnFiltersFeatures(
+            support_status=SupportStatus.Unsupported, supported_types=[]
         ),
         set_row_filters=SetRowFiltersFeatures(
             support_status=SupportStatus.Unsupported,
@@ -1673,6 +1679,9 @@ class PandasView(DataExplorerTableView):
                 ),
             ],
         ),
+        set_column_filters=SetColumnFiltersFeatures(
+            support_status=SupportStatus.Unsupported, supported_types=[]
+        ),
         set_row_filters=SetRowFiltersFeatures(
             support_status=SupportStatus.Supported,
             # Temporarily disabled for https://github.com/posit-dev/positron/issues/3489 on
@@ -2378,6 +2387,9 @@ class PolarsView(DataExplorerTableView):
 
     FEATURES = SupportedFeatures(
         search_schema=SearchSchemaFeatures(
+            support_status=SupportStatus.Unsupported, supported_types=[]
+        ),
+        set_column_filters=SetColumnFiltersFeatures(
             support_status=SupportStatus.Unsupported, supported_types=[]
         ),
         set_row_filters=SetRowFiltersFeatures(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -868,6 +868,10 @@ class SupportedFeatures(BaseModel):
         description="Support for 'search_schema' RPC and its features",
     )
 
+    set_column_filters: SetColumnFiltersFeatures = Field(
+        description="Support ofr 'set_column_filters' RPC and its features",
+    )
+
     set_row_filters: SetRowFiltersFeatures = Field(
         description="Support for 'set_row_filters' RPC and its features",
     )
@@ -888,6 +892,20 @@ class SupportedFeatures(BaseModel):
 class SearchSchemaFeatures(BaseModel):
     """
     Feature flags for 'search_schema' RPC
+    """
+
+    support_status: SupportStatus = Field(
+        description="The support status for this RPC method",
+    )
+
+    supported_types: List[ColumnFilterTypeSupportStatus] = Field(
+        description="A list of supported types",
+    )
+
+
+class SetColumnFiltersFeatures(BaseModel):
+    """
+    Feature flags for 'set_column_filters' RPC
     """
 
     support_status: SupportStatus = Field(
@@ -1292,7 +1310,7 @@ class SetColumnFiltersParams(BaseModel):
     """
 
     filters: List[ColumnFilter] = Field(
-        description="Zero or more filters to apply",
+        description="Column filters to apply (or pass empty array to clear column filters)",
     )
 
 
@@ -1317,7 +1335,7 @@ class SetColumnFiltersRequest(BaseModel):
 
 class SetRowFiltersParams(BaseModel):
     """
-    Set or clear row filters on table, replacing any previous filters
+    Row filters to apply (or pass empty array to clear row filters)
     """
 
     filters: List[RowFilter] = Field(
@@ -1327,7 +1345,7 @@ class SetRowFiltersParams(BaseModel):
 
 class SetRowFiltersRequest(BaseModel):
     """
-    Set or clear row filters on table, replacing any previous filters
+    Row filters to apply (or pass empty array to clear row filters)
     """
 
     params: SetRowFiltersParams = Field(
@@ -1526,6 +1544,8 @@ ColumnSortKey.update_forward_refs()
 SupportedFeatures.update_forward_refs()
 
 SearchSchemaFeatures.update_forward_refs()
+
+SetColumnFiltersFeatures.update_forward_refs()
 
 SetRowFiltersFeatures.update_forward_refs()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -244,7 +244,7 @@ class BackendState(BaseModel):
     )
 
     table_shape: TableShape = Field(
-        description="Number of rows and columns in table with filters applied",
+        description="Number of rows and columns in table with row/column filters applied",
     )
 
     table_unfiltered_shape: TableShape = Field(
@@ -252,15 +252,15 @@ class BackendState(BaseModel):
     )
 
     column_filters: List[ColumnFilter] = Field(
-        description="The set of currently applied column filters",
+        description="The currently applied column filters",
     )
 
     row_filters: List[RowFilter] = Field(
-        description="The set of currently applied row filters",
+        description="The currently applied row filters",
     )
 
     sort_keys: List[ColumnSortKey] = Field(
-        description="The set of currently applied sorts",
+        description="The currently applied column sort keys",
     )
 
     supported_features: SupportedFeatures = Field(
@@ -278,7 +278,7 @@ class ColumnSchema(BaseModel):
     )
 
     column_index: StrictInt = Field(
-        description="The position of the column within the schema",
+        description="The position of the column within the table without any column filters",
     )
 
     type_name: StrictStr = Field(
@@ -542,7 +542,7 @@ class ColumnProfileRequest(BaseModel):
     """
 
     column_index: StrictInt = Field(
-        description="The ordinal column index to profile",
+        description="The column index (absolute, relative to unfiltered table) to profile",
     )
 
     profiles: List[ColumnProfileSpec] = Field(
@@ -843,7 +843,7 @@ class ColumnSortKey(BaseModel):
     """
 
     column_index: StrictInt = Field(
-        description="Column index to sort by",
+        description="Column index (absolute, relative to unfiltered table) to sort by",
     )
 
     ascending: StrictBool = Field(
@@ -954,7 +954,7 @@ class DataSelection(BaseModel):
     """
 
     kind: DataSelectionKind = Field(
-        description="Type of selection",
+        description="Type of selection, all indices relative to filtered row/column indices",
     )
 
     selection: Selection = Field(
@@ -1062,7 +1062,7 @@ class DataExplorerBackendRequest(str, enum.Enum):
     # Request schema
     GetSchema = "get_schema"
 
-    # Search schema with column filters
+    # Search full, unfiltered table schema with column filters
     SearchSchema = "search_schema"
 
     # Get a rectangle of data values
@@ -1089,17 +1089,17 @@ class DataExplorerBackendRequest(str, enum.Enum):
 
 class GetSchemaParams(BaseModel):
     """
-    Request full schema for a table-like object
+    Request subset of column schemas for a table-like object
     """
 
     column_indices: List[StrictInt] = Field(
-        description="The column indices to fetch",
+        description="The column indices (relative to the filtered/selected columns) to fetch",
     )
 
 
 class GetSchemaRequest(BaseModel):
     """
-    Request full schema for a table-like object
+    Request subset of column schemas for a table-like object
     """
 
     params: GetSchemaParams = Field(
@@ -1118,7 +1118,8 @@ class GetSchemaRequest(BaseModel):
 
 class SearchSchemaParams(BaseModel):
     """
-    Search schema for column names matching a passed substring
+    Search full, unfiltered table schema for column names matching one or
+    more column filters
     """
 
     filters: List[ColumnFilter] = Field(
@@ -1136,7 +1137,8 @@ class SearchSchemaParams(BaseModel):
 
 class SearchSchemaRequest(BaseModel):
     """
-    Search schema for column names matching a passed substring
+    Search full, unfiltered table schema for column names matching one or
+    more column filters
     """
 
     params: SearchSchemaParams = Field(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -251,6 +251,10 @@ class BackendState(BaseModel):
         description="Number of rows and columns in table without any filters applied",
     )
 
+    column_filters: List[ColumnFilter] = Field(
+        description="The set of currently applied column filters",
+    )
+
     row_filters: List[RowFilter] = Field(
         description="The set of currently applied row filters",
     )
@@ -1067,6 +1071,9 @@ class DataExplorerBackendRequest(str, enum.Enum):
     # Export data selection as a string in different formats
     ExportDataSelection = "export_data_selection"
 
+    # Set column filters to select subset of table columns
+    SetColumnFilters = "set_column_filters"
+
     # Set row filters based on column values
     SetRowFilters = "set_row_filters"
 
@@ -1222,6 +1229,35 @@ class ExportDataSelectionRequest(BaseModel):
     )
 
 
+class SetColumnFiltersParams(BaseModel):
+    """
+    Set or clear column filters on table, replacing any previous filters
+    """
+
+    filters: List[ColumnFilter] = Field(
+        description="Zero or more filters to apply",
+    )
+
+
+class SetColumnFiltersRequest(BaseModel):
+    """
+    Set or clear column filters on table, replacing any previous filters
+    """
+
+    params: SetColumnFiltersParams = Field(
+        description="Parameters to the SetColumnFilters method",
+    )
+
+    method: Literal[DataExplorerBackendRequest.SetColumnFilters] = Field(
+        description="The JSON-RPC method name (set_column_filters)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
+
+
 class SetRowFiltersParams(BaseModel):
     """
     Set or clear row filters on table, replacing any previous filters
@@ -1317,7 +1353,7 @@ class GetColumnProfilesRequest(BaseModel):
 
 class GetStateRequest(BaseModel):
     """
-    Request the current backend state (shape, filters, sort keys,
+    Request the current backend state (table metadata, explorer state, and
     features)
     """
 
@@ -1338,6 +1374,7 @@ class DataExplorerBackendMessageContent(BaseModel):
         SearchSchemaRequest,
         GetDataValuesRequest,
         ExportDataSelectionRequest,
+        SetColumnFiltersRequest,
         SetRowFiltersRequest,
         SetSortColumnsRequest,
         GetColumnProfilesRequest,
@@ -1463,6 +1500,10 @@ GetDataValuesRequest.update_forward_refs()
 ExportDataSelectionParams.update_forward_refs()
 
 ExportDataSelectionRequest.update_forward_refs()
+
+SetColumnFiltersParams.update_forward_refs()
+
+SetColumnFiltersRequest.update_forward_refs()
 
 SetRowFiltersParams.update_forward_refs()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -1992,7 +1992,10 @@ def test_pandas_updated_with_sort_keys(dxf: DataExplorerFixture):
 
         state = view.state
 
-        new_view = PandasView(table, DataExplorerState(name, state.filters, state.sort_keys))
+        new_view = PandasView(
+            table,
+            DataExplorerState(name, row_filters=state.row_filters, sort_keys=state.sort_keys),
+        )
 
         schema_updated, new_state = new_view.get_updated_state(table)
 
@@ -2002,7 +2005,7 @@ def test_pandas_updated_with_sort_keys(dxf: DataExplorerFixture):
         else:
             assert not schema_updated
 
-        assert new_state.filters == state.filters
+        assert new_state.row_filters == state.row_filters
         assert new_state.sort_keys == state.sort_keys
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -391,12 +391,20 @@ class DataExplorerFixture:
     def get_state(self, table_name):
         return self.do_json_rpc(table_name, "get_state")
 
-    def get_data_values(self, table_name, format_options=DEFAULT_FORMAT, **params):
+    def get_data_values(self, table_name, format_options=DEFAULT_FORMAT, columns=None):
         return self.do_json_rpc(
             table_name,
             "get_data_values",
             format_options=format_options,
-            **params,
+            columns=columns,
+        )
+
+    def get_row_labels(self, table_name, selection, format_options=DEFAULT_FORMAT):
+        return self.do_json_rpc(
+            table_name,
+            "get_row_labels",
+            format_options=format_options,
+            selection=selection,
         )
 
     def export_data_selection(self, table_name, selection, format="csv"):
@@ -475,20 +483,12 @@ class DataExplorerFixture:
 
         assert state["table_shape"] == ex_state["table_shape"]
 
+        select_all = _select_all(table_shape[0], table_shape[1])
+
         # Query the data and check it yields the same result as the
         # manually constructed data frame without the filter
-        response = self.get_data_values(
-            table_id,
-            row_start_index=0,
-            num_rows=table_shape[0],
-            column_indices=list(range(table_shape[1])),
-        )
-        ex_response = self.get_data_values(
-            expected_id,
-            row_start_index=0,
-            num_rows=table_shape[0],
-            column_indices=list(range(table_shape[1])),
-        )
+        response = self.get_data_values(table_id, columns=select_all)
+        ex_response = self.get_data_values(expected_id, columns=select_all)
 
         assert len(response["columns"]) == len(ex_response["columns"])
         for left, right in zip(response["columns"], ex_response["columns"]):
@@ -498,6 +498,19 @@ class DataExplorerFixture:
             different_indices = (~mask).nonzero()[0]
             if len(different_indices) > 0:
                 raise AssertionError(f"Indices differ at {str(different_indices)}")
+
+
+def _select_all(num_rows, num_columns):
+    return [
+        {
+            "column_index": i,
+            "spec": {
+                "first_index": 0,
+                "last_index": num_rows - 1,
+            },
+        }
+        for i in range(num_columns)
+    ]
 
 
 @pytest.fixture
@@ -525,6 +538,8 @@ def test_pandas_get_state(dxf: DataExplorerFixture):
     ex_shape = {"num_rows": 5, "num_columns": 8}
     assert result["table_shape"] == ex_shape
     assert result["table_unfiltered_shape"] == ex_shape
+
+    assert result["has_row_labels"]
 
     schema = dxf.get_schema("simple")
 
@@ -873,9 +888,10 @@ def test_search_schema(dxf: DataExplorerFixture):
 def test_pandas_get_data_values(dxf: DataExplorerFixture):
     result = dxf.get_data_values(
         "simple",
-        row_start_index=0,
-        num_rows=20,
-        column_indices=list(range(8)),
+        columns=[
+            {"column_index": i, "spec": {"first_index": 0, "last_index": 20}}
+            for i in list(range(8))
+        ],
     )
 
     expected_columns = [
@@ -897,21 +913,31 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
 
     assert result["columns"] == expected_columns
 
-    assert result["row_labels"] == [["0", "1", "2", "3", "4"]]
-
     # Edge cases: request beyond end of table
-    response = dxf.get_data_values("simple", row_start_index=5, num_rows=10, column_indices=[0])
+    response = dxf.get_data_values(
+        "simple",
+        columns=[{"column_index": 0, "spec": {"first_index": 5, "last_index": 14}}],
+    )
     assert response["columns"] == [[]]
 
     # Issue #2149 -- return empty result when requesting non-existent
     # column indices
     response = dxf.get_data_values(
         "simple",
-        row_start_index=0,
-        num_rows=5,
-        column_indices=[2, 3, 4, 5, 6, 7],
+        columns=[
+            {"column_index": i, "spec": {"first_index": 0, "last_index": 4}}
+            for i in [2, 3, 4, 5, 6, 7]
+        ],
     )
     assert response["columns"] == expected_columns[2:]
+
+
+def test_pandas_get_row_labels(dxf: DataExplorerFixture):
+    result = dxf.get_row_labels("simple", {"first_index": 0, "last_index": 20})
+    assert result["row_labels"] == [["0", "1", "2", "3", "4"]]
+
+    result = dxf.get_row_labels("simple", {"indices": [0, 2, 4]})
+    assert result["row_labels"] == [["0", "2", "4"]]
 
 
 def _check_format_cases(dxf, table_name, cases):
@@ -922,9 +948,7 @@ def _check_format_cases(dxf, table_name, cases):
     for options, expected in cases:
         result = dxf.get_data_values(
             table_name,
-            row_start_index=0,
-            num_rows=num_rows,
-            column_indices=list(range(num_columns)),
+            columns=_select_all(num_rows, num_columns),
             format_options=options,
         )
 
@@ -1048,12 +1072,7 @@ def test_pandas_extension_dtypes(dxf: DataExplorerFixture):
 
     dxf.assign_and_open_viewer("df", df)
 
-    result = dxf.get_data_values(
-        "df",
-        row_start_index=0,
-        num_rows=5,
-        column_indices=list(range(3)),
-    )
+    result = dxf.get_data_values("df", columns=_select_all(5, 3))
 
     expected_columns = [
         [
@@ -1104,12 +1123,7 @@ def test_pandas_leading_whitespace(dxf: DataExplorerFixture):
     )
 
     dxf.register_table("ws", df)
-    result = dxf.get_data_values(
-        "ws",
-        row_start_index=0,
-        num_rows=5,
-        column_indices=list(range(6)),
-    )
+    result = dxf.get_data_values("ws", columns=_select_all(5, 2))
 
     expected_columns = [
         ["   foo", "  bar", " baz", "qux", "potato"],
@@ -2801,6 +2815,7 @@ def test_polars_get_state(dxf: DataExplorerFixture):
     assert state["table_unfiltered_shape"] == ex_shape
     assert state["sort_keys"] == []
     assert state["row_filters"] == []
+    assert not state["has_row_labels"]
 
     features = state["supported_features"]
     assert features["search_schema"]["support_status"] == SupportStatus.Unsupported
@@ -2826,12 +2841,7 @@ def test_polars_get_data_values(dxf: DataExplorerFixture):
     name = guid()
     dxf.register_table(name, df)
 
-    result = dxf.get_data_values(
-        name,
-        row_start_index=0,
-        num_rows=10,
-        column_indices=list(range(df.shape[1])),
-    )
+    result = dxf.get_data_values(name, columns=_select_all(10, df.shape[1]))
 
     expected_columns = [
         [_VALUE_NULL] * 4,  # Null
@@ -2875,19 +2885,24 @@ def test_polars_get_data_values(dxf: DataExplorerFixture):
     ]
 
     assert result["columns"] == expected_columns
-    assert result["row_labels"] is None
 
     result = dxf.get_data_values(
         name,
-        row_start_index=2,
-        num_rows=10,
-        column_indices=list(range(15, df.shape[1])),
+        columns=[
+            {
+                "column_index": i,
+                "spec": {
+                    "first_index": 2,
+                    "last_index": 11,
+                },
+            }
+            for i in range(15, df.shape[1])
+        ],
     )
     assert result["columns"] == [x[2:] for x in expected_columns[15:]]
 
-    result = dxf.get_data_values(name, row_start_index=10, num_rows=10, column_indices=[])
+    result = dxf.get_data_values(name, columns=[])
     assert result["columns"] == []
-    assert result["row_labels"] is None
 
 
 def test_polars_filter_between(dxf: DataExplorerFixture):

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -606,7 +606,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.122"
+      "ark": "0.1.123"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.7"

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -194,7 +194,7 @@
 			"params": [
 				{
 					"name": "filters",
-					"description": "Zero or more filters to apply",
+					"description": "Column filters to apply (or pass empty array to clear column filters)",
 					"required": true,
 					"schema": {
 						"type": "array",
@@ -209,7 +209,7 @@
 		{
 			"name": "set_row_filters",
 			"summary": "Set row filters based on column values",
-			"description": "Set or clear row filters on table, replacing any previous filters",
+			"description": "Row filters to apply (or pass empty array to clear row filters)",
 			"params": [
 				{
 					"name": "filters",
@@ -1229,6 +1229,7 @@
 				"description": "For each field, returns flags indicating supported features",
 				"required": [
 					"search_schema",
+					"set_column_filters",
 					"set_row_filters",
 					"get_column_profiles",
 					"set_sort_columns",
@@ -1238,6 +1239,10 @@
 					"search_schema": {
 						"description": "Support for 'search_schema' RPC and its features",
 						"$ref": "#/components/schemas/search_schema_features"
+					},
+					"set_column_filters": {
+						"description": "Support ofr 'set_column_filters' RPC and its features",
+						"$ref": "#/components/schemas/set_column_filters_features"
 					},
 					"set_row_filters": {
 						"description": "Support for 'set_row_filters' RPC and its features",
@@ -1260,6 +1265,27 @@
 			"search_schema_features": {
 				"type": "object",
 				"description": "Feature flags for 'search_schema' RPC",
+				"required": [
+					"support_status",
+					"supported_types"
+				],
+				"properties": {
+					"support_status": {
+						"$ref": "#/components/schemas/support_status",
+						"description": "The support status for this RPC method"
+					},
+					"supported_types": {
+						"type": "array",
+						"description": "A list of supported types",
+						"items": {
+							"$ref": "#/components/schemas/column_filter_type_support_status"
+						}
+					}
+				}
+			},
+			"set_column_filters_features": {
+				"type": "object",
+				"description": "Feature flags for 'set_column_filters' RPC",
 				"required": [
 					"support_status",
 					"supported_types"

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -8,11 +8,11 @@
 		{
 			"name": "get_schema",
 			"summary": "Request schema",
-			"description": "Request full schema for a table-like object",
+			"description": "Request subset of column schemas for a table-like object",
             "params": [
                 {
                     "name": "column_indices",
-                    "description": "The column indices to fetch",
+                    "description": "The column indices (relative to the filtered/selected columns) to fetch",
                     "required": true,
                     "schema": {
                         "type": "array",
@@ -30,8 +30,8 @@
 		},
 		{
 			"name": "search_schema",
-			"summary": "Search schema with column filters",
-			"description": "Search schema for column names matching a passed substring",
+			"summary": "Search full, unfiltered table schema with column filters",
+			"description": "Search full, unfiltered table schema for column names matching one or more column filters",
 			"params": [
 				{
 					"name": "filters",
@@ -310,7 +310,7 @@
 							"description": "Variable name or other string to display for tab name in UI"
 						},
 						"table_shape": {
-							"description": "Number of rows and columns in table with filters applied",
+							"description": "Number of rows and columns in table with row/column filters applied",
 							"$ref": "#/components/schemas/table_shape"
 						},
 						"table_unfiltered_shape": {
@@ -319,21 +319,21 @@
 						},
 						"column_filters": {
 							"type": "array",
-							"description": "The set of currently applied column filters",
+							"description": "The currently applied column filters",
 							"items": {
 								"$ref": "#/components/schemas/column_filter"
 							}
 						},
 						"row_filters": {
 							"type": "array",
-							"description": "The set of currently applied row filters",
+							"description": "The currently applied row filters",
 							"items": {
 								"$ref": "#/components/schemas/row_filter"
 							}
 						},
 						"sort_keys": {
 							"type": "array",
-							"description": "The set of currently applied sorts",
+							"description": "The currently applied column sort keys",
 							"items": {
 								"$ref": "#/components/schemas/column_sort_key"
 							}
@@ -382,7 +382,7 @@
 					},
 					"column_index": {
 						"type": "integer",
-						"description": "The position of the column within the schema"
+						"description": "The position of the column within the table without any column filters"
 					},
 					"type_name": {
 						"type": "string",
@@ -811,7 +811,7 @@
 				"properties": {
 					"column_index": {
 						"type": "integer",
-						"description": "The ordinal column index to profile"
+						"description": "The column index (absolute, relative to unfiltered table) to profile"
 					},
 					"profiles": {
 						"type": "array",
@@ -1189,7 +1189,7 @@
 				"properties": {
 					"column_index": {
 						"type": "integer",
-						"description": "Column index to sort by"
+						"description": "Column index (absolute, relative to unfiltered table) to sort by"
 					},
 					"ascending": {
 						"type": "boolean",
@@ -1342,7 +1342,7 @@
 				"properties": {
 					"kind": {
 						"type": "string",
-						"description": "Type of selection",
+						"description": "Type of selection, all indices relative to filtered row/column indices",
 						"enum": [
 							"single_cell",
 							"cell_range",

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -66,7 +66,7 @@
 					"name": "search_schema_result",
 					"type": "object",
 					"required": [
-						"schema",
+						"matches",
 						"total_num_matches"
 					],
 					"properties": {
@@ -84,33 +84,17 @@
 		},
 		{
 			"name": "get_data_values",
-			"summary": "Get a rectangle of data values",
-			"description": "Request a rectangular subset of data with values formatted as strings",
+			"summary": "Request formatted values from table columns",
+			"description": "Request data from table columns with values formatted as strings",
 			"params": [
 				{
-					"name": "row_start_index",
-					"description": "First row to fetch (inclusive)",
-					"required": true,
-					"schema": {
-						"type": "integer"
-					}
-				},
-				{
-					"name": "num_rows",
-					"description": "Number of rows to fetch from start index. May extend beyond end of table",
-					"required": true,
-					"schema": {
-						"type": "integer"
-					}
-				},
-				{
-					"name": "column_indices",
-					"description": "Indices to select, which can be a sequential, sparse, or random selection",
+					"name": "columns",
+					"description": "Array of column selections",
 					"required": true,
 					"schema": {
 						"type": "array",
 						"items": {
-							"type": "integer"
+							"$ref": "#/components/schemas/column_selection"
 						}
 					}
 				},
@@ -125,8 +109,37 @@
 			],
 			"result": {
 				"schema": {
-					"description": "Table values formatted as strings",
+					"description": "Requested values formatted as strings",
 					"$ref": "#/components/schemas/table_data"
+				}
+			}
+		},
+		{
+			"name": "get_row_labels",
+			"summary": "Request formatted row labels from table",
+			"description": "Request formatted row labels from table",
+			"params": [
+				{
+					"name": "selection",
+					"description": "Selection of row labels",
+					"required": true,
+					"schema": {
+						"$ref": "#/components/schemas/array_selection"
+					}
+				},
+				{
+					"name": "format_options",
+					"description": "Formatting options for returning labels as strings",
+					"required": true,
+					"schema": {
+						"$ref": "#/components/schemas/format_options"
+					}
+				}
+			],
+			"result": {
+				"schema": {
+					"description": "Requested formatted row labels",
+					"$ref": "#/components/schemas/table_row_labels"
 				}
 			}
 		},
@@ -140,7 +153,7 @@
 					"description": "The data selection",
 					"required": true,
 					"schema": {
-						"$ref": "#/components/schemas/data_selection"
+						"$ref": "#/components/schemas/table_selection"
 					}
 				},
 				{
@@ -299,6 +312,7 @@
 						"display_name",
 						"table_shape",
 						"table_unfiltered_shape",
+						"has_row_labels",
 						"column_filters",
 						"row_filters",
 						"sort_keys",
@@ -316,6 +330,10 @@
 						"table_unfiltered_shape": {
 							"description": "Number of rows and columns in table without any filters applied",
 							"$ref": "#/components/schemas/table_shape"
+						},
+						"has_row_labels": {
+							"type": "boolean",
+							"description": "Indicates whether table has row labels or whether rows should be labeled by ordinal position"
 						},
 						"column_filters": {
 							"type": "array",
@@ -450,13 +468,22 @@
 								"$ref": "#/components/schemas/column_value"
 							}
 						}
-					},
+					}
+				}
+			},
+			"table_row_labels": {
+				"type": "object",
+				"description": "Formatted table row labels formatted as strings",
+				"required": [
+					"row_labels"
+				],
+				"properties": {
 					"row_labels": {
 						"type": "array",
 						"description": "Zero or more arrays of row labels",
 						"items": {
 							"type": "array",
-							"description": "Column values formatted as strings",
+							"description": "Row labels formatted as strings",
 							"items": {
 								"type": "string"
 							}
@@ -1332,7 +1359,7 @@
 					}
 				}
 			},
-			"data_selection": {
+			"table_selection": {
 				"type": "object",
 				"description": "A selection on the data grid, for copying to the clipboard or other actions",
 				"required": [
@@ -1454,6 +1481,37 @@
 						}
 					}
 				}
+			},
+			"column_selection": {
+				"type": "object",
+				"description": "A union of different selection types for column values",
+				"required": [
+					"column_index",
+					"spec"
+				],
+				"properties": {
+					"column_index": {
+						"type": "integer",
+						"description": "Column index (relative to unfiltered schema) to select data from"
+					},
+					"spec": {
+						"description": "Union of selection specifications for array_selection",
+						"$ref": "#/components/schemas/array_selection"
+					}
+				}
+			},
+			"array_selection": {
+				"description": "Union of selection specifications for array_selection",
+				"oneOf": [
+					{
+						"name": "select_range",
+						"$ref": "#/components/schemas/data_selection_range"
+					},
+					{
+						"name": "select_indices",
+						"$ref": "#/components/schemas/data_selection_indices"
+					}
+				]
 			},
 			"export_format": {
 				"type": "string",

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -175,6 +175,25 @@
 			}
 		},
 		{
+			"name": "set_column_filters",
+			"summary": "Set column filters to select subset of table columns",
+			"description": "Set or clear column filters on table, replacing any previous filters",
+			"params": [
+				{
+					"name": "filters",
+					"description": "Zero or more filters to apply",
+					"required": true,
+					"schema": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/column_filter"
+						}
+					}
+				}
+			],
+			"result": {}
+		},
+		{
 			"name": "set_row_filters",
 			"summary": "Set row filters based on column values",
 			"description": "Set or clear row filters on table, replacing any previous filters",
@@ -269,7 +288,7 @@
 		{
 			"name": "get_state",
 			"summary": "Get the state",
-			"description": "Request the current backend state (shape, filters, sort keys, features)",
+			"description": "Request the current backend state (table metadata, explorer state, and features)",
 			"params": [],
 			"result": {
 				"schema": {
@@ -280,6 +299,7 @@
 						"display_name",
 						"table_shape",
 						"table_unfiltered_shape",
+						"column_filters",
 						"row_filters",
 						"sort_keys",
 						"supported_features"
@@ -296,6 +316,13 @@
 						"table_unfiltered_shape": {
 							"description": "Number of rows and columns in table without any filters applied",
 							"$ref": "#/components/schemas/table_shape"
+						},
+						"column_filters": {
+							"type": "array",
+							"description": "The set of currently applied column filters",
+							"items": {
+								"$ref": "#/components/schemas/column_filter"
+							}
 						},
 						"row_filters": {
 							"type": "array",

--- a/positron/comms/package-lock.json
+++ b/positron/comms/package-lock.json
@@ -16,6 +16,7 @@
       "resolved": "https://registry.npmjs.org/@bcherny/json-schema-ref-parser/-/json-schema-ref-parser-10.0.5-fork.tgz",
       "integrity": "sha512-E/jKbPoca1tfUPj3iSbitDZTGnq6FUFjkH6L8U2oDwSuwK1WhnnVtCG7oFOTg/DDnyoXbQYUiUiGOibHqaGVnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.6",
@@ -33,13 +34,15 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/minimatch": "*",
         "@types/node": "*"
@@ -49,58 +52,67 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.202",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
-      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
-      "dev": true
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
+      "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.1.tgz",
-      "integrity": "sha512-T2qwhjWwGH81vUEx4EXmBKsTJRXFXNZTL4v0gi01+zyBmCwzE6TyHszqX01m+QHTEq+EZNo13NeJIdEqf+Myrg==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
+      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.13.0"
       }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
       "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -110,16 +122,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
       "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cli-color": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.3.tgz",
-      "integrity": "sha512-OkoZnxyC4ERN3zLzZaY9Emb7f/MhBOIpePv0Ycok0fJYT+Ouo00UBEIwsVsr0yoow++n5YWlSUgST9GKhNHiRQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.4.tgz",
+      "integrity": "sha512-zlnpg0jNcibNrO7GG9IeHH7maWFeCz+Ja1wx/7tZNU5ASSSSZ+/qZciM0/LHCYxSdqv5h2sdbQ/PXYdOuetXvA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d": "^1.0.1",
-        "es5-ext": "^0.10.61",
+        "es5-ext": "^0.10.64",
         "es6-iterator": "^2.0.3",
         "memoizee": "^0.4.15",
         "timers-ext": "^0.1.7"
@@ -132,16 +146,21 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/es5-ext": {
@@ -150,6 +169,7 @@
       "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "ISC",
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -165,6 +185,7 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -172,13 +193,17 @@
       }
     },
     "node_modules/es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/es6-weak-map": {
@@ -186,6 +211,7 @@
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.46",
@@ -198,6 +224,7 @@
       "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
       "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.62",
@@ -208,17 +235,12 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/esniff/node_modules/type": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
-      "dev": true
-    },
     "node_modules/event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -229,27 +251,24 @@
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "type": "^2.7.2"
       }
-    },
-    "node_modules/ext/node_modules/type": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
-      "dev": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/get-stdin": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
       "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -261,7 +280,9 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -282,6 +303,7 @@
       "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-4.2.2.tgz",
       "integrity": "sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/glob": "^7.1.3"
       },
@@ -300,7 +322,9 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -310,13 +334,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -326,6 +352,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -337,13 +364,15 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -352,10 +381,11 @@
       }
     },
     "node_modules/json-schema-to-typescript": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-13.1.1.tgz",
-      "integrity": "sha512-F3CYhtA7F3yPbb8vF7sFchk/2dnr1/yTKf8RcvoNpjnh67ZS/ZMH1ElLt5KHAtf2/bymiejLQQszszPWEeTdSw==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-13.1.2.tgz",
+      "integrity": "sha512-17G+mjx4nunvOpkPvcz7fdwUwYCEwyH8vR3Ym3rFiQ8uzAL3go+c1306Kk7iGRk8HuXBXqy+JJJmpYl0cvOllw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@bcherny/json-schema-ref-parser": "10.0.5-fork",
         "@types/json-schema": "^7.0.11",
@@ -383,31 +413,37 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es5-ext": "~0.10.2"
       }
     },
     "node_modules/memoizee": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
-      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
+      "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.53",
+        "d": "^1.0.2",
+        "es5-ext": "^0.10.64",
         "es6-weak-map": "^2.0.3",
         "event-emitter": "^0.3.5",
         "is-promise": "^2.2.2",
         "lru-queue": "^0.1.0",
         "next-tick": "^1.1.0",
         "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/minimatch": {
@@ -415,6 +451,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -427,6 +464,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -436,6 +474,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -448,6 +487,7 @@
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -458,13 +498,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -474,6 +516,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
@@ -483,6 +526,7 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -492,6 +536,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -507,6 +552,7 @@
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -516,6 +562,7 @@
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -524,32 +571,39 @@
       }
     },
     "node_modules/timers-ext": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
-      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
+      "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "es5-ext": "~0.10.46",
-        "next-tick": "1"
+        "es5-ext": "^0.10.64",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "dev": true
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
+      "integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -778,6 +778,11 @@ export interface SupportedFeatures {
 	search_schema: SearchSchemaFeatures;
 
 	/**
+	 * Support ofr 'set_column_filters' RPC and its features
+	 */
+	set_column_filters: SetColumnFiltersFeatures;
+
+	/**
 	 * Support for 'set_row_filters' RPC and its features
 	 */
 	set_row_filters: SetRowFiltersFeatures;
@@ -803,6 +808,22 @@ export interface SupportedFeatures {
  * Feature flags for 'search_schema' RPC
  */
 export interface SearchSchemaFeatures {
+	/**
+	 * The support status for this RPC method
+	 */
+	support_status: SupportStatus;
+
+	/**
+	 * A list of supported types
+	 */
+	supported_types: Array<ColumnFilterTypeSupportStatus>;
+
+}
+
+/**
+ * Feature flags for 'set_column_filters' RPC
+ */
+export interface SetColumnFiltersFeatures {
 	/**
 	 * The support status for this RPC method
 	 */
@@ -1232,7 +1253,8 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 *
 	 * Set or clear column filters on table, replacing any previous filters
 	 *
-	 * @param filters Zero or more filters to apply
+	 * @param filters Column filters to apply (or pass empty array to clear
+	 * column filters)
 	 *
 	 */
 	setColumnFilters(filters: Array<ColumnFilter>): Promise<void> {
@@ -1242,7 +1264,7 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	/**
 	 * Set row filters based on column values
 	 *
-	 * Set or clear row filters on table, replacing any previous filters
+	 * Row filters to apply (or pass empty array to clear row filters)
 	 *
 	 * @param filters Zero or more filters to apply
 	 *

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -79,6 +79,11 @@ export interface BackendState {
 	table_unfiltered_shape: TableShape;
 
 	/**
+	 * The set of currently applied column filters
+	 */
+	column_filters: Array<ColumnFilter>;
+
+	/**
 	 * The set of currently applied row filters
 	 */
 	row_filters: Array<RowFilter>;
@@ -1096,6 +1101,7 @@ export enum DataExplorerBackendRequest {
 	SearchSchema = 'search_schema',
 	GetDataValues = 'get_data_values',
 	ExportDataSelection = 'export_data_selection',
+	SetColumnFilters = 'set_column_filters',
 	SetRowFilters = 'set_row_filters',
 	SetSortColumns = 'set_sort_columns',
 	GetColumnProfiles = 'get_column_profiles',
@@ -1177,6 +1183,18 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	}
 
 	/**
+	 * Set column filters to select subset of table columns
+	 *
+	 * Set or clear column filters on table, replacing any previous filters
+	 *
+	 * @param filters Zero or more filters to apply
+	 *
+	 */
+	setColumnFilters(filters: Array<ColumnFilter>): Promise<void> {
+		return super.performRpc('set_column_filters', ['filters'], [filters]);
+	}
+
+	/**
 	 * Set row filters based on column values
 	 *
 	 * Set or clear row filters on table, replacing any previous filters
@@ -1221,7 +1239,7 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	/**
 	 * Get the state
 	 *
-	 * Request the current backend state (shape, filters, sort keys,
+	 * Request the current backend state (table metadata, explorer state, and
 	 * features)
 	 *
 	 *

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -69,7 +69,7 @@ export interface BackendState {
 	display_name: string;
 
 	/**
-	 * Number of rows and columns in table with filters applied
+	 * Number of rows and columns in table with row/column filters applied
 	 */
 	table_shape: TableShape;
 
@@ -79,17 +79,17 @@ export interface BackendState {
 	table_unfiltered_shape: TableShape;
 
 	/**
-	 * The set of currently applied column filters
+	 * The currently applied column filters
 	 */
 	column_filters: Array<ColumnFilter>;
 
 	/**
-	 * The set of currently applied row filters
+	 * The currently applied row filters
 	 */
 	row_filters: Array<RowFilter>;
 
 	/**
-	 * The set of currently applied sorts
+	 * The currently applied column sort keys
 	 */
 	sort_keys: Array<ColumnSortKey>;
 
@@ -110,7 +110,7 @@ export interface ColumnSchema {
 	column_name: string;
 
 	/**
-	 * The position of the column within the schema
+	 * The position of the column within the table without any column filters
 	 */
 	column_index: number;
 
@@ -410,7 +410,7 @@ export interface ColumnFilterTypeSupportStatus {
  */
 export interface ColumnProfileRequest {
 	/**
-	 * The ordinal column index to profile
+	 * The column index (absolute, relative to unfiltered table) to profile
 	 */
 	column_index: number;
 
@@ -745,7 +745,7 @@ export interface ColumnQuantileValue {
  */
 export interface ColumnSortKey {
 	/**
-	 * Column index to sort by
+	 * Column index (absolute, relative to unfiltered table) to sort by
 	 */
 	column_index: number;
 
@@ -873,7 +873,7 @@ export interface SetSortColumnsFeatures {
  */
 export interface DataSelection {
 	/**
-	 * Type of selection
+	 * Type of selection, all indices relative to filtered row/column indices
 	 */
 	kind: DataSelectionKind;
 
@@ -1121,9 +1121,10 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	/**
 	 * Request schema
 	 *
-	 * Request full schema for a table-like object
+	 * Request subset of column schemas for a table-like object
 	 *
-	 * @param columnIndices The column indices to fetch
+	 * @param columnIndices The column indices (relative to the
+	 * filtered/selected columns) to fetch
 	 *
 	 * @returns undefined
 	 */
@@ -1132,9 +1133,10 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	}
 
 	/**
-	 * Search schema with column filters
+	 * Search full, unfiltered table schema with column filters
 	 *
-	 * Search schema for column names matching a passed substring
+	 * Search full, unfiltered table schema for column names matching one or
+	 * more column filters
 	 *
 	 * @param filters Column filters to apply when searching
 	 * @param startIndex Index (starting from zero) of first result to fetch

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -25,7 +25,7 @@ import { CustomContextMenuSeparator } from 'vs/workbench/browser/positronCompone
 import { PositronDataExplorerCommandId } from 'vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions';
 import { CustomContextMenuEntry, showCustomContextMenu } from 'vs/workbench/browser/positronComponents/customContextMenu/customContextMenu';
 import { dataExplorerExperimentalFeatureEnabled } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerExperimentalConfig';
-import { BackendState, ColumnSchema, DataSelection, DataSelectionCellRange, DataSelectionIndices, DataSelectionKind, DataSelectionRange, DataSelectionSingleCell, ExportFormat, RowFilter, SupportStatus } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { BackendState, ColumnSchema, DataSelectionCellRange, DataSelectionIndices, DataSelectionRange, DataSelectionSingleCell, ExportFormat, RowFilter, SupportStatus, TableSelection, TableSelectionKind } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 import { ClipboardCell, ClipboardCellRange, ClipboardColumnIndexes, ClipboardColumnRange, ClipboardData, ClipboardRowIndexes, ClipboardRowRange, ColumnSelectionState, ColumnSortKeyDescriptor, DataGridInstance, RowSelectionState } from 'vs/workbench/browser/positronDataGrid/classes/dataGridInstance';
 
 /**
@@ -498,14 +498,14 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	async copyClipboardData(clipboardData: ClipboardData): Promise<string | undefined> {
 		// Construct the data selection based on the clipboard data.
-		let dataSelection: DataSelection;
+		let dataSelection: TableSelection;
 		if (clipboardData instanceof ClipboardCell) {
 			const selection: DataSelectionSingleCell = {
 				column_index: clipboardData.columnIndex,
 				row_index: clipboardData.rowIndex,
 			};
 			dataSelection = {
-				kind: DataSelectionKind.SingleCell,
+				kind: TableSelectionKind.SingleCell,
 				selection
 			};
 		} else if (clipboardData instanceof ClipboardCellRange) {
@@ -516,7 +516,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 				last_row_index: clipboardData.lastRowIndex,
 			};
 			dataSelection = {
-				kind: DataSelectionKind.CellRange,
+				kind: TableSelectionKind.CellRange,
 				selection
 			};
 		} else if (clipboardData instanceof ClipboardColumnRange) {
@@ -525,7 +525,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 				last_index: clipboardData.lastColumnIndex
 			};
 			dataSelection = {
-				kind: DataSelectionKind.ColumnRange,
+				kind: TableSelectionKind.ColumnRange,
 				selection
 			};
 		} else if (clipboardData instanceof ClipboardColumnIndexes) {
@@ -533,7 +533,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 				indices: clipboardData.indexes
 			};
 			dataSelection = {
-				kind: DataSelectionKind.ColumnIndices,
+				kind: TableSelectionKind.ColumnIndices,
 				selection
 			};
 		} else if (clipboardData instanceof ClipboardRowRange) {
@@ -542,7 +542,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 				last_index: clipboardData.lastRowIndex
 			};
 			dataSelection = {
-				kind: DataSelectionKind.RowRange,
+				kind: TableSelectionKind.RowRange,
 				selection
 			};
 		} else if (clipboardData instanceof ClipboardRowIndexes) {
@@ -550,7 +550,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 				indices: clipboardData.indexes
 			};
 			dataSelection = {
-				kind: DataSelectionKind.RowIndices,
+				kind: TableSelectionKind.RowIndices,
 				selection
 			};
 		} else {

--- a/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/dataExplorerCache.ts
@@ -501,20 +501,12 @@ export class DataExplorerCache extends Disposable {
 
 				// Update the data cell cache, overwriting any entries we already have cached.
 				for (let row = 0; row < rows; row++) {
-					// Get the row index.
 					const rowIndex = rowIndices[row];
-
-					// If row labels were returned, cache the row label for the row.
-					if (tableData.row_labels) {
-						const rowLabel = tableData.row_labels[0][row];
-						this._rowLabelCache.set(rowIndex, rowLabel);
-					}
 
 					// Cache the data cells.
 					for (let column = 0; column < columnIndices.length; column++) {
 						const value = tableData.columns[column][row];
 						const columnIndex = columnIndices[column];
-						const rowIndex = rowIndices[row];
 						if (typeof value === 'number') {
 							this._dataCellCache.set(`${columnIndex},${rowIndex}`,
 								decodeSpecialValue(value)
@@ -525,6 +517,18 @@ export class DataExplorerCache extends Disposable {
 								kind: DataCellKind.NON_NULL
 							});
 						}
+					}
+				}
+
+				// Get the row labels, if any
+				if (tableState.has_row_labels) {
+					const rowLabels = await this._dataExplorerClientInstance.getRowLabels(
+						{ first_index: rowIndices[0], last_index: rowIndices[0] + rows - 1 }
+					);
+					for (let row = 0; row < rows; row++) {
+						const rowIndex = rowIndices[row];
+						const rowLabel = rowLabels.row_labels[0][row];
+						this._rowLabelCache.set(rowIndex, rowLabel);
 					}
 				}
 

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerMocks.ts
@@ -76,7 +76,6 @@ export function getExampleTableData(shape: [number, number], schema: TableSchema
 	}
 	return {
 		columns: generatedColumns,
-		row_labels: []
 	};
 }
 


### PR DESCRIPTION
As agreed to with @softwarenerd to align with the refactoring he's been doing in the data plane for the data explorer:

* There are instances where it is low-friction for the frontend to request an array of indices that it doesn't have cached for a particular column, whether other times it may be easier to request a range. 
* Similarly, what needs to be requested for each column may vary as the user moves around the table, so it is useful to be able to request a different range or set of indices for each column in the get data values request
* Accordingly, I've introduced a new "column_selection" OpenRPC type and an "array_selection" (range or indices) union to allow this to be expressed more exactly
* Relatedly, in light of the above, it doesn't make sense to always return the row labels in the get_data_values RPC request, so this adds as `has_row_labels` flag to the `get_state` response and a new `get_row_labels` request so these can be retrieved separately.
* I renamed a few things for clarity while we are in the process of breaking APIs

Lastly, in this PR I stubbed out placeholders (including in the state updates and features) for the `set_column_filters` request which can be implemented in a follow up PR. 

### QA Notes

We only need to verify that the existing smoke and CI tests continue to pass.