### PR TITLE
Bump timeout on macOS builds

### DIFF
--- a/.github/workflows/build-release-macos.yml
+++ b/.github/workflows/build-release-macos.yml
@@ -28,7 +28,7 @@ jobs:
   build-archs:
     name: Build macOS
     runs-on: [self-hosted-production, macos, arm64]
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change addresses an issue with the x64 macOS builds, which have recently started getting cancelled by Github due to 60 minute timeouts. The timeouts do not appear to be due to a hang, but we should also look into whether they're caused by a recent change. Prior to recent changes, the build x64 build took 50 minutes. 

### QA Notes

N/A, build change only.