### PR TITLE
Fix connections base comm events

### DIFF
--- a/extensions/positron-connections/src/comms/BaseComm.ts
+++ b/extensions/positron-connections/src/comms/BaseComm.ts
@@ -213,7 +213,8 @@ export class PositronBaseComm {
 		name: string,
 		properties: string[]
 	): Event<T> {
-		const event = this.clientInstance.onDidSendEvent((event: any) => {
+		const event = this.clientInstance.onDidSendEvent((output) => {
+			const event = output.data as any;
 			if (event.method === name) {
 				const args = event.params;
 				const namedArgs: any = {};


### PR DESCRIPTION
Fixes the `R - Connections are update after adding a database,[C663724]` smoke test, which was broken in https://github.com/posit-dev/positron/pull/4208.