### PR TITLE
Data Explorer: Add option for letting an algorithm decide on the number of histogram bins

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -15,7 +15,14 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+from ._vendor.pydantic import (
+    BaseModel,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+)
 
 
 @enum.unique
@@ -143,6 +150,17 @@ class ColumnProfileType(str, enum.Enum):
     FrequencyTable = "frequency_table"
 
     Histogram = "histogram"
+
+
+@enum.unique
+class ColumnHistogramParamsMethod(str, enum.Enum):
+    """
+    Possible values for Method in ColumnHistogramParams
+    """
+
+    Sturges = "sturges"
+
+    Fixed = "fixed"
 
 
 @enum.unique
@@ -770,7 +788,12 @@ class ColumnHistogramParams(BaseModel):
     Parameters for a column histogram profile request
     """
 
-    num_bins: StrictInt = Field(
+    method: ColumnHistogramParamsMethod = Field(
+        description="Method for determining number of bins",
+    )
+
+    num_bins: Optional[StrictInt] = Field(
+        default=None,
         description="Number of bins in the computed histogram",
     )
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -15,14 +15,7 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import (
-    BaseModel,
-    Field,
-    StrictBool,
-    StrictFloat,
-    StrictInt,
-    StrictStr,
-)
+from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 
 
 @enum.unique

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -2203,10 +2203,15 @@ def _get_null_count(column_index):
     return _profile_request(column_index, [{"profile_type": "null_count"}])
 
 
-def _get_histogram(column_index, bins):
+def _get_histogram(column_index, bins=None, method="fixed"):
     return _profile_request(
         column_index,
-        [{"profile_type": "histogram", "params": {"num_bins": bins}}],
+        [
+            {
+                "profile_type": "histogram",
+                "params": {"method": method, "num_bins": bins},
+            }
+        ],
     )
 
 
@@ -2581,7 +2586,7 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
 
     cases = [
         (
-            _get_histogram(0, 4),
+            _get_histogram(0, bins=4),
             {
                 "bin_edges": ["0.00", "2.50", "5.00", "7.50", "10.00"],
                 "bin_counts": [3, 2, 3, 3],
@@ -2589,7 +2594,7 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
             },
         ),
         (
-            _get_histogram(1, 4),
+            _get_histogram(1, bins=4),
             {
                 "bin_edges": [
                     "2000-01-01 00:00:00",
@@ -2603,7 +2608,7 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
             },
         ),
         (
-            _get_histogram(2, 6),
+            _get_histogram(2, bins=6),
             {
                 "bin_edges": [
                     "-10.00",
@@ -2619,7 +2624,7 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
             },
         ),
         (
-            _get_histogram(3, 4),
+            _get_histogram(3, bins=4),
             {
                 "bin_edges": [
                     "0.00",

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -1094,9 +1094,17 @@
 				"type": "object",
 				"description": "Parameters for a column histogram profile request",
 				"required": [
-					"num_bins"
+					"method"
 				],
 				"properties": {
+					"method": {
+						"description": "Method for determining number of bins",
+						"type": "string",
+						"enum": [
+							"sturges",
+							"fixed"
+						]
+					},
 					"num_bins": {
 						"type": "integer",
 						"description": "Number of bins in the computed histogram"

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -663,9 +663,14 @@ export interface SummaryStatsDatetime {
  */
 export interface ColumnHistogramParams {
 	/**
+	 * Method for determining number of bins
+	 */
+	method: ColumnHistogramParamsMethod;
+
+	/**
 	 * Number of bins in the computed histogram
 	 */
-	num_bins: number;
+	num_bins?: number;
 
 	/**
 	 * Sample quantiles (numbers between 0 and 1) to compute along with the
@@ -1099,6 +1104,14 @@ export enum ColumnProfileType {
 	SummaryStats = 'summary_stats',
 	FrequencyTable = 'frequency_table',
 	Histogram = 'histogram'
+}
+
+/**
+ * Possible values for Method in ColumnHistogramParams
+ */
+export enum ColumnHistogramParamsMethod {
+	Sturges = 'sturges',
+	Fixed = 'fixed'
 }
 
 /**


### PR DESCRIPTION
R defaults to the Sturges method of computing bin widths, and has some logic for returning a single bin for constant arrays. This adds an option for requesting an auto-sized histogram which is what the R `hist` function does, and we can implement similar logic in Python. 

Related to #4061 