### PR TITLE
Data Explorer: Auto-size column widths and rewritten cache layer for data and summary stats

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -1020,6 +1020,11 @@
 		"--zoom-factor",
 		"--test-bar-width",
 		"--widget-color",
-		"--text-link-decoration"
+		"--text-link-decoration",
+		"--positron-data-grid-column-header-description-font-size",
+		"--positron-data-grid-column-header-sort-index-font-size",
+		"--positron-data-grid-column-header-sort-index-font-variant-numeric",
+		"--positron-data-grid-column-header-sort-index-font-weight",
+		"--positron-data-grid-column-header-title-font-weight"
 	]
 }

--- a/extensions/positron-proxy/src/positronProxy.ts
+++ b/extensions/positron-proxy/src/positronProxy.ts
@@ -53,10 +53,12 @@ type ContentRewriter = (
 
 /**
  * Custom type guard for AddressInfo.
- * @param addressInfo The value.
- * @returns true if the value is aAddressInfo AddressInfo; otherwise, false.
+ * @param addressInfo The value to type guard.
+ * @returns true if the value is an AddressInfo; otherwise, false.
  */
-export const isAddressInfo = (addressInfo: string | AddressInfo | null): addressInfo is AddressInfo =>
+export const isAddressInfo = (
+	addressInfo: string | AddressInfo | null
+): addressInfo is AddressInfo =>
 	(addressInfo as AddressInfo).address !== undefined &&
 	(addressInfo as AddressInfo).family !== undefined &&
 	(addressInfo as AddressInfo).port !== undefined;

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.css
@@ -15,6 +15,26 @@
 
 .data-explorer-panel
 .data-explorer
+.column-name-exemplar {
+	font-weight: var(--positron-data-grid-column-header-title-font-weight);
+}
+
+.data-explorer-panel
+.data-explorer
+.type-name-exemplar {
+	font-size: var(--positron-data-grid-column-header-description-font-size);
+}
+
+.data-explorer-panel
+.data-explorer
+.sort-index-exemplar {
+	font-size: var(--positron-data-grid-column-header-sort-index-font-size);
+	font-weight: var(--positron-data-grid-column-header-sort-index-font-weight);
+	font-variant-numeric: var(--positron-data-grid-column-header-sort-index-font-variant-numeric);
+}
+
+.data-explorer-panel
+.data-explorer
 .column-1 {
 	min-width: 0;
 	min-height: 0;

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -8,11 +8,17 @@ import 'vs/css!./dataExplorer';
 
 // React.
 import * as React from 'react';
-import { useEffect, useRef, useState } from 'react'; // eslint-disable-line no-duplicate-imports
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'; // eslint-disable-line no-duplicate-imports
 
 // Other dependencies.
+import * as DOM from 'vs/base/browser/dom';
+import { PixelRatio } from 'vs/base/browser/pixelRatio';
 import { DisposableStore } from 'vs/base/common/lifecycle';
+import { BareFontInfo } from 'vs/editor/common/config/fontInfo';
+import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
+import { FontMeasurements } from 'vs/editor/browser/config/fontMeasurements';
 import { PositronDataGrid } from 'vs/workbench/browser/positronDataGrid/positronDataGrid';
+import { SORTING_BUTTON_WIDTH } from 'vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader';
 import { usePositronDataExplorerContext } from 'vs/workbench/browser/positronDataExplorer/positronDataExplorerContext';
 import { VerticalSplitter, VerticalSplitterResizeParams } from 'vs/base/browser/ui/positronComponents/splitters/verticalSplitter';
 import { PositronDataExplorerLayout } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
@@ -32,6 +38,9 @@ export const DataExplorer = () => {
 
 	// Reference hooks.
 	const dataExplorerRef = useRef<HTMLDivElement>(undefined!);
+	const columnNameExemplar = useRef<HTMLDivElement>(undefined!);
+	const typeNameExemplar = useRef<HTMLDivElement>(undefined!);
+	const sortIndexExemplar = useRef<HTMLDivElement>(undefined!);
 	const column1Ref = useRef<HTMLDivElement>(undefined!);
 	const splitterRef = useRef<HTMLDivElement>(undefined!);
 	const column2Ref = useRef<HTMLDivElement>(undefined!);
@@ -40,6 +49,153 @@ export const DataExplorer = () => {
 	const [width, setWidth] = useState(0);
 	const [layout, setLayout] = useState(context.instance.layout);
 	const [columnsWidth, setColumnsWidth] = useState(0);
+
+	// Dynamic column width layout.
+	useLayoutEffect(() => {
+		// Get the window for the data explorer.
+		const window = DOM.getWindow(dataExplorerRef.current);
+
+		// Calculate the horizontal cell padding. This is a setting, so it doesn't change over the
+		// lifetime of the table data data grid instance.
+		const horizontalCellPadding =
+			(context.instance.tableDataDataGridInstance.horizontalCellPadding * 2);
+
+		// Set the column header width calculator. Column header widths are measured using the font
+		// information from the column name exemplar and the type name exemplar. These exemplars
+		// must be styled the same as the data grid title and description.
+		context.instance.tableDataDataGridInstance.setColumnHeaderWidthCalculator(
+			(columnName: string, typeName: string) => {
+				// Calculate the basic column header width. This allows for horizontal cell padding,
+				// the sorting button, and the border to be displayed, at a minimum.
+				const basicColumnHeaderWidth =
+					horizontalCellPadding +
+					SORTING_BUTTON_WIDTH +
+					1; // +1 for the border.
+
+				// If the column header is empty, return the basic column header width.
+				if (!columnName && !typeName) {
+					return basicColumnHeaderWidth;
+				}
+
+				// Create a canvas and create a 2D rendering context for it to measure text.
+				const canvas = window.document.createElement('canvas');
+				const canvasRenderingContext2D = canvas.getContext('2d');
+
+				// If the 2D canvas rendering context couldn't be created, return the basic column
+				// header width.
+				if (!canvasRenderingContext2D) {
+					return basicColumnHeaderWidth;
+				}
+
+				// Set the column name width.
+				let columnNameWidth;
+				if (!columnName) {
+					columnNameWidth = 0;
+				} else {
+					// Measure the column name width using the font of the column name exemplar.
+					const columnNameExemplarStyle =
+						DOM.getComputedStyle(columnNameExemplar.current);
+					canvasRenderingContext2D.font = columnNameExemplarStyle.font;
+					columnNameWidth = canvasRenderingContext2D.measureText(columnName).width;
+				}
+
+				// Set the type name width.
+				let typeNameWidth;
+				if (!typeName) {
+					typeNameWidth = 0;
+				} else {
+					// Measure the type name width using the font of the type name exemplar.
+					const typeNameExemplarStyle = DOM.getComputedStyle(typeNameExemplar.current);
+					canvasRenderingContext2D.font = typeNameExemplarStyle.font;
+					typeNameWidth = canvasRenderingContext2D.measureText(typeName).width;
+				}
+
+				// Calculate return the column header width.
+				return Math.ceil(Math.max(columnNameWidth, typeNameWidth) + basicColumnHeaderWidth);
+			}
+		);
+
+		// Calculate the width of a sort digit. The sort index is styled with font-variant-numeric
+		// tabular-nums, so we can calculate the width of the sort index by multiplying the width of
+		// a sort digit by the length of the sort index.
+		const canvas = window.document.createElement('canvas');
+		const canvasRenderingContext2D = canvas.getContext('2d');
+		let sortIndexDigitWidth;
+		if (!canvasRenderingContext2D) {
+			sortIndexDigitWidth = 0;
+		} else {
+			const sortIndexExemplarStyle = DOM.getComputedStyle(sortIndexExemplar.current);
+			canvasRenderingContext2D.font = sortIndexExemplarStyle.font;
+			sortIndexDigitWidth = canvasRenderingContext2D.measureText('1').width;
+		}
+
+		// Set the sort index width calculator. Sort index widths are calculated.
+		context.instance.tableDataDataGridInstance.setSortIndexWidthCalculator(sortIndex =>
+			Math.ceil(sortIndex.toString().length * sortIndexDigitWidth)
+		);
+
+		// Calculate the editor font space width.
+		const editorFontSpaceWidth = FontMeasurements.readFontInfo(
+			window,
+			BareFontInfo.createFromRawSettings(
+				context.configurationService.getValue<IEditorOptions>('editor'),
+				PixelRatio.getInstance(window).value
+			)
+		).spaceWidth;
+
+		// Set the column value width calculator. Column value widths are calculated.
+		context.instance.tableDataDataGridInstance.setColumnValueWidthCalculator(length =>
+			Math.ceil(
+				(editorFontSpaceWidth * length) +
+				horizontalCellPadding +
+				+ 1 // +1 for the border.
+			)
+		);
+
+		// Add the onDidChangeConfiguration event handler.
+		context.configurationService.onDidChangeConfiguration(configurationChangeEvent => {
+			// When something in the editor changes, determine whether it's font-related and, if it
+			// is, apply the new font info.
+			if (configurationChangeEvent.affectsConfiguration('editor')) {
+				if (configurationChangeEvent.affectedKeys.has('editor.fontFamily') ||
+					configurationChangeEvent.affectedKeys.has('editor.fontWeight') ||
+					configurationChangeEvent.affectedKeys.has('editor.fontSize') ||
+					configurationChangeEvent.affectedKeys.has('editor.fontLigatures') ||
+					configurationChangeEvent.affectedKeys.has('editor.fontVariations') ||
+					configurationChangeEvent.affectedKeys.has('editor.lineHeight') ||
+					configurationChangeEvent.affectedKeys.has('editor.letterSpacing')
+				) {
+					// Set the column value width calculator.
+					context.instance.tableDataDataGridInstance.setColumnValueWidthCalculator(
+						length => {
+							// Calculate the editor font space width.
+							const editorFontSpaceWidth = FontMeasurements.readFontInfo(
+								window,
+								BareFontInfo.createFromRawSettings(
+									context.configurationService.getValue<IEditorOptions>('editor'),
+									PixelRatio.getInstance(window).value
+								)
+							).spaceWidth;
+
+							// Calculate the column value width using the font editor font.
+							return Math.ceil(
+								(editorFontSpaceWidth * length) +
+								horizontalCellPadding +
+								+ 1 // +1 for the border.
+							);
+						}
+					);
+				}
+			}
+		});
+
+		// Return the cleanup function.
+		return () => {
+			context.instance.tableDataDataGridInstance.setColumnHeaderWidthCalculator(undefined);
+			context.instance.tableDataDataGridInstance.setSortIndexWidthCalculator(undefined);
+			context.instance.tableDataDataGridInstance.setColumnValueWidthCalculator(undefined);
+		};
+	}, [context.configurationService, context.instance.tableDataDataGridInstance]);
 
 	// Main useEffect. This is where we set up event handlers.
 	useEffect(() => {
@@ -148,6 +304,9 @@ export const DataExplorer = () => {
 	// Render.
 	return (
 		<div ref={dataExplorerRef} className='data-explorer'>
+			<div ref={columnNameExemplar} className='column-name-exemplar' />
+			<div ref={typeNameExemplar} className='type-name-exemplar' />
+			<div ref={sortIndexExemplar} className='sort-index-exemplar' />
 			<div ref={column1Ref} className='column-1'>
 				<PositronDataGrid
 					configurationService={context.configurationService}

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -946,7 +946,7 @@ export abstract class DataGridInstance extends Disposable {
 	 * Gets the screen columns.
 	 */
 	get screenColumns() {
-		return Math.trunc(this._width / this._minimumColumnWidth) + 1;
+		return Math.ceil(this._width / this._minimumColumnWidth);
 	}
 
 	/**
@@ -982,7 +982,7 @@ export abstract class DataGridInstance extends Disposable {
 	 * Gets the screen rows.
 	 */
 	get screenRows() {
-		return Math.trunc(this._height / this._minimumRowHeight) + 1;
+		return Math.ceil(this._height / this._minimumRowHeight);
 	}
 
 	/**

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -92,7 +92,7 @@ type DisplayOptions = | {
 	automaticLayout: boolean;
 	rowsMargin?: number;
 	cellBorders?: boolean;
-	cursorInitiallyHidden?: boolean;
+	horizontalCellPadding?: number;
 };
 
 /**
@@ -581,6 +581,11 @@ export abstract class DataGridInstance extends Disposable {
 	private readonly _cellBorders: boolean;
 
 	/**
+	 * Gets the horizontal cell padding.
+	 */
+	private readonly _horizontalCellPadding: number;
+
+	/**
 	 * Gets or sets a value which indicates whether the cursor is initially hidden.
 	 */
 	private readonly _cursorInitiallyHidden: boolean;
@@ -664,19 +669,19 @@ export abstract class DataGridInstance extends Disposable {
 	 */
 	private _rowSelectionIndexes?: SelectionIndexes;
 
-	/**
-	 * Gets the column widths.
-	 */
-	private readonly _columnWidths = new Map<number, number>();
-
-	/**
-	 * Gets the row heights.
-	 */
-	private readonly _rowHeights = new Map<number, number>();
-
 	//#endregion Private Properties
 
 	//#region Protected Properties
+
+	/**
+	 * Gets the user-defined column widths.
+	 */
+	protected readonly _userDefinedColumnWidths = new Map<number, number>();
+
+	/**
+	 * Gets the user-defined row heights.
+	 */
+	protected readonly _userDefinedRowHeights = new Map<number, number>();
 
 	/**
 	 * Gets the column sort keys.
@@ -729,6 +734,7 @@ export abstract class DataGridInstance extends Disposable {
 		this._automaticLayout = options.automaticLayout;
 		this._rowsMargin = options.rowsMargin ?? 0;
 		this._cellBorders = options.cellBorders ?? true;
+		this._horizontalCellPadding = options.horizontalCellPadding ?? 0;
 
 		this._cursorInitiallyHidden = options.cursorInitiallyHidden ?? false;
 		if (options.cursorInitiallyHidden) {
@@ -868,8 +874,15 @@ export abstract class DataGridInstance extends Disposable {
 	/**
 	 * Gets a value which indicates whether to show cell borders.
 	 */
-	get cellBorder() {
+	get cellBorders() {
 		return this._cellBorders;
+	}
+
+	/**
+	 * Gets the horizontal cell padding.
+	 */
+	get horizontalCellPadding() {
+		return this._horizontalCellPadding;
 	}
 
 	/**
@@ -1146,7 +1159,7 @@ export abstract class DataGridInstance extends Disposable {
 	 * @param columnIndex The column index.
 	 */
 	getColumnWidth(columnIndex: number): number {
-		const columnWidth = this._columnWidths.get(columnIndex);
+		const columnWidth = this._userDefinedColumnWidths.get(columnIndex);
 		if (columnWidth !== undefined) {
 			return columnWidth;
 		} else {
@@ -1162,7 +1175,7 @@ export abstract class DataGridInstance extends Disposable {
 	 */
 	async setColumnWidth(columnIndex: number, columnWidth: number): Promise<void> {
 		// Get the current column width.
-		const currentColumnWidth = this._columnWidths.get(columnIndex);
+		const currentColumnWidth = this._userDefinedColumnWidths.get(columnIndex);
 		if (currentColumnWidth !== undefined) {
 			if (columnWidth === currentColumnWidth) {
 				return;
@@ -1170,7 +1183,7 @@ export abstract class DataGridInstance extends Disposable {
 		}
 
 		// Set the column width.
-		this._columnWidths.set(columnIndex, columnWidth);
+		this._userDefinedColumnWidths.set(columnIndex, columnWidth);
 
 		// Fetch data.
 		await this.fetchData();
@@ -1184,7 +1197,7 @@ export abstract class DataGridInstance extends Disposable {
 	 * @param rowIndex The row index.
 	 */
 	getRowHeight(rowIndex: number) {
-		const rowHeight = this._rowHeights.get(rowIndex);
+		const rowHeight = this._userDefinedRowHeights.get(rowIndex);
 		if (rowHeight !== undefined) {
 			return rowHeight;
 		} else {
@@ -1200,7 +1213,7 @@ export abstract class DataGridInstance extends Disposable {
 	 */
 	async setRowHeight(rowIndex: number, rowHeight: number): Promise<void> {
 		// Get the current row height.
-		const currentRowHeight = this._rowHeights.get(rowIndex);
+		const currentRowHeight = this._userDefinedRowHeights.get(rowIndex);
 		if (currentRowHeight !== undefined) {
 			if (rowHeight === currentRowHeight) {
 				return;
@@ -1208,7 +1221,7 @@ export abstract class DataGridInstance extends Disposable {
 		}
 
 		// Set the row height.
-		this._rowHeights.set(rowIndex, rowHeight);
+		this._userDefinedRowHeights.set(rowIndex, rowHeight);
 
 		// Fetch data.
 		await this.fetchData();

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.ts
@@ -47,9 +47,11 @@ type DefaultSizeOptions = | {
 type ColumnResizeOptions = | {
 	readonly columnResize: false;
 	readonly minimumColumnWidth?: never;
+	readonly maximumColumnWidth?: never;
 } | {
 	readonly columnResize: true;
 	readonly minimumColumnWidth: number;
+	readonly maximumColumnWidth: number;
 };
 
 /**
@@ -526,6 +528,11 @@ export abstract class DataGridInstance extends Disposable {
 	private readonly _minimumColumnWidth: number;
 
 	/**
+	 * Gets the maximum column width.
+	 */
+	private readonly _maximumColumnWidth: number;
+
+	/**
 	 * Gets the default column width.
 	 */
 	private readonly _defaultColumnWidth: number;
@@ -722,6 +729,7 @@ export abstract class DataGridInstance extends Disposable {
 
 		this._columnResize = options.columnResize || false;
 		this._minimumColumnWidth = options.minimumColumnWidth ?? this._defaultColumnWidth;
+		this._maximumColumnWidth = options.maximumColumnWidth ?? this._defaultColumnWidth;
 
 		this._rowResize = options.rowResize || false;
 		this._minimumRowHeight = options.minimumRowHeight ?? options.defaultRowHeight;
@@ -799,6 +807,13 @@ export abstract class DataGridInstance extends Disposable {
 	 */
 	get minimumColumnWidth() {
 		return this._minimumColumnWidth;
+	}
+
+	/**
+	 * Gets the maximum column width.
+	 */
+	get maximumColumnWidth() {
+		return this._maximumColumnWidth;
 	}
 
 	/**

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.css
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.css
@@ -63,7 +63,7 @@
 	position: relative;
 	align-items: center;
 	grid-column: content / right-gutter;
-	grid-template-columns: [left-margin] 7px [title-description] minmax(0, 1fr) [sort-indicator] min-content [button] 20px [right-margin] 7px [end];
+	grid-template-columns: [title-description] minmax(0, 1fr) [sort-indicator] min-content [button] 20px [button-end];
 }
 
 .data-grid-column-header
@@ -77,23 +77,23 @@
 .content
 .title-description
 .title {
-	font-weight: 600;
 	overflow: hidden;
 	white-space: nowrap;
 	line-height: normal;
 	text-overflow: ellipsis;
+	font-weight: var(--positron-data-grid-column-header-title-font-weight);
 }
 
 .data-grid-column-header
 .content
 .title-description
 .description {
-	font-size: 90%;
 	opacity: 80%;
 	overflow: hidden;
 	white-space: nowrap;
 	line-height: normal;
 	text-overflow: ellipsis;
+	font-size: var(--positron-data-grid-column-header-description-font-size);
 }
 
 .data-grid-column-header
@@ -115,16 +115,18 @@
 .content
 .sort-indicator
 .sort-index {
-	font-size: 80%;
-	font-weight: 600;
-	margin: 0 3px 0 3px;
+	margin: 0 3px;
 	color: var(--vscode-positronDataGrid-sortIndexForeground);
+	font-size: var(--positron-data-grid-column-header-sort-index-font-size);
+	font-weight: var(--positron-data-grid-column-header-sort-index-font-weight);
+	font-variant-numeric: var(--positron-data-grid-column-header-sort-index-font-variant-numeric);
 }
 
 .data-grid-column-header
 .content
 .sort-button {
 	z-index: 1;
+	width: 20px;
 	height: 20px;
 	display: flex;
 	cursor: pointer;
@@ -132,7 +134,7 @@
 	align-items: center;
 	box-sizing: border-box;
 	justify-content: center;
-	grid-column: button / right-margin;
+	grid-column: button / button-end;
 }
 
 .data-grid-column-header

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -173,7 +173,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 				<VerticalSplitter
 					onBeginResize={() => ({
 						minimumWidth: context.instance.minimumColumnWidth,
-						maximumWidth: 400,
+						maximumWidth: context.instance.maximumColumnWidth,
 						startingWidth: context.instance.getColumnWidth(props.columnIndex)
 					})}
 					onResize={async width =>

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -20,6 +20,11 @@ import { ColumnSelectionState } from 'vs/workbench/browser/positronDataGrid/clas
 import { usePositronDataGridContext } from 'vs/workbench/browser/positronDataGrid/positronDataGridContext';
 
 /**
+ * Constants.
+ */
+export const SORTING_BUTTON_WIDTH = 20;
+
+/**
  * DataGridColumnHeaderProps interface.
  */
 interface DataGridColumnHeaderProps {
@@ -110,7 +115,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 			}}
 			onMouseDown={mouseDownHandler}
 		>
-			{context.instance.cellBorder &&
+			{context.instance.cellBorders &&
 				<>
 					<div className='border-overlay' />
 					{selected &&
@@ -125,7 +130,13 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 					}
 				</>
 			}
-			<div className='content'>
+			<div
+				className='content'
+				style={{
+					paddingLeft: context.instance.horizontalCellPadding,
+					paddingRight: context.instance.horizontalCellPadding
+				}}
+			>
 				<div className='title-description'>
 					<div className='title'>{props.column?.name}</div>
 					{props.column?.description &&

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridCornerTopLeft.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridCornerTopLeft.tsx
@@ -35,7 +35,7 @@ export const DataGridCornerTopLeft = (props: DataGridCornerTopLeftProps) => {
 			<VerticalSplitter
 				onBeginResize={() => ({
 					minimumWidth: 20,
-					maximumWidth: 400,
+					maximumWidth: context.instance.maximumColumnWidth,
 					startingWidth: context.instance.rowHeadersWidth
 				})}
 				onResize={async width =>

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
@@ -176,7 +176,7 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 				<VerticalSplitter
 					onBeginResize={() => ({
 						minimumWidth: context.instance.minimumColumnWidth,
-						maximumWidth: 400,
+						maximumWidth: context.instance.maximumColumnWidth,
 						startingWidth: context.instance.getColumnWidth(props.columnIndex)
 					})}
 					onResize={async width =>

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
@@ -141,7 +141,7 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 			}}
 			onMouseDown={mouseDownHandler}
 		>
-			{context.instance.cellBorder &&
+			{context.instance.cellBorders &&
 				<>
 					<div className='border-overlay'>
 						{!selected && isCursorCell && <Cursor dimmed={!context.instance.focused} />}
@@ -162,7 +162,14 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 					}
 				</>
 			}
-			<div id={`data-grid-row-cell-content-${props.columnIndex}-${props.rowIndex}`} className='content'>
+			<div
+				id={`data-grid-row-cell-content-${props.columnIndex}-${props.rowIndex}`}
+				className='content'
+				style={{
+					paddingLeft: context.instance.horizontalCellPadding,
+					paddingRight: context.instance.horizontalCellPadding
+				}}
+			>
 				{context.instance.cell(props.columnIndex, props.rowIndex)}
 			</div>
 			{context.instance.columnResize &&

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
@@ -96,7 +96,7 @@ export const DataGridRowHeader = (props: DataGridRowHeaderProps) => {
 			}}
 			onMouseDown={mouseDownHandler}
 		>
-			{context.instance.cellBorder &&
+			{context.instance.cellBorders &&
 				<>
 					<div className='border-overlay' />
 					{selected &&

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
@@ -116,8 +116,8 @@ export const DataGridRowHeader = (props: DataGridRowHeaderProps) => {
 			</div>
 			<VerticalSplitter
 				onBeginResize={() => ({
-					minimumWidth: 20,
-					maximumWidth: 400,
+					minimumWidth: context.instance.minimumColumnWidth,
+					maximumWidth: context.instance.maximumColumnWidth,
 					startingWidth: context.instance.rowHeadersWidth
 				})}
 				onResize={async width =>

--- a/src/vs/workbench/browser/positronDataGrid/positronDataGrid.css
+++ b/src/vs/workbench/browser/positronDataGrid/positronDataGrid.css
@@ -3,6 +3,14 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+:root {
+	--positron-data-grid-column-header-title-font-weight: 600;
+	--positron-data-grid-column-header-description-font-size: 90%;
+	--positron-data-grid-column-header-sort-index-font-size: 80%;
+	--positron-data-grid-column-header-sort-index-font-weight: 600;
+	--positron-data-grid-column-header-sort-index-font-variant-numeric: tabular-nums;
+}
+
 .data-grid {
 	width: 100%;
 	height: 100%;

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -6,7 +6,7 @@
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
-import { ArraySelection, BackendState, ColumnProfileRequest, ColumnProfileResult, ColumnSchema, ColumnSortKey, ExportedData, ExportFormat, FilterResult, FormatOptions, PositronDataExplorerComm, RowFilter, SchemaUpdateEvent, SupportedFeatures, SupportStatus, TableData, TableRowLabels, TableSchema, TableSelection } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+import { ArraySelection, BackendState, ColumnProfileRequest, ColumnProfileResult, ColumnSchema, ColumnSelection, ColumnSortKey, ExportedData, ExportFormat, FilterResult, FormatOptions, PositronDataExplorerComm, RowFilter, SchemaUpdateEvent, SupportedFeatures, SupportStatus, TableData, TableRowLabels, TableSchema, TableSelection } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
 /**
  * TableSchemaSearchResult interface. This is here temporarily until searching the tabe schema
@@ -145,9 +145,9 @@ export class DataExplorerClientInstance extends Disposable {
 		}));
 
 		// Register the onDidDataUpdate event handler.
-		this._register(this._positronDataExplorerComm.onDidDataUpdate(() => {
-			this._onDidDataUpdateEmitter.fire();
-		}));
+		this._register(this._positronDataExplorerComm.onDidDataUpdate(() =>
+			this._onDidDataUpdateEmitter.fire()
+		));
 	}
 
 	override dispose(): void {
@@ -203,41 +203,40 @@ export class DataExplorerClientInstance extends Disposable {
 
 		this._backendPromise = this.runBackendTask(
 			() => this._positronDataExplorerComm.getState(),
-			() => {
-				return {
-					display_name: 'disconnected',
-					table_shape: { num_rows: 0, num_columns: 0 },
-					table_unfiltered_shape: { num_rows: 0, num_columns: 0 },
-					has_row_labels: false,
-					column_filters: [],
-					row_filters: [],
-					sort_keys: [],
-					supported_features: {
-						search_schema: {
-							support_status: SupportStatus.Unsupported,
-							supported_types: []
-						},
-						set_column_filters: {
-							support_status: SupportStatus.Unsupported,
-							supported_types: []
-						},
-						set_row_filters: {
-							support_status: SupportStatus.Unsupported,
-							supports_conditions: SupportStatus.Unsupported,
-							supported_types: []
-						},
-						get_column_profiles: {
-							support_status: SupportStatus.Unsupported,
-							supported_types: []
-						},
-						set_sort_columns: { support_status: SupportStatus.Unsupported, },
-						export_data_selection: {
-							support_status: SupportStatus.Unsupported,
-							supported_formats: []
-						}
+			() => ({
+				display_name: 'disconnected',
+				table_shape: { num_rows: 0, num_columns: 0 },
+				table_unfiltered_shape: { num_rows: 0, num_columns: 0 },
+				has_row_labels: false,
+				column_filters: [],
+				row_filters: [],
+				sort_keys: [],
+				supported_features: {
+					search_schema: {
+						support_status: SupportStatus.Unsupported,
+						supported_types: []
+					},
+					set_column_filters: {
+						support_status: SupportStatus.Unsupported,
+						supported_types: []
+					},
+					set_row_filters: {
+						support_status: SupportStatus.Unsupported,
+						supports_conditions: SupportStatus.Unsupported,
+						supported_types: []
+					},
+					get_column_profiles: {
+						support_status: SupportStatus.Unsupported,
+						supported_types: []
+					},
+					set_sort_columns: { support_status: SupportStatus.Unsupported, },
+					export_data_selection: {
+						support_status: SupportStatus.Unsupported,
+						supported_formats: []
 					}
-				};
-			});
+				}
+			})
+		);
 
 		this.cachedBackendState = await this._backendPromise;
 		this._backendPromise = undefined;
@@ -257,9 +256,7 @@ export class DataExplorerClientInstance extends Disposable {
 	async getSchema(columnIndices: Array<number>): Promise<TableSchema> {
 		return this.runBackendTask(
 			() => this._positronDataExplorerComm.getSchema(columnIndices),
-			() => {
-				return { columns: [] };
-			}
+			() => ({ columns: [] })
 		);
 	}
 
@@ -300,30 +297,14 @@ export class DataExplorerClientInstance extends Disposable {
 	}
 
 	/**
-	 * Get a rectangle of data values.
-	 * @param rowStartIndex The first row to fetch (inclusive).
-	 * @param numRows The number of rows to fetch from start index. May extend beyond end of table.
-	 * @param columnIndices Indices to select, which can be a sequential, sparse, or random selection.
+	 * Request formatted values from table columns.
+	 * @param columns Array of column selections.
 	 * @returns A Promise<TableData> that resolves when the operation is complete.
 	 */
-	async getDataValues(
-		rowStartIndex: number,
-		numRows: number,
-		columnIndices: Array<number>
-	): Promise<TableData> {
+	async getDataValues(columns: Array<ColumnSelection>): Promise<TableData> {
 		return this.runBackendTask(
-			() => this._positronDataExplorerComm.getDataValues(
-				columnIndices.map((i) => {
-					return {
-						column_index: i,
-						spec: { first_index: rowStartIndex, last_index: rowStartIndex + numRows - 1 }
-					};
-				}),
-				this._dataFormatOptions
-			),
-			() => {
-				return { columns: [[]] };
-			}
+			() => this._positronDataExplorerComm.getDataValues(columns, this._dataFormatOptions),
+			() => ({ columns: [[]] })
 		);
 	}
 
@@ -339,9 +320,7 @@ export class DataExplorerClientInstance extends Disposable {
 			() => this._positronDataExplorerComm.getRowLabels(selection,
 				this._dataFormatOptions
 			),
-			() => {
-				return { row_labels: [[]] };
-			}
+			() => ({ row_labels: [[]] })
 		);
 	}
 
@@ -373,12 +352,10 @@ export class DataExplorerClientInstance extends Disposable {
 	async exportDataSelection(selection: TableSelection, format: ExportFormat): Promise<ExportedData> {
 		return this.runBackendTask(
 			() => this._positronDataExplorerComm.exportDataSelection(selection, format),
-			() => {
-				return {
-					data: '',
-					format
-				};
-			}
+			() => ({
+				data: '',
+				format
+			})
 		);
 	}
 
@@ -390,9 +367,7 @@ export class DataExplorerClientInstance extends Disposable {
 	async setRowFilters(filters: Array<RowFilter>): Promise<FilterResult> {
 		return this.runBackendTask(
 			() => this._positronDataExplorerComm.setRowFilters(filters),
-			() => {
-				return { selected_num_rows: 0 };
-			}
+			() => ({ selected_num_rows: 0 })
 		);
 	}
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -140,14 +140,21 @@ export class DataExplorerClientInstance extends Disposable {
 
 		// Register the onDidSchemaUpdate event handler.
 		this._register(this._positronDataExplorerComm.onDidSchemaUpdate(async (e: SchemaUpdateEvent) => {
+			// Refresh the cached backend state.
 			await this.updateBackendState();
+
+			// Fire the onDidSchemaUpdate event.
 			this._onDidSchemaUpdateEmitter.fire(e);
 		}));
 
 		// Register the onDidDataUpdate event handler.
-		this._register(this._positronDataExplorerComm.onDidDataUpdate(() =>
-			this._onDidDataUpdateEmitter.fire()
-		));
+		this._register(this._positronDataExplorerComm.onDidDataUpdate(async () => {
+			// Refresh the cached backend state.
+			await this.updateBackendState();
+
+			// Fire the onDidDataUpdate event.
+			this._onDidDataUpdateEmitter.fire();
+		}));
 	}
 
 	override dispose(): void {

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.css
@@ -6,7 +6,6 @@
 .data-grid-row-cell .content .text-container {
 	height: 100%;
 	display: flex;
-	margin: 0 7px;
 	align-items: center;
 }
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
@@ -11,7 +11,7 @@ import * as React from 'react';
 
 // Other dependencies.
 import { positronClassNames } from 'vs/base/common/positronUtilities';
-import { DataCell, DataCellKind } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
+import { DataCell, DataCellKind } from 'vs/workbench/services/positronDataExplorer/common/tableDataCache';
 import { PositronDataExplorerColumn } from 'vs/workbench/services/positronDataExplorer/browser/positronDataExplorerColumn';
 
 /**

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -13,7 +13,8 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { DataExplorerCache } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
+import { TableDataCache } from 'vs/workbench/services/positronDataExplorer/common/tableDataCache';
+import { TableSummaryCache } from 'vs/workbench/services/positronDataExplorer/common/tableSummaryCache';
 import { TableDataDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance';
 import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
 import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
@@ -35,9 +36,14 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	//#region Private Properties
 
 	/**
-	 * Gets the DataExplorerCache.
+	 * Gets the table summary cache.
 	 */
-	private readonly _dataExplorerCache: DataExplorerCache;
+	private readonly _tableSummaryCache: TableSummaryCache;
+
+	/**
+	 * Gets the table data cache.
+	 */
+	private readonly _tableDataCache: TableDataCache;
 
 	/**
 	 * Gets or sets the layout.
@@ -119,20 +125,21 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 		super();
 
 		// Initialize.
-		this._dataExplorerCache = new DataExplorerCache(this._dataExplorerClientInstance);
+		this._tableSummaryCache = new TableSummaryCache(this._dataExplorerClientInstance);
 		this._tableSchemaDataGridInstance = new TableSummaryDataGridInstance(
 			this._configurationService,
 			this._hoverService,
 			this._dataExplorerClientInstance,
-			this._dataExplorerCache
+			this._tableSummaryCache
 		);
+		this._tableDataCache = new TableDataCache(this._dataExplorerClientInstance);
 		this._tableDataDataGridInstance = new TableDataDataGridInstance(
 			this._commandService,
 			this._configurationService,
 			this._keybindingService,
 			this._layoutService,
 			this._dataExplorerClientInstance,
-			this._dataExplorerCache
+			this._tableDataCache
 		);
 
 		// Add the onDidClose event handler.
@@ -265,14 +272,14 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 			selectedClipboardCells = columns * rows;
 		} else if (clipboardData instanceof ClipboardColumnRange) {
 			const columns = clipboardData.lastColumnIndex - clipboardData.firstColumnIndex;
-			selectedClipboardCells = columns * this._dataExplorerCache.rows;
+			selectedClipboardCells = columns * this._tableDataCache.rows;
 		} else if (clipboardData instanceof ClipboardColumnIndexes) {
-			selectedClipboardCells = clipboardData.indexes.length * this._dataExplorerCache.rows;
+			selectedClipboardCells = clipboardData.indexes.length * this._tableDataCache.rows;
 		} else if (clipboardData instanceof ClipboardRowRange) {
 			const rows = clipboardData.lastRowIndex - clipboardData.firstRowIndex;
-			selectedClipboardCells = rows * this._dataExplorerCache.columns;
+			selectedClipboardCells = rows * this._tableDataCache.columns;
 		} else if (clipboardData instanceof ClipboardRowIndexes) {
-			selectedClipboardCells = clipboardData.indexes.length * this._dataExplorerCache.columns;
+			selectedClipboardCells = clipboardData.indexes.length * this._tableDataCache.columns;
 		} else {
 			// This indicates a bug.
 			selectedClipboardCells = 0;
@@ -310,7 +317,7 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	 * Copies the table data to the clipboard.
 	 */
 	async copyTableDataToClipboard(): Promise<void> {
-		this._clipboardService.writeText(await this._dataExplorerCache.getTableData());
+		this._clipboardService.writeText(await this._tableDataCache.getTableData());
 	}
 
 	/**

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -82,6 +82,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			defaultRowHeight: 24,
 			columnResize: true,
 			minimumColumnWidth: 20,
+			maximumColumnWidth: 400,
 			rowResize: false,
 			horizontalScrollbar: true,
 			verticalScrollbar: true,
@@ -170,7 +171,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		// If we have a user-defined column width, return it.
 		const userDefinedColumnWidth = this._userDefinedColumnWidths.get(columnIndex);
 		if (userDefinedColumnWidth !== undefined) {
-			return Math.min(userDefinedColumnWidth, 400);
+			return Math.min(userDefinedColumnWidth, this.maximumColumnWidth);
 		}
 
 		// Get the column header width and the column value width.
@@ -192,11 +193,11 @@ export class TableDataDataGridInstance extends DataGridInstance {
 
 		// If we have a column header width and / or a column value width, return the column width.
 		if (columnHeaderWidth && columnValueWidth) {
-			return Math.min(Math.max(columnHeaderWidth, columnValueWidth), 400);
+			return Math.min(Math.max(columnHeaderWidth, columnValueWidth), this.maximumColumnWidth);
 		} else if (columnHeaderWidth) {
-			return Math.min(columnHeaderWidth, 400);
+			return Math.min(columnHeaderWidth, this.maximumColumnWidth);
 		} else if (columnValueWidth) {
-			return Math.min(columnValueWidth, 400);
+			return Math.min(columnValueWidth, this.maximumColumnWidth);
 		}
 
 		// Return the default column width.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -121,7 +121,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 
 		// Add the data explorer client onDidUpdateBackendState event handler.
 		this._register(this._dataExplorerClientInstance.onDidUpdateBackendState(
-			async (state: BackendState) => {
+			(state: BackendState) => {
 				// Clear column sort keys.
 				this._columnSortKeys.clear();
 				state.sort_keys.forEach((key, sortIndex) => {

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -81,7 +81,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			defaultColumnWidth: 200,
 			defaultRowHeight: 24,
 			columnResize: true,
-			minimumColumnWidth: 100,
+			minimumColumnWidth: 20,
 			rowResize: false,
 			horizontalScrollbar: true,
 			verticalScrollbar: true,

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableDataDataGridInstance.tsx
@@ -14,7 +14,7 @@ import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IColumnSortKey } from 'vs/workbench/browser/positronDataGrid/interfaces/columnSortKey';
-import { DataExplorerCache } from 'vs/workbench/services/positronDataExplorer/common/dataExplorerCache';
+import { TableDataCache } from 'vs/workbench/services/positronDataExplorer/common/tableDataCache';
 import { TableDataCell } from 'vs/workbench/services/positronDataExplorer/browser/components/tableDataCell';
 import { AnchorPoint } from 'vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup';
 import { TableDataRowHeader } from 'vs/workbench/services/positronDataExplorer/browser/components/tableDataRowHeader';
@@ -54,8 +54,8 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * @param _configurationService The configuration service.
 	 * @param _keybindingService The keybinding service.
 	 * @param _layoutService The layout service.
-	 * @param _dataExplorerClientInstance The DataExplorerClientInstance.
-	 * @param _dataExplorerCache The DataExplorerCache.
+	 * @param _dataExplorerClientInstance The data explorer client instance.
+	 * @param _tableDataCache The table data cache.
 	 */
 	constructor(
 		private readonly _commandService: ICommandService,
@@ -63,7 +63,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		private readonly _keybindingService: IKeybindingService,
 		private readonly _layoutService: ILayoutService,
 		private readonly _dataExplorerClientInstance: DataExplorerClientInstance,
-		private readonly _dataExplorerCache: DataExplorerCache,
+		private readonly _tableDataCache: TableDataCache,
 	) {
 		// Call the base class's constructor.
 		super({
@@ -87,21 +87,21 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			cursorOffset: 0.5,
 		});
 
-		// Add the onDidUpdateCache event handler.
-		this._register(this._dataExplorerCache.onDidUpdateCache(() =>
+		// Add the table data cache onDidUpdate event handler.
+		this._register(this._tableDataCache.onDidUpdateCache(() =>
 			this._onDidUpdateEmitter.fire()
 		));
 
 		// Add the onDidSchemaUpdate event handler.
 		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(async e => {
-			this._dataExplorerCache.invalidateDataCache();
+			this._tableDataCache.invalidateDataCache();
 			this.softReset();
 			await this.fetchData();
 		}));
 
 		// Add the onDidDataUpdate event handler.
 		this._register(this._dataExplorerClientInstance.onDidDataUpdate(async () => {
-			this._dataExplorerCache.invalidateDataCache();
+			this._tableDataCache.invalidateDataCache();
 			await this.fetchData();
 		}));
 
@@ -128,14 +128,14 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 * Gets the number of columns.
 	 */
 	get columns() {
-		return this._dataExplorerCache.columns;
+		return this._tableDataCache.columns;
 	}
 
 	/**
 	 * Gets the number of rows.
 	 */
 	get rows() {
-		return this._dataExplorerCache.rows;
+		return this._tableDataCache.rows;
 	}
 
 	//#endregion DataGridInstance Properties
@@ -156,7 +156,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		)));
 
 		// Clear the data cache and fetch new data.
-		this._dataExplorerCache.invalidateDataCache();
+		this._tableDataCache.invalidateDataCache();
 		await this.fetchData();
 	}
 
@@ -166,7 +166,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	override async fetchData() {
 		// Update the cache.
-		await this._dataExplorerCache.updateCache({
+		await this._tableDataCache.updateCache({
 			firstColumnIndex: this.firstColumnIndex,
 			visibleColumns: this.screenColumns,
 			firstRowIndex: this.firstRowIndex,
@@ -181,7 +181,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	override column(columnIndex: number) {
 		// Get the column schema.
-		const columnSchema = this._dataExplorerCache.getColumnSchema(columnIndex);
+		const columnSchema = this._tableDataCache.getColumnSchema(columnIndex);
 		if (!columnSchema) {
 			return undefined;
 		}
@@ -197,7 +197,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 	 */
 	override rowHeader(rowIndex: number) {
 		return (
-			<TableDataRowHeader value={this._dataExplorerCache.getRowLabel(rowIndex)} />
+			<TableDataRowHeader value={this._tableDataCache.getRowLabel(rowIndex)} />
 		);
 	}
 
@@ -215,7 +215,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		}
 
 		// Get the data cell.
-		const dataCell = this._dataExplorerCache.getDataCell(columnIndex, rowIndex);
+		const dataCell = this._tableDataCache.getDataCell(columnIndex, rowIndex);
 		if (!dataCell) {
 			return undefined;
 		}
@@ -305,7 +305,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			label: addFilterTitle,
 			disabled: !filterSupported,
 			onSelected: () => {
-				const columnSchema = this._dataExplorerCache.getColumnSchema(columnIndex);
+				const columnSchema = this._tableDataCache.getColumnSchema(columnIndex);
 				if (columnSchema) {
 					this._onAddFilterEmitter.fire(columnSchema);
 				}
@@ -459,7 +459,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 			label: addFilterTitle,
 			disabled: !filterSupported,
 			onSelected: () => {
-				const columnSchema = this._dataExplorerCache.getColumnSchema(columnIndex);
+				const columnSchema = this._tableDataCache.getColumnSchema(columnIndex);
 				if (columnSchema) {
 					this._onAddFilterEmitter.fire(columnSchema);
 				}
@@ -581,7 +581,7 @@ export class TableDataDataGridInstance extends DataGridInstance {
 		await this._dataExplorerClientInstance.updateBackendState();
 
 		// Reload the data grid.
-		this._dataExplorerCache.invalidateDataCache();
+		this._tableDataCache.invalidateDataCache();
 		this.resetSelection();
 		this.setFirstRow(0, true);
 		this.setCursorRow(0);

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -72,7 +72,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(async () => {
 			// Update the cache with invalidation.
 			await this._tableSummaryCache.update({
-				invaidateCache: true,
+				invalidateCache: true,
 				firstColumnIndex: this.firstColumnIndex,
 				screenColumns: this.screenRows
 			});
@@ -119,7 +119,7 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 */
 	override async fetchData() {
 		await this._tableSummaryCache.update({
-			invaidateCache: false,
+			invalidateCache: false,
 			firstColumnIndex: this.firstRowIndex,
 			screenColumns: this.screenRows
 		});

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -71,21 +71,17 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		// Add the data explorer client instance onDidSchemaUpdate event handler.
 		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(async () => {
 			// Update the cache with invalidation.
-			this._tableSummaryCache.update({
+			await this._tableSummaryCache.update({
 				invaidateCache: true,
 				firstColumnIndex: this.firstColumnIndex,
-				screenColumns: this.screenColumns
+				screenColumns: this.screenRows
 			});
 		}));
 
 		// Add the data explorer client instance onDidDataUpdate event handler.
 		this._register(this._dataExplorerClientInstance.onDidDataUpdate(async () => {
-			// Update the cache with invalidation.
-			this._tableSummaryCache.update({
-				invaidateCache: true,
-				firstColumnIndex: this.firstColumnIndex,
-				screenColumns: this.screenColumns
-			});
+			// Refresh the column profiles because they rely on the data.
+			await this._tableSummaryCache.refreshColumnProfiles();
 		}));
 
 		// Add the table summary cache onDidUpdate event handler.

--- a/src/vs/workbench/services/positronDataExplorer/common/columnSchemaCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/columnSchemaCache.ts
@@ -58,11 +58,6 @@ export class ColumnSchemaCache extends Disposable {
 	private _columns = 0;
 
 	/**
-	 * Gets the data explorer client instance that this data explorer cache is caching data for.
-	 */
-	private readonly _dataExplorerClientInstance: DataExplorerClientInstance;
-
-	/**
 	 * Gets the column schema cache.
 	 */
 	private readonly _columnSchemaCache = new Map<number, ColumnSchema>();
@@ -78,14 +73,11 @@ export class ColumnSchemaCache extends Disposable {
 
 	/**
 	 * Constructor.
-	 * @param dataExplorerClientInstance The DataExplorerClientInstance.
+	 * @param _dataExplorerClientInstance The data explorer client instance.
 	 */
-	constructor(dataExplorerClientInstance: DataExplorerClientInstance) {
+	constructor(private readonly _dataExplorerClientInstance: DataExplorerClientInstance) {
 		// Call the base class's constructor.
 		super();
-
-		// Set the data explorer client instance.
-		this._dataExplorerClientInstance = dataExplorerClientInstance;
 
 		// Add the onDidSchemaUpdate event handler.
 		this._register(this._dataExplorerClientInstance.onDidSchemaUpdate(async () => {

--- a/src/vs/workbench/services/positronDataExplorer/common/tableDataCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableDataCache.ts
@@ -23,7 +23,7 @@ export enum InvalidateCacheFlags {
 	None = 0,
 	ColumnSchema = 1 << 0,
 	Data = 1 << 1,
-	All = ~(~0 << 2)
+	All = ColumnSchema | Data
 }
 
 /**

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -286,7 +286,7 @@ export class TableSummaryCache extends Disposable {
 			return this.update(pendingUpdateDescriptor);
 		}
 
-		// If the cache was not invalidated, set the trim cache timeout.
+		// Schedule trimming the cache.
 		if (!invalidateCache) {
 			// Set the trim cache timeout.
 			this._trimCacheTimeout = setTimeout(() => {

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -5,7 +5,7 @@
 
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
-import { arrayFromIndexRange } from 'vs/workbench/services/positronDataExplorer/common/utils';
+import { arrayFromIndexRange, asyncDelay } from 'vs/workbench/services/positronDataExplorer/common/utils';
 import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
 import { ColumnProfileRequest, ColumnProfileResult, ColumnProfileSpec, ColumnProfileType, ColumnSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
 
@@ -317,6 +317,9 @@ export class TableSummaryCache extends Disposable {
 
 		// Fire the onDidUpdate event. Will this cause a repaint?
 		this._onDidUpdateEmitter.fire();
+
+		// Delay a bit.
+		await asyncDelay(2000);
 
 		// Load the column profiles.
 		const columnProfiles = await this._dataExplorerClientInstance.getColumnProfiles(

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -303,6 +303,11 @@ export class TableSummaryCache extends Disposable {
 	 * Refreshes the column profile cache.
 	 */
 	async refreshColumnProfiles(): Promise<void> {
+		// Get the size of the data.
+		const tableState = await this._dataExplorerClientInstance.getBackendState();
+		this._columns = tableState.table_shape.num_columns;
+		this._rows = tableState.table_shape.num_rows;
+
 		// Get the sorted column indicies so we can build the column profile requests in order.
 		const columnIndices = [...this._columnProfileCache.keys()].sort((a, b) => a - b);
 

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -1,0 +1,305 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter } from 'vs/base/common/event';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { arrayFromIndexRange } from 'vs/workbench/services/positronDataExplorer/common/utils';
+import { DataExplorerClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient';
+import { ColumnProfileRequest, ColumnProfileResult, ColumnProfileSpec, ColumnProfileType, ColumnSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+
+/**
+ * Constants.
+ */
+const OVERSCAN_FACTOR = 3;
+
+/**
+ * UpdateDescriptor interface.
+ */
+interface UpdateDescriptor {
+	invaidateCache: boolean;
+	firstColumnIndex: number;
+	screenColumns: number;
+}
+
+/**
+ * TableSummaryCache class.
+ */
+export class TableSummaryCache extends Disposable {
+	//#region Private Properties
+
+	/**
+	 * Gets or sets a value which indicates whether an update is in progress.
+	 */
+	private _updating = false;
+
+	/**
+	 * Gets or sets the pending update descriptor.
+	 */
+	private _pendingUpdateDescriptor?: UpdateDescriptor;
+
+	/**
+	 * Gets or sets the columns.
+	 */
+	private _columns = 0;
+
+	/**
+	 * Gets or sets the rows.
+	 */
+	private _rows = 0;
+
+	/**
+	 * Gets the expanded columns set.
+	 */
+	private readonly _expandedColumns = new Set<number>();
+
+	/**
+	 * Gets the column schema cache.
+	 */
+	private readonly _columnSchemaCache = new Map<number, ColumnSchema>();
+
+	/**
+	 * Gets the column profile.
+	 */
+	private readonly _columnProfileCache = new Map<number, ColumnProfileResult>();
+
+	/**
+	 * The onDidUpdate event emitter.
+	 */
+	protected readonly _onDidUpdateEmitter = this._register(new Emitter<void>);
+
+	//#endregion Private Properties
+
+	//#region Constructor & Dispose
+
+	/**
+	 * Constructor.
+	 * @param _dataExplorerClientInstance The data explorer client instance.
+	 */
+	constructor(private readonly _dataExplorerClientInstance: DataExplorerClientInstance) {
+		// Call the base class's constructor.
+		super();
+	}
+
+	//#endregion Constructor & Dispose
+
+	//#region Public Properties
+
+	/**
+	 * Gets the columns.
+	 */
+	get columns() {
+		return this._columns;
+	}
+
+	/**
+	 * Gets the rows.
+	 */
+	get rows() {
+		return this._rows;
+	}
+
+	//#endregion Public Properties
+
+	//#region Public Events
+
+	/**
+	 * onDidUpdate event.
+	 */
+	readonly onDidUpdate = this._onDidUpdateEmitter.event;
+
+	//#endregion Public Events
+
+	//#region Public Methods
+
+	/**
+	 * Returns a value which indicates whether the specified column index is expanded.
+	 * @param columnIndex The columm index.
+	 * @returns A value which indicates whether the specified column index is expanded.
+	 */
+	isColumnExpanded(columnIndex: number) {
+		return this._expandedColumns.has(columnIndex);
+	}
+
+	/**
+	 * Toggles the expanded state of the specified column index.
+	 * @param columnIndex The columm index.
+	 */
+	async toggleExpandColumn(columnIndex: number) {
+		// If the column is expanded, collpase it, fire the onDidUpdate event, and return.
+		if (this._expandedColumns.has(columnIndex)) {
+			this._expandedColumns.delete(columnIndex);
+			this._onDidUpdateEmitter.fire();
+			return;
+		}
+
+		// Expand the column.
+		this._expandedColumns.add(columnIndex);
+
+		// If we already have summary stats for the column, fire the onDidUpdate event and return.
+		if (this._columnProfileCache.get(columnIndex)?.summary_stats) {
+			this._onDidUpdateEmitter.fire();
+			return;
+		}
+
+		// Get the summary stats for the newly expanded column.
+		const columnProfileResults = await this._dataExplorerClientInstance.getColumnProfiles([({
+			column_index: columnIndex,
+			profiles: [{ profile_type: ColumnProfileType.SummaryStats }]
+		})]);
+
+		// Update the column profile.
+		if (columnProfileResults.length === 1) {
+			const columnProfile = this._columnProfileCache.get(columnIndex);
+			if (columnProfile) {
+				columnProfile.summary_stats = columnProfileResults[0].summary_stats;
+				this._onDidUpdateEmitter.fire();
+			}
+		}
+	}
+
+	/**
+	 * Updates the cache.
+	 * @param updateDescriptor The update descriptor.
+	 */
+	async update(updateDescriptor: UpdateDescriptor): Promise<void> {
+		// Update the cache.
+		await this.doUpdate(updateDescriptor);
+
+		// Fire the onDidUpdate event.
+		this._onDidUpdateEmitter.fire();
+	}
+
+	/**
+	 * Gets the column schema for the specified column index.
+	 * @param columnIndex The column index.
+	 * @returns The column schema for the specified column index.
+	 */
+	getColumnSchema(columnIndex: number) {
+		return this._columnSchemaCache.get(columnIndex);
+	}
+
+	/**
+	 * Gets the column profile for the specified column index.
+	 * @param columnIndex The column index.
+	 * @returns The column profile for the specified column index.
+	 */
+	getColumnProfile(columnIndex: number) {
+		return this._columnProfileCache.get(columnIndex);
+	}
+
+	//#endregion Public Methods
+
+	//#region Private Methods
+
+	/**
+	 * Updates the cache.
+	 * @param updateDescriptor The update descriptor.
+	 */
+	private async doUpdate(updateDescriptor: UpdateDescriptor): Promise<void> {
+		// If a cache update is already in progress, set the pending update descriptor and return.
+		// This allows cache updates that are happening in rapid succession to overwrite one another
+		// so that only the last one gets processed. (For example, this happens when a user drags a
+		// scrollbar rapidly.)
+		if (this._updating) {
+			this._pendingUpdateDescriptor = updateDescriptor;
+			return;
+		}
+
+		// Set the updating flag.
+		this._updating = true;
+
+		// Destructure the update descriptor.
+		const {
+			invaidateCache,
+			firstColumnIndex,
+			screenColumns
+		} = updateDescriptor;
+
+		// Get the size of the data.
+		const tableState = await this._dataExplorerClientInstance.getBackendState();
+		this._columns = tableState.table_shape.num_columns;
+		this._rows = tableState.table_shape.num_rows;
+
+		// Set the start column index and the end column index of the columns to cache.
+		const overscanColumns = screenColumns * OVERSCAN_FACTOR;
+		const startColumnIndex = Math.max(
+			0,
+			firstColumnIndex - overscanColumns
+		);
+		const endColumnIndex = Math.min(
+			this._columns - 1,
+			firstColumnIndex + screenColumns + overscanColumns
+		);
+
+		// Set the column indices to cache.
+		let columnIndices: number[];
+		if (invaidateCache) {
+			columnIndices = arrayFromIndexRange(startColumnIndex, endColumnIndex);
+		} else {
+			columnIndices = [];
+			for (let columnIndex = startColumnIndex; columnIndex <= endColumnIndex; columnIndex++) {
+				if (!this._columnSchemaCache.has(columnIndex)) {
+					columnIndices.push(columnIndex);
+				}
+			}
+		}
+
+		// Load the table schema for the column indices to cache.
+		const tableSchema = await this._dataExplorerClientInstance.getSchema(columnIndices);
+
+		// Clear the cache, if we're supposed to.
+		if (invaidateCache) {
+			this._columnSchemaCache.clear();
+			this._columnProfileCache.clear();
+		}
+
+		// Cache the table schema that was returned.
+		for (let i = 0; i < tableSchema.columns.length; i++) {
+			this._columnSchemaCache.set(columnIndices[i], tableSchema.columns[i]);
+		}
+
+		// Fire the onDidUpdate event. Will this cause a repaint?
+		this._onDidUpdateEmitter.fire();
+
+		// Load the column profiles.
+		const columnProfiles = await this._dataExplorerClientInstance.getColumnProfiles(
+			columnIndices.map((column_index): ColumnProfileRequest => {
+				// Build the array of column profiles to load.
+				const profiles: ColumnProfileSpec[] = [
+					{ profile_type: ColumnProfileType.NullCount }
+				];
+				if (this._expandedColumns.has(column_index)) {
+					profiles.push({ profile_type: ColumnProfileType.SummaryStats });
+				}
+
+				// Return the
+				return { column_index, profiles };
+			})
+		);
+
+		// Cache the column profiles that were returned.
+		for (let i = 0; i < columnProfiles.length; i++) {
+			this._columnProfileCache.set(columnIndices[i], columnProfiles[i]);
+		}
+
+		// Fire the onDidUpdate event.
+		this._onDidUpdateEmitter.fire();
+
+		// Clear the updating flag.
+		this._updating = false;
+
+		// If there is a pending update descriptor, update the cache for it.
+		if (this._pendingUpdateDescriptor) {
+			// Get the pending update descriptor and clear it.
+			const pendingUpdateDescriptor = this._pendingUpdateDescriptor;
+			this._pendingUpdateDescriptor = undefined;
+
+			// Update the cache for the pending update descriptor.
+			await this.update(pendingUpdateDescriptor);
+		}
+	}
+
+	//#endregion Private Methods
+}

--- a/src/vs/workbench/services/positronDataExplorer/common/utils.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/utils.ts
@@ -11,3 +11,12 @@
  */
 export const arrayFromIndexRange = (startIndex: number, endIndex: number) =>
 	Array.from({ length: endIndex - startIndex + 1 }, (_, i) => startIndex + i);
+
+/**
+ * Asychronously delays execution.
+ * @param ms The number of milliseconds to delay.
+ * @returns A Promise<void> that resolves when the delay is complete.
+ */
+export const asyncDelay = (ms: number) => {
+	return new Promise(resolve => setTimeout(resolve, ms));
+};


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR addresses https://github.com/posit-dev/positron/issues/2527 by adding reactive column widths to the Data Explorer.

In reality, it is an epic PR in which the Data Explorer caching layer was completely rewritten and optimized.

Here is a screen shot of reactive column widths in Data Explorer:

<img width="1530" alt="image" src="https://github.com/user-attachments/assets/dc2ea7ff-1c93-46e9-8af0-ceb53abd76b7">

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
