### PR TITLE
Bump quarto version

### DIFF
--- a/product.json
+++ b/product.json
@@ -208,7 +208,7 @@
 		},
 		{
 			"name": "quarto.quarto",
-			"version": "1.113.0",
+			"version": "1.114.0",
 			"repo": "https://github.com/quarto-dev/quarto/tree/main/apps/vscode",
 			"metadata": {
 				"id": "a1be81fc-0f3a-4f2e-92ee-3fdc7ab96c73",


### PR DESCRIPTION
Bumps the Quarto version to 1.114.0. This version addresses a significant issue in Markdown and also includes a change that allows the Quarto extension to find Positron's bundled version of Quarto.