### PR TITLE
Change to testrail service account

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Upload Test Results to TestRail
         id: testrail-upload
         if: always()
-        run: trcli --host "https://posit.testrail.io/" --project Positron --username jon.vanausdeln@posit.co --key ${{ secrets.TESTRAIL_API_KEY}} parse_junit --file ".build/logs/smoke-tests-electron/test-results/results.xml" --case-matcher name --title "$TESTRAIL_TITLE" --close-run
+        run: trcli --host "https://posit.testrail.io/" --project Positron --username testrailautomation@posit.co --key ${{ secrets.TESTRAIL_API_KEY}} parse_junit --file ".build/logs/smoke-tests-electron/test-results/results.xml" --case-matcher name --title "$TESTRAIL_TITLE" --close-run
 
       - name: Upload run artifacts
         if: always()


### PR DESCRIPTION
Switching the TestRail results upload to use the new service account instead of my own credentials

### QA Notes
We will also need to update the secret in the repo
