### PR TITLE
Fix positron-ipywidgets build

### DIFF
--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -434,7 +434,7 @@ const esbuildMediaScripts = [
     'ipynb/esbuild.js',
     'simple-browser/esbuild-preview.js',
     // --- Start Positron ---
-    'positron-ipywidgets/esbuild-renderer.js',
+    'positron-ipywidgets/renderer/esbuild.js',
     // --- End Positron ---
 ];
 async function webpackExtensions(taskName, isWatch, webpackConfigLocations) {

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -513,7 +513,7 @@ const esbuildMediaScripts = [
 	'ipynb/esbuild.js',
 	'simple-browser/esbuild-preview.js',
 	// --- Start Positron ---
-	'positron-ipywidgets/esbuild-renderer.js',
+	'positron-ipywidgets/renderer/esbuild.js',
 	// --- End Positron ---
 ];
 

--- a/extensions/positron-ipywidgets/renderer/esbuild.js
+++ b/extensions/positron-ipywidgets/renderer/esbuild.js
@@ -6,10 +6,10 @@
 // @ts-check
 const path = require('path');
 
-const srcDir = path.join(__dirname, 'renderer/src');
-const outDir = path.join(__dirname, 'renderer/media');
+const srcDir = path.join(__dirname, 'src');
+const outDir = path.join(__dirname, 'media');
 
-require('../esbuild-webview-common').run({
+require('../../esbuild-webview-common').run({
 	entryPoints: [
 		path.join(srcDir, 'index.ts'),
 	],


### PR DESCRIPTION
Second attempt to fix the positron-ipywidgets build following #4211.

The base esbuild script was only using the `path.basename` of the output directory, so it was building to `positron-ipywidgets/media` instead of `positron-ipywidgets/renderer/media`:

https://github.com/posit-dev/positron/blob/5053aa2682f6e2b95ea5aa33093acdcacd057298/extensions/esbuild-webview-common.js#L70

This PR attempts to fix it by moving the renderer's esbuild script into the `renderer` folder, where I think it belongs anyway.

I'm building locally to double-check that this worked.