### PR TITLE
Only slack full smoke test failures

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -148,7 +148,7 @@ jobs:
           path: .build/logs/smoke-tests-electron/
 
       - name: slack-smoke-test-report
-        if: always()
+        if: failure()
         uses: testlabauto/xunit-slack-reporter@v2.0.1
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel

--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -115,7 +115,7 @@ jobs:
           path: .build/logs/smoke-tests-electron/
 
       - name: slack-smoke-test-report
-        if: failure()
+        if: ${{ failure() && inputs.smoketest_target == 'smoketest-merge-to-main' }}
         uses: testlabauto/xunit-slack-reporter@v2.0.1
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel


### PR DESCRIPTION
Simply changing github action settings to only slack smoke test failures (not passing runs)

### QA Notes

Smoke test failures should be reported to slack.
