### PR TITLE
RMD preview smoke test

### DIFF
--- a/test/automation/src/positron/positronViewer.ts
+++ b/test/automation/src/positron/positronViewer.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Locator } from '@playwright/test';
+import { FrameLocator, Locator } from '@playwright/test';
 import { Code } from '../code';
 
 const OUTER_FRAME = '.webview';
@@ -19,6 +19,13 @@ export class PositronViewer {
 		const innerFrame = outerFrame.frameLocator(INNER_FRAME);
 		const element = innerFrame.locator(sublocator);
 		return element;
+	}
+
+	getViewerFrame(frameLocator: string): FrameLocator {
+		const outerFrame = this.code.driver.getFrame(OUTER_FRAME);
+		const innerFrame = outerFrame.frameLocator(INNER_FRAME);
+		const frame = innerFrame.frameLocator(frameLocator);
+		return frame;
 	}
 
 	async refreshViewer() {

--- a/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
+++ b/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
@@ -40,6 +40,7 @@ export function setup(logger: Logger) {
 
 		});
 
+		// test depends on the previous test
 		it('Preview RMarkdown [C709147]', async function () {
 			const app = this.app as Application; //Get handle to application
 

--- a/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
+++ b/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
@@ -40,6 +40,25 @@ export function setup(logger: Logger) {
 
 		});
 
+		it('Preview RMarkdown [C709147]', async function () {
+			const app = this.app as Application; //Get handle to application
 
+			// Preview
+			await app.code.dispatchKeybinding(process.platform === 'darwin' ? 'cmd+shift+k' : 'ctrl+shift+k');
+
+			// inner most frame has no useful identifying features
+			// not factoring this locator because its not part of positron
+			const viewerFrame = app.workbench.positronViewer.getViewerFrame('//iframe');
+
+			// not factoring this locator because its not part of positron
+			const gettingStarted = viewerFrame.locator('h2[data-anchor-id="getting-started"]');
+
+			const gettingStartedText = await gettingStarted.innerText();
+
+			expect(gettingStartedText).toBe('Getting started');
+
+			await app.workbench.positronTerminal.sendKeysToTerminal('Control+C');
+
+		});
 	});
 }


### PR DESCRIPTION
Simple RMD preview test to follow on after RMD render test.

- Starts preview with Command/Control - Shift - K
- Verifies preview by awaiting text three frames deep in the Viewer
- Stops preview at end of test case

### QA Notes

All smoke tests should pass
