### PR TITLE
Data Explorer: Add size limit for object dtype type inference for pandas

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -1033,6 +1033,22 @@ def _safe_stringify(x, max_length: int):
 # is small
 PANDAS_CACHE_CELLS_THRESHOLD = 10_000_000
 
+# For long data frames, inferring an exact data type for dtype=object
+# columns can significantly slow down get_schema requests. We make a
+# trade-off between being exhaustive and returning an exactly correct
+# result even in the most esoteric cases (e.g. consider a column of 10
+# million null values except for a string in the last entry). In the
+# event that we can't make a judgment after the limit here, we risk
+# being wrong in these exceptional cases, but in the interest of much
+# better performance in the > 99% of cases where the type can be
+# inferred accurately by looking at this number of cells.
+#
+# This 1 million cell limit means that we are willing to spend in the
+# ballpark of 10ms for each object column to determine an accurate
+# data type. Depending on feedback we can further reduce this to
+# improve performance if needed.
+PANDAS_INFER_DTYPE_SIZE_LIMIT = 1_000_000
+
 
 class PandasView(DataExplorerTableView):
     TYPE_NAME_MAPPING = {"boolean": "bool"}
@@ -1222,6 +1238,9 @@ class PandasView(DataExplorerTableView):
     def _get_inferred_dtype(cls, column, column_index: int, state: DataExplorerState):
         from pandas.api.types import infer_dtype
 
+        if len(column) > PANDAS_INFER_DTYPE_SIZE_LIMIT:
+            column = column.iloc[:PANDAS_INFER_DTYPE_SIZE_LIMIT]
+
         if column_index not in state.inferred_dtypes:
             state.inferred_dtypes[column_index] = infer_dtype(column)
         return state.inferred_dtypes[column_index]
@@ -1233,8 +1252,6 @@ class PandasView(DataExplorerTableView):
         # schema changes
         dtype = column.dtype
 
-        # TODO: pandas MultiIndex columns
-        # TODO: time zone for datetimetz datetime64[ns] types
         if dtype == object:  # noqa: E721
             type_name = cls._get_inferred_dtype(column, column_index, state)
             type_name = cls.TYPE_NAME_MAPPING.get(type_name, type_name)
@@ -1277,6 +1294,7 @@ class PandasView(DataExplorerTableView):
         "time": "time",
         "bytes": "string",
         "string": "string",
+        "empty": "unknown",
     }
 
     TYPE_MAPPERS = [_pandas_datetimetz_mapper]

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -30,6 +30,7 @@ from ..data_explorer import (
     _VALUE_NONE,
     _VALUE_NULL,
     COMPARE_OPS,
+    PANDAS_INFER_DTYPE_SIZE_LIMIT,
     SCHEMA_CACHE_THRESHOLD,
     DataExplorerService,
     DataExplorerState,
@@ -666,6 +667,7 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
             "number",
         ),
         ([1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, 5 + 5j], "complex128", "number"),
+        ([None] * 5, "empty", "unknown"),
     ]
 
     if hasattr(np, "complex256"):
@@ -722,6 +724,23 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
 
     result = dxf.get_schema(bigger_name, list(range(10, 20)))
     assert result == _wrap_json(ColumnSchema, bigger_schema[10:20])
+
+
+def test_pandas_get_schema_inference_limit(dxf: DataExplorerFixture):
+    arr = np.array([None] * PANDAS_INFER_DTYPE_SIZE_LIMIT + ["string"])
+    df = pd.DataFrame({"c0": arr})
+
+    assert dxf.get_schema_for(df) == _wrap_json(
+        ColumnSchema,
+        [
+            {
+                "column_name": "c0",
+                "column_index": 0,
+                "type_name": "empty",
+                "type_display": "unknown",
+            }
+        ],
+    )
 
 
 def test_pandas_series(dxf: DataExplorerFixture):


### PR DESCRIPTION
This is a performance optimization for large data frames where we have been using `pandas.api.types.infer_dtype` to exhaustively determine a data type for `object` dtype columns, but for very large data frames, this can result in a large delay in calls to `get_schema`. This puts in a cap at 1 million elements for doing this type inference, beyond which (if inconclusive -- e.g. all null values) we will show "unknown" in the UI. But these scenarios will be pretty infrequent, so I think it's a reasonable tradeoff to improve the > 99% of scenarios where the type can be well-determined by looking at this many data elements. 