### PR TITLE
Fix merge to main slack fail reporting - smoke test

### DIFF
--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -115,7 +115,7 @@ jobs:
           path: .build/logs/smoke-tests-electron/
 
       - name: slack-smoke-test-report
-        if: ${{ failure() && inputs.smoketest_target == 'smoketest-merge-to-main' }}
+        if: ${{ failure() && env.SMOKETEST_TARGET == 'smoketest-merge-to-main' }}
         uses: testlabauto/xunit-slack-reporter@v2.0.1
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel


### PR DESCRIPTION
Previous approach using "input" did not work.  Changing to use "env"

### QA Notes

Merge to main failures should report to slack 
