### PR TITLE
Skip smoke test cases needing work

### DIFF
--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -240,7 +240,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 			/**
 			 * Data Explorer 100x100 - R - Smoke Test.
 			 */
-			it('Data Explorer 100x100 - R - Smoke Test [C674521]', async function () {
+			it.skip('Data Explorer 100x100 - R - Smoke Test [C674521]', async function () {
 				// Get the app.
 				const app = this.app as Application;
 

--- a/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
+++ b/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
@@ -41,7 +41,8 @@ export function setup(logger: Logger) {
 		});
 
 		// test depends on the previous test
-		it('Preview RMarkdown [C709147]', async function () {
+		// skipping this test for now.  need to determine what to do about the dialog that is appearing in CI
+		it.skip('Preview RMarkdown [C709147]', async function () {
 			const app = this.app as Application; //Get handle to application
 
 			// Preview


### PR DESCRIPTION
Skipping two test cases that need work:
1) R 100x100 Data Explorer test - probably need a new r-100x100-linux.tsv from @softwarenerd 
2) RMD preview test - looks like there is a quarto dialog being blocked that the test is not prepared to handle anyways.  Need to determine how to proceed by chatting with @jmcphers 

### QA Notes

Remaining cases all pass
