### PR TITLE
Add missing `dependencies` entry for `which`, which was causing the wrong version of `which` to be used, which caused R not to load on some configurations of Windows 

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -598,8 +598,8 @@
     "split2": "^4.2.0",
     "vscode-languageclient": "^9.0.1",
     "web-tree-sitter": "^0.20.8",
-    "winreg": "^1.2.5",
-    "which": "^3.0.0"
+    "which": "^3.0.0",
+    "winreg": "^1.2.5"
   },
   "repository": {
     "type": "git",

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -598,7 +598,8 @@
     "split2": "^4.2.0",
     "vscode-languageclient": "^9.0.1",
     "web-tree-sitter": "^0.20.8",
-    "winreg": "^1.2.5"
+    "winreg": "^1.2.5",
+    "which": "^3.0.0"
   },
   "repository": {
     "type": "git",

--- a/extensions/positron-r/yarn.lock
+++ b/extensions/positron-r/yarn.lock
@@ -2315,6 +2315,13 @@ which@2.0.2, which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
+which@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-3.0.1.tgz#89f1cd0c23f629a8105ffe69b8172791c87b4be1"
+  integrity sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==
+  dependencies:
+    isexe "^2.0.0"
+
 winreg@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/winreg/-/winreg-1.2.5.tgz#b650383e89278952494b5d113ba049a5a4fa96d8"


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR addresses https://github.com/posit-dev/positron/issues/4280.

This issue was tracked down to the fact that the `positron-r` extension did not have an explicit `dependencies` entry for the `which` package, but it did have a `devDependencies` entry for `@types/which` (`"@types/which": "^3.0.0",`). 

As a result of this, the `positron-r/node_modules` folder contained `which` 2.0.2 (I believe) from:

```
mocha@^9.2.1:
  version "9.2.2"
  resolved "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz"
  integrity sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==
  dependencies:
    "@ungap/promise-all-settled" "1.1.2"
    ansi-colors "4.1.1"
    browser-stdout "1.3.1"
    chokidar "3.5.3"
    debug "4.3.3"
    diff "5.0.0"
    escape-string-regexp "4.0.0"
    find-up "5.0.0"
    glob "7.2.0"
    growl "1.10.5"
    he "1.2.0"
    js-yaml "4.1.0"
    log-symbols "4.1.0"
    minimatch "4.2.1"
    ms "2.1.3"
    nanoid "3.3.1"
    serialize-javascript "6.0.0"
    strip-json-comments "3.1.1"
    supports-color "8.1.1"
    which "2.0.2"
    workerpool "6.2.0"
    yargs "16.2.0"
    yargs-parser "20.2.4"
    yargs-unparser "2.0.0"
```

This version of `which` does not support the `nothrow` option for `async which`, which we rely on in this code fragment from `extensions/positron-r/src/provider.ts`:

```
	const whichR = await which('R', { nothrow: true }) as string;
```

Because of this, on some configurations of Windows, an error was being thrown which caused R not to load.

For background on this, see: https://github.com/npm/node-which/issues/80. This was the exact same problem. 

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
