### PR TITLE
Fixes the Data Explorer 100x100 smoke test so that numbers are considered to be equal if they are within ±0.05 of one another

### DIFF
--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -21,7 +21,6 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 		// Shared before/after handling.
 		installAllHandlers(logger);
 
-
 		/**
 		 * Tests the data explorer.
 		 * @param app The application.
@@ -91,8 +90,20 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 					// Get the cell.
 					const cell = await app.code.waitForElement(`#data-grid-row-cell-content-${columnIndex}-${rowIndex} .text-container .text-value`);
 
-					// Test the cell.
-					expect(cell.textContent, `${rowIndex},${columnIndex}`).toStrictEqual(row[columnIndex]);
+					// Get the cell value and test value.
+					const secsRemover = (value: string) => value.replace(/^(.*)( secs)$/, '$1');
+					const cellValue = secsRemover(cell.textContent);
+					const testValue = secsRemover(row[columnIndex]);
+
+					// If the test value is a number, perform a numerical "close enough" comparison;
+					// otherwise, perform a strict equal comparison.
+					if (testValue.match(/^-?\d*\.?\d*$/)) {
+						expect(
+							Math.abs(Number.parseFloat(cellValue) - Number.parseFloat(testValue))
+						).toBeLessThan(0.05);
+					} else {
+						expect(cell.textContent, `${rowIndex},${columnIndex}`).toStrictEqual(row[columnIndex]);
+					}
 
 					// Move to the next cell.
 					await app.workbench.positronDataExplorer.arrowRight();
@@ -219,7 +230,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 		/**
 		 * Data Explorer 100x100 - R.
 		 */
-		describe.skip('Data Explorer 100x100 - R', function () {
+		describe('Data Explorer 100x100 - R', function () {
 			/**
 			 * Before hook.
 			 */

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -270,7 +270,7 @@ export function setupDataExplorer100x100Test(logger: Logger) {
 						app.workspacePathOrFolder,
 						'data-files',
 						'100x100',
-						process.platform === 'linux' ? 'r-100x100-linux.tsv' : 'r-100x100.tsv'
+						'r-100x100.tsv'
 					)
 				);
 			});


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR fixes the "Data Explorer 100x100" smoke test such that numbers are considered to be equal if they are within ±0.05 of one another. 

This work was necessitated by the fact that Python and R language runtimes will generate slightly different output on different platforms and configurations.

### QA Notes

The `qa-example-content/data-files/100x100/r-100x100-linux.tsv` file is no longer needed and will be removed from the `qa-example-content` repo once this PR is merged.