### PR TITLE
Fix layout of ColumnSummaryCell to stop the ColumnNullPercent component from being pushed out of view to the right

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
@@ -44,6 +44,7 @@
 .basic-info {
 	display: grid;
 	align-items: center;
+	white-space: nowrap;
 	grid-row: basic-info / profile-info;
 	grid-template-columns: [left-gutter] 4px [expand-collapse] 25px [icon] 25px [title] 1fr [missing-values] min-content [right-gutter] 12px [end];
 }
@@ -107,10 +108,10 @@
 .column-summary
 .basic-info
 .column-name {
-	display: flex;
+	overflow: hidden;
 	font-weight: 600;
-	align-items: center;
-	justify-content: left;
+	margin-right: 4px;
+	text-overflow: ellipsis;
 	grid-column: title / missing-values;
 }
 


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR addresses https://github.com/posit-dev/positron/issues/4301 by adjusting the layout of the `column-name` element in the `ColumnSummaryCell` component so that it no longer pushes the `ColumnNullPercent` component out of view to the right when the column name is too long.

Before:

![image](https://github.com/user-attachments/assets/dec8937e-98c6-4102-99a0-30d26cf2e2a8)

After:

![image](https://github.com/user-attachments/assets/0155795a-9322-4ca0-90dc-3c852f47c07d)

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
