### PR TITLE
Data Explorer: Use concurrent.futures background job queue to return get_column_profiles results asynchronously

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -2631,8 +2631,6 @@ class DataExplorerService:
         if comm_id is None:
             comm_id = guid()
 
-        self.table_views[comm_id] = _get_table_view(table, DataExplorerState(title))
-
         base_comm = comm.create_comm(
             target_name=self.comm_target,
             comm_id=comm_id,
@@ -2651,7 +2649,7 @@ class DataExplorerService:
         wrapped_comm.on_msg(self.handle_msg, DataExplorerBackendMessageContent)
 
         self.table_views[comm_id] = _get_table_view(
-            table, wrapped_comm, DataExplorerState(full_title), self.job_queue
+            table, wrapped_comm, DataExplorerState(title), self.job_queue
         )
 
         if variable_path is not None:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -1163,7 +1163,7 @@ class DataExplorerBackendRequest(str, enum.Enum):
     # Set or clear sort-by-column(s)
     SetSortColumns = "set_sort_columns"
 
-    # Request a batch of column profiles
+    # Async request a batch of column profiles
     GetColumnProfiles = "get_column_profiles"
 
     # Get the state
@@ -1430,8 +1430,13 @@ class SetSortColumnsRequest(BaseModel):
 
 class GetColumnProfilesParams(BaseModel):
     """
-    Requests a statistical summary or data profile for batch of columns
+    Async request for a statistical summary or data profile for batch of
+    columns
     """
+
+    callback_id: StrictStr = Field(
+        description="Async callback unique identifier",
+    )
 
     profiles: List[ColumnProfileRequest] = Field(
         description="Array of requested profiles",
@@ -1444,7 +1449,8 @@ class GetColumnProfilesParams(BaseModel):
 
 class GetColumnProfilesRequest(BaseModel):
     """
-    Requests a statistical summary or data profile for batch of columns
+    Async request for a statistical summary or data profile for batch of
+    columns
     """
 
     params: GetColumnProfilesParams = Field(
@@ -1504,6 +1510,23 @@ class DataExplorerFrontendEvent(str, enum.Enum):
 
     # Clear cache and request fresh data
     DataUpdate = "data_update"
+
+    # Return async result of get_column_profiles request
+    ReturnColumnProfiles = "return_column_profiles"
+
+
+class ReturnColumnProfilesParams(BaseModel):
+    """
+    Return async result of get_column_profiles request
+    """
+
+    callback_id: StrictStr = Field(
+        description="Async callback unique identifier",
+    )
+
+    profiles: List[ColumnProfileResult] = Field(
+        description="Array of individual column profile results",
+    )
 
 
 SearchSchemaResult.update_forward_refs()
@@ -1639,3 +1662,5 @@ GetColumnProfilesParams.update_forward_refs()
 GetColumnProfilesRequest.update_forward_refs()
 
 GetStateRequest.update_forward_refs()
+
+ReturnColumnProfilesParams.update_forward_refs()

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -295,13 +295,14 @@ def test_register_table_with_variable_path(de_service: DataExplorerService):
     assert table_view.state.name == title
 
 
-def test_shutdown(de_service: DataExplorerService):
+def test_shutdown(de_service: DataExplorerService, event_loop):
     df = pd.DataFrame({"a": [1, 2, 3, 4, 5]})
     de_service.register_table(df, "t1", comm_id=guid())
     de_service.register_table(df, "t2", comm_id=guid())
     de_service.register_table(df, "t3", comm_id=guid())
 
     de_service.shutdown()
+
     assert len(de_service.comms) == 0
     assert len(de_service.table_views) == 0
 
@@ -370,11 +371,13 @@ class DataExplorerFixture:
         self.register_table(comm_id, df)
         return self.get_schema(comm_id)
 
-    def do_json_rpc(self, table_name, method, **params):
+    def _get_comm_id(self, table_name):
         paths = self.de_service.get_paths_for_variable(table_name)
         assert len(paths) == 1
+        return list(self.de_service.path_to_comm_ids[paths[0]])[0]
 
-        comm_id = list(self.de_service.path_to_comm_ids[paths[0]])[0]
+    def do_json_rpc(self, table_name, method, **params):
+        comm_id = self._get_comm_id(table_name)
 
         request = json_rpc_request(
             method,
@@ -439,12 +442,19 @@ class DataExplorerFixture:
         return self.do_json_rpc(table_name, "set_sort_columns", sort_keys=sort_keys)
 
     def get_column_profiles(self, table_name, profiles, format_options=DEFAULT_FORMAT):
-        return self.do_json_rpc(
+        callback_id = guid()
+        result = self.do_json_rpc(
             table_name,
             "get_column_profiles",
+            callback_id=callback_id,
             profiles=profiles,
             format_options=format_options,
         )
+        assert result == {}
+
+        self.de_service.job_queue.wait_for_all()
+        comm_id = self._get_comm_id(table_name)
+        return get_column_profile_result(self.de_service, comm_id, callback_id)
 
     def check_filter_case(self, table, filter_set, expected_table):
         table_id = guid()
@@ -517,6 +527,19 @@ class DataExplorerFixture:
                 raise AssertionError(f"Indices differ at {str(different_indices)}")
 
 
+def get_column_profile_result(de_service: DataExplorerService, comm_id: str, callback_id: str):
+    comm = cast(DummyComm, de_service.comms[comm_id].comm)
+    for message in comm.messages:
+        data = message["data"]
+        if data.get("method", "") == "return_column_profiles":
+            params = data["params"]
+            result_id = params["callback_id"]
+            if result_id == callback_id:
+                return params["profiles"]
+
+    raise KeyError(callback_id)
+
+
 def _select_all(num_rows, num_columns):
     return [
         {
@@ -538,7 +561,6 @@ def dxf(
 ):
     fixture = DataExplorerFixture(shell, de_service, variables_comm)
     yield fixture
-    de_service.shutdown()
 
 
 def _wrap_json(model: Type[BaseModel], data: JsonRecords):
@@ -2052,7 +2074,9 @@ def test_pandas_updated_with_sort_keys(dxf: DataExplorerFixture):
 
         new_view = PandasView(
             table,
+            None,  # type: ignore
             DataExplorerState(name, row_filters=state.row_filters, sort_keys=state.sort_keys),
+            dxf.de_service.job_queue,
         )
 
         schema_updated, new_state = new_view.get_updated_state(table)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -295,7 +295,7 @@ def test_register_table_with_variable_path(de_service: DataExplorerService):
     assert table_view.state.name == title
 
 
-def test_shutdown(de_service: DataExplorerService, event_loop):
+def test_shutdown(de_service: DataExplorerService):
     df = pd.DataFrame({"a": [1, 2, 3, 4, 5]})
     de_service.register_table(df, "t1", comm_id=guid())
     de_service.register_table(df, "t2", comm_id=guid())

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -634,7 +634,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.131"
+      "ark": "0.1.134"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.7"

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -634,7 +634,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.133"
+      "ark": "0.1.131"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.7"

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -265,9 +265,17 @@
 		},
 		{
 			"name": "get_column_profiles",
-			"summary": "Request a batch of column profiles",
-			"description": "Requests a statistical summary or data profile for batch of columns",
+			"summary": "Async request a batch of column profiles",
+			"description": "Async request for a statistical summary or data profile for batch of columns",
 			"params": [
+				{
+					"name": "callback_id",
+					"description": "Async callback unique identifier",
+					"required": true,
+					"schema": {
+						"type": "string"
+					}
+				},
 				{
 					"name": "profiles",
 					"description": "Array of requested profiles",
@@ -288,15 +296,7 @@
 					}
 				}
 			],
-			"result": {
-				"schema": {
-					"name": "column_profile_results",
-					"type": "array",
-					"items": {
-						"$ref": "#/components/schemas/column_profile_result"
-					}
-				}
-			}
+			"result": {}
 		},
 		{
 			"name": "get_state",

--- a/positron/comms/data_explorer-frontend-openrpc.json
+++ b/positron/comms/data_explorer-frontend-openrpc.json
@@ -16,6 +16,32 @@
 			"summary": "Clear cache and request fresh data",
 			"description": "Triggered when there is any data change detected, clearing cache data and triggering a refresh/redraw.",
 			"params": []
+		},
+		{
+			"name": "return_column_profiles",
+			"summary": "Return async result of get_column_profiles request",
+			"description": "Return async result of get_column_profiles request",
+			"params": [
+				{
+					"name": "callback_id",
+					"description": "Async callback unique identifier",
+					"required": true,
+					"schema": {
+						"type": "string"
+					}
+				},
+				{
+					"name": "profiles",
+					"description": "Array of individual column profile results",
+					"required": true,
+					"schema": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/column_profile_result"
+						}
+					}
+				}
+			]
 		}
 	]
 }

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -103,7 +103,7 @@ export class DataExplorerClientInstance extends Disposable {
 	_profileFormatOptions: FormatOptions;
 
 	/**
-	 * Promises for asynchronous tasks requested of the backend.
+	 * Promises for asynchronous tasks requested of the backend, keyed by callback ID.
 	 */
 	private readonly _asyncTasks = new Map<string, DeferredPromise<any>>();
 

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -1170,9 +1170,26 @@ export interface SchemaUpdateEvent {
 export interface DataUpdateEvent {
 }
 
+/**
+ * Event: Return async result of get_column_profiles request
+ */
+export interface ReturnColumnProfilesEvent {
+	/**
+	 * Async callback unique identifier
+	 */
+	callback_id: string;
+
+	/**
+	 * Array of individual column profile results
+	 */
+	profiles: Array<ColumnProfileResult>;
+
+}
+
 export enum DataExplorerFrontendEvent {
 	SchemaUpdate = 'schema_update',
-	DataUpdate = 'data_update'
+	DataUpdate = 'data_update',
+	ReturnColumnProfiles = 'return_column_profiles'
 }
 
 export enum DataExplorerBackendRequest {
@@ -1196,6 +1213,7 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 		super(instance, options);
 		this.onDidSchemaUpdate = super.createEventEmitter('schema_update', []);
 		this.onDidDataUpdate = super.createEventEmitter('data_update', []);
+		this.onDidReturnColumnProfiles = super.createEventEmitter('return_column_profiles', ['callback_id', 'profiles']);
 	}
 
 	/**
@@ -1316,18 +1334,19 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	}
 
 	/**
-	 * Request a batch of column profiles
+	 * Async request a batch of column profiles
 	 *
-	 * Requests a statistical summary or data profile for batch of columns
+	 * Async request for a statistical summary or data profile for batch of
+	 * columns
 	 *
+	 * @param callbackId Async callback unique identifier
 	 * @param profiles Array of requested profiles
 	 * @param formatOptions Formatting options for returning data values as
 	 * strings
 	 *
-	 * @returns undefined
 	 */
-	getColumnProfiles(profiles: Array<ColumnProfileRequest>, formatOptions: FormatOptions): Promise<Array<ColumnProfileResult>> {
-		return super.performRpc('get_column_profiles', ['profiles', 'format_options'], [profiles, formatOptions]);
+	getColumnProfiles(callbackId: string, profiles: Array<ColumnProfileRequest>, formatOptions: FormatOptions): Promise<void> {
+		return super.performRpc('get_column_profiles', ['callback_id', 'profiles', 'format_options'], [callbackId, profiles, formatOptions]);
 	}
 
 	/**
@@ -1357,5 +1376,11 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 	 * and triggering a refresh/redraw.
 	 */
 	onDidDataUpdate: Event<DataUpdateEvent>;
+	/**
+	 * Return async result of get_column_profiles request
+	 *
+	 * Return async result of get_column_profiles request
+	 */
+	onDidReturnColumnProfiles: Event<ReturnColumnProfilesEvent>;
 }
 

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -170,9 +170,8 @@ df2 = pd.DataFrame(data)`;
 
 				await app.workbench.positronLayouts.enterLayout('notebook');
 
-				let tableData;
 				await expect(async () => {
-					tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+					const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
 					expect(tableData.length).toBe(11);
 				}).toPass({ timeout: 60000 });
 
@@ -182,7 +181,7 @@ df2 = pd.DataFrame(data)`;
 				await app.code.driver.getLocator('.label-name:has-text("Data: df")').click();
 
 				await expect(async () => {
-					tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+					const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
 					expect(tableData.length).toBe(12);
 				}).toPass({ timeout: 60000 });
 
@@ -193,7 +192,7 @@ df2 = pd.DataFrame(data)`;
 				await app.workbench.positronDataExplorer.selectColumnMenuItem(1, 'Sort Descending');
 
 				await expect(async () => {
-					tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+					const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
 					expect(tableData[0]).toStrictEqual({ 'Year': '2025' });
 					expect(tableData.length).toBe(12);
 				}).toPass({ timeout: 60000 });

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -59,13 +59,16 @@ df = pd.DataFrame(data)`;
 
 				await app.workbench.positronSideBar.closeSecondarySideBar();
 
-				const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+				await expect(async () => {
 
-				expect(tableData[0]).toStrictEqual({ 'Name': 'Jai', 'Age': '27', 'Address': 'Delhi' });
-				expect(tableData[1]).toStrictEqual({ 'Name': 'Princi', 'Age': '24', 'Address': 'Kanpur' });
-				expect(tableData[2]).toStrictEqual({ 'Name': 'Gaurav', 'Age': '22', 'Address': 'Allahabad' });
-				expect(tableData[3]).toStrictEqual({ 'Name': 'Anuj', 'Age': '32', 'Address': 'Kannauj' });
-				expect(tableData.length).toBe(4);
+					const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+
+					expect(tableData[0]).toStrictEqual({ 'Name': 'Jai', 'Age': '27', 'Address': 'Delhi' });
+					expect(tableData[1]).toStrictEqual({ 'Name': 'Princi', 'Age': '24', 'Address': 'Kanpur' });
+					expect(tableData[2]).toStrictEqual({ 'Name': 'Gaurav', 'Age': '22', 'Address': 'Allahabad' });
+					expect(tableData[3]).toStrictEqual({ 'Name': 'Anuj', 'Age': '32', 'Address': 'Kannauj' });
+					expect(tableData.length).toBe(4);
+				}).toPass({ timeout: 60000 });
 
 				await app.workbench.positronDataExplorer.closeDataExplorer();
 				await app.workbench.positronVariables.openVariables();
@@ -98,14 +101,17 @@ df2 = pd.DataFrame(data)`;
 
 				await app.workbench.positronSideBar.closeSecondarySideBar();
 
-				const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+				await expect(async () => {
+					const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
 
-				expect(tableData[0]).toStrictEqual({ 'A': '1.00', 'B': 'foo', 'C': 'NaN', 'D': 'NaT', 'E': 'None' });
-				expect(tableData[1]).toStrictEqual({ 'A': '2.00', 'B': 'NaN', 'C': '2.50', 'D': 'NaT', 'E': 'text' });
-				expect(tableData[2]).toStrictEqual({ 'A': 'NaN', 'B': 'bar', 'C': '3.10', 'D': '2023-01-01 00:00:00', 'E': 'more text' });
-				expect(tableData[3]).toStrictEqual({ 'A': '4.00', 'B': 'baz', 'C': 'NaN', 'D': 'NaT', 'E': 'NaN' });
-				expect(tableData[4]).toStrictEqual({ 'A': '5.00', 'B': 'None', 'C': '4.80', 'D': '2023-02-01 00:00:00', 'E': 'even more text' });
-				expect(tableData.length).toBe(5);
+					expect(tableData[0]).toStrictEqual({ 'A': '1.00', 'B': 'foo', 'C': 'NaN', 'D': 'NaT', 'E': 'None' });
+					expect(tableData[1]).toStrictEqual({ 'A': '2.00', 'B': 'NaN', 'C': '2.50', 'D': 'NaT', 'E': 'text' });
+					expect(tableData[2]).toStrictEqual({ 'A': 'NaN', 'B': 'bar', 'C': '3.10', 'D': '2023-01-01 00:00:00', 'E': 'more text' });
+					expect(tableData[3]).toStrictEqual({ 'A': '4.00', 'B': 'baz', 'C': 'NaN', 'D': 'NaT', 'E': 'NaN' });
+					expect(tableData[4]).toStrictEqual({ 'A': '5.00', 'B': 'None', 'C': '4.80', 'D': '2023-02-01 00:00:00', 'E': 'even more text' });
+					expect(tableData.length).toBe(5);
+				}).toPass({ timeout: 60000 });
+
 
 			});
 			it('Python Pandas - Verifies data explorer column info functionality [C734263] #pr', async function () {
@@ -160,20 +166,25 @@ df2 = pd.DataFrame(data)`;
 				await expect(async () => {
 					await app.workbench.positronVariables.doubleClickVariableRow('df');
 					await app.code.driver.getLocator('.label-name:has-text("Data: df")').innerText();
-				}).toPass( {timeout: 50000} );
+				}).toPass({ timeout: 50000 });
 
 				await app.workbench.positronLayouts.enterLayout('notebook');
 
-				let tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
-				expect(tableData.length).toBe(11);
+				let tableData;
+				await expect(async () => {
+					tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+					expect(tableData.length).toBe(11);
+				}).toPass({ timeout: 60000 });
 
 				await app.code.driver.getLocator('.tabs .label-name:has-text("pandas-update-dataframe.ipynb")').click();
 				await app.workbench.notebook.focusNextCell();
 				await app.workbench.notebook.executeActiveCell();
 				await app.code.driver.getLocator('.label-name:has-text("Data: df")').click();
 
-				tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
-				expect(tableData.length).toBe(12);
+				await expect(async () => {
+					tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+					expect(tableData.length).toBe(12);
+				}).toPass({ timeout: 60000 });
 
 				await app.code.driver.getLocator('.tabs .label-name:has-text("pandas-update-dataframe.ipynb")').click();
 				await app.workbench.notebook.focusNextCell();
@@ -181,9 +192,11 @@ df2 = pd.DataFrame(data)`;
 				await app.code.driver.getLocator('.label-name:has-text("Data: df")').click();
 				await app.workbench.positronDataExplorer.selectColumnMenuItem(1, 'Sort Descending');
 
-				tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
-				expect(tableData[0]).toStrictEqual({ 'Year': '2025' });
-				expect(tableData.length).toBe(12);
+				await expect(async () => {
+					tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+					expect(tableData[0]).toStrictEqual({ 'Year': '2025' });
+					expect(tableData.length).toBe(12);
+				}).toPass({ timeout: 60000 });
 
 				await app.workbench.positronLayouts.enterLayout('stacked');
 			});
@@ -219,18 +232,20 @@ df2 = pd.DataFrame(data)`;
 
 				await app.workbench.positronSideBar.closeSecondarySideBar();
 
-				const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+				await expect(async () => {
+					const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
 
-				expect(tableData[0]['foo']).toBe('1');
-				expect(tableData[1]['foo']).toBe('2');
-				expect(tableData[2]['foo']).toBe('3');
-				expect(tableData[0]['bar']).toBe('6.00');
-				expect(tableData[1]['bar']).toBe('7.00');
-				expect(tableData[2]['bar']).toBe('8.00');
-				expect(tableData[0]['ham']).toBe('2020-01-02');
-				expect(tableData[1]['ham']).toBe('2021-03-04');
-				expect(tableData[2]['ham']).toBe('2022-05-06');
-				expect(tableData.length).toBe(3);
+					expect(tableData[0]['foo']).toBe('1');
+					expect(tableData[1]['foo']).toBe('2');
+					expect(tableData[2]['foo']).toBe('3');
+					expect(tableData[0]['bar']).toBe('6.00');
+					expect(tableData[1]['bar']).toBe('7.00');
+					expect(tableData[2]['bar']).toBe('8.00');
+					expect(tableData[0]['ham']).toBe('2020-01-02');
+					expect(tableData[1]['ham']).toBe('2021-03-04');
+					expect(tableData[2]['ham']).toBe('2022-05-06');
+					expect(tableData.length).toBe(3);
+				}).toPass({ timeout: 60000 });
 
 			});
 			it('Python Polars - Verifies basic data explorer column info functionality [C734264] #pr', async function () {
@@ -274,42 +289,51 @@ df2 = pd.DataFrame(data)`;
 				const FILTER_PARAMS = ['foo', 'is not equal to', '1'];
 				await app.workbench.positronDataExplorer.addFilter(...FILTER_PARAMS as [string, string, string]);
 
-				const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+				await expect(async () => {
 
-				expect(tableData[0]['foo']).toBe('2');
-				expect(tableData[1]['foo']).toBe('3');
-				expect(tableData[0]['bar']).toBe('7.00');
-				expect(tableData[1]['bar']).toBe('8.00');
-				expect(tableData[0]['ham']).toBe('2021-03-04');
-				expect(tableData[1]['ham']).toBe('2022-05-06');
-				expect(tableData.length).toBe(2);
+					const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+
+					expect(tableData[0]['foo']).toBe('2');
+					expect(tableData[1]['foo']).toBe('3');
+					expect(tableData[0]['bar']).toBe('7.00');
+					expect(tableData[1]['bar']).toBe('8.00');
+					expect(tableData[0]['ham']).toBe('2021-03-04');
+					expect(tableData[1]['ham']).toBe('2022-05-06');
+					expect(tableData.length).toBe(2);
+
+				}).toPass({ timeout: 60000 });
 			});
 
 			it('Python Polars - Add Simple Column Sort [C557561] #pr', async function () {
 				const app = this.app as Application;
 				await app.workbench.positronDataExplorer.selectColumnMenuItem(1, 'Sort Descending');
 
-				let tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+				let tableData;
+				await expect(async () => {
+					tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
 
-				expect(tableData[0]['foo']).toBe('3');
-				expect(tableData[1]['foo']).toBe('2');
-				expect(tableData[0]['bar']).toBe('8.00');
-				expect(tableData[1]['bar']).toBe('7.00');
-				expect(tableData[0]['ham']).toBe('2022-05-06');
-				expect(tableData[1]['ham']).toBe('2021-03-04');
-				expect(tableData.length).toBe(2);
+					expect(tableData[0]['foo']).toBe('3');
+					expect(tableData[1]['foo']).toBe('2');
+					expect(tableData[0]['bar']).toBe('8.00');
+					expect(tableData[1]['bar']).toBe('7.00');
+					expect(tableData[0]['ham']).toBe('2022-05-06');
+					expect(tableData[1]['ham']).toBe('2021-03-04');
+					expect(tableData.length).toBe(2);
+				}).toPass({ timeout: 60000 });
 
 				await app.workbench.positronDataExplorer.clearSortingButton.click();
 
-				tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+				await expect(async () => {
+					tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
 
-				expect(tableData[0]['foo']).toBe('2');
-				expect(tableData[1]['foo']).toBe('3');
-				expect(tableData[0]['bar']).toBe('7.00');
-				expect(tableData[1]['bar']).toBe('8.00');
-				expect(tableData[0]['ham']).toBe('2021-03-04');
-				expect(tableData[1]['ham']).toBe('2022-05-06');
-				expect(tableData.length).toBe(2);
+					expect(tableData[0]['foo']).toBe('2');
+					expect(tableData[1]['foo']).toBe('3');
+					expect(tableData[0]['bar']).toBe('7.00');
+					expect(tableData[1]['bar']).toBe('8.00');
+					expect(tableData[0]['ham']).toBe('2021-03-04');
+					expect(tableData[1]['ham']).toBe('2022-05-06');
+					expect(tableData.length).toBe(2);
+				}).toPass({ timeout: 60000 });
 
 			});
 		});
@@ -343,12 +367,14 @@ df2 = pd.DataFrame(data)`;
 
 				await app.workbench.positronSideBar.closeSecondarySideBar();
 
-				const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
+				await expect(async () => {
+					const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
 
-				expect(tableData[0]).toStrictEqual({ 'Training': 'Strength', 'Pulse': '100.00', 'Duration': '60.00', 'Note': 'NA' });
-				expect(tableData[1]).toStrictEqual({ 'Training': 'Stamina', 'Pulse': 'NA', 'Duration': '30.00', 'Note': 'NA' });
-				expect(tableData[2]).toStrictEqual({ 'Training': 'Other', 'Pulse': '120.00', 'Duration': '45.00', 'Note': 'Note' });
-				expect(tableData.length).toBe(3);
+					expect(tableData[0]).toStrictEqual({ 'Training': 'Strength', 'Pulse': '100.00', 'Duration': '60.00', 'Note': 'NA' });
+					expect(tableData[1]).toStrictEqual({ 'Training': 'Stamina', 'Pulse': 'NA', 'Duration': '30.00', 'Note': 'NA' });
+					expect(tableData[2]).toStrictEqual({ 'Training': 'Other', 'Pulse': '120.00', 'Duration': '45.00', 'Note': 'Note' });
+					expect(tableData.length).toBe(3);
+				}).toPass({ timeout: 60000 });
 
 
 			});


### PR DESCRIPTION
As discussed in #4300, comm requests have to be served in the order they are received. Since the data explorer has some request types, like `get_column_profiles` that can grow very expensive for large datasets, this blocks "fast" requests like `get_data_values` from executing while these "slow" requests are pending.

This change adds a `return_column_profiles` frontend method that allows these requests to be fulfilled in the background, allowing fast requests to be served unimpeded. This resolves the immediate performance issue that the data explorer is facing, so this pattern can be refined over time as we have need to do other asynchronous / background request handling in the kernels.

Here's what the "blocked request" behavior looks like on the main branch:

https://github.com/user-attachments/assets/e614bb8b-c265-4daa-9e15-4cd93fd5e671

And here is with this change:

https://github.com/user-attachments/assets/dce1eb8b-07d4-470a-b12c-c1f16566b8f2

The main difference is that the grid values load immediately, and then the null percentages load later when the `return_column_profiles` event is fired.

This change can't be merged until the corresponding changes are implemented in Ark. 