### PR TITLE
Send bokeh plots to the plots pane

### DIFF
--- a/extensions/positron-python/python_files/.vscode/launch.json
+++ b/extensions/positron-python/python_files/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Debug Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "purpose": [
+                "debug-test"
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": false
+        }
+    ],
+}

--- a/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
@@ -1,4 +1,6 @@
-bokeh==3.5.1
+bokeh==3.5.1; python_version >= '3.10'
+bokeh==3.4.3; python_version == '3.9'
+bokeh==3.1.0; python_version < '3.9'
 fastcore==1.5.29
 geopandas==0.13.2; python_version < '3.9'
 geopandas==1.0.1; python_version >= '3.9'

--- a/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
@@ -1,3 +1,4 @@
+bokeh==3.5.1
 fastcore==1.5.29
 geopandas==0.13.2; python_version < '3.9'
 geopandas==1.0.1; python_version >= '3.9'

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
@@ -393,12 +393,17 @@ def is_local_html_file(url: str) -> bool:
         parsed_url = urlparse(unquote(url))
 
         # Check if it's a file scheme
-        if parsed_url.scheme not in ("file"):
+        if parsed_url.scheme not in ("file",):
             return False
 
+        # On Windows, the file path might be in netloc. This is the case for Bokeh HTML file URLs.
+        path = parsed_url.path or parsed_url.netloc
+        if not path:
+            path = parsed_url.netloc
+
         # Check if the path contains the .html or .htm extensions
-        path = parsed_url.path.lower()
-        if any(ext in path for ext in (".html", ".htm")):
+        ext = Path(path).suffix.lower()
+        if ext in (".html", ".htm"):
             return True
 
         return False

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
@@ -25,7 +25,7 @@ from typing import (
     Union,
     cast,
 )
-from urllib.parse import urlparse, unquote
+from urllib.parse import unquote, urlparse
 
 JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool, None]
 JsonRecord = Dict[str, JsonData]
@@ -398,8 +398,6 @@ def is_local_html_file(url: str) -> bool:
 
         # On Windows, the file path might be in netloc. This is the case for Bokeh HTML file URLs.
         path = parsed_url.path or parsed_url.netloc
-        if not path:
-            path = parsed_url.netloc
 
         # Check if the path contains the .html or .htm extensions
         ext = Path(path).suffix.lower()


### PR DESCRIPTION
Addresses #4249.

### QA Notes

We're (unfortunately) inspecting the stack so it's worth testing on different Bokeh versions, Python versions, platforms, etc.

This should open in the plots pane, not the viewer pane:

```python
from bokeh.plotting import figure, show
p = figure(title="Simple line example", x_axis_label='x', y_axis_label='y')
p.line([1, 2, 3, 4, 5], [6, 7, 2, 4, 5], legend_label="Temp.", line_width=2)
show(p)
```