### PR TITLE
Add support for HoloViz/HoloViews plots

### DIFF
--- a/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
+++ b/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
@@ -120,11 +120,11 @@ export class PositronHoloViewsService extends Disposable implements IPositronHol
 		// for setup don't seem to be replayed if they are called again. This causes an issue for
 		// this technique as if we reload positron the service starts up again and the messages are
 		// lost which will cause very confusing failures of plots not showing up.
-		if (!this._messagesBySessionId.has(sessionId)) {
+		const messagesForSession = this._messagesBySessionId.get(sessionId);
+
+		if (!messagesForSession) {
 			throw new Error(`PositronHoloViewsService: Session ${sessionId} not found in messagesBySessionId map.`);
 		}
-		// Force the type since we just checked it and ininitialzed an array if it didnt exist.
-		const messagesForSession = this._messagesBySessionId.get(sessionId)!;
 		messagesForSession.push(msg);
 	}
 

--- a/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
+++ b/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
@@ -1,0 +1,163 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { Emitter, Event } from 'vs/base/common/event';
+import { ILanguageRuntimeMessageOutput, RuntimeOutputKind } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { NotebookOutputPlotClient } from 'vs/workbench/contrib/positronPlots/browser/notebookOutputPlotClient';
+import { IPositronHoloViewsService, MIME_TYPE_HOLOVIEWS_EXEC } from 'vs/workbench/services/positronHoloViews/common/positronHoloViewsService';
+import { ILanguageRuntimeSession, IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
+import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { IPositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
+
+const MIME_TYPE_HTML = 'text/html';
+const MIME_TYPE_PLAIN = 'text/plain';
+
+export class PositronHoloViewsService extends Disposable implements IPositronHoloViewsService {
+	/** Needed for service branding in dependency injector. */
+	_serviceBrand: undefined;
+
+	/** Placeholder for service initialization. */
+	initialize() { }
+
+	/** Map of holoviz messages keyed by session ID. */
+	private readonly _messagesBySessionId = new Map<string, ILanguageRuntimeMessageOutput[]>();
+
+	/**
+	 * Map to disposeable stores for each session. Used to preventing memory leaks caused by
+	 * repeatedly attaching to the same session which can happen in the case of the application
+	 * closing before the session ends
+	 */
+	private _sessionToDisposablesMap = new Map<string, DisposableStore>();
+
+	/** The emitter for the onDidCreatePlot event */
+	private readonly _onDidCreatePlot = this._register(new Emitter<NotebookOutputPlotClient>());
+
+	/** Emitted when a new HoloViews webview is created. */
+	onDidCreatePlot: Event<NotebookOutputPlotClient> = this._onDidCreatePlot.event;
+
+	constructor(
+		@IRuntimeSessionService private _runtimeSessionService: IRuntimeSessionService,
+		@IPositronNotebookOutputWebviewService private _notebookOutputWebviewService: IPositronNotebookOutputWebviewService
+	) {
+		super();
+
+		// Attach to existing sessions.
+		this._runtimeSessionService.activeSessions.forEach(session => {
+			this._attachSession(session);
+		});
+
+		// Attach to new sessions.
+		this._register(this._runtimeSessionService.onWillStartSession((event) => {
+			this._attachSession(event.session);
+		}));
+	}
+
+	override dispose(): void {
+		super.dispose();
+		// Clean up disposables linked to any connected sessions
+		this._sessionToDisposablesMap.forEach(disposables => disposables.dispose());
+	}
+
+	sessionInfo(sessionId: string) {
+		const messages = this._messagesBySessionId.get(sessionId);
+		if (!messages) {
+			return null;
+		}
+		return {
+			numberOfMessages: messages.length
+		};
+	}
+
+	private _attachSession(session: ILanguageRuntimeSession) {
+		// Check if the session is already attached.
+		if (this._sessionToDisposablesMap.has(session.sessionId)) {
+			return;
+		}
+
+		const disposables = new DisposableStore();
+		this._sessionToDisposablesMap.set(session.sessionId, disposables);
+		this._messagesBySessionId.set(session.sessionId, []);
+		const handleMessage = (msg: ILanguageRuntimeMessageOutput) => {
+			if (msg.kind !== RuntimeOutputKind.HoloViews) {
+				return;
+			}
+
+			this._addMessageForSession(session, msg);
+		};
+
+		disposables.add(session.onDidReceiveRuntimeMessageResult(handleMessage));
+		disposables.add(session.onDidReceiveRuntimeMessageOutput(handleMessage));
+	}
+
+	/**
+	 * Record a message to the store keyed by session.
+	 * @param session The session that the message is associated with.
+	 * @param msg The message to process
+	 */
+	private _addMessageForSession(session: ILanguageRuntimeSession, msg: ILanguageRuntimeMessageOutput) {
+		const sessionId = session.sessionId;
+
+		// Check if a message is a message that should be displayed rather than simple stored as
+		// dependencies for future display messages.
+		const isHoloViewDisplayMessage = MIME_TYPE_HOLOVIEWS_EXEC in msg.data &&
+			MIME_TYPE_HTML in msg.data &&
+			MIME_TYPE_PLAIN in msg.data;
+
+		if (isHoloViewDisplayMessage) {
+			// Create a new plot client.
+			this._createPlotClient(session, msg);
+			return;
+		}
+
+		// Save the message for later playback. One thing we should be aware of is that the messages
+		// for setup don't seem to be replayed if they are called again. This causes an issue for
+		// this technique as if we reload positron the service starts up again and the messages are
+		// lost which will cause very confusing failures of plots not showing up.
+		if (!this._messagesBySessionId.has(sessionId)) {
+			throw new Error(`PositronHoloViewsService: Session ${sessionId} not found in messagesBySessionId map.`);
+		}
+		// Force the type since we just checked it and ininitialzed an array if it didnt exist.
+		const messagesForSession = this._messagesBySessionId.get(sessionId)!;
+		messagesForSession.push(msg);
+	}
+
+	/**
+	 * Create a plot client for a display message by replaying all the associated previous messages.
+	 * Alerts the plots pane that a new plot is ready.
+	 * @param session Runtime session associated with the message.
+	 * @param displayMessage The message to display.
+	 */
+	private async _createPlotClient(
+		session: ILanguageRuntimeSession,
+		displayMessage: ILanguageRuntimeMessageOutput,
+	) {
+		const storedMessages = this._messagesBySessionId.get(session.sessionId) ?? [];
+		const outputWebview = await this._notebookOutputWebviewService.createMultiOutputWebview(
+			session,
+			[...storedMessages, displayMessage],
+			'jupyter-notebook'
+		);
+
+		if (!outputWebview) {
+			throw new Error(`PositronHoloViewsService: Could not create webview for HoloViews message: ${JSON.stringify(displayMessage)}`);
+		}
+
+		// Grab disposables for this session
+		const disposables = this._sessionToDisposablesMap.get(session.sessionId);
+		if (!disposables) {
+			throw new Error(`PositronHoloViewsService: Could not find disposables for session ${session.sessionId}`);
+		}
+
+		disposables.add(outputWebview);
+
+		// Create a plot client and fire event letting plots pane know it's good to go.
+		const client = disposables.add(new NotebookOutputPlotClient(outputWebview, displayMessage));
+		this._onDidCreatePlot.fire(client);
+	}
+}
+
+// Register the Positron IPyWidgets service.
+registerSingleton(IPositronHoloViewsService, PositronHoloViewsService, InstantiationType.Delayed);
+

--- a/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
+++ b/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
@@ -25,7 +25,7 @@ export class PositronHoloViewsService extends Disposable implements IPositronHol
 	private readonly _messagesBySessionId = new Map<string, ILanguageRuntimeMessageOutput[]>();
 
 	/**
-	 * Map to disposeable stores for each session. Used to preventing memory leaks caused by
+	 * Map to disposeable stores for each session. Used to prevent memory leaks caused by
 	 * repeatedly attaching to the same session which can happen in the case of the application
 	 * closing before the session ends
 	 */

--- a/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
+++ b/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
@@ -71,8 +71,11 @@ export class PositronHoloViewsService extends Disposable implements IPositronHol
 	}
 
 	private _attachSession(session: ILanguageRuntimeSession) {
-		// Check if the session is already attached.
-		if (this._sessionToDisposablesMap.has(session.sessionId)) {
+		// Only attach to new console sessions.
+		if (
+			session.metadata.sessionMode !== LanguageRuntimeSessionMode.Console ||
+			this._sessionToDisposablesMap.has(session.sessionId)
+		) {
 			return;
 		}
 
@@ -80,10 +83,6 @@ export class PositronHoloViewsService extends Disposable implements IPositronHol
 		this._sessionToDisposablesMap.set(session.sessionId, disposables);
 		this._messagesBySessionId.set(session.sessionId, []);
 
-		// Only attach to console sessions.
-		if (session.metadata.sessionMode !== LanguageRuntimeSessionMode.Console) {
-			return;
-		}
 
 		const handleMessage = (msg: ILanguageRuntimeMessageOutput) => {
 			if (msg.kind !== RuntimeOutputKind.HoloViews) {

--- a/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
+++ b/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
@@ -139,7 +139,7 @@ export class PositronHoloViewsService extends Disposable implements IPositronHol
 		displayMessage: ILanguageRuntimeMessageWebOutput,
 	) {
 		const storedMessages = this._messagesBySessionId.get(runtime.sessionId) ?? [];
-		const outputWebview = await this._notebookOutputWebviewService.createMultiOutputWebview({
+		const outputWebview = await this._notebookOutputWebviewService.createMultiMessageWebview({
 			runtime,
 			preReqMessages: storedMessages,
 			displayMessage: displayMessage,

--- a/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
+++ b/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
@@ -105,7 +105,7 @@ export class PositronHoloViewsService extends Disposable implements IPositronHol
 	private _addMessageForSession(session: ILanguageRuntimeSession, msg: ILanguageRuntimeMessageOutput) {
 		const sessionId = session.sessionId;
 
-		// Check if a message is a message that should be displayed rather than simple stored as
+		// Check if a message is a message that should be displayed rather than simply stored as
 		// dependencies for future display messages.
 		const isHoloViewDisplayMessage = MIME_TYPE_HOLOVIEWS_EXEC in msg.data &&
 			MIME_TYPE_HTML in msg.data &&

--- a/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
+++ b/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
@@ -164,6 +164,6 @@ export class PositronHoloViewsService extends Disposable implements IPositronHol
 	}
 }
 
-// Register the Positron IPyWidgets service.
+// Register service.
 registerSingleton(IPositronHoloViewsService, PositronHoloViewsService, InstantiationType.Delayed);
 

--- a/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
+++ b/src/vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { Emitter, Event } from 'vs/base/common/event';
-import { ILanguageRuntimeMessageOutput, RuntimeOutputKind } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeMessageOutput, LanguageRuntimeSessionMode, RuntimeOutputKind } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { NotebookOutputPlotClient } from 'vs/workbench/contrib/positronPlots/browser/notebookOutputPlotClient';
 import { IPositronHoloViewsService, MIME_TYPE_HOLOVIEWS_EXEC } from 'vs/workbench/services/positronHoloViews/common/positronHoloViewsService';
 import { ILanguageRuntimeSession, IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
@@ -39,7 +39,7 @@ export class PositronHoloViewsService extends Disposable implements IPositronHol
 
 	constructor(
 		@IRuntimeSessionService private _runtimeSessionService: IRuntimeSessionService,
-		@IPositronNotebookOutputWebviewService private _notebookOutputWebviewService: IPositronNotebookOutputWebviewService
+		@IPositronNotebookOutputWebviewService private _notebookOutputWebviewService: IPositronNotebookOutputWebviewService,
 	) {
 		super();
 
@@ -79,6 +79,12 @@ export class PositronHoloViewsService extends Disposable implements IPositronHol
 		const disposables = new DisposableStore();
 		this._sessionToDisposablesMap.set(session.sessionId, disposables);
 		this._messagesBySessionId.set(session.sessionId, []);
+
+		// Only attach to console sessions.
+		if (session.metadata.sessionMode !== LanguageRuntimeSessionMode.Console) {
+			return;
+		}
+
 		const handleMessage = (msg: ILanguageRuntimeMessageOutput) => {
 			if (msg.kind !== RuntimeOutputKind.HoloViews) {
 				return;

--- a/src/vs/workbench/contrib/positronHoloViews/browser/utils.ts
+++ b/src/vs/workbench/contrib/positronHoloViews/browser/utils.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ILanguageRuntimeMessageOutput } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { MIME_TYPE_HOLOVIEWS_LOAD, MIME_TYPE_HOLOVIEWS_EXEC } from 'vs/workbench/services/positronHoloViews/common/positronHoloViewsService';
+
+/**
+ * Check if a message represents a holoviews message.
+ * @param msg Message from language runtime.
+ * @returns True if the message is a holoviews message.
+ */
+export function isHoloViewsMessage(msg: ILanguageRuntimeMessageOutput): boolean {
+	return MIME_TYPE_HOLOVIEWS_LOAD in msg.data || MIME_TYPE_HOLOVIEWS_EXEC in msg.data;
+}

--- a/src/vs/workbench/contrib/positronHoloViews/test/browser/positronHoloViewsService.test.ts
+++ b/src/vs/workbench/contrib/positronHoloViews/test/browser/positronHoloViewsService.test.ts
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+import assert from 'assert';
+import { timeout } from 'vs/base/common/async';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
+import { INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorService';
+import { NotebookEditorWidgetService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorServiceImpl';
+import { NotebookRendererMessagingService } from 'vs/workbench/contrib/notebook/browser/services/notebookRendererMessagingServiceImpl';
+import { INotebookRendererInfo, INotebookStaticPreloadInfo } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { NotebookOutputRendererInfo } from 'vs/workbench/contrib/notebook/common/notebookOutputRenderer';
+import { INotebookRendererMessagingService } from 'vs/workbench/contrib/notebook/common/notebookRendererMessagingService';
+import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
+import { PositronHoloViewsService } from 'vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService';
+import { IPositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
+import { PositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl';
+import { WebviewPlotClient } from 'vs/workbench/contrib/positronPlots/browser/webviewPlotClient';
+import { IWebviewService } from 'vs/workbench/contrib/webview/browser/webview';
+import { WebviewService } from 'vs/workbench/contrib/webview/browser/webviewService';
+import { LanguageRuntimeSessionMode, RuntimeOutputKind } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
+import { TestLanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession';
+import { TestRuntimeSessionService } from 'vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService';
+import { workbenchInstantiationService } from 'vs/workbench/test/browser/workbenchTestServices';
+
+class TestNotebookService implements Partial<INotebookService> {
+	getRenderers(): INotebookRendererInfo[] {
+		return [];
+	}
+
+	getPreferredRenderer(_mimeType: string): NotebookOutputRendererInfo | undefined {
+		// Doesn't matter what the renderer is, just that it exists.
+		return <NotebookOutputRendererInfo>{
+			id: 'positron-ipywidgets',
+			extensionId: new ExtensionIdentifier('vscode.positron-ipywidgets'),
+		};
+	}
+
+	*getStaticPreloads(_viewType: string): Iterable<INotebookStaticPreloadInfo> {
+		// Yield nothing.
+	}
+}
+
+suite('Positron - PositronHoloViewsService', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let positronHoloViewsService: PositronHoloViewsService;
+	let runtimeSessionService: TestRuntimeSessionService;
+	let notebookEditorService: INotebookEditorService;
+
+	setup(() => {
+		const instantiationService = workbenchInstantiationService(undefined, disposables);
+		instantiationService.stub(INotebookRendererMessagingService, disposables.add(instantiationService.createInstance(NotebookRendererMessagingService)));
+		notebookEditorService = disposables.add(instantiationService.createInstance(NotebookEditorWidgetService));
+		instantiationService.stub(INotebookEditorService, notebookEditorService);
+		instantiationService.stub(INotebookService, new TestNotebookService());
+		instantiationService.stub(IWebviewService, disposables.add(new WebviewService(instantiationService)));
+		instantiationService.stub(IPositronNotebookOutputWebviewService, instantiationService.createInstance(PositronNotebookOutputWebviewService));
+		runtimeSessionService = disposables.add(new TestRuntimeSessionService());
+		instantiationService.stub(IRuntimeSessionService, runtimeSessionService);
+		positronHoloViewsService = disposables.add(instantiationService.createInstance(PositronHoloViewsService));
+	});
+
+	async function createConsoleSession() {
+
+		// Start a console session.
+		const session = disposables.add(new TestLanguageRuntimeSession(LanguageRuntimeSessionMode.Console));
+		runtimeSessionService.startSession(session);
+
+		await timeout(0);
+
+		const out: {
+			session: TestLanguageRuntimeSession;
+			plotClient: WebviewPlotClient | undefined;
+		} = {
+			session, plotClient: undefined,
+		};
+
+		disposables.add(positronHoloViewsService.onDidCreatePlot(client => {
+			out.plotClient = client;
+		}));
+
+		return out;
+	}
+
+	test('console session: dependency messages are absorbed without emitting plot', async () => {
+		const consoleSession = await createConsoleSession();
+
+		// Simulate the runtime sending an HoloViews output message.
+		consoleSession.session.receiveOutputMessage({
+			kind: RuntimeOutputKind.HoloViews,
+			data: {
+				'application/vnd.holoviews_load.v0+json': {},
+			},
+		});
+
+		await timeout(0);
+		assert(!Boolean(consoleSession.plotClient));
+		assert.equal(positronHoloViewsService.sessionInfo(consoleSession.session.sessionId)?.numberOfMessages, 1);
+
+		consoleSession.session.receiveOutputMessage({
+			kind: RuntimeOutputKind.HoloViews,
+			data: {
+				'application/vnd.holoviews_load.v0+json': 'bar',
+				'text/html': '<div></div>',
+			},
+		});
+		assert.equal(positronHoloViewsService.sessionInfo(consoleSession.session.sessionId)?.numberOfMessages, 2);
+
+		// Send a display message
+		const displayMessage = consoleSession.session.receiveOutputMessage({
+			kind: RuntimeOutputKind.HoloViews,
+			data: {
+				"application/vnd.holoviews_exec.v0+json": '',
+				'text/html': '<div></div>',
+				'text/plain': 'hello',
+			},
+		});
+		await timeout(0);
+
+		// Display message shouldnt have been absorbed into preload messages
+		assert.equal(positronHoloViewsService.sessionInfo(consoleSession.session.sessionId)?.numberOfMessages, 2);
+		assert(Boolean(consoleSession.plotClient));
+		assert.strictEqual(consoleSession.plotClient!.id, displayMessage.id);
+
+		// End the session.
+		consoleSession.session.endSession();
+		await timeout(0);
+	});
+
+});

--- a/src/vs/workbench/contrib/positronHoloViews/test/browser/positronHoloViewsService.test.ts
+++ b/src/vs/workbench/contrib/positronHoloViews/test/browser/positronHoloViewsService.test.ts
@@ -5,15 +5,11 @@
 import assert from 'assert';
 import { timeout } from 'vs/base/common/async';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
-import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
-import { INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorService';
-import { NotebookEditorWidgetService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorServiceImpl';
 import { NotebookRendererMessagingService } from 'vs/workbench/contrib/notebook/browser/services/notebookRendererMessagingServiceImpl';
-import { INotebookRendererInfo, INotebookStaticPreloadInfo } from 'vs/workbench/contrib/notebook/common/notebookCommon';
-import { NotebookOutputRendererInfo } from 'vs/workbench/contrib/notebook/common/notebookOutputRenderer';
 import { INotebookRendererMessagingService } from 'vs/workbench/contrib/notebook/common/notebookRendererMessagingService';
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
 import { PositronHoloViewsService } from 'vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService';
+import { TestNotebookService } from 'vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.test';
 import { IPositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
 import { PositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl';
 import { WebviewPlotClient } from 'vs/workbench/contrib/positronPlots/browser/webviewPlotClient';
@@ -25,23 +21,6 @@ import { TestLanguageRuntimeSession } from 'vs/workbench/services/runtimeSession
 import { TestRuntimeSessionService } from 'vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService';
 import { workbenchInstantiationService } from 'vs/workbench/test/browser/workbenchTestServices';
 
-class TestNotebookService implements Partial<INotebookService> {
-	getRenderers(): INotebookRendererInfo[] {
-		return [];
-	}
-
-	getPreferredRenderer(_mimeType: string): NotebookOutputRendererInfo | undefined {
-		// Doesn't matter what the renderer is, just that it exists.
-		return <NotebookOutputRendererInfo>{
-			id: 'positron-ipywidgets',
-			extensionId: new ExtensionIdentifier('vscode.positron-ipywidgets'),
-		};
-	}
-
-	*getStaticPreloads(_viewType: string): Iterable<INotebookStaticPreloadInfo> {
-		// Yield nothing.
-	}
-}
 
 const hvPreloadMessage1 = {
 	kind: RuntimeOutputKind.HoloViews,
@@ -72,13 +51,10 @@ suite('Positron - PositronHoloViewsService', () => {
 
 	let positronHoloViewsService: PositronHoloViewsService;
 	let runtimeSessionService: TestRuntimeSessionService;
-	let notebookEditorService: INotebookEditorService;
 
 	setup(() => {
 		const instantiationService = workbenchInstantiationService(undefined, disposables);
 		instantiationService.stub(INotebookRendererMessagingService, disposables.add(instantiationService.createInstance(NotebookRendererMessagingService)));
-		notebookEditorService = disposables.add(instantiationService.createInstance(NotebookEditorWidgetService));
-		instantiationService.stub(INotebookEditorService, notebookEditorService);
 		instantiationService.stub(INotebookService, new TestNotebookService());
 		instantiationService.stub(IWebviewService, disposables.add(new WebviewService(instantiationService)));
 		instantiationService.stub(IPositronNotebookOutputWebviewService, instantiationService.createInstance(PositronNotebookOutputWebviewService));

--- a/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.test.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/test/browser/positronIPyWidgetsService.test.ts
@@ -36,7 +36,7 @@ import { TestRuntimeSessionService } from 'vs/workbench/services/runtimeSession/
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { workbenchInstantiationService } from 'vs/workbench/test/browser/workbenchTestServices';
 
-class TestNotebookService implements Partial<INotebookService> {
+export class TestNotebookService implements Partial<INotebookService> {
 	getRenderers(): INotebookRendererInfo[] {
 		return [];
 	}

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -5,7 +5,7 @@
 
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IOverlayWebview, IWebviewElement } from 'vs/workbench/contrib/webview/browser/webview';
-import { ILanguageRuntimeMessageOutput } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageWebOutput } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { Event } from 'vs/base/common/event';
 import { IDisposable } from 'vs/base/common/lifecycle';
@@ -68,17 +68,20 @@ export interface IPositronNotebookOutputWebviewService {
 	 * This is useful for situations where a plot may have dependencies that are provided by
 	 * separate messages.
 	 *
-	 * @param runtime The runtime that emitted the output
-	 * @param outputs The messages to be sent to the webview. The final message that triggered the
-	 * plotting should be the final element of the array.
-	 * @param viewType The view type of the notebook e.g 'jupyter-notebook', if known. Used to
+	 * @param opts.runtime The runtime that emitted the output
+	 * @param opts.preReqMessages The messages linked to the final display output message that load the
+	 * required dependencies.
+	 * @param opts.displayMessage The message that triggered the plotting.
+	 * @param opts.viewType The view type of the notebook e.g 'jupyter-notebook', if known. Used to
 	 *  select the required notebook preload scripts for the webview.
 	 */
-	createMultiOutputWebview(
-		runtime: ILanguageRuntimeSession,
-		outputs: ILanguageRuntimeMessageOutput[],
-		viewType?: string,
-	): Promise<INotebookOutputWebview | undefined>;
+	createMultiOutputWebview(opts:
+		{
+			runtime: ILanguageRuntimeSession;
+			preReqMessages: ILanguageRuntimeMessageWebOutput[];
+			displayMessage: ILanguageRuntimeMessageWebOutput;
+			viewType?: string;
+		}): Promise<INotebookOutputWebview | undefined>;
 
 	/**
 	 * Create a new raw HTML output webview.

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -63,6 +63,24 @@ export interface IPositronNotebookOutputWebviewService {
 	): Promise<INotebookOutputWebview | undefined>;
 
 	/**
+	 * Create a new notebook output webview from a series of output messages.
+	 *
+	 * This is useful for situations where a plot may have dependencies that are provided by
+	 * separate messages.
+	 *
+	 * @param runtime The runtime that emitted the output
+	 * @param outputs The messages to be sent into webview. The final message that triggered the
+	 * plotting should be the final element of the array.
+	 * @param viewType The view type of the notebook e.g 'jupyter-notebook', if known. Used to
+	 *  select the required notebook preload scripts for the webview.
+	 */
+	createMultiOutputWebview(
+		runtime: ILanguageRuntimeSession,
+		outputs: ILanguageRuntimeMessageOutput[],
+		viewType?: string,
+	): Promise<INotebookOutputWebview | undefined>;
+
+	/**
 	 * Create a new raw HTML output webview.
 	 *
 	 * @param opts The options for the webview

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -75,7 +75,7 @@ export interface IPositronNotebookOutputWebviewService {
 	 * @param opts.viewType The view type of the notebook e.g 'jupyter-notebook', if known. Used to
 	 *  select the required notebook preload scripts for the webview.
 	 */
-	createMultiOutputWebview(opts:
+	createMultiMessageWebview(opts:
 		{
 			runtime: ILanguageRuntimeSession;
 			preReqMessages: ILanguageRuntimeMessageWebOutput[];

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -69,7 +69,7 @@ export interface IPositronNotebookOutputWebviewService {
 	 * separate messages.
 	 *
 	 * @param runtime The runtime that emitted the output
-	 * @param outputs The messages to be sent into webview. The final message that triggered the
+	 * @param outputs The messages to be sent to the webview. The final message that triggered the
 	 * plotting should be the final element of the array.
 	 * @param viewType The view type of the notebook e.g 'jupyter-notebook', if known. Used to
 	 *  select the required notebook preload scripts for the webview.

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -54,19 +54,19 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 	 * associated output message.
 	 */
 	private _findRenderersForOutputs(outputs: ILanguageRuntimeMessageWebOutput[]): MessageRenderInfo[] {
-		const toReturn: MessageRenderInfo[] = [];
-
-		for (const output of outputs) {
-			const info = this._findRendererForOutput(output);
-			if (!info) {
-				this._logService.warn(
-					'Failed to find renderer for output with mime types: ' +
-					Object.keys(output.data).join(', ') +
-					'/nOutput will be ignored.'
-				);
-			}
-		}
-		return toReturn;
+		return outputs
+			.map(output => {
+				const info = this._findRendererForOutput(output);
+				if (!info) {
+					this._logService.warn(
+						'Failed to find renderer for output with mime types: ' +
+						Object.keys(output.data).join(', ') +
+						'/nOutput will be ignored.'
+					);
+				}
+				return info;
+			})
+			.filter((info): info is MessageRenderInfo => Boolean(info));
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -83,7 +83,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 	 * @param runtime Runtime session associated with the outputs.
 	 * @param outputs Array of outputs to render.
 	 * @param viewType The type of view to render.
-	 * @returns Promise containing the webview messages will be renred into.
+	 * @returns Promise containing the webview that messages will be rendered into.
 	 */
 	async createMultiOutputWebview(
 		runtime: ILanguageRuntimeSession,

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -78,29 +78,24 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 		return toReturn;
 	}
 
-	/**
-	 * Create a webview associated with multiple outputs.
-	 * @param runtime Runtime session associated with the outputs.
-	 * @param outputs Array of outputs to render.
-	 * @param viewType The type of view to render.
-	 * @returns Promise containing the webview that messages will be rendered into.
-	 */
-	async createMultiOutputWebview(
-		runtime: ILanguageRuntimeSession,
-		outputs: ILanguageRuntimeMessageWebOutput[],
-		viewType?: string
-	): Promise<INotebookOutputWebview | undefined> {
-		const renderInfo = this._findRenderersForOutputs(outputs);
-		// We use the last output message as the id as it's typically the "display" message.
-		const idForOutput = outputs.at(-1)?.id;
-		if (!idForOutput) {
-			throw new Error('No output ID found');
-		}
+
+	async createMultiOutputWebview({
+		runtime,
+		preReqMessages,
+		displayMessage,
+		viewType
+	}: {
+		runtime: ILanguageRuntimeSession;
+		preReqMessages: ILanguageRuntimeMessageWebOutput[];
+		displayMessage: ILanguageRuntimeMessageWebOutput;
+		viewType?: string;
+	}): Promise<INotebookOutputWebview | undefined> {
+		const allMessages = [...preReqMessages, displayMessage];
 
 		return this.createNotebookRenderOutput(
-			idForOutput,
+			displayMessage.id,
 			runtime,
-			renderInfo,
+			this._findRenderersForOutputs(allMessages),
 			viewType
 		);
 	}

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -79,7 +79,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 	}
 
 
-	async createMultiOutputWebview({
+	async createMultiMessageWebview({
 		runtime,
 		preReqMessages,
 		displayMessage,

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -40,6 +40,7 @@ import { HtmlPlotClient } from 'vs/workbench/contrib/positronPlots/browser/htmlP
 import { PreviewHtml } from 'vs/workbench/contrib/positronPreview/browser/previewHtml';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { IPositronHoloViewsService } from 'vs/workbench/services/positronHoloViews/common/positronHoloViewsService';
 
 /** The maximum number of recent executions to store. */
 const MaxRecentExecutions = 10;
@@ -113,6 +114,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		@IOpenerService private _openerService: IOpenerService,
 		@IPositronNotebookOutputWebviewService private _notebookOutputWebviewService: IPositronNotebookOutputWebviewService,
 		@IPositronIPyWidgetsService private _positronIPyWidgetsService: IPositronIPyWidgetsService,
+		@IPositronHoloViewsService private _positronHoloViewsService: IPositronHoloViewsService,
 		@IPositronPreviewService private _positronPreviewService: IPositronPreviewService,
 		@IFileService private readonly _fileService: IFileService,
 		@IFileDialogService private readonly _fileDialogService: IFileDialogService,
@@ -147,6 +149,11 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		// Listen for plot clients being created by the IPyWidget service and register them with the plots service
 		// so they can be displayed in the plots pane.
 		this._register(this._positronIPyWidgetsService.onDidCreatePlot((plotClient) => {
+			this.registerNewPlotClient(plotClient);
+		}));
+		// Listen for plot clients from the holoviews service and register them with the plots
+		// service so they can be displayed in the plots pane.
+		this._register(this._positronHoloViewsService.onDidCreatePlot((plotClient) => {
 			this.registerNewPlotClient(plotClient);
 		}));
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -114,6 +114,12 @@ export enum RuntimeOutputKind {
 	IPyWidget = 'ipywidget',
 
 	/**
+	 * Holoviews message.
+	 * These are typically batched by the holoviews service for rendering.
+	 */
+	HoloViews = 'holoviews',
+
+	/**
 	 * Some other kind of output. We've never heard of it.
 	 */
 	Unknown = 'unknown',

--- a/src/vs/workbench/services/positronHoloViews/common/positronHoloViewsService.ts
+++ b/src/vs/workbench/services/positronHoloViews/common/positronHoloViewsService.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { Event } from 'vs/base/common/event';
+import { IPositronPlotClient } from 'vs/workbench/services/positronPlots/common/positronPlots';
+
+export const POSITRON_HOLOVIEWS_ID = 'positronHoloViewsService';
+export const MIME_TYPE_HOLOVIEWS_LOAD = 'application/vnd.holoviews_load.v0+json';
+export const MIME_TYPE_HOLOVIEWS_EXEC = 'application/vnd.holoviews_exec.v0+json';
+
+export const IPositronHoloViewsService = createDecorator<IPositronHoloViewsService>(POSITRON_HOLOVIEWS_ID);
+
+/**
+ * IPositronHoloViewsService interface.
+ */
+export interface IPositronHoloViewsService {
+	/**
+	 * Needed for service branding in dependency injector.
+	 */
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Placeholder for service initialization.
+	 */
+	initialize(): void;
+
+	/**
+	 * Notifies subscribers when a new plot client is created from HoloViews.
+	 */
+	readonly onDidCreatePlot: Event<IPositronPlotClient>;
+
+	/**
+	 * Session info (used for testing)
+	 */
+	sessionInfo(sessionId: string): { numberOfMessages: number } | null;
+}

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -447,4 +447,5 @@ import 'vs/workbench/services/positronConsole/browser/positronConsoleService';
 import 'vs/workbench/contrib/positronHelp/browser/positronHelpService';
 import 'vs/workbench/services/positronVariables/common/positronVariablesService';
 import 'vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService';
+import 'vs/workbench/contrib/positronHoloViews/browser/positronHoloViewsService';
 // --- End Positron ---


### PR DESCRIPTION
Addresses #3880 

### What
This PR adds a new service that intercepts messages from holoviz plots so they can be replayed when a plot is rendered into the plots pane. 

### Why
This is necessary because holoviz sends preliminary messages that load assets for displaying plots and these messages need to be sent to the plot webview along with the plotting message when rendering the plot or else various assets will not be available. 

This is not a problem in notebooks because all output is rendered into a single large "backlayer" webview and thus the preliminary messages are properly "remembered."

This is specific to holoviz/holoviews plots right now but there is a decent chance this pattern of remembering prerequisite messages and replaying them to the output webview will be useful for other libraries/situations. 

### Limitations
Right now we store the prereq messages in memory on the UI thread. This is nice and lightweight _but_ has the problem of forgetting those messages if the user reloads the front end. Since hvplots doesn't replay the asset loading messages on reload the plots won't work until the session is restarted. We could do something like make the storage of prereq messages use a non-ui layer cache, but I'm not convinced it will be a big issue. 


### Results
__hvplots now work in the plots pane__
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/d60dd978-8be9-4cc8-8827-71a5956d9fff">


__Behavior in notebooks should be unchanged__
<img width="953" alt="image" src="https://github.com/user-attachments/assets/8bd307d1-1b46-4c12-886c-ea2293aedac1">

### QA Notes

This code will create a simple hvplot scatter plot. It should work in the plots pane. 
```python
import polars as pl
import hvplot
import hvplot.polars
pl.DataFrame(dict(x=[1,2,3], y=[4,5,6])).hvplot.scatter(x="x", y="y")
```

The same code should work in a notebook. (Although even before this PR I noticed sometimes it was flakey which I think is due to how hvplots loads assets). 


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
