### PR TITLE
Retry logic awaiting line advance for fast R line execution test

### DIFF
--- a/test/automation/src/positron/positronEditor.ts
+++ b/test/automation/src/positron/positronEditor.ts
@@ -23,11 +23,14 @@ export class PositronEditor {
 		await lineLocator.press(press);
 	}
 
-	// This function returns the top value of the style attribute for the
-	// editor's current-line div parent (the current-line div is a child of the div that
-	// has the top attribute). It retries up to 10 times to get the value.
-	// Retries are necessary because the value is not always immediately
-	// available (presumably due to the change from one current line to another).
+	/**
+	 * This function returns the top value of the style attribute for the editor's current-line div
+	 * parent (the current-line div is a child of the div that has the top attribute). It retries up
+	 * to 10 times to get the value. Retries are necessary because the value is not always
+	 * immediately available (presumably due to the change from one current line to another).
+	 * @returns Promise that resolves to top value of the style attribute for the editor's
+	 * current-line div parent.
+	 */
 	async getCurrentLineTop(): Promise<number> {
 		let retries = 10;
 		let topValue: number = NaN;

--- a/test/automation/src/positron/positronEditor.ts
+++ b/test/automation/src/positron/positronEditor.ts
@@ -22,4 +22,21 @@ export class PositronEditor {
 		await lineLocator.press(press);
 	}
 
+	async getCurrentLineTop(retries: number = 10): Promise<number> {
+		const currentLine = this.code.driver.getLocator('.view-overlays .current-line');
+		const currentLineParent = currentLine.locator('..');
+
+		const top = await currentLineParent.evaluate((el) => {
+			return window.getComputedStyle(el).getPropertyValue('top');
+		});
+
+		const topValue = parseInt(top, 10);
+
+		if (isNaN(topValue) && retries > 0) {
+			return this.getCurrentLineTop(retries - 1);
+		}
+
+		return topValue;
+	}
+
 }

--- a/test/automation/src/positron/positronEditor.ts
+++ b/test/automation/src/positron/positronEditor.ts
@@ -7,6 +7,7 @@ import { Code } from '../code';
 
 // currently a dupe of declaration in ../editor.ts but trying not to modifiy that file
 const EDITOR = (filename: string) => `.monaco-editor[data-uri$="${filename}"]`;
+const CURRENT_LINE = '.view-overlays .current-line';
 
 
 export class PositronEditor {
@@ -23,7 +24,7 @@ export class PositronEditor {
 	}
 
 	async getCurrentLineTop(retries: number = 10): Promise<number> {
-		const currentLine = this.code.driver.getLocator('.view-overlays .current-line');
+		const currentLine = this.code.driver.getLocator(CURRENT_LINE);
 		const currentLineParent = currentLine.locator('..');
 
 		const top = await currentLineParent.evaluate((el) => {

--- a/test/automation/src/positron/positronEditor.ts
+++ b/test/automation/src/positron/positronEditor.ts
@@ -35,19 +35,17 @@ export class PositronEditor {
 		let retries = 10;
 		let topValue: number = NaN;
 
+		const currentLine = this.code.driver.getLocator(CURRENT_LINE);
+		// Note that '..' is used to get the parent of the current-line div
+		const currentLineParent = currentLine.locator('..');
+
 		// Note that this retry loop does not sleep.  This is because the
 		// test that uses this function needs to run as quickly as possible
 		// in order to verify that the editor is not executing code out of order.
 		while (retries > 0) {
-			const currentLine = this.code.driver.getLocator(CURRENT_LINE);
-			// Note that '..' is used to get the parent of the current-line div
-			const currentLineParent = currentLine.locator('..');
 
-			const top = await currentLineParent.evaluate((el) => {
-				return window.getComputedStyle(el).getPropertyValue('top');
-			});
-
-			topValue = parseInt(top, 10);
+			const boundingBox = await currentLineParent.boundingBox();
+			topValue = boundingBox?.y || NaN;
 
 			if (!isNaN(topValue)) {
 				break;

--- a/test/smoke/src/areas/positron/editor/fast-execution.test.ts
+++ b/test/smoke/src/areas/positron/editor/fast-execution.test.ts
@@ -30,16 +30,26 @@ export function setup(logger: Logger) {
 
 			});
 
+			// TODO: remove this test from the PR flow as it is very new and not yet stable
 			it('Verify fast execution is not out of order [C712539] #pr', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'fast-statement-execution', FILENAME));
 
 				let previousTop = -1;
+
+				// Note that this outer loop iterates 11 times.  This is because the length of the
+				// file fast-execution.r is 10 lines.  We want to be sure to send a Control+Enter
+				// for every line of the file (one extra iteration is included "just in case")
 				for (let i = 1; i < 12; i++) {
 					let currentTop = await app.workbench.positronEditor.getCurrentLineTop();
-					let retries = 10; // Allow up to 10 retries if currentTop equals previousTop
+					let retries = 10;
 
+					// Note that top is a measurement of the distance from the top of the editor
+					// to the top of the current line.  By monitoring the top value, we can determine
+					// if the editor is advancing to the next line.  Without this check, the test
+					// would send Control+Enter many times to the first line of the file and not
+					// perform the desrired test.
 					while (currentTop === previousTop && retries > 0) {
 						currentTop = await app.workbench.positronEditor.getCurrentLineTop();
 						retries--;

--- a/test/smoke/src/areas/positron/editor/fast-execution.test.ts
+++ b/test/smoke/src/areas/positron/editor/fast-execution.test.ts
@@ -37,10 +37,10 @@ export function setup(logger: Logger) {
 
 				let previousTop = -1;
 
-				// Note that this outer loop iterates 11 times.  This is because the length of the
+				// Note that this outer loop iterates 10 times.  This is because the length of the
 				// file fast-execution.r is 10 lines.  We want to be sure to send a Control+Enter
-				// for every line of the file (one extra iteration is included "just in case")
-				for (let i = 1; i < 12; i++) {
+				// for every line of the file
+				for (let i = 1; i < 11; i++) {
 					let currentTop = await app.workbench.positronEditor.getCurrentLineTop();
 					let retries = 10;
 
@@ -48,7 +48,7 @@ export function setup(logger: Logger) {
 					// to the top of the current line.  By monitoring the top value, we can determine
 					// if the editor is advancing to the next line.  Without this check, the test
 					// would send Control+Enter many times to the first line of the file and not
-					// perform the desrired test.
+					// perform the desired test.
 					while (currentTop === previousTop && retries > 0) {
 						currentTop = await app.workbench.positronEditor.getCurrentLineTop();
 						retries--;

--- a/test/smoke/src/areas/positron/editor/fast-execution.test.ts
+++ b/test/smoke/src/areas/positron/editor/fast-execution.test.ts
@@ -45,7 +45,6 @@ export function setup(logger: Logger) {
 						retries--;
 					}
 
-					console.log(currentTop);
 					previousTop = currentTop;
 
 					await app.code.driver.getKeyboard().press('Control+Enter');

--- a/test/smoke/src/areas/positron/editor/fast-execution.test.ts
+++ b/test/smoke/src/areas/positron/editor/fast-execution.test.ts
@@ -28,8 +28,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			// TODO: remove from #pr flow once validated
-			it('Verify fast execution is not out of order [C712539] #pr', async function () {
+			it('Verify fast execution is not out of order [C712539]', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'fast-statement-execution', FILENAME));

--- a/test/smoke/src/areas/positron/editor/fast-execution.test.ts
+++ b/test/smoke/src/areas/positron/editor/fast-execution.test.ts
@@ -38,7 +38,7 @@ export function setup(logger: Logger) {
 				// Note that this outer loop iterates 10 times.  This is because the length of the
 				// file fast-execution.r is 10 lines.  We want to be sure to send a Control+Enter
 				// for every line of the file
-				for (let i = 1; i < 11; i++) {
+				for (let i = 0; i < 10; i++) {
 					let currentTop = await app.workbench.positronEditor.getCurrentLineTop();
 					let retries = 10;
 

--- a/test/smoke/src/areas/positron/editor/fast-execution.test.ts
+++ b/test/smoke/src/areas/positron/editor/fast-execution.test.ts
@@ -15,7 +15,7 @@ export function setup(logger: Logger) {
 
 	// does not pass on Ubuntu CI runner as execution is too fast
 	// keeping for OSX and Windows execution
-	describe.skip('Editor Pane: R', () => {
+	describe('Editor Pane: R', () => {
 
 		// Shared before/after handling
 		installAllHandlers(logger);
@@ -30,12 +30,24 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Verify fast execution is not out of order [C712539]', async function () {
+			it('Verify fast execution is not out of order [C712539] #pr', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'fast-statement-execution', FILENAME));
 
+				let previousTop = -1;
 				for (let i = 1; i < 12; i++) {
+					let currentTop = await app.workbench.positronEditor.getCurrentLineTop();
+					let retries = 10; // Allow up to 10 retries if currentTop equals previousTop
+
+					while (currentTop === previousTop && retries > 0) {
+						currentTop = await app.workbench.positronEditor.getCurrentLineTop();
+						retries--;
+					}
+
+					console.log(currentTop);
+					previousTop = currentTop;
+
 					await app.code.driver.getKeyboard().press('Control+Enter');
 				}
 

--- a/test/smoke/src/areas/positron/editor/fast-execution.test.ts
+++ b/test/smoke/src/areas/positron/editor/fast-execution.test.ts
@@ -30,8 +30,7 @@ export function setup(logger: Logger) {
 
 			});
 
-			// TODO: remove this test from the PR flow as it is very new and not yet stable
-			it('Verify fast execution is not out of order [C712539] #pr', async function () {
+			it('Verify fast execution is not out of order [C712539]', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'fast-statement-execution', FILENAME));

--- a/test/smoke/src/areas/positron/editor/fast-execution.test.ts
+++ b/test/smoke/src/areas/positron/editor/fast-execution.test.ts
@@ -13,8 +13,6 @@ import { expect } from '@playwright/test';
  */
 export function setup(logger: Logger) {
 
-	// does not pass on Ubuntu CI runner as execution is too fast
-	// keeping for OSX and Windows execution
 	describe('Editor Pane: R', () => {
 
 		// Shared before/after handling

--- a/test/smoke/src/areas/positron/editor/fast-execution.test.ts
+++ b/test/smoke/src/areas/positron/editor/fast-execution.test.ts
@@ -28,7 +28,8 @@ export function setup(logger: Logger) {
 
 			});
 
-			it('Verify fast execution is not out of order [C712539]', async function () {
+			// TODO: remove from #pr flow once validated
+			it('Verify fast execution is not out of order [C712539] #pr', async function () {
 				const app = this.app as Application;
 
 				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'fast-statement-execution', FILENAME));


### PR DESCRIPTION
Fast execution test was passing on OSX and Windows but failing on Ubuntu executors.

This code implements multi-level retry logic to fix Ubuntu.  It tracks the current line in the editor and does not send a new "Control-Enter" until it detects an advance.  It very rapidly retries when trying to determine the current line.  No sleeping is employed because we want to move through the lines as fast as possible.

### QA Notes

All smoke tests pass.
