### PR TITLE
Make summary stats, histogram, and frequency table `SupportStatus.Supported`, display sparkline histogram for `ColumnDisplayType.Number` data

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -558,6 +558,7 @@
 		"--vscode-positronDataExplorer-columnNullPercentGraphBackgroundStroke",
 		"--vscode-positronDataExplorer-columnNullPercentGraphIndicatorFill",
 		"--vscode-positronDataExplorer-invalidFilterBackground",
+		"--vscode-positronDataExplorer-sparklineFill",
 		"--vscode-positronDataExplorer-statusIndicatorComputing",
 		"--vscode-positronDataExplorer-statusIndicatorDisconnected",
 		"--vscode-positronDataExplorer-selectionBackground",

--- a/extensions/positron-python/python_files/Notebooks intro.ipynb
+++ b/extensions/positron-python/python_files/Notebooks intro.ipynb
@@ -145,7 +145,8 @@
       "name": "python3"
     },
     "language_info": {
-      "version": "3.8.6-final"
+      "version": "3.8.6-final",
+      "name": "python3"
     }
   },
   "nbformat": 4,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -1719,15 +1719,15 @@ class PandasView(DataExplorerTableView):
                 # profiles.
                 ColumnProfileTypeSupportStatus(
                     profile_type=ColumnProfileType.SummaryStats,
-                    support_status=SupportStatus.Experimental,
+                    support_status=SupportStatus.Supported,
                 ),
                 ColumnProfileTypeSupportStatus(
                     profile_type=ColumnProfileType.Histogram,
-                    support_status=SupportStatus.Experimental,
+                    support_status=SupportStatus.Supported,
                 ),
                 ColumnProfileTypeSupportStatus(
                     profile_type=ColumnProfileType.FrequencyTable,
-                    support_status=SupportStatus.Experimental,
+                    support_status=SupportStatus.Supported,
                 ),
             ],
         ),
@@ -2456,7 +2456,7 @@ class PolarsView(DataExplorerTableView):
                 # profiles.
                 ColumnProfileTypeSupportStatus(
                     profile_type=ColumnProfileType.SummaryStats,
-                    support_status=SupportStatus.Experimental,
+                    support_status=SupportStatus.Supported,
                 ),
             ],
         ),

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -1712,11 +1712,6 @@ class PandasView(DataExplorerTableView):
                     profile_type=ColumnProfileType.NullCount,
                     support_status=SupportStatus.Supported,
                 ),
-                # Temporarily disabled for
-                # https://github.com/posit-dev/positron/issues/3490 on
-                # 6/11/2024. This will be enabled again when the UI
-                # has been reworked to more fully support column
-                # profiles.
                 ColumnProfileTypeSupportStatus(
                     profile_type=ColumnProfileType.SummaryStats,
                     support_status=SupportStatus.Supported,
@@ -2449,11 +2444,6 @@ class PolarsView(DataExplorerTableView):
                     profile_type=ColumnProfileType.NullCount,
                     support_status=SupportStatus.Supported,
                 ),
-                # Temporarily disabled for
-                # https://github.com/posit-dev/positron/issues/3490 on
-                # 6/11/2024. This will be enabled again when the UI
-                # has been reworked to more fully support column
-                # profiles.
                 ColumnProfileTypeSupportStatus(
                     profile_type=ColumnProfileType.SummaryStats,
                     support_status=SupportStatus.Supported,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -627,9 +627,6 @@ def test_pandas_supported_features(dxf: DataExplorerFixture):
         ColumnProfileTypeSupportStatus(
             profile_type="null_count", support_status=SupportStatus.Supported
         ),
-        # Temporarily disabled for https://github.com/posit-dev/positron/issues/3490
-        # on 6/11/2024. This will be enabled again when the UI has been reworked to
-        # more fully support column profiles.
         ColumnProfileTypeSupportStatus(
             profile_type="summary_stats",
             support_status=SupportStatus.Supported,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -632,15 +632,15 @@ def test_pandas_supported_features(dxf: DataExplorerFixture):
         # more fully support column profiles.
         ColumnProfileTypeSupportStatus(
             profile_type="summary_stats",
-            support_status=SupportStatus.Experimental,
+            support_status=SupportStatus.Supported,
         ),
         ColumnProfileTypeSupportStatus(
             profile_type="histogram",
-            support_status=SupportStatus.Experimental,
+            support_status=SupportStatus.Supported,
         ),
         ColumnProfileTypeSupportStatus(
             profile_type="frequency_table",
-            support_status=SupportStatus.Experimental,
+            support_status=SupportStatus.Supported,
         ),
     ]
     for tp in profile_types:
@@ -2906,7 +2906,7 @@ def test_polars_get_state(dxf: DataExplorerFixture):
         ),
         ColumnProfileTypeSupportStatus(
             profile_type="summary_stats",
-            support_status=SupportStatus.Experimental,
+            support_status=SupportStatus.Supported,
         ),
     ]
 

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1870,6 +1870,14 @@ export const POSITRON_DATA_EXPLORER_MISSING_VALUES_GRAPH_INDICATOR_FILL_COLOR = 
 	hcLight: '#e5edf3',
 }, localize('positronDataExplorer.columnNullPercentGraphIndicatorFill', "Positron data explorer missing values graph indicator fill color."));
 
+// Positron data explorer sparkline fill color.
+export const POSITRON_DATA_EXPLORER_SPARKLINE_FILL_COLOR = registerColor('positronDataExplorer.sparklineFill', {
+	dark: '#56a2dd',
+	light: '#56a2dd',
+	hcDark: '#56a2dd',
+	hcLight: '#56a2dd',
+}, localize('positronDataExplorer.sparklineFill', "Positron data explorer sparkline fill color."));
+
 // < --- Positron Variables --- >
 
 // Positron variables background color.

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnNullPercent.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnNullPercent.css
@@ -8,11 +8,12 @@
 	grid-gap: 5px;
 	align-items: center;
 	grid-column: missing-values / right-gutter;
-	grid-template-columns: [percent] min-content [graph] 25px [end];
+	grid-template-columns: [percent] 35px [graph] 25px [end];
 }
 
 .data-grid-row-cell .content .column-summary .column-null-percent .text-percent {
 	font-size: 90%;
+	text-align: right;
 	grid-column: percent / graph;
 }
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparkline.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparkline.css
@@ -1,0 +1,4 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparkline.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparkline.tsx
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import 'vs/css!./columnSparkline';
+
+// React.
+import * as React from 'react';
+
+// Other dependencies.
+import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
+import { ColumnSparklineHistogram } from 'vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram';
+
+/**
+ * ColumnSparklineProps interface.
+ */
+interface ColumnSparklineProps {
+	instance: TableSummaryDataGridInstance;
+	columnIndex: number;
+}
+
+/**
+ * ColumnSparkline component.
+ * @param props A ColumnSparklineProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const ColumnSparkline = (props: ColumnSparklineProps) => {
+	// Get the column histogram. If there is one, render it and return.
+	const columnHistogram = props.instance.getColumnHistogram(props.columnIndex);
+	if (columnHistogram) {
+		return <ColumnSparklineHistogram columnHistogram={columnHistogram} />;
+	}
+
+	// Render nothing.
+	return null;
+};

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.css
@@ -7,6 +7,6 @@
 	display: flex;
 }
 
-.data-grid-row-cell .content .column-summary .basic-info .sparkline-histogram .bin {
+.data-grid-row-cell .content .column-summary .basic-info .sparkline-histogram .sparkline-area {
 	fill: var(--vscode-positronDataExplorer-sparklineFill);
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.css
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.data-grid-row-cell .content .column-summary .basic-info .sparkline-histogram {
+	display: flex;
+}
+
+.data-grid-row-cell .content .column-summary .basic-info .sparkline-histogram .bin {
+	fill: var(--vscode-positronDataExplorer-sparklineFill);
+}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.tsx
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import 'vs/css!./columnSparklineHistogram';
+
+// React.
+import * as React from 'react';
+import { useState } from 'react'; // eslint-disable-line no-duplicate-imports
+
+// Other dependencies.
+import { linearConversion, Range } from 'vs/workbench/services/positronDataExplorer/common/utils';
+import { ColumnHistogram } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+
+/**
+ * Constants.
+ */
+const GRAPH_WIDTH = 80;
+const GRAPH_HEIGHT = 20;
+const GRAPH_RANGE: Range = { min: 0, max: GRAPH_HEIGHT };
+
+/**
+ * ColumnSparklineHistogramProps interface.
+ */
+interface ColumnSparklineHistogramProps {
+	readonly columnHistogram: ColumnHistogram;
+}
+
+/**
+ * ColumnSparklineHistogram component.
+ * @param props A ColumnSparklineHistogramProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const ColumnSparklineHistogram = (props: ColumnSparklineHistogramProps) => {
+	// State hooks.
+	const [binCountRange] = useState((): Range => {
+		// Find the minimum and maximum bin counts.
+		let min = 0;
+		let max = 0;
+		for (let bin = 0; bin < props.columnHistogram.bin_counts.length; bin++) {
+			const binCount = props.columnHistogram.bin_counts[bin];
+			if (binCount < min) {
+				min = binCount;
+			}
+			if (binCount > max) {
+				max = binCount;
+			}
+		}
+
+		// Return a range containg the minimum and maximum bin counts.
+		return {
+			min,
+			max
+		};
+	});
+
+	// Render.
+	return (
+		<div className='sparkline-histogram' style={{ width: GRAPH_WIDTH, height: GRAPH_HEIGHT }}>
+			<svg viewBox={`0 0 ${GRAPH_WIDTH} ${GRAPH_HEIGHT}`} shapeRendering='geometricPrecision'>
+				<g>
+					{props.columnHistogram.bin_counts.map((binCount, binIndex) => {
+						const height = linearConversion(binCount, binCountRange, GRAPH_RANGE);
+						return <rect className='bin'
+							key={binIndex}
+							x={binIndex}
+							y={GRAPH_HEIGHT - height}
+							width={1}
+							height={height}
+						/>;
+					})}
+				</g>
+			</svg>
+		</div >
+	);
+};

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.tsx
@@ -61,9 +61,15 @@ export const ColumnSparklineHistogram = (props: ColumnSparklineHistogramProps) =
 		<div className='sparkline-histogram' style={{ width: GRAPH_WIDTH, height: GRAPH_HEIGHT }}>
 			<svg viewBox={`0 0 ${GRAPH_WIDTH} ${GRAPH_HEIGHT}`} shapeRendering='geometricPrecision'>
 				<g>
+					<rect className='sparkline-area'
+						x={0}
+						y={GRAPH_HEIGHT - 0.5}
+						width={GRAPH_WIDTH}
+						height={0.5}
+					/>
 					{props.columnHistogram.bin_counts.map((binCount, binIndex) => {
 						const height = linearConversion(binCount, binCountRange, GRAPH_RANGE);
-						return <rect className='bin'
+						return <rect className='sparkline-area'
 							key={binIndex}
 							x={binIndex}
 							y={GRAPH_HEIGHT - height}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
@@ -35,7 +35,7 @@
 	align-items: center;
 	white-space: nowrap;
 	grid-row: basic-info / profile-info;
-	grid-template-columns: [left-gutter] 4px [expand-collapse] 25px [icon] 25px [title] 1fr [missing-values] min-content [right-gutter] 12px [end];
+	grid-template-columns: [left-gutter] 4px [expand-collapse] 25px [icon] 25px [title] 1fr [sparkline] min-content [missing-values] min-content [right-gutter] 12px [end];
 }
 
 .data-grid-row-cell .content .column-summary .basic-info .expand-collapse-button {
@@ -77,7 +77,7 @@
 	font-weight: 600;
 	margin-right: 4px;
 	text-overflow: ellipsis;
-	grid-column: title / missing-values;
+	grid-column: title / sparkline;
 }
 
 .data-grid-row-cell .content .column-summary .profile-info {

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -160,23 +160,24 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 	const expanded = props.instance.isColumnExpanded(props.columnIndex);
 
 	/**
-	 * Determines whether summary stats us supported.
+	 * Determines whether summary stats is supported.
 	 * @returns true, if summary stats is supported; otherwise, false.
 	 */
 	const isSummaryStatsSupported = () => {
-		// Check if the summary stats panel is supported.
 		const columnProfilesFeatures = props.instance.getSupportedFeatures().get_column_profiles;
-		const summaryStatsStatus = columnProfilesFeatures.supported_types.filter(status =>
+		const summaryStatsSupportStatus = columnProfilesFeatures.supported_types.find(status =>
 			status.profile_type === ColumnProfileType.SummaryStats
 		);
 
-		if (!summaryStatsStatus.length) {
+		if (!summaryStatsSupportStatus) {
 			return false;
 		}
 
-		return dataExplorerExperimentalFeatureEnabled(summaryStatsStatus[0].support_status, props.instance.configurationService);
+		return dataExplorerExperimentalFeatureEnabled(
+			summaryStatsSupportStatus.support_status,
+			props.instance.configurationService
+		);
 	};
-
 
 	// Set the summary supported flag.
 	let summaryStatsSupported;

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -19,6 +19,7 @@ import { usePositronDataGridContext } from 'vs/workbench/browser/positronDataGri
 import { ProfileNumber } from 'vs/workbench/services/positronDataExplorer/browser/components/profileNumber';
 import { ProfileString } from 'vs/workbench/services/positronDataExplorer/browser/components/profileString';
 import { ProfileBoolean } from 'vs/workbench/services/positronDataExplorer/browser/components/profileBoolean';
+import { ColumnSparkline } from 'vs/workbench/services/positronDataExplorer/browser/components/columnSparkline';
 import { ProfileDatetime } from 'vs/workbench/services/positronDataExplorer/browser/components/profileDatetime';
 import { ColumnNullPercent } from 'vs/workbench/services/positronDataExplorer/browser/components/columnNullPercent';
 import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
@@ -262,7 +263,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				<div className='column-name'>
 					{props.columnSchema.column_name}
 				</div>
-
+				<ColumnSparkline {...props} />
 				<ColumnNullPercent {...props} />
 			</div>
 			{expanded &&

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -125,7 +125,10 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 		super();
 
 		// Initialize.
-		this._tableSummaryCache = new TableSummaryCache(this._dataExplorerClientInstance);
+		this._tableSummaryCache = new TableSummaryCache(
+			this._configurationService,
+			this._dataExplorerClientInstance
+		);
 		this._tableSchemaDataGridInstance = new TableSummaryDataGridInstance(
 			this._configurationService,
 			this._hoverService,

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -340,5 +340,23 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		return this._tableSummaryCache.getColumnProfile(columnIndex)?.summary_stats;
 	}
 
+	/**
+	 * Gets the column histogram for the specified column index.
+	 * @param columnIndex The column index.
+	 * @returns The column histogram for the specified column index
+	 */
+	getColumnHistogram(columnIndex: number) {
+		return this._tableSummaryCache.getColumnProfile(columnIndex)?.histogram;
+	}
+
+	/**
+	 * Gets the column frequency table for the specified column index.
+	 * @param columnIndex The column index.
+	 * @returns The column frequency table for the specified column index
+	 */
+	getColumnFrequencyTable(columnIndex: number) {
+		return this._tableSummaryCache.getColumnProfile(columnIndex)?.frequency_table;
+	}
+
 	//#endregion Private Methods
 }

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -355,7 +355,14 @@ export class TableSummaryCache extends Disposable {
 
 				// Add histogram.
 				if (columnProfile.histogram) {
-					columnProfileSpecs.push({ profile_type: ColumnProfileType.Histogram });
+					columnProfileSpecs.push({
+						profile_type: ColumnProfileType.Histogram,
+						params: {
+							method: ColumnHistogramParamsMethod.Fixed,
+							num_bins: 80,
+							quantiles: [0.25, 0.50]
+						}
+					});
 				}
 
 				// Add frequency table.

--- a/src/vs/workbench/services/positronDataExplorer/common/utils.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/utils.ts
@@ -4,6 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
+ * Range interface.
+ */
+export interface Range {
+	readonly min: number;
+	readonly max: number;
+}
+
+/**
  * Creates an array from an index range.
  * @param startIndex The start index.
  * @param endIndex The end index.
@@ -11,3 +19,13 @@
  */
 export const arrayFromIndexRange = (startIndex: number, endIndex: number) =>
 	Array.from({ length: endIndex - startIndex + 1 }, (_, i) => startIndex + i);
+
+/**
+ * Performs a linear conversion from one range to another range.
+ * @param value The value to convert.
+ * @param from The from range.
+ * @param to The to range.
+ * @returns The converted value.
+ */
+export const linearConversion = (value: number, from: Range, to: Range) =>
+	((value - from.min) / (from.max - from.min)) * (to.max - to.min) + to.min;


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

**Data Explorer**

This PR changes the support status of `ColumnProfileType.SummaryStats`, `ColumnProfileType.Histogram`, and `ColumnProfileType.FrequencyTable` from `SupportStatus.Experimental` to `SupportStatus.Supported`.

Additionally, the first Data Explorer sparkline has been added. Sparkline histograms are now displayed for `ColumnDisplayType.Number` data.

![image](https://github.com/user-attachments/assets/f3d1033a-e85e-4fb8-8cf9-0a7ec355b901)

### QA Notes

None