### PR TITLE
Bump ark to v0.1.125

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -607,7 +607,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.124"
+      "ark": "0.1.125"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.7"


### PR DESCRIPTION
For: 

- https://github.com/posit-dev/ark/pull/474
- https://github.com/posit-dev/ark/pull/471
- https://github.com/posit-dev/ark/pull/468