### PR TITLE
Support file download links in webviews

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -211,6 +211,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/contrib/positronOutputWebview",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/contrib/preferences",
 			"project": "vscode-workbench"
 		},

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export type PositronDownloadMessage = {
+	type: 'positronDownload';
+	data: string | ArrayBuffer | null;
+	downloadName: string;
+};
+
+export function msgIsDownloadMessage(msg: any): msg is PositronDownloadMessage {
+	return msg.type === 'positronDownload';
+}
+
+// Let typescript know that the vscode object is available
+declare const vscode: {
+	postMessage(message: PositronDownloadMessage): void;
+};
+
+// Function is meant to be dependency free so it can be serialized into the webview with the
+// Function.toString() method
+export function handleWebviewClicks() {
+
+	// eslint-disable-next-line no-restricted-syntax
+	document.addEventListener('click', (event) => {
+		const suppressEvent = () => {
+			event.preventDefault();
+			event.stopPropagation();
+		};
+		for (const node of event.composedPath()) {
+			// eslint-disable-next-line no-restricted-syntax
+			if (node instanceof HTMLAnchorElement && node.href) {
+				if (node.href.startsWith('blob:')) {
+					handleBlobUrlClick(node.href, node.download);
+					suppressEvent();
+				} else if (node.href.startsWith('data:')) {
+					handleDataUrl(node.href, node.download);
+					suppressEvent();
+				} else {
+					console.log('handleDataUrl called with unknown href type', node.href);
+				}
+				break;
+			}
+		}
+	});
+
+	const handleBlobUrlClick = async (url: string, downloadName: string) => {
+		try {
+			const response = await fetch(url);
+			const blob = await response.blob();
+			const reader = new FileReader();
+			reader.addEventListener('load', () => {
+				handleDataUrl(reader.result, downloadName);
+			});
+			reader.readAsDataURL(blob);
+		} catch (e) {
+			console.error(e.message);
+		}
+	};
+
+	const handleDataUrl = async (data: string | ArrayBuffer | null, downloadName: string) => {
+		vscode.postMessage({
+			type: 'positronDownload',
+			data,
+			downloadName
+		});
+	};
+}

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
@@ -20,7 +20,7 @@ declare const vscode: {
 
 // Function is meant to be dependency free so it can be serialized into the webview with the
 // Function.toString() method
-export function handleWebviewClicks() {
+function handleWebviewClicks() {
 
 	// eslint-disable-next-line no-restricted-syntax
 	document.addEventListener('click', (event) => {
@@ -67,3 +67,10 @@ export function handleWebviewClicks() {
 		});
 	};
 }
+
+/**
+ * A string containing function to be injected into a webview to handle clicks on anchor elements.
+ * Pairs with listeners in the webview listening for the messages from the webview of the type
+ * 'PositronDownloadMessage'.
+ */
+export const handleWebviewClicksInjection = `(${handleWebviewClicks.toString()})()`;

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
@@ -66,6 +66,15 @@ function handleWebviewClicks() {
 			downloadName
 		});
 	};
+
+	// Override the prompt function to return the default value or 'myFile' if one isnt provided.
+	// This is needed because the prompt function is not supported in webviews and the prompt function
+	// is commonly used by libraries like bokeh to provide names for files to save. The main file save
+	// dialog that positron shows will already provide the ability to change the file name so we're
+	// just providing a default value here.
+	window.prompt = (message, _default) => {
+		return _default ?? 'myFile';
+	};
 }
 
 /**

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
@@ -76,7 +76,7 @@ function handleWebviewClicks() {
 	// dialog that positron shows will already provide the ability to change the file name so we're
 	// just providing a default value here.
 	window.prompt = (message, _default) => {
-		return _default ?? 'myFile';
+		return _default ?? 'Untitled';
 	};
 }
 

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
@@ -3,19 +3,19 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export type PositronDownloadMessage = {
-	type: 'positronDownload';
-	data: string | ArrayBuffer | null;
-	downloadName: string;
-};
+import type { IClickedDataUrlMessage } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages';
 
-export function msgIsDownloadMessage(msg: any): msg is PositronDownloadMessage {
-	return msg.type === 'positronDownload';
+
+export function msgIsDownloadMessage(msg: any): msg is IClickedDataUrlMessage {
+	if (!msg.__vscode_notebook_message) {
+		return false;
+	}
+	return msg.type === 'clicked-data-url';
 }
 
 // Let typescript know that the vscode object is available
 declare const vscode: {
-	postMessage(message: PositronDownloadMessage): void;
+	postMessage(message: IClickedDataUrlMessage): void;
 };
 
 // Function is meant to be dependency free so it can be serialized into the webview with the
@@ -64,7 +64,8 @@ function handleWebviewClicks() {
 
 	const handleDataUrl = async (data: string | ArrayBuffer | null, downloadName: string) => {
 		vscode.postMessage({
-			type: 'positronDownload',
+			__vscode_notebook_message: true,
+			type: 'clicked-data-url',
 			data,
 			downloadName
 		});

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
@@ -20,6 +20,9 @@ declare const vscode: {
 
 // Function is meant to be dependency free so it can be serialized into the webview with the
 // Function.toString() method
+// The logic here is largely taken from the `webviewPreloads.ts` file that gets injected into
+// notebook webviews. The implementation here is a bit simpler because there's contexts that don't
+// apply to the positron webviews that are handled in the notebook webviews.
 function handleWebviewClicks() {
 
 	// eslint-disable-next-line no-restricted-syntax

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
@@ -73,4 +73,4 @@ function handleWebviewClicks() {
  * Pairs with listeners in the webview listening for the messages from the webview of the type
  * 'PositronDownloadMessage'.
  */
-export const handleWebviewClicksInjection = `(${handleWebviewClicks.toString()})()`;
+export const handleWebviewLinkClicksInjection = `(${handleWebviewClicks.toString()})()`;

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
@@ -3,13 +3,31 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { decodeBase64, VSBuffer } from 'vs/base/common/buffer';
 import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
+import { getExtensionForMimeType } from 'vs/base/common/mime';
+import { localize } from 'vs/nls';
+import { joinPath } from 'vs/base/common/resources';
+import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IFileService } from 'vs/platform/files/common/files';
+import { ILogService } from 'vs/platform/log/common/log';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { INotebookWebviewMessage } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
-import { FromWebviewMessage } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages';
+import { FromWebviewMessage, IClickedDataUrlMessage } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages';
 import { IScopedRendererMessaging } from 'vs/workbench/contrib/notebook/common/notebookRendererMessagingService';
 import { INotebookOutputWebview } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
 import { IOverlayWebview, IWebviewElement } from 'vs/workbench/contrib/webview/browser/webview';
+
+interface NotebookOutputWebviewOptions<WType extends IOverlayWebview | IWebviewElement = IOverlayWebview> {
+	readonly id: string;
+	readonly sessionId: string;
+	readonly webview: WType;
+	readonly render?: () => void;
+	rendererMessaging?: IScopedRendererMessaging;
+}
+
 
 /**
  * A notebook output webview wraps a webview that contains rendered HTML content
@@ -19,6 +37,10 @@ export class NotebookOutputWebview<WType extends IOverlayWebview | IWebviewEleme
 
 	private readonly _onDidRender = new Emitter<void>;
 	private readonly _onDidReceiveMessage = new Emitter<INotebookWebviewMessage>();
+	readonly id: string;
+	readonly sessionId: string;
+	readonly webview: WType;
+	readonly render?: () => void;
 
 	/**
 	 * Create a new notebook output webview.
@@ -33,17 +55,28 @@ export class NotebookOutputWebview<WType extends IOverlayWebview | IWebviewEleme
 	 *   runtime and the renderer.
 	 */
 	constructor(
-		readonly id: string,
-		readonly sessionId: string,
-		readonly webview: WType,
-		readonly render?: () => void,
-		rendererMessaging?: IScopedRendererMessaging,
+		{
+			id,
+			sessionId,
+			webview,
+			render,
+			rendererMessaging
+		}: NotebookOutputWebviewOptions<WType>,
+		@IFileDialogService private _fileDialogService: IFileDialogService,
+		@IFileService private _fileService: IFileService,
+		@IWorkspaceContextService private _workspaceContextService: IWorkspaceContextService,
+		@ILogService private _logService: ILogService,
+		@INotificationService private _notificationService: INotificationService,
 	) {
 		super();
 
 		// Ensure that the underlying webview is disposed when notebook output webview is disposed.
 		this._register(webview);
 
+		this.id = id;
+		this.sessionId = sessionId;
+		this.webview = webview;
+		this.render = render;
 		this.onDidRender = this._onDidRender.event;
 		this._register(this._onDidRender);
 		this._register(this._onDidReceiveMessage);
@@ -72,8 +105,12 @@ export class NotebookOutputWebview<WType extends IOverlayWebview | IWebviewEleme
 			switch (data.type) {
 				case 'customRendererMessage':
 					rendererMessaging?.postMessage(data.rendererId, data.message);
+					break;
 				case 'positronRenderComplete':
 					this._onDidRender.fire();
+					break;
+				case 'clicked-data-url':
+					this._downloadData(data);
 					break;
 			}
 
@@ -81,4 +118,50 @@ export class NotebookOutputWebview<WType extends IOverlayWebview | IWebviewEleme
 	}
 
 	onDidRender: Event<void>;
+
+	private async _downloadData(payload: IClickedDataUrlMessage): Promise<void> {
+		try {
+
+			if (typeof payload.data !== 'string') {
+				return;
+			}
+
+			const [splitStart, splitData] = payload.data.split(';base64,');
+			if (!splitData || !splitStart) {
+				return;
+			}
+
+			const defaultDir = this._workspaceContextService.getWorkspace().folders[0]?.uri ?? await this._fileDialogService.defaultFilePath();
+			let defaultName: string;
+			if (payload.downloadName) {
+				defaultName = payload.downloadName;
+			} else {
+				const mimeType = splitStart.replace(/^data:/, '');
+				const candidateExtension = mimeType && getExtensionForMimeType(mimeType);
+				defaultName = candidateExtension ? `download${candidateExtension}` : 'download';
+			}
+
+			const defaultUri = joinPath(defaultDir, defaultName);
+			const newFileUri = await this._fileDialogService.showSaveDialog({
+				defaultUri
+			});
+			if (!newFileUri) {
+				return;
+			}
+
+			let buff: VSBuffer;
+			try {
+				buff = decodeBase64(splitData);
+			} catch (e) {
+				throw new Error(localize("base64DecodeError", "Failed to decode base64 data: {0}", e.message));
+			}
+
+			await this._fileService.writeFile(newFileUri, buff);
+		} catch (error) {
+			this._logService.error('Failed to download file', error);
+			this._notificationService.error(
+				localize('failedToDownloadFile', 'Failed to download file: {}', error.message)
+			);
+		}
+	}
 }

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -423,6 +423,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 
 		webview.setHtml(`
 <script src='${jQueryPath}'></script>
+${PositronNotebookOutputWebviewService.CssAddons}
 ${html}
 <script>
 const vscode = acquireVsCodeApi();
@@ -444,6 +445,17 @@ window.onload = function() {
 			webview as WType extends WebviewType.Overlay ? IOverlayWebview : IWebviewElement
 		);
 	}
+
+	/**
+	 * A set of CSS addons to inject into the HTML of the webview. Used to do things like
+	 * hide elements that are not functional in the context of positron such as links to
+	 * pages that can't be opened.
+	 */
+	static readonly CssAddons = `
+<style>
+	/* Hide actions button that does things like opening source code etc.. (See #2829) */
+</style>`;
+
 
 	private async _downloadData(
 		payload: PositronDownloadMessage,

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -423,7 +423,6 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 
 		webview.setHtml(`
 <script src='${jQueryPath}'></script>
-${PositronNotebookOutputWebviewService.CssAddons}
 ${html}
 <script>
 const vscode = acquireVsCodeApi();
@@ -445,17 +444,6 @@ window.onload = function() {
 			webview as WType extends WebviewType.Overlay ? IOverlayWebview : IWebviewElement
 		);
 	}
-
-	/**
-	 * A set of CSS addons to inject into the HTML of the webview. Used to do things like
-	 * hide elements that are not functional in the context of positron such as links to
-	 * pages that can't be opened.
-	 */
-	static readonly CssAddons = `
-<style>
-	/* Hide actions button that does things like opening source code etc.. (See #2829) */
-</style>`;
-
 
 	private async _downloadData(
 		payload: PositronDownloadMessage,

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -338,6 +338,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 			background-color: var(--vscode-editor-findMatchBackground);
 		}
 	</style>
+	${PositronNotebookOutputWebviewService.CssAddons}
 </head>
 <body>
 <div id='container'></div>

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -21,7 +21,7 @@ import { ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/co
 import { dirname, joinPath } from 'vs/base/common/resources';
 import { INotebookRendererMessagingService } from 'vs/workbench/contrib/notebook/common/notebookRendererMessagingService';
 import { ILogService } from 'vs/platform/log/common/log';
-import { msgIsDownloadMessage, PositronDownloadMessage, handleWebviewClicksInjection } from './downloadUtils';
+import { msgIsDownloadMessage, PositronDownloadMessage, handleWebviewLinkClicksInjection } from './downloadUtils';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IFileService } from 'vs/platform/files/common/files';
@@ -340,7 +340,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 <div id='container'></div>
 <div id="_defaultColorPalatte"></div>
 <script type="module">${preloads}</script>
-<script> ${handleWebviewClicksInjection} </script>
+<script> ${handleWebviewLinkClicksInjection} </script>
 </body>
 `);
 
@@ -432,7 +432,7 @@ window.onload = function() {
 		type: 'positronRenderComplete',
 	});
 
-	${handleWebviewClicksInjection};
+	${handleWebviewLinkClicksInjection};
 };
 </script>`);
 

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -270,7 +270,6 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 		preReqMessagesInfo?: MessageRenderInfo[];
 		viewType?: string;
 	}): Promise<INotebookOutputWebview> {
-		const webviewDisposables = new DisposableStore();
 
 		// Make message info into an array if it isn't already
 		const messagesInfo = [...preReqMessagesInfo ?? [], displayMessageInfo];
@@ -317,13 +316,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 
 		// Create the webview itself
 		const webview = this._webviewService.createWebviewOverlay(webviewInitInfo);
-		webview.onDidDispose(() => { webviewDisposables.dispose(); });
 
-		webviewDisposables.add(webview.onMessage(async ({ message }) => {
-			if (msgIsDownloadMessage(message)) {
-				this._downloadData(message);
-			}
-		}));
 
 		// Form the HTML to send to the webview. Currently, this is a very simplified version
 		// of the HTML that the notebook renderer API creates, but it works for many renderers.
@@ -340,7 +333,6 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 <div id='container'></div>
 <div id="_defaultColorPalatte"></div>
 <script type="module">${preloads}</script>
-<script> ${handleWebviewLinkClicksInjection} </script>
 </body>
 `);
 

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -492,7 +492,12 @@ window.onload = function() {
 				return;
 			}
 
-			const buff = decodeBase64(splitData);
+			let buff: VSBuffer;
+			try {
+				buff = decodeBase64(splitData);
+			} catch (e) {
+				throw new Error(localize("base64DecodeError", "Failed to decode base64 data: {0}", e.message));
+			}
 
 			await this._fileService.writeFile(newFileUri, buff);
 			await this._openerService.open(newFileUri);

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -129,7 +129,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 		for (const mimeType of Object.keys(output.data)) {
 			// Don't use a renderer for non-widget MIME types
 			if (mimeType === 'text/plain' ||
-				// mimeType === 'text/html' ||
+				mimeType === 'text/html' ||
 				mimeType === 'image/png') {
 				continue;
 			}

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -453,7 +453,11 @@ window.onload = function() {
 	 */
 	static readonly CssAddons = `
 <style>
-	/* Hide actions button that does things like opening source code etc.. (See #2829) */
+	/* Hide actions button that try and open external pages like opening source code as they don't currently work (See #2829)
+	/* We do support download link clicks, so keep those. */
+	.vega-actions a:not([download]) {
+		display: none;
+	}
 </style>`;
 
 

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -25,7 +25,6 @@ import { msgIsDownloadMessage, handleWebviewLinkClicksInjection } from './downlo
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IFileService } from 'vs/platform/files/common/files';
-import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { getExtensionForMimeType } from 'vs/base/common/mime';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { INotificationService } from 'vs/platform/notification/common/notification';
@@ -56,7 +55,6 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 		@IWorkspaceContextService private _workspaceContextService: IWorkspaceContextService,
 		@IFileDialogService private _fileDialogService: IFileDialogService,
 		@IFileService private _fileService: IFileService,
-		@IOpenerService private _openerService: IOpenerService,
 	) {
 	}
 
@@ -500,7 +498,6 @@ window.onload = function() {
 			}
 
 			await this._fileService.writeFile(newFileUri, buff);
-			await this._openerService.open(newFileUri);
 		} catch (error) {
 			this._logService.error('Failed to download file', error);
 			this._notificationService.error(

--- a/src/vs/workbench/contrib/webview/browser/pre/webview-events.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/webview-events.js
@@ -365,3 +365,12 @@ window.addEventListener('load', () => {
 		title: document.title,
 	});
 });
+
+// Override the prompt function to return the default value or 'myFile' if one isnt provided.
+// This is needed because the prompt function is not supported in webviews and the prompt function
+// is commonly used by libraries like bokeh to provide names for files to save. The main file save
+// dialog that positron shows will already provide the ability to change the file name so we're
+// just providing a default value here.
+window.prompt = (message, _default) => {
+	return _default ?? 'myFile';
+};

--- a/src/vs/workbench/contrib/webview/browser/pre/webview-events.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/webview-events.js
@@ -372,5 +372,5 @@ window.addEventListener('load', () => {
 // dialog that positron shows will already provide the ability to change the file name so we're
 // just providing a default value here.
 window.prompt = (message, _default) => {
-	return _default ?? 'myFile';
+	return _default ?? 'Untitled';
 };


### PR DESCRIPTION
Addresses #4087 
Adds logic for intercepting clicks on links for downloading assets (via `blob:` and `data"` schemes). 
This adds support for downloading plots etc from a interactive plotting libraries like altair. 

Previously for altair plots we simply hid the actions menu because it was unfunctional. Now we re-enable it and show the svg and png download options. 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/d69ef6e3-d959-4f88-af83-ec11b12ac4c3">

<img width="1076" alt="image" src="https://github.com/user-attachments/assets/2e9b1ffd-2934-41e6-a3e5-ef5cbcbe35e9">
<img width="1054" alt="image" src="https://github.com/user-attachments/assets/4b33df56-00eb-4edc-ab82-cdbfc2c58b29">

(We still hide the other options because their link types still dont open - and don't in other iframe-based environments like jupyter notebooks, either.)

Right now the only library that I'm sure we have enabled downloading for is Altair/vega, but in theory this is a common pattern. 

### Implementation
We take inspiration from the `webviewPreloads.ts` file for the logic. Luckily ours is a little simpler because we don't have to deal with the context of multiple outputs and focus changing. 

If the user clicks a blob url then we fetch the blob and convert to a data url, if it's a dataurl we just send it through via a new message type `PositronDownloadMessage` that is intercepted by a message watcher on the webview. 

### Future work
Currently, we handle a limited set of webview actions that affect external elements. This can be expanded in the future to include more utilities, such as opening links in the preview panel.

Also these patches are only used in the plots pane webviews currently, but would probably be useful for all instances of the preview or plots pane so things that use the `UiFrontendEvent.ShowHtmlFile` comm are also given the abilities. 
