### PR TITLE
use code server `preLaunchTask` for `Positron Server (Web)`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -282,14 +282,11 @@
 		{
 			"type": "node",
 			"request": "launch",
-			"name": "Positron Server (Web)",
-			"runtimeExecutable": "${workspaceFolder}/scripts/code-server.sh",
-			"windows": {
-				"runtimeExecutable": "${workspaceFolder}/scripts/code-server.bat",
-			},
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],
+			"name": "Positron Server (Web)",
+			"preLaunchTask": "Run code server",
 			"presentation": {
 				"group": "0_vscode",
 				"order": 2


### PR DESCRIPTION
### Description

- Addresses: https://github.com/posit-dev/positron/issues/4379

The `Positron Server (Web)` task isn't working, but the Chrome and Edge versions of the task are working fine. This is because the `Positron Server (Web)` launch task doesn't pass connection token info which is needed to run the server with a license key.

Instead of calling the `code-server` executable directly, we can instead use the "code server" pre-launch task which will pass the appropriate server arguments.

This change worked for me on Ubuntu and Mac.

### QA Notes

You'll need to have licensing set up. Feel free to ping me (or Jonathan) if you need a hand with this!

The task console will show the url `http://localhost:8080?tkn=dev-token`, which you can paste into your favourite web browser to confirm that Positron loads and you can play around with Positron.
