### PR TITLE
Put Data Explroer sparklines behind feature flag

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -24,7 +24,7 @@ import { ProfileDatetime } from 'vs/workbench/services/positronDataExplorer/brow
 import { ColumnNullPercent } from 'vs/workbench/services/positronDataExplorer/browser/components/columnNullPercent';
 import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
 import { ColumnDisplayType, ColumnProfileType, ColumnSchema } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
-import { dataExplorerExperimentalFeatureEnabled } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerExperimentalConfig';
+import { checkDataExplorerExperimentalFeaturesEnabled, dataExplorerExperimentalFeatureEnabled } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerExperimentalConfig';
 
 /**
  * ColumnSummaryCellProps interface.
@@ -264,7 +264,9 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				<div className='column-name'>
 					{props.columnSchema.column_name}
 				</div>
-				<ColumnSparkline {...props} />
+				{checkDataExplorerExperimentalFeaturesEnabled(context.configurationService) &&
+					<ColumnSparkline {...props} />
+				}
 				<ColumnNullPercent {...props} />
 			</div>
 			{expanded &&


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR puts Data Explorer sparklines behind the experimental feature flag.

<img width="1091" alt="image" src="https://github.com/user-attachments/assets/ef498ab5-92de-4d86-b892-2420452da7b6">

### QA Notes

None