### PR TITLE
Display sparkline frequency tables for `ColumnDisplayType.Boolean` and `ColumnDisplayType.String` data

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -559,6 +559,7 @@
 		"--vscode-positronDataExplorer-columnNullPercentGraphIndicatorFill",
 		"--vscode-positronDataExplorer-invalidFilterBackground",
 		"--vscode-positronDataExplorer-sparklineFill",
+		"--vscode-positronDataExplorer-sparklineStroke",
 		"--vscode-positronDataExplorer-statusIndicatorComputing",
 		"--vscode-positronDataExplorer-statusIndicatorDisconnected",
 		"--vscode-positronDataExplorer-selectionBackground",

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1878,6 +1878,14 @@ export const POSITRON_DATA_EXPLORER_SPARKLINE_FILL_COLOR = registerColor('positr
 	hcLight: '#56a2dd',
 }, localize('positronDataExplorer.sparklineFill', "Positron data explorer sparkline fill color."));
 
+// Positron data explorer sparkline stroke color.
+export const POSITRON_DATA_EXPLORER_SPARKLINE_STROKE_COLOR = registerColor('positronDataExplorer.sparklineStroke', {
+	dark: '#0066b6',
+	light: '#0066b6',
+	hcDark: '#0066b6',
+	hcLight: '#0066b6',
+}, localize('positronDataExplorer.sparklineStroke', "Positron data explorer sparkline stroke color."));
+
 // < --- Positron Variables --- >
 
 // Positron variables background color.

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparkline.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparkline.tsx
@@ -12,6 +12,7 @@ import * as React from 'react';
 // Other dependencies.
 import { TableSummaryDataGridInstance } from 'vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance';
 import { ColumnSparklineHistogram } from 'vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram';
+import { ColumnSparklineFrequencyTable } from 'vs/workbench/services/positronDataExplorer/browser/components/columnSparklineFrequencyTable';
 
 /**
  * ColumnSparklineProps interface.
@@ -31,6 +32,12 @@ export const ColumnSparkline = (props: ColumnSparklineProps) => {
 	const columnHistogram = props.instance.getColumnHistogram(props.columnIndex);
 	if (columnHistogram) {
 		return <ColumnSparklineHistogram columnHistogram={columnHistogram} />;
+	}
+
+	// Get the column frequency table. If there is one, render it and return.
+	const columnFrequencyTable = props.instance.getColumnFrequencyTable(props.columnIndex);
+	if (columnFrequencyTable) {
+		return <ColumnSparklineFrequencyTable columnFrequencyTable={columnFrequencyTable} />;
 	}
 
 	// Render nothing.

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineFrequencyTable.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineFrequencyTable.css
@@ -3,14 +3,14 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.data-grid-row-cell .content .column-summary .basic-info .sparkline-histogram {
+.data-grid-row-cell .content .column-summary .basic-info .sparkline-frequency-table {
 	display: flex;
 }
 
-.data-grid-row-cell .content .column-summary .basic-info .sparkline-histogram .bottom-edge {
+.data-grid-row-cell .content .column-summary .basic-info .sparkline-frequency-table .bottom-edge {
 	fill: var(--vscode-positronDataExplorer-sparklineFill);
 }
 
-.data-grid-row-cell .content .column-summary .basic-info .sparkline-histogram .bin-count {
+.data-grid-row-cell .content .column-summary .basic-info .sparkline-frequency-table .count {
 	fill: var(--vscode-positronDataExplorer-sparklineFill);
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineFrequencyTable.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineFrequencyTable.tsx
@@ -1,0 +1,128 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import 'vs/css!./columnSparklineFrequencyTable';
+
+// React.
+import * as React from 'react';
+import { useState } from 'react'; // eslint-disable-line no-duplicate-imports
+
+// Other dependencies.
+import { linearConversion, Range } from 'vs/workbench/services/positronDataExplorer/common/utils';
+import { ColumnFrequencyTable } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
+
+/**
+ * Constants.
+ */
+const GRAPH_WIDTH = 80;
+const GRAPH_HEIGHT = 20;
+const GRAPH_RANGE: Range = { min: 0, max: GRAPH_HEIGHT };
+
+/**
+ * ColumnSparklineFrequencyTableProps interface.
+ */
+interface ColumnSparklineFrequencyTableProps {
+	readonly columnFrequencyTable: ColumnFrequencyTable;
+}
+
+/**
+ * ColumnSparklineFrequencyTable component.
+ * @param columnFrequencyTable The column frequency table.
+ * @returns The rendered component.
+ */
+export const ColumnSparklineFrequencyTable = (
+	{ columnFrequencyTable }: ColumnSparklineFrequencyTableProps
+) => {
+	// State hooks.
+	const [countWidth] = useState(() => {
+		// Determine the number of counts that will be rendered.
+		let counts = columnFrequencyTable.counts.length;
+		if (columnFrequencyTable.other_count) {
+			counts++;
+		}
+
+		// If the number of counts that will be rendered is 0, return 0.
+		if (!counts) {
+			return 0;
+		}
+
+		// Return the count width.
+		return (GRAPH_WIDTH - (counts - 1)) / counts;
+	});
+	const [countRange] = useState((): Range => {
+		// Find the maximum count.
+		let maxCount = 0;
+		for (let i = 0; i < columnFrequencyTable.counts.length; i++) {
+			const count = columnFrequencyTable.counts[i];
+			if (count > maxCount) {
+				maxCount = count;
+			}
+		}
+
+		// Account for the other count in the maximum count.
+		if (columnFrequencyTable.other_count && columnFrequencyTable.other_count > maxCount) {
+			maxCount = columnFrequencyTable.other_count;
+		}
+
+		// Return the count range.
+		return {
+			min: 0,
+			max: maxCount
+		};
+	});
+
+	/**
+	 * OtherCount component
+	 * @returns The rendered component.
+	 */
+	const OtherCount = () => {
+		// Calculate the other count height.
+		const otherCountHeight = linearConversion(
+			columnFrequencyTable.other_count ?? 0,
+			countRange,
+			GRAPH_RANGE
+		);
+
+		// Render.
+		return (
+			<rect className='count'
+				x={GRAPH_WIDTH - countWidth}
+				y={GRAPH_HEIGHT - otherCountHeight}
+				width={countWidth}
+				height={otherCountHeight}
+			/>
+		);
+	};
+
+	// Render.
+	return (
+		<div className='sparkline-frequency-table' style={{ width: GRAPH_WIDTH, height: GRAPH_HEIGHT }}>
+			<svg viewBox={`0 0 ${GRAPH_WIDTH} ${GRAPH_HEIGHT}`} shapeRendering='crispEdges'>
+				<g>
+					<rect className='bottom-edge'
+						x={0}
+						y={GRAPH_HEIGHT - 0.5}
+						width={GRAPH_WIDTH}
+						height={0.5}
+					/>
+					{columnFrequencyTable.counts.map((count, countIndex) => {
+						const countHeight = linearConversion(count, countRange, GRAPH_RANGE);
+						return (
+							<rect className='count'
+								key={`count-${countIndex}`}
+								x={(countIndex * countWidth) + countIndex}
+								y={GRAPH_HEIGHT - countHeight}
+								width={countWidth}
+								height={countHeight}
+							/>
+						);
+					})}
+					{columnFrequencyTable.other_count && <OtherCount />}
+				</g>
+			</svg>
+		</div >
+	);
+};

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.tsx
@@ -30,52 +30,55 @@ interface ColumnSparklineHistogramProps {
 
 /**
  * ColumnSparklineHistogram component.
- * @param props A ColumnSparklineHistogramProps that contains the component properties.
+ * @param columnHistogram The column histogram.
  * @returns The rendered component.
  */
-export const ColumnSparklineHistogram = (props: ColumnSparklineHistogramProps) => {
+export const ColumnSparklineHistogram = ({ columnHistogram }: ColumnSparklineHistogramProps) => {
 	// State hooks.
+	const [binWidth] = useState(GRAPH_WIDTH / columnHistogram.bin_counts.length);
 	const [binCountRange] = useState((): Range => {
 		// Find the minimum and maximum bin counts.
-		let min = 0;
-		let max = 0;
-		for (let bin = 0; bin < props.columnHistogram.bin_counts.length; bin++) {
-			const binCount = props.columnHistogram.bin_counts[bin];
-			if (binCount < min) {
-				min = binCount;
+		let minBinCount = 0;
+		let maxBinCount = 0;
+		for (let i = 0; i < columnHistogram.bin_counts.length; i++) {
+			const binCount = columnHistogram.bin_counts[i];
+			if (binCount < minBinCount) {
+				minBinCount = binCount;
 			}
-			if (binCount > max) {
-				max = binCount;
+			if (binCount > maxBinCount) {
+				maxBinCount = binCount;
 			}
 		}
 
-		// Return a range containg the minimum and maximum bin counts.
+		// Return the bin count range.
 		return {
-			min,
-			max
+			min: minBinCount,
+			max: maxBinCount
 		};
 	});
 
 	// Render.
 	return (
 		<div className='sparkline-histogram' style={{ width: GRAPH_WIDTH, height: GRAPH_HEIGHT }}>
-			<svg viewBox={`0 0 ${GRAPH_WIDTH} ${GRAPH_HEIGHT}`} shapeRendering='geometricPrecision'>
+			<svg viewBox={`0 0 ${GRAPH_WIDTH} ${GRAPH_HEIGHT}`} shapeRendering='crispEdges'>
 				<g>
-					<rect className='sparkline-area'
+					<rect className='bottom-edge'
 						x={0}
 						y={GRAPH_HEIGHT - 0.5}
 						width={GRAPH_WIDTH}
 						height={0.5}
 					/>
-					{props.columnHistogram.bin_counts.map((binCount, binIndex) => {
-						const height = linearConversion(binCount, binCountRange, GRAPH_RANGE);
-						return <rect className='sparkline-area'
-							key={binIndex}
-							x={binIndex}
-							y={GRAPH_HEIGHT - height}
-							width={1}
-							height={height}
-						/>;
+					{columnHistogram.bin_counts.map((binCount, binIndex) => {
+						const binHeight = linearConversion(binCount, binCountRange, GRAPH_RANGE);
+						return (
+							<rect className='bin-count'
+								key={`bin-${binIndex}`}
+								x={binIndex * binWidth}
+								y={GRAPH_HEIGHT - binHeight}
+								width={binWidth}
+								height={binHeight}
+							/>
+						);
 					})}
 				</g>
 			</svg>


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR adds sparkline frequency tables for `ColumnDisplayType.Boolean` and `ColumnDisplayType.String` data.

![image](https://github.com/user-attachments/assets/6eb5ed61-7ffb-48fa-bac4-17fabed5e028)

### QA Notes

None.