### PR TITLE
Improve interactive plot webview lifecycle management

### DIFF
--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -113,7 +113,7 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 
 			// Create a webview to display the widget.
 			const webview = await this._notebookOutputWebviewService.createNotebookOutputWebview(
-				session, message, 'jupyter-notebook');
+				message.id, session, message, 'jupyter-notebook');
 
 			if (!webview) {
 				throw new Error(`Could not create webview for IPyWidget message: ${JSON.stringify(message)}`);

--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -111,19 +111,14 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 				return;
 			}
 
-			// Create a webview to display the widget.
-			const webview = await this._notebookOutputWebviewService.createNotebookOutputWebview(
-				message.id, session, message, 'jupyter-notebook');
-
-			if (!webview) {
-				throw new Error(`Could not create webview for IPyWidget message: ${JSON.stringify(message)}`);
-			}
-
-			disposables.add(webview);
+			// Create the plot client.
+			const client = disposables.add(new NotebookOutputPlotClient(
+				this._notebookOutputWebviewService, session, message
+			));
 
 			// Create the ipywidgets instance.
 			const messaging = disposables.add(new IPyWidgetsWebviewMessaging(
-				webview.id, this._notebookRendererMessagingService
+				client.id, this._notebookRendererMessagingService
 			));
 			const ipywidgetsInstance = disposables.add(
 				new IPyWidgetsInstance(session, messaging, this._logService)
@@ -138,7 +133,6 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 			// TODO: We probably need to dispose in more cases...
 
 			// Fire the onDidCreatePlot event.
-			const client = disposables.add(new NotebookOutputPlotClient(webview, message));
 			this._onDidCreatePlot.fire(client);
 		};
 

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
@@ -24,7 +24,6 @@ interface NotebookOutputWebviewOptions<WType extends IOverlayWebview | IWebviewE
 	readonly id: string;
 	readonly sessionId: string;
 	readonly webview: WType;
-	readonly render?: () => void;
 	rendererMessaging?: IScopedRendererMessaging;
 }
 
@@ -40,7 +39,6 @@ export class NotebookOutputWebview<WType extends IOverlayWebview | IWebviewEleme
 	readonly id: string;
 	readonly sessionId: string;
 	readonly webview: WType;
-	readonly render?: () => void;
 
 	/**
 	 * Create a new notebook output webview.
@@ -49,8 +47,6 @@ export class NotebookOutputWebview<WType extends IOverlayWebview | IWebviewEleme
 	 *   that created it.
 	 * @param sessionId The ID of the runtime that owns this webview.
 	 * @param webview The underlying webview.
-	 * @param render Optional method to render the output in the webview rather than doing so
-	 *   directly in the HTML content.
 	 * @param rendererMessaging Optional scoped messaging instance for communicating between a
 	 *   runtime and the renderer.
 	 */
@@ -59,7 +55,6 @@ export class NotebookOutputWebview<WType extends IOverlayWebview | IWebviewEleme
 			id,
 			sessionId,
 			webview,
-			render,
 			rendererMessaging
 		}: NotebookOutputWebviewOptions<WType>,
 		@IFileDialogService private _fileDialogService: IFileDialogService,
@@ -76,7 +71,6 @@ export class NotebookOutputWebview<WType extends IOverlayWebview | IWebviewEleme
 		this.id = id;
 		this.sessionId = sessionId;
 		this.webview = webview;
-		this.render = render;
 		this.onDidRender = this._onDidRender.event;
 		this._register(this._onDidRender);
 		this._register(this._onDidReceiveMessage);

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -43,6 +43,8 @@ export interface IPositronNotebookOutputWebviewService {
 	/**
 	 * Create a new notebook output webview from an output message.
 	 *
+	 * @param id A unique ID for this webview; typically the ID of the message
+	 *  that created it.
 	 * @param runtime The runtime that emitted the output
 	 * @param output The message containing the contents to be rendered in the webview.
 	 * @param viewType The view type of the notebook e.g 'jupyter-notebook', if known. Used to
@@ -51,6 +53,7 @@ export interface IPositronNotebookOutputWebviewService {
 	 *   output does not have a suitable renderer.
 	 */
 	createNotebookOutputWebview(
+		id: string,
 		runtime: ILanguageRuntimeSession,
 		output: ILanguageRuntimeMessageOutput,
 		viewType?: string,

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -28,12 +28,6 @@ export interface INotebookOutputWebview<WType extends IOverlayWebview | IWebview
 
 	/** Fired when the content completes rendering */
 	onDidRender: Event<void>;
-
-	/**
-	 * Optional method to render the output in the webview rather than doing so
-	 * directly in the HTML content
-	 */
-	render?(): void;
 }
 
 export enum WebviewType {

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -121,6 +121,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 	}
 
 	async createNotebookOutputWebview(
+		id: string,
 		runtime: ILanguageRuntimeSession,
 		output: ILanguageRuntimeMessageWebOutput,
 		viewType?: string,
@@ -138,7 +139,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 			const renderer = this._notebookService.getPreferredRenderer(mimeType);
 			if (renderer) {
 				return this.createNotebookRenderOutput({
-					id: output.id,
+					id,
 					runtime,
 					displayMessageInfo: { mimeType, renderer, output },
 					viewType
@@ -151,7 +152,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 		for (const mimeType of Object.keys(output.data)) {
 			if (mimeType === 'text/html') {
 				return this.createRawHtmlOutput({
-					id: output.id,
+					id,
 					runtimeOrSessionId: runtime,
 					html: output.data[mimeType],
 					webviewType: WebviewType.Overlay

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as DOM from 'vs/base/browser/dom';
 import { VSBuffer } from 'vs/base/common/buffer';
 import { Schemas } from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
@@ -291,6 +292,11 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 
 		// Create the metadata for the webview
 		const webviewInitInfo: WebviewInitInfo = {
+			// TODO: This is what the Viewer pane does. The back layer webview creates a UUID
+			//       per viewType. Not sure what we should do.
+			// Use the active window's origin. All webviews with the same origin will reuse the same
+			// service worker.
+			origin: DOM.getActiveWindow().origin,
 			contentOptions: {
 				allowScripts: true,
 				// Needed since we use the API ourselves, and it's also used by
@@ -382,6 +388,9 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 
 		// Create the metadata for the webview
 		const webviewInitInfo: WebviewInitInfo = {
+			// Use the active window's origin. All webviews with the same origin will reuse the same
+			// service worker.
+			origin: DOM.getActiveWindow().origin,
 			contentOptions: {
 				allowScripts: true,
 				localResourceRoots: [jupyterExtension.extensionLocation]

--- a/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotInstance.tsx
@@ -26,6 +26,7 @@ interface WebviewPlotInstanceProps {
  */
 export const WebviewPlotInstance = (props: WebviewPlotInstanceProps) => {
 	const webviewRef = React.useRef<HTMLDivElement>(null);
+	const [clientIsClaimed, setClientIsClaimed] = React.useState(false);
 
 	useEffect(() => {
 		const client = props.plotClient;
@@ -34,14 +35,23 @@ export const WebviewPlotInstance = (props: WebviewPlotInstanceProps) => {
 		if (props.visible) {
 			client.activate().then(() => {
 				client.claim(this);
+				setClientIsClaimed(true);
 			});
 		}
 		return () => {
 			client.release(this);
+			setClientIsClaimed(false);
 		};
 	}, [props.plotClient, props.visible]);
 
 	useEffect(() => {
+		// If the client is not claimed, do nothing.
+		// This is to avoid activating the client when it isn't claimed, which could happen
+		// if the previous effect is cleaned up before this one runs.
+		if (!clientIsClaimed) {
+			return;
+		}
+
 		const client = props.plotClient;
 		client.activate().then(() => {
 			if (webviewRef.current) {

--- a/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotInstance.tsx
@@ -32,7 +32,9 @@ export const WebviewPlotInstance = (props: WebviewPlotInstanceProps) => {
 		// Only claim if the plot is visible to avoid rendering the webview when
 		// the parent view pane is collapsed.
 		if (props.visible) {
-			client.claim(this);
+			client.activate().then(() => {
+				client.claim(this);
+			});
 		}
 		return () => {
 			client.release(this);
@@ -40,9 +42,12 @@ export const WebviewPlotInstance = (props: WebviewPlotInstanceProps) => {
 	}, [props.plotClient, props.visible]);
 
 	useEffect(() => {
-		if (webviewRef.current) {
-			props.plotClient.layoutWebviewOverElement(webviewRef.current);
-		}
+		const client = props.plotClient;
+		client.activate().then(() => {
+			if (webviewRef.current) {
+				client.layoutWebviewOverElement(webviewRef.current);
+			}
+		});
 	});
 
 	const style = {

--- a/src/vs/workbench/contrib/positronPlots/browser/htmlPlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/htmlPlotClient.ts
@@ -3,37 +3,69 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { DisposableStore, MutableDisposable } from 'vs/base/common/lifecycle';
+import { URI } from 'vs/base/common/uri';
 import { WebviewPlotClient } from 'vs/workbench/contrib/positronPlots/browser/webviewPlotClient';
+import { IPositronPreviewService } from 'vs/workbench/contrib/positronPreview/browser/positronPreviewSevice';
 import { PreviewHtml } from 'vs/workbench/contrib/positronPreview/browser/previewHtml';
+import { WebviewExtensionDescription } from 'vs/workbench/contrib/webview/browser/webview';
+import { IShowHtmlUriEvent } from 'vs/workbench/services/languageRuntime/common/languageRuntimeUiClient';
+import { ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 
 /**
  * A Positron plot instance that contains content from an HTML file.
  */
 export class HtmlPlotClient extends WebviewPlotClient {
 
+	private readonly _html = this._register(new MutableDisposable<PreviewHtml>());
+
+	private readonly _htmlEvents = this._register(new DisposableStore());
+
 	private static _nextId = 0;
 
 	/**
-	 * Creates a new HtmlPlotClient, which wraps an HTML preview webview in an
-	 * object that can be displayed in the Plots pane.
+	 * Creates a new HtmlPlotClient, which manages the lifecycle of an HTML preview webview,
+	 * wrapped in an object that can be displayed in the Plots pane.
 	 *
-	 * @param html The webview to wrap.
+	 * @param _positronPreviewService The preview service.
+	 * @param _session The runtime session that emitted the output.
+	 * @param _event The event that triggered the preview.
 	 */
-	constructor(public readonly html: PreviewHtml) {
+	constructor(
+		private readonly _positronPreviewService: IPositronPreviewService,
+		private readonly _session: ILanguageRuntimeSession,
+		private readonly _event: IShowHtmlUriEvent) {
 		// Create the metadata for the plot.
 		super({
 			id: `plot-${HtmlPlotClient._nextId++}`,
 			parent_id: '',
 			created: Date.now(),
-			session_id: html.sessionId,
+			session_id: _session.sessionId,
 			code: '',
-		}, html.webview.webview);
+		});
+	}
 
-		// Ensure that the preview is disposed when the plot client is disposed.
-		this._register(html);
+	get uri(): URI {
+		return this._event.uri;
+	}
+
+	async createWebview() {
+		if (this._html.value) {
+			// Already awake, do nothing.
+			return;
+		}
+		// Create the webview.
+		const extension = this._session.runtimeMetadata.extensionId;
+		const webviewExtension: WebviewExtensionDescription = {
+			id: extension
+		};
+		const html = this._positronPreviewService.createHtmlWebview(this._session.sessionId,
+			webviewExtension, this._event);
+		this._html.value = html;
+		this._webview.value = html.webview.webview;
 
 		// Render the thumbnail when the webview loads.
-		this._register(this.html.webview.onDidLoad(e => {
+		this._htmlEvents.add(html.webview.onDidLoad(e => {
 			this.nudgeRenderThumbnail();
 		}));
 	}

--- a/src/vs/workbench/contrib/positronPlots/browser/htmlPlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/htmlPlotClient.ts
@@ -49,10 +49,9 @@ export class HtmlPlotClient extends WebviewPlotClient {
 		return this._event.uri;
 	}
 
-	async createWebview() {
+	protected override async createWebview() {
 		if (this._html.value) {
-			// Already awake, do nothing.
-			return;
+			throw new Error('Webview already created. Dispose the existing webview first.');
 		}
 		// Create the webview.
 		const extension = this._session.runtimeMetadata.extensionId;
@@ -62,11 +61,17 @@ export class HtmlPlotClient extends WebviewPlotClient {
 		const html = this._positronPreviewService.createHtmlWebview(this._session.sessionId,
 			webviewExtension, this._event);
 		this._html.value = html;
-		this._webview.value = html.webview.webview;
 
 		// Render the thumbnail when the webview loads.
 		this._htmlEvents.add(html.webview.onDidLoad(e => {
 			this.nudgeRenderThumbnail();
 		}));
+
+		return html.webview.webview;
+	}
+
+	protected override disposeWebview() {
+		this._html.clear();
+		this._htmlEvents.clear();
 	}
 }

--- a/src/vs/workbench/contrib/positronPlots/browser/notebookMultiMessagePlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/notebookMultiMessagePlotClient.ts
@@ -47,9 +47,9 @@ export class NotebookMultiMessagePlotClient extends WebviewPlotClient {
 		});
 	}
 
-	async createWebview() {
+	protected override async createWebview() {
 		if (this._output.value) {
-			throw new Error('Webview already created');
+			throw new Error('Webview already created. Dispose the existing webview first.');
 		}
 		const output = await this._notebookOutputWebviewService.createMultiMessageWebview({
 			runtime: this._session,
@@ -61,13 +61,18 @@ export class NotebookMultiMessagePlotClient extends WebviewPlotClient {
 			throw new Error('Failed to create notebook output webview');
 		}
 		this._output.value = output;
-		this._webview.value = output.webview;
 
 		// Wait for the webview to finish rendering. When it does, nudge the
 		// timer that renders the thumbnail.
 		this._outputEvents.add(output.onDidRender(e => {
 			this.nudgeRenderThumbnail();
 		}));
+
+		return output.webview;
+	}
+
+	protected override disposeWebview() {
+		this._output.clear();
+		this._outputEvents.clear();
 	}
 }
-

--- a/src/vs/workbench/contrib/positronPlots/browser/notebookMultiMessagePlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/notebookMultiMessagePlotClient.ts
@@ -6,39 +6,42 @@
 import { DisposableStore, MutableDisposable } from 'vs/base/common/lifecycle';
 import { INotebookOutputWebview, IPositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
 import { WebviewPlotClient } from 'vs/workbench/contrib/positronPlots/browser/webviewPlotClient';
-import { ILanguageRuntimeMessageOutput } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeMessageWebOutput } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 
 /**
- * A Positron plot instance created from notebook output rendered into a
+ * A Positron plot instance created from multiple notebook output messages rendered into a
  * webview.
  */
-export class NotebookOutputPlotClient extends WebviewPlotClient {
+export class NotebookMultiMessagePlotClient extends WebviewPlotClient {
 
 	private readonly _output = this._register(new MutableDisposable<INotebookOutputWebview>());
 
 	private readonly _outputEvents = this._register(new DisposableStore());
 
 	/**
-	 * Creates a new NotebookOutputPlotClient, which manages the lifecycle of a notebook output
+	 * Creates a new NotebookMultiMessagePlotClient, which manages the lifecycle of a notebook output
 	 * webview, wrapped in an object that can be displayed in the Plots pane.
 	 *
 	 * @param _notebookOutputWebviewService The notebook output webview service.
 	 * @param _session The runtime session that emitted the output.
-	 * @param _message The message containing the contents to be rendered in the webview.
+	 * @param _preReqMessages The messages linked to the final display output message that load the
+	 * required dependencies.
+	 * @param _displayMessage The message containing the contents to be rendered in the webview.
 	 * @param code The code that generated the webview (if known)
 	 */
 	constructor(
 		private readonly _notebookOutputWebviewService: IPositronNotebookOutputWebviewService,
 		private readonly _session: ILanguageRuntimeSession,
-		private readonly _message: ILanguageRuntimeMessageOutput,
+		private readonly _preReqMessages: ILanguageRuntimeMessageWebOutput[],
+		private readonly _displayMessage: ILanguageRuntimeMessageWebOutput,
 		code?: string) {
 
 		// Create the metadata for the plot.
 		super({
-			id: _message.id,
-			parent_id: _message.parent_id,
-			created: Date.parse(_message.when),
+			id: _displayMessage.id,
+			parent_id: _displayMessage.parent_id,
+			created: Date.parse(_displayMessage.when),
 			session_id: _session.sessionId,
 			code: code ? code : '',
 		});
@@ -48,12 +51,12 @@ export class NotebookOutputPlotClient extends WebviewPlotClient {
 		if (this._output.value) {
 			throw new Error('Webview already created');
 		}
-		const output = await this._notebookOutputWebviewService.createNotebookOutputWebview(
-			this.id,
-			this._session,
-			this._message,
-			'jupyter-notebook'
-		);
+		const output = await this._notebookOutputWebviewService.createMultiMessageWebview({
+			runtime: this._session,
+			preReqMessages: this._preReqMessages,
+			displayMessage: this._displayMessage,
+			viewType: 'jupyter-notebook'
+		});
 		if (!output) {
 			throw new Error('Failed to create notebook output webview');
 		}
@@ -67,3 +70,4 @@ export class NotebookOutputPlotClient extends WebviewPlotClient {
 		}));
 	}
 }
+

--- a/src/vs/workbench/contrib/positronPlots/browser/notebookOutputPlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/notebookOutputPlotClient.ts
@@ -44,9 +44,9 @@ export class NotebookOutputPlotClient extends WebviewPlotClient {
 		});
 	}
 
-	async createWebview() {
+	protected override async createWebview() {
 		if (this._output.value) {
-			throw new Error('Webview already created');
+			throw new Error('Webview already created. Dispose the existing webview first.');
 		}
 		const output = await this._notebookOutputWebviewService.createNotebookOutputWebview(
 			this.id,
@@ -58,12 +58,17 @@ export class NotebookOutputPlotClient extends WebviewPlotClient {
 			throw new Error('Failed to create notebook output webview');
 		}
 		this._output.value = output;
-		this._webview.value = output.webview;
-
 		// Wait for the webview to finish rendering. When it does, nudge the
 		// timer that renders the thumbnail.
 		this._outputEvents.add(output.onDidRender(e => {
 			this.nudgeRenderThumbnail();
 		}));
+
+		return output.webview;
+	}
+
+	protected override disposeWebview() {
+		this._output.clear();
+		this._outputEvents.clear();
 	}
 }

--- a/src/vs/workbench/contrib/positronPlots/browser/notebookOutputPlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/notebookOutputPlotClient.ts
@@ -43,14 +43,4 @@ export class NotebookOutputPlotClient extends WebviewPlotClient {
 			this.nudgeRenderThumbnail();
 		}));
 	}
-
-	/**
-	 * Claims the underlying webview.
-	 *
-	 * @param claimant The object taking ownership.
-	 */
-	public override claim(claimant: any) {
-		super.claim(claimant);
-		this.output.render?.();
-	}
 }

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as DOM from 'vs/base/browser/dom';
-import { Disposable, toDisposable } from 'vs/base/common/lifecycle';
+import { Disposable } from 'vs/base/common/lifecycle';
 import { IPositronPlotMetadata, PlotClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimePlotClient';
 import { ILanguageRuntimeMessageOutput, LanguageRuntimeSessionMode, RuntimeOutputKind } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ILanguageRuntimeSession, IRuntimeSessionService, RuntimeClientType } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -648,7 +648,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		// Create a new webview
 
 		const webview = await this._notebookOutputWebviewService.createNotebookOutputWebview(
-			runtime, message);
+			message.id, runtime, message);
 		if (webview) {
 			this.registerNewPlotClient(new NotebookOutputPlotClient(webview, message, code));
 		}

--- a/src/vs/workbench/contrib/positronPlots/browser/webviewPlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/webviewPlotClient.ts
@@ -63,8 +63,8 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 	}
 
 	/** Whether the plot's underlying webview is active. */
-	isActive(): boolean {
-		return !!this._webview.value;
+	isActive(): this is { _webview: { value: IOverlayWebview } } {
+		return Boolean(this._webview.value);
 	}
 
 	/**
@@ -107,7 +107,7 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 	 * @param claimant The object taking ownership.
 	 */
 	public claim(claimant: any) {
-		if (!this._webview.value) {
+		if (!this.isActive()) {
 			throw new Error('No webview to claim');
 		}
 		this._webview.value.claim(claimant, DOM.getWindow(this._element), undefined);
@@ -120,7 +120,7 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 	 * @param ele The element over which to position the webview.
 	 */
 	public layoutWebviewOverElement(ele: HTMLElement) {
-		if (!this._webview.value) {
+		if (!this.isActive()) {
 			throw new Error('No webview to layout');
 		}
 		this._element = ele;
@@ -133,7 +133,7 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 	 * @param claimant The object releasing ownership.
 	 */
 	public release(claimant: any) {
-		if (!this._webview.value) {
+		if (!this.isActive()) {
 			throw new Error('No webview to release');
 		}
 		this._webview.value.release(claimant);
@@ -149,7 +149,7 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 	 * Electron APIs in desktop mode) as PNG.
 	 */
 	private renderThumbnail() {
-		if (!this._webview.value) {
+		if (!this.isActive()) {
 			throw new Error('No webview to render thumbnail');
 		}
 		this._webview.value.captureContentsAsPng().then(data => {

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -395,7 +395,7 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		const handleDidReceiveRuntimeMessageOutput = async (e: ILanguageRuntimeMessageOutput) => {
 			if (e.kind === RuntimeOutputKind.ViewerWidget) {
 				const webview = await
-					this._notebookOutputWebviewService.createNotebookOutputWebview(session, e);
+					this._notebookOutputWebviewService.createNotebookOutputWebview(e.id, session, e);
 				if (webview) {
 					const overlay = this.createOverlayWebview(webview.webview);
 					const preview = new PreviewWebview(

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as DOM from 'vs/base/browser/dom';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IPositronPreviewService } from 'vs/workbench/contrib/positronPreview/browser/positronPreview';
 import { Event, Emitter } from 'vs/base/common/event';
@@ -204,7 +205,7 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		uri: URI,
 		extension: WebviewExtensionDescription | undefined): PreviewOverlayWebview {
 		const webviewInitInfo: WebviewInitInfo = {
-			origin,
+			origin: DOM.getActiveWindow().origin,
 			providedViewType: viewType,
 			title: '',
 			options: {


### PR DESCRIPTION
This PR improves interactive plots by:

1. Retaining webview state (e.g. the plot's zoom level).
2. Reusing the service worker process.
3. Cleaning up unnecessary webviews:
    1. When the maximum number of active webview plots (currently 5) is exceeded, the least recently selected plot's webview is disposed.
    2. When a plot has not been selected for a while (currently 2 minutes), its webview is disposed.

Addresses #1713.

### Implementation

The following changes were required:

1. Enable `retainContextWhenHidden` for plot webviews, so that the webview context/state is retained when the plot loses focus.
2. Specify an explicit webview `origin` (currently the window's origin), so that the same service worker is reused.
4. Moved the creation of underlying webviews into `WebviewPlotClient` subclasses, so that we can dispose and recreate webviews as needed.

### QA Notes

Might be best to manually change the `WebviewPlotInactiveTimeout` constant to a shorter time to test that out.

When a webview is deactivated, there will be a log message. You'll also lose any state (e.g. the plot's zoom level).