### PR TITLE
Updates to sparklines for PM feedback and bug fixes

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -558,6 +558,7 @@
 		"--vscode-positronDataExplorer-columnNullPercentGraphBackgroundStroke",
 		"--vscode-positronDataExplorer-columnNullPercentGraphIndicatorFill",
 		"--vscode-positronDataExplorer-invalidFilterBackground",
+		"--vscode-positronDataExplorer-sparklineAxis",
 		"--vscode-positronDataExplorer-sparklineFill",
 		"--vscode-positronDataExplorer-sparklineStroke",
 		"--vscode-positronDataExplorer-statusIndicatorComputing",

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1870,6 +1870,14 @@ export const POSITRON_DATA_EXPLORER_MISSING_VALUES_GRAPH_INDICATOR_FILL_COLOR = 
 	hcLight: '#e5edf3',
 }, localize('positronDataExplorer.columnNullPercentGraphIndicatorFill', "Positron data explorer missing values graph indicator fill color."));
 
+// Positron data explorer sparkline axis color.
+export const POSITRON_DATA_EXPLORER_SPARKLINE_AXIS_COLOR = registerColor('positronDataExplorer.sparklineAxis', {
+	dark: '#b5b5b5',
+	light: '#b5b5b5',
+	hcDark: '#b5b5b5',
+	hcLight: '#b5b5b5',
+}, localize('positronDataExplorer.sparklineAxis', "Positron data explorer sparkline axis color."));
+
 // Positron data explorer sparkline fill color.
 export const POSITRON_DATA_EXPLORER_SPARKLINE_FILL_COLOR = registerColor('positronDataExplorer.sparklineFill', {
 	dark: '#56a2dd',

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineFrequencyTable.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineFrequencyTable.css
@@ -7,10 +7,14 @@
 	display: flex;
 }
 
-.data-grid-row-cell .content .column-summary .basic-info .sparkline-frequency-table .bottom-edge {
-	fill: var(--vscode-positronDataExplorer-sparklineFill);
+.data-grid-row-cell .content .column-summary .basic-info .sparkline-frequency-table .x-axis {
+	fill: var(--vscode-positronDataExplorer-sparklineAxis);
 }
 
 .data-grid-row-cell .content .column-summary .basic-info .sparkline-frequency-table .count {
 	fill: var(--vscode-positronDataExplorer-sparklineFill);
+}
+
+.data-grid-row-cell .content .column-summary .basic-info .sparkline-frequency-table .count.other {
+	opacity: 0.65;
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.css
@@ -7,8 +7,8 @@
 	display: flex;
 }
 
-.data-grid-row-cell .content .column-summary .basic-info .sparkline-histogram .bottom-edge {
-	fill: var(--vscode-positronDataExplorer-sparklineFill);
+.data-grid-row-cell .content .column-summary .basic-info .sparkline-histogram .x-axis {
+	fill: var(--vscode-positronDataExplorer-sparklineAxis);
 }
 
 .data-grid-row-cell .content .column-summary .basic-info .sparkline-histogram .bin-count {

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.tsx
@@ -33,9 +33,22 @@ interface ColumnSparklineHistogramProps {
  * @param columnHistogram The column histogram.
  * @returns The rendered component.
  */
-export const ColumnSparklineHistogram = ({ columnHistogram }: ColumnSparklineHistogramProps) => {
+export const ColumnSparklineHistogram = ({
+	columnHistogram
+}: ColumnSparklineHistogramProps) => {
 	// State hooks.
-	const [binWidth] = useState(GRAPH_WIDTH / columnHistogram.bin_counts.length);
+	const [binWidth] = useState(() => {
+		// Get the number of bin counts that will be rendered.
+		const binCounts = columnHistogram.bin_counts.length;
+
+		// If the number of bin counts that will be rendered is 0, return 0.
+		if (!binCounts) {
+			return 0;
+		}
+
+		// Return the bin count width.
+		return GRAPH_WIDTH / binCounts;
+	});
 	const [binCountRange] = useState((): Range => {
 		// Find the minimum and maximum bin counts.
 		let minBinCount = 0;
@@ -62,7 +75,7 @@ export const ColumnSparklineHistogram = ({ columnHistogram }: ColumnSparklineHis
 		<div className='sparkline-histogram' style={{ width: GRAPH_WIDTH, height: GRAPH_HEIGHT }}>
 			<svg viewBox={`0 0 ${GRAPH_WIDTH} ${GRAPH_HEIGHT}`} shapeRendering='crispEdges'>
 				<g>
-					<rect className='bottom-edge'
+					<rect className='x-axis'
 						x={0}
 						y={GRAPH_HEIGHT - 0.5}
 						width={GRAPH_WIDTH}
@@ -71,7 +84,8 @@ export const ColumnSparklineHistogram = ({ columnHistogram }: ColumnSparklineHis
 					{columnHistogram.bin_counts.map((binCount, binIndex) => {
 						const binHeight = linearConversion(binCount, binCountRange, GRAPH_RANGE);
 						return (
-							<rect className='bin-count'
+							<rect
+								className='bin-count'
 								key={`bin-${binIndex}`}
 								x={binIndex * binWidth}
 								y={GRAPH_HEIGHT - binHeight}

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -283,9 +283,7 @@ export class TableSummaryCache extends Disposable {
 							profiles.push({
 								profile_type: ColumnProfileType.Histogram,
 								params: {
-									method: ColumnHistogramParamsMethod.Fixed,
-									num_bins: 80,
-									quantiles: [0.25, 0.50]
+									method: ColumnHistogramParamsMethod.Sturges
 								}
 							});
 						}
@@ -391,9 +389,7 @@ export class TableSummaryCache extends Disposable {
 					columnProfileSpecs.push({
 						profile_type: ColumnProfileType.Histogram,
 						params: {
-							method: ColumnHistogramParamsMethod.Fixed,
-							num_bins: 80,
-							quantiles: [0.25, 0.50]
+							method: ColumnHistogramParamsMethod.Sturges
 						}
 					});
 				}


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR addresses PM feedback and bug fixes for sparklines.

1) Histograms are now created using the Sturges method.
2) Frequency tables are now oriented along the x-axis instead of the y-axis.

### QA Notes

This is how sparklines look as of this PR:

<img width="325" alt="sparklines2" src="https://github.com/user-attachments/assets/74876b00-9a5b-435d-b131-492bffe0a64c">

