### PR TITLE
Unsupported SQLAlchemy affects Data Explorer

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -287,7 +287,7 @@ class ConnectionsService:
         Checks if an object is supported by the connections pane.
         """
         try:
-            # This block might fail if for some reason 'Connection' or 'Engine' are 
+            # This block might fail if for some reason 'Connection' or 'Engine' are
             # not available in their modules.
             return safe_isinstance(obj, "sqlite3", "Connection") or safe_isinstance(
                 obj, "sqlalchemy", "Engine"

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -286,9 +286,15 @@ class ConnectionsService:
         """
         Checks if an object is supported by the connections pane.
         """
-        return safe_isinstance(obj, "sqlite3", "Connection") or safe_isinstance(
-            obj, "sqlalchemy", "Engine"
-        )
+        try:
+            # This block might fail if for some reason 'Connection' or 'Engine' are 
+            # not available in their modules.
+            return safe_isinstance(obj, "sqlite3", "Connection") or safe_isinstance(
+                obj, "sqlalchemy", "Engine"
+            )
+        except Exception as err:
+            logger.error(f"Error checking supported {err}")
+            return False
 
     def variable_has_active_connection(self, variable_name: str) -> bool:
         """


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4347

With a old SQLAlchemy version (eg `pip install sqlalchemy==1.3`) that doesn't have the `Engine` class, if you tried to open the data explorer for a variable, the check `object_is_supported()` would fail and thus causing the whole variables view to fail. We now make sure that `object_is_supported` never fails.

QA:

```
import sqlalchemy
sqlalchemy.__version__ # make sure you have 1.3 or less
import pandas as pd
x = pd.DataFrame({'x': [1,2,3]})
```

Open the data explorer by clicking in the variables pane. (Running `%view` will **not** exercise this codepath).
Viewing shouldn't fail after this PR.