### PR TITLE
Add support for help opening in bokeh plots

### DIFF
--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -323,12 +323,17 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 		webview.setHtml(`
 <head>
 	<style nonce="${id}">
-#_defaultColorPalatte {
+		#_defaultColorPalatte {
 			color: var(--vscode-editor-findMatchHighlightBackground);
 			background-color: var(--vscode-editor-findMatchBackground);
-}
-</style>
+		}
+	</style>
 	${PositronNotebookOutputWebviewService.CssAddons}
+	<script>
+		window.prompt = (message, _default) => {
+			return _default ?? 'Untitled';
+		};
+	</script>
 </head>
 <body>
 <div id='container'></div>

--- a/src/vs/workbench/contrib/positronPlots/browser/htmlPlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/htmlPlotClient.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { DisposableStore, MutableDisposable } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
 import { WebviewPlotClient } from 'vs/workbench/contrib/positronPlots/browser/webviewPlotClient';
@@ -33,6 +34,7 @@ export class HtmlPlotClient extends WebviewPlotClient {
 	 */
 	constructor(
 		private readonly _positronPreviewService: IPositronPreviewService,
+		private readonly _openerService: IOpenerService,
 		private readonly _session: ILanguageRuntimeSession,
 		private readonly _event: IShowHtmlUriEvent) {
 		// Create the metadata for the plot.
@@ -67,6 +69,12 @@ export class HtmlPlotClient extends WebviewPlotClient {
 			this.nudgeRenderThumbnail();
 		}));
 
+		// Handle link clicks from the webview
+		this._register(html.webview.webview.onDidClickLink((link) => {
+			this._openerService.open(link, {
+				fromUserGesture: true
+			});
+		}));
 		return html.webview.webview;
 	}
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -943,7 +943,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		const session = this._runtimeSessionService.getSession(sessionId);
 
 		// Create the plot client.
-		const plotClient = new HtmlPlotClient(this._positronPreviewService, session!, event);
+		const plotClient = new HtmlPlotClient(this._positronPreviewService, this._openerService, session!, event);
 
 		// Register the new plot client
 		await this.registerWebviewPlotClient(plotClient);

--- a/src/vs/workbench/contrib/webview/browser/pre/webview-events.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/webview-events.js
@@ -366,11 +366,21 @@ window.addEventListener('load', () => {
 	});
 });
 
-// Override the prompt function to return the default value or 'myFile' if one isnt provided.
+// Override the prompt function to return the default value or 'Untitled' if one isnt provided.
 // This is needed because the prompt function is not supported in webviews and the prompt function
 // is commonly used by libraries like bokeh to provide names for files to save. The main file save
 // dialog that positron shows will already provide the ability to change the file name so we're
 // just providing a default value here.
 window.prompt = (message, _default) => {
 	return _default ?? 'Untitled';
+};
+
+// Override the window.open function to send a message to the host to open the link instead.
+// Save the old window.open function so we can call it after sending the message in case there's
+// some other behavior that was depended upon that we're not aware of.
+const oldOpen = window.open;
+window.open = (url, target, features) => {
+	const uri = url instanceof URL ? url.href : url;
+	hostMessaging.postMessage('did-click-link', { uri });
+	return oldOpen(uri, target, features);
 };


### PR DESCRIPTION
Addresses the remaining half of #4235 

Add support for opening links in plot-bound html file opening cases and override window.open to trigger a link click for bokeh help link.

This PR does two things:

1. Adds a link click handler to webview plot clients
2. Patches `window.open()` which is what bokeh uses to open links (because who does plain `a` tags, anyway?)

The link click handler was needed because bokeh plots are a semi-special case where the `UiFrontendEvent.ShowHtmlFile` webview is sent to the plots pane so the preview panels handlers dont apply. 

Patching `window.open()` should be okay but there's always a chance a plot will try and do something like use the reference to the opened window and work with it. At least in this case something will happen unlike before where the whole call would error. 

### QA Notes

You should be able to now download and view help for bokeh plots. 


```python
from bokeh.plotting import figure, show
p = figure(title="Simple line example", x_axis_label='x', y_axis_label='y')
p.line([1, 2, 3, 4, 5], [6, 7, 2, 4, 5], legend_label="Temp.", line_width=2)
show(p)
```
<img width="761" alt="Screenshot 2024-08-20 at 11 35 15 AM" src="https://github.com/user-attachments/assets/c49cea99-ed10-4304-b8e6-8eb1f0baaffa">

