### PR TITLE
Data explorer smoke tests: missing values and column summary stats

### DIFF
--- a/test/automation/src/positron/positronDataExplorer.ts
+++ b/test/automation/src/positron/positronDataExplorer.ts
@@ -26,6 +26,10 @@ const APPLY_FILTER = '.positron-modal-overlay .button-apply-row-filter';
 const STATUS_BAR = '.positron-data-explorer .status-bar';
 const OVERLAY_BUTTON = '.positron-modal-overlay .positron-button';
 const CLEAR_SORTING_BUTTON = '.codicon-positron-clear-sorting';
+const MISSING_PERCENT = (rowNumber: number) => `${DATA_GRID_ROW}:nth-child(${rowNumber}) .column-null-percent .text-percent`;
+const EXPAND_COLLAPSE_PROFILE = (rowNumber: number) => `${DATA_GRID_ROW}:nth-child(${rowNumber}) .expand-collapse-button`;
+const PROFILE_LABELS = (rowNumber: number) => `${DATA_GRID_ROW}:nth-child(${rowNumber}) .profile-info .label`;
+const PROFILE_VALUES = (rowNumber: number) => `${DATA_GRID_ROW}:nth-child(${rowNumber}) .profile-info .value`;
 
 export interface CellData {
 	[key: string]: string;
@@ -107,7 +111,7 @@ export class PositronDataExplorer {
 			await this.code.waitAndClick(COLUMN_SELECTOR_CELL);
 			const checkValue = (await this.code.waitForElement(COLUMN_SELECTOR)).textContent;
 			expect(checkValue).toBe(columnName);
-		}).toPass({timeout: 10000});
+		}).toPass({ timeout: 10000 });
 
 
 		await this.code.waitAndClick(FUNCTION_SELECTOR);
@@ -160,5 +164,32 @@ export class PositronDataExplorer {
 
 	async arrowLeft(): Promise<void> {
 		await this.code.dispatchKeybinding('ArrowLeft');
+	}
+
+	async getColumnMissingPercent(rowNumber: number): Promise<string> {
+		const row = this.code.driver.getLocator(MISSING_PERCENT(rowNumber));
+		return await row.innerText();
+	}
+
+	async getColumnProfileInfo(rowNumber: number): Promise<{ [key: string]: string }> {
+		await this.code.driver.getLocator(EXPAND_COLLAPSE_PROFILE(rowNumber)).click();
+
+		const profileData: { [key: string]: string } = {};
+
+		const labels = await this.code.waitForElements(PROFILE_LABELS(rowNumber), false);
+		const values = await this.code.waitForElements(PROFILE_VALUES(rowNumber), false);
+
+		for (let i = 0; i < labels.length; i++) {
+			const label = labels[i].textContent;
+			const value = values[i].textContent;
+			if (label && value) {
+				profileData[label] = value; // Assign label as key and value as value
+			}
+		}
+
+		await this.code.driver.getLocator(EXPAND_COLLAPSE_PROFILE(rowNumber)).click();
+
+		return profileData;
+
 	}
 }

--- a/test/automation/src/positron/positronDataExplorer.ts
+++ b/test/automation/src/positron/positronDataExplorer.ts
@@ -28,6 +28,7 @@ const OVERLAY_BUTTON = '.positron-modal-overlay .positron-button';
 const CLEAR_SORTING_BUTTON = '.codicon-positron-clear-sorting';
 const MISSING_PERCENT = (rowNumber: number) => `${DATA_GRID_ROW}:nth-child(${rowNumber}) .column-null-percent .text-percent`;
 const EXPAND_COLLAPSE_PROFILE = (rowNumber: number) => `${DATA_GRID_ROW}:nth-child(${rowNumber}) .expand-collapse-button`;
+const EXPAND_COLLASPE_ICON = '.expand-collapse-icon';
 const PROFILE_LABELS = (rowNumber: number) => `${DATA_GRID_ROW}:nth-child(${rowNumber}) .profile-info .label`;
 const PROFILE_VALUES = (rowNumber: number) => `${DATA_GRID_ROW}:nth-child(${rowNumber}) .profile-info .value`;
 
@@ -178,7 +179,7 @@ export class PositronDataExplorer {
 		await expandCollapseLocator.scrollIntoViewIfNeeded();
 		await expandCollapseLocator.click();
 
-		await expect(expandCollapseLocator).toHaveAttribute('codicon-chevron-down');
+		await expect(expandCollapseLocator.locator(EXPAND_COLLASPE_ICON)).toHaveClass(/codicon-chevron-down/);
 
 		const profileData: { [key: string]: string } = {};
 
@@ -196,7 +197,7 @@ export class PositronDataExplorer {
 		await expandCollapseLocator.scrollIntoViewIfNeeded();
 		await expandCollapseLocator.click();
 
-		await expect(expandCollapseLocator).toHaveAttribute('codicon-chevron-right');
+		await expect(expandCollapseLocator.locator(EXPAND_COLLASPE_ICON)).toHaveClass(/codicon-chevron-right/);
 
 		return profileData;
 

--- a/test/automation/src/positron/positronDataExplorer.ts
+++ b/test/automation/src/positron/positronDataExplorer.ts
@@ -172,7 +172,13 @@ export class PositronDataExplorer {
 	}
 
 	async getColumnProfileInfo(rowNumber: number): Promise<{ [key: string]: string }> {
-		await this.code.driver.getLocator(EXPAND_COLLAPSE_PROFILE(rowNumber)).click();
+
+		const expandCollapseLocator = this.code.driver.getLocator(EXPAND_COLLAPSE_PROFILE(rowNumber));
+
+		await expandCollapseLocator.scrollIntoViewIfNeeded();
+		await expandCollapseLocator.click();
+
+		expect(expandCollapseLocator).toHaveAttribute('codicon-chevron-down');
 
 		const profileData: { [key: string]: string } = {};
 
@@ -187,7 +193,10 @@ export class PositronDataExplorer {
 			}
 		}
 
-		await this.code.driver.getLocator(EXPAND_COLLAPSE_PROFILE(rowNumber)).click();
+		await expandCollapseLocator.scrollIntoViewIfNeeded();
+		await expandCollapseLocator.click();
+
+		expect(expandCollapseLocator).toHaveAttribute('codicon-chevron-right');
 
 		return profileData;
 

--- a/test/automation/src/positron/positronDataExplorer.ts
+++ b/test/automation/src/positron/positronDataExplorer.ts
@@ -178,7 +178,7 @@ export class PositronDataExplorer {
 		await expandCollapseLocator.scrollIntoViewIfNeeded();
 		await expandCollapseLocator.click();
 
-		expect(expandCollapseLocator).toHaveAttribute('codicon-chevron-down');
+		await expect(expandCollapseLocator).toHaveAttribute('codicon-chevron-down');
 
 		const profileData: { [key: string]: string } = {};
 
@@ -196,7 +196,7 @@ export class PositronDataExplorer {
 		await expandCollapseLocator.scrollIntoViewIfNeeded();
 		await expandCollapseLocator.click();
 
-		expect(expandCollapseLocator).toHaveAttribute('codicon-chevron-right');
+		await expect(expandCollapseLocator).toHaveAttribute('codicon-chevron-right');
 
 		return profileData;
 

--- a/test/automation/src/positron/positronDataExplorer.ts
+++ b/test/automation/src/positron/positronDataExplorer.ts
@@ -183,8 +183,8 @@ export class PositronDataExplorer {
 
 		const profileData: { [key: string]: string } = {};
 
-		const labels = await this.code.waitForElements(PROFILE_LABELS(rowNumber), false);
-		const values = await this.code.waitForElements(PROFILE_VALUES(rowNumber), false);
+		const labels = await this.code.waitForElements(PROFILE_LABELS(rowNumber), false, (elements) => elements.length > 2);
+		const values = await this.code.waitForElements(PROFILE_VALUES(rowNumber), false, (elements) => elements.length > 2);
 
 		for (let i = 0; i < labels.length; i++) {
 			const label = labels[i].textContent;

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -117,6 +117,8 @@ df2 = pd.DataFrame(data)`;
 				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(4)).toBe('60%');
 				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(5)).toBe('40%');
 
+				await app.workbench.positronLayouts.enterLayout('notebook');
+
 				const col1ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(1);
 				expect(col1ProfileInfo).toStrictEqual({ 'Missing': '1', 'Min': '1.00', 'Median': '3.00', 'Mean': '3.00', 'Max': '5.00', 'SD': '1.83' });
 
@@ -131,6 +133,9 @@ df2 = pd.DataFrame(data)`;
 
 				const col5ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(5);
 				expect(col5ProfileInfo).toStrictEqual({ 'Missing': '2', 'Empty': '0', 'Unique': '3' });
+
+				await app.workbench.positronLayouts.enterLayout('stacked');
+				await app.workbench.positronSideBar.closeSecondarySideBar();
 
 			});
 		});
@@ -185,6 +190,8 @@ df2 = pd.DataFrame(data)`;
 				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(5)).toBe('33%');
 				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(6)).toBe('33%');
 
+				await app.workbench.positronLayouts.enterLayout('notebook');
+
 				const col1ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(1);
 				expect(col1ProfileInfo).toStrictEqual({ 'Missing': '0', 'Min': '1.00', 'Median': '2.00', 'Mean': '2.00', 'Max': '3.00', 'SD': '1.00' });
 
@@ -202,6 +209,9 @@ df2 = pd.DataFrame(data)`;
 
 				const col6ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(6);
 				expect(col6ProfileInfo).toStrictEqual({ 'Missing': '1', 'True': '1', 'False': '1' });
+
+				await app.workbench.positronLayouts.enterLayout('stacked');
+				await app.workbench.positronSideBar.closeSecondarySideBar();
 
 			});
 
@@ -299,6 +309,8 @@ df2 = pd.DataFrame(data)`;
 				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(3)).toBe('0%');
 				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(4)).toBe('66%');
 
+				await app.workbench.positronLayouts.enterLayout('notebook');
+
 				const col1ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(1);
 				expect(col1ProfileInfo).toStrictEqual({ 'Missing': '0', 'Empty': '0', 'Unique': '3' });
 
@@ -310,6 +322,9 @@ df2 = pd.DataFrame(data)`;
 
 				const col4ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(4);
 				expect(col4ProfileInfo).toStrictEqual({ 'Missing': '2', 'Empty': '0', 'Unique': '2' });
+
+				await app.workbench.positronLayouts.enterLayout('stacked');
+				await app.workbench.positronSideBar.closeSecondarySideBar();
 
 			});
 

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -38,15 +38,6 @@ export function setup(logger: Logger) {
 
 			});
 
-			afterEach(async function () {
-
-				const app = this.app as Application;
-
-				await app.workbench.positronDataExplorer.closeDataExplorer();
-				await app.workbench.positronVariables.openVariables();
-
-			});
-
 			it('Python Pandas - Verifies basic data explorer functionality [C557556] #pr', async function () {
 				const app = this.app as Application;
 
@@ -75,6 +66,9 @@ df = pd.DataFrame(data)`;
 				expect(tableData[2]).toStrictEqual({ 'Name': 'Gaurav', 'Age': '22', 'Address': 'Allahabad' });
 				expect(tableData[3]).toStrictEqual({ 'Name': 'Anuj', 'Age': '32', 'Address': 'Kannauj' });
 				expect(tableData.length).toBe(4);
+
+				await app.workbench.positronDataExplorer.closeDataExplorer();
+				await app.workbench.positronVariables.openVariables();
 
 			});
 
@@ -113,6 +107,11 @@ df2 = pd.DataFrame(data)`;
 				expect(tableData[4]).toStrictEqual({ 'A': '5.00', 'B': 'None', 'C': '4.80', 'D': '2023-02-01 00:00:00', 'E': 'even more text' });
 				expect(tableData.length).toBe(5);
 
+			});
+			it('Python Pandas - Verifies data explorer column info functionality [C734263] #pr', async function () {
+
+				const app = this.app as Application;
+
 				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(1)).toBe('20%');
 				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(2)).toBe('40%');
 				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(3)).toBe('40%');
@@ -138,6 +137,9 @@ df2 = pd.DataFrame(data)`;
 
 				await app.workbench.positronLayouts.enterLayout('stacked');
 				await app.workbench.positronSideBar.closeSecondarySideBar();
+
+				await app.workbench.positronDataExplorer.closeDataExplorer();
+				await app.workbench.positronVariables.openVariables();
 
 			});
 		});
@@ -184,6 +186,11 @@ df2 = pd.DataFrame(data)`;
 				expect(tableData[1]['ham']).toBe('2021-03-04');
 				expect(tableData[2]['ham']).toBe('2022-05-06');
 				expect(tableData.length).toBe(3);
+
+			});
+			it('Python Polars - Verifies basic data explorer column info functionality [C734264] #pr', async function () {
+
+				const app = this.app as Application;
 
 				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(1)).toBe('0%');
 				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(2)).toBe('0%');
@@ -269,14 +276,6 @@ df2 = pd.DataFrame(data)`;
 
 			});
 
-			afterEach(async function () {
-				const app = this.app as Application;
-
-				await app.workbench.positronDataExplorer.closeDataExplorer();
-				await app.workbench.quickaccess.runCommand('workbench.panel.positronVariables.focus');
-
-			});
-
 			it('R - Verifies basic data explorer functionality [C609620] #pr', async function () {
 				const app = this.app as Application;
 
@@ -306,6 +305,12 @@ df2 = pd.DataFrame(data)`;
 				expect(tableData[2]).toStrictEqual({ 'Training': 'Other', 'Pulse': '120.00', 'Duration': '45.00', 'Note': 'Note' });
 				expect(tableData.length).toBe(3);
 
+
+			});
+			it('R - Verifies basic data explorer column info functionality [C734265] #pr', async function () {
+
+				const app = this.app as Application;
+
 				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(1)).toBe('0%');
 				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(2)).toBe('33%');
 				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(3)).toBe('0%');
@@ -327,6 +332,9 @@ df2 = pd.DataFrame(data)`;
 
 				await app.workbench.positronLayouts.enterLayout('stacked');
 				await app.workbench.positronSideBar.closeSecondarySideBar();
+
+				await app.workbench.positronDataExplorer.closeDataExplorer();
+				await app.workbench.quickaccess.runCommand('workbench.panel.positronVariables.focus');
 
 			});
 
@@ -351,6 +359,9 @@ df2 = pd.DataFrame(data)`;
 				await expect(async () => {
 					await app.code.driver.getLocator('.label-name:has-text("Data: Data_Frame")').innerText();
 				}).toPass();
+
+				await app.workbench.positronDataExplorer.closeDataExplorer();
+				await app.workbench.quickaccess.runCommand('workbench.panel.positronVariables.focus');
 
 			});
 		});

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -31,7 +31,9 @@ export function setup(logger: Logger) {
 				const app = this.app as Application;
 
 				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors', { keepOpen: false });
+				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 				await app.workbench.positronConsole.barRestartButton.click();
+				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 				await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
 
 			});

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -111,9 +111,28 @@ df2 = pd.DataFrame(data)`;
 				expect(tableData[4]).toStrictEqual({ 'A': '5.00', 'B': 'None', 'C': '4.80', 'D': '2023-02-01 00:00:00', 'E': 'even more text' });
 				expect(tableData.length).toBe(5);
 
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(1)).toBe('20%');
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(2)).toBe('40%');
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(3)).toBe('40%');
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(4)).toBe('60%');
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(5)).toBe('40%');
+
+				const col1ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(1);
+				expect(col1ProfileInfo).toStrictEqual({ 'Missing': '1', 'Min': '1.00', 'Median': '3.00', 'Mean': '3.00', 'Max': '5.00', 'SD': '1.83' });
+
+				const col2ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(2);
+				expect(col2ProfileInfo).toStrictEqual({ 'Missing': '2', 'Empty': '0', 'Unique': '3' });
+
+				const col3ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(3);
+				expect(col3ProfileInfo).toStrictEqual({ 'Missing': '2', 'Min': '2.50', 'Median': '3.10', 'Mean': '3.47', 'Max': '4.80', 'SD': '1.19' });
+
+				const col4ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(4);
+				expect(col4ProfileInfo).toStrictEqual({ 'Missing': '3', 'Min': '2023-01-01 00:00:00', 'Median': 'NaT', 'Max': '2023-02-01 00:00:00', 'Timezone': 'None' });
+
+				const col5ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(5);
+				expect(col5ProfileInfo).toStrictEqual({ 'Missing': '2', 'Empty': '0', 'Unique': '3' });
+
 			});
-
-
 		});
 
 		describe('Python Polars Data Explorer', () => {
@@ -158,6 +177,31 @@ df2 = pd.DataFrame(data)`;
 				expect(tableData[1]['ham']).toBe('2021-03-04');
 				expect(tableData[2]['ham']).toBe('2022-05-06');
 				expect(tableData.length).toBe(3);
+
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(1)).toBe('0%');
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(2)).toBe('0%');
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(3)).toBe('0%');
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(4)).toBe('33%');
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(5)).toBe('33%');
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(6)).toBe('33%');
+
+				const col1ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(1);
+				expect(col1ProfileInfo).toStrictEqual({ 'Missing': '0', 'Min': '1.00', 'Median': '2.00', 'Mean': '2.00', 'Max': '3.00', 'SD': '1.00' });
+
+				const col2ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(2);
+				expect(col2ProfileInfo).toStrictEqual({ 'Missing': '0', 'Min': '6.00', 'Median': '7.00', 'Mean': '7.00', 'Max': '8.00', 'SD': '1.00' });
+
+				const col3ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(3);
+				expect(col3ProfileInfo).toStrictEqual({ 'Missing': '0', 'Min': '2020-01-02', 'Median': '2021-03-04', 'Max': '2022-05-06' });
+
+				const col4ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(4);
+				expect(col4ProfileInfo).toStrictEqual({ 'Missing': '1', 'Min': '2.00', 'Median': '2.50', 'Mean': '2.50', 'Max': '3.00', 'SD': '0.7071' });
+
+				const col5ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(5);
+				expect(col5ProfileInfo).toStrictEqual({ 'Missing': '1', 'Min': '0.5000', 'Median': '1.50', 'Mean': '1.50', 'Max': '2.50', 'SD': '1.41' });
+
+				const col6ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(6);
+				expect(col6ProfileInfo).toStrictEqual({ 'Missing': '1', 'True': '1', 'False': '1' });
 
 			});
 
@@ -249,6 +293,23 @@ df2 = pd.DataFrame(data)`;
 				expect(tableData[1]).toStrictEqual({ 'Training': 'Stamina', 'Pulse': 'NA', 'Duration': '30.00', 'Note': 'NA' });
 				expect(tableData[2]).toStrictEqual({ 'Training': 'Other', 'Pulse': '120.00', 'Duration': '45.00', 'Note': 'Note' });
 				expect(tableData.length).toBe(3);
+
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(1)).toBe('0%');
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(2)).toBe('33%');
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(3)).toBe('0%');
+				expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(4)).toBe('66%');
+
+				const col1ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(1);
+				expect(col1ProfileInfo).toStrictEqual({ 'Missing': '0', 'Empty': '0', 'Unique': '3' });
+
+				const col2ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(2);
+				expect(col2ProfileInfo).toStrictEqual({ 'Missing': '1', 'Min': '100.00', 'Median': '110.00', 'Mean': '110.00', 'Max': '120.00', 'SD': '14.14' });
+
+				const col3ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(3);
+				expect(col3ProfileInfo).toStrictEqual({ 'Missing': '0', 'Min': '30.00', 'Median': '45.00', 'Mean': '45.00', 'Max': '60.00', 'SD': '15.00' });
+
+				const col4ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(4);
+				expect(col4ProfileInfo).toStrictEqual({ 'Missing': '2', 'Empty': '0', 'Unique': '2' });
 
 			});
 


### PR DESCRIPTION
Add tests for data explorer:
* missing values check
* column summary stats 

I think I previously accidentally closed instead of merging this.  It was approved by Jon.

### QA Notes

All smoke tests should pass