### PR TITLE
Fix webview plot disposal

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/webviewPlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/webviewPlotClient.ts
@@ -148,7 +148,8 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 	 */
 	public release(claimant: any) {
 		if (!this.isActive()) {
-			throw new Error('No webview to release');
+			// Webview is already disposed so there's nothing to release.
+			return;
 		}
 		this._webview.value.release(claimant);
 		this._claimed = false;


### PR DESCRIPTION
Fixes a bug introduced in #4391 where an error was thrown when trying to `release` a webview plot client since it was already disposed. We don't need to throw the error in that case.