### PR TITLE
Don't attempt to plot gridspec layout ipymessages

### DIFF
--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -111,6 +111,13 @@ export class PositronIPyWidgetsService extends Disposable implements IPositronIP
 				return;
 			}
 
+			// Gridspec layout message attempt to weave together multiple ipywidgets in a way
+			// that we currently don't support. See #4256 for example.
+			const isGridspecLayoutMessage = message.data['text/plain']?.includes('GridspecLayout') ?? false;
+			if (isGridspecLayoutMessage) {
+				return;
+			}
+
 			// Create the plot client.
 			const client = disposables.add(new NotebookOutputPlotClient(
 				this._notebookOutputWebviewService, session, message


### PR DESCRIPTION
This is a bandaid workaround for #4256 

Fully fixing #4256 will take a good amount of investment. (It's worth noting that the mentioned example doesn't work in notebooks in vscode, either.)

This PR simply suppresses the final of the three messages that are produced by running `leafmap.linked_maps()`, which is one containing a `gridspec` widget that attempts to arrange the two previously emitted maps side-by-side. 

Prior to this PR the result was three results in the plots pane, with the final one being empty. 

<img width="1215" alt="Screenshot 2024-08-21 at 11 05 56 AM" src="https://github.com/user-attachments/assets/7252c0b1-1902-4404-83b8-864c5f661e9b">

After this PR two maps are shown in separate plots.
<img width="1205" alt="Screenshot 2024-08-21 at 11 07 37 AM" src="https://github.com/user-attachments/assets/1559929b-b9c6-4085-850d-c9e86f544ef7">


### QA Notes

The following code when run in the console should at least do something and not look like something is loading forever. 
_The behavior in the notebooks is not addressed here and does not work._
```
import leafmap
layers = ["ROADMAP", "HYBRID"]
leafmap.linked_maps(rows=1, cols=2, height="400px", layers=layers)
```
