### PR TITLE
Updates to Data Explorer sparklines from feedback

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineFrequencyTable.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineFrequencyTable.css
@@ -4,11 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .data-grid-row-cell .content .column-summary .basic-info .sparkline-frequency-table {
-	display: flex;
-}
-
-.data-grid-row-cell .content .column-summary .basic-info .sparkline-frequency-table .x-axis {
-	fill: var(--vscode-positronDataExplorer-sparklineAxis);
+	grid-column: sparkline / missing-values;
 }
 
 .data-grid-row-cell .content .column-summary .basic-info .sparkline-frequency-table .count {

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineFrequencyTable.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineFrequencyTable.tsx
@@ -62,12 +62,6 @@ export const ColumnSparklineFrequencyTable = ({
 		<div className='sparkline-frequency-table' style={{ width: GRAPH_WIDTH, height: GRAPH_HEIGHT }}>
 			<svg viewBox={`0 0 ${GRAPH_WIDTH} ${GRAPH_HEIGHT}`} shapeRendering='crispEdges'>
 				<g>
-					<rect className='x-axis'
-						x={0}
-						y={GRAPH_HEIGHT - 0.5}
-						width={GRAPH_WIDTH}
-						height={0.5}
-					/>
 					{columnFrequencyTable.counts.map((count, countIndex) => {
 						const countWidth = Math.max(
 							1,

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .data-grid-row-cell .content .column-summary .basic-info .sparkline-histogram {
-	display: flex;
+	grid-column: sparkline / missing-values;
 }
 
 .data-grid-row-cell .content .column-summary .basic-info .sparkline-histogram .x-axis {

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSparklineHistogram.tsx
@@ -19,6 +19,7 @@ import { ColumnHistogram } from 'vs/workbench/services/languageRuntime/common/po
  */
 const GRAPH_WIDTH = 80;
 const GRAPH_HEIGHT = 20;
+const X_AXIS_HEIGHT = 0.5;
 const GRAPH_RANGE: Range = { min: 0, max: GRAPH_HEIGHT };
 
 /**
@@ -72,14 +73,14 @@ export const ColumnSparklineHistogram = ({
 
 	// Render.
 	return (
-		<div className='sparkline-histogram' style={{ width: GRAPH_WIDTH, height: GRAPH_HEIGHT }}>
-			<svg viewBox={`0 0 ${GRAPH_WIDTH} ${GRAPH_HEIGHT}`} shapeRendering='crispEdges'>
+		<div className='sparkline-histogram' style={{ width: GRAPH_WIDTH, height: GRAPH_HEIGHT + X_AXIS_HEIGHT }}>
+			<svg viewBox={`0 0 ${GRAPH_WIDTH} ${GRAPH_HEIGHT + X_AXIS_HEIGHT}`} shapeRendering='crispEdges'>
 				<g>
 					<rect className='x-axis'
 						x={0}
-						y={GRAPH_HEIGHT - 0.5}
+						y={GRAPH_HEIGHT - X_AXIS_HEIGHT}
 						width={GRAPH_WIDTH}
-						height={0.5}
+						height={X_AXIS_HEIGHT}
 					/>
 					{columnHistogram.bin_counts.map((binCount, binIndex) => {
 						const binHeight = linearConversion(binCount, binCountRange, GRAPH_RANGE);
@@ -88,7 +89,7 @@ export const ColumnSparklineHistogram = ({
 								className='bin-count'
 								key={`bin-${binIndex}`}
 								x={binIndex * binWidth}
-								y={GRAPH_HEIGHT - binHeight}
+								y={GRAPH_HEIGHT - X_AXIS_HEIGHT - binHeight}
 								width={binWidth}
 								height={binHeight}
 							/>


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR updates how Data Explorer sparklines are displayed.

1. The x-axis line has been removed from frequency table sparklines.
2. The x-axis line has been moved outside the graph area for histogram sparklines.

<img width="657" alt="image" src="https://github.com/user-attachments/assets/d873c36f-7bfa-4fdb-b27e-311ebc54e12f">

### QA Notes

None