### PR TITLE
Fix incorrect description

### DIFF
--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -920,7 +920,7 @@
 						"$ref": "#/components/schemas/column_summary_stats"
 					},
 					"histogram": {
-						"description": "Results from summary_stats request",
+						"description": "Results from histogram request",
 						"$ref": "#/components/schemas/column_histogram"
 					},
 					"frequency_table": {


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR fixes an incorrect description in the `positron/comms/data_explorer-backend-openrpc.json` file. This fix will get picked up the next time comms are generated.

Before:

```
"histogram": {
	"description": "Results from summary_stats request",
	"$ref": "#/components/schemas/column_histogram"
},
```

After:

```
"histogram": {
	"description": "Results from histogram request",
	"$ref": "#/components/schemas/column_histogram"
},
```

### QA Notes

None