### PR TITLE
use non-null assertion on `this._webview.value`

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/webviewPlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/webviewPlotClient.ts
@@ -124,7 +124,7 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 		if (!this.isActive()) {
 			throw new Error('No webview to claim');
 		}
-		this._webview.value.claim(claimant, DOM.getWindow(this._element), undefined);
+		this._webview.value!.claim(claimant, DOM.getWindow(this._element), undefined);
 		this._claimed = true;
 	}
 
@@ -138,7 +138,7 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 			throw new Error('No webview to layout');
 		}
 		this._element = ele;
-		this._webview.value.layoutWebviewOverElement(ele);
+		this._webview.value!.layoutWebviewOverElement(ele);
 	}
 
 	/**
@@ -151,7 +151,7 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 			// Webview is already disposed so there's nothing to release.
 			return;
 		}
-		this._webview.value.release(claimant);
+		this._webview.value!.release(claimant);
 		this._claimed = false;
 
 		// We can't render a thumbnail while the webview isn't showing, so cancel the
@@ -167,7 +167,7 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 		if (!this.isActive()) {
 			throw new Error('No webview to render thumbnail');
 		}
-		this._webview.value.captureContentsAsPng().then(data => {
+		this._webview.value!.captureContentsAsPng().then(data => {
 			if (data) {
 				this._thumbnail = data;
 				this._onDidRenderThumbnail.fire(this.asDataUri(data));


### PR DESCRIPTION
Release builds on my Linux and Mac machines were failing towards the end with `Object is possibly 'undefined'` errors. Dev/debug builds run without issue.

```
webviewPlotClient.ts(127,3): Object is possibly 'undefined'.
webviewPlotClient.ts(141,3): Object is possibly 'undefined'.
webviewPlotClient.ts(154,3): Object is possibly 'undefined'.
webviewPlotClient.ts(170,3): Object is possibly 'undefined'.
```

Uses of `this._webview.value` which occur after `this.isActive()` checks can be asserted to be non-null, since `this.isActive()` checks that `this._webview.value` exists. I'm not sure if this is the preferred approach, so feel free to suggest an alternative!

### QA Notes

Release builds should succeed now!
