### PR TITLE
Data Explorer: Add support for Freedman Diaconis histograms

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -1768,10 +1768,10 @@ def _get_histogram_numpy(data, params: ColumnHistogramParams):
         width = data.max() - data.min()
         bins = np_.histogram_bin_edges(data, hist_params["bins"])
         if len(bins) > width and width > 0:
-            hist_params["bins"] = width
+            hist_params = {"bins": width}
         else:
             # Don't need to recompute the bin edges, so we pass them
-            hist_params["bins"] = bins
+            hist_params = {"bins": bins}
 
     try:
         bin_counts, bin_edges = np_.histogram(data, **hist_params)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -1765,13 +1765,13 @@ def _get_histogram_numpy(data, params: ColumnHistogramParams):
     # then than `data.max() - data.min()`, so we don't endup with more bins
     # then there's data to display.
     if issubclass(data.dtype.type, np_.integer):
-        width = data.max() - data.min()
+        width = (data.max() - data.min()).item()
         bins = np_.histogram_bin_edges(data, hist_params["bins"])
         if len(bins) > width and width > 0:
-            hist_params = {"bins": width}
+            hist_params = {"bins": width + 1}
         else:
             # Don't need to recompute the bin edges, so we pass them
-            hist_params = {"bins": bins}
+            hist_params = {"bins": bins.tolist()}
 
     try:
         bin_counts, bin_edges = np_.histogram(data, **hist_params)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -153,6 +153,10 @@ class ColumnHistogramParamsMethod(str, enum.Enum):
 
     Sturges = "sturges"
 
+    FreedmanDiaconis = "freedman_diaconis"
+
+    Scott = "scott"
+
     Fixed = "fixed"
 
 
@@ -615,7 +619,7 @@ class ColumnProfileResult(BaseModel):
 
     histogram: Optional[ColumnHistogram] = Field(
         default=None,
-        description="Results from summary_stats request",
+        description="Results from histogram request",
     )
 
     frequency_table: Optional[ColumnFrequencyTable] = Field(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -2622,7 +2622,7 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
             "f": np.ones(11),
         }
     )
-   
+
     dxf.register_table("df", df)
     dxf.register_table("dfp", dfp)
 
@@ -2710,7 +2710,7 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
                 "bin_counts": [11],
                 "quantiles": [],
             },
-        )
+        ),
     ]
 
     for name in ["df", "dfp"]:
@@ -2718,12 +2718,7 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
             result = dxf.get_column_profiles(name, [profile])
             assert result[0]["histogram"] == ex_result
 
-    
-    dfl = pd.DataFrame(
-        {
-            "a": range(10)*1000
-        }
-    )
+    dfl = pd.DataFrame({"a": range(10) * 1000})
     dxf.register_table("dfl", dfl)
     result = dxf.get_column_profiles("dfl", _get_histogram(0, bins=50))
     assert len(result[0]["histogram"]["bin_edges"]) == (10 + 1)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -2718,7 +2718,7 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
             result = dxf.get_column_profiles(name, [profile])
             assert result[0]["histogram"] == ex_result
 
-    dfl = pd.DataFrame({"a": range(10) * 1000})
+    dfl = pd.DataFrame({"a": list(range(10)) * 1000})
     dxf.register_table("dfl", dfl)
     result = dxf.get_column_profiles("dfl", _get_histogram(0, bins=50))
     assert len(result[0]["histogram"]["bin_edges"]) == (10 + 1)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -2602,7 +2602,6 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
 
 
 def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
-
     format_options = FormatOptions(
         large_num_digits=2,
         small_num_digits=4,
@@ -2722,10 +2721,10 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
             },
         ),
         (
-            _get_histogram(0, bins = 50),
+            _get_histogram(0, bins=50),
             {
-                "bin_edges": [_format_float(x) for x in np.linspace(0., 10.0, 12)],
-                "bin_counts": [1]*11,
+                "bin_edges": [_format_float(x) for x in np.linspace(0.0, 10.0, 12)],
+                "bin_counts": [1] * 11,
                 "quantiles": [],
             },
         ),

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -2622,7 +2622,7 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
             "f": np.ones(11),
         }
     )
-
+   
     dxf.register_table("df", df)
     dxf.register_table("dfp", dfp)
 
@@ -2695,12 +2695,38 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
                 "quantiles": [],
             },
         ),
+        (
+            _get_histogram(5, method="freedman_diaconis"),
+            {
+                "bin_edges": ["0.5000", "1.50"],
+                "bin_counts": [11],
+                "quantiles": [],
+            },
+        ),
+        (
+            _get_histogram(5, method="scott"),
+            {
+                "bin_edges": ["0.5000", "1.50"],
+                "bin_counts": [11],
+                "quantiles": [],
+            },
+        )
     ]
 
     for name in ["df", "dfp"]:
         for profile, ex_result in cases:
             result = dxf.get_column_profiles(name, [profile])
             assert result[0]["histogram"] == ex_result
+
+    
+    dfl = pd.DataFrame(
+        {
+            "a": range(10)*1000
+        }
+    )
+    dxf.register_table("dfl", dfl)
+    result = dxf.get_column_profiles("dfl", _get_histogram(0, bins=50))
+    assert len(result[0]["histogram"]["bin_edges"]) == (10 + 1)
 
 
 def test_pandas_polars_profile_frequency_table(dxf: DataExplorerFixture):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -2602,6 +2602,16 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
 
 
 def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
+
+    format_options = FormatOptions(
+        large_num_digits=2,
+        small_num_digits=4,
+        max_integral_digits=7,
+        max_value_length=1000,
+        thousands_sep="_",
+    )
+    _format_float = _get_float_formatter(format_options)
+
     df = pd.DataFrame(
         {
             "a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
@@ -2711,17 +2721,20 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
                 "quantiles": [],
             },
         ),
+        (
+            _get_histogram(0, bins = 50),
+            {
+                "bin_edges": [_format_float(x) for x in np.linspace(0., 10.0, 12)],
+                "bin_counts": [1]*11,
+                "quantiles": [],
+            },
+        ),
     ]
 
     for name in ["df", "dfp"]:
         for profile, ex_result in cases:
             result = dxf.get_column_profiles(name, [profile])
             assert result[0]["histogram"] == ex_result
-
-    dfl = pd.DataFrame({"a": list(range(10)) * 1000})
-    dxf.register_table("dfl", dfl)
-    result = dxf.get_column_profiles("dfl", _get_histogram(0, bins=50))
-    assert len(result[0]["histogram"]["bin_edges"]) == (10 + 1)
 
 
 def test_pandas_polars_profile_frequency_table(dxf: DataExplorerFixture):

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -1102,6 +1102,8 @@
 						"type": "string",
 						"enum": [
 							"sturges",
+							"freedman_diaconis",
+							"scott",
 							"fixed"
 						]
 					},

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -480,7 +480,7 @@ export interface ColumnProfileResult {
 	summary_stats?: ColumnSummaryStats;
 
 	/**
-	 * Results from summary_stats request
+	 * Results from histogram request
 	 */
 	histogram?: ColumnHistogram;
 
@@ -1111,6 +1111,8 @@ export enum ColumnProfileType {
  */
 export enum ColumnHistogramParamsMethod {
 	Sturges = 'sturges',
+	FreedmanDiaconis = 'freedman_diaconis',
+	Scott = 'scott',
 	Fixed = 'fixed'
 }
 

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -283,7 +283,7 @@ export class TableSummaryCache extends Disposable {
 							profiles.push({
 								profile_type: ColumnProfileType.Histogram,
 								params: {
-									method: ColumnHistogramParamsMethod.Sturges
+									method: ColumnHistogramParamsMethod.FreedmanDiaconis
 								}
 							});
 						}
@@ -389,7 +389,7 @@ export class TableSummaryCache extends Disposable {
 					columnProfileSpecs.push({
 						profile_type: ColumnProfileType.Histogram,
 						params: {
-							method: ColumnHistogramParamsMethod.Sturges
+							method: ColumnHistogramParamsMethod.FreedmanDiaconis
 						}
 					});
 				}


### PR DESCRIPTION
This PR adds support for the Freedman Diaconis algorithm for computing the histograms.
It also adds a simple rule to make histograms for integer variables better: if num bins proposed by the binning method is larger than the width of variable range (`data.max() - data.min()`), then we use the integer range as the number of bins.
