### PR TITLE
make R `current` path check case-insensitive

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -264,8 +264,9 @@ function discoverHQBinaries(): string[] {
 		// Windows: rig creates 'bin/', which is a directory of .bat files (at least, for now)
 		// https://github.com/r-lib/rig/issues/189
 		.map(listing => listing.filter(path => !path.endsWith('bin')))
-		// macOS: 'Current', if it exists, is a symlink to an actual version
-		.map(listing => listing.filter(path => !path.endsWith('Current')));
+		// macOS: 'Current' (uppercase 'C'), if it exists, is a symlink to an actual version
+		// linux: 'current' (lowercase 'c'), if it exists, is a symlink to an actual version
+		.map(listing => listing.filter(path => !path.toLowerCase().endsWith('current')));
 
 	// On Windows:
 	// In the case that both (1) and (2) exist we prefer (1).


### PR DESCRIPTION
### Description

- Addresses: #4450
- Checks that the binary path ends in 'current' in a case-insensitive way so that both Mac and Linux are supported

### QA Notes

See #4450 for repro steps!

It would be nice if we had some unit tests for this part of the R extension for Windows, Mac and Linux.