### PR TITLE
Fix possible race condition when rendering webview plots

### DIFF
--- a/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
+++ b/src/vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService.ts
@@ -354,8 +354,8 @@ class IPyWidgetsWebviewMessaging extends Disposable implements IIPyWidgetsWebvie
 	 *
 	 * @param message The message.
 	 */
-	postMessage(message: ToWebviewMessage) {
-		this._notebookRendererMessagingService.receiveMessage(
+	postMessage(message: ToWebviewMessage): Promise<boolean> {
+		return this._notebookRendererMessagingService.receiveMessage(
 			this._editorId, this._rendererId, message
 		);
 	}

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { decodeBase64, VSBuffer } from 'vs/base/common/buffer';
-import { Emitter, Event } from 'vs/base/common/event';
+import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { getExtensionForMimeType } from 'vs/base/common/mime';
 import { localize } from 'vs/nls';
@@ -14,7 +14,6 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { ILogService } from 'vs/platform/log/common/log';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
-import { INotebookWebviewMessage } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { FromWebviewMessage, IClickedDataUrlMessage } from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages';
 import { IScopedRendererMessaging } from 'vs/workbench/contrib/notebook/common/notebookRendererMessagingService';
 import { INotebookOutputWebview } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
@@ -34,11 +33,21 @@ interface NotebookOutputWebviewOptions<WType extends IOverlayWebview | IWebviewE
  */
 export class NotebookOutputWebview<WType extends IOverlayWebview | IWebviewElement = IOverlayWebview> extends Disposable implements INotebookOutputWebview<WType> {
 
-	private readonly _onDidRender = new Emitter<void>;
-	private readonly _onDidReceiveMessage = new Emitter<INotebookWebviewMessage>();
+	private readonly _onDidInitialize = this._register(new Emitter<void>());
+	private readonly _onDidRender = this._register(new Emitter<void>);
+
 	readonly id: string;
 	readonly sessionId: string;
 	readonly webview: WType;
+
+	/**
+	 * Fired when the webviewPreloads script is loaded.
+	 * Note: it will never fire in webviews that do not use the webviewPreloads script.
+	 */
+	onDidInitialize = this._onDidInitialize.event;
+
+	/** Fired when the content completes rendering */
+	onDidRender = this._onDidRender.event;
 
 	/**
 	 * Create a new notebook output webview.
@@ -71,9 +80,6 @@ export class NotebookOutputWebview<WType extends IOverlayWebview | IWebviewEleme
 		this.id = id;
 		this.sessionId = sessionId;
 		this.webview = webview;
-		this.onDidRender = this._onDidRender.event;
-		this._register(this._onDidRender);
-		this._register(this._onDidReceiveMessage);
 
 		if (rendererMessaging) {
 			this._register(rendererMessaging);
@@ -97,6 +103,9 @@ export class NotebookOutputWebview<WType extends IOverlayWebview | IWebviewEleme
 			}
 
 			switch (data.type) {
+				case 'initialized':
+					this._onDidInitialize.fire();
+					break;
 				case 'customRendererMessage':
 					rendererMessaging?.postMessage(data.rendererId, data.message);
 					break;
@@ -110,8 +119,6 @@ export class NotebookOutputWebview<WType extends IOverlayWebview | IWebviewEleme
 
 		}));
 	}
-
-	onDidRender: Event<void>;
 
 	private async _downloadData(payload: IClickedDataUrlMessage): Promise<void> {
 		try {

--- a/src/vs/workbench/contrib/positronPlots/browser/webviewPlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/webviewPlotClient.ts
@@ -65,7 +65,7 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 	}
 
 	/** Whether the plot's underlying webview is active. */
-	isActive(): this is { _webview: { value: IOverlayWebview } } {
+	isActive(): boolean {
 		return Boolean(this._webview.value);
 	}
 
@@ -84,7 +84,7 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 	 **/
 	public activate() {
 		// If we're already active, do nothing.
-		if (this.isActive()) {
+		if (this._webview.value) {
 			return Promise.resolve();
 		}
 
@@ -107,7 +107,7 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 	 * Deactivates the plot, disposing the underlying webview if needed.
 	 **/
 	public deactivate() {
-		if (!this.isActive()) {
+		if (!this._webview.value) {
 			// Already inactive, do nothing.
 			return;
 		}
@@ -121,10 +121,10 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 	 * @param claimant The object taking ownership.
 	 */
 	public claim(claimant: any) {
-		if (!this.isActive()) {
+		if (!this._webview.value) {
 			throw new Error('No webview to claim');
 		}
-		this._webview.value!.claim(claimant, DOM.getWindow(this._element), undefined);
+		this._webview.value.claim(claimant, DOM.getWindow(this._element), undefined);
 		this._claimed = true;
 	}
 
@@ -134,11 +134,11 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 	 * @param ele The element over which to position the webview.
 	 */
 	public layoutWebviewOverElement(ele: HTMLElement) {
-		if (!this.isActive()) {
+		if (!this._webview.value) {
 			throw new Error('No webview to layout');
 		}
 		this._element = ele;
-		this._webview.value!.layoutWebviewOverElement(ele);
+		this._webview.value.layoutWebviewOverElement(ele);
 	}
 
 	/**
@@ -147,11 +147,11 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 	 * @param claimant The object releasing ownership.
 	 */
 	public release(claimant: any) {
-		if (!this.isActive()) {
+		if (!this._webview.value) {
 			// Webview is already disposed so there's nothing to release.
 			return;
 		}
-		this._webview.value!.release(claimant);
+		this._webview.value.release(claimant);
 		this._claimed = false;
 
 		// We can't render a thumbnail while the webview isn't showing, so cancel the
@@ -164,10 +164,10 @@ export abstract class WebviewPlotClient extends Disposable implements IPositronP
 	 * Electron APIs in desktop mode) as PNG.
 	 */
 	private renderThumbnail() {
-		if (!this.isActive()) {
+		if (!this._webview.value) {
 			throw new Error('No webview to render thumbnail');
 		}
-		this._webview.value!.captureContentsAsPng().then(data => {
+		this._webview.value.captureContentsAsPng().then(data => {
 			if (data) {
 				this._thumbnail = data;
 				this._onDidRenderThumbnail.fire(this.asDataUri(data));

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeIPyWidgetClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeIPyWidgetClient.ts
@@ -14,7 +14,7 @@ import { ILogService } from 'vs/platform/log/common/log';
  */
 export interface IIPyWidgetsWebviewMessaging {
 	onDidReceiveMessage: Event<FromWebviewMessage>;
-	postMessage(message: ToWebviewMessage): void;
+	postMessage(message: ToWebviewMessage): Promise<boolean>;
 }
 
 /**

--- a/src/vs/workbench/services/languageRuntime/test/common/testIPyWidgetsWebviewMessaging.ts
+++ b/src/vs/workbench/services/languageRuntime/test/common/testIPyWidgetsWebviewMessaging.ts
@@ -24,9 +24,8 @@ export class TestIPyWidgetsWebviewMessaging extends Disposable implements IIPyWi
 	readonly messagesToWebview = new Array<ToWebviewMessage>();
 
 	/** Fire the onDidReceiveMessage event. */
-	receiveMessage(message: FromWebviewMessage): Promise<boolean> {
+	receiveMessage(message: FromWebviewMessage): void {
 		this._messageEmitter.fire(message);
-		return Promise.resolve(true);
 	}
 
 	private readonly _postMessageEmitter = new Emitter<ToWebviewMessage>();

--- a/src/vs/workbench/services/languageRuntime/test/common/testIPyWidgetsWebviewMessaging.ts
+++ b/src/vs/workbench/services/languageRuntime/test/common/testIPyWidgetsWebviewMessaging.ts
@@ -12,9 +12,10 @@ export class TestIPyWidgetsWebviewMessaging extends Disposable implements IIPyWi
 
 	readonly onDidReceiveMessage = this._messageEmitter.event;
 
-	postMessage(message: ToWebviewMessage): void {
+	postMessage(message: ToWebviewMessage): Promise<boolean> {
 		this._postMessageEmitter.fire(message);
 		this.messagesToWebview.push(message);
+		return Promise.resolve(true);
 	}
 
 	// Test helpers
@@ -23,8 +24,9 @@ export class TestIPyWidgetsWebviewMessaging extends Disposable implements IIPyWi
 	readonly messagesToWebview = new Array<ToWebviewMessage>();
 
 	/** Fire the onDidReceiveMessage event. */
-	receiveMessage(message: FromWebviewMessage): void {
+	receiveMessage(message: FromWebviewMessage): Promise<boolean> {
 		this._messageEmitter.fire(message);
+		return Promise.resolve(true);
 	}
 
 	private readonly _postMessageEmitter = new Emitter<ToWebviewMessage>();


### PR DESCRIPTION
This is an attempt to fix the failing smoke tests for IPyWidget plots (#4448).

I suspect the issue is that during the initial `claim` of the overlay webview, the render message is sent before the webview preloads script is fully initialized. This PR adds an `onDidInitialize` event to the notebook output webview, and delays sending the render messages until the event is fired, which is closer to how the backlayer webview works.

I also cleaned up a few other minor things that I thought were related while investigating.

### QA Notes

The full tests CI should pass (ideally more than once).