### PR TITLE
Data Explorer: Expand RPC contract to allow asking for larger sparkline plots

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -617,7 +617,7 @@ class ColumnProfileResult(BaseModel):
         description="Results from summary_stats request",
     )
 
-    histogram: Optional[ColumnHistogram] = Field(
+    histogram: Optional[ColumnHistograms] = Field(
         default=None,
         description="Results from histogram request",
     )
@@ -780,6 +780,21 @@ class SummaryStatsDatetime(BaseModel):
     )
 
 
+class ColumnHistogramsParams(BaseModel):
+    """
+    Parameters to produce histograms for the summary profile
+    """
+
+    histogram: ColumnHistogramParams = Field(
+        description="Parameters to build the smaller histogram",
+    )
+
+    large_histogram: Optional[LargeHistogram] = Field(
+        default=None,
+        description="Parameters for the larger histogram used when the column is expanded",
+    )
+
+
 class ColumnHistogramParams(BaseModel):
     """
     Parameters for a column histogram profile request
@@ -800,9 +815,25 @@ class ColumnHistogramParams(BaseModel):
     )
 
 
-class ColumnHistogram(BaseModel):
+class ColumnHistograms(BaseModel):
     """
     Result from a histogram profile request
+    """
+
+    histogram: ColumnHistogram = Field(
+        description="A histogram used as the small sparkline plot.",
+    )
+
+    large_histogram: Optional[ColumnHistogram] = Field(
+        default=None,
+        description="A larger histogram, used when the column is expanded in the summary profile",
+    )
+
+
+class ColumnHistogram(BaseModel):
+    """
+    A histogram object. Contains all necessary information to draw an
+    histogram
     """
 
     bin_edges: List[StrictStr] = Field(
@@ -1101,8 +1132,13 @@ ColumnFilterParams = Union[
 ]
 # Extra parameters for different profile types
 ColumnProfileParams = Union[
-    ColumnHistogramParams,
+    ColumnHistogramsParams,
     ColumnFrequencyTableParams,
+]
+# Parameters for the larger histogram used when the column is expanded
+LargeHistogram = Union[
+    Union[StrictInt, StrictFloat],
+    ColumnHistogramParams,
 ]
 # A union of selection types
 Selection = Union[
@@ -1549,7 +1585,11 @@ SummaryStatsDate.update_forward_refs()
 
 SummaryStatsDatetime.update_forward_refs()
 
+ColumnHistogramsParams.update_forward_refs()
+
 ColumnHistogramParams.update_forward_refs()
+
+ColumnHistograms.update_forward_refs()
 
 ColumnHistogram.update_forward_refs()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -2241,7 +2241,7 @@ def _get_histogram(column_index, bins=None, method="fixed"):
         [
             {
                 "profile_type": "histogram",
-                "params": {"method": method, "num_bins": bins},
+                "params": {"histogram": {"method": method, "num_bins": bins}},
             }
         ],
     )
@@ -2733,7 +2733,7 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
     for name in ["df", "dfp"]:
         for profile, ex_result in cases:
             result = dxf.get_column_profiles(name, [profile])
-            assert result[0]["histogram"] == ex_result
+            assert result[0]["histogram"]["histogram"] == ex_result
 
 
 def test_pandas_polars_profile_frequency_table(dxf: DataExplorerFixture):

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -870,8 +870,8 @@
 				"description": "Extra parameters for different profile types",
 				"oneOf": [
 					{
-						"name": "histogram",
-						"$ref": "#/components/schemas/column_histogram_params"
+						"name": "histograms",
+						"$ref": "#/components/schemas/column_histograms_params"
 					},
 					{
 						"name": "frequency_table",
@@ -921,7 +921,7 @@
 					},
 					"histogram": {
 						"description": "Results from histogram request",
-						"$ref": "#/components/schemas/column_histogram"
+						"$ref": "#/components/schemas/column_histograms"
 					},
 					"frequency_table": {
 						"description": "Results from frequency_table request",
@@ -1090,6 +1090,33 @@
 					}
 				}
 			},
+			"column_histograms_params": {
+				"type": "object",
+				"description": "Parameters to produce histograms for the summary profile",
+				"required": [
+					"histogram"
+				],
+				"properties": {
+					"histogram": {
+						"description": "Parameters to build the smaller histogram",
+						"$ref": "#/components/schemas/column_histogram_params"
+					},
+					"large_histogram": {
+						"description": "Parameters for the larger histogram used when the column is expanded",
+						"oneOf": [
+							{
+								"name": "num_bins_multiplier",
+								"description": "The number of bins will be this times larger as the number of bins of the smaller histogram",
+								"type": "number"
+							},
+							{
+								"name": "params",
+								"$ref": "#/components/schemas/column_histogram_params"
+							}
+						]
+					}
+				}
+			},
 			"column_histogram_params": {
 				"type": "object",
 				"description": "Parameters for a column histogram profile request",
@@ -1120,9 +1147,26 @@
 					}
 				}
 			},
-			"column_histogram": {
+			"column_histograms": {
 				"type": "object",
 				"description": "Result from a histogram profile request",
+				"required": [
+					"histogram"
+				],
+				"properties": {
+					"histogram": {
+						"description": "A histogram used as the small sparkline plot.",
+						"$ref": "#/components/schemas/column_histogram"
+					},
+					"large_histogram": {
+						"description": "A larger histogram, used when the column is expanded in the summary profile",
+						"$ref": "#/components/schemas/column_histogram"
+					}
+				}
+			},
+			"column_histogram": {
+				"type": "object",
+				"description": "A histogram object. Contains all necessary information to draw an histogram",
 				"required": [
 					"bin_edges",
 					"bin_counts",

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -482,7 +482,7 @@ export interface ColumnProfileResult {
 	/**
 	 * Results from histogram request
 	 */
-	histogram?: ColumnHistogram;
+	histogram?: ColumnHistograms;
 
 	/**
 	 * Results from frequency_table request
@@ -659,6 +659,22 @@ export interface SummaryStatsDatetime {
 }
 
 /**
+ * Parameters to produce histograms for the summary profile
+ */
+export interface ColumnHistogramsParams {
+	/**
+	 * Parameters to build the smaller histogram
+	 */
+	histogram: ColumnHistogramParams;
+
+	/**
+	 * Parameters for the larger histogram used when the column is expanded
+	 */
+	large_histogram?: LargeHistogram;
+
+}
+
+/**
  * Parameters for a column histogram profile request
  */
 export interface ColumnHistogramParams {
@@ -682,6 +698,24 @@ export interface ColumnHistogramParams {
 
 /**
  * Result from a histogram profile request
+ */
+export interface ColumnHistograms {
+	/**
+	 * A histogram used as the small sparkline plot.
+	 */
+	histogram: ColumnHistogram;
+
+	/**
+	 * A larger histogram, used when the column is expanded in the summary
+	 * profile
+	 */
+	large_histogram?: ColumnHistogram;
+
+}
+
+/**
+ * A histogram object. Contains all necessary information to draw an
+ * histogram
  */
 export interface ColumnHistogram {
 	/**
@@ -1017,7 +1051,10 @@ export type RowFilterParams = FilterBetween | FilterComparison | FilterTextSearc
 export type ColumnFilterParams = FilterTextSearch | FilterMatchDataTypes;
 
 /// Extra parameters for different profile types
-export type ColumnProfileParams = ColumnHistogramParams | ColumnFrequencyTableParams;
+export type ColumnProfileParams = ColumnHistogramsParams | ColumnFrequencyTableParams;
+
+/// Parameters for the larger histogram used when the column is expanded
+export type LargeHistogram = number | ColumnHistogramParams;
 
 /// A union of selection types
 export type Selection = DataSelectionSingleCell | DataSelectionCellRange | DataSelectionRange | DataSelectionIndices;

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -283,7 +283,9 @@ export class TableSummaryCache extends Disposable {
 							profiles.push({
 								profile_type: ColumnProfileType.Histogram,
 								params: {
-									method: ColumnHistogramParamsMethod.FreedmanDiaconis
+									histogram: {
+										method: ColumnHistogramParamsMethod.FreedmanDiaconis
+									}
 								}
 							});
 						}
@@ -389,7 +391,9 @@ export class TableSummaryCache extends Disposable {
 					columnProfileSpecs.push({
 						profile_type: ColumnProfileType.Histogram,
 						params: {
-							method: ColumnHistogramParamsMethod.FreedmanDiaconis
+							histogram: {
+								method: ColumnHistogramParamsMethod.FreedmanDiaconis
+							}
 						}
 					});
 				}


### PR DESCRIPTION
We expanded the RPC contract to allow querying a large histogram along with the smaller one. 
You can ask the larger histogram by providing the parameter `large_histogram`, in eg here:

https://github.com/posit-dev/positron/blob/7e74a5a9b1f97c9c90041eef13596e834c4d0331/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts#L391-L398

The large histogram can take an entire new set of histogram parameters (method, num_bins, etc) or a single number that will be multiplied by the number of bins of the smaller one to get the number of bins of the larger.

I implemented this way, instead of a completely new Profile type, because this allows for nice backends optimizations
related to being able to avoid recomputing the optimal number of bins. @softwarenerd do you think this works for you?

TODO:

- [ ] Add backend tests for the larger histogram
- [ ] Implement the same idea for frequency tables