### PR TITLE
Open file urls in external browser

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -126,10 +126,18 @@ export class UiClientInstance extends Disposable {
 			try {
 				let uri = URI.parse(e.url);
 
-				// If this is a file URI, then treat it as a local file to be
-				// opened in a browser
+				// If this is an HTML file URI, then treat it as a local file to
+				// be opened in a browser
 				if (uri.scheme === 'file') {
-					this.openHtmlFile(e.url);
+					// Does the URI point to a plain directory (presumably
+					// containing an index.html of some kind), or a specific
+					// HTML file?  (lowercase to be case-insensitive)
+					const uriPath = uri.path.toLowerCase();
+					if (uriPath.endsWith('/') ||
+						uriPath.endsWith('.html') ||
+						uriPath.endsWith('.htm')) {
+						this.openHtmlFile(e.url);
+					}
 					return;
 				}
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -125,6 +125,15 @@ export class UiClientInstance extends Disposable {
 		this._register(this._comm.onDidShowUrl(async e => {
 			try {
 				let uri = URI.parse(e.url);
+
+				// If this is a file URI, then treat it as a local file to be
+				// opened in a browser
+				if (uri.scheme === 'file') {
+					this.openHtmlFile(e.url);
+					return;
+				}
+
+				// Resolve the URI if it is an external URI
 				try {
 					const resolvedUri = await this._openerService.resolveExternalUri(uri);
 					uri = resolvedUri.resolved;
@@ -143,22 +152,8 @@ export class UiClientInstance extends Disposable {
 		// Wrap the ShowHtmlFile event to start a proxy server for the HTML file.
 		this._register(this._comm.onDidShowHtmlFile(async e => {
 			try {
-				const url = await this._commandService.executeCommand<string>(
-					'positronProxy.startHtmlProxyServer',
-					e.path
-				);
-
-				if (!url) {
-					throw new Error('Failed to start HTML file proxy server');
-				}
-
-				let uri = URI.parse(url);
-				try {
-					const resolvedUri = await this._openerService.resolveExternalUri(uri);
-					uri = resolvedUri.resolved;
-				} catch {
-					// Noop; use the original URI
-				}
+				// Start an HTML proxy server for the file
+				const uri = await this.startHtmlProxyServer(e.path);
 
 				if (e.is_plot) {
 					// Check the configuration to see if we should open the plot
@@ -180,5 +175,48 @@ export class UiClientInstance extends Disposable {
 				this._logService.error(`Failed to show HTML file ${e.path}: ${error}`);
 			}
 		}));
+	}
+
+	/**
+	 * Opens a file URI in an external browser.
+	 *
+	 * @param url The URL to open in the browser
+	 */
+	private async openHtmlFile(url: string): Promise<void> {
+		// Start an HTML proxy server for the file
+		const resolved = await this.startHtmlProxyServer(url);
+
+		// Open the resolved URI in the external browser. (Consider: should
+		// _all_ file URIs be opened in the external browser?)
+		this._openerService.open(resolved.toString(), {
+			openExternal: true,
+		});
+	}
+
+	/**
+	 * Starts an HTML proxy server for the given HTML file.
+	 *
+	 * @param htmlPath The path to the HTML file to open
+	 * @returns A URI representing the HTML file
+	 */
+	private async startHtmlProxyServer(htmlPath: string): Promise<URI> {
+		const url = await this._commandService.executeCommand<string>(
+			'positronProxy.startHtmlProxyServer',
+			htmlPath
+		);
+
+		if (!url) {
+			throw new Error('Failed to start HTML file proxy server');
+		}
+
+		let uri = URI.parse(url);
+		try {
+			const resolvedUri = await this._openerService.resolveExternalUri(uri);
+			uri = resolvedUri.resolved;
+		} catch {
+			// Noop; use the original URI
+		}
+
+		return uri;
 	}
 }


### PR DESCRIPTION
This change causes certain URLs to HTML files to open in an external browser rather than opening up the HTML file in Positron's editor, addressing a regression from #4151. 

In the aforementioned change, we added some machinery that automatically transforms and proxies URLs that arrive from language runtimes. This is intended for http URLs, but also runs for file URLs, resulting in those files being opened in the editor instead of an external browser. Probably OK if e.g. a runtime asks us to show a `.cpp` file, but not cool for HTML content.

The fix is to check for this situation specifically; when we're handed a file URI that looks like HTML, we start a proxy for it and then open it externally.

I'm not sure it's always right to open these in an external browser (maybe sometimes we'll want the Viewer pane?) but it's what people expect for scenarios where this is broken now, so we can start here and see how it feels.

Addresses https://github.com/posit-dev/positron/issues/4297.

### QA Notes

- It's worth double checking a couple of the scenarios from #4151 to make sure all that good stuff still works.
- This change is also intended to work on Workbench and on remote SSH scenarios where we can't just load the file URL directly since it's on the remote host.