### PR TITLE
Data Explorer: Respect num bins

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -789,9 +789,8 @@ class ColumnHistogramParams(BaseModel):
         description="Method for determining number of bins",
     )
 
-    num_bins: Optional[StrictInt] = Field(
-        default=None,
-        description="Number of bins in the computed histogram",
+    num_bins: StrictInt = Field(
+        description="Maximum number of bins in the computed histogram.",
     )
 
     quantiles: Optional[List[Union[StrictInt, StrictFloat]]] = Field(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -2235,7 +2235,7 @@ def _get_null_count(column_index):
     return _profile_request(column_index, [{"profile_type": "null_count"}])
 
 
-def _get_histogram(column_index, bins=None, method="fixed"):
+def _get_histogram(column_index, bins=2000, method="fixed"):
     return _profile_request(
         column_index,
         [
@@ -2734,6 +2734,13 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
         for profile, ex_result in cases:
             result = dxf.get_column_profiles(name, [profile])
             assert result[0]["histogram"] == ex_result
+
+    dfl = pd.DataFrame({"x": np.random.exponential(2, 2000)})
+    dxf.register_table("dfl", dfl)
+    result = dxf.get_column_profiles(
+        "dfl", [_get_histogram(0, bins=10, method="freedman_diaconis")]
+    )
+    assert len(result[0]["histogram"]["bin_counts"]) == 10
 
 
 def test_pandas_polars_profile_frequency_table(dxf: DataExplorerFixture):

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -1094,7 +1094,8 @@
 				"type": "object",
 				"description": "Parameters for a column histogram profile request",
 				"required": [
-					"method"
+					"method",
+					"num_bins"
 				],
 				"properties": {
 					"method": {
@@ -1109,7 +1110,7 @@
 					},
 					"num_bins": {
 						"type": "integer",
-						"description": "Number of bins in the computed histogram"
+						"description": "Maximum number of bins in the computed histogram."
 					},
 					"quantiles": {
 						"type": "array",

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -668,9 +668,9 @@ export interface ColumnHistogramParams {
 	method: ColumnHistogramParamsMethod;
 
 	/**
-	 * Number of bins in the computed histogram
+	 * Maximum number of bins in the computed histogram.
 	 */
-	num_bins?: number;
+	num_bins: number;
 
 	/**
 	 * Sample quantiles (numbers between 0 and 1) to compute along with the

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -283,7 +283,8 @@ export class TableSummaryCache extends Disposable {
 							profiles.push({
 								profile_type: ColumnProfileType.Histogram,
 								params: {
-									method: ColumnHistogramParamsMethod.FreedmanDiaconis
+									method: ColumnHistogramParamsMethod.FreedmanDiaconis,
+									num_bins: 100
 								}
 							});
 						}
@@ -389,7 +390,8 @@ export class TableSummaryCache extends Disposable {
 					columnProfileSpecs.push({
 						profile_type: ColumnProfileType.Histogram,
 						params: {
-							method: ColumnHistogramParamsMethod.FreedmanDiaconis
+							method: ColumnHistogramParamsMethod.FreedmanDiaconis,
+							num_bins: 100
 						}
 					});
 				}


### PR DESCRIPTION
Make sure the `num_bins` is respected and corresponds to the maximum supported number of bins that we can render in the front-end.