### PR TITLE
Data Explorer: Allow requesting for small and large histograms from the backend

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -510,14 +510,24 @@ class DataExplorerTableView(abc.ABC):
                 results["null_count"] = self._prof_null_count(column_index)
             elif profile_type == ColumnProfileType.SummaryStats:
                 results["summary_stats"] = self._prof_summary_stats(column_index, format_options)
-            elif profile_type == ColumnProfileType.FrequencyTable:
+            elif profile_type == ColumnProfileType.SmallFrequencyTable:
                 assert isinstance(spec.params, ColumnFrequencyTableParams)
-                results["frequency_table"] = self._prof_freq_table(
+                results["small_frequency_table"] = self._prof_freq_table(
                     column_index, spec.params, format_options
                 )
-            elif profile_type == ColumnProfileType.Histogram:
+            elif profile_type == ColumnProfileType.LargeFrequencyTable:
+                assert isinstance(spec.params, ColumnFrequencyTableParams)
+                results["large_frequency_table"] = self._prof_freq_table(
+                    column_index, spec.params, format_options
+                )
+            elif profile_type == ColumnProfileType.SmallHistogram:
                 assert isinstance(spec.params, ColumnHistogramParams)
-                results["histogram"] = self._prof_histogram(
+                results["small_histogram"] = self._prof_histogram(
+                    column_index, spec.params, format_options
+                )
+            elif profile_type == ColumnProfileType.LargeHistogram:
+                assert isinstance(spec.params, ColumnHistogramParams)
+                results["large_histogram"] = self._prof_histogram(
                     column_index, spec.params, format_options
                 )
             else:
@@ -1717,11 +1727,19 @@ class PandasView(DataExplorerTableView):
                     support_status=SupportStatus.Supported,
                 ),
                 ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.Histogram,
+                    profile_type=ColumnProfileType.SmallHistogram,
                     support_status=SupportStatus.Supported,
                 ),
                 ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.FrequencyTable,
+                    profile_type=ColumnProfileType.LargeHistogram,
+                    support_status=SupportStatus.Supported,
+                ),
+                ColumnProfileTypeSupportStatus(
+                    profile_type=ColumnProfileType.SmallFrequencyTable,
+                    support_status=SupportStatus.Supported,
+                ),
+                ColumnProfileTypeSupportStatus(
+                    profile_type=ColumnProfileType.LargeFrequencyTable,
                     support_status=SupportStatus.Supported,
                 ),
             ],

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -140,9 +140,13 @@ class ColumnProfileType(str, enum.Enum):
 
     SummaryStats = "summary_stats"
 
-    FrequencyTable = "frequency_table"
+    SmallFrequencyTable = "small_frequency_table"
 
-    Histogram = "histogram"
+    LargeFrequencyTable = "large_frequency_table"
+
+    SmallHistogram = "small_histogram"
+
+    LargeHistogram = "large_histogram"
 
 
 @enum.unique
@@ -617,14 +621,24 @@ class ColumnProfileResult(BaseModel):
         description="Results from summary_stats request",
     )
 
-    histogram: Optional[ColumnHistogram] = Field(
+    small_histogram: Optional[ColumnHistogram] = Field(
         default=None,
-        description="Results from histogram request",
+        description="Results from small histogram request",
     )
 
-    frequency_table: Optional[ColumnFrequencyTable] = Field(
+    large_histogram: Optional[ColumnHistogram] = Field(
         default=None,
-        description="Results from frequency_table request",
+        description="Results from large histogram request",
+    )
+
+    small_frequency_table: Optional[ColumnFrequencyTable] = Field(
+        default=None,
+        description="Results from small frequency_table request",
+    )
+
+    large_frequency_table: Optional[ColumnFrequencyTable] = Field(
+        default=None,
+        description="Results from large frequency_table request",
     )
 
 
@@ -1101,6 +1115,8 @@ ColumnFilterParams = Union[
 # Extra parameters for different profile types
 ColumnProfileParams = Union[
     ColumnHistogramParams,
+    ColumnHistogramParams,
+    ColumnFrequencyTableParams,
     ColumnFrequencyTableParams,
 ]
 # A union of selection types

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -632,11 +632,19 @@ def test_pandas_supported_features(dxf: DataExplorerFixture):
             support_status=SupportStatus.Supported,
         ),
         ColumnProfileTypeSupportStatus(
-            profile_type="histogram",
+            profile_type="small_histogram",
             support_status=SupportStatus.Supported,
         ),
         ColumnProfileTypeSupportStatus(
-            profile_type="frequency_table",
+            profile_type="large_histogram",
+            support_status=SupportStatus.Supported,
+        ),
+        ColumnProfileTypeSupportStatus(
+            profile_type="small_frequency_table",
+            support_status=SupportStatus.Supported,
+        ),
+        ColumnProfileTypeSupportStatus(
+            profile_type="large_frequency_table",
             support_status=SupportStatus.Supported,
         ),
     ]
@@ -2240,7 +2248,7 @@ def _get_histogram(column_index, bins=2000, method="fixed"):
         column_index,
         [
             {
-                "profile_type": "histogram",
+                "profile_type": "small_histogram",
                 "params": {"method": method, "num_bins": bins},
             }
         ],
@@ -2250,7 +2258,7 @@ def _get_histogram(column_index, bins=2000, method="fixed"):
 def _get_frequency_table(column_index, limit):
     return _profile_request(
         column_index,
-        [{"profile_type": "frequency_table", "params": {"limit": limit}}],
+        [{"profile_type": "small_frequency_table", "params": {"limit": limit}}],
     )
 
 
@@ -2733,14 +2741,14 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
     for name in ["df", "dfp"]:
         for profile, ex_result in cases:
             result = dxf.get_column_profiles(name, [profile])
-            assert result[0]["histogram"] == ex_result
+            assert result[0]["small_histogram"] == ex_result
 
     dfl = pd.DataFrame({"x": np.random.exponential(2, 2000)})
     dxf.register_table("dfl", dfl)
     result = dxf.get_column_profiles(
         "dfl", [_get_histogram(0, bins=10, method="freedman_diaconis")]
     )
-    assert len(result[0]["histogram"]["bin_counts"]) == 10
+    assert len(result[0]["small_histogram"]["bin_counts"]) == 10
 
 
 def test_pandas_polars_profile_frequency_table(dxf: DataExplorerFixture):
@@ -2784,7 +2792,7 @@ def test_pandas_polars_profile_frequency_table(dxf: DataExplorerFixture):
     for name in ["df", "dfp"]:
         for profile, ex_result in cases:
             result = dxf.get_column_profiles(name, [profile])
-            assert result[0]["frequency_table"] == ex_result
+            assert result[0]["small_frequency_table"] == ex_result
 
 
 # ----------------------------------------------------------------------

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -607,7 +607,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.126"
+      "ark": "0.1.127"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.7"

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -870,11 +870,19 @@
 				"description": "Extra parameters for different profile types",
 				"oneOf": [
 					{
-						"name": "histogram",
+						"name": "small_histogram",
 						"$ref": "#/components/schemas/column_histogram_params"
 					},
 					{
-						"name": "frequency_table",
+						"name": "large_histogram",
+						"$ref": "#/components/schemas/column_histogram_params"
+					},
+					{
+						"name": "small_frequency_table",
+						"$ref": "#/components/schemas/column_frequency_table_params"
+					},
+					{
+						"name": "large_frequency_table",
 						"$ref": "#/components/schemas/column_frequency_table_params"
 					}
 				]
@@ -885,8 +893,10 @@
 				"enum": [
 					"null_count",
 					"summary_stats",
-					"frequency_table",
-					"histogram"
+					"small_frequency_table",
+					"large_frequency_table",
+					"small_histogram",
+					"large_histogram"
 				]
 			},
 			"column_profile_type_support_status": {
@@ -919,12 +929,20 @@
 						"description": "Results from summary_stats request",
 						"$ref": "#/components/schemas/column_summary_stats"
 					},
-					"histogram": {
-						"description": "Results from histogram request",
+					"small_histogram": {
+						"description": "Results from small histogram request",
 						"$ref": "#/components/schemas/column_histogram"
 					},
-					"frequency_table": {
-						"description": "Results from frequency_table request",
+					"large_histogram": {
+						"description": "Results from large histogram request",
+						"$ref": "#/components/schemas/column_histogram"
+					},
+					"small_frequency_table": {
+						"description": "Results from small frequency_table request",
+						"$ref": "#/components/schemas/column_frequency_table"
+					},
+					"large_frequency_table": {
+						"description": "Results from large frequency_table request",
 						"$ref": "#/components/schemas/column_frequency_table"
 					}
 				}

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -480,14 +480,24 @@ export interface ColumnProfileResult {
 	summary_stats?: ColumnSummaryStats;
 
 	/**
-	 * Results from histogram request
+	 * Results from small histogram request
 	 */
-	histogram?: ColumnHistogram;
+	small_histogram?: ColumnHistogram;
 
 	/**
-	 * Results from frequency_table request
+	 * Results from large histogram request
 	 */
-	frequency_table?: ColumnFrequencyTable;
+	large_histogram?: ColumnHistogram;
+
+	/**
+	 * Results from small frequency_table request
+	 */
+	small_frequency_table?: ColumnFrequencyTable;
+
+	/**
+	 * Results from large frequency_table request
+	 */
+	large_frequency_table?: ColumnFrequencyTable;
 
 }
 
@@ -1017,7 +1027,7 @@ export type RowFilterParams = FilterBetween | FilterComparison | FilterTextSearc
 export type ColumnFilterParams = FilterTextSearch | FilterMatchDataTypes;
 
 /// Extra parameters for different profile types
-export type ColumnProfileParams = ColumnHistogramParams | ColumnFrequencyTableParams;
+export type ColumnProfileParams = ColumnHistogramParams | ColumnHistogramParams | ColumnFrequencyTableParams | ColumnFrequencyTableParams;
 
 /// A union of selection types
 export type Selection = DataSelectionSingleCell | DataSelectionCellRange | DataSelectionRange | DataSelectionIndices;
@@ -1102,8 +1112,10 @@ export enum ColumnFilterType {
 export enum ColumnProfileType {
 	NullCount = 'null_count',
 	SummaryStats = 'summary_stats',
-	FrequencyTable = 'frequency_table',
-	Histogram = 'histogram'
+	SmallFrequencyTable = 'small_frequency_table',
+	LargeFrequencyTable = 'large_frequency_table',
+	SmallHistogram = 'small_histogram',
+	LargeHistogram = 'large_histogram'
 }
 
 /**

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -68,7 +68,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			// Column display types that render a histogram sparkline.
 			case ColumnDisplayType.Number: {
 				// Get the column histogram. If there is one, render the ColumnSparklineHistogram.
-				const columnHistogram = props.instance.getColumnHistogram(props.columnIndex);
+				const columnHistogram = props.instance.getColumnSmallHistogram(props.columnIndex);
 				if (columnHistogram) {
 					return <ColumnSparklineHistogram columnHistogram={columnHistogram} />;
 				}
@@ -81,7 +81,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			case ColumnDisplayType.Boolean:
 			case ColumnDisplayType.String: {
 				// Get the column frequency table. If there is one, render it and return.
-				const columnFrequencyTable = props.instance.getColumnFrequencyTable(props.columnIndex);
+				const columnFrequencyTable = props.instance.getColumnSmallFrequencyTable(props.columnIndex);
 				if (columnFrequencyTable) {
 					return <ColumnSparklineFrequencyTable columnFrequencyTable={columnFrequencyTable} />;
 				}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/profileBoolean.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/profileBoolean.tsx
@@ -36,7 +36,7 @@ interface ProfileBooleanProps {
  */
 export const ProfileBoolean = (props: ProfileBooleanProps) => {
 	// Get the column profile.
-	const columnFrequencyTable = props.instance.getColumnFrequencyTable(props.columnIndex);
+	const columnFrequencyTable = props.instance.getColumnSmallFrequencyTable(props.columnIndex);
 	const stats = props.instance.getColumnSummaryStats(props.columnIndex)?.boolean_stats;
 
 	// Render.

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/profileNumber.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/profileNumber.tsx
@@ -36,7 +36,7 @@ interface ProfileNumberProps {
  */
 export const ProfileNumber = (props: ProfileNumberProps) => {
 	// Get the column profile.
-	const columnHistogram = props.instance.getColumnHistogram(props.columnIndex);
+	const columnHistogram = props.instance.getColumnSmallHistogram(props.columnIndex);
 	const stats = props.instance.getColumnSummaryStats(props.columnIndex)?.number_stats;
 
 	// Render.

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/profileString.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/profileString.tsx
@@ -36,7 +36,7 @@ interface ProfileStringProps {
  */
 export const ProfileString = (props: ProfileStringProps) => {
 	// Get the column profile.
-	const columnFrequencyTable = props.instance.getColumnFrequencyTable(props.columnIndex);
+	const columnFrequencyTable = props.instance.getColumnSmallFrequencyTable(props.columnIndex);
 	const stats = props.instance.getColumnSummaryStats(props.columnIndex)?.string_stats;
 
 	// Render.

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -357,8 +357,8 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 * @param columnIndex The column index.
 	 * @returns The column histogram for the specified column index
 	 */
-	getColumnHistogram(columnIndex: number) {
-		return this._tableSummaryCache.getColumnProfile(columnIndex)?.histogram;
+	getColumnSmallHistogram(columnIndex: number) {
+		return this._tableSummaryCache.getColumnProfile(columnIndex)?.small_histogram;
 	}
 
 	/**
@@ -366,8 +366,8 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	 * @param columnIndex The column index.
 	 * @returns The column frequency table for the specified column index
 	 */
-	getColumnFrequencyTable(columnIndex: number) {
-		return this._tableSummaryCache.getColumnProfile(columnIndex)?.frequency_table;
+	getColumnSmallFrequencyTable(columnIndex: number) {
+		return this._tableSummaryCache.getColumnProfile(columnIndex)?.small_frequency_table;
 	}
 
 	//#endregion Private Methods

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -281,7 +281,7 @@ export class TableSummaryCache extends Disposable {
 					case ColumnDisplayType.Number: {
 						if (histogramSupported) {
 							profiles.push({
-								profile_type: ColumnProfileType.Histogram,
+								profile_type: ColumnProfileType.SmallHistogram,
 								params: {
 									method: ColumnHistogramParamsMethod.FreedmanDiaconis,
 									num_bins: 100
@@ -295,7 +295,7 @@ export class TableSummaryCache extends Disposable {
 					case ColumnDisplayType.Boolean: {
 						if (frequencyTableSupported) {
 							profiles.push({
-								profile_type: ColumnProfileType.FrequencyTable,
+								profile_type: ColumnProfileType.SmallFrequencyTable,
 								params: {
 									limit: 2
 								}
@@ -308,7 +308,7 @@ export class TableSummaryCache extends Disposable {
 					case ColumnDisplayType.String: {
 						if (frequencyTableSupported) {
 							profiles.push({
-								profile_type: ColumnProfileType.FrequencyTable,
+								profile_type: ColumnProfileType.SmallFrequencyTable,
 								params: {
 									limit: 7
 								}
@@ -386,9 +386,9 @@ export class TableSummaryCache extends Disposable {
 				}
 
 				// Add histogram.
-				if (columnProfile.histogram) {
+				if (columnProfile.small_histogram) {
 					columnProfileSpecs.push({
-						profile_type: ColumnProfileType.Histogram,
+						profile_type: ColumnProfileType.SmallHistogram,
 						params: {
 							method: ColumnHistogramParamsMethod.FreedmanDiaconis,
 							num_bins: 100
@@ -397,8 +397,8 @@ export class TableSummaryCache extends Disposable {
 				}
 
 				// Add frequency table.
-				if (columnProfile.frequency_table) {
-					columnProfileSpecs.push({ profile_type: ColumnProfileType.FrequencyTable });
+				if (columnProfile.small_frequency_table) {
+					columnProfileSpecs.push({ profile_type: ColumnProfileType.SmallFrequencyTable });
 				}
 
 				// Add the column profile request.
@@ -453,7 +453,7 @@ export class TableSummaryCache extends Disposable {
 		const columnProfilesFeatures = this._dataExplorerClientInstance.getSupportedFeatures()
 			.get_column_profiles;
 		const histogramSupportStatus = columnProfilesFeatures.supported_types.find(status =>
-			status.profile_type === ColumnProfileType.Histogram
+			status.profile_type === ColumnProfileType.SmallHistogram
 		);
 
 		if (!histogramSupportStatus) {
@@ -474,7 +474,7 @@ export class TableSummaryCache extends Disposable {
 		const columnProfilesFeatures = this._dataExplorerClientInstance.getSupportedFeatures()
 			.get_column_profiles;
 		const frequencyTableSupportStatus = columnProfilesFeatures.supported_types.find(status =>
-			status.profile_type === ColumnProfileType.FrequencyTable
+			status.profile_type === ColumnProfileType.SmallFrequencyTable
 		);
 
 		if (!frequencyTableSupportStatus) {


### PR DESCRIPTION
Adds small and large histograms as well as large and small frequency tables to allow the front-end to request multiple plot sizes depending on its needs in a single get_profile call.