### PR TITLE
python: show bokeh in plots pane on windows

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -10,6 +10,7 @@ import sys
 import webbrowser
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
+from urllib.parse import urlparse
 
 from comm.base_comm import BaseComm
 
@@ -198,6 +199,10 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
                     ):
                         is_plot = True
                         break
+
+            # windows will not accept file:// at beginning of url
+            if os.name == "nt":
+                url = urlparse(url).netloc
 
             self._comm.send_event(
                 name=UiFrontendEvent.ShowHtmlFile,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -199,10 +199,9 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
                     ):
                         is_plot = True
                         break
-
-            # windows will not accept file:// at beginning of url
-            if os.name == "nt":
-                url = urlparse(url).netloc
+                # windows will not accept file:// at beginning of url
+                if os.name == "nt":
+                    url = urlparse(url).netloc or urlparse(url).path
 
             self._comm.send_event(
                 name=UiFrontendEvent.ShowHtmlFile,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

addresses #4397 

osx wants the url for this file to be in `file://....` format where windows just wants `c://...`, so making a small check to account for that!

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

```python
from bokeh.plotting import figure, show
p = figure(title="Simple line example", x_axis_label='x', y_axis_label='y')
p.line([1, 2, 3, 4, 5], [6, 7, 2, 4, 5], legend_label="Temp.", line_width=2)
show(p)
```

should run without error
