### PR TITLE
Detect hyperlinks surrounded by angle brackets

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/outputRunWithLinks.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/outputRunWithLinks.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { usePositronConsoleContext } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleContext';
+import { detectHyperlinks } from 'vs/workbench/contrib/positronConsole/common/linkDetector';
 
 // OutputRunWithLinksProps interface.
 export interface OutputRunWithLinksProps {
@@ -47,10 +48,7 @@ export const OutputRunWithLinks = (props: OutputRunWithLinksProps) => {
 
 	// Look for a hyperlink in the text.
 	//
-	// Note that this regex ignores characters that typically delimit a
-	// hyperlink, such as quotes, parentheses, and braces, even though these
-	// characters are technically allowed in a URL.
-	const hyperlinkMatch = props.text.match(/\bhttps?:\/\/[^'")}\s]+/);
+	const hyperlinkMatch = detectHyperlinks(props.text);
 	if (hyperlinkMatch) {
 		// Create an array of text and hyperlinks for each entry in the match array.
 		const parts = [];

--- a/src/vs/workbench/contrib/positronConsole/common/linkDetector.ts
+++ b/src/vs/workbench/contrib/positronConsole/common/linkDetector.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ *
+ * Detects hyperlinks in a string of text.
+ *
+ * Note that this function uses a simple regex that ignores characters that
+ * typically delimit a hyperlink, such as quotes, parentheses, and braces, even
+ * though these characters are technically allowed in a URL.
+ *
+ * @param text The text to search for hyperlinks.
+ * @returns An array of hyperlinks found in the text, if any.
+ */
+export function detectHyperlinks(text: string): Array<string> {
+	const matches = text.match(/\bhttps?:\/\/[^'">)}\s]+/g);
+	return matches ? matches : [];
+}

--- a/src/vs/workbench/contrib/positronConsole/test/common/linkDetector.test.ts
+++ b/src/vs/workbench/contrib/positronConsole/test/common/linkDetector.test.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import assert from 'assert';
+import { detectHyperlinks } from 'vs/workbench/contrib/positronConsole/common/linkDetector';
+
+/**
+ * Suite of tests for link detector
+ */
+suite('Output Run with Links', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('basic links correctly extracted', () => {
+		const text = "This is a link to https://www.example.com";
+		const links = detectHyperlinks(text);
+
+		assert.equal(links.length, 1);
+		assert.equal(links[0], 'https://www.example.com');
+	});
+
+	test('multiple links extracted', () => {
+		const text = "This is a link to http://localhost:8080/ and another to http://localhost:8081/";
+		const links = detectHyperlinks(text);
+
+		assert.equal(links.length, 2);
+		assert.equal(links[0], 'http://localhost:8080/');
+		assert.equal(links[1], 'http://localhost:8081/');
+	});
+
+	test('quotes ignored', () => {
+		const text = `There's no place like "http://127.0.0.1/"`;
+		const links = detectHyperlinks(text);
+
+		assert.equal(links.length, 1);
+		assert.equal(links[0], 'http://127.0.0.1/');
+	});
+
+	test('angle brackets ignored', () => {
+		const text = `See more about numbers at <http://localhost:1234>`;
+		const links = detectHyperlinks(text);
+
+		assert.equal(links.length, 1);
+		assert.equal(links[0], 'http://localhost:1234');
+	});
+});


### PR DESCRIPTION
This change fixes a problem wherein links like `Look up docs at <http://example.com/topic>` do not work in the console because the closing `>` is interpreted as part of the link. The link detection is currently a simple regex, so the only actual fix here is just adding `>` to the list of characters that are considered to terminate a link.

However, the change looks bigger because I also moved the link detector into its own file and added some unit tests to it so that we can make this more robust.

Addresses https://github.com/posit-dev/positron/issues/4413.

### QA Notes

There are good repro cases in the bug! This only touches console-related code.