### PR TITLE
Await default interpreter startup before starting a new one

### DIFF
--- a/test/automation/src/positron/fixtures/positronPythonFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronPythonFixtures.ts
@@ -14,12 +14,12 @@ export class PositronPythonFixtures {
 
 	constructor(private app: Application) { }
 
-	static async SetupFixtures(app: Application) {
+	static async SetupFixtures(app: Application, skipReadinessCheck: boolean = false) {
 		const fixtures = new PositronPythonFixtures(app);
-		await fixtures.startPythonInterpreter();
+		await fixtures.startPythonInterpreter(skipReadinessCheck);
 	}
 
-	async startPythonInterpreter() {
+	async startPythonInterpreter(skipReadinessCheck: boolean = false) {
 
 		const desiredPython = process.env.POSITRON_PY_VER_SEL;
 		if (desiredPython === undefined) {
@@ -28,7 +28,7 @@ export class PositronPythonFixtures {
 
 		// We currently don't capture fixtures in the Playwright trace, so take a screenshot on failure
 		try {
-			await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.Python, desiredPython);
+			await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.Python, desiredPython, skipReadinessCheck);
 			await this.app.workbench.positronConsole.waitForReady('>>>', 2000);
 		} catch (e) {
 			this.app.code.driver.takeScreenshot('startPythonInterpreter');

--- a/test/automation/src/positron/fixtures/positronRFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronRFixtures.ts
@@ -14,12 +14,12 @@ export class PositronRFixtures {
 
 	constructor(private app: Application) { }
 
-	static async SetupFixtures(app: Application) {
+	static async SetupFixtures(app: Application, skipReadinessCheck: boolean = false) {
 		const fixtures = new PositronRFixtures(app);
-		await fixtures.startRInterpreter();
+		await fixtures.startRInterpreter(skipReadinessCheck);
 	}
 
-	async startRInterpreter() {
+	async startRInterpreter(skipReadinessCheck: boolean = false) {
 
 		const desiredR = process.env.POSITRON_R_VER_SEL;
 		if (desiredR === undefined) {
@@ -29,7 +29,7 @@ export class PositronRFixtures {
 
 		// We currently don't capture fixtures in the Playwright trace, so take a screenshot on failure
 		try {
-			await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.R, desiredR);
+			await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.R, desiredR, skipReadinessCheck);
 			await this.app.workbench.positronConsole.waitForReady('>', 2000);
 		} catch (e) {
 			this.app.code.driver.takeScreenshot('startRInterpreter');

--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -45,6 +45,10 @@ export class PositronConsole {
 	}
 
 	async selectInterpreter(desiredInterpreterType: InterpreterType, desiredInterpreterString: string): Promise<IElement | undefined> {
+
+		// don't try to start a new interpreter if one is currently starting up
+		await this.waitForReadyOrNoInterpreter();
+
 		let command: string;
 		if (desiredInterpreterType === InterpreterType.Python) {
 			command = 'python.setInterpreter';

--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -44,10 +44,12 @@ export class PositronConsole {
 		this.consoleRestartButton = new PositronBaseElement(CONSOLE_RESTART_BUTTON, this.code);
 	}
 
-	async selectInterpreter(desiredInterpreterType: InterpreterType, desiredInterpreterString: string): Promise<IElement | undefined> {
+	async selectInterpreter(desiredInterpreterType: InterpreterType, desiredInterpreterString: string, skipWait: boolean = false): Promise<IElement | undefined> {
 
 		// don't try to start a new interpreter if one is currently starting up
-		await this.waitForReadyOrNoInterpreter();
+		if (!skipWait) {
+			await this.waitForReadyOrNoInterpreter();
+		}
 
 		let command: string;
 		if (desiredInterpreterType === InterpreterType.Python) {
@@ -77,7 +79,8 @@ export class PositronConsole {
 	): Promise<InterpreterInfo | undefined> {
 		const interpreterElem = await this.selectInterpreter(
 			desiredInterpreterType,
-			desiredInterpreter
+			desiredInterpreter,
+			true
 		);
 
 		if (interpreterElem) {

--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -151,7 +151,7 @@ export class PositronConsole {
 	 * @param retryCount The number of times to retry waiting for the console to be ready.
 	 * @throws An error if the console is not ready after the retry count.
 	 */
-	async waitForReadyOrNoInterpreter(retryCount: number = 200) {
+	async waitForReadyOrNoInterpreter(retryCount: number = 800) {
 		for (let i = 0; i < retryCount; i++) {
 			// Check if the console is ready with Python.
 			try {

--- a/test/automation/src/positron/positronEditor.ts
+++ b/test/automation/src/positron/positronEditor.ts
@@ -32,7 +32,7 @@ export class PositronEditor {
 	 * current-line div parent.
 	 */
 	async getCurrentLineTop(): Promise<number> {
-		let retries = 10;
+		let retries = 20;
 		let topValue: number = NaN;
 
 		const currentLine = this.code.driver.getLocator(CURRENT_LINE);

--- a/test/automation/src/positron/positronVariables.ts
+++ b/test/automation/src/positron/positronVariables.ts
@@ -14,7 +14,7 @@ interface FlatVariables {
 	type: string;
 }
 
-const VARIABLE_ITEMS = '.variables-instance .list .variable-item';
+const VARIABLE_ITEMS = '.variables-instance[style*="z-index: 1"] .list .variable-item';
 const VARIABLE_NAMES = 'name-column';
 const VARIABLE_DETAILS = 'details-column';
 const VARIABLES_NAME_COLUMN = '.variable-item .name-column';

--- a/test/smoke/src/areas/positron/apps/shiny.test.ts
+++ b/test/smoke/src/areas/positron/apps/shiny.test.ts
@@ -53,7 +53,8 @@ export function setup(logger: Logger) {
 
 		describe('Shiny Application - R', () => {
 			before(async function () {
-				await PositronRFixtures.SetupFixtures(this.app as Application);
+				// setup R but do not wait for a default interpreter to finish starting
+				await PositronRFixtures.SetupFixtures(this.app as Application, true);
 			});
 
 			it('R - Verify Basic Shiny App [C699100]', async function () {

--- a/test/smoke/src/areas/positron/apps/shiny.test.ts
+++ b/test/smoke/src/areas/positron/apps/shiny.test.ts
@@ -38,7 +38,7 @@ export function setup(logger: Logger) {
 
 				const headerLocator = app.workbench.positronViewer.getViewerLocator('h1');
 
-				const headerText = await headerLocator.innerText();
+				const headerText = await headerLocator.innerText({ timeout: 30000 });
 
 				expect(headerText).toBe('Restaurant tipping');
 
@@ -69,7 +69,7 @@ runExample("01_hello")`;
 
 				const headerLocator = app.workbench.positronViewer.getViewerLocator('h1');
 
-				const headerText = await headerLocator.innerText();
+				const headerText = await headerLocator.innerText({ timeout: 30000 });
 
 				expect(headerText).toBe('Hello Shiny!');
 

--- a/test/smoke/src/areas/positron/console/consoleClipboard.test.ts
+++ b/test/smoke/src/areas/positron/console/consoleClipboard.test.ts
@@ -77,7 +77,8 @@ export function setup(logger: Logger) {
 
 		describe('Console Clipboard - R', () => {
 			before(async function () {
-				await PositronRFixtures.SetupFixtures(this.app as Application);
+				// setup R but do not wait for a default interpreter to finish starting
+				await PositronRFixtures.SetupFixtures(this.app as Application, true);
 			});
 
 			it('R - Copy from console & paste to console [C663725]', async function () {

--- a/test/smoke/src/areas/positron/console/consoleHistory.test.ts
+++ b/test/smoke/src/areas/positron/console/consoleHistory.test.ts
@@ -74,7 +74,8 @@ export function setup(logger: Logger) {
 
 		describe('Console History - R', () => {
 			before(async function () {
-				await PositronRFixtures.SetupFixtures(this.app as Application);
+				// setup R but do not wait for a default interpreter to finish starting
+				await PositronRFixtures.SetupFixtures(this.app as Application, true);
 			});
 
 			after(async function () {

--- a/test/smoke/src/areas/positron/editor/fast-execution.test.ts
+++ b/test/smoke/src/areas/positron/editor/fast-execution.test.ts
@@ -40,7 +40,7 @@ export function setup(logger: Logger) {
 				// for every line of the file
 				for (let i = 0; i < 10; i++) {
 					let currentTop = await app.workbench.positronEditor.getCurrentLineTop();
-					let retries = 10;
+					let retries = 20;
 
 					// Note that top is a measurement of the distance from the top of the editor
 					// to the top of the current line.  By monitoring the top value, we can determine


### PR DESCRIPTION
Occasionally we see startup crashes in tests that have been difficult to debug.  One theory as to why this is happening is that the test might be trying to start the test interpreter at the same time the default interpreter is still starting up.  This PR adds code to wait for the default interpreter (or definitively no interpreter) to start up before initiating the process of starting a new one.

### QA Notes

All smoke tests should pass.
