### PR TITLE
Smoke Plot tests robustness

### DIFF
--- a/test/smoke/src/areas/positron/plots/plots.test.ts
+++ b/test/smoke/src/areas/positron/plots/plots.test.ts
@@ -114,7 +114,9 @@ plt.show()`;
 					fail(`Image comparison failed with mismatch percentage: ${data.rawMisMatchPercentage}`);
 				}
 
+				await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
 				await app.workbench.positronPlots.clearPlots();
+				await app.workbench.positronLayouts.enterLayout('stacked');
 
 				await app.workbench.positronPlots.waitForNoPlots();
 			});
@@ -160,7 +162,9 @@ IPython.display.display_png(h)`;
 					fail(`Image comparison failed with mismatch percentage: ${data.rawMisMatchPercentage}`);
 				}
 
+				await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
 				await app.workbench.positronPlots.clearPlots();
+				await app.workbench.positronLayouts.enterLayout('stacked');
 
 				await app.workbench.positronPlots.waitForNoPlots();
 			});
@@ -250,7 +254,9 @@ plt.show()`;
 				await expect(app.workbench.positronPlots.previousPlotButton).not.toBeDisabled();
 				await expect(app.workbench.positronPlots.plotSizeButton).not.toBeDisabled();
 
+				await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
 				await app.workbench.positronPlots.clearPlots();
+				await app.workbench.positronLayouts.enterLayout('stacked');
 
 				await app.workbench.positronPlots.waitForNoPlots();
 			});
@@ -299,7 +305,9 @@ plt.show()`;
 				// verify the plot is in the file explorer with the new file name and format
 				await app.workbench.positronExplorer.waitForProjectFileToAppear('Python-scatter.jpeg');
 
+				await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
 				await app.workbench.positronPlots.clearPlots();
+				await app.workbench.positronLayouts.enterLayout('stacked');
 
 				await app.workbench.positronPlots.waitForNoPlots();
 			});
@@ -444,7 +452,9 @@ show(graph)`;
 				const data = await compareImages(bufferAfterZoom, bufferBeforeZoom, options);
 				expect(data.rawMisMatchPercentage).toBeGreaterThan(0.0);
 
+				await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
 				await app.workbench.positronPlots.clearPlots();
+				await app.workbench.positronLayouts.enterLayout('stacked');
 
 				await app.workbench.positronPlots.waitForNoPlots();
 
@@ -491,7 +501,9 @@ title(main="Autos", col.main="red", font.main=4)`;
 					fail(`Image comparison failed with mismatch percentage: ${data.rawMisMatchPercentage}`);
 				}
 
+				await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
 				await app.workbench.positronPlots.clearPlots();
+				await app.workbench.positronLayouts.enterLayout('stacked');
 
 				await app.workbench.positronPlots.waitForNoPlots();
 			});
@@ -536,7 +548,9 @@ title(main="Autos", col.main="red", font.main=4)`;
 				// verify the plot is in the file explorer with the new file name and format
 				await app.workbench.positronExplorer.waitForProjectFileToAppear('R-cars.svg');
 
+				await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
 				await app.workbench.positronPlots.clearPlots();
+				await app.workbench.positronLayouts.enterLayout('stacked');
 
 				await app.workbench.positronPlots.waitForNoPlots();
 			});
@@ -561,7 +575,9 @@ rplot(x, shape = 20, colors = c("red", "green"), legend = TRUE)`;
 				await app.workbench.positronConsole.sendEnterKey();
 				await app.workbench.positronPlots.waitForCurrentPlot();
 
+				await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
 				await app.workbench.positronPlots.clearPlots();
+				await app.workbench.positronLayouts.enterLayout('stacked');
 
 				await app.workbench.positronPlots.waitForNoPlots();
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->
### Intent
Part of addressing #4505. 

### Approach
Sometimes the `clear` button on plots pain isn't visible due to screen size. 
This surrounds the call with layout changes to maximize tha auxbar where the plots pane lives.

### QA Notes
 All Plots Smoke test should pass in CI
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
