### PR TITLE
use correct property name for reh-web and web `positronBuildNumber`

### DIFF
--- a/build/gulpfile.vscode.web.js
+++ b/build/gulpfile.vscode.web.js
@@ -89,10 +89,10 @@ exports.vscodeWebEntryPoints = vscodeWebEntryPoints;
 
 // --- Begin Positron ---
 // Use the POSITRON_BUILD_NUMBER var if it's set; otherwise, call show-version to compute it.
-const buildNumber =
+const positronBuildNumber =
 	process.env.POSITRON_BUILD_NUMBER ??
 	child_process.execSync(`node ${REPO_ROOT}/versions/show-version.js --build`).toString().trim();
-exports.positronBuildNumber = buildNumber;
+exports.positronBuildNumber = positronBuildNumber;
 // --- End Positron ---
 
 /**
@@ -110,7 +110,7 @@ const createVSCodeWebProductConfigurationPatcher = (product) => {
 				...product,
 				// --- Start Positron ---
 				positronVersion,
-				buildNumber,
+				positronBuildNumber,
 				// --- End Positron ---
 				version,
 				commit,


### PR DESCRIPTION
### Description

- A follow-up to #1618 and #4426
- Fixes the incorrect product.json property name by changing `buildNumber` to `positronBuildNumber` in the reh-web and web, resolving an issue where the build number always shows as `0` in dev and release builds for reh-web
- I just saw https://github.com/posit-dev/positron/issues/2059 which is related, but this does not resolve that issue, which is specific to dev builds where product.json doesn't get injected. Note that the hardcoded product info in that code doesn't include `positronBuildNumber`, so it will display `0` by default.

#### Preview

![image](https://github.com/user-attachments/assets/e86f6fc8-3788-4656-a950-39025fc0dce6)

### QA Notes

See https://github.com/posit-dev/positron-builds/pull/49 for instructions on how to run a build.

The build's "About Positron" dialog should show the actual build number, which is the number of commits since the anchor commit in a release build.