### PR TITLE
Fix intermittent failure in ANSIOutput test...

### DIFF
--- a/src/vs/base/test/common/ansiOutput.test.ts
+++ b/src/vs/base/test/common/ansiOutput.test.ts
@@ -454,7 +454,7 @@ const makeLines = (count: number): string[] => {
 	// Make the lines.
 	const lines: string[] = [];
 	for (let i = 0; i < count; i++) {
-		lines.push('0'.repeat(Math.floor(Math.random() * 1025)));
+		lines.push('0'.repeat(Math.floor(Math.random() * 1024) + (i === count - 1 ? 1 : 0)));
 	}
 
 	// Done.
@@ -1694,9 +1694,9 @@ suite('ANSIOutout', () => {
 
 	const testOutputLines = (count: number, terminator: string) => {
 		// Setup.
-		const lines = makeLines(10);
+		const lines = makeLines(count);
 		const ansiOutput = new ANSIOutput();
-		ansiOutput.processOutput(lines.join(LF));
+		ansiOutput.processOutput(lines.join(terminator));
 		const outputLines = ansiOutput.outputLines;
 
 		// Tests.

--- a/src/vs/base/test/common/ansiOutput.test.ts
+++ b/src/vs/base/test/common/ansiOutput.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { ANSIColor, ANSIFormat, ANSIOutput, ANSIStyle } from 'vs/base/common/ansiOutput';
 
 //#region Test Helpers
@@ -1721,6 +1722,9 @@ suite('ANSIOutout', () => {
 		assert.equal(ansiOutput['_outputLine' as keyof ANSIOutput] as unknown as number, outputLine);
 		assert.equal(ansiOutput['_outputColumn' as keyof ANSIOutput] as unknown as number, outputColumn);
 	};
+
+	// Ensure that no disposables are leaked.
+	ensureNoDisposablesAreLeakedInTestSuite();
 });
 
 //#endregion Test Suite


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR addresses https://github.com/posit-dev/positron/issues/2734.

The issue was traced down to the `makeLines` helper function. Previously, this function would generate a set of test lines varying in length between 0 characters and 1024 characters. Sometimes, randomly, this would result in the last test line being 0 characters long. When this happened, the last line would be ignored by `ANSIOutput.processOutput` (as expected), resulting in a test failure like this:

```
1) ANSIOutout
       Test ANSIOutput with 10,000 output lines separated by LF and CRLF:

      AssertionError [ERR_ASSERTION]: 9 == 10
      + expected - actual

      -9
      +10
      
      at testOutputLines (out/vs/base/test/common/ansiOutput.test.js:1553:20)
      at Context.<anonymous> (out/vs/base/test/common/ansiOutput.test.js:540:13)
      at process.processImmediate (node:internal/timers:478:21)
``` 

The fix was to ensure that the last line returned from the `makeLines` helper function is at least one character long so it won't get ignored by `ANSIOutput.processOutput`.

Additionally, I fixed the `testOutputLines` function to use its arguments and I added in a call to `ensureNoDisposablesAreLeakedInTestSuite`, as required now.

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

I was able to reproduce this issue locally by running thousands of iterations of the following test:

```
test('Test ANSIOutput with 10 lines separated by LF and CRLF', () => {
	for (let i = 0; i < 10000; i++) {
		testOutputLines(10, LF);
		testOutputLines(10, CRLF);
	}
});
```

Which would result in a failure nearly 100% of the time. You can test this locally by adding the `for` loop to this this.