### PR TITLE
Plumb through Jupyter `clear_output` messages

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterClearOutput.ts
+++ b/extensions/jupyter-adapter/src/JupyterClearOutput.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Represents a clear_output message from the Jupyter kernel to the front end.
+ *
+ * @link https://jupyter-client.readthedocs.io/en/latest/messaging.html#clear-output
+ */
+export interface JupyterClearOutput {
+	/** Wait to clear the output until new output is available. */
+	wait: boolean;
+}

--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -33,6 +33,7 @@ import { uuidv4 } from './utils';
 import { JupyterCommRequest } from './JupyterCommRequest';
 import { JupyterSessionState } from './JupyterSession';
 import { JupyterSerializedSession, workspaceStateKey } from './JupyterSessionSerialization';
+import { JupyterClearOutput } from './JupyterClearOutput';
 
 /**
  * LangaugeRuntimeSessionAdapter wraps a JupyterKernel in a LanguageRuntime
@@ -582,6 +583,9 @@ export class LanguageRuntimeSessionAdapter
 		}
 
 		switch (msg.msgType) {
+			case 'clear_output':
+				this.onClearOutput(msg, message as JupyterClearOutput);
+				break;
 			case 'display_data':
 				this.onDisplayData(msg, message as JupyterDisplayData);
 				break;
@@ -706,6 +710,24 @@ export class LanguageRuntimeSessionAdapter
 			data: msg.data,
 			metadata: message.metadata,
 		} as positron.LanguageRuntimeCommClosed);
+	}
+
+	/**
+	 * Converts a Jupyter clear_output message to a LanguageRuntimeMessage and
+	 * emits it.
+	 *
+	 * @param message The message packet
+	 * @param data The clear_output message
+	 */
+	onClearOutput(message: JupyterMessagePacket, data: JupyterClearOutput) {
+		this._messages.fire({
+			id: message.msgId,
+			parent_id: message.originId,
+			when: message.when,
+			type: positron.LanguageRuntimeMessageType.ClearOutput,
+			wait: data.wait,
+			metadata: message.metadata,
+		} as positron.LanguageRuntimeClearOutput);
 	}
 
 	/**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -20,6 +20,9 @@ declare module 'positron' {
 
 	/** The set of possible language runtime messages */
 	export enum LanguageRuntimeMessageType {
+		/** A message instructing the frontend to clear the output of a runtime execution. */
+		ClearOutput = 'clear_output',
+
 		/** A message representing output (text, plots, etc.) */
 		Output = 'output',
 
@@ -211,6 +214,14 @@ declare module 'positron' {
 
 		/** Additional binary data, if any */
 		buffers?: Array<Uint8Array>;
+	}
+
+	/**
+	 * LanguageRuntimeClearOutput is a LanguageRuntimeMessage instructing the frontend to clear the
+	 * output of a runtime execution. */
+	export interface LanguageRuntimeClearOutput extends LanguageRuntimeMessage {
+		/** Wait to clear the output until new output is available. */
+		wait: boolean;
 	}
 
 	/** LanguageRuntimeOutput is a LanguageRuntimeMessage representing output (text, plots, etc.) */

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -56,6 +56,9 @@ export enum RuntimeOnlineState {
 
 /** The set of possible language runtime messages */
 export enum LanguageRuntimeMessageType {
+	/** A message instructing the frontend to clear the output of a runtime execution. */
+	ClearOutput = 'clear_output',
+
 	/** A message representing output (text, plots, etc.) */
 	Output = 'output',
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -125,6 +125,14 @@ export enum RuntimeOutputKind {
 	Unknown = 'unknown',
 }
 
+/**
+ * LanguageRuntimeClearOutput is a LanguageRuntimeMessage instructing the frontend to clear the
+ * output of a runtime execution. */
+export interface ILanguageRuntimeMessageClearOutput extends ILanguageRuntimeMessage {
+	/** Wait to clear the output until new output is available. */
+	readonly wait: boolean;
+}
+
 /** LanguageRuntimeOutput is a LanguageRuntimeMessage representing output (text, plots, etc.) */
 export interface ILanguageRuntimeMessageOutput extends ILanguageRuntimeMessage {
 	/**
@@ -426,6 +434,9 @@ export enum RuntimeOnlineState {
 
 /** The set of possible language runtime messages */
 export enum LanguageRuntimeMessageType {
+	/** A message instructing the frontend to clear the output of a runtime execution. */
+	ClearOutput = 'clear_output',
+
 	/** A message representing output (text, plots, etc.) */
 	Output = 'output',
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -6,7 +6,7 @@
 import { Event } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, ILanguageRuntimeSessionState, RuntimeState, ILanguageRuntimeInfo, ILanguageRuntimeStartupFailure, ILanguageRuntimeExit, ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageStream, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageError, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, RuntimeCodeExecutionMode, RuntimeErrorBehavior, RuntimeCodeFragmentStatus, RuntimeExitReason, ILanguageRuntimeMessageResult } from '../../languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, ILanguageRuntimeSessionState, RuntimeState, ILanguageRuntimeInfo, ILanguageRuntimeStartupFailure, ILanguageRuntimeExit, ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageStream, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageError, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, RuntimeCodeExecutionMode, RuntimeErrorBehavior, RuntimeCodeFragmentStatus, RuntimeExitReason, ILanguageRuntimeMessageResult, ILanguageRuntimeMessageClearOutput } from '../../languageRuntime/common/languageRuntimeService';
 import { RuntimeClientType, IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
 import { IRuntimeClientEvent } from 'vs/workbench/services/languageRuntime/common/languageRuntimeUiClient';
 import { IDisposable } from 'vs/base/common/lifecycle';
@@ -107,6 +107,7 @@ export interface ILanguageRuntimeSession {
 	 */
 	onDidCreateClientInstance: Event<ILanguageRuntimeClientCreatedEvent>;
 
+	onDidReceiveRuntimeMessageClearOutput: Event<ILanguageRuntimeMessageClearOutput>;
 	onDidReceiveRuntimeMessageOutput: Event<ILanguageRuntimeMessageOutput>;
 	onDidReceiveRuntimeMessageResult: Event<ILanguageRuntimeMessageResult>;
 	onDidReceiveRuntimeMessageStream: Event<ILanguageRuntimeMessageStream>;

--- a/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
@@ -9,7 +9,7 @@ import { URI } from 'vs/base/common/uri';
 import { generateUuid } from 'vs/base/common/uuid';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionMetadata, RuntimeClientType } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
-import { ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeExit, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageResult, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeStartupFailure, LanguageRuntimeMessageType, LanguageRuntimeSessionLocation, LanguageRuntimeSessionMode, LanguageRuntimeStartupBehavior, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeOutputKind, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeExit, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageClearOutput, ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageResult, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeStartupFailure, LanguageRuntimeMessageType, LanguageRuntimeSessionLocation, LanguageRuntimeSessionMode, LanguageRuntimeStartupBehavior, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeOutputKind, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IRuntimeClientEvent } from 'vs/workbench/services/languageRuntime/common/languageRuntimeUiClient';
 import { TestRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/test/common/testRuntimeClientInstance';
 
@@ -21,6 +21,7 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 	private readonly _onDidEndSession = this._register(new Emitter<ILanguageRuntimeExit>());
 	private readonly _onDidCreateClientInstance = this._register(new Emitter<ILanguageRuntimeClientCreatedEvent>());
 
+	private readonly _onDidReceiveRuntimeMessageClearOutput = this._register(new Emitter<ILanguageRuntimeMessageClearOutput>());
 	private readonly _onDidReceiveRuntimeMessageOutput = this._register(new Emitter<ILanguageRuntimeMessageOutput>());
 	private readonly _onDidReceiveRuntimeMessageResult = this._register(new Emitter<ILanguageRuntimeMessageResult>());
 	private readonly _onDidReceiveRuntimeMessageStream = this._register(new Emitter<ILanguageRuntimeMessageStream>());
@@ -42,6 +43,7 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 	onDidEndSession = this._onDidEndSession.event;
 	onDidCreateClientInstance = this._onDidCreateClientInstance.event;
 
+	onDidReceiveRuntimeMessageClearOutput = this._onDidReceiveRuntimeMessageClearOutput.event;
 	onDidReceiveRuntimeMessageOutput = this._onDidReceiveRuntimeMessageOutput.event;
 	onDidReceiveRuntimeMessageResult = this._onDidReceiveRuntimeMessageResult.event;
 	onDidReceiveRuntimeMessageStream = this._onDidReceiveRuntimeMessageStream.event;
@@ -217,6 +219,15 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 			metadata: message.metadata ?? new Map(),
 			buffers: [],
 		};
+	}
+
+	receiveClearOutputMessage(message: Partial<ILanguageRuntimeMessageClearOutput>) {
+		const clearOutput = {
+			...this._defaultMessage(message, LanguageRuntimeMessageType.Output),
+			wait: message.wait ?? false,
+		};
+		this._onDidReceiveRuntimeMessageClearOutput.fire(clearOutput);
+		return clearOutput;
 	}
 
 	receiveOutputMessage(message: Partial<ILanguageRuntimeMessageOutput>) {


### PR DESCRIPTION
This PR plumbs through the `clear_output` message, which is required to support [IPyWidget Output widgets](https://ipywidgets.readthedocs.io/en/latest/examples/Output%20Widget.html) (#4390).

### QA Notes

There should be no functional change since we aren't yet handling `clear_output` messages.