### PR TITLE
Never show the user a pop up on an LSP error

### DIFF
--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -15,6 +15,7 @@ import {
 	LanguageClientOptions,
 	State,
 	StreamInfo,
+	RevealOutputChannelOn
 } from 'vscode-languageclient/node';
 
 import { Socket } from 'net';
@@ -118,7 +119,8 @@ export class ArkLsp implements vscode.Disposable {
 					fileEvents: vscode.workspace.createFileSystemWatcher('**/*.R')
 				},
 			errorHandler: new RErrorHandler(this._version, port),
-			outputChannel: outputChannel
+			outputChannel: outputChannel,
+			revealOutputChannelOn: RevealOutputChannelOn.Never
 		};
 
 		// With a `.` rather than a `-` so vscode-languageserver can look up related options correctly


### PR DESCRIPTION
I was investigating https://github.com/posit-dev/positron/issues/3467, particularly the `completionItem/resolve` failure pop up you get when you do

```r
bar <- function(...) {}

bar()
```

And hit `Tab` while your cursor is here `bar(<tab>)`

<img width="1483" alt="Screenshot 2024-08-29 at 4 37 52 PM" src="https://github.com/user-attachments/assets/b45e0121-ebae-49f7-be1a-9c9228f7fb69">

https://github.com/posit-dev/ark/pull/431 is an attempt to fix the underlying issue here, and I do think we will merge a variant of that.

However, I realized that this is yet again a case of VS Code being too aggressive about showing non-actionable LSP messages to the user, so I went to see if we could turn this one off. As usual, there was an option for this!

Note that the `RevealOutputChannelOn` enum is used in [exactly 1 place](https://github.com/search?q=repo%3Amicrosoft%2Fvscode-languageserver-node%20RevealOutputChannelOn&type=code) in the `Client` middleware:

Particularly, right [here](https://github.com/microsoft/vscode-languageserver-node/blob/14ddabfc22187b698e83ecde072247aa40727308/client/src/common/client.ts#L1180-L1188) in `logOutputMessage()`, where it helps decide whether or not to `showNotificationMessage()` to the user when `showNotification` is `true`

It defaults to `RevealOutputChannelOn.Error`, but if we set this to `RevealOutputChannelOn.Never` then it means that every instance of `this.error()` in that `client.ts` file will no longer show the user an error notification. Note that `Request completionItem/resolve failed` was [one of these cases](https://github.com/microsoft/vscode-languageserver-node/blob/14ddabfc22187b698e83ecde072247aa40727308/client/src/common/client.ts#L2239).

The most important thing to note is that even with `Never`, the error message is always always [always logged](https://github.com/microsoft/vscode-languageserver-node/blob/14ddabfc22187b698e83ecde072247aa40727308/client/src/common/client.ts#L1181) to the corresponding `Positron Language Server: R x.y.z (console)` Output channel. This is great. This is exactly what we want...and nothing more. If the error doesn't crash the LSP, we probably don't want to show it to the user, even if there is some kind of bug that we probably should fix, because the user can't do anything about that!

See also this issue which describes in nice detail how this `revealOutputChannelOn` option works, confirming my analysis here: https://github.com/microsoft/vscode-languageserver-node/issues/818

As further evidence, we are not alone in wanting to do this 🫡 
https://github.com/search?q=RevealOutputChannelOn.Never&type=code

Notably:
- The PowerShell LSP does this
- [vscode-R](https://github.com/REditorSupport/vscode-R/blob/b196c7d8257a04509de68a3bfe7acf9c1f2fba85/src/languageService.ts#L138) does too
- [rust-analyzer](https://github.com/rust-lang/rust-analyzer/blob/master/editors/code/src/lang_client.ts) effectively does too by overriding `handleFailedRequest()` entirely, but I don't think we need to go that far.