### PR TITLE
Clean up smoke test depencies (move all to qa-example-content)

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -115,7 +115,7 @@ jobs:
           curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install matplotlib ipykernel trcli graphviz
+          python -m pip install ipykernel trcli
 
       - name: Run Smoke Tests (Electron)
         env:

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -115,7 +115,7 @@ jobs:
           curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install ipykernel trcli
+          python -m pip install ipykernel trcli==1.9.5
 
       - name: Run Smoke Tests (Electron)
         env:

--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -90,7 +90,7 @@ jobs:
           curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install matplotlib ipykernel graphviz trcli
+          python -m pip install ipykernel trcli
 
       - name: Run Unit Tests (node.js)
         id: nodejs-unit-tests

--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -90,7 +90,7 @@ jobs:
           curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install ipykernel trcli
+          python -m pip install ipykernel trcli==1.9.5
 
       - name: Run Unit Tests (node.js)
         id: nodejs-unit-tests


### PR DESCRIPTION
Moving all Python dependencies other than ones that are part of the test infrastructure to [qa-example-content](https://github.com/posit-dev/qa-example-content).

This is in an effort to simplify the decision making process when adding new dependencies for smoke tests.  Python dependencies go in [requirements.txt](https://github.com/posit-dev/qa-example-content/blob/main/requirements.txt) and R dependencies go in [DESCRIPTION](https://github.com/posit-dev/qa-example-content/blob/main/DESCRIPTION). 

The dependencies are kept in a separate repo because qa-example-content has all the same requirements and we want to only manage one list of dependencies for R and one for Python.

The only Python dependencies which remain in Positron workflows for smoke tests are:
* ipykernel - needed for any Python testing
* trcli - test rail cli.  needed to publish test results. 

### QA Notes

All smoke tests should pass.
