### PR TITLE
add Project Wizard related Python extension tests

### DIFF
--- a/extensions/positron-python/src/client/positron/createEnvApi.ts
+++ b/extensions/positron-python/src/client/positron/createEnvApi.ts
@@ -3,10 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// --- Start Positron ---
 // eslint-disable-next-line import/no-unresolved
 import * as positron from 'positron';
-// --- End Positron ---
 import { CreateEnvironmentOptionsInternal } from '../pythonEnvironments/creation/types';
 import {
     CreateEnvironmentOptions,

--- a/extensions/positron-python/src/client/positron/createEnvApi.ts
+++ b/extensions/positron-python/src/client/positron/createEnvApi.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CreateEnvironmentOptionsInternal } from '../pythonEnvironments/creation/types';
+import { CreateEnvironmentAndRegisterResult, CreateEnvironmentOptions, CreateEnvironmentProvider } from '../pythonEnvironments/creation/proposed.createEnvApis';
+import { handleCreateEnvironmentCommand } from '../pythonEnvironments/creation/createEnvironment';
+import { IPythonRuntimeManager } from './manager';
+
+/**
+ * A simplified version of an environment provider that can be used in the Positron Project Wizard
+ */
+interface WizardEnvironmentProviders {
+    id: string;
+    name: string;
+    description: string;
+};
+
+/**
+ * Get the list of providers that can be used in the Positron Project Wizard
+ * @param providers The available environment creation providers
+ * @returns A list of providers that can be used in the Positron Project Wizard
+ */
+export async function getCreateEnvironmentProviders(
+    providers: readonly CreateEnvironmentProvider[],
+): Promise<WizardEnvironmentProviders[]> {
+    const providersForWizard = providers.map((provider) => ({
+        id: provider.id,
+        name: provider.name,
+        description: provider.description,
+    }));
+    return providersForWizard;
+}
+
+/**
+ * Create an environment and register it with the Python runtime manager
+ * @param providers The available environment creation providers
+ * @param pythonRuntimeManager The manager for the Python runtimes
+ * @param options Options for creating the environment
+ * @returns The result of creating the environment and registering it, including the metadata for the environment
+ */
+export async function createEnvironmentAndRegister(
+    providers: readonly CreateEnvironmentProvider[],
+    pythonRuntimeManager: IPythonRuntimeManager,
+    options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
+): Promise<(CreateEnvironmentAndRegisterResult) | undefined> {
+    const result = await handleCreateEnvironmentCommand(providers, options);
+    if (result?.path) {
+        const metadata = await pythonRuntimeManager.registerLanguageRuntimeFromPath(result.path);
+        return { ...result, metadata };
+    }
+    return result;
+}

--- a/extensions/positron-python/src/client/positron/createEnvApi.ts
+++ b/extensions/positron-python/src/client/positron/createEnvApi.ts
@@ -4,7 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CreateEnvironmentOptionsInternal } from '../pythonEnvironments/creation/types';
-import { CreateEnvironmentAndRegisterResult, CreateEnvironmentOptions, CreateEnvironmentProvider } from '../pythonEnvironments/creation/proposed.createEnvApis';
+import {
+    CreateEnvironmentAndRegisterResult,
+    CreateEnvironmentOptions,
+    CreateEnvironmentProvider,
+} from '../pythonEnvironments/creation/proposed.createEnvApis';
 import { handleCreateEnvironmentCommand } from '../pythonEnvironments/creation/createEnvironment';
 import { IPythonRuntimeManager } from './manager';
 
@@ -15,7 +19,7 @@ interface WizardEnvironmentProviders {
     id: string;
     name: string;
     description: string;
-};
+}
 
 /**
  * Get the list of providers that can be used in the Positron Project Wizard
@@ -44,7 +48,7 @@ export async function createEnvironmentAndRegister(
     providers: readonly CreateEnvironmentProvider[],
     pythonRuntimeManager: IPythonRuntimeManager,
     options: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
-): Promise<(CreateEnvironmentAndRegisterResult) | undefined> {
+): Promise<CreateEnvironmentAndRegisterResult | undefined> {
     if (!options.providerId || (!options.interpreterPath && !options.condaPythonVersion)) {
         return {
             error: new Error(

--- a/extensions/positron-python/src/client/positron/createEnvApi.ts
+++ b/extensions/positron-python/src/client/positron/createEnvApi.ts
@@ -3,11 +3,15 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// --- Start Positron ---
+// eslint-disable-next-line import/no-unresolved
+import * as positron from 'positron';
+// --- End Positron ---
 import { CreateEnvironmentOptionsInternal } from '../pythonEnvironments/creation/types';
 import {
-    CreateEnvironmentAndRegisterResult,
     CreateEnvironmentOptions,
     CreateEnvironmentProvider,
+    CreateEnvironmentResult,
 } from '../pythonEnvironments/creation/proposed.createEnvApis';
 import { handleCreateEnvironmentCommand } from '../pythonEnvironments/creation/createEnvironment';
 import { IPythonRuntimeManager } from './manager';
@@ -20,6 +24,11 @@ interface WizardEnvironmentProviders {
     name: string;
     description: string;
 }
+
+/**
+ * Result of creating a Python environment and registering it with the language runtime manager.
+ */
+type CreateEnvironmentAndRegisterResult = CreateEnvironmentResult & { metadata?: positron.LanguageRuntimeMetadata };
 
 /**
  * Get the list of providers that can be used in the Positron Project Wizard

--- a/extensions/positron-python/src/client/positron/createEnvApi.ts
+++ b/extensions/positron-python/src/client/positron/createEnvApi.ts
@@ -43,8 +43,15 @@ export async function getCreateEnvironmentProviders(
 export async function createEnvironmentAndRegister(
     providers: readonly CreateEnvironmentProvider[],
     pythonRuntimeManager: IPythonRuntimeManager,
-    options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
+    options: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
 ): Promise<(CreateEnvironmentAndRegisterResult) | undefined> {
+    if (!options.providerId || (!options.interpreterPath && !options.condaPythonVersion)) {
+        return {
+            error: new Error(
+                'Missing required options for creating an environment. Please specify a provider ID and a Python interpreter path or a Conda Python version.',
+            ),
+        };
+    }
     const result = await handleCreateEnvironmentCommand(providers, options);
     if (result?.path) {
         const metadata = await pythonRuntimeManager.registerLanguageRuntimeFromPath(result.path);

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -96,7 +96,7 @@ export function registerCreateEnvironmentFeatures(
         }),
         registerCommand(
             Commands.Create_Environment_And_Register,
-            (options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal) => {
+            (options: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal) => {
                 const providers = _createEnvironmentProviders.getAll();
                 return createEnvironmentAndRegister(
                     providers,

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -98,12 +98,9 @@ export function registerCreateEnvironmentFeatures(
             Commands.Create_Environment_And_Register,
             (options: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal) => {
                 const providers = _createEnvironmentProviders.getAll();
-                return createEnvironmentAndRegister(
-                    providers,
-                    pythonRuntimeManager,
-                    options
-                )
-            }),
+                return createEnvironmentAndRegister(providers, pythonRuntimeManager, options);
+            },
+        ),
         registerCommand(
             Commands.Is_Conda_Installed,
             async (): Promise<boolean> => {

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -1,11 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// --- Start Positron ---
-// eslint-disable-next-line import/no-unresolved
-import { LanguageRuntimeMetadata } from 'positron';
-// --- End Positron ---
-
 import { ConfigurationTarget, Disposable } from 'vscode';
 import { Commands } from '../../common/constants';
 import { IDisposableRegistry, IInterpreterPathService, IPathUtils } from '../../common/types';
@@ -31,6 +26,7 @@ import { CreateEnvironmentOptionsInternal } from './types';
 import { getCondaPythonVersions } from './provider/condaUtils';
 import { IPythonRuntimeManager } from '../../positron/manager';
 import { Conda } from '../common/environmentManagers/conda';
+import { createEnvironmentAndRegister, getCreateEnvironmentProviders } from '../../positron/createEnvApi';
 // --- End Positron ---
 
 class CreateEnvironmentProviders {
@@ -96,27 +92,18 @@ export function registerCreateEnvironmentFeatures(
         // --- Start Positron ---
         registerCommand(Commands.Get_Create_Environment_Providers, () => {
             const providers = _createEnvironmentProviders.getAll();
-            const providersForWizard = providers.map((provider) => ({
-                id: provider.id,
-                name: provider.name,
-                description: provider.description,
-            }));
-            return providersForWizard;
+            return getCreateEnvironmentProviders(providers);
         }),
         registerCommand(
             Commands.Create_Environment_And_Register,
-            async (
-                options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
-            ): Promise<(CreateEnvironmentResult & { metadata?: LanguageRuntimeMetadata }) | undefined> => {
+            (options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal) => {
                 const providers = _createEnvironmentProviders.getAll();
-                const result = await handleCreateEnvironmentCommand(providers, options);
-                if (result?.path) {
-                    const metadata = await pythonRuntimeManager.registerLanguageRuntimeFromPath(result.path);
-                    return { ...result, metadata };
-                }
-                return result;
-            },
-        ),
+                return createEnvironmentAndRegister(
+                    providers,
+                    pythonRuntimeManager,
+                    options
+                )
+            }),
         registerCommand(
             Commands.Is_Conda_Installed,
             async (): Promise<boolean> => {

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/proposed.createEnvApis.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/proposed.createEnvApis.ts
@@ -3,6 +3,9 @@
 
 import { Event, Disposable, WorkspaceFolder } from 'vscode';
 import { EnvironmentTools } from '../../api/types';
+// --- Start Positron ---
+import { CreateEnvironmentOptionsInternal } from './types';
+// --- End Positron ---
 
 export type CreateEnvironmentUserActions = 'Back' | 'Cancel';
 export type EnvironmentProviderId = string;
@@ -128,12 +131,16 @@ export interface CreateEnvironmentProvider {
      * user wants. This API is expected to show a QuickPick or QuickInput to get the user input and return
      * the path to the Python executable in the environment.
      *
-     * @param {CreateEnvironmentOptions} [options] Options used to create a Python environment.
+     * // --- Start Positron ---
+     * @param {CreateEnvironmentOptions & CreateEnvironmentOptionsInternal} [options] Options used to create a Python environment.
+     * // --- End Positron ---
      *
      * @returns a promise that resolves to the path to the
      * Python executable in the environment. Or any action taken by the user, such as back or cancel.
      */
-    createEnvironment(options?: CreateEnvironmentOptions): Promise<CreateEnvironmentResult | undefined>;
+    // --- Start Positron ---
+    createEnvironment(options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal): Promise<CreateEnvironmentResult | undefined>;
+    // --- End Positron ---
 
     /**
      * Unique ID for the creation provider, typically <ExtensionId>:<environment-type | guid>

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/proposed.createEnvApis.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/proposed.createEnvApis.ts
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License
 
-// --- Start Positron ---
-// eslint-disable-next-line import/no-unresolved
-import { LanguageRuntimeMetadata } from 'positron';
-// --- End Positron ---
 import { Event, Disposable, WorkspaceFolder } from 'vscode';
 import { EnvironmentTools } from '../../api/types';
 // --- Start Positron ---
@@ -124,13 +120,6 @@ export type EnvironmentDidCreateEvent = CreateEnvironmentResult & {
      */
     readonly options: CreateEnvironmentOptions | undefined;
 };
-
-// --- Start Positron ---
-/**
- * Result of creating a Python environment and registering it with the language runtime manager.
- */
-export type CreateEnvironmentAndRegisterResult = CreateEnvironmentResult & { metadata?: LanguageRuntimeMetadata };
-// --- End Positron ---
 
 /**
  * Extensions that want to contribute their own environment creation can do that by registering an object

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/proposed.createEnvApis.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/proposed.createEnvApis.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License
 
+// --- Start Positron ---
+// eslint-disable-next-line import/no-unresolved
+import { LanguageRuntimeMetadata } from 'positron';
+// --- End Positron ---
 import { Event, Disposable, WorkspaceFolder } from 'vscode';
 import { EnvironmentTools } from '../../api/types';
 // --- Start Positron ---
@@ -120,6 +124,13 @@ export type EnvironmentDidCreateEvent = CreateEnvironmentResult & {
      */
     readonly options: CreateEnvironmentOptions | undefined;
 };
+
+// --- Start Positron ---
+/**
+ * Result of creating a Python environment and registering it with the language runtime manager.
+ */
+export type CreateEnvironmentAndRegisterResult = CreateEnvironmentResult & { metadata?: LanguageRuntimeMetadata };
+// --- End Positron ---
 
 /**
  * Extensions that want to contribute their own environment creation can do that by registering an object

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/proposed.createEnvApis.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/proposed.createEnvApis.ts
@@ -150,7 +150,9 @@ export interface CreateEnvironmentProvider {
      * Python executable in the environment. Or any action taken by the user, such as back or cancel.
      */
     // --- Start Positron ---
-    createEnvironment(options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal): Promise<CreateEnvironmentResult | undefined>;
+    createEnvironment(
+        options?: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal,
+    ): Promise<CreateEnvironmentResult | undefined>;
     // --- End Positron ---
 
     /**

--- a/extensions/positron-python/src/test/positron/createEnvApi.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/createEnvApi.unit.test.ts
@@ -12,23 +12,23 @@ import { Uri } from 'vscode';
 // eslint-disable-next-line import/no-unresolved
 import * as positron from 'positron';
 import * as path from 'path';
-import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../constants';
-import * as commandApis from '../../../client/common/vscodeApis/commandApis';
-import * as createEnvironmentApis from '../../../client/pythonEnvironments/creation/createEnvironment';
-import { IDisposableRegistry, IInterpreterPathService, IPathUtils } from '../../../client/common/types';
-import { registerCreateEnvironmentFeatures } from '../../../client/pythonEnvironments/creation/createEnvApi';
+import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
+import * as commandApis from '../../client/common/vscodeApis/commandApis';
+import * as createEnvironmentApis from '../../client/pythonEnvironments/creation/createEnvironment';
+import { IDisposableRegistry, IInterpreterPathService, IPathUtils } from '../../client/common/types';
+import { registerCreateEnvironmentFeatures } from '../../client/pythonEnvironments/creation/createEnvApi';
 import {
     CreateEnvironmentOptions,
     CreateEnvironmentProvider,
-} from '../../../client/pythonEnvironments/creation/proposed.createEnvApis';
-import { CreateEnvironmentOptionsInternal } from '../../../client/pythonEnvironments/creation/types';
-import { IPythonRuntimeManager } from '../../../client/positron/manager';
-import { IInterpreterQuickPick } from '../../../client/interpreter/configuration/types';
-import { createEnvironmentAndRegister } from '../../../client/positron/createEnvApi';
+} from '../../client/pythonEnvironments/creation/proposed.createEnvApis';
+import { CreateEnvironmentOptionsInternal } from '../../client/pythonEnvironments/creation/types';
+import { IPythonRuntimeManager } from '../../client/positron/manager';
+import { IInterpreterQuickPick } from '../../client/interpreter/configuration/types';
+import { createEnvironmentAndRegister } from '../../client/positron/createEnvApi';
 
 chaiUse(chaiAsPromised);
 
-suite('Create Environment and Register Tests', () => {
+suite('Positron Create Environment APIs', () => {
     let registerCommandStub: sinon.SinonStub;
     let handleCreateEnvironmentCommandStub: sinon.SinonStub;
 

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -125,6 +125,22 @@ suite('Python runtime manager', () => {
         assert.deepStrictEqual(validated, runtimeMetadata.object);
     });
 
+    test('validateMetadata: returns the full metadata when a metadata fragment is provided', async () => {
+        // Set the full runtime metadata in the manager.
+        pythonRuntimeManager.registeredPythonRuntimes.set(pythonPath, runtimeMetadata.object);
+
+        // Create a metadata fragment (only contains extra data python path).
+        const runtimeMetadataFragment = TypeMoq.Mock.ofType<positron.LanguageRuntimeMetadata>();
+        runtimeMetadataFragment.setup((r) => r.extraRuntimeData).returns(() => ({ pythonPath }));
+
+        // Override the pathExists stub to return true and validate the metadata.
+        sinon.stub(fs, 'pathExists').resolves(true);
+        const validated = await pythonRuntimeManager.validateMetadata(runtimeMetadataFragment.object);
+
+        // The validated metadata should be the full metadata.
+        assert.deepStrictEqual(validated, runtimeMetadata.object);
+    });
+
     test('validateMetadata: throws if extra data is missing', async () => {
         const invalidRuntimeMetadata = TypeMoq.Mock.ofType<positron.LanguageRuntimeMetadata>();
         assert.rejects(() => pythonRuntimeManager.validateMetadata(invalidRuntimeMetadata.object));

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -141,7 +141,8 @@ suite('Python runtime manager', () => {
             .resolves(runtimeMetadata.object);
 
         await assertRegisterLanguageRuntime(async () => {
-            await pythonRuntimeManager.registerLanguageRuntimeFromPath(pythonPath);
+            const registeredRuntime = await pythonRuntimeManager.registerLanguageRuntimeFromPath(pythonPath);
+            assert.equal(registeredRuntime?.extraRuntimeData.pythonPath, pythonPath);
         });
 
         sinon.assert.calledOnceWithExactly(

--- a/extensions/positron-python/src/test/pythonEnvironments/creation/createEnvironmentAndRegister.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/creation/createEnvironmentAndRegister.unit.test.ts
@@ -10,7 +10,7 @@ import * as typemoq from 'typemoq';
 import { assert, use as chaiUse } from 'chai';
 import { Uri } from 'vscode';
 // eslint-disable-next-line import/no-unresolved
-import { LanguageRuntimeMetadata } from 'positron';
+import * as positron from 'positron';
 import * as path from 'path';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../constants';
 import * as commandApis from '../../../client/common/vscodeApis/commandApis';
@@ -98,7 +98,7 @@ suite('Create Environment and Register Tests', () => {
             const resultPath = '/path/to/created/env';
             pythonRuntimeManager
                 .setup((p) => p.registerLanguageRuntimeFromPath(resultPath))
-                .returns(() => Promise.resolve(typemoq.Mock.ofType<LanguageRuntimeMetadata>().object))
+                .returns(() => Promise.resolve(typemoq.Mock.ofType<positron.LanguageRuntimeMetadata>().object))
                 .verifiable(typemoq.Times.once());
             handleCreateEnvironmentCommandStub.returns(Promise.resolve({ path: resultPath }));
 
@@ -117,7 +117,7 @@ suite('Create Environment and Register Tests', () => {
         test(`Environment creation fails when options are missing: ${optionsName} `, async () => {
             pythonRuntimeManager
                 .setup((p) => p.registerLanguageRuntimeFromPath(typemoq.It.isAny()))
-                .returns(() => Promise.resolve(typemoq.Mock.ofType<LanguageRuntimeMetadata>().object))
+                .returns(() => Promise.resolve(typemoq.Mock.ofType<positron.LanguageRuntimeMetadata>().object))
                 .verifiable(typemoq.Times.never());
 
             const result = await createEnvironmentAndRegister(mockProviders, pythonRuntimeManager.object, options);

--- a/extensions/positron-python/src/test/pythonEnvironments/creation/createEnvironmentAndRegister.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/creation/createEnvironmentAndRegister.unit.test.ts
@@ -1,0 +1,140 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as chaiAsPromised from 'chai-as-promised';
+import * as sinon from 'sinon';
+import * as typemoq from 'typemoq';
+import { assert, use as chaiUse } from 'chai';
+import { Uri } from 'vscode';
+// eslint-disable-next-line import/no-unresolved
+import { LanguageRuntimeMetadata } from 'positron';
+import * as path from 'path';
+import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../constants';
+import * as commandApis from '../../../client/common/vscodeApis/commandApis';
+import * as createEnvironmentApis from '../../../client/pythonEnvironments/creation/createEnvironment';
+import { IDisposableRegistry, IInterpreterPathService, IPathUtils } from '../../../client/common/types';
+import { registerCreateEnvironmentFeatures } from '../../../client/pythonEnvironments/creation/createEnvApi';
+import { CreateEnvironmentOptions, CreateEnvironmentProvider } from '../../../client/pythonEnvironments/creation/proposed.createEnvApis';
+import { CreateEnvironmentOptionsInternal } from '../../../client/pythonEnvironments/creation/types';
+import { IPythonRuntimeManager } from '../../../client/positron/manager';
+import { IInterpreterQuickPick } from '../../../client/interpreter/configuration/types';
+import { createEnvironmentAndRegister } from '../../../client/positron/createEnvApi';
+
+chaiUse(chaiAsPromised);
+
+suite('Create Environment and Register Tests', () => {
+    let registerCommandStub: sinon.SinonStub;
+    let handleCreateEnvironmentCommandStub: sinon.SinonStub;
+
+    const disposables: IDisposableRegistry = [];
+    const mockProvider = typemoq.Mock.ofType<CreateEnvironmentProvider>();
+    const mockProviders = [mockProvider.object];
+
+    let pythonRuntimeManager: typemoq.IMock<IPythonRuntimeManager>;
+    let pathUtils: typemoq.IMock<IPathUtils>;
+    let interpreterQuickPick: typemoq.IMock<IInterpreterQuickPick>;
+    let interpreterPathService: typemoq.IMock<IInterpreterPathService>;
+
+    // Test workspace
+    const workspace1 = {
+        uri: Uri.file(path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src', 'testMultiRootWkspc', 'workspace1')),
+        name: 'workspace1',
+        index: 0,
+    };
+
+    // Environment options
+    const envOptions: CreateEnvironmentOptions & CreateEnvironmentOptionsInternal = {
+        providerId: 'envProvider-id',
+        interpreterPath: '/path/to/venv/python',
+        workspaceFolder: workspace1,
+    };
+    const envOptionsWithInfo = {
+        withInterpreterPath: { ...envOptions },
+        withCondaPythonVersion: { ...envOptions, interpreterPath: undefined, condaPythonVersion: '3.12' },
+    }
+    const envOptionsMissingInfo = {
+        noProviderId: { ...envOptions, providerId: undefined },
+        noPythonSpecified: { ...envOptions, interpreterPath: undefined, condaPythonVersion: undefined },
+    };
+
+    setup(() => {
+        registerCommandStub = sinon.stub(commandApis, 'registerCommand');
+        handleCreateEnvironmentCommandStub = sinon.stub(createEnvironmentApis, 'handleCreateEnvironmentCommand');
+
+        pythonRuntimeManager = typemoq.Mock.ofType<IPythonRuntimeManager>();
+        pathUtils = typemoq.Mock.ofType<IPathUtils>();
+        interpreterQuickPick = typemoq.Mock.ofType<IInterpreterQuickPick>();
+        interpreterPathService = typemoq.Mock.ofType<IInterpreterPathService>();
+
+        registerCommandStub.callsFake((_command: string, _callback: (...args: any[]) => any) => ({
+            dispose: () => {
+                // Do nothing
+            },
+        }));
+        pathUtils.setup((p) => p.getDisplayName(typemoq.It.isAny())).returns(() => 'test');
+
+        registerCreateEnvironmentFeatures(
+            disposables,
+            interpreterQuickPick.object,
+            interpreterPathService.object,
+            pathUtils.object,
+            pythonRuntimeManager.object,
+        );
+    });
+
+    teardown(() => {
+        disposables.forEach((d) => d.dispose());
+        sinon.restore();
+    });
+
+    Object.entries(envOptionsWithInfo).forEach(([optionsName, options]) => {
+        test(`Environment creation succeeds when required options specified: ${optionsName}`, async () => {
+            const resultPath = '/path/to/created/env';
+            pythonRuntimeManager
+                .setup((p) => p.registerLanguageRuntimeFromPath(resultPath))
+                .returns(() => Promise.resolve(typemoq.Mock.ofType<LanguageRuntimeMetadata>().object))
+                .verifiable(typemoq.Times.once());
+            handleCreateEnvironmentCommandStub.returns(
+                Promise.resolve({ path: resultPath })
+            );
+
+            const result = await createEnvironmentAndRegister(
+                mockProviders,
+                pythonRuntimeManager.object,
+                options
+            );
+
+            assert.isDefined(result);
+            assert.isDefined(result?.path);
+            assert.isDefined(result?.metadata);
+            assert.isUndefined(result?.error);
+            assert.isTrue(handleCreateEnvironmentCommandStub.calledOnce);
+            pythonRuntimeManager.verifyAll();
+        });
+    });
+
+    Object.entries(envOptionsMissingInfo).forEach(([optionsName, options]) => {
+        test(`Environment creation fails when options are missing: ${optionsName} `, async () => {
+            pythonRuntimeManager
+                .setup((p) => p.registerLanguageRuntimeFromPath(typemoq.It.isAny()))
+                .returns(() => Promise.resolve(typemoq.Mock.ofType<LanguageRuntimeMetadata>().object))
+                .verifiable(typemoq.Times.never());
+
+            const result = await createEnvironmentAndRegister(
+                mockProviders,
+                pythonRuntimeManager.object,
+                options
+            );
+
+            assert.isDefined(result);
+            assert.isUndefined(result?.path);
+            assert.isUndefined(result?.metadata);
+            assert.isDefined(result?.error);
+            assert.isTrue(handleCreateEnvironmentCommandStub.notCalled);
+            pythonRuntimeManager.verifyAll();
+        });
+    });
+});

--- a/extensions/positron-python/src/test/pythonEnvironments/creation/createEnvironmentAndRegister.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/creation/createEnvironmentAndRegister.unit.test.ts
@@ -17,7 +17,10 @@ import * as commandApis from '../../../client/common/vscodeApis/commandApis';
 import * as createEnvironmentApis from '../../../client/pythonEnvironments/creation/createEnvironment';
 import { IDisposableRegistry, IInterpreterPathService, IPathUtils } from '../../../client/common/types';
 import { registerCreateEnvironmentFeatures } from '../../../client/pythonEnvironments/creation/createEnvApi';
-import { CreateEnvironmentOptions, CreateEnvironmentProvider } from '../../../client/pythonEnvironments/creation/proposed.createEnvApis';
+import {
+    CreateEnvironmentOptions,
+    CreateEnvironmentProvider,
+} from '../../../client/pythonEnvironments/creation/proposed.createEnvApis';
 import { CreateEnvironmentOptionsInternal } from '../../../client/pythonEnvironments/creation/types';
 import { IPythonRuntimeManager } from '../../../client/positron/manager';
 import { IInterpreterQuickPick } from '../../../client/interpreter/configuration/types';
@@ -54,7 +57,7 @@ suite('Create Environment and Register Tests', () => {
     const envOptionsWithInfo = {
         withInterpreterPath: { ...envOptions },
         withCondaPythonVersion: { ...envOptions, interpreterPath: undefined, condaPythonVersion: '3.12' },
-    }
+    };
     const envOptionsMissingInfo = {
         noProviderId: { ...envOptions, providerId: undefined },
         noPythonSpecified: { ...envOptions, interpreterPath: undefined, condaPythonVersion: undefined },
@@ -97,15 +100,9 @@ suite('Create Environment and Register Tests', () => {
                 .setup((p) => p.registerLanguageRuntimeFromPath(resultPath))
                 .returns(() => Promise.resolve(typemoq.Mock.ofType<LanguageRuntimeMetadata>().object))
                 .verifiable(typemoq.Times.once());
-            handleCreateEnvironmentCommandStub.returns(
-                Promise.resolve({ path: resultPath })
-            );
+            handleCreateEnvironmentCommandStub.returns(Promise.resolve({ path: resultPath }));
 
-            const result = await createEnvironmentAndRegister(
-                mockProviders,
-                pythonRuntimeManager.object,
-                options
-            );
+            const result = await createEnvironmentAndRegister(mockProviders, pythonRuntimeManager.object, options);
 
             assert.isDefined(result);
             assert.isDefined(result?.path);
@@ -123,11 +120,7 @@ suite('Create Environment and Register Tests', () => {
                 .returns(() => Promise.resolve(typemoq.Mock.ofType<LanguageRuntimeMetadata>().object))
                 .verifiable(typemoq.Times.never());
 
-            const result = await createEnvironmentAndRegister(
-                mockProviders,
-                pythonRuntimeManager.object,
-                options
-            );
+            const result = await createEnvironmentAndRegister(mockProviders, pythonRuntimeManager.object, options);
 
             assert.isDefined(result);
             assert.isUndefined(result?.path);


### PR DESCRIPTION
### Description

- Addresses: https://github.com/posit-dev/positron/issues/3433

#### 🆕 Test Changes
- `extensions/positron-python/src/test/positron/manager.unit.test.ts`
    - added a test to validate a metadata fragment
    - updated an existing test to check the result of
- `extensions/positron-python/src/test/positron/createEnvApi.unit.test.ts`
    - create new tests for the `createEnvironmentAndRegister` api
- `extensions/positron-python/src/test/pythonEnvironments/creation/provider/condaCreationProvider.unit.test.ts`
    - added a test to create a conda env with the code path used by the project wizard
- `extensions/positron-python/src/test/pythonEnvironments/creation/provider/venvCreationProvider.unit.test.ts`
    - added a test to create a venv with the code path used by the project wizard

#### Code Changes
- moved the Positron createEnvironment command implementations to separate functions in `extensions/positron-python/src/client/positron/createEnvApi.ts` to make them more easily testable (without having to call the commands)
- `extensions/positron-python/src/client/pythonEnvironments/creation/proposed.createEnvApis.ts`
    - added/fixed types for createEnvironment options and return type

### QA Notes

- python extension unit tests should pass
- project wizard smoke tests in particular should continue to pass
