### PR TITLE
Data explorer: Make date summary stats optional

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -744,23 +744,28 @@ class SummaryStatsDate(BaseModel):
     SummaryStatsDate in Schemas
     """
 
-    num_unique: StrictInt = Field(
+    num_unique: Optional[StrictInt] = Field(
+        default=None,
         description="The exact number of distinct values",
     )
 
-    min_date: StrictStr = Field(
+    min_date: Optional[StrictStr] = Field(
+        default=None,
         description="Minimum date value as string",
     )
 
-    mean_date: StrictStr = Field(
+    mean_date: Optional[StrictStr] = Field(
+        default=None,
         description="Average date value as string",
     )
 
-    median_date: StrictStr = Field(
+    median_date: Optional[StrictStr] = Field(
+        default=None,
         description="Sample median (50% value) date value as string",
     )
 
-    max_date: StrictStr = Field(
+    max_date: Optional[StrictStr] = Field(
+        default=None,
         description="Maximum date value as string",
     )
 
@@ -770,23 +775,28 @@ class SummaryStatsDatetime(BaseModel):
     SummaryStatsDatetime in Schemas
     """
 
-    num_unique: StrictInt = Field(
+    num_unique: Optional[StrictInt] = Field(
+        default=None,
         description="The exact number of distinct values",
     )
 
-    min_date: StrictStr = Field(
+    min_date: Optional[StrictStr] = Field(
+        default=None,
         description="Minimum date value as string",
     )
 
-    mean_date: StrictStr = Field(
+    mean_date: Optional[StrictStr] = Field(
+        default=None,
         description="Average date value as string",
     )
 
-    median_date: StrictStr = Field(
+    median_date: Optional[StrictStr] = Field(
+        default=None,
         description="Sample median (50% value) date value as string",
     )
 
-    max_date: StrictStr = Field(
+    max_date: Optional[StrictStr] = Field(
+        default=None,
         description="Maximum date value as string",
     )
 

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -635,7 +635,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.140"
+      "ark": "0.1.141"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.7"

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -1043,13 +1043,7 @@
 			},
 			"summary_stats_date": {
 				"type": "object",
-				"required": [
-					"num_unique",
-					"min_date",
-					"mean_date",
-					"median_date",
-					"max_date"
-				],
+				"required": [],
 				"properties": {
 					"num_unique": {
 						"type": "integer",
@@ -1075,13 +1069,7 @@
 			},
 			"summary_stats_datetime": {
 				"type": "object",
-				"required": [
-					"num_unique",
-					"min_date",
-					"mean_date",
-					"median_date",
-					"max_date"
-				],
+				"required": [],
 				"properties": {
 					"num_unique": {
 						"type": "integer",

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -608,27 +608,27 @@ export interface SummaryStatsDate {
 	/**
 	 * The exact number of distinct values
 	 */
-	num_unique: number;
+	num_unique?: number;
 
 	/**
 	 * Minimum date value as string
 	 */
-	min_date: string;
+	min_date?: string;
 
 	/**
 	 * Average date value as string
 	 */
-	mean_date: string;
+	mean_date?: string;
 
 	/**
 	 * Sample median (50% value) date value as string
 	 */
-	median_date: string;
+	median_date?: string;
 
 	/**
 	 * Maximum date value as string
 	 */
-	max_date: string;
+	max_date?: string;
 
 }
 
@@ -639,27 +639,27 @@ export interface SummaryStatsDatetime {
 	/**
 	 * The exact number of distinct values
 	 */
-	num_unique: number;
+	num_unique?: number;
 
 	/**
 	 * Minimum date value as string
 	 */
-	min_date: string;
+	min_date?: string;
 
 	/**
 	 * Average date value as string
 	 */
-	mean_date: string;
+	mean_date?: string;
 
 	/**
 	 * Sample median (50% value) date value as string
 	 */
-	median_date: string;
+	median_date?: string;
 
 	/**
 	 * Maximum date value as string
 	 */
-	max_date: string;
+	max_date?: string;
 
 	/**
 	 * Time zone for timestamp with time zone


### PR DESCRIPTION
Addresses: https://github.com/posit-dev/positron/issues/4356
Pairs with: https://github.com/posit-dev/ark/pull/501

Allows for summary stats for dates to be optional, so we make the behavior similar to the behavior of number statistics.

```
View(data.frame(x = 1 + NA, y = as.Date(NA)))
```

Will be displayed as:

![image](https://github.com/user-attachments/assets/3a878516-8c69-475f-b3cf-04b6ad3303a0)

instead of:

![image](https://github.com/user-attachments/assets/9ef38e46-3759-4412-8605-c6c0ec340ae3)

Which is more consistent with how numeric values are displayed.

