### PR TITLE
Do not contribute `"r.sourceCurrentFile"` affordances in an R package

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -412,7 +412,7 @@
           "command": "r.sourceCurrentFile",
           "icon": "$(play)",
           "title": "%r.command.sourceCurrentFile.title%",
-          "when": "editorLangId == r && !isRPackage"
+          "when": "editorLangId == r"
         },
         {
           "category": "R",

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -396,7 +396,7 @@
         "command": "r.sourceCurrentFile",
         "key": "ctrl+shift+enter",
         "mac": "cmd+shift+enter",
-        "when": "editorLangId == r"
+        "when": "editorLangId == r && !isRPackage"
       },
       {
         "command": "r.insertSection",
@@ -412,7 +412,7 @@
           "command": "r.sourceCurrentFile",
           "icon": "$(play)",
           "title": "%r.command.sourceCurrentFile.title%",
-          "when": "editorLangId == r"
+          "when": "editorLangId == r && !isRPackage"
         },
         {
           "category": "R",
@@ -484,7 +484,7 @@
           "command": "r.sourceCurrentFile",
           "group": "R",
           "title": "%r.command.sourceCurrentFile.title%",
-          "when": "editorLangId == r"
+          "when": "editorLangId == r && !isRPackage"
         },
         {
           "command": "r.rmarkdownRender",
@@ -499,7 +499,7 @@
           "group": "navigation@0",
           "icon": "$(play)",
           "title": "%r.command.sourceCurrentFile.title%",
-          "when": "resourceLangId == r && !isInDiffEditor"
+          "when": "resourceLangId == r && !isInDiffEditor && !isRPackage"
         },
         {
           "command": "r.rmarkdownRender",


### PR DESCRIPTION
Addresses #1359 

I can't think of good reasons why people would in fact want any of these affordances in an R package. Even without them, you can still do something like <kbd>Cmd</kbd>+<kbd>Enter</kbd> to get a function defined, as well as of course the better/recommended options like `devtools::load_all()`, etc.

### QA Notes

After this change,

- when you are in an `.R` file but _not_ in an R package, you get the command to source your current file on the editor action bar, in the context menu, and via the keybinding.
- when you _are_ in an R package in an `.R` file, you do not see this command in any of these three spots.

I kept the command in the command palette because it is used [in testing](https://github.com/posit-dev/positron/blob/de05c42d65938e0dfc7755d67d59eda49957ef2e/test/smoke/src/areas/positron/dataexplorer/largeDataFrame.test.ts#L99) (the testing workspaces look like R packages) and it's not _super_ prominent for users there.
