### PR TITLE
Enable LSP in `.Rprofile

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -269,6 +269,7 @@
         "extensions": [
           ".R",
           ".r",
+          ".Rprofile",
           ".rprofile"
         ],
         "aliases": [

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -24,6 +24,7 @@ export const R_DOCUMENT_SELECTORS = [
 	{ language: 'r', scheme: 'untitled' },
 	{ language: 'r', scheme: 'inmemory' },  // Console
 	{ language: 'r', pattern: '**/*.{r,R}' },
+	{ language: 'r', pattern: '**/*.{rprofile,Rprofile}' },
 	{ language: 'r', pattern: '**/*.{qmd,Qmd}' },
 	{ language: 'r', pattern: '**/*.{rmd,Rmd}' },
 ];


### PR DESCRIPTION
Addresses #2887 pretty much exactly how @DavisVaughan outlined

### QA Notes

You can bring up your own personal `.Rprofile` via `usethis::edit_r_profile()`. Before this PR, there were no features provided by the LSP such as completions, but with this PR we do see LSP features such as completions. You can try typing `libr` and then using <kbd>Tab</kbd> to see the difference.