### PR TITLE
Bump ark version to v0.1.130

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -608,7 +608,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.129"
+      "ark": "0.1.130"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.7"


### PR DESCRIPTION
For:

- https://github.com/posit-dev/ark/pull/504
- https://github.com/posit-dev/ark/pull/493