### PR TITLE
Add `--quiet` flag for R extension tasks run as `ShellExecution`

### DIFF
--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -78,7 +78,7 @@ export async function getRPackageTasks(editorFilePath?: string): Promise<vscode.
 			// out of caution.
 			exec = new vscode.ProcessExecution(
 				binpath,
-				['-e', data.rcode],
+				['--quiet --no-restore --no-save -e', data.rcode],
 				{ env }
 			);
 		} else {
@@ -86,7 +86,7 @@ export async function getRPackageTasks(editorFilePath?: string): Promise<vscode.
 			// test any changes on Windows.
 			exec = new vscode.ShellExecution(
 				binpath,
-				['--quiet -e', { value: data.rcode, quoting: vscode.ShellQuoting.Strong }],
+				['--quiet --no-restore --no-save -e', { value: data.rcode, quoting: vscode.ShellQuoting.Strong }],
 				{ env }
 			);
 		}

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -86,7 +86,7 @@ export async function getRPackageTasks(editorFilePath?: string): Promise<vscode.
 			// test any changes on Windows.
 			exec = new vscode.ShellExecution(
 				binpath,
-				['-e', { value: data.rcode, quoting: vscode.ShellQuoting.Strong }],
+				['--quiet -e', { value: data.rcode, quoting: vscode.ShellQuoting.Strong }],
 				{ env }
 			);
 		}

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -78,7 +78,7 @@ export async function getRPackageTasks(editorFilePath?: string): Promise<vscode.
 			// out of caution.
 			exec = new vscode.ProcessExecution(
 				binpath,
-				['--quiet --no-restore --no-save -e', data.rcode],
+				['--quiet', '--no-restore', '--no-save', '-e', data.rcode],
 				{ env }
 			);
 		} else {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/2715

### QA Notes

After this PR is merged, if you run one of the R extension tasks that use `ShellExecution` like "R: Test R Package", you will not the see R startup message in the terminal where the task is run via shell execution:

![Screenshot 2024-09-04 at 3 51 18 PM](https://github.com/user-attachments/assets/474d7269-eca8-4bcd-a48d-87b46c2c0bba)

We should be sure to test the command that uses R Markdown to render specifically on Windows as well, similar to https://github.com/posit-dev/positron/issues/3816.
