### PR TITLE
python: pip install holoviews for nightly tests

### DIFF
--- a/extensions/positron-python/python_files/positron/test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/test-requirements.txt
@@ -1,7 +1,7 @@
 bokeh
 fastcore
 geopandas
-holoviz
+holoviews
 ipykernel
 ipywidgets
 matplotlib


### PR DESCRIPTION
noticed the failure here: https://github.com/posit-dev/positron/actions/runs/10712733287/job/29703612600

Embarrassingly, I did not install the [right package](https://holoviews.org/install.html#installing-holoviews) 😩 