### PR TITLE
Add "run selection" command to command palette, context menu, toolbar menu

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -121,6 +121,12 @@
         "icon": "$(play)"
       },
       {
+        "command": "workbench.action.positronConsole.executeCode",
+        "category": "R",
+        "title": "%r.command.executeSelectionInConsole.title%",
+        "icon": "$(play)"
+      },
+      {
         "command": "r.rmarkdownRender",
         "category": "R",
         "title": "%r.command.rmarkdownRender.title%",
@@ -417,6 +423,13 @@
         },
         {
           "category": "R",
+          "command": "workbench.action.positronConsole.executeCode",
+          "icon": "$(play)",
+          "title": "%r.command.executeSelectionInConsole.title%",
+          "when": "editorLangId == r"
+        },
+        {
+          "category": "R",
           "command": "r.rmarkdownRender",
           "icon": "$(play)",
           "title": "%r.command.rmarkdownRender.title%",
@@ -488,6 +501,13 @@
           "when": "editorLangId == r && !isRPackage"
         },
         {
+          "command": "workbench.action.positronConsole.executeCode",
+          "group": "R",
+          "title": "%r.command.executeSelectionInConsole.title%",
+          "when": "editorLangId == r"
+        },
+
+        {
           "command": "r.rmarkdownRender",
           "group": "R",
           "title": "%r.command.rmarkdownRender.title%",
@@ -501,6 +521,12 @@
           "icon": "$(play)",
           "title": "%r.command.sourceCurrentFile.title%",
           "when": "resourceLangId == r && !isInDiffEditor && !isRPackage"
+        },
+        {
+          "command": "workbench.action.positronConsole.executeCode",
+          "icon": "$(play)",
+          "title": "%r.command.executeSelectionInConsole.title%",
+          "when": "resourceLangId == r && !isInDiffEditor"
         },
         {
           "command": "r.rmarkdownRender",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -3,6 +3,7 @@
 	"description": "R Language Pack for Positron",
 	"r.capabilities.untrustedWorkspaces.description": "R cannot be started in untrusted folders.",
 	"r.command.sourceCurrentFile.title": "Source R File",
+	"r.command.executeSelectionInConsole.title": "Run Selection in Console",
 	"r.command.createNewFile.title": "New R File",
 	"r.command.packageLoad.title": "Load R Package",
 	"r.command.insertPipe.title": "Insert the pipe operator",


### PR DESCRIPTION
Addresses #2084 

In #2068 we added access to the command `workbench.action.positronConsole.executeCode` for Python to:

- the context menu (right click menu)
- the command palette
- the toolbar menu

This PR adds access to the same command in the same places for R.

### QA Notes

With this PR, you can now use the command `workbench.action.positronConsole.executeCode` (i.e. run your current line or selection in the console) with any of those three UI gestures. It should look fairly similar to what you see with Python files, although the context menu for Python is a little different.