### PR TITLE
Don't show Bokeh GlyphRenderer() messages in plots pane

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/patch/bokeh.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/patch/bokeh.py
@@ -80,6 +80,7 @@ def hide_glyph_renderer_output():
     """
     try:
         from bokeh.models import Model
+
         del Model._repr_html_
 
     except ImportError:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/patch/bokeh.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/patch/bokeh.py
@@ -75,20 +75,12 @@ def add_preload_mime_type():
 
 def hide_glyph_renderer_output():
     """
-    Disable the `_repr_html_` method on the GlyphRenderer class to prevent it from being called
-    when the model is displayed and thus confusing positron into thinking it's a plot to show.
+    Disable the `_repr_html_` method on the Model class to prevent it from being called when the
+    model is displayed and thus confusing positron into thinking it's a plot to show.
     """
     try:
-        from bokeh.models import renderers
-
-        renderers.GlyphRenderer._repr_html_ = empty_repr_html
+        from bokeh.models import Model
+        del Model._repr_html_
 
     except ImportError:
         return
-
-
-def empty_repr_html(self):
-    """
-    Empty function used to disable html printing of a class.
-    """
-    return ""

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_patch/test_bokeh.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_patch/test_bokeh.py
@@ -36,3 +36,21 @@ show(p)
         and "text/html" in call.kwargs["data"]
         for call in calls
     )
+
+
+def test_model_repr_html_disabled(shell: PositronShell, mock_display_pub: Mock):
+    """
+    Test to make sure that the _repr_html_ method is disabled on objects of the Bokeh Model class.
+    This is used to prevent the awkward behavior of simple text showing up in the plots pane when a
+    user builds a bokeh plot command line-by-line in the console.
+    """
+
+    shell.run_cell(
+        """\
+from bokeh.plotting import figure, show
+p = figure(title="Simple line example", x_axis_label='x', y_axis_label='y')
+has_repr_html = hasattr(p, '_repr_html_') and p._repr_html_() not in (None)
+"""
+    )
+
+    assert not shell.ns_table["user_local"]["has_repr_html"]

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_patch/test_bokeh.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_patch/test_bokeh.py
@@ -52,5 +52,7 @@ p = figure(title="Simple line example", x_axis_label='x', y_axis_label='y')
 has_repr_html = hasattr(p, '_repr_html_') and p._repr_html_() not in (None)
 """
     )
-
+    # May be better to if the machinery inside to print an html output of the object was activated,
+    # but it's substantially easier to test this way and plumbing the mocks for testing testing the
+    # internals would be a bit more complex.
     assert not shell.ns_table["user_local"]["has_repr_html"]

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_patch/test_bokeh.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_patch/test_bokeh.py
@@ -7,6 +7,8 @@ from unittest.mock import Mock
 
 from positron_ipykernel.positron_ipkernel import PositronShell
 
+from ..conftest import TestSession
+
 MIME_TYPE_POSITRON_WEBVIEW_FLAG = "application/positron-webview-load.v0+json"
 
 
@@ -38,9 +40,9 @@ show(p)
     )
 
 
-def test_model_repr_html_disabled(shell: PositronShell, mock_display_pub: Mock):
+def test_model_repr_html_disabled(shell: PositronShell, session: TestSession):
     """
-    Test to make sure that the _repr_html_ method is disabled on objects of the Bokeh Model class.
+    Test to make sure that the text/html mime type is excluded from Bokeh Model subclass instances.
     This is used to prevent the awkward behavior of simple text showing up in the plots pane when a
     user builds a bokeh plot command line-by-line in the console.
     """
@@ -49,10 +51,9 @@ def test_model_repr_html_disabled(shell: PositronShell, mock_display_pub: Mock):
         """\
 from bokeh.plotting import figure, show
 p = figure(title="Simple line example", x_axis_label='x', y_axis_label='y')
-has_repr_html = hasattr(p, '_repr_html_') and p._repr_html_() not in (None)
+p
 """
     )
-    # May be better to if the machinery inside to print an html output of the object was activated,
-    # but it's substantially easier to test this way and plumbing the mocks for testing testing the
-    # internals would be a bit more complex.
-    assert not shell.ns_table["user_local"]["has_repr_html"]
+
+    # Assert that none of the messages have a text/html mime type
+    assert not any("text/html" in message["content"]["data"] for message in session.messages)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/utils.py
@@ -119,6 +119,7 @@ def json_rpc_request(
             },
             **content,
         },
+        "header": {},
     }
 
 

--- a/extensions/positron-python/python_files/pyproject.toml
+++ b/extensions/positron-python/python_files/pyproject.toml
@@ -69,7 +69,6 @@ docstring-code-format = true
 
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"
-
 # --- Start Positron ---
 [tool.pytest.ini_options]
 # Enable colors in the VSCode Test Results pane.

--- a/extensions/positron-python/python_files/pyproject.toml
+++ b/extensions/positron-python/python_files/pyproject.toml
@@ -69,3 +69,9 @@ docstring-code-format = true
 
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"
+
+# --- Start Positron ---
+[tool.pytest.ini_options]
+# Enable colors in the VSCode Test Results pane.
+addopts = "--color=yes"
+# --- End Positron ---


### PR DESCRIPTION
Addresses #4597

This PR overrides the `_repr_html_` method on the `GlyphRenderer` class so it doesn't output html that gets shown in the plots pane. 
This commonly happens when running line-by-line while making a bokeh plot. 

### Testing

Running the following (making sure the `p.line(...)` line is last.)

```python
from bokeh.plotting import figure, show
p = figure(title="Simple line example", x_axis_label='x', y_axis_label='y')
p.line([1, 2, 3, 4, 5], [6, 7, 2, 4, 5], legend_label="Temp.", line_width=2)
```
Should no longer print an ugly `GlyphRenderer(...)` message to the plots pane. 


### Open question:
This just fixes the problem for `GlyphRenderer` but you can also still get similar style "plots" for anything in bokeh that inherits from the `Model` base class. This includes things like `Figure`. You can run the following line:
```python
from bokeh.plotting import figure, show
figure(title="Simple line example", x_axis_label='x', y_axis_label='y')
```
You should get a plot pane just like the `GlyphRenderer`. A way to get around this is to simply disable the `_repr_html_` method for the whole `Model` class, which works fine but may be a bit heavy-handed. 