### PR TITLE
modify `npx eslint` command to avoid errors on Windows

### DIFF
--- a/build/eslint-mocha-only.js
+++ b/build/eslint-mocha-only.js
@@ -48,7 +48,7 @@ try {
 	}
 	// Non-ideal way to fail on `only` being used in mocha tests without triggering other linting rules.
 	const result = child_process.execSync(
-		`npx eslint --no-eslintrc --parser '@typescript-eslint/parser' --plugin 'mocha' --rule 'mocha/no-exclusive-tests: error' ${files}`,
+		`npx eslint --no-eslintrc --parser "@typescript-eslint/parser" --plugin "mocha" --rule "mocha/no-exclusive-tests:error" ${files}`,
 		{ encoding: 'utf8' }
 	);
 	process.exit(ExitCodes.SUCCESS);


### PR DESCRIPTION
### Description

- addresses #4599 

On Windows, `npx eslint` is not a fan of single quotes and spaces within quotes 🤷 

### QA Notes

The mocha `.only` pre-commit linting should continue to work on linux and mac dev environments. I've tested this on my mac and the linting behaviour has remained the same.