### PR TITLE
Fix copy plot to clipboard on web

### DIFF
--- a/src/vs/platform/clipboard/browser/clipboardService.ts
+++ b/src/vs/platform/clipboard/browser/clipboardService.ts
@@ -191,7 +191,17 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 
 	// --- Start Positron ---
 	async writeImage(data: string): Promise<void> {
-		const blob = new Blob([data], { type: 'image/png' });
+		// convert image data to bytes
+		const byteString = atob(data.split(',')[1]);
+		const mimeString = data.split(',')[0].split(':')[1].split(';')[0];
+		const intArray = [];
+
+		// convert bytes to int array
+		for (let i = 0; i < byteString.length; i++) {
+			intArray.push(byteString.charCodeAt(i));
+		}
+
+		const blob = new Blob([new Uint8Array(intArray)], { type: mimeString });
 		navigator.clipboard.write([
 			new ClipboardItem({
 				[blob.type]: blob

--- a/src/vs/platform/clipboard/browser/clipboardService.ts
+++ b/src/vs/platform/clipboard/browser/clipboardService.ts
@@ -196,6 +196,10 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 		const mimeString = data.split(',')[0].split(':')[1].split(';')[0];
 		const intArray = [];
 
+		if (!ClipboardItem.supports(mimeString)) {
+			throw new Error(`Unsupported image format: ${mimeString}`);
+		}
+
 		// convert bytes to int array
 		for (let i = 0; i < byteString.length; i++) {
 			intArray.push(byteString.charCodeAt(i));

--- a/src/vs/platform/clipboard/common/clipboardService.ts
+++ b/src/vs/platform/clipboard/common/clipboardService.ts
@@ -38,6 +38,12 @@ export interface IClipboardService {
 	writeResources(resources: URI[]): Promise<void>;
 
 	// --- Start Positron ---
+	/**
+	 * Writes an image to the system clipboard.
+	 *
+	 * @param data The image data in data URI format
+	 * @throws if the image data is invalid or mime type is unsupported
+	 */
 	writeImage(data: string): Promise<void>;
 	// --- End Positron ---
 


### PR DESCRIPTION
Address #4433 

The blob wasn't the right format to create the clipboard item. The data URI needed the mime type stripped and the image data used for the blob.

I suppose we could check that the mime type is a supported for writing to the clipboard but I'm not sure if there are any types that wouldn't work and we always generate PNGs for plots.