### PR TITLE
Push nightly python ci results to positron-test-results

### DIFF
--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -71,7 +71,7 @@ jobs:
         run: python -m pip install -r build/test-requirements.txt
 
       - name: Run Python unit tests
-        run: python python_files/tests/run_all.py
+        run: python python_files/tests/run_all.py --junit-xml= python-unit-test-results.xml
 
       - name: slack-smoke-test-report
         uses: testlabauto/xunit-slack-reporter@v2.0.1

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -74,7 +74,6 @@ jobs:
         run: python python_files/tests/run_all.py
 
       - name: slack-smoke-test-report
-        if: failure()
         uses: testlabauto/xunit-slack-reporter@v2.0.1
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel
@@ -119,7 +118,6 @@ jobs:
         run: pytest python_files/positron
 
       - name: slack-smoke-test-report
-        if: failure()
         uses: testlabauto/xunit-slack-reporter@v2.0.1
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           find . | grep python-unit-test-results.xml
           pwd
+          echo ${{ github.workspace }}
 
       - name: slack-smoke-test-report
         if: runner.os == 'Linux'
@@ -85,7 +86,7 @@ jobs:
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel
           SLACK_TOKEN: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
-          XUNIT_PATH: ./python-unit-test-results.xml
+          XUNIT_PATH: ${{ github.workspace }}/python-unit-test-results.xml
 
   # Install the latest releases of test dependencies
   positron-ipykernel-tests-latest:
@@ -125,7 +126,7 @@ jobs:
         run: pytest python_files/positron --junit-xml=python-test-results.xml
 
       - name: slack-smoke-test-report
-        if: runner.os == 'Linux'
+        if: ${{ failure() && runner.os == 'Linux' }}
         uses: testlabauto/xunit-slack-reporter@v2.0.1
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -75,7 +75,9 @@ jobs:
 
       - name: debug
         if: runner.os == 'Linux'
-        run: find . | grep python-unit-test-results.xml
+        run: |
+          find . | grep python-unit-test-results.xml
+          pwd
 
       - name: slack-smoke-test-report
         if: runner.os == 'Linux'
@@ -83,7 +85,7 @@ jobs:
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel
           SLACK_TOKEN: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
-          XUNIT_PATH: python-unit-test-results.xml
+          XUNIT_PATH: ./python-unit-test-results.xml
 
   # Install the latest releases of test dependencies
   positron-ipykernel-tests-latest:

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -83,7 +83,7 @@ jobs:
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel
           SLACK_TOKEN: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
-          XUNIT_PATH: extensions/positron-python/python-unit-test-results.xml
+          XUNIT_PATH: python-unit-test-results.xml
 
   # Install the latest releases of test dependencies
   positron-ipykernel-tests-latest:

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -107,3 +107,10 @@ jobs:
       - name: Run Positron IPyKernel unit tests
         run: pytest python_files/positron
 
+      - name: slack-smoke-test-report
+        uses: testlabauto/xunit-slack-reporter@v2.0.1
+        env:
+          SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel
+          SLACK_TOKEN: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
+          XUNIT_PATH: test-results.xml
+

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -115,7 +115,7 @@ jobs:
         run: python -m pip install --prefer-binary --upgrade -r python_files/positron/test-requirements.txt
 
       - name: Run Positron IPyKernel unit tests
-        run: pytest python_files/positron
+        run: pytest python_files/positron --junit-xml= python-test-results.xml #wherever you want the path to be
 
       - name: slack-smoke-test-report
         uses: testlabauto/xunit-slack-reporter@v2.0.1

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -73,7 +73,12 @@ jobs:
       - name: Run Python unit tests
         run: python python_files/tests/run_all.py --junit-xml=python-unit-test-results.xml
 
+      - name: debug
+        if: runner.os == 'Linux'
+        run: find . | grep python-unit-test-results.xml
+
       - name: slack-smoke-test-report
+        if: runner.os == 'Linux'
         uses: testlabauto/xunit-slack-reporter@v2.0.1
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel
@@ -118,6 +123,7 @@ jobs:
         run: pytest python_files/positron --junit-xml=python-test-results.xml
 
       - name: slack-smoke-test-report
+        if: runner.os == 'Linux'
         uses: testlabauto/xunit-slack-reporter@v2.0.1
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -4,6 +4,7 @@ name: 'Nightly: Python CI'
 on:
   schedule:
     - cron: "0 2 * * 1-5"
+  workflow_dispatch:
 
 defaults:
  run:
@@ -69,6 +70,14 @@ jobs:
 
       - name: Run Python unit tests
         run: python python_files/tests/run_all.py
+
+      - name: slack-smoke-test-report
+        if: failure()
+        uses: testlabauto/xunit-slack-reporter@v2.0.1
+        env:
+          SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel
+          SLACK_TOKEN: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
+          XUNIT_PATH: test-results.xml
 
   # Install the latest releases of test dependencies
   positron-ipykernel-tests-latest:

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -4,9 +4,6 @@ name: 'Nightly: Python CI'
 on:
   schedule:
     - cron: "0 2 * * 1-5"
-  workflow_dispatch:
-  push:
-    branches: ['main', 'cmead/push-python*']
 
 defaults:
  run:
@@ -81,7 +78,7 @@ jobs:
           echo ${{ github.workspace }}
 
       - name: slack-smoke-test-report
-        if: runner.os == 'Linux'
+        if: ${{ failure() && runner.os == 'Linux' }}
         uses: testlabauto/xunit-slack-reporter@v2.0.1
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: "0 2 * * 1-5"
   workflow_dispatch:
+  push:
+    branches: ['main', 'cmead/push-python*']
 
 defaults:
  run:

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -86,7 +86,7 @@ jobs:
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel
           SLACK_TOKEN: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
-          XUNIT_PATH: ${{ github.workspace }}/python-unit-test-results.xml
+          XUNIT_PATH: ${{ github.workspace }}/${{ env.special-working-directory-relative }}/extensions/positron-python/python-unit-test-results.xml
 
   # Install the latest releases of test dependencies
   positron-ipykernel-tests-latest:

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -70,13 +70,6 @@ jobs:
       - name: Run Python unit tests
         run: python python_files/tests/run_all.py --junit-xml=python-unit-test-results.xml
 
-      - name: debug
-        if: runner.os == 'Linux'
-        run: |
-          find . | grep python-unit-test-results.xml
-          pwd
-          echo ${{ github.workspace }}
-
       - name: slack-smoke-test-report
         if: ${{ failure() && runner.os == 'Linux' }}
         uses: testlabauto/xunit-slack-reporter@v2.0.1

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -108,6 +108,7 @@ jobs:
         run: pytest python_files/positron
 
       - name: slack-smoke-test-report
+        if: failure()
         uses: testlabauto/xunit-slack-reporter@v2.0.1
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -115,12 +115,12 @@ jobs:
         run: python -m pip install --prefer-binary --upgrade -r python_files/positron/test-requirements.txt
 
       - name: Run Positron IPyKernel unit tests
-        run: pytest python_files/positron --junit-xml= python-test-results.xml #wherever you want the path to be
+        run: pytest python_files/positron --junit-xml=python-test-results.xml #wherever you want the path to be
 
       - name: slack-smoke-test-report
         uses: testlabauto/xunit-slack-reporter@v2.0.1
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel
           SLACK_TOKEN: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
-          XUNIT_PATH: test-results.xml
+          XUNIT_PATH: extensions/positron-python/python-test-results.xml
 

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -71,14 +71,14 @@ jobs:
         run: python -m pip install -r build/test-requirements.txt
 
       - name: Run Python unit tests
-        run: python python_files/tests/run_all.py --junit-xml= python-unit-test-results.xml
+        run: python python_files/tests/run_all.py --junit-xml=python-unit-test-results.xml
 
       - name: slack-smoke-test-report
         uses: testlabauto/xunit-slack-reporter@v2.0.1
         env:
           SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel
           SLACK_TOKEN: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
-          XUNIT_PATH: test-results.xml
+          XUNIT_PATH: extensions/positron-python/python-unit-test-results.xml
 
   # Install the latest releases of test dependencies
   positron-ipykernel-tests-latest:
@@ -115,7 +115,7 @@ jobs:
         run: python -m pip install --prefer-binary --upgrade -r python_files/positron/test-requirements.txt
 
       - name: Run Positron IPyKernel unit tests
-        run: pytest python_files/positron --junit-xml=python-test-results.xml #wherever you want the path to be
+        run: pytest python_files/positron --junit-xml=python-test-results.xml
 
       - name: slack-smoke-test-report
         uses: testlabauto/xunit-slack-reporter@v2.0.1


### PR DESCRIPTION
Simply push failing test results to #positron-test-results

Currently will only work for Ubuntu, but filing another ticket to fix that.

### QA Notes

Failed test results should be pushed to slack
