### PR TITLE
Add missing packageManager specification. Fix order of 'open' dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,10 +106,10 @@
     "native-keymap": "^3.3.5",
     "native-watchdog": "^1.4.1",
     "node-pty": "1.1.0-beta11",
+    "open": "^8.4.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-window": "^1.8.8",
-    "open": "^8.4.2",
     "tas-client-umd": "0.2.0",
     "v8-inspect-profiler": "^0.1.1",
     "vscode-oniguruma": "1.7.0",
@@ -252,5 +252,6 @@
   },
   "optionalDependencies": {
     "windows-foreground-love": "0.5.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
This PR addresses two problems:

First, on some Windows machines, after running `corepack enable`, running `yarn` in the `positron` folder resulted in `yarn` `v4.4.0` being used. It is not clear why this was happening to some Windows developers (e.g. me) and not to others. The fix for this was to add:

```
"packageManager": "yarn@1.22.22"
```

To the `positron/package.json` file so that the right version of `yarn` will be used.

This is the equivalent of running:

```
corepack use yarn@1.22.22
```

(Somehow, this is remembered. We don't know where it is remembered yet.)

Second, the 'open' dependency was not sorted properly in the `package.json` file.

### QA Notes

@jonvanausdeln - this is the solution to the Windows build problem I was experiencing.