### PR TITLE
Fix/3472 keyboard shortcuts display incorrectly

### DIFF
--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.css
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.css
@@ -90,9 +90,7 @@
 
 .custom-context-menu-item
 .shortcut {
-	/* display: block; */
-	letter-spacing: .2rem;
 	white-space: nowrap;
 	grid-column: shortcut / end;
-	padding: 10px 0 10px 10px;
+	padding: 10px;
 }

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.css
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.css
@@ -90,7 +90,7 @@
 
 .custom-context-menu-item
 .shortcut {
+	padding: 10px;
 	white-space: nowrap;
 	grid-column: shortcut / end;
-	padding: 10px;
 }

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 // Other dependencies.
 import * as DOM from 'vs/base/browser/dom';
+import { isMacintosh } from 'vs/base/common/platform';
 import { positronClassNames } from 'vs/base/common/positronUtilities';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
@@ -151,8 +152,13 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 		if (options.commandId) {
 			const keybinding = props.keybindingService.lookupKeybinding(options.commandId);
 			if (keybinding) {
-				const label = keybinding.getLabel();
+				let label = keybinding.getLabel();
 				if (label) {
+					if (isMacintosh) {
+						label = label.replace('⇧', '⇧ ');
+						label = label.replace('⌥', '⌥ ');
+						label = label.replace('⌘', '⌘ ');
+					}
 					shortcut = label;
 				}
 			}


### PR DESCRIPTION
This PR addresses #3472. 

Prior to this PR, each character in a custom context menu shortcut was being displayed with a `letter-spacing` of `.2rem`. This resulted in incorrect display of custom context menu shortcuts on Windows and Linux:

![image](https://github.com/user-attachments/assets/cfce62c6-43bd-40f5-a638-b95e879818ba)

Now, on macOS, custom context menu shortcuts are adjusted such that `⇧`, `⌥`, and `⌘` are displayed with a trailing space by this code:

```
label = label.replace('⇧', '⇧ ');
label = label.replace('⌥', '⌥ ');
label = label.replace('⌘', '⌘ ');
```

Here's a screenshot of this in action:

<img width="252" alt="image" src="https://github.com/user-attachments/assets/0e059e3d-113e-45aa-bfbc-d4c53d04076f">

With this change, our custom context menu shortcuts now match system context menu shortcuts on macOS:

<img width="238" alt="image" src="https://github.com/user-attachments/assets/3064cb55-0fd5-4eec-929b-520c6d770635">

And on Windows and Linux:

<img width="201" alt="image" src="https://github.com/user-attachments/assets/48ebd9f1-84b8-49c5-8384-0a0cd3e09224">


### QA Notes

None.