### PR TITLE
Bump ark to 0.1.133

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -634,7 +634,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.130"
+      "ark": "0.1.133"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.7"


### PR DESCRIPTION
0.1.133

- Reverts 0.1.131

0.1.132

- https://github.com/posit-dev/ark/pull/486

~0.1.131~

~- https://github.com/posit-dev/ark/pull/473~
~- https://github.com/posit-dev/ark/pull/502~

~@dfalbel Is it safe to merge ark 0.1.131 before https://github.com/posit-dev/positron/pull/4326 is merged?~