### PR TITLE
Data Explorer: Add "does not contain" string search type

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -1537,6 +1537,8 @@ class PandasView(DataExplorerTableView):
                     term = term.lower()
                 if params.search_type == TextSearchType.Contains:
                     mask = col.str.contains(term)
+                elif params.search_type == TextSearchType.NotContains:
+                    mask = ~col.str.contains(term, na=True)
                 elif params.search_type == TextSearchType.StartsWith:
                     mask = col.str.startswith(term)
                 elif params.search_type == TextSearchType.EndsWith:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -112,6 +112,8 @@ class TextSearchType(str, enum.Enum):
 
     Contains = "contains"
 
+    NotContains = "not_contains"
+
     StartsWith = "starts_with"
 
     EndsWith = "ends_with"

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -1537,6 +1537,20 @@ def test_pandas_filter_search(dxf: DataExplorerFixture):
         ),
         ("contains", schema[0], "foo", True, df["a"].str.contains("foo")),
         (
+            "not_contains",
+            schema[0],
+            "foo",
+            False,
+            ~df["a"].str.lower().str.contains("foo", na=True),
+        ),
+        (
+            "not_contains",
+            schema[0],
+            "foo",
+            True,
+            ~df["a"].str.contains("foo", na=True),
+        ),
+        (
             "starts_with",
             schema[0],
             "foo",
@@ -2282,7 +2296,12 @@ def _get_histogram(column_index, bins=2000, method="fixed"):
 def _get_frequency_table(column_index, limit):
     return _profile_request(
         column_index,
-        [{"profile_type": "small_frequency_table", "params": {"limit": limit}}],
+        [
+            {
+                "profile_type": "small_frequency_table",
+                "params": {"limit": limit},
+            }
+        ],
     )
 
 

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -750,6 +750,7 @@
 				"description": "Type of string text search filter to perform",
 				"enum": [
 					"contains",
+					"not_contains",
 					"starts_with",
 					"ends_with",
 					"regex_match"

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -94,6 +94,7 @@ const filterNumParams = (filterType: RowFilterDescrType | undefined) => {
 		case RowFilterDescrType.IS_LESS_OR_EQUAL:
 		case RowFilterDescrType.IS_LESS_THAN:
 		case RowFilterDescrType.SEARCH_CONTAINS:
+		case RowFilterDescrType.SEARCH_NOT_CONTAINS:
 		case RowFilterDescrType.SEARCH_STARTS_WITH:
 		case RowFilterDescrType.SEARCH_ENDS_WITH:
 		case RowFilterDescrType.SEARCH_REGEX_MATCHES:

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -222,6 +222,14 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 				value: RowFilterDescrType.SEARCH_CONTAINS
 			}));
 			conditionEntries.push(new DropDownListBoxItem({
+				identifier: RowFilterDescrType.SEARCH_NOT_CONTAINS,
+				title: localize(
+					'positron.addEditRowFilter.conditionSearchNotContains',
+					"does not contain"
+				),
+				value: RowFilterDescrType.SEARCH_NOT_CONTAINS
+			}));
+			conditionEntries.push(new DropDownListBoxItem({
 				identifier: RowFilterDescrType.SEARCH_STARTS_WITH,
 				title: localize(
 					'positron.addEditRowFilter.conditionSearchStartsWith',
@@ -659,6 +667,7 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 
 			// Apply comparison row filter.
 			case RowFilterDescrType.SEARCH_CONTAINS:
+			case RowFilterDescrType.SEARCH_NOT_CONTAINS:
 			case RowFilterDescrType.SEARCH_STARTS_WITH:
 			case RowFilterDescrType.SEARCH_ENDS_WITH:
 			case RowFilterDescrType.SEARCH_REGEX_MATCHES: {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/rowFilterDescriptor.ts
@@ -37,6 +37,7 @@ export enum RowFilterDescrType {
 	IS_EQUAL_TO = 'is-equal-to',
 	IS_NOT_EQUAL_TO = 'is-not-equal-to',
 	SEARCH_CONTAINS = 'search-contains',
+	SEARCH_NOT_CONTAINS = 'search-not-contains',
 	SEARCH_STARTS_WITH = 'search-starts-with',
 	SEARCH_ENDS_WITH = 'search-ends-with',
 	SEARCH_REGEX_MATCHES = 'search-regex',
@@ -391,6 +392,8 @@ export class RowFilterDescriptorSearch extends SingleValueRowFilterDescriptor {
 		switch (this._descrType) {
 			case RowFilterDescrType.SEARCH_CONTAINS:
 				return 'contains';
+			case RowFilterDescrType.SEARCH_NOT_CONTAINS:
+				return 'does not contain';
 			case RowFilterDescrType.SEARCH_STARTS_WITH:
 				return 'starts with';
 			case RowFilterDescrType.SEARCH_ENDS_WITH:
@@ -417,6 +420,8 @@ export class RowFilterDescriptorSearch extends SingleValueRowFilterDescriptor {
 			switch (this._descrType) {
 				case RowFilterDescrType.SEARCH_CONTAINS:
 					return TextSearchType.Contains;
+				case RowFilterDescrType.SEARCH_NOT_CONTAINS:
+					return TextSearchType.NotContains;
 				case RowFilterDescrType.SEARCH_STARTS_WITH:
 					return TextSearchType.StartsWith;
 				case RowFilterDescrType.SEARCH_ENDS_WITH:
@@ -594,6 +599,8 @@ function getSearchDescrType(searchType: TextSearchType) {
 	switch (searchType) {
 		case TextSearchType.Contains:
 			return RowFilterDescrType.SEARCH_CONTAINS;
+		case TextSearchType.NotContains:
+			return RowFilterDescrType.SEARCH_NOT_CONTAINS;
 		case TextSearchType.EndsWith:
 			return RowFilterDescrType.SEARCH_ENDS_WITH;
 		case TextSearchType.StartsWith:

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -1093,6 +1093,7 @@ export enum FilterComparisonOp {
  */
 export enum TextSearchType {
 	Contains = 'contains',
+	NotContains = 'not_contains',
 	StartsWith = 'starts_with',
 	EndsWith = 'ends_with',
 	RegexMatch = 'regex_match'


### PR DESCRIPTION
As discussed in #4375, this adds the "does not contain" / "not contains" string search type to the data explorer protocol and adds a simple implementation for Python.

https://github.com/user-attachments/assets/dad0863a-eb8d-4794-9eb7-936f24d47a1c

Ark PR: https://github.com/posit-dev/ark/pull/519