### PR TITLE
Console UI/brighter console prompt

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -621,6 +621,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				fixedOverflowWidgets: true,
 				lineDecorationsWidth: '1.0ch',
 				renderLineHighlight: 'none',
+				renderFinalNewline: 'on',
 				wordWrap: 'bounded',
 				wordWrapColumn: 2048,
 				scrollbar: {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -17,7 +17,6 @@ import { Schemas } from 'vs/base/common/network';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { generateUuid } from 'vs/base/common/uuid';
 import { isMacintosh } from 'vs/base/common/platform';
-import { getActiveElement } from 'vs/base/browser/dom';
 import { HistoryNavigator2 } from 'vs/base/common/history';
 import { ISelection } from 'vs/editor/common/core/selection';
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
@@ -763,7 +762,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 						// Only take focus if there is no focused editor to avoid stealing
 						// focus when the user could be actively working in an editor
 
-						const ctxt = positronConsoleContext.contextKeyService.getContext(getActiveElement());
+						const ctxt = positronConsoleContext.contextKeyService.getContext(DOM.getActiveElement());
 
 						// Sensitive to all editor contexts, simple (e.g. git commit textbox) or not (e.g. code editor)
 						const inTextInput = ctxt.getValue(EditorContextKeys.textInputFocus.key);


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR addresses https://github.com/posit-dev/positron/issues/3970. This issue was caused by `dimmed` being the default value for  `IEditorOptions.renderFinalNewline` on  Linux:

```
/**
 * Render last line number when the file ends with a newline.
 * Defaults to 'on' for Windows and macOS and 'dimmed' for Linux.
*/
renderFinalNewline?: 'on' | 'off' | 'dimmed';
```

The fix was to set `renderFinalNewline` to `on` in the `ConsoleInput` component to override this default value.