### PR TITLE
set reh-web package.json line endings to LF

### DIFF
--- a/remote/reh-web/.gitattributes
+++ b/remote/reh-web/.gitattributes
@@ -1,0 +1,1 @@
+package.json eof=LF

--- a/remote/reh-web/README.md
+++ b/remote/reh-web/README.md
@@ -9,5 +9,7 @@ The package.json file in this directory is created/updated via the [build/npm/po
 
 Since the files in this directory are auto-generated, please don't edit them directly. Running `yarn` at the top-level of the project will kick off updates to these files.
 
+Git line ending normalization is set to LF for package.json via [.gitattributes](./.gitattributes) to avoid changing the line endings when the file is generated on different platforms.
+
 > [!NOTE]
 > Please commit the created/updated package.json and yarn.lock files in this directory when they are updated.


### PR DESCRIPTION
- addresses https://github.com/posit-dev/positron/issues/4646

It seemed that the line endings of `remote/reh-web/package.json` were being changed to CRLF on Windows, resulting in uncommitted changes to the file despite no other changes to the contents of the file.

The default behaviour we've set for text files is to let Git automatically decide the line endings.
https://github.com/posit-dev/positron/blob/b3ac5dfd4f976fec1fd9117feef2690f7c7620a4/.gitattributes#L1

some relevant git spec
- https://git-scm.com/docs/gitattributes#_text
- https://git-scm.com/docs/gitattributes#_eol
- https://git-scm.com/docs/gitattributes#_end_of_line_conversion

I've added a `.gitattributes` file specific to the `remote/reh-web` directory to set line ending normalization to LF for package.json. This avoids changing the line endings when the file is generated on different platforms.

### QA Notes

Assuming the remote and web package.json files have no changes, running `yarn` on Windows should now **not** result in the remote/reh-web/package.json having changes.

Example steps
- delete `remote/reh-web/package.json`
- run `yarn`
- `remote/reh-web/package.json` should be regenerated with LF and not result in uncommitted changes to the file
   - if you still see it in unstaged changes, stage it and it should disappear

I've also run these steps on Mac to check that things haven't changed ✅ 