### PR TITLE
Fix array of args for R task `ShellExecution`

### DIFF
--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -94,7 +94,7 @@ export async function getRPackageTasks(editorFilePath?: string): Promise<vscode.
 			// test any changes on Windows.
 			exec = new vscode.ShellExecution(
 				binpath,
-				['--quiet --no-restore --no-save -e', { value: data.rcode, quoting: vscode.ShellQuoting.Strong }],
+				['--quiet', '--no-restore', '--no-save', '-e', { value: data.rcode, quoting: vscode.ShellQuoting.Strong }],
 				{ env }
 			);
 		}

--- a/test/smoke/src/areas/positron/r-pkg-development/r-pkg-development.test.ts
+++ b/test/smoke/src/areas/positron/r-pkg-development/r-pkg-development.test.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import path = require('path');
+import { Application, Logger, PositronRFixtures, PositronUserSettingsFixtures } from '../../../../../automation';
+import { installAllHandlers } from '../../../utils';
+import { expect } from '@playwright/test';
+
+export function setup(logger: Logger) {
+	describe('R Package Development', () => {
+		// Shared before/after handling
+		installAllHandlers(logger);
+
+		let app: Application;
+		let userSettings: PositronUserSettingsFixtures;
+
+		describe('R Package Development - R', () => {
+			before(async function () {
+				app = this.app as Application;
+				try {
+					await PositronRFixtures.SetupFixtures(this.app as Application);
+					userSettings = new PositronUserSettingsFixtures(app);
+
+					// don't use native file picker
+					await userSettings.setUserSetting(['files.simpleDialog.enable', 'true']);
+					await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+					await app.workbench.positronConsole.barClearButton.click();
+					await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+				} catch (e) {
+					this.app.code.driver.takeScreenshot('rPackageSetup');
+					throw e;
+				}
+			});
+
+			after(async function () {
+				// unset the use of the VSCode file picker
+				await userSettings.unsetUserSettings();
+			});
+
+			it('R Package Development Tasks', async function () {
+				await expect(async () => {
+					// Navigate to https://github.com/posit-dev/qa-example-content/tree/main/workspaces/r_testing
+					// This is an R package embedded in qa-example-content
+					await app.workbench.quickaccess.runCommand('workbench.action.files.openFolder', { keepOpen: true });
+					await app.workbench.quickinput.waitForQuickInputOpened();
+					await app.workbench.quickinput.type(path.join(app.workspacePathOrFolder, 'workspaces', 'r_testing'));
+					// Had to add a positron class, because Microsoft did not have this:
+					await app.workbench.quickinput.clickOkOnQuickInput();
+
+					// Wait for the console to be ready
+					await app.workbench.positronConsole.waitForReady('>', 10000);
+				}).toPass({ timeout: 50000 });
+
+				logger.log('Test R Package');
+				await expect(async () => {
+					await app.workbench.quickaccess.runCommand('r.packageTest');
+					await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.startsWith('[ FAIL 1 | WARN 0 | SKIP 0 | PASS 16 ]')));
+				}).toPass({ timeout: 50000 });
+
+				logger.log('Check R Package');
+				await expect(async () => {
+					await app.workbench.quickaccess.runCommand('r.packageCheck');
+					await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.startsWith('Error: R CMD check found ERRORs')));
+				}).toPass({ timeout: 50000 });
+
+				logger.log('Install R Package and Restart R');
+				await expect(async () => {
+					await app.workbench.quickaccess.runCommand('r.packageInstall');
+					await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.startsWith('✔ Installed testfun 0.0.0.9000')));
+					await app.workbench.positronConsole.waitForReady('>');
+					await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
+				}).toPass({ timeout: 50000 });
+			});
+		});
+	});
+}

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -56,6 +56,7 @@ import { setup as setupShinyTest } from './areas/positron/apps/shiny.test';
 import { setup as setupFastExecutionTest } from './areas/positron/editor/fast-execution.test';
 import { setup as setupInterpreterDropdownTest } from './areas/positron/top-action-bar/interpreter-dropdown.test';
 import { setup as setupTestExplorerTest } from './areas/positron/test-explorer/test-explorer.test';
+import { setup as setupRPKgDevelopment } from './areas/positron/r-pkg-development/r-pkg-development.test';
 import { setup as setupViewersTest } from './areas/positron/viewer/viewer.test';
 // --- End Positron ---
 
@@ -468,6 +469,7 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	setupShinyTest(logger);
 	setupFastExecutionTest(logger);
 	setupTestExplorerTest(logger);
+	setupRPKgDevelopment(logger);
 	setupInterpreterDropdownTest(logger);
 	setupViewersTest(logger);
 	// --- End Positron ---


### PR DESCRIPTION
Addresses #4649 

The combination of the `vscode.ShellQuoting.Strong` for the code with spaces and the R args being passed in as one string instead of an array made this unhappy. I believe I introduced this regression in #4576.

### QA Notes

The "R: Install R Package and Restart R" command should work again, along with the other R package commands.

It would be good to have tests that run these commands (just executing the commands directly would be good enough) in an R package test environment and check for no errors.
