### PR TITLE
dataexplorer.test.ts: skip due to intermittent failures

### DIFF
--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -13,7 +13,7 @@ import { join } from 'path';
  *  Data explorer tests with small data frames
  */
 export function setup(logger: Logger) {
-	describe('Data Explorer', () => {
+	describe.skip('Data Explorer', () => {
 
 		// Shared before/after handling
 		installAllHandlers(logger);

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -13,6 +13,8 @@ import { join } from 'path';
  *  Data explorer tests with small data frames
  */
 export function setup(logger: Logger) {
+	// There is a known issue with the data explorer tests causing them to intermittently fail:
+	// https://github.com/posit-dev/positron/issues/4663
 	describe.skip('Data Explorer', () => {
 
 		// Shared before/after handling

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -13,9 +13,7 @@ import { join } from 'path';
  *  Data explorer tests with small data frames
  */
 export function setup(logger: Logger) {
-	// There is a known issue with the data explorer tests causing them to intermittently fail:
-	// https://github.com/posit-dev/positron/issues/4663
-	describe.skip('Data Explorer', () => {
+	describe('Data Explorer', () => {
 
 		// Shared before/after handling
 		installAllHandlers(logger);
@@ -203,7 +201,9 @@ df2 = pd.DataFrame(data)`;
 			});
 		});
 
-		describe('Python Polars Data Explorer', () => {
+		// There is a known issue with the data explorer tests causing them to intermittently fail:
+		// https://github.com/posit-dev/positron/issues/4663
+		describe.skip('Python Polars Data Explorer', () => {
 			before(async function () {
 
 				await PositronPythonFixtures.SetupFixtures(this.app as Application);


### PR DESCRIPTION
### Intent
This test has recently become flakey due to [this](https://github.com/posit-dev/positron/issues/4663) known issue. In the mean time, we are disabling it to prevent blocking of pipelines.

### QA Notes
N/A