### PR TITLE
Implement copy plot for editor

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -25,7 +25,7 @@ import { ZoomPlotMenuButton } from 'vs/workbench/contrib/positronPlots/browser/c
 import { PlotClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimePlotClient';
 import { StaticPlotClient } from 'vs/workbench/services/positronPlots/common/staticPlotClient';
 import { INotificationService } from 'vs/platform/notification/common/notification';
-import { PlotsClearAction, PlotsCopyAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsSaveAction } from 'vs/workbench/contrib/positronPlots/browser/positronPlotsActions';
+import { CopyPlotTarget, PlotsClearAction, PlotsCopyAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsSaveAction } from 'vs/workbench/contrib/positronPlots/browser/positronPlotsActions';
 import { IHoverService } from 'vs/platform/hover/browser/hover';
 import { HtmlPlotClient } from 'vs/workbench/contrib/positronPlots/browser/htmlPlotClient';
 import { POSITRON_EDITOR_PLOTS, positronPlotsEditorEnabled } from 'vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.contribution';
@@ -129,7 +129,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	};
 
 	const copyPlotHandler = () => {
-		props.commandService.executeCommand(PlotsCopyAction.ID);
+		props.commandService.executeCommand(PlotsCopyAction.ID, CopyPlotTarget.VIEW);
 	};
 
 	const popoutPlotHandler = () => {

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -18,7 +18,7 @@ import { IPositronPlotsService, POSITRON_PLOTS_VIEW_ID } from 'vs/workbench/serv
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { Extensions as ViewContainerExtensions, IViewsRegistry } from 'vs/workbench/common/views';
 import { registerAction2 } from 'vs/platform/actions/common/actions';
-import { PlotsClearAction, PlotsCopyAction, PlotsEditorAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsRefreshAction, PlotsSaveAction } from 'vs/workbench/contrib/positronPlots/browser/positronPlotsActions';
+import { PlotsActiveEditorCopyAction, PlotsClearAction, PlotsCopyAction, PlotsEditorAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsRefreshAction, PlotsSaveAction } from 'vs/workbench/contrib/positronPlots/browser/positronPlotsActions';
 import { POSITRON_SESSION_CONTAINER } from 'vs/workbench/contrib/positronSession/browser/positronSessionContainer';
 
 // Register the Positron plots service.
@@ -70,6 +70,7 @@ class PositronPlotsContribution extends Disposable implements IWorkbenchContribu
 		registerAction2(PlotsClearAction);
 		registerAction2(PlotsPopoutAction);
 		registerAction2(PlotsEditorAction);
+		registerAction2(PlotsActiveEditorCopyAction);
 	}
 }
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -96,7 +96,7 @@ export class PlotsCopyAction extends Action2 {
 		});
 	}
 
-	private getItems(plotsService: IPositronPlotsService, editorService: IEditorService): IQuickPickItem[] {
+	private getItems(editorService: IEditorService): IQuickPickItem[] {
 		const items: IQuickPickItem[] = [
 			{
 				type: 'item',
@@ -152,6 +152,12 @@ export class PlotsCopyAction extends Action2 {
 			target = CopyPlotTarget.VIEW;
 		}
 
+		const quickPickItems = this.getItems(editorService);
+		// no need to show the quick pick if the only option is the Plots View
+		if (quickPickItems.length === 1) {
+			target = CopyPlotTarget.VIEW;
+		}
+
 		if (target === CopyPlotTarget.VIEW) {
 			if (plotsService.selectedPlotId) {
 				this.copyPlotToClipboard(plotsService, notificationService, plotsService.selectedPlotId);
@@ -167,7 +173,7 @@ export class PlotsCopyAction extends Action2 {
 		} else {
 			this._currentQuickPick = quickPick.createQuickPick();
 
-			this._currentQuickPick.items = this.getItems(plotsService, editorService);
+			this._currentQuickPick.items = quickPickItems;
 			this._currentQuickPick.ignoreFocusOut = true;
 			this._currentQuickPick.hideInput = true;
 			this._currentQuickPick.title = localize('positronPlots.copyQuickPickTitle', 'Select the plot to copy to clipboard');

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -912,8 +912,13 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		});
 	}
 
-	async copyPlotToClipboard(): Promise<void> {
-		const plot = this._plots.find(plot => plot.id === this.selectedPlotId);
+	async copyPlotToClipboard(plotId?: string): Promise<void> {
+		const isEditorPlot = plotId?.startsWith(Schemas.positronPlotsEditor);
+		const plotToCopy = plotId?.replace(`${Schemas.positronPlotsEditor}:`, '').trim() ?? this.selectedPlotId;
+		const plot = isEditorPlot && plotToCopy ?
+			this._editorPlots.get(plotToCopy)
+			: this._plots.find(plot => plot.id === plotToCopy);
+
 		if (plot instanceof StaticPlotClient) {
 			try {
 				await this._clipboardService.writeImage(plot.uri);

--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.contribution.ts
@@ -8,6 +8,7 @@ import { Schemas } from 'vs/base/common/network';
 import { localize } from 'vs/nls';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope } from 'vs/platform/configuration/common/configurationRegistry';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { Registry } from 'vs/platform/registry/common/platform';
@@ -95,3 +96,5 @@ configurationRegistry.registerConfiguration({
 export function positronPlotsEditorEnabled(configurationService: IConfigurationService) {
 	return Boolean(configurationService.getValue(POSITRON_EDITOR_PLOTS));
 }
+
+export const PLOT_IS_ACTIVE_EDITOR = ContextKeyExpr.equals('activeEditor', PositronPlotsEditorInput.EditorID);

--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
@@ -164,9 +164,7 @@ export class PositronPlotsEditor extends EditorPane implements IPositronPlotsEdi
 			throw new Error('Plot client not found');
 		}
 
-		const code = this._plotClient.metadata.code.trim();
-
-		input.setName(`Plot: ${code.length === 0 ? this._plotClient.id : code}`);
+		input.setName(`Plot: ${this._plotClient.id}`);
 
 		this.renderContainer(this._plotClient);
 		this.onSizeChanged((event: ISize) => {

--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
@@ -12,7 +12,7 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
-import { IEditorOptions } from 'vs/platform/editor/common/editor';
+import { EditorActivation, IEditorOptions } from 'vs/platform/editor/common/editor';
 import { IHoverService } from 'vs/platform/hover/browser/hover';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { INotificationService } from 'vs/platform/notification/common/notification';
@@ -74,6 +74,9 @@ export class PositronPlotsEditor extends EditorPane implements IPositronPlotsEdi
 	}
 
 	takeFocus(): void {
+		if (this.input) {
+			this._group.openEditor(this.input, { activation: EditorActivation.ACTIVATE });
+		}
 		this.focus();
 	}
 
@@ -111,6 +114,7 @@ export class PositronPlotsEditor extends EditorPane implements IPositronPlotsEdi
 		);
 
 		this._container = DOM.$('.positron-plots-editor-container');
+		this._container.onclick = () => this.takeFocus();
 	}
 
 	private renderContainer(plotClient: IPositronPlotClient): void {
@@ -160,7 +164,9 @@ export class PositronPlotsEditor extends EditorPane implements IPositronPlotsEdi
 			throw new Error('Plot client not found');
 		}
 
-		input.setName(this._plotClient.id);
+		const code = this._plotClient.metadata.code.trim();
+
+		input.setName(`Plot: ${code.length === 0 ? this._plotClient.id : code}`);
 
 		this.renderContainer(this._plotClient);
 		this.onSizeChanged((event: ISize) => {
@@ -190,6 +196,11 @@ export class PositronPlotsEditor extends EditorPane implements IPositronPlotsEdi
 	override dispose(): void {
 		this.disposeReactRenderer();
 		super.dispose();
+	}
+
+	override focus(): void {
+		super.focus();
+		this._container.focus();
 	}
 }
 

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -152,12 +152,19 @@ export interface IPositronPlotsService {
 	selectHistoryPolicy(policy: HistoryPolicy): void;
 
 	/**
-	 * Copies a plot to the clipboard.
+	 * Copies the current plot from the Plots View to the clipboard.
 	 *
-	 * @param plotId The id of the plot to copy. If not specified, the currently selected plot is copied.
 	 * @throws An error if the plot cannot be copied.
 	 */
-	copyPlotToClipboard(plotId?: string): Promise<void>;
+	copyViewPlotToClipboard(): Promise<void>;
+
+	/**
+	 * Copies the plot from the editor tab to the clipboard.
+	 *
+	 * @param plotId The id of the plot to copy.
+	 * @throws An error if the plot cannot be copied.
+	 */
+	copyEditorPlotToClipboard(plotId: string): Promise<void>;
 
 	/**
 	 * Opens the selected plot in a new window.

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -152,11 +152,12 @@ export interface IPositronPlotsService {
 	selectHistoryPolicy(policy: HistoryPolicy): void;
 
 	/**
-	 * Copies the selected plot to the clipboard.
+	 * Copies a plot to the clipboard.
 	 *
+	 * @param plotId The id of the plot to copy. If not specified, the currently selected plot is copied.
 	 * @throws An error if the plot cannot be copied.
 	 */
-	copyPlotToClipboard(): Promise<void>;
+	copyPlotToClipboard(plotId?: string): Promise<void>;
 
 	/**
 	 * Opens the selected plot in a new window.
@@ -168,10 +169,24 @@ export interface IPositronPlotsService {
 	 */
 	savePlot(): void;
 
+	/**
+	 * Opens the currently selected plot in an editor.
+	 */
 	openEditor(): Promise<void>;
 
+	/**
+	 * Gets the plot client that is connected to an editor for the specified id.
+	 *
+	 * @param id The id of the plot client to get.
+	 * @returns The plot client, or undefined if the plot client does not exist.
+	 */
 	getEditorInstance(id: string): IPositronPlotClient | undefined;
 
+	/**
+	 * Removes the plot client and if no other clients are connected to the plot comm, disposes it.
+	 *
+	 * @param plotClient the plot client to unregister
+	 */
 	unregisterPlotClient(plotClient: IPositronPlotClient): void;
 
 	/**


### PR DESCRIPTION
Address #4362 

Refactors the copy plot action so that it can be used to copy a plot from the Plots view or an editor. A copy target is supplied to the action to determine the plot to copy. If no target is given, a quick pick is shown to select which plot to copy.

This is the quick pick:
![image](https://github.com/user-attachments/assets/a412d6ad-d9f0-4673-ab83-80726e736c38)

If the editor feature is disabled, the command palette action will copy from the Plots View without the quick pick.

The editor now uses the plot's `metadata.code` as the title. If that is not available, it falls back to the less-friendly plot id. The editor title is used in the quick pick for the list of editors.

https://github.com/user-attachments/assets/158dafa3-d953-4f0d-9ae6-2397a5a12e6c

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes
The quick pick appears when executing the action and there are multiple copy plot targets. So opening a plot in an editor will enable the quick pick to choose whether to copy from the editor or the view.

This is hidden behind the experimental plots in editor flag in the preferences. When disabled, the copy plot action only works on the Plots view.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
