### PR TITLE
Fix scroll painting in the Console

### DIFF
--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -232,8 +232,8 @@ class PositronConsoleService extends Disposable implements IPositronConsoleServi
 			// exited runtime with a matching language.
 			const positronConsoleInstance = this._positronConsoleInstancesByLanguageId.get(e.session.runtimeMetadata.languageId);
 			if (positronConsoleInstance && positronConsoleInstance.state === PositronConsoleState.Exited) {
-				positronConsoleInstance.setRuntimeSession(e.session, attachMode);
 				this._positronConsoleInstancesBySessionId.delete(positronConsoleInstance.session.sessionId);
+				positronConsoleInstance.setRuntimeSession(e.session, attachMode);
 				this._positronConsoleInstancesBySessionId.set(e.session.sessionId, positronConsoleInstance);
 			} else {
 				// New runtime with a new language, so start a new Positron console instance.


### PR DESCRIPTION
This change fixes an issue in which the Console can draw incorrectly after being moved. 

The problem was just two lines being out of order:
- the console stores console instances by session ID
- due to the error, we never clean up the reference to the old session ID
- when the console is moved, all the old session IDs are replayed as new consoles
- since we reused the console instance across several sessions (by design!) the consoles for every "session" are the same instance and are painted on top of each other

Addresses https://github.com/posit-dev/positron/issues/2116.

### QA Notes

As part of fixing this, @softwarenerd and I discovered a reliable repo for it.

1. With either R or Python, shut down the session (manually).
2. Wait until shutdown has completed, then start a new R or Python session (use the Restart button in the console or the Power button)
3. Repeat steps 1 and 2 two or three times. Note that you do need to do a full shutdown/start so you get an entirely new session ID.
4. Drag the Console to a new location.
