### PR TITLE
Remove 'Summary Hidden' feature

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/actionBar/components/layoutMenuButton.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/actionBar/components/layoutMenuButton.tsx
@@ -12,8 +12,8 @@ import { useEffect, useState } from 'react'; // eslint-disable-line no-duplicate
 
 // Other dependencies.
 import { localize } from 'vs/nls';
+import { IAction } from 'vs/base/common/actions';
 import { DisposableStore } from 'vs/base/common/lifecycle';
-import { IAction, Separator } from 'vs/base/common/actions';
 import { ActionBarMenuButton } from 'vs/platform/positronActionBar/browser/components/actionBarMenuButton';
 import { usePositronDataExplorerContext } from 'vs/workbench/browser/positronDataExplorer/positronDataExplorerContext';
 import { PositronDataExplorerLayout } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
@@ -25,7 +25,6 @@ const layoutButtonTitle = localize('positron.layoutButtonTitle', "Layout");
 const layoutButtonDescription = localize('positron.layoutButtonDescription', "Change layout");
 const summaryOnLeft = localize('positron.summaryOnLeft', "Summary on Left");
 const summaryOnRight = localize('positron.summaryOnRight', "Summary on Right");
-const summaryHidden = localize('positron.summaryHidden', "Summary Hidden");
 
 /**
  * LayoutMenuButton component.
@@ -86,22 +85,6 @@ export const LayoutMenuButton = () => {
 			}
 		});
 
-		// Separator.
-		actions.push(new Separator());
-
-		// Summary hidden.
-		actions.push({
-			id: 'SummaryHidden',
-			label: summaryHidden,
-			tooltip: '',
-			class: undefined,
-			enabled: true,
-			checked: layout === PositronDataExplorerLayout.SummaryHidden,
-			run: () => {
-				context.instance.layout = PositronDataExplorerLayout.SummaryHidden;
-			}
-		});
-
 		// Done. Return the actions.
 		return actions;
 	};
@@ -119,10 +102,6 @@ export const LayoutMenuButton = () => {
 			// Summary on right.
 			case PositronDataExplorerLayout.SummaryOnRight:
 				return 'positron-data-explorer-summary-on-right';
-
-			// Summary hidden.
-			case PositronDataExplorerLayout.SummaryHidden:
-				return 'positron-data-explorer-summary-hidden';
 
 			// Can't happen.
 			default:

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -266,20 +266,6 @@ export const DataExplorer = () => {
 				column2Ref.current.style.gridColumn = 'column-1 / splitter';
 				column2Ref.current.style.display = 'grid';
 				break;
-
-			// Summary hidden.
-			case PositronDataExplorerLayout.SummaryHidden:
-				dataExplorerRef.current.style.gridTemplateColumns = `[column] 1fr [end]`;
-
-				column1Ref.current.style.gridColumn = '';
-				column1Ref.current.style.display = 'none';
-
-				splitterRef.current.style.gridColumn = '';
-				splitterRef.current.style.display = 'none';
-
-				column2Ref.current.style.gridColumn = 'column / end';
-				column2Ref.current.style.display = 'grid';
-				break;
 		}
 	}, [layout]);
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService.ts
@@ -14,8 +14,7 @@ export const IPositronDataExplorerService = createDecorator<IPositronDataExplore
  */
 export enum PositronDataExplorerLayout {
 	SummaryOnLeft = 'SummaryOnLeft',
-	SummaryOnRight = 'SummaryOnRight',
-	SummaryHidden = 'SummaryHidden',
+	SummaryOnRight = 'SummaryOnRight'
 }
 
 /**


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR addresses https://github.com/posit-dev/positron/issues/4672 by removing the **Summary Hidden** Data Explorer layout option.

### QA Notes

The Layout context menu will now appear without the **Summary Hidden** entry.

<img width="1518" alt="image" src="https://github.com/user-attachments/assets/20fdc68e-60fa-479d-905b-3bdc2b5725a2">