### PR TITLE
Use automattic slack reporter for tests

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -14,7 +14,7 @@ jobs:
 
   linux:
     name: Tests on Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4x
     timeout-minutes: 60
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -157,10 +157,10 @@ jobs:
           name: run-artifacts
           path: .build/logs/smoke-tests-electron/
 
-      - name: slack-smoke-test-report
-        if: failure()
-        uses: testlabauto/xunit-slack-reporter@v2.0.1
-        env:
-          SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel
-          SLACK_TOKEN: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
-          XUNIT_PATH: .build/logs/smoke-tests-electron/test-results/results.xml
+      - name: 'Send Slack notification'
+        uses: automattic/action-test-results-to-slack@v0.3.1
+        with:
+          github_token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          slack_token: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
+          slack_channel: C07FR1JNZNJ #positron-test-results channel
+

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -157,8 +157,13 @@ jobs:
           name: run-artifacts
           path: .build/logs/smoke-tests-electron/
 
+  slack-notification:
+    name: 'Send Slack notification'
+    runs-on: ubuntu-latest
+    needs: linux
+    if: ${{ failure() }}
+    steps:
       - name: 'Send Slack notification'
-        if: always()
         uses: automattic/action-test-results-to-slack@v0.3.1
         with:
           github_token: ${{ secrets.POSITRON_GITHUB_PAT }}

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -158,6 +158,7 @@ jobs:
           path: .build/logs/smoke-tests-electron/
 
       - name: 'Send Slack notification'
+        if: always()
         uses: automattic/action-test-results-to-slack@v0.3.1
         with:
           github_token: ${{ secrets.POSITRON_GITHUB_PAT }}

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -169,4 +169,5 @@ jobs:
           github_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_token: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
           slack_channel: C07FR1JNZNJ #positron-test-results channel
+          suite_name: Positron Full Test Suite
 

--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -222,4 +222,5 @@ jobs:
           github_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_token: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
           slack_channel: C07FR1JNZNJ #positron-test-results channel
+          suite_name: Positron Merge to Main Test Suite
 

--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -30,7 +30,7 @@ jobs:
 
   linux:
     name: Tests on Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4x
     timeout-minutes: 45
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -135,12 +135,11 @@ jobs:
           name: run-artifacts
           path: .build/logs/smoke-tests-electron/
 
-      - name: slack-smoke-test-report
-        if: ${{ failure() && env.SMOKETEST_TARGET == 'smoketest-merge-to-main' }}
-        uses: testlabauto/xunit-slack-reporter@v2.0.1
-        env:
-          SLACK_CHANNEL: C07FR1JNZNJ #positron-test-results channel
-          SLACK_TOKEN: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
-          XUNIT_PATH: .build/logs/smoke-tests-electron/test-results/results.xml
-
+      - name: 'Send Slack notification'
+        if: env.SMOKETEST_TARGET == 'smoketest-merge-to-main'
+        uses: automattic/action-test-results-to-slack@v0.3.1
+        with:
+          github_token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          slack_token: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
+          slack_channel: C07FR1JNZNJ #positron-test-results channel
 

--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -209,7 +209,7 @@ jobs:
           path: .build/logs/smoke-tests-electron/
 
       - name: 'Send Slack notification'
-        if: env.SMOKETEST_TARGET == 'smoketest-merge-to-main'
+        if: ${{ failure() && env.SMOKETEST_TARGET == 'smoketest-merge-to-main' }}
         uses: automattic/action-test-results-to-slack@v0.3.1
         with:
           github_token: ${{ secrets.POSITRON_GITHUB_PAT }}

--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -207,9 +207,16 @@ jobs:
         with:
           name: run-artifacts
           path: .build/logs/smoke-tests-electron/
+    outputs:
+      target: ${{ env.SMOKETEST_TARGET }}
 
+  slack-notification:
+    name: 'Send Slack notification'
+    runs-on: ubuntu-latest
+    needs: linux
+    if: ${{ failure() && needs.linux.outputs.target  == 'smoketest-merge-to-main' }}
+    steps:
       - name: 'Send Slack notification'
-        if: ${{ failure() && env.SMOKETEST_TARGET == 'smoketest-merge-to-main' }}
         uses: automattic/action-test-results-to-slack@v0.3.1
         with:
           github_token: ${{ secrets.POSITRON_GITHUB_PAT }}

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -9,6 +9,9 @@ import { Application, Logger, PositronPythonFixtures, PositronRFixtures } from '
 import { installAllHandlers } from '../../../utils';
 import { join } from 'path';
 
+// todo: remove me
+import { fail } from 'assert';
+
 /*
  *  Data explorer tests with small data frames
  */
@@ -72,6 +75,9 @@ df = pd.DataFrame(data)`;
 
 				await app.workbench.positronDataExplorer.closeDataExplorer();
 				await app.workbench.positronVariables.openVariables();
+
+				// todo remove me
+				fail('dummy failure');
 
 			});
 

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -9,8 +9,6 @@ import { Application, Logger, PositronPythonFixtures, PositronRFixtures } from '
 import { installAllHandlers } from '../../../utils';
 import { join } from 'path';
 
-// todo: remove me
-import { fail } from 'assert';
 
 /*
  *  Data explorer tests with small data frames
@@ -75,9 +73,6 @@ df = pd.DataFrame(data)`;
 
 				await app.workbench.positronDataExplorer.closeDataExplorer();
 				await app.workbench.positronVariables.openVariables();
-
-				// todo remove me
-				fail('dummy failure');
 
 			});
 

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -9,7 +9,6 @@ import { Application, Logger, PositronPythonFixtures, PositronRFixtures } from '
 import { installAllHandlers } from '../../../utils';
 import { join } from 'path';
 
-
 /*
  *  Data explorer tests with small data frames
  */


### PR DESCRIPTION
Using the automattic slack reporter in place our the previous custom one.  Benefits:
* unit test failures will also be reported
* same reporter python tests are using
* more concise format that also links to commit

Also bumping smoke test workflows to use ubuntu-latest-4x

### QA Notes

Test failures properly reported
