### PR TITLE
update reh-web README with windows line endings note

### DIFF
--- a/remote/reh-web/README.md
+++ b/remote/reh-web/README.md
@@ -3,13 +3,15 @@
 > [!IMPORTANT]
 > **Please don't edit files in this directory directly.**
 
+> [!NOTE]
+> Please commit the created/updated `package.json` and `yarn.lock` files in this directory when they are updated.
+
 The [package.json](./package.json) file in this directory is a merge of the [remote/package.json](../package.json) file and the [remote/web/package.json](../web/package.json) file, as the packages needed to build reh-web are a combination of the remote and web packages.
 
-The package.json file in this directory is created/updated via the [build/npm/postinstall.js](../../build/npm/postinstall.js) script. That script is automatically run after `yarn` is executed in the top-level directory. The script includes some handling to update the package.json file and run `yarn` to update yarn.lock and node_modules in this directory.
+The package.json file in this directory is created/updated via the [build/npm/postinstall.js](../../build/npm/postinstall.js) script. That script is automatically run after `yarn` is executed in the top-level directory and updates the package.json, yarn.lock and node_modules in this directory.
 
-Since the files in this directory are auto-generated, please don't edit them directly. Running `yarn` at the top-level of the project will kick off updates to these files.
+Since the files in this directory are auto-generated via the `postinstall.js` script, please don't edit them directly. Running `yarn` at the top-level of the project will kick off updates to these files.
 
-Git line ending normalization is set to LF for package.json via [.gitattributes](./.gitattributes) to avoid changing the line endings when the file is generated on different platforms.
-
-> [!NOTE]
-> Please commit the created/updated package.json and yarn.lock files in this directory when they are updated.
+If you're building on Windows, it's possible you might see 👻 invisible 👻 unstaged changes to the [package.json](./package.json) file.
+- **The tl;dr**: if this happens, stage the file and it should disappear and you shouldn't have to think about this again.
+- **The details**: this should only happen the first time you run `yarn` (and maybe also if you clear the Git index/cache) on Windows. The "invisible" changes occur after regenerating package.json on Windows, where CRLF is used for line endings instead of LF. Git line ending normalization has been set to LF for package.json via [.gitattributes](./.gitattributes) to avoid changing the line endings when the file is generated on different platforms. So, when you stage the file, the conversion to LF happens and it will no longer appear as modified.


### PR DESCRIPTION
Updates the reh-web README on how to deal with `remote/reh-web/package.json` showing up as unstaged with invisible changes on Windows as per the discussion here https://github.com/posit-dev/positron/commit/be3b7468394d6101f600c6b4e84f51c315ecf4e6. I also moved around some of the text in the README.

Preview the updated README here: https://github.com/posit-dev/positron/blob/reh-web-package-json-windows-readme/remote/reh-web/README.md

### QA Notes

Just a read through for typos and clarity :)