### PR TITLE
Fix Data explorer tab order for Summary Right layout

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
@@ -88,7 +88,6 @@ export const ColumnSelectorModalPopup = (props: ColumnSelectorModalPopupProps) =
 						layoutService={props.renderer.layoutService}
 						ref={positronDataGridRef}
 						id='column-positron-data-grid'
-						tabIndex={0}
 						instance={props.columnSelectorDataGridInstance}
 					/>
 				</div>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.css
@@ -4,12 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 .data-explorer-panel .data-explorer {
-	min-width: 0;
-	min-height: 0;
 	display: grid;
-	overflow: hidden;
-	grid-template-rows: [row] 1fr [end];
 	grid-row: data-explorer / status-bar;
+	grid-template-rows: [main-row] 1fr [end-rows];
+}
+
+.data-explorer-panel .data-explorer.summary-on-left {
+	grid-template-columns: [left-column] min-content [collapsed-left-spacer] min-content [splitter] max-content [collapsed-right-spacer] min-content [right-column] 1fr [end-columns];
+}
+
+.data-explorer-panel .data-explorer.summary-on-right {
+	grid-template-columns: [left-column] 1fr [collapsed-left-spacer] min-content [splitter] max-content [collapsed-right-spacer] min-content [right-column] min-content [end-columns];
 }
 
 .data-explorer-panel .data-explorer .column-name-exemplar {
@@ -26,28 +31,23 @@
 	font-variant-numeric: var(--positron-data-grid-column-header-sort-index-font-variant-numeric);
 }
 
-.data-explorer-panel .data-explorer .column-1 {
-	min-width: 0;
-	min-height: 0;
-	display: none;
-	grid-row: row / end;
+.data-explorer-panel .data-explorer .left-column {
+	display: grid;
+	grid-row: main-row / end-rows;
+	grid-column: left-column / collapsed-left-spacer;
 }
 
 .data-explorer-panel .data-explorer .collapsed-left-spacer {
-	width: 12px;
-	grid-row: row / end;
+	width: 10px;
+	grid-row: main-row / end-rows;
+	grid-column: collapsed-left-spacer / splitter;
 	background-color: var(--vscode-positronDataExplorer-contrastBackground);
 }
 
 .data-explorer-panel .data-explorer .splitter {
-	display: none;
-	grid-row: row / end;
-}
-
-.data-explorer-panel .data-explorer .collapsed-right-spacer {
-	width: 12px;
-	grid-row: row / end;
-	background-color: var(--vscode-positronDataExplorer-contrastBackground);
+	display: grid;
+	grid-row: main-row / end-rows;
+	grid-column: splitter / collapsed-right-spacer;
 }
 
 .data-explorer-panel .data-explorer .splitter .vertical-splitter {
@@ -56,9 +56,15 @@
 	background-color: var(--vscode-positronDataExplorer-contrastBackground);
 }
 
-.data-explorer-panel .data-explorer .column-2 {
-	min-width: 0;
-	min-height: 0;
-	display: none;
-	grid-row: row / end;
+.data-explorer-panel .data-explorer .collapsed-right-spacer {
+	width: 10px;
+	grid-row: main-row / end-rows;
+	grid-column: collapsed-right-spacer / right-column;
+	background-color: var(--vscode-positronDataExplorer-contrastBackground);
+}
+
+.data-explorer-panel .data-explorer .right-column {
+	display: grid;
+	grid-row: main-row / end-rows;
+	grid-column: right-column / end-columns;
 }

--- a/src/vs/workbench/browser/positronDataGrid/positronDataGrid.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/positronDataGrid.tsx
@@ -19,7 +19,6 @@ import { PositronDataGridConfiguration, PositronDataGridContextProvider } from '
  */
 interface PositronDataGridProps extends PositronDataGridConfiguration {
 	id?: string;
-	tabIndex: number;
 }
 
 /**

--- a/test/automation/src/positron/positronDataExplorer.ts
+++ b/test/automation/src/positron/positronDataExplorer.ts
@@ -8,9 +8,9 @@ import { expect } from '@playwright/test';
 import { Code } from '../code';
 import { PositronBaseElement } from './positronBaseElement';
 
-const COLUMN_HEADERS = '.data-explorer-panel .column-2 .data-grid-column-headers';
+const COLUMN_HEADERS = '.data-explorer-panel .right-column .data-grid-column-headers';
 const HEADER_TITLES = '.data-grid-column-header .title-description .title';
-const DATA_GRID_ROWS = '.data-explorer-panel .column-2 .data-grid-rows';
+const DATA_GRID_ROWS = '.data-explorer-panel .right-column .data-grid-rows';
 const DATA_GRID_ROW = '.data-grid-row';
 const CLOSE_DATA_EXPLORER = '.tab .codicon-close';
 const IDLE_STATUS = '.status-bar-indicator .icon.idle';


### PR DESCRIPTION
### Description

This PR addresses https://github.com/posit-dev/positron/issues/3778.

Prior to this PR, Data Explorer rendered the table summary Data Grid first and the table data Data Grid second, regardless of the layout. This meant that tabbing through the Data Explorer always resulted in the table summary Data Grid being the first tab stop and the table data Data Grid being the second tab stop, even when their layout was reversed.

With this PR, Data Explorer now renders the table summary Data Grid and the table data Data Grid in layout order. So, the rendering order is:

**Summary Left:**

```mermaid
block-beta
      TableSummary\nDataGrid:5 Splitter:1 TableData\nDataGrid:5
```

**Summary Right:**

```mermaid
block-beta
      TableData\nDataGrid:5 Splitter:1 TableSummary\nDataGrid:5
```

Which results in the correct tab stop order for the Summary Right layout.

### QA Notes

To test this, switch the Data Explorer layout between Summary Left and Summary Right and note how the tab stop order changes.