### PR TITLE
Improve how last focused element is determined in PositronModalReactRenderer

### DIFF
--- a/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.tsx
+++ b/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.tsx
@@ -121,9 +121,17 @@ export class PositronModalReactRenderer extends Disposable {
 		// Call the base class's constructor.
 		super();
 
-		// Set the last focused element.
-		const activeElement = DOM.getWindow(options.parent).document.activeElement;
-		if (activeElement instanceof HTMLElement) {
+		// Get the active element.
+		let activeElement: Element | null = null;
+		if (options.parent) {
+			activeElement = DOM.getWindow(options.parent).document.activeElement;
+		}
+		if (!activeElement) {
+			activeElement = DOM.getActiveWindow().document.activeElement;
+		}
+
+		// If the active element is an HTML element, set it as the last focused element.
+		if (DOM.isHTMLElement(activeElement)) {
 			this._lastFocusedElement = activeElement;
 		}
 


### PR DESCRIPTION
### Description

This PR addresses https://github.com/posit-dev/positron/issues/3978.

Prior to this PR, `PositronModalReactRenderer` was not correctly setting `_lastFocusedElement` when the `options.parent` element was undefined. This resulted in focus to being restored to the main window instead of the popped out window.

For future reference:

```
// This returns the active element of the main window.
const activeElement1 = DOM.getWindow(undefined).document.activeElement;

// This returns the active element of the active (in this case, popped out) window.
const activeElement2 = DOM.getActiveWindow().document.activeElement;
```

### QA Notes
