### PR TITLE
Data explorer UI/fix hover, cursor, and focus indicators in table summary

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
@@ -85,6 +85,7 @@
 /* column-sparkline */
 
 .data-grid-row-cell .content .column-summary .basic-info .column-sparkline {
+	pointer-events: none;
 	grid-column: sparkline / missing-values;
 }
 
@@ -94,6 +95,7 @@
 	display: grid;
 	grid-gap: 5px;
 	align-items: center;
+	pointer-events: none;
 	grid-column: missing-values / right-gutter;
 	grid-template-columns: [percent] 35px [graph] 25px [end];
 }

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
@@ -134,6 +134,7 @@
 .data-grid-row-cell .content .column-summary .column-profile-info {
 	display: grid;
 	margin: 0 auto;
+	pointer-events: none;
 	grid-row: profile-info / end-rows;
 	grid-template-rows: [sparkline] min-content [tabular-info] min-content [end-rows];
 	grid-template-columns: [left-gutter] 55px [sparkline-tabular-info] 1fr [right-gutter] 30px [end-column];

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
@@ -15,19 +15,28 @@
 	grid-template-rows: [basic-info] 34px [profile-info] 1fr [end-rows];
 }
 
-.data-grid-row-cell .content .column-summary .cursor {
+.data-grid-row-cell .content .column-summary .cursor-indicator {
 	top: 2px;
 	right: 2px;
 	bottom: 2px;
 	left: 2px;
 	z-index: -1;
+	opacity: 50%;
 	position: absolute;
 	border-radius: 4px;
+}
+
+.data-grid-row-cell .content .column-summary:hover .cursor-indicator {
 	background-color: var(--vscode-positronDataGrid-selectionBackground);
 }
 
-.data-grid-row-cell .content .column-summary .cursor:not(.focused) {
-	opacity: 50%;
+.data-grid-row-cell .content .column-summary .cursor-indicator.cursor {
+	background-color: var(--vscode-positronDataGrid-selectionBackground);
+}
+
+.data-grid-row-cell .content .column-summary .cursor-indicator.cursor.focused {
+	opacity: 100%;
+	border: 1px solid var(--vscode-positronDataGrid-selectionBorder);
 }
 
 /* basic-info */

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -8,7 +8,7 @@ import 'vs/css!./columnSummaryCell';
 
 // React.
 import * as React from 'react';
-import { useRef, useState } from 'react'; // eslint-disable-line no-duplicate-imports
+import { useRef } from 'react'; // eslint-disable-line no-duplicate-imports
 
 // Other dependencies.
 import { IHoverService } from 'vs/platform/hover/browser/hover';
@@ -55,9 +55,6 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 
 	// Reference hooks.
 	const dataTypeRef = useRef<HTMLDivElement>(undefined!);
-
-	// State hooks.
-	const [mouseInside, setMouseInside] = useState(false);
 
 	/**
 	 * Determines whether summary stats is supported.
@@ -366,21 +363,18 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		<div
 			className='column-summary'
 			onDoubleClick={props.onDoubleClick}
-			onMouseEnter={() => setMouseInside(true)}
-			onMouseLeave={() => setMouseInside(false)}
 			onMouseDown={() => {
 				props.instance.scrollToRow(props.columnIndex);
 				props.instance.setCursorRow(props.columnIndex);
 			}}
 		>
-			{(mouseInside || cursor) &&
-				<div
-					className={positronClassNames(
-						'cursor',
-						{ 'focused': context.instance.focused && cursor }
-					)}
-				/>
-			}
+			<div
+				className={positronClassNames(
+					'cursor-indicator',
+					{ 'cursor': cursor },
+					{ 'focused': cursor && context.instance.focused }
+				)}
+			/>
 			<div className='basic-info'>
 				<div
 					className={


### PR DESCRIPTION
### Description

This PR addresses https://github.com/posit-dev/positron/issues/4632 by turning off pointer events for the `ColumnSparkline`, `ColumnNullPercent`, and `ColumnProfile` components, which are not clickable in any way.

One manifestation of this problem was that rapidly hovering over `ColumnSummaryCell` components in a Data Explorer would result in some of the column summary cells getting "stuck" in the hover state:

https://github.com/user-attachments/assets/8fdc8183-6a32-421f-8aef-156b816f7a4f

Another manifestation of this problem was that single-clicking on a `ColumnSparkline`, `ColumnNullPercent`, or `ColumnProfile` component would steal focus from the column summary panel. It would then take another click to drive focus back into the column summary panel.

### QA Notes
