### PR TITLE
Modernize yarn invocations

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -101,8 +101,8 @@ jobs:
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
           POSITRON_GITHUB_PAT: ${{ github.token }}
         run: |
-          # Install Yarn
-          npm install -g yarn
+          # Enable corepack (for yarn)
+          corepack enable
 
           # Install node-gyp; this is required by some packages, and yarn
           # sometimes fails to automatically install it.
@@ -111,8 +111,8 @@ jobs:
           # Perform the main yarn command; this installs all Node packages and
           # dependencies
           yarn --immutable --network-timeout 120000
-          yarn --cwd test/automation install install --frozen-lockfile
-          yarn --cwd test/smoke install install --frozen-lockfile
+          yarn --cwd test/automation add install --frozen-lockfile
+          yarn --cwd test/smoke add install --frozen-lockfile
 
       # Note cache-hit will be set to true only when cache hit occurs for the exact key match.
       # For a partial key match it will be set to false

--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -103,8 +103,8 @@ jobs:
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
           POSITRON_GITHUB_PAT: ${{ github.token }}
         run: |
-          # Install Yarn
-          npm install -g yarn
+          # Enable corepack (for yarn)
+          corepack enable
 
           # Install node-gyp; this is required by some packages, and yarn
           # sometimes fails to automatically install it.
@@ -113,8 +113,9 @@ jobs:
           # Perform the main yarn command; this installs all Node packages and
           # dependencies
           yarn --immutable --network-timeout 120000
-          yarn --cwd test/automation install --frozen-lockfile
-          yarn --cwd test/smoke install --frozen-lockfile
+          yarn --cwd test/automation add install --frozen-lockfile
+          yarn --cwd test/smoke add install --frozen-lockfile
+
 
       # Note cache-hit will be set to true only when cache hit occurs for the exact key match.
       # For a partial key match it will be set to false


### PR DESCRIPTION
This change addresses CI failures of the form:

```
yarn install v1.22.22
warning ../package.json: No license field
error `install` has been replaced with `add` to add new dependencies. Run "yarn add install" instead.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
```

Example run: https://github.com/posit-dev/positron/actions/runs/10896318741/job/30235932351

The fix is twofold:
- Install `yarn` with `corepack` (the recommended mechanism as of Node 20)
- Use `yarn add` instead of `yarn install` as recommended in the message

### QA Notes

No product change; changes to CI files only