### PR TITLE
Fix timing in R development Smoke Test

### DIFF
--- a/test/smoke/src/areas/positron/r-pkg-development/r-pkg-development.test.ts
+++ b/test/smoke/src/areas/positron/r-pkg-development/r-pkg-development.test.ts
@@ -54,20 +54,23 @@ export function setup(logger: Logger) {
 				}).toPass({ timeout: 50000 });
 
 				logger.log('Test R Package');
+				await app.workbench.quickaccess.runCommand('r.packageTest');
 				await expect(async () => {
-					await app.workbench.quickaccess.runCommand('r.packageTest');
 					await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.startsWith('[ FAIL 1 | WARN 0 | SKIP 0 | PASS 16 ]')));
+					await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.includes('Terminal will be reused by tasks')));
 				}).toPass({ timeout: 50000 });
 
 				logger.log('Check R Package');
+				await app.workbench.quickaccess.runCommand('workbench.action.terminal.clear');
+				await app.workbench.quickaccess.runCommand('r.packageCheck');
 				await expect(async () => {
-					await app.workbench.quickaccess.runCommand('r.packageCheck');
 					await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.startsWith('Error: R CMD check found ERRORs')));
+					await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.includes('Terminal will be reused by tasks')));
 				}).toPass({ timeout: 50000 });
 
 				logger.log('Install R Package and Restart R');
+				await app.workbench.quickaccess.runCommand('r.packageInstall');
 				await expect(async () => {
-					await app.workbench.quickaccess.runCommand('r.packageInstall');
 					await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.startsWith('✔ Installed testfun 0.0.0.9000')));
 					await app.workbench.positronConsole.waitForReady('>');
 					await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->
### Intent

It appears to be a slight timing issue that causes these test to fail in CI

## Approach

* Moved the `runCommand` calls out of the retry loops to avoid overloading the terminal
* Added additional line to check when command finished. This also needed a "clear terminal" to ensure it was checking for the correct command output

### QA Notes

All tests should pass in CI
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
