### PR TITLE
Use arm64 builds of Ark on Linux

### DIFF
--- a/extensions/positron-r/scripts/install-kernel.ts
+++ b/extensions/positron-r/scripts/install-kernel.ts
@@ -7,7 +7,7 @@ import * as decompress from 'decompress';
 import * as fs from 'fs';
 import { IncomingMessage } from 'http';
 import * as https from 'https';
-import { platform } from 'os';
+import { platform, arch } from 'os';
 import * as path from 'path';
 import { promisify } from 'util';
 
@@ -188,7 +188,7 @@ async function downloadAndReplaceArk(version: string,
 			switch (platform()) {
 				case 'win32': os = 'windows-x64'; break;
 				case 'darwin': os = 'darwin-universal'; break;
-				case 'linux': os = 'linux-x64'; break;
+				case 'linux': os = (arch()  === 'arm64' ? 'linux-arm64' : 'linux-x64'); break;
 				default: {
 					console.error(`Unsupported platform ${platform()}.`);
 					return;


### PR DESCRIPTION
As a prerequisite to making arm64 builds of Positron, we need Positron to bundle arm64 builds of ark when building on arm64 Linux. This change does just that. 

Ark is already producing arm64 builds of Linux, e.g. https://github.com/posit-dev/ark/releases/tag/0.1.136.

### QA Notes

N/A; this does not currently impact any shipping releases since none are made on arm64. 