### PR TITLE
Ignore "responses" that don't have 'result' or 'error' keys

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance.ts
@@ -82,7 +82,7 @@ export interface IRuntimeClientInstance<Input, Output> extends Disposable {
 	getClientId(): string;
 	getClientType(): RuntimeClientType;
 	performRpcWithBuffers(request: Input, timeout: number): Promise<IRuntimeClientOutput<Output>>;
-	performRpc(request: Input, timeout: number): Promise<Output>;
+	performRpc(request: Input, timeout: number, responseKeys: Array<string>): Promise<Output>;
 	sendMessage(message: any): void;
 	messageCounter: ISettableObservable<number>;
 	clientState: ISettableObservable<RuntimeClientState>;

--- a/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
@@ -235,7 +235,9 @@ export class PositronBaseComm extends Disposable {
 		let response = {} as any;
 		try {
 			const timeout = this.options?.[rpcName]?.timeout ?? 5000;
-			response = await this.clientInstance.performRpc(request, timeout);
+			// Wait for a response to this message that includes a 'result' or
+			// 'error' field.
+			response = await this.clientInstance.performRpc(request, timeout, ['result', 'error']);
 		} catch (err) {
 			// Convert the error to a runtime method error. This handles errors
 			// that occur while performing the RPC; if the RPC is successfully


### PR DESCRIPTION
Speculative change to address https://github.com/posit-dev/positron/issues/4663.

As noted in that issue, this is mostly a workaround for an issue that exists in the Python kernel wherein comm messages emitted always have the parent ID of the most recent message to the shell (even if they are not a reply to that message). This can cause problems in Positron since it assumes that, after a message is sent, the next message with a matching `parent_id` is the reply to that message.

The fix is to check a message for `result` or `error` keys before treating it as an RPC response. We can't do this for _all_ messages since many codepaths/comms do not use the JSON-RPC structure, but we do it for all formally defined Positron comms.

This is admittedly a little janky. Some things that could make this better (but are higher risk than this change):
- a more robust way of identifying Positron's JSON-RPC comm messages
- having Positron supply its own ID with each request that must be returned in the reply body in order to deterministically pair requests and replies (i.e. don't rely on `parent_id` since it can be hard to control)
- moving Positron comms off the shell socket (@lionel- has suggested e.g. moving them to the control socket to allow them to operate independently of the current shell command)

### QA Notes

This change is small but it's a hot codepath -- almost every comm message goes through here. Sanity test the data explorer, and ipywidgets. They use this codepath but specifically do not want the new behavior added here.