### PR TITLE
DO NOT MERGE: Quote this path

### DIFF
--- a/extensions/jupyter-adapter/src/JupyterKernel.ts
+++ b/extensions/jupyter-adapter/src/JupyterKernel.ts
@@ -745,6 +745,10 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 		const wrapperName = os.platform() === 'win32' ? 'kernel-wrapper.bat' : 'kernel-wrapper.sh';
 		const shellPath = path.join(this._context.extensionPath, 'resources', wrapperName);
 
+		// defense against very old versions of Windows
+		// https://github.com/posit-dev/positron/issues/3788
+		const quotedShellPath = os.platform() === 'win32' ? `"${shellPath}"` : shellPath;
+
 		const shellArgs = [logFile].concat(args);
 
 		// Use the VS Code terminal API to create a terminal for the kernel
@@ -752,7 +756,7 @@ export class JupyterKernel extends EventEmitter implements vscode.Disposable {
 			name: this._spec.display_name,
 			// Always start notebook sessions in the directory of the notebook
 			cwd: this._notebookUri ? path.dirname(this._notebookUri.fsPath) : undefined,
-			shellPath: shellPath,
+			shellPath: quotedShellPath,
 			shellArgs: shellArgs,
 			env,
 			message: '',


### PR DESCRIPTION
Exploration to address #3788

I was hoping that quoting the filepath to the kernel wrapper script would help in the #3788 situation and be harmless otherwise. **However** this change truly does seem to break things for me on Windows. I have no idea if it would help on the very old Windows systems mentioned in #3788 and a similar thread on Posit Community (https://forum.posit.co/t/in-positron-how-can-i-get-the-r-terminal-to-work/189806). But it's a complete nonstarter if it actively causes breakage in modern setups.

Specifically, I do not get a live R process in the Console with this change.

@jmcphers (or anyone else in a good position) Will you be a second person to experience this? If you check out this PR, can you confirm that you do not get a live R process in the Console?

If I can get confirmation, we will leave things as they are and tell folks on old versions of Windows that this is a #wontfix.
