### PR TITLE
remove `add` from `yarn install` CI command

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -111,8 +111,8 @@ jobs:
           # Perform the main yarn command; this installs all Node packages and
           # dependencies
           yarn --immutable --network-timeout 120000
-          yarn --cwd test/automation add install --frozen-lockfile
-          yarn --cwd test/smoke add install --frozen-lockfile
+          yarn --cwd test/automation install --frozen-lockfile
+          yarn --cwd test/smoke install --frozen-lockfile
 
       # Note cache-hit will be set to true only when cache hit occurs for the exact key match.
       # For a partial key match it will be set to false

--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -113,8 +113,8 @@ jobs:
           # Perform the main yarn command; this installs all Node packages and
           # dependencies
           yarn --immutable --network-timeout 120000
-          yarn --cwd test/automation add install --frozen-lockfile
-          yarn --cwd test/smoke add install --frozen-lockfile
+          yarn --cwd test/automation install --frozen-lockfile
+          yarn --cwd test/smoke install --frozen-lockfile
 
 
       # Note cache-hit will be set to true only when cache hit occurs for the exact key match.


### PR DESCRIPTION
Following https://github.com/posit-dev/positron/pull/4704, I think we want `yarn install` instead of `yarn add install` in these CI commands, as the latter will add the package `install` to the corresponding package.json. I think we just want to install dependencies from the frozen lockfiles on these lines and don't intend to install the `install` package.

It seems like an extra `install` got introduced to those lines at some point, which is why we were getting an error about `install install` not being the right way to install the `install` package.

### QA Notes

We can test this by running the yarn commands locally.

1. Delete `test/smoke/node_modules`
2. Run `yarn --cwd test/smoke add install --frozen-lockfile`
3. Notice that dependencies are installed, but we also added a new dependency "install"
4. Revert the changes to package.json and yarn.lock and delete `test/smoke/node_modules`
5. Run `yarn --cwd test/smoke install --frozen-lockfile`
6. Dependencies are still installed, but we don't install the `install` package