### PR TITLE
Update default modal button handling so that pressing the Enter key clicks the default button in a PositronModalDialog

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -82,9 +82,8 @@ export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProp
 	const keyDownHandler = (e: KeyboardEvent<HTMLButtonElement>) => {
 		// Process the key down event.
 		switch (e.code) {
-			// Space or Enter trigger the onPressed event.
+			// Space triggers the onPressed event.
 			case 'Space':
-			case 'Enter':
 				sendOnPressed(e);
 				break;
 		}

--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -82,7 +82,8 @@ export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProp
 	const keyDownHandler = (e: KeyboardEvent<HTMLButtonElement>) => {
 		// Process the key down event.
 		switch (e.code) {
-			// Space triggers the onPressed event.
+			// Space triggers the onPressed event. Note: Do not add 'Enter' here. Enter is reserved
+			// for clicking the default button in modal popups and modal dialogs.
 			case 'Space':
 				sendOnPressed(e);
 				break;

--- a/src/vs/base/browser/ui/positronComponents/button/positronButton.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/positronButton.tsx
@@ -52,9 +52,8 @@ export const PositronButton = forwardRef<HTMLDivElement, PropsWithChildren<Props
 	const keyDownHandler = (e: KeyboardEvent<HTMLDivElement>) => {
 		// Process the key down event.
 		switch (e.code) {
-			// Space or Enter trigger the onPressed event.
+			// Space triggers the onPressed event.
 			case 'Space':
-			case 'Enter':
 				// Consume the event.
 				e.preventDefault();
 				e.stopPropagation();
@@ -123,3 +122,6 @@ export const PositronButton = forwardRef<HTMLDivElement, PropsWithChildren<Props
 		</div>
 	);
 });
+
+// Set the display name.
+PositronButton.displayName = 'PositronButton';

--- a/src/vs/base/browser/ui/positronComponents/button/positronButton.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/positronButton.tsx
@@ -52,7 +52,8 @@ export const PositronButton = forwardRef<HTMLDivElement, PropsWithChildren<Props
 	const keyDownHandler = (e: KeyboardEvent<HTMLDivElement>) => {
 		// Process the key down event.
 		switch (e.code) {
-			// Space triggers the onPressed event.
+			// Space triggers the onPressed event. Note: Do not add 'Enter' here. Enter is reserved
+			// for clicking the default button in modal popups and modal dialogs.
 			case 'Space':
 				// Consume the event.
 				e.preventDefault();

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.tsx
@@ -112,6 +112,13 @@ export const PositronModalDialog = (props: PropsWithChildren<PositronModalDialog
 			switch (e.key) {
 				// Enter clicks the first default button that is not disabled, if there is one.
 				case 'Enter': {
+					// If the active element is a text area, return.
+					const activeElement = DOM.getDocument(dialogBoxRef.current).activeElement;
+					if (DOM.isHTMLTextAreaElement(activeElement)) {
+						return;
+					}
+
+					// Get the first default button that is not disabled. If there is one, click it.
 					const defaultButton = dialogBoxRef.current.querySelector<HTMLElement>(
 						'button.default:not([disabled])'
 					);

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.tsx
@@ -42,8 +42,6 @@ export interface PositronModalDialogProps {
 	title: string;
 	width: number;
 	height: number;
-	enterAccepts?: boolean;
-	onAccept: () => void;
 	onCancel?: () => void;
 }
 
@@ -112,11 +110,14 @@ export const PositronModalDialog = (props: PropsWithChildren<PositronModalDialog
 
 			// Handle the event.
 			switch (e.key) {
-				// Enter accepts dialog, if configured to.
+				// Enter clicks the first default button that is not disabled, if there is one.
 				case 'Enter': {
-					consumeEvent();
-					if (props.enterAccepts && props.onAccept) {
-						props.onAccept();
+					const defaultButton = dialogBoxRef.current.querySelector<HTMLElement>(
+						'button.default:not([disabled])'
+					);
+					if (defaultButton) {
+						consumeEvent();
+						defaultButton.click();
 					}
 					break;
 				}

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronOKModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronOKModalDialog.tsx
@@ -20,6 +20,7 @@ import { PositronModalDialog, PositronModalDialogProps } from 'vs/workbench/brow
  */
 export interface OKModalDialogProps extends PositronModalDialogProps {
 	okButtonTitle?: string;
+	onAccept: () => void;
 }
 
 /**

--- a/src/vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog.tsx
@@ -111,7 +111,6 @@ const ChooseNewProjectWindowModalDialog = (props: ChooseNewProjectWindowModalDia
 					'positron.chooseNewProjectWindowModalDialog.title',
 					'Create New Project'
 				))()}
-			onAccept={accept}
 		>
 			<div className='choose-new-project-window-modal-dialog'>
 				<VerticalStack>

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -195,7 +195,6 @@ const NewProjectModalDialog = (props: NewProjectModalDialogProps) => {
 			renderer={props.renderer}
 			width={700} height={520}
 			title={(() => localize('positronNewProjectWizard.title', "Create New Project"))()}
-			onAccept={acceptHandler}
 			onCancel={cancelHandler}
 		>
 			<NewProjectWizardStepContainer cancel={cancelHandler} accept={acceptHandler} />

--- a/src/vs/workbench/contrib/positronModalDialogs/browser/positronModalDialogs.tsx
+++ b/src/vs/workbench/contrib/positronModalDialogs/browser/positronModalDialogs.tsx
@@ -117,7 +117,7 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 		};
 
 		renderer.render(
-			<PositronModalDialog renderer={renderer} title={title} width={400} height={200} onAccept={acceptHandler} onCancel={cancelHandler}>
+			<PositronModalDialog renderer={renderer} title={title} width={400} height={200} onCancel={cancelHandler}>
 				<ContentArea>
 					{renderHtml(
 						message,
@@ -188,7 +188,6 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 				title={title}
 				width={400}
 				height={200}
-				onAccept={acceptHandler}
 				onCancel={cancelHandler}
 			>
 				<ContentArea>

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -282,7 +282,6 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 			width={SAVE_PLOT_MODAL_DIALOG_WIDTH}
 			height={SAVE_PLOT_MODAL_DIALOG_HEIGHT}
 			title={(() => localize('positron.savePlotModalDialog.title', "Save Plot"))()}
-			onAccept={acceptHandler}
 			onCancel={cancelHandler}
 			renderer={props.renderer}>
 			<ContentArea>

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/setPlotSizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/setPlotSizeModalDialog.tsx
@@ -106,7 +106,6 @@ const SetPlotSizeModalDialog = (props: SetPlotSizeModalDialogProps) => {
 			width={350}
 			height={200}
 			title={(() => localize('positronSetPlotSizeModalDialogTitle', "Custom Plot Size"))()}
-			onAccept={acceptHandler}
 			onCancel={cancelHandler}>
 			<ContentArea>
 				<table>

--- a/src/vs/workbench/contrib/positronVariables/browser/modalDialogs/deleteAllVariablesModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/modalDialogs/deleteAllVariablesModalDialog.tsx
@@ -58,7 +58,6 @@ export const DeleteAllVariablesModalDialog = (props: DeleteAllVariablesModalDial
 			renderer={props.renderer}
 			width={375}
 			height={175}
-			enterAccepts={true}
 			title={(() => localize(
 				'positron.deleteAllVariablesModalDialogTitle',
 				"Delete All Variables"
@@ -66,7 +65,6 @@ export const DeleteAllVariablesModalDialog = (props: DeleteAllVariablesModalDial
 			secondaryActionTitle={(() => localize('positron.delete', "Delete"))()}
 			secondaryActionDestructive={true}
 			primaryActionTitle={(() => localize('positron.cancel', "Cancel"))()}
-			onAccept={cancelHandler}
 			onCancel={cancelHandler}
 			onSecondaryAction={acceptHandler}
 			onPrimaryAction={cancelHandler}


### PR DESCRIPTION
### Description

This PR addresses:
https://github.com/posit-dev/positron/issues/3491
https://github.com/posit-dev/positron/issues/4203

By making three changes:

1) The `enterAccepts` option has been removed from the `PositronModalDialogProps` interface. It was a confusing option that was only used in one place.

2) When a `PositronModalDialog` is being displayed, and the active element is not a `textarea`, pressing the **Enter** key will now find the first default button that is not disabled and it will click that button. (This replaces the `enterAccepts` option.) 

3) `Button` and `PositronButton` components no longer listen for the **Enter** key as a way to click them. They still listen for the `Space` key as a way to click them.

### QA Notes

Pressing **Enter** in a PositronModalDialog now clicks the default button. (There should only ever be one default button.)

