### PR TITLE
Re-enable R indentation tests

### DIFF
--- a/extensions/positron-r/src/test/indentation.test.ts
+++ b/extensions/positron-r/src/test/indentation.test.ts
@@ -37,17 +37,6 @@ suite('Indentation', () => {
 	// run, a failure is emitted. You can either commit the new output or discard
 	// it if that's a bug to fix.
 	test('Regenerate and check', async () => {
-		// ** TODO **
-		//
-		// This test currently causes the entire test suite to be unexpectedly
-		// terminated. It's disabled on CI until we can figure out why.
-		//
-		// We use the `POSITRON_BUILD_NUMBER` environment variable to detect if
-		// we are running on CI; this is always set by the CI environment.
-		if (env['POSITRON_BUILD_NUMBER']) {
-			return;
-		}
-
 		await init();
 
 		// There doesn't seem to be a method that resolves when a language is


### PR DESCRIPTION
Re-enables the R indentation tests that were temporarily disabled due to CI errors like the one below.

```
[70500:0912/140020.690157:INFO:CONSOLE(460)] "Canceled: Canceled", source: vscode-file://vscode-app/Users/jmcphers/git/positron/out/vs/workbench/services/extensions/common/abstractExtensionService.js (460)
[main 2024-09-12T21:00:20.698Z] Extension host with pid 70540 exited with code: 0, signal: unknown.
[main 2024-09-12T21:00:20.713Z] [UtilityProcessWorker]: terminated unexpectedly with code 1863645568, signal: unknown
Exit code:   1
Error: Test run failed with code 1
    at ChildProcess.onProcessClosed (/Users/jmcphers/git/positron/node_modules/@vscode/test-electron/out/runTest.js:110:24)
    at ChildProcess.emit (node:events:514:28)
    at ChildProcess._handle.onexit (node:internal/child_process:291:12)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
