### PR TITLE
data explorer: add graph trend test

### DIFF
--- a/test/automation/src/positron/positronDataExplorer.ts
+++ b/test/automation/src/positron/positronDataExplorer.ts
@@ -202,4 +202,9 @@ export class PositronDataExplorer {
 		return profileData;
 
 	}
+
+	async expandColumnProfile(rowNumber = 0): Promise<void> {
+		await this.code.driver.getLocator(EXPAND_COLLASPE_ICON).nth(rowNumber).click();
+	}
+
 }

--- a/test/smoke/src/areas/positron/dataexplorer/graphTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/graphTrend.test.ts
@@ -8,7 +8,7 @@ import { Application, Logger, PositronPythonFixtures } from '../../../../../auto
 import { installAllHandlers } from '../../../utils';
 
 export function setup(logger: Logger) {
-	describe('Data Explorer', () => {
+	describe('Data Explorer #pr', () => {
 
 		installAllHandlers(logger);
 
@@ -33,14 +33,16 @@ export function setup(logger: Logger) {
 
 			async function verifyGraphBarHeights(app: Application) {
 				// Get all graph graph bars/rectangles
-				const rects = app.code.driver.getLocator('rect.count');
+				await expect(async () => {
+					const rects = app.code.driver.getLocator('rect.count');
 
-				// Iterate over each rect and verify the height
-				const expectedHeights = ['50', '40', '30', '20', '10'];
-				for (let i = 0; i < expectedHeights.length; i++) {
-					const height = await rects.nth(i).getAttribute('height');
-					expect(height).toBe(expectedHeights[i]);
-				}
+					// Iterate over each rect and verify the height
+					const expectedHeights = ['50', '40', '30', '20', '10'];
+					for (let i = 0; i < expectedHeights.length; i++) {
+						const height = await rects.nth(i).getAttribute('height');
+						expect(height).toBe(expectedHeights[i]);
+					}
+				}).toPass({ timeout: 10000 });
 			}
 
 			it('Python Pandas - Verifies downward trending graph', async function () {

--- a/test/smoke/src/areas/positron/dataexplorer/graphTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/graphTrend.test.ts
@@ -96,7 +96,6 @@ labs(x = "Category", y = "Total Values", title = "Bar Graph with Summed Values")
 theme_minimal()`;
 
 				logger.log('Sending code to console');
-				await app.workbench.quickaccess.runCommand('workbench.action.toggleDevTools');
 				await app.workbench.positronConsole.executeCode('R', script, '>');
 
 				logger.log('Opening data grid');

--- a/test/smoke/src/areas/positron/dataexplorer/graphTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/graphTrend.test.ts
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from '@playwright/test';
+import { Application, Logger, PositronPythonFixtures } from '../../../../../automation/out';
+import { installAllHandlers } from '../../../utils';
+
+export function setup(logger: Logger) {
+	describe('Data Explorer', () => {
+
+		installAllHandlers(logger);
+
+		describe('Graph Trend #pr', () => {
+
+			beforeEach(async function () {
+				await this.app.workbench.positronLayouts.enterLayout('stacked');
+				await PositronPythonFixtures.SetupFixtures(this.app as Application);
+			});
+
+			it('Python Pandas - Verifies downward trending graph', async function () {
+				const app = this.app as Application;
+
+				// Script to create a trending downward bar graph with summarized data
+				const script = `import pandas as pd
+import matplotlib.pyplot as plt
+
+# Example data with multiple values for the same category
+graphData = pd.DataFrame({
+'category': ['A', 'A', 'A', 'A', 'B', 'B', 'B', 'C', 'C', 'D', 'E', 'A', 'B', 'C', 'D'],
+'values': [1, 2, 3, 4, 5, 9, 10, 11, 13, 25, 7, 15, 20, 5, 6]
+})
+
+# Summarize data by summing values per category
+summarized_data = graphData.groupby('category', as_index=False).sum()
+
+# Create a bar graph
+plt.bar(summarized_data['category'], summarized_data['values'], color='steelblue')
+plt.xlabel('Category')
+plt.ylabel('Total Values')
+plt.title('Bar Graph with Summed Values')
+plt.show()`;
+
+				logger.log('Sending code to console');
+				await app.workbench.positronConsole.executeCode('Python', script, '>>>');
+
+				logger.log('Opening data grid');
+				await expect(async () => {
+					await app.workbench.positronVariables.doubleClickVariableRow('graphData');
+					await app.code.driver.getLocator('.label-name:has-text("Data: graphData")').innerText();
+				}).toPass();
+
+				await app.workbench.positronSideBar.closeSecondarySideBar();
+				await app.workbench.positronDataExplorer.expandColumnProfile(0);
+
+				// Get all graph graph bars/rectangles
+				const rects = app.code.driver.getLocator('rect.count');
+				const expectedHeights = ['50', '40', '30', '20', '10'];
+
+				// Iterate over each rect and verify the height
+				for (let i = 0; i < expectedHeights.length; i++) {
+					const height = await rects.nth(i).getAttribute('height');
+					expect(height).toBe(expectedHeights[i]);
+				}
+			});
+
+
+			it('R - Verifies downward trending graph', async function () {
+				const app = this.app as Application;
+
+				// Script to create a trending downward bar graph with summarized data
+				const script = `library(ggplot2)
+library(dplyr)
+
+# Example data with multiple values for the same category
+graphData <- tibble(
+category = c("A", "A", "A", "A", "B", "B", "B", "C", "C", "D", "E", "A", "B", "C", "D"),
+values = c(1, 2, 3, 4, 5, 9, 10, 11, 13, 25, 7, 15, 20, 5, 6)
+)
+
+# Summarize data by summing values per category
+summarized_data <- graphData %>%
+group_by(category) %>%
+summarise(total_values = sum(values))
+
+# Create a bar graph
+ggplot(summarized_data, aes(x = reorder(category, -total_values), y = total_values)) +
+geom_bar(stat = "identity", fill = "steelblue") +
+labs(x = "Category", y = "Total Values", title = "Bar Graph with Summed Values") +
+theme_minimal()`;
+
+				logger.log('Sending code to console');
+				await app.workbench.quickaccess.runCommand('workbench.action.toggleDevTools');
+				await app.workbench.positronConsole.executeCode('R', script, '>');
+
+				logger.log('Opening data grid');
+				await expect(async () => {
+					await app.workbench.positronVariables.doubleClickVariableRow('graphData');
+					await app.code.driver.getLocator('.label-name:has-text("Data: graphData")').innerText();
+				}).toPass();
+
+				await app.workbench.positronSideBar.closeSecondarySideBar();
+				await app.workbench.positronDataExplorer.expandColumnProfile(0);
+
+				// Get all graph graph bars/rectangles
+				const rects = app.code.driver.getLocator('rect.count');
+				const expectedHeights = ['50', '40', '30', '20', '10'];
+
+				// Iterate over each rect and verify the height
+				for (let i = 0; i < expectedHeights.length; i++) {
+					const height = await rects.nth(i).getAttribute('height');
+					expect(height).toBe(expectedHeights[i]);
+				}
+			});
+		});
+	});
+}

--- a/test/smoke/src/areas/positron/dataexplorer/graphTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/graphTrend.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from '@playwright/test';
-import { Application, Logger, PositronPythonFixtures } from '../../../../../automation/out';
+import { Application, Logger, PositronPythonFixtures } from '../../../../../automation';
 import { installAllHandlers } from '../../../utils';
 
 export function setup(logger: Logger) {

--- a/test/smoke/src/areas/positron/dataexplorer/graphTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/graphTrend.test.ts
@@ -8,7 +8,7 @@ import { Application, Logger, PositronPythonFixtures } from '../../../../../auto
 import { installAllHandlers } from '../../../utils';
 
 export function setup(logger: Logger) {
-	describe('Data Explorer #pr', () => {
+	describe('Data Explorer', () => {
 
 		installAllHandlers(logger);
 

--- a/test/smoke/src/areas/positron/dataexplorer/graphTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/graphTrend.test.ts
@@ -12,12 +12,24 @@ export function setup(logger: Logger) {
 
 		installAllHandlers(logger);
 
-		describe('Graph Trend #pr', () => {
+		describe('Graph Trend', () => {
 
 			beforeEach(async function () {
 				await this.app.workbench.positronLayouts.enterLayout('stacked');
 				await PositronPythonFixtures.SetupFixtures(this.app as Application);
 			});
+
+			// Helper function to verify the height of graph bars
+			async function verifyGraphBarHeights(app: Application, expectedHeights = ['50', '40', '30', '20', '10']) {
+				// Get all graph graph bars/rectangles
+				const rects = app.code.driver.getLocator('rect.count');
+
+				// Iterate over each rect and verify the height
+				for (let i = 0; i < expectedHeights.length; i++) {
+					const height = await rects.nth(i).getAttribute('height');
+					expect(height).toBe(expectedHeights[i]);
+				}
+			}
 
 			it('Python Pandas - Verifies downward trending graph', async function () {
 				const app = this.app as Application;
@@ -51,18 +63,11 @@ plt.show()`;
 					await app.code.driver.getLocator('.label-name:has-text("Data: graphData")').innerText();
 				}).toPass();
 
+				logger.log('Expand column profile');
 				await app.workbench.positronSideBar.closeSecondarySideBar();
 				await app.workbench.positronDataExplorer.expandColumnProfile(0);
 
-				// Get all graph graph bars/rectangles
-				const rects = app.code.driver.getLocator('rect.count');
-				const expectedHeights = ['50', '40', '30', '20', '10'];
-
-				// Iterate over each rect and verify the height
-				for (let i = 0; i < expectedHeights.length; i++) {
-					const height = await rects.nth(i).getAttribute('height');
-					expect(height).toBe(expectedHeights[i]);
-				}
+				verifyGraphBarHeights(app);
 			});
 
 
@@ -100,18 +105,11 @@ theme_minimal()`;
 					await app.code.driver.getLocator('.label-name:has-text("Data: graphData")').innerText();
 				}).toPass();
 
+				logger.log('Expand column profile');
 				await app.workbench.positronSideBar.closeSecondarySideBar();
 				await app.workbench.positronDataExplorer.expandColumnProfile(0);
 
-				// Get all graph graph bars/rectangles
-				const rects = app.code.driver.getLocator('rect.count');
-				const expectedHeights = ['50', '40', '30', '20', '10'];
-
-				// Iterate over each rect and verify the height
-				for (let i = 0; i < expectedHeights.length; i++) {
-					const height = await rects.nth(i).getAttribute('height');
-					expect(height).toBe(expectedHeights[i]);
-				}
+				verifyGraphBarHeights(app);
 			});
 		});
 	});

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -59,6 +59,7 @@ import { setup as setupTestExplorerTest } from './areas/positron/test-explorer/t
 import { setup as setupRPKgDevelopment } from './areas/positron/r-pkg-development/r-pkg-development.test';
 import { setup as setupViewersTest } from './areas/positron/viewer/viewer.test';
 import { setup as setupVeryLargeDataFrameTest } from './areas/positron/dataexplorer/veryLargeDataFrame.test';
+import { setup as setupGraphTrendTest } from './areas/positron/dataexplorer/graphTrend.test';
 // --- End Positron ---
 
 const rootPath = path.join(__dirname, '..', '..', '..');
@@ -474,5 +475,6 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	setupInterpreterDropdownTest(logger);
 	setupViewersTest(logger);
 	setupVeryLargeDataFrameTest(logger);
+	setupGraphTrendTest(logger);
 	// --- End Positron ---
 });


### PR DESCRIPTION
### Intent
Add a test to verify the data explorer sparkline trends render as expected.
<img width="294" alt="Screenshot 2024-09-19 at 6 24 17 AM" src="https://github.com/user-attachments/assets/2c7b6d1c-7d41-47cd-909b-289d65f14009">

### Approach
I added scripts (both for R and Pandas) that generate a simple downward trend. The test executes this code and then asserts that the rectangles that make up the trend are of the expected decreasing height.

### QA Notes
Ran test locally with passing results.
Ran test on PR with passing results. (have since removed #pr)
<img width="518" alt="Screenshot 2024-09-19 at 8 34 10 AM" src="https://github.com/user-attachments/assets/37c45d6c-6619-44fb-95eb-05c85a0c50c7">

