### PR TITLE
Include missing files in reh-web binary

### DIFF
--- a/build/gulpfile.reh.js
+++ b/build/gulpfile.reh.js
@@ -63,6 +63,8 @@ const BUILD_TARGETS = [
 const serverResourceIncludes = [
 	// --- Start Positron ---
 	'out-build/react-dom/client.js',
+	'out-build/vs/code/browser/workbench/rsLoginCheck.js',
+	'out-build/vs/code/browser/workbench/urlPorts.js',
 	// --- End Positron ---
 
 	// NLS

--- a/build/gulpfile.reh.js
+++ b/build/gulpfile.reh.js
@@ -64,7 +64,6 @@ const serverResourceIncludes = [
 	// --- Start Positron ---
 	'out-build/react-dom/client.js',
 	'out-build/vs/code/browser/workbench/rsLoginCheck.js',
-	'out-build/vs/code/browser/workbench/urlPorts.js',
 	// --- End Positron ---
 
 	// NLS

--- a/build/gulpfile.vscode.web.js
+++ b/build/gulpfile.vscode.web.js
@@ -57,6 +57,11 @@ const vscodeWebResourceIncludes = isESM() ? [
 	// Webview
 	'out-build/vs/workbench/contrib/webview/browser/pre/*.{js,html}',
 
+	// --- Start Positron ---
+	// Positron Help
+	'out-build/vs/workbench/contrib/positronHelp/browser/resources/help.html',
+	// --- End Positron ---
+
 	// Tree Sitter highlights
 	'out-build/vs/editor/common/languages/highlights/*.scm',
 
@@ -76,6 +81,11 @@ const vscodeWebResourceIncludes = isESM() ? [
 	// Webview
 	'out-build/vs/workbench/contrib/webview/browser/pre/*.js',
 	'out-build/vs/workbench/contrib/webview/browser/pre/*.html',
+
+	// --- Start Positron ---
+	// Positron Help
+	'out-build/vs/workbench/contrib/positronHelp/browser/resources/help.html',
+	// --- End Positron ---
 
 	// Extension Worker
 	'out-build/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html',


### PR DESCRIPTION
- Part of #4274
- Adds missing files to the includes -- these are new files from Workbench via #4655 and the help.html help container page

### QA Notes

When running Positron in Workbench, there should be no server or dev console errors around missing these files. Positron should load in Workbench.