### PR TITLE
Rename plots in editor tab feature flag

### DIFF
--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.contribution.ts
@@ -19,7 +19,7 @@ import { PositronPlotsEditor } from 'vs/workbench/contrib/positronPlotsEditor/br
 import { PositronPlotsEditorInput } from 'vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditorInput';
 import { IEditorResolverService, RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
 
-export const POSITRON_EDITOR_PLOTS = 'application.experimental.positronPlotsEditor';
+export const POSITRON_EDITOR_PLOTS = 'application.experimental.positronPlotsInEditorTab';
 
 class PositronPlotsEditorContribution extends Disposable {
 	static readonly ID = 'workbench.contrib.positronPlotsEditor';


### PR DESCRIPTION
Rename the feature flag title.

The title uses the configuration property key so users will have to re-enable on upgrade.


![image](https://github.com/user-attachments/assets/fe2ea1bf-88a4-4440-810f-de961986674c)

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes
The plots in editor feature will be off after upgrading to a build with this change.
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
