### PR TITLE
Trying (again) to use @vscode/windows-registry

### DIFF
--- a/extensions/positron-r/extension.webpack.config.js
+++ b/extensions/positron-r/extension.webpack.config.js
@@ -7,7 +7,6 @@
 
 'use strict';
 
-const path = require('path');
 const withDefaults = require('../shared.webpack.config');
 
 module.exports = withDefaults({

--- a/extensions/positron-r/extension.webpack.config.js
+++ b/extensions/positron-r/extension.webpack.config.js
@@ -1,6 +1,6 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 //@ts-check

--- a/extensions/positron-r/extension.webpack.config.js
+++ b/extensions/positron-r/extension.webpack.config.js
@@ -15,4 +15,8 @@ module.exports = withDefaults({
 	entry: {
 		extension: './src/extension.ts',
 	},
+	externals: {
+		// eslint-disable-next-line @typescript-eslint/naming-convention
+		'@vscode/windows-registry': 'commonjs @vscode/windows-registry'
+	}
 });

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -619,13 +619,15 @@
     "vsce": "^2.11.0"
   },
   "dependencies": {
-    "@vscode/windows-registry": "^1.1.0",
     "fs-extra": "^10.0.1",
     "p-queue": "^6.6.2",
     "split2": "^4.2.0",
     "vscode-languageclient": "^9.0.1",
     "web-tree-sitter": "^0.20.8",
     "which": "^3.0.0"
+  },
+  "peerDependencies": {
+    "@vscode/windows-registry": "^1.0.0"
   },
   "repository": {
     "type": "git",

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -506,7 +506,6 @@
           "title": "%r.command.executeSelectionInConsole.title%",
           "when": "editorLangId == r"
         },
-
         {
           "command": "r.rmarkdownRender",
           "group": "R",
@@ -620,13 +619,13 @@
     "vsce": "^2.11.0"
   },
   "dependencies": {
+    "@vscode/windows-registry": "^1.1.0",
     "fs-extra": "^10.0.1",
     "p-queue": "^6.6.2",
     "split2": "^4.2.0",
     "vscode-languageclient": "^9.0.1",
     "web-tree-sitter": "^0.20.8",
-    "which": "^3.0.0",
-    "winreg": "^1.2.5"
+    "which": "^3.0.0"
   },
   "repository": {
     "type": "git",

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -401,6 +401,12 @@ async function getRegistryInstallPath(hive: 'HKEY_CURRENT_USER' | 'HKEY_LOCAL_MA
 	// 'R64' here is another place where we explicitly ignore 32-bit R
 	// Amend a WOW path after "Software" if requested
 	const R64_KEY: string = `SOFTWARE\\${wow ? wow + '\\' : ''}R-core\\R64`;
+
+	if (os.platform() !== 'win32') {
+		LOGGER.info('Skipping registry check on non-Windows platform');
+		return undefined;
+	}
+
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	const Registry = await import('@vscode/windows-registry');
 

--- a/extensions/positron-r/yarn.lock
+++ b/extensions/positron-r/yarn.lock
@@ -251,6 +251,11 @@
     rimraf "^3.0.2"
     unzipper "^0.10.11"
 
+"@vscode/windows-registry@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@vscode/windows-registry/-/windows-registry-1.1.0.tgz#03dace7c29c46f658588b9885b9580e453ad21f9"
+  integrity sha512-5AZzuWJpGscyiMOed0IuyEwt6iKmV5Us7zuwCDCFYMIq7tsvooO9BUiciywsvuthGz6UG4LSpeDeCxvgMVhnIw==
+
 acorn-jsx@^5.3.1:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
@@ -2321,11 +2326,6 @@ which@^3.0.0:
   integrity sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==
   dependencies:
     isexe "^2.0.0"
-
-winreg@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/winreg/-/winreg-1.2.5.tgz#b650383e89278952494b5d113ba049a5a4fa96d8"
-  integrity sha512-uf7tHf+tw0B1y+x+mKTLHkykBgK2KMs3g+KlzmyMbLvICSHQyB/xOFjTT8qZ3oeTFyU7Bbj4FzXitGG6jvKhYw==
 
 word-wrap@^1.2.3:
   version "1.2.4"

--- a/extensions/positron-r/yarn.lock
+++ b/extensions/positron-r/yarn.lock
@@ -251,11 +251,6 @@
     rimraf "^3.0.2"
     unzipper "^0.10.11"
 
-"@vscode/windows-registry@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@vscode/windows-registry/-/windows-registry-1.1.0.tgz#03dace7c29c46f658588b9885b9580e453ad21f9"
-  integrity sha512-5AZzuWJpGscyiMOed0IuyEwt6iKmV5Us7zuwCDCFYMIq7tsvooO9BUiciywsvuthGz6UG4LSpeDeCxvgMVhnIw==
-
 acorn-jsx@^5.3.1:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"


### PR DESCRIPTION
Addresses #3787. See the issue for why I want to use `@vscode/windows-registry`.

This PR reinstates my original, eventually-reverted attempt at this #2410 and includes the changes necessary to successfully create a release build on all platforms.

The big challenge is that [`@vscode/windows-registry`](https://github.com/microsoft/vscode-windows-registry) is a native module, i.e. it contains C++ code. This then requires special care when building the application.

VS Code (and, therefore, Positron) itself handles this with specific entries in `.moduleignore` files:

* In [`build/.moduleignore`](https://github.com/posit-dev/positron/blob/89a59c04d7dfdc36f1e38119db19e1731729caa5/build/.moduleignore#L53-L56). This default ignore spec excludes most of the module files, but explicitly includes the `*.node` file. This is the effective ignore spec for `@vscode/windows-registry` on Windows.
* In [`build/.moduleignore.darwin`](https://github.com/posit-dev/positron/blob/main/build/.moduleignore.darwin#L12-L17). The macOS ignores exclude almost all files, but explicitly include the types.
* In [`build/.moduleignore.linux`](https://github.com/posit-dev/positron/blob/main/build/.moduleignore.linux#L12-L17). Same deal as macOS.
* *[`build/.moduleignore.win32`](https://github.com/posit-dev/positron/blob/main/build/.moduleignore.win32) does exist, but it is empty, as there are no additional ignores needed/wanted for native modules on Windows. The default ignores are what you want.*

These ignores are then put into force in various build scripts, such as (but not limited to): [`build/gulpfile.vscode.js`](https://github.com/posit-dev/positron/blob/cf127d6c38010e753122f96d9a871eeeb189f838/build/gulpfile.vscode.js#L332-L333).

At first I tried to emulate these ignores in positron-r's webpack config ([`extensions/positron-r/extension.webpack.config.js`](https://github.com/posit-dev/positron/blob/cf127d6c38010e753122f96d9a871eeeb189f838/extensions/positron-r/extension.webpack.config.js#L1)), because the immediate error you are confronted with is from `webpack-stream`. It looks like this (yeah, you get NO INFORMATION on which extension or which file is the problem, lovely):

```
[03:12:24] 'vscode-win32-x64' errored after 49 min
[03:12:24] Error in plugin "webpack-stream"
Message:
    Module parse failed: Unexpected character '�' (1:2)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
(Source code omitted for this binary file)
Details:
    domainEmitter: [object Object]
    domainThrown: false

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 1.
```

There are various active ways to intervene in webpack's processing, via loaders and plugins, but I never managed to achieve my goal, although presumably that approach is workable in the right hands.

Instead I decided to do as little as possible and rely on the fact that that Positron itself is already handling the fussy packaging of this module and the positron-r extension can assume `@vscode/windows-registry` is already provided by the environment in which it is running.

In the end two small changes are needed in extension config:

* Declare `@vscode/windows-registry` as an external dependency, which keeps webpack from bundling it.
* List `@vscode/windows-registry` in `peerDependencies` in `package.json` instead of `dependencies`, which keeps it from being installed into positron-r's `node_modules/` directory.

### QA Notes

This PR is successful if we can create usable release builds on all OSes and continue to consult with Windows registry re: the current version of R. On Windows, assuming the current R version has been recorded in the registry (which is default behaviour), the Positron R Extension output channel should show something like this (along with lots of other keys that don't pan out, because they don't exist, which is to be expected):

```
2024-09-25 16:35:17.653 [info] Checking for 'InstallPath' in registry key HKEY_LOCAL_MACHINE\SOFTWARE\R-core\R64
2024-09-25 16:35:17.653 [info] Identified the current version of R from the registry: C:\Program Files\R\R-4.4.1\bin\x64\R.exe
```

I have just kicked off a daily release build: https://github.com/posit-dev/positron-builds/actions/runs/11041496695.