### PR TITLE
sparklineTrend.test.ts: fix flakes

### DIFF
--- a/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
@@ -20,11 +20,11 @@ export function setup(logger: Logger) {
 				await app.workbench.positronLayouts.enterLayout('stacked');
 			});
 
-			afterEach(async function () {
+			afterEach(async () => {
 				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors', { keepOpen: false });
 			});
 
-			it('Python Pandas - Verifies downward trending graph [C830552]', async function () {
+			it('Python Pandas - Verifies downward trending graph [C830552]', async () => {
 				await PositronPythonFixtures.SetupFixtures(app);
 
 				await app.workbench.positronConsole.executeCode('Python', pythonScript, '>>>');
@@ -33,7 +33,7 @@ export function setup(logger: Logger) {
 			});
 
 
-			it('R - Verifies downward trending graph [C830553]', async function () {
+			it('R - Verifies downward trending graph [C830553]', async () => {
 				await PositronRFixtures.SetupFixtures(app);
 
 				await app.workbench.positronConsole.executeCode('R', rScript, '>');

--- a/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
@@ -12,19 +12,20 @@ export function setup(logger: Logger) {
 
 		installAllHandlers(logger);
 
-		describe('Sparklines', () => {
+		describe('Sparklines', function () {
+			let app: Application;
 
 			beforeEach(async function () {
-				await this.app.workbench.positronLayouts.enterLayout('stacked');
+				app = this.app;
+				await app.workbench.positronLayouts.enterLayout('stacked');
 			});
 
 			afterEach(async function () {
-				await this.app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors', { keepOpen: false });
+				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors', { keepOpen: false });
 			});
 
 			it('Python Pandas - Verifies downward trending graph [C830552]', async function () {
-				await PositronPythonFixtures.SetupFixtures(this.app as Application);
-				const app = this.app as Application;
+				await PositronPythonFixtures.SetupFixtures(app);
 
 				await app.workbench.positronConsole.executeCode('Python', pythonScript, '>>>');
 				await openDataExplorerColumnProfile(app, 'pythonData');
@@ -33,8 +34,7 @@ export function setup(logger: Logger) {
 
 
 			it('R - Verifies downward trending graph [C830553]', async function () {
-				await PositronRFixtures.SetupFixtures(this.app as Application);
-				const app = this.app as Application;
+				await PositronRFixtures.SetupFixtures(app);
 
 				await app.workbench.positronConsole.executeCode('R', rScript, '>');
 				await openDataExplorerColumnProfile(app, 'rData');

--- a/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
@@ -12,7 +12,7 @@ export function setup(logger: Logger) {
 
 		installAllHandlers(logger);
 
-		describe('Sparklines', function () {
+		describe('Sparklines', () => {
 			let app: Application;
 
 			beforeEach(async function () {

--- a/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
@@ -14,13 +14,16 @@ export function setup(logger: Logger) {
 
 		describe('Sparklines', () => {
 
+			beforeEach(async function () {
+				await this.app.workbench.positronLayouts.enterLayout('stacked');
+			});
+
 			afterEach(async function () {
 				await this.app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors', { keepOpen: false });
 			});
 
 			it('Python Pandas - Verifies downward trending graph [C830552]', async function () {
 				await PositronPythonFixtures.SetupFixtures(this.app as Application);
-				await this.app.workbench.positronLayouts.enterLayout('stacked');
 				const app = this.app as Application;
 
 				await app.workbench.positronConsole.executeCode('Python', pythonScript, '>>>');
@@ -31,7 +34,6 @@ export function setup(logger: Logger) {
 
 			it('R - Verifies downward trending graph [C830553]', async function () {
 				await PositronRFixtures.SetupFixtures(this.app as Application);
-				await this.app.workbench.positronLayouts.enterLayout('stacked');
 				const app = this.app as Application;
 
 				await app.workbench.positronConsole.executeCode('R', rScript, '>');

--- a/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
@@ -8,7 +8,7 @@ import { Application, Logger, PositronPythonFixtures, PositronRFixtures } from '
 import { installAllHandlers } from '../../../utils';
 
 export function setup(logger: Logger) {
-	describe('Data Explorer #pr', () => {
+	describe('Data Explorer', () => {
 
 		installAllHandlers(logger);
 

--- a/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
@@ -8,7 +8,7 @@ import { Application, Logger, PositronPythonFixtures, PositronRFixtures } from '
 import { installAllHandlers } from '../../../utils';
 
 export function setup(logger: Logger) {
-	describe('Data Explorer', () => {
+	describe('Data Explorer #pr', () => {
 
 		installAllHandlers(logger);
 

--- a/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
@@ -50,8 +50,6 @@ export function setup(logger: Logger) {
 			}).toPass();
 
 			await app.workbench.positronDataExplorer.getDataExplorerTableData();
-
-			logger.log('Expand column profile');
 			await app.workbench.positronSideBar.closeSecondarySideBar();
 			await app.workbench.positronDataExplorer.expandColumnProfile(0);
 		}
@@ -72,10 +70,8 @@ export function setup(logger: Logger) {
 	});
 }
 
-const rScript = `library(ggplot2)
-library(dplyr)
+const rScript = `library(dplyr)
 
-# Example data with multiple values for the same category
 rData <- tibble(
 category = c("A", "A", "A", "A", "B", "B", "B", "C", "C", "D", "E", "A", "B", "C", "D"),
 values = c(1, 2, 3, 4, 5, 9, 10, 11, 13, 25, 7, 15, 20, 5, 6)
@@ -85,7 +81,6 @@ values = c(1, 2, 3, 4, 5, 9, 10, 11, 13, 25, 7, 15, 20, 5, 6)
 const pythonScript = `import pandas as pd
 import matplotlib.pyplot as plt
 
-# Example data with multiple values for the same category
 pythonData = pd.DataFrame({
 'category': ['A', 'A', 'A', 'A', 'B', 'B', 'B', 'C', 'C', 'D', 'E', 'A', 'B', 'C', 'D'],
 'values': [1, 2, 3, 4, 5, 9, 10, 11, 13, 25, 7, 15, 20, 5, 6]

--- a/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
@@ -14,14 +14,16 @@ export function setup(logger: Logger) {
 
 		describe('Sparklines', () => {
 
+			afterEach(async function () {
+				await this.app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors', { keepOpen: false });
+			});
+
 			it('Python Pandas - Verifies downward trending graph [C830552]', async function () {
 				await PositronPythonFixtures.SetupFixtures(this.app as Application);
 				await this.app.workbench.positronLayouts.enterLayout('stacked');
 				const app = this.app as Application;
 
-				logger.log('[Python] Sending code to console');
 				await app.workbench.positronConsole.executeCode('Python', pythonScript, '>>>');
-
 				await openDataExplorerColumnProfile(app, 'pythonData');
 				await verifyGraphBarHeights(app);
 			});
@@ -32,9 +34,7 @@ export function setup(logger: Logger) {
 				await this.app.workbench.positronLayouts.enterLayout('stacked');
 				const app = this.app as Application;
 
-				logger.log('[R] Sending code to console');
 				await app.workbench.positronConsole.executeCode('R', rScript, '>');
-
 				await openDataExplorerColumnProfile(app, 'rData');
 				await verifyGraphBarHeights(app);
 			});

--- a/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from '@playwright/test';
-import { Application, Logger, PositronPythonFixtures } from '../../../../../automation';
+import { Application, Logger, PositronPythonFixtures, PositronRFixtures } from '../../../../../automation';
 import { installAllHandlers } from '../../../utils';
 
 export function setup(logger: Logger) {
@@ -14,58 +14,59 @@ export function setup(logger: Logger) {
 
 		describe('Sparklines', () => {
 
-			beforeEach(async function () {
-				await this.app.workbench.positronLayouts.enterLayout('stacked');
-				await PositronPythonFixtures.SetupFixtures(this.app as Application);
-			});
-
-			async function openDataExplorerColumnProfile(app: Application) {
-				logger.log('Opening data grid');
-				await expect(async () => {
-					await app.workbench.positronVariables.doubleClickVariableRow('graphData');
-					await app.code.driver.getLocator('.label-name:has-text("Data: graphData")').innerText();
-				}).toPass();
-
-				logger.log('Expand column profile');
-				await app.workbench.positronSideBar.closeSecondarySideBar();
-				await app.workbench.positronDataExplorer.expandColumnProfile(0);
-			}
-
-			async function verifyGraphBarHeights(app: Application) {
-				// Get all graph graph bars/rectangles
-				await expect(async () => {
-					const rects = app.code.driver.getLocator('rect.count');
-
-					// Iterate over each rect and verify the height
-					const expectedHeights = ['50', '40', '30', '20', '10'];
-					for (let i = 0; i < expectedHeights.length; i++) {
-						const height = await rects.nth(i).getAttribute('height');
-						expect(height).toBe(expectedHeights[i]);
-					}
-				}).toPass({ timeout: 10000 });
-			}
-
 			it('Python Pandas - Verifies downward trending graph [C830552]', async function () {
+				await PositronPythonFixtures.SetupFixtures(this.app as Application);
+				await this.app.workbench.positronLayouts.enterLayout('stacked');
 				const app = this.app as Application;
 
 				logger.log('[Python] Sending code to console');
 				await app.workbench.positronConsole.executeCode('Python', pythonScript, '>>>');
 
-				await openDataExplorerColumnProfile(app);
+				await openDataExplorerColumnProfile(app, 'pythonData');
 				await verifyGraphBarHeights(app);
 			});
 
 
 			it('R - Verifies downward trending graph [C830553]', async function () {
+				await PositronRFixtures.SetupFixtures(this.app as Application);
+				await this.app.workbench.positronLayouts.enterLayout('stacked');
 				const app = this.app as Application;
 
 				logger.log('[R] Sending code to console');
 				await app.workbench.positronConsole.executeCode('R', rScript, '>');
 
-				await openDataExplorerColumnProfile(app);
+				await openDataExplorerColumnProfile(app, 'rData');
 				await verifyGraphBarHeights(app);
 			});
 		});
+
+		async function openDataExplorerColumnProfile(app: Application, variableName: string) {
+
+			await expect(async () => {
+				await app.workbench.positronVariables.doubleClickVariableRow(variableName);
+				await app.code.driver.getLocator(`.label-name:has-text("Data: ${variableName}")`).innerText();
+			}).toPass();
+
+			await app.workbench.positronDataExplorer.getDataExplorerTableData();
+
+			logger.log('Expand column profile');
+			await app.workbench.positronSideBar.closeSecondarySideBar();
+			await app.workbench.positronDataExplorer.expandColumnProfile(0);
+		}
+
+		async function verifyGraphBarHeights(app: Application) {
+			// Get all graph graph bars/rectangles
+			await expect(async () => {
+				const rects = app.code.driver.getLocator('rect.count');
+
+				// Iterate over each rect and verify the height
+				const expectedHeights = ['50', '40', '30', '20', '10'];
+				for (let i = 0; i < expectedHeights.length; i++) {
+					const height = await rects.nth(i).getAttribute('height');
+					expect(height).toBe(expectedHeights[i]);
+				}
+			}).toPass({ timeout: 10000 });
+		}
 	});
 }
 
@@ -73,38 +74,18 @@ const rScript = `library(ggplot2)
 library(dplyr)
 
 # Example data with multiple values for the same category
-graphData <- tibble(
+rData <- tibble(
 category = c("A", "A", "A", "A", "B", "B", "B", "C", "C", "D", "E", "A", "B", "C", "D"),
 values = c(1, 2, 3, 4, 5, 9, 10, 11, 13, 25, 7, 15, 20, 5, 6)
-)
-
-# Summarize data by summing values per category
-summarized_data <- graphData %>%
-group_by(category) %>%
-summarise(total_values = sum(values))
-
-# Create a bar graph
-ggplot(summarized_data, aes(x = reorder(category, -total_values), y = total_values)) +
-geom_bar(stat = "identity", fill = "steelblue") +
-labs(x = "Category", y = "Total Values", title = "Bar Graph with Summed Values") +
-theme_minimal()`;
+)`;
 
 
 const pythonScript = `import pandas as pd
 import matplotlib.pyplot as plt
 
 # Example data with multiple values for the same category
-graphData = pd.DataFrame({
+pythonData = pd.DataFrame({
 'category': ['A', 'A', 'A', 'A', 'B', 'B', 'B', 'C', 'C', 'D', 'E', 'A', 'B', 'C', 'D'],
 'values': [1, 2, 3, 4, 5, 9, 10, 11, 13, 25, 7, 15, 20, 5, 6]
-})
+})`;
 
-# Summarize data by summing values per category
-summarized_data = graphData.groupby('category', as_index=False).sum()
-
-# Create a bar graph
-plt.bar(summarized_data['category'], summarized_data['values'], color='steelblue')
-plt.xlabel('Category')
-plt.ylabel('Total Values')
-plt.title('Bar Graph with Summed Values')
-plt.show()`;


### PR DESCRIPTION
Making improvements to data explorer sparkline trend test to make it easier to debug and prevent flakes.

### QA Notes
Ran locally and passed.
Ran in GHA and passed (multiple times).
