### PR TITLE
Enable web testing for smoke tests; bump slack reporter

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -173,7 +173,7 @@ jobs:
     if: ${{ failure() }}
     steps:
       - name: "Send Slack notification"
-        uses: testlabauto/action-test-results-to-slack@v0.0.4
+        uses: testlabauto/action-test-results-to-slack@v0.0.6
         with:
           github_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_token: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}

--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -152,7 +152,7 @@ jobs:
     if: ${{ failure() && needs.linux.outputs.target  == 'smoketest-merge-to-main' }}
     steps:
       - name: 'Send Slack notification'
-        uses: testlabauto/action-test-results-to-slack@v0.0.4
+        uses: testlabauto/action-test-results-to-slack@v0.0.6
         with:
           github_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_token: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -538,6 +538,33 @@
 			}
 		},
 		{
+			"type": "node",
+			"request": "launch",
+			"name": "Launch Web Smoke Test",
+			"program": "${workspaceFolder}/test/smoke/test/index.js",
+			"cwd": "${workspaceFolder}/test/smoke",
+			"timeout": 240000,
+			"args": [
+				"--tracing",
+				"--web"
+			],
+			"outFiles": [
+				"${cwd}/out/**/*.js"
+			],
+			//---- Start Positron
+			"sourceMaps": true,
+			"resolveSourceMapLocations": [
+				"${workspaceFolder}/**",
+				"!**/node_modules/**"
+			],
+			//--- End Positron
+			"env": {
+				"NODE_ENV": "development",
+				"VSCODE_DEV": "1",
+				"VSCODE_CLI": "1"
+			}
+		},
+		{
 			"name": "Launch Built-in Extension",
 			"type": "extensionHost",
 			"request": "launch",

--- a/test/automation/src/playwrightBrowser.ts
+++ b/test/automation/src/playwrightBrowser.ts
@@ -50,7 +50,11 @@ async function launchServer(options: LaunchOptions) {
 		`--extensions-dir=${extensionsPath}`,
 		`--server-data-dir=${agentFolder}`,
 		'--accept-server-license-terms',
-		`--logsPath=${serverLogsPath}`
+		`--logsPath=${serverLogsPath}`,
+		// --- Start Positron ---
+		`--connection-token`,
+		`dev-token`
+		// --- End Positron ---
 	];
 
 	if (options.verbose) {


### PR DESCRIPTION
Enable web testing for smoke tests; bump slack reporter.

Keep in mind that [positron-license](https://github.com/posit-dev/positron-license) is needed parallel to positron and it needs to be set up.

### QA Notes

All smoke tests should pass
Web smoke tests should be locally runnable
Slack reporter for workflow_dispatch should report branch
