### PR TITLE
Fix plot progress bar

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotInstance.tsx
@@ -119,6 +119,11 @@ export const DynamicPlotInstance = (props: DynamicPlotInstanceProps) => {
 
 			// If we're rendering, show a progress bar.
 			if (state === PlotClientState.Rendering) {
+				// Before starting a new render, remove any existing progress bars. This prevents
+				// a buildup of progress bars when rendering multiple times and ensures the progress bar
+				// is removed when a new render is requested before the previous one completes.
+				progressRef.current.replaceChildren();
+
 				// Create the progress bar.
 				progressBar = new ProgressBar(progressRef.current);
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
@@ -144,6 +144,10 @@
 	transition: opacity 0.2s ease-in-out;
 }
 
+.plot-instance {
+	flex-direction: column;
+}
+
 .plot-thumbnail,
 .plot-instance {
 	display: flex;


### PR DESCRIPTION
Address #4562 

Add a flex direction on the plot element so that the children are in a single column.

There was another issue with leftover progress bars that's been fixed by removing any existing ones before creating a new one. Sometimes this would leave a progress bar in perpetual animation when another render is called before the current one completes (triggered by resizing the plot container when a render is in progress). It looked even worse when another render is called and it becomes difficult to distinguish the current progress bar with a previous one.

Before:
![image](https://github.com/user-attachments/assets/876a55b8-ebf6-40c3-8ff6-f757193c560d)

After:

https://github.com/user-attachments/assets/dcd77ea1-a0fb-4b53-96fa-8e6fa4bc0916


<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes
The feature flag to enable plots in editors has changed recently and reset the flag. It may need to be re-enabled.

Viewing a plot in an editor would render the progress bar in the middle, behind the plot image. Trigger a render by resizing the editor or changing the sizing policy in the Plots View.

Resizing a plot in editor or the Plots View would create another progress bar. If a render is triggered while one is already in progress, the old progress bar may not be set to done so it looks like a render is always in progress.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
