### PR TITLE
Improve destructive button theme colors

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -595,6 +595,7 @@
 		"--vscode-positronModalDialog-buttonDisabledBackground",
 		"--vscode-positronModalDialog-buttonDisabledBorder",
 		"--vscode-positronModalDialog-buttonDisabledForeground",
+		"--vscode-positronModalDialog-buttonDestructiveBackground",
 		"--vscode-positronModalDialog-buttonDestructiveForeground",
 		"--vscode-positronModalDialog-buttonForeground",
 		"--vscode-positronModalDialog-buttonHoverBackground",

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.css
@@ -18,8 +18,8 @@
 	position: fixed;
 	align-items: center;
 	justify-content: center;
+	background-color: rgba(0, 0, 0, 0.2);
 	animation: positronModalDialog-fadeIn 0.25s;
-	background: rgba(0, 0, 0, 0.2);
 }
 
 .positron-modal-dialog-container {
@@ -30,9 +30,9 @@
 	height: 100%;
 	position: absolute;
 	outline: none !important;
-	animation: positronModalDialog-fadeIn 0.25s;
 	/* Makes some devices run their hardware acceleration. */
 	transform: translate3d(0px, 0px, 0px);
+	animation: positronModalDialog-fadeIn 0.25s;
 }
 
 .positron-modal-dialog-box {
@@ -41,8 +41,8 @@
 	position: absolute;
 	border-radius: 5px;
 	color: var(--vscode-positronModalDialog-foreground);
-	background: var(--vscode-positronModalDialog-background);
 	border: 1px solid var(--vscode-positronModalDialog-border);
+	background-color: var(--vscode-positronModalDialog-background);
 	box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1), 0 6px 20px 0 rgba(0, 0, 0, 0.1);
 }
 
@@ -52,26 +52,27 @@
 	border-radius: 5px;
 	align-items: center;
 	justify-content: center;
-	border: 1px solid var(--vscode-positronModalDialog-buttonBorder);
 	color: var(--vscode-positronModalDialog-buttonForeground);
-	background: var(--vscode-positronModalDialog-buttonBackground);
+	border: 1px solid var(--vscode-positronModalDialog-buttonBorder);
+	background-color: var(--vscode-positronModalDialog-buttonBackground);
 }
 
 .positron-modal-dialog-box .action-bar-button:hover {
-	background: var(--vscode-positronModalDialog-buttonHoverBackground);
+	background-color: var(--vscode-positronModalDialog-buttonHoverBackground);
 }
 
 .positron-modal-dialog-box .action-bar-button.default {
 	color: var(--vscode-positronModalDialog-defaultButtonForeground);
-	background: var(--vscode-positronModalDialog-defaultButtonBackground);
+	background-color: var(--vscode-positronModalDialog-defaultButtonBackground);
 }
 
 .positron-modal-dialog-box .action-bar-button.default:hover {
-	background: var(--vscode-positronModalDialog-defaultButtonHoverBackground);
+	background-color: var(--vscode-positronModalDialog-defaultButtonHoverBackground);
 }
 
 .positron-modal-dialog-box .action-bar-button.destructive {
 	color: var(--vscode-positronModalDialog-buttonDestructiveForeground);
+	background-color: var(--vscode-positronModalDialog-buttonDestructiveBackground);
 }
 
 .positron-modal-dialog-box .action-bar-button:focus {
@@ -90,13 +91,13 @@
 	padding: 4px;
 	border-radius: 4px;
 	box-sizing: border-box;
-	background: var(--vscode-positronModalDialog-textInputBackground);
 	border: 1px solid var(--vscode-positronModalDialog-textInputBorder);
+	background-color: var(--vscode-positronModalDialog-textInputBackground);
 }
 
 .positron-modal-dialog-box .text-input::selection {
 	color: var(--vscode-positronModalDialog-textInputSelectionForeground);
-	background: var(--vscode-positronModalDialog-textInputSelectionBackground);
+	background-color: var(--vscode-positronModalDialog-textInputSelectionBackground);
 }
 
 .positron-modal-dialog-box .error-msg {

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -6,7 +6,7 @@
 import { localize } from 'vs/nls';
 import { registerColor, editorBackground, contrastBorder, transparent, editorWidgetBackground, textLinkForeground, lighten, darken, focusBorder, activeContrastBorder, editorWidgetForeground, editorErrorForeground, editorWarningForeground, editorInfoForeground, treeIndentGuidesStroke, errorForeground, listActiveSelectionBackground, listActiveSelectionForeground, editorForeground, toolbarHoverBackground, inputBorder, widgetBorder, scrollbarShadow, textPreformatForeground } from 'vs/platform/theme/common/colorRegistry';
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
-import { Color } from 'vs/base/common/color';
+import { Color, HSLA } from 'vs/base/common/color';
 import { ColorScheme } from 'vs/platform/theme/common/theme';
 
 // --- Start Positron ---
@@ -46,6 +46,15 @@ export function WORKBENCH_BACKGROUND(theme: IColorTheme): Color {
 			return Color.fromHex('#252526');
 	}
 }
+
+/**
+ * Changes the hue of a color.
+ * @param color The color to change.
+ * @param h The hue to change to.
+ * @returns The new color.
+ */
+const changeHue = (color: Color, h: number) =>
+	new Color(new HSLA(h, color.hsla.s, color.hsla.l, color.hsla.a));
 
 // < --- Tabs --- >
 
@@ -1294,12 +1303,20 @@ export const POSITRON_MODAL_DIALOG_DEFAULT_BUTTON_FOREGROUND = registerColor('po
 	hcLight: buttonForeground
 }, localize('positronModalDialog.defaultButtonForeground', "Positron modal dialog default button foreground color."));
 
+// Positron modal dialog button destructive background color.
+export const POSITRON_MODAL_DIALOG_BUTTON_DESTRUCTIVE_BACKGROUND = registerColor('positronModalDialog.buttonDestructiveBackground', {
+	dark: buttonSecondaryBackground,
+	light: buttonSecondaryBackground,
+	hcDark: buttonSecondaryBackground,
+	hcLight: buttonSecondaryBackground
+}, localize('positronModalDialog.buttonDestructiveBackground', "Positron modal dialog button destructive background color."));
+
 // Positron modal dialog button destructive foreground color.
 export const POSITRON_MODAL_DIALOG_BUTTON_DESTRUCTIVE_FOREGROUND = registerColor('positronModalDialog.buttonDestructiveForeground', {
-	dark: errorForeground,
-	light: '#B30600',
-	hcDark: errorForeground,
-	hcLight: errorForeground
+	dark: changeHue(Color.fromHex(buttonSecondaryForeground), 0),
+	light: changeHue(Color.fromHex(buttonSecondaryForeground), 0),
+	hcDark: buttonSecondaryForeground,
+	hcLight: buttonSecondaryForeground
 }, localize('positronModalDialog.buttonDestructiveForeground', "Positron modal dialog button destructive foreground color."));
 
 // Positron modal dialog button disabled foreground color.


### PR DESCRIPTION
### Description

This PR partially addresses https://github.com/posit-dev/positron/issues/3799 by changing the background color and foreground color of "destructive" buttons.

Now, destructive buttons are drawn using:

```
background-color: var(--vscode-positronModalDialog-buttonDestructiveBackground);
color: var(--vscode-positronModalDialog-buttonDestructiveForeground);
```

Where:

`buttonDestructiveBackground` is defined to be the `buttonSecondaryBackground` theme color
`buttonDestructiveForeground` is defined to be the `buttonSecondaryForegound` theme color, but changed in hue to red.

### QA Notes

