### PR TITLE
[python] support shiny apps if ext not installed

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -330,6 +330,13 @@
             },
             {
                 "category": "Python",
+                "command": "python.execShinyInTerminal",
+                "icon": "$(play)",
+                "title": "%python.command.python.execShinyInTerminal.title%",
+                "enablement": "pythonAppFramework == shiny"
+            },
+            {
+                "category": "Python",
                 "command": "python.execStreamlitInTerminal",
                 "icon": "$(play)",
                 "title": "%python.command.python.execStreamlitInTerminal.title%",
@@ -1500,6 +1507,11 @@
                     "when": "pythonAppFramework == flask"
                 },
                 {
+                    "command": "python.execShinyInTerminal",
+                    "group": "Python",
+                    "when": "pythonAppFramework == shiny"
+                },
+                {
                     "command": "python.execStreamlitInTerminal",
                     "group": "Python",
                     "when": "pythonAppFramework == streamlit"
@@ -1562,6 +1574,12 @@
                     "group": "navigation@0",
                     "title": "%python.command.python.execFlaskInTerminal.title%",
                     "when": "pythonAppFramework == flask"
+                },
+                {
+                    "command": "python.execShinyInTerminal",
+                    "group": "navigation@0",
+                    "title": "%python.command.python.execShinyInTerminal.title%",
+                    "when": "pythonAppFramework == shiny"
                 },
                 {
                     "command": "python.execStreamlitInTerminal",

--- a/extensions/positron-python/package.nls.json
+++ b/extensions/positron-python/package.nls.json
@@ -10,6 +10,7 @@
     "python.command.python.execFastAPIInTerminal.title": "Run FastAPI App in Terminal",
     "python.command.python.execFlaskInTerminal.title": "Run Flask App in Terminal",
     "python.command.python.execGradioInTerminal.title": "Run Gradio App in Terminal",
+    "python.command.python.execShinyInTerminal.title": "Run Shiny App in Terminal", 
     "python.command.python.execStreamlitInTerminal.title": "Run Streamlit App in Terminal",
     "python.command.python.execInConsole.title": "Run Python File in Console",
     "python.command.python.debugInTerminal.title": "Debug Python File in Terminal",

--- a/extensions/positron-python/src/client/common/application/commands.ts
+++ b/extensions/positron-python/src/client/common/application/commands.ts
@@ -106,6 +106,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [Commands.Exec_FastAPI_In_Terminal]: [];
     [Commands.Exec_Flask_In_Terminal]: [];
     [Commands.Exec_Gradio_In_Terminal]: [];
+    [Commands.Exec_Shiny_In_Terminal]: [];
     [Commands.Exec_Streamlit_In_Terminal]: [];
     [Commands.Exec_In_Console]: [];
     [Commands.Focus_Positron_Console]: [];

--- a/extensions/positron-python/src/client/common/constants.ts
+++ b/extensions/positron-python/src/client/common/constants.ts
@@ -56,6 +56,7 @@ export namespace Commands {
     export const Exec_FastAPI_In_Terminal = 'python.execFastAPIInTerminal';
     export const Exec_Flask_In_Terminal = 'python.execFlaskInTerminal';
     export const Exec_Gradio_In_Terminal = 'python.execGradioInTerminal';
+    export const Exec_Shiny_In_Terminal = 'python.execShinyInTerminal';
     export const Exec_Streamlit_In_Terminal = 'python.execStreamlitInTerminal';
     export const Exec_In_Console = 'python.execInConsole';
     export const Exec_Selection_In_Console = 'python.execSelectionInConsole';

--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -123,6 +123,27 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             });
         }),
 
+        vscode.commands.registerCommand(Commands.Exec_Shiny_In_Terminal, async () => {
+            const runAppApi = await getPositronRunAppApi();
+            await runAppApi.runApplication({
+                name: 'Shiny',
+                getTerminalOptions(runtime, document, port, _urlPrefix) {
+                    const args = [
+                        runtime.runtimePath,
+                        '-m',
+                        'shiny',
+                        'run',
+                        '--reload',
+                        document.uri.fsPath,
+                    ];
+                    if (port) {
+                        args.push('--port', port);
+                    }
+                    return { commandLine: args.join(' ') };
+                },
+            });
+        }),
+
         vscode.commands.registerCommand(Commands.Exec_Streamlit_In_Terminal, async () => {
             const runAppApi = await getPositronRunAppApi();
             await runAppApi.runApplication({

--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -128,14 +128,7 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             await runAppApi.runApplication({
                 name: 'Shiny',
                 getTerminalOptions(runtime, document, port, _urlPrefix) {
-                    const args = [
-                        runtime.runtimePath,
-                        '-m',
-                        'shiny',
-                        'run',
-                        '--reload',
-                        document.uri.fsPath,
-                    ];
+                    const args = [runtime.runtimePath, '-m', 'shiny', 'run', '--reload', document.uri.fsPath];
                     if (port) {
                         args.push('--port', port);
                     }

--- a/extensions/positron-python/src/client/positron/webAppContexts.ts
+++ b/extensions/positron-python/src/client/positron/webAppContexts.ts
@@ -14,12 +14,10 @@ function getSupportedLibraries(): string[] {
 
     // if shiny extension is installed, we don't need to handle it
     if (shinyExtension && shinyExtension.isActive) {
-        return libraries
-    } else {
-        return libraries.concat('shiny')
+        return libraries;
     }
+    return libraries.concat('shiny');
 }
-
 
 export function detectWebApp(document: vscode.TextDocument): void {
     const text = document.getText();

--- a/extensions/positron-python/src/client/positron/webAppContexts.ts
+++ b/extensions/positron-python/src/client/positron/webAppContexts.ts
@@ -6,7 +6,20 @@
 import * as vscode from 'vscode';
 import { executeCommand } from '../common/vscodeApis/commandApis';
 
-const libraries: string[] = ['streamlit', 'shiny', 'dash', 'gradio', 'flask', 'fastapi'];
+function getSupportedLibraries(): string[] {
+    const libraries: string[] = ['streamlit', 'dash', 'gradio', 'flask', 'fastapi'];
+
+    const shinyExtensionId = 'Posit.shiny';
+    const shinyExtension = vscode.extensions.getExtension(shinyExtensionId);
+
+    // if shiny extension is installed, we don't need to handle it
+    if (shinyExtension && shinyExtension.isActive) {
+        return libraries
+    } else {
+        return libraries.concat('shiny')
+    }
+}
+
 
 export function detectWebApp(document: vscode.TextDocument): void {
     const text = document.getText();
@@ -15,6 +28,7 @@ export function detectWebApp(document: vscode.TextDocument): void {
 }
 
 export function getFramework(text: string): string | undefined {
+    const libraries = getSupportedLibraries();
     const importPattern = new RegExp(`import\\s+(${libraries.join('|')})`, 'g');
     const fromImportPattern = new RegExp(`from\\s+(${libraries.join('|')})\\S*\\simport`, 'g');
     const importMatch = importPattern.exec(text);

--- a/extensions/positron-python/src/client/positron/webAppContexts.ts
+++ b/extensions/positron-python/src/client/positron/webAppContexts.ts
@@ -13,7 +13,7 @@ function getSupportedLibraries(): string[] {
     const shinyExtension = vscode.extensions.getExtension(shinyExtensionId);
 
     // if shiny extension is installed, we don't need to handle it
-    if (shinyExtension && shinyExtension.isActive) {
+    if (shinyExtension) {
         return libraries;
     }
     return libraries.concat('shiny');

--- a/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
@@ -230,12 +230,9 @@ suite('Web app commands', () => {
     });
 
     test('Exec Shiny in terminal - without port and urlPrefix', async () => {
-        await verifyRunAppCommand(
-            Commands.Exec_Shiny_In_Terminal,
-            {
-                commandLine: `${runtimePath} -m shiny run --reload ${documentPath}`,
-            },
-        );
+        await verifyRunAppCommand(Commands.Exec_Shiny_In_Terminal, {
+            commandLine: `${runtimePath} -m shiny run --reload ${documentPath}`,
+        });
     });
 
     test('Exec Shiny in terminal - with port and urlPrefix', async () => {

--- a/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
@@ -229,6 +229,25 @@ suite('Web app commands', () => {
         );
     });
 
+    test('Exec Shiny in terminal - without port and urlPrefix', async () => {
+        await verifyRunAppCommand(
+            Commands.Exec_Shiny_In_Terminal,
+            {
+                commandLine: `${runtimePath} -m shiny run --reload ${documentPath}`,
+            },
+        );
+    });
+
+    test('Exec Shiny in terminal - with port and urlPrefix', async () => {
+        await verifyRunAppCommand(
+            Commands.Exec_Shiny_In_Terminal,
+            {
+                commandLine: `${runtimePath} -m shiny run --reload ${documentPath} --port ${port}`,
+            },
+            { port, urlPrefix },
+        );
+    });
+
     test('Exec Streamlit in terminal - without port and urlPrefix', async () => {
         await verifyRunAppCommand(Commands.Exec_Streamlit_In_Terminal, {
             commandLine: `${runtimePath} -m streamlit run ${documentPath} --server.headless true`,

--- a/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
@@ -13,6 +13,7 @@ import { IDisposableRegistry } from '../../client/common/types';
 suite('Discover Web app frameworks', () => {
     let document: vscode.TextDocument;
     let executeCommandStub: sinon.SinonStub;
+    let getExtensionStub: sinon.SinonStub;
     const disposables: IDisposableRegistry = [];
 
     setup(() => {
@@ -20,6 +21,7 @@ suite('Discover Web app frameworks', () => {
         document = {
             getText: () => '',
         } as vscode.TextDocument;
+        getExtensionStub = sinon.stub(vscode.extensions, 'getExtension');
     });
 
     teardown(() => {
@@ -35,6 +37,7 @@ suite('Discover Web app frameworks', () => {
     Object.entries(texts).forEach(([text, framework]) => {
         const expected = text.includes('numpy') ? undefined : framework;
         test('should set context pythonAppFramework if application is found', () => {
+            getExtensionStub.withArgs('Posit.shiny').returns({ isActive: false });
             document.getText = () => text;
             detectWebApp(document);
 
@@ -63,5 +66,12 @@ suite('Discover Web app frameworks', () => {
 
             assert.strictEqual(actual, expected);
         });
+    });
+    test(`should not detect shiny if extension is installed`, () => {
+        getExtensionStub.withArgs('Posit.shiny').returns({ isActive: true });
+        const text = `from shiny import XYZ`;
+        const actual = getFramework(text);
+
+        assert.strictEqual(actual, undefined);
     });
 });

--- a/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
@@ -10,7 +10,7 @@ import * as cmdApis from '../../client/common/vscodeApis/commandApis';
 import { detectWebApp, getFramework } from '../../client/positron/webAppContexts';
 import { IDisposableRegistry } from '../../client/common/types';
 
-suite('Discover webapp frameworks', () => {
+suite('Discover Web app frameworks', () => {
     let document: vscode.TextDocument;
     let executeCommandStub: sinon.SinonStub;
     const disposables: IDisposableRegistry = [];

--- a/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
@@ -37,7 +37,7 @@ suite('Discover Web app frameworks', () => {
     Object.entries(texts).forEach(([text, framework]) => {
         const expected = text.includes('numpy') ? undefined : framework;
         test('should set context pythonAppFramework if application is found', () => {
-            getExtensionStub.withArgs('Posit.shiny').returns({ isActive: false });
+            getExtensionStub.withArgs('Posit.shiny').returns(undefined);
             document.getText = () => text;
             detectWebApp(document);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

related to #4675 

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

create file named `app.py`
```python
from shiny import App, reactive, render, ui

app_ui = ui.page_fluid(
    ui.input_action_button("action_button", "Action"),  
    ui.output_text("counter"),
)

def server(input, output, session):
    @render.text()
    @reactive.event(input.action_button)
    def counter():
        return f"{input.action_button()}"

app = App(app_ui, server)

```

when shiny ext installed:

![Screenshot 2024-09-30 at 11 49 44 AM](https://github.com/user-attachments/assets/09f20c88-f255-4801-a918-4452e66edd33)

when shiny ext not installed/enabled, should have `Run Shiny App in Terminal` as first button

