### PR TITLE
Bump ark to 0.1.139

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -634,7 +634,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.138"
+      "ark": "0.1.139"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.7"


### PR DESCRIPTION
Waiting on https://github.com/posit-dev/ark/actions/runs/11019872315

- https://github.com/posit-dev/positron/issues/4544
- https://github.com/posit-dev/positron/issues/4700
- https://github.com/posit-dev/positron/issues/4741
- https://github.com/posit-dev/positron/issues/4677
- https://github.com/posit-dev/positron/issues/2943
- https://github.com/posit-dev/positron/issues/3632 (from 0.1.138 actually)
- https://github.com/posit-dev/positron/issues/3775 (from earlier actually)