### PR TITLE
Fix resizing plotly web clients

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
@@ -20,6 +20,7 @@ from positron_ipykernel.positron_ipkernel import (
 )
 from positron_ipykernel.session_mode import SessionMode
 from positron_ipykernel.variables import VariablesService
+from http.server import HTTPServer
 
 utils.TESTING = True
 
@@ -192,6 +193,13 @@ def mock_displayhook(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> M
 def mock_display_pub(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell, "display_pub", mock)
+    return mock
+
+
+@pytest.fixture
+def mock_handle_request(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    mock = Mock()
+    monkeypatch.setattr(HTTPServer, "handle_request", mock)
     return mock
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
@@ -31,6 +31,7 @@ from .utils import (
     json_rpc_response,
     preserve_working_directory,
 )
+from unittest.mock import Mock
 
 TARGET_NAME = "target_name"
 
@@ -245,6 +246,7 @@ def test_holoview_extension_sends_events(shell: PositronShell, ui_comm: DummyCom
 def test_plotly_show_sends_events(
     shell: PositronShell,
     ui_comm: DummyComm,
+    mock_handle_request: Mock,
 ) -> None:
     """
     Test that showing a Plotly plot sends the expected UI events.
@@ -265,6 +267,7 @@ fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
 fig.show()
 """
     )
+    mock_handle_request.assert_called()
     assert len(ui_comm.messages) == 1
     params = ui_comm.messages[0]["data"]["params"]
     assert params["title"] == ""

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -197,7 +197,7 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
             if os.name == "nt":
                 url = urlparse(url).netloc or urlparse(url).path
 
-            self._comm.send_event(
+            return self._comm.send_event(
                 name=UiFrontendEvent.ShowHtmlFile,
                 payload=ShowHtmlFileParams(
                     path=url,
@@ -208,7 +208,6 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
                     height=0,
                 ).dict(),
             )
-            return True
 
         for addr in _localhosts:
             if addr in url:
@@ -240,6 +239,8 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
 
 
     def _send_show_html_event(self, url, is_plot):
+        if self._comm is None:
+            return False
         self._comm.send_event(
             name=UiFrontendEvent.ShowHtmlFile,
             payload=ShowHtmlFileParams(
@@ -251,3 +252,4 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
                 height=0,
             ).dict(),
         )
+        return True

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -194,8 +194,6 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
             # Identify bokeh plots by checking the stack for the bokeh.io.showing.show function.
             # This is not great but currently the only information we have.
             is_plot = self._is_module_function("bokeh.io.showing", "show")
-            if os.name == "nt":
-                url = urlparse(url).netloc or urlparse(url).path
 
             return self._send_show_html_event(url, is_plot)
 
@@ -203,8 +201,6 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
             if addr in url:
                 is_plot = self._is_module_function("plotly.basedatatypes", "show")
                 if is_plot:
-                    if os.name == "nt":
-                        url = urlparse(url).netloc or urlparse(url).path
                     return self._send_show_html_event(url, is_plot)
                 else:
                     event = ShowUrlParams(url=url)
@@ -215,7 +211,8 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
         return False
 
 
-    def _is_module_function(self, module_name: str, function_name: str) -> bool:
+    @staticmethod
+    def _is_module_function(module_name: str, function_name: str) -> bool:
         module = sys.modules.get(module_name)
         if module:
             for frame_info in inspect.stack():
@@ -231,6 +228,8 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
         if self._comm is None:
             logger.warning("No comm available to send ShowHtmlFile event")
             return False
+        if os.name == "nt":
+            url = urlparse(url).netloc or urlparse(url).path
         self._comm.send_event(
             name=UiFrontendEvent.ShowHtmlFile,
             payload=ShowHtmlFileParams(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -189,7 +189,6 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
         is_plot = False
         # If url is pointing to an HTML file, route to the ShowHtmlFile comm
         if is_local_html_file(url):
-
             # Send bokeh plots to the plots pane.
             # Identify bokeh plots by checking the stack for the bokeh.io.showing.show function.
             # This is not great but currently the only information we have.
@@ -210,7 +209,6 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
         # pass back to webbrowser's list of browsers to open up the link
         return False
 
-
     @staticmethod
     def _is_module_function(module_name: str, function_name: str) -> bool:
         module = sys.modules.get(module_name)
@@ -222,7 +220,6 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
                 ):
                     return True
         return False
-
 
     def _send_show_html_event(self, url: str, is_plot: bool) -> bool:
         if self._comm is None:

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -177,6 +177,11 @@ export class PythonRuntimeManager implements IPythonRuntimeManager {
         // only provided for new sessions; existing (restored) sessions already
         // have one.
         const env = await environmentVariablesProvider.getEnvironmentVariables();
+        if (sessionMetadata.sessionMode === positron.LanguageRuntimeSessionMode.Console) {
+            // Workaround to use Plotly's browser renderer. Ensures the plot is
+            // displayed to fill the webview.
+            env.PLOTLY_RENDERER = 'browser';
+        }
         const kernelSpec: JupyterKernelSpec = {
             argv: args,
             display_name: `${runtimeMetadata.runtimeName}`,

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -161,9 +161,14 @@ export class UiClientInstance extends Disposable {
 
 		// Wrap the ShowHtmlFile event to start a proxy server for the HTML file.
 		this._register(this._comm.onDidShowHtmlFile(async e => {
+			let uri: URI;
 			try {
-				// Start an HTML proxy server for the file
-				const uri = await this.startHtmlProxyServer(e.path);
+				if (e.path.endsWith('.html') || e.path.endsWith('.htm')) {
+					// Start an HTML proxy server for the file
+					uri = await this.startHtmlProxyServer(e.path);
+				} else {
+					uri = URI.parse(e.path);
+				}
 
 				if (e.is_plot) {
 					// Check the configuration to see if we should open the plot


### PR DESCRIPTION
Address #4245 

Sets Plotly to use its browser renderer. When calling `show()`, we intercept and send an event so that the URL is displayed in a webview in the Plots View instead of the viewer (or in the Viewer if the preference is set).

Plotly's browser renderer fills width and height to 100% when no plot size is defined compared to the JupyterLab renderer (or vscode?) that defaults to Plots View's width and height 450px. Underneath, the browser renderer sets `responsive: True` for the config, which will set width and height to 100%.

I'm not sure about the proxy part. We don't create one for the Viewer so I'm not sure if this will need more work when using this in Posit Workbench.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes
Code to generate a Plotly plot. `pip install plotly` before running.
```python
import plotly.express as px
fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
fig.show()
```

Disable this setting so the plot shows in Plots instead of the Viewer.
![image](https://github.com/user-attachments/assets/7ee5fb5d-dd56-42e6-86d4-f93c9fc69c6c)


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
