### PR TITLE
Updates to modal rendering and focus management

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.css
@@ -3,36 +3,11 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-@keyframes positronModalDialog-fadeIn {
-	0% { opacity: 0; }
-	100% { opacity: 1; }
-}
-
-.positron-modal-dialog-overlay {
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-	z-index: 20000;
-	display: flex;
-	position: fixed;
-	align-items: center;
-	justify-content: center;
-	animation: positronModalDialog-fadeIn 0.25s;
-	background: rgba(0, 0, 0, 0.2);
-}
-
 .positron-modal-dialog-container {
-	animation: positronModalDialog-fadeIn 0.25s;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
+	inset: 0;
 	position: absolute;
 	outline: none !important;
-	animation: positronModalDialog-fadeIn 0.25s;
-	/* Makes some devices run their hardware acceleration. */
-	transform: translate3d(0px, 0px, 0px);
+	background: rgba(0, 0, 0, 0.2);
 }
 
 .positron-modal-dialog-box {

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.tsx
@@ -293,12 +293,10 @@ export const PositronModalDialog = (props: PropsWithChildren<PositronModalDialog
 
 	// Render.
 	return (
-		<div className='positron-modal-dialog-overlay'>
-			<div ref={dialogContainerRef} className='positron-modal-dialog-container' role='dialog'>
-				<div ref={dialogBoxRef} className='positron-modal-dialog-box' style={{ left: dialogBoxState.left, top: dialogBoxState.top, width: props.width, height: props.height }}>
-					<DraggableTitleBar {...props} onStartDrag={startDragHandler} onDrag={dragHandler} onStopDrag={stopDragHandler} />
-					{props.children}
-				</div>
+		<div ref={dialogContainerRef} className='positron-modal-dialog-container' role='dialog'>
+			<div ref={dialogBoxRef} className='positron-modal-dialog-box' style={{ left: dialogBoxState.left, top: dialogBoxState.top, width: props.width, height: props.height }}>
+				<DraggableTitleBar {...props} onStartDrag={startDragHandler} onDrag={dragHandler} onStopDrag={stopDragHandler} />
+				{props.children}
 			</div>
 		</div>
 	);

--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.css
@@ -4,18 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 .positron-modal-popup-container {
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
+	inset: 0;
 	position: absolute;
 	outline: none !important;
-	/* Makes some devices run their hardware acceleration. */
-	transform: translate3d(0px, 0px, 0px);
 }
 
-.positron-modal-popup-container
-.positron-modal-popup {
+.positron-modal-popup-container .positron-modal-popup {
 	display: flex;
 	overflow: auto;
 	position: absolute;
@@ -28,19 +22,15 @@
 	background-color: var(--vscode-positronModalDialog-background);
 }
 
-.positron-modal-popup-container
-.positron-modal-popup.shadow-top {
+.positron-modal-popup-container .positron-modal-popup.shadow-top {
 	box-shadow: 0px -4px 10px 0 rgba(0, 0, 0, 0.1);
 }
 
-.positron-modal-popup-container
-.positron-modal-popup.shadow-bottom {
+.positron-modal-popup-container .positron-modal-popup.shadow-bottom {
 	box-shadow: 0px 4px 10px 0 rgba(0, 0, 0, 0.1);
 }
 
-.positron-modal-popup-container
-.positron-modal-popup
-.positron-modal-popup-children {
+.positron-modal-popup-container .positron-modal-popup .positron-modal-popup-children {
 	width: 100%;
 	height: 100%;
 }

--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -182,7 +182,7 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 		 * Positions the popup aligned with the right edge of the anchor element.
 		 */
 		const positionRight = () => {
-			popupLayout.right = -(anchorLayout.anchorX + anchorLayout.anchorWidth);
+			popupLayout.right = documentWidth - (anchorLayout.anchorX + anchorLayout.anchorWidth);
 		};
 
 		// Adjust the popup layout for the popup alignment.

--- a/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.css
+++ b/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.css
@@ -3,20 +3,21 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-@keyframes positronModalReactRenderer-fadeIn {
-	0% { opacity: 0; }
-	100% { opacity: 1; }
+@keyframes positron-modal-overlay-fade-in {
+	0% {
+		opacity: 0;
+	}
+
+	100% {
+		opacity: 1;
+	}
 }
 
 .positron-modal-overlay {
-	top: 0;
-	left: 0;
-	width: 0;
-	height: 0;
+	inset: 0;
 	z-index: 20000;
-	display: flex;
-	position: fixed;
-	align-items: center;
-	justify-content: center;
-	animation: positronModalReactRenderer-fadeIn 0.25s;
+	position: absolute;
+	/* Makes some devices run their hardware acceleration. */
+	transform: translate3d(0px, 0px, 0px);
+	animation: positron-modal-overlay-fade-in 0.1s ease-out;
 }

--- a/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.tsx
+++ b/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.tsx
@@ -237,11 +237,16 @@ export class PositronModalReactRenderer extends Disposable {
 
 			// Create the overlay element in the container and the root element in the overlay
 			// element.
-			this._overlay = this._options.container.appendChild(DOM.$('.positron-modal-overlay'));
+			this._overlay = this._options.container.appendChild(
+				DOM.$('.positron-modal-overlay', { tabIndex: 0 })
+			);
 			this._root = createRoot(this._overlay);
 
 			// Render the ReactElement that was supplied.
 			this._root.render(reactElement);
+
+			// Drive focus into the overlay element.
+			this._overlay.focus();
 
 			// Push this renderer onto the renderers stack and bind event listeners.
 			PositronModalReactRenderer._renderersStack.add(this);


### PR DESCRIPTION
### Description

This PR addresses two issues:

1) After pressing a button that launches a React modal popup (in this example, adding a column filter), clicking over the button again resulted in the modal popup being dismissed and launched again.

Here's a screen recording of this issue:

https://github.com/user-attachments/assets/ad3168fb-7f00-4659-9cc9-1d5a9511364d

2) As documented in https://github.com/posit-dev/positron/issues/4765, after pressing a button that launches a React modal dialog or modal popup, focus was being left in the button that was pressed. In this state, pressing the button again using the Space key allowed the user to launch another instance of the modal dialog or modal popup. This could be done again and again, resulting in many instances of the modal dialog or modal popup being displayed, each of which would have to be dismissed.

Here's a screen recording of this issue:

https://github.com/user-attachments/assets/1b22709c-8182-4af0-954f-8ad4e09a855b

### QA Notes

Please smoke test all the modal popups and modal dialogs to ensure there is no regression.