### PR TITLE
Add Move into New Window action bar button to Data Explorer

### DIFF
--- a/extensions/positron-connections/src/test/connection.test.ts
+++ b/extensions/positron-connections/src/test/connection.test.ts
@@ -10,12 +10,12 @@ import { ConnectionItemsProvider } from '../connection';
 import * as mocha from 'mocha';
 import { randomUUID } from 'crypto';
 
-suite.skip('Connections pane works for R', () => {
+suite('Connections pane works for R', () => {
 	suiteTeardown(() => {
 		vscode.window.showInformationMessage('All tests done!');
 	});
 
-	test.skip('Can list tables and fields from R connections', async () => {
+	test('Can list tables and fields from R connections', async () => {
 
 		// Waits until positron is ready to start a runtime
 		const info = await assert_or_timeout(async () => {

--- a/extensions/positron-connections/src/test/connection.test.ts
+++ b/extensions/positron-connections/src/test/connection.test.ts
@@ -10,12 +10,12 @@ import { ConnectionItemsProvider } from '../connection';
 import * as mocha from 'mocha';
 import { randomUUID } from 'crypto';
 
-suite('Connections pane works for R', () => {
+suite.skip('Connections pane works for R', () => {
 	suiteTeardown(() => {
 		vscode.window.showInformationMessage('All tests done!');
 	});
 
-	test('Can list tables and fields from R connections', async () => {
+	test.skip('Can list tables and fields from R connections', async () => {
 
 		// Waits until positron is ready to start a runtime
 		const info = await assert_or_timeout(async () => {

--- a/src/vs/workbench/browser/positronDataExplorer/components/actionBar/actionBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/actionBar/actionBar.tsx
@@ -8,9 +8,12 @@ import 'vs/css!./actionBar';
 
 // React.
 import * as React from 'react';
+import { useEffect, useRef, useState } from 'react'; // eslint-disable-line no-duplicate-imports
 
 // Other dependencies.
 import { localize } from 'vs/nls';
+import * as DOM from 'vs/base/browser/dom';
+import { isAuxiliaryWindow } from 'vs/base/browser/window';
 import { PositronActionBar } from 'vs/platform/positronActionBar/browser/positronActionBar';
 import { ActionBarRegion } from 'vs/platform/positronActionBar/browser/components/actionBarRegion';
 import { ActionBarButton } from 'vs/platform/positronActionBar/browser/components/actionBarButton';
@@ -27,8 +30,12 @@ const kPaddingRight = 8;
 /**
  * Localized strings.
  */
-const clearSortButtonTitle = localize('positron.clearSortButtonLabel', "Clear Sorting");
+const clearSortButtonTitle = localize('positron.clearSortButtonTitle', "Clear Sorting");
 const clearSortButtonDescription = localize('positron.clearSortButtonDescription', "Clear sorting");
+const moveIntoNewWindowButtonDescription = localize(
+	'positron.moveIntoNewWindowButtonDescription',
+	"Move into New Window"
+);
 
 /**
  * ActionBar component.
@@ -38,10 +45,21 @@ export const ActionBar = () => {
 	// Context hooks.
 	const context = usePositronDataExplorerContext();
 
+	// Reference hooks.
+	const ref = useRef<HTMLDivElement>(undefined!);
+
+	// State hooks.
+	const [moveIntoNewWindowDisabled, setMoveIntoNewWindowDisabled] = useState(true);
+
+	// Main useEffect.
+	useEffect(() => {
+		setMoveIntoNewWindowDisabled(isAuxiliaryWindow(DOM.getWindow(ref.current)));
+	}, []);
+
 	// Render.
 	return (
 		<PositronActionBarContextProvider {...context}>
-			<div className='action-bar'>
+			<div ref={ref} className='action-bar'>
 				<PositronActionBar
 					size='small'
 					borderBottom={true}
@@ -50,18 +68,29 @@ export const ActionBar = () => {
 				>
 					<ActionBarRegion location='left'>
 						<ActionBarButton
-							disabled={false}
 							iconId='positron-clear-sorting'
 							text={clearSortButtonTitle}
 							tooltip={clearSortButtonDescription}
 							ariaLabel={clearSortButtonDescription}
 							onPressed={async () =>
-								await context.instance.tableDataDataGridInstance.clearColumnSortKeys()
+								await context.instance.tableDataDataGridInstance.
+									clearColumnSortKeys()
 							}
 						/>
 					</ActionBarRegion>
 					<ActionBarRegion location='right'>
 						<LayoutMenuButton />
+						<ActionBarButton
+							disabled={moveIntoNewWindowDisabled}
+							iconId='positron-open-in-new-window'
+							tooltip={moveIntoNewWindowButtonDescription}
+							ariaLabel={moveIntoNewWindowButtonDescription}
+							onPressed={() => {
+								context.commandService.executeCommand(
+									'workbench.action.moveEditorToNewWindow'
+								);
+							}}
+						/>
 					</ActionBarRegion>
 				</PositronActionBar>
 			</div>


### PR DESCRIPTION
### Description

This PR addresses https://github.com/posit-dev/positron/issues/3839 by adding a "Move into New Window" button to the Data Explorer Action Bar.

![image](https://github.com/user-attachments/assets/53fd0d24-26f5-459d-ba83-d39525a59fdb)

The button is enabled when Data Explorer is in the main window.

Here's a screen capture of the feature:

https://github.com/user-attachments/assets/66a0e8a8-5ddc-4719-8ddc-7063246ad7f8

### QA Notes

None.