### PR TITLE
Disable integration tests temporarily

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -135,9 +135,10 @@ jobs:
         id: browser-unit-tests
         run: DISPLAY=:10 yarn test-browser-no-install --browser chromium
 
-      - name: Run Integration Tests (Electron)
-        id: electron-integration-tests
-        run: DISPLAY=:10 ./scripts/test-integration.sh
+      # disabled due to test issues
+      # - name: Run Integration Tests (Electron)
+      #   id: electron-integration-tests
+      #  run: DISPLAY=:10 ./scripts/test-integration.sh
 
       #      Remote integration tests currently disabled since licensing is required.
       #      See https://github.com/posit-dev/positron/issues/3514 for details.

--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -118,9 +118,10 @@ jobs:
         id: nodejs-unit-tests
         run: yarn test-node
 
-      - name: Run Integration Tests (Electron)
-        id: electron-integration-tests
-        run: DISPLAY=:10 ./scripts/test-integration-pr.sh
+      # disabled due to test issues
+      # - name: Run Integration Tests (Electron)
+      #   id: electron-integration-tests
+      #   run: DISPLAY=:10 ./scripts/test-integration-pr.sh
 
       - name: Run Smoke Tests (Electron)
         env:


### PR DESCRIPTION
The integration tests have become unstable and need to be fixed before re-enabling.

### QA Notes

Test suites pass
