### PR TITLE
Cmead/enable more web tests

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -220,7 +220,7 @@ jobs:
     name: "Send Slack notification"
     runs-on: ubuntu-latest
     needs: linux
-    if: ${{ failure() }}
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
     steps:
       - name: "Send Slack notification"
         uses: testlabauto/action-test-results-to-slack@v0.0.6

--- a/test/automation/src/positron/positronNotebooks.ts
+++ b/test/automation/src/positron/positronNotebooks.ts
@@ -48,7 +48,8 @@ export class PositronNotebooks {
 		}
 
 		// if select kernel appears, select the proper kernel
-		if (interpreterManagerText === SELECT_KERNEL_TEXT) {
+		// also if the wrong kernel has shown up, select the proper kernel
+		if (interpreterManagerText === SELECT_KERNEL_TEXT || !interpreterManagerText.includes(desiredKernel)) {
 			await this.code.waitAndClick(KERNEL_ACTION);
 			await this.quickinput.waitForQuickInputOpened();
 			// depending on random timing, it may or may not be necessary to select the kernel group

--- a/test/automation/src/positron/positronPlots.ts
+++ b/test/automation/src/positron/positronPlots.ts
@@ -59,7 +59,7 @@ export class PositronPlots {
 	}
 
 	async waitForWebviewPlot(selector: string, state: 'attached' | 'visible' = 'visible') {
-		await this.getWebviewPlotLocator(selector).waitFor({ state });
+		await this.getWebviewPlotLocator(selector).waitFor({ state, timeout: 30000 });
 	}
 
 	async clearPlots() {

--- a/test/smoke/src/areas/positron/connections/dbConnections.test.ts
+++ b/test/smoke/src/areas/positron/connections/dbConnections.test.ts
@@ -39,18 +39,19 @@ export function setup(logger: Logger) {
 
 			it('Python - SQLite DB Connection [C628636]', async function () {
 
-
 				const app = this.app as Application;
 				await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'chinook-db-py', 'sqlite.py'));
 				await app.workbench.quickaccess.runCommand('python.execInConsole');
 
-				logger.log('Opening connections pane');
-				await app.workbench.positronVariables.doubleClickVariableRow('conn');
-				// in Python this will open all table connections, so should be fine.
-				await app.workbench.positronConnections.openTree();
+				await expect(async () => {
+					logger.log('Opening connections pane');
+					await app.workbench.positronVariables.doubleClickVariableRow('conn');
+					// in Python this will open all table connections, so should be fine.
+					await app.workbench.positronConnections.openTree();
 
-				// click in reverse order to avoid scrolling issues
-				await app.workbench.positronConnections.hasConnectionNodes(['albums']);
+					// click in reverse order to avoid scrolling issues
+					await app.workbench.positronConnections.hasConnectionNodes(['albums']);
+				}).toPass({ timeout: 60000 });
 
 				// disconnect icon appearance requires hover
 				await app.workbench.positronConnections.pythonConnectionOpenState.hover();
@@ -96,7 +97,7 @@ export function setup(logger: Logger) {
 					// in R, the opneTree command only shows all tables, we click to also
 					// display fields
 					await app.workbench.positronConnections.openConnectionsNodes(tables);
-				}).toPass();
+				}).toPass({ timeout: 60000 });
 
 				// disconnect icon appearance requires hover
 				await app.workbench.positronConnections.rConnectionOpenState.hover();
@@ -127,7 +128,7 @@ export function setup(logger: Logger) {
 				}
 
 				await expect(async () => {
-				// now we add a dataframe to that connection
+					// now we add a dataframe to that connection
 					await app.workbench.positronConsole.executeCode(
 						'R',
 						`DBI::dbWriteTable(con, "mtcars", mtcars)`,

--- a/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
+++ b/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
@@ -35,16 +35,23 @@ export function setup(logger: Logger) {
 			it('Python - Basic notebook creation and execution (code) [C628631] #pr', async function () {
 				const app = this.app as Application;
 
-				await app.workbench.positronNotebooks.createNewNotebook();
-
-				await app.workbench.positronNotebooks.selectInterpreter('Python Environments', process.env.POSITRON_PY_VER_SEL!);
-
-				await app.workbench.positronNotebooks.addCodeToFirstCell('eval("8**2")');
 
 				await expect(async () => {
-					await app.workbench.positronNotebooks.executeCodeInCell();
-					expect(await app.workbench.positronNotebooks.getPythonCellOutput()).toBe('64');
-				}).toPass({ timeout: 60000 });
+
+					try {
+						await app.workbench.positronNotebooks.createNewNotebook();
+
+						await app.workbench.positronNotebooks.selectInterpreter('Python Environments', process.env.POSITRON_PY_VER_SEL!);
+
+						await app.workbench.positronNotebooks.addCodeToFirstCell('eval("8**2")');
+
+						await app.workbench.positronNotebooks.executeCodeInCell();
+
+						expect(await app.workbench.positronNotebooks.getPythonCellOutput()).toBe('64');
+					} catch (e) {
+						await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
+					}
+				}).toPass({ timeout: 120000 });
 
 			});
 

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -449,10 +449,10 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	// if (!opts.web && !opts.remote) { setupLaunchTests(logger); }
 	setupVariablesTest(logger);
 	setupDataExplorerTest(logger);
-	if (!opts.web) { setupDataExplorer100x100Test(logger); }
-	if (!opts.web) { setupPlotsTest(logger); }
-	if (!opts.web) { setupPythonConsoleTest(logger); }
-	if (!opts.web) { setupRConsoleTest(logger); }
+	if (!opts.web) { setupDataExplorer100x100Test(logger); } // skipping for web since it's slow
+	if (!opts.web) { setupPlotsTest(logger); } // bugs 4800 & 4804
+	setupPythonConsoleTest(logger);
+	setupRConsoleTest(logger);
 	if (!opts.web) { setupLargeDataFrameTest(logger); }
 	if (!opts.web) { setupNotebookCreateTest(logger); }
 	if (!opts.web) { setupConnectionsTest(logger); }

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -454,7 +454,7 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	setupPythonConsoleTest(logger);
 	setupRConsoleTest(logger);
 	setupLargeDataFrameTest(logger);
-	if (!opts.web) { setupNotebookCreateTest(logger); }
+	setupNotebookCreateTest(logger);
 	if (!opts.web) { setupConnectionsTest(logger); }
 	if (!opts.web) { setupNewProjectWizardTest(logger); }
 	if (!opts.web) { setupXLSXDataFrameTest(logger); }

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -453,7 +453,7 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	if (!opts.web) { setupPlotsTest(logger); } // bugs 4800 & 4804
 	setupPythonConsoleTest(logger);
 	setupRConsoleTest(logger);
-	if (!opts.web) { setupLargeDataFrameTest(logger); }
+	setupLargeDataFrameTest(logger);
 	if (!opts.web) { setupNotebookCreateTest(logger); }
 	if (!opts.web) { setupConnectionsTest(logger); }
 	if (!opts.web) { setupNewProjectWizardTest(logger); }


### PR DESCRIPTION
Enabling more web smoke tests

Also, only report Full Test Suite failures for main.
Also, retry connection test opens for python test
Also, wait for longer for webview plots
Also, more robust handling for notebookCreate.test.ts

### QA Notes

All smoke tests should pass.
