### PR TITLE
Update destructive button theme colors (give up on red foreground color)

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -595,6 +595,7 @@
 		"--vscode-positronModalDialog-buttonDisabledBackground",
 		"--vscode-positronModalDialog-buttonDisabledBorder",
 		"--vscode-positronModalDialog-buttonDisabledForeground",
+		"--vscode-positronModalDialog-buttonDestructiveBackground",
 		"--vscode-positronModalDialog-buttonDestructiveForeground",
 		"--vscode-positronModalDialog-buttonForeground",
 		"--vscode-positronModalDialog-buttonHoverBackground",

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.css
@@ -47,6 +47,7 @@
 
 .positron-modal-dialog-box .action-bar-button.destructive {
 	color: var(--vscode-positronModalDialog-buttonDestructiveForeground);
+	background-color: var(--vscode-positronModalDialog-buttonDestructiveBackground);
 }
 
 .positron-modal-dialog-box .action-bar-button:focus {

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1294,12 +1294,20 @@ export const POSITRON_MODAL_DIALOG_DEFAULT_BUTTON_FOREGROUND = registerColor('po
 	hcLight: buttonForeground
 }, localize('positronModalDialog.defaultButtonForeground', "Positron modal dialog default button foreground color."));
 
+// Positron modal dialog button destructive background color.
+export const POSITRON_MODAL_DIALOG_BUTTON_DESTRUCTIVE_BACKGROUND = registerColor('positronModalDialog.buttonDestructiveBackground', {
+	dark: buttonSecondaryBackground,
+	light: buttonSecondaryBackground,
+	hcDark: buttonSecondaryBackground,
+	hcLight: buttonSecondaryBackground
+}, localize('positronModalDialog.buttonDestructiveBackground', "Positron modal dialog button destructive background color."));
+
 // Positron modal dialog button destructive foreground color.
 export const POSITRON_MODAL_DIALOG_BUTTON_DESTRUCTIVE_FOREGROUND = registerColor('positronModalDialog.buttonDestructiveForeground', {
-	dark: errorForeground,
-	light: '#B30600',
-	hcDark: errorForeground,
-	hcLight: errorForeground
+	dark: buttonSecondaryForeground,
+	light: buttonSecondaryForeground,
+	hcDark: buttonSecondaryForeground,
+	hcLight: buttonSecondaryForeground
 }, localize('positronModalDialog.buttonDestructiveForeground', "Positron modal dialog button destructive foreground color."));
 
 // Positron modal dialog button disabled foreground color.


### PR DESCRIPTION
### Description

This PR partially addresses https://github.com/posit-dev/positron/issues/3799 by changing the foreground color and background color of **destructive** buttons.

Now, destructive buttons are drawn using:

```
color: var(--vscode-positronModalDialog-buttonDestructiveForeground);
background-color: var(--vscode-positronModalDialog-buttonDestructiveBackground);
```

Where:

`buttonDestructiveForeground` is defined to be the `buttonSecondaryForegound` theme color.
`buttonDestructiveBackground` is defined to be the `buttonSecondaryBackground` theme color.

Prior to this PR, we attempted to repurpose a "red" color (`errorForeground`) from `src/vs/workbench/common/theme.ts` for the destructive button foreground (in the dark theme, anyway). This proved to be problematic because in many custom color themes, `errorForeground` does not work well (i.e. have enough contrast) with the `buttonSecondaryBackground` color.

So, we have abandoned the idea of using a "red" color for the destructive button foreground color.

Because we have `buttonDestructiveForeground` and `buttonDestructiveBackground` theme colors, they can be themed in custom Positron themes in the future.

### QA Notes
