### PR TITLE
Fix broken Data Explorer scrollbars after resize

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.css
@@ -4,7 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 .data-explorer-panel .data-explorer {
+	min-width: 0;
+	min-height: 0;
 	display: grid;
+	overflow: hidden;
 	grid-row: data-explorer / status-bar;
 	grid-template-rows: [main-row] 1fr [end-rows];
 }
@@ -32,7 +35,10 @@
 }
 
 .data-explorer-panel .data-explorer .left-column {
+	min-width: 0;
+	min-height: 0;
 	display: grid;
+	overflow: hidden;
 	grid-row: main-row / end-rows;
 	grid-column: left-column / collapsed-left-spacer;
 }
@@ -64,7 +70,10 @@
 }
 
 .data-explorer-panel .data-explorer .right-column {
+	min-width: 0;
+	min-height: 0;
 	display: grid;
+	overflow: hidden;
 	grid-row: main-row / end-rows;
 	grid-column: right-column / end-columns;
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.css
@@ -38,7 +38,6 @@
 	min-width: 0;
 	min-height: 0;
 	display: grid;
-	overflow: hidden;
 	grid-row: main-row / end-rows;
 	grid-column: left-column / collapsed-left-spacer;
 }
@@ -73,7 +72,6 @@
 	min-width: 0;
 	min-height: 0;
 	display: grid;
-	overflow: hidden;
 	grid-row: main-row / end-rows;
 	grid-column: right-column / end-columns;
 }


### PR DESCRIPTION
### Description

This PR addresses https://github.com/posit-dev/positron/issues/4834, which was a regression, by adding `min-width: 0`, `min-height: 0`, and `overflow: hidden` styles back to the Data Explorer.

```css
.data-explorer-panel .data-explorer {
	min-width: 0;
	min-height: 0;
	display: grid;
	overflow: hidden;
	grid-row: data-explorer / status-bar;
	grid-template-rows: [main-row] 1fr [end-rows];
}

.data-explorer-panel .data-explorer .left-column {
	min-width: 0;
	min-height: 0;
	display: grid;
	grid-row: main-row / end-rows;
	grid-column: left-column / collapsed-left-spacer;
}

.data-explorer-panel .data-explorer .right-column {
	min-width: 0;
	min-height: 0;
	display: grid;
	grid-row: main-row / end-rows;
	grid-column: right-column / end-columns;
}
```

### QA Notes

Before this PR:

https://github.com/user-attachments/assets/5af8a5fa-8522-40c8-b88d-31b4b5124545

After this PR:

https://github.com/user-attachments/assets/087b8aeb-e5de-41c8-b06a-e954f29e697b