### PR TITLE
Fix overlapping test result file paths

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -189,11 +189,21 @@ jobs:
           cd ..
           rm -rf positron-license
 
-      - name: Publish Test Report
+      - name: Publish Electron Test Report
         uses: mikepenz/action-junit-report@v4
-        if: success() || failure() # always run even if the previous step fails
+        if: success() || failure()
         with:
           report_paths: "**/.build/logs/smoke-tests-electron/test-results/*results.xml"
+          check_name: "Electron Test Results"
+          token: ${{ secrets.POSITRON_GITHUB_PAT }}
+
+      - name: Publish Web Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: success() || failure()
+        with:
+          report_paths: "**/.build/logs/smoke-tests-browser/test-results/*results.xml"
+          check_name: "Web Test Results"
+          token: ${{ secrets.POSITRON_GITHUB_PAT }}
 
       - name: Set TestRail Run Title
         id: set-testrail-run-title

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -195,7 +195,7 @@ jobs:
         with:
           report_paths: "**/.build/logs/smoke-tests-electron/test-results/*results.xml"
           check_name: "Electron Test Results"
-          token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Web Test Report
         uses: mikepenz/action-junit-report@v4
@@ -203,7 +203,7 @@ jobs:
         with:
           report_paths: "**/.build/logs/smoke-tests-browser/test-results/*results.xml"
           check_name: "Web Test Results"
-          token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set TestRail Run Title
         id: set-testrail-run-title

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "smoketest-no-compile": "cd test/smoke && BUILD_ARTIFACTSTAGINGDIRECTORY=../../.build/logs/smoke-tests-electron node test/index.js",
     "smoketest-pr": "cd test/smoke && BUILD_ARTIFACTSTAGINGDIRECTORY=../../.build/logs/smoke-tests-electron TEST_FILTER=/#pr/ node test/index.js",
     "smoketest-merge-to-main": "cd test/smoke && BUILD_ARTIFACTSTAGINGDIRECTORY=../../.build/logs/smoke-tests-electron node test/index.js",
-    "smoketest-web": "cd test/smoke && BUILD_ARTIFACTSTAGINGDIRECTORY=../../.build/logs/smoke-tests-electron node test/index.js --web",
+    "smoketest-web": "cd test/smoke && BUILD_ARTIFACTSTAGINGDIRECTORY=../../.build/logs/smoke-tests-browser node test/index.js --web",
     "download-builtin-extensions": "node build/lib/builtInExtensions.js",
     "download-builtin-extensions-cg": "node build/lib/builtInExtensionsCG.js",
     "download-quarto": "node build/lib/quarto.js",


### PR DESCRIPTION
The electron and browser tests were using the same results path and thus only web tests were being report to TestRail.

Also added a run summary block for the web tests.

### QA Notes

Should see full electron run reported to testrail.
