### PR TITLE
More web test cases

### DIFF
--- a/test/smoke/src/areas/positron/console/python-console.test.ts
+++ b/test/smoke/src/areas/positron/console/python-console.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { expect } from '@playwright/test';
 import { Application, Logger, PositronPythonFixtures } from '../../../../../automation';
 import { installAllHandlers } from '../../../utils';
 
@@ -17,6 +18,11 @@ export function setup(logger: Logger) {
 
 		describe('Python Console Restart', () => {
 
+			before(async function () {
+				// Need to make console bigger to see all bar buttons
+				await this.app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+			});
+
 			beforeEach(async function () {
 
 				await PositronPythonFixtures.SetupFixtures(this.app as Application);
@@ -24,27 +30,27 @@ export function setup(logger: Logger) {
 			});
 
 			it('Verify restart button inside the console [C377918]', async function () {
-				this.retries(1);
+
 				const app = this.app as Application;
-				// Need to make console bigger to see all bar buttons
-				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
-				await app.workbench.positronConsole.barClearButton.click();
-				await app.workbench.positronConsole.barPowerButton.click();
-				await app.workbench.positronConsole.consoleRestartButton.click();
-				await app.workbench.positronConsole.waitForReady('>>>');
-				await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
-				await app.workbench.positronConsole.consoleRestartButton.isNotVisible();
+				await expect(async () => {
+					await app.workbench.positronConsole.barClearButton.click();
+					await app.workbench.positronConsole.barPowerButton.click();
+					await app.workbench.positronConsole.consoleRestartButton.click();
+					await app.workbench.positronConsole.waitForReady('>>>');
+					await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
+					await app.workbench.positronConsole.consoleRestartButton.isNotVisible();
+				}).toPass();
 			});
 
 			it('Verify restart button on console bar [C617464]', async function () {
-				this.retries(1);
+
 				const app = this.app as Application;
-				// Need to make console bigger to see all bar buttons
-				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
-				await app.workbench.positronConsole.barClearButton.click();
-				await app.workbench.positronConsole.barRestartButton.click();
-				await app.workbench.positronConsole.waitForReady('>>>');
-				await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
+				await expect(async () => {
+					await app.workbench.positronConsole.barClearButton.click();
+					await app.workbench.positronConsole.barRestartButton.click();
+					await app.workbench.positronConsole.waitForReady('>>>');
+					await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
+				}).toPass();
 			});
 
 		});

--- a/test/smoke/src/areas/positron/console/r-console.test.ts
+++ b/test/smoke/src/areas/positron/console/r-console.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { expect } from '@playwright/test';
 import { Application, Logger, PositronRFixtures } from '../../../../../automation';
 import { installAllHandlers } from '../../../utils';
 
@@ -17,6 +18,11 @@ export function setup(logger: Logger) {
 
 		describe('R Console Restart', () => {
 
+			before(async function () {
+				// Need to make console bigger to see all bar buttons
+				await this.app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+			});
+
 			beforeEach(async function () {
 
 				await PositronRFixtures.SetupFixtures(this.app as Application);
@@ -24,27 +30,25 @@ export function setup(logger: Logger) {
 			});
 
 			it('Verify restart button inside the console [C377917]', async function () {
-				this.retries(1);
 				const app = this.app as Application;
-				// Need to make console bigger to see all bar buttons
-				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
-				await app.workbench.positronConsole.barClearButton.click();
-				await app.workbench.positronConsole.barPowerButton.click();
-				await app.workbench.positronConsole.consoleRestartButton.click();
-				await app.workbench.positronConsole.waitForReady('>');
-				await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
-				await app.workbench.positronConsole.consoleRestartButton.isNotVisible();
+				await expect(async () => {
+					await app.workbench.positronConsole.barClearButton.click();
+					await app.workbench.positronConsole.barPowerButton.click();
+					await app.workbench.positronConsole.consoleRestartButton.click();
+					await app.workbench.positronConsole.waitForReady('>');
+					await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
+					await app.workbench.positronConsole.consoleRestartButton.isNotVisible();
+				}).toPass();
 			});
 
 			it('Verify restart button on console bar [C620636]', async function () {
-				this.retries(1);
 				const app = this.app as Application;
-				// Need to make console bigger to see all bar buttons
-				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
-				await app.workbench.positronConsole.barClearButton.click();
-				await app.workbench.positronConsole.barRestartButton.click();
-				await app.workbench.positronConsole.waitForReady('>');
-				await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
+				await expect(async () => {
+					await app.workbench.positronConsole.barClearButton.click();
+					await app.workbench.positronConsole.barRestartButton.click();
+					await app.workbench.positronConsole.waitForReady('>');
+					await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
+				}).toPass();
 			});
 
 		});

--- a/test/smoke/src/areas/positron/output/consoleOutputLog.test.ts
+++ b/test/smoke/src/areas/positron/output/consoleOutputLog.test.ts
@@ -34,7 +34,7 @@ export function setup(logger: Logger) {
 
 				// retry in case the console output log is slow to appear
 				await expect(async () => {
-					await app.workbench.positronOutput.openOutputPane('Console: Python');
+					await app.workbench.positronOutput.openOutputPane(process.env.POSITRON_PY_VER_SEL!);
 
 					await app.workbench.positronLayouts.enterLayout('fullSizedPanel');
 
@@ -70,7 +70,7 @@ export function setup(logger: Logger) {
 
 				// retry in case the console output log is slow to appear
 				await expect(async () => {
-					await app.workbench.positronOutput.openOutputPane('Console: R');
+					await app.workbench.positronOutput.openOutputPane(process.env.POSITRON_R_VER_SEL!);
 
 					await app.workbench.positronLayouts.enterLayout('fullSizedPanel');
 

--- a/test/smoke/src/areas/positron/top-action-bar/top-action-bar.test.ts
+++ b/test/smoke/src/areas/positron/top-action-bar/top-action-bar.test.ts
@@ -5,7 +5,7 @@
 
 import { join } from 'path';
 import { expect } from '@playwright/test';
-import { Application, Logger } from '../../../../../automation';
+import { Application, Logger, PositronUserSettingsFixtures } from '../../../../../automation';
 import { installAllHandlers } from '../../../utils';
 
 /*
@@ -16,16 +16,29 @@ export function setup(logger: Logger) {
 		// Shared before/after handling
 		installAllHandlers(logger);
 
+		let userSettings: PositronUserSettingsFixtures;
+
 		describe('Save Actions', () => {
 			before(async function () {
+				if (this.app.web) {
+					userSettings = new PositronUserSettingsFixtures(this.app);
+					await userSettings.setUserSetting(['files.autoSave', 'false']);
+				}
+			});
 
+			after(async function () {
+				if (this.app.web) {
+					await userSettings.unsetUserSettings();
+				}
 			});
 
 			it('Save and Save All both disabled when no unsaved editors are open [C656253]', async function () {
 				const app = this.app as Application;
 				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors', { keepOpen: false });
-				expect(await app.workbench.positronTopActionBar.saveButton.isDisabled()).toBeTruthy();
-				expect(await app.workbench.positronTopActionBar.saveAllButton.isDisabled()).toBeTruthy();
+				await expect(async () => {
+					expect(await app.workbench.positronTopActionBar.saveButton.isDisabled()).toBeTruthy();
+					expect(await app.workbench.positronTopActionBar.saveAllButton.isDisabled()).toBeTruthy();
+				}).toPass({ timeout: 20000 });
 			});
 
 			it('Save enabled and Save All disabled when a single unsaved file is open [C656254]', async function () {

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -468,15 +468,15 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	if (process.platform !== 'win32') { setupConsoleOutputLogTest(logger); }
 	if (process.platform !== 'win32') { setupBasicRMarkdownTest(logger); }
 	if (!opts.web && process.platform !== 'win32') { setupWelcomeTest(logger); } // web bug 4851
-	if (!opts.web && process.platform !== 'win32') { setupConsoleHistoryTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupShinyTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupFastExecutionTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupTestExplorerTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupRPKgDevelopment(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupInterpreterDropdownTest(logger); }
+	if (process.platform !== 'win32') { setupConsoleHistoryTest(logger); }
+	if (!opts.web && process.platform !== 'win32') { setupShinyTest(logger); } // frame location is diff on web
+	if (process.platform !== 'win32') { setupFastExecutionTest(logger); }
+	if (!opts.web && process.platform !== 'win32') { setupTestExplorerTest(logger); } // test results too small in web
+	if (process.platform !== 'win32') { setupRPKgDevelopment(logger); }
+	if (process.platform !== 'win32') { setupInterpreterDropdownTest(logger); }
 	if (!opts.web && process.platform !== 'win32') { setupViewersTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupVeryLargeDataFrameTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupGraphTrendTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupQuartoTest(logger); }
+	if (!opts.web && process.platform !== 'win32') { setupVeryLargeDataFrameTest(logger); } // frame location is diff on web
+	if (process.platform !== 'win32') { setupGraphTrendTest(logger); }
+	if (process.platform !== 'win32') { setupQuartoTest(logger); }
 	// --- End Positron ---
 });

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -450,24 +450,24 @@ describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	setupVariablesTest(logger);
 	if (process.platform !== 'win32') { setupDataExplorerTest(logger); }
 	if (!opts.web && process.platform !== 'win32') { setupDataExplorer100x100Test(logger); } // skipping for web since it's slow
-	if (!opts.web && process.platform !== 'win32') { setupPlotsTest(logger); } // bugs 4800 & 4804
-	if (!opts.web && process.platform !== 'win32') { setupPythonConsoleTest(logger); }
+	if (!opts.web && process.platform !== 'win32') { setupPlotsTest(logger); } // web bugs 4800 & 4804
+	if (process.platform !== 'win32') { setupPythonConsoleTest(logger); }
 	if (process.platform !== 'win32') { setupRConsoleTest(logger); }
 	if (process.platform !== 'win32') { setupLargeDataFrameTest(logger); }
 	if (process.platform !== 'win32') { setupNotebookCreateTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupConnectionsTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupNewProjectWizardTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupXLSXDataFrameTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupHelpTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupClipboardTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupTopActionBarTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupLayoutTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupNotebookVariablesTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupConsoleInputTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupConsoleANSITest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupConsoleOutputLogTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupBasicRMarkdownTest(logger); }
-	if (!opts.web && process.platform !== 'win32') { setupWelcomeTest(logger); }
+	if (process.platform !== 'win32') { setupConnectionsTest(logger); }
+	if (!opts.web && process.platform !== 'win32') { setupNewProjectWizardTest(logger); } // web bug 4840
+	if (process.platform !== 'win32') { setupXLSXDataFrameTest(logger); }
+	if (!opts.web && process.platform !== 'win32') { setupHelpTest(logger); } // web bug 4847
+	if (!opts.web && process.platform !== 'win32') { setupClipboardTest(logger); } // has an "allow paste" dialog & typeToConsole is flaky
+	if (process.platform !== 'win32') { setupTopActionBarTest(logger); }
+	if (process.platform !== 'win32') { setupLayoutTest(logger); }
+	if (process.platform !== 'win32') { setupNotebookVariablesTest(logger); }
+	if (process.platform !== 'win32') { setupConsoleInputTest(logger); }
+	if (!opts.web && process.platform !== 'win32') { setupConsoleANSITest(logger); } // web bug 4847
+	if (process.platform !== 'win32') { setupConsoleOutputLogTest(logger); }
+	if (process.platform !== 'win32') { setupBasicRMarkdownTest(logger); }
+	if (!opts.web && process.platform !== 'win32') { setupWelcomeTest(logger); } // web bug 4851
 	if (!opts.web && process.platform !== 'win32') { setupConsoleHistoryTest(logger); }
 	if (!opts.web && process.platform !== 'win32') { setupShinyTest(logger); }
 	if (!opts.web && process.platform !== 'win32') { setupFastExecutionTest(logger); }


### PR DESCRIPTION
Enabling more web smoke tests.

Remaining tests that are not enabled for web are commented with issue number or note.

Also, added better handling for console tests and conditional (on web) turn off of auto save for top action bar tests.

### QA Notes

All smoke tests pass.
