### PR TITLE
Bump minimum renv version to 1.0.9

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -638,6 +638,6 @@
       "ark": "0.1.140"
     },
     "minimumRVersion": "4.2.0",
-    "minimumRenvVersion": "1.0.7"
+    "minimumRenvVersion": "1.0.8"
   }
 }

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -638,6 +638,6 @@
       "ark": "0.1.140"
     },
     "minimumRVersion": "4.2.0",
-    "minimumRenvVersion": "1.0.8"
+    "minimumRenvVersion": "1.0.9"
   }
 }


### PR DESCRIPTION
Addresses #3439 

### QA Notes

If you have renv < 1.0.8 installed and trigger the `"r.renvInit"` command (via the New Project Wizard or directly) you will see:

![Screenshot 2024-09-30 at 3 28 20 PM](https://github.com/user-attachments/assets/3ae90841-c765-4abf-bded-a79e26be26f5)

