### PR TITLE
Disable retries globally for smoke tests

### DIFF
--- a/test/smoke/test/positronIndex.js
+++ b/test/smoke/test/positronIndex.js
@@ -75,7 +75,7 @@ function getMochaOptions(opts) {
 			spec: '-',  // Console output
 			xunit: REPORT_PATH,
 		},
-		retries: 1,
+		retries: 0,
 	};
 }
 


### PR DESCRIPTION
Retries might be creating very confusing traces, so disabling globally for a windows workflow rerun.

### QA Notes

All smoke tests pass
