### PR TITLE
Fixed layout issue for dataexplorer test on windows

### DIFF
--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -338,7 +338,7 @@ df2 = pd.DataFrame(data)`;
 		});
 	});
 
-	describe('R Data Explorer #web', () => {
+	describe('R Data Explorer', () => {
 
 		before(async function () {
 			await PositronRFixtures.SetupFixtures(this.app as Application);
@@ -365,7 +365,7 @@ df2 = pd.DataFrame(data)`;
 				await app.code.driver.getLocator('.label-name:has-text("Data: Data_Frame")').innerText();
 			}).toPass();
 
-			await app.workbench.positronSideBar.closeSecondarySideBar();
+			await app.workbench.positronLayouts.enterLayout('notebook');
 
 			await expect(async () => {
 				const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
@@ -376,8 +376,7 @@ df2 = pd.DataFrame(data)`;
 				expect(tableData.length).toBe(3);
 			}).toPass({ timeout: 60000 });
 
-			await app.workbench.quickaccess.runCommand('workbench.action.restorePanel');
-			await app.workbench.quickaccess.runCommand('workbench.action.toggleSidebarVisibility');
+			await app.workbench.positronLayouts.enterLayout('stacked');
 
 
 		});


### PR DESCRIPTION
### Intent
Fixed failing data explorer test on windows CI

### Approach
R test was missing command to go into `notebook` layout

I also removed an extraneous #web identifier, as it was covered by the parent describe block.

### QA Notes

All tests in CI should pass

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
