### PR TITLE
always send html plot content to a proxy server

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -161,14 +161,9 @@ export class UiClientInstance extends Disposable {
 
 		// Wrap the ShowHtmlFile event to start a proxy server for the HTML file.
 		this._register(this._comm.onDidShowHtmlFile(async e => {
-			let uri: URI;
 			try {
-				if (e.path.endsWith('.html') || e.path.endsWith('.htm')) {
-					// Start an HTML proxy server for the file
-					uri = await this.startHtmlProxyServer(e.path);
-				} else {
-					uri = URI.parse(e.path);
-				}
+				// Start an HTML proxy server for the file
+				const uri = await this.startHtmlProxyServer(e.path);
 
 				if (e.is_plot) {
 					// Check the configuration to see if we should open the plot


### PR DESCRIPTION
### Description

A follow-up to #4806 to revert `src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts` back to using a proxy for interactive plots. A generic HTTP proxy was added via #4855, so server plots can be proxied appropriately in Server Web and Workbench.

Related to
- https://github.com/posit-dev/positron/issues/4804
- https://github.com/posit-dev/positron/issues/4274
- https://github.com/posit-dev/positron/issues/4245

### QA Notes

On Server Web and Workbench, running the following in the corresponding consoles:

##### Python

`pip install plotly nbformat pandas`

```python
import plotly.express as px
fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
fig.show()
```

##### R

`install.packages('plotly')`

```r
library(plotly)
fig <- plot_ly(data = iris, x = ~Sepal.Length, y = ~Petal.Length)
fig
```

#### Expected Result

The corresponding interactive plots should display in the plots pane and be interact-able!


