### PR TITLE
Discover (non-current) R installations from Windows registry

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -480,7 +480,7 @@ async function findCurrentRBinaryFromRegistry(): Promise<string | undefined> {
 				const key = Registry.GetStringRegKey(hive, R64_KEY, 'InstallPath');
 				if (key) {
 					installPath = key;
-					LOGGER.info(`Registry key ${hive}\\${R64_KEY}\\InstallPath reports an R installation at ${key}`);
+					LOGGER.info(`Registry key ${hive}\\${R64_KEY}\\InstallPath reports the current R installation is at ${key}`);
 					break;
 				}
 			} catch { }

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -384,14 +384,23 @@ async function discoverRegistryBinaries(): Promise<string[]> {
 	return binPaths;
 }
 
+let cachedRBinary: string | undefined;
+
 export async function findCurrentRBinary(): Promise<string | undefined> {
+	if (cachedRBinary !== undefined) {
+		return cachedRBinary;
+	}
+
 	if (os.platform() === 'win32') {
 		const registryBinary = await findCurrentRBinaryFromRegistry();
 		if (registryBinary) {
+			cachedRBinary = registryBinary;
 			return registryBinary;
 		}
 	}
-	return findRBinaryFromPATH();
+
+	cachedRBinary = await findRBinaryFromPATH();
+	return cachedRBinary;
 }
 
 async function findRBinaryFromPATH(): Promise<string | undefined> {

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -28,6 +28,18 @@ export const R_DOCUMENT_SELECTORS = [
 ];
 
 /**
+ * Enum represents the source from which an R binary was discovered.
+ */
+enum BinarySource {
+	/* eslint-disable-next-line @typescript-eslint/naming-convention */
+	HQ = 'HQ',
+	adHoc = 'ad hoc locations',
+	registry = 'Windows registry',
+	/* eslint-disable-next-line @typescript-eslint/naming-convention */
+	PATH = 'PATH'
+}
+
+/**
  * Discovers R language runtimes for Positron; implements
  * positron.LanguageRuntimeDiscoverer.
  *


### PR DESCRIPTION
Addresses #4820

The goal is to discover non-current R installations from the Windows registry. These were previously not discovered by Positron if the installation also happened to be in a nonstandard location (and was not on the PATH).

### QA Notes

The bare minimum would be to ensure that your current R installations continue to be discovered, i.e. that this PR hasn't broken anything. That is the most one could do on non-Windows.

More ambitious QA, which I have done, on Windows:

* Install R at a non-standard location. This will have to be via the CRAN installer since rig doesn't give you any choice about this. Therefore I removed my rig-installed released version of R and re-installed released R with the CRAN installer below `C:/nonstandardRLocation/`. Make sure the box to write to the registry is checked (that is the default).
* Now use rig (or other means) to make *some other R version* the current version. In my setup, R 4.2.3 and 4.3.3 are good candidates for the new current version of R, e.g. `rig default 4.3.3`.
* Fire up Positron. You should see the released version of R, installed at `C:/nonstandardRLocation/R-4.4.1` available to you in the interpreter drop down after this PR. In a release build prior to this PR, that R installation would not be picked up by Positron.

Other things that can be noticed in the Positron R output channel:

* Early on, you are likely to see the registry being consulted re: the current R version:

  ```
  2024-10-02 16:51:34.246 [info] Registry key HKEY_LOCAL_MACHINE\SOFTWARE\R-core\R64\InstallPath reports the current R installation is at C:\Program Files\R\R-4.2.3
  2024-10-02 16:51:34.246 [info] Identified the current R binary: C:\Program Files\R\R-4.2.3\bin\x64\R.exe
  ```
  This is happening when we validate metadata of the last-used R runtime. The logging has been tightened up and this finding is also now cached, which eliminates some repetitive discovery and logging that happens when we do the main, broad search for R installations.
* These are completely new registry findings re: R installations that may or may not be the current one:

  ```
  2024-10-02 16:51:34.573 [info] Registry key HKEY_LOCAL_MACHINE\SOFTWARE\R-core\R64\4.2.3\InstallPath reports an R installation at C:\Program Files\R\R-4.2.3
  2024-10-02 16:51:34.573 [info] Registry key HKEY_LOCAL_MACHINE\SOFTWARE\R-core\R64\4.3.3\InstallPath reports an R installation at C:\Program Files\R\R-4.3.3
  2024-10-02 16:51:34.573 [info] Registry key HKEY_LOCAL_MACHINE\SOFTWARE\R-core\R64\4.4.1\InstallPath reports an R installation at C:\nonstandardRLocation\R-4.4.1
  2024-10-02 16:51:34.573 [info] Registry key HKEY_LOCAL_MACHINE\SOFTWARE\R-core\R64\4.5.0 Pre-release\InstallPath reports an R installation at C:\Program Files\R\R-devel
  ```
  The installations below `C:\Program Files\R` would be discovered anyway, because they are in a well-known place for this OS. What's new is that we find `C:\nonstandardRLocation\R-4.4.1`.
* We no longer message about registry keys that are not found, because folks were regularly misinterpreting that as some sort of error, whereas it's expected that we might check for keys that aren't defined.
