### PR TITLE
smoke tests: add ability to target build

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -170,7 +170,7 @@ jobs:
           POSITRON_PY_VER_SEL: 3.10.12
           POSITRON_R_VER_SEL: 4.4.0
         id: electron-smoke-tests
-        run: DISPLAY=:10 yarn smoketest-all --tracing --parallel --jobs 2
+        run: DISPLAY=:10 yarn smoketest-all --tracing --parallel --jobs 2 --skip-cleanup
 
       - name: Run Web Smoke Tests
         if: always()

--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -125,7 +125,7 @@ jobs:
           POSITRON_PY_VER_SEL: 3.10.12
           POSITRON_R_VER_SEL: 4.4.0
         id: electron-smoke-tests
-        run: DISPLAY=:10 yarn ${{ env.SMOKETEST_TARGET }} --tracing --parallel --jobs 2
+        run: DISPLAY=:10 yarn ${{ env.SMOKETEST_TARGET }} --tracing --parallel --jobs 2 --skip-cleanup
 
       - name: Convert XUnit to JUnit
         id: xunit-to-junit

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -215,6 +215,16 @@ The following smoketest scripts are currently available:
 - `smoketest-win`: Runs tests tagged with `#win` (Windows)
 - `smoketest-pr`: Runs tests tagged with `#pr`
 
+#### Target a Positron Build
+
+You can specify a custom build of Positron to run your tests against using the `--build` option. This allows you to point to a local installation or a specific build of the application.
+
+```bash
+yarn smoketest-pr --build /Applications/Positron.app --parallel --jobs 3
+```
+
+**Note:** During the setup phase, the script will automatically detect and display the version of Positron being tested. This helps verify that the correct build is being used.
+
 ## Test Project
 
 Before any of the tests start executing the test framework clones down the [QA Content Examples](https://github.com/posit-dev/qa-example-content) repo.  This repo contains R and Python files that are run by the automated tests and also includes data files (such as Excel, SQLite, & parquet) that support the test scripts.  If you make additions to QA Content Examples for a test, please be sure that the data files are free to use in a public repository.

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -17,9 +17,8 @@ describe('Data Explorer #web #win', () => {
 	describe('Python Pandas Data Explorer #pr', () => {
 
 		before(async function () {
-
+			this.timeout(120000);
 			await PositronPythonFixtures.SetupFixtures(this.app as Application);
-
 		});
 
 		after(async function () {
@@ -204,9 +203,8 @@ df2 = pd.DataFrame(data)`;
 	// https://github.com/posit-dev/positron/issues/4663
 	describe('Python Polars Data Explorer #pr', () => {
 		before(async function () {
-
+			this.timeout(120000);
 			await PositronPythonFixtures.SetupFixtures(this.app as Application);
-
 		});
 
 		after(async function () {
@@ -341,8 +339,8 @@ df2 = pd.DataFrame(data)`;
 	describe('R Data Explorer', () => {
 
 		before(async function () {
+			this.timeout(120000);
 			await PositronRFixtures.SetupFixtures(this.app as Application);
-
 		});
 
 		it('R - Verifies basic data explorer functionality [C609620] #pr', async function () {

--- a/test/smoke/src/positronUtils.ts
+++ b/test/smoke/src/positronUtils.ts
@@ -114,7 +114,7 @@ function setTestDefaults(logger: Logger, logsRootPath: string, crashesRootPath: 
  * @param logsRootPath the root path for the logs
  * @returns Logger instance
  */
-export function createLogger(logsRootPath: string): Logger {
+export function createLogger(logsRootPath: string, logsFileName = `smoke-test-runner.log`): Logger {
 	const loggers: Logger[] = [];
 
 	if (OPTS.verbose) {
@@ -124,7 +124,7 @@ export function createLogger(logsRootPath: string): Logger {
 	fs.rmSync(logsRootPath, { recursive: true, force: true, maxRetries: 3 });
 	mkdirp.sync(logsRootPath);
 
-	loggers.push(new FileLogger(path.join(logsRootPath, `smoke-test-runner.log`)));
+	loggers.push(new FileLogger(path.join(logsRootPath, logsFileName)));
 
 	return new MultiLogger(loggers);
 }

--- a/test/smoke/src/positronUtils.ts
+++ b/test/smoke/src/positronUtils.ts
@@ -6,15 +6,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as mkdirp from 'mkdirp';
-// import * as vscodetest from '@vscode/test-electron';
-// import fetch from 'node-fetch';
 import { MultiLogger, ConsoleLogger, FileLogger, Logger, } from '../../automation';
 import { installAllHandlers, } from './utils';
 
 export const ROOT_PATH = path.join(__dirname, '..', '..', '..');
 const TEST_DATA_PATH = process.env.TEST_DATA_PATH || 'TEST_DATA_PATH not set';
-const WORKSPACE_PATH = path.join(TEST_DATA_PATH, 'qa-example-content');
-const EXTENSIONS_PATH = path.join(TEST_DATA_PATH, 'extensions-dir');
+const WORKSPACE_PATH = process.env.WORKSPACE_PATH || 'WORKSPACE_PATH not set';
+const EXTENSIONS_PATH = process.env.EXTENSIONS_PATH || 'EXTENSIONS_PATH not set';
 const LOGS_DIR = process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || 'smoke-tests-default';
 
 const asBoolean = (value: string | undefined): boolean | undefined => {
@@ -82,6 +80,13 @@ function getTestFileName(): string {
 	}
 }
 
+/**
+ * Set the default options for the test suite.
+ *
+ * @param logger the logger instance for the test suite
+ * @param logsRootPath  the root path for the logs
+ * @param crashesRootPath the root path for the crashes
+ */
 function setTestDefaults(logger: Logger, logsRootPath: string, crashesRootPath: string) {
 	before(async function () {
 		this.defaultOptions = {
@@ -103,6 +108,12 @@ function setTestDefaults(logger: Logger, logsRootPath: string, crashesRootPath: 
 	});
 }
 
+/**
+ * Create a logger instance.
+ *
+ * @param logsRootPath the root path for the logs
+ * @returns Logger instance
+ */
 export function createLogger(logsRootPath: string): Logger {
 	const loggers: Logger[] = [];
 

--- a/test/smoke/test/positronIndex.js
+++ b/test/smoke/test/positronIndex.js
@@ -7,9 +7,9 @@
 'use strict';
 
 // Node.js core modules
-const cp = require('child_process');
 const fs = require('fs');
 const os = require('os');
+const cp = require('child_process');
 const path = require('path');
 const { join } = require('path');
 
@@ -18,24 +18,105 @@ const Mocha = require('mocha');
 const minimist = require('minimist');
 const mkdirp = require('mkdirp');
 const rimraf = require('rimraf');
+const vscodetest = require('@vscode/test-electron');
+
+// Internal modules
+const { createLogger, ROOT_PATH } = require('../out/positronUtils');
+const { retry } = require('../out/utils');
+const { getBuildVersion, measureAndLog, getBuildElectronPath, getDevElectronPath } = require('../../automation/out');
 
 // Constants
 const REPORT_PATH = join(process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || '', 'test-results/xunit-results.xml');
-console.log('Reporting to -->', REPORT_PATH);
 const TEST_DATA_PATH = join(os.tmpdir(), 'vscsmoke');
 const WORKSPACE_PATH = join(TEST_DATA_PATH, 'qa-example-content');
 const EXTENSIONS_PATH = join(TEST_DATA_PATH, 'extensions-dir');
 
-// Parse command-line arguments
-const opts = minimist(process.argv.slice(2));
-
 // Set environment variables based on options
-configureEnvVarsFromOptions(opts);
+const OPTS = minimist(process.argv.slice(2));
+configureEnvVarsFromOptions(OPTS);
+
+// Define a logger instance for `test-setup`
+const logsRootPath = path.join(ROOT_PATH, '.build', 'logs', 'test-setup');
+const logger = createLogger(logsRootPath);
+let version;
 
 // Main execution flow
-prepareTestDataDirectory();
-cloneTestRepo();
-runMochaTests();
+(async function main() {
+	await prepareTestEnv();
+	cloneTestRepo();
+	runMochaTests();
+})();
+
+/**
+ * Prepares the test environment for Electron or Web smoke tests.
+ */
+async function prepareTestEnv() {
+	try {
+		initializeTestEnvironment(logger);
+		console.log('Test environment setup completed successfully.');
+
+		// Ensure the code is stable before running tests
+		if (!OPTS.web && !OPTS.remote && OPTS.build) {
+			// Only enabled when running with --build and not in web or remote
+			version = getBuildVersion(OPTS.build);
+			console.log('!!!', TEST_DATA_PATH, version);
+			await ensureStableCode(TEST_DATA_PATH, logger, OPTS);
+		}
+
+		prepareTestDataDirectory();
+	} catch (error) {
+		console.error('Failed to set up the test environment:', error);
+		process.exit(1);
+	}
+}
+
+/**
+ * Configures environment variables based on parsed options.
+ */
+function configureEnvVarsFromOptions(opts) {
+	const envVars = {
+		BUILD: opts['build'] || '',
+		HEADLESS: opts['headless'] || '',
+		PARALLEL: opts['parallel'] || '',
+		REMOTE: opts['remote'] || '',
+		TRACING: opts['tracing'] || '',
+		VERBOSE: opts['verbose'] || '',
+		WEB: opts['web'] || '',
+		WIN: opts['win'] || '',
+		PR: opts['pr'] || '',
+		EXTENSIONS_PATH: EXTENSIONS_PATH,
+		WORKSPACE_PATH: WORKSPACE_PATH,
+		TEST_DATA_PATH: TEST_DATA_PATH,
+		REPORT_PATH: REPORT_PATH,
+	};
+	Object.assign(process.env, envVars);
+}
+
+/**
+ * Runs Mocha tests.
+ */
+function runMochaTests() {
+	const mocha = new Mocha(getMochaOptions(OPTS));
+	applyTestFilters(mocha);
+
+	const testFiles = findTestFilesRecursive(path.resolve('out/areas/positron'));
+	testFiles.forEach(file => mocha.addFile(file));
+
+	mocha.run(failures => {
+		if (failures) {
+			console.log(getFailureLogs());
+		} else {
+			console.log('All tests passed.');
+		}
+		cleanupTestData(err => {
+			if (err) {
+				console.log('Error cleaning up test data:', err);
+			} else {
+				process.exit(failures ? 1 : 0);
+			}
+		});
+	});
+}
 
 /**
  * Configures environment variables based on parsed options.
@@ -113,16 +194,16 @@ function prepareTestDataDirectory() {
 function cloneTestRepo() {
 	const testRepoUrl = 'https://github.com/posit-dev/qa-example-content.git';
 
-	if (opts['test-repo']) {
-		console.log('Copying test project repository from:', opts['test-repo']);
+	if (OPTS['test-repo']) {
+		console.log('Copying test project repository from:', OPTS['test-repo']);
 		// Remove the existing workspace path if the option is provided
 		rimraf.sync(WORKSPACE_PATH);
 
 		// Copy the repository based on the platform (Windows vs. non-Windows)
 		if (process.platform === 'win32') {
-			cp.execSync(`xcopy /E "${opts['test-repo']}" "${WORKSPACE_PATH}\\*"`);
+			cp.execSync(`xcopy /E "${OPTS['test-repo']}" "${WORKSPACE_PATH}\\*"`);
 		} else {
-			cp.execSync(`cp -R "${opts['test-repo']}" "${WORKSPACE_PATH}"`);
+			cp.execSync(`cp -R "${OPTS['test-repo']}" "${WORKSPACE_PATH}"`);
 		}
 	} else {
 		// If no test-repo is specified, clone the repository if it doesn't exist
@@ -178,41 +259,6 @@ function getFailureLogs() {
 }
 
 /**
- * Runs the Mocha tests and cleans up test data when done.
- */
-function runMochaTests() {
-	const mocha = new Mocha(getMochaOptions(opts));
-	applyTestFilters(mocha);
-	// mocha.dryRun();
-
-	// Find all test files recursively starting from `testDirPath`
-	const testDirPath = path.resolve('out/areas/positron');
-	const testFiles = findTestFilesRecursive(testDirPath);
-
-	// Add each test file to Mocha
-	testFiles.forEach(file => mocha.addFile(file));
-
-	// Run the tests
-	mocha.run(failures => {
-		// Handle test results
-		if (failures) {
-			console.log(getFailureLogs());
-		} else {
-			console.log('All tests passed.');
-		}
-
-		// Cleanup test data and handle exit
-		cleanupTestData(err => {
-			if (err) {
-				console.log('Error cleaning up test data:', err);
-			} else {
-				process.exit(failures ? 1 : 0);  // Exit based on test results
-			}
-		});
-	});
-}
-
-/**
  * Recursively finds all test files in child directories.
  */
 function findTestFilesRecursive(dirPath) {
@@ -245,4 +291,121 @@ function cleanupTestData(callback) {
 		console.log('Test data cleaned up successfully.');
 		callback(null);
 	});
+}
+
+/**
+ * Parses the version string into its major, minor, and patch components.
+ */
+function parseVersion(version) {
+	const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+	if (!match) {
+		throw new Error(`Invalid version format: ${version}`);
+	}
+	const [, major, minor, patch] = match;
+	return { major: parseInt(major), minor: parseInt(minor), patch: parseInt(patch) };
+}
+
+/**
+ * Ensures a stable version of VSCode is downloaded if not already available.
+ */
+async function ensureStableCode(testDataPath, logger, opts) {
+	let stableCodePath = opts['stable-build'];
+
+	// Ensure that the `vscsmoke` folder exists before proceeding
+	mkdirp.sync(testDataPath);
+
+	if (!stableCodePath) {
+		const current = parseVersion(version);  // Use version declared in main
+		const versionsReq = await retry(() => measureAndLog(() => fetch('https://update.code.visualstudio.com/api/releases/stable'), 'versionReq', logger), 1000, 20);
+
+		if (!versionsReq.ok) {
+			throw new Error('Could not fetch releases from update server');
+		}
+
+		const versions = await measureAndLog(() => versionsReq.json(), 'versionReq.json()', logger);
+		const stableVersion = versions.find(raw => {
+			const version = parseVersion(raw);
+			return version.major < current.major || (version.major === current.major && version.minor < current.minor);
+		});
+
+		if (!stableVersion) {
+			throw new Error(`Could not find suitable stable version for ${version}`);
+		}
+
+		logger.log(`Found VS Code v${version}, downloading previous VS Code version ${stableVersion}...`);
+
+		const stableCodeDestination = path.join(testDataPath, 's');
+		const stableCodeExecutable = await retry(() => measureAndLog(() => vscodetest.download({
+			cachePath: stableCodeDestination,
+			version: stableVersion,
+			extractSync: true,
+		}), 'download stable code', logger), 1000, 3);
+
+		stableCodePath = path.dirname(stableCodeExecutable);
+	}
+
+	if (!fs.existsSync(stableCodePath)) {
+		throw new Error(`Cannot find Stable VSCode at ${stableCodePath}.`);
+	}
+
+	logger.log(`Using stable build ${stableCodePath} for migration tests`);
+	opts['stable-build'] = stableCodePath;
+}
+
+/**
+ * Sets up the test environment for Electron or Web smoke tests.
+ */
+function initializeTestEnvironment(logger) {
+	//
+	// #### Electron Smoke Tests ####
+	//
+
+	if (!OPTS.web) {
+		let testCodePath = OPTS.build;
+		let electronPath;
+
+		if (testCodePath) {
+			electronPath = getBuildElectronPath(testCodePath);
+			version = getBuildVersion(testCodePath);
+		} else {
+			testCodePath = getDevElectronPath();
+			electronPath = testCodePath;
+			process.env.VSCODE_REPOSITORY = ROOT_PATH;
+			process.env.VSCODE_DEV = '1';
+			process.env.VSCODE_CLI = '1';
+		}
+
+		if (!fs.existsSync(electronPath || '')) {
+			throw new Error(`Cannot find VSCode at ${electronPath}. Please run VSCode once first (scripts/code.sh, scripts\\code.bat) and try again.`);
+		}
+
+		if (OPTS.remote) {
+			logger.log(`Running desktop remote smoke tests against ${electronPath}`);
+		} else {
+			logger.log(`Running desktop smoke tests against ${electronPath}`);
+		}
+	}
+
+	//
+	// #### Web Smoke Tests ####
+	//
+	else {
+		const testCodeServerPath = OPTS.build || process.env.VSCODE_REMOTE_SERVER_PATH;
+
+		if (typeof testCodeServerPath === 'string') {
+			if (!fs.existsSync(testCodeServerPath)) {
+				throw new Error(`Cannot find Code server at ${testCodeServerPath}.`);
+			} else {
+				logger.log(`Running web smoke tests against ${testCodeServerPath}`);
+			}
+		}
+
+		if (!testCodeServerPath) {
+			process.env.VSCODE_REPOSITORY = ROOT_PATH;
+			process.env.VSCODE_DEV = '1';
+			process.env.VSCODE_CLI = '1';
+
+			logger.log(`Running web smoke out of sources`);
+		}
+	}
 }

--- a/test/smoke/test/positronIndex.js
+++ b/test/smoke/test/positronIndex.js
@@ -34,7 +34,7 @@ configureEnvVarsFromOptions(OPTS);
 // Internal modules
 const { createLogger, ROOT_PATH } = require('../out/positronUtils');
 const { retry } = require('../out/utils');
-const { getBuildVersion, measureAndLog, getBuildElectronPath, getDevElectronPath } = require('../../automation/out');
+const { measureAndLog, getBuildElectronPath, getDevElectronPath } = require('../../automation/out');
 
 // Define a logger instance for `test-setup`
 const logsRootPath = path.join(ROOT_PATH, '.build', 'logs', 'test-setup');
@@ -98,7 +98,7 @@ function runMochaTests() {
 	testFiles.forEach(file => mocha.addFile(file));
 
 	// Run the Mocha tests
-	mocha.run(failures => {
+	const runner = mocha.run(failures => {
 		if (failures) {
 			console.log(getFailureLogs());
 		} else {
@@ -111,6 +111,12 @@ function runMochaTests() {
 				process.exit(failures ? 1 : 0);
 			}
 		});
+	});
+
+	// Attach the 'retry' event listener to the runner
+	runner.on('retry', (test, err) => {
+		console.error('Test failed, retrying:', test.fullTitle());
+		console.error(err);
 	});
 }
 

--- a/test/smoke/test/positronIndex.js
+++ b/test/smoke/test/positronIndex.js
@@ -42,8 +42,8 @@ const logger = createLogger(logsRootPath);
 let version;
 
 // Main execution flow
-(async function main() {
-	await prepareTestEnv();
+(function main() {
+	prepareTestEnv();
 	cloneTestRepo();
 	runMochaTests();
 })();
@@ -51,13 +51,13 @@ let version;
 /**
  * Prepares the test environment for Electron or Web smoke tests.
  */
-async function prepareTestEnv() {
+function prepareTestEnv() {
 	try {
 		initializeTestEnvironment(logger);
 		console.log('Test environment setup completed successfully.');
 
 		// Disabling this section of code for now. It's used to download a stable version of VSCode
-		// I'm guessing we would want to update this to download a stable version of Positron some day?
+		// Maybe we would want to update this to download a stable version of Positron some day?
 		// if (!OPTS.web && !OPTS.remote && OPTS.build) {
 		// 	// Only enabled when running with --build and not in web or remote
 		// 	version = getBuildVersion(OPTS.build);

--- a/test/smoke/test/positronIndex.js
+++ b/test/smoke/test/positronIndex.js
@@ -87,7 +87,30 @@ function runMochaTests() {
 			spec: '-',  // Console output
 			xunit: REPORT_PATH,
 		},
-		retries: 1,
+		retries: 0,
+	});
+
+	// Apply test filters based on CLI options
+	applyTestFilters(mocha);
+
+	// Add test files to the Mocha runner
+	const testFiles = findTestFilesRecursive(path.resolve('out/areas/positron'));
+	testFiles.forEach(file => mocha.addFile(file));
+
+	// Run the Mocha tests
+	mocha.run(failures => {
+		if (failures) {
+			console.log(getFailureLogs());
+		} else {
+			console.log('All tests passed.');
+		}
+		cleanupTestData(err => {
+			if (err) {
+				console.log('Error cleaning up test data:', err);
+			} else {
+				process.exit(failures ? 1 : 0);
+			}
+		});
 	});
 }
 

--- a/test/smoke/test/positronIndex.js
+++ b/test/smoke/test/positronIndex.js
@@ -36,7 +36,6 @@ const { createLogger, ROOT_PATH } = require('../out/positronUtils');
 const { retry } = require('../out/utils');
 const { getBuildVersion, measureAndLog, getBuildElectronPath, getDevElectronPath } = require('../../automation/out');
 
-
 // Define a logger instance for `test-setup`
 const logsRootPath = path.join(ROOT_PATH, '.build', 'logs', 'test-setup');
 const logger = createLogger(logsRootPath);
@@ -237,14 +236,18 @@ function findTestFilesRecursive(dirPath) {
  * Cleans up the test data directory.
  */
 function cleanupTestData(callback) {
-	rimraf(TEST_DATA_PATH, { maxBusyTries: 10 }, error => {
-		if (error) {
-			console.error('Error cleaning up test data:', error);
-			return callback(error);
-		}
-		console.log('Test data cleaned up successfully.');
+	if (process.env.SKIP_CLEANUP) {
 		callback(null);
-	});
+	} else {
+		rimraf(TEST_DATA_PATH, { maxBusyTries: 10 }, error => {
+			if (error) {
+				console.error('Error cleaning up test data:', error);
+				return callback(error);
+			}
+			console.log('Test data cleaned up successfully.');
+			callback(null);
+		});
+	}
 }
 
 /**
@@ -378,6 +381,7 @@ function configureEnvVarsFromOptions(opts) {
 		WEB: opts['web'] || '',
 		WIN: opts['win'] || '',
 		PR: opts['pr'] || '',
+		SKIP_CLEANUP: opts['skip-cleanup'] || '',
 		EXTENSIONS_PATH: EXTENSIONS_PATH,
 		WORKSPACE_PATH: WORKSPACE_PATH,
 		TEST_DATA_PATH: TEST_DATA_PATH,

--- a/test/smoke/test/positronIndex.js
+++ b/test/smoke/test/positronIndex.js
@@ -20,11 +20,6 @@ const mkdirp = require('mkdirp');
 const rimraf = require('rimraf');
 const vscodetest = require('@vscode/test-electron');
 
-// Internal modules
-const { createLogger, ROOT_PATH } = require('../out/positronUtils');
-const { retry } = require('../out/utils');
-const { getBuildVersion, measureAndLog, getBuildElectronPath, getDevElectronPath } = require('../../automation/out');
-
 // Constants
 const REPORT_PATH = join(process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || '', 'test-results/xunit-results.xml');
 const TEST_DATA_PATH = join(os.tmpdir(), 'vscsmoke');
@@ -34,6 +29,12 @@ const EXTENSIONS_PATH = join(TEST_DATA_PATH, 'extensions-dir');
 // Set environment variables based on options
 const OPTS = minimist(process.argv.slice(2));
 configureEnvVarsFromOptions(OPTS);
+
+// Internal modules
+const { createLogger, ROOT_PATH } = require('../out/positronUtils');
+const { retry } = require('../out/utils');
+const { getBuildVersion, measureAndLog, getBuildElectronPath, getDevElectronPath } = require('../../automation/out');
+
 
 // Define a logger instance for `test-setup`
 const logsRootPath = path.join(ROOT_PATH, '.build', 'logs', 'test-setup');

--- a/test/smoke/test/positronIndex.js
+++ b/test/smoke/test/positronIndex.js
@@ -56,12 +56,13 @@ async function prepareTestEnv() {
 		initializeTestEnvironment(logger);
 		console.log('Test environment setup completed successfully.');
 
-		// Ensure the code is stable before running tests
-		if (!OPTS.web && !OPTS.remote && OPTS.build) {
-			// Only enabled when running with --build and not in web or remote
-			version = getBuildVersion(OPTS.build);
-			await ensureStableCode(TEST_DATA_PATH, logger, OPTS);
-		}
+		// Disabling this section of code for now. It's used to download a stable version of VSCode
+		// I'm guessing we would want to update this to download a stable version of Positron
+		// if (!OPTS.web && !OPTS.remote && OPTS.build) {
+		// 	// Only enabled when running with --build and not in web or remote
+		// 	version = getBuildVersion(OPTS.build);
+		// 	await ensureStableCode(TEST_DATA_PATH, logger, OPTS);
+		// }
 
 		prepareTestDataDirectory();
 	} catch (error) {

--- a/test/smoke/test/positronIndex.js
+++ b/test/smoke/test/positronIndex.js
@@ -27,6 +27,7 @@ const WORKSPACE_PATH = join(TEST_DATA_PATH, 'qa-example-content');
 const EXTENSIONS_PATH = join(TEST_DATA_PATH, 'extensions-dir');
 
 // Set environment variables based on options
+// NOTE: Must be set before importing internal modules
 const OPTS = minimist(process.argv.slice(2));
 configureEnvVarsFromOptions(OPTS);
 
@@ -87,7 +88,7 @@ function runMochaTests() {
 			xunit: REPORT_PATH,
 		},
 		retries: 1,
-	};
+	});
 }
 
 /**

--- a/test/smoke/test/positronIndex.js
+++ b/test/smoke/test/positronIndex.js
@@ -57,7 +57,7 @@ async function prepareTestEnv() {
 		console.log('Test environment setup completed successfully.');
 
 		// Disabling this section of code for now. It's used to download a stable version of VSCode
-		// I'm guessing we would want to update this to download a stable version of Positron
+		// I'm guessing we would want to update this to download a stable version of Positron some day?
 		// if (!OPTS.web && !OPTS.remote && OPTS.build) {
 		// 	// Only enabled when running with --build and not in web or remote
 		// 	version = getBuildVersion(OPTS.build);
@@ -324,7 +324,8 @@ function initializeTestEnvironment(logger) {
 
 		if (testCodePath) {
 			electronPath = getBuildElectronPath(testCodePath);
-			version = getBuildVersion(testCodePath);
+			version = getPositronVersion(testCodePath);
+			console.log('POSITRON VERSION:', version);
 		} else {
 			testCodePath = getDevElectronPath();
 			electronPath = testCodePath;
@@ -389,4 +390,19 @@ function configureEnvVarsFromOptions(opts) {
 		REPORT_PATH: REPORT_PATH,
 	};
 	Object.assign(process.env, envVars);
+}
+
+function getPositronVersion(testCodePath) {
+	const productJsonPath = join(testCodePath, 'Contents', 'Resources', 'app', 'product.json');
+
+	// Read and parse the JSON file
+	const productJson = JSON.parse(fs.readFileSync(productJsonPath, 'utf8'));
+
+	// Return the `positronVersion` property if it exists, otherwise log an error
+	if (productJson.positronVersion) {
+		return productJson.positronVersion;
+	} else {
+		console.error('positronVersion not found in product.json.');
+		return null;
+	}
 }


### PR DESCRIPTION
### Intent
Restructure the Mocha test runner code to ensure that all test setup and environment preparation steps are executed before the actual test suite begins. This restructuring was necessary to allow the test runner to properly target a specific Positron build using the `--build` flag.

### Approach
* Moved all environment setup and configuration logic to run before the test suite starts.
* Refactored code to handle `--build` path validation and setup early in the execution.
* Ensured environment variables are correctly defined during the setup phase.

### QA Notes
To target a build:
```
yarn smoketest-pr --build /Applications/Positron.app
```

The console will log the version of the targeted build:
<img width="702" alt="Screenshot 2024-10-03 at 9 39 49 AM" src="https://github.com/user-attachments/assets/47b6d127-2f70-496b-b275-d209de40eea4">

* Ran full test suite against PR and things look good. 👍 