### PR TITLE
Add beforeEach check for interpreter

### DIFF
--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from '@playwright/test';
-import { Application, PositronPythonFixtures, ProjectType, ProjectWizardNavigateAction } from '../../../../../automation';
+import { Application, PositronPythonFixtures, ProjectType, ProjectWizardNavigateAction, PositronConsole } from '../../../../../automation';
 import { setupAndStartApp } from '../../../positronUtils';
 
 describe('New Project Wizard', () => {
@@ -203,6 +203,11 @@ describe('New Project Wizard', () => {
 		});
 
 		describe('R Project with Renv Environment', () => {
+			beforeEach(async function () {
+				const app = this.app as Application;
+				await app.workbench.positronConsole.waitForReadyOrNoInterpreter();
+			});
+
 			it('Accept Renv install [C633084]', async function () {
 				const projSuffix = addRandomNumSuffix('_installRenv');
 				const app = this.app as Application;

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from '@playwright/test';
-import { Application, PositronPythonFixtures, ProjectType, ProjectWizardNavigateAction, PositronConsole } from '../../../../../automation';
+import { Application, PositronPythonFixtures, ProjectType, ProjectWizardNavigateAction } from '../../../../../automation';
 import { setupAndStartApp } from '../../../positronUtils';
 
 describe('New Project Wizard', () => {


### PR DESCRIPTION
### Intent
Fix some instability in newproject tests where the interpreter startup intefers with typing in the project name.

### Approach
Allow inerpreter to finish loading in beforeEach for the suite of tests

### QA Notes
All smoke tests in CI should pass
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
