### PR TITLE
smoke tests: remove declarations

### DIFF
--- a/test/smoke/tsconfig.json
+++ b/test/smoke/tsconfig.json
@@ -11,9 +11,6 @@
 		"outDir": "out",
 		"sourceMap": true,
 		"skipLibCheck": true,
-		// --- Start Positron ---
-		"declaration": true,
-		// --- End Positron ---
 		"lib": [
 			"esnext", // for #201187
 			"dom"


### PR DESCRIPTION
Remove generate declarations for `test/smoke` dir.