### PR TITLE
Fix plotly showing in Viewer

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
@@ -249,7 +249,7 @@ def test_plotly_show_sends_events(
     mock_handle_request: Mock,
 ) -> None:
     """
-    Test that showing a Plotly plot sends the expected UI events.
+    Test that showing a Plotly plot sends the expected UI events when using `fig.show()` and `fig`.
     """
     shell.run_cell(
         """\
@@ -265,11 +265,16 @@ import plotly.express as px
 
 fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
 fig.show()
+fig
 """
     )
     mock_handle_request.assert_called()
-    assert len(ui_comm.messages) == 1
+    assert len(ui_comm.messages) == 2
     params = ui_comm.messages[0]["data"]["params"]
+    assert params["title"] == ""
+    assert params["is_plot"]
+    assert params["height"] == 0
+    params = ui_comm.messages[1]["data"]["params"]
     assert params["title"] == ""
     assert params["is_plot"]
     assert params["height"] == 0

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -198,7 +198,7 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
 
         for addr in _localhosts:
             if addr in url:
-                is_plot = self._is_module_function("plotly.basedatatypes", "show")
+                is_plot = self._is_module_function("plotly.basedatatypes")
                 if is_plot:
                     return self._send_show_html_event(url, is_plot)
                 else:
@@ -210,15 +210,18 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
         return False
 
     @staticmethod
-    def _is_module_function(module_name: str, function_name: str) -> bool:
+    def _is_module_function(module_name: str, function_name: str = None) -> bool:
         module = sys.modules.get(module_name)
         if module:
-            for frame_info in inspect.stack():
-                if (
-                    inspect.getmodule(frame_info.frame, frame_info.filename) == module
-                    and frame_info.function == function_name
-                ):
-                    return True
+            if function_name:
+                for frame_info in inspect.stack():
+                    if (
+                        inspect.getmodule(frame_info.frame, frame_info.filename) == module
+                        and frame_info.function == function_name
+                    ):
+                        return True
+            else:
+                return True
         return False
 
     def _send_show_html_event(self, url: str, is_plot: bool) -> bool:


### PR DESCRIPTION
Address regression found during verifying #4245
Regression issue: #4909 

```python
import plotly.express as px
fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
fig
```

Not invoking the `show()` function still displays the plot but always in the Viewer.

Only check if plotly module is in call stack. This came up during the initial bug fix whether we should check the function name too. Looks like it's better to do that so we can catch this scenario.

Update the unit test to check the alternate way of displaying a plot.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes
`fig` and `fig.show()` should display in the Plots view.
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
