### PR TITLE
Only hide editor if panel hasn't been explicitly hidden

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -367,9 +367,11 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		 * onDidVisibleEditorsChange event handler.
 		 */
 		const onDidVisibleEditorsChangeHandler = () => {
-			// When the panel position is bottom and the panel alignment is center, and there isn't
-			// an active editor, and the editor isn't hidden, then we want to hide the editor.
-			if (this.getPanelPosition() === Position.BOTTOM &&
+			// When the panel is visible (i.e. user hasn't explicitly hidden it), position is
+			// bottom, and the panel alignment is center, and there isn't an active editor, and the
+			// editor isn't hidden, then we want to hide the editor to maximize the panel.
+			if (this.isVisible(Parts.PANEL_PART) &&
+				this.getPanelPosition() === Position.BOTTOM &&
 				this.getPanelAlignment() === 'center' &&
 				!this.editorService.activeEditor &&
 				!this.stateModel.getRuntimeValue(LayoutStateKeys.EDITOR_HIDDEN)) {
@@ -396,7 +398,8 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		// is ready to avoid conflicts on startup
 		this.editorGroupService.whenRestored.then(() => {
 			// --- Start Positron ---
-			if (this.getPanelPosition() === Position.BOTTOM &&
+			if (this.isVisible(Parts.PANEL_PART) &&
+				this.getPanelPosition() === Position.BOTTOM &&
 				this.getPanelAlignment() === 'center' &&
 				!this.editorService.activeEditor &&
 				!this.stateModel.getRuntimeValue(LayoutStateKeys.EDITOR_HIDDEN)) {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4756

This has been driving me _crazy_! I am one of those people that prefers to move everything out of the Panel and then _explicitly hide it_ with `CMD + J`.

Due to https://github.com/posit-dev/positron/pull/1782/ at this request https://github.com/posit-dev/positron/issues/980, when:
- The last open editor closes
- Or when there are no editors open on startup

then the Panel is forcibly popped up and maximized. This is useful if your Console lives there, but is super annoying if you don't have anything in the Panel and have it "hidden" (see the video in https://github.com/posit-dev/positron/issues/4756).

I think that if we also require that the Panel be "visible" (i.e. the user hasn't explicitly hidden it) before hiding the editor, then we can respect the spirit of the request in https://github.com/posit-dev/positron/issues/980 while also respecting people like me who hide the Panel.

Video shows:
- Panel stays hidden after last tab is closed
- Panel stays hidden after a reload (simulating opening Positron)
- Then we make the Panel visible and try those again, to prove that the old behavior is still in place

https://github.com/user-attachments/assets/8e3cca0f-4bb1-48ef-acde-ae017c49c7cc


