### PR TITLE
added platform specific paths to smoke test --build flag

### DIFF
--- a/test/smoke/src/test-runner/test-setup.ts
+++ b/test/smoke/src/test-runner/test-setup.ts
@@ -130,7 +130,7 @@ function getPositronVersion(testCodePath: string): string | null {
 			productJsonPath = join(testCodePath, 'resources', 'app', 'product.json');
 			break;
 		default:
-			throw new Error('Unsupported platform.');
+			return null;
 	}
 
 	// Read and parse the JSON file

--- a/test/smoke/src/test-runner/test-setup.ts
+++ b/test/smoke/src/test-runner/test-setup.ts
@@ -118,7 +118,20 @@ function prepareTestDataDirectory() {
 }
 
 function getPositronVersion(testCodePath: string): string | null {
-	const productJsonPath = join(testCodePath, 'Contents', 'Resources', 'app', 'product.json');
+	let productJsonPath;
+	switch (process.platform) {
+		case 'darwin':
+			productJsonPath = join(testCodePath, 'Contents', 'Resources', 'app', 'product.json');
+			break;
+		case 'linux':
+			productJsonPath = join(testCodePath, 'resources', 'app', 'product.json');
+			break;
+		case 'win32':
+			productJsonPath = join(testCodePath, 'resources', 'app', 'product.json');
+			break;
+		default:
+			throw new Error('Unsupported platform.');
+	}
 
 	// Read and parse the JSON file
 	const productJson = JSON.parse(fs.readFileSync(productJsonPath, 'utf8'));


### PR DESCRIPTION
### Intent

The `--build` flag failed on windows & linux because the getPositronVersion only used MacOS pathing.

### Approach
Added correct pathing for each OS

## QA Notes
Using the --build flag works on all platforms