### PR TITLE
notebookCreate test: fix test setup

### DIFF
--- a/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
+++ b/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
@@ -12,33 +12,28 @@ describe('Notebooks #pr #web #win', () => {
 	setupAndStartApp();
 
 	describe('Python Notebooks', () => {
+		let app: Application;
 
 		before(async function () {
-
-			await PositronPythonFixtures.SetupFixtures(this.app as Application);
-
+			app = this.app as Application;
+			await PositronPythonFixtures.SetupFixtures(app);
+			await app.workbench.positronLayouts.enterLayout('notebook');
 		});
 
-		after(async function () {
+		beforeEach(async function () {
+			await app.workbench.positronNotebooks.createNewNotebook();
+			await app.workbench.positronNotebooks.selectInterpreter('Python Environments', process.env.POSITRON_PY_VER_SEL!);
+		});
 
-			const app = this.app as Application;
+		afterEach(async function () {
 			await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
 		});
 
 		it('Python - Basic notebook creation and execution (code) [C628631]', async function () {
-			const app = this.app as Application;
-
-			await app.workbench.positronLayouts.enterLayout('notebook');
-
 			await expect(async () => {
 
 				try {
-					await app.workbench.positronNotebooks.createNewNotebook();
-
-					await app.workbench.positronNotebooks.selectInterpreter('Python Environments', process.env.POSITRON_PY_VER_SEL!);
-
 					await app.workbench.positronNotebooks.addCodeToFirstCell('eval("8**2")');
-
 					await app.workbench.positronNotebooks.executeCodeInCell();
 
 					expect(await app.workbench.positronNotebooks.getPythonCellOutput()).toBe('64');
@@ -50,15 +45,13 @@ describe('Notebooks #pr #web #win', () => {
 		});
 
 		it('Python - Basic notebook creation and execution (markdown) [C628632]', async function () {
-			const app = this.app as Application;
+			const randomText = Math.random().toString(36).substring(7);
 
 			await app.workbench.notebook.insertNotebookCell('markdown');
-
-			await app.workbench.notebook.waitForTypeInEditor('## hello2! ');
+			await app.workbench.notebook.waitForTypeInEditor(`## ${randomText} `);
 			await app.workbench.notebook.stopEditingCell();
 
-			expect(await app.workbench.positronNotebooks.getMarkdownText('h2')).toBe('hello2!');
-
+			expect(await app.workbench.positronNotebooks.getMarkdownText(`h2 >> text="${randomText}"`)).toBe(randomText);
 		});
 	});
 });
@@ -67,28 +60,23 @@ describe('Notebooks #pr #web #win', () => {
 	setupAndStartApp();
 
 	describe('R Notebooks', () => {
+		let app: Application;
 
 		before(async function () {
-
+			app = this.app as Application;
 			await PositronRFixtures.SetupFixtures(this.app as Application);
-
 		});
 
-		after(async function () {
+		beforeEach(async function () {
+			await app.workbench.positronNotebooks.createNewNotebook();
+			await app.workbench.positronNotebooks.selectInterpreter('R Environments', process.env.POSITRON_R_VER_SEL!);
+		});
 
-			const app = this.app as Application;
+		afterEach(async function () {
 			await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
 		});
 
 		it('R - Basic notebook creation and execution (code) [C628629]', async function () {
-			const app = this.app as Application;
-
-			await app.workbench.positronLayouts.enterLayout('notebook');
-
-			await app.workbench.positronNotebooks.createNewNotebook();
-
-			await app.workbench.positronNotebooks.selectInterpreter('R Environments', process.env.POSITRON_R_VER_SEL!);
-
 			await app.workbench.positronNotebooks.addCodeToFirstCell('eval(parse(text="8**2"))');
 
 			await expect(async () => {
@@ -99,14 +87,13 @@ describe('Notebooks #pr #web #win', () => {
 		});
 
 		it('R - Basic notebook creation and execution (markdown) [C628630]', async function () {
-			const app = this.app as Application;
+			const randomText = Math.random().toString(36).substring(7);
 
 			await app.workbench.notebook.insertNotebookCell('markdown');
-
-			await app.workbench.notebook.waitForTypeInEditor('## hello2! ');
+			await app.workbench.notebook.waitForTypeInEditor(`## ${randomText} `);
 			await app.workbench.notebook.stopEditingCell();
 
-			expect(await app.workbench.positronNotebooks.getMarkdownText('h2')).toBe('hello2!');
+			expect(await app.workbench.positronNotebooks.getMarkdownText(`h2 >> text="${randomText}"`)).toBe(randomText);
 
 		});
 	});

--- a/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
+++ b/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
@@ -31,17 +31,11 @@ describe('Notebooks #pr #web #win', () => {
 
 		it('Python - Basic notebook creation and execution (code) [C628631]', async function () {
 			await expect(async () => {
+				await app.workbench.positronNotebooks.addCodeToFirstCell('eval("8**2")');
+				await app.workbench.positronNotebooks.executeCodeInCell();
 
-				try {
-					await app.workbench.positronNotebooks.addCodeToFirstCell('eval("8**2")');
-					await app.workbench.positronNotebooks.executeCodeInCell();
-
-					expect(await app.workbench.positronNotebooks.getPythonCellOutput()).toBe('64');
-				} catch (e) {
-					await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
-				}
+				expect(await app.workbench.positronNotebooks.getPythonCellOutput()).toBe('64');
 			}).toPass({ timeout: 120000 });
-
 		});
 
 		it('Python - Basic notebook creation and execution (markdown) [C628632]', async function () {


### PR DESCRIPTION
### Intent
Noticed two issues with this test. First, the tests within each describe block are not independent and rely on the first one. So I re-organized the before/beforeEach blocks so each test can standalone. The 2nd issue is that if the 2nd tests attempt to retry they will potentially fail because there will be duplicate matching markdown text from the first attempt.

### Approach
1. New notebook for each test
2. Random text used to verify h2 markdown