### PR TITLE
Add Open Folder to web Welcome

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
@@ -128,7 +128,7 @@ export const startEntries: GettingStartedStartEntryContent = [
 		title: localize('gettingStarted.openFolder.title', "Open Folder..."),
 		description: localize('gettingStarted.openFolder.description', "Open a folder to start working"),
 		icon: Codicon.folderOpened,
-		when: '!isWeb && !isMac',
+		when: 'isWeb || !isMac',
 		content: {
 			type: 'startEntry',
 			command: 'command:workbench.action.files.openFolder',


### PR DESCRIPTION
Address #4851 

Enables the `Open Folder...` action for the Welcome page. It's the same action as File > Open Folder.

### QA Notes
This is how it would look and is the same as on Windows and Linux. Only Mac uses a single action to open a file or folder.
![image](https://github.com/user-attachments/assets/9bb0dee6-9a0e-4cca-b664-e1f786407360)


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
