### PR TITLE
Fix notebook stream output ANSI code handling

### DIFF
--- a/extensions/positron-notebook-controllers/src/notebookController.ts
+++ b/extensions/positron-notebook-controllers/src/notebookController.ts
@@ -221,6 +221,7 @@ export class NotebookController implements vscode.Disposable {
 					NotebookCellOutputType.DisplayData,
 					execution,
 				);
+				break;
 			case positron.LanguageRuntimeMessageType.Result:
 				await handleRuntimeMessageOutput(
 					message as positron.LanguageRuntimeResult,


### PR DESCRIPTION
Addresses #3723. The main change is in `handleRuntimeMessageStream`, where we now append to an existing output if possible.