### PR TITLE
default to HTML file proxy unless uri is http or https

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -213,16 +213,18 @@ export class UiClientInstance extends Disposable {
 		const uriScheme = URI.parse(targetPath).scheme;
 		let url;
 
-		if (uriScheme === 'file') {
-			// If the path is for a file, start an HTML proxy server.
-			url = await this._commandService.executeCommand<string>(
-				'positronProxy.startHtmlProxyServer',
-				targetPath
-			);
-		} else if (uriScheme === 'http' || uriScheme === 'https') {
+		if (uriScheme === 'http' || uriScheme === 'https') {
 			// If the path is for a server, start a generic proxy server.
 			url = await this._commandService.executeCommand<string>(
 				'positronProxy.startHttpProxyServer',
+				targetPath
+			);
+		} else {
+			// Assume the path is for a file and start an HTML proxy server.
+			// The uriScheme could be 'file' in this case, or even 'C' if the path is for an HTML
+			// file on a Windows machine.
+			url = await this._commandService.executeCommand<string>(
+				'positronProxy.startHtmlProxyServer',
 				targetPath
 			);
 		}


### PR DESCRIPTION
- Addresses https://github.com/posit-dev/positron/issues/4930

On Windows, a file path has scheme `C`, which was not handled in https://github.com/posit-dev/positron/pull/4855. I had assumed local file paths would all have scheme `file`, but that is not the case on Windows!

I've updated the logic to start a generic HTTP proxy server when the scheme is `http` or `https`, but to assume all other paths are HTML file paths.

The behaviour of `startHtmlProxyServer` before https://github.com/posit-dev/positron/pull/4855 was to always start an HTML proxy server, so this PR restores that assumption by always starting an HTML proxy server unless we have an `http`/`https` URL (in which case we want to start a generic proxy server).

### QA Notes

See #4930 for repro notes.