### PR TITLE
Fix for flaky interpreter dropdown test and more logging

### DIFF
--- a/test/automation/src/positron/positronInterpreterDropdown.ts
+++ b/test/automation/src/positron/positronInterpreterDropdown.ts
@@ -221,6 +221,7 @@ export class PositronInterpreterDropdown {
 		// Fail if green dot running indicator missing
 		const runningIndicator = primaryInterpreter.locator('.running-icon');
 		if (!(await runningIndicator.isVisible())) {
+			this.code.logger.log('Green dot running indicator missing');
 			return false;
 		}
 
@@ -232,6 +233,7 @@ export class PositronInterpreterDropdown {
 			!(await restartButton.isVisible()) ||
 			!(await restartButton.isEnabled())
 		) {
+			this.code.logger.log('Restart button not visible and enabled');
 			return false;
 		}
 
@@ -243,6 +245,7 @@ export class PositronInterpreterDropdown {
 			!(await stopButton.isVisible()) ||
 			!(await stopButton.isEnabled())
 		) {
+			this.code.logger.log('Stop button not visible and enabled');
 			return false;
 		}
 

--- a/test/smoke/src/areas/positron/apps/pythonApps.test.ts
+++ b/test/smoke/src/areas/positron/apps/pythonApps.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect } from '@playwright/test';
-import { Application, PositronPythonFixtures } from '../../../../../automation/out';
+import { Application, PositronPythonFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 import { join } from 'path';
 

--- a/test/smoke/src/areas/positron/top-action-bar/interpreter-dropdown.test.ts
+++ b/test/smoke/src/areas/positron/top-action-bar/interpreter-dropdown.test.ts
@@ -96,11 +96,13 @@ describe('Interpreter Dropdown in Top Action Bar #web', () => {
 		expect(interpreterInfo!.path).toBeDefined();
 
 		// The interpreter dropdown should show the expected running indicators
-		expect(
-			await interpreterDropdown.primaryInterpreterShowsRunning(
-				interpreterInfo!.path
-			)
-		).toBe(true);
+		await expect(async () => {
+			expect(
+				await interpreterDropdown.primaryInterpreterShowsRunning(
+					interpreterInfo!.path
+				)
+			).toBe(true);
+		}).toPass({ timeout: 30_000 });
 
 		// Close the interpreter dropdown.
 		await interpreterDropdown.closeInterpreterDropdown();
@@ -127,9 +129,11 @@ describe('Interpreter Dropdown in Top Action Bar #web', () => {
 		await positronConsole.waitForReady('>>>', 10_000);
 
 		// The interpreter dropdown should show the expected running indicators
-		expect(
-			await interpreterDropdown.primaryInterpreterShowsRunning('Python')
-		).toBe(true);
+		await expect(async () => {
+			expect(
+				await interpreterDropdown.primaryInterpreterShowsRunning('Python')
+			).toBe(true);
+		}).toPass({ timeout: 30_000 });
 
 		// Close the interpreter dropdown.
 		await interpreterDropdown.closeInterpreterDropdown();

--- a/test/smoke/src/areas/positron/top-action-bar/interpreter-dropdown.test.ts
+++ b/test/smoke/src/areas/positron/top-action-bar/interpreter-dropdown.test.ts
@@ -158,11 +158,13 @@ describe('Interpreter Dropdown in Top Action Bar #web', () => {
 		await interpreterDropdown.closeInterpreterDropdown();
 
 		// The interpreter dropdown should show the expected running indicators
-		expect(
-			await interpreterDropdown.primaryInterpreterShowsRunning(
-				interpreterInfo!.path
-			)
-		).toBe(true);
+		await expect(async () => {
+			expect(
+				await interpreterDropdown.primaryInterpreterShowsRunning(
+					interpreterInfo!.path
+				)
+			).toBe(true);
+		}).toPass({ timeout: 30_000 });
 
 		// Close the interpreter dropdown.
 		await interpreterDropdown.closeInterpreterDropdown();


### PR DESCRIPTION
Allow more time for evaluating the state of the interpreter dropdown post restart and log specific failure when error occurs.

Also, minor cleanup of import in pythonApps.test.ts.

### QA Notes

All smoke tests should pass.
