### PR TITLE
Urls always opening in Plots view

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
@@ -304,6 +304,5 @@ webbrowser.open("file://file.html")
     assert "is_plot" not in params
 
     params = ui_comm.messages[1]["data"]["params"]
-    assert params["path"] == "file://file.html"
+    assert params["path"] == "file.html" if sys.platform == "win32" else "file://file.html"
     assert params["is_plot"] is False
-

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
@@ -278,3 +278,32 @@ fig
     assert params["title"] == ""
     assert params["is_plot"]
     assert params["height"] == 0
+
+
+def test_is_not_plot_url_events(
+    shell: PositronShell,
+    ui_comm: DummyComm,
+) -> None:
+    """
+    Test that opening a URL that is not a plot sends the expected UI events.
+    Checks that the `is_plot` parameter is not sent or is `False`.
+    """
+    shell.run_cell(
+        """\
+import webbrowser
+# Only enable the positron viewer browser; avoids system browsers opening during tests.
+webbrowser._tryorder = ["positron_viewer"]
+
+webbrowser.open("http://127.0.0.1:8000")
+webbrowser.open("file://file.html")
+"""
+    )
+    assert len(ui_comm.messages) == 2
+    params = ui_comm.messages[0]["data"]["params"]
+    assert params["url"] == "http://127.0.0.1:8000"
+    assert "is_plot" not in params
+
+    params = ui_comm.messages[1]["data"]["params"]
+    assert params["path"] == "file://file.html"
+    assert params["is_plot"] is False
+

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -213,15 +213,18 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
     def _is_module_function(module_name: str, function_name: str = None) -> bool:
         module = sys.modules.get(module_name)
         if module:
-            if function_name:
-                for frame_info in inspect.stack():
+            for frame_info in inspect.stack():
+                if function_name:
                     if (
                         inspect.getmodule(frame_info.frame, frame_info.filename) == module
                         and frame_info.function == function_name
                     ):
                         return True
-            else:
-                return True
+                else:
+                    if inspect.getmodule(frame_info.frame) == module:
+                        return True
+        else:
+            return True
         return False
 
     def _send_show_html_event(self, url: str, is_plot: bool) -> bool:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -210,7 +210,7 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
         return False
 
     @staticmethod
-    def _is_module_function(module_name: str, function_name: str = None) -> bool:
+    def _is_module_function(module_name: str, function_name: Union[str, None] = None) -> bool:
         module = sys.modules.get(module_name)
         if module:
             for frame_info in inspect.stack():

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -223,8 +223,6 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
                 else:
                     if inspect.getmodule(frame_info.frame) == module:
                         return True
-        else:
-            return True
         return False
 
     def _send_show_html_event(self, url: str, is_plot: bool) -> bool:


### PR DESCRIPTION
Address #4909 

The first PR didn't actually check the call stack. This checks the call stack properly for Plotly being called.

### QA Notes
This was initially discovered because the Plotly module is loaded because of other tests that use it. So, Plotly only needs to be imported to reproduce the bug.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
