### PR TITLE
Allow workspace override for interpreter settings

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -138,13 +138,13 @@ configurationRegistry.registerConfiguration({
 	...positronConfigurationNodeBase,
 	properties: {
 		'positron.interpreters.restartOnCrash': {
-			scope: ConfigurationScope.MACHINE,
+			scope: ConfigurationScope.MACHINE_OVERRIDABLE,
 			type: 'boolean',
 			default: true,
 			description: nls.localize('positron.runtime.restartOnCrash', "When enabled, interpreters are automatically restarted after a crash.")
 		},
 		'positron.interpreters.automaticStartup': {
-			scope: ConfigurationScope.MACHINE,
+			scope: ConfigurationScope.MACHINE_OVERRIDABLE,
 			type: 'boolean',
 			default: true,
 			description: nls.localize('positron.runtime.automaticStartup', "When enabled, interpreters can start automatically.")


### PR DESCRIPTION
This change allows interpreter-related settings to be configured at the workspace level, if desired.
