### PR TITLE
Add Python App tests to windows workflow

### DIFF
--- a/test/smoke/src/areas/positron/apps/pythonApps.test.ts
+++ b/test/smoke/src/areas/positron/apps/pythonApps.test.ts
@@ -8,7 +8,7 @@ import { Application, PositronPythonFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 import { join } from 'path';
 
-describe('Python Applications #pr', () => {
+describe('Python Applications #pr #win', () => {
 	setupAndStartApp();
 
 	describe('Python Applications', () => {

--- a/test/smoke/src/areas/positron/apps/pythonApps.test.ts
+++ b/test/smoke/src/areas/positron/apps/pythonApps.test.ts
@@ -80,6 +80,7 @@ describe('Python Applications #pr #win', () => {
 			await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
 			await expect(headerLocator).toHaveText('Deploy', { timeout: 45000 });
 			await app.workbench.positronLayouts.enterLayout('stacked');
+			await app.workbench.quickaccess.runCommand('workbench.action.terminal.focus');
 
 		});
 	});

--- a/test/smoke/src/areas/positron/apps/pythonApps.test.ts
+++ b/test/smoke/src/areas/positron/apps/pythonApps.test.ts
@@ -77,7 +77,9 @@ describe('Python Applications #pr #win', () => {
 
 			const headerLocator = app.workbench.positronViewer.getViewerLocator('div.stAppDeployButton', this.app.web);
 
+			await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
 			await expect(headerLocator).toHaveText('Deploy', { timeout: 45000 });
+			await app.workbench.positronLayouts.enterLayout('stacked');
 
 		});
 	});


### PR DESCRIPTION
### Intent

Continuing to address #4867, adds they Python app tests


### Approach

Had to expand the viewer pane for streamlit test to make it visible and then focus terminal again.

### QA Notes

All smoke tests pass in CI

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
