### PR TITLE
mocha runner: better logs around test cleanup

### DIFF
--- a/test/smoke/run-tests.js
+++ b/test/smoke/run-tests.js
@@ -11,8 +11,8 @@ const minimist = require('minimist');
 const { prepareTestEnv, cloneTestRepo, runMochaTests } = require('./out/test-runner');
 const OPTS = minimist(process.argv.slice(2));
 
-(function main() {
+(async function main() {
 	prepareTestEnv();
 	cloneTestRepo();
-	runMochaTests(OPTS);
+	await runMochaTests(OPTS);
 })();

--- a/test/smoke/src/test-runner/mocha-runner.ts
+++ b/test/smoke/src/test-runner/mocha-runner.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'path';
-import * as fs from 'fs/promises'; // Import only fs/promises for consistency
+// eslint-disable-next-line local/code-import-patterns
+import * as fs from 'fs/promises';
 const Mocha = require('mocha');
 
 const TEST_DATA_PATH = process.env.TEST_DATA_PATH || 'TEST_DATA_PATH not set';


### PR DESCRIPTION
### Intent
When running a large number of tests in parallel, the script cleans up the test data generated during the run, which can sometimes take a while. To save time, there’s an option to skip this step, commonly used in CICD pipelines. This option was already available, but the recent update improves its visibility to make it clearer to the person running the tests.
Note: This does not delete traces, but rather temporary files created by the runner.

### Approach
Enhanced the logging to provide better visibility, highlighting when the cleanup is being skipped to reduce confusion and improve monitoring.

#### Without skipping clean up
<img width="583" alt="Screenshot 2024-10-10 at 2 20 32 PM" src="https://github.com/user-attachments/assets/5522e993-1f6d-4e16-8ec1-0d18ad654e76">

#### With skipping clean up  (`--skip-cleanup`)
<img width="220" alt="Screenshot 2024-10-10 at 2 20 02 PM" src="https://github.com/user-attachments/assets/5b909df4-535f-433b-9c3a-390953fe7a59">
