### PR TITLE
Add Shiny, Connections, and console tests to windows

### DIFF
--- a/test/smoke/src/areas/positron/apps/shiny.test.ts
+++ b/test/smoke/src/areas/positron/apps/shiny.test.ts
@@ -8,7 +8,7 @@ import { setupAndStartApp } from '../../../test-runner/test-hooks';
 import { expect } from '@playwright/test';
 import { join } from 'path';
 
-describe('Shiny Application', () => {
+describe('Shiny Application #win', () => {
 	setupAndStartApp();
 
 	before(async function () {

--- a/test/smoke/src/areas/positron/connections/dbConnections.test.ts
+++ b/test/smoke/src/areas/positron/connections/dbConnections.test.ts
@@ -12,7 +12,7 @@ import { setupAndStartApp } from '../../../test-runner/test-hooks';
 let logger;
 const tables = ['tracks', 'playlist_track', 'playlists', 'media_types', 'invoice_items', 'invoices', 'genres', 'employees', 'customers', 'artists', 'albums'];
 
-describe('Connections Pane #web', () => {
+describe('Connections Pane #web #win', () => {
 	logger = setupAndStartApp();
 
 	describe('Python - SQLite DB', () => {

--- a/test/smoke/src/areas/positron/console/consoleHistory.test.ts
+++ b/test/smoke/src/areas/positron/console/consoleHistory.test.ts
@@ -48,6 +48,7 @@ describe('Console History #web #win', () => {
 			}).toPass({ timeout: 40000 });
 
 			await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+			await app.workbench.quickaccess.runCommand('workbench.action.toggleSidebarVisibility');
 			await app.workbench.positronConsole.barClearButton.click();
 
 			await app.workbench.positronConsole.sendKeyboardKey('ArrowUp');

--- a/test/smoke/src/areas/positron/console/consoleHistory.test.ts
+++ b/test/smoke/src/areas/positron/console/consoleHistory.test.ts
@@ -9,7 +9,7 @@ import { Application, PositronPythonFixtures, PositronRFixtures } from '../../..
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 
 
-describe('Console History #web', () => {
+describe('Console History #web #win', () => {
 	setupAndStartApp();
 
 	describe('Console History - Python', () => {

--- a/test/smoke/src/areas/positron/console/consoleInput.test.ts
+++ b/test/smoke/src/areas/positron/console/consoleInput.test.ts
@@ -8,7 +8,7 @@ import { expect } from '@playwright/test';
 import { Application, PositronPythonFixtures, PositronRFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 
-describe('Console Input #web #pr', () => {
+describe('Console Input #web #pr #win', () => {
 	setupAndStartApp();
 
 	describe('Console Input - Python', () => {

--- a/test/smoke/src/areas/positron/console/consoleOutput.test.ts
+++ b/test/smoke/src/areas/positron/console/consoleOutput.test.ts
@@ -7,7 +7,7 @@
 import { Application, PositronRFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 
-describe('Console Output', () => {
+describe('Console Output #win', () => {
 	setupAndStartApp();
 
 	describe('Console Output - R', () => {


### PR DESCRIPTION
### Intent
Continuing #4867, added 
* Shiny
* Connecctions
* Remaining Console

### Approach

Only consoleHistory required test modification to add hiding the primary side bar.

### QA Notes

All test pass in both Linux and WIndows runs.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
