### PR TITLE
e2e tests: add retry.log

### DIFF
--- a/test/smoke/src/test-runner/config.ts
+++ b/test/smoke/src/test-runner/config.ts
@@ -28,6 +28,7 @@ Object.assign(process.env, {
 	EXTENSIONS_PATH: path.join(TEST_DATA_PATH, 'extensions-dir'),
 	WORKSPACE_PATH: path.join(TEST_DATA_PATH, 'qa-example-content'),
 	REPORT_PATH: path.join(process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || '', 'test-results/'),
+	RETRY_LOG_PATH: path.join(process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || ''),
 	LOGS_DIR: process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || 'smoke-tests-default',
 });
 

--- a/test/smoke/src/test-runner/config.ts
+++ b/test/smoke/src/test-runner/config.ts
@@ -27,7 +27,7 @@ Object.assign(process.env, {
 	ROOT_PATH: path.join(__dirname, '..', '..', '..', '..'),
 	EXTENSIONS_PATH: path.join(TEST_DATA_PATH, 'extensions-dir'),
 	WORKSPACE_PATH: path.join(TEST_DATA_PATH, 'qa-example-content'),
-	REPORT_PATH: path.join(process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || '', 'test-results/xunit-results.xml'),
+	REPORT_PATH: path.join(process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || '', 'test-results/'),
 	LOGS_DIR: process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || 'smoke-tests-default',
 });
 

--- a/test/smoke/src/test-runner/logger.ts
+++ b/test/smoke/src/test-runner/logger.ts
@@ -5,6 +5,8 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
+// eslint-disable-next-line local/code-import-patterns
+import * as fsp from 'fs/promises';
 import mkdirp = require('mkdirp');
 import { ConsoleLogger, FileLogger, Logger, MultiLogger } from '../../../automation';
 
@@ -30,4 +32,34 @@ export function createLogger(logsRootPath: string): Logger {
 	loggers.push(new FileLogger(path.join(logsRootPath, logsFileName)));
 
 	return new MultiLogger(loggers);
+}
+
+// Log queue to ensure writes happen sequentially
+const logQueue: Array<Promise<void>> = [];
+
+/**
+ * Log a message to a file using fs.promises and a queue.
+ *
+ * @param filePath the file path
+ * @param message the message to log
+ * @returns Promise<void>
+ */
+export async function logToFile(filePath: string, message: string): Promise<void> {
+	const ansiRegex = /\u001b\[[0-9;]*m/g;
+	const cleanMessage = message.replace(ansiRegex, '');  // Remove ANSI codes
+
+	// Write operation that appends the message to the log file
+	const writeOperation = async () => {
+		await fsp.appendFile(filePath, cleanMessage + '\n', 'utf-8');
+	};
+
+	// Add the current write operation to the queue
+	const lastOperation = logQueue.length > 0 ? logQueue[logQueue.length - 1] : Promise.resolve();
+
+	// Chain the new write operation after the last one
+	const newOperation = lastOperation.then(writeOperation);
+	logQueue.push(newOperation);
+
+	// Wait for the new operation to complete
+	await newOperation;
 }

--- a/test/smoke/src/test-runner/logger.ts
+++ b/test/smoke/src/test-runner/logger.ts
@@ -39,15 +39,16 @@ export function createLogger(logsRootPath: string): Logger {
  * @param message the message to log
  */
 function logToFile(logFilePath: string, message: string): void {
-	const logDir = path.dirname(logFilePath);  // Get the directory part of the path
+	const logDir = path.dirname(logFilePath);
 
 	// Ensure the directory exists
 	if (!fs.existsSync(logDir)) {
 		fs.mkdirSync(logDir, { recursive: true });
 	}
 
+	// Remove ANSI escape codes from the message
 	const ansiRegex = /\u001b\[[0-9;]*m/g;
-	const cleanMessage = message.replace(ansiRegex, '');  // Remove ANSI codes
+	const cleanMessage = message.replace(ansiRegex, '');
 
 	try {
 		fs.appendFileSync(logFilePath, cleanMessage + '\n', 'utf-8');
@@ -79,7 +80,7 @@ export function logErrorToFile(test: any, err: Error): void {
  * Returns a string of dashes based on the length.
  *
  * @param length number of dashes to print
- * @returns
+ * @returns string of dashes
  */
 function printDashes(length: number): string {
 	const minLength = 45;

--- a/test/smoke/src/test-runner/logger.ts
+++ b/test/smoke/src/test-runner/logger.ts
@@ -5,7 +5,6 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
-// eslint-disable-next-line local/code-import-patterns
 import mkdirp = require('mkdirp');
 import { ConsoleLogger, FileLogger, Logger, MultiLogger } from '../../../automation';
 
@@ -33,16 +32,19 @@ export function createLogger(logsRootPath: string): Logger {
 	return new MultiLogger(loggers);
 }
 
-function logToFile(testLogDir: string, message: string): void {
-	const logFilePath = path.join(testLogDir, 'retry.log');
+/**
+ * Logs a message to the file specified
+ *
+ * @param logFile the directory where the log file is saved
+ * @param message the message to log
+ */
+function logToFile(logFilePath: string, message: string): void {
+	const logDir = path.dirname(logFilePath);  // Get the directory part of the path
 
 	// Ensure the directory exists
-	if (!fs.existsSync(testLogDir)) {
-		fs.mkdirSync(testLogDir, { recursive: true });
+	if (!fs.existsSync(logDir)) {
+		fs.mkdirSync(logDir, { recursive: true });
 	}
-
-	console.log(`Writing log to ${logFilePath}`);
-
 
 	const ansiRegex = /\u001b\[[0-9;]*m/g;
 	const cleanMessage = message.replace(ansiRegex, '');  // Remove ANSI codes
@@ -64,7 +66,7 @@ export function logErrorToFile(test: any, err: Error): void {
 	const RETRY_LOG_PATH = process.env.RETRY_LOG_PATH || 'RETRY_LOG_PATH not set';
 
 	const fileName = path.basename(test.file);
-	const testLogPath = path.join(RETRY_LOG_PATH, fileName);
+	const testLogPath = path.join(RETRY_LOG_PATH, fileName, 'retry.log');
 
 	const title = `[RUN #${test.currentRetry()}] ${test.fullTitle()}`;
 	const dashes = printDashes(title.length);

--- a/test/smoke/src/test-runner/mocha-runner.ts
+++ b/test/smoke/src/test-runner/mocha-runner.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 // eslint-disable-next-line local/code-import-patterns
 import * as fs from 'fs/promises';
-import { logToFile } from './logger';
+import { logErrorToFile } from './logger';
 const Mocha = require('mocha');
 
 const TEST_DATA_PATH = process.env.TEST_DATA_PATH || 'TEST_DATA_PATH not set';
@@ -50,20 +50,12 @@ export async function runMochaTests(OPTS: any) {
 		process.exit(failures ? 1 : 0);
 	});
 
-	// Attach the 'retry' event listener to the runner
-	const retryLogs = path.resolve(REPORT_PATH, 'retry-logs.txt');
 	runner.on('retry', (test, err) => {
-		logToFile(retryLogs, `-----------------------------------------------`);
-		logToFile(retryLogs, `[RUN #${test.currentRetry()}] ${test.fullTitle()}`);
-		logToFile(retryLogs, `-----------------------------------------------`);
-		if (err) { logToFile(retryLogs, `${err.stack || err.message}\n`); }
+		logErrorToFile(test, err);
 	});
 
 	runner.on('fail', (test, err) => {
-		logToFile(retryLogs, `-----------------------------------------------`);
-		logToFile(retryLogs, `[RUN #${test.currentRetry()}] ${test.fullTitle()}`);
-		logToFile(retryLogs, `-----------------------------------------------`);
-		if (err) { logToFile(retryLogs, `${err.stack || err.message}\n`); }
+		logErrorToFile(test, err);
 	});
 }
 


### PR DESCRIPTION
### Intent

We are currently logging stack traces in the test report, which makes the logs difficult to read and negatively impacts the xUnit/JUnit reports. To retain this important information without cluttering the reports, I moved the stack traces to a `retry.log` file within each test’s directory.

### Approach

Each test already has its own directory for relevant logs. I added a `retry.log` file to this directory, which captures the stack traces for all retry attempts of that specific test.

<img width="281" alt="Screenshot 2024-10-11 at 2 13 58 PM" src="https://github.com/user-attachments/assets/908250ca-2dfd-4fed-8018-f12c6e5ef0a7">
<img width="806" alt="Screenshot 2024-10-11 at 2 13 48 PM" src="https://github.com/user-attachments/assets/7418233d-6742-4a57-bc7b-0c1f7768f6f8">

### QA Notes
Confirmed that all reports and traces are still present.