### PR TITLE
Bump release test executor back to 8x

### DIFF
--- a/.github/workflows/smoke-test-release-run-ubuntu.yml
+++ b/.github/workflows/smoke-test-release-run-ubuntu.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   linux:
     name: e2e-electron-tests
-    runs-on: ubuntu-latest-4x
+    runs-on: ubuntu-latest-8x
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Tried 4x once it was merged and hit more errors.  :(

### QA Notes

All smoke tests pass
