### PR TITLE
Add more windows tests

### DIFF
--- a/.github/workflows/positron-windows-nightly.yml
+++ b/.github/workflows/positron-windows-nightly.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10.10"
-          
+
       - name: Cache node_modules, build, extensions, and remote
         uses: ./.github/actions/cache-multi-paths
 
@@ -92,6 +92,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tinytex: true
+
+      - name: Setup AWS S3 Access
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws-role-to-assume }}
+          aws-region: ${{ secrets.aws-region }}
 
       - name: Run Smoke Tests (Electron)
         env:

--- a/.github/workflows/positron-windows-nightly.yml
+++ b/.github/workflows/positron-windows-nightly.yml
@@ -96,8 +96,8 @@ jobs:
       - name: Setup AWS S3 Access
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.aws-role-to-assume }}
-          aws-region: ${{ secrets.aws-region }}
+          role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
+          aws-region: ${{ secrets.QA_AWS_REGION }}
 
       - name: Run Smoke Tests (Electron)
         env:

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -9,7 +9,7 @@ import { Application, PositronPythonFixtures, PositronRFixtures } from '../../..
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 import { join } from 'path';
 
-describe('Data Explorer 100x100', function () {
+describe('Data Explorer 100x100 #win', function () {
 	setupAndStartApp();
 
 	/**

--- a/test/smoke/src/areas/positron/dataexplorer/largeDataFrame.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/largeDataFrame.test.ts
@@ -15,7 +15,7 @@ const LAST_CELL_CONTENTS = '2013-09-30 08:00:00';
 const FILTER_PARAMS = ['distance', 'is equal to', '2586'];
 const POST_FILTER_DATA_SUMMARY = 'Showing 8,204 rows (2.44% of 336,776 total)  19 columns';
 
-describe('Data Explorer - Large Data Frame #pr #web', () => {
+describe('Data Explorer - Large Data Frame #pr #web #win', () => {
 	logger = setupAndStartApp();
 
 	describe('Python Data Explorer (Large Data Frame)', () => {

--- a/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
@@ -7,7 +7,7 @@ import { expect } from '@playwright/test';
 import { Application, PositronPythonFixtures, PositronRFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 
-describe('Data Explorer #web', () => {
+describe('Data Explorer #web #win', () => {
 	setupAndStartApp();
 
 	describe('Sparklines', () => {

--- a/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
@@ -47,10 +47,10 @@ describe('Data Explorer #web #win', () => {
 			await app.code.driver.getLocator(`.label-name:has-text("Data: ${variableName}")`).innerText();
 		}).toPass();
 
-		await app.workbench.positronDataExplorer.getDataExplorerTableData();
-		await app.workbench.positronSideBar.closeSecondarySideBar();
-		await app.workbench.positronDataExplorer.expandColumnProfile(0);
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleSidebarVisibility');
+		await app.workbench.positronSideBar.closeSecondarySideBar();
+		await app.workbench.positronDataExplorer.getDataExplorerTableData();
+		await app.workbench.positronDataExplorer.expandColumnProfile(0);
 	}
 
 	async function verifyGraphBarHeights(app: Application) {

--- a/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/sparklinesTrend.test.ts
@@ -50,6 +50,7 @@ describe('Data Explorer #web #win', () => {
 		await app.workbench.positronDataExplorer.getDataExplorerTableData();
 		await app.workbench.positronSideBar.closeSecondarySideBar();
 		await app.workbench.positronDataExplorer.expandColumnProfile(0);
+		await app.workbench.quickaccess.runCommand('workbench.action.toggleSidebarVisibility');
 	}
 
 	async function verifyGraphBarHeights(app: Application) {

--- a/test/smoke/src/areas/positron/dataexplorer/veryLargeDataFrame.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/veryLargeDataFrame.test.ts
@@ -19,7 +19,7 @@ const objectKey = "largeParquet.parquet";
 
 const githubActions = process.env.GITHUB_ACTIONS === "true";
 
-describe('Data Explorer - Very Large Data Frame', () => {
+describe('Data Explorer - Very Large Data Frame #win', () => {
 	logger = setupAndStartApp();
 
 	before(async function () {

--- a/test/smoke/src/areas/positron/dataexplorer/xlsxDataFrame.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/xlsxDataFrame.test.ts
@@ -11,7 +11,7 @@ import { setupAndStartApp } from '../../../test-runner/test-hooks';
 
 let logger;
 
-describe('Data Explorer - XLSX #web', () => {
+describe('Data Explorer - XLSX #web #win', () => {
 	logger = setupAndStartApp();
 
 	describe('Python Data Explorer (XLSX file)', () => {


### PR DESCRIPTION
### Intent

More windows tests for #4867

### Approach

Turned on rest of data explorer tests.  Had to modify sparklines to hide sidebars and make enough of the dataexplorer tab visible

### QA Notes
All test pass on Windows & Linux CI

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
