### PR TITLE
Bump Ark to 0.1.144

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -635,7 +635,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.143"
+      "ark": "0.1.144"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
For:
- https://github.com/posit-dev/ark/pull/571
- https://github.com/posit-dev/ark/pull/568
- https://github.com/posit-dev/ark/pull/580

Full test job:
https://github.com/posit-dev/positron/actions/runs/11327535488