### PR TITLE
Never autostart runtimes that have `Manual` startup behavior.

### DIFF
--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -617,7 +617,7 @@ class ReticulateRuntimeMetadata implements positron.LanguageRuntimeMetadata {
 	runtimeVersion: string = '1.0';
 	runtimeSource: string = 'reticulate';
 	languageVersion = '1.0';
-	startupBehavior: positron.LanguageRuntimeStartupBehavior = positron.LanguageRuntimeStartupBehavior.Explicit;
+	startupBehavior: positron.LanguageRuntimeStartupBehavior = positron.LanguageRuntimeStartupBehavior.Manual;
 	sessionLocation: positron.LanguageRuntimeSessionLocation = positron.LanguageRuntimeSessionLocation.Workspace;
 }
 

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -617,7 +617,7 @@ class ReticulateRuntimeMetadata implements positron.LanguageRuntimeMetadata {
 	runtimeVersion: string = '1.0';
 	runtimeSource: string = 'reticulate';
 	languageVersion = '1.0';
-	startupBehavior: positron.LanguageRuntimeStartupBehavior = positron.LanguageRuntimeStartupBehavior.Immediate;
+	startupBehavior: positron.LanguageRuntimeStartupBehavior = positron.LanguageRuntimeStartupBehavior.Explicit;
 	sessionLocation: positron.LanguageRuntimeSessionLocation = positron.LanguageRuntimeSessionLocation.Workspace;
 }
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -510,6 +510,14 @@ declare module 'positron' {
 		 * usually used for runtimes that only provide REPLs
 		 */
 		Explicit = 'explicit',
+
+		/**
+		 * The runtime only starts up if manually requested by the user.
+		 * The difference from Explicit, is that Manual startup never
+		 * starts automatically, even if the run time is affiliated to the
+		 * workspace.
+		 */
+		Manual = 'manual'
 	}
 
 	/**

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -288,6 +288,14 @@ export enum LanguageRuntimeStartupBehavior {
 	 * usually used for runtimes that only provide REPLs
 	 */
 	Explicit = 'explicit',
+
+	/**
+	 * The runtime only starts up if manually requested by the user.
+	 * The difference from Explicit, is that Manual startup never
+	 * starts automatically, even if the run time is affiliated to the
+	 * workspace.
+	 */
+	Manual = 'manual'
 }
 
 /**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -521,6 +521,14 @@ export enum LanguageRuntimeStartupBehavior {
 	 * usually used for runtimes that only provide REPLs
 	 */
 	Explicit = 'explicit',
+
+	/**
+	 * The runtime only starts up if manually requested by the user.
+	 * The difference from Explicit, is that Manual startup never
+	 * starts automatically, even if the run time is affiliated to the
+	 * workspace.
+	 */
+	Manual = 'manual'
 }
 
 

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -463,6 +463,14 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 					return;
 				}
 
+				if (metadata.startupBehavior === LanguageRuntimeStartupBehavior.Explicit) {
+					this._logService.info(`Language runtime ` +
+						`${formatLanguageRuntimeMetadata(affiliatedRuntimeMetadata)} ` +
+						`is affiliated with this workspace, but won't be started because its ` +
+						`startup behavior is explicit.`);
+					return;
+				}
+
 				this._runtimeSessionService.startNewRuntimeSession(metadata.runtimeId,
 					metadata.runtimeName,
 					LanguageRuntimeSessionMode.Console,
@@ -655,7 +663,17 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			// Check the setting to see if we should be auto-starting.
 			const autoStart = this._configurationService.getValue<boolean>(
 				'positron.interpreters.automaticStartup');
+
 			if (autoStart) {
+
+				if (affiliatedRuntimeMetadata.startupBehavior === LanguageRuntimeStartupBehavior.Explicit) {
+					this._logService.info(`Language runtime ` +
+						`${formatLanguageRuntimeMetadata(affiliatedRuntimeMetadata)} ` +
+						`is affiliated with this workspace, but won't be started because it's startup ` +
+						`behavior is explicit.`);
+					return;
+				}
+
 				this._runtimeSessionService.autoStartRuntime(affiliatedRuntimeMetadata,
 					`Affiliated ${languageId} runtime for workspace`);
 			} else {

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -351,6 +351,10 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			return;
 		}
 
+		if (session.runtimeMetadata.startupBehavior === LanguageRuntimeStartupBehavior.Manual) {
+			return;
+		}
+
 		// Save this runtime as the affiliated runtime for the current workspace.
 		this._storageService.store(this.storageKeyForRuntime(session.runtimeMetadata),
 			JSON.stringify(session.runtimeMetadata),
@@ -773,7 +777,8 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				session.getRuntimeState() !== RuntimeState.Uninitialized &&
 				session.getRuntimeState() !== RuntimeState.Initializing &&
 				session.getRuntimeState() !== RuntimeState.Exited &&
-				session.runtimeMetadata.sessionLocation === LanguageRuntimeSessionLocation.Workspace)
+				session.runtimeMetadata.sessionLocation === LanguageRuntimeSessionLocation.Workspace
+			)
 			.map(session => {
 				const metadata: SerializedSessionMetadata = {
 					metadata: session.metadata,

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -463,11 +463,11 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 					return;
 				}
 
-				if (metadata.startupBehavior === LanguageRuntimeStartupBehavior.Explicit) {
+				if (metadata.startupBehavior === LanguageRuntimeStartupBehavior.Manual) {
 					this._logService.info(`Language runtime ` +
 						`${formatLanguageRuntimeMetadata(affiliatedRuntimeMetadata)} ` +
 						`is affiliated with this workspace, but won't be started because its ` +
-						`startup behavior is explicit.`);
+						`startup behavior is manual.`);
 					return;
 				}
 
@@ -666,11 +666,11 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 
 			if (autoStart) {
 
-				if (affiliatedRuntimeMetadata.startupBehavior === LanguageRuntimeStartupBehavior.Explicit) {
+				if (affiliatedRuntimeMetadata.startupBehavior === LanguageRuntimeStartupBehavior.Manual) {
 					this._logService.info(`Language runtime ` +
 						`${formatLanguageRuntimeMetadata(affiliatedRuntimeMetadata)} ` +
 						`is affiliated with this workspace, but won't be started because it's startup ` +
-						`behavior is explicit.`);
+						`behavior is manual.`);
 					return;
 				}
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4870 by adding a new `Manual` startup behavior, that never automatically starts.


Edit: 



<details>
<summary>This actually breaks some assumptions for recently created environments, so I'm adding a new behavior type.</summary>
My understanding is that runtimes with startp behavior  == `Explicit` should never auto start, even if they are affiliated with a workspace:

https://github.com/posit-dev/positron/blob/53f07362a44bb60eaf98af4e2c923588c314c8d8/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts#L519-L523

The 'explicit' behavior seems to only be used in the Python extension for non-recommended runtimes that don't have IPykernel installed, so it seems fine to change this behavior.

https://github.com/posit-dev/positron/blob/53f07362a44bb60eaf98af4e2c923588c314c8d8/extensions/positron-python/src/client/positron/runtime.ts#L63-L64

Happy to add a new behavior type though, if we prefer the current behavior of `Explicit`.

</details>