### PR TITLE
Fix R grammar for highlighting

### DIFF
--- a/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
@@ -3,19 +3,15 @@
 	"comment": "https://macromates.com/manual/en/language_grammars",
 	"name": "R",
 	"scopeName": "source.r",
-	"fileTypes": [
-		"R",
-		"r",
-		"Rprofile"
-	],
+	"fileTypes": ["R", "r", "Rprofile"],
 	"foldingStartMarker": "\\{\\s*(?:#|$)",
 	"foldingStopMarker": "^\\s*\\}",
 	"variables": {
-		"bracket": "keyword.operator",
-		"identifier": "constant.other",
+		"bracket": "meta.bracket",
+		"identifier": "variable.object",
 		"latex": "keyword.other",
 		"operator": "keyword.operator",
-		"parameter": "entity.name.tag",
+		"parameter": "variable.parameter",
 		"roxygen-tag": "keyword.other"
 	},
 	"patterns": [
@@ -57,7 +53,7 @@
 		"brackets": {
 			"patterns": [
 				{
-					"name": "keyword.operator",
+					"name": "meta.bracket",
 					"begin": "\\{",
 					"end": "\\}",
 					"patterns": [
@@ -67,7 +63,7 @@
 					]
 				},
 				{
-					"name": "keyword.operator",
+					"name": "meta.bracket",
 					"begin": "\\[",
 					"end": "\\]",
 					"patterns": [
@@ -75,7 +71,7 @@
 							"match": "([\\w.]+)\\s*(?==[^=])",
 							"captures": {
 								"1": {
-									"name": "entity.name.tag"
+									"name": "variable.parameter"
 								}
 							}
 						},
@@ -85,7 +81,7 @@
 					]
 				},
 				{
-					"name": "keyword.operator",
+					"name": "meta.bracket",
 					"begin": "\\(",
 					"end": "\\)",
 					"patterns": [
@@ -93,7 +89,7 @@
 							"match": "([\\w.]+)\\s*(?==[^=])",
 							"captures": {
 								"1": {
-									"name": "entity.name.tag"
+									"name": "variable.parameter"
 								}
 							}
 						},
@@ -179,24 +175,27 @@
 			]
 		},
 		"function-call": {
-			"name": "entity.name.function",
-			"match": "([\\w.]+)(?=\\()"
+			"match": "([\\w.]+)(?=\\()",
+			"captures": {
+				"0": { "name": "meta.function-call" },
+				"1": { "name": "entity.name.function" }
+			}
 		},
 		"function-definition": {
-			"name": "keyword",
+			"name": "meta.function.definition",
 			"begin": "(function)\\s*(\\()",
 			"beginCaptures": {
 				"1": {
-					"name": "keyword"
+					"name": "keyword.other"
 				},
 				"2": {
-					"name": "keyword.operator"
+					"name": "meta.bracket"
 				}
 			},
 			"end": "(\\))",
 			"endCaptures": {
 				"1": {
-					"name": "keyword.operator"
+					"name": "meta.bracket"
 				}
 			},
 			"patterns": [
@@ -204,7 +203,7 @@
 					"begin": "([\\w.]+)",
 					"beginCaptures": {
 						"1": {
-							"name": "entity.name.tag"
+							"name": "variable.parameter"
 						}
 					},
 					"end": "(?=[,)])",
@@ -230,11 +229,11 @@
 			]
 		},
 		"identifier-syntactic": {
-			"name": "constant.other",
+			"name": "variable.object",
 			"match": "[\\p{L}\\p{Nl}.][\\p{L}\\p{Nl}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}.]*"
 		},
 		"identifier-quoted": {
-			"name": "constant.other",
+			"name": "variable.object",
 			"begin": "`",
 			"end": "`",
 			"patterns": [
@@ -305,10 +304,10 @@
 					"match": "(\\[)(?:(\\w+)(:{2,3}))?(\\w+)(\\(\\))?(\\])",
 					"captures": {
 						"1": {
-							"name": "keyword.operator"
+							"name": "meta.bracket"
 						},
 						"2": {
-							"name": "constant.other"
+							"name": "variable.object"
 						},
 						"3": {
 							"name": "keyword.operator"
@@ -317,10 +316,10 @@
 							"name": "entity.name.function"
 						},
 						"5": {
-							"name": "keyword.operator"
+							"name": "meta.bracket"
 						},
 						"6": {
-							"name": "keyword.operator"
+							"name": "meta.bracket"
 						}
 					}
 				},
@@ -480,7 +479,7 @@
 					"match": "^\\s*#+'"
 				},
 				{
-					"name": "keyword.operator",
+					"name": "meta.bracket",
 					"match": "[\\[\\(\\{\\}\\)\\]]"
 				},
 				{
@@ -510,7 +509,7 @@
 					"end": "(?:\\s|$)",
 					"patterns": [
 						{
-							"name": "entity.name.tag",
+							"name": "variable.parameter",
 							"match": "([\\w.]+)"
 						},
 						{

--- a/extensions/positron-r/syntaxes/r.tmGrammar.src.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.src.json
@@ -3,19 +3,15 @@
 	"comment": "https://macromates.com/manual/en/language_grammars",
 	"name": "R",
 	"scopeName": "source.r",
-	"fileTypes": [
-		"R",
-		"r",
-		"Rprofile"
-	],
+	"fileTypes": ["R", "r", "Rprofile"],
 	"foldingStartMarker": "\\{\\s*(?:#|$)",
 	"foldingStopMarker": "^\\s*\\}",
 	"variables": {
-		"bracket": "keyword.operator",
-		"identifier": "constant.other",
+		"bracket": "meta.bracket",
+		"identifier": "variable.object",
 		"latex": "keyword.other",
 		"operator": "keyword.operator",
-		"parameter": "entity.name.tag",
+		"parameter": "variable.parameter",
 		"roxygen-tag": "keyword.other"
 	},
 	"patterns": [
@@ -179,15 +175,18 @@
 			]
 		},
 		"function-call": {
-			"name": "entity.name.function",
-			"match": "([\\w.]+)(?=\\()"
+			"match": "([\\w.]+)(?=\\()",
+			"captures": {
+				"0": { "name": "meta.function-call" },
+				"1": { "name": "entity.name.function" }
+			}
 		},
 		"function-definition": {
-			"name": "keyword",
+			"name": "meta.function.definition",
 			"begin": "(function)\\s*(\\()",
 			"beginCaptures": {
 				"1": {
-					"name": "keyword"
+					"name": "keyword.other"
 				},
 				"2": {
 					"name": "{{ bracket }}"


### PR DESCRIPTION
These changes fix a number of syntax higlighting issues caused by our TextMate grammar for R. Addresses #3688.

We are currently styling most of R variables as keywords or constants, which looks jarring with many themes. With the following changes we now style R variables with the conventional `variable.parameter` and `variable.object` scopes:

- The scopes of identifiers are renamed from `constant.other` to `variable.object` and from `entity.name.tag` to `variable.parameter`.

- To ensure these scopes are not overridden by a larger entity scope, we no longer use `keyword.operator` for bracket scopes, but `meta.bracket`. This is the appropriate scope prefix for large components in the code, see https://macromates.com/manual/en/language_grammars. This particular scope, `meta.bracket`, is not as popular as the ones discussed above but is used in the ObjC and Julia grammars.

  Similarly, we no longer scope function definitions as `keyword` but as `meta.function.definition`, the convention scope for these entities.

These changes allow colour themes to style R code much more consistently as they do other languages.

Before with Material:

<img width="560" alt="Screenshot 2024-10-14 at 17 06 05" src="https://github.com/user-attachments/assets/57b83602-d3eb-4672-bc16-942401765dc4">

After with Material:

<img width="613" alt="Screenshot 2024-10-14 at 17 06 31" src="https://github.com/user-attachments/assets/57848e80-2782-4bf2-8915-d5e0487a9673">

Before with Monokai:


<img width="675" alt="Screenshot 2024-10-14 at 16 26 16" src="https://github.com/user-attachments/assets/b8093713-682a-40aa-82c7-c6642ca8519a">

After with Monokai:

<img width="640" alt="Screenshot 2024-10-14 at 16 26 23" src="https://github.com/user-attachments/assets/7fd7f109-4d58-44aa-ad3c-154cab330c4d">

Note how these are less heavily styled.

We see kind of the opposite pattern with the default themes because they surprisingly seem to weigh more heavily regular text as opposed to keyword:

Before with Positron Light:

<img width="666" alt="Screenshot 2024-10-14 at 17 11 14" src="https://github.com/user-attachments/assets/5c66b72f-0278-4f4e-b545-d57290ea5d9d">

After with Positron Light:

<img width="616" alt="Screenshot 2024-10-14 at 17 10 58" src="https://github.com/user-attachments/assets/a56dfd7a-8446-4b7f-b9f1-f8faeabd0152">

Before with Positron Dark:

<img width="650" alt="Screenshot 2024-10-14 at 16 26 46" src="https://github.com/user-attachments/assets/0bcdd42e-84d5-4b37-b4cd-52d395b300e5">

After with Positron Dark:

<img width="615" alt="Screenshot 2024-10-14 at 16 26 52" src="https://github.com/user-attachments/assets/59024796-0bfe-4db8-aa6b-e4ae353ffb2c">

That said, this makes R styling consistent with how the theme works with other languages, here is how Positron Light and Dark style a C file for comparison:

<img width="660" alt="Screenshot 2024-10-14 at 17 04 12" src="https://github.com/user-attachments/assets/912f36c9-3319-4de1-9be2-c17d9a9668d3">

<img width="658" alt="Screenshot 2024-10-14 at 16 28 22" src="https://github.com/user-attachments/assets/36ba9d64-793d-4502-94e1-4b3e5b5abf2c">
