### PR TITLE
Improve restarting behavior of the reticulate session.

### DIFF
--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -517,7 +517,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 			}
 		});
 
-		await this.shutdown(positron.RuntimeExitReason.Restart);
+		await this.shutdown(positron.RuntimeExitReason.Shutdown);
 		return;
 	}
 

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -485,14 +485,14 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 		// We have to send a restart to the R session, and send a reticulate::repl_python()
 		// command to it.
 		const restart = await positron.window.showSimpleModalDialogPrompt(
-			'Restarting reticulate',
-			'This is will also restart the parent R session. Are you sure you want to continue?',
-			'Yes',
-			'No'
+			vscode.l10n.t('Restarting reticulate'),
+			vscode.l10n.t('This is will also restart the parent R session. Are you sure you want to continue?'),
+			vscode.l10n.t('Yes'),
+			vscode.l10n.t('No')
 		);
 
 		if (!restart) {
-			return;
+			throw new Error('Restart cancelled.');
 		}
 
 		// The events below will make sure that things occure in the right order:
@@ -517,7 +517,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 			}
 		});
 
-		await this.shutdown(positron.RuntimeExitReason.SwitchRuntime);
+		await this.shutdown(positron.RuntimeExitReason.Restart);
 		return;
 	}
 

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -495,7 +495,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 			throw new Error('Restart cancelled.');
 		}
 
-		// The events below will make sure that things occure in the right order:
+		// The events below will make sure that things occur in the right order:
 		// 1. shutdown the current reticulate session
 		// 2. restart the attached R session
 		// 3. start a new reticulate session.


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4887 by making sure the correct order of action happens:

1. Shutdown the Reticulate Python kernel
2. Restart the R session
3. Start a new reticulate session

We also added a new dialog when restarting the reticulate kernel, to make sure that the user is aware that the R kernel is also restarting, not just the reticulate kernel.

We can't restart the reticulate kernel without restarting the R session because Reticulate binds to a single Python session only once. If simply restarted Ipykernel, it would still point to the same Python session as before (eg same variables, etc).