### PR TITLE
Add experimental wording for positron notebooks setting

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -35,7 +35,7 @@ import { IPositronNotebookInstance } from 'vs/workbench/services/positronNoteboo
 /**
  * Key for the configuration setting that determines whether to use the Positron Notebook editor
  */
-const USE_POSITRON_NOTEBOOK_EDITOR_CONFIG_KEY = 'positron.notebooks.usePositronNotebooks';
+const USE_POSITRON_NOTEBOOK_EDITOR_CONFIG_KEY = 'positron.notebooks.usePositronNotebooksExperimental';
 
 /**
  * Retrieve the value of the configuration setting that determines whether to use the Positron
@@ -55,7 +55,10 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		[USE_POSITRON_NOTEBOOK_EDITOR_CONFIG_KEY]: {
 			type: 'boolean',
 			default: false,
-			markdownDescription: localize('positron.usePositronNotebooks', "Should the Positron Notebook editor be used instead of the default one?"),
+			markdownDescription: localize(
+				'positron.usePositronNotebooks',
+				"Use experimental Positron Notebook editor.\n\n**CAUTION**: The Positron Notebook editor is experimental and does not yet support all notebook features."
+			),
 		}
 	}
 });


### PR DESCRIPTION
The wording on the notebook setting was very nonchalant before. Now we match other positron experimental features by making it as clear as possible that the notebooks are not ready for primetime yet. 

<img width="906" alt="image" src="https://github.com/user-attachments/assets/d3fb0c8f-ab31-42d5-94de-56fc5ac923a1">


<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes
The setting key was changed to `positron.notebooks.usePositronNotebooksExperimental` from `positron.notebooks.usePositronNotebooks`.  Which could cause issues it the tests manually set this flag. There doesn't appear to be any instances of this in the main positron repo, though. 
