### PR TITLE
e2e tests: shorten screenshot name

### DIFF
--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -64,7 +64,7 @@ export class PlaywrightDriver {
 			let persistPath: string | undefined = undefined;
 			if (persist) {
 				// --- Start Positron ---
-				persistPath = join(this.options.logsPath, `playwright-trace-${PlaywrightDriver.traceCounter++}-${name.replace(/\s+/g, '-')}_${Date.now()}.zip`);
+				persistPath = join(this.options.logsPath, `${PlaywrightDriver.traceCounter++}-${name.replace(/\s+/g, '-')}.zip`);
 				// --- End Positron ---
 			}
 
@@ -169,7 +169,7 @@ export class PlaywrightDriver {
 	async takeScreenshot(name: string): Promise<void> {
 		// --- End Positron ---
 		try {
-			const persistPath = join(this.options.logsPath, `playwright-screenshot-${PlaywrightDriver.screenShotCounter++}-${name.replace(/\s+/g, '-')}.png`);
+			const persistPath = join(this.options.logsPath, `${PlaywrightDriver.screenShotCounter++}-${name.replace(/\s+/g, '-')}.png`);
 
 			await measureAndLog(() => this.page.screenshot({ path: persistPath, type: 'png' }), 'takeScreenshot', this.options.logger);
 		} catch (error) {

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -65,7 +65,7 @@ export class PlaywrightDriver {
 			if (persist) {
 				// --- Start Positron ---
 				// Positron: Windows has issues with long paths, shortened the name
-				persistPath = join(this.options.logsPath, `${PlaywrightDriver.traceCounter++}-${name.replace(/\s+/g, '-')}.zip`);
+				persistPath = join(this.options.logsPath, `trace-${PlaywrightDriver.traceCounter++}-${name.replace(/\s+/g, '-')}.zip`);
 				// --- End Positron ---
 			}
 
@@ -170,7 +170,7 @@ export class PlaywrightDriver {
 	async takeScreenshot(name: string): Promise<void> {
 		try {
 			// Positron: Windows has issues with long paths, shortened the name
-			const persistPath = join(this.options.logsPath, `${PlaywrightDriver.screenShotCounter++}-${name.replace(/\s+/g, '-')}.png`);
+			const persistPath = join(this.options.logsPath, `screenshot-${PlaywrightDriver.screenShotCounter++}-${name.replace(/\s+/g, '-')}.png`);
 			// --- End Positron ---
 
 			await measureAndLog(() => this.page.screenshot({ path: persistPath, type: 'png' }), 'takeScreenshot', this.options.logger);

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -64,6 +64,7 @@ export class PlaywrightDriver {
 			let persistPath: string | undefined = undefined;
 			if (persist) {
 				// --- Start Positron ---
+				// Positron: Windows has issues with long paths, shortened the name
 				persistPath = join(this.options.logsPath, `${PlaywrightDriver.traceCounter++}-${name.replace(/\s+/g, '-')}.zip`);
 				// --- End Positron ---
 			}
@@ -76,7 +77,7 @@ export class PlaywrightDriver {
 			// some driver action ran before.
 			if (persist) {
 				// --- Start Positron ---
-				await this.takeScreenshot(`${name}_${Date.now()}`);
+				await this.takeScreenshot(`${name}`);
 				// --- End Positron ---
 			}
 		} catch (error) {
@@ -167,9 +168,10 @@ export class PlaywrightDriver {
 	// --- Start Positron ---
 	// Positron: make this method public for access from R/Python fixtures
 	async takeScreenshot(name: string): Promise<void> {
-		// --- End Positron ---
 		try {
+			// Positron: Windows has issues with long paths, shortened the name
 			const persistPath = join(this.options.logsPath, `${PlaywrightDriver.screenShotCounter++}-${name.replace(/\s+/g, '-')}.png`);
+			// --- End Positron ---
 
 			await measureAndLog(() => this.page.screenshot({ path: persistPath, type: 'png' }), 'takeScreenshot', this.options.logger);
 		} catch (error) {

--- a/test/smoke/src/areas/positron/variables/notebookVariables.test.ts
+++ b/test/smoke/src/areas/positron/variables/notebookVariables.test.ts
@@ -28,7 +28,6 @@ describe('Variables Pane - Notebook #pr #web', () => {
 			this.timeout(120000);
 
 			const app = this.app as Application;
-			expect(1).toBe(2);
 
 			await app.workbench.positronNotebooks.createNewNotebook();
 

--- a/test/smoke/src/areas/positron/variables/notebookVariables.test.ts
+++ b/test/smoke/src/areas/positron/variables/notebookVariables.test.ts
@@ -28,6 +28,7 @@ describe('Variables Pane - Notebook #pr #web', () => {
 			this.timeout(120000);
 
 			const app = this.app as Application;
+			expect(1).toBe(2);
 
 			await app.workbench.positronNotebooks.createNewNotebook();
 


### PR DESCRIPTION
### Intent

@jonvanausdeln  reported that Windows machines were experiencing issues opening screenshots with long filenames. The goal of this PR is to simplify and clean up the attachment filenames to address this.

### Approach

I removed unnecessary prefixes/suffixes from the attachment filenames. Since we are already using a counter to ensure each file has a unique name, we don't need to include the timestamp in the filenames. This simplifies the file naming convention while maintaining uniqueness.

### QA Notes

- Forced a failure in order to confirm that artifacts are still present as expected. All looks good:
<img width="692" alt="Screenshot 2024-10-15 at 11 49 09 AM" src="https://github.com/user-attachments/assets/2c31ae68-ae9f-4361-b1f7-94ea637227fb">
