### PR TITLE
Re-enable R console input tests

### DIFF
--- a/test/smoke/src/areas/positron/console/consoleInput.test.ts
+++ b/test/smoke/src/areas/positron/console/consoleInput.test.ts
@@ -48,8 +48,7 @@ print(f'Hello {val}!')`;
 		});
 	});
 
-	//Skipping due to https://github.com/posit-dev/positron/issues/4901
-	describe.skip('Console Input - R', () => {
+	describe('Console Input - R', () => {
 		before(async function () {
 			await PositronRFixtures.SetupFixtures(this.app as Application);
 			await this.app.workbench.positronLayouts.enterLayout('fullSizedPanel');


### PR DESCRIPTION
### Intent

Turn cnosole input test again as #4901 has been fixed in `main`

### Approach

Removed `skip`. Also note that these tests will now run as part of the PR jobs as requested by dev.

## QA Notes

Tests pass in CI