### PR TITLE
Rename indexed dbs with `positron` prefix

### DIFF
--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -459,9 +459,11 @@ export class BrowserMain extends Disposable {
 
 		// IndexedDB is used for logging and user data
 		let indexedDB: IndexedDB | undefined;
-		const userDataStore = 'vscode-userdata-store';
-		const logsStore = 'vscode-logs-store';
-		const handlesStore = 'vscode-filehandles-store';
+		// --- Start Positron ---
+		const userDataStore = 'positron-userdata-store';
+		const logsStore = 'positron-logs-store';
+		const handlesStore = 'positron-filehandles-store';
+		// --- End Positron ---
 		try {
 			// --- Start Positron ---
 			indexedDB = await IndexedDB.create('positron-web-db', 3, [userDataStore, logsStore, handlesStore]);

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -463,7 +463,9 @@ export class BrowserMain extends Disposable {
 		const logsStore = 'vscode-logs-store';
 		const handlesStore = 'vscode-filehandles-store';
 		try {
-			indexedDB = await IndexedDB.create('vscode-web-db', 3, [userDataStore, logsStore, handlesStore]);
+			// --- Start Positron ---
+			indexedDB = await IndexedDB.create('positron-web-db', 3, [userDataStore, logsStore, handlesStore]);
+			// --- End Positron ---
 
 			// Close onWillShutdown
 			this.onWillShutdownDisposables.add(toDisposable(() => indexedDB?.close()));

--- a/src/vs/workbench/services/storage/browser/storageService.ts
+++ b/src/vs/workbench/services/storage/browser/storageService.ts
@@ -339,7 +339,9 @@ export class IndexedDBStorageDatabase extends Disposable implements IIndexedDBSt
 		}
 	}
 
-	private static readonly STORAGE_DATABASE_PREFIX = 'vscode-web-state-db-';
+	// --- Start Positron ---
+	private static readonly STORAGE_DATABASE_PREFIX = 'positron-web-state-db-';
+	// --- End Positron ---
 	private static readonly STORAGE_OBJECT_STORE = 'ItemTable';
 
 	private readonly _onDidChangeItemsExternal = this._register(new Emitter<IStorageItemsChangeEvent>());


### PR DESCRIPTION
- Addresses: #4864
- updates the prefixes for web IndexedDB databases and stores to use `positron` instead of `vscode`
- we don't delete the existing stores that are prefixed with `vscode`

I've done some testing on a dev build of Server Web on Mac and a local release build of Positron on Workbench on Ubuntu 24.

### QA Notes

- this change impacts Positron Web / Server Web only
- the data stores are working if:
    - you're seeing the renamed databases and stores in Developer Tools > Application > Storage > IndexedDB
    - the layout state is being persisted when you close and reopen Positron in the same browser; for example:
        1. Open up a folder in Positron Web / Server Web
        2. Command Prompt > View: Toggle Zen Mode
        3. Close the browser
        4. Open up the same folder in the same browser in Positron Web / Server Web
        5. You should still be in Zen Mode