### PR TITLE
Saving Plots in Positron Web

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -165,12 +165,12 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 		setDpi({ value: newDpi, valid: newDpi >= 1 && newDpi <= 300 && !isNaN(newDpi) });
 	};
 
-	const updatePath = (pathString: string) => {
+	const updatePath = (path: URI) => {
 		try {
-			const newPath = URI.file(pathString);
-			props.fileService.exists(newPath).then(exists => {
+			props.fileService.exists(path).then(exists => {
 				setDirectory({
-					value: newPath, valid: exists,
+					value: path,
+					valid: exists,
 					errorMessage: exists ? undefined : localize('positron.savePlotModalDialog.pathDoesNotExist', "Path does not exist.")
 				});
 			});
@@ -190,7 +190,7 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 		});
 
 		if (uri && uri.length > 0) {
-			updatePath(uri[0].fsPath);
+			updatePath(uri[0]);
 		}
 	};
 
@@ -301,7 +301,7 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 									"Directory"
 								))()}
 								value={directory.value.fsPath}
-								onChange={e => updatePath(e.target.value)}
+								onChange={e => updatePath(directory.value.with({ path: e.target.value }))}
 								onBrowse={browseHandler}
 								readOnlyInput={false}
 								error={!directory.valid}

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -869,7 +869,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	}
 
 	private savePlotAs = (options: SavePlotOptions) => {
-		const htmlFileSystemProvider = this._fileService.getProvider(Schemas.file) as HTMLFileSystemProvider;
+		const htmlFileSystemProvider = this._fileService.getProvider(options.path.scheme) as HTMLFileSystemProvider;
 		const dataUri = this.splitPlotDataUri(options.uri);
 
 		if (!dataUri) {

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -25,7 +25,7 @@ import { PlotSizingPolicyCustom } from 'vs/workbench/services/positronPlots/comm
 import { IPositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
 import { IPositronIPyWidgetsService } from 'vs/workbench/services/positronIPyWidgets/common/positronIPyWidgetsService';
 import { Schemas } from 'vs/base/common/network';
-import { IDialogService, IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { decodeBase64 } from 'vs/base/common/buffer';
 import { SavePlotOptions, showSavePlotModalDialog } from 'vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
@@ -47,6 +47,7 @@ import { WebviewPlotClient } from 'vs/workbench/contrib/positronPlots/browser/we
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { URI } from 'vs/base/common/uri';
 import { PositronPlotCommProxy } from 'vs/workbench/services/languageRuntime/common/positronPlotCommProxy';
+import { IPositronModalDialogsService } from 'vs/workbench/services/positronModalDialogs/common/positronModalDialogs';
 
 /** The maximum number of recent executions to store. */
 const MaxRecentExecutions = 10;
@@ -155,7 +156,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@IClipboardService private _clipboardService: IClipboardService,
-		@IDialogService private readonly _dialogService: IDialogService,
+		@IPositronModalDialogsService private readonly _modalDialogService: IPositronModalDialogsService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@ILogService private readonly _logService: ILogService,
 		@INotificationService private readonly _notificationService: INotificationService,
@@ -847,7 +848,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 								this._selectedSizingPolicy,
 								this._layoutService,
 								this._keybindingService,
-								this._dialogService,
+								this._modalDialogService,
 								this._fileService,
 								this._fileDialogService,
 								this._logService,
@@ -880,7 +881,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 
 		htmlFileSystemProvider.writeFile(options.path, decodeBase64(data).buffer, { create: true, overwrite: true, unlock: true, atomic: false })
 			.catch((error: Error) => {
-				this._dialogService.error(localize('positronPlotsService.savePlotError.unknown', 'Error saving plot: {0}', error.message));
+				this._notificationService.error(localize('positronPlotsService.savePlotError.unknown', 'Error saving plot: {0}', error.message));
 			});
 	};
 


### PR DESCRIPTION
Address #4800 

Saving had always assumed using file URIs. Changing it to use the URI scheme from the suggested URI (the suggestion is retrieved from the file dialog service) fixes the saving. 

The overwrite confirmation was switched over to our own dialog so that it works in web, which also makes the theme match.

Web uses a quick pick for a file picker so that you can browse the remote file system. It's a bit hacky but the quick input controller makes it easy to check if there is a Positron modal and reparents the UI to it so that the modal overlay doesn't block interaction. There's some other code to handle closing the quick pick if the modal has closed and switching the parent back (the quick input UI is created once and reused).

There are still some quirks:
* Pressing Esc while the quick pick is open closes the modal as well
* You can still interact with the modal while the quick pick is open

https://github.com/user-attachments/assets/5851f04f-504f-4adb-863f-3e1244913fde


![image](https://github.com/user-attachments/assets/4aaa14eb-7b67-43cb-92c8-0768db4ada2f)


### QA Notes
This affects the command palette `Cmd+Shift+P` (it's a quick input). There are changes to ensure it displays as intended when there is no modal open.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
