### PR TITLE
Add saving plot as tiff

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
@@ -32,6 +32,8 @@ class RenderFormat(str, enum.Enum):
 
     Pdf = "pdf"
 
+    Tiff = "tiff"
+
 
 @enum.unique
 class PlotUnit(str, enum.Enum):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
@@ -32,6 +32,7 @@ MIME_TYPE = {
     "svg": "image/svg+xml",
     "pdf": "application/pdf",
     "jpeg": "image/jpeg",
+    "tiff": "image/tiff",
 }
 
 

--- a/positron/comms/plot-backend-openrpc.json
+++ b/positron/comms/plot-backend-openrpc.json
@@ -68,7 +68,7 @@
 					"description": "The requested plot format",
 					"schema": {
 						"type": "string",
-						"enum": ["png", "jpeg", "svg", "pdf"]
+						"enum": ["png", "jpeg", "svg", "pdf", "tiff"]
 					}
 				}
 			],

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -214,7 +214,7 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 					props.savePlotCallback({ uri: plotResult.uri, path: filePath });
 				})
 				.catch((error) => {
-					props.notificationService.error(localize('positron.savePlotModalDialog.errorSavingPlot', "Error saving plot: {0}", error.toString()));
+					props.notificationService.error(localize('positron.savePlotModalDialog.errorSavingPlot', "Error saving plot: {0}", JSON.stringify(error)));
 				})
 				.finally(() => {
 					setRendering(false);

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -326,6 +326,7 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 											new DropDownListBoxItem<RenderFormat, RenderFormat>({ identifier: RenderFormat.Jpeg, title: RenderFormat.Jpeg.toUpperCase(), value: RenderFormat.Jpeg }),
 											new DropDownListBoxItem<RenderFormat, RenderFormat>({ identifier: RenderFormat.Svg, title: RenderFormat.Svg.toUpperCase(), value: RenderFormat.Svg }),
 											new DropDownListBoxItem<RenderFormat, RenderFormat>({ identifier: RenderFormat.Pdf, title: RenderFormat.Pdf.toUpperCase(), value: RenderFormat.Pdf }),
+											new DropDownListBoxItem<RenderFormat, RenderFormat>({ identifier: RenderFormat.Tiff, title: RenderFormat.Tiff.toUpperCase(), value: RenderFormat.Tiff }),
 										]} />
 								</label>
 							</div>

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -864,7 +864,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 
 	private savePlotAs = (options: SavePlotOptions) => {
 		const htmlFileSystemProvider = this._fileService.getProvider(Schemas.file) as HTMLFileSystemProvider;
-		const matches = this.getPlotUri(options.uri);
+		const matches = this.splitPlotDataUri(options.uri);
 
 		if (!matches) {
 			return;
@@ -878,17 +878,27 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 			});
 	};
 
-	private getPlotUri(plotData: string) {
-		const regex = /^data:.+\/(.+);base64,(.*)$/;
-		const matches = plotData.match(regex);
-		if (!matches || matches.length !== 3) {
+	/**
+	 * Splits an image data URI into its MIME, type, and data.
+	 * @param plotDataUri the data URI
+	 * @returns an array containing the MIME type, the type of the image, and the image data
+	 */
+	private splitPlotDataUri(plotDataUri: string) {
+		// match the data URI scheme
+		// the data portion isn't matched because of javascript regex performance with large stringszs
+		const mimeAndData = plotDataUri.split('base64,');
+		if (mimeAndData.length !== 2) {
 			return null;
 		}
-		return matches;
+
+		const mime = mimeAndData[0].split('data:')[1];
+		const imageData = mimeAndData[1];
+
+		return [mime, mime.split('/')[1], imageData];
 	}
 
 	showSavePlotDialog(uri: string) {
-		const matches = this.getPlotUri(uri);
+		const matches = this.splitPlotDataUri(uri);
 
 		if (!matches) {
 			return;

--- a/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
@@ -76,7 +76,8 @@ export enum RenderFormat {
 	Png = 'png',
 	Jpeg = 'jpeg',
 	Svg = 'svg',
-	Pdf = 'pdf'
+	Pdf = 'pdf',
+	Tiff = 'tiff'
 }
 
 /**


### PR DESCRIPTION
Address #4690

Adds TIFF to the plot comm and Python support.

The data URI parsing had to be changed since TIFF generates a large URI that caused performance issues when using regex. Using `split` is faster to determine the file extension and get the image data for saving.

Ark will also need an update for R support: https://github.com/posit-dev/ark/pull/591

![image](https://github.com/user-attachments/assets/87f2e295-19a8-4ec5-b8b0-d0e0fce76d46)


<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes
This adds a new format option to the save plot dialog.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
