### PR TITLE
Fix new project wizard for web

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators.ts
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators.ts
@@ -93,6 +93,25 @@ export async function checkIfPathExists(path: string | number, fileService: IFil
 	return undefined;
 }
 
+/**
+ * Check if the current URI exists. For use with Positron web.
+ *
+ * @see `checkIfPathValid` `useDebouncedValidator` `LabeledTextInput` `LabeledFolderInput`
+ * @returns Promise with error message if path doesn't exist or undefined if it does.
+ */
+export async function checkIfURIExists(path: URI, fileService: IFileService): Promise<string | undefined> {
+	try {
+		const pathExists = await fileService.exists(path);
+
+		if (!pathExists) {
+			return localize('pathDoesNotExistError', "The path {0} does not exist.", sanitizePathForDisplay(path.path));
+		}
+	} catch (e) {
+		return localize('errorCheckingIfPathExists', "An error occurred while checking if the path {0} exists.", sanitizePathForDisplay(path.path));
+	}
+
+	return undefined;
+}
 
 /**
  * Helper function to print paths in a more readable format.

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/labeledTextInput.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/labeledTextInput.tsx
@@ -29,7 +29,7 @@ export interface LabeledTextInputProps {
 	 * Custom error message. Will override the validator error message if present.
 	 */
 	errorMsg?: string;
-	validator?: ValidatorFn;
+	validator?: ValidatorFn<string | number>;
 	onChange: ChangeEventHandler<HTMLInputElement>;
 	/**
 	 * Maximum allowed number of characters in the input field.

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/useDebouncedValidator.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/useDebouncedValidator.tsx
@@ -5,13 +5,13 @@
 
 import * as React from 'react';
 
-export type ValidatorFn = (value: string | number) => (string | undefined) | Promise<string | undefined>;
+export type ValidatorFn<T> = (value: T) => (string | undefined) | Promise<string | undefined>;
 
 /**
  * A hook to debounce the validation of input values.
  * @param validator The function to validate the input value. Can be synchronous or asynchronous.
  */
-export function useDebouncedValidator({ validator, value, debounceDelayMs = 100 }: { validator?: ValidatorFn; value: string | number; debounceDelayMs?: number }) {
+export function useDebouncedValidator<T>({ validator, value, debounceDelayMs = 100 }: { validator?: ValidatorFn<T>; value: T; debounceDelayMs?: number }) {
 	const [errorMsg, setErrorMsg] = React.useState<string | undefined>(undefined);
 
 	const callbackTimeoutRef = React.useRef<NodeJS.Timeout | undefined>();

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
@@ -133,6 +133,10 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 		}
 	};
 
+	function validatorCallback(x: string | number): string | undefined {
+		return checkIfPathValid(x, { parentPath: result.parentFolder });
+	}
+
 	// Render.
 	return (
 		<OKCancelModalDialog
@@ -153,7 +157,7 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 					autoFocus
 					value={result.folder}
 					onChange={e => setResult({ ...result, folder: e.target.value })}
-					validator={x => checkIfPathValid(x, { parentPath: result.parentFolder })}
+					validator={validatorCallback}
 				/>
 				<LabeledFolderInput
 					label={(() => localize(

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
@@ -133,10 +133,6 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 		}
 	};
 
-	function validatorCallback(x: string | number): string | undefined {
-		return checkIfPathValid(x, { parentPath: result.parentFolder });
-	}
-
 	// Render.
 	return (
 		<OKCancelModalDialog
@@ -157,7 +153,7 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 					autoFocus
 					value={result.folder}
 					onChange={e => setResult({ ...result, folder: e.target.value })}
-					validator={validatorCallback}
+					validator={(x: string | number) => checkIfPathValid(x, { parentPath: result.parentFolder })}
 				/>
 				<LabeledFolderInput
 					label={(() => localize(

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -151,7 +151,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 							maxLength={65}
 							pathComponents={
 								locationForNewEnv(
-									context.parentFolder,
+									context.parentFolder.path,
 									context.projectName,
 									envProviderNameForId(envProviderId, envProviders!)
 								)

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -19,7 +19,6 @@ import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/com
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer';
 import { PositronModalDialog } from 'vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog';
-import { URI } from 'vs/base/common/uri';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { IFileService } from 'vs/platform/files/common/files';
 import { ICommandService } from 'vs/platform/commands/common/commands';
@@ -74,14 +73,14 @@ export const showNewProjectModalDialog = async (
 				runtimeSessionService,
 				runtimeStartupService,
 			}}
-			parentFolder={(await fileDialogService.defaultFolderPath()).fsPath}
+			parentFolder={await fileDialogService.defaultFolderPath()}
 			initialStep={NewProjectWizardStep.ProjectTypeSelection}
 		>
 			<NewProjectModalDialog
 				renderer={renderer}
 				createProject={async result => {
 					// Create the new project folder if it doesn't already exist.
-					const folder = URI.file((await pathService.path).join(result.parentFolder, result.projectName));
+					const folder = result.parentFolder.with({ path: (await pathService.path).join(result.parentFolder.fsPath, result.projectName) });
 					const existingFolder = await fileService.exists(folder);
 					if (!existingFolder) {
 						await fileService.createFolder(folder);

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -23,6 +23,7 @@ import { WizardFormattedTextItem } from 'vs/workbench/browser/positronNewProject
 import { LanguageIds, NewProjectType } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { CondaPythonVersionInfo, EMPTY_CONDA_PYTHON_VERSION_INFO } from 'vs/workbench/browser/positronNewProjectWizard/utilities/condaUtils';
+import { URI } from 'vs/base/common/uri';
 
 /**
  * NewProjectWizardServices interface.
@@ -49,7 +50,7 @@ interface NewProjectWizardServices {
  */
 export interface NewProjectWizardStateConfig {
 	readonly services: NewProjectWizardServices;
-	readonly parentFolder: string;
+	readonly parentFolder: URI;
 	readonly initialStep: NewProjectWizardStep;
 	readonly steps?: NewProjectWizardStep[];
 }
@@ -62,7 +63,7 @@ export interface NewProjectWizardState {
 	selectedRuntime: ILanguageRuntimeMetadata | undefined;
 	projectType: NewProjectType | undefined;
 	projectName: string;
-	parentFolder: string;
+	parentFolder: URI;
 	initGitRepo: boolean;
 	openInNewWindow: boolean;
 	pythonEnvSetupType: EnvironmentSetupType | undefined;
@@ -106,7 +107,7 @@ export class NewProjectWizardStateManager
 	private _projectType: NewProjectType | undefined;
 	private _projectName: string;
 	private _projectNameFeedback: WizardFormattedTextItem | undefined;
-	private _parentFolder: string;
+	private _parentFolder: URI;
 	private _initGitRepo: boolean;
 	private _openInNewWindow: boolean;
 	// Python-specific state.
@@ -282,7 +283,7 @@ export class NewProjectWizardStateManager
 	 * Gets the parent folder.
 	 * @returns The parent folder.
 	 */
-	get parentFolder(): string {
+	get parentFolder(): URI {
 		return this._parentFolder;
 	}
 
@@ -290,7 +291,7 @@ export class NewProjectWizardStateManager
 	 * Sets the parent folder.
 	 * @param value The parent folder.
 	 */
-	set parentFolder(value: string) {
+	set parentFolder(value: URI) {
 		this._parentFolder = value;
 		this._onUpdateProjectDirectoryEmitter.fire();
 	}

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils.ts
@@ -19,7 +19,7 @@ import { IPathService } from 'vs/workbench/services/path/common/pathService';
  */
 export const checkProjectName = async (
 	projectName: string,
-	parentFolder: string,
+	parentFolder: URI,
 	pathService: IPathService,
 	fileService: IFileService
 ) => {
@@ -37,9 +37,7 @@ export const checkProjectName = async (
 	// TODO: Additional project name validation (i.e. unsupported characters, length, etc.)
 
 	// The project directory can't already exist.
-	const folderPath = URI.file(
-		(await pathService.path).join(parentFolder, projectName)
-	);
+	const folderPath = parentFolder.with({ path: (await pathService.path).join(parentFolder.fsPath, projectName) });
 	if (await fileService.exists(folderPath)) {
 		return {
 			type: WizardFormattedTextType.Error,


### PR DESCRIPTION
Address #4840 

Switch to using URI where applicable for the project path. The file service can handle checking if the path exists. It also gets the default path so reusing that URI will decide whether the URI will be remote or local.

Changing the debounced validator to be generic will make it easier to fix the `LabeledFolderInput` component that's used in the new folder and new folder from git dialogs (issues #5045 and #5048).

The file picker is still stuck behind the modal overlay but the fix for #4800 will allow the quick pick to sit above the overlay.

The path exists check will work like on desktop and it should create the project in the given location. The URI scheme is `vscode-remote` for web.

https://github.com/user-attachments/assets/ad666d6e-cbc8-44f8-ae18-03ac24a064e8


<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes
The project should be created on the server, not locally. The browse button is fixed separately but should show a quick pick instead of the native file browser. The native file browser is only for desktop.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
