### PR TITLE
Do not update global `python.defaultInterpreterPath` when a runtime starts

### DIFF
--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -277,7 +277,6 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         await this._installIpykernel();
 
         // Update the active environment in the Python extension.
-        this._interpreterPathService.update(undefined, vscode.ConfigurationTarget.Global, this.interpreter.path);
         this._interpreterPathService.update(
             undefined,
             vscode.ConfigurationTarget.WorkspaceFolder,
@@ -451,15 +450,15 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         }
         const kernel = this.kernelSpec
             ? // We have a kernel spec, so we're creating a new session
-              await this.adapterApi.createSession(
-                  this.runtimeMetadata,
-                  this.metadata,
-                  this.kernelSpec,
-                  this.dynState,
-                  createJupyterKernelExtra(),
-              )
+            await this.adapterApi.createSession(
+                this.runtimeMetadata,
+                this.metadata,
+                this.kernelSpec,
+                this.dynState,
+                createJupyterKernelExtra(),
+            )
             : // We don't have a kernel spec, so we're restoring a session
-              await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
+            await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
 
         kernel.onDidChangeRuntimeState((state) => {
             this._stateEmitter.fire(state);
@@ -582,10 +581,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             const regex = /^(\w*Error|Exception)\b/m;
             const errortext = regex.test(logFileContent)
                 ? vscode.l10n.t(
-                      '{0} exited unexpectedly with error: {1}',
-                      kernel.runtimeMetadata.runtimeName,
-                      logFileContent,
-                  )
+                    '{0} exited unexpectedly with error: {1}',
+                    kernel.runtimeMetadata.runtimeName,
+                    logFileContent,
+                )
                 : Console.consoleExitGeneric;
 
             const res = await showErrorMessage(errortext, vscode.l10n.t('Open Logs'));

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -450,15 +450,15 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         }
         const kernel = this.kernelSpec
             ? // We have a kernel spec, so we're creating a new session
-            await this.adapterApi.createSession(
-                this.runtimeMetadata,
-                this.metadata,
-                this.kernelSpec,
-                this.dynState,
-                createJupyterKernelExtra(),
-            )
+              await this.adapterApi.createSession(
+                  this.runtimeMetadata,
+                  this.metadata,
+                  this.kernelSpec,
+                  this.dynState,
+                  createJupyterKernelExtra(),
+              )
             : // We don't have a kernel spec, so we're restoring a session
-            await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
+              await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
 
         kernel.onDidChangeRuntimeState((state) => {
             this._stateEmitter.fire(state);
@@ -581,10 +581,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             const regex = /^(\w*Error|Exception)\b/m;
             const errortext = regex.test(logFileContent)
                 ? vscode.l10n.t(
-                    '{0} exited unexpectedly with error: {1}',
-                    kernel.runtimeMetadata.runtimeName,
-                    logFileContent,
-                )
+                      '{0} exited unexpectedly with error: {1}',
+                      kernel.runtimeMetadata.runtimeName,
+                      logFileContent,
+                  )
                 : Console.consoleExitGeneric;
 
             const res = await showErrorMessage(errortext, vscode.l10n.t('Open Logs'));


### PR DESCRIPTION
Addresses #4552 

I want to point out #3255 where we _added_ updating the path in the workspace. I suspect (???) that updating the setting globally was never the right thing to do; this was added in the massive https://github.com/posit-dev/positron-python/pull/413 for multi-session support.

This PR does not address how updating the `python.defaultInterpreterPath` user setting starts Python. I have [some more notes here](https://github.com/posit-dev/positron/issues/4552#issuecomment-2418322327) and we can open a followup PR if folks think this is a problem. It seems mostly like intended/inherited behavior from upstream to me.

### QA Notes

- Open a workspace and have R only running.
- Open an additional workspace and have R only running.
- Start a Python runtime in the second workspace via the top bar.

You should _not_ see any Python runtime start in the first workspace/window.

We should still see the correct behavior for #3169 and #3255.

I don't think we can write a useful unit test for this and we don't currently have multi-workspace tests. It might be worth putting that (smoke tests for multiple workspaces) on the todo list eventually but certainly seems like an advanced move.