### PR TITLE
increase `quarto` fetch timeout to 90 seconds

### DIFF
--- a/build/lib/fetch.js
+++ b/build/lib/fetch.js
@@ -47,7 +47,10 @@ async function fetchUrl(url, options, retries = 10, retryDelay = 1000) {
             startTime = new Date().getTime();
         }
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 30 * 1000);
+        // --- Start Positron ---
+        // Increase the timeout to 90 seconds to accommodate slower downloads.
+        const timeout = setTimeout(() => controller.abort(), 90 * 1000);
+        // --- End Positron ---
         try {
             const response = await fetch(url, {
                 ...options.nodeFetchOptions,

--- a/build/lib/fetch.js
+++ b/build/lib/fetch.js
@@ -48,8 +48,8 @@ async function fetchUrl(url, options, retries = 10, retryDelay = 1000) {
         }
         const controller = new AbortController();
         // --- Start Positron ---
-        // Increase the timeout to 90 seconds to accommodate slower downloads.
-        const timeout = setTimeout(() => controller.abort(), 90 * 1000);
+        const timeoutSeconds = options.timeoutSeconds ?? 30;
+        const timeout = setTimeout(() => controller.abort(), timeoutSeconds * 1000);
         // --- End Positron ---
         try {
             const response = await fetch(url, {

--- a/build/lib/fetch.ts
+++ b/build/lib/fetch.ts
@@ -58,7 +58,10 @@ export async function fetchUrl(url: string, options: IFetchOptions, retries = 10
 			startTime = new Date().getTime();
 		}
 		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), 30 * 1000);
+		// --- Start Positron ---
+		// Increase the timeout to 90 seconds to accommodate slower downloads.
+		const timeout = setTimeout(() => controller.abort(), 90 * 1000);
+		// --- End Positron ---
 		try {
 			const response = await fetch(url, {
 				...options.nodeFetchOptions,

--- a/build/lib/fetch.ts
+++ b/build/lib/fetch.ts
@@ -20,6 +20,9 @@ export interface IFetchOptions {
 	nodeFetchOptions?: RequestInit;
 	verbose?: boolean;
 	checksumSha256?: string;
+	// --- Start Positron ---
+	timeoutSeconds?: number;
+	// --- End Positron ---
 }
 
 export function fetchUrls(urls: string[] | string, options: IFetchOptions): es.ThroughStream {
@@ -59,8 +62,8 @@ export async function fetchUrl(url: string, options: IFetchOptions, retries = 10
 		}
 		const controller = new AbortController();
 		// --- Start Positron ---
-		// Increase the timeout to 90 seconds to accommodate slower downloads.
-		const timeout = setTimeout(() => controller.abort(), 90 * 1000);
+		const timeoutSeconds = options.timeoutSeconds ?? 30;
+		const timeout = setTimeout(() => controller.abort(), timeoutSeconds * 1000);
 		// --- End Positron ---
 		try {
 			const response = await fetch(url, {

--- a/build/lib/quarto.js
+++ b/build/lib/quarto.js
@@ -32,6 +32,7 @@ function getQuartoWindows(version) {
     return (0, fetch_1.fetchUrls)([`${basename}.zip`], {
         base: getBaseUrl(version),
         verbose: true,
+        timeoutSeconds: 90,
     })
         .pipe(unzip());
 }
@@ -47,6 +48,7 @@ function getQuartoMacOS(version) {
     return (0, fetch_1.fetchUrls)([`quarto-${version}-macos.tar.gz`], {
         base: getBaseUrl(version),
         verbose: true,
+        timeoutSeconds: 90,
     })
         // Unzip, then untar
         .pipe(gunzip())
@@ -67,6 +69,7 @@ function getQuartoLinux(version) {
     return (0, fetch_1.fetchUrls)([`${basename}.tar.gz`], {
         base: getBaseUrl(version),
         verbose: true,
+        timeoutSeconds: 90,
     })
         // Unzip, then untar
         .pipe(gunzip())

--- a/build/lib/quarto.ts
+++ b/build/lib/quarto.ts
@@ -32,6 +32,7 @@ function getQuartoWindows(version: string): Stream {
 	return fetchUrls([`${basename}.zip`], {
 		base: getBaseUrl(version),
 		verbose: true,
+		timeoutSeconds: 90,
 	})
 		.pipe(unzip());
 }
@@ -49,6 +50,7 @@ function getQuartoMacOS(version: string): Stream {
 	return fetchUrls([`quarto-${version}-macos.tar.gz`], {
 		base: getBaseUrl(version),
 		verbose: true,
+		timeoutSeconds: 90,
 	})
 		// Unzip, then untar
 		.pipe(gunzip())
@@ -72,6 +74,7 @@ function getQuartoLinux(version: string): Stream {
 	return fetchUrls([`${basename}.tar.gz`], {
 		base: getBaseUrl(version),
 		verbose: true,
+		timeoutSeconds: 90,
 	})
 		// Unzip, then untar
 		.pipe(gunzip())


### PR DESCRIPTION
### Summary

- this change resolves an issue with the quarto download taking too long, causing a local release build to fail
- added new property `timeoutSeconds` to `IFetchOptions`, which can be used to set a different timeout than the default 30 seconds
- set `timeoutSeconds` to 90s for quarto downloads, which were taking upwards of 50 seconds to download on my machine
- ran `yarn compile` in the `build` directory to update the corresponding `.js` files

### Background

The quarto download was failing for me on Mac:
```
[14:52:05] Synchronizing quarto 1.5.55...
[14:52:05] [Fetch queue] start fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.55/quarto-1.5.55-macos.tar.gz (0 remaining)
[14:52:05] Start fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.55/quarto-1.5.55-macos.tar.gz
[14:52:08] Fetch completed: Status 200. Took 2593 ms
[14:52:35] Fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.55/quarto-1.5.55-macos.tar.gz failed: AbortError: This operation was aborted
[14:52:36] Start fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.55/quarto-1.5.55-macos.tar.gz (1 retry)
[14:52:37] Fetch completed: Status 200. Took 353 ms
[14:53:06] Fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.55/quarto-1.5.55-macos.tar.gz failed: AbortError: This operation was aborted
...
[14:57:15] Start fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.55/quarto-1.5.55-macos.tar.gz (10 retry)
[14:57:16] Fetch completed: Status 200. Took 243 ms
[14:57:45] Fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.55/quarto-1.5.55-macos.tar.gz failed: AbortError: This operation was aborted
[14:57:45] [Fetch queue] failed fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.55/quarto-1.5.55-macos.tar.gz (0 remaining): AbortError: This operation was aborted
[14:57:45] 'vscode' errored after 48 min
[14:57:45] AbortError: This operation was aborted
    at new DOMException (node:internal/per_context/domexception:53:5)
    at AbortController.abort (node:internal/abort_controller:392:18)
    at Timeout._onTimeout (/Users/sashimi/dev/positron-dev/build/lib/fetch.js:50:53)
    at listOnTimeout (node:internal/timers:573:17)
```

<details>
    <summary>Debugging Details</summary>

Created an isolated version of
https://github.com/posit-dev/positron/blob/e8be5d21df9dc92b4e94b9cd4930dff142880cd1/build/lib/fetch.ts#L52

to test with a longer timeout.

### Notebook Cell

```ts
const url = 'https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.55/quarto-1.5.55-macos.tar.gz';
const totalRetries = 10;
const timeoutSeconds = 90; // currently 30 seconds

const fetchUrl = async (url: string, retries: number, retryDelay = 1000) => {
    try {
        console.log(`Start fetching ${url}${retries !== 10 ? ` (${totalRetries - retries} retry)` : ''}`);
        let startTime = new Date().getTime();
        const controller = new AbortController();
        const timeout = setTimeout(() => {
            console.log(`Fetch timed out after 30 seconds -- aborting`);
            controller.abort();
        }
            , timeoutSeconds * 1000);
        try {
            const response = await fetch(url, { signal: controller.signal });
            console.log(`Fetch completed: Status ${response.status}. Took ${`${new Date().getTime() - startTime} ms`}`);
            if (response.ok && (response.status >= 200 && response.status < 300)) {
                console.time('await response.arrayBuffer()');
                const contents = await response.arrayBuffer();
                console.timeEnd('await response.arrayBuffer()');
                console.log(`Fetched response body buffer: ${`${contents.byteLength} bytes`}`);
                return;
            }
            if (!response.ok) {
                throw new Error(`Failed to fetch ${url}: ${response.statusText}`);
            }
            let err = `Request ${url} failed with status code: ${response.status}`;
            if (response.status === 403) {
                err += ' (you may be rate limited)';
            }
            throw new Error(err);
        } finally {
            console.log(`Clearing timeout`);
            clearTimeout(timeout);
            console.log(`Timeout cleared`);
        }
    } catch (e) {
        console.log(`Fetching ${url} failed: ${e}`);
        if (retries > 0) {
            console.log(`Retrying in ${retryDelay} ms`);
            await new Promise(resolve => setTimeout(resolve, retryDelay));
            return fetchUrl(url, retries - 1, retryDelay);
        }
        throw e;
    }
}

await fetchUrl(url, totalRetries);
```

### Cell Output - Successful `timeoutSeconds = 90`
```
Start fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.55/quarto-1.5.55-macos.tar.gz
Fetch completed: Status 200. Took 636 ms
await response.arrayBuffer(): 50758ms  <--- *** this is the culprit!
Fetched response body buffer: 206199994 bytes
Clearing timeout
Timeout cleared
```

### Cell Output - Failing `timeoutSeconds = 30`
```
Start fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.55/quarto-1.5.55-macos.tar.gz (0 retry)
Fetch completed: Status 200. Took 459 ms
Fetch timed out after 30 seconds -- aborting
Clearing timeout
Timeout cleared
Fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.55/quarto-1.5.55-macos.tar.gz failed: AbortError: The signal has been aborted
Retrying in 1000 ms
Start fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.55/quarto-1.5.55-macos.tar.gz (1 retry)
Fetch completed: Status 200. Took 352 ms
Timer 'await response.arrayBuffer()' already exists
Fetch timed out after 30 seconds -- aborting
Clearing timeout
Timeout cleared
Fetching https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.55/quarto-1.5.55-macos.tar.gz failed: AbortError: The signal has been aborted
Stack trace:
DOMException: The signal has been aborted
    at new DOMException (ext:deno_web/01_dom_exception.js:116:20)
    at AbortSignal.[[[signalAbort]]] (ext:deno_web/03_abort_signal.js:143:14)
    at AbortController.abort (ext:deno_web/03_abort_signal.js:283:30)
    at <anonymous>:11:18
    at eventLoopTick (ext:core/01_core.js:203:13)
```

</details>

### QA Notes

Running release builds should no longer timeout on the quarto step as long as it takes no more than 90 seconds.
