### PR TITLE
Fix interpreter popup scroll for web

### DIFF
--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterGroup.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterGroup.tsx
@@ -106,6 +106,7 @@ export const InterpreterGroup = (props: InterpreterGroupProps) => {
 					// window.ts#registerListeners() discards the wheel event to prevent back/forward gestures
 					// send it to the div so it is not lost
 					e.currentTarget.scrollBy(e.deltaX, e.deltaY);
+					e.stopPropagation();
 				}}>
 					{props.interpreterGroup.alternateRuntimes.map(runtime =>
 						<SecondaryInterpreter

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterGroup.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterGroup.tsx
@@ -102,7 +102,11 @@ export const InterpreterGroup = (props: InterpreterGroupProps) => {
 				onActivate={async () => await props.onActivateRuntime(props.interpreterGroup.primaryRuntime)}
 			/>
 			{(alternateRuntimeAlive || showAllVersions) &&
-				<div className='secondary-interpreters'>
+				<div className='secondary-interpreters' onWheel={(e) => {
+					// window.ts#registerListeners() discards the wheel event to prevent back/forward gestures
+					// send it to the div so it is not lost
+					e.currentTarget.scrollBy(e.deltaX, e.deltaY);
+				}}>
 					{props.interpreterGroup.alternateRuntimes.map(runtime =>
 						<SecondaryInterpreter
 							key={runtime.runtimeId}

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterGroup.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterGroup.tsx
@@ -106,7 +106,7 @@ export const InterpreterGroup = (props: InterpreterGroupProps) => {
 					// window.ts#registerListeners() discards the wheel event to prevent back/forward gestures
 					// send it to the div so it is not lost
 					e.currentTarget.scrollBy(e.deltaX, e.deltaY);
-					e.stopPropagation();
+					e.preventDefault();
 				}}>
 					{props.interpreterGroup.alternateRuntimes.map(runtime =>
 						<SecondaryInterpreter

--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -478,7 +478,7 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 					// window.ts#registerListeners() discards the wheel event to prevent back/forward gestures
 					// send it to the div so it is not lost
 					e.currentTarget.scrollBy(e.deltaX, e.deltaY);
-					e.stopPropagation();
+					e.preventDefault();
 				}}
 			>
 				<div ref={popupChildrenRef} className='positron-modal-popup-children'>

--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -474,6 +474,12 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 					height: props.height,
 					minHeight: props.minHeight ?? 'auto'
 				}}
+				onWheel={(e) => {
+					// window.ts#registerListeners() discards the wheel event to prevent back/forward gestures
+					// send it to the div so it is not lost
+					e.currentTarget.scrollBy(e.deltaX, e.deltaY);
+					e.stopPropagation();
+				}}
 			>
 				<div ref={popupChildrenRef} className='positron-modal-popup-children'>
 					{props.children}


### PR DESCRIPTION
Address #4888 

When checking the scroll and wheel event listeners on the element, there were some parent elements listening in. `window.ts` is one of the listeners and it drops the event to prevent back/forward gestures. See [`window.ts#L251`](https://github.com/posit-dev/positron/blob/bugfix/interpreter-scroll/src/vs/workbench/browser/window.ts#L251-L252)

This adds a wheel listener on the interpreter group so that it can scroll it manually. It works well in desktop and web.


<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes
Web should still disallow gesture navigation for back/forward. The upstream comment says it's only for Mac but the code runs on all platforms. So it's probably good to check other platforms that gesture navigation is disabled.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
