### PR TITLE
Update positron cli and linux package info with positron version output

### DIFF
--- a/build/gulpfile.reh.js
+++ b/build/gulpfile.reh.js
@@ -445,12 +445,16 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
 		if (platform === 'win32') {
 			result = es.merge(result,
 				gulp.src('resources/server/bin/remote-cli/code.cmd', { base: '.' })
-					.pipe(replace('@@VERSION@@', version))
+					// --- Start Positron ---
+					.pipe(replace('@@VERSION@@', positronVersion))
+					// --- End Positron ---
 					.pipe(replace('@@COMMIT@@', commit))
 					.pipe(replace('@@APPNAME@@', product.applicationName))
 					.pipe(rename(`bin/remote-cli/${product.applicationName}.cmd`)),
 				gulp.src('resources/server/bin/helpers/browser.cmd', { base: '.' })
-					.pipe(replace('@@VERSION@@', version))
+					// --- Start Positron ---
+					.pipe(replace('@@VERSION@@', positronVersion))
+					// --- End Positron ---
 					.pipe(replace('@@COMMIT@@', commit))
 					.pipe(replace('@@APPNAME@@', product.applicationName))
 					.pipe(rename(`bin/helpers/browser.cmd`)),
@@ -460,13 +464,17 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
 		} else if (platform === 'linux' || platform === 'alpine' || platform === 'darwin') {
 			result = es.merge(result,
 				gulp.src(`resources/server/bin/remote-cli/${platform === 'darwin' ? 'code-darwin.sh' : 'code-linux.sh'}`, { base: '.' })
-					.pipe(replace('@@VERSION@@', version))
+					// --- Start Positron ---
+					.pipe(replace('@@VERSION@@', positronVersion))
+					// --- End Positron ---
 					.pipe(replace('@@COMMIT@@', commit))
 					.pipe(replace('@@APPNAME@@', product.applicationName))
 					.pipe(rename(`bin/remote-cli/${product.applicationName}`))
 					.pipe(util.setExecutableBit()),
 				gulp.src(`resources/server/bin/helpers/${platform === 'darwin' ? 'browser-darwin.sh' : 'browser-linux.sh'}`, { base: '.' })
-					.pipe(replace('@@VERSION@@', version))
+					// --- Start Positron ---
+					.pipe(replace('@@VERSION@@', positronVersion))
+					// --- End Positron ---
 					.pipe(replace('@@COMMIT@@', commit))
 					.pipe(replace('@@APPNAME@@', product.applicationName))
 					.pipe(rename(`bin/helpers/browser.sh`))

--- a/build/gulpfile.reh.js
+++ b/build/gulpfile.reh.js
@@ -445,15 +445,19 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
 		if (platform === 'win32') {
 			result = es.merge(result,
 				gulp.src('resources/server/bin/remote-cli/code.cmd', { base: '.' })
+					.pipe(replace('@@VERSION@@', version))
 					// --- Start Positron ---
-					.pipe(replace('@@VERSION@@', positronVersion))
+					.pipe(replace('@@POSITRONVERSION@@', positronVersion))
+					.pipe(replace('@@BUILDNUMBER@@', positronBuildNumber))
 					// --- End Positron ---
 					.pipe(replace('@@COMMIT@@', commit))
 					.pipe(replace('@@APPNAME@@', product.applicationName))
 					.pipe(rename(`bin/remote-cli/${product.applicationName}.cmd`)),
 				gulp.src('resources/server/bin/helpers/browser.cmd', { base: '.' })
+					.pipe(replace('@@VERSION@@', version))
 					// --- Start Positron ---
-					.pipe(replace('@@VERSION@@', positronVersion))
+					.pipe(replace('@@POSITRONVERSION@@', positronVersion))
+					.pipe(replace('@@BUILDNUMBER@@', positronBuildNumber))
 					// --- End Positron ---
 					.pipe(replace('@@COMMIT@@', commit))
 					.pipe(replace('@@APPNAME@@', product.applicationName))
@@ -464,16 +468,20 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
 		} else if (platform === 'linux' || platform === 'alpine' || platform === 'darwin') {
 			result = es.merge(result,
 				gulp.src(`resources/server/bin/remote-cli/${platform === 'darwin' ? 'code-darwin.sh' : 'code-linux.sh'}`, { base: '.' })
+					.pipe(replace('@@VERSION@@', version))
 					// --- Start Positron ---
-					.pipe(replace('@@VERSION@@', positronVersion))
+					.pipe(replace('@@POSITRONVERSION@@', positronVersion))
+					.pipe(replace('@@BUILDNUMBER@@', positronBuildNumber))
 					// --- End Positron ---
 					.pipe(replace('@@COMMIT@@', commit))
 					.pipe(replace('@@APPNAME@@', product.applicationName))
 					.pipe(rename(`bin/remote-cli/${product.applicationName}`))
 					.pipe(util.setExecutableBit()),
 				gulp.src(`resources/server/bin/helpers/${platform === 'darwin' ? 'browser-darwin.sh' : 'browser-linux.sh'}`, { base: '.' })
+					.pipe(replace('@@VERSION@@', version))
 					// --- Start Positron ---
-					.pipe(replace('@@VERSION@@', positronVersion))
+					.pipe(replace('@@POSITRONVERSION@@', positronVersion))
+					.pipe(replace('@@BUILDNUMBER@@', positronBuildNumber))
 					// --- End Positron ---
 					.pipe(replace('@@COMMIT@@', commit))
 					.pipe(replace('@@APPNAME@@', product.applicationName))

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -547,7 +547,9 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 			result = es.merge(result, gulp.src('resources/win32/bin/code.sh', { base: 'resources/win32' })
 				.pipe(replace('@@NAME@@', product.nameShort))
 				.pipe(replace('@@PRODNAME@@', product.nameLong))
-				.pipe(replace('@@VERSION@@', version))
+				// --- Start Positron ---
+				.pipe(replace('@@VERSION@@', positronVersion))
+				// --- End Positron ---
 				.pipe(replace('@@COMMIT@@', commit))
 				.pipe(replace('@@APPNAME@@', product.applicationName))
 				.pipe(replace('@@SERVERDATAFOLDER@@', product.serverDataFolderName || '.vscode-remote'))

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -548,7 +548,10 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 				.pipe(replace('@@NAME@@', product.nameShort))
 				.pipe(replace('@@PRODNAME@@', product.nameLong))
 				// --- Start Positron ---
-				.pipe(replace('@@VERSION@@', positronVersion))
+				// These are commented out since they're not currently used in 'resources/win32/bin/code.sh'
+				// .pipe(replace('@@VERSION@@', version))
+				// .pipe(replace('@@POSITRONVERSION@@', positronVersion))
+				// .pipe(replace('@@BUILDNUMBER@@', positronBuildNumber))
 				// --- End Positron ---
 				.pipe(replace('@@COMMIT@@', commit))
 				.pipe(replace('@@APPNAME@@', product.applicationName))

--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -100,7 +100,7 @@ function prepareDebPackage(arch) {
 					.pipe(replace('@@NAME@@', product.applicationName))
 					// --- Start Positron ---
 					.pipe(replace('@@VERSION@@', product.version))
-					.pipe(replace('@@POSITRONVERSION@@', product.positronVersion + '-' + linuxPackageRevision))
+					.pipe(replace('@@POSITRONVERSION@@', `${product.positronVersion}+${product.positronBuildNumber}-${linuxPackageRevision}`))
 					.pipe(replace('@@BUILDNUMBER@@', product.positronBuildNumber))
 					// --- End Positron ---
 					.pipe(replace('@@ARCHITECTURE@@', debArch))

--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -226,7 +226,7 @@ function prepareRpmPackage(arch) {
 					.pipe(replace('@@ICON@@', product.linuxIconName))
 					// --- Start Positron ---
 					.pipe(replace('@@VERSION@@', product.version))
-					.pipe(replace('@@POSITRONVERSION@@', product.positronVersion))
+					.pipe(replace('@@POSITRONVERSION@@', `${product.positronVersion}+${product.positronBuildNumber}`))
 					.pipe(replace('@@BUILDNUMBER@@', product.positronBuildNumber))
 					// --- End Positron ---
 					.pipe(replace('@@RELEASE@@', linuxPackageRevision))

--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -222,7 +222,9 @@ function prepareRpmPackage(arch) {
 					.pipe(replace('@@NAME@@', product.applicationName))
 					.pipe(replace('@@NAME_LONG@@', product.nameLong))
 					.pipe(replace('@@ICON@@', product.linuxIconName))
-					.pipe(replace('@@VERSION@@', packageJson.version))
+					// --- Start Positron ---
+					.pipe(replace('@@VERSION@@', product.positronVersion))
+					// --- End Positron ---
 					.pipe(replace('@@RELEASE@@', linuxPackageRevision))
 					.pipe(replace('@@ARCHITECTURE@@', rpmArch))
 					.pipe(replace('@@LICENSE@@', product.licenseName))
@@ -302,6 +304,7 @@ function prepareSnapPackage(arch) {
 
 		const snapcraft = gulp.src('resources/linux/snap/snapcraft.yaml', { base: '.' })
 			.pipe(replace('@@NAME@@', product.applicationName))
+			// here?
 			.pipe(replace('@@VERSION@@', commit.substr(0, 8)))
 			// Possible run-on values https://snapcraft.io/docs/architectures
 			.pipe(replace('@@ARCHITECTURE@@', arch === 'x64' ? 'amd64' : arch))

--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -99,7 +99,9 @@ function prepareDebPackage(arch) {
 					// --- End Positron ---
 					.pipe(replace('@@NAME@@', product.applicationName))
 					// --- Start Positron ---
-					.pipe(replace('@@VERSION@@', product.positronVersion + '-' + linuxPackageRevision))
+					.pipe(replace('@@VERSION@@', product.version))
+					.pipe(replace('@@POSITRONVERSION@@', product.positronVersion + '-' + linuxPackageRevision))
+					.pipe(replace('@@BUILDNUMBER@@', product.positronBuildNumber))
 					// --- End Positron ---
 					.pipe(replace('@@ARCHITECTURE@@', debArch))
 					.pipe(replace('@@DEPENDS@@', dependencies.join(', ')))
@@ -223,7 +225,9 @@ function prepareRpmPackage(arch) {
 					.pipe(replace('@@NAME_LONG@@', product.nameLong))
 					.pipe(replace('@@ICON@@', product.linuxIconName))
 					// --- Start Positron ---
-					.pipe(replace('@@VERSION@@', product.positronVersion))
+					.pipe(replace('@@VERSION@@', product.version))
+					.pipe(replace('@@POSITRONVERSION@@', product.positronVersion))
+					.pipe(replace('@@BUILDNUMBER@@', product.positronBuildNumber))
 					// --- End Positron ---
 					.pipe(replace('@@RELEASE@@', linuxPackageRevision))
 					.pipe(replace('@@ARCHITECTURE@@', rpmArch))
@@ -304,8 +308,12 @@ function prepareSnapPackage(arch) {
 
 		const snapcraft = gulp.src('resources/linux/snap/snapcraft.yaml', { base: '.' })
 			.pipe(replace('@@NAME@@', product.applicationName))
-			// here?
-			.pipe(replace('@@VERSION@@', commit.substr(0, 8)))
+			// --- Start Positron ---
+			.pipe(replace('@@VERSION@@', product.version))
+			.pipe(replace('@@POSITRONVERSION@@', product.positronVersion))
+			.pipe(replace('@@BUILDNUMBER@@', positronBuildNumber))
+			.pipe(replace('@@LICENSE@@', product.licenseName))
+			// --- End Positron ---
 			// Possible run-on values https://snapcraft.io/docs/architectures
 			.pipe(replace('@@ARCHITECTURE@@', arch === 'x64' ? 'amd64' : arch))
 			.pipe(rename('snap/snapcraft.yaml'));

--- a/resources/linux/debian/positron.control.template
+++ b/resources/linux/debian/positron.control.template
@@ -1,5 +1,5 @@
 Package: @@NAME@@
-Version: @@VERSION@@
+Version: @@POSITRONVERSION@@ build @@BUILDNUMBER@@
 Section: devel
 Depends: @@DEPENDS@@
 Recommends: @@RECOMMENDS@@

--- a/resources/linux/debian/positron.control.template
+++ b/resources/linux/debian/positron.control.template
@@ -1,5 +1,5 @@
 Package: @@NAME@@
-Version: @@POSITRONVERSION@@ build @@BUILDNUMBER@@
+Version: @@POSITRONVERSION@@
 Section: devel
 Depends: @@DEPENDS@@
 Recommends: @@RECOMMENDS@@

--- a/resources/linux/rpm/positron.spec.template
+++ b/resources/linux/rpm/positron.spec.template
@@ -1,5 +1,5 @@
 Name:     @@NAME@@
-Version:  @@VERSION@@
+Version:  @@POSITRONVERSION@@ build @@BUILDNUMBER@@
 Release:  @@RELEASE@@.el8
 Summary:  A next-generation data science IDE.
 Group:    Development/Tools

--- a/resources/linux/rpm/positron.spec.template
+++ b/resources/linux/rpm/positron.spec.template
@@ -1,5 +1,5 @@
 Name:     @@NAME@@
-Version:  @@POSITRONVERSION@@ build @@BUILDNUMBER@@
+Version:  @@POSITRONVERSION@@
 Release:  @@RELEASE@@.el8
 Summary:  A next-generation data science IDE.
 Group:    Development/Tools

--- a/resources/linux/snap/snapcraft.yaml
+++ b/resources/linux/snap/snapcraft.yaml
@@ -1,10 +1,10 @@
 name: @@NAME@@
-version: '@@VERSION@@'
-summary: Code editing. Redefined.
+version: '@@POSITRONVERSION@@ build @@BUILDNUMBER@@'
+summary: A next-generation data science IDE.
 description: |
-  Visual Studio Code is a new choice of tool that combines the
-  simplicity of a code editor with what developers need for the core
-  edit-build-debug cycle.
+  Positron is an extensible, polyglot tool for writing code and
+  exploring data in Python, R, and other languages.
+license: @@LICENSE@@
 
 architectures:
   - build-on: amd64

--- a/resources/server/bin/helpers/browser-darwin.sh
+++ b/resources/server/bin/helpers/browser-darwin.sh
@@ -15,8 +15,12 @@ realdir() {
 ROOT="$(dirname "$(dirname "$(realdir "$0")")")"
 
 APP_NAME="@@APPNAME@@"
+# --- Start Positron ---
+POSITRON_VERSION="@@POSITRONVERSION@@"
+BUILD_NUMBER="@@BUILDNUMBER@@"
+# --- End Positron ---
 VERSION="@@VERSION@@"
 COMMIT="@@COMMIT@@"
 EXEC_NAME="@@APPNAME@@"
 CLI_SCRIPT="$ROOT/out/server-cli.js"
-"$ROOT/node" "$CLI_SCRIPT" "$APP_NAME" "$VERSION" "$COMMIT" "$EXEC_NAME" "--openExternal" "$@"
+"$ROOT/node" "$CLI_SCRIPT" "$APP_NAME" "$POSITRON_VERSION" "$BUILD_NUMBER" "$VERSION" "$COMMIT" "$EXEC_NAME" "--openExternal" "$@"

--- a/resources/server/bin/helpers/browser-darwin.sh
+++ b/resources/server/bin/helpers/browser-darwin.sh
@@ -23,4 +23,6 @@ VERSION="@@VERSION@@"
 COMMIT="@@COMMIT@@"
 EXEC_NAME="@@APPNAME@@"
 CLI_SCRIPT="$ROOT/out/server-cli.js"
+# --- Start Positron ---
 "$ROOT/node" "$CLI_SCRIPT" "$APP_NAME" "$POSITRON_VERSION" "$BUILD_NUMBER" "$VERSION" "$COMMIT" "$EXEC_NAME" "--openExternal" "$@"
+# --- End Positron ---

--- a/resources/server/bin/helpers/browser-linux.sh
+++ b/resources/server/bin/helpers/browser-linux.sh
@@ -5,8 +5,12 @@
 ROOT="$(dirname "$(dirname "$(dirname "$(readlink -f "$0")")")")"
 
 APP_NAME="@@APPNAME@@"
+# --- Start Positron ---
+POSITRON_VERSION="@@POSITRONVERSION@@"
+BUILD_NUMBER="@@BUILDNUMBER@@"
+# --- End Positron ---
 VERSION="@@VERSION@@"
 COMMIT="@@COMMIT@@"
 EXEC_NAME="@@APPNAME@@"
 CLI_SCRIPT="$ROOT/out/server-cli.js"
-"$ROOT/node" "$CLI_SCRIPT" "$APP_NAME" "$VERSION" "$COMMIT" "$EXEC_NAME" "--openExternal" "$@"
+"$ROOT/node" "$CLI_SCRIPT" "$APP_NAME" "$POSITRON_VERSION" "$BUILD_NUMBER" "$VERSION" "$COMMIT" "$EXEC_NAME" "--openExternal" "$@"

--- a/resources/server/bin/helpers/browser-linux.sh
+++ b/resources/server/bin/helpers/browser-linux.sh
@@ -13,4 +13,6 @@ VERSION="@@VERSION@@"
 COMMIT="@@COMMIT@@"
 EXEC_NAME="@@APPNAME@@"
 CLI_SCRIPT="$ROOT/out/server-cli.js"
+# --- Start Positron ---
 "$ROOT/node" "$CLI_SCRIPT" "$APP_NAME" "$POSITRON_VERSION" "$BUILD_NUMBER" "$VERSION" "$COMMIT" "$EXEC_NAME" "--openExternal" "$@"
+# --- End Positron ---

--- a/resources/server/bin/helpers/browser.cmd
+++ b/resources/server/bin/helpers/browser.cmd
@@ -1,5 +1,7 @@
 @echo off
 setlocal
 set ROOT_DIR=%~dp0..\..
+@REM --- Start Positron ---
 start "Open Browser" /B "%ROOT_DIR%\node.exe" "%ROOT_DIR%\out\server-cli.js" "@@APPNAME@@" "@@POSITRONVERSION@@" "@@BUILDNUMBER@@" "@@VERSION@@" "@@COMMIT@@" "@@APPNAME@@.cmd" "--openExternal" "%*"
+@REM --- End Positron ---
 endlocal

--- a/resources/server/bin/helpers/browser.cmd
+++ b/resources/server/bin/helpers/browser.cmd
@@ -1,5 +1,5 @@
 @echo off
 setlocal
 set ROOT_DIR=%~dp0..\..
-start "Open Browser" /B "%ROOT_DIR%\node.exe" "%ROOT_DIR%\out\server-cli.js" "@@APPNAME@@" "@@VERSION@@" "@@COMMIT@@" "@@APPNAME@@.cmd" "--openExternal" "%*"
+start "Open Browser" /B "%ROOT_DIR%\node.exe" "%ROOT_DIR%\out\server-cli.js" "@@APPNAME@@" "@@POSITRONVERSION@@" "@@BUILDNUMBER@@" "@@VERSION@@" "@@COMMIT@@" "@@APPNAME@@.cmd" "--openExternal" "%*"
 endlocal

--- a/resources/server/bin/remote-cli/code-darwin.sh
+++ b/resources/server/bin/remote-cli/code-darwin.sh
@@ -23,4 +23,6 @@ VERSION="@@VERSION@@"
 COMMIT="@@COMMIT@@"
 EXEC_NAME="@@APPNAME@@"
 CLI_SCRIPT="$ROOT/out/server-cli.js"
+# --- Start Positron ---
 "$ROOT/node" "$CLI_SCRIPT" "$APP_NAME" "$POSITRON_VERSION" "$BUILD_NUMBER" "$VERSION" "$COMMIT" "$EXEC_NAME" "$@"
+# --- End Positron ---

--- a/resources/server/bin/remote-cli/code-darwin.sh
+++ b/resources/server/bin/remote-cli/code-darwin.sh
@@ -15,8 +15,12 @@ realdir() {
 ROOT="$(dirname "$(dirname "$(realdir "$0")")")"
 
 APP_NAME="@@APPNAME@@"
+# --- Start Positron ---
+POSITRON_VERSION="@@POSITRONVERSION@@"
+BUILD_NUMBER="@@BUILDNUMBER@@"
+# --- End Positron ---
 VERSION="@@VERSION@@"
 COMMIT="@@COMMIT@@"
 EXEC_NAME="@@APPNAME@@"
 CLI_SCRIPT="$ROOT/out/server-cli.js"
-"$ROOT/node" "$CLI_SCRIPT" "$APP_NAME" "$VERSION" "$COMMIT" "$EXEC_NAME" "$@"
+"$ROOT/node" "$CLI_SCRIPT" "$APP_NAME" "$POSITRON_VERSION" "$BUILD_NUMBER" "$VERSION" "$COMMIT" "$EXEC_NAME" "$@"

--- a/resources/server/bin/remote-cli/code-linux.sh
+++ b/resources/server/bin/remote-cli/code-linux.sh
@@ -13,4 +13,6 @@ VERSION="@@VERSION@@"
 COMMIT="@@COMMIT@@"
 EXEC_NAME="@@APPNAME@@"
 CLI_SCRIPT="$ROOT/out/server-cli.js"
+# --- Start Positron ---
 "$ROOT/node" "$CLI_SCRIPT" "$APP_NAME" "$POSITRON_VERSION" "$BUILD_NUMBER" "$VERSION" "$COMMIT" "$EXEC_NAME" "$@"
+# --- End Positron ---

--- a/resources/server/bin/remote-cli/code-linux.sh
+++ b/resources/server/bin/remote-cli/code-linux.sh
@@ -5,8 +5,12 @@
 ROOT="$(dirname "$(dirname "$(dirname "$(readlink -f "$0")")")")"
 
 APP_NAME="@@APPNAME@@"
+# --- Start Positron ---
+POSITRON_VERSION="@@POSITRONVERSION@@"
+BUILD_NUMBER="@@BUILDNUMBER@@"
+# --- End Positron ---
 VERSION="@@VERSION@@"
 COMMIT="@@COMMIT@@"
 EXEC_NAME="@@APPNAME@@"
 CLI_SCRIPT="$ROOT/out/server-cli.js"
-"$ROOT/node" "$CLI_SCRIPT" "$APP_NAME" "$VERSION" "$COMMIT" "$EXEC_NAME" "$@"
+"$ROOT/node" "$CLI_SCRIPT" "$APP_NAME" "$POSITRON_VERSION" "$BUILD_NUMBER" "$VERSION" "$COMMIT" "$EXEC_NAME" "$@"

--- a/resources/server/bin/remote-cli/code.cmd
+++ b/resources/server/bin/remote-cli/code.cmd
@@ -1,5 +1,5 @@
 @echo off
 setlocal
 set ROOT_DIR=%~dp0..\..
-call "%ROOT_DIR%\node.exe" "%ROOT_DIR%\out\server-cli.js" "@@APPNAME@@" "@@VERSION@@" "@@COMMIT@@" "@@APPNAME@@.cmd" %*
+call "%ROOT_DIR%\node.exe" "%ROOT_DIR%\out\server-cli.js" "@@APPNAME@@" "@@POSITRONVERSION@@" "@@BUILDNUMBER@@" "@@VERSION@@" "@@COMMIT@@" "@@APPNAME@@.cmd" %*
 endlocal

--- a/resources/server/bin/remote-cli/code.cmd
+++ b/resources/server/bin/remote-cli/code.cmd
@@ -1,5 +1,7 @@
 @echo off
 setlocal
 set ROOT_DIR=%~dp0..\..
+@REM --- Start Positron ---
 call "%ROOT_DIR%\node.exe" "%ROOT_DIR%\out\server-cli.js" "@@APPNAME@@" "@@POSITRONVERSION@@" "@@BUILDNUMBER@@" "@@VERSION@@" "@@COMMIT@@" "@@APPNAME@@.cmd" %*
+@REM --- End Positron ---
 endlocal

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -15,7 +15,10 @@ import { whenDeleted, writeFileSync } from 'vs/base/node/pfs';
 import { findFreePort } from 'vs/base/node/ports';
 import { watchFileContents } from 'vs/platform/files/node/watcher/nodejs/nodejsWatcherLib';
 import { NativeParsedArgs } from 'vs/platform/environment/common/argv';
-import { buildHelpMessage, buildPositronVersionMessage, NATIVE_CLI_COMMANDS, OPTIONS } from 'vs/platform/environment/node/argv';
+// --- Start Positron ---
+// @ts-ignore - unused import buildVersionMessage is preserved to avoid upstream merge conflicts.
+// --- End Positron ---
+import { buildHelpMessage, buildVersionMessage, NATIVE_CLI_COMMANDS, OPTIONS } from 'vs/platform/environment/node/argv';
 import { addArg, parseCLIProcessArgv } from 'vs/platform/environment/node/argvHelper';
 import { getStdinFilePath, hasStdinWithoutTty, readFromStdin, stdinDataListener } from 'vs/platform/environment/node/stdin';
 import { createWaitMarkerFileSync } from 'vs/platform/environment/node/wait';
@@ -28,6 +31,11 @@ import { cwd } from 'vs/base/common/process';
 import { addUNCHostToAllowlist } from 'vs/base/node/unc';
 import { URI } from 'vs/base/common/uri';
 import { DeferredPromise } from 'vs/base/common/async';
+
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { buildPositronVersionMessage } from 'vs/platform/environment/node/argv';
+// --- End Positron ---
 
 function shouldSpawnCliProcess(argv: NativeParsedArgs): boolean {
 	return !!argv['install-source']

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -90,7 +90,9 @@ export async function main(argv: string[]): Promise<any> {
 	// Help
 	if (args.help) {
 		const executable = `${product.applicationName}${isWindows ? '.exe' : ''}`;
-		console.log(buildHelpMessage(product.nameLong, executable, product.version, OPTIONS));
+		// --- Start Positron ---
+		console.log(buildHelpMessage(product.nameLong, executable, product.positronVersion, OPTIONS));
+		// --- End Positron ---
 	}
 
 	// Version Info

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -95,7 +95,9 @@ export async function main(argv: string[]): Promise<any> {
 
 	// Version Info
 	else if (args.version) {
-		console.log(buildVersionMessage(product.version, product.commit));
+		// --- Start Positron ---
+		console.log(buildVersionMessage(product.positronVersion, product.commit));
+		// --- End Positron ---
 	}
 
 	// Shell integration

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -96,7 +96,7 @@ export async function main(argv: string[]): Promise<any> {
 	// Version Info
 	else if (args.version) {
 		// --- Start Positron ---
-		console.log(buildVersionMessage(product.positronVersion, product.commit));
+		console.log(buildVersionMessage(product.positronVersion, product.positronBuildNumber, product.version, product.commit));
 		// --- End Positron ---
 	}
 

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -15,7 +15,7 @@ import { whenDeleted, writeFileSync } from 'vs/base/node/pfs';
 import { findFreePort } from 'vs/base/node/ports';
 import { watchFileContents } from 'vs/platform/files/node/watcher/nodejs/nodejsWatcherLib';
 import { NativeParsedArgs } from 'vs/platform/environment/common/argv';
-import { buildHelpMessage, buildVersionMessage, NATIVE_CLI_COMMANDS, OPTIONS } from 'vs/platform/environment/node/argv';
+import { buildHelpMessage, buildPositronVersionMessage, NATIVE_CLI_COMMANDS, OPTIONS } from 'vs/platform/environment/node/argv';
 import { addArg, parseCLIProcessArgv } from 'vs/platform/environment/node/argvHelper';
 import { getStdinFilePath, hasStdinWithoutTty, readFromStdin, stdinDataListener } from 'vs/platform/environment/node/stdin';
 import { createWaitMarkerFileSync } from 'vs/platform/environment/node/wait';
@@ -98,7 +98,7 @@ export async function main(argv: string[]): Promise<any> {
 	// Version Info
 	else if (args.version) {
 		// --- Start Positron ---
-		console.log(buildVersionMessage(product.positronVersion, product.positronBuildNumber, product.version, product.commit));
+		console.log(buildPositronVersionMessage(product.positronVersion, product.positronBuildNumber, product.version, product.commit));
 		// --- End Positron ---
 	}
 

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -467,16 +467,25 @@ export function buildHelpMessage(productName: string, executableName: string, ve
 }
 
 // --- Start Positron ---
-export function buildVersionMessage(
+/**
+ * @deprecated To build the Positron version message, use `buildPositronVersionMessage` instead.
+ */
+// --- End Positron ---
+export function buildVersionMessage(version: string | undefined, commit: string | undefined): string {
+	return `${version || localize('unknownVersion', "Unknown version")}\n${commit || localize('unknownCommit', "Unknown commit")}\n${process.arch}`;
+}
+
+// --- Start Positron ---
+export function buildPositronVersionMessage(
 	positronVersion: string | undefined,
 	positronBuildNumber: number | string | undefined,
 	codeOSSVersion: string | undefined,
 	commit: string | undefined
 ): string {
-	const positronVersionString = `${positronVersion || localize('buildVersionMessage.unknownPositronVersion', "Unknown Positron version")}`;
-	const positronBuildString = `${positronBuildNumber === undefined ? localize('buildVersionMessage.unknownBuildNumber', "Unknown build number") : positronBuildNumber}`;
-	const positronCommitString = `${commit || localize('buildVersionMessage.unknownCommit', "Unknown commit")}`;
-	const codeOSSVersionString = `${codeOSSVersion || localize('buildVersionMessage.unknownCodeOssVersion', "Unknown Code OSS version")}`;
+	const positronVersionString = `${positronVersion || localize('buildPositronVersionMessage.unknownPositronVersion', "Unknown Positron version")}`;
+	const positronBuildString = `${positronBuildNumber === undefined ? localize('buildPositronVersionMessage.unknownBuildNumber', "Unknown build number") : positronBuildNumber}`;
+	const positronCommitString = `${commit || localize('buildPositronVersionMessage.unknownCommit', "Unknown commit")}`;
+	const codeOSSVersionString = `${codeOSSVersion || localize('buildPositronVersionMessage.unknownCodeOssVersion', "Unknown Code OSS version")}`;
 
 	/**
 	 * Preview of version string:
@@ -486,10 +495,10 @@ export function buildVersionMessage(
 	 * Arch: arm64
 	 */
 	const versionString = [
-		`${localize('buildVersionMessage.positronVersion', "Positron: {0} build {1}", positronVersionString, positronBuildString)}`,
-		`${localize('buildVersionMessage.positronCommit', "Positron SHA: {0}", positronCommitString)}`,
-		`${localize('buildVersionMessage.codeOSSVersion', "Code OSS: {0}", codeOSSVersionString)}`,
-		`${localize('buildVersionMessage.arch', "Arch: {0}", process.arch)}`,
+		`${localize('buildPositronVersionMessage.positronVersion', "Positron: {0} build {1}", positronVersionString, positronBuildString)}`,
+		`${localize('buildPositronVersionMessage.positronCommit', "Positron SHA: {0}", positronCommitString)}`,
+		`${localize('buildPositronVersionMessage.codeOSSVersion', "Code OSS: {0}", codeOSSVersionString)}`,
+		`${localize('buildPositronVersionMessage.arch', "Arch: {0}", process.arch)}`,
 	];
 	return versionString.join('\n');
 }

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -475,20 +475,21 @@ export function buildVersionMessage(
 ): string {
 	const positronVersionString = `${positronVersion || localize('buildVersionMessage.unknownPositronVersion', "Unknown Positron version")}`;
 	const positronBuildString = `${positronBuildNumber === undefined ? localize('buildVersionMessage.unknownBuildNumber', "Unknown build number") : positronBuildNumber}`;
-	const codeOssVersionString = `${codeOssVersion || localize('buildVersionMessage.unknownCodeOssVersion', "Unknown Code OSS version")}`;
+	const positronCommitString = `${commit || localize('buildVersionMessage.unknownCommit', "Unknown commit")}`;
+	const codeOSSVersionString = `${codeOssVersion || localize('buildVersionMessage.unknownCodeOssVersion', "Unknown Code OSS version")}`;
 
 	/**
 	 * Preview of version string:
-	 * 2024.11.0 build 16
-	 * d2h9d01905129j37g1j998c654e9h6vx6168de4
-	 * 1.94.0 (Code - OSS)
-	 * arm64
+	 * Positron: 2024.11.0 build 16
+	 * Positron SHA: d2h9d01905129j37g1j998c654e9h6vx6168de4
+	 * Code OSS: 1.94.0
+	 * Arch: arm64
 	 */
 	const versionString = [
-		`${localize('buildVersionMessage.positronVersion', "{0} build {1}", positronVersionString, positronBuildString)}`,
-		`${commit || localize('buildVersionMessage.unknownCommit', "Unknown commit")}`,
-		`${localize('buildVersionMessage.codeOssVersion', "{0} (Code - OSS)", codeOssVersionString)}`,
-		process.arch
+		`${localize('buildVersionMessage.positronVersion', "Positron: {0} build {1}", positronVersionString, positronBuildString)}`,
+		`${localize('buildVersionMessage.positronCommit', "Positron SHA: {0}", positronCommitString)}`,
+		`${localize('buildVersionMessage.codeOSSVersion', "Code OSS: {0}", codeOSSVersionString)}`,
+		`${localize('buildVersionMessage.arch', "Arch: {0}", process.arch)}`,
 	];
 	return versionString.join('\n');
 }

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -466,6 +466,30 @@ export function buildHelpMessage(productName: string, executableName: string, ve
 	return help.join('\n');
 }
 
-export function buildVersionMessage(version: string | undefined, commit: string | undefined): string {
-	return `${version || localize('unknownVersion', "Unknown version")}\n${commit || localize('unknownCommit', "Unknown commit")}\n${process.arch}`;
+// --- Start Positron ---
+export function buildVersionMessage(
+	positronVersion: string | undefined,
+	positronBuildNumber: number | string | undefined,
+	codeOssVersion: string | undefined,
+	commit: string | undefined
+): string {
+	const positronVersionString = `${positronVersion || localize('buildVersionMessage.unknownPositronVersion', "Unknown Positron version")}`;
+	const positronBuildString = `${positronBuildNumber === undefined ? localize('buildVersionMessage.unknownBuildNumber', "Unknown build number") : positronBuildNumber}`;
+	const codeOssVersionString = `${codeOssVersion || localize('buildVersionMessage.unknownCodeOssVersion', "Unknown Code OSS version")}`;
+
+	/**
+	 * Preview of version string:
+	 * 2024.11.0 build 16
+	 * d2h9d01905129j37g1j998c654e9h6vx6168de4
+	 * 1.94.0 (Code - OSS)
+	 * arm64
+	 */
+	const versionString = [
+		`${localize('buildVersionMessage.positronVersion', "{0} build {1}", positronVersionString, positronBuildString)}`,
+		`${commit || localize('buildVersionMessage.unknownCommit', "Unknown commit")}`,
+		`${localize('buildVersionMessage.codeOssVersion', "{0} (Code - OSS)", codeOssVersionString)}`,
+		process.arch
+	];
+	return versionString.join('\n');
 }
+// --- End Positron ---

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -470,13 +470,13 @@ export function buildHelpMessage(productName: string, executableName: string, ve
 export function buildVersionMessage(
 	positronVersion: string | undefined,
 	positronBuildNumber: number | string | undefined,
-	codeOssVersion: string | undefined,
+	codeOSSVersion: string | undefined,
 	commit: string | undefined
 ): string {
 	const positronVersionString = `${positronVersion || localize('buildVersionMessage.unknownPositronVersion', "Unknown Positron version")}`;
 	const positronBuildString = `${positronBuildNumber === undefined ? localize('buildVersionMessage.unknownBuildNumber', "Unknown build number") : positronBuildNumber}`;
 	const positronCommitString = `${commit || localize('buildVersionMessage.unknownCommit', "Unknown commit")}`;
-	const codeOSSVersionString = `${codeOssVersion || localize('buildVersionMessage.unknownCodeOssVersion', "Unknown Code OSS version")}`;
+	const codeOSSVersionString = `${codeOSSVersion || localize('buildVersionMessage.unknownCodeOssVersion', "Unknown Code OSS version")}`;
 
 	/**
 	 * Preview of version string:

--- a/src/vs/server/node/remoteExtensionHostAgentCli.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentCli.ts
@@ -37,7 +37,7 @@ import { DownloadService } from 'vs/platform/download/common/downloadService';
 import { IDownloadService } from 'vs/platform/download/common/download';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { UriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentityService';
-import { buildHelpMessage, buildVersionMessage, OptionDescriptions } from 'vs/platform/environment/node/argv';
+import { buildHelpMessage, buildPositronVersionMessage, OptionDescriptions } from 'vs/platform/environment/node/argv';
 import { isWindows } from 'vs/base/common/platform';
 import { IExtensionsScannerService } from 'vs/platform/extensionManagement/common/extensionsScannerService';
 import { ExtensionsScannerService } from 'vs/server/node/extensionsScannerService';
@@ -190,7 +190,7 @@ export async function run(args: ServerParsedArgs, REMOTE_DATA_FOLDER: string, op
 	// Version Info
 	if (args.version) {
 		// --- Start Positron ---
-		console.log(buildVersionMessage(product.positronVersion, product.positronBuildNumber, product.version, product.commit));
+		console.log(buildPositronVersionMessage(product.positronVersion, product.positronBuildNumber, product.version, product.commit));
 		// --- End Positron ---
 		return;
 	}

--- a/src/vs/server/node/remoteExtensionHostAgentCli.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentCli.ts
@@ -182,7 +182,9 @@ function eventuallyExit(code: number): void {
 export async function run(args: ServerParsedArgs, REMOTE_DATA_FOLDER: string, optionDescriptions: OptionDescriptions<ServerParsedArgs>): Promise<void> {
 	if (args.help) {
 		const executable = product.serverApplicationName + (isWindows ? '.cmd' : '');
-		console.log(buildHelpMessage(product.nameLong, executable, product.version, optionDescriptions, { noInputFiles: true, noPipe: true }));
+		// --- Start Positron ---
+		console.log(buildHelpMessage(product.nameLong, executable, product.positronVersion, optionDescriptions, { noInputFiles: true, noPipe: true }));
+		// --- End Positron ---
 		return;
 	}
 	// Version Info

--- a/src/vs/server/node/remoteExtensionHostAgentCli.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentCli.ts
@@ -37,7 +37,10 @@ import { DownloadService } from 'vs/platform/download/common/downloadService';
 import { IDownloadService } from 'vs/platform/download/common/download';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { UriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentityService';
-import { buildHelpMessage, buildPositronVersionMessage, OptionDescriptions } from 'vs/platform/environment/node/argv';
+// --- Start Positron ---
+// @ts-ignore - unused import buildVersionMessage is preserved to avoid upstream merge conflicts.
+// --- End Positron ---
+import { buildHelpMessage, buildVersionMessage, OptionDescriptions } from 'vs/platform/environment/node/argv';
 import { isWindows } from 'vs/base/common/platform';
 import { IExtensionsScannerService } from 'vs/platform/extensionManagement/common/extensionsScannerService';
 import { ExtensionsScannerService } from 'vs/server/node/extensionsScannerService';
@@ -50,6 +53,11 @@ import { LogService } from 'vs/platform/log/common/logService';
 import { LoggerService } from 'vs/platform/log/node/loggerService';
 import { localize } from 'vs/nls';
 import { addUNCHostToAllowlist, disableUNCAccessRestrictions } from 'vs/base/node/unc';
+
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { buildPositronVersionMessage } from 'vs/platform/environment/node/argv';
+// --- End Positron ---
 
 class CliMain extends Disposable {
 

--- a/src/vs/server/node/remoteExtensionHostAgentCli.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentCli.ts
@@ -188,7 +188,7 @@ export async function run(args: ServerParsedArgs, REMOTE_DATA_FOLDER: string, op
 	// Version Info
 	if (args.version) {
 		// --- Start Positron ---
-		console.log(buildVersionMessage(product.positronVersion, product.commit));
+		console.log(buildVersionMessage(product.positronVersion, product.positronBuildNumber, product.version, product.commit));
 		// --- End Positron ---
 		return;
 	}

--- a/src/vs/server/node/remoteExtensionHostAgentCli.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentCli.ts
@@ -187,7 +187,9 @@ export async function run(args: ServerParsedArgs, REMOTE_DATA_FOLDER: string, op
 	}
 	// Version Info
 	if (args.version) {
-		console.log(buildVersionMessage(product.version, product.commit));
+		// --- Start Positron ---
+		console.log(buildVersionMessage(product.positronVersion, product.commit));
+		// --- End Positron ---
 		return;
 	}
 

--- a/src/vs/server/node/server.cli.ts
+++ b/src/vs/server/node/server.cli.ts
@@ -132,6 +132,9 @@ export async function main(desc: ProductDescription, args: string[]): Promise<vo
 		return;
 	}
 	if (parsedArgs.version) {
+		// --- Start Positron ---
+		// The version passed into the server-cli will be the positron version.
+		// --- End Positron ---
 		console.log(buildVersionMessage(desc.version, desc.commit));
 		return;
 	}

--- a/src/vs/server/node/server.cli.ts
+++ b/src/vs/server/node/server.cli.ts
@@ -9,7 +9,7 @@ import * as cp from 'child_process';
 import * as http from 'http';
 import { cwd } from 'vs/base/common/process';
 import { dirname, extname, resolve, join } from 'vs/base/common/path';
-import { parseArgs, buildHelpMessage, buildVersionMessage, OPTIONS, OptionDescriptions, ErrorReporter } from 'vs/platform/environment/node/argv';
+import { parseArgs, buildHelpMessage, buildPositronVersionMessage, OPTIONS, OptionDescriptions, ErrorReporter } from 'vs/platform/environment/node/argv';
 import { NativeParsedArgs } from 'vs/platform/environment/common/argv';
 import { createWaitMarkerFileSync } from 'vs/platform/environment/node/wait';
 import { PipeCommand } from 'vs/workbench/api/node/extHostCLIServer';
@@ -139,7 +139,7 @@ export async function main(desc: ProductDescription, args: string[]): Promise<vo
 	}
 	if (parsedArgs.version) {
 		// --- Start Positron ---
-		console.log(buildVersionMessage(desc.positronVersion, desc.positronBuildNumber, desc.version, desc.commit));
+		console.log(buildPositronVersionMessage(desc.positronVersion, desc.positronBuildNumber, desc.version, desc.commit));
 		// --- End Positron ---
 		return;
 	}

--- a/src/vs/server/node/server.cli.ts
+++ b/src/vs/server/node/server.cli.ts
@@ -133,8 +133,7 @@ export async function main(desc: ProductDescription, args: string[]): Promise<vo
 
 	if (parsedArgs.help) {
 		// --- Start Positron ---
-		const positronVersionAndBuild = `${desc.positronVersion} build ${desc.positronBuildNumber}`;
-		console.log(buildHelpMessage(desc.productName, desc.executableName, positronVersionAndBuild, options));
+		console.log(buildHelpMessage(desc.productName, desc.executableName, desc.positronVersion, options));
 		// --- End Positron ---
 		return;
 	}

--- a/src/vs/server/node/server.cli.ts
+++ b/src/vs/server/node/server.cli.ts
@@ -28,6 +28,10 @@ import { DeferredPromise } from 'vs/base/common/async';
 interface ProductDescription {
 	productName: string;
 	version: string;
+	// --- Start Positron ---
+	positronVersion: string;
+	positronBuildNumber: number | string;
+	// --- End Positron ---
 	commit: string;
 	executableName: string;
 }
@@ -128,14 +132,16 @@ export async function main(desc: ProductDescription, args: string[]): Promise<vo
 	const verbose = !!parsedArgs['verbose'];
 
 	if (parsedArgs.help) {
-		console.log(buildHelpMessage(desc.productName, desc.executableName, desc.version, options));
+		// --- Start Positron ---
+		const positronVersionAndBuild = `${desc.positronVersion} build ${desc.positronBuildNumber}`;
+		console.log(buildHelpMessage(desc.productName, desc.executableName, positronVersionAndBuild, options));
+		// --- End Positron ---
 		return;
 	}
 	if (parsedArgs.version) {
 		// --- Start Positron ---
-		// The version passed into the server-cli will be the positron version.
+		console.log(buildVersionMessage(desc.positronVersion, desc.positronBuildNumber, desc.version, desc.commit));
 		// --- End Positron ---
-		console.log(buildVersionMessage(desc.version, desc.commit));
 		return;
 	}
 	if (parsedArgs['locate-shell-integration-path']) {
@@ -497,7 +503,11 @@ function mapFileToRemoteUri(uri: string): string {
 	return uri.replace(/^file:\/\//, 'vscode-remote://' + cliRemoteAuthority);
 }
 
-const [, , productName, version, commit, executableName, ...remainingArgs] = process.argv;
-main({ productName, version, commit, executableName }, remainingArgs).then(null, err => {
+// --- Start Positron ---
+// Call the CLI with the following argument order:
+// (node exe), (cli script), APPNAME, POSITRONVERSION, BUILDNUMBER, VERSION, COMMIT, EXEC NAME, ...
+const [, , productName, positronVersion, positronBuildNumber, version, commit, executableName, ...remainingArgs] = process.argv;
+main({ productName, positronVersion, positronBuildNumber, version, commit, executableName }, remainingArgs).then(null, err => {
+	// --- End Positron ---
 	console.error(err.message || err.stack || err);
 });

--- a/src/vs/server/node/server.cli.ts
+++ b/src/vs/server/node/server.cli.ts
@@ -9,12 +9,20 @@ import * as cp from 'child_process';
 import * as http from 'http';
 import { cwd } from 'vs/base/common/process';
 import { dirname, extname, resolve, join } from 'vs/base/common/path';
-import { parseArgs, buildHelpMessage, buildPositronVersionMessage, OPTIONS, OptionDescriptions, ErrorReporter } from 'vs/platform/environment/node/argv';
+// --- Start Positron ---
+// @ts-ignore - unused import buildVersionMessage is preserved to avoid upstream merge conflicts.
+// --- End Positron ---
+import { parseArgs, buildHelpMessage, buildVersionMessage, OPTIONS, OptionDescriptions, ErrorReporter } from 'vs/platform/environment/node/argv';
 import { NativeParsedArgs } from 'vs/platform/environment/common/argv';
 import { createWaitMarkerFileSync } from 'vs/platform/environment/node/wait';
 import { PipeCommand } from 'vs/workbench/api/node/extHostCLIServer';
 import { hasStdinWithoutTty, getStdinFilePath, readFromStdin } from 'vs/platform/environment/node/stdin';
 import { DeferredPromise } from 'vs/base/common/async';
+
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { buildPositronVersionMessage } from 'vs/platform/environment/node/argv';
+// --- End Positron ---
 
 /*
  * Implements a standalone CLI app that opens VS Code from a remote terminal.


### PR DESCRIPTION
## Description

- addresses #1373
- updates `positron --version`, `positron --help`, `positron-server --version`, `positron-server --help` to output Positron version information
- updates Linux package version info to use Positron version
- I updated our snapcraft.yml, but we don't publish on Snap yet, so it's just a speculative change for now

## QA Notes

Please test this functionality in each of our builds across all platforms! I've tested this with Desktop Mac and REH-Web on Ubuntu.

Note that the Command Prompt command to install `positron` in PATH is not available on every operating system. On some platforms, it seems that `positron` is automatically installed in the PATH upon installation.

### Check `--version`

Sample Output:
```
Positron: 2024.11.0 build 70
Positron SHA: 51829054cdff5f1c0464f27fb223921cf9c7f427
Code OSS: 1.93.0
Arch: arm64
```

#### Desktop Build
1. Use the Command Prompt to `Shell Command: Install 'positron' command in PATH` (`workbench.action.installCommandLine`)
2. Run `positron --version` in a Terminal
3. Confirm the output contains the expected information and format

#### REH or REH Web Build
1. Locate the `positron-server` executable, which will be in the `bin` directory of the REH or REH Web binary
2. Run `positron-server --version` in a Terminal
3. Confirm the output contains the expected information and format

### Check `--help`

Sample Output:
```
Positron 2024.11.0
<REST_OF_HELP>
```

#### Desktop Build
1. Use the Command Prompt to `Shell Command: Install 'positron' command in PATH` (`workbench.action.installCommandLine`)
2. Run `positron --help` in a Terminal
3. The first line of output should show `Positron <POSITRON_VERSION>`

#### REH or REH Web Build
1. Locate the `positron-server` executable, which will be in the `bin` directory of REH or REH Web binary
2. Run `positron-server --help` in a Terminal
3. The first line of output should show `Positron <POSITRON_VERSION>`

### Check package info

See https://github.com/posit-dev/positron/pull/5140 for notes on how to verify the version output of DEB and RPM packages.