### PR TITLE
new command to set default editor opener type

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileCommands.ts
+++ b/src/vs/workbench/contrib/files/browser/fileCommands.ts
@@ -54,7 +54,7 @@ import { ExplorerView } from 'vs/workbench/contrib/files/browser/views/explorerV
 import { IListService } from 'vs/platform/list/browser/listService';
 
 // --- Start Positron ---
-import { SAVE_ALL_TITLED_COMMAND_ID } from 'vs/workbench/contrib/files/browser/fileConstants';
+import { SAVE_ALL_TITLED_COMMAND_ID, SET_DEFAULT_EDITOR_COMMAND_ID } from 'vs/workbench/contrib/files/browser/fileConstants';
 // --- End Positron ---
 
 export const openWindowCommand = (accessor: ServicesAccessor, toOpen: IWindowOpenable[], options?: IOpenWindowOptions) => {
@@ -363,6 +363,22 @@ CommandsRegistry.registerCommand({
 		return undefined;
 	}
 });
+
+// --- Start Positron ---
+CommandsRegistry.registerCommand({
+	id: SET_DEFAULT_EDITOR_COMMAND_ID,
+	handler: async (accessor, resource: URI | object, editorType: string) => {
+		const editorService = accessor.get(IEditorService);
+		const listService = accessor.get(IListService);
+		const uri = getResourceForCommand(resource, editorService, listService);
+		if (uri) {
+			return editorService.setDefaultEditor({ resource: uri, options: { override: EditorResolution.PICK, source: EditorOpenSource.USER } }, editorType);
+		}
+
+		return undefined;
+	}
+});
+// --- End Positron ---
 
 // Save / Save As / Save All / Revert
 

--- a/src/vs/workbench/contrib/files/browser/fileCommands.ts
+++ b/src/vs/workbench/contrib/files/browser/fileCommands.ts
@@ -372,7 +372,7 @@ CommandsRegistry.registerCommand({
 		const listService = accessor.get(IListService);
 		const uri = getResourceForCommand(resource, editorService, listService);
 		if (uri) {
-			return editorService.setDefaultEditor({ resource: uri, options: { override: EditorResolution.PICK, source: EditorOpenSource.USER } }, editorType);
+			return editorService.setDefaultEditor({ resource: uri }, editorType);
 		}
 
 		return undefined;

--- a/src/vs/workbench/contrib/files/browser/fileConstants.ts
+++ b/src/vs/workbench/contrib/files/browser/fileConstants.ts
@@ -10,6 +10,9 @@ export const REVEAL_IN_EXPLORER_COMMAND_ID = 'revealInExplorer';
 export const REVERT_FILE_COMMAND_ID = 'workbench.action.files.revert';
 export const OPEN_TO_SIDE_COMMAND_ID = 'explorer.openToSide';
 export const OPEN_WITH_EXPLORER_COMMAND_ID = 'explorer.openWith';
+// --- Start Positron ---
+export const SET_DEFAULT_EDITOR_COMMAND_ID = 'explorer.setDefaultEditor';
+// --- End Positron ---
 export const SELECT_FOR_COMPARE_COMMAND_ID = 'selectForCompare';
 
 export const COMPARE_SELECTED_COMMAND_ID = 'compareSelected';

--- a/src/vs/workbench/contrib/files/browser/fileConstants.ts
+++ b/src/vs/workbench/contrib/files/browser/fileConstants.ts
@@ -11,7 +11,8 @@ export const REVERT_FILE_COMMAND_ID = 'workbench.action.files.revert';
 export const OPEN_TO_SIDE_COMMAND_ID = 'explorer.openToSide';
 export const OPEN_WITH_EXPLORER_COMMAND_ID = 'explorer.openWith';
 // --- Start Positron ---
-export const SET_DEFAULT_EDITOR_COMMAND_ID = 'explorer.setDefaultEditor';
+export const SET_DEFAULT_EDITOR_COMMAND_ID = 'workbench.action.setDefaultEditor';
+export const SET_DEFAULT_EDITOR_COMMAND_TITLE = 'Set new default editor opener';
 // --- End Positron ---
 export const SELECT_FOR_COMPARE_COMMAND_ID = 'selectForCompare';
 

--- a/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
@@ -59,7 +59,8 @@ import { IFileService } from 'vs/platform/files/common/files';
 
 // --- Start Positron ---
 // eslint-disable-next-line no-duplicate-imports
-import { SAVE_ALL_TITLED_COMMAND_ID, SAVE_ALL_TITLED_LABEL } from 'vs/workbench/contrib/files/browser/fileConstants';
+import { SET_DEFAULT_EDITOR_COMMAND_TITLE, SET_DEFAULT_EDITOR_COMMAND_ID, SAVE_ALL_TITLED_COMMAND_ID, SAVE_ALL_TITLED_LABEL } from 'vs/workbench/contrib/files/browser/fileConstants';
+import { Uri } from 'vscode';
 // --- End Positron ---
 
 const $ = dom.$;
@@ -915,6 +916,21 @@ registerAction2(class extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const commandService = accessor.get(ICommandService);
 		await commandService.executeCommand(SAVE_ALL_TITLED_COMMAND_ID);
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: SET_DEFAULT_EDITOR_COMMAND_ID,
+			title: SET_DEFAULT_EDITOR_COMMAND_TITLE,
+			f1: false,
+		});
+	}
+
+	async run(accessor: ServicesAccessor, editor: Uri, editorType: string): Promise<void> {
+		const commandService = accessor.get(ICommandService);
+		await commandService.executeCommand(SET_DEFAULT_EDITOR_COMMAND_ID, editor, editorType);
 	}
 });
 // --- End Positron ---

--- a/src/vs/workbench/services/editor/browser/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/browser/editorResolverService.ts
@@ -809,6 +809,18 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 		}
 	}
 
+	// --- Start Positron ---
+	public setDefaultEditor(editor: IUntypedEditorInput, editorOpener: string) {
+		let resource = EditorResourceAccessor.getOriginalUri(editor, { supportSideBySide: SideBySideEditor.PRIMARY });
+
+		if (resource === undefined) {
+			resource = URI.from({ scheme: Schemas.untitled });
+		}
+
+		this.updateUserAssociations(`*${extname(resource)}`, editorOpener);
+	}
+	// --- End Positron ---
+
 	private cacheEditors() {
 		// Create a set to store glob patterns
 		const cacheStorage: Set<string> = new Set<string>();

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -573,6 +573,12 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		return group.openEditor(typedEditor, options);
 	}
 
+	// --- Start Positron ---
+	async setDefaultEditor(editor: EditorInput | IUntypedEditorInput, prefferedEditor: string) {
+		this.editorResolverService.setDefaultEditor(editor, prefferedEditor);
+	}
+	// --- End Positron ---
+
 	//#endregion
 
 	//#region openEditors()

--- a/src/vs/workbench/services/editor/common/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/common/editorResolverService.ts
@@ -187,6 +187,13 @@ export interface IEditorResolverService {
 	 * Get a complete list of editor associations.
 	 */
 	getAllUserAssociations(): EditorAssociations;
+
+	// --- Start Positron ---
+	/**
+	 * Set default editor
+	 */
+	setDefaultEditor(editor: IUntypedEditorInput, editorOpener: string): void;
+	// --- End Positron ---
 }
 
 //#endregion

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -357,4 +357,13 @@ export interface IEditorService {
 	 * to the main editor group container of the main window.
 	 */
 	createScoped(editorGroupsContainer: IEditorGroupsContainer | 'main', disposables: DisposableStore): IEditorService;
+
+	// --- Start Positron ---
+	/**
+	 * Set a default editor for type
+	 * @param editor
+	 * @param editorOpener
+	 */
+	setDefaultEditor(editor: IUntypedEditorInput, editorOpener: string): void;
+	// --- End Positron ---
 }

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1072,6 +1072,10 @@ export class TestEditorService extends Disposable implements EditorServiceImpl {
 	saveAll(options?: ISaveEditorsOptions): Promise<ISaveEditorsResult> { throw new Error('Method not implemented.'); }
 	revert(editors: IEditorIdentifier[], options?: IRevertOptions): Promise<boolean> { throw new Error('Method not implemented.'); }
 	revertAll(options?: IRevertAllEditorsOptions): Promise<boolean> { throw new Error('Method not implemented.'); }
+	// --- Start Positron ---
+	setDefaultEditor(editor: IUntypedEditorInput, editorOpener: string): void {
+	}
+	// --- End Positron ---
 }
 
 export class TestFileService implements IFileService {


### PR DESCRIPTION
as part of #2933 

to test with quarto extension SETUP:
1. launch positron dev
2. clone/open https://github.com/quarto-dev/quarto as workspace
3. check out branch `save-editor-type` https://github.com/quarto-dev/quarto/pull/577
4. run `yarn dev-vscode`
5. from debug tab, click play button (will launch another positron instance)
6. go to settings -> search "quarto editor" and swap between visual/source and open qmds. they should open with default editor.
---
testing the changes: 
7. in a qmd file, add `editor: source` to top yaml. check that it opens in source, regardless of default editor. 
8. step 7 again, but with `editor: visual`
9. create a `_quarto.yml` file in the root of the workspace. add `editor: source` and see that qmds with no specific editor noted will open in source mode
10. step 9 again, but with `editor: visual`
