### PR TITLE
smoke tests: fix paths

### DIFF
--- a/test/smoke/src/test-runner/config.ts
+++ b/test/smoke/src/test-runner/config.ts
@@ -9,6 +9,8 @@ import minimist = require('minimist');
 
 const TEST_DATA_PATH = path.join(os.tmpdir(), 'vscsmoke');
 export const OPTS = minimist(process.argv.slice(2));
+const ARTIFACT_DIR = process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || 'smoke-tests-default';
+const ROOT_PATH = path.join(__dirname, '..', '..', '..', '..');
 
 // Set environment variables
 Object.assign(process.env, {
@@ -24,11 +26,11 @@ Object.assign(process.env, {
 	PR: OPTS['pr'] || '',
 	SKIP_CLEANUP: OPTS['skip-cleanup'] || '',
 	TEST_DATA_PATH: TEST_DATA_PATH,
-	ROOT_PATH: path.join(__dirname, '..', '..', '..', '..'),
+	ROOT_PATH,
 	EXTENSIONS_PATH: path.join(TEST_DATA_PATH, 'extensions-dir'),
 	WORKSPACE_PATH: path.join(TEST_DATA_PATH, 'qa-example-content'),
-	REPORT_PATH: path.join(process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || '', 'test-results/'),
-	RETRY_LOG_PATH: path.join(process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || ''),
-	LOGS_DIR: process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || 'smoke-tests-default',
+	REPORT_PATH: path.join(ROOT_PATH, '.build', 'logs', ARTIFACT_DIR, 'test-results'),
+	LOGS_ROOT_PATH: path.join(ROOT_PATH, '.build', 'logs', ARTIFACT_DIR),
+	CRASHES_ROOT_PATH: path.join(ROOT_PATH, '.build', 'crashes', ARTIFACT_DIR),
 });
 

--- a/test/smoke/src/test-runner/config.ts
+++ b/test/smoke/src/test-runner/config.ts
@@ -7,8 +7,8 @@ import * as path from 'path';
 import * as os from 'os';
 import minimist = require('minimist');
 
-const TEST_DATA_PATH = path.join(os.tmpdir(), 'vscsmoke');
 export const OPTS = minimist(process.argv.slice(2));
+const TEST_DATA_PATH = path.join(os.tmpdir(), 'vscsmoke');
 const ARTIFACT_DIR = process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || 'smoke-tests-default';
 const ROOT_PATH = path.join(__dirname, '..', '..', '..', '..');
 
@@ -26,7 +26,6 @@ Object.assign(process.env, {
 	PR: OPTS['pr'] || '',
 	SKIP_CLEANUP: OPTS['skip-cleanup'] || '',
 	TEST_DATA_PATH: TEST_DATA_PATH,
-	ROOT_PATH,
 	EXTENSIONS_PATH: path.join(TEST_DATA_PATH, 'extensions-dir'),
 	WORKSPACE_PATH: path.join(TEST_DATA_PATH, 'qa-example-content'),
 	REPORT_PATH: path.join(ROOT_PATH, '.build', 'logs', ARTIFACT_DIR, 'test-results'),

--- a/test/smoke/src/test-runner/logger.ts
+++ b/test/smoke/src/test-runner/logger.ts
@@ -64,10 +64,10 @@ function logToFile(logFilePath: string, message: string): void {
  * @param err error
  */
 export function logErrorToFile(test: any, err: Error): void {
-	const RETRY_LOG_PATH = process.env.RETRY_LOG_PATH || 'RETRY_LOG_PATH not set';
+	const LOGS_ROOT_PATH = process.env.LOGS_ROOT_PATH || 'LOGS_ROOT_PATH not set';
 
 	const fileName = path.basename(test.file);
-	const testLogPath = path.join(RETRY_LOG_PATH, fileName, 'retry.log');
+	const testLogPath = path.join(LOGS_ROOT_PATH, fileName, 'retry.log');
 
 	const title = `[RUN #${test.currentRetry()}] ${test.fullTitle()}`;
 	const dashes = printDashes(title.length);

--- a/test/smoke/src/test-runner/mocha-runner.ts
+++ b/test/smoke/src/test-runner/mocha-runner.ts
@@ -26,7 +26,7 @@ export async function runMochaTests(OPTS: any) {
 		reporter: 'mocha-multi',
 		reporterOptions: {
 			spec: '-',  // Console output
-			xunit: REPORT_PATH + 'xunit-results.xml',
+			xunit: path.join(REPORT_PATH, 'xunit-results.xml')
 		},
 		retries: 1,
 	});

--- a/test/smoke/src/test-runner/test-hooks.ts
+++ b/test/smoke/src/test-runner/test-hooks.ts
@@ -13,8 +13,8 @@ export const ROOT_PATH = join(__dirname, '..', '..', '..', '..');
 const TEST_DATA_PATH = process.env.TEST_DATA_PATH || 'TEST_DATA_PATH not set';
 const WORKSPACE_PATH = process.env.WORKSPACE_PATH || 'WORKSPACE_PATH not set';
 const EXTENSIONS_PATH = process.env.EXTENSIONS_PATH || 'EXTENSIONS_PATH not set';
-const LOGS_DIR = process.env.BUILD_ARTIFACTSTAGINGDIRECTORY || 'smoke-tests-default';
-
+const LOGS_ROOT_PATH = process.env.LOGS_ROOT_PATH || 'LOGS_ROOT_PATH not set';
+const CRASHES_ROOT_PATH = process.env.CRASHES_ROOT_PATH || 'CRASHES_ROOT_PATH not set';
 
 const asBoolean = (value: string | undefined): boolean | undefined => {
 	return value === 'true' ? true : value === 'false' ? false : undefined;
@@ -42,8 +42,8 @@ const OPTS: ParseOptions = {
 export function setupAndStartApp(): Logger {
 	// Dynamically determine the test file name
 	const suiteName = getTestFileName();
-	const logsRootPath = join(ROOT_PATH, '.build', 'logs', LOGS_DIR, suiteName);
-	const crashesRootPath = join(ROOT_PATH, '.build', 'crashes', LOGS_DIR, suiteName);
+	const logsRootPath = join(LOGS_ROOT_PATH, suiteName);
+	const crashesRootPath = join(CRASHES_ROOT_PATH, suiteName);
 
 	// Create a new logger for this suite
 	const logger = createLogger(logsRootPath);


### PR DESCRIPTION
When running smoke tests without specifying `BUILD_ARTIFACTSTAGINGDIRECTORY`, the `retry.log` file was placed in the wrong location. I updated the environment variables to ensure the correct path is always set.

### QA Notes
* Confirmed by running with `BUILD_ARTIFACTSTAGINGDIRECTORY` set that logs appear in right place
* Confirmed by running _without_ `BUILD_ARTIFACTSTAGINGDIRECTORY` set that logs appear in right place
