### PR TITLE
Test Stability: Bumped timout for conda new project

### DIFF
--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -49,7 +49,7 @@ describe('New Project Wizard', () => {
 					expect(projectFiles).toContain('.conda');
 				}).toPass({ timeout: 50000 });
 				// The console should initialize without any prompts to install ipykernel
-				await app.workbench.positronConsole.waitForReady('>>>', 10000);
+				await app.workbench.positronConsole.waitForReady('>>>', 20000);
 				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 				await app.workbench.positronConsole.barClearButton.click();
 				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');


### PR DESCRIPTION
### Intent

New project conda test has timed out a few times waiting for conda env to start. I see the retry saves it occasionally, but still fails sometimes.

### Approach

Bump timeout waitng for new env to start up

### QA Notes

Tests should pass on all runs