### PR TITLE
Data Explorer: Get positron-duckdb extension working on Windows

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -46,9 +46,11 @@ class DuckDBInstance {
 			mainModule: join(distPath, 'duckdb-eh.wasm'),
 			mainWorker: join(distPath, 'duckdb-node-eh.worker.cjs')
 		};
-		// On Windows, we need to call pathToFileURL on mainModule and mainWorkerto get the correct path format
+
+		// On Windows, we need to call pathToFileURL on mainWorker because the web-worker package
+		// does not support Windows paths that start with a drive letter.
 		if (process.platform === 'win32') {
-			bundle.mainModule = pathToFileURL(bundle.mainModule).toString();
+			// Example: file:///c:/Users/sharon/positron/extensions/positron-duckdb/node_modules/@duckdb/duckdb-wasm/dist/duckdb-node-eh.worker.cjs
 			bundle.mainWorker = pathToFileURL(bundle.mainWorker).toString();
 		}
 

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -32,6 +32,7 @@ import * as duckdb from '@duckdb/duckdb-wasm';
 import Worker from 'web-worker';
 import { basename, extname, join } from 'path';
 import { Table } from 'apache-arrow';
+import { pathToFileURL } from 'url';
 
 class DuckDBInstance {
 	constructor(readonly db: duckdb.AsyncDuckDB, readonly con: duckdb.AsyncDuckDBConnection) { }
@@ -45,6 +46,12 @@ class DuckDBInstance {
 			mainModule: join(distPath, 'duckdb-eh.wasm'),
 			mainWorker: join(distPath, 'duckdb-node-eh.worker.cjs')
 		};
+		// On Windows, we need to call pathToFileURL on mainModule and mainWorkerto get the correct path format
+		if (process.platform === 'win32') {
+			bundle.mainModule = pathToFileURL(bundle.mainModule).toString();
+			bundle.mainWorker = pathToFileURL(bundle.mainWorker).toString();
+		}
+
 		const logger = new duckdb.VoidLogger();
 
 		const worker = new Worker(bundle.mainWorker);

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
@@ -132,8 +132,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 	async openDataset() {
 		const result = await this._execRpc<OpenDatasetResult>({
 			method: DataExplorerBackendRequest.OpenDataset,
-			uri: this.filePath,
-			params: {},
+			params: { uri: this.filePath }
 		});
 
 		if (result.error_message) {

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
@@ -132,7 +132,8 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 	async openDataset() {
 		const result = await this._execRpc<OpenDatasetResult>({
 			method: DataExplorerBackendRequest.OpenDataset,
-			params: { uri: this.filePath }
+			uri: this.filePath,
+			params: {},
 		});
 
 		if (result.error_message) {


### PR DESCRIPTION
Addresses #5084. The extension needed some massaging of file paths on Windows to get the web worker loading and the SQL strings in a format where DuckDB can read the files.

I verify that opening files from the command palette works on Windows, so the bug from #5076 appears to only affect macOS for now