### PR TITLE
Exit R gracefully exits the Reticulate Python session

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_jedilsp.py
@@ -216,6 +216,11 @@ class PositronJediLanguageServer(JediLanguageServer):
         # Give the LSP server access to the kernel to enhance completions with live variables
         self.shell = shell
 
+        # If self.lsp has been used previously in this process and sucessfully exited, it will be
+        # marked with a shutdown flag, which makes it ignore all messages.
+        # We reset it here, so we allow the server to start again.
+        self.lsp._shutdown = False
+
         if self._server_thread is not None:
             logger.warning("LSP server thread was not properly shutdown")
             return

--- a/extensions/positron-python/python_files/positron/positron_language_server.py
+++ b/extensions/positron-python/python_files/positron/positron_language_server.py
@@ -9,7 +9,7 @@ import logging
 import os
 import sys
 
-from positron_ipykernel.positron_ipkernel import PositronIPKernelApp, PositronIPyKernel
+from positron_ipykernel.positron_ipkernel import PositronIPKernelApp, PositronIPyKernel, PositronShell
 from positron_ipykernel.positron_jedilsp import POSITRON
 from positron_ipykernel.session_mode import SessionMode
 
@@ -151,8 +151,10 @@ if __name__ == "__main__":
     # When the app is gone, it should be safe to clear singleton instances.
     # This allows re-starting the ipykernel in the same process, using different
     # connection strings, etc.
+    PositronShell.clear_instance()
     PositronIPyKernel.clear_instance()
     PositronIPKernelApp.clear_instance()
+    app.close()
 
     logger.info(f"Exiting process with status {exit_status}")
     sys.exit(exit_status)

--- a/extensions/positron-python/python_files/positron/positron_language_server.py
+++ b/extensions/positron-python/python_files/positron/positron_language_server.py
@@ -9,7 +9,11 @@ import logging
 import os
 import sys
 
-from positron_ipykernel.positron_ipkernel import PositronIPKernelApp, PositronIPyKernel, PositronShell
+from positron_ipykernel.positron_ipkernel import (
+    PositronIPKernelApp,
+    PositronIPyKernel,
+    PositronShell,
+)
 from positron_ipykernel.positron_jedilsp import POSITRON
 from positron_ipykernel.session_mode import SessionMode
 

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -523,15 +523,6 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 
 	public async shutdown(exitReason: positron.RuntimeExitReason) {
 		await this.pythonSession.shutdown(exitReason);
-		// Tell Positron that the kernel has exit. When launching IPykernel from a standalone
-		// process, when the kernel exits, then all of it's threads, specially the IOPub thread
-		// holding the ZeroMQ sockets will cease to exist, and thus Positron identifies that the
-		// kernel has successfuly closed. However, since we launch positron from a different thread,
-		// when the kernel exits, the thread exits, but all other dangling threads are still alive,
-		// thus Positron never identifies that the kernel exited. We must then manually fire exit event.
-		// We rely on an implementation detail of the jupyter adapter, that allows us to force the
-		// kernels to disconnect.
-		(this.pythonSession as any)._kernel._kernel._allSockets.forEach((socket: any) => socket.disconnect());
 		return;
 	}
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/5083
Requires Ark side: https://github.com/posit-dev/ark/pull/603
This is built on top of https://github.com/posit-dev/positron/pull/5056 so should merge it before this one.

In the Ark side we added a finalizer using `reg.finalizer` to the `reticulate` namespace. So whenever the reticulate namespace is unloaded (or when the R session is about to exit), we'll send a shutdown event to the reticulate extension. The R side waits for the event to be processed and for the comm client to be disposed before really finalizing the session. Thus making sure that the reticulate Python session has gracefully exited before ending the R session - which would cause IPykernel to crash otherwise.

I'm not sure this is the best approach although it's the one that doesn't need to introduce any new concepts.
We could also:

1. Add API's to register shutdown callbacks to `positron.RuntimeSession`, these callbacks would be `await` before calling the session `shutdown` routines.
2. Perhaps exposing the `Exiting` RuntimeState. Although this might not be enough, because we really need to wait for the Python session to end before proceeding.

   https://github.com/posit-dev/positron/blob/bf3de59fe4bc6963c63b69819115b4ea39da5477/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts#L299-L301

3. Introducing the concept of parent/child sessions and 'parents' would be resposnible for shutting down their child sessions before shutting them down.

@jmcphers do you have a sense if the current approach is reasonable?