### PR TITLE
Bumped timeouts and fixed env variable

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -17,7 +17,6 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       POSITRON_BUILD_NUMBER: 0 # CI skips building releases
-      _R_CHECK_FUTURE_FILE_TIMESTAMPS_: false # this check can be flaky in the R pkg tests
     steps:
       - uses: actions/checkout@v4
 
@@ -100,6 +99,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       POSITRON_BUILD_NUMBER: 0 # CI skips building releases
+      _R_CHECK_FUTURE_FILE_TIMESTAMPS_: false # this check can be flaky in the R pkg tests
     steps:
       - uses: actions/checkout@v4
 
@@ -166,6 +166,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       POSITRON_BUILD_NUMBER: 0 # CI skips building releases
+      _R_CHECK_FUTURE_FILE_TIMESTAMPS_: false # this check can be flaky in the R pkg tests
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -34,6 +34,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       POSITRON_BUILD_NUMBER: 0 # CI skips building releases
+      _R_CHECK_FUTURE_FILE_TIMESTAMPS_: false # this check can be flaky in the R pkg tests
     steps:
       - uses: actions/checkout@v4
 

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -29,6 +29,8 @@ describe('New Project Wizard', () => {
 			});
 			it('Create a new Conda environment [C628628]', async function () {
 				// This test relies on Conda already being installed on the machine
+				this.timeout(180000);
+
 				const projSuffix = addRandomNumSuffix('_condaInstalled');
 				const app = this.app as Application;
 				const pw = app.workbench.positronNewProjectWizard;
@@ -49,7 +51,7 @@ describe('New Project Wizard', () => {
 					expect(projectFiles).toContain('.conda');
 				}).toPass({ timeout: 50000 });
 				// The console should initialize without any prompts to install ipykernel
-				await app.workbench.positronConsole.waitForReady('>>>', 20000);
+				await app.workbench.positronConsole.waitForReady('>>>', 40000);
 				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 				await app.workbench.positronConsole.barClearButton.click();
 				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');

--- a/test/smoke/src/areas/positron/r-pkg-development/r-pkg-development.test.ts
+++ b/test/smoke/src/areas/positron/r-pkg-development/r-pkg-development.test.ts
@@ -40,7 +40,7 @@ describe('R Package Development #web', () => {
 
 		it('R Package Development Tasks [C809821]', async function () {
 
-			this.timeout(180000);
+			this.timeout(200000);
 
 			await expect(async () => {
 				// Navigate to https://github.com/posit-dev/qa-example-content/tree/main/workspaces/r_testing


### PR DESCRIPTION
### Intent

Some timeouts to get better test stability

### Approach

R Package Dev Test: The check for future timestamps can take very long due to external server. Adding env variable to workflows will turn off that particular check.
New Project: Conda interpreter can take a long time to start, so bumping up the timeout (again)

### QA Notes

Tests should pass in CI