### PR TITLE
Temporarily disable `positron-run-app` tests

### DIFF
--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -140,12 +140,6 @@ yarn test-extension -l positron-connections
 kill_app
 
 echo
-echo "### Positron Run App tests"
-echo
-yarn test-extension -l positron-run-app
-kill_app
-
-echo
 echo "### Positron DuckDB tests"
 echo
 yarn test-extension -l positron-duckdb


### PR DESCRIPTION
Disabling since they've been flaky in CI. I'll try to debug them separately and re-enable once they're stable.