### PR TITLE
Use new website instead of links to wiki

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -8,7 +8,7 @@ about: Create a new issue for Positron.
 Thanks for taking the time to file an issue!
 
 Take a look at our guidance on feedback and issues:
-https://github.com/posit-dev/positron/wiki/Feedback-and-Issues
+https://positron.posit.co/feedback.html
 
 General questions about Positron should start in GitHub Discussions rather than as an issue:
 https://github.com/posit-dev/positron/discussions
@@ -49,7 +49,7 @@ additional information to help us prioritize the issue.
 <!--
 
 - Open the Developer Tools console by running the `Developer: Toggle Developer Tools` command from the Command Palette
-- Open the relevant Output Channel logs by utilizing this guide https://github.com/posit-dev/positron/wiki/Troubleshooting
+- Open the relevant Output Channel logs by utilizing this guide: https://positron.posit.co/troubleshooting.html
 
 -->
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Positron  <a href="https://github.com/posit-dev/positron"><img src="positron-product-icons/positron.png" align="right" height="138" alt="Positron" /></a>
 
-What is Positron?
+What is [Positron](https://positron.posit.co/)?
 
 - A next-generation data science IDE built by [Posit PBC](https://posit.co/)
 - An extensible, polyglot tool for writing code and exploring data
 - A familiar environment for reproducible authoring and publishing
 
 > [!IMPORTANT]
-> Positron is an early stage project under active development and may [not yet be a good fit for you](https://github.com/posit-dev/positron/wiki#is-positron-for-me). If you are interested in experimenting with it, we welcome your feedback!
+> Positron is an early stage project under active development and may [not yet be a good fit for you](https://positron.posit.co/start.html#is-positron-for-me). If you are interested in experimenting with it, we welcome your feedback!
 
 
 
@@ -16,7 +16,7 @@ https://github.com/posit-dev/positron/assets/29187501/d1c4c9f0-7bd5-4132-bc24-c3
 
 ## Get started using Positron
 
-Check out [our wiki](https://github.com/posit-dev/positron/wiki) for information on what you should do before installing Positron, troubleshooting Positron, and more. Our [FAQ](https://github.com/posit-dev/positron/wiki/Frequently-Asked-Questions) also covers some common or expected questions. 
+Check out [our website](https://positron.posit.co/) for information on what you should do before installing Positron, troubleshooting Positron, and more. Our [FAQ](https://positron.posit.co/faqs.html) also covers some common or expected questions.
 
 Positron is built on [Code OSS](https://github.com/microsoft/vscode). To learn about basic features like commands, settings, using source control, and more, see the [VS Code documentation](https://code.visualstudio.com/docs).
 
@@ -28,7 +28,7 @@ Currently, Positron is producing pre-release builds from a continuous integratio
 
 ## Share your feedback about Positron
 
-We invite you to join us on [GitHub Discussions](https://github.com/posit-dev/positron/discussions) to ask questions and share feedback. [Read more](https://github.com/posit-dev/positron/wiki/Feedback-and-Issues) about giving feedback and reporting bugs.
+We invite you to join us on [GitHub Discussions](https://github.com/posit-dev/positron/discussions) to ask questions and share feedback. [Read more](https://positron.posit.co/feedback.html) about giving feedback and reporting bugs.
 
 ## Code of conduct
 
@@ -38,7 +38,7 @@ in this project you agree to abide by its terms.
 
 ## License
 
-Positron™ is licensed under the [Elastic License 2.0](https://github.com/posit-dev/positron?tab=License-1-ov-file#readme), a source-available license. [Read more](https://github.com/posit-dev/positron/wiki/Licensing) about what this license means and our decision to use it.
+Positron™ is licensed under the [Elastic License 2.0](https://github.com/posit-dev/positron?tab=License-1-ov-file#readme), a source-available license. [Read more](https://positron.posit.co/licensing.html) about what this license means and our decision to use it.
 
 Positron™ and the Positron icon™ are trademarks of Posit Software, PBC. All rights reserved.
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
@@ -335,7 +335,7 @@ def positron_ipykernel_usage():
     interpreter, with convenient shell features, special commands, command
     history mechanism and output results caching. It is an adapted version of an
     [IPython](https://ipython.readthedocs.io/en/stable/) kernel. For more information, check out the
-    [Positron documentation](https://github.com/posit-dev/positron/wiki).
+    [Positron documentation](https://positron.posit.co/).
 
     GETTING HELP
     ------------

--- a/resources/linux/positron.appdata.xml
+++ b/resources/linux/positron.appdata.xml
@@ -7,7 +7,7 @@
 	<url type="homepage">https://github.com/posit-dev/positron</url>
 	<summary>A next-generation data science IDE from Posit Software, PBC.</summary>
 	<description>
-		<p>Positron™ is an extensible, polyglot tool for writing code and exploring data in Python, R, and other languages. Positron is an early stage project under active development. See https://github.com/posit-dev/positron/wiki for installation instructions and an FAQ.</p>
+		<p>Positron™ is an extensible, polyglot tool for writing code and exploring data in Python, R, and other languages. Positron is an early stage project under active development. See https://positron.posit.co/ for installation instructions and an FAQ.</p>
 	</description>
 	<screenshots>
 		<screenshot type="default">

--- a/src/vs/workbench/contrib/issue/browser/issueReporterPage.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueReporterPage.ts
@@ -17,13 +17,13 @@ const reviewGuidanceLabel = localize( // intentionally not escaped because of it
 		key: 'reviewGuidanceLabel',
 		comment: [
 			// --- Start Positron ---
-			'{Locked="<a href=\"https://github.com/posit-dev/positron/wiki/Feedback-and-Issues\" target=\"_blank\">"}',
+			'{Locked="<a href=\"https://positron.posit.co/feedback.html\" target=\"_blank\">"}',
 			// --- End Positron ---
 			'{Locked="</a>"}'
 		]
 	},
 	// --- Start Positron ---
-	'Before you report an issue here please <a href="https://github.com/posit-dev/positron/wiki/Feedback-and-Issues" target="_blank">review the guidance we provide</a>.'
+	'Before you report an issue here please <a href="https://positron.posit.co/feedback.html" target="_blank">review the guidance we provide</a>.'
 	// --- End Positron ---
 );
 

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageHelp.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageHelp.tsx
@@ -23,7 +23,7 @@ export const PositronWelcomePageHelp = (props: PropsWithChildren<PositronWelcome
 		return (
 			<div className='welcome-help-links'>
 				<ExternalLink
-					href='https://github.com/posit-dev/positron/wiki'
+					href='https://positron.posit.co/'
 					openerService={props.openerService}
 				>
 					{localize('positron.welcome.positronDocumentation', "Positron Documentation")}


### PR DESCRIPTION
Addresses #2663

### QA Notes

After this PR, there should be no links to https://github.com/posit-dev/positron/wiki in our repo.
