### PR TITLE
Truncated long notebook outputs

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/NotebookInstanceProvider.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/NotebookInstanceProvider.tsx
@@ -35,4 +35,21 @@ export function useNotebookInstance() {
 	return instance;
 }
 
+/**
+ * Grab notebook config options from the current notebook instance.
+ * @returns Notebook options for the current notebook instance.
+ */
+export function useNotebookOptions() {
+	const instance = useNotebookInstance();
+	// Wrap in a usestate so we can trigger rerendering of notebooks when options change.
+	const [notebookOptions, setNotebookOptions] = React.useState(instance.notebookOptions);
 
+	React.useEffect(() => {
+		const listener = instance.notebookOptions.onDidChangeOptions(() => {
+			setNotebookOptions(instance.notebookOptions);
+		});
+		return () => listener.dispose();
+	}, [instance.notebookOptions]);
+
+	return notebookOptions;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
@@ -18,6 +18,13 @@
 	overflow: scroll;
 }
 
+.positron-notebook-text-output.long-output-scroll.scrolling {
+	border: var(--vscode-positronNotebook-border);
+	border-radius: var(--vscode-positronNotebook-cell-radius);
+	padding: 0.15rem 0.25rem;
+}
+
+
 .notebook-output-truncation-message {
 	font-size: 0.95em;
 	opacity: 0.8;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
@@ -16,16 +16,21 @@
 	/* TODO: This should match the height of the output if truncated */
 	max-height: 400px;
 	overflow: scroll;
-}
-
-.positron-notebook-text-output.long-output-scroll.scrolling {
 	border: var(--vscode-positronNotebook-border);
 	border-radius: var(--vscode-positronNotebook-cell-radius);
 	padding: 0.15rem 0.25rem;
+	position: relative;
 }
 
 
 .notebook-output-truncation-message {
+	display: block;
 	font-size: 0.95em;
 	opacity: 0.8;
+
+	&.truncation-mode-scroll {
+		text-align: right;
+	}
 }
+
+

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
@@ -17,3 +17,8 @@
 	max-height: 400px;
 	overflow: scroll;
 }
+
+.notebook-output-truncation-message {
+	font-size: 0.95em;
+	opacity: 0.8;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
@@ -27,10 +27,6 @@
 	display: block;
 	font-size: 0.95em;
 	opacity: 0.8;
-/*
-	&.truncation-mode-scroll {
-		text-align: right;
-	} */
 }
 
 .positron-notebook-text-output.long-output-scroll + .notebook-output-truncation-message {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
@@ -27,10 +27,18 @@
 	display: block;
 	font-size: 0.95em;
 	opacity: 0.8;
-
+/*
 	&.truncation-mode-scroll {
 		text-align: right;
-	}
+	} */
 }
 
+.positron-notebook-text-output.long-output-scroll + .notebook-output-truncation-message {
+	text-align: right;
+}
+
+/* Hide the truncation message when were not showing scrollbars. */
+.positron-notebook-text-output:not(.long-output-scroll) + .notebook-output-truncation-message {
+	display: none;
+}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
@@ -11,3 +11,9 @@
 	font-size: var(--vscode-positronNotebook-text-output-font-size);
 	white-space: pre-wrap;
 }
+
+.positron-notebook-text-output.long-output-scroll {
+	/* TODO: This should match the height of the output if truncated */
+	max-height: 400px;
+	overflow: scroll;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -15,7 +15,6 @@ import { NotebookDisplayOptions } from 'vs/workbench/contrib/notebook/browser/no
 
 
 type LongOutputOptions = Pick<NotebookDisplayOptions, 'outputLineLimit' | 'outputScrolling'>;
-// type LongOutputOptions = { outputScrolling: Boolean; outputLineLimit: number };
 
 type TruncationResult =
 	{ content: string } & (
@@ -33,10 +32,9 @@ type TruncationResult =
 function useLongOutputBehavior(content: string): {
 	containerRef: React.RefObject<HTMLDivElement>; truncation: TruncationResult;
 } {
+	const containerRef = React.useRef<HTMLDivElement>(null);
 	const notebookOptions = useNotebookOptions();
 	const layoutOptions = notebookOptions.getLayoutConfiguration();
-
-	const containerRef = React.useRef<HTMLDivElement>(null);
 
 	const [truncation, setTruncation] = React.useState<TruncationResult>(() => truncateToNumberOfLines(content, layoutOptions));
 
@@ -61,7 +59,8 @@ function useLongOutputBehavior(content: string): {
 
 
 function truncateToNumberOfLines(content: string, { outputScrolling, outputLineLimit: maxLines }: LongOutputOptions): TruncationResult {
-	const splitByLine = content.split('\n');
+	// Trim newline from end of content if it exists.
+	const splitByLine = content.trimEnd().split('\n');
 	const numLines = splitByLine.length;
 
 	const isLong = numLines > maxLines;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -9,17 +9,53 @@ import { ANSIOutput } from 'vs/base/common/ansiOutput';
 import { OutputLines } from 'vs/workbench/browser/positronAnsiRenderer/outputLines';
 import { useServices } from 'vs/workbench/contrib/positronNotebook/browser/ServicesProvider';
 import { ParsedTextOutput } from 'vs/workbench/contrib/positronNotebook/browser/getOutputContents';
+import { useNotebookOptions } from 'vs/workbench/contrib/positronNotebook/browser/NotebookInstanceProvider';
+
+
+function useLongOutputBehavior(): { mode: 'scroll' } | { mode: 'truncate'; outputLineLimit: number } {
+	const notebookOptions = useNotebookOptions();
+	const layoutOptions = notebookOptions.getLayoutConfiguration();
+
+	const outputLineLimit = layoutOptions.outputLineLimit;
+	const outputScrolling = layoutOptions.outputScrolling;
+
+	if (outputScrolling) {
+		return { mode: 'scroll' };
+	}
+	return { mode: 'truncate', outputLineLimit };
+}
 
 export function CellTextOutput({ content, type }: ParsedTextOutput) {
 
 	const { openerService, notificationService } = useServices();
+	const longOutputBehavior = useLongOutputBehavior();
 
-	const processedAnsi = ANSIOutput.processOutput(content);
+	const { truncatedContent, wasTruncated } = truncateToNumberOfLines(content, longOutputBehavior.mode === 'truncate' ? longOutputBehavior.outputLineLimit : undefined);
+	const processedAnsi = ANSIOutput.processOutput(truncatedContent);
 
-	return <div className={`notebook-${type} positron-notebook-text-output`}>
+	return <div className={`notebook-${type} positron-notebook-text-output long-output-${longOutputBehavior.mode}`}>
 		<OutputLines
 			outputLines={processedAnsi}
 			openerService={openerService}
 			notificationService={notificationService} />
+		{
+			wasTruncated ? <span>Long content truncated</span> : null
+		}
 	</div>;
+}
+
+function truncateToNumberOfLines(content: string, maxLines?: number): { truncatedContent: string; wasTruncated: boolean } {
+	if (!maxLines) { return { truncatedContent: content, wasTruncated: false }; }
+	const splitByLine = content.split('\n');
+	const numLines = splitByLine.length;
+	if (numLines <= maxLines) { return { truncatedContent: content, wasTruncated: false }; }
+
+	return {
+		truncatedContent: [
+			...splitByLine.slice(0, maxLines - 1),
+			'...',
+			splitByLine[splitByLine.length - 1]
+		].join('\n'),
+		wasTruncated: true
+	};
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -36,6 +36,12 @@ export function NotebookCellWrapper({ cell, children }: { cell: IPositronNoteboo
 			if (childOfEditor || selectionStatus === CellSelectionStatus.Editing) {
 				return;
 			}
+
+			// If the clicked element is a link, let it do its thing.
+			if (clickTarget.tagName === 'A') {
+				return;
+			}
+
 			if (selectionStatus === CellSelectionStatus.Selected) {
 				cell.deselect();
 				return;


### PR DESCRIPTION
Addresses #5058 

This PR adds basic truncation to long text-based outputs in positron notebooks. Previously we would just render the whole output inline which could... really mess up navigating a notebook. Now we default to truncation and respect the same options set for the vscode notebooks if the user wants to switch to scrolling. 

https://github.com/user-attachments/assets/97f1a1ab-ce2b-491a-8294-4a18c84d5f07

## Main change

### Handling Long Outputs:
* Introduced CSS styles for handling long outputs with scrolling and truncation messages in `CellTextOutput.css`.
* Implemented logic in `CellTextOutput.tsx` to manage long outputs, including truncation and scrolling behavior, and added a user interface for changing output settings.

## Secondary changes
### Notebook Options Management:
* Added `useNotebookOptions` function to manage notebook options and trigger rerendering when options change in `NotebookInstanceProvider.tsx`.

### Notebook Instance Lifecycle:
* Updated `PositronNotebookInstance` to detach the view when an existing instance is reused.
* Refactored the creation of `NotebookOptions` to use the instantiation service, removing the dependency on `ICodeEditorService`. [[1]](diffhunk://#diff-692a2d6ddf3fade96a06ef062de5b4282ba64e37294f3524f0b47877e4b3d3bcL219-R220) [[2]](diffhunk://#diff-692a2d6ddf3fade96a06ef062de5b4282ba64e37294f3524f0b47877e4b3d3bcL248)
* Ensured `notebookOptions` is set to `undefined` when detaching the view.

### Miscellaneous:
* Prevented cell deselection when clicking on links in `NotebookCellWrapper.tsx`.
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes

You should be able to run the following code in a notebook cell and get truncation, the link should take you to the settings field for updating the behavior. 
```python
n = 100  # Change this value to control the number of lines
output = "\n".join(f"Line {i+1}" for i in range(n))
print(output)
```
