### PR TITLE
Use remote file handle for git init step

### DIFF
--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -118,6 +118,7 @@ export const showNewProjectModalDialog = async (
 
 					// Create the new project configuration.
 					const newProjectConfig: NewProjectConfiguration = {
+						folderScheme: folder.scheme,
 						runtimeMetadata: result.selectedRuntime || undefined,
 						projectType: result.projectType || '',
 						projectFolder: folder.fsPath,

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -84,6 +84,7 @@ export enum NewProjectTask {
  * NewProjectConfiguration interface. Defines the configuration for a new project.
  */
 export interface NewProjectConfiguration {
+	readonly folderScheme: string;
 	readonly runtimeMetadata: ILanguageRuntimeMetadata | undefined;
 	readonly projectType: string;
 	readonly projectFolder: string;

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -22,6 +22,7 @@ import { URI } from 'vs/base/common/uri';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { localize } from 'vs/nls';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
+import { Schemas } from 'vs/base/common/network';
 
 /**
  * PositronNewProjectService class.
@@ -327,7 +328,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	 * Relies on extension vscode.git
 	 */
 	private async _runGitInit() {
-		const projectRoot = URI.file(this._newProjectConfig?.projectFolder!);
+		const projectRoot = URI.from({ scheme: this._newProjectConfig?.folderScheme ?? Schemas.file, path: this._newProjectConfig?.projectFolder });
 
 		// true to skip the folder prompt
 		await this._commandService.executeCommand('git.init', true)


### PR DESCRIPTION
Address #5089 

Added a file scheme to the project config that is stored. This is used to recreate the URI with the correct scheme.

I think the `git init` command is fine since it runs on the server. The error was occurring when trying to create the `.gitignore` and `README.md` since it calls the file service.

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
