### PR TITLE
Windows Stability fixes

### DIFF
--- a/test/automation/src/positron/positronDataExplorer.ts
+++ b/test/automation/src/positron/positronDataExplorer.ts
@@ -7,6 +7,7 @@
 import { expect } from '@playwright/test';
 import { Code } from '../code';
 import { PositronBaseElement } from './positronBaseElement';
+import { Workbench } from '../workbench';
 
 const COLUMN_HEADERS = '.data-explorer-panel .right-column .data-grid-column-headers';
 const HEADER_TITLES = '.data-grid-column-header .title-description .title';
@@ -32,6 +33,7 @@ const EXPAND_COLLASPE_ICON = '.expand-collapse-icon';
 const PROFILE_LABELS = (rowNumber: number) => `${DATA_GRID_ROW}:nth-child(${rowNumber}) .column-profile-info .label`;
 const PROFILE_VALUES = (rowNumber: number) => `${DATA_GRID_ROW}:nth-child(${rowNumber}) .column-profile-info .value`;
 
+
 export interface CellData {
 	[key: string]: string;
 }
@@ -43,7 +45,7 @@ export class PositronDataExplorer {
 
 	clearSortingButton: PositronBaseElement;
 
-	constructor(private code: Code) {
+	constructor(private code: Code, private workbench: Workbench) {
 		this.clearSortingButton = new PositronBaseElement(CLEAR_SORTING_BUTTON, this.code);
 	}
 
@@ -210,6 +212,13 @@ export class PositronDataExplorer {
 
 	async expandColumnProfile(rowNumber = 0): Promise<void> {
 		await this.code.driver.getLocator(EXPAND_COLLASPE_ICON).nth(rowNumber).click();
+	}
+
+	async maximizeDataExplorer(): Promise<void> {
+		await this.workbench.positronLayouts.enterLayout('stacked');
+		await this.workbench.quickaccess.runCommand('workbench.action.toggleSidebarVisibility');
+		await this.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+		await this.workbench.quickaccess.runCommand('workbench.action.togglePanel');
 	}
 
 }

--- a/test/automation/src/workbench.ts
+++ b/test/automation/src/workbench.ts
@@ -121,7 +121,7 @@ export class Workbench {
 		this.positronInterpreterDropdown = new PositronInterpreterDropdown(code);
 		this.positronConsole = new PositronConsole(code, this.quickaccess, this.quickinput);
 		this.positronVariables = new PositronVariables(code);
-		this.positronDataExplorer = new PositronDataExplorer(code);
+		this.positronDataExplorer = new PositronDataExplorer(code, this);
 		this.positronSideBar = new PositronSideBar(code);
 		this.positronPlots = new PositronPlots(code);
 		this.positronNotebooks = new PositronNotebooks(code, this.quickinput, this.quickaccess, this.notebook);

--- a/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/data-explorer-100x100.test.ts
@@ -44,6 +44,9 @@ describe('Data Explorer 100x100 #win', function () {
 			await app.code.driver.getLocator(`.label-name:has-text("Data: ${dataFrameName}")`).innerText();
 		}).toPass();
 
+		// Maximize the data explorer.
+		await app.workbench.positronDataExplorer.maximizeDataExplorer();
+
 		// Drive focus into the data explorer.
 		await app.workbench.positronDataExplorer.clickUpperLeftCorner();
 
@@ -99,12 +102,16 @@ describe('Data Explorer 100x100 #win', function () {
 				// Move to the next cell.
 				await app.workbench.positronDataExplorer.arrowRight();
 			}
+
 		};
 
 		// Check the first row, the middle row, and the last row.
 		await testRow(0);
 		await testRow(Math.trunc(tsvValues.length / 2));
 		await testRow(tsvValues.length - 1);
+
+		// Return to Stacked layout
+		await app.workbench.positronLayouts.enterLayout('stacked');
 	};
 
 	/**

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -11,7 +11,7 @@ import { setupAndStartApp } from '../../../test-runner/test-hooks';
 
 let logger;
 
-describe('Data Explorer #web #win', () => {
+describe('Data Explorer #web', () => {
 	logger = setupAndStartApp();
 
 	describe('Python Pandas Data Explorer #pr', () => {
@@ -32,7 +32,7 @@ describe('Data Explorer #web #win', () => {
 
 		});
 
-		it('Python Pandas - Verifies basic data explorer functionality [C557556]', async function () {
+		it('Python Pandas - Verifies basic data explorer functionality [C557556] #win', async function () {
 			const app = this.app as Application;
 			this.timeout(120000);
 
@@ -113,7 +113,7 @@ df2 = pd.DataFrame(data)`;
 
 
 		});
-		it('Python Pandas - Verifies data explorer column info functionality [C734263]', async function () {
+		it('Python Pandas - Verifies data explorer column info functionality [C734263] #win', async function () {
 
 			const app = this.app as Application;
 			this.timeout(120000);
@@ -149,7 +149,7 @@ df2 = pd.DataFrame(data)`;
 
 		});
 		// This test is not dependent on the previous test, so it refreshes the python environment
-		it('Python Pandas - Verifies data explorer after modification [C557574]', async function () {
+		it('Python Pandas - Verifies data explorer after modification [C557574] #win', async function () {
 
 			const app = this.app as Application;
 			this.timeout(120000);
@@ -288,7 +288,7 @@ df2 = pd.DataFrame(data)`;
 
 		});
 
-		it('Python Polars - Add Simple Column filter [C557557]', async function () {
+		it('Python Polars - Add Simple Column filter [C557557] #win', async function () {
 			const app = this.app as Application;
 			this.timeout(120000);
 
@@ -310,7 +310,7 @@ df2 = pd.DataFrame(data)`;
 			}).toPass({ timeout: 60000 });
 		});
 
-		it('Python Polars - Add Simple Column Sort [C557561]', async function () {
+		it('Python Polars - Add Simple Column Sort [C557561] #win', async function () {
 			const app = this.app as Application;
 			this.timeout(120000);
 
@@ -346,7 +346,7 @@ df2 = pd.DataFrame(data)`;
 		});
 	});
 
-	describe('R Data Explorer', () => {
+	describe('R Data Explorer #win', () => {
 
 		before(async function () {
 			await PositronRFixtures.SetupFixtures(this.app as Application);


### PR DESCRIPTION
Some more windows stability fixes

* Added maximizeDataExplorer method
* 100x100 tests needed to maximize grid
* Several tests had to be skipped on windows until we can hide the summary stats pane with a shortcut.