### PR TITLE
Add two `ctrl` keybindings on macOS for Quarto

### DIFF
--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -122,6 +122,16 @@
         "command": "quarto.insertCodeCell"
       },
       {
+        "mac": "ctrl+enter",
+        "when": "config.rstudio.keymap.enable && editorTextFocus && editorLangId == quarto && !findInputFocussed && !replaceInputFocussed",
+        "command": "quarto.runCurrent"
+      },
+      {
+        "mac": "ctrl+shift+enter",
+        "when": "config.rstudio.keymap.enable && editorTextFocus && editorLangId == quarto && !findInputFocussed && !replaceInputFocussed",
+        "command": "quarto.runCurrentCell"
+      },
+      {
         "mac": "cmd+i",
         "win": "ctrl+i",
         "linux": "ctrl+i",


### PR DESCRIPTION
Addresses #4767 

I first thought about doing this in Quarto in https://github.com/quarto-dev/quarto/pull/583 but really don't think it belongs there. Instead, let's provide these two keybindings, <kbd>Ctrl</kbd>+<kbd>Enter</kbd> and <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Enter</kbd>, on macOS via the RStudio Keymap, since we are adding this for folks familiar with the RStudio behavior.

Note that in RStudio, you can use <kbd>Ctrl</kbd> instead of <kbd>Cmd</kbd> for basically all keybindings, but we don't intend to provide every single one.

### QA Notes

If you have the RStudio Keymap enabled, you can send a single line from a Quarto cell to the console via <kbd>Ctrl</kbd>+<kbd>Enter</kbd> and an entire cell to the console via <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Enter</kbd>. This is in addition to the <kbd>Cmd</kbd> keybindings for these.
