### PR TITLE
Add Collapse Summary and Expand Summary actions to Data Explorer

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -39,9 +39,9 @@ export const DataExplorer = () => {
 
 	// Reference hooks.
 	const dataExplorerRef = useRef<HTMLDivElement>(undefined!);
-	const columnNameExemplar = useRef<HTMLDivElement>(undefined!);
-	const typeNameExemplar = useRef<HTMLDivElement>(undefined!);
-	const sortIndexExemplar = useRef<HTMLDivElement>(undefined!);
+	const columnNameExemplarRef = useRef<HTMLDivElement>(undefined!);
+	const typeNameExemplarRef = useRef<HTMLDivElement>(undefined!);
+	const sortIndexExemplarRef = useRef<HTMLDivElement>(undefined!);
 	const leftColumnRef = useRef<HTMLDivElement>(undefined!);
 	const splitterRef = useRef<HTMLDivElement>(undefined!);
 	const rightColumnRef = useRef<HTMLDivElement>(undefined!);
@@ -72,7 +72,7 @@ export const DataExplorer = () => {
 		if (!canvasRenderingContext2D) {
 			sortIndexWidth = 0;
 		} else {
-			const sortIndexExemplarStyle = DOM.getComputedStyle(sortIndexExemplar.current);
+			const sortIndexExemplarStyle = DOM.getComputedStyle(sortIndexExemplarRef.current);
 			canvasRenderingContext2D.font = sortIndexExemplarStyle.font;
 			sortIndexWidth = canvasRenderingContext2D.measureText('99').width;
 		}
@@ -117,7 +117,7 @@ export const DataExplorer = () => {
 			} else {
 				// Measure the column name width using the font of the column name exemplar.
 				const columnNameExemplarStyle =
-					DOM.getComputedStyle(columnNameExemplar.current);
+					DOM.getComputedStyle(columnNameExemplarRef.current);
 				canvasRenderingContext2D.font = columnNameExemplarStyle.font;
 				columnNameWidth = canvasRenderingContext2D.measureText(columnName).width;
 			}
@@ -128,7 +128,7 @@ export const DataExplorer = () => {
 				typeNameWidth = 0;
 			} else {
 				// Measure the type name width using the font of the type name exemplar.
-				const typeNameExemplarStyle = DOM.getComputedStyle(typeNameExemplar.current);
+				const typeNameExemplarStyle = DOM.getComputedStyle(typeNameExemplarRef.current);
 				canvasRenderingContext2D.font = typeNameExemplarStyle.font;
 				typeNameWidth = canvasRenderingContext2D.measureText(typeName).width;
 			}
@@ -146,6 +146,7 @@ export const DataExplorer = () => {
 			)
 		);
 
+		// Set the width calculators.
 		context.instance.tableDataDataGridInstance.setWidthCalculators({
 			columnHeaderWidthCalculator,
 			columnValueWidthCalculator: length => Math.ceil(
@@ -205,9 +206,25 @@ export const DataExplorer = () => {
 			setLayout(layout);
 		}));
 
+		// Add the onDidCollapseSummary event handler.
+		disposableStore.add(context.instance.onDidCollapseSummary(() => {
+			if (!columnsCollapsed) {
+				setAnimateColumnsWidth(!context.accessibilityService.isMotionReduced());
+				setColumnsCollapsed(true);
+			}
+		}));
+
+		// Add the onDidExpandSummary event handler.
+		disposableStore.add(context.instance.onDidExpandSummary(() => {
+			if (columnsCollapsed) {
+				setAnimateColumnsWidth(!context.accessibilityService.isMotionReduced());
+				setColumnsCollapsed(false);
+			}
+		}));
+
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, [context.instance]);
+	}, [columnsCollapsed, context.accessibilityService, context.instance]);
 
 	// Automatic layout useEffect.
 	useLayoutEffect(() => {
@@ -297,9 +314,9 @@ export const DataExplorer = () => {
 				{ 'summary-on-right': layout === PositronDataExplorerLayout.SummaryOnRight }
 			)}
 		>
-			<div ref={columnNameExemplar} className='column-name-exemplar' />
-			<div ref={typeNameExemplar} className='type-name-exemplar' />
-			<div ref={sortIndexExemplar} className='sort-index-exemplar' />
+			<div ref={columnNameExemplarRef} className='column-name-exemplar' />
+			<div ref={typeNameExemplarRef} className='type-name-exemplar' />
+			<div ref={sortIndexExemplarRef} className='sort-index-exemplar' />
 
 			<div ref={leftColumnRef} className='left-column'>
 				<PositronDataGrid

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -41,6 +41,8 @@ const category: ILocalizedString = {
 export const enum PositronDataExplorerCommandId {
 	CopyAction = 'workbench.action.positronDataExplorer.copy',
 	CopyTableDataAction = 'workbench.action.positronDataExplorer.copyTableData',
+	CollapseSummaryAction = 'workbench.action.positronDataExplorer.collapseSummary',
+	ExpandSummaryAction = 'workbench.action.positronDataExplorer.expandSummary',
 }
 
 /**
@@ -230,9 +232,161 @@ class PositronDataExplorerCopyTableDataAction extends Action2 {
 }
 
 /**
+ * PositronDataExplorerCollapseSummaryAction action.
+ */
+class PositronDataExplorerCollapseSummaryAction extends Action2 {
+	constructor() {
+		super({
+			id: PositronDataExplorerCommandId.CollapseSummaryAction,
+			title: {
+				value: localize('positronDataExplorer.collapseSummary', 'Collapse Summary'),
+				original: 'Collapse Summary'
+			},
+			category,
+			f1: true,
+			precondition: POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR
+		});
+	}
+
+	/**
+	 * Runs the action.
+	 * @param accessor The services accessor.
+	 */
+	async run(accessor: ServicesAccessor): Promise<void> {
+		// Access the services we need.
+		const editorService = accessor.get(IEditorService);
+		const notificationService = accessor.get(INotificationService);
+		const positronDataExplorerService = accessor.get(IPositronDataExplorerService);
+
+		// Get the Positron data explorer editor.
+		const positronDataExplorerEditor = getPositronDataExplorerEditorFromEditorPane(
+			editorService.activeEditorPane
+		);
+
+		/**
+		 * Notifies the user that collapse summary failed.
+		 */
+		const notifyUserThatCollapseSummaryFailed = () => {
+			// Notify the user.
+			notificationService.notify({
+				severity: Severity.Error,
+				message: localize('positron.dataExplorer.collapseSummary.noActiveEditor', "Cannot collapse the Summary. A Positron Data Explorer is not active."),
+				sticky: false
+			});
+		};
+
+		// Make sure that the Positron data explorer editor was returned.
+		if (!positronDataExplorerEditor) {
+			notifyUserThatCollapseSummaryFailed();
+			return;
+		}
+
+		// Get the identifier.
+		const identifier = positronDataExplorerEditor.identifier;
+
+		// Make sure the identifier was returned.
+		if (!identifier) {
+			notifyUserThatCollapseSummaryFailed();
+			return;
+		}
+
+		// Get the Positron data explorer instance.
+		const positronDataExplorerInstance = positronDataExplorerService.getInstance(
+			identifier
+		);
+
+		// Make sure the Positron data explorer instance was returned.
+		if (!positronDataExplorerInstance) {
+			notifyUserThatCollapseSummaryFailed();
+			return;
+		}
+
+		// Collapse the summary.
+		positronDataExplorerInstance.collapseSummary();
+	}
+}
+
+/**
+ * PositronDataExplorerExpandSummaryAction action.
+ */
+class PositronDataExplorerExpandSummaryAction extends Action2 {
+	constructor() {
+		super({
+			id: PositronDataExplorerCommandId.ExpandSummaryAction,
+			title: {
+				value: localize('positronDataExplorer.expandSummary', 'Expand Summary'),
+				original: 'Expand Summary'
+			},
+			category,
+			f1: true,
+			precondition: POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR
+		});
+	}
+
+	/**
+	 * Runs the action.
+	 * @param accessor The services accessor.
+	 */
+	async run(accessor: ServicesAccessor): Promise<void> {
+		// Access the services we need.
+		const editorService = accessor.get(IEditorService);
+		const notificationService = accessor.get(INotificationService);
+		const positronDataExplorerService = accessor.get(IPositronDataExplorerService);
+
+		// Get the Positron data explorer editor.
+		const positronDataExplorerEditor = getPositronDataExplorerEditorFromEditorPane(
+			editorService.activeEditorPane
+		);
+
+		/**
+		 * Notifies the user that expand summary failed.
+		 */
+		const notifyUserThatExpandSummaryFailed = () => {
+			// Notify the user.
+			notificationService.notify({
+				severity: Severity.Error,
+				message: localize('positron.dataExplorer.expandSummary.noActiveEditor', "Cannot expand the Summary. A Positron Data Explorer is not active."),
+				sticky: false
+			});
+		};
+
+		// Make sure that the Positron data explorer editor was returned.
+		if (!positronDataExplorerEditor) {
+			notifyUserThatExpandSummaryFailed();
+			return;
+		}
+
+		// Get the identifier.
+		const identifier = positronDataExplorerEditor.identifier;
+
+		// Make sure the identifier was returned.
+		if (!identifier) {
+			notifyUserThatExpandSummaryFailed();
+			return;
+		}
+
+		// Get the Positron data explorer instance.
+		const positronDataExplorerInstance = positronDataExplorerService.getInstance(
+			identifier
+		);
+
+		// Make sure the Positron data explorer instance was returned.
+		if (!positronDataExplorerInstance) {
+			notifyUserThatExpandSummaryFailed();
+			return;
+		}
+
+		// Expand the summary.
+		positronDataExplorerInstance.expandSummary();
+	}
+}
+
+/**
  * Registers Positron data explorer actions.
  */
 export function registerPositronDataExplorerActions() {
 	registerAction2(PositronDataExplorerCopyAction);
 	registerAction2(PositronDataExplorerCopyTableDataAction);
+	registerAction2(PositronDataExplorerCollapseSummaryAction);
+	registerAction2(PositronDataExplorerExpandSummaryAction);
 }

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -270,7 +270,7 @@ class PositronDataExplorerCollapseSummaryAction extends Action2 {
 			// Notify the user.
 			notificationService.notify({
 				severity: Severity.Error,
-				message: localize('positron.dataExplorer.collapseSummary.noActiveEditor', "Cannot collapse the Summary. A Positron Data Explorer is not active."),
+				message: localize('positron.dataExplorer.collapseSummary.noActiveEditor', "Cannot Collapse Summary. A Positron Data Explorer is not active."),
 				sticky: false
 			});
 		};
@@ -345,7 +345,7 @@ class PositronDataExplorerExpandSummaryAction extends Action2 {
 			// Notify the user.
 			notificationService.notify({
 				severity: Severity.Error,
-				message: localize('positron.dataExplorer.expandSummary.noActiveEditor', "Cannot expand the Summary. A Positron Data Explorer is not active."),
+				message: localize('positron.dataExplorer.expandSummary.noActiveEditor', "Cannot Expand Summary. A Positron Data Explorer is not active."),
 				sticky: false
 			});
 		};

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
@@ -65,9 +65,29 @@ export interface IPositronDataExplorerInstance extends IDisposable {
 	readonly onDidRequestFocus: Event<void>;
 
 	/**
+	 * The onDidCollapseSummary event.
+	 */
+	readonly onDidCollapseSummary: Event<void>;
+
+	/**
+	 * The onDidExpandSummary event.
+	 */
+	readonly onDidExpandSummary: Event<void>;
+
+	/**
 	 * Requests focus for the instance.
 	 */
 	requestFocus(): void;
+
+	/**
+	 * Collapses the summary.
+	 */
+	collapseSummary(): void;
+
+	/**
+	 * Expands the summary.
+	 */
+	expandSummary(): void;
 
 	/**
 	 * Copies the selection or cursor cell to the clipboard.

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -92,6 +92,16 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	 */
 	private readonly _onDidRequestFocusEmitter = this._register(new Emitter<void>());
 
+	/**
+	 * The onDidCollapseSummary event emitter.
+	 */
+	private readonly _onDidCollapseSummaryEmitter = this._register(new Emitter<void>());
+
+	/**
+	 * The onDidExpandSummary event emitter.
+	 */
+	private readonly _onDidExpandSummaryEmitter = this._register(new Emitter<void>());
+
 	//#endregion Private Properties
 
 	//#region Constructor
@@ -242,6 +252,20 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	}
 
 	/**
+	 * Collapses the summary.
+	 */
+	collapseSummary(): void {
+		this._onDidCollapseSummaryEmitter.fire();
+	}
+
+	/**
+	 * Expands the summary.
+	 */
+	expandSummary(): void {
+		this._onDidExpandSummaryEmitter.fire();
+	}
+
+	/**
 	 * Copies the selection or cursor cell to the clipboard.
 	 */
 	async copyToClipboard(): Promise<void> {
@@ -377,6 +401,16 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	 * onDidRequestFocus event.
 	 */
 	readonly onDidRequestFocus = this._onDidRequestFocusEmitter.event;
+
+	/**
+	 * onDidCollapseSummary event.
+	 */
+	readonly onDidCollapseSummary = this._onDidCollapseSummaryEmitter.event;
+
+	/**
+	 * onDidExpandSummary event.
+	 */
+	readonly onDidExpandSummary = this._onDidExpandSummaryEmitter.event;
 
 	//#endregion IPositronDataExplorerInstance Implementation
 }


### PR DESCRIPTION
### Description

This PR adds two new Data Explorer actions:

**Positron Data Explorer: Collapse Summary**
`CollapseSummaryAction = 'workbench.action.positronDataExplorer.collapseSummary'`

**Positron Data Explorer: Expand Summary**
`ExpandSummaryAction = 'workbench.action.positronDataExplorer.expandSummary'`

These actions allow the Data Explorer Summary panel to be collapsed and expanded from the Command Palette.

Here's a screen recording of these actions:

https://github.com/user-attachments/assets/9e234656-7c98-4f09-845f-8fe922c47637

### QA Notes

This feature was added largely for QA purposes as there is limited screen real estate available in smoke tests.