### PR TITLE
Switching the variables pane focus trigger a refresh

### DIFF
--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -261,6 +261,7 @@ class PositronVariablesService extends Disposable implements IPositronVariablesS
 	) {
 		// Set the active instance and fire the onDidChangeActivePositronVariablesInstance event.
 		this._activePositronVariablesInstance = positronVariablesInstance;
+		this._activePositronVariablesInstance?.requestRefresh();
 		this._onDidChangeActivePositronVariablesInstanceEmitter.fire(positronVariablesInstance);
 	}
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/4869 by requesting a variables pane refresh every time the foreground session changes.