### PR TITLE
Fix version build number in DEB and RPM package info

### DIFF
--- a/build/gulpfile.reh.js
+++ b/build/gulpfile.reh.js
@@ -29,7 +29,8 @@ const glob = require('glob');
 const { compileBuildTask } = require('./gulpfile.compile');
 const { compileExtensionsBuildTask, compileExtensionMediaBuildTask } = require('./gulpfile.extensions');
 // --- Start Positron ---
-const { vscodeWebEntryPoints, vscodeWebResourceIncludes, createVSCodeWebFileContentMapper, positronBuildNumber } = require('./gulpfile.vscode.web');
+const { vscodeWebEntryPoints, vscodeWebResourceIncludes, createVSCodeWebFileContentMapper } = require('./gulpfile.vscode.web');
+const { positronBuildNumber } = require('./utils');
 // --- End Positron ---
 const cp = require('child_process');
 const log = require('fancy-log');

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -38,9 +38,9 @@ const glob = promisify(require('glob'));
 const rcedit = promisify(require('rcedit'));
 
 // --- Start Positron ---
-const child_process = require('child_process');
 const fancyLog = require('fancy-log');
 const { getQuartoStream } = require('./lib/quarto');
+const { positronBuildNumber } = require('./utils');
 // --- End Positron ---
 
 // Build
@@ -342,14 +342,6 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 
 		// --- Start Positron ---
 		const positronVersion = product.positronVersion;
-
-		// Use the POSITRON_BUILD_NUMBER var if it's set; otherwise, call
-		// show-version to compute it.
-		const positronBuildNumber =
-			process.env.POSITRON_BUILD_NUMBER ??
-			child_process.execSync(
-				`node ${path.dirname(__dirname)}/versions/show-version.js --build`).toString().trim();
-
 		// --- End Positron ---
 
 		const quality = product.quality;

--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -21,6 +21,10 @@ const path = require('path');
 const cp = require('child_process');
 const util = require('util');
 
+// --- Start Positron ---
+const { positronBuildNumber } = require('./utils');
+// --- End Positron ---
+
 const exec = util.promisify(cp.exec);
 const root = path.dirname(__dirname);
 const commit = getVersion(root);
@@ -100,8 +104,8 @@ function prepareDebPackage(arch) {
 					.pipe(replace('@@NAME@@', product.applicationName))
 					// --- Start Positron ---
 					.pipe(replace('@@VERSION@@', product.version))
-					.pipe(replace('@@POSITRONVERSION@@', `${product.positronVersion}+${product.positronBuildNumber}-${linuxPackageRevision}`))
-					.pipe(replace('@@BUILDNUMBER@@', product.positronBuildNumber))
+					.pipe(replace('@@POSITRONVERSION@@', `${product.positronVersion}+${positronBuildNumber}-${linuxPackageRevision}`))
+					.pipe(replace('@@BUILDNUMBER@@', positronBuildNumber))
 					// --- End Positron ---
 					.pipe(replace('@@ARCHITECTURE@@', debArch))
 					.pipe(replace('@@DEPENDS@@', dependencies.join(', ')))
@@ -226,8 +230,8 @@ function prepareRpmPackage(arch) {
 					.pipe(replace('@@ICON@@', product.linuxIconName))
 					// --- Start Positron ---
 					.pipe(replace('@@VERSION@@', product.version))
-					.pipe(replace('@@POSITRONVERSION@@', `${product.positronVersion}+${product.positronBuildNumber}`))
-					.pipe(replace('@@BUILDNUMBER@@', product.positronBuildNumber))
+					.pipe(replace('@@POSITRONVERSION@@', `${product.positronVersion}+${positronBuildNumber}`))
+					.pipe(replace('@@BUILDNUMBER@@', positronBuildNumber))
 					// --- End Positron ---
 					.pipe(replace('@@RELEASE@@', linuxPackageRevision))
 					.pipe(replace('@@ARCHITECTURE@@', rpmArch))

--- a/build/gulpfile.vscode.web.js
+++ b/build/gulpfile.vscode.web.js
@@ -24,7 +24,7 @@ const extensions = require('./lib/extensions');
 const { isESM } = require('./lib/esm');
 
 // --- Start Positron ---
-const child_process = require('child_process');
+const { positronBuildNumber } = require('./utils');
 // --- End Positron ---
 
 const REPO_ROOT = path.dirname(__dirname);
@@ -134,14 +134,6 @@ const vscodeWebEntryPoints = isESM() ? [
 	buildfile.keyboardMaps,
 	buildfile.workbenchWeb()
 ].flat();
-
-// --- Begin Positron ---
-// Use the POSITRON_BUILD_NUMBER var if it's set; otherwise, call show-version to compute it.
-const positronBuildNumber =
-	process.env.POSITRON_BUILD_NUMBER ??
-	child_process.execSync(`node ${REPO_ROOT}/versions/show-version.js --build`).toString().trim();
-exports.positronBuildNumber = positronBuildNumber;
-// --- End Positron ---
 
 /**
  * @param {object} product The parsed product.json file contents

--- a/build/utils.js
+++ b/build/utils.js
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+const child_process = require('child_process');
+const path = require('path');
+
+const REPO_ROOT = path.dirname(__dirname);
+
+/**
+ * Get the build number for Positron.
+ */
+const positronBuildNumber =
+	process.env.POSITRON_BUILD_NUMBER ??
+	child_process.execSync(`node ${REPO_ROOT}/versions/show-version.js --build`).toString().trim();
+exports.positronBuildNumber = positronBuildNumber;


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/5159
- related to #1373
- a follow-up to https://github.com/posit-dev/positron/pull/5072 to fix up the DEB and RPM package info build number

### Changes

- The `positronBuildNumber` from the package.json file will always be zero -- instead, we need to use the calculated build number from show-version.js when possible.
- We are already using the calculated build number in a few places, but a few were missing, resulting in a build number of zero `0` in the DEB and RPM package info.
- The `positronBuildVersion` variable is now in a separate util file, so the value can be used across the gulpfiles.

### QA Notes

I've checked the version output of the DEB on Ubuntu 24 (x86_64) and the RPM on Fedora 40 (arm).

#### DEB
1. Run `dpkg --info <POSITRON_BINARY>.deb`
2. Confirm the Version field in the output shows `<POSITRON_VERSION>+<BUILD_NUMBER>-<LINUX_REVISION>`

Sample Output:
```
<SOME_INITIAL_INFO>
Package: positron
Version: 2024.11.0+999-1729709839
<REST_OF_INFO>
```

#### RPM
1. Run `rpm -qi <POSITRON_BINARY>.rpm`
2. Confirm the Version field in the output shows `<POSITRON_VERSION>+<BUILD_NUMBER>`

Sample Output:
```
Name        : positron
Version     : 2024.11.0+999
<REST_OF_INFO>
```
