### PR TITLE
Data Explorer: Implement value formatting logic in duckdb get_data_values RPC

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -61,8 +61,7 @@ class DuckDBInstance {
 		}
 
 		const worker = new Worker(bundle.mainWorker);
-		const logger = new duckdb.ConsoleLogger();
-		// const logger = new duckdb.VoidLogger();
+		const logger = new duckdb.VoidLogger();
 		const db = new duckdb.AsyncDuckDB(logger, worker);
 		await db.instantiate(bundle.mainModule);
 

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -7,13 +7,17 @@ import * as vscode from 'vscode';
 import {
 	BackendState,
 	ColumnDisplayType,
+	ColumnFilter,
 	ColumnProfileResult,
 	ColumnProfileType,
+	ColumnSortKey,
 	DataExplorerBackendRequest,
 	DataExplorerFrontendEvent,
 	DataExplorerResponse,
 	DataExplorerRpc,
 	DataExplorerUiEvent,
+	ExportDataSelectionParams,
+	ExportedData,
 	FilterResult,
 	GetColumnProfilesParams,
 	GetDataValuesParams,
@@ -22,7 +26,9 @@ import {
 	OpenDatasetParams,
 	OpenDatasetResult,
 	ReturnColumnProfilesEvent,
+	RowFilter,
 	SetRowFiltersParams,
+	SetSortColumnsParams,
 	SupportStatus,
 	TableData,
 	TableRowLabels,
@@ -53,10 +59,8 @@ class DuckDBInstance {
 			bundle.mainWorker = pathToFileURL(bundle.mainWorker).toString();
 		}
 
-		const logger = new duckdb.ConsoleLogger();
-
 		const worker = new Worker(bundle.mainWorker);
-
+		const logger = new duckdb.VoidLogger();
 		const db = new duckdb.AsyncDuckDB(logger, worker);
 		await db.instantiate(bundle.mainModule);
 
@@ -65,9 +69,14 @@ class DuckDBInstance {
 		return new DuckDBInstance(db, con);
 	}
 
-	public async runQuery(query: string) {
-		return this.con.query(query);
+	async runQuery(query: string): Promise<Table<any> | string> {
+		try {
+			return await this.con.query(query);
+		} catch (error) {
+			return JSON.stringify(error);
+		}
 	}
+
 }
 
 type RpcResponse<Type> = Promise<Type | string>;
@@ -108,104 +117,52 @@ function uriToFilePath(uri: string) {
 	return uri;
 }
 
+// TODO
+// - Decimal
+// - Nested types
+// - JSON
+const SCHEMA_TYPE_MAPPING = new Map<string, ColumnDisplayType>([
+	['BOOLEAN', ColumnDisplayType.Boolean],
+	['TINYINT', ColumnDisplayType.Number],
+	['SMALLINT', ColumnDisplayType.Number],
+	['INTEGER', ColumnDisplayType.Number],
+	['BIGINT', ColumnDisplayType.Number],
+	['FLOAT', ColumnDisplayType.Number],
+	['DOUBLE', ColumnDisplayType.Number],
+	['VARCHAR', ColumnDisplayType.String],
+	['UUID', ColumnDisplayType.String],
+	['DATE', ColumnDisplayType.Date],
+	['TIMESTAMP', ColumnDisplayType.Datetime],
+	['TIMESTAMP_NS', ColumnDisplayType.Datetime],
+	['TIMESTAMP WITH TIME ZONE', ColumnDisplayType.Datetime],
+	['TIMESTAMP_NS WITH TIME ZONE', ColumnDisplayType.Datetime],
+	['TIME', ColumnDisplayType.Time]
+]);
+
 /**
- * Implementation of Data Explorer backend protocol using duckdb-wasm,
- * for serving requests coming in through the vscode command.
+ * Interface for serving data explorer requests for a particular table in DuckDB
  */
-export class DataExplorerRpcHandler {
+export class DuckDBTableView {
+	private sortKeys: Array<ColumnSortKey> = [];
+	private rowFilters: Array<RowFilter> = [];
+	private columnFilters: Array<ColumnFilter> = [];
 
-	// TODO
-	// - Decimal
-	// - Nested types
-	// - JSON
-	private readonly _displayTypeMapping = new Map<string, ColumnDisplayType>([
-		['BOOLEAN', ColumnDisplayType.Boolean],
-		['TINYINT', ColumnDisplayType.Number],
-		['SMALLINT', ColumnDisplayType.Number],
-		['INTEGER', ColumnDisplayType.Number],
-		['BIGINT', ColumnDisplayType.Number],
-		['FLOAT', ColumnDisplayType.Number],
-		['DOUBLE', ColumnDisplayType.Number],
-		['VARCHAR', ColumnDisplayType.String],
-		['UUID', ColumnDisplayType.String],
-		['DATE', ColumnDisplayType.Date],
-		['TIMESTAMP', ColumnDisplayType.Datetime],
-		['TIMESTAMP_NS', ColumnDisplayType.Datetime],
-		['TIMESTAMP WITH TIME ZONE', ColumnDisplayType.Datetime],
-		['TIMESTAMP_NS WITH TIME ZONE', ColumnDisplayType.Datetime],
-		['TIME', ColumnDisplayType.Time]
-	]);
+	private _unfilteredShape: Promise<[number, number]>;
+	private _filteredShape: Promise<[number, number]>;
 
-	private readonly _uriToSchema = new Map<string, Array<SchemaEntry>>();
-	private readonly _uriToTableName = new Map<string, string>();
-	private readonly _uriToUnfilteredShape = new Map<string, [number, number]>();
-	private _tableIndex: number = 0;
-
-	constructor(private readonly db: DuckDBInstance) { }
-
-	private async runQuery(query: string): Promise<Table<any> | string> {
-		// console.log(query);
-		try {
-			const result = await this.db.runQuery(query);
-			return result;
-		} catch (error) {
-			console.error(error);
-			return JSON.stringify(error);
-		}
+	constructor(readonly uri: string, readonly tableName: string,
+		readonly fullSchema: Array<SchemaEntry>,
+		readonly db: DuckDBInstance
+	) {
+		this._unfilteredShape = this._getUnfilteredShape();
+		this._filteredShape = this._unfilteredShape;
 	}
 
-	async openDataset(params: OpenDatasetParams): Promise<OpenDatasetResult> {
-		const tableName = `positron_${this._tableIndex++}`;
-
-		this._uriToTableName.set(params.uri, tableName);
-
-		const filePath = uriToFilePath(params.uri);
-		const fileExt = path.extname(filePath);
-
-		let scanOperation;
-		switch (fileExt) {
-			case '.parquet':
-			case '.parq':
-				scanOperation = `parquet_scan('${filePath}')`;
-				break;
-			// TODO: Will need to be able to pass CSV / TSV options from the
-			// UI at some point.
-			case '.csv':
-				scanOperation = `read_csv('${filePath}')`;
-				break;
-			case '.tsv':
-				scanOperation = `read_csv('${filePath}', delim='\t')`;
-				break;
-			default:
-				return { error_message: `Unsupported file extension: ${fileExt}` };
-		}
-
-		const ctasQuery = `
-		CREATE TABLE ${tableName} AS
-		SELECT * FROM ${scanOperation}`;
-
-		let result = await this.runQuery(ctasQuery);
-		if (typeof result === 'string') {
-			return { error_message: result };
-		}
-
-		const schemaQuery = `DESCRIBE ${tableName};`;
-		result = await this.runQuery(schemaQuery);
-		if (typeof result === 'string') {
-			return { error_message: result };
-		}
-
-		this._uriToSchema.set(params.uri, result.toArray());
-
-		return {};
-	}
-
-	async getSchema(uri: string, params: GetSchemaParams): RpcResponse<TableSchema> {
-		const schema = this.getCachedSchema(uri);
+	async getSchema(params: GetSchemaParams): RpcResponse<TableSchema> {
 		return {
 			columns: params.column_indices.map((index) => {
-				const entry = schema[index];
-				let type_display = this._displayTypeMapping.get(entry.column_type);
+				const entry = this.fullSchema[index];
+				let type_display = SCHEMA_TYPE_MAPPING.get(entry.column_type);
 				if (type_display === undefined) {
 					type_display = ColumnDisplayType.Unknown;
 				}
@@ -219,9 +176,7 @@ export class DataExplorerRpcHandler {
 		};
 	}
 
-	async getDataValues(uri: string, params: GetDataValuesParams): RpcResponse<TableData> {
-		const fullSchema = this.getCachedSchema(uri);
-
+	async getDataValues(params: GetDataValuesParams): RpcResponse<TableData> {
 		// Because DuckDB is a SQL engine, we opt to always select a row range of
 		// formatted data for a range of rows, and then return the requested selections
 		// based on what the UI requested. This blunt approach could end up being wasteful in
@@ -229,6 +184,13 @@ export class DataExplorerRpcHandler {
 		// performance.
 		let lowerLimit = Infinity;
 		let upperLimit = -Infinity;
+
+		const smallNumDigits = params.format_options.small_num_digits;
+		const largeNumDigits = params.format_options.large_num_digits;
+		const thousandsSep = params.format_options.thousands_sep;
+		const sciNotationLimit = '1' + '0'.repeat(params.format_options.max_integral_digits);
+		const scientificFormat = `%.${largeNumDigits}e`;
+		const varcharLimit = params.format_options.max_value_length;
 
 		const columnSelectors: Array<string> = [];
 		for (const column of params.columns) {
@@ -242,7 +204,7 @@ export class DataExplorerRpcHandler {
 				upperLimit = Math.max(upperLimit, ...column.spec.indices);
 			}
 
-			const columnSchema = fullSchema[column.column_index];
+			const columnSchema = this.fullSchema[column.column_index];
 			const quotedName = `"${columnSchema.column_name}"`;
 
 			// TODO: what is column_index is out of bounds?
@@ -250,8 +212,32 @@ export class DataExplorerRpcHandler {
 			// Build column selector. Just casting to string for now
 			let columnSelector;
 			switch (columnSchema.column_type) {
+				case 'FLOAT':
+				case 'DOUBLE': {
+					let largeFormatter, smallFormatter;
+					if (thousandsSep !== undefined) {
+						largeFormatter = `FORMAT('%,.${largeNumDigits}f', ${quotedName})`;
+						smallFormatter = `FORMAT('%,.${smallNumDigits}f', ${quotedName})`;
+						if (thousandsSep !== ',') {
+							largeFormatter = `REPLACE(${largeFormatter}, ',', '${thousandsSep}')`;
+							smallFormatter = `REPLACE(${smallFormatter}, ',', '${thousandsSep}')`;
+						}
+					} else {
+						largeFormatter = `FORMAT('%.${largeNumDigits}f', ${quotedName})`;
+						smallFormatter = `FORMAT('%.${smallNumDigits}f', ${quotedName})`;
+					}
+					columnSelector = `CASE WHEN ${quotedName} IS NULL THEN 'NULL'
+WHEN isinf(${quotedName}) AND ${quotedName} > 0 THEN 'Inf'
+WHEN isinf(${quotedName}) AND value < 0 THEN '-Inf'
+WHEN isnan(${quotedName}) THEN 'NaN'
+WHEN abs(${quotedName}) >= ${sciNotationLimit} THEN FORMAT(${scientificFormat}, ${quotedName})
+WHEN abs(${quotedName}) < 1 THEN ${smallFormatter}
+ELSE ${largeFormatter}
+END`;
+					break;
+				}
 				case 'VARCHAR':
-					columnSelector = quotedName;
+					columnSelector = `SUBSTRING(${quotedName}, 1, ${varcharLimit})`;
 					break;
 				case 'TIMESTAMP':
 					columnSelector = `strftime(${quotedName} AT TIME ZONE 'UTC', '%Y-%m-%d %H:%M:%S')`;
@@ -260,9 +246,8 @@ export class DataExplorerRpcHandler {
 					columnSelector = `CAST(${quotedName} AS VARCHAR)`;
 					break;
 			}
-			columnSelectors.push(columnSelector);
+			columnSelectors.push(`${columnSelector} AS formatted_${columnSelectors.length} `);
 		}
-		const tableName = this.getTableName(uri);
 
 		let numRows = 0;
 		if (isFinite(lowerLimit) && isFinite(upperLimit)) {
@@ -280,11 +265,11 @@ export class DataExplorerRpcHandler {
 		}
 
 		const query = `select ${columnSelectors.join(',\n    ')}
-		FROM ${tableName}
+		FROM ${this.tableName}
 		LIMIT ${numRows}
-		OFFSET ${lowerLimit}`;
+		OFFSET ${lowerLimit} `;
 
-		const queryResult = await this.runQuery(query);
+		const queryResult = await this.db.runQuery(query);
 		if (typeof queryResult === 'string') {
 			// query error
 			return queryResult;
@@ -340,21 +325,37 @@ export class DataExplorerRpcHandler {
 		return result;
 	}
 
-	async getRowLabels(uri: string, params: GetRowLabelsParams): RpcResponse<TableRowLabels> {
+	async getRowLabels(params: GetRowLabelsParams): RpcResponse<TableRowLabels> {
 		return 'not implemented';
 	}
 
-	async getState(uri: string): RpcResponse<BackendState> {
-		const [num_rows, num_columns] = await this._getUnfilteredShape(uri);
+	async getState(): RpcResponse<BackendState> {
+		const [unfiltedNumRows, unfilteredNumCols] = await this._unfilteredShape;
+		const [filteredNumRows, filteredNumCols] = await this._filteredShape;
 		return {
-			display_name: path.basename(uri),
-			table_shape: { num_rows, num_columns },
-			table_unfiltered_shape: { num_rows, num_columns },
+			display_name: path.basename(this.uri),
+			table_shape: {
+				num_rows: filteredNumRows,
+				num_columns: filteredNumCols
+			},
+			table_unfiltered_shape: {
+				num_rows: unfiltedNumRows,
+				num_columns: unfilteredNumCols
+			},
 			has_row_labels: false,
-			column_filters: [],
-			row_filters: [],
-			sort_keys: [],
+			column_filters: this.columnFilters,
+			row_filters: this.rowFilters,
+			sort_keys: this.sortKeys,
 			supported_features: {
+				get_column_profiles: {
+					support_status: SupportStatus.Supported,
+					supported_types: [
+						{
+							profile_type: ColumnProfileType.NullCount,
+							support_status: SupportStatus.Supported
+						}
+					]
+				},
 				search_schema: {
 					support_status: SupportStatus.Unsupported,
 					supported_types: []
@@ -368,15 +369,6 @@ export class DataExplorerRpcHandler {
 					supports_conditions: SupportStatus.Unsupported,
 					supported_types: []
 				},
-				get_column_profiles: {
-					support_status: SupportStatus.Supported,
-					supported_types: [
-						{
-							profile_type: ColumnProfileType.NullCount,
-							support_status: SupportStatus.Supported
-						}
-					]
-				},
 				set_sort_columns: { support_status: SupportStatus.Unsupported, },
 				export_data_selection: {
 					support_status: SupportStatus.Unsupported,
@@ -386,21 +378,18 @@ export class DataExplorerRpcHandler {
 		};
 	}
 
-	async getColumnProfiles(uri: string, params: GetColumnProfilesParams): RpcResponse<void> {
+	async getColumnProfiles(params: GetColumnProfilesParams): RpcResponse<void> {
 		// Initiate but do not await profile evaluations
-		this._evaluateColumnProfiles(uri, params);
+		this._evaluateColumnProfiles(params);
 	}
 
-	private async _evaluateColumnProfiles(uri: string, params: GetColumnProfilesParams) {
-		const tableName = this.getTableName(uri);
-		const fullSchema = this.getCachedSchema(uri);
-
+	private async _evaluateColumnProfiles(params: GetColumnProfilesParams) {
 		const profileExprs: Array<string> = [];
 		const queryResultIds: Array<Array<number | undefined>> = [];
 
 		let resultIndex = 0;
 		for (const request of params.profiles) {
-			const columnSchema = fullSchema[request.column_index];
+			const columnSchema = this.fullSchema[request.column_index];
 			const quotedName = `"${columnSchema.column_name}"`;
 			const resultIds: Array<number | undefined> = [];
 			request.profiles.map((profile, index) => {
@@ -414,7 +403,7 @@ export class DataExplorerRpcHandler {
 						resultIds.push(undefined);
 						return;
 				}
-				profileExprs.push(`${profileExpr} AS profile_${resultIndex}`);
+				profileExprs.push(`${profileExpr} AS profile_${resultIndex} `);
 				resultIds.push(resultIndex++);
 			});
 			queryResultIds.push(resultIds);
@@ -424,8 +413,8 @@ export class DataExplorerRpcHandler {
 		if (profileExprs.length > 0) {
 			const profileQuery = `
 			SELECT ${profileExprs.join(',\n    ')}
-			FROM ${tableName}`;
-			result = await this.runQuery(profileQuery);
+			FROM ${this.tableName} `;
+			result = await this.db.runQuery(profileQuery);
 			if (typeof result === 'string') {
 				// Query failed for some reason, need to return to UI
 				return;
@@ -466,25 +455,30 @@ export class DataExplorerRpcHandler {
 
 		await vscode.commands.executeCommand(
 			'positron-data-explorer.sendUiEvent', {
-				uri,
+				uri: this.uri,
 				method: DataExplorerFrontendEvent.ReturnColumnProfiles,
 				params: response
 			} satisfies DataExplorerUiEvent
 		);
 	}
 
-	async setRowFilters(uri: string, params: SetRowFiltersParams): RpcResponse<FilterResult> {
+	async setRowFilters(params: SetRowFiltersParams): RpcResponse<FilterResult> {
 		return 'not implemented';
 	}
 
-	private async _getUnfilteredShape(uri: string) {
-		const schema = this.getCachedSchema(uri);
-		const numColumns = schema.length;
+	async setSortColumns(params: SetSortColumnsParams): RpcResponse<void> {
+		return 'not implemented';
+	}
 
-		const tableName = this.getTableName(uri);
-		const countStar = `SELECT count(*) AS num_rows FROM ${tableName} `;
+	async exportDataSelection(params: ExportDataSelectionParams): RpcResponse<ExportedData> {
+		return 'not implemented';
+	}
 
-		const result = await this.runQuery(countStar);
+	private async _getUnfilteredShape(): Promise<[number, number]> {
+		const numColumns = this.fullSchema.length;
+		const countStar = `SELECT count(*) AS num_rows FROM ${this.tableName} `;
+
+		const result = await this.db.runQuery(countStar);
 
 		let numRows: number;
 		if (typeof result === 'string') {
@@ -495,13 +489,65 @@ export class DataExplorerRpcHandler {
 		}
 		return [numRows, numColumns];
 	}
+}
 
-	getTableName(uri: string): string {
-		return this._uriToTableName.get(uri) as string;
+/**
+ * Implementation of Data Explorer backend protocol using duckdb-wasm,
+ * for serving requests coming in through the vscode command.
+ */
+export class DataExplorerRpcHandler {
+	private readonly _uriToTableView = new Map<string, DuckDBTableView>();
+	private _tableIndex: number = 0;
+
+	constructor(private readonly db: DuckDBInstance) { }
+
+	async openDataset(params: OpenDatasetParams): Promise<OpenDatasetResult> {
+		const tableName = `positron_${this._tableIndex++}`;
+
+		const filePath = uriToFilePath(params.uri);
+		const fileExt = path.extname(filePath);
+
+		let scanOperation;
+		switch (fileExt) {
+			case '.parquet':
+			case '.parq':
+				scanOperation = `parquet_scan('${filePath}')`;
+				break;
+			// TODO: Will need to be able to pass CSV / TSV options from the
+			// UI at some point.
+			case '.csv':
+				scanOperation = `read_csv('${filePath}')`;
+				break;
+			case '.tsv':
+				scanOperation = `read_csv('${filePath}', delim='\t')`;
+				break;
+			default:
+				return { error_message: `Unsupported file extension: ${fileExt}` };
+		}
+
+		const ctasQuery = `
+		CREATE TABLE ${tableName} AS
+		SELECT * FROM ${scanOperation}`;
+
+		let result = await this.db.runQuery(ctasQuery);
+		if (typeof result === 'string') {
+			return { error_message: result };
+		}
+
+		const schemaQuery = `DESCRIBE ${tableName};`;
+		result = await this.db.runQuery(schemaQuery);
+		if (typeof result === 'string') {
+			return { error_message: result };
+		}
+
+		const tableView = new DuckDBTableView(params.uri, tableName, result.toArray(), this.db);
+		this._uriToTableView.set(params.uri, tableView);
+
+		return {};
 	}
 
-	private getCachedSchema(uri: string): Array<SchemaEntry> {
-		return this._uriToSchema.get(uri) as Array<SchemaEntry>;
+	async createTableFromSQL(createQuery: string) {
+
 	}
 
 	async handleRequest(rpc: DataExplorerRpc): Promise<DataExplorerResponse> {
@@ -521,22 +567,25 @@ export class DataExplorerRpcHandler {
 		if (rpc.uri === undefined) {
 			return `URI for open dataset must be provided: ${rpc.method} `;
 		}
+		const table = this._uriToTableView.get(rpc.uri) as DuckDBTableView;
 		switch (rpc.method) {
-			case DataExplorerBackendRequest.GetSchema:
-				return this.getSchema(rpc.uri, rpc.params as GetSchemaParams);
-			case DataExplorerBackendRequest.GetDataValues:
-				return this.getDataValues(rpc.uri, rpc.params as GetDataValuesParams);
-			case DataExplorerBackendRequest.GetRowLabels:
-				return this.getRowLabels(rpc.uri, rpc.params as GetRowLabelsParams);
-			case DataExplorerBackendRequest.GetState:
-				return this.getState(rpc.uri);
-			case DataExplorerBackendRequest.SetRowFilters:
-				return this.setRowFilters(rpc.uri, rpc.params as SetRowFiltersParams);
-			case DataExplorerBackendRequest.GetColumnProfiles:
-				return this.getColumnProfiles(rpc.uri, rpc.params as GetColumnProfilesParams);
 			case DataExplorerBackendRequest.ExportDataSelection:
-			case DataExplorerBackendRequest.SetColumnFilters:
+				return table.exportDataSelection(rpc.params as ExportDataSelectionParams);
+			case DataExplorerBackendRequest.GetColumnProfiles:
+				return table.getColumnProfiles(rpc.params as GetColumnProfilesParams);
+			case DataExplorerBackendRequest.GetDataValues:
+				return table.getDataValues(rpc.params as GetDataValuesParams);
+			case DataExplorerBackendRequest.GetRowLabels:
+				return table.getRowLabels(rpc.params as GetRowLabelsParams);
+			case DataExplorerBackendRequest.GetSchema:
+				return table.getSchema(rpc.params as GetSchemaParams);
+			case DataExplorerBackendRequest.GetState:
+				return table.getState();
+			case DataExplorerBackendRequest.SetRowFilters:
+				return table.setRowFilters(rpc.params as SetRowFiltersParams);
 			case DataExplorerBackendRequest.SetSortColumns:
+				return table.setSortColumns(rpc.params as SetSortColumnsParams);
+			case DataExplorerBackendRequest.SetColumnFilters:
 			case DataExplorerBackendRequest.SearchSchema:
 				return `${rpc.method} not yet implemented`;
 			default:
@@ -557,11 +606,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('positron-duckdb.runQuery',
 			async (query: string) => {
-				try {
-					const result = await db.runQuery(query);
+				const result = await db.runQuery(query);
+				if (typeof result === 'string') {
+					console.error('DuckDB error:', result);
+				} else {
 					return result.toArray();
-				} catch (error) {
-					console.error('DuckDB error:', error);
 				}
 			})
 	);

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -14,8 +14,8 @@ suite('Positron DuckDB Extension Test Suite', () => {
 
 	// Not sure why it is not possible to use Mocha's 'before' for this
 	async function activateExtension() {
-		const extension = vscode.extensions.getExtension('vscode.positron-duckdb');
-		await extension?.activate();  // Ensure the extension is activated
+		// Ensure the extension is activated
+		await vscode.extensions.getExtension('vscode.positron-duckdb')?.activate();
 	}
 
 	async function runQuery<Type>(query: string): Promise<Array<Type>> {

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -3,25 +3,123 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Table } from 'apache-arrow';
 import * as assert from 'assert';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { ColumnDisplayType, ColumnProfileType, ColumnSchema, DataExplorerBackendRequest, DataExplorerResponse, DataExplorerRpc, GetSchemaParams, SupportStatus, TableSchema } from '../interfaces';
+import {
+	BackendState,
+	ColumnDisplayType,
+	ColumnProfileType,
+	ColumnSchema,
+	ColumnValue,
+	DataExplorerBackendRequest,
+	DataExplorerResponse,
+	DataExplorerRpc,
+	FormatOptions,
+	GetDataValuesParams,
+	GetSchemaParams,
+	SupportStatus,
+	TableData,
+	TableSchema
+} from '../interfaces';
+import { randomUUID } from 'crypto';
+
+const DEFAULT_FORMAT_OPTIONS: FormatOptions = {
+	large_num_digits: 2,
+	small_num_digits: 4,
+	max_integral_digits: 9,
+	max_value_length: 100
+};
+
+// Not sure why it is not possible to use Mocha's 'before' for this
+async function activateExtension() {
+	// Ensure the extension is activated
+	await vscode.extensions.getExtension('vscode.positron-duckdb')?.activate();
+}
+
+async function runQuery<Type>(query: string): Promise<Array<Type>> {
+	await activateExtension();
+	// Uncomment to debug queries being sent
+	// console.log(query);
+	return vscode.commands.executeCommand('positron-duckdb.runQuery', query);
+}
+
+async function dxExec(rpc: DataExplorerRpc): Promise<any> {
+	await activateExtension();
+	const resp: DataExplorerResponse = await vscode.commands.executeCommand(
+		'positron-duckdb.dataExplorerRpc', rpc
+	);
+	if (resp.error_message) {
+		return Promise.reject(new Error(resp.error_message));
+	} else if (resp.result === undefined) {
+		console.log(JSON.stringify(resp));
+		return Promise.reject(new Error('No error message or result in response'));
+	} else {
+		return resp.result;
+	}
+}
+
+function makeTempTableName(): string {
+	return `positron_${randomUUID().slice(0, 5)}`;
+}
+
+type InsertColumn = { name: string; type: string; values: Array<string> };
+
+async function createTempTable(
+	tableName: string,
+	columns: Array<InsertColumn>
+) {
+	// Create the table with indicated schema
+	const schema = columns.map(column => `${column.name} ${column.type}`).join(', ');
+	await runQuery(`CREATE TABLE ${tableName} (${schema});`);
+
+	// Assuming at least one column and all values arrays same length
+	const length = columns[0].values.length;
+
+	const tuples: Array<string> = [];
+	for (let i = 0; i < length; i++) {
+		tuples.push(`(${columns.map(c => c.values[i]).join(', ')})`);
+	}
+	await runQuery(`INSERT INTO ${tableName} VALUES\n${tuples.join(',\n')};`);
+
+	// Now set up the new table so it will respond to RPCs with a duckdb://${tableName} prefix
+	await dxExec({
+		method: DataExplorerBackendRequest.OpenDataset,
+		params: { uri: `duckdb://${tableName}` }
+	});
+}
+
+async function getState(uri: string): Promise<BackendState> {
+	return dxExec({
+		method: DataExplorerBackendRequest.GetState,
+		uri,
+		params: {}
+	});
+}
+
+async function getAllDataValues(tableName: string, formatOptions?: FormatOptions) {
+	const uri = `duckdb://${tableName}`;
+	const state = await getState(uri);
+	const shape = state.table_shape;
+	return dxExec({
+		method: DataExplorerBackendRequest.GetDataValues,
+		uri,
+		params: {
+			columns: Array.from(
+				{ length: shape.num_columns }, (_, i) => i
+			).map(column_index => {
+				return {
+					column_index,
+					spec: { first_index: 0, last_index: shape.num_rows - 1 }
+				};
+			}),
+			format_options: formatOptions ?? DEFAULT_FORMAT_OPTIONS
+		} satisfies GetDataValuesParams
+	}) as Promise<TableData>;
+}
 
 suite('Positron DuckDB Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
-
-	// Not sure why it is not possible to use Mocha's 'before' for this
-	async function activateExtension() {
-		// Ensure the extension is activated
-		await vscode.extensions.getExtension('vscode.positron-duckdb')?.activate();
-	}
-
-	async function runQuery<Type>(query: string): Promise<Array<Type>> {
-		await activateExtension();
-		return vscode.commands.executeCommand('positron-duckdb.runQuery', query);
-	}
 
 	test('Command `positron-duckdb.runQuery` should be registered', async () => {
 		await activateExtension();
@@ -38,21 +136,6 @@ suite('Positron DuckDB Extension Test Suite', () => {
 			'Expected DuckDB query result to return answer as 42');
 	});
 
-	async function dxExec(rpc: DataExplorerRpc): Promise<any> {
-		await activateExtension();
-		const resp: DataExplorerResponse = await vscode.commands.executeCommand(
-			'positron-duckdb.dataExplorerRpc', rpc
-		);
-		if (resp.error_message) {
-			return Promise.reject(new Error(resp.error_message));
-		} else if (resp.result === undefined) {
-			console.log(JSON.stringify(resp));
-			return Promise.reject(new Error('No error message or result in response'));
-		} else {
-			return resp.result;
-		}
-	}
-
 	test('DuckDB flights.parquet', async () => {
 		const uri = path.join(__dirname, 'data', 'flights.parquet');
 
@@ -62,12 +145,8 @@ suite('Positron DuckDB Extension Test Suite', () => {
 		});
 		assert.deepStrictEqual(result, {});
 
-		result = await dxExec({
-			method: DataExplorerBackendRequest.GetState,
-			uri,
-			params: {}
-		});
-		assert.deepStrictEqual(result, {
+		const state = await getState(uri);
+		assert.deepStrictEqual(state, {
 			display_name: 'flights.parquet',
 			table_shape: { num_rows: 100, num_columns: 19 },
 			table_unfiltered_shape: { num_rows: 100, num_columns: 19 },
@@ -234,5 +313,201 @@ suite('Positron DuckDB Extension Test Suite', () => {
 		assert.deepStrictEqual(result, {
 			columns: expectedSchema
 		} satisfies TableSchema);
+	});
+
+	test('get_data_values formatting', async () => {
+		type TestCaseType = [InsertColumn[] | undefined, ColumnValue[][], FormatOptions];
+
+		const testCases: Array<TestCaseType> = [
+			// Boolean
+			[
+				[
+					{
+						name: 'a',
+						type: 'BOOLEAN',
+						values: [
+							'true', 'false', 'NULL'
+						]
+					}
+				],
+				[
+					['true', 'false', 0]
+				],
+				DEFAULT_FORMAT_OPTIONS
+			],
+			// Integer: special values
+			[
+				[
+					{
+						name: 'a',
+						type: 'TINYINT',
+						values: ['127', '-128', '0', 'NULL']
+					},
+					{
+						name: 'b',
+						type: 'SMALLINT',
+						values: ['32767', '-32768', '0', 'NULL']
+					},
+					{
+						name: 'c',
+						type: 'INTEGER',
+						values: ['2147483647', '-2147483648', '0', 'NULL']
+					},
+					{
+						name: 'd',
+						type: 'BIGINT',
+						values: ['9223372036854775807', '-9223372036854775808', '0', 'NULL']
+					},
+				],
+				[
+					['127', '-128', '0', 0],
+					['32767', '-32768', '0', 0],
+					['2147483647', '-2147483648', '0', 0],
+					['9223372036854775807', '-9223372036854775808', '0', 0]
+				],
+				DEFAULT_FORMAT_OPTIONS
+			],
+			[
+				undefined, // use previous table
+				[
+					['127', '-128', '0', 0],
+					['32,767', '-32,768', '0', 0],
+					['2,147,483,647', '-2,147,483,648', '0', 0],
+					['9,223,372,036,854,775,807', '-9,223,372,036,854,775,808', '0', 0]
+				],
+				{ ...DEFAULT_FORMAT_OPTIONS, thousands_sep: ',' }
+			],
+			// Floating point: special values
+			[
+				[
+					{
+						name: 'a',
+						type: 'DOUBLE',
+						values: [
+							'0', '1.125', '0.12345', 'NULL', '\'NaN\'',
+							'\'Infinity\'', '\'-Infinity\'',
+						]
+					},
+					{
+						name: 'b',
+						type: 'FLOAT',
+						values: [
+							'0', '1.115', '0.12366', 'NULL', '\'NaN\'',
+							'\'Infinity\'', '\'-Infinity\'',
+						]
+					}
+				],
+				[
+					['0.00', '1.13', '0.1235', 0, 2, 10, 11],
+					['0.00', '1.12', '0.1237', 0, 2, 10, 11],
+				],
+				DEFAULT_FORMAT_OPTIONS
+			],
+			// Floating point: Test thousands separator
+			[
+				[
+					{
+						name: 'a',
+						type: 'DOUBLE',
+						values: [
+							'123456789.78', '456789.78'
+						]
+					}
+				],
+				[
+					['123,456,789.78', '456,789.78']
+				],
+				{ ...DEFAULT_FORMAT_OPTIONS, thousands_sep: ',' }
+			],
+			[
+				undefined, // use preceding table
+				[
+					['123_456_789.78', '456_789.78']
+				],
+				{ ...DEFAULT_FORMAT_OPTIONS, thousands_sep: '_' }
+			],
+			// Floating point: Scientific notation
+			[
+				[
+					{
+						name: 'a',
+						type: 'DOUBLE',
+						values: [
+							'155500', '150000', '15000'
+						]
+					}
+				],
+				[
+					['1.56e+05', '1.50e+05', '15000.00']
+				],
+				{ ...DEFAULT_FORMAT_OPTIONS, max_integral_digits: 5 }
+			],
+			// Varchar: string values truncated
+			[
+				[
+					{
+						name: 'a',
+						type: 'VARCHAR',
+						values: [
+							'\'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\'',
+							'\'aaaaaaaaaaaaaaaaaaaaaaaaa\'',
+							'\'aaaaaaaaaaaa\''
+						]
+					}
+				],
+				[
+					['aaaaaaaaaaaaaaaaaaaa', 'aaaaaaaaaaaaaaaaaaaa', 'aaaaaaaaaaaa']
+				],
+				{ ...DEFAULT_FORMAT_OPTIONS, max_value_length: 20 }
+			],
+			// Date, Timestamp, Time
+			[
+				[
+					{
+						name: 'date0',
+						type: 'DATE',
+						values: ['\'2023-10-20\'', '\'2024-01-01\'', 'NULL']
+					},
+					{
+						name: 'timestamp0',
+						type: 'TIMESTAMP',
+						values: ['\'2023-10-20 15:30:00\'', '\'2024-01-01 08:00:00\'', 'NULL']
+					},
+					{
+						name: 'timestamptz0',
+						type: 'TIMESTAMP WITH TIME ZONE',
+						values: ['\'2023-10-20 15:30:00+00\'', '\'2024-01-01 08:00:00-05\'', 'NULL']
+					},
+					{
+						name: 'time0',
+						type: 'TIME',
+						values: ['\'13:30:00\'', '\'07:12:34.567\'', 'NULL']
+					}
+				],
+				[
+					['2023-10-20', '2024-01-01', 0],
+					['2023-10-20 15:30:00', '2024-01-01 08:00:00', 0],
+					// Formatted as UTC for consistency across locales
+					['2023-10-20 15:30:00+00', '2024-01-01 13:00:00+00', 0],
+					['13:30:00', '07:12:34.567', 0]
+				],
+				DEFAULT_FORMAT_OPTIONS
+			],
+		];
+
+		let tableName, testInput, testResults, formatOptions;
+		for ([testInput, testResults, formatOptions] of testCases) {
+			// If testInput is undefined, just reuse the table from the previous test case
+			if (testInput !== undefined) {
+				tableName = makeTempTableName();
+				await createTempTable(tableName, testInput);
+			}
+			const data = await getAllDataValues(tableName!, formatOptions);
+			assert.deepStrictEqual(data,
+				{
+					columns: testResults
+				}
+			);
+		}
 	});
 });


### PR DESCRIPTION
Addresses #5125. The formatting rules are tested via `yarn test-extension -l positron-duckdb` and functions to insert test data into an ephemeral duckdb instance. We can keep expanding the test cases as we run into other issues. This also refactors the extension a bit to make things look a bit more like the Python runtime (a `DuckDBTableView` class per table)

## QA Notes

You can verify that floating point numbers are rounded to 2 or 4 digits depending on magnitude, and check that NULL/NaN special values show up greyed out. 