### PR TITLE
e2e: fix `notebookVariables.test.ts`

### DIFF
--- a/test/automation/src/positron/positronNotebooks.ts
+++ b/test/automation/src/positron/positronNotebooks.ts
@@ -3,8 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-
-import { expect } from '@playwright/test';
 import { Code } from '../code';
 import { Notebook } from '../notebook';
 import { QuickAccess } from '../quickaccess';

--- a/test/automation/src/positron/positronNotebooks.ts
+++ b/test/automation/src/positron/positronNotebooks.ts
@@ -16,7 +16,7 @@ const KERNEL_ACTION = '.kernel-action-view-item';
 const SELECT_KERNEL_TEXT = 'Select Kernel';
 const DETECTING_KERNELS_TEXT = 'Detecting Kernels';
 const NEW_NOTEBOOK_COMMAND = 'ipynb.newUntitledIpynb';
-const EDIT_CELL_COMMAND = 'notebook.cell.edit';
+const CELL_LINE = '.cell div.view-lines';
 const EXECUTE_CELL_COMMAND = 'notebook.cell.execute';
 const OUTER_FRAME = '.webview';
 const INNER_FRAME = '#active-frame';
@@ -77,19 +77,9 @@ export class PositronNotebooks {
 	}
 
 	async addCodeToFirstCell(code: string) {
-
-		// Attempt to add code to a cell.  If the code is not added correctly, delete the cell and try
-		// again for up to 60 seconds
-		await expect(async () => {
-			try {
-				await this.quickaccess.runCommand(EDIT_CELL_COMMAND);
-				await this.notebook.waitForTypeInEditor(code);
-				await this.notebook.waitForActiveCellEditorContents(code);
-			} catch (e) {
-				await this.notebook.deleteActiveCell();
-				throw e;
-			}
-		}).toPass({ timeout: 60000 });
+		await this.code.driver.getLocator(CELL_LINE).click();
+		await this.notebook.waitForTypeInEditor(code);
+		await this.notebook.waitForActiveCellEditorContents(code);
 	}
 
 	async executeCodeInCell() {

--- a/test/automation/src/positron/positronNotebooks.ts
+++ b/test/automation/src/positron/positronNotebooks.ts
@@ -77,7 +77,7 @@ export class PositronNotebooks {
 	}
 
 	async addCodeToFirstCell(code: string) {
-		await this.code.driver.getLocator(CELL_LINE).click();
+		await this.code.driver.getLocator(CELL_LINE).first().click();
 		await this.notebook.waitForTypeInEditor(code);
 		await this.notebook.waitForActiveCellEditorContents(code);
 	}

--- a/test/smoke/src/areas/positron/variables/notebookVariables.test.ts
+++ b/test/smoke/src/areas/positron/variables/notebookVariables.test.ts
@@ -25,8 +25,6 @@ describe('Variables Pane - Notebook #pr #web', () => {
 		});
 
 		it('Verifies Variables pane basic function for notebook with python interpreter [C669188]', async function () {
-			this.timeout(120000);
-
 			const app = this.app as Application;
 
 			await app.workbench.positronNotebooks.createNewNotebook();
@@ -36,9 +34,6 @@ describe('Variables Pane - Notebook #pr #web', () => {
 			await app.workbench.positronNotebooks.addCodeToFirstCell('y = [2, 3, 4, 5]');
 
 			await app.workbench.positronNotebooks.executeCodeInCell();
-
-			// just to be safe, give cell some execution time
-			await app.code.wait(1000);
 
 			const interpreter = await app.workbench.positronVariables.getVariablesInterpreter();
 
@@ -53,11 +48,7 @@ describe('Variables Pane - Notebook #pr #web', () => {
 		});
 
 	});
-});
 
-describe('Variables Pane - Notebook #pr #web', () => {
-
-	setupAndStartApp();
 
 	describe('R Notebook Variables Pane', () => {
 
@@ -83,9 +74,6 @@ describe('Variables Pane - Notebook #pr #web', () => {
 			await app.workbench.positronNotebooks.addCodeToFirstCell('y <- c(2, 3, 4, 5)');
 
 			await app.workbench.positronNotebooks.executeCodeInCell();
-
-			// just to be safe, give cell some execution time
-			await app.code.wait(1000);
 
 			const interpreter = await app.workbench.positronVariables.getVariablesInterpreter();
 


### PR DESCRIPTION
### Intent

Stabilize the `notebookVariables.test.ts` test to prevent flakiness.

### Approach

I observed that this test was flaky, and when debugging, I couldn’t get the second test to pass without restarting the app (same as the test was doing). This indicated something was off. To address this, I replaced the use of the quick access menu for editing the cell with a direct manual selection. With this change, both tests now run successfully in the same app instance without any issues.

### QA Notes
Passed on both Electron and Web.