### PR TITLE
allow machine override of `python.languageServerLogLevel`

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -618,7 +618,7 @@
                         "info",
                         "debug"
                     ],
-                    "scope": "application",
+                    "scope": "machine-overridable",
                     "type": "string"
                 },
                 "python.interpreter.infoVisibility": {

--- a/extensions/positron-python/src/client/common/configSettings.ts
+++ b/extensions/positron-python/src/client/common/configSettings.ts
@@ -310,7 +310,7 @@ export class PythonSettings implements IPythonSettings {
         this.languageServerDebug = pythonSettings.get<boolean>('languageServerDebug') === true;
 
         // Control the language server log level
-        this.languageServerLogLevel = pythonSettings.get<string>('languageServerLogLevel')!;
+        this.languageServerLogLevel = systemVariables.resolveAny(pythonSettings.get<string>('languageServerLogLevel'))!;
 
         // Whether to suppress the banner on startup of the IPython shell
         this.quietMode = pythonSettings.get<boolean>('quietMode') === true;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

add setting in `.vscode/settings.json` and see changes reflected in Settings pane, eg,

```
{
    "python.languageServerLogLevel": "critical"
}
```