### PR TITLE
Propagate failures in download scripts

### DIFF
--- a/extensions/kallichore-adapter/scripts/install-kallichore-server.ts
+++ b/extensions/kallichore-adapter/scripts/install-kallichore-server.ts
@@ -47,8 +47,7 @@ async function getVersionFromPackageJson(): Promise<string | null> {
 		const packageJson = JSON.parse(await readFileAsync('package.json', 'utf-8'));
 		return packageJson.positron.binaryDependencies?.kallichore || null;
 	} catch (error) {
-		console.error('Error reading package.json: ', error);
-		return null;
+		throw new Error(`Error reading package.json: ${error}`);
 	}
 }
 
@@ -67,8 +66,7 @@ async function getLocalKallichoreVersion(): Promise<string | null> {
 		}
 		return readFileAsync(versionFile, 'utf-8');
 	} catch (error) {
-		console.error('Error determining Kallichore version: ', error);
-		return null;
+		throw new Error(`Error determining Kallichore version: ${error}`);
 	}
 }
 
@@ -191,8 +189,7 @@ async function downloadAndReplaceKallichore(version: string,
 			}
 			const release = releases.find((asset: any) => asset.tag_name === version);
 			if (!release) {
-				console.error(`Could not find Kallichore ${version} in the releases.`);
-				return;
+				throw new Error(`Could not find Kallichore ${version} in the releases.`);
 			}
 
 			let os: string;
@@ -201,16 +198,14 @@ async function downloadAndReplaceKallichore(version: string,
 				case 'darwin': os = 'darwin-universal'; break;
 				case 'linux': os = (arch() === 'arm64' ? 'linux-arm64' : 'linux-x64'); break;
 				default: {
-					console.error(`Unsupported platform ${platform()}.`);
-					return;
+					throw new Error(`Unsupported platform ${platform()}.`);
 				}
 			}
 
 			const assetName = `kallichore-${version}-${os}.zip`;
 			const asset = release.assets.find((asset: any) => asset.name === assetName);
 			if (!asset) {
-				console.error(`Could not find Kallichore with asset name ${assetName} in the release.`);
-				return;
+				throw new Error(`Could not find Kallichore with asset name ${assetName} in the release.`);
 			}
 			console.log(`Downloading Kallichore ${version} from ${asset.url}...`);
 			const url = new URL(asset.url);
@@ -259,7 +254,7 @@ async function downloadAndReplaceKallichore(version: string,
 			});
 		});
 	} catch (error) {
-		console.error('Error downloading Kallichore:', error);
+		throw new Error(`Error downloading Kallichore: ${error}`);
 	}
 }
 
@@ -296,8 +291,7 @@ async function main() {
 	const localKallichoreVersion = await getLocalKallichoreVersion();
 
 	if (!packageJsonVersion) {
-		console.error('Could not determine Kallichore version from package.json.');
-		return;
+		throw new Error('Could not determine Kallichore version from package.json.');
 	}
 
 	console.log(`package.json version: ${packageJsonVersion} `);


### PR DESCRIPTION
This change causes our builds to fail if the R kernel or Jupyter supervisor cannot be downloaded, by converting errors that were just logged and discarded into exceptions that will fail the script.

When I originally started doing this I was going to set things up so we were only picky in CI environments, but on further reflection it's probably good for devs to see these errors too as it's better than trying to figure out why the component is missing later, and failures should be rare since both repositories are public. If you really need an offline build, you can always build these components locally or download them manually. 

Addresses https://github.com/posit-dev/positron/issues/4815. 

### QA Notes

No impact on shipping code.