### PR TITLE
Data Explorer: Compute column profiles in smaller batches for large data frames, avoid timeouts

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -402,9 +402,9 @@ export class DataExplorerClientInstance extends Disposable {
 				this._asyncTasks.set(callbackId, promise);
 				await this._backendClient.getColumnProfiles(callbackId, profiles, this._profileFormatOptions);
 
-				const timeout = 10000;
+				const timeout = 60000;
 
-				// Don't leave unfulfilled promise indefinitely; reject after 10 seconds pass
+				// Don't leave unfulfilled promise indefinitely; reject after one minute
 				// for now just in case
 				setTimeout(() => {
 					// If the promise has already been resolved, do nothing.

--- a/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableSummaryCache.ts
@@ -418,21 +418,13 @@ export class TableSummaryCache extends Disposable {
 		// better responsiveness
 		const BATCH_PROFILE_THRESHOLD = 10_000_000;
 		if (tableState.table_shape.num_rows > BATCH_PROFILE_THRESHOLD) {
-			const pendingRequests: Array<() => Promise<void>> = [];
 			for (let i = 0; i < columnIndices.length; i++) {
-				pendingRequests.push(() => this._dataExplorerClientInstance.getColumnProfiles([columnRequests[i]])
-					.then((result) => {
-						// Cache the column profiles that were returned
-						this._columnProfileCache.set(columnIndices[i], result[0]);
-
-						// Fire the onDidUpdate event so things update as soon as they are returned
-						this._onDidUpdateEmitter.fire();
-					})
-				);
-			}
-			for (const request of pendingRequests) {
 				// Run the requests one at a time
-				await request();
+				const result = await this._dataExplorerClientInstance.getColumnProfiles([columnRequests[i]]);
+				// Cache the column profiles that were returned
+				this._columnProfileCache.set(columnIndices[i], result[0]);
+				// Fire the onDidUpdate event so things update as soon as they are returned
+				this._onDidUpdateEmitter.fire();
 			}
 		} else {
 			// Load the column profiles as a batch


### PR DESCRIPTION
Addresses #4629 and #2851. This fixes timeouts that were occurring, making it seem like the data explorer is broken on large datasets, while improving the performance / responsiveness by computing updates incrementally rather than in a monolithic batch which may take 10s of seconds to return.

I found that if we spam the backend with all of the profile requests at once, the `get_data_values` request doesn't get served because of all the thread contention, so this just has one profile request active a time. 

You can see what a 33M row dataset looks like on the initial open and then various filtering workflows

https://github.com/user-attachments/assets/9df973a7-9cc4-4237-806d-01dbf2872ec8

This does make the lack of a loading indicator somewhat more pronounced, but that can be addressed separately. 

If you watch the end of the video, you can see that there is a bug where after the profiles are all computed, the cache is cleared and they are computed again. This bug appears to be present even without this change so I will open another issue (see #5150). 