### PR TITLE
Check if Python has sqlite3 is installed before attempting to install ipykernel

### DIFF
--- a/extensions/positron-python/src/client/common/installer/moduleInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/moduleInstaller.ts
@@ -303,6 +303,8 @@ export function translateProductToModule(product: Product): string {
         // --- Start Positron ---
         case Product.fastapiCli:
             return 'fastapi_cli';
+        case Product.sqlite3:
+            return '_sqlite3';
         // --- End Positron ---
         default: {
             throw new Error(`Product ${product} cannot be installed as a Python Module.`);

--- a/extensions/positron-python/src/client/common/installer/productService.ts
+++ b/extensions/positron-python/src/client/common/installer/productService.ts
@@ -23,6 +23,7 @@ export class ProductService implements IProductService {
         this.ProductTypes.set(Product.python, ProductType.Python);
         // --- Start Positron ---
         this.ProductTypes.set(Product.fastapiCli, ProductType.DataScience);
+        this.ProductTypes.set(Product.sqlite3, ProductType.DataScience);
         // --- End Positron ---
     }
     public getProductType(product: Product): ProductType {

--- a/extensions/positron-python/src/client/common/types.ts
+++ b/extensions/positron-python/src/client/common/types.ts
@@ -101,6 +101,7 @@ export enum Product {
     python = 29,
     // --- Start Positron ---
     fastapiCli = 101,
+    sqlite3 = 102,
     // --- End Positron ---
 }
 

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -224,7 +224,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             const hasSqlite3 = await installer.isInstalled(Product.sqlite3, this.interpreter);
             if (!hasSqlite3) {
                 throw new Error(
-                    `The Python sqlite3 extension is required but not installed for interpreter: ${this.interpreter?.displayName}. Missing the SQLite3 lib?`,
+                    `The Python sqlite3 extension is required but not installed for interpreter: ${this.interpreter?.displayName}. Missing the system library for SQLite?`,
                 );
             }
 

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -219,6 +219,15 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         );
 
         if (hasCompatibleKernel !== ProductInstallStatus.Installed) {
+            // Check if sqlite3 if installed before attempting to install ipykernel
+            // https://github.com/posit-dev/positron/issues/4698
+            const hasSqlite3 = await installer.isInstalled(Product.sqlite3, this.interpreter);
+            if (!hasSqlite3) {
+                throw new Error(
+                    `The Python sqlite3 extension is required but not installed for interpreter: ${this.interpreter?.displayName}. Missing the SQLite3 lib?`,
+                );
+            }
+
             // Pass a cancellation token to enable VSCode's progress indicator and let the user
             // cancel the install.
             const tokenSource = new vscode.CancellationTokenSource();


### PR DESCRIPTION
Addresses #4698

Currently the message says this if your Python doesn't have sqlite3 there:

![Screenshot 2024-10-23 at 4 08 08 PM](https://github.com/user-attachments/assets/29a85fc9-4d2e-4101-a79c-49afc9cc2e1a)

Thoughts or feedback? We believe this is most likely to happen on Linux when you are missing a sysreq.

### QA Notes

To confirm this is working as expected, you need two Python envs:

- Make one new Python env that is "normal", i.e. has the built-in sqlite3 module, but doesn't have ipykernel installed (perhaps via `pyenv virtualenv`). You should be able to choose this env via "Python: Select Interpreter", agree to the ipykernel installation, and see the ipykernel installation succeed. ✅ 
- Make one new Python env that has ✨ problems ✨ i.e. does not have the built-in sqlite3 module. The only way I could find to do this is to delete it: first [find where it is for the Python you are about to destroy](https://stackoverflow.com/questions/2501746/deleting-python-modules) and then delete it, i.e. like `rm /Users/juliasilge/.pyenv/versions/3.11.5/lib/python3.11/lib-dynload/_sqlite3.cpython-311-darwin.so`. Now choose this Python env via "Python: Select Interpreter" and see the message telling you that you need sqlite3. 🚫 
