### PR TITLE
Data Explorer: Fix profiles computing twice after backend state change

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -34,11 +34,6 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 	//#region Private Properties
 
 	/**
-	 * Gets or sets the last row filters.
-	 */
-	private _lastRowFilters: string = '[]';
-
-	/**
 	 * The onDidSelectColumn event emitter.
 	 */
 	private readonly _onDidSelectColumnEmitter = this._register(new Emitter<number>);
@@ -132,18 +127,8 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 			// Update the layout entries.
 			await updateLayoutEntries(state);
 
-			// Stringify the row filters.
-			const rowFilters = JSON.stringify(state.row_filters);
-
-			// If the row filters have changed, refresh the column profiles because they rely on the
-			// data
-			if (this._lastRowFilters !== rowFilters) {
-				this._lastRowFilters = rowFilters;
-				await this._tableSummaryCache.refreshColumnProfiles();
-			}
-
-			// Fetch data.
-			await this.fetchData(true);
+			// Invalidate cache and fetch data, profiles
+			await this.fetchData(/* invalidateCache=*/true);
 		}));
 
 		// Add the table summary cache onDidUpdate event handler.


### PR DESCRIPTION
Attempts to address #5150. In the backend-state-updated event handler, the profiles were being refreshed only before `fetchData` was called with an argument to invalidate all caches including the profiles, so the profiles have to immediately be recomputed. This resolves the double computation that I observed in #5148. 