### PR TITLE
e2e test: `pythonApplications.test.ts` improvements

### DIFF
--- a/test/automation/src/positron/fixtures/positronPythonFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronPythonFixtures.ts
@@ -6,6 +6,7 @@
 import { fail } from 'assert';
 import { Application } from '../../application';
 import { InterpreterInfo, InterpreterType } from '../utils/positronInterpreterInfo';
+import { expect } from '@playwright/test';
 
 /*
  *  Reuseable Positron Python fixture tests can leverage to get a Python interpreter selected.
@@ -16,7 +17,11 @@ export class PositronPythonFixtures {
 
 	static async SetupFixtures(app: Application, skipReadinessCheck: boolean = false) {
 		const fixtures = new PositronPythonFixtures(app);
-		await fixtures.startPythonInterpreter(skipReadinessCheck);
+		await expect(async () => {
+			await fixtures.startPythonInterpreter(skipReadinessCheck);
+		}).toPass({
+			timeout: 60000
+		});
 	}
 
 	async startPythonInterpreter(skipReadinessCheck: boolean = false) {

--- a/test/automation/src/positron/positronNotebooks.ts
+++ b/test/automation/src/positron/positronNotebooks.ts
@@ -18,6 +18,7 @@ const NEW_NOTEBOOK_COMMAND = 'ipynb.newUntitledIpynb';
 const CELL_LINE = '.cell div.view-lines';
 const EXECUTE_CELL_COMMAND = 'notebook.cell.execute';
 const EXECUTE_CELL_SPINNER = '.cell-status-item .codicon-modifier-spin';
+const OUTER_FRAME = '.webview';
 const INNER_FRAME = '#active-frame';
 const REVERT_AND_CLOSE = 'workbench.action.revertAndCloseActiveEditor';
 const MARKDOWN_TEXT = '#preview';
@@ -29,7 +30,7 @@ const ACTIVE_ROW_SELECTOR = `.notebook-editor .monaco-list-row.focused`;
  */
 export class PositronNotebooks {
 	kernelLabel = this.code.driver.getLocator(KERNEL_LABEL);
-	frameLocator = this.code.driver.page.frameLocator('iframe').frameLocator(INNER_FRAME);
+	frameLocator = this.code.driver.page.frameLocator(OUTER_FRAME).frameLocator(INNER_FRAME);
 
 	constructor(private code: Code, private quickinput: QuickInput, private quickaccess: QuickAccess, private notebook: Notebook) { }
 

--- a/test/automation/src/positron/positronNotebooks.ts
+++ b/test/automation/src/positron/positronNotebooks.ts
@@ -16,10 +16,8 @@ const DETECTING_KERNELS_TEXT = 'Detecting Kernels';
 const NEW_NOTEBOOK_COMMAND = 'ipynb.newUntitledIpynb';
 const CELL_LINE = '.cell div.view-lines';
 const EXECUTE_CELL_COMMAND = 'notebook.cell.execute';
-const OUTER_FRAME = '.webview';
+const EXECUTE_CELL_SPINNER = '.cell-status-item .codicon-modifier-spin';
 const INNER_FRAME = '#active-frame';
-const PYTHON_OUTPUT = '.output-plaintext';
-const R_OUTPUT = '.output_container .output';
 const REVERT_AND_CLOSE = 'workbench.action.revertAndCloseActiveEditor';
 const MARKDOWN_TEXT = '#preview';
 const ACTIVE_ROW_SELECTOR = `.notebook-editor .monaco-list-row.focused`;
@@ -29,6 +27,7 @@ const ACTIVE_ROW_SELECTOR = `.notebook-editor .monaco-list-row.focused`;
  */
 export class PositronNotebooks {
 	kernelLabel = this.code.driver.getLocator(KERNEL_LABEL);
+	frameLocator = this.code.driver.page.frameLocator('iframe').frameLocator(INNER_FRAME);
 
 	constructor(private code: Code, private quickinput: QuickInput, private quickaccess: QuickAccess, private notebook: Notebook) { }
 
@@ -75,7 +74,7 @@ export class PositronNotebooks {
 	}
 
 	async addCodeToFirstCell(code: string) {
-		await this.code.driver.getLocator(CELL_LINE).first().click();
+		await this.code.driver.page.locator(CELL_LINE).first().click();
 		await this.notebook.waitForTypeInEditor(code);
 		await this.notebook.waitForActiveCellEditorContents(code);
 	}
@@ -84,31 +83,17 @@ export class PositronNotebooks {
 		await this.quickaccess.runCommand(EXECUTE_CELL_COMMAND);
 	}
 
-	async getPythonCellOutput(): Promise<string> {
-		// basic CSS selection doesn't support frames (or nested frames)
-		const notebookFrame = this.code.driver.getFrame(OUTER_FRAME).frameLocator(INNER_FRAME);
-		const outputLocator = notebookFrame.locator(PYTHON_OUTPUT);
-		const outputText = await outputLocator.textContent();
-		return outputText!;
-	}
-
-	async getRCellOutput(): Promise<string> {
-		// basic CSS selection doesn't support frames (or nested frames)
-		const notebookFrame = this.code.driver.getFrame(OUTER_FRAME).frameLocator(INNER_FRAME);
-		const outputLocator = notebookFrame.locator(R_OUTPUT).nth(0);
-		const outputText = await outputLocator.textContent();
-		return outputText!;
+	async assertCellOutput(text: string): Promise<void> {
+		await expect(this.frameLocator.getByText(text)).toBeVisible();
 	}
 
 	async closeNotebookWithoutSaving() {
 		await this.quickaccess.runCommand(REVERT_AND_CLOSE);
 	}
 
-	async getMarkdownText(tag: string): Promise<string> {
-		// basic CSS selection doesn't support frames (or nested frames)
-		const frame = this.code.driver.getFrame(OUTER_FRAME).frameLocator(INNER_FRAME);
-		const element = frame.locator(`${MARKDOWN_TEXT} ${tag}`);
-		const text = await element.textContent();
-		return text!;
+	async assertMarkdownText(tag: string, expectedText: string): Promise<void> {
+		const markdownLocator = this.frameLocator.locator(`${MARKDOWN_TEXT} ${tag}`);
+		await expect(markdownLocator).toBeVisible();
+		await expect(markdownLocator).toHaveText(expectedText);
 	}
 }

--- a/test/automation/src/positron/positronVariables.ts
+++ b/test/automation/src/positron/positronVariables.ts
@@ -27,6 +27,7 @@ const VARIABLE_INDENTED = '.name-column-indenter[style*="margin-left: 40px"]';
  *  Reuseable Positron variables functionality for tests to leverage.
  */
 export class PositronVariables {
+	interpreterLocator = this.code.driver.page.locator(VARIABLES_INTERPRETER);
 
 	constructor(private code: Code) { }
 
@@ -99,10 +100,12 @@ export class PositronVariables {
 		await this.toggleVariable({ variableName, action: 'collapse' });
 	}
 
-	async getVariablesInterpreter(): Promise<IElement> {
-		const interpreter = await this.code.waitForElement(VARIABLES_INTERPRETER);
-		return interpreter;
-	}
+	// async getVariablesInterpreter(): Promise<Locator> {
+	// 	return this.code.driver.page.locator(VARIABLES_INTERPRETER);
+	// }
+
+	// async assertVariablesInterpreter(expectedInterpreter: string) {
+	// 	expect()
 
 	/**
 	 * Gets the data (value and type) for the children of a parent variable.

--- a/test/automation/src/positron/positronVariables.ts
+++ b/test/automation/src/positron/positronVariables.ts
@@ -6,7 +6,6 @@
 
 import { Code } from '../code';
 import * as os from 'os';
-import { IElement } from '../driver';
 import { expect, Locator } from '@playwright/test';
 
 interface FlatVariables {

--- a/test/automation/src/positron/positronVariables.ts
+++ b/test/automation/src/positron/positronVariables.ts
@@ -99,13 +99,6 @@ export class PositronVariables {
 		await this.toggleVariable({ variableName, action: 'collapse' });
 	}
 
-	// async getVariablesInterpreter(): Promise<Locator> {
-	// 	return this.code.driver.page.locator(VARIABLES_INTERPRETER);
-	// }
-
-	// async assertVariablesInterpreter(expectedInterpreter: string) {
-	// 	expect()
-
 	/**
 	 * Gets the data (value and type) for the children of a parent variable.
 	 * NOTE: it assumes that either ALL variables are collapsed or ONLY the parent variable is expanded.

--- a/test/automation/src/positron/positronViewer.ts
+++ b/test/automation/src/positron/positronViewer.ts
@@ -14,27 +14,24 @@ const FULL_APP = 'body';
 export class PositronViewer {
 
 	fullApp = this.code.driver.getLocator(FULL_APP);
+	viewerFrame = this.code.driver.page.frameLocator('iframe').frameLocator(INNER_FRAME);
 
 	constructor(private code: Code) { }
 
-	getViewerLocator(locator: string, additionalNesting = false): Locator {
-		if (!additionalNesting) {
-			return this.getViewerFrame().locator(locator);
-		} else {
-			const innerInnerFrame = this.getViewerFrame().frameLocator('//iframe');
-			return innerInnerFrame.locator(locator);
+	getViewerLocator(locator: string, { nestedFrame }: { nestedFrame?: string } = {}): Locator {
+		if (nestedFrame) {
+			return this.viewerFrame.frameLocator(nestedFrame).locator(locator);
 		}
+
+		return this.viewerFrame.locator(locator);
 	}
 
-	getViewerFrame(frameLocator?: string): FrameLocator {
-		const outerFrame = this.code.driver.page.frameLocator('iframe').frameLocator(INNER_FRAME);
-
-		// if frameLocator is provided, use it; otherwise, return the default outerFrame
-		if (frameLocator) {
-			return outerFrame.frameLocator(frameLocator);
+	getViewerFrame(nestedFrame?: string): FrameLocator {
+		if (nestedFrame) {
+			return this.viewerFrame.frameLocator(nestedFrame);
 		}
 
-		return outerFrame;
+		return this.viewerFrame;
 	}
 
 	async refreshViewer() {

--- a/test/automation/src/positron/positronViewer.ts
+++ b/test/automation/src/positron/positronViewer.ts
@@ -6,7 +6,6 @@
 import { FrameLocator, Locator } from '@playwright/test';
 import { Code } from '../code';
 
-const OUTER_FRAME = '.webview';
 const INNER_FRAME = '#active-frame';
 const REFRESH_BUTTON = '.codicon-positron-refresh';
 
@@ -18,24 +17,8 @@ export class PositronViewer {
 
 	constructor(private code: Code) { }
 
-	getViewerLocator(sublocator: string, additionalNesting = false): Locator {
-		const outerFrame = this.code.driver.getFrame(OUTER_FRAME);
-		const innerFrame = outerFrame.frameLocator(INNER_FRAME);
-		if (!additionalNesting) {
-			const element = innerFrame.locator(sublocator);
-			return element;
-		} else {
-			const innerInnerFrame = innerFrame.frameLocator('//iframe');
-			const element = innerInnerFrame.locator(sublocator);
-			return element;
-		}
-	}
-
-	getViewerFrame(frameLocator: string): FrameLocator {
-		const outerFrame = this.code.driver.getFrame(OUTER_FRAME);
-		const innerFrame = outerFrame.frameLocator(INNER_FRAME);
-		const frame = innerFrame.frameLocator(frameLocator);
-		return frame;
+	getViewerFrame(): FrameLocator {
+		return this.code.driver.page.frameLocator('iframe').frameLocator(INNER_FRAME);
 	}
 
 	async refreshViewer() {

--- a/test/automation/src/positron/positronViewer.ts
+++ b/test/automation/src/positron/positronViewer.ts
@@ -17,6 +17,15 @@ export class PositronViewer {
 
 	constructor(private code: Code) { }
 
+	getViewerLocator(sublocator: string, additionalNesting = false): Locator {
+		if (!additionalNesting) {
+			return this.getViewerFrame().locator(sublocator);
+		} else {
+			const innerInnerFrame = this.getViewerFrame().frameLocator('//iframe');
+			return innerInnerFrame.locator(sublocator);
+		}
+	}
+
 	getViewerFrame(): FrameLocator {
 		return this.code.driver.page.frameLocator('iframe').frameLocator(INNER_FRAME);
 	}

--- a/test/automation/src/positron/positronViewer.ts
+++ b/test/automation/src/positron/positronViewer.ts
@@ -6,6 +6,7 @@
 import { FrameLocator, Locator } from '@playwright/test';
 import { Code } from '../code';
 
+const OUTER_FRAME = '.webview';
 const INNER_FRAME = '#active-frame';
 const REFRESH_BUTTON = '.codicon-positron-refresh';
 
@@ -14,7 +15,7 @@ const FULL_APP = 'body';
 export class PositronViewer {
 
 	fullApp = this.code.driver.getLocator(FULL_APP);
-	viewerFrame = this.code.driver.page.frameLocator('iframe').frameLocator(INNER_FRAME);
+	viewerFrame = this.code.driver.page.frameLocator(OUTER_FRAME).frameLocator(INNER_FRAME);
 
 	constructor(private code: Code) { }
 

--- a/test/automation/src/positron/positronViewer.ts
+++ b/test/automation/src/positron/positronViewer.ts
@@ -17,17 +17,24 @@ export class PositronViewer {
 
 	constructor(private code: Code) { }
 
-	getViewerLocator(sublocator: string, additionalNesting = false): Locator {
+	getViewerLocator(locator: string, additionalNesting = false): Locator {
 		if (!additionalNesting) {
-			return this.getViewerFrame().locator(sublocator);
+			return this.getViewerFrame().locator(locator);
 		} else {
 			const innerInnerFrame = this.getViewerFrame().frameLocator('//iframe');
-			return innerInnerFrame.locator(sublocator);
+			return innerInnerFrame.locator(locator);
 		}
 	}
 
-	getViewerFrame(): FrameLocator {
-		return this.code.driver.page.frameLocator('iframe').frameLocator(INNER_FRAME);
+	getViewerFrame(frameLocator?: string): FrameLocator {
+		const outerFrame = this.code.driver.page.frameLocator('iframe').frameLocator(INNER_FRAME);
+
+		// if frameLocator is provided, use it; otherwise, return the default outerFrame
+		if (frameLocator) {
+			return outerFrame.frameLocator(frameLocator);
+		}
+
+		return outerFrame;
 	}
 
 	async refreshViewer() {

--- a/test/automation/src/positron/positronViewer.ts
+++ b/test/automation/src/positron/positronViewer.ts
@@ -19,19 +19,11 @@ export class PositronViewer {
 
 	constructor(private code: Code) { }
 
-	getViewerLocator(locator: string, { nestedFrame }: { nestedFrame?: string } = {}): Locator {
-		if (nestedFrame) {
-			return this.viewerFrame.frameLocator(nestedFrame).locator(locator);
-		}
-
+	getViewerLocator(locator: string,): Locator {
 		return this.viewerFrame.locator(locator);
 	}
 
-	getViewerFrame(nestedFrame?: string): FrameLocator {
-		if (nestedFrame) {
-			return this.viewerFrame.frameLocator(nestedFrame);
-		}
-
+	getViewerFrame(): FrameLocator {
 		return this.viewerFrame;
 	}
 

--- a/test/smoke/src/areas/positron/apps/python-apps.test.ts
+++ b/test/smoke/src/areas/positron/apps/python-apps.test.ts
@@ -8,7 +8,7 @@ import { Application, PositronPythonFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 import { join } from 'path';
 
-describe.only('Python Applications #pr #win', () => {
+describe('Python Applications #pr #win', () => {
 	setupAndStartApp();
 
 	describe('Python Applications', () => {

--- a/test/smoke/src/areas/positron/apps/python-apps.test.ts
+++ b/test/smoke/src/areas/positron/apps/python-apps.test.ts
@@ -62,6 +62,7 @@ describe('Python Applications #pr #win', () => {
 			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'python_apps', 'streamlit_example', 'streamlit_example.py'));
 			await app.workbench.positronEditor.pressPlay();
 
+			await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
 			const viewerFrame = viewer.getViewerFrame();
 			const headerLocator = this.app.web
 				? viewerFrame.frameLocator('iframe').getByRole('button', { name: 'Deploy' })

--- a/test/smoke/src/areas/positron/apps/python-apps.test.ts
+++ b/test/smoke/src/areas/positron/apps/python-apps.test.ts
@@ -8,7 +8,7 @@ import { Application, PositronPythonFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 import { join } from 'path';
 
-describe('Python Applications #pr #win', () => {
+describe.only('Python Applications #pr #win', () => {
 	setupAndStartApp();
 
 	describe('Python Applications', () => {

--- a/test/smoke/src/areas/positron/apps/python-apps.test.ts
+++ b/test/smoke/src/areas/positron/apps/python-apps.test.ts
@@ -17,6 +17,7 @@ describe('Python Applications #pr #win', () => {
 		});
 
 		afterEach(async function () {
+			await this.app.workbench.quickaccess.runCommand('workbench.action.terminal.focus');
 			await this.app.workbench.positronTerminal.sendKeysToTerminal('Control+C');
 
 			// unreliable on ubuntu:
@@ -68,6 +69,7 @@ describe('Python Applications #pr #win', () => {
 				? viewerFrame.frameLocator('iframe').getByRole('button', { name: 'Deploy' })
 				: viewerFrame.getByRole('button', { name: 'Deploy' });
 			await expect(headerLocator).toBeVisible({ timeout: 30000 });
+			await app.workbench.positronLayouts.enterLayout('stacked');
 		});
 	});
 });

--- a/test/smoke/src/areas/positron/apps/pythonApps.test.ts
+++ b/test/smoke/src/areas/positron/apps/pythonApps.test.ts
@@ -61,7 +61,12 @@ describe('Python Applications #pr #win', () => {
 
 			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'python_apps', 'streamlit_example', 'streamlit_example.py'));
 			await app.workbench.positronEditor.pressPlay();
-			await expect(viewer.getViewerFrame().getByRole('button', { name: 'Deploy' })).toBeVisible({ timeout: 30000 });
+
+			const viewerFrame = viewer.getViewerFrame();
+			const headerLocator = this.app.web
+				? viewerFrame.frameLocator('iframe').getByRole('button', { name: 'Deploy' })
+				: viewerFrame.getByRole('button', { name: 'Deploy' });
+			await expect(headerLocator).toBeVisible();
 		});
 	});
 });

--- a/test/smoke/src/areas/positron/apps/pythonApps.test.ts
+++ b/test/smoke/src/areas/positron/apps/pythonApps.test.ts
@@ -11,7 +11,7 @@ import { join } from 'path';
 describe('Python Applications #pr #win', () => {
 	setupAndStartApp();
 
-	describe('Python Applications', () => {
+	describe('Python Applications #pr #web', () => {
 		before(async function () {
 			await PositronPythonFixtures.SetupFixtures(this.app as Application);
 		});

--- a/test/smoke/src/areas/positron/apps/pythonApps.test.ts
+++ b/test/smoke/src/areas/positron/apps/pythonApps.test.ts
@@ -8,8 +8,7 @@ import { Application, PositronPythonFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 import { join } from 'path';
 
-// MARIE will remove web before merging
-describe('Python Applications #pr #win #web', () => {
+describe('Python Applications #pr #win', () => {
 	setupAndStartApp();
 
 	describe('Python Applications', () => {

--- a/test/smoke/src/areas/positron/apps/pythonApps.test.ts
+++ b/test/smoke/src/areas/positron/apps/pythonApps.test.ts
@@ -8,10 +8,11 @@ import { Application, PositronPythonFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 import { join } from 'path';
 
-describe('Python Applications #pr #win', () => {
+// MARIE will remove web before merging
+describe('Python Applications #pr #win #web', () => {
 	setupAndStartApp();
 
-	describe('Python Applications #pr #web', () => {
+	describe('Python Applications', () => {
 		before(async function () {
 			await PositronPythonFixtures.SetupFixtures(this.app as Application);
 		});

--- a/test/smoke/src/areas/positron/apps/pythonApps.test.ts
+++ b/test/smoke/src/areas/positron/apps/pythonApps.test.ts
@@ -66,7 +66,7 @@ describe('Python Applications #pr #win', () => {
 			const headerLocator = this.app.web
 				? viewerFrame.frameLocator('iframe').getByRole('button', { name: 'Deploy' })
 				: viewerFrame.getByRole('button', { name: 'Deploy' });
-			await expect(headerLocator).toBeVisible();
+			await expect(headerLocator).toBeVisible({ timeout: 30000 });
 		});
 	});
 });

--- a/test/smoke/src/areas/positron/apps/pythonApps.test.ts
+++ b/test/smoke/src/areas/positron/apps/pythonApps.test.ts
@@ -13,8 +13,6 @@ describe('Python Applications #pr #win', () => {
 
 	describe('Python Applications', () => {
 		before(async function () {
-			await this.app.workbench.positronConsole.waitForReadyOrNoInterpreter();
-
 			await PositronPythonFixtures.SetupFixtures(this.app as Application);
 		});
 
@@ -28,63 +26,42 @@ describe('Python Applications #pr #win', () => {
 		});
 
 		it('Python - Verify Basic Dash App [C903305]', async function () {
-
 			this.retries(1);
-
 			const app = this.app as Application;
+			const viewer = app.workbench.positronViewer;
 
 			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'python_apps', 'dash_example', 'dash_example.py'));
-
 			await app.workbench.positronEditor.pressPlay();
-
-			const headerLocator = app.workbench.positronViewer.getViewerLocator('#_dash-app-content');
-
-			await expect(headerLocator).toHaveText('Hello World', { timeout: 45000 });
-
+			await expect(viewer.getViewerFrame().getByText('Hello World')).toBeVisible({ timeout: 30000 });
 		});
 
 		// https://github.com/posit-dev/positron/issues/4949
 		// FastAPI is not working as expected on Ubuntu
 		it.skip('Python - Verify Basic FastAPI App [C903306]', async function () {
 			const app = this.app as Application;
+			const viewer = app.workbench.positronViewer;
 
 			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'python_apps', 'fastapi_example', 'fastapi_example.py'));
-
 			await app.workbench.positronEditor.pressPlay();
-
-			const headerLocator = app.workbench.positronViewer.getViewerLocator('h2.title');
-
-			await expect(headerLocator).toContainText('FastAPI', { timeout: 45000 });
-
+			await expect(viewer.getViewerFrame().getByText('FastAPI')).toBeVisible({ timeout: 30000 });
 		});
 
 		it('Python - Verify Basic Gradio App [C903307]', async function () {
 			const app = this.app as Application;
+			const viewer = app.workbench.positronViewer;
 
 			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'python_apps', 'gradio_example', 'gradio_example.py'));
-
 			await app.workbench.positronEditor.pressPlay();
-
-			const headerLocator = app.workbench.positronViewer.getViewerLocator('button.primary');
-
-			await expect(headerLocator).toHaveText('Submit', { timeout: 45000 });
-
+			await expect(viewer.getViewerFrame().getByRole('button', { name: 'Submit' })).toBeVisible({ timeout: 30000 });
 		});
 
 		it('Python - Verify Basic Streamlit App [C903308] #web', async function () {
 			const app = this.app as Application;
+			const viewer = app.workbench.positronViewer;
 
 			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'python_apps', 'streamlit_example', 'streamlit_example.py'));
-
 			await app.workbench.positronEditor.pressPlay();
-
-			const headerLocator = app.workbench.positronViewer.getViewerLocator('div.stAppDeployButton', this.app.web);
-
-			await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
-			await expect(headerLocator).toHaveText('Deploy', { timeout: 45000 });
-			await app.workbench.positronLayouts.enterLayout('stacked');
-			await app.workbench.quickaccess.runCommand('workbench.action.terminal.focus');
-
+			await expect(viewer.getViewerFrame().getByRole('button', { name: 'Deploy' })).toBeVisible({ timeout: 30000 });
 		});
 	});
 });

--- a/test/smoke/src/areas/positron/quarto/quarto.test.ts
+++ b/test/smoke/src/areas/positron/quarto/quarto.test.ts
@@ -46,7 +46,10 @@ describe('Quarto #web', () => {
 	it('should be able to generate preview [C842891]', async function () {
 		await app.workbench.quickaccess.runCommand('quarto.preview', { keepOpen: true });
 
-		const previewHeader = app.workbench.positronViewer.getViewerFrame('//iframe').locator('h1');
+		// const previewHeader = app.workbench.positronViewer.getViewerFrame('//iframe').locator('h1');
+		const previewHeader = app.workbench.positronViewer.getViewerLocator('h1', {
+			nestedFrame: '//iframe'
+		});
 		await expect(previewHeader).toBeVisible({ timeout: 20000 });
 		await expect(previewHeader).toHaveText('Diamond sizes');
 	});

--- a/test/smoke/src/areas/positron/quarto/quarto.test.ts
+++ b/test/smoke/src/areas/positron/quarto/quarto.test.ts
@@ -46,7 +46,6 @@ describe('Quarto #web', () => {
 	it('should be able to generate preview [C842891]', async function () {
 		await app.workbench.quickaccess.runCommand('quarto.preview', { keepOpen: true });
 
-		// const previewHeader = app.workbench.positronViewer.getViewerFrame('//iframe').locator('h1');
 		const previewHeader = app.workbench.positronViewer.getViewerLocator('h1', {
 			nestedFrame: '//iframe'
 		});

--- a/test/smoke/src/areas/positron/quarto/quarto.test.ts
+++ b/test/smoke/src/areas/positron/quarto/quarto.test.ts
@@ -46,9 +46,7 @@ describe('Quarto #web', () => {
 	it('should be able to generate preview [C842891]', async function () {
 		await app.workbench.quickaccess.runCommand('quarto.preview', { keepOpen: true });
 
-		const previewHeader = app.workbench.positronViewer.getViewerLocator('h1', {
-			nestedFrame: '//iframe'
-		});
+		const previewHeader = app.workbench.positronViewer.getViewerFrame().frameLocator('iframe').locator('h1');
 		await expect(previewHeader).toBeVisible({ timeout: 20000 });
 		await expect(previewHeader).toHaveText('Diamond sizes');
 	});

--- a/test/smoke/src/areas/positron/quarto/quarto.test.ts
+++ b/test/smoke/src/areas/positron/quarto/quarto.test.ts
@@ -45,10 +45,10 @@ describe('Quarto #web', () => {
 
 	it('should be able to generate preview [C842891]', async function () {
 		await app.workbench.quickaccess.runCommand('quarto.preview', { keepOpen: true });
-		const viewerFrame = app.workbench.positronViewer.getViewerFrame('//iframe');
 
-		// verify preview displays
-		expect(await viewerFrame.locator('h1').innerText()).toBe('Diamond sizes');
+		const previewHeader = app.workbench.positronViewer.getViewerFrame('//iframe').locator('h1');
+		await expect(previewHeader).toBeVisible({ timeout: 20000 });
+		await expect(previewHeader).toHaveText('Diamond sizes');
 	});
 });
 

--- a/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
+++ b/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
@@ -45,16 +45,9 @@ describe('RMarkdown #web', () => {
 
 		// inner most frame has no useful identifying features
 		// not factoring this locator because its not part of positron
-		const viewerFrame = app.workbench.positronViewer.getViewerFrame('//iframe');
+		const gettingStarted = app.workbench.positronViewer.getViewerFrame().frameLocator('iframe').locator('h2[data-anchor-id="getting-started"]');
 
-		// not factoring this locator because its not part of positron
-		const gettingStarted = viewerFrame.locator('h2[data-anchor-id="getting-started"]');
-
-		const gettingStartedText = await gettingStarted.innerText();
-
-		expect(gettingStartedText).toBe('Getting started');
-
-		await app.workbench.positronTerminal.sendKeysToTerminal('Control+C');
-
+		await expect(gettingStarted).toBeVisible({ timeout: 30000 });
+		await expect(gettingStarted).toHaveText('Getting started');
 	});
 });

--- a/test/smoke/src/areas/positron/variables/variables-notebook.test.ts
+++ b/test/smoke/src/areas/positron/variables/variables-notebook.test.ts
@@ -9,25 +9,12 @@ import { setupAndStartApp } from '../../../test-runner/test-hooks';
 
 describe('Variables Pane - Notebook #pr #web', () => {
 
-	afterEach(async function () {
-		const app = this.app as Application;
-		await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
-	});
-
 	// This test fails on WEB: https://github.com/posit-dev/positron/issues/2452
 	describe('Python Notebook Variables Pane', () => {
 		setupAndStartApp();
 
 		before(async function () {
 			await PositronPythonFixtures.SetupFixtures(this.app as Application);
-		});
-
-		after(async function () {
-
-			const app = this.app as Application;
-			await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
-
-			await app.workbench.positronLayouts.enterLayout('stacked');
 		});
 
 		it('Verifies Variables pane basic function for notebook with python interpreter [C669188]', async function () {
@@ -54,14 +41,6 @@ describe('Variables Pane - Notebook #pr #web', () => {
 
 		before(async function () {
 			await PositronRFixtures.SetupFixtures(this.app as Application);
-		});
-
-		after(async function () {
-
-			const app = this.app as Application;
-			await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
-
-			await app.workbench.positronLayouts.enterLayout('stacked');
 		});
 
 		it('Verifies Variables pane basic function for notebook with R interpreter [C669189]', async function () {

--- a/test/smoke/src/areas/positron/variables/variables-notebook.test.ts
+++ b/test/smoke/src/areas/positron/variables/variables-notebook.test.ts
@@ -7,7 +7,7 @@ import { expect } from '@playwright/test';
 import { Application, PositronPythonFixtures, PositronRFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 
-describe('Notebook Variables Pane #pr', () => {
+describe('Variables Pane - Notebook #pr', () => {
 	setupAndStartApp();
 
 	afterEach(async function () {

--- a/test/smoke/src/areas/positron/variables/variables-notebook.test.ts
+++ b/test/smoke/src/areas/positron/variables/variables-notebook.test.ts
@@ -15,8 +15,7 @@ describe('Variables Pane - Notebook #pr', () => {
 		await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
 	});
 
-	// WEB - is there a bug? The interpreter is always set to Python
-	// Don't worry, I'm coming back to fix this tomorrow!
+	// This test fails on WEB: https://github.com/posit-dev/positron/issues/2452
 	describe('Python Notebook Variables Pane', () => {
 
 		it('Verifies Variables pane basic function for notebook with python interpreter [C669188]', async function () {

--- a/test/smoke/src/areas/positron/variables/variables-notebook.test.ts
+++ b/test/smoke/src/areas/positron/variables/variables-notebook.test.ts
@@ -7,85 +7,56 @@ import { expect } from '@playwright/test';
 import { Application, PositronPythonFixtures, PositronRFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 
-describe('Variables Pane - Notebook #pr #web', () => {
+describe('Notebook Variables Pane #pr', () => {
 	setupAndStartApp();
 
-	describe('Python Notebook Variables Pane', () => {
+	afterEach(async function () {
+		const app = this.app as Application;
+		await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
+	});
 
-		before(async function () {
-			await PositronPythonFixtures.SetupFixtures(this.app as Application);
-		});
-
-		after(async function () {
-
-			const app = this.app as Application;
-			await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
-
-			await app.workbench.positronLayouts.enterLayout('stacked');
-		});
+	// WEB - is there a bug? The interpreter is always set to Python
+	describe('Pyton Notebook Variables Pane', () => {
 
 		it('Verifies Variables pane basic function for notebook with python interpreter [C669188]', async function () {
 			const app = this.app as Application;
+			await PositronPythonFixtures.SetupFixtures(this.app as Application);
 
 			await app.workbench.positronNotebooks.createNewNotebook();
-
 			await app.workbench.positronNotebooks.selectInterpreter('Python Environments', process.env.POSITRON_PY_VER_SEL!);
-
 			await app.workbench.positronNotebooks.addCodeToFirstCell('y = [2, 3, 4, 5]');
-
 			await app.workbench.positronNotebooks.executeCodeInCell();
 
-			const interpreter = await app.workbench.positronVariables.getVariablesInterpreter();
-
-			expect(interpreter.textContent).toBe('Untitled-1.ipynb');
+			const interpreter = app.workbench.positronVariables.interpreterLocator;
+			await expect(interpreter).toBeVisible();
+			await expect(interpreter).toHaveText('Untitled-1.ipynb');
 
 			await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
-
 			const variablesMap = await app.workbench.positronVariables.getFlatVariables();
-
 			expect(variablesMap.get('y')).toStrictEqual({ value: '[2, 3, 4, 5]', type: 'list [4]' });
-
 		});
-
 	});
 
-
-	describe('R Notebook Variables Pane', () => {
-
-		before(async function () {
-			await PositronRFixtures.SetupFixtures(this.app as Application);
-		});
-
-		after(async function () {
-
-			const app = this.app as Application;
-			await app.workbench.positronNotebooks.closeNotebookWithoutSaving();
-
-			await app.workbench.positronLayouts.enterLayout('stacked');
-		});
+	describe('R Notebook Variables Pane #web', () => {
 
 		it('Verifies Variables pane basic function for notebook with R interpreter [C669189]', async function () {
 			const app = this.app as Application;
+			await PositronRFixtures.SetupFixtures(this.app as Application);
 
 			await app.workbench.positronNotebooks.createNewNotebook();
-
 			await app.workbench.positronNotebooks.selectInterpreter('R Environments', process.env.POSITRON_R_VER_SEL!);
-
 			await app.workbench.positronNotebooks.addCodeToFirstCell('y <- c(2, 3, 4, 5)');
-
 			await app.workbench.positronNotebooks.executeCodeInCell();
 
-			const interpreter = await app.workbench.positronVariables.getVariablesInterpreter();
-
-			expect(interpreter.textContent).toBe('Untitled-1.ipynb');
+			const interpreter = app.workbench.positronVariables.interpreterLocator;
+			await expect(interpreter).toBeVisible();
+			await expect(interpreter).toHaveText('Untitled-1.ipynb');
 
 			await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');
-
 			const variablesMap = await app.workbench.positronVariables.getFlatVariables();
-
 			expect(variablesMap.get('y')).toStrictEqual({ value: '2 3 4 5', type: 'dbl [4]' });
-
 		});
 
 	});
 });
+

--- a/test/smoke/src/areas/positron/variables/variables-notebook.test.ts
+++ b/test/smoke/src/areas/positron/variables/variables-notebook.test.ts
@@ -16,6 +16,7 @@ describe('Variables Pane - Notebook #pr', () => {
 	});
 
 	// WEB - is there a bug? The interpreter is always set to Python
+	// Don't worry, I'm coming back to fix this tomorrow!
 	describe('Python Notebook Variables Pane', () => {
 
 		it('Verifies Variables pane basic function for notebook with python interpreter [C669188]', async function () {

--- a/test/smoke/src/areas/positron/variables/variables-notebook.test.ts
+++ b/test/smoke/src/areas/positron/variables/variables-notebook.test.ts
@@ -16,7 +16,7 @@ describe('Variables Pane - Notebook #pr', () => {
 	});
 
 	// WEB - is there a bug? The interpreter is always set to Python
-	describe('Pyton Notebook Variables Pane', () => {
+	describe('Python Notebook Variables Pane', () => {
 
 		it('Verifies Variables pane basic function for notebook with python interpreter [C669188]', async function () {
 			const app = this.app as Application;

--- a/test/smoke/src/areas/positron/variables/variables-notebook.test.ts
+++ b/test/smoke/src/areas/positron/variables/variables-notebook.test.ts
@@ -7,10 +7,10 @@ import { expect } from '@playwright/test';
 import { Application, PositronPythonFixtures, PositronRFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 
-describe('Variables Pane - Notebook #pr #web', () => {
+describe('Variables Pane - Notebook', () => {
 
 	// This test fails on WEB: https://github.com/posit-dev/positron/issues/2452
-	describe('Python Notebook Variables Pane', () => {
+	describe('Python Notebook Variables Pane #pr', () => {
 		setupAndStartApp();
 
 		before(async function () {
@@ -36,7 +36,7 @@ describe('Variables Pane - Notebook #pr #web', () => {
 		});
 	});
 
-	describe('R Notebook Variables Pane', () => {
+	describe('R Notebook Variables Pane #pr #web', () => {
 		setupAndStartApp();
 
 		before(async function () {


### PR DESCRIPTION
I’ve made improvements to the Python application tests to reduce flaky results. Currently, the tests are tagged with #pr and #web as I’m running them multiple times to confirm stability. I’ll remove these tags before merging. Additionally, I discovered a potential bug that only affects web (python) tests. I’ll bring this up with the team but will remove this one test from the web runs for now.

### QA Notes
✅ this test passed 5 consecutive runs on PR
✅ [Full test suite](https://github.com/posit-dev/positron/actions/runs/11508968684) passed
✅ [Windows suite](https://github.com/posit-dev/positron/actions/runs/11521232269/job/32074401285)  passed