### PR TITLE
Fix vetiver test

### DIFF
--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -283,4 +283,8 @@ export class PositronConsole {
 
 		return suggestionList;
 	}
+
+	async clickConsoleTab() {
+		await this.code.driver.page.locator('.basepanel').getByRole('tab', { name: 'Console', exact: true }).locator('a').click();
+	}
 }

--- a/test/smoke/src/areas/positron/viewer/viewer.test.ts
+++ b/test/smoke/src/areas/positron/viewer/viewer.test.ts
@@ -37,9 +37,11 @@ VetiverAPI(v).run()`;
 
 			await theDoc.waitFor({ state: 'attached', timeout: 60000 });
 
-			await app.workbench.positronConsole.activeConsole.click();
-			// if click accidentally hits a link, use Escape to close the dialog
-			await app.workbench.positronConsole.sendKeyboardKey('Escape');
+			// This is bad because it can end up clicking a link inside the console:
+			//await app.workbench.positronConsole.activeConsole.click();
+
+			await app.workbench.positronConsole.clickConsoleTab();
+
 			await app.workbench.positronConsole.sendKeyboardKey('Control+C');
 
 			await app.workbench.positronConsole.waitForConsoleContents(buffer => buffer.some(line => line.includes('Application shutdown complete.')));


### PR DESCRIPTION
The vetiver test shutdown process sometimes accidentally clicked a link in the console and broke the following steps.

With this change, the console tab text is clicked instead.

### QA Notes

All smoke tests should pass
