### PR TITLE
Data Explorer: Implement row filters and column sorting for duckdb backend

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -225,8 +225,8 @@ function makeWhereExpr(rowFilter: RowFilter): string {
 				case TextSearchType.EndsWith:
 					return `${searchArg} LIKE '%' || ${searchTerm}`;
 				case TextSearchType.RegexMatch: {
-					const regexOp = params.case_sensitive ? '~' : '~*';
-					return `${searchArg} ${regexOp} ${params.term}`;
+					const options = params.case_sensitive ? ', \'i\'' : '';
+					return `regexp_matches(${searchArg}, \'${params.term}\'${options})`;
 				}
 			}
 		}
@@ -661,6 +661,10 @@ END`;
 		if (this.rowFilters.length === 0) {
 			this._whereClause = '';
 			const unfilteredShape = await this._unfilteredShape;
+
+			// reset filtered shape
+			this._filteredShape = this._unfilteredShape;
+
 			return { selected_num_rows: unfilteredShape[0] };
 		}
 

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -18,6 +18,8 @@ import {
 	FormatOptions,
 	GetDataValuesParams,
 	GetSchemaParams,
+	RowFilterType,
+	SupportedFeatures,
 	SupportStatus,
 	TableData,
 	TableSchema
@@ -164,9 +166,11 @@ suite('Positron DuckDB Extension Test Suite', () => {
 					supported_types: []
 				},
 				set_row_filters: {
-					support_status: SupportStatus.Unsupported,
+					support_status: SupportStatus.Supported,
 					supports_conditions: SupportStatus.Unsupported,
-					supported_types: []
+					supported_types: Object.values(RowFilterType).map((value) => {
+						return { row_filter_type: value, support_status: SupportStatus.Supported };
+					})
 				},
 				get_column_profiles: {
 					support_status: SupportStatus.Supported,
@@ -177,13 +181,13 @@ suite('Positron DuckDB Extension Test Suite', () => {
 						}
 					]
 				},
-				set_sort_columns: { support_status: SupportStatus.Unsupported, },
+				set_sort_columns: { support_status: SupportStatus.Supported, },
 				export_data_selection: {
 					support_status: SupportStatus.Unsupported,
 					supported_formats: []
 				}
 			}
-		});
+		} satisfies BackendState);
 
 		result = await dxExec({
 			method: DataExplorerBackendRequest.GetSchema,
@@ -193,125 +197,39 @@ suite('Positron DuckDB Extension Test Suite', () => {
 			} satisfies GetSchemaParams
 		});
 
-		const expectedSchema: Array<ColumnSchema> = [
-			{
-				column_name: 'year',
-				column_index: 0,
-				type_name: 'SMALLINT',
-				type_display: ColumnDisplayType.Number
-			},
-			{
-				column_name: 'month',
-				column_index: 1,
-				type_name: 'TINYINT',
-				type_display: ColumnDisplayType.Number
-			},
-			{
-				column_name: 'day',
-				column_index: 2,
-				type_name: 'TINYINT',
-				type_display: ColumnDisplayType.Number
-			},
-			{
-				column_name: 'dep_time',
-				column_index: 3,
-				type_name: 'SMALLINT',
-				type_display: ColumnDisplayType.Number
-			},
-			{
-				column_name: 'sched_dep_time',
-				column_index: 4,
-				type_name: 'SMALLINT',
-				type_display: ColumnDisplayType.Number
-			},
-			{
-				column_name: 'dep_delay',
-				column_index: 5,
-				type_name: 'SMALLINT',
-				type_display: ColumnDisplayType.Number
-			},
-			{
-				column_name: 'arr_time',
-				column_index: 6,
-				type_name: 'SMALLINT',
-				type_display: ColumnDisplayType.Number
-			},
-			{
-				column_name: 'sched_arr_time',
-				column_index: 7,
-				type_name: 'SMALLINT',
-				type_display: ColumnDisplayType.Number
-			},
-			{
-				column_name: 'arr_delay',
-				column_index: 8,
-				type_name: 'SMALLINT',
-				type_display: ColumnDisplayType.Number
-			},
-			{
-				column_name: 'carrier',
-				column_index: 9,
-				type_name: 'VARCHAR',
-				type_display: ColumnDisplayType.String
-			},
-			{
-				column_name: 'flight',
-				column_index: 10,
-				type_name: 'SMALLINT',
-				type_display: ColumnDisplayType.Number
-			},
-			{
-				column_name: 'tailnum',
-				column_index: 11,
-				type_name: 'VARCHAR',
-				type_display: ColumnDisplayType.String
-			},
-			{
-				column_name: 'origin',
-				column_index: 12,
-				type_name: 'VARCHAR',
-				type_display: ColumnDisplayType.String
-			},
-			{
-				column_name: 'dest',
-				column_index: 13,
-				type_name: 'VARCHAR',
-				type_display: ColumnDisplayType.String
-			},
-			{
-				column_name: 'air_time',
-				column_index: 14,
-				type_name: 'SMALLINT',
-				type_display: ColumnDisplayType.Number
-			},
-			{
-				column_name: 'distance',
-				column_index: 15,
-				type_name: 'SMALLINT',
-				type_display: ColumnDisplayType.Number
-			},
-			{
-				column_name: 'hour',
-				column_index: 16,
-				type_name: 'TINYINT',
-				type_display: ColumnDisplayType.Number
-			},
-			{
-				column_name: 'minute',
-				column_index: 17,
-				type_name: 'TINYINT',
-				type_display: ColumnDisplayType.Number
-			},
-			{
-				column_name: 'time_hour',
-				column_index: 18,
-				type_name: 'TIMESTAMP_NS',
-				type_display: ColumnDisplayType.Datetime
-			}
+		const schemaEntries: Array<[string, string, ColumnDisplayType]> = [
+			['year', 'SMALLINT', ColumnDisplayType.Number],
+			['month', 'TINYINT', ColumnDisplayType.Number],
+			['day', 'TINYINT', ColumnDisplayType.Number],
+			['dep_time', 'SMALLINT', ColumnDisplayType.Number],
+			['sched_dep_time', 'SMALLINT', ColumnDisplayType.Number],
+			['dep_delay', 'SMALLINT', ColumnDisplayType.Number],
+			['arr_time', 'SMALLINT', ColumnDisplayType.Number],
+			['sched_arr_time', 'SMALLINT', ColumnDisplayType.Number],
+			['arr_delay', 'SMALLINT', ColumnDisplayType.Number],
+			['carrier', 'VARCHAR', ColumnDisplayType.String],
+			['flight', 'SMALLINT', ColumnDisplayType.Number],
+			['tailnum', 'VARCHAR', ColumnDisplayType.String],
+			['origin', 'VARCHAR', ColumnDisplayType.String],
+			['dest', 'VARCHAR', ColumnDisplayType.String],
+			['air_time', 'SMALLINT', ColumnDisplayType.Number],
+			['distance', 'SMALLINT', ColumnDisplayType.Number],
+			['hour', 'TINYINT', ColumnDisplayType.Number],
+			['minute', 'TINYINT', ColumnDisplayType.Number],
+			['time_hour', 'TIMESTAMP_NS', ColumnDisplayType.Datetime],
 		];
 
 		assert.deepStrictEqual(result, {
-			columns: expectedSchema
+			columns: schemaEntries.map(
+				([column_name, type_name, type_display], column_index) => {
+					return {
+						column_name,
+						column_index,
+						type_name,
+						type_display
+					};
+				}
+			)
 		} satisfies TableSchema);
 	});
 

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
@@ -152,7 +152,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 		return this._execRpc<TableSchema>({
 			method: DataExplorerBackendRequest.GetSchema,
 			uri: this.filePath,
-			params: { column_indices: columnIndices }
+			params: { column_indices: columnIndices } satisfies GetSchemaParams
 		});
 	}
 
@@ -163,7 +163,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 			params: {
 				columns,
 				format_options: formatOptions
-			}
+			} satisfies GetDataValuesParams
 		});
 	}
 
@@ -185,7 +185,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 			params: {
 				selection,
 				format
-			}
+			} satisfies ExportDataSelectionParams
 		});
 	}
 
@@ -193,7 +193,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 		return this._execRpc<void>({
 			method: DataExplorerBackendRequest.SetColumnFilters,
 			uri: this.filePath,
-			params: { filters }
+			params: { filters } satisfies SetColumnFiltersParams
 		});
 	}
 
@@ -201,15 +201,15 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 		return this._execRpc<FilterResult>({
 			method: DataExplorerBackendRequest.SetRowFilters,
 			uri: this.filePath,
-			params: { filters }
+			params: { filters } satisfies SetRowFiltersParams
 		});
 	}
 
 	async setSortColumns(sortKeys: Array<ColumnSortKey>): Promise<void> {
 		return this._execRpc<void>({
-			method: DataExplorerBackendRequest.SetRowFilters,
+			method: DataExplorerBackendRequest.SetSortColumns,
 			uri: this.filePath,
-			params: { sort_keys: sortKeys }
+			params: { sort_keys: sortKeys } satisfies SetSortColumnsParams
 		});
 	}
 


### PR DESCRIPTION
Addresses #5126 and #5127. It provides the full set of row filter types and column sorting. A lot of the work was in writing the unit tests code (with `yarn test-extension -l positron-duckdb`) to verify correctness, but I was fairly thorough and turned up some bugs while writing the unit tests. 

DuckDB does not provide stable sorting (i.e. rows may be permuted if the sort keys are equal) so I had to introduce an auxiliary "row_index" field to do an order-preserving sort to make it easier to unit test. 