### PR TITLE
Data Explorer: Do not send backend empty schema, data, profile requests

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -276,7 +276,7 @@ END`;
 			numRows = upperLimit - lowerLimit + 1;
 		}
 
-		// No column selectors case -- TODO: why is the backend even sending this?
+		// No column selectors case, do not error if we get a request like this
 		if (columnSelectors.length === 0) {
 			return { columns: [] };
 		} else if (numRows === 0) {

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -317,6 +317,10 @@ export class DataExplorerClientInstance extends Disposable {
 	 * @returns A promise that resolves to the table schema.
 	 */
 	async getSchema(columnIndices: Array<number>): Promise<TableSchema> {
+		if (columnIndices.length === 0) {
+			// Do not send backend requests for an empty selection
+			return { columns: [] };
+		}
 		return this.runBackendTask(
 			() => this._backendClient.getSchema(columnIndices),
 			() => ({ columns: [] })
@@ -365,6 +369,10 @@ export class DataExplorerClientInstance extends Disposable {
 	 * @returns A Promise<TableData> that resolves when the operation is complete.
 	 */
 	async getDataValues(columns: Array<ColumnSelection>): Promise<TableData> {
+		if (columns.length === 0) {
+			// Do not send backend requests for an empty selection
+			return { columns: [] };
+		}
 		return this.runBackendTask(
 			() => this._backendClient.getDataValues(columns, this._dataFormatOptions),
 			() => ({ columns: [[]] })
@@ -395,6 +403,10 @@ export class DataExplorerClientInstance extends Disposable {
 	async getColumnProfiles(
 		profiles: Array<ColumnProfileRequest>
 	): Promise<Array<ColumnProfileResult>> {
+		if (profiles.length === 0) {
+			// Do not send backend a request if empty array passed
+			return [];
+		}
 		return this.runBackendTask(
 			async () => {
 				const callbackId = generateUuid();

--- a/src/vs/workbench/services/positronDataExplorer/common/tableDataCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableDataCache.ts
@@ -401,13 +401,13 @@ export class TableDataCache extends Disposable {
 			}
 		}
 
-		// Load the column schemas we need to load.
-		const tableSchema = await this._dataExplorerClientInstance.getSchema(columnIndices);
-
 		// Clear the column schema cache, if we're supposed to.
 		if (invalidateColumnSchemaCache) {
 			this._columnSchemaCache.clear();
 		}
+
+		// Load the column schemas we need to load.
+		const tableSchema = await this._dataExplorerClientInstance.getSchema(columnIndices);
 
 		// Cache the column schemas that were returned.
 		for (let i = 0; i < tableSchema.columns.length; i++) {
@@ -501,9 +501,6 @@ export class TableDataCache extends Disposable {
 			}
 		}
 
-		// Get the data values.
-		const tableData = await this._dataExplorerClientInstance.getDataValues(columnSelections);
-
 		// Get the row labels.
 		let rowLabels: ArraySelection | undefined;
 		if (!tableState.has_row_labels) {
@@ -555,6 +552,9 @@ export class TableDataCache extends Disposable {
 			this._rowLabelCache.clear();
 			this._dataColumnCache.clear();
 		}
+
+		// Get the data values
+		const tableData = await this._dataExplorerClientInstance.getDataValues(columnSelections);
 
 		// Update the data column cache.
 		for (let column = 0; column < tableData.columns.length; column++) {


### PR DESCRIPTION
I noticed that the data explorer UI was sending the backends empty schema, data, and profile requests (length-0 array of requests), which makes it look like computations are happening (the loading indicator activates when scrolling) even though the data is fully cached. It is also extra Jupyter comm chatter that is not needed. 