### PR TITLE
Data Explorer: Display duckdb error message when file fails to open

### DIFF
--- a/extensions/positron-duckdb/src/interfaces.ts
+++ b/extensions/positron-duckdb/src/interfaces.ts
@@ -58,6 +58,7 @@ export interface DataExplorerResponse {
 // AUTO-GENERATED from data_explorer.json; do not edit.
 //
 
+
 /**
  * Result in Methods
  */
@@ -161,6 +162,18 @@ export interface BackendState {
 	 * The features currently supported by the backend instance
 	 */
 	supported_features: SupportedFeatures;
+
+	/**
+	 * Optional flag allowing backend to report that it is unable to serve
+	 * requests. This parameter may change.
+	 */
+	connected?: boolean;
+
+	/**
+	 * Optional experimental parameter to provide an explanation when
+	 * connected=false. This parameter may change.
+	 */
+	error_message?: string;
 
 }
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -302,6 +302,16 @@ class BackendState(BaseModel):
         description="The features currently supported by the backend instance",
     )
 
+    connected: Optional[StrictBool] = Field(
+        default=None,
+        description="Optional flag allowing backend to report that it is unable to serve requests. This parameter may change.",
+    )
+
+    error_message: Optional[StrictStr] = Field(
+        default=None,
+        description="Optional experimental parameter to provide an explanation when connected=false. This parameter may change.",
+    )
+
 
 class ColumnSchema(BaseModel):
     """

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -387,6 +387,14 @@
 						"supported_features": {
 							"description": "The features currently supported by the backend instance",
 							"$ref": "#/components/schemas/supported_features"
+						},
+						"connected": {
+							"type": "boolean",
+							"description": "Optional flag allowing backend to report that it is unable to serve requests. This parameter may change."
+						},
+						"error_message": {
+							"type": "string",
+							"description": "Optional experimental parameter to provide an explanation when connected=false. This parameter may change."
 						}
 					}
 				}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerClosed/positronDataExplorerClosed.css
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerClosed/positronDataExplorerClosed.css
@@ -12,31 +12,41 @@
 	display: grid;
 	position: absolute;
 	background-color: transparent;
-	grid-template-rows: [top-gutter] 1fr [message] max-content [bottom-gutter] 1fr [end];
-	grid-template-columns: [left-gutter] 1fr [message] max-content [right-gutter] 1fr [end];
+	background: rgba(0, 0, 0, 0.05);
+	grid-template-rows: [top-gutter] 1fr [dialog-box] max-content [bottom-gutter] 1fr [end-rows];
+	grid-template-columns: [left-gutter] 1fr [dialog-box] max-content [right-gutter] 1fr [end-columns];
 }
 
-.positron-data-explorer-closed
-.message {
-	color: white;
+.positron-data-explorer-closed .dialog-box {
 	display: flex;
-	row-gap: 10px;
+	row-gap: 12px;
 	font-size: 14px;
 	cursor: pointer;
-	padding: 25px 50px;
+	max-width: 300px;
+	padding: 20px;
+	align-items: center;
 	border-radius: 6px;
-	text-align: center;
 	flex-direction: column;
-	grid-row: message / bottom-gutter;
-	grid-column: message / right-gutter;
+	grid-row: dialog-box / bottom-gutter;
+	grid-column: dialog-box / right-gutter;
 	box-shadow: 0 0 8px 2px var(--vscode-widget-shadow);
 	color: var(--vscode-positronModalDialog-foreground);
 	border: 1px solid var(--vscode-positronModalDialog-border);
 	background-color: var(--vscode-positronModalDialog-background);
 }
 
-.positron-data-explorer-closed
-.close-button {
+.positron-data-explorer-closed .dialog-box .message {
+	font-size: 16px;
+	font-weight: bold;
+	text-align: center;
+}
+
+.positron-data-explorer-closed .dialog-box .error-message {
+	text-align: left;
+	max-height: 200px;
+}
+
+.positron-data-explorer-closed .dialog-box .close-button {
 	display: flex;
 	font-size: 14px;
 	cursor: pointer;
@@ -44,23 +54,21 @@
 	border-radius: 5px;
 	align-items: center;
 	justify-content: center;
+	max-width: max-content;
 	border: 1px solid var(--vscode-positronModalDialog-buttonBorder);
 	color: var(--vscode-positronModalDialog-defaultButtonForeground);
 	background: var(--vscode-positronModalDialog-defaultButtonBackground);
 }
 
-.positron-data-explorer-closed
-.close-button:hover {
+.positron-data-explorer-closed .dialog-box .close-button:hover {
 	background: var(--vscode-positronModalDialog-defaultButtonHoverBackground);
 }
 
-.positron-data-explorer-closed
-.close-button:focus {
+.positron-data-explorer-closed .dialog-box .close-button:focus {
 	outline: none;
 }
 
-.positron-data-explorer-closed
-.close-button:focus-visible {
+.positron-data-explorer-closed .dialog-box .close-button:focus-visible {
 	outline-offset: 2px;
 	outline: 1px solid var(--vscode-focusBorder);
 }

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerClosed/positronDataExplorerClosed.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerClosed/positronDataExplorerClosed.tsx
@@ -14,6 +14,9 @@ import { PropsWithChildren } from 'react'; // eslint-disable-line no-duplicate-i
 import { localize } from 'vs/nls';
 import { Button } from 'vs/base/browser/ui/positronComponents/button/button';
 
+/**
+ * PositronDataExplorerClosedStatus enum.
+ */
 export enum PositronDataExplorerClosedStatus {
 	UNAVAILABLE = 'unavailable',
 	ERROR = 'error'
@@ -33,39 +36,45 @@ export interface PositronDataExplorerClosedProps {
  * @param props A PositronDataExplorerClosedProps that contains the component properties.
  * @returns The rendered component.
  */
-export const PositronDataExplorerClosed = (props: PropsWithChildren<PositronDataExplorerClosedProps>) => {
-	// Constants.
+export const PositronDataExplorerClosed = (
+	props: PropsWithChildren<PositronDataExplorerClosedProps>
+) => {
+	// Construct the message and error message.
+	let message, errorMessage;
+	if (props.closedReason === PositronDataExplorerClosedStatus.ERROR) {
+		message = localize(
+			'positron.dataExplorerEditor.errorOpeningDataExplorer',
+			'Error Opening Data Explorer'
+		);
+		errorMessage = props.errorMessage;
+	} else {
+		message = localize(
+			'positron.dataExplorerEditor.connectionClosed',
+			'Connection Closed'
+		);
+		errorMessage = localize(
+			'positron.dataExplorerEditor.objectNoLongerAvailable',
+			'This object is no longer available.'
+		);
+	}
+
+	// Localize the close button.
 	const closeDataExplorer = localize(
 		'positron.dataExplorerEditor.closeDataExplorer',
 		"Close Data Explorer"
 	);
 
-	const unavailableMessage = localize(
-		'positron.dataExplorerEditor.thisObjectIsNoLongerAvailable',
-		'This object is no longer available.'
-	);
-
-	const errorOpeningMessage = localize(
-		'positron.dataExplorerEditor.errorOpeningDataExplorer',
-		'Error opening data explorer'
-	);
-
-	let userMessage;
-	if (props.closedReason === PositronDataExplorerClosedStatus.ERROR) {
-		userMessage = `${errorOpeningMessage}: ${props.errorMessage}`;
-	} else {
-		userMessage = unavailableMessage;
-	}
-
 	// Render.
 	return (
 		<div className='positron-data-explorer-closed'>
-			<div className='message' >
-				<div>
-					{(() => userMessage)()}
+			<div className='dialog-box' >
+				<div className='message'>
+					{message}
 				</div>
-				<Button
-					className='close-button'
+				<div className='error-message'>
+					{errorMessage}
+				</div>
+				<Button className='close-button'
 					ariaLabel={closeDataExplorer}
 					onPressed={props.onClose}
 				>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerClosed/positronDataExplorerClosed.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerClosed/positronDataExplorerClosed.tsx
@@ -14,10 +14,17 @@ import { PropsWithChildren } from 'react'; // eslint-disable-line no-duplicate-i
 import { localize } from 'vs/nls';
 import { Button } from 'vs/base/browser/ui/positronComponents/button/button';
 
+export enum PositronDataExplorerClosedStatus {
+	UNAVAILABLE = 'unavailable',
+	ERROR = 'error'
+}
+
 /**
  * PositronDataExplorerClosedProps interface.
  */
 export interface PositronDataExplorerClosedProps {
+	closedReason: PositronDataExplorerClosedStatus;
+	errorMessage?: string;
 	onClose: () => void;
 }
 
@@ -33,15 +40,29 @@ export const PositronDataExplorerClosed = (props: PropsWithChildren<PositronData
 		"Close Data Explorer"
 	);
 
+	const unavailableMessage = localize(
+		'positron.dataExplorerEditor.thisObjectIsNoLongerAvailable',
+		'This object is no longer available.'
+	);
+
+	const errorOpeningMessage = localize(
+		'positron.dataExplorerEditor.errorOpeningDataExplorer',
+		'Error opening data explorer'
+	);
+
+	let userMessage;
+	if (props.closedReason === PositronDataExplorerClosedStatus.ERROR) {
+		userMessage = `${errorOpeningMessage}: ${props.errorMessage}`;
+	} else {
+		userMessage = unavailableMessage;
+	}
+
 	// Render.
 	return (
 		<div className='positron-data-explorer-closed'>
 			<div className='message' >
 				<div>
-					{(() => localize(
-						'positron.dataExplorerEditor.thisObjectIsNoLongerAvailable',
-						'This object is no longer available.'
-					))()}
+					{(() => userMessage)()}
 				</div>
 				<Button
 					className='close-button'

--- a/src/vs/workbench/browser/positronDataExplorer/positronDataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/positronDataExplorer.tsx
@@ -92,11 +92,13 @@ export const PositronDataExplorer = (props: PropsWithChildren<PositronDataExplor
 			<div className='positron-data-explorer'>
 				<ActionBar />
 				<DataExplorerPanel />
-				{closed && <PositronDataExplorerClosed
-					closedReason={reason}
-					errorMessage={errorMessage}
-					onClose={props.onClose}
-				/>}
+				{closed && (
+					<PositronDataExplorerClosed
+						closedReason={reason}
+						errorMessage={errorMessage}
+						onClose={props.onClose}
+					/>
+				)}
 			</div>
 		</PositronDataExplorerContextProvider>
 	);

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -34,7 +34,7 @@ import { IReactComponentContainer, ISize, PositronReactRenderer } from 'vs/base/
 import { PositronDataExplorerUri } from 'vs/workbench/services/positronDataExplorer/common/positronDataExplorerUri';
 import { IPositronDataExplorerService } from 'vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerService';
 import { PositronDataExplorerEditorInput } from 'vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput';
-import { PositronDataExplorerClosed } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerClosed/positronDataExplorerClosed';
+import { PositronDataExplorerClosed, PositronDataExplorerClosedStatus } from 'vs/workbench/browser/positronDataExplorer/components/dataExplorerClosed/positronDataExplorerClosed';
 
 /**
  * IPositronDataExplorerEditorOptions interface.
@@ -352,6 +352,7 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 			} else {
 				this._positronReactRenderer.render(
 					<PositronDataExplorerClosed
+						closedReason={PositronDataExplorerClosedStatus.UNAVAILABLE}
 						onClose={() => this._group.closeEditor(this.input)}
 					/>
 				);

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeDataExplorerClient.ts
@@ -304,6 +304,11 @@ export class DataExplorerClientInstance extends Disposable {
 		this.cachedBackendState = await this._backendPromise;
 		this._backendPromise = undefined;
 
+		if (this.cachedBackendState.connected === false) {
+			// Halt more requests from going out
+			this.status = DataExplorerClientStatus.Disconnected;
+		}
+
 		// Notify listeners
 		this._onDidUpdateBackendStateEmitter.fire(this.cachedBackendState);
 

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -115,6 +115,18 @@ export interface BackendState {
 	 */
 	supported_features: SupportedFeatures;
 
+	/**
+	 * Optional flag allowing backend to report that it is unable to serve
+	 * requests. This parameter may change.
+	 */
+	connected?: boolean;
+
+	/**
+	 * Optional experimental parameter to provide an explanation when
+	 * connected=false. This parameter may change.
+	 */
+	error_message?: string;
+
 }
 
 /**


### PR DESCRIPTION
Addresses #5133. This was a bit messy but the simplest way I saw to bubble up the error information. I added optional parameters to BackendState that allow an error message to be intercepted and displayed.

![image](https://github.com/user-attachments/assets/9945add9-b469-4329-ae15-34f979620c54)

I need some CSS help to make the div a reasonable relative width and for the text to wrap.