### PR TITLE
Smoke tests: data explorer fixes

### DIFF
--- a/test/automation/src/positron/positronVariables.ts
+++ b/test/automation/src/positron/positronVariables.ts
@@ -132,4 +132,11 @@ export class PositronVariables {
 
 		return result;
 	}
+
+	async selectVariablesGroup(name: string) {
+		await this.code.driver.page.locator('.positron-variables-container .action-bar-button-text').click();
+		await this.code.driver.page.locator('a.action-menu-item', { hasText: name }).isVisible();
+		await this.code.wait(500);
+		await this.code.driver.page.locator('a.action-menu-item', { hasText: name }).click();
+	}
 }

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -163,9 +163,19 @@ df2 = pd.DataFrame(data)`;
 			await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 			await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
 
-			await app.workbench.positronNotebooks.openNotebook(join(app.workspacePathOrFolder, 'workspaces', 'data-explorer-update-datasets', 'pandas-update-dataframe.ipynb'));
+			const filename = 'pandas-update-dataframe.ipynb';
+			await app.workbench.positronNotebooks.openNotebook(join(app.workspacePathOrFolder, 'workspaces', 'data-explorer-update-datasets', filename));
 			await app.workbench.notebook.focusFirstCell();
 			await app.workbench.notebook.executeActiveCell();
+
+			// temporary workaround for fact that variables group
+			// not properly autoselected on web
+			if (app.web) {
+				await app.code.driver.page.locator('.positron-variables-container .action-bar-button-text').click();
+				await app.code.driver.page.locator('a.action-menu-item', { hasText: filename }).isVisible();
+				await app.code.driver.page.locator('a.action-menu-item', { hasText: filename }).click();
+			}
+
 			await expect(async () => {
 				await app.workbench.positronVariables.doubleClickVariableRow('df');
 				await app.code.driver.getLocator('.label-name:has-text("Data: df")').innerText();
@@ -204,8 +214,12 @@ df2 = pd.DataFrame(data)`;
 		});
 	});
 
-	// There is a known issue with the data explorer tests causing them to intermittently fail:
-	// https://github.com/posit-dev/positron/issues/4663
+});
+
+
+describe('Data Explorer #web #win', () => {
+	logger = setupAndStartApp();
+
 	describe('Python Polars Data Explorer #pr', () => {
 		before(async function () {
 			await PositronPythonFixtures.SetupFixtures(this.app as Application);
@@ -346,6 +360,12 @@ df2 = pd.DataFrame(data)`;
 
 		});
 	});
+
+});
+
+
+describe('Data Explorer #web #win', () => {
+	logger = setupAndStartApp();
 
 	describe('R Data Explorer', () => {
 

--- a/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
+++ b/test/smoke/src/areas/positron/dataexplorer/dataexplorer.test.ts
@@ -171,9 +171,7 @@ df2 = pd.DataFrame(data)`;
 			// temporary workaround for fact that variables group
 			// not properly autoselected on web
 			if (app.web) {
-				await app.code.driver.page.locator('.positron-variables-container .action-bar-button-text').click();
-				await app.code.driver.page.locator('a.action-menu-item', { hasText: filename }).isVisible();
-				await app.code.driver.page.locator('a.action-menu-item', { hasText: filename }).click();
+				await app.workbench.positronVariables.selectVariablesGroup(filename);
 			}
 
 			await expect(async () => {


### PR DESCRIPTION
Break data explorer tests into separate app instances and add variables selection workaround for web.

### QA Notes

All smoke tests should pass.
