### PR TITLE
e2e: untagging expanded-variables from windows

### DIFF
--- a/test/smoke/src/areas/positron/variables/variables-expanded.test.ts
+++ b/test/smoke/src/areas/positron/variables/variables-expanded.test.ts
@@ -7,7 +7,7 @@ import { expect } from '@playwright/test';
 import { Application, PositronPythonFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 
-describe('Variables - Expanded View #web #win', () => {
+describe('Variables - Expanded View #web', () => {
 	setupAndStartApp();
 
 	beforeEach(async function () {


### PR DESCRIPTION
Untagging expanded variables test from windows run.

### QA Notes
n/a
