### PR TITLE
Use `echo = TRUE` for R source command

### DIFF
--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -150,7 +150,7 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 				// In the future, we may want to shorten the path by making it
 				// relative to the current working directory.
 				if (filePath) {
-					const command = `source(${JSON.stringify(filePath)})`;
+					const command = `source(${JSON.stringify(filePath)}, echo = TRUE)`;
 					positron.runtime.executeCode('r', command, false);
 				}
 			} catch (e) {


### PR DESCRIPTION
Addresses #5191


### QA Notes

With this change, the `r.sourceCurrentFile` command (which you can use, for example, by clicking the play button on an `.R` file) now uses `echo = TRUE`:

![echo-true](https://github.com/user-attachments/assets/f194272e-31c7-4890-800e-dc2ce83f44be)
