### PR TITLE
Smoke tests: reliability fixes for notebook and rmarkdown tests

### DIFF
--- a/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
+++ b/test/smoke/src/areas/positron/notebook/notebookCreate.test.ts
@@ -29,12 +29,18 @@ describe('Notebooks #pr #web #win', () => {
 		});
 
 		it('R - Basic notebook creation and execution (code) [C628629]', async function () {
+
+			this.retries(1);
+
 			await notebooks.addCodeToFirstCell('eval(parse(text="8**2"))');
 			await notebooks.executeCodeInCell();
 			await notebooks.assertCellOutput('[1] 64');
 		});
 
 		it('R - Basic notebook creation and execution (markdown) [C628630]', async function () {
+
+			this.retries(1);
+
 			const randomText = Math.random().toString(36).substring(7);
 
 			await app.workbench.notebook.insertNotebookCell('markdown');
@@ -64,12 +70,18 @@ describe('Notebooks #pr #web #win', () => {
 		});
 
 		it('Python - Basic notebook creation and execution (code) [C628631]', async function () {
+
+			this.retries(1);
+
 			await notebooks.addCodeToFirstCell('eval("8**2")');
 			await notebooks.executeCodeInCell();
 			await notebooks.assertCellOutput('64');
 		});
 
 		it('Python - Basic notebook creation and execution (markdown) [C628632]', async function () {
+
+			this.retries(1);
+
 			const randomText = Math.random().toString(36).substring(7);
 
 			await app.workbench.notebook.insertNotebookCell('markdown');

--- a/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
+++ b/test/smoke/src/areas/positron/rmarkdown/rmarkdown.test.ts
@@ -38,6 +38,9 @@ describe('RMarkdown #web', () => {
 
 	// test depends on the previous test
 	it('Preview RMarkdown [C709147]', async function () {
+
+		this.timeout(90000);
+
 		const app = this.app as Application; //Get handle to application
 
 		// Preview
@@ -47,7 +50,7 @@ describe('RMarkdown #web', () => {
 		// not factoring this locator because its not part of positron
 		const gettingStarted = app.workbench.positronViewer.getViewerFrame().frameLocator('iframe').locator('h2[data-anchor-id="getting-started"]');
 
-		await expect(gettingStarted).toBeVisible({ timeout: 30000 });
+		await expect(gettingStarted).toBeVisible({ timeout: 60000 });
 		await expect(gettingStarted).toHaveText('Getting started');
 	});
 });


### PR DESCRIPTION
Enable retries for notebook tests

Wait longer for RMarkdown render

### QA Notes

All smoke tests should pass
