### PR TITLE
Smoke tests: possible fix for streamlit app test

### DIFF
--- a/test/smoke/src/areas/positron/apps/python-apps.test.ts
+++ b/test/smoke/src/areas/positron/apps/python-apps.test.ts
@@ -57,6 +57,9 @@ describe('Python Applications #pr #win', () => {
 		});
 
 		it('Python - Verify Basic Streamlit App [C903308] #web', async function () {
+
+			this.timeout(90000);
+
 			const app = this.app as Application;
 			const viewer = app.workbench.positronViewer;
 
@@ -68,7 +71,11 @@ describe('Python Applications #pr #win', () => {
 			const headerLocator = this.app.web
 				? viewerFrame.frameLocator('iframe').getByRole('button', { name: 'Deploy' })
 				: viewerFrame.getByRole('button', { name: 'Deploy' });
-			await expect(headerLocator).toBeVisible({ timeout: 30000 });
+
+			await expect(async () => {
+				await expect(headerLocator).toBeVisible({ timeout: 30000 });
+			}).toPass({ timeout: 60000 });
+
 			await app.workbench.positronLayouts.enterLayout('stacked');
 		});
 	});


### PR DESCRIPTION
We have observed that toBeVisible might not function as expected with respect to the timeout in cases where the element be waited on belongs inside a structure that itself is not yet visible.  This fix attempts to rectify this.

### QA Notes

All smoke tests pass
