### PR TITLE
fix folder creation errors on Windows; disallow empty input in new folder modals

### DIFF
--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -130,7 +130,6 @@ export class PositronNewFolderAction extends Action2 {
 			accessor.get(IFileService),
 			accessor.get(IKeybindingService),
 			accessor.get(IWorkbenchLayoutService),
-			accessor.get(IPathService)
 		);
 	}
 }

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators.ts
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators.ts
@@ -119,8 +119,7 @@ export async function checkIfURIExists(path: URI, fileService: IFileService): Pr
  * @returns Whether the input is empty.
  */
 export function isInputEmpty(input: string | number): boolean {
-	const inputString = typeof input === 'number' ? input.toString() : input;
-	return inputString.trim() === '';
+	return typeof input === 'number' ? false : input.trim() === '';
 }
 
 /**

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators.ts
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators.ts
@@ -114,6 +114,16 @@ export async function checkIfURIExists(path: URI, fileService: IFileService): Pr
 }
 
 /**
+ * Check if the input is empty.
+ * @param input The input to check if it is empty.
+ * @returns Whether the input is empty.
+ */
+export function isInputEmpty(input: string | number): boolean {
+	const inputString = typeof input === 'number' ? input.toString() : input;
+	return inputString.trim() === '';
+}
+
+/**
  * Helper function to print paths in a more readable format.
  * @param path Full path to sanitize.
  * @returns The sanitized path.

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
@@ -68,7 +68,7 @@ export const showNewFolderFromGitModalDialog = async (
 						await commandService.executeCommand(
 							'git.clone',
 							result.repo,
-							result.parentFolder.path
+							result.parentFolder.fsPath
 						);
 					} finally {
 						configurationService.updateValue(kGitOpenAfterClone, prevOpenAfterClone);
@@ -163,7 +163,7 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 						'positron.createFolderAsSubfolderOf',
 						"Create folder as subfolder of"
 					))()}
-					value={result.parentFolder.path}
+					value={result.parentFolder.fsPath}
 					onBrowse={browseHandler}
 					onChange={e => setResult({ ...result, parentFolder: result.parentFolder.with({ path: e.target.value }) })}
 				/>

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
@@ -25,6 +25,7 @@ import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalRe
 import { LabeledTextInput } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/labeledTextInput';
 import { OKCancelModalDialog } from 'vs/workbench/browser/positronComponents/positronModalDialog/positronOKCancelModalDialog';
 import { LabeledFolderInput } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/labeledFolderInput';
+import { isInputEmpty } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators';
 
 /**
  * Shows the new folder from Git modal dialog.
@@ -142,6 +143,9 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 			))()}
 			catchErrors
 			onAccept={async () => {
+				if (isInputEmpty(result.repo)) {
+					throw new Error(localize('positron.gitRepoNotProvided', "A git repository URL was not provided."));
+				}
 				await props.createFolder(result);
 				props.renderer.dispose();
 			}}

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
@@ -60,8 +60,7 @@ export const showNewFolderModalDialog = async (
 			parentFolder={await fileDialogService.defaultFolderPath()}
 			createFolder={async result => {
 				// Create the folder path.
-				const path = await pathService.path;
-				const folderURI = result.parentFolder.with({ path: path.join(result.parentFolder.path, result.folder) });
+				const folderURI = URI.joinPath(result.parentFolder, result.folder);
 
 				// Create the new folder, if it doesn't already exist.
 				if (!(await fileService.exists(folderURI))) {
@@ -160,7 +159,7 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 						'positron.createFolderAsSubfolderOf',
 						"Create folder as subfolder of"
 					))()}
-					value={result.parentFolder.path}
+					value={result.parentFolder.fsPath}
 					onBrowse={browseHandler}
 					onChange={e => setResult({ ...result, parentFolder: result.parentFolder.with({ path: e.target.value }) })}
 				/>

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
@@ -25,7 +25,7 @@ import { PositronModalReactRenderer } from 'vs/workbench/browser/positronModalRe
 import { LabeledTextInput } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/labeledTextInput';
 import { OKCancelModalDialog } from 'vs/workbench/browser/positronComponents/positronModalDialog/positronOKCancelModalDialog';
 import { LabeledFolderInput } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/labeledFolderInput';
-import { checkIfPathValid } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators';
+import { checkIfPathValid, isInputEmpty } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators';
 
 /**
  * Shows the new folder modal dialog.
@@ -138,6 +138,9 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 			title={(() => localize('positronNewFolderModalDialogTitle', "New Folder"))()}
 			catchErrors
 			onAccept={async () => {
+				if (isInputEmpty(result.folder)) {
+					throw new Error(localize('positron.folderNameNotProvided', "A folder name was not provided."));
+				}
 				await props.createFolder(result);
 				props.renderer.dispose();
 			}}

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
@@ -16,7 +16,6 @@ import { URI } from 'vs/base/common/uri';
 import { IFileService } from 'vs/platform/files/common/files';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
-import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { Checkbox } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/checkbox';
@@ -35,7 +34,6 @@ import { checkIfPathValid } from 'vs/workbench/browser/positronComponents/positr
  * @param fileService The file service.
  * @param keybindingService The keybinding service.
  * @param layoutService The layout service.
- * @param pathService The path service.
  */
 export const showNewFolderModalDialog = async (
 	commandService: ICommandService,
@@ -43,7 +41,6 @@ export const showNewFolderModalDialog = async (
 	fileService: IFileService,
 	keybindingService: IKeybindingService,
 	layoutService: IWorkbenchLayoutService,
-	pathService: IPathService
 ): Promise<void> => {
 	// Create the renderer.
 	const renderer = new PositronModalReactRenderer({

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -29,6 +29,7 @@ import { EnvironmentSetupType, NewProjectWizardStep } from 'vs/workbench/browser
 import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 import { showChooseNewProjectWindowModalDialog } from 'vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { URI } from 'vs/base/common/uri';
 
 /**
  * Shows the NewProjectModalDialog.
@@ -80,7 +81,7 @@ export const showNewProjectModalDialog = async (
 				renderer={renderer}
 				createProject={async result => {
 					// Create the new project folder if it doesn't already exist.
-					const folder = result.parentFolder.with({ path: (await pathService.path).join(result.parentFolder.fsPath, result.projectName) });
+					const folder = URI.joinPath(result.parentFolder, result.projectName);
 					const existingFolder = await fileService.exists(folder);
 					if (!existingFolder) {
 						await fileService.createFolder(folder);

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -153,7 +153,7 @@ describe('New Project Wizard', () => {
 			});
 		});
 
-		it('Default Python Project with git init [C674522] #pr', async function () {
+		it('Default Python Project with git init [C674522] #pr #win', async function () {
 			const projSuffix = addRandomNumSuffix('_gitInit');
 			const app = this.app as Application;
 			const pw = app.workbench.positronNewProjectWizard;
@@ -191,7 +191,7 @@ describe('New Project Wizard', () => {
 	});
 
 	describe('R - New Project Wizard', () => {
-		it('R Project Defaults [C627913] #pr', async function () {
+		it('R Project Defaults [C627913] #pr #win', async function () {
 			const app = this.app as Application;
 			const pw = app.workbench.positronNewProjectWizard;
 			await pw.startNewProject(ProjectType.R_PROJECT);


### PR DESCRIPTION
- addresses: #5195 
- since I was in the area, I added a fix for https://github.com/posit-dev/positron/issues/2777 to disallow the modal accept if no folder name or git repo was entered

### QA Notes

I've tested on Windows 11 Desktop, Mac Desktop, Mac Server Web and Linux REH-Web.

Each of the following modals should now work for creating a new folder/project on Windows.
- New Folder
- New Folder from Git
- New Project

Clicking <kbd>OK</kbd> in New Folder and New Folder from Git modals without entering a folder name or git repo now shows and error and doesn't proceed unless the user tries again with the required input.