### PR TITLE
User configurable R location

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -188,6 +188,24 @@
         "type": "object",
         "title": "%r.configuration.title-dev%",
         "properties": {
+          "positron.r.customRootFolders": {
+            "scope": "window",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "markdownDescription": "%r.configuration.customRootFolders.markdownDescription%"
+          },
+          "positron.r.customBinaries": {
+            "scope": "window",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "markdownDescription": "%r.configuration.customBinaries.markdownDescription%"
+          },
           "positron.r.kernel.path": {
             "scope": "window",
             "type": "string",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -31,6 +31,8 @@
 	"r.menu.rmarkdownRender.title": "Render Document With R Markdown",
 	"r.configuration.title": "Positron R Language Pack",
 	"r.configuration.title-dev": "Positron R Language Pack (advanced)",
+	"r.configuration.customRootFolders.markdownDescription": "List of additional folders to search for R installations. These folders are searched after and in the same way as the default folder for your operating system (e.g. `C:/Program Files/R` on Windows).",
+	"r.configuration.customBinaries.markdownDescription": "List of additional R binaries. If you want to use an R installation that is not automatically discovered, provide the path to its binary here. For example, on Windows this might look like `C:/some/unusual/location/R-4.4.1/bin/x64/R.exe`.",
 	"r.configuration.kernelPath.description": "Path on disk to the ARK kernel executable; use this to override the default (embedded) kernel. Note that this is not the path to R.",
 	"r.configuration.tracing.description": "Traces the communication between VS Code and the language server",
 	"r.configuration.tracing.off.description": "No tracing.",

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -300,7 +300,7 @@ function userRBinaries(): string[] {
 	const userBinaries = config.get<string[]>('customBinaries');
 	if (userBinaries && userBinaries.length > 0) {
 		const formattedPaths = JSON.stringify(userBinaries, null, 2);
-		LOGGER.info(`User-specified R binaries:\n${userBinaries}`);
+		LOGGER.info(`User-specified R binaries:\n${formattedPaths}`);
 		return userBinaries;
 	} else {
 		return [];

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -79,8 +79,7 @@ export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRun
 	}
 
 	// same as above but user-specified, ad hoc binaries
-	const userPossibleBinaries: string[] = vscode.workspace.getConfiguration('positron-r')
-		.get('customBinaries', []);
+	const userPossibleBinaries = userRBinaries();
 	const userMoreBinaries = userPossibleBinaries
 		.filter(b => fs.existsSync(b))
 		.map(b => fs.realpathSync(b));
@@ -290,6 +289,19 @@ function userRHeadquarters(): string[] {
 		const formattedPaths = JSON.stringify(userHqDirs, null, 2);
 		LOGGER.info(`User-specified directories to scan for R installations:\n${formattedPaths}`);
 		return userHqDirs;
+	} else {
+		return [];
+	}
+}
+
+// ad hoc binaries this user wants Positron to know about
+function userRBinaries(): string[] {
+	const config = vscode.workspace.getConfiguration('positron.r');
+	const userBinaries = config.get<string[]>('customBinaries');
+	if (userBinaries && userBinaries.length > 0) {
+		const formattedPaths = JSON.stringify(userBinaries, null, 2);
+		LOGGER.info(`User-specified R binaries:\n${userBinaries}`);
+		return userBinaries;
 	} else {
 		return [];
 	}

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -405,18 +405,26 @@ export async function findCurrentRBinary(): Promise<string | undefined> {
 	return cachedRBinary;
 }
 
+let cachedRBinaryFromPATH: string | undefined;
+
 async function findRBinaryFromPATH(): Promise<string | undefined> {
+	if (cachedRBinaryFromPATH !== undefined) {
+		return cachedRBinaryFromPATH;
+	}
+
 	const whichR = await which('R', { nothrow: true }) as string;
 	if (whichR) {
 		LOGGER.info(`Possibly found R on PATH: ${whichR}.`);
 		if (os.platform() === 'win32') {
-			return await findRBinaryFromPATHWindows(whichR);
+			cachedRBinaryFromPATH = await findRBinaryFromPATHWindows(whichR);
 		} else {
-			return await findRBinaryFromPATHNotWindows(whichR);
+			cachedRBinaryFromPATH = await findRBinaryFromPATHNotWindows(whichR);
 		}
 	} else {
-		return undefined;
+		cachedRBinaryFromPATH = undefined;
 	}
+
+	return cachedRBinaryFromPATH;
 }
 
 export async function findRBinaryFromPATHWindows(whichR: string): Promise<string | undefined> {


### PR DESCRIPTION
Addresses #2235 

Adds 2 configuration points:

* `positron.r.customRootFolders` is an array. Each entry is a folder that is searched for 1 or more R installations.
* `positron.r.customBinaries` is an array. Each entry is the path to a specific R binary.

### QA Notes

It's hard to get into a position where this configuration comes into play, because you have to make sure that four methods of automatic discovery _won't work_. I'm focusing on Windows because that's the main OS that drives the need for this.

* Install R at a non-standard location. This will have to be via the CRAN installer since rig doesn't give you any choice about this. Therefore I removed my rig-installed released version of R and re-installed released R with the CRAN installer below `C:/nonstandardRLocation/`. Make sure to **uncheck the box** to write to the registry! If you forget or you're doing this with an existing installation, you can remove the registry keys with `C:/nonstandardRLocation/R-4.4.1/bin/x64/RSetReg.exe /U` (note the `/U` argument for **un**setting keys). All R installations on Windows ship with this executable for setting/unsetting registry keys.
* Now use rig (or other means) to make *some other R version* the current version. In my setup, R 4.2.3 and 4.3.3 are good candidates for the new current version of R, e.g. `rig default 4.3.3`.
* Make sure this R installation is not on the PATH.
* Fire up Positron. The interpreter drop down should not include this R version that is
  - not in the standard root folder for R, i.e. not in `C:/Program Files/R` nor in `C:/Users/<Username>/AppData/Local/Programs/R`
  - not the current version of R
  - not recorded in the registry
  - not on the PATH
 
Use the command palette to do *Preferences: Open Settings*. Go to *Extensions > R > Positron R Language Pack (advanced)* and do each of these, in turn:

* In *Custom Binaries*, add the path to the nonstandard R binary, e.g. `C:/nonstandardRLocation/R-4.4.1/bin/x64/R.exe`
* In *Custom Root Folders*, add the parent folder of the nonstandard R version, e.g. `C:/nonstandardRLocation`

Fire up Positron again. Either of these settings should make the nonstandard installation appear in the interpreter dropdown.

Other things that can be noticed in the Positron R output channel:

* In the presence of custom binaries, you'll see something like this:
  
      2024-10-30 01:03:07.761 [info] User-specified R binaries:
      [
        "C:/nonstandardRLocation/R-4.4.1-bin/x64.R.exe"
      ]
* In the presence of a custom root folder, you'll see something like this:

      2024-10-30 00:56:15.137 [info] User-specified directories to scan for R installations:
      [
        "C:/nonstandardRLocation"
      ]
