### PR TITLE
Data Explorer: Do not swallow column profile errors nor fail to return a result, work around Windows numpy.int32 histogram bug

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -2876,6 +2876,31 @@ def test_pandas_polars_profile_frequency_table(dxf: DataExplorerFixture):
             assert result[0]["small_frequency_table"] == ex_result
 
 
+def test_profile_histogram_windows_int32_bug():
+    # See #5176 -- we catch errors caused by a bug in NumPy and cast
+    # integer arrays to float as a fallback strategy to compute histograms
+    from ..data_explorer import _get_histogram_numpy
+
+    arr = np.array(
+        [
+            -428566661,
+            1901704889,
+            957355142,
+            -401364305,
+            -1978594834,
+            519144975,
+            1384373326,
+            1974689646,
+            194821408,
+            -1564699930,
+        ],
+        dtype=np.int32,
+    )
+    result = _get_histogram_numpy(arr, 10, method="fd")[0]
+    expected = _get_histogram_numpy(arr.astype(np.float64), 10, method="fd")[0]
+    assert (result == expected).all()
+
+
 # ----------------------------------------------------------------------
 # polars backend functionality tests
 


### PR DESCRIPTION
Addresses #5176. When an exception was raised when computing a column profile, it was crashing the asynchronous task and causing the timeout on the frontend to timeout after 60 seconds. Firstly, we log these errors and do not crash the asynchronous task when a single column profile fails to compute.

Secondly, the bug in #5176 was caused by `numpy.histogram` erroring on the `column_5_Int32` column. I was able to reduce this bug to a small example that fails on Windows 64-bit (NumPy 2.1.1).

```python
In [1]: import numpy as np

In [2]: arr = np.array([ -428566661,  1901704889,   957355142,  -401364305, -1978594834,^M
   ...:                519144975,  1384373326,  1974689646,   194821408, -1564699930], dtype=np.int32)^M
   ...: np.histogram(arr)^M
   ...:
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<snip>
IndexError: index -45 is out of bounds for axis 0 with size 11
```

This looks like a NumPy bug so I will report upstream. Added a unit test so we are protected against this class of error here again.