### PR TITLE
update workbench extension version number

### DIFF
--- a/product.json
+++ b/product.json
@@ -223,10 +223,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "1.5.7",
+			"version": "1.5.13",
 			"s3Bucket": "rsw-vscode-extension",
 			"type": "reh-web",
-			"sha256": "9ac536b65c91fd86274fe2cbb2ea2c381e13ba309027044bc98438730c4fa66c",
+			"sha256": "bfa920d48646f4828f83dc2dbc553e12c5871d6cd75182a0427ef3db4364733f",
 			"metadata": {
 				"publisherDisplayName": "Posit PBC"
 			}


### PR DESCRIPTION
Bump the Workbench extension version to 1.5.13 to match upstream. Normally this will be updated by the upstream merge, but since that process is on hold I'm updating the number manually so we can do some testing.

### QA Notes
This will be tested on the Workbench side. FYI @Trevor-Reid 
