### PR TITLE
Bump version to 2024.12

### DIFF
--- a/product.json
+++ b/product.json
@@ -1,7 +1,7 @@
 {
 	"nameShort": "Positron",
 	"nameLong": "Positron",
-	"positronVersion": "2024.11.0",
+	"positronVersion": "2024.12.0",
 	"positronBuildNumber": 0,
 	"applicationName": "positron",
 	"dataFolderName": ".positron",

--- a/versions/2024.12.0.commit
+++ b/versions/2024.12.0.commit
@@ -1,0 +1,1 @@
+e0d844b031f95acbf89f234a2cce2af9b6721f6c


### PR DESCRIPTION
Bumps the version to 2024.12 as we've now branched the 2024.11 release.