### PR TITLE
Update how commands to source R files work

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -121,6 +121,12 @@
         "icon": "$(play)"
       },
       {
+        "command": "r.sourceCurrentFileWithEcho",
+        "category": "R",
+        "title": "%r.command.sourceCurrentFileWithEcho.title%",
+        "icon": "$(play)"
+      },
+      {
         "command": "workbench.action.positronConsole.executeCode",
         "category": "R",
         "title": "%r.command.executeSelectionInConsole.title%",
@@ -441,6 +447,13 @@
         },
         {
           "category": "R",
+          "command": "r.sourceCurrentFileWithEcho",
+          "icon": "$(play)",
+          "title": "%r.command.sourceCurrentFileWithEcho.title%",
+          "when": "editorLangId == r"
+        },
+        {
+          "category": "R",
           "command": "workbench.action.positronConsole.executeCode",
           "icon": "$(play)",
           "title": "%r.command.executeSelectionInConsole.title%",
@@ -537,6 +550,13 @@
           "group": "navigation@0",
           "icon": "$(play)",
           "title": "%r.command.sourceCurrentFile.title%",
+          "when": "resourceLangId == r && !isInDiffEditor && !isRPackage"
+        },
+        {
+          "command": "r.sourceCurrentFileWithEcho",
+          "group": "navigation@0",
+          "icon": "$(play)",
+          "title": "%r.command.sourceCurrentFileWithEcho.title%",
           "when": "resourceLangId == r && !isInDiffEditor && !isRPackage"
         },
         {

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -3,6 +3,7 @@
 	"description": "R Language Pack for Positron",
 	"r.capabilities.untrustedWorkspaces.description": "R cannot be started in untrusted folders.",
 	"r.command.sourceCurrentFile.title": "Source R File",
+	"r.command.sourceCurrentFileWithEcho.title": "Source R File with Echo",
 	"r.command.executeSelectionInConsole.title": "Run Selection in Console",
 	"r.command.createNewFile.title": "New R File",
 	"r.command.packageLoad.title": "Load R Package",

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -143,24 +143,12 @@ export async function registerCommands(context: vscode.ExtensionContext) {
 			await vscode.commands.executeCommand('workbench.action.languageRuntime.select', 'r');
 		}),
 
-		// Command used to source the current file
+		// Commands used to source the current file
 		vscode.commands.registerCommand('r.sourceCurrentFile', async () => {
-			try {
-				const filePath = await getEditorFilePathForCommand();
-				// In the future, we may want to shorten the path by making it
-				// relative to the current working directory.
-				if (filePath) {
-					const command = `source(${JSON.stringify(filePath)}, echo = TRUE)`;
-					positron.runtime.executeCode('r', command, false);
-				}
-			} catch (e) {
-				// This is not a valid file path, which isn't an error; it just
-				// means the active editor has something loaded into it that
-				// isn't a file on disk.  In Positron, there is currently a bug
-				// which causes the REPL to act like an active editor. See:
-				//
-				// https://github.com/posit-dev/positron/issues/780
-			}
+			sourceCurrentFile(false);
+		}),
+		vscode.commands.registerCommand('r.sourceCurrentFileWithEcho', async () => {
+			sourceCurrentFile(true);
 		}),
 
 		// Command used to source the current file
@@ -332,4 +320,27 @@ export async function getEditorFilePathForCommand() {
 		return filePath.replace(/\\/g, '/');
 	}
 	return;
+}
+
+async function sourceCurrentFile(echo: boolean) {
+	try {
+		const filePath = await getEditorFilePathForCommand();
+		// In the future, we may want to shorten the path by making it
+		// relative to the current working directory.
+		if (filePath) {
+			let command = `source(${JSON.stringify(filePath)})`;
+			if (echo) {
+				command = `source(${JSON.stringify(filePath)}, echo = TRUE)`;
+			}
+			positron.runtime.executeCode('r', command, false);
+		}
+	} catch (e) {
+		// This is not a valid file path, which isn't an error; it just
+		// means the active editor has something loaded into it that
+		// isn't a file on disk.  In Positron, there is currently a bug
+		// which causes the REPL to act like an active editor. See:
+		//
+		// https://github.com/posit-dev/positron/issues/780
+	}
+
 }

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -170,6 +170,13 @@
         "key": "ctrl+shift+s",
         "when": "config.rstudio.keymap.enable && editorLangId == r",
         "command": "r.sourceCurrentFile"
+      },      {
+        "mac": "cmd+shift+enter",
+        "win": "ctrl+shift+enter",
+        "linux": "ctrl+shift+enter",
+        "key": "ctrl+shift+enter",
+        "when": "config.rstudio.keymap.enable && editorLangId == r",
+        "command": "r.sourceCurrentFileWithEcho"
       },
       {
         "mac": "cmd+shift+m",


### PR DESCRIPTION
Related to https://github.com/posit-dev/positron/pull/5200

I don't think we quite got there on making this behavior similar enough to RStudio for folks. Notice that there are two commands:

![Screenshot 2024-10-31 at 1 25 21 PM](https://github.com/user-attachments/assets/c9f911a5-e41a-4868-bbcd-7473a782eae1)

In RStudio, this button "remembers" which one you chose last time so it is understandable that folks (including me!) think it just works in a certain way. However, it will be better to provide both. This will let folks who are building a "Source on Save" keybinding or rule, as outlined in https://github.com/posit-dev/positron/pull/5200#issuecomment-2447294244, to still have access to `r.sourceCurrentFile`.


### QA Notes

We can now either source with `echo = TRUE` or without an arg there, in which case it will use `getOption("verbose")`. I set up the keybinding in the RStudio Keymap as well.
