### PR TITLE
Fix loading react, react-dom, and react-dom/client.js for unit tests

### DIFF
--- a/src/vs/loader.js
+++ b/src/vs/loader.js
@@ -1614,7 +1614,7 @@ var AMDLoader;
 					// The set of original paths adjust.
 					const reactDomClientElectron = `/out/../node_modules/react-dom/umd/react-dom.${edition}.js/client.js`;
 					const reactDomClientWeb = `remote/web/node_modules/react-dom/umd/react-dom.${edition}.js/client.js`;
-					// REH web release builds load from 'static'
+					// REH web release builds load from 'static'.
 					const reactDomClientRehWeb = `static/node_modules/react-dom/umd/react-dom.${edition}.js/client.js`;
 
 					// Attempt to adjust the original path.
@@ -1624,6 +1624,14 @@ var AMDLoader;
 						paths[0] = `${paths[0].substr(0, paths[0].length - reactDomClientWeb.length)}out/react-dom/client.js`;
 					} else if (paths[0].endsWith(reactDomClientRehWeb)) {
 						paths[0] = `${paths[0].substr(0, paths[0].length - reactDomClientRehWeb.length)}static/out/react-dom/client.js`;
+					} else {
+						// Unit tests load client.js from 'http://localhost'. For example:
+						// http://localhost:51262/e9416c1769b269baf1f33978a0695be1/node_modules/react-dom/umd/react-dom.production.min.js/client.js
+						const reactDomClientLocalhost = /(http:\/\/localhost:[0-9]+\/[0-9A-Fa-f]+)(\/node_modules\/react-dom\/umd\/react-dom.production.min.js\/client.js)/;
+						const result = paths[0].match(reactDomClientLocalhost);
+						if (result && result.length === 3) {
+							paths[0] = `${result[1]}/out/react-dom/client.js`;
+						}
 					}
 				}
 

--- a/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
@@ -7,19 +7,19 @@
 import 'vs/css!./editorActionBarControl';
 
 // React.
-// import * as React from 'react';
+import * as React from 'react';
 
 // Other dependencies.
 import { Emitter } from 'vs/base/common/event';
-// import { IHoverService } from 'vs/platform/hover/browser/hover';
+import { IHoverService } from 'vs/platform/hover/browser/hover';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
-// import { ICommandService } from 'vs/platform/commands/common/commands';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IEditorGroupView } from 'vs/workbench/browser/parts/editor/editor';
-// import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-// import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { PositronReactRenderer } from 'vs/base/browser/positronReactRenderer';
-// import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
-// import { EditorActionBar } from 'vs/workbench/browser/parts/editor/editorActionBar';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { EditorActionBar } from 'vs/workbench/browser/parts/editor/editorActionBar';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
@@ -61,12 +61,12 @@ export class EditorActionBarControl extends Disposable {
 	 */
 	constructor(
 		private readonly _parent: HTMLElement,
-		// @ICommandService private readonly _commandService: ICommandService,
-		// @IConfigurationService private readonly _configurationService: IConfigurationService,
-		// @IContextKeyService private readonly _contextKeyService: IContextKeyService,
-		// @IContextMenuService private readonly _contextMenuService: IContextMenuService,
-		// @IHoverService private readonly _hoverService: IHoverService,
-		// @IKeybindingService private readonly _keybindingService: IKeybindingService,
+		@ICommandService private readonly _commandService: ICommandService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
+		@IHoverService private readonly _hoverService: IHoverService,
+		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 	) {
 		// Call the base class's constructor.
 		super();
@@ -77,17 +77,17 @@ export class EditorActionBarControl extends Disposable {
 		this._parent.appendChild(this._container);
 
 		// Render the editor action bar component in the editor action bar container.
-		// this._positronReactRenderer = new PositronReactRenderer(this._container);
-		// this._positronReactRenderer.render(
-		// 	<EditorActionBar
-		// 		commandService={this._commandService}
-		// 		configurationService={this._configurationService}
-		// 		contextKeyService={this._contextKeyService}
-		// 		contextMenuService={this._contextMenuService}
-		// 		hoverService={this._hoverService}
-		// 		keybindingService={this._keybindingService}
-		// 	/>
-		// );
+		this._positronReactRenderer = new PositronReactRenderer(this._container);
+		this._positronReactRenderer.render(
+			<EditorActionBar
+				commandService={this._commandService}
+				configurationService={this._configurationService}
+				contextKeyService={this._contextKeyService}
+				contextMenuService={this._contextMenuService}
+				hoverService={this._hoverService}
+				keybindingService={this._keybindingService}
+			/>
+		);
 	}
 
 	/**

--- a/test/unit/browser/renderer.html
+++ b/test/unit/browser/renderer.html
@@ -60,7 +60,11 @@
 				'@xterm/xterm': new URL('../../../node_modules/@xterm/xterm/lib/xterm.js', baseUrl).href,
 				'@vscode/iconv-lite-umd': new URL('../../../node_modules/@vscode/iconv-lite-umd/lib/iconv-lite-umd.js', baseUrl).href,
 				'@vscode/tree-sitter-wasm': new URL('../../../node_modules/@vscode/tree-sitter-wasm/wasm/tree-sitter.js', baseUrl).href,
-				jschardet: new URL('../../../node_modules/jschardet/dist/jschardet.min.js', baseUrl).href
+				jschardet: new URL('../../../node_modules/jschardet/dist/jschardet.min.js', baseUrl).href,
+				// --- Start Positron ---
+                'react': new URL('../../../node_modules/react/umd/react.production.min.js', baseUrl).href,
+                'react-dom': new URL('../../../node_modules/react-dom/umd/react-dom.production.min.js', baseUrl).href,
+				// --- End Positron ---
 			}
 		});
 	</script>


### PR DESCRIPTION
### Description

This PR fixes how `react`, `react-dom`, and `react-dom/client.js` are loaded in unit tests. This fixes the unit test hang that was seen as a result of https://github.com/posit-dev/positron/pull/5181.

### QA Notes

`yarn test-browser-no-install --browser chromium` is now working again. If you run:

`yarn test-browser-no-install --browser chromium --debug`

You will see new output that shows how we are loading `react-dom/client.js`:

```
loader.js:1641 ------------------------------------------------------------------------
loader.js:1641 Changing where the react-dom client.js file is loaded from.
loader.js:1642 Original path: http://localhost:59048/46eec0d9769be1346e735ed63b8fd4da/node_modules/react-dom/umd/react-dom.production.min.js/client.js
loader.js:1643 Adjusted path: http://localhost:59048/46eec0d9769be1346e735ed63b8fd4da/out/react-dom/client.js
loader.js:1648 ------------------------------------------------------------------------
```

<img width="1395" alt="image" src="https://github.com/user-attachments/assets/97a05644-753b-4b45-9fa8-a3767877779a">

This work also fixes the long-standing warnings that were happening when loading the `notebookServiceImpl.test` module:

![image](https://github.com/user-attachments/assets/c92b0337-6dfd-4fe5-b52a-78df7f2051c2)

