### PR TITLE
Smoke tests: fix for gradio test

### DIFF
--- a/test/smoke/src/areas/positron/apps/python-apps.test.ts
+++ b/test/smoke/src/areas/positron/apps/python-apps.test.ts
@@ -48,12 +48,17 @@ describe('Python Applications #pr #win', () => {
 		});
 
 		it('Python - Verify Basic Gradio App [C903307]', async function () {
+
+			this.timeout(90000);
+
 			const app = this.app as Application;
 			const viewer = app.workbench.positronViewer;
 
 			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'python_apps', 'gradio_example', 'gradio_example.py'));
 			await app.workbench.positronEditor.pressPlay();
-			await expect(viewer.getViewerFrame().getByRole('button', { name: 'Submit' })).toBeVisible({ timeout: 30000 });
+			await expect(async () => {
+				await expect(viewer.getViewerFrame().getByRole('button', { name: 'Submit' })).toBeVisible({ timeout: 30000 });
+			}).toPass({ timeout: 60000 });
 		});
 
 		it('Python - Verify Basic Streamlit App [C903308] #web', async function () {


### PR DESCRIPTION
expect().toBeVisible() seems to be unreliable in terms of its timeout when the containing structure is not present... nested frames here, specifically.

### QA Notes

All smoke tests pass
