### PR TITLE
Jupyter Supervisor: fix server reconnect in dev mode

### DIFF
--- a/extensions/kallichore-adapter/package.json
+++ b/extensions/kallichore-adapter/package.json
@@ -89,7 +89,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.15"
+      "kallichore": "0.1.17"
     }
   },
   "dependencies": {

--- a/extensions/kallichore-adapter/src/jupyter/JupyterRequest.ts
+++ b/extensions/kallichore-adapter/src/jupyter/JupyterRequest.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { WebSocket } from 'ws';
 import { JupyterChannel } from './JupyterChannel';
 import { PromiseHandles } from '../async';
 import { JupyterCommand } from './JupyterCommand';


### PR DESCRIPTION
This change fixes an issue that causes buggy reconnects in dev environments. There's nothing really meaningful here on the Positron side except for some better status logging; the real change here is bringing in version 0.1.17 of the supervisor. 

The underlying issue is that -- in dev environments -- the extension host is never shut down when the browser is disconnected or closed. In production environments the converse appears to be true; closing the browser causes the extension host to exit immediately. This behavior was surprising to me, as in dev mode it causes zombie extension hosts to accumulate quickly if you reload the browser a few times, but it's not unique to Positron; a vanilla clone of the upstream repository has exactly the same behavior.

Because the old extension host is not shut down, the WebSocket connection between Positron and the supervisor is never closed. When the new extension host starts after the reload, it makes a _second_ (or third, or fourth...) WebSocket connection to the supervisor. The supervisor didn't handle this correctly, and wound up spreading the messages evenly among all the connected clients, which confused them very much.

The fix is on the supervisor end, and it's basically just to discard any existing WebSocket clients when a new one tries to connect to a given session.

Addresses https://github.com/posit-dev/positron/issues/5235.

### QA Notes

I think this is only an issue in dev mode, but it's worth checking in a Workbench release just in case.
