### PR TITLE
Include shellscript extension in positron

### DIFF
--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -78,6 +78,9 @@ const compilations = [
 	'extensions/php-language-features/tsconfig.json',
 	'extensions/references-view/tsconfig.json',
 	'extensions/search-result/tsconfig.json',
+	// --- Start Positron ---
+	'extensions/shellscript/tsconfig.json',
+	// --- End Positron ---
 	'extensions/simple-browser/tsconfig.json',
 	'extensions/tunnel-forwarding/tsconfig.json',
 	'extensions/typescript-language-features/test-workspace/tsconfig.json',

--- a/build/npm/dirs.js
+++ b/build/npm/dirs.js
@@ -61,6 +61,9 @@ const dirs = [
 	'extensions/php-language-features',
 	'extensions/references-view',
 	'extensions/search-result',
+	// --- Start Positron ---
+	'extensions/shellscript',
+	// --- End Positron ---
 	'extensions/simple-browser',
 	'extensions/tunnel-forwarding',
 	'extensions/typescript-language-features',

--- a/extensions/shellscript/package.json
+++ b/extensions/shellscript/package.json
@@ -13,6 +13,14 @@
   },
   "categories": ["Programming Languages"],
   "contributes": {
+    "keybindings": [
+      {
+        "command": "workbench.action.terminal.runSelectedText",
+        "key": "ctrl+enter",
+        "mac": "cmd+enter",
+        "when": "editorTextFocus && editorLangId == shellscript"
+      }
+    ],
     "languages": [
       {
         "id": "shellscript",


### PR DESCRIPTION
Addresses #5251
Add a conditional keybinding of Ctrl+Enter (Cmd+Enter on Mac) that sends the current selected text to the active Terminal for editor files of language id 'shellscript'.


#### New Features

- Include the shellscript extension in Positron and add a keybinding to allow commands to be sent to the active Terminal from the editor.

#### Bug Fixes
