### PR TITLE
Update version to 2024.11.1

### DIFF
--- a/product.json
+++ b/product.json
@@ -1,7 +1,7 @@
 {
 	"nameShort": "Positron",
 	"nameLong": "Positron",
-	"positronVersion": "2024.11.0",
+	"positronVersion": "2024.11.1",
 	"positronBuildNumber": 0,
 	"applicationName": "positron",
 	"dataFolderName": ".positron",

--- a/versions/2024.11.1.commit
+++ b/versions/2024.11.1.commit
@@ -1,0 +1,1 @@
+e0d844b031f95acbf89f234a2cce2af9b6721f6c

--- a/versions/create-anchor.js
+++ b/versions/create-anchor.js
@@ -26,12 +26,6 @@ if (fs.existsSync(anchorPath)) {
 	return 0;
 }
 
-const branch = child_process.execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
-if (branch !== 'main') {
-	console.error(`Commit anchors can only be created on the main branch. You're on '${branch}'.`);
-	return 1;
-}
-
 // Create the anchor file with the commit hash at the head of the current branch
 const commit = child_process.execSync('git rev-parse HEAD').toString().trim();
 fs.writeFileSync(anchorPath, commit);


### PR DESCRIPTION
Updates the version on the prerelease branch to 2024.11.1. Also, removes the requirement that you need to be on `main` to bump versions. (I'll also make this change on `main`.)