### PR TITLE
Ignore branch when creating a version anchor

### DIFF
--- a/versions/create-anchor.js
+++ b/versions/create-anchor.js
@@ -26,12 +26,6 @@ if (fs.existsSync(anchorPath)) {
 	return 0;
 }
 
-const branch = child_process.execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
-if (branch !== 'main') {
-	console.error(`Commit anchors can only be created on the main branch. You're on '${branch}'.`);
-	return 1;
-}
-
 // Create the anchor file with the commit hash at the head of the current branch
 const commit = child_process.execSync('git rev-parse HEAD').toString().trim();
 fs.writeFileSync(anchorPath, commit);


### PR DESCRIPTION
We currently insist that you're on `main` when creating an anchor, to avoid anchors being created that result in identical build numbers being applied to different commits. However, this doesn't really apply now that we have release branches with their own build sequence, so we need to relax this restriction. This change just removes the superfluous check.