### PR TITLE
check for appReadyMessage before previewing app

### DIFF
--- a/extensions/positron-python/src/client/positron-run-app.d.ts
+++ b/extensions/positron-python/src/client/positron-run-app.d.ts
@@ -53,7 +53,7 @@ export interface RunAppOptions {
     /**
      * The optional app ready message to wait for in the terminal before previewing the application.
      */
-    appReadyMessage?: string,
+    appReadyMessage?: string;
 }
 
 /**
@@ -87,7 +87,7 @@ export interface DebugAppOptions {
     /**
      * The optional app ready message to wait for in the terminal before previewing the application.
      */
-    appReadyMessage?: string,
+    appReadyMessage?: string;
 }
 
 /**

--- a/extensions/positron-python/src/client/positron-run-app.d.ts
+++ b/extensions/positron-python/src/client/positron-run-app.d.ts
@@ -49,6 +49,11 @@ export interface RunAppOptions {
      * The optional URL path at which to preview the application.
      */
     urlPath?: string;
+
+    /**
+     * The optional app ready message to wait for in the terminal before previewing the application.
+     */
+    appReadyMessage?: string,
 }
 
 /**
@@ -78,9 +83,12 @@ export interface DebugAppOptions {
      * The optional URL path at which to preview the application.
      */
     urlPath?: string;
-}
 
-export interface DebugConfiguration {}
+    /**
+     * The optional app ready message to wait for in the terminal before previewing the application.
+     */
+    appReadyMessage?: string,
+}
 
 /**
  * The public API of the Positron Run App extension.

--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -24,6 +24,7 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             'FastAPI',
             (runtime, document, _urlPrefix) => getFastAPIDebugConfig(serviceContainer, runtime, document),
             '/docs',
+            'Application startup complete',
         ),
         registerExecCommand(Commands.Exec_Flask_In_Terminal, 'Flask', (_runtime, document, _urlPrefix) =>
             getFlaskDebugConfig(document),
@@ -42,6 +43,8 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
         ),
         registerDebugCommand(Commands.Debug_FastAPI_In_Terminal, 'FastAPI', (runtime, document, _urlPrefix) =>
             getFastAPIDebugConfig(serviceContainer, runtime, document),
+            '/docs',
+            'Application startup complete',
         ),
         registerDebugCommand(Commands.Debug_Flask_In_Terminal, 'Flask', (_runtime, document, _urlPrefix) =>
             getFlaskDebugConfig(document),
@@ -67,6 +70,7 @@ function registerExecCommand(
         urlPrefix?: string,
     ) => DebugConfiguration | undefined | Promise<DebugConfiguration | undefined>,
     urlPath?: string,
+    appReadyMessage?: string,
 ): vscode.Disposable {
     return vscode.commands.registerCommand(command, async () => {
         const runAppApi = await getPositronRunAppApi();
@@ -98,6 +102,7 @@ function registerExecCommand(
                 return terminalOptions;
             },
             urlPath,
+            appReadyMessage,
         });
     });
 }
@@ -110,6 +115,8 @@ function registerDebugCommand(
         document: vscode.TextDocument,
         urlPrefix?: string,
     ) => DebugConfiguration | undefined | Promise<DebugConfiguration | undefined>,
+    urlPath?: string,
+    appReadyMessage?: string,
 ): vscode.Disposable {
     return vscode.commands.registerCommand(command, async () => {
         const runAppApi = await getPositronRunAppApi();
@@ -129,6 +136,8 @@ function registerDebugCommand(
                     stopOnEntry: false,
                 };
             },
+            urlPath,
+            appReadyMessage,
         });
     });
 }

--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -34,6 +34,8 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
         ),
         registerExecCommand(Commands.Exec_Shiny_In_Terminal, 'Shiny', (_runtime, document, _urlPrefix) =>
             getShinyDebugConfig(document),
+            undefined,
+            'Application startup complete',
         ),
         registerExecCommand(Commands.Exec_Streamlit_In_Terminal, 'Streamlit', (_runtime, document, _urlPrefix) =>
             getStreamlitDebugConfig(document),
@@ -54,6 +56,8 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
         ),
         registerDebugCommand(Commands.Debug_Shiny_In_Terminal, 'Shiny', (_runtime, document, _urlPrefix) =>
             getShinyDebugConfig(document),
+            undefined,
+            'Application startup complete',
         ),
         registerDebugCommand(Commands.Debug_Streamlit_In_Terminal, 'Streamlit', (_runtime, document, _urlPrefix) =>
             getStreamlitDebugConfig(document),

--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -32,8 +32,10 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
         registerExecCommand(Commands.Exec_Gradio_In_Terminal, 'Gradio', (_runtime, document, urlPrefix) =>
             getGradioDebugConfig(document, urlPrefix),
         ),
-        registerExecCommand(Commands.Exec_Shiny_In_Terminal, 'Shiny', (_runtime, document, _urlPrefix) =>
-            getShinyDebugConfig(document),
+        registerExecCommand(
+            Commands.Exec_Shiny_In_Terminal,
+            'Shiny',
+            (_runtime, document, _urlPrefix) => getShinyDebugConfig(document),
             undefined,
             'Application startup complete',
         ),
@@ -43,8 +45,10 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
         registerDebugCommand(Commands.Debug_Dash_In_Terminal, 'Dash', (_runtime, document, urlPrefix) =>
             getDashDebugConfig(document, urlPrefix),
         ),
-        registerDebugCommand(Commands.Debug_FastAPI_In_Terminal, 'FastAPI', (runtime, document, _urlPrefix) =>
-            getFastAPIDebugConfig(serviceContainer, runtime, document),
+        registerDebugCommand(
+            Commands.Debug_FastAPI_In_Terminal,
+            'FastAPI',
+            (runtime, document, _urlPrefix) => getFastAPIDebugConfig(serviceContainer, runtime, document),
             '/docs',
             'Application startup complete',
         ),
@@ -54,8 +58,10 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
         registerDebugCommand(Commands.Debug_Gradio_In_Terminal, 'Gradio', (_runtime, document, urlPrefix) =>
             getGradioDebugConfig(document, urlPrefix),
         ),
-        registerDebugCommand(Commands.Debug_Shiny_In_Terminal, 'Shiny', (_runtime, document, _urlPrefix) =>
-            getShinyDebugConfig(document),
+        registerDebugCommand(
+            Commands.Debug_Shiny_In_Terminal,
+            'Shiny',
+            (_runtime, document, _urlPrefix) => getShinyDebugConfig(document),
             undefined,
             'Application startup complete',
         ),

--- a/extensions/positron-run-app/src/positron-run-app.d.ts
+++ b/extensions/positron-run-app/src/positron-run-app.d.ts
@@ -53,7 +53,7 @@ export interface RunAppOptions {
 	/**
 	 * The optional app ready message to wait for in the terminal before previewing the application.
 	 */
-	appReadyMessage?: string,
+	appReadyMessage?: string;
 }
 
 /**
@@ -87,7 +87,7 @@ export interface DebugAppOptions {
 	/**
 	 * The optional app ready message to wait for in the terminal before previewing the application.
 	 */
-	appReadyMessage?: string,
+	appReadyMessage?: string;
 }
 
 /**

--- a/extensions/positron-run-app/src/positron-run-app.d.ts
+++ b/extensions/positron-run-app/src/positron-run-app.d.ts
@@ -49,6 +49,11 @@ export interface RunAppOptions {
 	 * The optional URL path at which to preview the application.
 	 */
 	urlPath?: string;
+
+	/**
+	 * The optional app ready message to wait for in the terminal before previewing the application.
+	 */
+	appReadyMessage?: string,
 }
 
 /**
@@ -78,9 +83,11 @@ export interface DebugAppOptions {
 	 * The optional URL path at which to preview the application.
 	 */
 	urlPath?: string;
-}
 
-export interface DebugConfiguration {
+	/**
+	 * The optional app ready message to wait for in the terminal before previewing the application.
+	 */
+	appReadyMessage?: string,
 }
 
 /**

--- a/test/smoke/src/areas/positron/apps/python-apps.test.ts
+++ b/test/smoke/src/areas/positron/apps/python-apps.test.ts
@@ -36,9 +36,7 @@ describe('Python Applications #pr #win', () => {
 			await expect(viewer.getViewerFrame().getByText('Hello World')).toBeVisible({ timeout: 30000 });
 		});
 
-		// https://github.com/posit-dev/positron/issues/4949
-		// FastAPI is not working as expected on Ubuntu
-		it.skip('Python - Verify Basic FastAPI App [C903306]', async function () {
+		it('Python - Verify Basic FastAPI App [C903306]', async function () {
 			const app = this.app as Application;
 			const viewer = app.workbench.positronViewer;
 


### PR DESCRIPTION
- addresses https://github.com/posit-dev/positron/issues/5187
- ❓ possibly also addresses https://github.com/posit-dev/positron/issues/4949

### Implementation Notes
- adds optional `appReadyMessage` property to `RunAppOptions` and `DebugAppOptions`
- specify an `appReadyMessage` of `'Application startup complete'` for FastAPI and Shiny apps, which leverage uvicorn and output that message when the app is ready
- delete empty `DebugConfiguration` object from the `positron-run-app.d.ts` files, as I think they are unused?
- modified the logging level in `api.ts` for a few messages
- `previewUrlInExecutionOutput` now checks for both the app url and the `appReadyMessage` if provided, 
    - an app is considered ready if:
        - the `appReadyMessage` was not provided and the app url has been matched; or
        - the `appReadyMessage` was provided and matched, and the app url has been matched
    - if the `appReadyMessage` was provided but not matched, and the app url has been matched, we'll time out of the `raceTimeout`, but the url will have been matched, so we'll still try to open the app in the Viewer

### QA Notes

- I've renabled `Python - Verify Basic FastAPI App [C903306]` which now passes
- Please use the repro steps from the issue: https://github.com/posit-dev/positron/issues/5187
