### PR TITLE
set `terminal.integrated.defaultProfile.linux` default to `bash`

### DIFF
--- a/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
+++ b/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
@@ -395,9 +395,19 @@ export function registerTerminalDefaultProfileConfiguration(detectedProfiles?: {
 		properties: {
 			[TerminalSettingId.DefaultProfileLinux]: {
 				restricted: true,
-				markdownDescription: localize('terminal.integrated.defaultProfile.linux', "The default terminal profile on Linux."),
+				// --- Start Positron ---
+				// markdownDescription: localize('terminal.integrated.defaultProfile.linux', "The default terminal profile on Linux."),
+				markdownDescription: localize('terminal.integrated.defaultProfile.linux', "The default terminal profile on Linux.\n\nPositron sets the default profile to `bash` for a smoother Python Run App experience."),
+				// --- End Positron ---
 				type: ['string', 'null'],
-				default: null,
+				// --- Start Positron ---
+				// For a smoother Python Run App experience, we default to bash, as the default
+				// shell on Linux tends to be sh, which is not a supported Integrated Terminal.
+				// Refer to the markdown description of the 'terminal.integrated.shellIntegration.enabled'
+				// setting for more information on supported shells.
+				// default: null,
+				default: 'bash',
+				// --- End Positron ---
 				enum: detectedProfiles?.os === OperatingSystem.Linux ? profileEnum?.values : undefined,
 				markdownEnumDescriptions: detectedProfiles?.os === OperatingSystem.Linux ? profileEnum?.markdownDescriptions : undefined
 			},


### PR DESCRIPTION
- addresses https://github.com/posit-dev/positron/issues/4946

### QA Notes

#### Verify the default setting is applied in the `defaultSettings.json` file

_Note: this can be verified on any operating system_

1. Command Prompt > Preferences: Open Default Settings (JSON)
2. In the defaultSettings.json file, search for `terminal.integrated.defaultProfile.linux`
3. You should see the default setting `bash` applied

<img width="817" alt="image" src="https://github.com/user-attachments/assets/7e1fd403-016c-45e5-8f1b-1aedaf67c1fb">

#### Verify that the default setting is applied to user settings on Linux

1. Command Prompt > Preferences: Open User Settings
2. Search for `terminal.integrated.defaultProfile.linux`
3. Unless the user has overridden the default setting, it should say `bash`

<img width="880" alt="image" src="https://github.com/user-attachments/assets/d6b51a9b-e777-4a5b-ba93-78de9138249c">

Sidenote: not sure why there's so many duplicate shells?