### PR TITLE
Use basic single quote in license to avoid encoding issues

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -34,7 +34,7 @@ in the software, and you may not remove or obscure any functionality in the
 software that is protected by the license key.
 
 You may not alter, remove, or obscure any licensing, copyright, or other notices
-of the licensor in the software. Any use of the licensor’s trademarks is subject
+of the licensor in the software. Any use of the licensor's trademarks is subject
 to applicable law.
 
 


### PR DESCRIPTION
Addresses #5277

This is related to https://github.com/posit-dev/positron/pull/4596 as well, so I took a careful look through the file and do not see any further problematic characters.

### QA Notes

The license agreement we see in the Windows installer should no longer show the garbled apostrophe.
