### PR TITLE
Smoke tests: Large python notebook

### DIFF
--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -80,7 +80,7 @@ jobs:
           POSITRON_PY_VER_SEL: 3.10.12
           POSITRON_R_VER_SEL: 4.4.0
         id: electron-smoke-tests
-        run: DISPLAY=:10 yarn ${{ env.SMOKETEST_TARGET }} --tracing --parallel --jobs 2 --skip-cleanup
+        run: DISPLAY=:10 yarn ${{ env.SMOKETEST_TARGET }} --tracing --skip-cleanup
 
       - name: Convert XUnit to JUnit
         id: xunit-to-junit

--- a/.github/workflows/positron-merge-to-main.yml
+++ b/.github/workflows/positron-merge-to-main.yml
@@ -80,7 +80,7 @@ jobs:
           POSITRON_PY_VER_SEL: 3.10.12
           POSITRON_R_VER_SEL: 4.4.0
         id: electron-smoke-tests
-        run: DISPLAY=:10 yarn ${{ env.SMOKETEST_TARGET }} --tracing --skip-cleanup
+        run: DISPLAY=:10 yarn ${{ env.SMOKETEST_TARGET }} --tracing --parallel --jobs 2 --skip-cleanup
 
       - name: Convert XUnit to JUnit
         id: xunit-to-junit

--- a/test/smoke/src/areas/positron/notebook/largePythonNotebook.test.ts
+++ b/test/smoke/src/areas/positron/notebook/largePythonNotebook.test.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { Application, PositronNotebooks, PositronPythonFixtures } from '../../../../../automation';
+import { setupAndStartApp } from '../../../test-runner/test-hooks';
+import { IElement } from '../../../../../automation/out/driver';
+
+describe('Large Notebooks', () => {
+	setupAndStartApp();
+
+	describe('Large Python Notebook', () => {
+		let app: Application;
+		let notebooks: PositronNotebooks;
+
+		before(async function () {
+			app = this.app as Application;
+			notebooks = app.workbench.positronNotebooks;
+			await PositronPythonFixtures.SetupFixtures(app);
+		});
+
+		it('Python - Large notebook execution [C...]', async function () {
+
+			this.timeout(90000);
+
+			await app.workbench.positronQuickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'large_py_notebook', 'spotify.ipynb'));
+
+			await notebooks.selectInterpreter('Python Environments', process.env.POSITRON_PY_VER_SEL!);
+
+			await app.code.driver.page.getByText('Run All').click();
+
+			const stopExecutionLocator = app.code.driver.page.locator('a').filter({ hasText: 'Stop Execution' });
+
+			while (await stopExecutionLocator.isVisible()) {
+				await app.code.wait(5000);
+			}
+
+			await app.workbench.quickaccess.runCommand('notebook.focusTop');
+			//await app.workbench.quickaccess.runCommand('notebook.focusBottom');
+
+			await app.code.driver.page.click('.notebook-overview-ruler-container');
+
+			const allFigures: IElement[] = [];
+			for (let i = 0; i < 20; i++) {
+
+				await app.code.driver.page.mouse.move(0, i * 10);
+
+				await app.code.driver.page.mouse.down();
+				await app.code.driver.page.mouse.move(0, 10);
+				await app.code.driver.page.mouse.up();
+
+				await app.code.wait(1000);
+
+				const figures = await app.code.getElements('.plot-container', false);
+
+				if (figures!.length > 0) {
+					allFigures.push(...figures!);
+				}
+			}
+
+			console.log('debug');
+
+
+		});
+	});
+});

--- a/test/smoke/src/areas/positron/notebook/largePythonNotebook.test.ts
+++ b/test/smoke/src/areas/positron/notebook/largePythonNotebook.test.ts
@@ -9,7 +9,7 @@ import { setupAndStartApp } from '../../../test-runner/test-hooks';
 import { expect } from '@playwright/test';
 
 // This test is too time consuming to pass on web
-describe('Large Notebooks', () => {
+describe('Large Notebooks #web #win', () => {
 	setupAndStartApp();
 
 	describe('Large Python Notebook', () => {
@@ -24,9 +24,8 @@ describe('Large Notebooks', () => {
 
 		it('Python - Large notebook execution [C983592]', async function () {
 
-			// very long timeout
-			// not recommended for web or windows
-			this.timeout(240_000);
+			// huge timeout because this is a heavy test
+			this.timeout(480_000);
 
 			await app.workbench.positronQuickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'large_py_notebook', 'spotify.ipynb'));
 
@@ -37,7 +36,7 @@ describe('Large Notebooks', () => {
 			const stopExecutionLocator = app.code.driver.page.locator('a').filter({ hasText: 'Stop Execution' });
 
 			await expect(stopExecutionLocator).toBeVisible();
-			await expect(stopExecutionLocator).not.toBeVisible({ timeout: 60000 });
+			await expect(stopExecutionLocator).not.toBeVisible({ timeout: 120000 });
 
 			await app.workbench.quickaccess.runCommand('notebook.focusTop');
 
@@ -48,6 +47,8 @@ describe('Large Notebooks', () => {
 
 			for (let i = 0; i < 6; i++) {
 
+				// the second param to wheel (y) seems to be ignored so we send
+				// more messages instead of one with a large y value
 				for (let j = 0; j < 100; j++) {
 					await app.code.driver.page.mouse.wheel(0, 1);
 					await app.code.wait(100);

--- a/test/smoke/src/areas/positron/notebook/largePythonNotebook.test.ts
+++ b/test/smoke/src/areas/positron/notebook/largePythonNotebook.test.ts
@@ -8,8 +8,8 @@ import { Application, PositronNotebooks, PositronPythonFixtures } from '../../..
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 import { expect } from '@playwright/test';
 
-// This test is too time consuming to pass on web
-describe('Large Notebooks #web #win', () => {
+// Note that this test is too heavy to pass on web and windows
+describe('Large Notebooks', () => {
 	setupAndStartApp();
 
 	describe('Large Python Notebook', () => {

--- a/test/smoke/src/areas/positron/notebook/largePythonNotebook.test.ts
+++ b/test/smoke/src/areas/positron/notebook/largePythonNotebook.test.ts
@@ -8,7 +8,7 @@ import { Application, PositronNotebooks, PositronPythonFixtures } from '../../..
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 import { expect } from '@playwright/test';
 
-
+// This test is too time consuming to pass on web
 describe('Large Notebooks', () => {
 	setupAndStartApp();
 
@@ -24,7 +24,7 @@ describe('Large Notebooks', () => {
 
 		it('Python - Large notebook execution [C...]', async function () {
 
-			this.timeout(160000);
+			this.timeout(120_000);
 
 			await app.workbench.positronQuickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'large_py_notebook', 'spotify.ipynb'));
 
@@ -35,36 +35,36 @@ describe('Large Notebooks', () => {
 			const stopExecutionLocator = app.code.driver.page.locator('a').filter({ hasText: 'Stop Execution' });
 
 			await expect(stopExecutionLocator).toBeVisible();
-			await expect(stopExecutionLocator).not.toBeVisible({ timeout: 30000 });
+			await expect(stopExecutionLocator).not.toBeVisible({ timeout: 60000 });
 
 			await app.workbench.quickaccess.runCommand('notebook.focusTop');
 
 			await app.code.driver.page.locator('span').filter({ hasText: 'import pandas as pd' }).locator('span').first().click();
 
 			const allFigures: any[] = [];
-			const uniqueFigureParents = new Set<string>();
+			const uniqueLocators = new Set<string>();
 
-			for (let i = 0; i < 500; i++) {
-				await app.code.driver.page.mouse.wheel(0, 1000);
+			for (let i = 0; i < 6; i++) {
+
+				for (let j = 0; j < 100; j++) {
+					await app.code.driver.page.mouse.wheel(0, 1);
+					await app.code.wait(100);
+				}
 
 				const figureLocator = app.workbench.positronNotebooks.frameLocator.locator('.plot-container');
 				const figures = await figureLocator.all();
 
 				if (figures!.length > 0) {
 					for (const figure of figures!) {
-						const figureParentLocator = figure.locator('..');
-						const figureParent = await figureParentLocator.textContent();
-
-						if (figureParent && !uniqueFigureParents.has(figureParent)) {
-							uniqueFigureParents.add(figureParent);
+						if (!uniqueLocators.has(figure.toString())) {
 							allFigures.push(figure);
+							uniqueLocators.add(figure.toString());
 						}
 					}
 				}
 			}
 
-			console.log('debug');
-
+			expect(allFigures.length).toBeGreaterThan(20);
 
 		});
 	});

--- a/test/smoke/src/areas/positron/notebook/largePythonNotebook.test.ts
+++ b/test/smoke/src/areas/positron/notebook/largePythonNotebook.test.ts
@@ -24,7 +24,9 @@ describe('Large Notebooks', () => {
 
 		it('Python - Large notebook execution [C...]', async function () {
 
-			this.timeout(120_000);
+			// very long timeout
+			// not recommended for web or windows
+			this.timeout(240_000);
 
 			await app.workbench.positronQuickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'large_py_notebook', 'spotify.ipynb'));
 

--- a/test/smoke/src/areas/positron/notebook/largePythonNotebook.test.ts
+++ b/test/smoke/src/areas/positron/notebook/largePythonNotebook.test.ts
@@ -22,7 +22,7 @@ describe('Large Notebooks', () => {
 			await PositronPythonFixtures.SetupFixtures(app);
 		});
 
-		it('Python - Large notebook execution [C...]', async function () {
+		it('Python - Large notebook execution [C983592]', async function () {
 
 			// very long timeout
 			// not recommended for web or windows


### PR DESCRIPTION
This test uses this [large python notebook](https://github.com/posit-dev/qa-example-content/blob/main/workspaces/large_py_notebook/spotify.ipynb)

It opens the notebook and runs it.  Then it scrolls though about 2/3 of the output collecting image refs to loosely ensure that the document generated correctly.

It is a pretty heavy test.  Not planning to run it on web and windows.  Tested on web and just running the notebook takes over a minute.

### QA Notes

All smoke tests should pass.
