### PR TITLE
pull in PWB Code Server upstream changes and use Positron product name

### DIFF
--- a/product.json
+++ b/product.json
@@ -223,10 +223,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "1.5.13",
+			"version": "1.5.16",
 			"s3Bucket": "rsw-vscode-extension",
 			"type": "reh-web",
-			"sha256": "bfa920d48646f4828f83dc2dbc553e12c5871d6cd75182a0427ef3db4364733f",
+			"sha256": "520c252f9147ee87483cc698369659c58f52ee39a5e72df4bc557bd4f29d9272",
 			"metadata": {
 				"publisherDisplayName": "Posit PBC"
 			}


### PR DESCRIPTION
Pulls in changes from https://github.com/rstudio/vscode-server/pull/142 and updates the product name to be Positron-specific. 

This will allow the Workbench team to cleanly implement the RPCs necessary to save session state between user logouts. 

### QA Notes

Some work will still need to be done on the Workbench side. See https://github.com/rstudio/rstudio-pro/issues/6820 
The Workbench team will need to retest the VS Code state work and rework those existing tests to work with Positron. 
