### PR TITLE
Remove positron dark theme overrides for textLink foreground

### DIFF
--- a/extensions/theme-defaults/themes/positron_dark.json
+++ b/extensions/theme-defaults/themes/positron_dark.json
@@ -27,8 +27,6 @@
 		"tab.activeBorderTop": "#32485B",
 		"terminalCursor.foreground": "#32485B",
 		"terminal.tab.activeBorder": "#32485B",
-		"textLink.activeForeground": "#32485B",
-		"textLink.foreground": "#32485B",
 		"welcomePage.progress.foreground": "#32485B",
 	},
 }


### PR DESCRIPTION
Addresses #4790

These overrides for links in the welcome page and help content are too dark for dark mode. Removing these overrides and relying on the parent theme renders much more clearly.

```
-               "textLink.activeForeground": "#32485B",
-               "textLink.foreground": "#32485B",
```