### PR TITLE
Fix changing notebook Python intepreter also changing console

### DIFF
--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -285,12 +285,14 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         // Ensure that the ipykernel module is installed for the interpreter.
         await this._installIpykernel();
 
-        // Update the active environment in the Python extension.
-        this._interpreterPathService.update(
-            undefined,
-            vscode.ConfigurationTarget.WorkspaceFolder,
-            this.interpreter.path,
-        );
+        if (this.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console) {
+            // Update the active environment in the Python extension.
+            this._interpreterPathService.update(
+                undefined,
+                vscode.ConfigurationTarget.WorkspaceFolder,
+                this.interpreter.path,
+            );
+        }
 
         // Register for console width changes, if we haven't already
         if (!this._consoleWidthDisposable) {

--- a/extensions/positron-python/src/test/mocks/pst/index.ts
+++ b/extensions/positron-python/src/test/mocks/pst/index.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export enum LanguageRuntimeSessionMode {
+    Console = 'console',
+    Notebook = 'notebook',
+    Background = 'background',
+}

--- a/extensions/positron-python/src/test/mocks/pst/index.ts
+++ b/extensions/positron-python/src/test/mocks/pst/index.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/extensions/positron-python/src/test/positron/session.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/session.unit.test.ts
@@ -1,0 +1,167 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// eslint-disable-next-line import/no-unresolved
+import * as positron from 'positron';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { ILanguageServerOutputChannel } from '../../client/activation/types';
+import { IWorkspaceService } from '../../client/common/application/types';
+import {
+    IConfigurationService,
+    IInstaller,
+    IInterpreterPathService,
+    InstallerResponse,
+    IPythonSettings,
+    ProductInstallStatus,
+} from '../../client/common/types';
+import { IEnvironmentVariablesProvider } from '../../client/common/variables/types';
+import { IInterpreterService } from '../../client/interpreter/contracts';
+import { IServiceContainer } from '../../client/ioc/types';
+import { JupyterAdapterApi, JupyterKernelSpec, JupyterLanguageRuntimeSession } from '../../client/jupyter-adapter.d';
+import { PythonRuntimeSession } from '../../client/positron/session';
+import { PythonEnvironment } from '../../client/pythonEnvironments/info';
+
+suite('Python Runtime Session', () => {
+    let runtimeMetadata: positron.LanguageRuntimeMetadata;
+    let interpreterPathService: IInterpreterPathService;
+    let interpreter: PythonEnvironment;
+    let serviceContainer: IServiceContainer;
+    let kernelSpec: JupyterKernelSpec;
+    let consoleSession: positron.LanguageRuntimeSession;
+    let notebookSession: positron.LanguageRuntimeSession;
+
+    setup(() => {
+        interpreterPathService = ({
+            update: () => Promise.resolve(),
+        } as Partial<IInterpreterPathService>) as IInterpreterPathService;
+
+        interpreter = {
+            id: 'pythonEnvironmentId',
+            path: '/path/to/python',
+        } as PythonEnvironment;
+
+        runtimeMetadata = {
+            extraRuntimeData: { pythonEnvironmentId: interpreter.id },
+        } as positron.LanguageRuntimeMetadata;
+
+        const interpreterService = {
+            getInterpreters: () => [interpreter],
+        } as IInterpreterService;
+
+        const installer = ({
+            isInstalled: () => Promise.resolve(true),
+            promptToInstall: () => Promise.resolve(InstallerResponse.Installed),
+            isProductVersionCompatible: () => Promise.resolve(ProductInstallStatus.Installed),
+        } as Partial<IInstaller>) as IInstaller;
+
+        const outputChannel = {} as ILanguageServerOutputChannel;
+
+        const workspaceService = ({
+            workspaceFolders: undefined,
+            getWorkspaceFolder: () => undefined,
+        } as Partial<IWorkspaceService>) as IWorkspaceService;
+
+        const pythonSettings = ({ autoComplete: { extraPaths: [] } } as Partial<IPythonSettings>) as IPythonSettings;
+
+        const configService = {
+            getSettings: () => pythonSettings,
+        } as IConfigurationService;
+
+        const envVarsProvider = ({
+            onDidEnvironmentVariablesChange: () => ({ dispose() {} }),
+        } as Partial<IEnvironmentVariablesProvider>) as IEnvironmentVariablesProvider;
+
+        serviceContainer = {
+            get: (serviceIdentifier) => {
+                switch (serviceIdentifier) {
+                    case IInterpreterService:
+                        return interpreterService;
+                    case IInterpreterPathService:
+                        return interpreterPathService;
+                    case IInstaller:
+                        return installer;
+                    case ILanguageServerOutputChannel:
+                        return outputChannel;
+                    case IWorkspaceService:
+                        return workspaceService;
+                    case IEnvironmentVariablesProvider:
+                        return envVarsProvider;
+                    case IConfigurationService:
+                        return configService;
+                    default:
+                        return undefined;
+                }
+            },
+        } as IServiceContainer;
+
+        kernelSpec = {} as JupyterKernelSpec;
+
+        const kernel = ({
+            onDidChangeRuntimeState: () => ({ dispose() {} }),
+            onDidReceiveRuntimeMessage: () => ({ dispose() {} }),
+            onDidEndSession: () => ({ dispose() {} }),
+            start() {
+                return Promise.resolve();
+            },
+        } as Partial<JupyterLanguageRuntimeSession>) as JupyterLanguageRuntimeSession;
+
+        const adapterApi = ({
+            createSession: sinon.stub().resolves(kernel),
+        } as Partial<JupyterAdapterApi>) as JupyterAdapterApi;
+
+        sinon.stub(vscode.extensions, 'getExtension').callsFake((extensionId) => {
+            if (extensionId === 'vscode.kallichore-adapter' || extensionId === 'vscode.jupyter-adapter') {
+                return {
+                    id: '',
+                    extensionPath: '',
+                    extensionKind: vscode.ExtensionKind.UI,
+                    isActive: true,
+                    packageJSON: {},
+                    exports: adapterApi,
+                    extensionUri: vscode.Uri.parse(''),
+                    activate: () => Promise.resolve(adapterApi),
+                };
+            }
+            return undefined;
+        });
+
+        const consoleMetadata = {
+            sessionMode: positron.LanguageRuntimeSessionMode.Console,
+        } as positron.RuntimeSessionMetadata;
+        consoleSession = new PythonRuntimeSession(runtimeMetadata, consoleMetadata, serviceContainer, kernelSpec);
+
+        const notebookMetadata = {
+            sessionMode: positron.LanguageRuntimeSessionMode.Notebook,
+        } as positron.RuntimeSessionMetadata;
+        notebookSession = new PythonRuntimeSession(runtimeMetadata, notebookMetadata, serviceContainer, kernelSpec);
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('Start: updates the active interpreter for console sessions', async () => {
+        const target = sinon.spy(interpreterPathService, 'update');
+
+        await consoleSession.start();
+
+        sinon.assert.calledOnceWithExactly(
+            target,
+            undefined,
+            vscode.ConfigurationTarget.WorkspaceFolder,
+            interpreter.path,
+        );
+    });
+
+    test('Start: does not update the active interpreter for notebook sessions', async () => {
+        const target = sinon.spy(interpreterPathService, 'update');
+
+        await notebookSession.start();
+
+        sinon.assert.notCalled(target);
+    });
+});

--- a/extensions/positron-python/src/test/positron/session.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/session.unit.test.ts
@@ -129,6 +129,11 @@ suite('Python Runtime Session', () => {
             return undefined;
         });
 
+        const nullConfig = ({ get: () => undefined } as Partial<
+            vscode.WorkspaceConfiguration
+        >) as vscode.WorkspaceConfiguration;
+        vscode.workspace.getConfiguration = () => nullConfig;
+
         const consoleMetadata = {
             sessionMode: positron.LanguageRuntimeSessionMode.Console,
         } as positron.RuntimeSessionMetadata;

--- a/extensions/positron-python/src/test/vscode-mock.ts
+++ b/extensions/positron-python/src/test/vscode-mock.ts
@@ -16,6 +16,8 @@ export const mockedVSCodeNamespaces: { [P in keyof VSCode]?: VSCode[P] } = {};
 const originalLoad = Module._load;
 
 // --- Start Positron ---
+import * as positronMocks from './mocks/pst';
+
 // Import Positron for its type (the actual module is mocked below).
 import * as positron from 'positron';
 
@@ -174,3 +176,7 @@ mockedVSCode.LogLevel = vscodeMocks.LogLevel;
 (mockedVSCode as any).ProtocolTypeHierarchyItem = vscodeMocks.vscMockExtHostedTypes.ProtocolTypeHierarchyItem;
 (mockedVSCode as any).CancellationError = vscodeMocks.vscMockExtHostedTypes.CancellationError;
 (mockedVSCode as any).LSPCancellationError = vscodeMocks.vscMockExtHostedTypes.LSPCancellationError;
+
+// --- Start Positron ---
+mockedPositron.LanguageRuntimeSessionMode = positronMocks.LanguageRuntimeSessionMode;
+// --- End Positron ---

--- a/extensions/positron-python/src/test/vscode-mock.ts
+++ b/extensions/positron-python/src/test/vscode-mock.ts
@@ -176,7 +176,6 @@ mockedVSCode.LogLevel = vscodeMocks.LogLevel;
 (mockedVSCode as any).ProtocolTypeHierarchyItem = vscodeMocks.vscMockExtHostedTypes.ProtocolTypeHierarchyItem;
 (mockedVSCode as any).CancellationError = vscodeMocks.vscMockExtHostedTypes.CancellationError;
 (mockedVSCode as any).LSPCancellationError = vscodeMocks.vscMockExtHostedTypes.LSPCancellationError;
-
 // --- Start Positron ---
 mockedPositron.LanguageRuntimeSessionMode = positronMocks.LanguageRuntimeSessionMode;
 // --- End Positron ---


### PR DESCRIPTION
Addresses #5305. I also added unit tests for the Python runtime session class. They're not necessary for this specific change, but the setup will be useful moving forward.