### PR TITLE
Remove fields from manifest that cause PWA install behavior.

### DIFF
--- a/resources/server/manifest.json
+++ b/resources/server/manifest.json
@@ -1,10 +1,7 @@
 {
 	"name": "Positron",
 	"short_name": "Positron",
-	"start_url": "/",
-	"lang": "en-US",
-	"display": "standalone",
-	"display_override": ["window-controls-overlay"],
+	"display": "browser",
 	"icons": [
 		{
 			"src": "positron-192.png",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

This PR removes the fields in web mode that prompt the user to install positron to their desktop. This behavior was caused by positron being setup as a "progressive web app." 

## Before
<img width="653" alt="Screenshot 2024-11-08 at 3 42 36 PM" src="https://github.com/user-attachments/assets/dd0076f7-916e-4710-882f-6d706ec3233d">

## After
<img width="732" alt="Screenshot 2024-11-08 at 3 43 31 PM" src="https://github.com/user-attachments/assets/e2c95863-97e2-4f21-b536-07bcaa731bdb">


### Potential downsides

I don't _think_ this manifest adjustment will cause any issues with other PWA niceties but it's a possibility. I didn't notice anything out-of-the-ordinary in my brief testing. 

### QA Notes

I tested locally running the "Positron Server (Web)" debug mode. Should be good for deployed-as-server scenarios as well. 


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
