### PR TITLE
Backport R crash fix to 2024.11

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -650,7 +650,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.149"
+      "ark": "0.1.151"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
Backport of the fix for https://github.com/posit-dev/positron/issues/4959 to the 2024.11 branch.