### PR TITLE
Make temp table name in positron-duckdb tests more random to avoid sporadic extension test failures

### DIFF
--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -68,7 +68,7 @@ async function dxExec(rpc: DataExplorerRpc): Promise<any> {
 }
 
 function makeTempTableName(): string {
-	return `positron_${randomUUID().slice(0, 5)}`;
+	return `positron_${randomUUID().replace(/-/g, '')}`;
 }
 
 type InsertColumn = { name: string; type: string; values: Array<string> };


### PR DESCRIPTION
Attempts to address #5308 by making temporary table names in the DuckDB catalog more random. If this does not fix the issue, then I'm not sure what else it might be, but we can see if the error recurs elsewhere. 