### PR TITLE
Add Positron instantiation service test helpers; refactor tests to use runtime services

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -898,6 +898,10 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 	}
 
 	static clientCounter = 0;
+
+	dispose(): void {
+		// Do nothing.
+	}
 }
 
 /**

--- a/src/vs/workbench/contrib/positronPlots/test/electron-sandbox/positronPlotsService.test.ts
+++ b/src/vs/workbench/contrib/positronPlots/test/electron-sandbox/positronPlotsService.test.ts
@@ -4,44 +4,30 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { raceTimeout, timeout } from 'vs/base/common/async';
+import { raceTimeout } from 'vs/base/common/async';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
-import { PositronIPyWidgetsService } from 'vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService';
-import { PositronPlotsService } from 'vs/workbench/contrib/positronPlots/browser/positronPlotsService';
-import { PositronWebviewPreloadService } from 'vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { PositronTestServiceAccessor, positronWorkbenchInstantiationService as positronWorkbenchInstantiationService } from 'vs/workbench/test/browser/positronWorkbenchTestServices';
 import { IPositronPlotMetadata } from 'vs/workbench/services/languageRuntime/common/languageRuntimePlotClient';
-import { LanguageRuntimeSessionMode } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
-import { IPositronIPyWidgetsService } from 'vs/workbench/services/positronIPyWidgets/common/positronIPyWidgetsService';
-import { HistoryPolicy, IPositronPlotClient } from 'vs/workbench/services/positronPlots/common/positronPlots';
-import { IPositronWebviewPreloadService } from 'vs/workbench/services/positronWebviewPreloads/common/positronWebviewPreloadService';
-import { IRuntimeSessionService, RuntimeClientType } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
+import { HistoryPolicy, IPositronPlotClient, IPositronPlotsService } from 'vs/workbench/services/positronPlots/common/positronPlots';
+import { RuntimeClientType } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { TestLanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession';
-import { TestRuntimeSessionService } from 'vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService';
-import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
-import { TestViewsService, workbenchInstantiationService } from 'vs/workbench/test/browser/workbenchTestServices';
+import { startTestLanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService';
 
 suite('Positron - Plots Service', () => {
 
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
-	let plotsService: PositronPlotsService;
-	let runtimeSessionService: TestRuntimeSessionService;
+	let instantiationService: TestInstantiationService;
+	let plotsService: IPositronPlotsService;
 
 	setup(() => {
-		const instantiationService = workbenchInstantiationService(undefined, disposables);
-		runtimeSessionService = disposables.add(instantiationService.createInstance(TestRuntimeSessionService));
-		instantiationService.stub(IRuntimeSessionService, runtimeSessionService);
-		instantiationService.stub(IPositronWebviewPreloadService, disposables.add(instantiationService.createInstance(PositronWebviewPreloadService)));
-		instantiationService.stub(IPositronIPyWidgetsService, disposables.add(instantiationService.createInstance(PositronIPyWidgetsService)));
-		instantiationService.stub(IViewsService, new TestViewsService());
-
-		plotsService = disposables.add(instantiationService.createInstance(PositronPlotsService));
+		instantiationService = positronWorkbenchInstantiationService(disposables);
+		const accessor = instantiationService.createInstance(PositronTestServiceAccessor);
+		plotsService = accessor.positronPlotsService;
 	});
 
 	async function createSession() {
-		const session = disposables.add(new TestLanguageRuntimeSession(LanguageRuntimeSessionMode.Console));
-		runtimeSessionService.startSession(session);
-
-		await timeout(0);
+		const session = await startTestLanguageRuntimeSession(instantiationService, disposables);
 
 		const out: {
 			session: TestLanguageRuntimeSession;

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntime.ts
@@ -81,7 +81,7 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 	registerRuntime(metadata: ILanguageRuntimeMetadata): IDisposable {
 		// If the runtime has already been registered, return early.
 		if (this._registeredRuntimesByRuntimeId.has(metadata.runtimeId)) {
-			return toDisposable(() => { });
+			return this._register(toDisposable(() => { }));
 		}
 
 		// Add the runtime to the registered runtimes.
@@ -93,9 +93,9 @@ export class LanguageRuntimeService extends Disposable implements ILanguageRunti
 		// Logging.
 		this._logService.trace(`Language runtime ${formatLanguageRuntimeMetadata(metadata)} successfully registered.`);
 
-		return toDisposable(() => {
+		return this._register(toDisposable(() => {
 			this._registeredRuntimesByRuntimeId.delete(metadata.runtimeId);
-		});
+		}));
 	}
 
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -109,7 +109,7 @@ export class UiClientInstance extends Disposable {
 		super();
 		this._register(this._client);
 
-		this._comm = new PositronUiCommInstance(this._client);
+		this._comm = this._register(new PositronUiCommInstance(this._client));
 		this.onDidBusy = this._comm.onDidBusy;
 		this.onDidClearConsole = this._comm.onDidClearConsole;
 		this.onDidSetEditorSelections = this._comm.onDidSetEditorSelections;

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -74,7 +74,7 @@ export interface IRuntimeSessionMetadata {
  * The main interface for interacting with a language runtime session.
  */
 
-export interface ILanguageRuntimeSession {
+export interface ILanguageRuntimeSession extends IDisposable {
 	/** The language runtime's static metadata */
 	readonly runtimeMetadata: ILanguageRuntimeMetadata;
 

--- a/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
@@ -2,34 +2,122 @@
  *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
-import { Emitter } from 'vs/base/common/event';
-import { Disposable } from 'vs/base/common/lifecycle';
-import { ILanguageRuntimeClientCreatedEvent } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
-import { ILanguageRuntimeGlobalEvent, ILanguageRuntimeSession, IRuntimeSessionService, IRuntimeSessionWillStartEvent } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { URI } from 'vs/base/common/uri';
+import { generateUuid } from 'vs/base/common/uuid';
+import { ILanguageService } from 'vs/editor/common/languages/language';
+import { LanguageService } from 'vs/editor/common/services/languageService';
+import { ICommandService } from 'vs/platform/commands/common/commands';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
+import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { MockKeybindingService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
+import { ILogService, NullLogService } from 'vs/platform/log/common/log';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
+import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { LanguageRuntimeService } from 'vs/workbench/services/languageRuntime/common/languageRuntime';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionLocation, LanguageRuntimeSessionMode, LanguageRuntimeStartupBehavior } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { IPositronModalDialogsService } from 'vs/workbench/services/positronModalDialogs/common/positronModalDialogs';
+import { RuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSession';
+import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
+import { TestLanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession';
+import { TestOpenerService, TestPositronModalDialogService, TestCommandService, TestRuntimeSessionManager } from 'vs/workbench/test/common/positronWorkbenchTestServices';
+import { TestExtensionService, TestStorageService, TestWorkspaceTrustManagementService } from 'vs/workbench/test/common/workbenchTestServices';
 
-export class TestRuntimeSessionService extends Disposable implements Partial<IRuntimeSessionService> {
-	private readonly _willStartEmitter = this._register(new Emitter<IRuntimeSessionWillStartEvent>());
-	private readonly _didStartRuntime = this._register(new Emitter<ILanguageRuntimeSession>());
-	private readonly _didReceiveRuntimeEvent = this._register(new Emitter<ILanguageRuntimeGlobalEvent>());
-	private readonly _didCreateClientInstance = this._register(new Emitter<ILanguageRuntimeClientCreatedEvent>());
-
-	readonly activeSessions = new Array<ILanguageRuntimeSession>();
-
-	readonly onWillStartSession = this._willStartEmitter.event;
-
-	readonly onDidStartRuntime = this._didStartRuntime.event;
-
-	readonly onDidReceiveRuntimeEvent = this._didReceiveRuntimeEvent.event;
-
-	readonly onDidCreateClientInstance = this._didCreateClientInstance.event;
-
-	// Test helpers.
-
-	startSession(session: ILanguageRuntimeSession): void {
-		this.activeSessions.push(session);
-		this._register(session.onDidCreateClientInstance(e => this._didCreateClientInstance.fire(e)));
-		this._willStartEmitter.fire({ session, isNew: true });
-		this._didStartRuntime.fire(session);
-	}
+export function createRuntimeServices(
+	instantiationService: TestInstantiationService,
+	disposables: Pick<DisposableStore, 'add'> = new DisposableStore,
+): TestInstantiationService {
+	instantiationService.stub(IOpenerService, new TestOpenerService());
+	instantiationService.stub(ILanguageService, disposables.add(new LanguageService()));
+	instantiationService.stub(IExtensionService, new TestExtensionService());
+	instantiationService.stub(IStorageService, disposables.add(new TestStorageService()));
+	instantiationService.stub(ILogService, new NullLogService());
+	instantiationService.stub(IWorkspaceTrustManagementService, disposables.add(new TestWorkspaceTrustManagementService()));
+	instantiationService.stub(ILanguageRuntimeService, disposables.add(instantiationService.createInstance(LanguageRuntimeService)));
+	instantiationService.stub(IPositronModalDialogsService, new TestPositronModalDialogService());
+	instantiationService.stub(IConfigurationService, new TestConfigurationService());
+	instantiationService.stub(ICommandService, new TestCommandService(instantiationService));
+	instantiationService.stub(IKeybindingService, new MockKeybindingService());
+	instantiationService.stub(IRuntimeSessionService, disposables.add(instantiationService.createInstance(RuntimeSessionService)));
+	return instantiationService;
 }
 
+export function createTestLanguageRuntimeMetadata(
+	instantiationService: TestInstantiationService,
+	disposables: Pick<DisposableStore, 'add'>,
+): ILanguageRuntimeMetadata {
+	const languageRuntimeService = instantiationService.get(ILanguageRuntimeService);
+	const runtimeSessionService = instantiationService.get(IRuntimeSessionService);
+
+	// Register the test runtime.
+	const languageName = 'Test';
+	const languageVersion = '0.0.1';
+	const runtime = {
+		extensionId: new ExtensionIdentifier('test-extension'),
+		base64EncodedIconSvg: '',
+		extraRuntimeData: {},
+		languageId: 'test',
+		languageName,
+		languageVersion,
+		runtimeId: generateUuid(),
+		runtimeName: `${languageName} ${languageVersion}`,
+		runtimePath: '/test',
+		runtimeShortName: languageVersion,
+		runtimeSource: 'Test',
+		runtimeVersion: '0.0.1',
+		sessionLocation: LanguageRuntimeSessionLocation.Browser,
+		startupBehavior: LanguageRuntimeStartupBehavior.Implicit,
+	};
+	disposables.add(languageRuntimeService.registerRuntime(runtime));
+
+	// Register the test runtime manager.
+	const manager = new TestRuntimeSessionManager();
+	disposables.add(runtimeSessionService.registerSessionManager(manager));
+
+	return runtime;
+}
+
+export interface IStartTestLanguageRuntimeSessionOptions {
+	runtime?: ILanguageRuntimeMetadata;
+	sessionName?: string;
+	sessionMode?: LanguageRuntimeSessionMode;
+	notebookUri?: URI;
+	startReason?: string;
+}
+
+export async function startTestLanguageRuntimeSession(
+	instantiationService: TestInstantiationService,
+	disposables: Pick<DisposableStore, 'add'>,
+	options?: IStartTestLanguageRuntimeSessionOptions,
+): Promise<TestLanguageRuntimeSession> {
+	// Get or create the runtime.
+	const runtime = options?.runtime ?? createTestLanguageRuntimeMetadata(instantiationService, disposables);
+
+	// Start the session.
+	const runtimeSessionService = instantiationService.get(IRuntimeSessionService);
+	const sessionId = await runtimeSessionService.startNewRuntimeSession(
+		runtime.runtimeId,
+		options?.sessionName ?? 'test-session',
+		options?.sessionMode ?? LanguageRuntimeSessionMode.Console,
+		options?.notebookUri,
+		options?.startReason ?? 'Test requested to start a runtime session',
+	);
+
+	// Get the session.
+	const session = runtimeSessionService.getSession(sessionId);
+	if (!session) {
+		throw new Error(`Failed to get session with ID '${sessionId}' after starting it`);
+	}
+
+	if (!(session instanceof TestLanguageRuntimeSession)) {
+		throw new Error(`Session with ID '${sessionId}' is not a TestLanguageRuntimeSession`);
+	}
+
+	disposables.add(session);
+	return session;
+}

--- a/src/vs/workbench/test/browser/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/positronWorkbenchTestServices.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { ILogService } from 'vs/platform/log/common/log';
+import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
+import { INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorService';
+import { NotebookEditorWidgetService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorServiceImpl';
+import { NotebookRendererMessagingService } from 'vs/workbench/contrib/notebook/browser/services/notebookRendererMessagingServiceImpl';
+import { INotebookRendererMessagingService } from 'vs/workbench/contrib/notebook/common/notebookRendererMessagingService';
+import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
+import { PositronIPyWidgetsService } from 'vs/workbench/contrib/positronIPyWidgets/browser/positronIPyWidgetsService';
+import { IPositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService';
+import { PositronNotebookOutputWebviewService } from 'vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl';
+import { PositronPlotsService } from 'vs/workbench/contrib/positronPlots/browser/positronPlotsService';
+import { PositronWebviewPreloadService } from 'vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService';
+import { IWebviewService } from 'vs/workbench/contrib/webview/browser/webview';
+import { WebviewService } from 'vs/workbench/contrib/webview/browser/webviewService';
+import { INotebookDocumentService, NotebookDocumentWorkbenchService } from 'vs/workbench/services/notebook/common/notebookDocumentService';
+import { IPositronIPyWidgetsService } from 'vs/workbench/services/positronIPyWidgets/common/positronIPyWidgetsService';
+import { IPositronPlotsService } from 'vs/workbench/services/positronPlots/common/positronPlots';
+import { IPositronWebviewPreloadService } from 'vs/workbench/services/positronWebviewPreloads/common/positronWebviewPreloadService';
+import { createRuntimeServices } from 'vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService';
+import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
+import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
+import { workbenchInstantiationService as baseWorkbenchInstantiationService, TestViewsService } from 'vs/workbench/test/browser/workbenchTestServices';
+import { TestNotebookService } from 'vs/workbench/test/common/positronWorkbenchTestServices';
+
+export function positronWorkbenchInstantiationService(
+	disposables: Pick<DisposableStore, 'add'> = new DisposableStore(),
+): TestInstantiationService {
+	const instantiationService = baseWorkbenchInstantiationService(undefined, disposables);
+
+	createRuntimeServices(instantiationService, disposables);
+
+	instantiationService.stub(INotebookRendererMessagingService, disposables.add(instantiationService.createInstance(NotebookRendererMessagingService)));
+	instantiationService.stub(INotebookEditorService, disposables.add(instantiationService.createInstance(NotebookEditorWidgetService)));
+	instantiationService.stub(IWorkbenchThemeService, new TestThemeService() as any);
+	instantiationService.stub(INotebookDocumentService, new NotebookDocumentWorkbenchService());
+	instantiationService.stub(INotebookService, new TestNotebookService());
+	instantiationService.stub(IWebviewService, disposables.add(new WebviewService(instantiationService)));
+	instantiationService.stub(IPositronNotebookOutputWebviewService, instantiationService.createInstance(PositronNotebookOutputWebviewService));
+	instantiationService.stub(IPositronIPyWidgetsService, disposables.add(instantiationService.createInstance(PositronIPyWidgetsService)));
+	instantiationService.stub(IPositronWebviewPreloadService, disposables.add(instantiationService.createInstance(PositronWebviewPreloadService)));
+	instantiationService.stub(IPositronIPyWidgetsService, disposables.add(instantiationService.createInstance(PositronIPyWidgetsService)));
+	instantiationService.stub(IViewsService, new TestViewsService());
+	instantiationService.stub(IPositronPlotsService, disposables.add(instantiationService.createInstance(PositronPlotsService)));
+
+	return instantiationService;
+}
+
+export class PositronTestServiceAccessor {
+	constructor(
+		@ILogService public logService: ILogService,
+		@INotebookEditorService public notebookEditorService: INotebookEditorService,
+		@IPositronIPyWidgetsService public positronIPyWidgetsService: PositronIPyWidgetsService,
+		@IPositronPlotsService public positronPlotsService: IPositronPlotsService,
+		@IPositronWebviewPreloadService public positronWebviewPreloadService: PositronWebviewPreloadService,
+	) { }
+}

--- a/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, Event } from 'vs/base/common/event';
+import { IDisposable } from 'vs/base/common/lifecycle';
+import { URI } from 'vs/base/common/uri';
+import { ICommandService, ICommandEvent, CommandsRegistry } from 'vs/platform/commands/common/commands';
+import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IOpenerService, IOpener, IValidator, IExternalUriResolver, IExternalOpener, OpenInternalOptions, OpenExternalOptions, ResolveExternalUriOptions, IResolvedExternalUri } from 'vs/platform/opener/common/opener';
+import { INotebookRendererInfo, INotebookStaticPreloadInfo } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { NotebookOutputRendererInfo } from 'vs/workbench/contrib/notebook/common/notebookOutputRenderer';
+import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
+import { ILanguageRuntimeMetadata } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { IPositronModalDialogsService, ShowConfirmationModalDialogOptions, IModalDialogPromptInstance } from 'vs/workbench/services/positronModalDialogs/common/positronModalDialogs';
+import { ILanguageRuntimeSessionManager, IRuntimeSessionMetadata, ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
+import { TestLanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession';
+
+export class TestNotebookService implements Partial<INotebookService> {
+	getRenderers(): INotebookRendererInfo[] {
+		return [];
+	}
+
+	getPreferredRenderer(_mimeType: string): NotebookOutputRendererInfo | undefined {
+		return <NotebookOutputRendererInfo>{
+			id: 'positron-ipywidgets',
+			extensionId: new ExtensionIdentifier('vscode.positron-ipywidgets'),
+		};
+	}
+
+	*getStaticPreloads(_viewType: string): Iterable<INotebookStaticPreloadInfo> {
+		// Yield nothing.
+	}
+}
+
+export class TestOpenerService implements IOpenerService {
+	_serviceBrand: undefined;
+	registerOpener(opener: IOpener): IDisposable {
+		return { dispose() { } };
+	}
+	registerValidator(validator: IValidator): IDisposable {
+		throw new Error('Method not implemented.');
+	}
+	registerExternalUriResolver(resolver: IExternalUriResolver): IDisposable {
+		throw new Error('Method not implemented.');
+	}
+	setDefaultExternalOpener(opener: IExternalOpener): void {
+		throw new Error('Method not implemented.');
+	}
+	registerExternalOpener(opener: IExternalOpener): IDisposable {
+		throw new Error('Method not implemented.');
+	}
+	open(resource: URI | string, options?: OpenInternalOptions | OpenExternalOptions): Promise<boolean> {
+		throw new Error('Method not implemented.');
+	}
+	resolveExternalUri(resource: URI, options?: ResolveExternalUriOptions): Promise<IResolvedExternalUri> {
+		throw new Error('Method not implemented.');
+	}
+}
+// Copied from src/vs/editor/test/browser/editorTestServices.ts for access outside of the browser context.
+export class TestCommandService implements ICommandService {
+	declare readonly _serviceBrand: undefined;
+
+	private readonly _instantiationService: IInstantiationService;
+
+	private readonly _onWillExecuteCommand = new Emitter<ICommandEvent>();
+	public readonly onWillExecuteCommand: Event<ICommandEvent> = this._onWillExecuteCommand.event;
+
+	private readonly _onDidExecuteCommand = new Emitter<ICommandEvent>();
+	public readonly onDidExecuteCommand: Event<ICommandEvent> = this._onDidExecuteCommand.event;
+
+	constructor(instantiationService: IInstantiationService) {
+		this._instantiationService = instantiationService;
+	}
+
+	public executeCommand<T>(id: string, ...args: any[]): Promise<T> {
+		const command = CommandsRegistry.getCommand(id);
+		if (!command) {
+			return Promise.reject(new Error(`command '${id}' not found`));
+		}
+
+		try {
+			this._onWillExecuteCommand.fire({ commandId: id, args });
+			const result = this._instantiationService.invokeFunction.apply(this._instantiationService, [command.handler, ...args]) as T;
+			this._onDidExecuteCommand.fire({ commandId: id, args });
+			return Promise.resolve(result);
+		} catch (err) {
+			return Promise.reject(err);
+		}
+	}
+}
+export class TestPositronModalDialogService implements IPositronModalDialogsService {
+	_serviceBrand: undefined;
+	showConfirmationModalDialog(options: ShowConfirmationModalDialogOptions): void {
+		throw new Error('Method not implemented.');
+	}
+	showModalDialogPrompt(title: string, message: string, okButtonTitle?: string, cancelButtonTitle?: string): IModalDialogPromptInstance {
+		throw new Error('Method not implemented.');
+	}
+	showSimpleModalDialogPrompt(title: string, message: string, okButtonTitle?: string, cancelButtonTitle?: string): Promise<boolean> {
+		throw new Error('Method not implemented.');
+	}
+	showSimpleModalDialogMessage(title: string, message: string, okButtonTitle?: string): Promise<null> {
+		throw new Error('Method not implemented.');
+	}
+}
+export class TestRuntimeSessionManager implements ILanguageRuntimeSessionManager {
+	async managesRuntime(runtime: ILanguageRuntimeMetadata): Promise<boolean> {
+		return true;
+	}
+
+	async createSession(runtimeMetadata: ILanguageRuntimeMetadata, sessionMetadata: IRuntimeSessionMetadata): Promise<ILanguageRuntimeSession> {
+		return new TestLanguageRuntimeSession(sessionMetadata, runtimeMetadata);
+	}
+
+	async restoreSession(runtimeMetadata: ILanguageRuntimeMetadata, sessionMetadata: IRuntimeSessionMetadata): Promise<ILanguageRuntimeSession> {
+		return new TestLanguageRuntimeSession(sessionMetadata, runtimeMetadata);
+	}
+
+	validateMetadata(metadata: ILanguageRuntimeMetadata): Promise<ILanguageRuntimeMetadata> {
+		throw new Error('Method not implemented');
+	}
+}


### PR DESCRIPTION
This is in preparation for writing unit tests for the runtime session service since I intend on making changes to it for #2671.

The main addition is the `positronWorkbenchInstantiationService` function, which sets up a test instantiation service with a bunch of test dummies, following upstream's `workbenchInstantiationService` function. I also refactored our existing unit tests to use the new function.

#### QA Notes

1. Positron unit tests should pass. They can be run locally with:

    ```sh
    ./scripts/test-positron.sh
    ```
2. There are a few minor code changes to runtime-related code, mainly to fix leaked disposables, which could use a review.