### PR TITLE
improve Run App url matching and fix preview timeout issue

### DIFF
--- a/extensions/positron-python/src/client/positron-run-app.d.ts
+++ b/extensions/positron-python/src/client/positron-run-app.d.ts
@@ -8,7 +8,18 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 
 /**
- * Defines a string that contains the `${{APP_URL}}` placeholder.
+ * Defines a string type that contains the app url placeholder.
+ *
+ * Unfortunately, if a string is constructed programmatically with this format, TypeScript will not
+ * recognize it as an `AppUrlString`. For example, the following will not work:
+ * ```ts
+ * const appUrlString = 'The url will be:' + '{{APP_URL}}';
+ * ```
+ *
+ * Strings must be defined as literals in the source code to be recognized as `AppUrlString`. For
+ * example, the following will work:
+ * ```ts
+ * const appUrlString: AppUrlString = 'The url will be: {{APP_URL}}';
  */
 export type AppUrlString = `${string}{{APP_URL}}${string}`;
 
@@ -63,7 +74,7 @@ export interface RunAppOptions {
     /**
      * An optional array of app URI formats to parse the URI from the terminal output.
      */
-    appUriFormat?: AppUrlString[];
+    appUrlStrings?: AppUrlString[];
 }
 
 /**
@@ -102,7 +113,7 @@ export interface DebugAppOptions {
     /**
      * An optional array of app URI formats to parse the URI from the terminal output.
      */
-    appUriFormat?: AppUrlString[];
+    appUrlStrings?: AppUrlString[];
 }
 
 /**

--- a/extensions/positron-python/src/client/positron-run-app.d.ts
+++ b/extensions/positron-python/src/client/positron-run-app.d.ts
@@ -9,17 +9,28 @@ import * as vscode from 'vscode';
 
 /**
  * Defines a string type that contains the app url placeholder.
+ * @example 'The url will be: {{APP_URL}}'
+ * @example 'string one' + '{{APP_URL}}' + 'string two' as AppUrlString
  *
- * Unfortunately, if a string is constructed programmatically with this format, TypeScript will not
- * recognize it as an `AppUrlString`. For example, the following will not work:
+ * Strings must be defined as literals in the source code to be recognized as `AppUrlString` if not
+ * using type assertions. For example, the following _will_ work:
+ * ```ts
+ * const appUrlString: AppUrlString = 'The url will be: {{APP_URL}}';
+ * ```
+ *
+ * Unfortunately, if a string is constructed programmatically with this format, TypeScript won't
+ * recognize it as an `AppUrlString`. For example, the following _will not_ work:
  * ```ts
  * const appUrlString = 'The url will be:' + '{{APP_URL}}';
  * ```
  *
- * Strings must be defined as literals in the source code to be recognized as `AppUrlString`. For
- * example, the following will work:
+ * One way to work around this is to use a type assertion:
  * ```ts
- * const appUrlString: AppUrlString = 'The url will be: {{APP_URL}}';
+ * const appUrlString = 'The url will be:' + '{{APP_URL}}' as AppUrlString;
+ * ```
+ *
+ * @see https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-inference for
+ * more on literal type inference.
  */
 export type AppUrlString = `${string}{{APP_URL}}${string}`;
 

--- a/extensions/positron-python/src/client/positron-run-app.d.ts
+++ b/extensions/positron-python/src/client/positron-run-app.d.ts
@@ -8,6 +8,11 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 
 /**
+ * Defines a string that contains the `${{APP_URL}}` placeholder.
+ */
+export type AppUrlString = `${string}{{APP_URL}}${string}`;
+
+/**
  * Represents options returned from ${@link RunAppOptions.getTerminalOptions}.
  */
 export interface RunAppTerminalOptions {
@@ -54,6 +59,11 @@ export interface RunAppOptions {
      * The optional app ready message to wait for in the terminal before previewing the application.
      */
     appReadyMessage?: string;
+
+    /**
+     * An optional array of app URI formats to parse the URI from the terminal output.
+     */
+    appUriFormat?: AppUrlString[];
 }
 
 /**
@@ -88,6 +98,11 @@ export interface DebugAppOptions {
      * The optional app ready message to wait for in the terminal before previewing the application.
      */
     appReadyMessage?: string;
+
+    /**
+     * An optional array of app URI formats to parse the URI from the terminal output.
+     */
+    appUriFormat?: AppUrlString[];
 }
 
 /**

--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -36,6 +36,7 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             getFlaskDebugConfig(document),
             undefined,
             undefined,
+            // Flask url string is from Werkzeug: https://github.com/pallets/werkzeug/blob/7868bef5d978093a8baa0784464ebe5d775ae92a/src/werkzeug/serving.py#L833-L865
             ['Running on {{APP_URL}}'],
         ),
         registerExecCommand(Commands.Exec_Gradio_In_Terminal, 'Gradio', (_runtime, document, urlPrefix) =>
@@ -44,8 +45,8 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             undefined,
             // Gradio url strings: https://github.com/gradio-app/gradio/blob/main/gradio/strings.py
             [
-                'Running on local URL: {{APP_URL}}',
-                'Running on public URL: {{APP_URL}}',
+                'Running on local URL:  {{APP_URL}}',
+                'Running on public URL:  {{APP_URL}}',
             ],
         ),
         registerExecCommand(
@@ -85,6 +86,7 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             getFlaskDebugConfig(document),
             undefined,
             undefined,
+            // Flask url string is from Werkzeug: https://github.com/pallets/werkzeug/blob/7868bef5d978093a8baa0784464ebe5d775ae92a/src/werkzeug/serving.py#L833-L865
             ['Running on {{APP_URL}}'],
         ),
         registerDebugCommand(Commands.Debug_Gradio_In_Terminal, 'Gradio', (_runtime, document, urlPrefix) =>
@@ -93,8 +95,8 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             undefined,
             // Gradio url strings: https://github.com/gradio-app/gradio/blob/main/gradio/strings.py
             [
-                'Running on local URL: {{APP_URL}}',
-                'Running on public URL: {{APP_URL}}',
+                'Running on local URL:  {{APP_URL}}',
+                'Running on public URL:  {{APP_URL}}',
             ],
         ),
         registerDebugCommand(
@@ -126,7 +128,7 @@ function registerExecCommand(
     ) => DebugConfiguration | undefined | Promise<DebugConfiguration | undefined>,
     urlPath?: string,
     appReadyMessage?: string,
-    appUriFormat?: AppUrlString[],
+    appUrlStrings?: AppUrlString[],
 ): vscode.Disposable {
     return vscode.commands.registerCommand(command, async () => {
         const runAppApi = await getPositronRunAppApi();
@@ -159,7 +161,7 @@ function registerExecCommand(
             },
             urlPath,
             appReadyMessage,
-            appUriFormat,
+            appUrlStrings,
         });
     });
 }
@@ -174,7 +176,7 @@ function registerDebugCommand(
     ) => DebugConfiguration | undefined | Promise<DebugConfiguration | undefined>,
     urlPath?: string,
     appReadyMessage?: string,
-    appUriFormat?: AppUrlString[],
+    appUrlStrings?: AppUrlString[],
 ): vscode.Disposable {
     return vscode.commands.registerCommand(command, async () => {
         const runAppApi = await getPositronRunAppApi();
@@ -196,7 +198,7 @@ function registerDebugCommand(
             },
             urlPath,
             appReadyMessage,
-            appUriFormat,
+            appUrlStrings,
         });
     });
 }

--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 // eslint-disable-next-line import/no-unresolved
 import * as positron from 'positron';
 import * as vscode from 'vscode';
-import { PositronRunApp, RunAppTerminalOptions } from '../positron-run-app.d';
+import { AppUrlString, PositronRunApp, RunAppTerminalOptions } from '../positron-run-app.d';
 import { IServiceContainer } from '../ioc/types';
 import { IInterpreterService } from '../interpreter/contracts';
 import { IInstaller, Product } from '../common/types';
@@ -18,6 +18,10 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
     disposables.push(
         registerExecCommand(Commands.Exec_Dash_In_Terminal, 'Dash', (_runtime, document, urlPrefix) =>
             getDashDebugConfig(document, urlPrefix),
+            undefined,
+            undefined,
+            // Dash url string: https://github.com/plotly/dash/blob/95665785f184aba4ce462637c30ccb7789280911/dash/dash.py#L2160
+            ['Dash is running on {{APP_URL}}'],
         ),
         registerExecCommand(
             Commands.Exec_FastAPI_In_Terminal,
@@ -25,12 +29,24 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             (runtime, document, _urlPrefix) => getFastAPIDebugConfig(serviceContainer, runtime, document),
             '/docs',
             'Application startup complete',
+            // Uvicorn url string: https://github.com/encode/uvicorn/blob/fe3910083e3990695bc19c2ef671dd447262ae18/uvicorn/config.py#L479-L525
+            ['Uvicorn running on {{APP_URL}}'],
         ),
         registerExecCommand(Commands.Exec_Flask_In_Terminal, 'Flask', (_runtime, document, _urlPrefix) =>
             getFlaskDebugConfig(document),
+            undefined,
+            undefined,
+            ['Running on {{APP_URL}}'],
         ),
         registerExecCommand(Commands.Exec_Gradio_In_Terminal, 'Gradio', (_runtime, document, urlPrefix) =>
             getGradioDebugConfig(document, urlPrefix),
+            undefined,
+            undefined,
+            // Gradio url strings: https://github.com/gradio-app/gradio/blob/main/gradio/strings.py
+            [
+                'Running on local URL: {{APP_URL}}',
+                'Running on public URL: {{APP_URL}}',
+            ],
         ),
         registerExecCommand(
             Commands.Exec_Shiny_In_Terminal,
@@ -38,12 +54,22 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             (_runtime, document, _urlPrefix) => getShinyDebugConfig(document),
             undefined,
             'Application startup complete',
+            // Uvicorn url string: https://github.com/encode/uvicorn/blob/fe3910083e3990695bc19c2ef671dd447262ae18/uvicorn/config.py#L479-L525
+            ['Uvicorn running on {{APP_URL}}'],
         ),
         registerExecCommand(Commands.Exec_Streamlit_In_Terminal, 'Streamlit', (_runtime, document, _urlPrefix) =>
             getStreamlitDebugConfig(document),
+            undefined,
+            undefined,
+            // Streamlit url string: https://github.com/streamlit/streamlit/blob/3e6248461cce366b1f54c273e787adf84a66148d/lib/streamlit/web/bootstrap.py#L197
+            ['Local URL: {{APP_URL}}'],
         ),
         registerDebugCommand(Commands.Debug_Dash_In_Terminal, 'Dash', (_runtime, document, urlPrefix) =>
             getDashDebugConfig(document, urlPrefix),
+            undefined,
+            undefined,
+            // Dash url string: https://github.com/plotly/dash/blob/95665785f184aba4ce462637c30ccb7789280911/dash/dash.py#L2160
+            ['Dash is running on {{APP_URL}}'],
         ),
         registerDebugCommand(
             Commands.Debug_FastAPI_In_Terminal,
@@ -51,12 +77,25 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             (runtime, document, _urlPrefix) => getFastAPIDebugConfig(serviceContainer, runtime, document),
             '/docs',
             'Application startup complete',
+            // Uvicorn url string: https://github.com/encode/uvicorn/blob/fe3910083e3990695bc19c2ef671dd447262ae18/uvicorn/config.py#L479-L525
+            ['Uvicorn running on {{APP_URL}}'],
+
         ),
         registerDebugCommand(Commands.Debug_Flask_In_Terminal, 'Flask', (_runtime, document, _urlPrefix) =>
             getFlaskDebugConfig(document),
+            undefined,
+            undefined,
+            ['Running on {{APP_URL}}'],
         ),
         registerDebugCommand(Commands.Debug_Gradio_In_Terminal, 'Gradio', (_runtime, document, urlPrefix) =>
             getGradioDebugConfig(document, urlPrefix),
+            undefined,
+            undefined,
+            // Gradio url strings: https://github.com/gradio-app/gradio/blob/main/gradio/strings.py
+            [
+                'Running on local URL: {{APP_URL}}',
+                'Running on public URL: {{APP_URL}}',
+            ],
         ),
         registerDebugCommand(
             Commands.Debug_Shiny_In_Terminal,
@@ -64,9 +103,15 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             (_runtime, document, _urlPrefix) => getShinyDebugConfig(document),
             undefined,
             'Application startup complete',
+            // Uvicorn url string: https://github.com/encode/uvicorn/blob/fe3910083e3990695bc19c2ef671dd447262ae18/uvicorn/config.py#L479-L525
+            ['Uvicorn running on {{APP_URL}}'],
         ),
         registerDebugCommand(Commands.Debug_Streamlit_In_Terminal, 'Streamlit', (_runtime, document, _urlPrefix) =>
             getStreamlitDebugConfig(document),
+            undefined,
+            undefined,
+            // Streamlit url string: https://github.com/streamlit/streamlit/blob/3e6248461cce366b1f54c273e787adf84a66148d/lib/streamlit/web/bootstrap.py#L197
+            ['Local URL: {{APP_URL}}'],
         ),
     );
 }
@@ -81,6 +126,7 @@ function registerExecCommand(
     ) => DebugConfiguration | undefined | Promise<DebugConfiguration | undefined>,
     urlPath?: string,
     appReadyMessage?: string,
+    appUriFormat?: AppUrlString[],
 ): vscode.Disposable {
     return vscode.commands.registerCommand(command, async () => {
         const runAppApi = await getPositronRunAppApi();
@@ -113,6 +159,7 @@ function registerExecCommand(
             },
             urlPath,
             appReadyMessage,
+            appUriFormat,
         });
     });
 }
@@ -127,6 +174,7 @@ function registerDebugCommand(
     ) => DebugConfiguration | undefined | Promise<DebugConfiguration | undefined>,
     urlPath?: string,
     appReadyMessage?: string,
+    appUriFormat?: AppUrlString[],
 ): vscode.Disposable {
     return vscode.commands.registerCommand(command, async () => {
         const runAppApi = await getPositronRunAppApi();
@@ -148,6 +196,7 @@ function registerDebugCommand(
             },
             urlPath,
             appReadyMessage,
+            appUriFormat,
         });
     });
 }

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -603,10 +603,7 @@ function extractAppUrlFromString(str: string, appUrlStrings?: AppUrlString[]) {
 				// Placeholder is in the middle of the string.
 				// Example: 'Open {{APP_URL}} to view the app'
 				// [0] = 'Open ', [1] = '{{APP_URL}}', [2] = ' to view the app'
-				if (!startsWithAppUrl && !endsWithAppUrl) {
-					// The placeholder is not at the start or end of the string, so it's in the middle.
-					return match[1];
-				}
+				return match[1];
 			}
 		}
 	}

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -8,14 +8,24 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { DebugAdapterTrackerFactory } from './debugAdapterTrackerFactory';
 import { Config, log } from './extension';
-import { DebugAppOptions, PositronRunApp, RunAppOptions } from './positron-run-app';
+import { AppUrlString, DebugAppOptions, PositronRunApp, RunAppOptions } from './positron-run-app';
 import { raceTimeout, removeAnsiEscapeCodes, SequencerByKey } from './utils';
 
-// Regex to match a URL with the format http://localhost:1234/path
-const localUrlRegex = /http:\/\/(localhost|127\.0\.0\.1):(\d{1,5})(\/[^\s]*)?/;
+// Regex to match a string that starts with http:// or https://.
+const httpUrlRegex = /((https?:\/\/)([a-zA-Z0-9.-]+)(:\d{1,5})?(\/[^\s]*)?)/;
+// A more permissive URL regex to be used with the AppUrlString type.
+const urlLikeRegex = /((https?:\/\/)?([a-zA-Z0-9.-]*[.:][a-zA-Z0-9.-]*)(:\d{1,5})?(\/[^\s]*)?)/;
 
+// App URL Placeholder string.
+const APP_URL_PLACEHOLDER = '{{APP_URL}}';
+
+// Flags to determine where Positron is running.
 const isPositronWeb = vscode.env.uiKind === vscode.UIKind.Web;
 const isRunningOnPwb = !!process.env.RS_SERVER_URL && isPositronWeb;
+
+// Timeouts.
+const terminalOutputTimeout = 25_000;
+const didPreviewUrlTimeout = terminalOutputTimeout + 5_000;
 
 type PositronProxyInfo = {
 	proxyPath: string;
@@ -27,6 +37,7 @@ type AppPreviewOptions = {
 	proxyInfo?: PositronProxyInfo;
 	urlPath?: string;
 	appReadyMessage?: string;
+	appUrlStrings?: AppUrlString[];
 };
 
 export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable {
@@ -172,6 +183,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 							proxyInfo,
 							urlPath: options.urlPath,
 							appReadyMessage: options.appReadyMessage,
+							appUrlStrings: options.appUrlStrings,
 						};
 						const didPreviewUrl = await previewUrlInExecutionOutput(e.execution, previewOptions);
 						if (didPreviewUrl) {
@@ -181,7 +193,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 				});
 				this._runApplicationDisposableByName.set(options.name, disposable);
 			}),
-			10_000,
+			didPreviewUrlTimeout,
 			async () => {
 				await this.setShellIntegrationSupported(false);
 			});
@@ -294,6 +306,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 									proxyInfo,
 									urlPath: options.urlPath,
 									appReadyMessage: options.appReadyMessage,
+									appUrlStrings: options.appUrlStrings,
 								};
 								const didPreviewUrl = await previewUrlInExecutionOutput(e.execution, previewOptions);
 								if (didPreviewUrl) {
@@ -305,7 +318,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 				});
 				this._debugApplicationDisposableByName.set(options.name, disposable);
 			}),
-			10_000,
+			didPreviewUrlTimeout,
 			async () => {
 				await this.setShellIntegrationSupported(false);
 			});
@@ -386,12 +399,11 @@ async function previewUrlInExecutionOutput(execution: vscode.TerminalShellExecut
 						}
 					}
 				}
-
 				// Check if the app url is found in the terminal output.
 				if (!appUrl) {
-					const match = dataCleaned.match(localUrlRegex)?.[0];
+					const match = extractAppUrlFromString(dataCleaned, options.appUrlStrings);
 					if (match) {
-						appUrl = new URL(match.trim());
+						appUrl = new URL(match);
 						log.debug(`Found app URL in terminal output: ${appUrl.toString()}`);
 						// If the app is ready, we're done!
 						if (appReady) {
@@ -413,7 +425,7 @@ async function previewUrlInExecutionOutput(execution: vscode.TerminalShellExecut
 			}
 			return appUrl;
 		})(),
-		15_000,
+		terminalOutputTimeout,
 		() => log.error('Timed out waiting for server output in terminal'),
 	);
 
@@ -553,4 +565,53 @@ function shouldUsePositronProxy(appName: string) {
 			// By default, proxy the app.
 			return true;
 	}
+}
+
+/**
+ * Extracts a URL from a string using the provided appUrlStrings.
+ * @param str The string to match the URL in.
+ * @param appUrlStrings An array of app url strings to match and extract the URL from.
+ * @returns The matched URL, or undefined if no URL is found.
+ */
+function extractAppUrlFromString(str: string, appUrlStrings?: AppUrlString[]) {
+	if (appUrlStrings && appUrlStrings.length > 0) {
+		// Try to match any of the provided appUrlStrings.
+		log.debug('Attempting to match URL with:', appUrlStrings);
+		for (const appUrlString of appUrlStrings) {
+			const pattern = appUrlString.replace(APP_URL_PLACEHOLDER, urlLikeRegex.source);
+			const appUrlRegex = new RegExp(pattern);
+
+			const match = str.match(appUrlRegex);
+			if (match) {
+				const endsWithAppUrl = appUrlString.endsWith(APP_URL_PLACEHOLDER);
+				// Placeholder is at the end of the string. This is the most common case.
+				// Example: 'The app is running at {{APP_URL}}'
+				// [0] = 'The app is running at ', [1] = '{{APP_URL}}'
+				// Also covers the case where the placeholder is the entire string.
+				if (endsWithAppUrl) {
+					return match[1];
+				}
+
+				const startsWithAppUrl = appUrlString.startsWith(APP_URL_PLACEHOLDER);
+				// Placeholder is at the start of the string.
+				// Example: '{{APP_URL}} is where the app is running'
+				// [0] = '{{APP_URL}}', [1] = ' is where the app is running'
+				if (startsWithAppUrl) {
+					return match[0];
+				}
+
+				// Placeholder is in the middle of the string.
+				// Example: 'Open {{APP_URL}} to view the app'
+				// [0] = 'Open ', [1] = '{{APP_URL}}', [2] = ' to view the app'
+				if (!startsWithAppUrl && !endsWithAppUrl) {
+					// The placeholder is not at the start or end of the string, so it's in the middle.
+					return match[1];
+				}
+			}
+		}
+	}
+
+	// Fall back to the default URL regex if no appUrlStrings were provided or matched.
+	log.debug('No appUrlStrings matched. Falling back to default URL regex to match URL.');
+	return str.match(httpUrlRegex)?.[0];
 }

--- a/extensions/positron-run-app/src/positron-run-app.d.ts
+++ b/extensions/positron-run-app/src/positron-run-app.d.ts
@@ -8,7 +8,18 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 
 /**
- * Defines a string that contains the `${{APP_URL}}` placeholder.
+ * Defines a string type that contains the app url placeholder.
+ *
+ * Unfortunately, if a string is constructed programmatically with this format, TypeScript will not
+ * recognize it as an `AppUrlString`. For example, the following will not work:
+ * ```ts
+ * const appUrlString = 'The url will be:' + '{{APP_URL}}';
+ * ```
+ *
+ * Strings must be defined as literals in the source code to be recognized as `AppUrlString`. For
+ * example, the following will work:
+ * ```ts
+ * const appUrlString: AppUrlString = 'The url will be: {{APP_URL}}';
  */
 export type AppUrlString = `${string}{{APP_URL}}${string}`;
 
@@ -63,7 +74,7 @@ export interface RunAppOptions {
 	/**
 	 * An optional array of app URI formats to parse the URI from the terminal output.
 	 */
-	appUriFormat?: AppUrlString[];
+	appUrlStrings?: AppUrlString[];
 }
 
 /**
@@ -102,7 +113,7 @@ export interface DebugAppOptions {
 	/**
 	 * An optional array of app URI formats to parse the URI from the terminal output.
 	 */
-	appUriFormat?: AppUrlString[];
+	appUrlStrings?: AppUrlString[];
 }
 
 /**

--- a/extensions/positron-run-app/src/positron-run-app.d.ts
+++ b/extensions/positron-run-app/src/positron-run-app.d.ts
@@ -9,17 +9,28 @@ import * as vscode from 'vscode';
 
 /**
  * Defines a string type that contains the app url placeholder.
+ * @example 'The url will be: {{APP_URL}}'
+ * @example 'string one' + '{{APP_URL}}' + 'string two' as AppUrlString
  *
- * Unfortunately, if a string is constructed programmatically with this format, TypeScript will not
- * recognize it as an `AppUrlString`. For example, the following will not work:
+ * Strings must be defined as literals in the source code to be recognized as `AppUrlString` if not
+ * using type assertions. For example, the following _will_ work:
+ * ```ts
+ * const appUrlString: AppUrlString = 'The url will be: {{APP_URL}}';
+ * ```
+ *
+ * Unfortunately, if a string is constructed programmatically with this format, TypeScript won't
+ * recognize it as an `AppUrlString`. For example, the following _will not_ work:
  * ```ts
  * const appUrlString = 'The url will be:' + '{{APP_URL}}';
  * ```
  *
- * Strings must be defined as literals in the source code to be recognized as `AppUrlString`. For
- * example, the following will work:
+ * One way to work around this is to use a type assertion:
  * ```ts
- * const appUrlString: AppUrlString = 'The url will be: {{APP_URL}}';
+ * const appUrlString = 'The url will be:' + '{{APP_URL}}' as AppUrlString;
+ * ```
+ *
+ * @see https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-inference for
+ * more on literal type inference.
  */
 export type AppUrlString = `${string}{{APP_URL}}${string}`;
 

--- a/extensions/positron-run-app/src/positron-run-app.d.ts
+++ b/extensions/positron-run-app/src/positron-run-app.d.ts
@@ -8,6 +8,11 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 
 /**
+ * Defines a string that contains the `${{APP_URL}}` placeholder.
+ */
+export type AppUrlString = `${string}{{APP_URL}}${string}`;
+
+/**
  * Represents options returned from ${@link RunAppOptions.getTerminalOptions}.
  */
 export interface RunAppTerminalOptions {
@@ -54,6 +59,11 @@ export interface RunAppOptions {
 	 * The optional app ready message to wait for in the terminal before previewing the application.
 	 */
 	appReadyMessage?: string;
+
+	/**
+	 * An optional array of app URI formats to parse the URI from the terminal output.
+	 */
+	appUriFormat?: AppUrlString[];
 }
 
 /**
@@ -88,6 +98,11 @@ export interface DebugAppOptions {
 	 * The optional app ready message to wait for in the terminal before previewing the application.
 	 */
 	appReadyMessage?: string;
+
+	/**
+	 * An optional array of app URI formats to parse the URI from the terminal output.
+	 */
+	appUriFormat?: AppUrlString[];
 }
 
 /**


### PR DESCRIPTION
### Addresses
- https://github.com/posit-dev/positron/issues/5197
- https://github.com/posit-dev/positron/issues/5306

### Implementation Notes

#### URL Matching
- introduces `appUrlStrings` to the run and debug app options, which is an optional array of `AppUrlString`s, which we will attempt to extract the app url from
    - `AppUrlString` is a string type that has the placeholder template `{{APP_URL}}` in the string, which indicates the location of the app url relative to the string
- adds the appropriate `appUrlStrings` for each framework we support
- expands on our url matching by:
    - attempting to match url-like text where `{{APP_URL}}` is found in the provided `appUrlStrings`
    - if matching against `appUrlStrings` fails or no `appUrlStrings` are found, we fallback to a more basic url match for strings that start with http or https

#### Shell Integration Warning Message
This PR should also fix a timing issue where the `didPreviewUrlTimeout` would time out before 
`terminalOutputTimeout`, causing the shell integration warning message to show. We now set `didPreviewUrlTimeout` to be 5 seconds longer than `terminalOutputTimeout`, so that it doesn't timeout before the app preview is done.

### QA Notes

This PR fixes Run App in Terminal url detection for non-local URLs. One way to get a non-local url is by running the `shiny-py-example` in Positron on Workbench (see https://github.com/posit-dev/positron/issues/5197).

Other app types like Dash, Streamlit, Fastapi, Flask and Gradio should continue to work on Desktop, Server Web and Positron on Workbench.

This PR should also fix the issue seen in #5306, which can be tested by running the [Dash Py Example](https://github.com/posit-dev/qa-example-content/tree/main/workspaces/dash-py-example) several times to check that the issue does not occur.
