### PR TITLE
Suppress dumping env var information into Python logs

### DIFF
--- a/extensions/positron-python/src/client/common/variables/environmentVariablesProvider.ts
+++ b/extensions/positron-python/src/client/common/variables/environmentVariablesProvider.ts
@@ -7,7 +7,9 @@
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { ConfigurationChangeEvent, Disposable, Event, EventEmitter, FileSystemWatcher, Uri } from 'vscode';
-import { traceError, traceVerbose } from '../../logging';
+// --- Start Positron ---
+import { traceError } from '../../logging';
+// --- End Positron ---
 import { sendFileCreationTelemetry } from '../../telemetry/envFileTelemetry';
 import { IWorkspaceService } from '../application/types';
 import { PythonSettings } from '../configSettings';
@@ -72,7 +74,10 @@ export class EnvironmentVariablesProvider implements IEnvironmentVariablesProvid
         }
         const vars = await this._getEnvironmentVariables(resource);
         this.setCachedEnvironmentVariables(resource, vars);
-        traceVerbose('Dump environment variables', JSON.stringify(vars, null, 4));
+        // --- Start Positron ---
+        // Avoid printing out environment variables to the log as they may contain secrets.
+        // traceVerbose('Dump environment variables', JSON.stringify(vars, null, 4));
+        // --- End Positron ---
         return vars;
     }
 

--- a/extensions/positron-python/src/client/terminals/envCollectionActivation/service.ts
+++ b/extensions/positron-python/src/client/terminals/envCollectionActivation/service.ts
@@ -183,6 +183,7 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
         );
         const env = activatedEnv ? normCaseKeys(activatedEnv) : undefined;
         // --- Start Positron ---
+        // Avoid printing out environment variables to the log as they may contain secrets.
         traceVerbose(`Activated environment variables for ${resource?.fsPath}`);
         // --- End Positron ---
         if (!env) {

--- a/extensions/positron-python/src/client/terminals/envCollectionActivation/service.ts
+++ b/extensions/positron-python/src/client/terminals/envCollectionActivation/service.ts
@@ -182,7 +182,9 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
             shell,
         );
         const env = activatedEnv ? normCaseKeys(activatedEnv) : undefined;
-        traceVerbose(`Activated environment variables for ${resource?.fsPath}`, env);
+        // --- Start Positron ---
+        traceVerbose(`Activated environment variables for ${resource?.fsPath}`);
+        // --- End Positron ---
         if (!env) {
             const shellType = identifyShellFromShellPath(shell);
             const defaultShell = defaultShells[this.platform.osType];


### PR DESCRIPTION
Addresses the positron-python extension piece of #5320

Sensitive information may be in env vars, we should not output this to the logs by default. Users can always debug their environment using a Terminal.


### QA Notes

After Positron has successfully finished scanning for interpreters and has started a Python interpreter, check the Output tab on the Panel with the `Python` output channel and confirm that a dump of env vars is not present even at the most verbose level.