### PR TITLE
improve Run App url matching and fix preview timeout issue

### DIFF
--- a/extensions/positron-python/src/client/positron-run-app.d.ts
+++ b/extensions/positron-python/src/client/positron-run-app.d.ts
@@ -8,33 +8,6 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 
 /**
- * Defines a string type that contains the app url placeholder.
- * @example 'The url will be: {{APP_URL}}'
- * @example 'string one' + '{{APP_URL}}' + 'string two' as AppUrlString
- *
- * Strings must be defined as literals in the source code to be recognized as `AppUrlString` if not
- * using type assertions. For example, the following _will_ work:
- * ```ts
- * const appUrlString: AppUrlString = 'The url will be: {{APP_URL}}';
- * ```
- *
- * Unfortunately, if a string is constructed programmatically with this format, TypeScript won't
- * recognize it as an `AppUrlString`. For example, the following _will not_ work:
- * ```ts
- * const appUrlString = 'The url will be:' + '{{APP_URL}}';
- * ```
- *
- * One way to work around this is to use a type assertion:
- * ```ts
- * const appUrlString = 'The url will be:' + '{{APP_URL}}' as AppUrlString;
- * ```
- *
- * @see https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-inference for
- * more on literal type inference.
- */
-export type AppUrlString = `${string}{{APP_URL}}${string}`;
-
-/**
  * Represents options returned from ${@link RunAppOptions.getTerminalOptions}.
  */
 export interface RunAppTerminalOptions {
@@ -85,7 +58,7 @@ export interface RunAppOptions {
     /**
      * An optional array of app URI formats to parse the URI from the terminal output.
      */
-    appUrlStrings?: AppUrlString[];
+    appUrlStrings?: string[];
 }
 
 /**
@@ -124,7 +97,7 @@ export interface DebugAppOptions {
     /**
      * An optional array of app URI formats to parse the URI from the terminal output.
      */
-    appUrlStrings?: AppUrlString[];
+    appUrlStrings?: string[];
 }
 
 /**

--- a/extensions/positron-python/src/client/positron-run-app.d.ts
+++ b/extensions/positron-python/src/client/positron-run-app.d.ts
@@ -8,6 +8,33 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 
 /**
+ * Defines a string type that contains the app url placeholder.
+ * @example 'The url will be: {{APP_URL}}'
+ * @example 'string one' + '{{APP_URL}}' + 'string two' as AppUrlString
+ *
+ * Strings must be defined as literals in the source code to be recognized as `AppUrlString` if not
+ * using type assertions. For example, the following _will_ work:
+ * ```ts
+ * const appUrlString: AppUrlString = 'The url will be: {{APP_URL}}';
+ * ```
+ *
+ * Unfortunately, if a string is constructed programmatically with this format, TypeScript won't
+ * recognize it as an `AppUrlString`. For example, the following _will not_ work:
+ * ```ts
+ * const appUrlString = 'The url will be:' + '{{APP_URL}}';
+ * ```
+ *
+ * One way to work around this is to use a type assertion:
+ * ```ts
+ * const appUrlString = 'The url will be:' + '{{APP_URL}}' as AppUrlString;
+ * ```
+ *
+ * @see https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-inference for
+ * more on literal type inference.
+ */
+export type AppUrlString = `${string}{{APP_URL}}${string}`;
+
+/**
  * Represents options returned from ${@link RunAppOptions.getTerminalOptions}.
  */
 export interface RunAppTerminalOptions {
@@ -54,6 +81,11 @@ export interface RunAppOptions {
      * The optional app ready message to wait for in the terminal before previewing the application.
      */
     appReadyMessage?: string;
+
+    /**
+     * An optional array of app URI formats to parse the URI from the terminal output.
+     */
+    appUrlStrings?: AppUrlString[];
 }
 
 /**
@@ -88,6 +120,11 @@ export interface DebugAppOptions {
      * The optional app ready message to wait for in the terminal before previewing the application.
      */
     appReadyMessage?: string;
+
+    /**
+     * An optional array of app URI formats to parse the URI from the terminal output.
+     */
+    appUrlStrings?: AppUrlString[];
 }
 
 /**

--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 // eslint-disable-next-line import/no-unresolved
 import * as positron from 'positron';
 import * as vscode from 'vscode';
-import { AppUrlString, PositronRunApp, RunAppTerminalOptions } from '../positron-run-app.d';
+import { PositronRunApp, RunAppTerminalOptions } from '../positron-run-app.d';
 import { IServiceContainer } from '../ioc/types';
 import { IInterpreterService } from '../interpreter/contracts';
 import { IInstaller, Product } from '../common/types';
@@ -137,7 +137,7 @@ function registerExecCommand(
     ) => DebugConfiguration | undefined | Promise<DebugConfiguration | undefined>,
     urlPath?: string,
     appReadyMessage?: string,
-    appUrlStrings?: AppUrlString[],
+    appUrlStrings?: string[],
 ): vscode.Disposable {
     return vscode.commands.registerCommand(command, async () => {
         const runAppApi = await getPositronRunAppApi();
@@ -185,7 +185,7 @@ function registerDebugCommand(
     ) => DebugConfiguration | undefined | Promise<DebugConfiguration | undefined>,
     urlPath?: string,
     appReadyMessage?: string,
-    appUrlStrings?: AppUrlString[],
+    appUrlStrings?: string[],
 ): vscode.Disposable {
     return vscode.commands.registerCommand(command, async () => {
         const runAppApi = await getPositronRunAppApi();

--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -16,8 +16,10 @@ import { Commands } from '../common/constants';
 
 export function activateWebAppCommands(serviceContainer: IServiceContainer, disposables: vscode.Disposable[]): void {
     disposables.push(
-        registerExecCommand(Commands.Exec_Dash_In_Terminal, 'Dash', (_runtime, document, urlPrefix) =>
-            getDashDebugConfig(document, urlPrefix),
+        registerExecCommand(
+            Commands.Exec_Dash_In_Terminal,
+            'Dash',
+            (_runtime, document, urlPrefix) => getDashDebugConfig(document, urlPrefix),
             undefined,
             undefined,
             // Dash url string: https://github.com/plotly/dash/blob/95665785f184aba4ce462637c30ccb7789280911/dash/dash.py#L2160
@@ -32,22 +34,23 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             // Uvicorn url string: https://github.com/encode/uvicorn/blob/fe3910083e3990695bc19c2ef671dd447262ae18/uvicorn/config.py#L479-L525
             ['Uvicorn running on {{APP_URL}}'],
         ),
-        registerExecCommand(Commands.Exec_Flask_In_Terminal, 'Flask', (_runtime, document, _urlPrefix) =>
-            getFlaskDebugConfig(document),
+        registerExecCommand(
+            Commands.Exec_Flask_In_Terminal,
+            'Flask',
+            (_runtime, document, _urlPrefix) => getFlaskDebugConfig(document),
             undefined,
             undefined,
             // Flask url string is from Werkzeug: https://github.com/pallets/werkzeug/blob/7868bef5d978093a8baa0784464ebe5d775ae92a/src/werkzeug/serving.py#L833-L865
             ['Running on {{APP_URL}}'],
         ),
-        registerExecCommand(Commands.Exec_Gradio_In_Terminal, 'Gradio', (_runtime, document, urlPrefix) =>
-            getGradioDebugConfig(document, urlPrefix),
+        registerExecCommand(
+            Commands.Exec_Gradio_In_Terminal,
+            'Gradio',
+            (_runtime, document, urlPrefix) => getGradioDebugConfig(document, urlPrefix),
             undefined,
             undefined,
             // Gradio url strings: https://github.com/gradio-app/gradio/blob/main/gradio/strings.py
-            [
-                'Running on local URL:  {{APP_URL}}',
-                'Running on public URL:  {{APP_URL}}',
-            ],
+            ['Running on local URL:  {{APP_URL}}', 'Running on public URL:  {{APP_URL}}'],
         ),
         registerExecCommand(
             Commands.Exec_Shiny_In_Terminal,
@@ -58,15 +61,19 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             // Uvicorn url string: https://github.com/encode/uvicorn/blob/fe3910083e3990695bc19c2ef671dd447262ae18/uvicorn/config.py#L479-L525
             ['Uvicorn running on {{APP_URL}}'],
         ),
-        registerExecCommand(Commands.Exec_Streamlit_In_Terminal, 'Streamlit', (_runtime, document, _urlPrefix) =>
-            getStreamlitDebugConfig(document),
+        registerExecCommand(
+            Commands.Exec_Streamlit_In_Terminal,
+            'Streamlit',
+            (_runtime, document, _urlPrefix) => getStreamlitDebugConfig(document),
             undefined,
             undefined,
             // Streamlit url string: https://github.com/streamlit/streamlit/blob/3e6248461cce366b1f54c273e787adf84a66148d/lib/streamlit/web/bootstrap.py#L197
             ['Local URL: {{APP_URL}}'],
         ),
-        registerDebugCommand(Commands.Debug_Dash_In_Terminal, 'Dash', (_runtime, document, urlPrefix) =>
-            getDashDebugConfig(document, urlPrefix),
+        registerDebugCommand(
+            Commands.Debug_Dash_In_Terminal,
+            'Dash',
+            (_runtime, document, urlPrefix) => getDashDebugConfig(document, urlPrefix),
             undefined,
             undefined,
             // Dash url string: https://github.com/plotly/dash/blob/95665785f184aba4ce462637c30ccb7789280911/dash/dash.py#L2160
@@ -80,24 +87,24 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             'Application startup complete',
             // Uvicorn url string: https://github.com/encode/uvicorn/blob/fe3910083e3990695bc19c2ef671dd447262ae18/uvicorn/config.py#L479-L525
             ['Uvicorn running on {{APP_URL}}'],
-
         ),
-        registerDebugCommand(Commands.Debug_Flask_In_Terminal, 'Flask', (_runtime, document, _urlPrefix) =>
-            getFlaskDebugConfig(document),
+        registerDebugCommand(
+            Commands.Debug_Flask_In_Terminal,
+            'Flask',
+            (_runtime, document, _urlPrefix) => getFlaskDebugConfig(document),
             undefined,
             undefined,
             // Flask url string is from Werkzeug: https://github.com/pallets/werkzeug/blob/7868bef5d978093a8baa0784464ebe5d775ae92a/src/werkzeug/serving.py#L833-L865
             ['Running on {{APP_URL}}'],
         ),
-        registerDebugCommand(Commands.Debug_Gradio_In_Terminal, 'Gradio', (_runtime, document, urlPrefix) =>
-            getGradioDebugConfig(document, urlPrefix),
+        registerDebugCommand(
+            Commands.Debug_Gradio_In_Terminal,
+            'Gradio',
+            (_runtime, document, urlPrefix) => getGradioDebugConfig(document, urlPrefix),
             undefined,
             undefined,
             // Gradio url strings: https://github.com/gradio-app/gradio/blob/main/gradio/strings.py
-            [
-                'Running on local URL:  {{APP_URL}}',
-                'Running on public URL:  {{APP_URL}}',
-            ],
+            ['Running on local URL:  {{APP_URL}}', 'Running on public URL:  {{APP_URL}}'],
         ),
         registerDebugCommand(
             Commands.Debug_Shiny_In_Terminal,
@@ -108,8 +115,10 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
             // Uvicorn url string: https://github.com/encode/uvicorn/blob/fe3910083e3990695bc19c2ef671dd447262ae18/uvicorn/config.py#L479-L525
             ['Uvicorn running on {{APP_URL}}'],
         ),
-        registerDebugCommand(Commands.Debug_Streamlit_In_Terminal, 'Streamlit', (_runtime, document, _urlPrefix) =>
-            getStreamlitDebugConfig(document),
+        registerDebugCommand(
+            Commands.Debug_Streamlit_In_Terminal,
+            'Streamlit',
+            (_runtime, document, _urlPrefix) => getStreamlitDebugConfig(document),
             undefined,
             undefined,
             // Streamlit url string: https://github.com/streamlit/streamlit/blob/3e6248461cce366b1f54c273e787adf84a66148d/lib/streamlit/web/bootstrap.py#L197

--- a/extensions/positron-run-app/src/positron-run-app.d.ts
+++ b/extensions/positron-run-app/src/positron-run-app.d.ts
@@ -8,33 +8,6 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 
 /**
- * Defines a string type that contains the app url placeholder.
- * @example 'The url will be: {{APP_URL}}'
- * @example 'string one' + '{{APP_URL}}' + 'string two' as AppUrlString
- *
- * Strings must be defined as literals in the source code to be recognized as `AppUrlString` if not
- * using type assertions. For example, the following _will_ work:
- * ```ts
- * const appUrlString: AppUrlString = 'The url will be: {{APP_URL}}';
- * ```
- *
- * Unfortunately, if a string is constructed programmatically with this format, TypeScript won't
- * recognize it as an `AppUrlString`. For example, the following _will not_ work:
- * ```ts
- * const appUrlString = 'The url will be:' + '{{APP_URL}}';
- * ```
- *
- * One way to work around this is to use a type assertion:
- * ```ts
- * const appUrlString = 'The url will be:' + '{{APP_URL}}' as AppUrlString;
- * ```
- *
- * @see https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-inference for
- * more on literal type inference.
- */
-export type AppUrlString = `${string}{{APP_URL}}${string}`;
-
-/**
  * Represents options returned from ${@link RunAppOptions.getTerminalOptions}.
  */
 export interface RunAppTerminalOptions {
@@ -85,7 +58,7 @@ export interface RunAppOptions {
 	/**
 	 * An optional array of app URI formats to parse the URI from the terminal output.
 	 */
-	appUrlStrings?: AppUrlString[];
+	appUrlStrings?: string[];
 }
 
 /**
@@ -124,7 +97,7 @@ export interface DebugAppOptions {
 	/**
 	 * An optional array of app URI formats to parse the URI from the terminal output.
 	 */
-	appUrlStrings?: AppUrlString[];
+	appUrlStrings?: string[];
 }
 
 /**

--- a/extensions/positron-run-app/src/positron-run-app.d.ts
+++ b/extensions/positron-run-app/src/positron-run-app.d.ts
@@ -8,6 +8,33 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 
 /**
+ * Defines a string type that contains the app url placeholder.
+ * @example 'The url will be: {{APP_URL}}'
+ * @example 'string one' + '{{APP_URL}}' + 'string two' as AppUrlString
+ *
+ * Strings must be defined as literals in the source code to be recognized as `AppUrlString` if not
+ * using type assertions. For example, the following _will_ work:
+ * ```ts
+ * const appUrlString: AppUrlString = 'The url will be: {{APP_URL}}';
+ * ```
+ *
+ * Unfortunately, if a string is constructed programmatically with this format, TypeScript won't
+ * recognize it as an `AppUrlString`. For example, the following _will not_ work:
+ * ```ts
+ * const appUrlString = 'The url will be:' + '{{APP_URL}}';
+ * ```
+ *
+ * One way to work around this is to use a type assertion:
+ * ```ts
+ * const appUrlString = 'The url will be:' + '{{APP_URL}}' as AppUrlString;
+ * ```
+ *
+ * @see https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-inference for
+ * more on literal type inference.
+ */
+export type AppUrlString = `${string}{{APP_URL}}${string}`;
+
+/**
  * Represents options returned from ${@link RunAppOptions.getTerminalOptions}.
  */
 export interface RunAppTerminalOptions {
@@ -54,6 +81,11 @@ export interface RunAppOptions {
 	 * The optional app ready message to wait for in the terminal before previewing the application.
 	 */
 	appReadyMessage?: string;
+
+	/**
+	 * An optional array of app URI formats to parse the URI from the terminal output.
+	 */
+	appUrlStrings?: AppUrlString[];
 }
 
 /**
@@ -88,6 +120,11 @@ export interface DebugAppOptions {
 	 * The optional app ready message to wait for in the terminal before previewing the application.
 	 */
 	appReadyMessage?: string;
+
+	/**
+	 * An optional array of app URI formats to parse the URI from the terminal output.
+	 */
+	appUrlStrings?: AppUrlString[];
 }
 
 /**


### PR DESCRIPTION
Cherry-picks https://github.com/posit-dev/positron/pull/5336 to bring the fix from the 2024.11 patch branch to the `main` branch. The below description is copied from #5336 and modified to remove the AppUrlString type changes.

The prerelease branch will need to be updated again to include the additional changes.

### Addresses
- https://github.com/posit-dev/positron/issues/5197
- https://github.com/posit-dev/positron/issues/5306

### Implementation Notes

#### URL Matching
- introduces `appUrlStrings` to the run and debug app options, which we will attempt to extract the app url from
- the strings should contain the placeholder `{{APP_URL}}`, which indicates the location of the app url relative to the string
- adds the appropriate `appUrlStrings` for each framework we support
- expands on our url matching by:
    - attempting to match url-like text where `{{APP_URL}}` is found in the provided `appUrlStrings`
    - if matching against `appUrlStrings` fails or no `appUrlStrings` are found, we fallback to a more basic url match for strings that start with http or https

#### Shell Integration Warning Message
This PR should also fix a timing issue where the `didPreviewUrlTimeout` would time out before `terminalOutputTimeout`, causing the shell integration warning message to show. We now set `didPreviewUrlTimeout` to be 5 seconds longer than `terminalOutputTimeout`, so that it doesn't timeout before the app preview is done.

### QA Notes

This PR fixes Run App in Terminal url detection for non-local URLs. One way to get a non-local url is by running the `shiny-py-example` in Positron on Workbench (see https://github.com/posit-dev/positron/issues/5197).

Other app types like Dash, Streamlit, Fastapi, Flask and Gradio should continue to work on Desktop, Server Web and Positron on Workbench.

This PR should also fix the issue seen in #5306, which can be tested by running the [Dash Py Example](https://github.com/posit-dev/qa-example-content/tree/main/workspaces/dash-py-example) several times to check that the issue does not occur.