### PR TITLE
test: add basic positron-zed extensions test

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -82,6 +82,11 @@ const extensions = [
 		workspaceFolder: path.join(os.tmpdir(), `positron-supervisor-${Math.floor(Math.random() * 100000)}`),
 		mocha: { timeout: 60_000 }
 	},
+	{
+		label: 'positron-zed',
+		workspaceFolder: path.join(os.tmpdir(), `positron-zed-${Math.floor(Math.random() * 100000)}`),
+		mocha: { timeout: 60_000 }
+	},
 	// --- End Positron ---
 	{
 		label: 'microsoft-authentication',

--- a/extensions/positron-zed/src/extension.ts
+++ b/extensions/positron-zed/src/extension.ts
@@ -9,7 +9,7 @@ import { ZedRuntimeManager } from './manager';
 
 /**
  * Activates the extension.
- * @param context An ExtensionContext that contains the extention context.
+ * @param context An ExtensionContext that contains the extension context.
  */
 export function activate(context: vscode.ExtensionContext) {
 	// Register the Zed runtime manager with the Positron runtime.

--- a/extensions/positron-zed/src/test/README.md
+++ b/extensions/positron-zed/src/test/README.md
@@ -1,0 +1,5 @@
+Launch tests by running this from the repository root:
+
+```sh
+yarn test-extension -l positron-zed
+```

--- a/extensions/positron-zed/src/test/extension.test.ts
+++ b/extensions/positron-zed/src/test/extension.test.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+suite('Zed Interpreter Extension Test Suite', () => {
+	vscode.window.showInformationMessage('Start all tests.');
+
+	test('Zed Interpreter Activation Test', async () => {
+		const extension = vscode.extensions.getExtension('vscode.positron-zed');
+		assert.ok(extension, 'Extension not found');
+		await extension.activate();
+		assert.ok(extension.isActive, 'Extension is not active');
+	});
+});

--- a/extensions/positron-zed/src/test/extension.test.ts
+++ b/extensions/positron-zed/src/test/extension.test.ts
@@ -9,10 +9,51 @@ import * as vscode from 'vscode';
 suite('Zed Interpreter Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
-	test('Zed Interpreter Activation Test', async () => {
-		const extension = vscode.extensions.getExtension('vscode.positron-zed');
-		assert.ok(extension, 'Extension not found');
-		await extension.activate();
-		assert.ok(extension.isActive, 'Extension is not active');
+	test('should be able to activate extension', async () => {
+		await activateZedExtension();
+	});
+
+	test('should display and execute `Move To New Window` for zed file', async () => {
+		await activateZedExtension();
+		await openZedFile();
+		await checkAndExecuteCommand('workbench.action.moveEditorToNewWindow', 'Move into New Window');
+
+		// verify that the active editor has changed or been closed in the current window
+		const activeEditor = vscode.window.activeTextEditor;
+		assert.ok(!activeEditor, 'Editor was not moved to a new window as expected');
+		console.log('Editor successfully moved to a new window');
+
+		// clean up by closing the opened .zed document
+		await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
 	});
 });
+
+async function activateZedExtension() {
+	const extension = vscode.extensions.getExtension('vscode.positron-zed');
+	assert.ok(extension, 'Zed extension not found');
+	await extension.activate();
+	assert.ok(extension.isActive, 'Zed extension failed to activate');
+	console.log('Zed extension activated successfully');
+	return extension;
+}
+
+async function openZedFile() {
+	// open a .zed file in the editor
+	const document = await vscode.workspace.openTextDocument({ language: 'zed', content: 'empty document' });
+	const editor = await vscode.window.showTextDocument(document);
+	assert.ok(editor, 'Failed to open .zed document in the editor');
+	console.log('Opened .zed document in editor');
+	return editor;
+}
+
+async function checkAndExecuteCommand(commandId: string, description: string) {
+	// retrieve available commands and check the presence of the command action
+	const commands = await vscode.commands.getCommands();
+	const commandExists = commands.includes(commandId);
+	assert.ok(commandExists, `${description} is not available`);
+	console.log(`Command "${description}" is available in commands`);
+
+	// execute command to ensure it works
+	await vscode.commands.executeCommand(commandId);
+	console.log(`Executed "${commandId}" command`);
+}

--- a/scripts/test-integration-pr.sh
+++ b/scripts/test-integration-pr.sh
@@ -64,6 +64,12 @@ echo
 yarn test-extension -l positron-duckdb
 kill_app
 
+echo
+echo "### Positron Zed tests"
+echo
+yarn test-extension -l positron-zed
+kill_app
+
 # Cleanup
 
 rm -rf $VSCODEUSERDATADIR

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -145,6 +145,12 @@ echo
 yarn test-extension -l positron-duckdb
 kill_app
 
+echo
+echo "### Positron Zed tests"
+echo
+yarn test-extension -l positron-zed
+kill_app
+
 # --- End Positron ---
 
 # Tests standalone (CommonJS)


### PR DESCRIPTION
### Summary

This PR introduces the framework for automated testing of the Zed extension. The initial setup includes a test to verify the activation of the Zed extension and confirms that the key editor action, `Move to New Window`, is accessible and functional.

### Future Work

As additional editor actions are implemented, this test suite will be expanded to increase test coverage for these actions, ensuring they perform as expected within the Zed extension.

### QA Notes

Verified that the initial test framework runs successfully and passes.
