### PR TITLE
add prerelease branches to the PR CI workflow

### DIFF
--- a/.github/workflows/positron-pull-requests.yml
+++ b/.github/workflows/positron-pull-requests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'prerelease/**'
 
 jobs:
   positron-ci:


### PR DESCRIPTION
Following https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-branches, we can add the prerelease branch pattern `prerelease/**` so that the usual PR CI is triggered when PRs are opened against prerelease branches.

This is helpful for verifying backported fixes or fixes targeted for prerelease branches.

I noticed this when I targeted my fix for #5197 for the prerelease branch, merged it, but then ran into CI failures in my PR to bring in the same fix to main. For the patch branch PR, I manually ran the Full and Windows test suites, but missed the Python one.

### QA Notes

Once this change is backported to a `prerelease` branch, PRs against `prerelease` branches should now automatically kick off the usual CI workflows that we see for PRs against `main`.

This change can be tested when this commit is backported to the prerelease branches in a PR. The PR CI workflow should run.