### PR TITLE
3735 new projects should use better default name

### DIFF
--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectTypeStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectTypeStep.tsx
@@ -26,7 +26,7 @@ import { NewProjectType } from 'vs/workbench/services/positronNewProject/common/
  * @param projectType - The type of the project for which to generate a default name.
  * @returns The default project name as a string.
  */
-export const getDefaultProjectName = (projectType: NewProjectType) => {
+const getDefaultProjectName = (projectType: NewProjectType) => {
 	return localize(
 		'positron.newProjectWizard.projectTypeStep.defaultProjectNamePrefix',
 		"my"

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectTypeStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectTypeStep.tsx
@@ -18,6 +18,26 @@ import { NewProjectWizardStepProps } from 'vs/workbench/browser/positronNewProje
 import { OKCancelBackNextActionBar } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelBackNextActionBar';
 import { ProjectTypeGroup } from 'vs/workbench/browser/positronNewProjectWizard/components/projectTypeGroup';
 import { checkProjectName } from 'vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils';
+import { NewProjectType } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
+
+/**
+ * Generates a default project name based on the provided project type.
+ *
+ * @param projectType - The type of the project for which to generate a default name.
+ * @returns The default project name as a string.
+ */
+export const getDefaultProjectName = (projectType: NewProjectType) => {
+	const defaultProjectName = localize(
+		'positron.newProjectWizard.projectTypeStep.defaultProjectNamePrefix',
+		"my"
+	);
+	// If the project type is an R Project, the project name is 'my-r-project'.
+	if (projectType === NewProjectType.RProject) {
+		return defaultProjectName + '-' + projectType.toLowerCase().replace(/\s/g, '-');
+	}
+	// The project name for all other project types is 'my' + projectType without spaces, eg. 'myPythonProject'.
+	return defaultProjectName + projectType.replace(/\s/g, '');
+};
 
 /**
  * The ProjectTypeStep component is the first step in the new project wizard, used to
@@ -45,12 +65,7 @@ export const ProjectTypeStep = (props: PropsWithChildren<NewProjectWizardStepPro
 			context.projectType !== selectedProjectType ||
 			context.projectName === ''
 		) {
-			// The default project name is 'my' + projectType without spaces, eg. 'myPythonProject'.
-			const defaultProjectName =
-				localize(
-					'positron.newProjectWizard.projectTypeStep.defaultProjectNamePrefix',
-					"my"
-				) + selectedProjectType.replace(/\s/g, '');
+			const defaultProjectName = getDefaultProjectName(selectedProjectType);
 			context.projectType = selectedProjectType;
 			context.projectName = defaultProjectName;
 			context.projectNameFeedback = await checkProjectName(

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectTypeStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectTypeStep.tsx
@@ -21,22 +21,16 @@ import { checkProjectName } from 'vs/workbench/browser/positronNewProjectWizard/
 import { NewProjectType } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
 
 /**
- * Generates a default project name based on the provided project type.
+ * Generates a default project name in kebab case based on the provided project type.
  *
  * @param projectType - The type of the project for which to generate a default name.
  * @returns The default project name as a string.
  */
 export const getDefaultProjectName = (projectType: NewProjectType) => {
-	const defaultProjectName = localize(
+	return localize(
 		'positron.newProjectWizard.projectTypeStep.defaultProjectNamePrefix',
 		"my"
-	);
-	// If the project type is an R Project, the project name is 'my-r-project'.
-	if (projectType === NewProjectType.RProject) {
-		return defaultProjectName + '-' + projectType.toLowerCase().replace(/\s/g, '-');
-	}
-	// The project name for all other project types is 'my' + projectType without spaces, eg. 'myPythonProject'.
-	return defaultProjectName + projectType.replace(/\s/g, '');
+	) + '-' + projectType.toLowerCase().replace(/\s/g, '-');
 };
 
 /**

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -116,6 +116,8 @@ An [example test](https://github.com/posit-dev/positron/blob/main/test/smoke/src
 
 In order to run the tests you'll need to have two environment variables set. These are so Positron knows what R and Python versions to load. A typical place to set them on a mac is in your `.zshrc`, but you should use your environment variable setting method of choice!
 
+Make sure you have the selected R and Python version installed that you are using for the environment variables. The easiest way is to open Positron and copy a version number you have available in the interpreter picker.
+
 Add these to your .zshrc or the relevant configuration file for your shell:
 
 ```bash
@@ -123,11 +125,11 @@ export POSITRON_PY_VER_SEL="3.11.5"
 export POSITRON_R_VER_SEL="4.2.1"
 ```
 
-Make sure you actually have the version you chose installed. Easiest way is to open Positron and just copy a version number you have available in the picker.
-
-_Note: If you forgot to do this before trying to run the tests, you'll need to restart VSCode or whatever editor you're using before they will take effect._
+_Note: If you forgot to set the environment variables before running the tests, you'll need to restart your editor or shell session for the environment variables to be loaded in._
 
 ## Dependencies
+
+Below are the different package and environment dependencies you'll need to install that are used in the smoke tests.
 
 ### Python Dependencies
 
@@ -158,7 +160,7 @@ Graphviz is external software that has a Python package to render graphs. Instal
 
 Some smoke tests use Conda environments. Install a lightweight version of Conda:
 
-- [miniforge](https://github.com/conda-forge/miniforge?tab=readme-ov-file#install) (On Mac, you can `brew install miniforge`. The equivalent installer may also be available via package managers on Linux and Windows.)
+- [miniforge](https://github.com/conda-forge/miniforge/tree/main?tab=readme-ov-file#install) (On Mac, you can `brew install miniforge`. The equivalent installer may also be available via package managers on Linux and Windows.)
 - [miniconda](https://docs.anaconda.com/miniconda/#quick-command-line-install) (On Mac, you can `brew install miniconda`. The equivalent installer may also be available via package managers on Linux and Windows.)
 
 ### Resemblejs
@@ -196,7 +198,7 @@ _You may see errors in test files before you run this builder step once, as it's
 
 You can start the smoke tests using the `Launch Smoke Test` action from the debug dropdown (it’s near the bottom of the list). In debug mode, **tests run serially - parallel execution is not supported** — so running the entire suite can take a long time.
 
-To speed things up, you can focus on specific tests by adding the `it()` function to your test. If the runner detects any `it.only()` blocks, it will limit execution to just those tests.
+To speed things up, you can focus on specific tests by adding the `.only()` function to your test. If the runner detects any `it.only()` blocks, it will limit execution to just those tests.
 
 _Note: Don't forget to remove the `.only()`s when you're done!_
 
@@ -208,7 +210,7 @@ The command line is a faster way to run tests since it **allows for parallel exe
 2. Execute the following command to trigger the subset of tests:
 
 ```bash
-yarn somketest-only
+yarn smoketest-only
 ```
 
 Remember to remove any `#only` from test titles before committing!

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -191,6 +191,8 @@ describe('New Project Wizard', () => {
 	});
 
 	describe('R - New Project Wizard', () => {
+		const defaultProjectName = 'my-r-project';
+
 		it('R Project Defaults [C627913] #pr #win', async function () {
 			const app = this.app as Application;
 			const pw = app.workbench.positronNewProjectWizard;
@@ -199,7 +201,7 @@ describe('New Project Wizard', () => {
 			await pw.navigate(ProjectWizardNavigateAction.NEXT);
 			await pw.navigate(ProjectWizardNavigateAction.CREATE);
 			await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
-			await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myRProject');
+			await app.workbench.positronExplorer.explorerProjectTitle.waitForText(defaultProjectName);
 			// NOTE: For completeness, we probably want to await app.workbench.positronConsole.waitForReady('>', 10000);
 			// here, but it's timing out in CI, so it is not included for now.
 		});
@@ -225,7 +227,7 @@ describe('New Project Wizard', () => {
 				await pw.navigate(ProjectWizardNavigateAction.CREATE);
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
-					`myRProject${projSuffix}`
+					defaultProjectName + projSuffix
 				);
 				// Interact with the modal to install renv
 				await app.workbench.positronPopups.installRenv();
@@ -269,7 +271,7 @@ describe('New Project Wizard', () => {
 				await pw.navigate(ProjectWizardNavigateAction.CREATE);
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
-					`myRProject${projSuffix}`
+					defaultProjectName + projSuffix
 				);
 				// Verify renv files are present
 				await expect(async () => {
@@ -303,7 +305,7 @@ describe('New Project Wizard', () => {
 				await pw.navigate(ProjectWizardNavigateAction.CREATE);
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
-					`myRProject${projSuffix}`
+					defaultProjectName + projSuffix
 				);
 				// Interact with the modal to skip installing renv
 				await app.workbench.positronPopups.installRenv(false);

--- a/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
+++ b/test/smoke/src/areas/positron/new-project-wizard/new-project.test.ts
@@ -11,6 +11,8 @@ describe('New Project Wizard', () => {
 	setupAndStartApp();
 
 	describe('Python - New Project Wizard', () => {
+		const defaultProjectName = 'my-python-project';
+
 		describe('Python Project with new environment', () => {
 			it('Create a new Venv environment [C627912] #pr', async function () {
 				// This is the default behaviour for a new Python Project in the Project Wizard
@@ -21,7 +23,7 @@ describe('New Project Wizard', () => {
 				await pw.navigate(ProjectWizardNavigateAction.NEXT);
 				await pw.navigate(ProjectWizardNavigateAction.CREATE);
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
-				await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myPythonProject');
+				await app.workbench.positronExplorer.explorerProjectTitle.waitForText(defaultProjectName);
 				await app.workbench.positronConsole.waitForReady('>>>', 10000);
 				await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 				await app.workbench.positronConsole.barClearButton.click();
@@ -43,7 +45,7 @@ describe('New Project Wizard', () => {
 				await pw.navigate(ProjectWizardNavigateAction.CREATE);
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
-					`myPythonProject${projSuffix}`
+					defaultProjectName + projSuffix
 				);
 				// Check that the `.conda` folder gets created in the project
 				await expect(async () => {
@@ -93,7 +95,7 @@ describe('New Project Wizard', () => {
 				await pw.navigate(ProjectWizardNavigateAction.CREATE);
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
-					`myPythonProject${projSuffix}`
+					defaultProjectName + projSuffix
 				);
 				// The console should initialize without any prompts to install ipykernel
 				await app.workbench.positronConsole.waitForReady('>>>', 10000);
@@ -142,7 +144,7 @@ describe('New Project Wizard', () => {
 				await pw.navigate(ProjectWizardNavigateAction.CREATE);
 				await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 				await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
-					`myPythonProject${projSuffix}`
+					defaultProjectName + projSuffix
 				);
 				// If ipykernel was successfully installed during the new project initialization,
 				// the console should be ready without any prompts to install ipykernel
@@ -170,7 +172,7 @@ describe('New Project Wizard', () => {
 			// Open the new project in the current window and wait for the console to be ready
 			await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
 			await app.workbench.positronExplorer.explorerProjectTitle.waitForText(
-				`myPythonProject${projSuffix}`
+				defaultProjectName + projSuffix
 			);
 			await app.workbench.positronConsole.waitForReady('>>>', 10000);
 
@@ -321,6 +323,8 @@ describe('New Project Wizard', () => {
 	});
 
 	describe('Jupyter - New Project Wizard', () => {
+		const defaultProjectName = 'my-jupyter-notebook';
+
 		it('Jupyter Project Defaults [C629352] #pr', async function () {
 			const app = this.app as Application;
 			const pw = app.workbench.positronNewProjectWizard;
@@ -329,7 +333,7 @@ describe('New Project Wizard', () => {
 			await pw.navigate(ProjectWizardNavigateAction.NEXT);
 			await pw.navigate(ProjectWizardNavigateAction.CREATE);
 			await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
-			await app.workbench.positronExplorer.explorerProjectTitle.waitForText('myJupyterNotebook');
+			await app.workbench.positronExplorer.explorerProjectTitle.waitForText(defaultProjectName);
 			// NOTE: For completeness, we probably want to await app.workbench.positronConsole.waitForReady('>>>', 10000);
 			// here, but it's timing out in CI, so it is not included for now.
 		});


### PR DESCRIPTION
### Description
Addresses #3735 

Updating the default name for all projects to use kebab case instead of camel case. Camel case is not a very common format to use for directory names and kebab case should better align with user expectations for directory names.

### Screenshots

**Creating a new project**

https://github.com/user-attachments/assets/30d1be78-f8fd-41b4-ac34-3eb2c91c4222

**Project Name Validation Error**

https://github.com/user-attachments/assets/d2b7ab02-185b-4dd6-b110-51360877eb8c

### QA Notes

- [ ] Verify paths for creating a new project should now use kebab case
  - [ ] Verify the default r project name is: `my-r-project`
  - [ ] Verify the default python project name is: `my-python-project`
  - [ ] Verify the default jupyter notebook name is: `my-jupyter-notebook`