### PR TITLE
New function to expose more info about an installed package

### DIFF
--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -534,7 +534,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		// Wait for the the runtime to be idle, or for the timeout:
 		await Promise.race([promise, timeout(2e4, 'waiting for package installation')]);
 
-		pkgInst = await this.packageVersion(pkgName, minimumVersion);
+		pkgInst = await this.packageVersion(pkgName, minimumVersion, true);
 		compatible = pkgInst?.compatible ?? false;
 		return compatible;
 	}

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -80,7 +80,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	private _created: number;
 
 	/** Cache of installed packages and associated version info */
-	private packageCache: Map<string, RPackageInstallation> = new Map();
+	private _packageCache: Map<string, RPackageInstallation> = new Map();
 
 	/** The current dynamic runtime state */
 	public dynState: positron.LanguageRuntimeDynState;
@@ -408,14 +408,14 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		const cacheKey = `${pkgName}>=${minimumVersion ?? '0.0.0'}`;
 
 		if (!refresh) {
-			if (this.packageCache.has(cacheKey)) {
-				return this.packageCache.get(cacheKey)!;
+			if (this._packageCache.has(cacheKey)) {
+				return this._packageCache.get(cacheKey)!;
 			}
 
 			if (minimumVersion === null) {
-				for (const key of this.packageCache.keys()) {
+				for (const key of this._packageCache.keys()) {
 					if (key.startsWith(pkgName)) {
-						return this.packageCache.get(key)!;
+						return this._packageCache.get(key)!;
 					}
 				}
 			}
@@ -426,16 +426,16 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		// - The package is in the cache, but version is insufficient (last time we checked).
 
 		// Remove a pre-existing cache entry for this package, regardless of minimumVersion.
-		for (const key of this.packageCache.keys()) {
+		for (const key of this._packageCache.keys()) {
 			if (key.startsWith(pkgName)) {
-				this.packageCache.delete(key);
+				this._packageCache.delete(key);
 			}
 		}
 
 		const pkgInst = await this._getPackageVersion(pkgName, minimumVersion);
 
 		if (pkgInst) {
-			this.packageCache.set(cacheKey, pkgInst);
+			this._packageCache.set(cacheKey, pkgInst);
 		}
 
 		return pkgInst;


### PR DESCRIPTION
Addresses #1957

Requires https://github.com/posit-dev/ark/pull/625

What's the payoff?

* Sometimes you want to get info about a package version without necessarily challenging the user to install/upgrade. (I need this to finish #5231, for example). 
* If you do need to invite the user to install or upgrade a package, this extra info allows us to build a better message.

### QA Notes

To experience that `checkInstalled()` still works and to see the user-facing message in the absence of a minimum version requirement, here's one idea:

* Remove the styler package: `remove.packages("styler")`
* Trigger the *Format Document* command

You should see this:

<img width="404" alt="Screenshot 2024-11-13 at 3 46 39 PM" src="https://github.com/user-attachments/assets/2231ec70-d335-4f99-b5f9-598cd1c19301">

To experience that `checkInstalled()` still works and to see the user-facing message in the presence of a minimum version requirement, here's one idea:

* Install renv at a version below positron-r's minimum version, which is currently 1.0.9. I would do this with `pak::pak("renv@1.0.8")`.
* Walk through *File > New Project > R Project* and click the box to use renv:

  <img width="701" alt="Screenshot 2024-11-13 at 3 35 45 PM" src="https://github.com/user-attachments/assets/430908cb-9fce-43fe-8d39-a6fec56f9a70">

As the new project is being stood up, you should see this:

<img width="401" alt="Screenshot 2024-11-13 at 3 37 12 PM" src="https://github.com/user-attachments/assets/ee3d82a1-5479-47e6-82bd-a693583d2f4a">
