### PR TITLE
Reticulate: Access ipykernel path

### DIFF
--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -722,7 +722,7 @@ export function activate(context: vscode.ExtensionContext) {
 			if (!api) {
 				throw new Error('Failed to find the Positron Python extension API.');
 			}
-			return api.extensionPath + '/python_files/ipykernel';
+			return api.extensionPath + '/python_files/positron';
 		})
 	);
 

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -718,7 +718,6 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand('positron.reticulate.getIPykernelPath', () => {
-			console.log('Getting IPykernel path');
 			const api = vscode.extensions.getExtension('ms-python.python');
 			if (!api) {
 				throw new Error('Failed to find the Positron Python extension API.');

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -722,7 +722,7 @@ export function activate(context: vscode.ExtensionContext) {
 			if (!api) {
 				throw new Error('Failed to find the Positron Python extension API.');
 			}
-			return api.extensionPath + '/python_files/positron';
+			return api.extensionPath + '/python_files/positron/positron_ipykernel';
 		})
 	);
 

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -716,6 +716,17 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 		}));
 
+	context.subscriptions.push(
+		vscode.commands.registerCommand('positron.reticulate.getIPykernelPath', () => {
+			console.log('Getting IPykernel path');
+			const api = vscode.extensions.getExtension('ms-python.python');
+			if (!api) {
+				throw new Error('Failed to find the Positron Python extension API.');
+			}
+			return api.extensionPath + '/python_files/ipykernel';
+		})
+	);
+
 	context.subscriptions.push(reticulateProvider);
 
 	return reticulateProvider;

--- a/src/vs/workbench/api/common/positron/extHostMethods.ts
+++ b/src/vs/workbench/api/common/positron/extHostMethods.ts
@@ -281,7 +281,13 @@ export class ExtHostMethods implements extHostProtocol.ExtHostMethodsShape {
 	}
 
 	async executeCommand(commandId: string): Promise<any> {
-		return await this.commands.executeCommand(commandId);
+		const result = await this.commands.executeCommand(commandId);
+		if (result === undefined) {
+			// If result is undefined, it probably means that the command is a `void` function
+			// and we should return null.
+			return null;
+		}
+		return result;
 	}
 
 	async showQuestion(title: string, message: string, okButtonTitle: string, cancelButtonTitle: string): Promise<boolean> {

--- a/src/vs/workbench/api/common/positron/extHostMethods.ts
+++ b/src/vs/workbench/api/common/positron/extHostMethods.ts
@@ -280,9 +280,8 @@ export class ExtHostMethods implements extHostProtocol.ExtHostMethodsShape {
 		return null;
 	}
 
-	async executeCommand(commandId: string): Promise<null> {
-		await this.commands.executeCommand(commandId);
-		return null;
+	async executeCommand(commandId: string): Promise<any> {
+		return await this.commands.executeCommand(commandId);
 	}
 
 	async showQuestion(title: string, message: string, okButtonTitle: string, cancelButtonTitle: string): Promise<boolean> {


### PR DESCRIPTION
This PR pairs with: https://github.com/rstudio/reticulate/pull/1692
The reticulate PR addresses: https://github.com/posit-dev/positron/issues/3502#issue-2347621967

It allows Reticulate to reliably obtain the path to the Positron `inspectors.py` which implements
the variables pane methods. By calling:

```
.ps.ui.executeCommand("positron.reticulate.getIPykernelPath")
```

