### PR TITLE
Bump ark to 0.1.152

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -670,7 +670,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.151"
+      "ark": "0.1.152"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
### Release Notes

#### New Features

- N/A

#### Bug Fixes

- On Windows, indents of size 1 are no longer randomly added in R scripts (https://github.com/posit-dev/positron/issues/5258).