### PR TITLE
Skip r restart test

### DIFF
--- a/test/smoke/src/areas/positron/console/r-console.test.ts
+++ b/test/smoke/src/areas/positron/console/r-console.test.ts
@@ -7,7 +7,8 @@ import { expect } from '@playwright/test';
 import { Application, PositronRFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 
-describe('Console Pane: R', () => {
+// Skipping due to https://github.com/posit-dev/positron/issues/5356
+describe.skip('Console Pane: R', () => {
 	setupAndStartApp();
 
 	describe('R Console Restart #web #win', () => {


### PR DESCRIPTION
### Intent

Due to https://github.com/posit-dev/positron/issues/5356 , need to skip the R restart test as it almost always fails.

### QA Notes
R console test is skipped.test