### PR TITLE
test: report skipped e2e tests to qa channel weekly

### DIFF
--- a/.github/workflows/slack-skipped-tests.yml
+++ b/.github/workflows/slack-skipped-tests.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 14 * * 2'
   workflow_dispatch:
 
+env:
+  SLACK_WEBHOOK_URL: https://hooks.slack.com/services/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
+
 jobs:
   slack-skipped-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/slack-skipped-tests.yml
+++ b/.github/workflows/slack-skipped-tests.yml
@@ -1,0 +1,19 @@
+name: Slack Skipped Tests
+
+on:
+  schedule:
+    # Run every Tuesday at 2pm UTC / 8am CST / 9am EST
+    - cron: '0 14 * * 2'
+  workflow_dispatch:
+
+jobs:
+  slack-skipped-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Slack Skipped Tests Script
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: node scripts/slack-skipped-tests.js $SLACK_WEBHOOK_URL

--- a/.github/workflows/slack-skipped-tests.yml
+++ b/.github/workflows/slack-skipped-tests.yml
@@ -1,9 +1,12 @@
 name: Slack Skipped Tests
 
 on:
-  schedule:
-    # Run every Tuesday at 2pm UTC / 8am CST / 9am EST
-    - cron: '0 14 * * 2'
+  pull_request:
+    branches:
+      - main
+  # schedule:
+  #   # Run every Tuesday at 2pm UTC / 8am CST / 9am EST
+  #   - cron: '0 14 * * 2'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/slack-skipped-tests.yml
+++ b/.github/workflows/slack-skipped-tests.yml
@@ -1,12 +1,9 @@
 name: Slack Skipped Tests
 
 on:
-  pull_request:
-    branches:
-      - main
-  # schedule:
-  #   # Run every Tuesday at 2pm UTC / 8am CST / 9am EST
-  #   - cron: '0 14 * * 2'
+  schedule:
+    # Run every Tuesday at 2pm UTC / 8am CST / 9am EST
+    - cron: '0 14 * * 2'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/slack-skipped-tests.yml
+++ b/.github/workflows/slack-skipped-tests.yml
@@ -17,6 +17,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Slack Skipped Tests Script
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_E2E_TEST_WEBHOOK }}
-        run: node scripts/slack-skipped-tests.js $SLACK_WEBHOOK_URL
+        run: node scripts/slack-skipped-tests.js ${{ secrets.SLACK_E2E_TEST_WEBHOOK }}

--- a/.github/workflows/slack-skipped-tests.yml
+++ b/.github/workflows/slack-skipped-tests.yml
@@ -6,9 +6,6 @@ on:
     - cron: '0 14 * * 2'
   workflow_dispatch:
 
-env:
-  SLACK_WEBHOOK_URL: https://hooks.slack.com/services/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
-
 jobs:
   slack-skipped-tests:
     runs-on: ubuntu-latest
@@ -18,5 +15,5 @@ jobs:
 
       - name: Run Slack Skipped Tests Script
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_E2E_TEST_WEBHOOK }}
         run: node scripts/slack-skipped-tests.js $SLACK_WEBHOOK_URL

--- a/scripts/slack-skipped-tests.js
+++ b/scripts/slack-skipped-tests.js
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const { execSync } = require('child_process');
+
+const slackSkippedTests = (slackWebhookUrl) => {
+	try {
+		const skippedTests = execSync(
+			`grep -r --include \\*.test.ts -E "describe\\.skip|it\\.skip" test/smoke/src/areas/positron | sed 's/\\.test\\.ts.*$/.test.ts/'`
+		).toString();
+
+		const slackMessage = {
+			attachments: [
+				{
+					mrkdwn_in: ['text'],
+					color: skippedTests === '' ? '#CCCCCC' : '#FF0000',
+					pretext: ':skipping:*Skipped Tests*',
+					text: skippedTests === '' ? 'There are no skipped tests. :tada:' : skippedTests,
+				},
+			],
+		};
+
+		console.log(skippedTests);
+		console.log(JSON.stringify(slackMessage, null, 2));
+
+		execSync(
+			`curl -X POST -H 'Content-type: application/json' --data '${JSON.stringify(
+				slackMessage
+			)}' ${slackWebhookUrl}`
+		);
+	} catch (error) {
+		console.error(`Error: ${error}`);
+	}
+};
+
+slackSkippedTests(process.argv[2]);


### PR DESCRIPTION
### Intent
Ensure the QA team stays informed about skipped tests to prevent oversight and avoid accumulating technical debt.

### Approach
Implement a cron job that scans (using grep) the test suite to identify any skipped tests. The results are formatted in a clear, user-friendly manner and posted to the positron QA channel every Tuesday morning. The workflow can also be dispatched manually at any time.

### QA
Confirmed (in private channel) reports as expected.
<img width="605" alt="Screenshot 2024-11-15 at 9 39 39 AM" src="https://github.com/user-attachments/assets/0e9f772a-a9e6-4d2b-a0fd-1a2b5a8ca737">
