### PR TITLE
Improve runtime session service stability

### DIFF
--- a/extensions/positron-notebook-controllers/src/notebookController.ts
+++ b/extensions/positron-notebook-controllers/src/notebookController.ts
@@ -331,10 +331,19 @@ function executeCode(
 					}
 				}
 			}).catch(error => {
+				// Stop listening for replies.
 				handler.dispose();
+
+				// Reject the outer execution promise since we've encountered an error.
 				reject(error);
+
+				// Rethrow the error to stop any replies that are chained to this promise.
 				throw error;
 			});
+
+			// Avoid unhandled rejections being logged to the console.
+			// The actual error-handling is in the catch block above.
+			currentMessagePromise.catch(() => { });
 		});
 
 		// Execute the cell.

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreview.contribution.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreview.contribution.ts
@@ -20,11 +20,10 @@ import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensio
 import { registerAction2 } from 'vs/platform/actions/common/actions';
 import { PositronOpenUrlInViewerAction } from 'vs/workbench/contrib/positronPreview/browser/positronPreviewActions';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope, } from 'vs/platform/configuration/common/configurationRegistry';
+import { POSITRON_PREVIEW_PLOTS_IN_VIEWER } from 'vs/workbench/services/languageRuntime/common/languageRuntimeUiClient';
 
 // The Positron preview view icon.
 const positronPreviewViewIcon = registerIcon('positron-preview-view-icon', Codicon.positronPreviewView, nls.localize('positronPreviewViewIcon', 'View icon of the Positron preview view.'));
-
-export const POSITRON_PREVIEW_PLOTS_IN_VIEWER = 'positron.viewer.interactivePlotsInViewer';
 
 // Register the Positron preview container.
 const VIEW_CONTAINER: ViewContainer = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry).registerViewContainer({

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -13,8 +13,8 @@ import { URI } from 'vs/base/common/uri';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { POSITRON_PREVIEW_PLOTS_IN_VIEWER } from 'vs/workbench/contrib/positronPreview/browser/positronPreview.contribution';
 
+export const POSITRON_PREVIEW_PLOTS_IN_VIEWER = 'positron.viewer.interactivePlotsInViewer';
 
 /**
  * The types of messages that can be sent to the backend.

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -517,6 +517,8 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		} catch (err) {
 			startPromise.error(err);
 		}
+
+		startPromise.p.catch((err) => this._logService.debug(`Error starting session: ${err}`));
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -627,18 +627,19 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				`${formatLanguageRuntimeMetadata(metadata)} (Source: ${source}) ` +
 				`because workspace trust has not been granted. ` +
 				`The runtime will be started when workspace trust is granted.`);
-			this._workspaceTrustManagementService.onDidChangeTrust((trusted) => {
+			const disposable = this._register(this._workspaceTrustManagementService.onDidChangeTrust((trusted) => {
 				if (!trusted) {
 					// If the workspace is still not trusted, do nothing.
-					return '';
+					return;
 				}
 				// If the workspace is trusted, start the runtime.
+				disposable.dispose();
 				this._logService.info(`Language runtime ` +
 					`${formatLanguageRuntimeMetadata(metadata)} ` +
 					`automatically starting after workspace trust was granted. ` +
 					`Source: ${source}`);
-				return this.doAutoStartRuntime(metadata, source);
-			});
+				this.doAutoStartRuntime(metadata, source);
+			}));
 		}
 
 		return '';

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -996,14 +996,15 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 						this.foregroundSession = session;
 					}
 
-					// If this is a console session and there isn't already a console session
-					// for this language, set this one as the console session.
-					// (This restores the console session in the case of a
-					// restart)
+					// Restore the session in the case of a restart.
 					if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Console &&
 						!this._consoleSessionsByLanguageId.has(session.runtimeMetadata.languageId)) {
 						this._consoleSessionsByLanguageId.set(session.runtimeMetadata.languageId,
 							session);
+					} else if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Notebook &&
+						session.metadata.notebookUri &&
+						!this._notebookSessionsByNotebookUri.has(session.metadata.notebookUri)) {
+						this._notebookSessionsByNotebookUri.set(session.metadata.notebookUri, session);
 					}
 
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -426,7 +426,11 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// If the workspace is not trusted, defer starting the runtime until the
 		// workspace is trusted.
 		if (!this._workspaceTrustManagementService.isWorkspaceTrusted()) {
-			return this.autoStartRuntime(languageRuntime, source);
+			if (sessionMode === LanguageRuntimeSessionMode.Console) {
+				return this.autoStartRuntime(languageRuntime, source);
+			} else {
+				throw new Error(`Cannot start a ${sessionMode} session in an untrusted workspace.`);
+			}
 		}
 
 		// Start the runtime.

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -264,7 +264,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 *  no console session with the given runtime identifier exists.
 	 */
 	getConsoleSessionForRuntime(runtimeId: string): ILanguageRuntimeSession | undefined {
-		const session = Array.from(this._activeSessionsBySessionId.values()).find(session =>
+		// It's possible that there are multiple consoles for the same runtime,
+		// for example, if one failed to start and is uninitialized. In that case,
+		// we return the last.
+		const session = Array.from(this._activeSessionsBySessionId.values()).reverse().find(session =>
 			session.session.runtimeMetadata.runtimeId === runtimeId &&
 			session.session.metadata.sessionMode === LanguageRuntimeSessionMode.Console &&
 			session.state !== RuntimeState.Exited);

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -461,6 +461,24 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 					`is already starting for the notebook ${notebookUri.toString()}. ` +
 					`Request source: ${source}`);
 			}
+
+			// If there is already a runtime running for the notebook, throw an error.
+			const runningLanguageRuntime = this._notebookSessionsByNotebookUri.get(notebookUri);
+			if (runningLanguageRuntime) {
+				const metadata = runningLanguageRuntime.runtimeMetadata;
+				if (metadata.runtimeId === languageRuntime.runtimeId) {
+					// If the runtime that is running is the one we were just asked
+					// to start, we're technically in good shape since the runtime
+					// is already running!
+					return runningLanguageRuntime.sessionId;
+				} else {
+					throw new Error(`A notebook for ` +
+						`${formatLanguageRuntimeMetadata(languageRuntime)} ` +
+						`cannot be started because a notebook for ` +
+						`${formatLanguageRuntimeMetadata(metadata)} is already running ` +
+						`for the URI ${notebookUri.toString()}.`);
+				}
+			}
 		}
 
 		// If the workspace is not trusted, defer starting the runtime until the

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -445,6 +445,11 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 						`for the ${metadata.languageName} language.`);
 				}
 			}
+		} else if (sessionMode === LanguageRuntimeSessionMode.Notebook) {
+			// If no notebook URI is provided, throw an error.
+			if (!notebookUri) {
+				throw new Error(`A notebook URI must be provided when starting a notebook session.`);
+			}
 		}
 
 		// If the workspace is not trusted, defer starting the runtime until the

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1240,8 +1240,19 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			state === RuntimeState.Ready) {
 			// The runtime looks like it could handle a restart request, so send
 			// one over.
+
+			// Mark the session as starting until the restart sequence completes.
 			this.setStartingSessionMaps(
 				session.metadata.sessionMode, session.runtimeMetadata, session.metadata.notebookUri);
+			const disposable = this._register(session.onDidChangeRuntimeState((state) => {
+				if (state === RuntimeState.Ready) {
+					disposable.dispose();
+					this.clearStartingSessionMaps(
+						session.metadata.sessionMode, session.runtimeMetadata, session.metadata.notebookUri);
+				}
+			}));
+
+			// Restart the session.
 			return session.restart();
 		} else if (state === RuntimeState.Uninitialized ||
 			state === RuntimeState.Exited) {

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -816,11 +816,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		}
 
 		// Create a promise that resolves when the runtime is ready to use, if there isn't already one.
-		let startPromise = this._startingSessionsBySessionMapKey.get(
-			getSessionMapKey(sessionMode, runtimeMetadata.runtimeId, notebookUri));
+		const sessionMapKey = getSessionMapKey(sessionMode, runtimeMetadata.runtimeId, notebookUri);
+		let startPromise = this._startingSessionsBySessionMapKey.get(sessionMapKey);
 		if (!startPromise || startPromise.isSettled) {
 			startPromise = new DeferredPromise<string>();
-			const sessionMapKey = getSessionMapKey(sessionMode, runtimeMetadata.runtimeId, notebookUri);
 			this._startingSessionsBySessionMapKey.set(sessionMapKey, startPromise);
 		}
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -311,8 +311,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	async selectRuntime(runtimeId: string, source: string): Promise<void> {
 		const runtime = this._languageRuntimeService.getRegisteredRuntime(runtimeId);
 		if (!runtime) {
-			return Promise.reject(new Error(`Language runtime ID '${runtimeId}' ` +
-				`is not registered.`));
+			throw new Error(`No language runtime with id '${runtimeId}' was found.`);
 		}
 
 		// Shut down any other runtime consoles for the language.

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -482,6 +482,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			sessionMetadata.sessionMode, runtimeMetadata.runtimeId, sessionMetadata.notebookUri);
 		this._startingSessionsBySessionMapKey.set(sessionMapKey, startPromise);
 
+		// It's possible that startPromise is never awaited, so we log any errors here
+		// at the debug level since we still expect the error to be handled/logged elsewhere.
+		startPromise.p.catch((err) => this._logService.debug(`Error starting session: ${err}`));
+
 		// Add the runtime to the starting runtimes.
 		if (sessionMetadata.sessionMode === LanguageRuntimeSessionMode.Console) {
 			this._startingConsolesByLanguageId.set(runtimeMetadata.languageId, runtimeMetadata);
@@ -520,8 +524,6 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		} catch (err) {
 			startPromise.error(err);
 		}
-
-		startPromise.p.catch((err) => this._logService.debug(`Error starting session: ${err}`));
 	}
 
 	/**
@@ -728,6 +730,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		const sessionMapKey = getSessionMapKey(sessionMode, metadata.runtimeId, notebookUri);
 		this._startingSessionsBySessionMapKey.set(sessionMapKey, startPromise);
 
+		// It's possible that startPromise is never awaited, so we log any errors here
+		// at the debug level since we still expect the error to be handled/logged elsewhere.
+		startPromise.p.catch(err => this._logService.debug(`Error starting runtime session: ${err}`));
+
 		// Check to see if the runtime has already been registered with the
 		// language runtime service.
 		const languageRuntime =
@@ -821,6 +827,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		if (!startPromise || startPromise.isSettled) {
 			startPromise = new DeferredPromise<string>();
 			this._startingSessionsBySessionMapKey.set(sessionMapKey, startPromise);
+
+			// It's possible that startPromise is never awaited, so we log any errors here
+			// at the debug level since we still expect the error to be handled/logged elsewhere.
+			startPromise.p.catch(err => this._logService.debug(`Error starting runtime session: ${err}`));
 		}
 
 		const sessionManager = await this.getManagerForRuntime(runtimeMetadata);
@@ -860,10 +870,6 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		} catch (err) {
 			startPromise.error(err);
 		}
-
-		// It's possible that startPromise is never awaited, so we log any errors here
-		// at the debug level since we still expect the error to be handled/logged elsewhere.
-		startPromise.p.catch(err => this._logService.debug(`Error starting runtime session: ${err}`));
 
 		return sessionId;
 	}

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -831,6 +831,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			startPromise.error(err);
 		}
 
+		// It's possible that startPromise is never awaited, so we log any errors here
+		// at the debug level since we still expect the error to be handled/logged elsewhere.
+		startPromise.p.catch(err => this._logService.debug(`Error starting runtime session: ${err}`));
+
 		return sessionId;
 	}
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -266,11 +266,13 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	getConsoleSessionForRuntime(runtimeId: string): ILanguageRuntimeSession | undefined {
 		// It's possible that there are multiple consoles for the same runtime,
 		// for example, if one failed to start and is uninitialized. In that case,
-		// we return the last.
-		const session = Array.from(this._activeSessionsBySessionId.values()).reverse().find(session =>
-			session.session.runtimeMetadata.runtimeId === runtimeId &&
-			session.session.metadata.sessionMode === LanguageRuntimeSessionMode.Console &&
-			session.state !== RuntimeState.Exited);
+		// we return the most recently created.
+		const session = Array.from(this._activeSessionsBySessionId.values())
+			.sort((a, b) => b.session.metadata.createdTimestamp - a.session.metadata.createdTimestamp)
+			.find(session =>
+				session.session.runtimeMetadata.runtimeId === runtimeId &&
+				session.session.metadata.sessionMode === LanguageRuntimeSessionMode.Console &&
+				session.state !== RuntimeState.Exited);
 		if (session) {
 			return session.session;
 		} else {

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -795,5 +795,17 @@ suite('Positron - RuntimeSessionService', () => {
 
 			sinon.assert.calledThrice(target);
 		});
+
+		test(`restart ${mode} while ready -> start`, async () => {
+			const session = await start();
+			await waitForRuntimeState(session, RuntimeState.Ready);
+
+			await restartSession(session.sessionId);
+			await waitForRuntimeState(session, RuntimeState.Ready);
+
+			const newSession = await start();
+
+			assertSingleSessionIsReady(newSession);
+		});
 	}
 });

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -222,10 +222,7 @@ suite('Positron - RuntimeSessionService', () => {
 
 	async function selectRuntime(runtimeMetadata = runtime) {
 		await runtimeSessionService.selectRuntime(runtimeMetadata.runtimeId, startReason);
-		// Get the last active session matching the runtime.
-		const session = runtimeSessionService.activeSessions.reverse()
-			.find(session => session.runtimeMetadata.runtimeId === runtimeMetadata.runtimeId &&
-				session.metadata.sessionMode === LanguageRuntimeSessionMode.Console);
+		const session = runtimeSessionService.getConsoleSessionForRuntime(runtimeMetadata.runtimeId);
 		assert.ok(session instanceof TestLanguageRuntimeSession);
 		disposables.add(session);
 		return session;

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -223,12 +223,9 @@ suite('Positron - RuntimeSessionService', () => {
 	async function selectRuntime(runtimeMetadata = runtime) {
 		await runtimeSessionService.selectRuntime(runtimeMetadata.runtimeId, startReason);
 		// Get the last active session matching the runtime.
-		const sessionId = runtimeSessionService.activeSessions.reverse()
+		const session = runtimeSessionService.activeSessions.reverse()
 			.find(session => session.runtimeMetadata.runtimeId === runtimeMetadata.runtimeId &&
-				session.metadata.sessionMode === LanguageRuntimeSessionMode.Console)
-			?.sessionId;
-		assert.ok(sessionId);
-		const session = runtimeSessionService.getSession(sessionId);
+				session.metadata.sessionMode === LanguageRuntimeSessionMode.Console);
 		assert.ok(session instanceof TestLanguageRuntimeSession);
 		disposables.add(session);
 		return session;

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -683,13 +683,13 @@ suite('Positron - RuntimeSessionService', () => {
 						hasStartingOrRunningConsole: true,
 						consoleSession: newSession,
 						activeSessions: [session, newSession],
-					})
+					});
 				} else {
 					assertServiceState({
 						notebookSession: newSession,
 						notebookSessionForNotebookUri: newSession,
 						activeSessions: [session, newSession],
-					})
+					});
 				}
 			});
 		}
@@ -773,7 +773,7 @@ suite('Positron - RuntimeSessionService', () => {
 
 		// TODO: I think this behavior is undefined at the moment... We don't have any safety checks
 		//       in start based on restart behavior.
-		test(`restart console -> start console`, async () => {
+		test.skip(`restart console -> start console`, async () => {
 			const session = await startConsole();
 			await waitForRuntimeState(session, RuntimeState.Ready);
 

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -121,8 +121,7 @@ suite('Positron - RuntimeSessionService', () => {
 
 	function assertServiceState(expectedState?: IServiceState, runtimeMetadata = runtime): void {
 		// Check the active sessions.
-		assertActiveSessions(expectedState?.activeSessions ??
-			[expectedState?.consoleSession, expectedState?.notebookSession].filter(session => !!session));
+		assertActiveSessions(expectedState?.activeSessions ?? []);
 
 		// Check the console session state.
 		assert.equal(
@@ -171,11 +170,13 @@ suite('Positron - RuntimeSessionService', () => {
 				consoleSession: session,
 				consoleSessionForLanguage: session,
 				consoleSessionForRuntime: session,
+				activeSessions: [session],
 			}, session.runtimeMetadata);
 		} else if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Notebook) {
 			assertServiceState({
 				notebookSession: session,
 				notebookSessionForNotebookUri: session,
+				activeSessions: [session],
 			}, session.runtimeMetadata);
 		}
 	}

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -13,8 +13,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
-// import { formatLanguageRuntimeMetadata, ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, RuntimeExitReason, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
-import { formatLanguageRuntimeMetadata, ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionMode, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { formatLanguageRuntimeMetadata, ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionMode, RuntimeExitReason, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService, IRuntimeSessionWillStartEvent } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { TestLanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession';
 import { createRuntimeServices, createTestLanguageRuntimeMetadata, startTestLanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService';
@@ -463,150 +462,6 @@ suite('Positron - RuntimeSessionService', () => {
 				});
 			});
 		}
-
-		// function restartSession(sessionId: string) {
-		// 	return runtimeSessionService.restartSession(
-		// 		sessionId, 'Test requested to restart a runtime session'
-		// 	);
-		// }
-
-		// suite('restartSession', () => {
-		// 	test('restart console in "ready" state', async () => {
-		// 		const session = await startConsole();
-		// 		await waitForRuntimeState(session, RuntimeState.Ready);
-
-		// 		await restartSession(session.sessionId);
-
-		// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
-		// 	});
-
-		// 	test('restart console in "starting" state', async () => {
-		// 		const session = await startConsole();
-
-		// 		await restartSession(session.sessionId);
-
-		// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
-		// 	});
-
-		// 	test('restart console in "exited" state', async () => {
-		// 		const session = await startConsole();
-		// 		await session.shutdown(RuntimeExitReason.Shutdown);
-		// 		await waitForRuntimeState(session, RuntimeState.Exited);
-
-		// 		await restartSession(session.sessionId);
-
-		// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
-		// 	});
-
-		// 	test('restart session with unknown session id', async () => {
-		// 		const sessionId = 'unknown-session-id';
-		// 		assert.rejects(
-		// 			restartSession(sessionId),
-		// 			new Error(`No session with ID '${sessionId}' was found.`),
-		// 		);
-		// 	});
-
-		// 	test('restart console concurrently', async () => {
-		// 		const session = await startConsole();
-		// 		await waitForRuntimeState(session, RuntimeState.Ready);
-
-		// 		const target = sinon.spy(session, 'restart');
-
-		// 		await Promise.all([
-		// 			restartSession(session.sessionId),
-		// 			restartSession(session.sessionId),
-		// 			restartSession(session.sessionId),
-		// 		]);
-
-		// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
-		// 		assertServiceState({ hasStartingOrRunningConsole: true, consoleSession: session });
-
-		// 		sinon.assert.calledOnce(target);
-		// 	});
-
-		// 	test('restart console successively', async () => {
-		// 		const session = await startConsole();
-
-		// 		const target = sinon.spy(session, 'restart');
-
-		// 		await waitForRuntimeState(session, RuntimeState.Ready);
-		// 		await restartSession(session.sessionId);
-		// 		await waitForRuntimeState(session, RuntimeState.Ready);
-		// 		await restartSession(session.sessionId);
-		// 		await waitForRuntimeState(session, RuntimeState.Ready);
-		// 		await restartSession(session.sessionId);
-
-		// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
-		// 		assertServiceState({ hasStartingOrRunningConsole: true, consoleSession: session });
-
-		// 		sinon.assert.calledThrice(target);
-		// 	});
-
-		// });
-
-		// suite('queuing', () => {
-		// 	test(`${name} notebook while shutting down`, async () => {
-		// 		const session1 = await startNotebook();
-
-		// 		const [, session2,] = await Promise.all([
-		// 			runtimeSessionService.shutdownNotebookSession(notebookUri, RuntimeExitReason.Shutdown),
-		// 			startNotebook(),
-		// 		]);
-
-		// 		assert.equal(session1.getRuntimeState(), RuntimeState.Exited);
-		// 		assert.equal(session2.getRuntimeState(), RuntimeState.Starting);
-		// 		assertServiceState({
-		// 			notebookSession: session2,
-		// 			notebookSessionForNotebookUri: session2,
-		// 			activeSessions: [session1, session2],
-		// 		});
-		// 	});
-
-		// 	test(`${name} notebook while restarting and in "exited" state`, async () => {
-		// 		const session = await startNotebook();
-		// 		await waitForRuntimeState(session, RuntimeState.Ready);
-
-		// 		const target = sinon.spy(session, 'restart');
-
-		// 		const startPromise = new Promise<TestLanguageRuntimeSession>(resolve => {
-		// 			const disposable = session.onDidChangeRuntimeState(state => {
-		// 				if (state === RuntimeState.Exited) {
-		// 					disposable.dispose();
-		// 					resolve(startNotebook());
-		// 				}
-		// 			});
-		// 		});
-
-		// 		const [, session2,] = await Promise.all([
-		// 			restartSession(session.sessionId),
-		// 			startPromise,
-		// 			// startNotebook(),
-		// 		]);
-
-		// 		assert.equal(session, session2);
-
-		// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
-		// 		assertServiceState({
-		// 			notebookSession: session,
-		// 			notebookSessionForNotebookUri: session,
-		// 		});
-
-		// 		sinon.assert.calledOnce(target);
-		// 	});
-
-		// 	test('restart notebook while shutting down', async () => {
-		// 		const session = await startNotebook();
-
-		// 		await Promise.all([
-		// 			runtimeSessionService.shutdownNotebookSession(notebookUri, RuntimeExitReason.Shutdown),
-		// 			restartSession(session.sessionId),
-		// 		]);
-
-		// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
-		// 		assertNotebookSessionIsStarted(session);
-		// 	});
-
-		// });
 	}
 
 	test(`start notebook without notebook uri`, async () => {
@@ -726,8 +581,205 @@ suite('Positron - RuntimeSessionService', () => {
 
 		assert.equal(session1, session2);
 		assert.equal(runtimeSessionService.foregroundSession, session1);
-
 	});
+
+	function restartSession(sessionId: string) {
+		return runtimeSessionService.restartSession(sessionId, startReason);
+	}
+
+	for (const { mode, start } of [
+		{ mode: LanguageRuntimeSessionMode.Console, start: startConsole },
+		{ mode: LanguageRuntimeSessionMode.Notebook, start: startNotebook },
+	]) {
+		test(`restart ${mode} throws if session not found`, async () => {
+			const sessionId = 'unknown-session-id';
+			assert.rejects(
+				restartSession(sessionId),
+				new Error(`No session with ID '${sessionId}' was found.`),
+			);
+		});
+
+		for (const state of [RuntimeState.Busy, RuntimeState.Idle, RuntimeState.Ready]) {
+			test(`restart ${mode} in '${state}' state`, async () => {
+				// Start the session and wait for it to be ready.
+				const session = await start();
+				await waitForRuntimeState(session, RuntimeState.Ready);
+
+				// Set the state to the desired state.
+				if (session.getRuntimeState() !== state) {
+					session.setRuntimeState(state);
+				}
+
+				await restartSession(session.sessionId);
+
+				assertSessionIsStarting(session);
+			});
+		}
+
+		for (const state of [RuntimeState.Uninitialized, RuntimeState.Exited]) {
+			test(`restart ${mode} in '${state}' state`, async () => {
+				// Get a session to the exited state.
+				const session = await start();
+				await session.shutdown(RuntimeExitReason.Shutdown);
+				await waitForRuntimeState(session, RuntimeState.Exited);
+
+				await restartSession(session.sessionId);
+
+				// The existing sessino should remain exited.
+				assert.equal(session.getRuntimeState(), RuntimeState.Exited);
+
+				// A new session should be starting.
+				let newSession: ILanguageRuntimeSession | undefined;
+				if (mode === LanguageRuntimeSessionMode.Console) {
+					newSession = runtimeSessionService.getConsoleSessionForRuntime(runtime.runtimeId);
+				} else {
+					newSession = runtimeSessionService.getNotebookSessionForNotebookUri(notebookUri);
+				}
+				assert.ok(newSession);
+				disposables.add(newSession);
+
+				assert.equal(newSession.getRuntimeState(), RuntimeState.Starting);
+				assert.equal(newSession.metadata.sessionName, session.metadata.sessionName);
+				assert.equal(newSession.metadata.sessionMode, session.metadata.sessionMode);
+				assert.equal(newSession.metadata.notebookUri, session.metadata.notebookUri);
+				assert.equal(newSession.runtimeMetadata, session.runtimeMetadata);
+
+				if (mode === LanguageRuntimeSessionMode.Console) {
+					assertServiceState({
+						hasStartingOrRunningConsole: true,
+						consoleSession: newSession,
+						activeSessions: [session, newSession],
+					})
+				} else {
+					assertServiceState({
+						notebookSession: newSession,
+						notebookSessionForNotebookUri: newSession,
+						activeSessions: [session, newSession],
+					})
+				}
+			});
+		}
+
+		test(`restart ${mode} in 'starting' state`, async () => {
+			const session = await start();
+			assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+
+			await restartSession(session.sessionId);
+
+			assertSessionIsStarting(session);
+		});
+
+		test(`restart ${mode} in 'restarting' state`, async () => {
+			const session = await start();
+			await waitForRuntimeState(session, RuntimeState.Ready);
+
+			session.restart();
+			assert.equal(session.getRuntimeState(), RuntimeState.Restarting);
+
+			const target = sinon.spy(session, 'restart');
+
+			await restartSession(session.sessionId);
+
+			assertSessionIsStarting(session);
+
+			sinon.assert.notCalled(target);
+		});
+
+		test(`restart ${mode} concurrently`, async () => {
+			const session = await start();
+			await waitForRuntimeState(session, RuntimeState.Ready);
+
+			const target = sinon.spy(session, 'restart');
+
+			await Promise.all([
+				restartSession(session.sessionId),
+				restartSession(session.sessionId),
+				restartSession(session.sessionId),
+			]);
+
+			assertSessionIsStarting(session);
+
+			sinon.assert.calledOnce(target);
+		});
+
+		test(`restart ${mode} successively`, async () => {
+			const session = await start();
+
+			const target = sinon.spy(session, 'restart');
+
+			await waitForRuntimeState(session, RuntimeState.Ready);
+			await restartSession(session.sessionId);
+			await waitForRuntimeState(session, RuntimeState.Ready);
+			await restartSession(session.sessionId);
+			await waitForRuntimeState(session, RuntimeState.Ready);
+			await restartSession(session.sessionId);
+
+			assertSessionIsStarting(session);
+
+			sinon.assert.calledThrice(target);
+		});
+	}
+
+	// 	test(`${name} notebook while shutting down`, async () => {
+	// 		const session1 = await startNotebook();
+
+	// 		const [, session2,] = await Promise.all([
+	// 			runtimeSessionService.shutdownNotebookSession(notebookUri, RuntimeExitReason.Shutdown),
+	// 			startNotebook(),
+	// 		]);
+
+	// 		assert.equal(session1.getRuntimeState(), RuntimeState.Exited);
+	// 		assert.equal(session2.getRuntimeState(), RuntimeState.Starting);
+	// 		assertServiceState({
+	// 			notebookSession: session2,
+	// 			notebookSessionForNotebookUri: session2,
+	// 			activeSessions: [session1, session2],
+	// 		});
+	// 	});
+
+	// 	test(`${name} notebook while restarting and in "exited" state`, async () => {
+	// 		const session = await startNotebook();
+	// 		await waitForRuntimeState(session, RuntimeState.Ready);
+
+	// 		const target = sinon.spy(session, 'restart');
+
+	// 		const startPromise = new Promise<TestLanguageRuntimeSession>(resolve => {
+	// 			const disposable = session.onDidChangeRuntimeState(state => {
+	// 				if (state === RuntimeState.Exited) {
+	// 					disposable.dispose();
+	// 					resolve(startNotebook());
+	// 				}
+	// 			});
+	// 		});
+
+	// 		const [, session2,] = await Promise.all([
+	// 			restartSession(session.sessionId),
+	// 			startPromise,
+	// 			// startNotebook(),
+	// 		]);
+
+	// 		assert.equal(session, session2);
+
+	// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+	// 		assertServiceState({
+	// 			notebookSession: session,
+	// 			notebookSessionForNotebookUri: session,
+	// 		});
+
+	// 		sinon.assert.calledOnce(target);
+	// 	});
+
+	// 	test('restart notebook while shutting down', async () => {
+	// 		const session = await startNotebook();
+
+	// 		await Promise.all([
+	// 			runtimeSessionService.shutdownNotebookSession(notebookUri, RuntimeExitReason.Shutdown),
+	// 			restartSession(session.sessionId),
+	// 		]);
+
+	// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+	// 		assertNotebookSessionIsStarted(session);
+	// 	});
 });
 
 async function waitForRuntimeState(

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -1,0 +1,995 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { strict as assert } from 'assert';
+import * as sinon from 'sinon';
+import { CancellationError } from 'vs/base/common/errors';
+import { URI } from 'vs/base/common/uri';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
+// import { formatLanguageRuntimeMetadata, ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, RuntimeExitReason, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { formatLanguageRuntimeMetadata, ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionMode, RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService, IRuntimeSessionWillStartEvent } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
+import { TestLanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession';
+import { createRuntimeServices, createTestLanguageRuntimeMetadata, startTestLanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService';
+import { TestRuntimeSessionManager } from 'vs/workbench/test/common/positronWorkbenchTestServices';
+import { TestWorkspaceTrustManagementService } from 'vs/workbench/test/common/workbenchTestServices';
+
+type IStartSessionTask = (runtimeMetadata?: ILanguageRuntimeMetadata) => Promise<TestLanguageRuntimeSession>;
+type IValidator<T> = (obj: T) => void;
+
+suite('Positron - RuntimeSessionService', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+	const sessionName = 'Test session';
+	const startReason = 'Test requested to start a runtime session';
+	const notebookUri = URI.file('/path/to/notebook');
+	let instantiationService: TestInstantiationService;
+	let languageRuntimeService: ILanguageRuntimeService;
+	let runtimeSessionService: IRuntimeSessionService;
+	let runtime: ILanguageRuntimeMetadata;
+	let anotherRuntime: ILanguageRuntimeMetadata;
+	let unregisteredRuntime: ILanguageRuntimeMetadata;
+
+	setup(() => {
+		instantiationService = disposables.add(new TestInstantiationService());
+		createRuntimeServices(instantiationService, disposables);
+		languageRuntimeService = instantiationService.get(ILanguageRuntimeService);
+		runtimeSessionService = instantiationService.get(IRuntimeSessionService);
+		runtime = createTestLanguageRuntimeMetadata(instantiationService, disposables);
+		anotherRuntime = createTestLanguageRuntimeMetadata(instantiationService, disposables);
+		unregisteredRuntime = { runtimeId: 'unregistered-runtime-id' } as ILanguageRuntimeMetadata;
+	});
+
+	function startSession(
+		runtimeMetadata = runtime,
+		sessionMode: LanguageRuntimeSessionMode,
+		notebookUri?: URI,
+	) {
+		return startTestLanguageRuntimeSession(
+			instantiationService,
+			disposables,
+			{
+				runtime: runtimeMetadata,
+				sessionName,
+				startReason,
+				sessionMode,
+				notebookUri,
+			},
+		);
+	}
+
+	function startConsole(runtimeMetadata?: ILanguageRuntimeMetadata) {
+		return startSession(runtimeMetadata, LanguageRuntimeSessionMode.Console);
+	}
+
+	function startNotebook(runtimeMetadata?: ILanguageRuntimeMetadata, notebookUri_ = notebookUri) {
+		return startSession(runtimeMetadata, LanguageRuntimeSessionMode.Notebook, notebookUri_);
+	}
+
+	interface IServiceState {
+		hasStartingOrRunningConsole?: boolean;
+		consoleSession?: ILanguageRuntimeSession;
+		notebookSession?: ILanguageRuntimeSession;
+		notebookSessionForNotebookUri?: ILanguageRuntimeSession;
+		activeSessions?: ILanguageRuntimeSession[];
+	}
+
+	function assertServiceState(expectedState?: IServiceState): void {
+		// Check the console session state.
+		assert.equal(
+			runtimeSessionService.hasStartingOrRunningConsole(runtime.languageId),
+			expectedState?.hasStartingOrRunningConsole ?? false,
+		);
+		assert.equal(
+			runtimeSessionService.getConsoleSessionForLanguage(runtime.languageId)?.sessionId,
+			expectedState?.consoleSession?.sessionId,
+		);
+		assert.equal(
+			runtimeSessionService.getConsoleSessionForRuntime(runtime.runtimeId)?.sessionId,
+			expectedState?.consoleSession?.sessionId,
+		);
+		assert.equal(
+			runtimeSessionService.getSession(expectedState?.consoleSession?.sessionId ?? '')?.sessionId,
+			expectedState?.consoleSession?.sessionId,
+		);
+
+		// Check the notebook session state.
+		assert.equal(
+			runtimeSessionService.getSession(expectedState?.notebookSession?.sessionId ?? '')?.sessionId,
+			expectedState?.notebookSession?.sessionId,
+		);
+		assert.equal(
+			runtimeSessionService.getNotebookSessionForNotebookUri(notebookUri)?.sessionId,
+			expectedState?.notebookSessionForNotebookUri?.sessionId,
+		);
+
+		// Check the global state.
+		assert.deepEqual(
+			runtimeSessionService.activeSessions?.map(session => session.sessionId),
+			expectedState?.activeSessions?.map(session => session?.sessionId) ??
+			[expectedState?.consoleSession?.sessionId, expectedState?.notebookSession?.sessionId].filter(session => Boolean(session)),
+		);
+	}
+
+	async function testCallSuccessively<T>(task: () => Promise<T>, validate: IValidator<T>) {
+		const result1 = await task();
+		const result2 = await task();
+		const result3 = await task();
+
+		assert.equal(result1, result2);
+		assert.equal(result2, result3);
+
+		validate(result1);
+	}
+
+	async function testCallConcurrently<T>(task: () => Promise<T>, validate: (obj: T) => void) {
+		const [result1, result2, result3] = await Promise.all([task(), task(), task()]);
+
+		assert.equal(result1, result2);
+		assert.equal(result2, result3);
+
+		validate(result1);
+	}
+
+	async function testStartSuccessively(start: IStartSessionTask) {
+		await testCallSuccessively(start, (session) => assertSessionIsStarting(session));
+	}
+
+	async function testStartConcurrently(start: IStartSessionTask) {
+		await testCallConcurrently(start, (session) => assertSessionIsStarting(session));
+	}
+
+	async function testStartConsoleWhileAnotherIsStarting(start: IStartSessionTask, source?: string) {
+		await assert.rejects(
+			Promise.all([
+				start(),
+				start(anotherRuntime),
+			]),
+			new Error(`Session for language runtime ${formatLanguageRuntimeMetadata(anotherRuntime)} ` +
+				`cannot be started because language runtime ${formatLanguageRuntimeMetadata(runtime)} ` +
+				`is already starting for the language.`
+				+ (source ? ` Request source: ${startReason}` : '')),
+		);
+	}
+
+	async function testStartConsoleWhileAnotherIsRunning(start: IStartSessionTask, source?: string) {
+		await start();
+		await assert.rejects(
+			start(anotherRuntime),
+			new Error(`A console for ${formatLanguageRuntimeMetadata(anotherRuntime)} cannot ` +
+				`be started because a console for ${formatLanguageRuntimeMetadata(runtime)} ` +
+				`is already running for the ${runtime.languageName} language.` +
+				(source ? ` Request source: ${startReason}` : '')),
+		);
+	}
+
+	async function testStartNotebookWhileAnotherIsStarting(start: IStartSessionTask, source?: string) {
+		await assert.rejects(
+			Promise.all([
+				start(),
+				start(anotherRuntime),
+			]),
+			new Error(`Session for language runtime ${formatLanguageRuntimeMetadata(anotherRuntime)} cannot ` +
+				`be started because language runtime ${formatLanguageRuntimeMetadata(runtime)} ` +
+				`is already starting for the notebook ${notebookUri.toString()}.`
+				+ (source ? ` Request source: ${startReason}` : ''))
+		);
+	}
+
+	async function testStartNotebookWhileAnotherIsRunning(start: IStartSessionTask, source?: string) {
+		await start();
+		await assert.rejects(
+			start(anotherRuntime),
+			new Error(`A notebook for ${formatLanguageRuntimeMetadata(anotherRuntime)} cannot ` +
+				`be started because a notebook for ${formatLanguageRuntimeMetadata(runtime)} ` +
+				`is already running for the URI ${notebookUri.toString()}.` +
+				(source ? ` Request source: ${startReason}` : '')),
+		);
+	}
+
+	async function testStartReturnsExpectedSession(start: IStartSessionTask) {
+		const session = await start();
+
+		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+		assert.equal(session.metadata.sessionName, sessionName);
+		assert.equal(session.metadata.startReason, startReason);
+		assert.equal(session.runtimeMetadata, runtime);
+
+		if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Console) {
+			assert.equal(session.metadata.notebookUri, undefined);
+		} else if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Notebook) {
+			assert.equal(session.metadata.notebookUri, notebookUri);
+		} else {
+			throw new Error(`Unexpected session mode: ${session.metadata.sessionMode}`);
+		}
+	}
+
+	async function testStartSetsExpectedServiceState(
+		start: IStartSessionTask,
+		verifyWhileStarting: () => void,
+		verifyAfterStarted: (session: ILanguageRuntimeSession) => void,
+	) {
+		// Check the initial state.
+		assertServiceState();
+
+		const promise = start();
+
+		// Check the state while starting.
+		verifyWhileStarting();
+
+		const session = await promise;
+
+		// Check the state after starting.
+		verifyAfterStarted(session);
+	}
+
+	function testStartConsoleSetsExpectedServiceState(start: IStartSessionTask) {
+		return testStartSetsExpectedServiceState(
+			start,
+			() => assertServiceState({ hasStartingOrRunningConsole: true }),
+			session => assertServiceState({ hasStartingOrRunningConsole: true, consoleSession: session }),
+		);
+	}
+
+	function testStartNotebookSetsExpectedServiceState(start: IStartSessionTask) {
+		return testStartSetsExpectedServiceState(
+			start,
+			() => assertServiceState(),
+			session => assertServiceState({ notebookSession: session, notebookSessionForNotebookUri: session }),
+		);
+	}
+
+	async function testStartFiresOnWillStartSession(start: IStartSessionTask, verify: () => void) {
+		let error: Error | undefined;
+		const target = sinon.spy(({ session }: IRuntimeSessionWillStartEvent) => {
+			try {
+				// TODO: Should onWillStartSession only fire once?
+				if (target.callCount > 1) {
+					return;
+				}
+				assert.equal(session.getRuntimeState(), RuntimeState.Uninitialized);
+				verify();
+			} catch (e) {
+				error = e;
+			}
+		});
+		disposables.add(runtimeSessionService.onWillStartSession(target));
+		const session = await start();
+
+		// TODO: Should onWillStartSession only fire once?
+		sinon.assert.calledTwice(target);
+		sinon.assert.alwaysCalledWithExactly(target, { isNew: true, session });
+		assert.ifError(error);
+	}
+
+	async function testStartFiresOnDidStartRuntime(
+		start: IStartSessionTask,
+		verify: (session: ILanguageRuntimeSession) => void,
+	) {
+		let error: Error | undefined;
+		const target = sinon.stub<[e: ILanguageRuntimeSession]>().callsFake(session => {
+			try {
+				assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+				verify(session);
+			} catch (e) {
+				error = e;
+			}
+		});
+		disposables.add(runtimeSessionService.onDidStartRuntime(target));
+
+		const session = await start();
+
+		sinon.assert.calledOnceWithExactly(target, session);
+		assert.ifError(error);
+	}
+
+	async function testEncountersSessionStartError(
+		start: IStartSessionTask,
+		verify: (session: ILanguageRuntimeSession) => void,
+	) {
+		// Listen to the onWillStartSession event and stub session.start() to throw an error.
+		const willStartSession = sinon.spy((e: IRuntimeSessionWillStartEvent) => {
+			sinon.stub(e.session, 'start').rejects(new Error('Session failed to start'));
+		});
+		disposables.add(runtimeSessionService.onWillStartSession(willStartSession));
+
+		const didFailStartRuntime = sinon.spy();
+		disposables.add(runtimeSessionService.onDidFailStartRuntime(didFailStartRuntime));
+
+		const didStartRuntime = sinon.spy();
+		disposables.add(runtimeSessionService.onDidStartRuntime(didStartRuntime));
+
+		const session = await start();
+
+		assert.equal(session.getRuntimeState(), RuntimeState.Uninitialized);
+
+		verify(session);
+
+		sinon.assert.calledOnceWithExactly(didFailStartRuntime, session);
+		sinon.assert.callOrder(willStartSession, didFailStartRuntime);
+		sinon.assert.notCalled(didStartRuntime);
+	}
+
+	async function testStartFiresEventsInOrder(start: IStartSessionTask) {
+		const willStartSession = sinon.spy();
+		disposables.add(runtimeSessionService.onWillStartSession(willStartSession));
+
+		const didStartRuntime = sinon.spy();
+		disposables.add(runtimeSessionService.onDidStartRuntime(didStartRuntime));
+
+		await start();
+
+		sinon.assert.callOrder(willStartSession, didStartRuntime);
+	}
+
+	async function testStartUnknownRuntime(start: IStartSessionTask = startNotebook) {
+		const runtimeId = 'unknown-runtime-id';
+		await assert.rejects(
+			start({ runtimeId } as ILanguageRuntimeMetadata,),
+			new Error(`No language runtime with id '${runtimeId}' was found.`),
+		);
+	}
+
+	function assertSessionIsStarting(session: ILanguageRuntimeSession) {
+		if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Console) {
+			assertServiceState({ hasStartingOrRunningConsole: true, consoleSession: session });
+		} else if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Notebook) {
+			assertServiceState({ notebookSession: session, notebookSessionForNotebookUri: session });
+		}
+	}
+
+	suite('startNewRuntimeSession', () => {
+		test('start console returns the expected session', async () => {
+			await testStartReturnsExpectedSession(startConsole);
+		});
+
+		test('start notebook returns the expected session', async () => {
+			await testStartReturnsExpectedSession(startNotebook);
+		});
+
+		test('start console sets the expected service state', async () => {
+			await testStartConsoleSetsExpectedServiceState(startConsole);
+		});
+
+		test('start notebook sets the expected service state', async () => {
+			await testStartNotebookSetsExpectedServiceState(startNotebook);
+		});
+
+		test('start console fires onWillStartSession', async () => {
+			await testStartFiresOnWillStartSession(
+				startConsole,
+				() => assertServiceState({ hasStartingOrRunningConsole: true }),
+			);
+		});
+
+		test('start notebook fires onWillStartSession', async () => {
+			await testStartFiresOnWillStartSession(
+				startNotebook,
+				() => assertServiceState(),
+			);
+		});
+
+		test('start console fires onDidStartRuntime', async () => {
+			await testStartFiresOnDidStartRuntime(
+				startConsole,
+				session => assertServiceState({ hasStartingOrRunningConsole: true, consoleSession: session }),
+			);
+		});
+
+		test('start notebook fires onDidStartRuntime', async () => {
+			await testStartFiresOnDidStartRuntime(
+				startNotebook,
+				session => assertSessionIsStarting(session),
+			);
+		});
+
+		test('start console fires events in order', async () => {
+			await testStartFiresEventsInOrder(startConsole);
+		});
+
+		test('start notebook fires events in order', async () => {
+			await testStartFiresEventsInOrder(startNotebook);
+		});
+
+		test('start console sets foregroundSession', async () => {
+			const target = sinon.spy();
+			disposables.add(runtimeSessionService.onDidChangeForegroundSession(target));
+
+			const session = await startConsole();
+
+			assert.equal(runtimeSessionService.foregroundSession, session);
+
+			await waitForRuntimeState(session, RuntimeState.Ready);
+
+			// TODO: Feels a bit surprising that this isn't fired. It's because we set the private
+			//       _foregroundSession property instead of the setter. When the 'ready' state is
+			//       entered, we skip setting foregroundSession because it already matches the session.
+			sinon.assert.notCalled(target);
+		});
+
+		test('start console for unknown runtime', async () => {
+			await testStartUnknownRuntime(startConsole);
+		});
+
+		test('start notebook for unknown runtime', async () => {
+			await testStartUnknownRuntime(startNotebook);
+		});
+
+		test('start notebook without notebook uri', async () => {
+			await assert.rejects(
+				startSession(undefined, LanguageRuntimeSessionMode.Notebook, undefined),
+				new Error('A notebook URI must be provided when starting a notebook session.'),
+			);
+		});
+
+		test('start console encounters session.start() error', async () => {
+			await testEncountersSessionStartError(
+				startConsole,
+				session => {
+					// TODO: Seems unexpected that some of these are defined and others not.
+					assert.equal(runtimeSessionService.hasStartingOrRunningConsole(runtime.languageId), false);
+					assert.equal(runtimeSessionService.getConsoleSessionForLanguage(runtime.languageId), undefined);
+					assert.equal(runtimeSessionService.getConsoleSessionForRuntime(runtime.runtimeId), session);
+					assert.equal(runtimeSessionService.getSession(session.sessionId), session);
+					assert.deepEqual(runtimeSessionService.activeSessions, [session]);
+				}
+			);
+		});
+
+		test('start notebook encounters session.start() error', async () => {
+			await testEncountersSessionStartError(
+				startNotebook,
+				session => {
+					// TODO: Should failed notebook sessions be included in activeSessions?
+					assertServiceState({ activeSessions: [session] });
+				},
+			);
+		});
+
+		test('start console and notebook from the same runtime concurrently', async () => {
+			// Consoles and notebooks shouldn't interfere with each other, even for the same runtime.
+			const [consoleSession, notebookSession] = await Promise.all([
+				startConsole(),
+				startNotebook(),
+			]);
+
+			assert.equal(consoleSession.getRuntimeState(), RuntimeState.Starting);
+			assert.equal(notebookSession.getRuntimeState(), RuntimeState.Starting);
+
+			assertServiceState({
+				hasStartingOrRunningConsole: true,
+				consoleSession,
+				notebookSession,
+				notebookSessionForNotebookUri: notebookSession,
+				activeSessions: [consoleSession, notebookSession],
+			});
+		});
+
+		test('start console while another runtime is starting for the language', async () => {
+			await testStartConsoleWhileAnotherIsStarting(startConsole, startReason);
+		});
+
+		test('start notebook while another runtime is starting for the notebook', async () => {
+			await testStartNotebookWhileAnotherIsStarting(startNotebook, startReason);
+		});
+
+		test('start console while another runtime is running for the language', async () => {
+			await testStartConsoleWhileAnotherIsRunning(startConsole, startReason);
+		});
+
+		test('start notebook while another runtime is running for the notebook', async () => {
+			await testStartNotebookWhileAnotherIsRunning(startNotebook, startReason);
+		});
+
+		test('start console successively', async () => {
+			await testStartSuccessively(startConsole);
+		});
+
+		test('start notebook successively', async () => {
+			await testStartSuccessively(startNotebook);
+		});
+
+		test('start console concurrently', async () => {
+			await testStartConcurrently(startConsole);
+		});
+
+		test('start notebook concurrently', async () => {
+			await testStartConcurrently(startNotebook);
+		});
+	});
+
+	async function restoreSession(
+		sessionMetadata: IRuntimeSessionMetadata, runtimeMetadata = runtime,
+	) {
+		await runtimeSessionService.restoreRuntimeSession(runtimeMetadata, sessionMetadata);
+
+		// Ensure that the session gets disposed after the test.
+		const session = runtimeSessionService.getSession(sessionMetadata.sessionId);
+		assert.ok(session instanceof TestLanguageRuntimeSession);
+		disposables.add(session);
+
+		return session;
+	}
+
+	function restoreConsole(runtimeMetadata?: ILanguageRuntimeMetadata) {
+		return restoreSession(consoleSessionMetadata, runtimeMetadata);
+	}
+
+	function restoreNotebook(runtimeMetadata?: ILanguageRuntimeMetadata) {
+		return restoreSession(notebookSessionMetadata, runtimeMetadata);
+	}
+
+	const consoleSessionMetadata = {
+		sessionId: 'test-session-id',
+		sessionName: 'Test session',
+		sessionMode: LanguageRuntimeSessionMode.Console,
+		createdTimestamp: Date.now(),
+		startReason,
+	} as IRuntimeSessionMetadata;
+
+	const notebookSessionMetadata = {
+		...consoleSessionMetadata,
+		sessionMode: LanguageRuntimeSessionMode.Notebook,
+		notebookUri,
+	};
+
+	suite('restoreRuntimeSession', () => {
+		test('restore console returns the expected session', async () => {
+			await testStartReturnsExpectedSession(restoreConsole);
+		});
+
+		test('restore notebook returns the expected session', async () => {
+			await testStartReturnsExpectedSession(restoreNotebook);
+		});
+
+		test('restore console sets the expected service state', async () => {
+			await testStartConsoleSetsExpectedServiceState(restoreConsole);
+		});
+
+		test('restore notebook sets the expected service state', async () => {
+			await testStartNotebookSetsExpectedServiceState(restoreNotebook);
+		});
+
+		test('restore console registers runtime if unregistered', async () => {
+			// The runtime should not yet be registered.
+			assert.equal(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), undefined);
+
+			await restoreConsole(unregisteredRuntime);
+
+			// The runtime should now be registered.
+			assert.equal(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), unregisteredRuntime);
+		});
+
+		test('restore notebook without notebook URI', async () => {
+			await assert.rejects(
+				restoreSession({ ...consoleSessionMetadata, sessionMode: LanguageRuntimeSessionMode.Notebook }),
+				new Error('A notebook URI must be provided when starting a notebook session.'),
+			);
+		});
+
+		test('restore console while another runtime is starting for the language', async () => {
+			await testStartConsoleWhileAnotherIsStarting(restoreConsole);
+		});
+
+		test('restore notebook while another runtime is starting for the notebook', async () => {
+			await testStartNotebookWhileAnotherIsStarting(restoreNotebook);
+		});
+
+		test('restore console while another runtime is running for the language', async () => {
+			await testStartConsoleWhileAnotherIsRunning(restoreConsole);
+		});
+
+		test('restore notebook while another runtime is running for the notebook', async () => {
+			await testStartNotebookWhileAnotherIsRunning(restoreNotebook);
+		});
+
+		test('restore console successively', async () => {
+			await testStartSuccessively(restoreConsole);
+		});
+
+		test('restore notebook successively', async () => {
+			await testStartSuccessively(restoreNotebook);
+		});
+
+		test('restore console concurrently', async () => {
+			await testStartConcurrently(restoreConsole);
+		});
+
+		test('restore notebook concurrently', async () => {
+			await testStartConcurrently(restoreNotebook);
+		});
+	});
+
+	suite('autoStartRuntime', () => {
+		async function autoStartSession(runtimeMetadata = runtime) {
+			const sessionId = await runtimeSessionService.autoStartRuntime(runtimeMetadata, 'Test requested to auto-start a runtime');
+			if (!sessionId) {
+				return undefined;
+			}
+			const session = runtimeSessionService.getSession(sessionId);
+			assert.ok(session);
+			disposables.add(session);
+			return session;
+		}
+
+		let configService: TestConfigurationService;
+		let workspaceTrustManagementService: TestWorkspaceTrustManagementService;
+		let manager: TestRuntimeSessionManager;
+
+		setup(() => {
+			configService = instantiationService.get(IConfigurationService) as TestConfigurationService;
+			workspaceTrustManagementService = instantiationService.get(IWorkspaceTrustManagementService) as TestWorkspaceTrustManagementService;
+			manager = TestRuntimeSessionManager.instance;
+
+			// Enable automatic startup.
+			configService.setUserConfiguration('positron.interpreters.automaticStartup', true);
+
+			// Trust the workspace.
+			workspaceTrustManagementService.setWorkspaceTrust(true);
+		});
+
+		test('auto start console in a trusted workspace', async () => {
+			const promise = autoStartSession();
+
+			assert.equal(runtimeSessionService.hasStartingOrRunningConsole(runtime.languageId), false);
+
+			const session = await promise;
+
+			// TODO: Do we need this? It's the same as starting a session.
+			assert.ok(session);
+			assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+			assert.equal(session.metadata.sessionName, runtime.runtimeName);
+			assert.equal(session.metadata.sessionMode, LanguageRuntimeSessionMode.Console);
+			assert.equal(session.metadata.startReason, 'Test requested to auto-start a runtime');
+			assert.equal(session.runtimeMetadata, runtime);
+		});
+
+		// TODO: Should auto starting a notebook error?
+
+		test('auto start validates runtime if unregistered', async () => {
+			// The runtime should not yet be registered.
+			assert.equal(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), undefined);
+
+			manager.setValidateMetadata(async (metadata: ILanguageRuntimeMetadata) => {
+				return { ...metadata, extraRuntimeData: { someNewKey: 'someNewValue' } };
+			});
+
+			await autoStartSession(unregisteredRuntime);
+
+			// The *validated* runtime should now be registered.
+			assert.deepEqual(
+				languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId),
+				{ ...unregisteredRuntime, extraRuntimeData: { someNewKey: 'someNewValue' } }
+			);
+		});
+
+		test('auto start encounters runtime validation error', async () => {
+			// The runtime should not yet be registered.
+			assert.equal(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), undefined);
+
+			const error = new Error('Failed to validate runtime metadata');
+			manager.setValidateMetadata(async (metadata: ILanguageRuntimeMetadata) => {
+				throw error;
+			});
+
+			await assert.rejects(autoStartSession(unregisteredRuntime), error);
+
+			// The runtime should still not be registered.
+			assert.equal(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), undefined);
+		});
+
+		test('auto start console does nothing if automatic startup is disabled', async () => {
+			configService.setUserConfiguration('positron.interpreters.automaticStartup', false);
+
+			const session = await autoStartSession();
+			assert.equal(session, undefined);
+
+			// TODO: Do we also need to check the session state?
+		});
+
+		test('auto start console in an untrusted workspace starts when trust is granted', async () => {
+			workspaceTrustManagementService.setWorkspaceTrust(false);
+
+			const sessionId = await runtimeSessionService.autoStartRuntime(runtime, 'Test requested to auto-start a runtime');
+			assert.equal(sessionId, '');
+
+			workspaceTrustManagementService.setWorkspaceTrust(true);
+
+			await new Promise<void>(resolve => {
+				disposables.add(runtimeSessionService.onDidStartRuntime(session => {
+					if (session.runtimeMetadata === runtime) {
+						disposables.add(session);
+						resolve();
+					}
+				}));
+			});
+
+			// TODO: We should probably check more things here?
+		});
+
+		// TODO: Should we handle this?
+		test.skip('auto start console while another runtime is starting for the language', async () => {
+			await assert.rejects(
+				Promise.all([
+					autoStartSession(),
+					autoStartSession(anotherRuntime),
+				]),
+				new Error(`Session for language runtime ${formatLanguageRuntimeMetadata(anotherRuntime)} ` +
+					`cannot be started because language runtime ${formatLanguageRuntimeMetadata(runtime)} ` +
+					`is already starting for the language.`),
+			);
+		});
+
+		// TODO: Should we handle this?
+		test.skip('auto start console while another runtime is running for the language', async () => {
+			await autoStartSession();
+			await assert.rejects(
+				autoStartSession(anotherRuntime),
+				new Error(`A console for ${formatLanguageRuntimeMetadata(anotherRuntime)} cannot ` +
+					`be started because a console for ${formatLanguageRuntimeMetadata(runtime)} ` +
+					`is already running for the ${runtime.languageName} language.`),
+			);
+		});
+
+		// TODO: Should we handle this?
+		test.skip('auto start console successively', async () => {
+			const session1 = await autoStartSession();
+			const session2 = await autoStartSession();
+			const session3 = await autoStartSession();
+
+			// Check that the same session was returned each time.
+			assert.equal(session1, session2);
+			assert.equal(session2, session3);
+
+			// Check that only one session was started.
+			assertServiceState({ hasStartingOrRunningConsole: true, consoleSession: session1 });
+		});
+
+		// TODO: Should we handle this?
+		test.skip('auto start console concurrently', async () => {
+			const [session1, session2, session3] = await Promise.all([
+				autoStartSession(),
+				autoStartSession(),
+				autoStartSession(),
+			]);
+
+			// Check that the same session was returned.
+			assert.equal(session1, session2);
+			assert.equal(session2, session3);
+
+			// Check that only one session was started.
+			assertServiceState({ hasStartingOrRunningConsole: true, consoleSession: session1 });
+		});
+	});
+
+	suite('selectRuntime', () => {
+		async function selectRuntime(runtimeMetadata = runtime) {
+			await runtimeSessionService.selectRuntime(runtimeMetadata.runtimeId, 'Test requested to select a runtime');
+			const session = runtimeSessionService.getConsoleSessionForRuntime(runtimeMetadata.runtimeId);
+			assert.ok(session, 'Expected a session to be started');
+			disposables.add(session);
+			return session;
+		}
+
+		test('select runtime', async () => {
+			await testStartConsoleSetsExpectedServiceState(selectRuntime);
+		});
+	});
+
+	// TODO: Check sessionManager validation...
+
+	// TODO: If workspace is trusted,
+
+	// suite('shutdownNotebookSession', () => {
+	// 	test('shutdown notebook', async () => {
+	// 		const session = await startNotebook();
+
+	// 		await runtimeSessionService.shutdownNotebookSession(notebookUri, RuntimeExitReason.Shutdown);
+
+	// 		assert.equal(session.getRuntimeState(), RuntimeState.Exited);
+	// 		// TODO: The session is in activeSessions and returned by getSession but not by
+	// 		//       getNotebookSessionForNotebookUri. Is that correct? This is also the only reason
+	// 		//       we need a notebookForNotebookUri parameter in assertServiceState.
+	// 		assertServiceState({ notebookSession: session });
+	// 	});
+
+	// 	test('shutdown notebook without running runtime', async () => {
+	// 		// It should not error, since it's already in the desired state.
+	// 		await runtimeSessionService.shutdownNotebookSession(notebookUri, RuntimeExitReason.Shutdown);
+	// 		assertServiceState();
+	// 	});
+
+	// 	test('shutdown notebook concurrently', async () => {
+	// 		const session = await startNotebook();
+
+	// 		await Promise.all([
+	// 			runtimeSessionService.shutdownNotebookSession(notebookUri, RuntimeExitReason.Shutdown),
+	// 			runtimeSessionService.shutdownNotebookSession(notebookUri, RuntimeExitReason.Shutdown),
+	// 			runtimeSessionService.shutdownNotebookSession(notebookUri, RuntimeExitReason.Shutdown),
+	// 		]);
+
+	// 		assert.equal(session.getRuntimeState(), RuntimeState.Exited);
+	// 	});
+
+	// 	test('shutdown notebook while starting', async () => {
+	// 		const [session,] = await Promise.all([
+	// 			startNotebook(),
+	// 			runtimeSessionService.shutdownNotebookSession(notebookUri, RuntimeExitReason.Shutdown),
+	// 		]);
+
+	// 		assert.equal(session.getRuntimeState(), RuntimeState.Exited);
+	// 		assertServiceState({ notebookSession: session });
+	// 	});
+	// });
+
+
+	// function restartSession(sessionId: string) {
+	// 	return runtimeSessionService.restartSession(
+	// 		sessionId, 'Test requested to restart a runtime session'
+	// 	);
+	// }
+
+	// suite('restartSession', () => {
+	// 	test('restart console in "ready" state', async () => {
+	// 		const session = await startConsole();
+	// 		await waitForRuntimeState(session, RuntimeState.Ready);
+
+	// 		await restartSession(session.sessionId);
+
+	// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+	// 	});
+
+	// 	test('restart console in "starting" state', async () => {
+	// 		const session = await startConsole();
+
+	// 		await restartSession(session.sessionId);
+
+	// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+	// 	});
+
+	// 	test('restart console in "exited" state', async () => {
+	// 		const session = await startConsole();
+	// 		await session.shutdown(RuntimeExitReason.Shutdown);
+	// 		await waitForRuntimeState(session, RuntimeState.Exited);
+
+	// 		await restartSession(session.sessionId);
+
+	// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+	// 	});
+
+	// 	test('restart session with unknown session id', async () => {
+	// 		const sessionId = 'unknown-session-id';
+	// 		assert.rejects(
+	// 			restartSession(sessionId),
+	// 			new Error(`No session with ID '${sessionId}' was found.`),
+	// 		);
+	// 	});
+
+	// 	test('restart console concurrently', async () => {
+	// 		const session = await startConsole();
+	// 		await waitForRuntimeState(session, RuntimeState.Ready);
+
+	// 		const target = sinon.spy(session, 'restart');
+
+	// 		await Promise.all([
+	// 			restartSession(session.sessionId),
+	// 			restartSession(session.sessionId),
+	// 			restartSession(session.sessionId),
+	// 		]);
+
+	// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+	// 		assertServiceState({ hasStartingOrRunningConsole: true, consoleSession: session });
+
+	// 		sinon.assert.calledOnce(target);
+	// 	});
+
+	// 	test('restart console successively', async () => {
+	// 		const session = await startConsole();
+
+	// 		const target = sinon.spy(session, 'restart');
+
+	// 		await waitForRuntimeState(session, RuntimeState.Ready);
+	// 		await restartSession(session.sessionId);
+	// 		await waitForRuntimeState(session, RuntimeState.Ready);
+	// 		await restartSession(session.sessionId);
+	// 		await waitForRuntimeState(session, RuntimeState.Ready);
+	// 		await restartSession(session.sessionId);
+
+	// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+	// 		assertServiceState({ hasStartingOrRunningConsole: true, consoleSession: session });
+
+	// 		sinon.assert.calledThrice(target);
+	// 	});
+
+	// });
+
+	// suite('queuing', () => {
+	// 	test('start notebook while shutting down', async () => {
+	// 		const session1 = await startNotebook();
+
+	// 		const [, session2,] = await Promise.all([
+	// 			runtimeSessionService.shutdownNotebookSession(notebookUri, RuntimeExitReason.Shutdown),
+	// 			startNotebook(),
+	// 		]);
+
+	// 		assert.equal(session1.getRuntimeState(), RuntimeState.Exited);
+	// 		assert.equal(session2.getRuntimeState(), RuntimeState.Starting);
+	// 		assertServiceState({
+	// 			notebookSession: session2,
+	// 			notebookSessionForNotebookUri: session2,
+	// 			activeSessions: [session1, session2],
+	// 		});
+	// 	});
+
+	// 	test('start notebook while restarting and in "exited" state', async () => {
+	// 		const session = await startNotebook();
+	// 		await waitForRuntimeState(session, RuntimeState.Ready);
+
+	// 		const target = sinon.spy(session, 'restart');
+
+	// 		const startPromise = new Promise<TestLanguageRuntimeSession>(resolve => {
+	// 			const disposable = session.onDidChangeRuntimeState(state => {
+	// 				if (state === RuntimeState.Exited) {
+	// 					disposable.dispose();
+	// 					resolve(startNotebook());
+	// 				}
+	// 			});
+	// 		});
+
+	// 		const [, session2,] = await Promise.all([
+	// 			restartSession(session.sessionId),
+	// 			startPromise,
+	// 			// startNotebook(),
+	// 		]);
+
+	// 		assert.equal(session, session2);
+
+	// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+	// 		assertServiceState({
+	// 			notebookSession: session,
+	// 			notebookSessionForNotebookUri: session,
+	// 		});
+
+	// 		sinon.assert.calledOnce(target);
+	// 	});
+
+	// 	test('restart notebook while shutting down', async () => {
+	// 		const session = await startNotebook();
+
+	// 		await Promise.all([
+	// 			runtimeSessionService.shutdownNotebookSession(notebookUri, RuntimeExitReason.Shutdown),
+	// 			restartSession(session.sessionId),
+	// 		]);
+
+	// 		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+	// 		assertNotebookSessionIsStarted(session);
+	// 	});
+
+	// });
+});
+
+async function waitForRuntimeState(
+	session: ILanguageRuntimeSession,
+	state: RuntimeState,
+	timeout = 10_000,
+) {
+	return new Promise<void>((resolve, reject) => {
+		const timer = setTimeout(() => {
+			disposable.dispose();
+			reject(new CancellationError());
+		}, timeout);
+
+		const disposable = session.onDidChangeRuntimeState(newState => {
+			if (newState === state) {
+				clearTimeout(timer);
+				disposable.dispose();
+				resolve();
+			}
+		});
+	});
+}

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -211,7 +211,6 @@ suite('Positron - RuntimeSessionService', () => {
 	}
 
 	async function autoStartSession(runtimeMetadata = runtime) {
-		// TODO: Maybe all of these functions can return a sessionId?
 		const sessionId = await runtimeSessionService.autoStartRuntime(runtimeMetadata, startReason);
 		assert.ok(sessionId);
 		const session = runtimeSessionService.getSession(sessionId);

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -228,7 +228,13 @@ suite('Positron - RuntimeSessionService', () => {
 
 	async function selectRuntime(runtimeMetadata = runtime) {
 		await runtimeSessionService.selectRuntime(runtimeMetadata.runtimeId, startReason);
-		const session = runtimeSessionService.getConsoleSessionForRuntime(runtimeMetadata.runtimeId);
+		// Get the last active session matching the runtime.
+		const sessionId = runtimeSessionService.activeSessions.reverse()
+			.find(session => session.runtimeMetadata.runtimeId === runtimeMetadata.runtimeId &&
+				session.metadata.sessionMode === LanguageRuntimeSessionMode.Console)
+			?.sessionId;
+		assert.ok(sessionId);
+		const session = runtimeSessionService.getSession(sessionId);
 		assert.ok(session instanceof TestLanguageRuntimeSession);
 		disposables.add(session);
 		return session;

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -341,6 +341,14 @@ suite('Positron - RuntimeSessionService', () => {
 				});
 			}
 
+			const createOrRestoreMethod = action === 'restore' ? 'restoreSession' : 'createSession';
+			test(`${action} ${mode} encounters ${createOrRestoreMethod}() error`, async () => {
+				const error = new Error('Failed to create session');
+				sinon.stub(manager, createOrRestoreMethod).rejects(error);
+
+				await assert.rejects(start(), error);
+			});
+
 			test(`${action} ${mode} fires onDidFailStartRuntime if session.start() errors`, async () => {
 				// Listen to the onWillStartSession event and stub session.start() to throw an error.
 				const willStartSession = sinon.spy((e: IRuntimeSessionWillStartEvent) => {

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -35,8 +35,6 @@ suite('Positron - RuntimeSessionService', () => {
 	let anotherRuntime: ILanguageRuntimeMetadata;
 	let sessionName: string;
 	let unregisteredRuntime: ILanguageRuntimeMetadata;
-	let consoleSessionMetadata: IRuntimeSessionMetadata;
-	let notebookSessionMetadata: IRuntimeSessionMetadata;
 
 	setup(() => {
 		instantiationService = disposables.add(new TestInstantiationService());
@@ -49,25 +47,8 @@ suite('Positron - RuntimeSessionService', () => {
 
 		runtime = createTestLanguageRuntimeMetadata(instantiationService, disposables);
 		anotherRuntime = createTestLanguageRuntimeMetadata(instantiationService, disposables);
-		unregisteredRuntime = { runtimeId: 'unregistered-runtime-id' } as ILanguageRuntimeMetadata;
-
 		sessionName = runtime.runtimeName;
-		consoleSessionMetadata = {
-			sessionId: 'test-console-session-id',
-			sessionName,
-			sessionMode: LanguageRuntimeSessionMode.Console,
-			createdTimestamp: Date.now(),
-			notebookUri: undefined,
-			startReason,
-		};
-		notebookSessionMetadata = {
-			sessionId: 'test-notebook-session-id',
-			sessionName,
-			sessionMode: LanguageRuntimeSessionMode.Notebook,
-			createdTimestamp: Date.now(),
-			notebookUri,
-			startReason,
-		};
+		unregisteredRuntime = { runtimeId: 'unregistered-runtime-id' } as ILanguageRuntimeMetadata;
 
 		// Enable automatic startup.
 		configService.setUserConfiguration('positron.interpreters.automaticStartup', true);
@@ -202,12 +183,28 @@ suite('Positron - RuntimeSessionService', () => {
 		return session;
 	}
 
-	function restoreConsole(runtimeMetadata?: ILanguageRuntimeMetadata) {
-		return restoreSession(consoleSessionMetadata, runtimeMetadata);
+	function restoreConsole(runtimeMetadata = runtime) {
+		const sessionMetadata: IRuntimeSessionMetadata = {
+			sessionId: 'test-console-session-id',
+			sessionName,
+			sessionMode: LanguageRuntimeSessionMode.Console,
+			createdTimestamp: Date.now(),
+			notebookUri: undefined,
+			startReason,
+		};
+		return restoreSession(sessionMetadata, runtimeMetadata);
 	}
 
-	function restoreNotebook(runtimeMetadata?: ILanguageRuntimeMetadata) {
-		return restoreSession(notebookSessionMetadata, runtimeMetadata);
+	function restoreNotebook(runtimeMetadata = runtime) {
+		const sessionMetadata: IRuntimeSessionMetadata = {
+			sessionId: 'test-notebook-session-id',
+			sessionName,
+			sessionMode: LanguageRuntimeSessionMode.Notebook,
+			createdTimestamp: Date.now(),
+			notebookUri,
+			startReason,
+		};
+		return restoreSession(sessionMetadata, runtimeMetadata);
 	}
 
 	async function autoStartSession(runtimeMetadata = runtime) {

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -112,16 +112,9 @@ suite('Positron - RuntimeSessionService', () => {
 		activeSessions?: ILanguageRuntimeSession[];
 	}
 
-	function assertActiveSessions(expectedSessions: ILanguageRuntimeSession[]) {
-		assert.deepEqual(
-			runtimeSessionService.activeSessions.map(session => session.sessionId),
-			expectedSessions.map(session => session.sessionId),
-		);
-	}
-
 	function assertServiceState(expectedState?: IServiceState, runtimeMetadata = runtime): void {
 		// Check the active sessions.
-		assertActiveSessions(expectedState?.activeSessions ?? []);
+		assert.deepEqual(runtimeSessionService.activeSessions, expectedState?.activeSessions ?? []);
 
 		// Check the console session state.
 		assert.equal(
@@ -132,26 +125,26 @@ suite('Positron - RuntimeSessionService', () => {
 				'Expected no starting or running console session',
 		);
 		assert.equal(
-			runtimeSessionService.getConsoleSessionForLanguage(runtimeMetadata.languageId)?.sessionId,
-			expectedState?.consoleSessionForLanguage?.sessionId,
+			runtimeSessionService.getConsoleSessionForLanguage(runtimeMetadata.languageId),
+			expectedState?.consoleSessionForLanguage,
 		);
 		assert.equal(
-			runtimeSessionService.getConsoleSessionForRuntime(runtimeMetadata.runtimeId)?.sessionId,
-			expectedState?.consoleSessionForRuntime?.sessionId,
+			runtimeSessionService.getConsoleSessionForRuntime(runtimeMetadata.runtimeId),
+			expectedState?.consoleSessionForRuntime,
 		);
 		assert.equal(
-			runtimeSessionService.getSession(expectedState?.consoleSession?.sessionId ?? '')?.sessionId,
-			expectedState?.consoleSession?.sessionId,
+			runtimeSessionService.getSession(expectedState?.consoleSession?.sessionId ?? ''),
+			expectedState?.consoleSession,
 		);
 
 		// Check the notebook session state.
 		assert.equal(
-			runtimeSessionService.getSession(expectedState?.notebookSession?.sessionId ?? '')?.sessionId,
-			expectedState?.notebookSession?.sessionId,
+			runtimeSessionService.getSession(expectedState?.notebookSession?.sessionId ?? ''),
+			expectedState?.notebookSession,
 		);
 		assert.equal(
-			runtimeSessionService.getNotebookSessionForNotebookUri(notebookUri)?.sessionId,
-			expectedState?.notebookSessionForNotebookUri?.sessionId,
+			runtimeSessionService.getNotebookSessionForNotebookUri(notebookUri),
+			expectedState?.notebookSessionForNotebookUri,
 		);
 	}
 

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { strict as assert } from 'assert';
+import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { Event } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
@@ -95,35 +95,35 @@ suite('Positron - RuntimeSessionService', () => {
 
 	function assertServiceState(expectedState?: IServiceState, runtimeMetadata = runtime): void {
 		// Check the active sessions.
-		assert.deepEqual(runtimeSessionService.activeSessions, expectedState?.activeSessions ?? []);
+		assert.deepStrictEqual(runtimeSessionService.activeSessions, expectedState?.activeSessions ?? []);
 
 		// Check the console session state.
-		assert.equal(
+		assert.strictEqual(
 			runtimeSessionService.hasStartingOrRunningConsole(runtimeMetadata.languageId),
 			expectedState?.hasStartingOrRunningConsole ?? false,
 			expectedState?.hasStartingOrRunningConsole ?
 				'Expected a starting or running console session' :
 				'Expected no starting or running console session',
 		);
-		assert.equal(
+		assert.strictEqual(
 			runtimeSessionService.getConsoleSessionForLanguage(runtimeMetadata.languageId),
 			expectedState?.consoleSessionForLanguage,
 		);
-		assert.equal(
+		assert.strictEqual(
 			runtimeSessionService.getConsoleSessionForRuntime(runtimeMetadata.runtimeId),
 			expectedState?.consoleSessionForRuntime,
 		);
-		assert.equal(
+		assert.strictEqual(
 			runtimeSessionService.getSession(expectedState?.consoleSession?.sessionId ?? ''),
 			expectedState?.consoleSession,
 		);
 
 		// Check the notebook session state.
-		assert.equal(
+		assert.strictEqual(
 			runtimeSessionService.getSession(expectedState?.notebookSession?.sessionId ?? ''),
 			expectedState?.notebookSession,
 		);
-		assert.equal(
+		assert.strictEqual(
 			runtimeSessionService.getNotebookSessionForNotebookUri(notebookUri),
 			expectedState?.notebookSessionForNotebookUri,
 		);
@@ -157,17 +157,17 @@ suite('Positron - RuntimeSessionService', () => {
 
 	function assertSingleSessionIsStarting(session: ILanguageRuntimeSession) {
 		assertHasSingleSession(session);
-		assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+		assert.strictEqual(session.getRuntimeState(), RuntimeState.Starting);
 	}
 
 	function assertSingleSessionIsRestarting(session: ILanguageRuntimeSession) {
 		assertHasSingleSession(session);
-		assert.equal(session.getRuntimeState(), RuntimeState.Restarting);
+		assert.strictEqual(session.getRuntimeState(), RuntimeState.Restarting);
 	}
 
 	function assertSingleSessionIsReady(session: ILanguageRuntimeSession) {
 		assertHasSingleSession(session);
-		assert.equal(session.getRuntimeState(), RuntimeState.Ready);
+		assert.strictEqual(session.getRuntimeState(), RuntimeState.Ready);
 	}
 
 	async function restoreSession(
@@ -241,16 +241,16 @@ suite('Positron - RuntimeSessionService', () => {
 			test(`${action} ${mode} returns the expected session`, async () => {
 				const session = await start();
 
-				assert.equal(session.getRuntimeState(), RuntimeState.Starting);
-				assert.equal(session.metadata.sessionName, sessionName);
-				assert.equal(session.metadata.sessionMode, mode);
-				assert.equal(session.metadata.startReason, startReason);
-				assert.equal(session.runtimeMetadata, runtime);
+				assert.strictEqual(session.getRuntimeState(), RuntimeState.Starting);
+				assert.strictEqual(session.metadata.sessionName, sessionName);
+				assert.strictEqual(session.metadata.sessionMode, mode);
+				assert.strictEqual(session.metadata.startReason, startReason);
+				assert.strictEqual(session.runtimeMetadata, runtime);
 
 				if (mode === LanguageRuntimeSessionMode.Console) {
-					assert.equal(session.metadata.notebookUri, undefined);
+					assert.strictEqual(session.metadata.notebookUri, undefined);
 				} else {
-					assert.equal(session.metadata.notebookUri, notebookUri);
+					assert.strictEqual(session.metadata.notebookUri, notebookUri);
 				}
 			});
 
@@ -279,7 +279,7 @@ suite('Positron - RuntimeSessionService', () => {
 						if (target.callCount > 1) {
 							return;
 						}
-						assert.equal(session.getRuntimeState(), RuntimeState.Uninitialized);
+						assert.strictEqual(session.getRuntimeState(), RuntimeState.Uninitialized);
 
 						assertSingleSessionWillStart(mode);
 					} catch (e) {
@@ -300,7 +300,7 @@ suite('Positron - RuntimeSessionService', () => {
 				let error: Error | undefined;
 				const target = sinon.stub<[e: ILanguageRuntimeSession]>().callsFake(session => {
 					try {
-						assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+						assert.strictEqual(session.getRuntimeState(), RuntimeState.Starting);
 
 						assertSingleSessionIsStarting(session);
 					} catch (e) {
@@ -334,7 +334,7 @@ suite('Positron - RuntimeSessionService', () => {
 
 					const session = await start();
 
-					assert.equal(runtimeSessionService.foregroundSession, session);
+					assert.strictEqual(runtimeSessionService.foregroundSession, session);
 
 					await waitForRuntimeState(session, RuntimeState.Ready);
 
@@ -384,7 +384,7 @@ suite('Positron - RuntimeSessionService', () => {
 
 				const session1 = await start();
 
-				assert.equal(session1.getRuntimeState(), RuntimeState.Uninitialized);
+				assert.strictEqual(session1.getRuntimeState(), RuntimeState.Uninitialized);
 
 				if (mode === LanguageRuntimeSessionMode.Console) {
 					assertServiceState({
@@ -407,7 +407,7 @@ suite('Positron - RuntimeSessionService', () => {
 				willStartSessionDisposable.dispose();
 				const session2 = await start();
 
-				assert.equal(session2.getRuntimeState(), RuntimeState.Starting);
+				assert.strictEqual(session2.getRuntimeState(), RuntimeState.Starting);
 
 				const expectedActiveSessions = action === 'restore' ?
 					// Restoring a session twice overwrites the previous session in activeSessions.
@@ -483,8 +483,8 @@ suite('Positron - RuntimeSessionService', () => {
 				const result2 = await start();
 				const result3 = await start();
 
-				assert.equal(result1, result2);
-				assert.equal(result2, result3);
+				assert.strictEqual(result1, result2);
+				assert.strictEqual(result2, result3);
 
 				assertSingleSessionIsStarting(result1);
 			});
@@ -492,8 +492,8 @@ suite('Positron - RuntimeSessionService', () => {
 			test(`${action} ${mode} concurrently`, async () => {
 				const [result1, result2, result3] = await Promise.all([start(), start(), start()]);
 
-				assert.equal(result1, result2);
-				assert.equal(result2, result3);
+				assert.strictEqual(result1, result2);
+				assert.strictEqual(result2, result3);
 
 				assertSingleSessionIsStarting(result1);
 			});
@@ -507,8 +507,8 @@ suite('Positron - RuntimeSessionService', () => {
 					startNotebook(),
 				]);
 
-				assert.equal(consoleSession.getRuntimeState(), RuntimeState.Starting);
-				assert.equal(notebookSession.getRuntimeState(), RuntimeState.Starting);
+				assert.strictEqual(consoleSession.getRuntimeState(), RuntimeState.Starting);
+				assert.strictEqual(notebookSession.getRuntimeState(), RuntimeState.Starting);
 
 				assertServiceState({
 					hasStartingOrRunningConsole: true,
@@ -532,17 +532,17 @@ suite('Positron - RuntimeSessionService', () => {
 
 	test('restore console registers runtime if unregistered', async () => {
 		// The runtime should not yet be registered.
-		assert.equal(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), undefined);
+		assert.strictEqual(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), undefined);
 
 		await restoreConsole(unregisteredRuntime);
 
 		// The runtime should now be registered.
-		assert.equal(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), unregisteredRuntime);
+		assert.strictEqual(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), unregisteredRuntime);
 	});
 
 	test('auto start validates runtime if unregistered', async () => {
 		// The runtime should not yet be registered.
-		assert.equal(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), undefined);
+		assert.strictEqual(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), undefined);
 
 		// Update the validator to add extra runtime data.
 		const validatedMetadata: Partial<ILanguageRuntimeMetadata> = {
@@ -555,7 +555,7 @@ suite('Positron - RuntimeSessionService', () => {
 		await autoStartSession(unregisteredRuntime);
 
 		// The validated metadata should now be registered.
-		assert.deepEqual(
+		assert.deepStrictEqual(
 			languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId),
 			{ ...unregisteredRuntime, ...validatedMetadata }
 		);
@@ -563,7 +563,7 @@ suite('Positron - RuntimeSessionService', () => {
 
 	test('auto start throws if runtime validation errors', async () => {
 		// The runtime should not yet be registered.
-		assert.equal(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), undefined);
+		assert.strictEqual(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), undefined);
 
 		// Update the validator to throw.
 		const error = new Error('Failed to validate runtime metadata');
@@ -574,7 +574,7 @@ suite('Positron - RuntimeSessionService', () => {
 		await assert.rejects(autoStartSession(unregisteredRuntime), error);
 
 		// The runtime should remain unregistered.
-		assert.equal(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), undefined);
+		assert.strictEqual(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId), undefined);
 	});
 
 	test('auto start console does nothing if automatic startup is disabled', async () => {
@@ -582,7 +582,7 @@ suite('Positron - RuntimeSessionService', () => {
 
 		const sessionId = await runtimeSessionService.autoStartRuntime(runtime, startReason);
 
-		assert.equal(sessionId, '');
+		assert.strictEqual(sessionId, '');
 		assertServiceState();
 	});
 
@@ -598,7 +598,7 @@ suite('Positron - RuntimeSessionService', () => {
 					runtime.runtimeId, sessionName, LanguageRuntimeSessionMode.Console, undefined, startReason);
 			}
 
-			assert.equal(sessionId, '');
+			assert.strictEqual(sessionId, '');
 			assertServiceState();
 
 			workspaceTrustManagementService.setWorkspaceTrust(true);
@@ -622,8 +622,8 @@ suite('Positron - RuntimeSessionService', () => {
 		await waitForRuntimeState(session1, RuntimeState.Ready);
 		const session2 = await selectRuntime();
 
-		assert.equal(session1.getRuntimeState(), RuntimeState.Exited);
-		assert.equal(session2.getRuntimeState(), RuntimeState.Starting);
+		assert.strictEqual(session1.getRuntimeState(), RuntimeState.Exited);
+		assert.strictEqual(session2.getRuntimeState(), RuntimeState.Starting);
 
 		assertServiceState({
 			hasStartingOrRunningConsole: true,
@@ -649,8 +649,8 @@ suite('Positron - RuntimeSessionService', () => {
 
 		const session2 = await selectRuntime();
 
-		assert.equal(session1, session2);
-		assert.equal(runtimeSessionService.foregroundSession, session1);
+		assert.strictEqual(session1, session2);
+		assert.strictEqual(runtimeSessionService.foregroundSession, session1);
 	});
 
 	test(`select console to another runtime and first session never fires onDidEndSession`, async () => {
@@ -711,7 +711,7 @@ suite('Positron - RuntimeSessionService', () => {
 
 				await restartSession(session.sessionId);
 
-				assert.equal(session.getRuntimeState(), RuntimeState.Restarting);
+				assert.strictEqual(session.getRuntimeState(), RuntimeState.Restarting);
 				assertSingleSessionIsRestarting(session);
 
 				await waitForRuntimeState(session, RuntimeState.Ready);
@@ -730,7 +730,7 @@ suite('Positron - RuntimeSessionService', () => {
 				await restartSession(session.sessionId);
 
 				// The existing sessino should remain exited.
-				assert.equal(session.getRuntimeState(), RuntimeState.Exited);
+				assert.strictEqual(session.getRuntimeState(), RuntimeState.Exited);
 
 				// A new session should be starting.
 				let newSession: ILanguageRuntimeSession | undefined;
@@ -742,11 +742,11 @@ suite('Positron - RuntimeSessionService', () => {
 				assert.ok(newSession);
 				disposables.add(newSession);
 
-				assert.equal(newSession.getRuntimeState(), RuntimeState.Starting);
-				assert.equal(newSession.metadata.sessionName, session.metadata.sessionName);
-				assert.equal(newSession.metadata.sessionMode, session.metadata.sessionMode);
-				assert.equal(newSession.metadata.notebookUri, session.metadata.notebookUri);
-				assert.equal(newSession.runtimeMetadata, session.runtimeMetadata);
+				assert.strictEqual(newSession.getRuntimeState(), RuntimeState.Starting);
+				assert.strictEqual(newSession.metadata.sessionName, session.metadata.sessionName);
+				assert.strictEqual(newSession.metadata.sessionMode, session.metadata.sessionMode);
+				assert.strictEqual(newSession.metadata.notebookUri, session.metadata.notebookUri);
+				assert.strictEqual(newSession.runtimeMetadata, session.runtimeMetadata);
 
 				if (mode === LanguageRuntimeSessionMode.Console) {
 					assertServiceState({
@@ -768,7 +768,7 @@ suite('Positron - RuntimeSessionService', () => {
 
 		test(`restart ${mode} in 'starting' state`, async () => {
 			const session = await start();
-			assert.equal(session.getRuntimeState(), RuntimeState.Starting);
+			assert.strictEqual(session.getRuntimeState(), RuntimeState.Starting);
 
 			await restartSession(session.sessionId);
 
@@ -780,7 +780,7 @@ suite('Positron - RuntimeSessionService', () => {
 			await waitForRuntimeState(session, RuntimeState.Ready);
 
 			session.restart();
-			assert.equal(session.getRuntimeState(), RuntimeState.Restarting);
+			assert.strictEqual(session.getRuntimeState(), RuntimeState.Restarting);
 
 			const target = sinon.spy(session, 'restart');
 

--- a/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
@@ -163,7 +163,14 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 
 	async restart(): Promise<void> {
 		await this.shutdown(RuntimeExitReason.Restart);
-		waitForRuntimeState(this, RuntimeState.Exited).then(() => this.start());
+
+		// Wait for the session to exit, then start it again.
+		const disposable = this._register(this.onDidChangeRuntimeState(state => {
+			if (state === RuntimeState.Exited) {
+				disposable.dispose();
+				this.start();
+			}
+		}));
 	}
 
 	async shutdown(exitReason: RuntimeExitReason): Promise<void> {
@@ -202,10 +209,6 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 
 	async showProfile(): Promise<void> {
 		throw new Error('Not implemented.');
-	}
-
-	override dispose() {
-		super.dispose();
 	}
 
 	// Test helpers

--- a/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
@@ -76,7 +76,7 @@ export function createTestLanguageRuntimeMetadata(
 	disposables.add(languageRuntimeService.registerRuntime(runtime));
 
 	// Register the test runtime manager.
-	const manager = new TestRuntimeSessionManager();
+	const manager = TestRuntimeSessionManager.instance;
 	disposables.add(runtimeSessionService.registerSessionManager(manager));
 
 	return runtime;

--- a/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
@@ -107,6 +107,10 @@ export class TestPositronModalDialogService implements IPositronModalDialogsServ
 	}
 }
 export class TestRuntimeSessionManager implements ILanguageRuntimeSessionManager {
+	public static readonly instance = new TestRuntimeSessionManager();
+
+	private _validateMetadata?: (metadata: ILanguageRuntimeMetadata) => Promise<ILanguageRuntimeMetadata>;
+
 	async managesRuntime(runtime: ILanguageRuntimeMetadata): Promise<boolean> {
 		return true;
 	}
@@ -119,7 +123,14 @@ export class TestRuntimeSessionManager implements ILanguageRuntimeSessionManager
 		return new TestLanguageRuntimeSession(sessionMetadata, runtimeMetadata);
 	}
 
-	validateMetadata(metadata: ILanguageRuntimeMetadata): Promise<ILanguageRuntimeMetadata> {
-		throw new Error('Method not implemented');
+	async validateMetadata(metadata: ILanguageRuntimeMetadata): Promise<ILanguageRuntimeMetadata> {
+		if (this._validateMetadata) {
+			return this._validateMetadata(metadata);
+		}
+		return metadata;
+	}
+
+	setValidateMetadata(handler: (metadata: ILanguageRuntimeMetadata) => Promise<ILanguageRuntimeMetadata>): void {
+		this._validateMetadata = handler;
 	}
 }


### PR DESCRIPTION
The aim of this PR is to improve the stability of the runtime session service, with a slight focus on notebooks.

This is another step toward https://github.com/posit-dev/positron/issues/2671.

I've also added an extensive suite of unit tests for the runtime session service, for two reasons:

1. Some of the issues we're seeing with notebooks are intermittent and therefore tricky to reproduce without tests.
2. I wanted to ensure that I didn't break any existing behavior with these changes as well as more planned changes to add notebook-runtime methods to the extension API.

Since there are a bunch of changes to some core code, I've annotated them with comments.