### PR TITLE
test: add missing await to db-connection test

### DIFF
--- a/test/smoke/src/areas/positron/connections/dbConnections.test.ts
+++ b/test/smoke/src/areas/positron/connections/dbConnections.test.ts
@@ -63,7 +63,7 @@ describe('Connections Pane #web #win', () => {
 		afterEach(async function () {
 
 			const app = this.app as Application;
-			app.workbench.positronConnections.removeConnectionButton.click();
+			await app.workbench.positronConnections.removeConnectionButton.click();
 
 		});
 

--- a/test/smoke/src/areas/positron/connections/dbConnections.test.ts
+++ b/test/smoke/src/areas/positron/connections/dbConnections.test.ts
@@ -26,7 +26,7 @@ describe('Connections Pane #web #win', () => {
 		after(async function () {
 
 			const app = this.app as Application;
-			app.workbench.positronConnections.removeConnectionButton.click();
+			await app.workbench.positronConnections.removeConnectionButton.click();
 
 		});
 


### PR DESCRIPTION
### QA Notes
I was having an issue of a test trying to log after the test was done (in PW poc branch) and I was able to figure out it was because of this missing await! Maybe it will help the CI runs.