### PR TITLE
Connections smoke test: hover to get disconnect button

### DIFF
--- a/test/smoke/src/areas/positron/connections/dbConnections.test.ts
+++ b/test/smoke/src/areas/positron/connections/dbConnections.test.ts
@@ -124,6 +124,11 @@ describe('Connections Pane #web #win', () => {
 				await app.workbench.positronConnections.openConnectionsNodes(["mtcars"]);
 			}).toPass();
 
+			// disconnect icon appearance requires hover
+			await app.workbench.positronConnections.rConnectionOpenState.hover();
+			await app.workbench.positronConnections.disconnectButton.click();
+			await app.workbench.positronConnections.reconnectButton.waitforVisible();
+
 		});
 
 	});


### PR DESCRIPTION
After adding some missing awaits, another issue with the connections test was exposed whereby we were not hovering the connection to get the disconnect button to appear

### QA Notes

Connections tests should pass
