### PR TITLE
Fix R restart test with new Kallichore build

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -97,7 +97,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.18"
+      "kallichore": "0.1.19"
     }
   },
   "dependencies": {

--- a/test/smoke/src/areas/positron/console/r-console.test.ts
+++ b/test/smoke/src/areas/positron/console/r-console.test.ts
@@ -7,8 +7,7 @@ import { expect } from '@playwright/test';
 import { Application, PositronRFixtures } from '../../../../../automation';
 import { setupAndStartApp } from '../../../test-runner/test-hooks';
 
-// Skipping due to https://github.com/posit-dev/positron/issues/5356
-describe.skip('Console Pane: R', () => {
+describe('Console Pane: R', () => {
 	setupAndStartApp();
 
 	describe('R Console Restart #web #win', () => {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/5356; fixes restarts on R and re-enables the R console tests.

The bug was upstream, in the supervisor; the issue was that during a restart, the channel that broadcast status updates to the client would blink offline. If the 'starting' status got sent during that blink, the client would miss it and not detect startup correctly. The fix is to ensure the channel always broadcasts updates throughout the restart cycle.

### QA Notes

As noted by @jonvanausdeln, this is 100% reproducible on Windows, so it should be easy to test the fix there. 