### PR TITLE
add prerelease branches to the PR CI workflow (#5352)

### DIFF
--- a/.github/workflows/positron-pull-requests.yml
+++ b/.github/workflows/positron-pull-requests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'prerelease/**'
 
 jobs:
   positron-ci:


### PR DESCRIPTION
Backport https://github.com/posit-dev/positron/pull/5352 to the prerelease/2024.10 branch.