### PR TITLE
Smoke tests: remove quarto install from CI process

### DIFF
--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -23,13 +23,6 @@ runs:
     - name: Setup Graphviz
       uses: ts-graphviz/setup-graphviz@v2.0.2
 
-    - name: Setup Quarto
-      uses: quarto-dev/quarto-actions/setup@v2
-      env:
-        GH_TOKEN: ${{ inputs.github-token }}
-      with:
-        tinytex: true
-
     - name: Setup Conda (Miniforge3)
       shell: bash
       run: |


### PR DESCRIPTION
Now that https://github.com/posit-dev/positron/issues/4511 has been resolved, we should no longer need a quarto install as part of the CI process.

### QA Notes

All smoke tests pass.
