### PR TITLE
Fix F1 for help in Python

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_comm.py
@@ -87,7 +87,7 @@ class PositronComm:
 
     def __init__(self, comm: comm.base_comm.BaseComm) -> None:
         self.comm = comm
-        self.send_lock = threading.Lock()
+        self.send_lock = threading.RLock()
 
     @classmethod
     def create(cls, target_name: str, comm_id: str) -> PositronComm:
@@ -193,6 +193,24 @@ class PositronComm:
                 _handle_msg(raw_msg)
 
         self.comm.on_msg(handle_msg)
+
+    def handle_msg(self, raw_msg: JsonRecord) -> None:
+        """
+        Handle a raw JSON-RPC message from the frontend-side version of this comm.
+
+        Parameters
+        ----------
+        raw_msg
+            The raw JSON-RPC message.
+        """
+        return self.comm.handle_msg(raw_msg)
+
+    @property
+    def messages(self):
+        """
+        Messages sent to the frontend-side version of this comm, when recorded for testing purposes.
+        """
+        return getattr(self.comm, "messages")
 
     def send_result(self, data: JsonData = None, metadata: Optional[JsonRecord] = None) -> None:
         """


### PR DESCRIPTION
Addresses #5290. The issue was a deadlock when handling the `show_help_topic` request when it tries to send the `show_help` event, since both `PositronComm.on_msg` and `send_event` acquire the same lock.

@wesm IIUC the purpose was to allow delaying a `send_event` call in a separate thread until after the message handler completes. I think both cases are solved by using a reentrant lock (`RLock()`).

### QA Notes

F1 should work again in Python.