### PR TITLE
python ci: update macos version to latest

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -217,7 +217,7 @@ jobs:
         working-directory: ${{ env.special-working-directory }}/${{ env.PROJECT_DIR}}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: ['3.x']
         test-suite: [ts-unit, venv, single-workspace, debugger, functional, smoke]
         # TODO: Add integration tests on windows and ubuntu. This requires updating

--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -217,7 +217,7 @@ jobs:
         working-directory: ${{ env.special-working-directory }}/${{ env.PROJECT_DIR}}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: ['3.x']
         test-suite: [ts-unit, venv, single-workspace, debugger, functional, smoke]
         # TODO: Add integration tests on windows and ubuntu. This requires updating

--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -154,7 +154,7 @@ jobs:
         include:
           - os: 'ubuntu-latest'
             python: '3.8'
-          - os: 'macos-13'
+          - os: 'macos-latest'
             python: '3.9'
           - os: 'windows-latest'
             python: '3.10'
@@ -326,6 +326,12 @@ jobs:
           } else {
             & ".venv/bin/python" ./build/ci/addEnvPath.py ${{ env.PYTHON_VIRTUAL_ENVS_LOCATION }} venvPath
           }
+
+      - name: Install miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        if: matrix.os == 'macos-latest'
+        with:
+          python-version: ${{ matrix.python }}
 
       - name: Prepare conda for venv tests
         env:

--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -331,7 +331,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         if: matrix.os == 'macos-latest'
         with:
-          python-version: ${{ matrix.python }}
+          python-version: "3.11"
 
       - name: Prepare conda for venv tests
         env:

--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -329,7 +329,7 @@ jobs:
 
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v3
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-latest' && matrix.test-suite == 'venv'
         with:
           python-version: "3.11"
 

--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -217,7 +217,7 @@ jobs:
         working-directory: ${{ env.special-working-directory }}/${{ env.PROJECT_DIR}}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         python: ['3.x']
         test-suite: [ts-unit, venv, single-workspace, debugger, functional, smoke]
         # TODO: Add integration tests on windows and ubuntu. This requires updating


### PR DESCRIPTION
from errors noted in #5405 ; macos-12 has been deprecated https://github.com/actions/runner-images/issues/10721