### PR TITLE
Expand console area for gradio test

### DIFF
--- a/test/smoke/src/areas/positron/apps/python-apps.test.ts
+++ b/test/smoke/src/areas/positron/apps/python-apps.test.ts
@@ -54,10 +54,14 @@ describe('Python Applications #pr', () => {
 			const viewer = app.workbench.positronViewer;
 
 			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'python_apps', 'gradio_example', 'gradio_example.py'));
+			await app.workbench.quickaccess.runCommand('workbench.action.toggleSidebarVisibility');
+			await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 			await app.workbench.positronEditor.pressPlay();
+			await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 			await expect(async () => {
 				await expect(viewer.getViewerFrame().getByRole('button', { name: 'Submit' })).toBeVisible({ timeout: 30000 });
 			}).toPass({ timeout: 60000 });
+			await app.workbench.quickaccess.runCommand('workbench.action.toggleSidebarVisibility');
 		});
 
 		it('Python - Verify Basic Streamlit App [C903308] #web #win', async function () {


### PR DESCRIPTION
### Intent

Due to https://github.com/posit-dev/positron/issues/5407 , the console pane needs to be bigger for windows CI Tests

### Approach

In gradio test, added minimizing both sidebars before running app, then bringing them back before viewer is checked.

### QA Notes

Python app test should pass.
https://github.com/posit-dev/positron/actions/runs/11900458691