### PR TITLE
Data Explorer: Implement summary stats and histograms/frequency tables to make sparklines

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -399,6 +399,8 @@ class ColumnProfileEvaluator {
 		FROM freq_table
 		ORDER BY freq DESC;`) as Table<any>;
 
+		// TODO: compute the OTHER group
+
 		const values: string[] = [];
 		const counts: number[] = [];
 

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -967,11 +967,7 @@ END`;
 							support_status: SupportStatus.Supported
 						},
 						{
-							profile_type: ColumnProfileType.SmallHistogram,
-							support_status: SupportStatus.Supported
-						},
-						{
-							profile_type: ColumnProfileType.LargeHistogram,
+							profile_type: ColumnProfileType.SummaryStats,
 							support_status: SupportStatus.Supported
 						},
 						{
@@ -983,9 +979,13 @@ END`;
 							support_status: SupportStatus.Supported
 						},
 						{
-							profile_type: ColumnProfileType.SummaryStats,
+							profile_type: ColumnProfileType.SmallHistogram,
 							support_status: SupportStatus.Supported
 						},
+						{
+							profile_type: ColumnProfileType.LargeHistogram,
+							support_status: SupportStatus.Supported
+						}
 					]
 				},
 				search_schema: {
@@ -1191,7 +1191,7 @@ export class DataExplorerRpcHandler {
 			// but slower) vs CREATE TABLE (more memory but faster). We may tweak this threshold,
 			// and especially given that Parquet files may materialize much larger than that appear
 			// on disk.
-			const VIEW_THRESHOLD = 10_000_000;
+			const VIEW_THRESHOLD = 25_000_000;
 			const catalogType = fileStats.size > VIEW_THRESHOLD ? 'VIEW' : 'TABLE';
 
 			scanQuery = `

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -573,17 +573,6 @@ class ColumnProfileEvaluator {
 					num_unique: Number(stats.get(`nunique_${columnSchema.column_name}`))
 				}
 			};
-		} else if (columnSchema.column_type === 'DATE') {
-			return {
-				type_display: ColumnDisplayType.Datetime,
-				date_stats: {
-					min_date: stats.get(`string_min_${columnSchema.column_name}`),
-					max_date: stats.get(`string_max_${columnSchema.column_name}`),
-					mean_date: stats.get(`string_mean_${columnSchema.column_name}`),
-					median_date: stats.get(`string_median_${columnSchema.column_name}`),
-					num_unique: Number(stats.get(`nunique_${columnSchema.column_name}`))
-				}
-			};
 		} else {
 			return {
 				type_display: ColumnDisplayType.Unknown

--- a/extensions/positron-duckdb/src/interfaces.ts
+++ b/extensions/positron-duckdb/src/interfaces.ts
@@ -1380,6 +1380,12 @@ export interface ReturnColumnProfilesParams {
 	 * Array of individual column profile results
 	 */
 	profiles: Array<ColumnProfileResult>;
+
+	/**
+	 * Optional error message if something failed to compute
+	 */
+	error_message?: string;
+
 }
 
 /**
@@ -1407,6 +1413,11 @@ export interface ReturnColumnProfilesEvent {
 	 * Array of individual column profile results
 	 */
 	profiles: Array<ColumnProfileResult>;
+
+	/**
+	 * Optional error message if something failed to compute
+	 */
+	error_message?: string;
 
 }
 

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -25,8 +25,6 @@ import {
 	RowFilterParams,
 	RowFilterType,
 	SetRowFiltersParams,
-	SetSortColumnsParams,
-	SupportedFeatures,
 	SupportStatus,
 	TableData,
 	TableSchema,
@@ -205,12 +203,9 @@ suite('Positron DuckDB Extension Test Suite', () => {
 				},
 				get_column_profiles: {
 					support_status: SupportStatus.Supported,
-					supported_types: [
-						{
-							profile_type: ColumnProfileType.NullCount,
-							support_status: SupportStatus.Supported
-						}
-					]
+					supported_types: Object.values(ColumnProfileType).map((value) => {
+						return { profile_type: value, support_status: SupportStatus.Supported };
+					})
 				},
 				set_sort_columns: { support_status: SupportStatus.Supported, },
 				export_data_selection: {

--- a/positron/comms/data_explorer-frontend-openrpc.json
+++ b/positron/comms/data_explorer-frontend-openrpc.json
@@ -40,6 +40,13 @@
 							"$ref": "#/components/schemas/column_profile_result"
 						}
 					}
+				},
+				{
+					"name": "error_message",
+					"description": "Optional error message if something failed to compute",
+					"schema": {
+						"type": "string"
+					}
 				}
 			]
 		}

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -1546,15 +1546,17 @@ async function createCommInterface() {
 				writeFileSync(tsOutputFile, ts, { encoding: 'utf-8' });
 
 				// Create the Rust output file
-				const rustOutputFile = path.join(rustOutputDir, `${name}_comm.rs`);
-				let rust = '';
-				for await (const chunk of createRustComm(name, frontend, backend)) {
-					rust += chunk;
-				}
+				if (existsSync(rustOutputDir)) {
+					const rustOutputFile = path.join(rustOutputDir, `${name}_comm.rs`);
+					let rust = '';
+					for await (const chunk of createRustComm(name, frontend, backend)) {
+						rust += chunk;
+					}
 
-				// Write the output file
-				console.log(`Writing to ${rustOutputFile}`);
-				writeFileSync(rustOutputFile, rust, { encoding: 'utf-8' });
+					// Write the output file
+					console.log(`Writing to ${rustOutputFile}`);
+					writeFileSync(rustOutputFile, rust, { encoding: 'utf-8' });
+				}
 
 				// Create the Python output file
 				const pythonOutputFile = path.join(pythonOutputDir, `${name}_comm.py`);

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -1332,6 +1332,11 @@ export interface ReturnColumnProfilesParams {
 	 * Array of individual column profile results
 	 */
 	profiles: Array<ColumnProfileResult>;
+
+	/**
+	 * Optional error message if something failed to compute
+	 */
+	error_message?: string;
 }
 
 /**
@@ -1359,6 +1364,11 @@ export interface ReturnColumnProfilesEvent {
 	 * Array of individual column profile results
 	 */
 	profiles: Array<ColumnProfileResult>;
+
+	/**
+	 * Optional error message if something failed to compute
+	 */
+	error_message?: string;
 
 }
 
@@ -1390,7 +1400,7 @@ export class PositronDataExplorerComm extends PositronBaseComm {
 		super(instance, options);
 		this.onDidSchemaUpdate = super.createEventEmitter('schema_update', []);
 		this.onDidDataUpdate = super.createEventEmitter('data_update', []);
-		this.onDidReturnColumnProfiles = super.createEventEmitter('return_column_profiles', ['callback_id', 'profiles']);
+		this.onDidReturnColumnProfiles = super.createEventEmitter('return_column_profiles', ['callback_id', 'profiles', 'error_message']);
 	}
 
 	/**


### PR DESCRIPTION
Addresses #5128. There is a more refinement to do here and plenty of edge case scenarios to test (e.g. histograms of very large INT64 / BIGINT values, completing summary statistics for date/time values). Unit testing this code is a bit of a pain -- my goal was to get this working and at looking the same as R/Python at a glance, and then go through data type by data type to add test coverage for different edge cases.