### PR TITLE
Make it so notebooks actually display the file name in their editor tab

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
@@ -17,6 +17,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { PositronNotebookInstance } from 'vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance';
 import { ILogService } from 'vs/platform/log/common/log';
+import { ExtUri } from 'vs/base/common/resources';
 
 /**
  * Mostly empty options object. Based on the same one in `vs/workbench/contrib/notebook/browser/notebookEditorInput.ts`
@@ -139,7 +140,8 @@ export class PositronNotebookEditorInput extends EditorInput {
 	 * @returns The display name of this input.
 	 */
 	override getName(): string {
-		return localize('positronNotebookInputName', "Positron Notebook");
+		const extUri = new ExtUri(() => false);
+		return extUri.basename(this.resource) ?? localize('positronNotebookInputName', "Positron Notebook");
 	}
 
 	/**


### PR DESCRIPTION
Addresses #2628.

Previously we just displayed the helpful name 'Positron Notebook' for every positron notebook 2.0 tab open. This updates this to just display the file name. 

<img width="298" alt="image" src="https://github.com/user-attachments/assets/136754e3-4710-4383-9c59-652a6d7d58ab">


<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes
Steps:
- Enable the `positron.notebooks.usePositronNotebooksExperimental` flag
- Open an existing notebook
- Check that the name is displayed properly

New notebooks should also work and just show `untitled-*.ipynb` (Although they still wont actually function until #4089 is fixed)

There's a chance that the code doesn't handle some weird file name edge cases but I couldn't find any. 
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
