### PR TITLE
Use a tight bounding box when plotting at the intrinsic size

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
@@ -119,7 +119,7 @@ class Plot:
                 request.params.pixel_ratio,
                 request.params.format,
             )
-        if isinstance(request, GetIntrinsicSizeRequest):
+        elif isinstance(request, GetIntrinsicSizeRequest):
             self._handle_get_intrinsic_size()
         else:
             logger.warning(f"Unhandled request: {request}")

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/utils.py
@@ -94,12 +94,12 @@ def json_rpc_error(code: int, message: str) -> JsonRecord:
     )
 
 
-def json_rpc_notification(method: str, params: JsonRecord) -> JsonRecord:
+def json_rpc_notification(method: str, params: Optional[JsonRecord] = None) -> JsonRecord:
     return comm_message(
         {
             "jsonrpc": "2.0",
             "method": method,
-            "params": params,
+            "params": {} if params is None else params,
         }
     )
 
@@ -135,3 +135,7 @@ def json_rpc_response(result: JsonData) -> JsonRecord:
 # remove "<class '...'>" from value
 def get_type_as_str(value: Any) -> str:
     return repr(type(value))[8:-2]
+
+
+def percent_difference(actual: float, expected: float) -> float:
+    return abs(actual - expected) / actual

--- a/extensions/positron-python/python_files/positron/positron_language_server.py
+++ b/extensions/positron-python/python_files/positron/positron_language_server.py
@@ -5,6 +5,7 @@ Server and IPyKernel in the same environment.
 
 import argparse
 import asyncio
+import asyncio.events
 import logging
 import os
 import sys
@@ -137,12 +138,15 @@ if __name__ == "__main__":
 
     # IPyKernel uses Tornado which (as of version 5.0) shares the same event
     # loop as asyncio.
-    loop = asyncio.get_event_loop_policy().get_event_loop()
+    loop: asyncio.events.AbstractEventLoop = asyncio.get_event_loop_policy().get_event_loop()
 
     # Enable asyncio debug mode.
     if args.loglevel == "DEBUG":
         loop.set_debug(True)
         POSITRON.set_debug(True)
+
+        # Log all callbacks that take longer than 0.5 seconds (the current default is too noisy).
+        loop.slow_callback_duration = 0.5
 
     try:
         loop.run_forever()

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/labeledTextInput.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/labeledTextInput.tsx
@@ -30,7 +30,7 @@ export interface LabeledTextInputProps {
 	 */
 	errorMsg?: string;
 	validator?: ValidatorFn<string | number>;
-	onChange: ChangeEventHandler<HTMLInputElement>;
+	onChange?: ChangeEventHandler<HTMLInputElement>;
 	/**
 	 * Maximum allowed number of characters in the input field.
 	 */

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -23,11 +23,11 @@ import { FileFilter } from 'electron';
 import { DropDownListBox } from 'vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBox';
 import { DropDownListBoxItem } from 'vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBoxItem';
 import { IFileService } from 'vs/platform/files/common/files';
-import { IntrinsicSize, PlotUnit, RenderFormat } from 'vs/workbench/services/languageRuntime/common/positronPlotComm';
+import { IntrinsicSize, RenderFormat } from 'vs/workbench/services/languageRuntime/common/positronPlotComm';
 import { Checkbox } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/checkbox';
 import { IPlotSize, IPositronPlotSizingPolicy } from 'vs/workbench/services/positronPlots/common/sizingPolicy';
 import { ILogService } from 'vs/platform/log/common/log';
-import { PlotSizingPolicyIntrinsic } from 'vs/workbench/services/positronPlots/common/sizingPolicyIntrinsic';
+import { formatPlotUnit, PlotSizingPolicyIntrinsic } from 'vs/workbench/services/positronPlots/common/sizingPolicyIntrinsic';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IRenderedPlot } from 'vs/workbench/services/languageRuntime/common/positronPlotCommProxy';
 import { IPositronModalDialogsService } from 'vs/workbench/services/positronModalDialogs/common/positronModalDialogs';
@@ -268,20 +268,21 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 		);
 	};
 
-	let displayWidth: number;
-	let displayHeight: number;
+	let intrinsicWidth = '';
+	let intrinsicHeight = '';
 	if (enableIntrinsicSize && props.plotIntrinsicSize) {
-		displayWidth = props.plotIntrinsicSize.width;
-		displayHeight = props.plotIntrinsicSize.height;
-
-		// Convert intrinsic size to pixels if necessary
-		if (props.plotIntrinsicSize.unit === PlotUnit.Inches) {
-			displayWidth *= dpi.value;
-			displayHeight *= dpi.value;
-		}
-	} else {
-		displayWidth = width.value;
-		displayHeight = height.value;
+		intrinsicWidth = localize(
+			'positron.savePlotModalDialog.width.intrinsicSize',
+			"{0}{1}",
+			props.plotIntrinsicSize.width,
+			formatPlotUnit(props.plotIntrinsicSize.unit),
+		);
+		intrinsicHeight = localize(
+			'positron.savePlotModalDialog.height.intrinsicSize',
+			"{0}{1}",
+			props.plotIntrinsicSize.height,
+			formatPlotUnit(props.plotIntrinsicSize.unit),
+		);
 	}
 
 	return (
@@ -339,30 +340,49 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 							</div>
 						</div>
 						<div className='plot-input'>
-							<LabeledTextInput
-								label={(() => localize(
-									'positron.savePlotModalDialog.width',
-									"Width"
-								))()}
-								value={displayWidth}
-								type={'number'}
-								onChange={e => updateWidth(e.target.value)}
-								min={1}
-								error={!width.valid}
-								disabled={enableIntrinsicSize}
-							/>
-							<LabeledTextInput
-								label={(() => localize(
-									'positron.savePlotModalDialog.height',
-									"Height"
-								))()}
-								value={displayHeight}
-								type={'number'}
-								onChange={e => updateHeight(e.target.value)}
-								min={1}
-								error={!height.valid}
-								disabled={enableIntrinsicSize}
-							/>
+							{enableIntrinsicSize ? <>
+								<LabeledTextInput
+									label={(() => localize(
+										'positron.savePlotModalDialog.width',
+										"Width"
+									))()}
+									type={'text'}
+									value={intrinsicWidth}
+									disabled={true}
+								/>
+								<LabeledTextInput
+									label={(() => localize(
+										'positron.savePlotModalDialog.height',
+										"Height"
+									))()}
+									type={'text'}
+									value={intrinsicHeight}
+									disabled={true}
+								/>
+							</> : <>
+								<LabeledTextInput
+									label={(() => localize(
+										'positron.savePlotModalDialog.width',
+										"Width"
+									))()}
+									value={width.value}
+									type={'number'}
+									onChange={e => updateWidth(e.target.value)}
+									min={1}
+									error={!width.valid}
+								/>
+								<LabeledTextInput
+									label={(() => localize(
+										'positron.savePlotModalDialog.height',
+										"Height"
+									))()}
+									value={height.value}
+									type={'number'}
+									onChange={e => updateHeight(e.target.value)}
+									min={1}
+									error={!height.valid}
+								/>
+							</>}
 							{enableDPI && <LabeledTextInput
 								label={(() => localize(
 									'positron.savePlotModalDialog.dpi',

--- a/src/vs/workbench/services/positronPlots/common/sizingPolicyIntrinsic.ts
+++ b/src/vs/workbench/services/positronPlots/common/sizingPolicyIntrinsic.ts
@@ -24,29 +24,34 @@ export class PlotSizingPolicyIntrinsic implements IPositronPlotSizingPolicy {
 			return this._name;
 		}
 
-		// Determine the user-facing unit of measurement.
-		let unit = '';
-		switch (intrinsicSize.unit) {
-			case PlotUnit.Inches:
-				unit = nls.localize('plotSizingPolicy.intrinsic.unit.inches', 'in');
-				break;
-			case PlotUnit.Pixels:
-				unit = nls.localize('plotSizingPolicy.intrinsic.unit.pixels', 'px');
-				break;
-		}
-
 		return nls.localize(
 			'plotSizingPolicy.intrinsic.name',
 			"{0} ({1}{3}×{2}{3})",
 			intrinsicSize.source,
 			intrinsicSize.width,
 			intrinsicSize.height,
-			unit
+			formatPlotUnit(intrinsicSize.unit),
 		);
 	}
 
 	public getPlotSize(viewportSize: IPlotSize): IPlotSize | undefined {
 		// Don't specify a size; the language runtime will use the intrinsic size of the plot.
 		return undefined;
+	}
+}
+
+/**
+ * Determine the user-facing unit of measurement.
+ *
+ * @param unit The unit of measurement.
+ */
+export function formatPlotUnit(unit: PlotUnit): string {
+	switch (unit) {
+		case PlotUnit.Inches:
+			return nls.localize('plotSizingPolicy.intrinsic.unit.inches', 'in');
+		case PlotUnit.Pixels:
+			return nls.localize('plotSizingPolicy.intrinsic.unit.pixels', 'px');
+		default:
+			throw new Error(`Unknown plot unit: ${unit}`);
 	}
 }


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/5068. This brings our matplotlib configuration closer to Jupyter Notebooks when using the intrinsic sizing policy which is probably more familiar to users.

Since the produced image pixel size is no longer guaranteed, I also changed the save plot modal to display the size in intrinsic units instead of pixels.

### Known Issues

If you plot totally outside of the default bounding box, it's missed by our current plot change detection and an "update" is not sent to the frontend. I was unable to find a fix in a reasonable amount of fiddling.

It's a bit of a hack but you can manually request an update with `fig.canvas.manager.update()`. Maybe a better workaround would be to add a refresh button to the plots action bar?

### QA Notes

Running the following code in a single execution should include the title in the plot (you can't run it line-by-line because of the known issue above).

```python
fig, ax = plt.subplots()
fig.text(x=0.5, y=1, s='title')
plt.show()
```