### PR TITLE
Fix console scrolling for web

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -567,6 +567,15 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	};
 
 	/**
+	 * Fixes the scroll event override that VS Code drops to prevent gesture navigation.
+	 * @param e A WheelEvent<HTMLDivElement>
+	 */
+	const scrollOverrideHandler = (e: WheelEvent<HTMLDivElement>) => {
+		consoleInstanceRef.current.scrollBy(e.deltaX, e.deltaY);
+		e.preventDefault();
+	};
+
+	/**
 	 * onWheel event handler.
 	 * @param e A WheelEvent<HTMLDivElement> that describes a user interaction with the wheel.
 	 */
@@ -608,7 +617,11 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			onMouseDown={mouseDownHandler}
 			onWheel={wheelHandler}
 			onScroll={scrollHandler}>
-			<div ref={consoleInstanceContainerRef} className='console-instance-container'>
+			<div
+				ref={consoleInstanceContainerRef}
+				className='console-instance-container'
+				onWheel={scrollOverrideHandler}
+			>
 				<ConsoleInstanceItems
 					positronConsoleInstance={props.positronConsoleInstance}
 					editorFontInfo={editorFontInfo}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -14,7 +14,7 @@ import { KeyboardEvent, MouseEvent, UIEvent, useCallback, useEffect, useLayoutEf
 import * as nls from 'vs/nls';
 import * as DOM from 'vs/base/browser/dom';
 import { generateUuid } from 'vs/base/common/uuid';
-import { isMacintosh } from 'vs/base/common/platform';
+import { isMacintosh, isWeb } from 'vs/base/common/platform';
 import { PixelRatio } from 'vs/base/browser/pixelRatio';
 import { disposableTimeout } from 'vs/base/common/async';
 import { DisposableStore } from 'vs/base/common/lifecycle';
@@ -571,8 +571,9 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	 * @param e A WheelEvent<HTMLDivElement>
 	 */
 	const scrollOverrideHandler = (e: WheelEvent<HTMLDivElement>) => {
-		consoleInstanceRef.current.scrollBy(e.deltaX, e.deltaY);
-		e.preventDefault();
+		if (isWeb) {
+			consoleInstanceRef.current.scrollBy(e.deltaX, e.deltaY);
+		}
 	};
 
 	/**


### PR DESCRIPTION
Address #2056 

VS Code drops the wheel scroll event to prevent gesture navigation. This listens to the event on the top level element in the console and forwards the scroll to the parent container.

The fix also didn't seem to affect desktop but it seems safer to add an `isWeb` check.

I suspect there may be other places that have this problem too. Going forward, it might be better to try to use the Scrollable component that uses VS Code's scrollable code and that would hopefully avoid this bug. However, Scrollable needs to know the container dimensions and the content dimensions to properly size the scroll bar.

### QA Notes
I tested locally with a trackpad but the event should also be triggered for a standard mouse wheel to fix the scrolling.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
