### PR TITLE
E2E tests: fix pressplay and disable gradio test

### DIFF
--- a/test/automation/src/positron/positronEditor.ts
+++ b/test/automation/src/positron/positronEditor.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { expect } from '@playwright/test';
 import { Code } from '../code';
 
 // currently a dupe of declaration in ../editor.ts but trying not to modifiy that file
@@ -17,6 +18,10 @@ export class PositronEditor {
 
 	async pressPlay(): Promise<void> {
 		await this.code.driver.getLocator(PLAY_BUTTON).click();
+
+		// await appearance and disappearance of the toast
+		await expect(this.code.driver.page.locator('.notifications-toasts')).toBeVisible({ timeout: 30000 });
+		await expect(this.code.driver.page.locator('.notifications-toasts')).not.toBeVisible({ timeout: 30000 });
 	}
 
 	async pressToLine(filename: string, lineNumber: number, press: string): Promise<void> {

--- a/test/smoke/src/areas/positron/apps/python-apps.test.ts
+++ b/test/smoke/src/areas/positron/apps/python-apps.test.ts
@@ -37,10 +37,10 @@ test.describe('Python Applications', { tag: ['@pr'] }, () => {
 		await expect(viewer.getViewerFrame().getByText('FastAPI')).toBeVisible({ timeout: 30000 });
 	});
 
-	// gradio test skipped because we seem to need
-	// share=True
-	// and this will cause Crowdstrike to fire and security will have to respond
-	test.skip('Python - Verify Basic Gradio App [C903307]', { tag: ['@win'] }, async function ({ app, python }) {
+	test.skip('Python - Verify Basic Gradio App [C903307]', {
+		tag: ['@win'],
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5459' }]
+	}, async function ({ app, python }) {
 		const viewer = app.workbench.positronViewer;
 
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'python_apps', 'gradio_example', 'gradio_example.py'));

--- a/test/smoke/src/areas/positron/apps/python-apps.test.ts
+++ b/test/smoke/src/areas/positron/apps/python-apps.test.ts
@@ -37,7 +37,10 @@ test.describe('Python Applications', { tag: ['@pr'] }, () => {
 		await expect(viewer.getViewerFrame().getByText('FastAPI')).toBeVisible({ timeout: 30000 });
 	});
 
-	test('Python - Verify Basic Gradio App [C903307]', { tag: ['@win'] }, async function ({ app, python }) {
+	// gradio test skipped because we seem to need
+	// share=True
+	// and this will cause Crowdstrike to fire and security will have to respond
+	test.skip('Python - Verify Basic Gradio App [C903307]', { tag: ['@win'] }, async function ({ app, python }) {
 		const viewer = app.workbench.positronViewer;
 
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'python_apps', 'gradio_example', 'gradio_example.py'));
@@ -77,7 +80,6 @@ test.describe('Python Applications', { tag: ['@pr'] }, () => {
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleSidebarVisibility');
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 		await app.workbench.positronEditor.pressPlay();
-		await expect(page.locator('.notifications-toasts')).not.toBeVisible({ timeout: 30000 });
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 		const viewerFrame = viewer.getViewerFrame();
 		const loginLocator = app.web


### PR DESCRIPTION
Await the toast(s) for press play actions and disable gradio test as it doesn't stay running on OSX and Windows.

### QA Notes

All smoke tests should pass.
