### PR TITLE
Use a text editor to render connection code when resuming connections

### DIFF
--- a/src/vs/workbench/contrib/positronConnections/browser/components/resumeConnectionModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/resumeConnectionModalDialog.tsx
@@ -69,7 +69,12 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 		const editor = services.instantiationService.createInstance(
 			CodeEditorWidget,
 			editorContainerRef.current,
-			{ ...getSimpleEditorOptions(services.configurationService), readOnly: true },
+			{
+				...getSimpleEditorOptions(services.configurationService),
+				readOnly: true,
+				domReadOnly: true,
+				cursorBlinking: 'solid',
+			},
 			getSimpleCodeEditorWidgetOptions()
 		);
 
@@ -127,7 +132,7 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 		}
 
 		editor.focus();
-		editor.updateOptions({ readOnly: false });
+		editor.updateOptions({ readOnly: false, domReadOnly: false, cursorBlinking: 'blink' });
 		editor.setScrollTop(0);
 	};
 

--- a/src/vs/workbench/contrib/positronConnections/browser/components/resumeConnectionModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/resumeConnectionModalDialog.tsx
@@ -66,7 +66,7 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 		}
 
 		const disposableStore = new DisposableStore();
-		const editor = services.instantiationService.createInstance(
+		const editor = disposableStore.add(services.instantiationService.createInstance(
 			CodeEditorWidget,
 			editorContainerRef.current,
 			{
@@ -76,21 +76,17 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 				cursorBlinking: 'solid',
 			},
 			getSimpleCodeEditorWidgetOptions()
-		);
+		));
 
-		const emitter = new Emitter<string>;
-		const inputModel = services.modelService.createModel(
+		const emitter = disposableStore.add(new Emitter<string>);
+		const inputModel = disposableStore.add(services.modelService.createModel(
 			code || '',
 			{ languageId: language_id || '', onDidChange: emitter.event },
 			undefined,
 			true
-		);
+		));
 
 		editor.setModel(inputModel);
-		disposableStore.add(editor);
-		disposableStore.add(inputModel);
-		disposableStore.add(emitter);
-
 		editorRef.current = editor;
 
 		return () => {
@@ -141,6 +137,7 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 			return;
 		}
 
+		// Acquire code before disposing of the renderer
 		const code = editorRef.current?.getValue();
 
 		props.renderer.dispose();

--- a/src/vs/workbench/contrib/positronConnections/browser/components/resumeConnectionModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/resumeConnectionModalDialog.tsx
@@ -54,17 +54,13 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 	const { services, activeInstaceId } = props;
 	const activeInstance = services.connectionsService.getConnections().find(item => item.id === activeInstaceId);
 
-	const editorContainerRef = useRef<HTMLDivElement>(null);
-	const editorRef = useRef<CodeEditorWidget | null>(null);
+	const editorContainerRef = useRef<HTMLDivElement>(undefined!);
+	const editorRef = useRef<CodeEditorWidget>(undefined!);
 
 	const code = activeInstance?.metadata.code;
 	const language_id = activeInstance?.metadata.language_id;
 
 	useEffect(() => {
-		if (!editorContainerRef.current) {
-			return () => { };
-		}
-
 		const disposableStore = new DisposableStore();
 		const editor = disposableStore.add(services.instantiationService.createInstance(
 			CodeEditorWidget,
@@ -91,7 +87,6 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 
 		return () => {
 			disposableStore.dispose();
-			editorRef.current = null;
 		};
 	},
 		[

--- a/src/vs/workbench/contrib/positronConnections/browser/positronConnectionsContext.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/positronConnectionsContext.tsx
@@ -5,6 +5,7 @@
 
 import React, { PropsWithChildren, createContext, useContext } from 'react';
 import { IReactComponentContainer } from 'vs/base/browser/positronReactRenderer';
+import { IModelService } from 'vs/editor/common/services/model';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { ICommandService } from 'vs/platform/commands/common/commands';
@@ -12,6 +13,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IHoverService } from 'vs/platform/hover/browser/hover';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
@@ -32,6 +34,8 @@ export interface PositronConnectionsServices {
 	readonly clipboardService: IClipboardService;
 	readonly notificationService: INotificationService;
 	readonly editorService: IEditorService;
+	readonly instantiationService: IInstantiationService;
+	readonly modelService: IModelService;
 }
 
 const PositronConnectionsContext = createContext<PositronConnectionsServices>(undefined!);

--- a/src/vs/workbench/contrib/positronConnections/browser/positronConnectionsView.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/positronConnectionsView.tsx
@@ -31,6 +31,7 @@ import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
+import { IModelService } from 'vs/editor/common/services/model';
 
 export class PositronConnectionsView
 	extends PositronViewPane
@@ -89,7 +90,8 @@ export class PositronConnectionsView
 		@ILayoutService private readonly layoutService: ILayoutService,
 		@IClipboardService private readonly clipboardService: IClipboardService,
 		@INotificationService private readonly notificationService: INotificationService,
-		@IEditorService private readonly editorService: IEditorService
+		@IEditorService private readonly editorService: IEditorService,
+		@IModelService private readonly modelService: IModelService
 	) {
 		super(
 			options,
@@ -148,6 +150,8 @@ export class PositronConnectionsView
 				clipboardService={this.clipboardService}
 				notificationService={this.notificationService}
 				editorService={this.editorService}
+				instantiationService={this.instantiationService}
+				modelService={this.modelService}
 			/>
 		);
 	}

--- a/src/vs/workbench/services/positronConnections/browser/interfaces/positronConnectionsInstance.ts
+++ b/src/vs/workbench/services/positronConnections/browser/interfaces/positronConnectionsInstance.ts
@@ -6,13 +6,35 @@
 import { Emitter, Event } from 'vs/base/common/event';
 import { IPositronConnectionEntry } from 'vs/workbench/services/positronConnections/browser/positronConnectionsUtils';
 
-export interface ConnectionMetadata {
+export interface IConnectionMetadata {
 	name: string;
 	language_id: string;
 	host?: string;
 	type?: string;
 	code?: string;
 	icon?: string;
+}
+
+export class ConnectionMetadata implements IConnectionMetadata {
+	name: string;
+	language_id: string;
+	host?: string;
+	type?: string;
+	code?: string;
+	icon?: string;
+
+	constructor(metadata: IConnectionMetadata) {
+		this.name = metadata.name;
+		this.language_id = metadata.language_id;
+		this.code = metadata.code;
+		this.update(metadata);
+	}
+
+	update(values: Partial<IConnectionMetadata>): void {
+		console.log(values);
+		Object.assign(this, values);
+		console.log(this);
+	}
 }
 
 /***

--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsService.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsService.ts
@@ -6,7 +6,7 @@
 import { Disposable } from 'vs/base/common/lifecycle';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { ConnectionsClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeConnectionsClient';
-import { ConnectionMetadata, IPositronConnectionInstance } from 'vs/workbench/services/positronConnections/browser/interfaces/positronConnectionsInstance';
+import { ConnectionMetadata, IConnectionMetadata, IPositronConnectionInstance } from 'vs/workbench/services/positronConnections/browser/interfaces/positronConnectionsInstance';
 import { IPositronConnectionsService, POSITRON_CONNECTIONS_VIEW_ID } from 'vs/workbench/services/positronConnections/browser/interfaces/positronConnectionsService';
 import { DisconnectedPositronConnectionsInstance, PositronConnectionsInstance } from 'vs/workbench/services/positronConnections/browser/positronConnectionsInstance';
 import { ILanguageRuntimeSession, IRuntimeSessionService, RuntimeClientType } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
@@ -52,7 +52,7 @@ class PositronConnectionsService extends Disposable implements IPositronConnecti
 			this.attachRuntime(runtime);
 		}));
 
-		const storedConnections: ConnectionMetadata[] = JSON.parse(
+		const storedConnections: IConnectionMetadata[] = JSON.parse(
 			this.storageService.get('positron-connections', StorageScope.WORKSPACE, '[]')
 		);
 		storedConnections.forEach((metadata) => {
@@ -61,7 +61,7 @@ class PositronConnectionsService extends Disposable implements IPositronConnecti
 			}
 
 			const instance = new DisconnectedPositronConnectionsInstance(
-				metadata,
+				new ConnectionMetadata(metadata),
 				this.runtimeSessionService,
 				this
 			);
@@ -103,7 +103,7 @@ class PositronConnectionsService extends Disposable implements IPositronConnecti
 			}
 
 			const instance = await PositronConnectionsInstance.init(
-				message.data as ConnectionMetadata,
+				new ConnectionMetadata(message.data as IConnectionMetadata),
 				new ConnectionsClientInstance(client),
 				this
 			);
@@ -121,7 +121,7 @@ class PositronConnectionsService extends Disposable implements IPositronConnecti
 				const metadata = await connectionsClient.getMetadata();
 
 				const instance = await PositronConnectionsInstance.init(
-					metadata,
+					new ConnectionMetadata(metadata),
 					connectionsClient,
 					this
 				);


### PR DESCRIPTION
Adresses https://github.com/posit-dev/positron/issues/5219
Use a CodeEditorWidget to display the connections code so it's easily editable
and highlighted.

TODO:

- [x] Improve behavior of text editor before clicking edit - maybe make it unclickable and with a different type of cursor?

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

The resume connection modal should now show a text editor. After clicking in 'edit' the code should be editable and copy, resume should still work as expected.

https://github.com/user-attachments/assets/c81274dc-2f31-414f-9d84-21bcf2604017

