### PR TITLE
Add RuntimeCodeExecutionMode to `runtime.executeCode()` in the API

### DIFF
--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1213,7 +1213,7 @@ declare module 'positron' {
 		 * @param focus Whether to focus the runtime's console
 		 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 		 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
-		 * @param runtimeCodeExecutionMode Possible code execution modes for a language runtime
+		* @param mode Possible code execution modes for a language runtime
 		 * @returns A Thenable that resolves with true if the code was sent to a
 		 *   runtime successfully, false otherwise.
 		 */
@@ -1221,7 +1221,7 @@ declare module 'positron' {
 			code: string,
 			focus: boolean,
 			allowIncomplete?: boolean,
-			runtimeCodeExecutionMode?: RuntimeCodeExecutionMode): Thenable<boolean>;
+			mode?: RuntimeCodeExecutionMode): Thenable<boolean>;
 
 		/**
 		 * Register a language runtime manager with Positron. Returns a

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1213,13 +1213,15 @@ declare module 'positron' {
 		 * @param focus Whether to focus the runtime's console
 		 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 		 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
+		 * @param runtimeCodeExecutionMode Possible code execution modes for a language runtime
 		 * @returns A Thenable that resolves with true if the code was sent to a
 		 *   runtime successfully, false otherwise.
 		 */
 		export function executeCode(languageId: string,
 			code: string,
 			focus: boolean,
-			allowIncomplete?: boolean): Thenable<boolean>;
+			allowIncomplete?: boolean,
+			runtimeCodeExecutionMode?: RuntimeCodeExecutionMode): Thenable<boolean>;
 
 		/**
 		 * Register a language runtime manager with Positron. Returns a

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1252,8 +1252,8 @@ export class MainThreadLanguageRuntime
 		}
 	}
 
-	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean): Promise<boolean> {
-		return this._positronConsoleService.executeCode(languageId, code, focus, allowIncomplete);
+	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, runtimeCodeExecutionMode?: RuntimeCodeExecutionMode): Promise<boolean> {
+		return this._positronConsoleService.executeCode(languageId, code, focus, allowIncomplete, runtimeCodeExecutionMode);
 	}
 
 	public dispose(): void {

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1252,8 +1252,8 @@ export class MainThreadLanguageRuntime
 		}
 	}
 
-	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, runtimeCodeExecutionMode?: RuntimeCodeExecutionMode): Promise<boolean> {
-		return this._positronConsoleService.executeCode(languageId, code, focus, allowIncomplete, runtimeCodeExecutionMode);
+	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode): Promise<boolean> {
+		return this._positronConsoleService.executeCode(languageId, code, focus, allowIncomplete, mode);
 	}
 
 	public dispose(): void {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -76,8 +76,8 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 		// --- Start Positron ---
 		const runtime: typeof positron.runtime = {
-			executeCode(languageId, code, focus, allowIncomplete): Thenable<boolean> {
-				return extHostLanguageRuntime.executeCode(languageId, code, focus, allowIncomplete);
+			executeCode(languageId, code, focus, allowIncomplete, runtimeCodeExecutionMode): Thenable<boolean> {
+				return extHostLanguageRuntime.executeCode(languageId, code, focus, allowIncomplete, runtimeCodeExecutionMode);
 			},
 			registerLanguageRuntimeManager(
 				manager: positron.LanguageRuntimeManager): vscode.Disposable {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -76,8 +76,8 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 		// --- Start Positron ---
 		const runtime: typeof positron.runtime = {
-			executeCode(languageId, code, focus, allowIncomplete, runtimeCodeExecutionMode): Thenable<boolean> {
-				return extHostLanguageRuntime.executeCode(languageId, code, focus, allowIncomplete, runtimeCodeExecutionMode);
+			executeCode(languageId, code, focus, allowIncomplete, mode): Thenable<boolean> {
+				return extHostLanguageRuntime.executeCode(languageId, code, focus, allowIncomplete, mode);
 			},
 			registerLanguageRuntimeManager(
 				manager: positron.LanguageRuntimeManager): vscode.Disposable {

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -36,7 +36,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$startLanguageRuntime(runtimeId: string, sessionName: string, sessionMode: LanguageRuntimeSessionMode, notebookUri: URI | undefined): Promise<string>;
 	$completeLanguageRuntimeDiscovery(): void;
 	$unregisterLanguageRuntime(handle: number): void;
-	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean): Promise<boolean>;
+	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, runtimeCodeExecutionMode?: RuntimeCodeExecutionMode): Promise<boolean>;
 	$getPreferredRuntime(languageId: string): Promise<ILanguageRuntimeMetadata>;
 	$getForegroundSession(): Promise<string | undefined>;
 	$getNotebookSession(notebookUri: URI): Promise<string | undefined>;

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -36,7 +36,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$startLanguageRuntime(runtimeId: string, sessionName: string, sessionMode: LanguageRuntimeSessionMode, notebookUri: URI | undefined): Promise<string>;
 	$completeLanguageRuntimeDiscovery(): void;
 	$unregisterLanguageRuntime(handle: number): void;
-	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, runtimeCodeExecutionMode?: RuntimeCodeExecutionMode): Promise<boolean>;
+	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode): Promise<boolean>;
 	$getPreferredRuntime(languageId: string): Promise<ILanguageRuntimeMetadata>;
 	$getForegroundSession(): Promise<string | undefined>;
 	$getNotebookSession(notebookUri: URI): Promise<string | undefined>;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -715,8 +715,8 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		});
 	}
 
-	public executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, runtimeCodeExecutionMode?: RuntimeCodeExecutionMode): Promise<boolean> {
-		return this._proxy.$executeCode(languageId, code, focus, allowIncomplete, runtimeCodeExecutionMode);
+	public executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode): Promise<boolean> {
+		return this._proxy.$executeCode(languageId, code, focus, allowIncomplete, mode);
 	}
 
 	/**

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -715,8 +715,8 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		});
 	}
 
-	public executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean): Promise<boolean> {
-		return this._proxy.$executeCode(languageId, code, focus, allowIncomplete);
+	public executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, runtimeCodeExecutionMode?: RuntimeCodeExecutionMode): Promise<boolean> {
+		return this._proxy.$executeCode(languageId, code, focus, allowIncomplete, runtimeCodeExecutionMode);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -40,7 +40,7 @@ import { ParameterHintsController } from 'vs/editor/contrib/parameterHints/brows
 import { IInputHistoryEntry } from 'vs/workbench/contrib/executionHistory/common/executionHistoryService';
 import { SelectionClipboardContributionID } from 'vs/workbench/contrib/codeEditor/browser/selectionClipboard';
 import { usePositronConsoleContext } from 'vs/workbench/contrib/positronConsole/browser/positronConsoleContext';
-import { RuntimeCodeFragmentStatus } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { HistoryBrowserPopup } from 'vs/workbench/contrib/positronConsole/browser/components/historyBrowserPopup';
 import { HistoryInfixMatchStrategy } from 'vs/workbench/contrib/positronConsole/common/historyInfixMatchStrategy';
 import { HistoryPrefixMatchStrategy } from 'vs/workbench/contrib/positronConsole/common/historyPrefixMatchStrategy';
@@ -866,11 +866,12 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 		}));
 
 		// Add the onDidExecuteCode event handler.
-		disposableStore.add(props.positronConsoleInstance.onDidExecuteCode(code => {
-			// Trim the code. If it isn't empty, or a duplicate of the last history entry, add it to
-			// the history.
+		disposableStore.add(props.positronConsoleInstance.onDidExecuteCode(({ code, mode }) => {
+			// Trim the code
 			const trimmedCode = code.trim();
-			if (trimmedCode.length) {
+
+			// If the code isn't empty and run interactively, add it to the history.
+			if (trimmedCode.length && mode === RuntimeCodeExecutionMode.Interactive) {
 				// Creates an IInputHistoryEntry.
 				const createInputHistoryEntry = (): IInputHistoryEntry => ({
 					when: new Date().getTime(),

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -276,7 +276,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 		}));
 
 		// Add the onDidExecuteCode event handler.
-		disposableStore.add(props.positronConsoleInstance.onDidExecuteCode(_code => {
+		disposableStore.add(props.positronConsoleInstance.onDidExecuteCode(() => {
 			scrollToBottom();
 		}));
 

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -270,7 +270,7 @@ export function registerPositronConsoleActions() {
 		 *   - allowIncomplete: Optionally, should incomplete statements be accepted? If `undefined`, treated as `false`.
 		 *   - languageId: Optionally, a language override for the code to execute. If `undefined`, the language of the active text editor is used. Useful for notebooks.
 		 *   - advance: Optionally, if the cursor should be advanced to the next statement. If `undefined`, fallbacks to `true`.
-		 *   - runtimeCodeExecutionMode: Optionally, the code execution mode for a language runtime. If `undefined` fallbacks to `Interactive`.
+		 *   - mode: Optionally, the code execution mode for a language runtime. If `undefined` fallbacks to `Interactive`.
 		 */
 		async run(
 			accessor: ServicesAccessor,
@@ -278,7 +278,7 @@ export function registerPositronConsoleActions() {
 				allowIncomplete?: boolean;
 				languageId?: string;
 				advance?: boolean;
-				runtimeCodeExecutionMode?: RuntimeCodeExecutionMode;
+				mode?: RuntimeCodeExecutionMode;
 			} = {}
 		) {
 			// Access services.
@@ -430,7 +430,7 @@ export function registerPositronConsoleActions() {
 
 			// Ask the Positron console service to execute the code. Do not focus the console as
 			// this will rip focus away from the editor.
-			if (!await positronConsoleService.executeCode(languageId, code, false, allowIncomplete, opts.runtimeCodeExecutionMode)) {
+			if (!await positronConsoleService.executeCode(languageId, code, false, allowIncomplete, opts.mode)) {
 				const languageName = languageService.getLanguageName(languageId);
 				notificationService.notify({
 					severity: Severity.Info,

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -89,10 +89,10 @@ export interface IPositronConsoleService {
 	 * @param focus A value which indicates whether to focus Positron console instance.
 	 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 	 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
-	 * @param runtimeCodeExecutionMode Possible code execution modes for a language runtime
+	 * @param mode Possible code execution modes for a language runtime
 	 * @returns A value which indicates whether the code could be executed.
 	 */
-	executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, runtimeCodeExecutionMode?: RuntimeCodeExecutionMode): Promise<boolean>;
+	executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode): Promise<boolean>;
 }
 
 /**
@@ -298,16 +298,16 @@ export interface IPositronConsoleInstance {
 	 * @param code The code to enqueue.
 	 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 	 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
-	 * @param runtimeCodeExecutionMode Possible code execution modes for a language runtime.
+	 * @param mode Possible code execution modes for a language runtime.
 	 */
-	enqueueCode(code: string, allowIncomplete?: boolean, runtimeCodeExecutionMode?: RuntimeCodeExecutionMode): Promise<void>;
+	enqueueCode(code: string, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode): Promise<void>;
 
 	/**
 	 * Executes code.
 	 * @param code The code to execute.
-	 * @param runtimeCodeExecutionMode Possible code execution modes for a language runtime.
+	 * @param mode Possible code execution modes for a language runtime.
 	 */
-	executeCode(code: string, runtimeCodeExecutionMode?: RuntimeCodeExecutionMode): void;
+	executeCode(code: string, mode?: RuntimeCodeExecutionMode): void;
 
 	/**
 	 * Replies to a prompt.

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -6,9 +6,10 @@
 import { Event } from 'vs/base/common/event';
 import { IEditor } from 'vs/editor/common/editorCommon';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { ActivityItemPrompt } from 'vs/workbench/services/positronConsole/browser/classes/activityItemPrompt';
 import { RuntimeItem } from 'vs/workbench/services/positronConsole/browser/classes/runtimeItem';
 import { ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
+import { ActivityItemPrompt } from 'vs/workbench/services/positronConsole/browser/classes/activityItemPrompt';
+import { RuntimeCodeExecutionMode } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 
 // Create the decorator for the Positron console service (used in dependency injection).
 export const IPositronConsoleService = createDecorator<IPositronConsoleService>('positronConsoleService');
@@ -88,9 +89,10 @@ export interface IPositronConsoleService {
 	 * @param focus A value which indicates whether to focus Positron console instance.
 	 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 	 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
+	 * @param runtimeCodeExecutionMode Possible code execution modes for a language runtime
 	 * @returns A value which indicates whether the code could be executed.
 	 */
-	executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean): Promise<boolean>;
+	executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, runtimeCodeExecutionMode?: RuntimeCodeExecutionMode): Promise<boolean>;
 }
 
 /**
@@ -296,14 +298,16 @@ export interface IPositronConsoleInstance {
 	 * @param code The code to enqueue.
 	 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 	 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
+	 * @param runtimeCodeExecutionMode Possible code execution modes for a language runtime.
 	 */
-	enqueueCode(code: string, allowIncomplete?: boolean): Promise<void>;
+	enqueueCode(code: string, allowIncomplete?: boolean, runtimeCodeExecutionMode?: RuntimeCodeExecutionMode): Promise<void>;
 
 	/**
 	 * Executes code.
 	 * @param code The code to execute.
+	 * @param runtimeCodeExecutionMode Possible code execution modes for a language runtime.
 	 */
-	executeCode(code: string): void;
+	executeCode(code: string, runtimeCodeExecutionMode?: RuntimeCodeExecutionMode): void;
 
 	/**
 	 * Replies to a prompt.

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -113,6 +113,17 @@ export enum SessionAttachMode {
 }
 
 /**
+ * An event that fires after code has been executed in a language runtime session
+ */
+export interface ILanguageRuntimeCodeExecutedEvent {
+	/* The code that was executed in the language runtime session */
+	code: string;
+
+	/* The mode used to execute the code in the language runtime session */
+	mode: RuntimeCodeExecutionMode;
+}
+
+/**
  * IPositronConsoleInstance interface.
  */
 export interface IPositronConsoleInstance {
@@ -214,7 +225,7 @@ export interface IPositronConsoleInstance {
 	/**
 	 * The onDidExecuteCode event.
 	 */
-	readonly onDidExecuteCode: Event<string>;
+	readonly onDidExecuteCode: Event<ILanguageRuntimeCodeExecutedEvent>;
 
 	/**
 	 * The onDidSelectPlot event.

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -113,7 +113,7 @@ export enum SessionAttachMode {
 }
 
 /**
- * An event that fires after code has been executed in a language runtime session
+ * Represents a code fragment and its execution options sent to a language runtime.
  */
 export interface ILanguageRuntimeCodeExecutedEvent {
 	/* The code that was executed in the language runtime session */

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -2091,8 +2091,10 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		// Create the ID for the code that will be executed.
 		const id = `fragment-${generateUuid()}`;
 
-		// If the code exection mode is silent, skip creating a runtimeItem
-		// to prevent the code input from being exposed in the console UI
+		/**
+		 * If the code execution mode is silent, an ActivityItem for the code fragment
+		 * should not be added to avoid UI side effects from the code execution.
+		 */
 		if (mode !== RuntimeCodeExecutionMode.Silent) {
 			// Create the provisional ActivityItemInput.
 			const activityItemInput = new ActivityItemInput(
@@ -2111,7 +2113,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			this.addOrUpdateUpdateRuntimeItemActivity(id, activityItemInput);
 		}
 
-		// Execute the code.
+		/**
+		 * Execute the code.
+		 *
+		 * The jupyter protocol advises kernels to rebroadcast execution inputs.
+		 * The kernels don't rebroadcast silent input and thus will not be
+		 * added back into the runtimeItemActivities list which powers the UI.
+		 */
 		this.session.execute(
 			code,
 			id,

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -2091,21 +2091,25 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		// Create the ID for the code that will be executed.
 		const id = `fragment-${generateUuid()}`;
 
-		// Create the provisional ActivityItemInput.
-		const activityItemInput = new ActivityItemInput(
-			ActivityItemInputState.Provisional,
-			id,
-			id,
-			new Date(),
-			this._session.dynState.inputPrompt,
-			this._session.dynState.continuationPrompt,
-			code
-		);
+		// If the code exection mode is silent, prevent the code input
+		// from being exposed in the console UI
+		if (runtimeCodeExecutionMode !== RuntimeCodeExecutionMode.Silent) {
+			// Create the provisional ActivityItemInput.
+			const activityItemInput = new ActivityItemInput(
+				ActivityItemInputState.Provisional,
+				id,
+				id,
+				new Date(),
+				this._session.dynState.inputPrompt,
+				this._session.dynState.continuationPrompt,
+				code
+			);
 
-		// Add the provisional ActivityItemInput. This provisional ActivityItemInput will be
-		// replaced with the real ActivityItemInput when the runtime sends it (which can take a
-		// moment or two to happen).
-		this.addOrUpdateUpdateRuntimeItemActivity(id, activityItemInput);
+			// Add the provisional ActivityItemInput. This provisional ActivityItemInput will be
+			// replaced with the real ActivityItemInput when the runtime sends it (which can take a
+			// moment or two to happen).
+			this.addOrUpdateUpdateRuntimeItemActivity(id, activityItemInput);
+		}
 
 		// Fallback to an interactive exection mode if one is not provided
 		const codeExecutionMode = runtimeCodeExecutionMode || RuntimeCodeExecutionMode.Interactive;


### PR DESCRIPTION
### Description
This partially addresses the ask from #4856. 

The ask is to make the positron API `executeCode` call respect the `RuntimeCodeExecutionMode` and `RuntimeErrorBehavior` values being passes in. This PR only handles `RuntimeCodeExecutionMode`. The work for `RuntimeErrorBehavior` will be done in a separate PR.

The runtime session `execute` is already setup to work with `RuntimeCodeExecutionMode`, see `workbench.action.executeCode.silently` (https://github.com/posit-dev/positron/pull/2684) for an example of silent code execution via the session directly.

For code execution to work as expected, some changes were made in the `PositronConsoleService` to prevent data from being rendered in the console or added to history based off the `RuntimeCodeExecutionMode`.

### QA Notes
Note: These changes will need to be tested in a dev build as we do not have a way to test the API for extensions in a release build, see comment [here](https://github.com/posit-dev/positron/pull/5450#pullrequestreview-2455509543).

We will want to verify that the three different values for `RuntimeCodeExecutionMode` are respected when `positron.runtime.executeCode()` is called and verify there aren't any regressions:
- `RuntimeCodeExecutionMode.Interactive` means the input/output is displayed and stored in the runtime's history
  - We should verify that executing code via the console and adds to history.
  - We should verify that `positron.runtime.executeCode()` without a `RuntimeCodeExecutionMode` defaults to `RuntimeCodeExecutionMode.Interactive`
  - Verify the command `workbench.action.executeCode.console` runs the code interactively

- `RuntimeCodeExecutionMode.Transient` means the code should be executed (shown in console) but not stored in history

- `RuntimeCodeExecutionMode.Silent` means the code output is displayed or stored in history
  - Verify the command `workbench.action.executeCode.silently` runs the code silently as described above.

The `PositronZedLanguageRuntime` has a new command `exec silent` that can execute a code snippet in the language silently. The `exec` command now explicitly passes a `RuntimeCodeExecutionMode` of `Interactive` to make it clear what is happening. 
	
### Screenshot

**Silent Code Execution - Print**

https://github.com/user-attachments/assets/ce57bb56-bf72-40be-bce0-d134d34d560b

**Silent Code Execution - Variable Assignment**

https://github.com/user-attachments/assets/f792a7a8-bd46-45af-a8e5-3acadd6a608a

**Interactive Code Execution - Print**

https://github.com/user-attachments/assets/ec46d151-1df4-4ab2-badb-b60a71fcc4db

**Interactive Code Execution - Variable Assignment**

https://github.com/user-attachments/assets/b4146441-a288-4897-803f-d71146ffcfaa



