### PR TITLE
Use new Quarto context keys in keyboard shortcuts

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -373,7 +373,7 @@
         "command": "r.insertPipe",
         "key": "ctrl+shift+m",
         "mac": "cmd+shift+m",
-        "when": "editorLangId == r || quartoLangId == r"
+        "when": "editorLangId == r || quarto.document.languageId == r"
       },
       {
         "command": "r.insertPipeConsole",
@@ -385,7 +385,7 @@
         "command": "r.insertLeftAssignment",
         "key": "alt+-",
         "mac": "alt+-",
-        "when": "editorLangId == r || quartoLangId == r"
+        "when": "editorLangId == r || quarto.document.languageId == r"
       },
       {
         "command": "r.insertLeftAssignmentConsole",
@@ -469,7 +469,7 @@
         {
           "category": "R",
           "command": "r.insertPipe",
-          "when": "editorLangId == r || quartoLangId == r"
+          "when": "editorLangId == r || quarto.document.languageId == r"
         },
         {
           "category": "R",
@@ -479,7 +479,7 @@
         {
           "category": "R",
           "command": "r.insertLeftAssignment",
-          "when": "editorLangId == r || quartoLangId == r"
+          "when": "editorLangId == r || quarto.document.languageId == r"
         },
         {
           "category": "R",

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -373,7 +373,7 @@
         "command": "r.insertPipe",
         "key": "ctrl+shift+m",
         "mac": "cmd+shift+m",
-        "when": "editorLangId == r"
+        "when": "editorLangId == r || quartoLangId == r"
       },
       {
         "command": "r.insertPipeConsole",
@@ -385,7 +385,7 @@
         "command": "r.insertLeftAssignment",
         "key": "alt+-",
         "mac": "alt+-",
-        "when": "editorLangId == r"
+        "when": "editorLangId == r || quartoLangId == r"
       },
       {
         "command": "r.insertLeftAssignmentConsole",
@@ -469,7 +469,7 @@
         {
           "category": "R",
           "command": "r.insertPipe",
-          "when": "editorLangId == r"
+          "when": "editorLangId == r || quartoLangId == r"
         },
         {
           "category": "R",
@@ -479,7 +479,7 @@
         {
           "category": "R",
           "command": "r.insertLeftAssignment",
-          "when": "editorLangId == r"
+          "when": "editorLangId == r || quartoLangId == r"
         },
         {
           "category": "R",

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -179,22 +179,6 @@
         "command": "r.sourceCurrentFileWithEcho"
       },
       {
-        "mac": "cmd+shift+m",
-        "win": "ctrl+shift+m",
-        "linux": "ctrl+shift+m",
-        "key": "ctrl+shift+m",
-        "when": "config.rstudio.keymap.enable && editorLangId == quarto",
-        "command": "r.insertPipe"
-      },
-      {
-        "mac": "alt+-",
-        "win": "alt+-",
-        "linux": "alt+-",
-        "key": "alt+-",
-        "when": "config.rstudio.keymap.enable && editorLangId == quarto",
-        "command": "r.insertLeftAssignment"
-      },
-      {
         "mac": "ctrl+alt+left",
         "win": "ctrl+alt+left",
         "linux": "ctrl+alt+left",

--- a/product.json
+++ b/product.json
@@ -208,7 +208,7 @@
 		},
 		{
 			"name": "quarto.quarto",
-			"version": "1.114.0",
+			"version": "1.118.0",
 			"repo": "https://github.com/quarto-dev/quarto/tree/main/apps/vscode",
 			"metadata": {
 				"id": "a1be81fc-0f3a-4f2e-92ee-3fdc7ab96c73",


### PR DESCRIPTION
Addresses #1955 together with https://github.com/quarto-dev/quarto/pull/608

The Quarto PR provides new context keys for the main language of a Quarto document (for example, R or Python) and we can consume those to provide keyboard shortcuts.

There are really only a couple of R ones that we want right now which means that there is no real change here in an R `.qmd` in behavior compared to what is in the RStudio Keymap. 🙈 However, I think this is still worth getting in since we've gone to the trouble of figuring it out, it lets us offer these without the RStudio Keymap being on, we can offer them _only_ in R `.qmd` files (right now, these also show up in Python `.qmd` files if you have the RStudio Keymap on), and we can use this infrastructure in the future.

I did remove these from the RStudio Keymap just to clean things up, but it wouldn't hurt _a lot_ to keep them, if there is some reason I am not thinking of? If we do want to remove them, we'll need to do a Quarto release and update the bundled Quarto VS Code extension version in this PR to keep these keybindings functional.

### QA Notes

With the new version of the Quarto extension (updated here), you can use the keyboard shortcuts for the pipe and assignment operator in R Quarto documents but not Python ones:

- <kbd>Alt</kbd>+<kbd>-</kbd> to get you `<-`
- <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd> to get you `|>`
