### PR TITLE
Bump ark to v0.1.155

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -670,7 +670,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.154"
+      "ark": "0.1.155"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
For:

- https://github.com/posit-dev/ark/pull/631
- https://github.com/posit-dev/ark/pull/629

See https://github.com/posit-dev/ark/pull/635