### PR TITLE
e2e test: update db connections test

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "e2e-pr": "npx playwright test --project e2e-electron --grep @pr",
     "e2e-win": "npx playwright test --project e2e-electron --grep @win",
     "e2e-failed": "npx playwright test --last-failed",
+    "e2e-ui": "npx playwright test --ui",
     "download-builtin-extensions": "node build/lib/builtInExtensions.js",
     "download-builtin-extensions-cg": "node build/lib/builtInExtensionsCG.js",
     "download-quarto": "node build/lib/quarto.js",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,6 +23,9 @@ export default defineConfig<CustomTestOptions>({
 		max: 10,
 		threshold: 60 * 1000, // 1 minute
 	},
+	expect: {
+		timeout: 15000,
+	},
 	reporter: process.env.CI
 		? [
 			['@midleman/github-actions-reporter', <GitHubActionOptions>{
@@ -45,6 +48,8 @@ export default defineConfig<CustomTestOptions>({
 	use: {
 		headless: false,
 		trace: 'off', // we are manually handling tracing in _test.setup.ts
+		actionTimeout: 15000,
+		navigationTimeout: 15000,
 	},
 
 	projects: [

--- a/test/automation/src/positron/positronConnections.ts
+++ b/test/automation/src/positron/positronConnections.ts
@@ -7,16 +7,9 @@
 import { expect, Locator } from '@playwright/test';
 import { Code } from '../code';
 import { QuickAccess } from '../quickaccess';
-import { PositronBaseElement } from './positronBaseElement';
 
-const REMOVE_CONNECTION_BUTTON = 'a[aria-label="Remove connection from history"]';
-
-const PYTHON_CONNECTION_OPEN_STATE = 'div[aria-label="SQLite Connection"]';
-const R_CONNECTION_OPEN_STATE = 'div[aria-label="SQLiteConnection"]:first-child';
-const RECONNECT_BUTTON = 'a[aria-label="Execute connection code in the console"]';
-
-const CONNECTIONS_TAB_LINK = 'a[aria-label="Connections"]';
 const CONNECTION_ITEM = '.connections-items-container';
+const CONNECTION_ICON = '.codicon-arrow-circle-right';
 
 /*
  *  Reuseable Positron connections tab functionality for tests to leverage
@@ -25,19 +18,12 @@ export class PositronConnections {
 
 	deleteConnectionButton: Locator;
 	disconnectButton: Locator;
-	rConnectionOpenState: PositronBaseElement;
-	pythonConnectionOpenState: PositronBaseElement;
-	reconnectButton: PositronBaseElement;
-	connectionsTabLink: PositronBaseElement;
+	connectionIcon: Locator;
 
 	constructor(private code: Code, private quickaccess: QuickAccess) {
-
 		this.deleteConnectionButton = code.driver.page.getByLabel('Delete Connection');
 		this.disconnectButton = code.driver.page.getByLabel('Disconnect');
-		this.rConnectionOpenState = new PositronBaseElement(R_CONNECTION_OPEN_STATE, this.code);
-		this.pythonConnectionOpenState = new PositronBaseElement(PYTHON_CONNECTION_OPEN_STATE, this.code);
-		this.reconnectButton = new PositronBaseElement(RECONNECT_BUTTON, this.code);
-		this.connectionsTabLink = new PositronBaseElement(CONNECTIONS_TAB_LINK, this.code);
+		this.connectionIcon = code.driver.page.locator(CONNECTION_ICON);
 	}
 
 	async openConnectionsNodes(nodes: string[]) {
@@ -49,25 +35,20 @@ export class PositronConnections {
 
 	async assertConnectionNodes(nodes: string[]): Promise<void> {
 		const waits = nodes.map(async node => {
-			this.assertConnectionNode(node);
+			await expect(
+				this.code.driver.page.locator(CONNECTION_ITEM).getByText(node)
+			).toBeVisible();
 		});
 		await Promise.all(waits);
 	}
 
-	async assertConnectionNode(node: string) {
-		await expect(
-			this.code.driver.page.locator(CONNECTION_ITEM).getByText(node)
-		).toBeVisible();
-	}
-
 	async openConnectionPane() {
 		await this.quickaccess.runCommand('connections.focus');
-		// await this.connectionPaneIsOpen(); // waiting for the pane to open
 	}
 
-	// async connectionPaneIsOpen() {
-	// 	await this.code.wait(500);
-	// }
+	async viewConnection(name: string) {
+		await this.code.driver.page.locator('.connections-list-item').filter({ hasText: name }).locator('.col-action > .codicon').click();
+	}
 
 	async openTree() {
 		await this.quickaccess.runCommand('positron.connections.expandAll');

--- a/test/automation/src/positron/positronConnections.ts
+++ b/test/automation/src/positron/positronConnections.ts
@@ -23,7 +23,7 @@ const CONNECTION_ITEM = '.connections-items-container';
  */
 export class PositronConnections {
 
-	removeConnectionButton: PositronBaseElement;
+	deleteConnectionButton: Locator;
 	disconnectButton: Locator;
 	rConnectionOpenState: PositronBaseElement;
 	pythonConnectionOpenState: PositronBaseElement;
@@ -32,7 +32,7 @@ export class PositronConnections {
 
 	constructor(private code: Code, private quickaccess: QuickAccess) {
 
-		this.removeConnectionButton = new PositronBaseElement(REMOVE_CONNECTION_BUTTON, this.code);
+		this.deleteConnectionButton = code.driver.page.getByLabel('Delete Connection');
 		this.disconnectButton = code.driver.page.getByLabel('Disconnect');
 		this.rConnectionOpenState = new PositronBaseElement(R_CONNECTION_OPEN_STATE, this.code);
 		this.pythonConnectionOpenState = new PositronBaseElement(PYTHON_CONNECTION_OPEN_STATE, this.code);

--- a/test/automation/src/positron/positronConnections.ts
+++ b/test/automation/src/positron/positronConnections.ts
@@ -8,7 +8,8 @@ import { expect, Locator } from '@playwright/test';
 import { Code } from '../code';
 import { QuickAccess } from '../quickaccess';
 
-const CONNECTION_ITEM = '.connections-items-container';
+const CONNECTION_CONTAINER = '.connections-items-container';
+const CONNECTION_ITEM = '.connections-list-item';
 const CONNECTION_ICON = '.codicon-arrow-circle-right';
 
 /*
@@ -36,7 +37,7 @@ export class PositronConnections {
 	async assertConnectionNodes(nodes: string[]): Promise<void> {
 		const waits = nodes.map(async node => {
 			await expect(
-				this.code.driver.page.locator(CONNECTION_ITEM).getByText(node)
+				this.code.driver.page.locator(CONNECTION_CONTAINER).getByText(node)
 			).toBeVisible();
 		});
 		await Promise.all(waits);
@@ -47,7 +48,7 @@ export class PositronConnections {
 	}
 
 	async viewConnection(name: string) {
-		await this.code.driver.page.locator('.connections-list-item').filter({ hasText: name }).locator('.col-action > .codicon').click();
+		await this.code.driver.page.locator(CONNECTION_ITEM).filter({ hasText: name }).locator(CONNECTION_ICON).click();
 	}
 
 	async openTree() {

--- a/test/automation/src/positron/positronConnections.ts
+++ b/test/automation/src/positron/positronConnections.ts
@@ -8,7 +8,7 @@ import { expect, Locator } from '@playwright/test';
 import { Code } from '../code';
 import { QuickAccess } from '../quickaccess';
 
-const CONNECTION_CONTAINER = '.connections-items-container';
+const CONNECTIONS_CONTAINER = '.connections-items-container';
 const CONNECTION_ITEM = '.connections-list-item';
 const CONNECTION_ICON = '.codicon-arrow-circle-right';
 
@@ -37,7 +37,7 @@ export class PositronConnections {
 	async assertConnectionNodes(nodes: string[]): Promise<void> {
 		const waits = nodes.map(async node => {
 			await expect(
-				this.code.driver.page.locator(CONNECTION_CONTAINER).getByText(node)
+				this.code.driver.page.locator(CONNECTIONS_CONTAINER).getByText(node)
 			).toBeVisible();
 		});
 		await Promise.all(waits);

--- a/test/automation/src/positron/positronConnections.ts
+++ b/test/automation/src/positron/positronConnections.ts
@@ -9,6 +9,7 @@ import { Code } from '../code';
 import { QuickAccess } from '../quickaccess';
 
 const CONNECTIONS_CONTAINER = '.connections-items-container';
+const CONNECTIONS_ITEM = '.connections-item';
 
 /*
  *  Reuseable Positron connections tab functionality for tests to leverage
@@ -29,8 +30,8 @@ export class PositronConnections {
 
 	async openConnectionsNodes(nodes: string[]) {
 		for (const node of nodes) {
-			await this.code.driver.page.locator('.connections-item').filter({ hasText: node }).locator('.codicon-chevron-right').click();
-			await expect(this.code.driver.page.locator('.connections-item').filter({ hasText: node }).locator('.codicon-chevron-down')).toBeVisible();
+			await this.code.driver.page.locator(CONNECTIONS_ITEM).filter({ hasText: node }).locator('.codicon-chevron-right').click();
+			await expect(this.code.driver.page.locator(CONNECTIONS_ITEM).filter({ hasText: node }).locator('.codicon-chevron-down')).toBeVisible();
 		}
 	}
 

--- a/test/automation/src/positron/positronConnections.ts
+++ b/test/automation/src/positron/positronConnections.ts
@@ -54,4 +54,10 @@ export class PositronConnections {
 	async openTree() {
 		await this.quickaccess.runCommand('positron.connections.expandAll');
 	}
+
+	async deleteConnection() {
+		await expect(this.code.driver.page.getByLabel('Delete Connection')).toBeVisible();
+		this.deleteConnectionButton.click();
+	}
+
 }

--- a/test/automation/src/positron/positronConnections.ts
+++ b/test/automation/src/positron/positronConnections.ts
@@ -9,8 +9,6 @@ import { Code } from '../code';
 import { QuickAccess } from '../quickaccess';
 
 const CONNECTIONS_CONTAINER = '.connections-items-container';
-const CONNECTION_ITEM = '.connections-list-item';
-const CONNECTION_ICON = '.codicon-arrow-circle-right';
 
 /*
  *  Reuseable Positron connections tab functionality for tests to leverage
@@ -19,12 +17,14 @@ export class PositronConnections {
 
 	deleteConnectionButton: Locator;
 	disconnectButton: Locator;
-	connectionIcon: Locator;
+	connectIcon: Locator;
+	connectionItems: Locator;
 
 	constructor(private code: Code, private quickaccess: QuickAccess) {
 		this.deleteConnectionButton = code.driver.page.getByLabel('Delete Connection');
 		this.disconnectButton = code.driver.page.getByLabel('Disconnect');
-		this.connectionIcon = code.driver.page.locator(CONNECTION_ICON);
+		this.connectIcon = code.driver.page.locator('.codicon-arrow-circle-right');
+		this.connectionItems = code.driver.page.locator('.connections-list-item');
 	}
 
 	async openConnectionsNodes(nodes: string[]) {
@@ -48,7 +48,7 @@ export class PositronConnections {
 	}
 
 	async viewConnection(name: string) {
-		await this.code.driver.page.locator(CONNECTION_ITEM).filter({ hasText: name }).locator(CONNECTION_ICON).click();
+		await this.connectionItems.filter({ hasText: name }).locator(this.connectIcon).click();
 	}
 
 	async openTree() {

--- a/test/automation/src/positron/positronVariables.ts
+++ b/test/automation/src/positron/positronVariables.ts
@@ -139,4 +139,9 @@ export class PositronVariables {
 		await this.code.wait(500);
 		await this.code.driver.page.locator('a.action-menu-item', { hasText: name }).click();
 	}
+
+	async clickDatabaseIconForVariableRow(rowName: string) {
+		const DATABASE_ICON = '.codicon-database';
+		await this.code.driver.page.locator(VARIABLE_ITEMS).filter({ hasText: rowName }).locator(DATABASE_ICON).click();
+	}
 }

--- a/test/smoke/src/areas/positron/connections/connections-db.test.ts
+++ b/test/smoke/src/areas/positron/connections/connections-db.test.ts
@@ -19,95 +19,81 @@ test.describe('SQLite DB Connection', { tag: ['@web', '@win', '@pr'] }, () => {
 	});
 
 	test.afterEach(async function ({ app, page }) {
+		await app.workbench.positronConnections.disconnectButton.click();
+		await page.locator('.connections-list-item').click();
 		await expect(page.getByLabel('Delete Connection')).toBeVisible();
 		await app.workbench.positronConnections.deleteConnectionButton.click();
 	});
 
 	test('Python - SQLite DB Connection [C628636]', async function ({ app, page, logger, python }) {
-		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'chinook-db-py', 'chinook-sqlite.py'));
-		await app.workbench.quickaccess.runCommand('python.execInConsole');
+		await test.step('Open a Python file and run it', async () => {
+			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'chinook-db-py', 'chinook-sqlite.py'));
+			await app.workbench.quickaccess.runCommand('python.execInConsole');
+		});
 
-		await page.locator('div:nth-child(4) > .details-column > .right-column > .viewer-icon').click();
-		await page.locator('.connections-list-item > .col-icon').click();
-		await page.locator('.col-action > .codicon').click(); // arrow on right
-		await page.locator('.expand-collapse-area > .codicon').click(); // caret on left
+		await test.step('Open connections pane', async () => {
+			await app.workbench.positronVariables.clickDatabaseIconForVariableRow('conn');
+			await app.workbench.positronConnections.connectionIcon.click();
+		});
 
-		// click in reverse order to avoid scrolling issues
-		await app.workbench.positronConnections.assertConnectionNodes(['albums']);
-
-		// disconnect
-		await app.workbench.positronConnections.disconnectButton.click();
-		await page.getByText('SQLite Connection').click();
-
+		await test.step('Verify connection nodes', async () => {
+			await app.workbench.positronConnections.openConnectionsNodes(['main']);
+			await app.workbench.positronConnections.assertConnectionNodes(['albums']);
+		});
 	});
 
-
 	test('R - SQLite DB Connection [C628637]', async function ({ app, page, logger, r }) {
-		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'chinook-db-r', 'chinook-sqlite.r'));
-		await app.workbench.quickaccess.runCommand('r.sourceCurrentFile');
+		await test.step('Open an R file and run it', async () => {
+			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'chinook-db-r', 'chinook-sqlite.r'));
+			await app.workbench.quickaccess.runCommand('r.sourceCurrentFile');
+		});
 
-		// open connections pane
-		await app.workbench.positronConnections.openConnectionPane();
-		await page.locator('.col-action > .codicon').click(); // arrow on right
-		await page.locator('.expand-collapse-area > .codicon').click(); // caret on left
+		await test.step('Open connections pane', async () => {
+			await app.workbench.positronConnections.openConnectionPane();
+			await app.workbench.positronConnections.viewConnection('SQLiteConnection');
+		});
 
-		// click in reverse order to avoid scrolling issues
-		await app.workbench.positronConnections.openConnectionsNodes(['Default']);
-		await app.workbench.positronConnections.openConnectionsNodes(tables);
-
-		// disconnect icon appearance requires hover
-		// await app.workbench.positronConnections.rConnectionOpenState.hover();
-		// await app.workbench.positronConnections.disconnectButton.click();
-		// await app.workbench.positronConnections.reconnectButton.waitforVisible();
-		await app.workbench.positronConnections.disconnectButton.click();
-		await page.getByText('SQLiteConnection').click();
+		await test.step('Verify connection nodes', async () => {
+			await app.workbench.positronConnections.openConnectionsNodes(['SQLiteConnection', 'Default']);
+			await app.workbench.positronConnections.openConnectionsNodes(tables);
+		});
 	});
 
 	test('R - Connections are update after adding a database,[C663724]', async function ({ app, page, logger, r }) {
-		// open an empty connection
-		await app.workbench.positronConsole.executeCode(
-			'R',
-			`con <- connections::connection_open(RSQLite::SQLite(), tempfile())`,
-			'>'
-		);
+		await test.step('Open an empty connection', async () => {
+			await app.workbench.positronConsole.executeCode(
+				'R',
+				`con <- connections::connection_open(RSQLite::SQLite(), tempfile())`,
+				'>'
+			);
+		});
 
-		// // should be able to see the new connection in the connections pane
-		// logger.log('Opening connections pane');
-		// await app.workbench.positronConnections.connectionsTabLink.click();
+		await test.step('Open connections pane', async () => {
+			await app.workbench.positronConnections.openConnectionPane();
+			await app.workbench.positronConnections.viewConnection('SQLiteConnection');
+			await app.workbench.positronConnections.openConnectionsNodes(['SQLiteConnection', 'Default']);
 
-		// await app.workbench.positronConnections.openTree();
-		// open connections pane
-		await app.workbench.positronConnections.openConnectionPane();
-		await page.locator('.col-action > .codicon').click(); // arrow on right
-		await page.locator('.expand-collapse-area > .codicon').click(); // caret on left
+			// mtcars node should not exist
+			await expect(
+				page.locator('.connections-items-container').getByText('mtcars')
+			).not.toBeVisible();
+		});
 
 
+		await test.step('Add a dataframe to the connection', async () => {
+			await app.workbench.positronConsole.executeCode(
+				'R',
+				`DBI::dbWriteTable(con, 'mtcars', mtcars)`,
+				'>'
+			);
 
-		// mtcars node should not exist
-		await app.workbench.positronConnections.openConnectionsNodes(['Default']);
-		await expect(
-			page.locator('.connections-items-container').getByText('mtcars')
-		).not.toBeVisible();
-
-		// now we add a dataframe to that connection
-		await app.workbench.positronConsole.executeCode(
-			'R',
-			`DBI::dbWriteTable(con, "mtcars", mtcars)`,
-			'>'
-		);
-
-		await page.getByRole('button', { name: 'Refresh' }).click();
-		await app.workbench.positronConnections.openConnectionsNodes(["mtcars"]);
-
-		await app.workbench.positronConnections.disconnectButton.click();
-		await page.getByText('SQLiteConnection').click();
-		// disconnect icon appearance requires hover
-		// await app.workbench.positronConnections.rConnectionOpenState.hover();
-		// await app.workbench.positronConnections.disconnectButton.click();
-		// await app.workbench.positronConnections.reconnectButton.waitforVisible();
+			// refresh and mtcars should exist
+			await page.getByRole('button', { name: 'Refresh' }).click();
+			await app.workbench.positronConnections.openConnectionsNodes(['mtcars']);
+		});
 	});
 
 });
 
-
+// reverse order to avoid scrolling issues
 const tables = ['tracks', 'playlist_track', 'playlists', 'media_types', 'invoice_items', 'invoices', 'genres', 'employees', 'customers', 'artists', 'albums'];

--- a/test/smoke/src/areas/positron/connections/connections-db.test.ts
+++ b/test/smoke/src/areas/positron/connections/connections-db.test.ts
@@ -19,8 +19,8 @@ test.describe('SQLite DB Connection', { tag: ['@web', '@win', '@pr'] }, () => {
 	});
 
 	test.afterEach(async function ({ app, page }) {
-		// await app.workbench.positronConnections.removeConnectionButton.click();
-		await page.getByLabel('Delete Connection').click();
+		await expect(page.getByLabel('Delete Connection')).toBeVisible();
+		await app.workbench.positronConnections.deleteConnectionButton.click();
 	});
 
 	test('Python - SQLite DB Connection [C628636]', async function ({ app, page, logger, python }) {
@@ -38,7 +38,7 @@ test.describe('SQLite DB Connection', { tag: ['@web', '@win', '@pr'] }, () => {
 		// disconnect
 		await app.workbench.positronConnections.disconnectButton.click();
 		await page.getByText('SQLite Connection').click();
-		await expect(page.getByLabel('Delete Connection')).toBeVisible();
+
 	});
 
 
@@ -61,7 +61,6 @@ test.describe('SQLite DB Connection', { tag: ['@web', '@win', '@pr'] }, () => {
 		// await app.workbench.positronConnections.reconnectButton.waitforVisible();
 		await app.workbench.positronConnections.disconnectButton.click();
 		await page.getByText('SQLiteConnection').click();
-		await expect(page.getByLabel('Delete Connection')).toBeVisible();
 	});
 
 	test('R - Connections are update after adding a database,[C663724]', async function ({ app, page, logger, r }) {
@@ -102,7 +101,6 @@ test.describe('SQLite DB Connection', { tag: ['@web', '@win', '@pr'] }, () => {
 
 		await app.workbench.positronConnections.disconnectButton.click();
 		await page.getByText('SQLiteConnection').click();
-		await expect(page.getByLabel('Delete Connection')).toBeVisible();
 		// disconnect icon appearance requires hover
 		// await app.workbench.positronConnections.rConnectionOpenState.hover();
 		// await app.workbench.positronConnections.disconnectButton.click();

--- a/test/smoke/src/areas/positron/connections/connections-db.test.ts
+++ b/test/smoke/src/areas/positron/connections/connections-db.test.ts
@@ -5,59 +5,66 @@
 
 import { join } from 'path';
 import { test, expect } from '../_test.setup';
+import { UserSetting } from '../../../../../automation';
+
+const connectionSetting: UserSetting = ['positron.connections.showConnectionPane', 'true'];
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
 });
 
 test.describe('SQLite DB Connection', { tag: ['@web', '@win'] }, () => {
-	test.afterEach(async function ({ app }) {
-		await app.workbench.positronConnections.removeConnectionButton.click();
+	test.beforeAll(async function ({ userSettings }) {
+		await userSettings.set([connectionSetting], true);
 	});
 
-	test('Python - SQLite DB Connection [C628636]', async function ({ app, logger, python }) {
+	test.afterEach(async function ({ app, page }) {
+		// await app.workbench.positronConnections.removeConnectionButton.click();
+		await page.getByLabel('Delete Connection').click();
+	});
+
+	test('Python - SQLite DB Connection [C628636]', async function ({ app, page, logger, python }) {
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'chinook-db-py', 'chinook-sqlite.py'));
 		await app.workbench.quickaccess.runCommand('python.execInConsole');
 
-		await expect(async () => {
-			logger.log('Opening connections pane');
-			await app.workbench.positronVariables.doubleClickVariableRow('conn');
-			// in Python this will open all table connections, so should be fine.
-			await app.workbench.positronConnections.openTree();
+		await page.locator('div:nth-child(4) > .details-column > .right-column > .viewer-icon').click();
+		await page.locator('.connections-list-item > .col-icon').click();
+		await page.locator('.col-action > .codicon').click(); // arrow on right
+		await page.locator('.expand-collapse-area > .codicon').click(); // caret on left
 
-			// click in reverse order to avoid scrolling issues
-			await app.workbench.positronConnections.hasConnectionNodes(['albums']);
-		}).toPass({ timeout: 60000 });
+		// click in reverse order to avoid scrolling issues
+		await app.workbench.positronConnections.assertConnectionNodes(['albums']);
 
-		// disconnect icon appearance requires hover
-		await app.workbench.positronConnections.pythonConnectionOpenState.hover();
+		// disconnect
 		await app.workbench.positronConnections.disconnectButton.click();
-		await app.workbench.positronConnections.reconnectButton.waitforVisible();
+		await page.getByText('SQLite Connection').click();
+		await expect(page.getByLabel('Delete Connection')).toBeVisible();
 	});
 
 
-	test('R - SQLite DB Connection [C628637]', async function ({ app, logger, r }) {
+	test('R - SQLite DB Connection [C628637]', async function ({ app, page, logger, r }) {
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'chinook-db-r', 'chinook-sqlite.r'));
 		await app.workbench.quickaccess.runCommand('r.sourceCurrentFile');
 
-		await expect(async () => {
-			logger.log('Opening connections pane');
-			await app.workbench.positronConnections.openConnectionPane();
-			await app.workbench.positronConnections.openTree();
+		// open connections pane
+		await app.workbench.positronConnections.openConnectionPane();
+		await page.locator('.col-action > .codicon').click(); // arrow on right
+		await page.locator('.expand-collapse-area > .codicon').click(); // caret on left
 
-			// click in reverse order to avoid scrolling issues
-			// in R, the opneTree command only shows all tables, we click to also
-			// display fields
-			await app.workbench.positronConnections.openConnectionsNodes(tables);
-		}).toPass({ timeout: 60000 });
+		// click in reverse order to avoid scrolling issues
+		await app.workbench.positronConnections.openConnectionsNodes(['Default']);
+		await app.workbench.positronConnections.openConnectionsNodes(tables);
 
 		// disconnect icon appearance requires hover
-		await app.workbench.positronConnections.rConnectionOpenState.hover();
+		// await app.workbench.positronConnections.rConnectionOpenState.hover();
+		// await app.workbench.positronConnections.disconnectButton.click();
+		// await app.workbench.positronConnections.reconnectButton.waitforVisible();
 		await app.workbench.positronConnections.disconnectButton.click();
-		await app.workbench.positronConnections.reconnectButton.waitforVisible();
+		await page.getByText('SQLiteConnection').click();
+		await expect(page.getByLabel('Delete Connection')).toBeVisible();
 	});
 
-	test('R - Connections are update after adding a database,[C663724]', async function ({ app, logger, r }) {
+	test('R - Connections are update after adding a database,[C663724]', async function ({ app, page, logger, r }) {
 		// open an empty connection
 		await app.workbench.positronConsole.executeCode(
 			'R',
@@ -65,33 +72,41 @@ test.describe('SQLite DB Connection', { tag: ['@web', '@win'] }, () => {
 			'>'
 		);
 
-		// should be able to see the new connection in the connections pane
-		logger.log('Opening connections pane');
-		await app.workbench.positronConnections.connectionsTabLink.click();
+		// // should be able to see the new connection in the connections pane
+		// logger.log('Opening connections pane');
+		// await app.workbench.positronConnections.connectionsTabLink.click();
 
-		await app.workbench.positronConnections.openTree();
+		// await app.workbench.positronConnections.openTree();
+		// open connections pane
+		await app.workbench.positronConnections.openConnectionPane();
+		await page.locator('.col-action > .codicon').click(); // arrow on right
+		await page.locator('.expand-collapse-area > .codicon').click(); // caret on left
 
-		const visible = await app.workbench.positronConnections.hasConnectionNode("mtcars");
-		if (visible) {
-			throw new Error("mtcars should not be visible");
-		}
 
-		await expect(async () => {
-			// now we add a dataframe to that connection
-			await app.workbench.positronConsole.executeCode(
-				'R',
-				`DBI::dbWriteTable(con, "mtcars", mtcars)`,
-				'>'
-			);
-			// the panel should be automatically updated and we should be able to see
-			// that table and click on it
-			await app.workbench.positronConnections.openConnectionsNodes(["mtcars"]);
-		}).toPass();
 
-		// disconnect icon appearance requires hover
-		await app.workbench.positronConnections.rConnectionOpenState.hover();
+		// mtcars node should not exist
+		await app.workbench.positronConnections.openConnectionsNodes(['Default']);
+		await expect(
+			page.locator('.connections-items-container').getByText('mtcars')
+		).not.toBeVisible();
+
+		// now we add a dataframe to that connection
+		await app.workbench.positronConsole.executeCode(
+			'R',
+			`DBI::dbWriteTable(con, "mtcars", mtcars)`,
+			'>'
+		);
+
+		await page.getByRole('button', { name: 'Refresh' }).click();
+		await app.workbench.positronConnections.openConnectionsNodes(["mtcars"]);
+
 		await app.workbench.positronConnections.disconnectButton.click();
-		await app.workbench.positronConnections.reconnectButton.waitforVisible();
+		await page.getByText('SQLiteConnection').click();
+		await expect(page.getByLabel('Delete Connection')).toBeVisible();
+		// disconnect icon appearance requires hover
+		// await app.workbench.positronConnections.rConnectionOpenState.hover();
+		// await app.workbench.positronConnections.disconnectButton.click();
+		// await app.workbench.positronConnections.reconnectButton.waitforVisible();
 	});
 
 });

--- a/test/smoke/src/areas/positron/connections/connections-db.test.ts
+++ b/test/smoke/src/areas/positron/connections/connections-db.test.ts
@@ -10,7 +10,7 @@ import { UserSetting } from '../../../../../automation';
 const connectionSetting: UserSetting = ['positron.connections.showConnectionPane', 'true'];
 
 test.use({
-	suiteId: __filename,
+	suiteId: __filename
 });
 
 test.describe('SQLite DB Connection', { tag: ['@web', '@win', '@pr'] }, () => {
@@ -33,7 +33,7 @@ test.describe('SQLite DB Connection', { tag: ['@web', '@win', '@pr'] }, () => {
 
 		await test.step('Open connections pane', async () => {
 			await app.workbench.positronVariables.clickDatabaseIconForVariableRow('conn');
-			await app.workbench.positronConnections.connectionIcon.click();
+			await app.workbench.positronConnections.connectIcon.click();
 		});
 
 		await test.step('Verify connection nodes', async () => {

--- a/test/smoke/src/areas/positron/connections/connections-db.test.ts
+++ b/test/smoke/src/areas/positron/connections/connections-db.test.ts
@@ -18,13 +18,13 @@ test.describe('SQLite DB Connection', { tag: ['@web', '@win', '@pr'] }, () => {
 		await userSettings.set([connectionSetting], true);
 	});
 
-	test.afterEach(async function ({ app, page }) {
+	test.afterEach(async function ({ app }) {
 		await app.workbench.positronConnections.disconnectButton.click();
 		await app.workbench.positronConnections.connectionItems.first().click();
 		await app.workbench.positronConnections.deleteConnection();
 	});
 
-	test('Python - SQLite DB Connection [C628636]', async function ({ app, page, logger, python }) {
+	test('Python - SQLite DB Connection [C628636]', async function ({ app, python }) {
 		await test.step('Open a Python file and run it', async () => {
 			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'chinook-db-py', 'chinook-sqlite.py'));
 			await app.workbench.quickaccess.runCommand('python.execInConsole');
@@ -41,7 +41,7 @@ test.describe('SQLite DB Connection', { tag: ['@web', '@win', '@pr'] }, () => {
 		});
 	});
 
-	test('R - SQLite DB Connection [C628637]', async function ({ app, page, logger, r }) {
+	test('R - SQLite DB Connection [C628637]', async function ({ app, r }) {
 		await test.step('Open an R file and run it', async () => {
 			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'chinook-db-r', 'chinook-sqlite.r'));
 			await app.workbench.quickaccess.runCommand('r.sourceCurrentFile');
@@ -58,7 +58,7 @@ test.describe('SQLite DB Connection', { tag: ['@web', '@win', '@pr'] }, () => {
 		});
 	});
 
-	test('R - Connections are update after adding a database,[C663724]', async function ({ app, page, logger, r }) {
+	test('R - Connections are update after adding a database,[C663724]', async function ({ app, page, r }) {
 		await test.step('Open an empty connection', async () => {
 			await app.workbench.positronConsole.executeCode(
 				'R',

--- a/test/smoke/src/areas/positron/connections/connections-db.test.ts
+++ b/test/smoke/src/areas/positron/connections/connections-db.test.ts
@@ -20,9 +20,8 @@ test.describe('SQLite DB Connection', { tag: ['@web', '@win', '@pr'] }, () => {
 
 	test.afterEach(async function ({ app, page }) {
 		await app.workbench.positronConnections.disconnectButton.click();
-		await page.locator('.connections-list-item').click();
-		await expect(page.getByLabel('Delete Connection')).toBeVisible();
-		await app.workbench.positronConnections.deleteConnectionButton.click();
+		await app.workbench.positronConnections.connectionItems.first().click();
+		await app.workbench.positronConnections.deleteConnection();
 	});
 
 	test('Python - SQLite DB Connection [C628636]', async function ({ app, page, logger, python }) {

--- a/test/smoke/src/areas/positron/connections/connections-db.test.ts
+++ b/test/smoke/src/areas/positron/connections/connections-db.test.ts
@@ -13,7 +13,7 @@ test.use({
 	suiteId: __filename,
 });
 
-test.describe('SQLite DB Connection', { tag: ['@web', '@win'] }, () => {
+test.describe('SQLite DB Connection', { tag: ['@web', '@win', '@pr'] }, () => {
 	test.beforeAll(async function ({ userSettings }) {
 		await userSettings.set([connectionSetting], true);
 	});


### PR DESCRIPTION
### Intent
Update the existing database connections test to support the new DB connections pane changes by toggling the appropriate feature flag (which restarts the app) and updating the test logic accordingly.

### Approach
Modify the database connections test to use the new fixture and update all locators and methods to interact with the updated connections pane.

### QA Notes

You might be wondering what those `test.steps` are there for? They make the HTML report easier to read like so:

<img width="605" alt="Screenshot 2024-11-22 at 9 21 06 AM" src="https://github.com/user-attachments/assets/453d5262-9d8d-4b99-87a5-2c2f5b618a32">

If you forget what it looks before, it was this nonsense:
<img width="1022" alt="Screenshot 2024-11-22 at 10 07 29 AM" src="https://github.com/user-attachments/assets/785bc9e8-ffd6-41bc-a474-c665bd7ae0d0">

I think this will be a little bit of an art. They are optional and you certainly don't want them for every single line of code, but it does help lump steps together to ease debugging of reports. Note: the trace viewer will not show them grouped like the report does.
