### PR TITLE
Store connection metadata in the secret storage

### DIFF
--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsService.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsService.ts
@@ -98,7 +98,7 @@ class PositronConnectionsService extends Disposable implements IPositronConnecti
 
 	private async addStoredConnections() {
 		const id = this.getPrivateStorageId();
-		const storedConnections: ConnectionMetadata[] = JSON.parse(
+		const storedConnections: IConnectionMetadata[] = JSON.parse(
 			await this.secretStorageService.get(id) || '[]'
 		);
 
@@ -108,7 +108,7 @@ class PositronConnectionsService extends Disposable implements IPositronConnecti
 			}
 
 			const instance = new DisconnectedPositronConnectionsInstance(
-				metadata,
+				new ConnectionMetadata(metadata),
 				this.runtimeSessionService,
 				this
 			);

--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsService.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsService.ts
@@ -11,13 +11,13 @@ import { IPositronConnectionsService, POSITRON_CONNECTIONS_VIEW_ID } from 'vs/wo
 import { DisconnectedPositronConnectionsInstance, PositronConnectionsInstance } from 'vs/workbench/services/positronConnections/browser/positronConnectionsInstance';
 import { ILanguageRuntimeSession, IRuntimeSessionService, RuntimeClientType } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { Event, Emitter } from 'vs/base/common/event';
-import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { POSITRON_CONNECTIONS_VIEW_ENABLED, USE_POSITRON_CONNECTIONS_KEY } from 'vs/workbench/services/positronConnections/browser/positronConnectionsFeatureFlag';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IConfigurationChangeEvent, IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { ISecretStorageService } from 'vs/platform/secrets/common/secrets';
 
 class PositronConnectionsService extends Disposable implements IPositronConnectionsService {
 
@@ -34,7 +34,7 @@ class PositronConnectionsService extends Disposable implements IPositronConnecti
 
 	constructor(
 		@IRuntimeSessionService public readonly runtimeSessionService: IRuntimeSessionService,
-		@IStorageService private readonly storageService: IStorageService,
+		@ISecretStorageService private readonly secretStorageService: ISecretStorageService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@IViewsService private readonly viewsService: IViewsService,
@@ -52,21 +52,9 @@ class PositronConnectionsService extends Disposable implements IPositronConnecti
 			this.attachRuntime(runtime);
 		}));
 
-		const storedConnections: IConnectionMetadata[] = JSON.parse(
-			this.storageService.get('positron-connections', StorageScope.WORKSPACE, '[]')
-		);
-		storedConnections.forEach((metadata) => {
-			if (metadata === null) {
-				return;
-			}
-
-			const instance = new DisconnectedPositronConnectionsInstance(
-				new ConnectionMetadata(metadata),
-				this.runtimeSessionService,
-				this
-			);
-
-			this.addConnection(instance);
+		this.addStoredConnections().catch((e) => {
+			this.logService.error('Error while adding stored connections', e);
+			this.notificationService.error('Error while loading stored connections');
 		});
 
 		this._register(this.configurationService.onDidChangeConfiguration((e) => {
@@ -90,6 +78,26 @@ class PositronConnectionsService extends Disposable implements IPositronConnecti
 	}
 
 	initialize(): void { }
+
+	private async addStoredConnections() {
+		const storedConnections: ConnectionMetadata[] = JSON.parse(
+			await this.secretStorageService.get('positron-connections') || '[]'
+		);
+
+		storedConnections.forEach((metadata) => {
+			if (metadata === null) {
+				return;
+			}
+
+			const instance = new DisconnectedPositronConnectionsInstance(
+				metadata,
+				this.runtimeSessionService,
+				this
+			);
+
+			this.addConnection(instance);
+		});
+	}
 
 	attachRuntime(session: ILanguageRuntimeSession) {
 		this._register(session.onDidCreateClientInstance(async ({ message, client }) => {
@@ -219,13 +227,11 @@ class PositronConnectionsService extends Disposable implements IPositronConnecti
 	}
 
 	private saveConnectionsState() {
-		this.storageService.store(
+		this.secretStorageService.set(
 			'positron-connections',
-			this.connections.map((con) => {
+			JSON.stringify(this.connections.map((con) => {
 				return con.metadata;
-			}),
-			StorageScope.WORKSPACE,
-			StorageTarget.USER
+			}))
 		);
 	}
 }


### PR DESCRIPTION
Adresses https://github.com/posit-dev/positron/issues/5108

TODO:

- [x] Make sure storage is per-project and that saved connection don't appear in separate projects.

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

Should be an invisible change. We should persist connections after closing the IDE and reopening. 
Connections should also be stored in a per-project basis.