### PR TITLE
Fix duplicate sessions in debug runtimes view

### DIFF
--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/actionBars.tsx
@@ -44,7 +44,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	const positronSessionsContext = usePositronRuntimeSessionsContext();
 
 	// If there are no instances, return null.
-	if (positronSessionsContext.positronSessions.length === 0) {
+	if (positronSessionsContext.positronSessions.size === 0) {
 		return null;
 	}
 
@@ -53,7 +53,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		<PositronActionBarContextProvider {...props}>
 			<div className='action-bars'>
 				<PositronActionBar size='small' borderTop={true} borderBottom={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
-					{positronSessionsContext.positronSessions.length} sessions
+					{positronSessionsContext.positronSessions.size} sessions
 				</PositronActionBar>
 			</div>
 		</PositronActionBarContextProvider>

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/sessionsCore.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/sessionsCore.tsx
@@ -32,7 +32,7 @@ export const SessionsCore = (props: SessionsCoreProps) => {
 	// Context hooks.
 	const positronSessionsContext = usePositronRuntimeSessionsContext();
 
-	if (!positronSessionsContext.positronSessions.length) {
+	if (!positronSessionsContext.positronSessions.size) {
 		return null;
 	}
 
@@ -41,7 +41,7 @@ export const SessionsCore = (props: SessionsCoreProps) => {
 
 	// Sort sessions by created time, so that most recent sessions are at the
 	// top.
-	const allSessions = positronSessionsContext.positronSessions.sort((a, b) => {
+	const allSessions = Array.from(positronSessionsContext.positronSessions.values()).sort((a, b) => {
 		return b.metadata.createdTimestamp - a.metadata.createdTimestamp;
 	});
 

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessionsState.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessionsState.tsx
@@ -42,12 +42,17 @@ export const usePositronRuntimeSessionsState = (services: PositronSessionsServic
 
 		// Add the onDidStartPositronSessionsInstance event handler.
 		disposableStore.add(services.runtimeSessionService.onDidStartRuntime(session => {
-			setPositronSessions(positronSessions => [...positronSessions, session]);
+			setPositronSessions(positronSessions => {
+				if (positronSessions.some(existingSession => existingSession.sessionId === session.sessionId)) {
+					return positronSessions;
+				}
+				return [...positronSessions, session];
+			});
 		}));
 
 		// Return the clean up for our event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [services.runtimeSessionService]);
 
 	// Return the Positron variables state.
 	return {

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessionsState.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessionsState.tsx
@@ -21,7 +21,7 @@ export interface PositronSessionsServices extends PositronActionBarServices {
  * PositronRuntimeSessionsState interface.
  */
 export interface PositronRuntimeSessionsState extends PositronSessionsServices {
-	positronSessions: ILanguageRuntimeSession[];
+	positronSessions: Map<string, ILanguageRuntimeSession>;
 }
 
 /**
@@ -31,8 +31,8 @@ export interface PositronRuntimeSessionsState extends PositronSessionsServices {
 export const usePositronRuntimeSessionsState = (services: PositronSessionsServices): PositronRuntimeSessionsState => {
 	// Hooks.
 	const [positronSessions, setPositronSessions] =
-		useState<ILanguageRuntimeSession[]>(
-			services.runtimeSessionService.activeSessions
+		useState(
+			new Map(services.runtimeSessionService.activeSessions.map(session => [session.sessionId, session])),
 		);
 
 	// Add event handlers.
@@ -42,12 +42,7 @@ export const usePositronRuntimeSessionsState = (services: PositronSessionsServic
 
 		// Add the onDidStartPositronSessionsInstance event handler.
 		disposableStore.add(services.runtimeSessionService.onDidStartRuntime(session => {
-			setPositronSessions(positronSessions => {
-				if (positronSessions.some(existingSession => existingSession.sessionId === session.sessionId)) {
-					return positronSessions;
-				}
-				return [...positronSessions, session];
-			});
+			setPositronSessions(positronSessions => new Map(positronSessions).set(session.sessionId, session));
 		}));
 
 		// Return the clean up for our event handlers.


### PR DESCRIPTION
I've been using the runtimes view often while debugging, and sometimes encountered duplicate sessions.