### PR TITLE
E2E test: fix plot save issue

### DIFF
--- a/test/automation/src/positron/positronPopups.ts
+++ b/test/automation/src/positron/positronPopups.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 
+import { expect } from '@playwright/test';
 import { Code } from '../code';
 
 const POSITRON_MODAL_DIALOG_BOX = '.positron-modal-dialog-box';
@@ -89,6 +90,10 @@ export class PositronPopups {
 
 	async waitForModalDialogBox() {
 		await this.code.waitForElement(POSITRON_MODAL_DIALOG_BOX);
+	}
+
+	async waitForModalDialogBoxToDisappear() {
+		expect(this.code.driver.page.locator(POSITRON_MODAL_DIALOG_BOX)).not.toBeVisible({ timeout: 30000 });
 	}
 
 	async clickOkOnModalDialogBox() {

--- a/test/smoke/src/areas/positron/plots/plots.test.ts
+++ b/test/smoke/src/areas/positron/plots/plots.test.ts
@@ -149,8 +149,13 @@ test.describe('Plots', () => {
 			await app.code.driver.getLocator('.positron-modal-dialog-box .file .positron-button.drop-down-list-box').click();
 			await app.workbench.positronPopups.clickOnModalDialogPopupOption('JPEG');
 
+			// bug workaround
+			await app.code.wait(1000);
+
 			// save the plot
 			await app.workbench.positronPopups.clickOkOnModalDialogBox();
+
+			await app.workbench.positronPopups.waitForModalDialogBoxToDisappear();
 
 			// verify the plot is in the file explorer with the new file name and format
 			await app.workbench.positronLayouts.enterLayout('stacked');


### PR DESCRIPTION
Python plot save was failing.  Added a brief wait before clicking save and a wait for the dialog to disappear.

### QA Notes

All smoke tests should pass.
