### PR TITLE
e2e-test: leverage userSettings fixture

### DIFF
--- a/test/smoke/src/areas/positron/_test.setup.ts
+++ b/test/smoke/src/areas/positron/_test.setup.ts
@@ -126,6 +126,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleDevTools');
 		await use();
 	},
+
 	{ scope: 'test' }],
 
 	userSettings: [async ({ app }, use) => {
@@ -143,8 +144,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 		});
 
 		await userSettings.unsetUserSettings();
-	},
-	{ scope: 'worker' }],
+	}, { scope: 'worker' }],
 
 	attachScreenshotsToReport: [async ({ app }, use, testInfo) => {
 		let screenShotCounter = 1;
@@ -168,7 +168,6 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 		for (const screenshotPath of screenshots) {
 			testInfo.attachments.push({ name: path.basename(screenshotPath), path: screenshotPath, contentType: 'image/png' });
 		}
-
 	}, { auto: true }],
 
 	attachLogsToReport: [async ({ suiteId, logsPath }, use, testInfo) => {

--- a/test/smoke/src/areas/positron/_test.setup.ts
+++ b/test/smoke/src/areas/positron/_test.setup.ts
@@ -140,7 +140,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 		};
 
 		await use({
-			set: setUserSetting,
+			set: setUserSetting
 		});
 
 		await userSettings.unsetUserSettings();

--- a/test/smoke/src/areas/positron/_test.setup.ts
+++ b/test/smoke/src/areas/positron/_test.setup.ts
@@ -128,22 +128,26 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 	},
 	{ scope: 'test' }],
 
-	userSettings: [async ({ app }, use) => {
-		const userSettings = new PositronUserSettingsFixtures(app);
+	userSettings: [
+		async ({ app }, use) => {
+			const userSettings = new PositronUserSettingsFixtures(app);
 
-		// define the set method
-		const setUserSetting = async (settings: UserSetting[], restartApp = false) => {
-			await userSettings.setUserSettings(settings, restartApp);
-		};
+			const setUserSetting = async (
+				settings: [string, string][],
+				restartApp = false
+			) => {
+				await userSettings.setUserSettings(settings, restartApp);
+			};
 
-		// use the fixture
-		await use({
-			set: setUserSetting
-		});
+			await use({
+				set: setUserSetting,
+			});
 
-		// cleanup after worker
-		await userSettings.unsetUserSettings();
-	}, { scope: 'worker' }],
+			await userSettings.unsetUserSettings();
+		},
+		{ scope: 'worker' },
+	],
+
 	attachScreenshotsToReport: [async ({ app }, use, testInfo) => {
 		let screenShotCounter = 1;
 		const page = app.code.driver.page;

--- a/test/smoke/src/areas/positron/_test.setup.ts
+++ b/test/smoke/src/areas/positron/_test.setup.ts
@@ -128,25 +128,23 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 	},
 	{ scope: 'test' }],
 
-	userSettings: [
-		async ({ app }, use) => {
-			const userSettings = new PositronUserSettingsFixtures(app);
+	userSettings: [async ({ app }, use) => {
+		const userSettings = new PositronUserSettingsFixtures(app);
 
-			const setUserSetting = async (
-				settings: [string, string][],
-				restartApp = false
-			) => {
-				await userSettings.setUserSettings(settings, restartApp);
-			};
+		const setUserSetting = async (
+			settings: [string, string][],
+			restartApp = false
+		) => {
+			await userSettings.setUserSettings(settings, restartApp);
+		};
 
-			await use({
-				set: setUserSetting,
-			});
+		await use({
+			set: setUserSetting,
+		});
 
-			await userSettings.unsetUserSettings();
-		},
-		{ scope: 'worker' },
-	],
+		await userSettings.unsetUserSettings();
+	},
+	{ scope: 'worker' }],
 
 	attachScreenshotsToReport: [async ({ app }, use, testInfo) => {
 		let screenShotCounter = 1;

--- a/test/smoke/src/areas/positron/connections/connections-db.test.ts
+++ b/test/smoke/src/areas/positron/connections/connections-db.test.ts
@@ -5,9 +5,6 @@
 
 import { join } from 'path';
 import { test, expect } from '../_test.setup';
-import { UserSetting } from '../../../../../automation';
-
-const connectionSetting: UserSetting = ['positron.connections.showConnectionPane', 'true'];
 
 test.use({
 	suiteId: __filename
@@ -15,7 +12,7 @@ test.use({
 
 test.describe('SQLite DB Connection', { tag: ['@web', '@win', '@pr'] }, () => {
 	test.beforeAll(async function ({ userSettings }) {
-		await userSettings.set([connectionSetting], true);
+		await userSettings.set([['positron.connections.showConnectionPane', 'true']], true);
 	});
 
 	test.afterEach(async function ({ app }) {

--- a/test/smoke/src/areas/positron/r-pkg-development/r-pkg-development.test.ts
+++ b/test/smoke/src/areas/positron/r-pkg-development/r-pkg-development.test.ts
@@ -5,22 +5,16 @@
 
 import path = require('path');
 import { test, expect } from '../_test.setup';
-import { PositronUserSettingsFixtures } from '../../../../../automation';
 
 test.use({
 	suiteId: __filename
 });
 
-
 test.describe('R Package Development', { tag: ['@web'] }, () => {
-	let userSettings: PositronUserSettingsFixtures;
-
-	test.beforeAll(async function ({ app, r }) {
+	test.beforeAll(async function ({ app, r, userSettings }) {
 		try {
-			userSettings = new PositronUserSettingsFixtures(app);
-
 			// don't use native file picker
-			await userSettings.setUserSetting(['files.simpleDialog.enable', 'true']);
+			await userSettings.set([['files.simpleDialog.enable', 'true']]);
 			await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 			await app.workbench.positronConsole.barClearButton.click();
 			await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
@@ -28,11 +22,6 @@ test.describe('R Package Development', { tag: ['@web'] }, () => {
 			app.code.driver.takeScreenshot('rPackageSetup');
 			throw e;
 		}
-	});
-
-	test.afterAll(async function () {
-		// unset the use of the VSCode file picker
-		await userSettings.unsetUserSettings();
 	});
 
 	test('R Package Development Tasks [C809821]', async function ({ app, logger }) {

--- a/test/smoke/src/areas/positron/reticulate/reticulate.test.ts
+++ b/test/smoke/src/areas/positron/reticulate/reticulate.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test, expect } from '../_test.setup';
-import { PositronUserSettingsFixtures, UserSetting } from '../../../../../automation';
+import { UserSetting } from '../../../../../automation';
 
 test.use({
 	suiteId: __filename
@@ -13,22 +13,19 @@ test.use({
 // In order to run this test on Windows, I think we need to set the env var:
 // RETICULATE_PYTHON
 // to the installed python path
-let userSettings: PositronUserSettingsFixtures;
 
 test.describe('Reticulate', {
 	tag: ['@web'],
 	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5226' }]
 }, () => {
-	test.beforeAll(async function ({ app }) {
+	test.beforeAll(async function ({ app, userSettings }) {
 		try {
-			userSettings = new PositronUserSettingsFixtures(app);
-
 			// remove this once https://github.com/posit-dev/positron/issues/5226
 			// is resolved
 			const kernelSupervisorSetting: UserSetting = ['positronKernelSupervisor.enable', 'false'];
 			const reticulateSetting: UserSetting = ['positron.reticulate.enabled', 'true'];
 
-			await userSettings.setUserSettings([
+			await userSettings.set([
 				kernelSupervisorSetting,
 				reticulateSetting
 			]);
@@ -37,11 +34,6 @@ test.describe('Reticulate', {
 			app.code.driver.takeScreenshot('reticulateSetup');
 			throw e;
 		}
-	});
-
-	test.afterAll(async function () {
-		await userSettings.unsetUserSettings();
-
 	});
 
 	test('R - Verify Basic Reticulate Functionality [C...]', async function ({ app, r, interpreter }) {

--- a/test/smoke/src/areas/positron/test-explorer/test-explorer.test.ts
+++ b/test/smoke/src/areas/positron/test-explorer/test-explorer.test.ts
@@ -5,24 +5,19 @@
 
 import path = require('path');
 import { test, expect } from '../_test.setup';
-import { PositronUserSettingsFixtures } from '../../../../../automation';
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Test Explorer', () => {
-	let userSettings: PositronUserSettingsFixtures;
-
-	test.beforeAll(async function ({ app, r }) {
+	test.beforeAll(async function ({ app, r, userSettings }) {
 		try {
-			userSettings = new PositronUserSettingsFixtures(app);
-
 			// don't use native file picker
-			await userSettings.setUserSetting([
+			await userSettings.set([[
 				'files.simpleDialog.enable',
 				'true',
-			]);
+			]]);
 
 			await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 			await app.workbench.positronConsole.barClearButton.click();
@@ -31,11 +26,6 @@ test.describe('Test Explorer', () => {
 			app.code.driver.takeScreenshot('testExplorerSetup');
 			throw e;
 		}
-	});
-
-	test.afterEach(async function () {
-		// unset the use of the VSCode file picker
-		await userSettings.unsetUserSettings();
 	});
 
 	test('R - Verify Basic Test Explorer Functionality [C749378]', async function ({ app }) {

--- a/test/smoke/src/areas/positron/top-action-bar/top-action-bar-save.test.ts
+++ b/test/smoke/src/areas/positron/top-action-bar/top-action-bar-save.test.ts
@@ -5,7 +5,6 @@
 
 import { join } from 'path';
 import { test, expect } from '../_test.setup';
-import { PositronUserSettingsFixtures } from '../../../../../automation';
 
 test.use({
 	suiteId: __filename
@@ -15,12 +14,9 @@ test.describe('Top Action Bar - Save Actions', {
 	tag: ['@web']
 }, () => {
 
-	let userSettings: PositronUserSettingsFixtures;
-
-	test.beforeAll(async function ({ app }) {
+	test.beforeAll(async function ({ app, userSettings }) {
 		if (app.web) {
-			userSettings = new PositronUserSettingsFixtures(app);
-			await userSettings.setUserSetting(['files.autoSave', 'false']);
+			await userSettings.set([['files.autoSave', 'false']]);
 		}
 	});
 


### PR DESCRIPTION
Updated existing tests to use new `userSettings` fixture.

### QA Notes
Running full suite to make sure things are good: https://github.com/posit-dev/positron/actions/runs/11978168106

