### PR TITLE
Add "Set as Working Directory" command

### DIFF
--- a/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
+++ b/extensions/jupyter-adapter/src/LanguageRuntimeAdapter.ts
@@ -266,6 +266,19 @@ export class LanguageRuntimeSessionAdapter
 	}
 
 	/**
+	 * Set the working directory for the kernel. This is a stub implementation since Jupyter
+	 * doesn't have a concept of a working directory.
+	 *
+	 * @param workingDirectory The working directory to set
+	 * @returns Nothing
+	 * @throws An error message indicating that this method is not implemented
+	 */
+	public setWorkingDirectory(workingDirectory: string): Promise<void> {
+		return Promise.reject(
+			`Cannot change working directory to ${workingDirectory} (not implemented)`);
+	}
+
+	/**
 	 * Interrupts the kernel.
 	 */
 	public async interrupt(): Promise<void> {

--- a/extensions/positron-javascript/src/session.ts
+++ b/extensions/positron-javascript/src/session.ts
@@ -148,6 +148,10 @@ export class JavaScriptLanguageRuntimeSession implements positron.LanguageRuntim
 		throw new Error('Method not implemented.');
 	}
 
+	setWorkingDirectory(dir: string): Thenable<void> {
+		throw new Error('Method not implemented.');
+	}
+
 	async start(): Promise<positron.LanguageRuntimeInfo> {
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Initializing);
 		this._onDidChangeRuntimeState.fire(positron.RuntimeState.Starting);

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -411,7 +411,7 @@ class PositronIPyKernel(IPythonKernel):
         # Create Positron services
         self.data_explorer_service = DataExplorerService(_CommTarget.DataExplorer, self.job_queue)
         self.plots_service = PlotsService(_CommTarget.Plot, self.session_mode)
-        self.ui_service = UiService()
+        self.ui_service = UiService(self)
         self.help_service = HelpService()
         self.lsp_service = LSPService(self)
         self.variables_service = VariablesService(self)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
@@ -123,6 +123,25 @@ def test_open_editor(ui_service: UiService, ui_comm: DummyComm) -> None:
     ]
 
 
+def test_is_module_loaded(ui_comm: DummyComm) -> None:
+    """
+    Test the `isModuleLoaded` RPC method called from Positron.
+    """
+    module = "fallingStars"
+    msg = json_rpc_request(
+        "call_method",
+        {
+            "method": "isModuleLoaded",
+            "params": [module],
+        },
+        comm_id="dummy_comm_id",
+    )
+    ui_comm.handle_msg(msg)
+
+    # Check that the response is sent, with a result of False.
+    assert ui_comm.messages == [json_rpc_response(False)]
+
+
 def test_clear_console(ui_service: UiService, ui_comm: DummyComm) -> None:
     ui_service.clear_console()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -91,7 +91,7 @@ def _set_console_width(kernel: "PositronIPyKernel", params: List[JsonData]) -> N
         torch_.set_printoptions(linewidth=width)
 
 
-_RPC_METHODS: Dict[str, Callable[[List[JsonData]], JsonData]] = {
+_RPC_METHODS: Dict[str, Callable[["PositronIPyKernel", List[JsonData]], Optional[JsonData]]] = {
     "setConsoleWidth": _set_console_width,
     "isModuleLoaded": _is_module_loaded,
 }

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -9,7 +9,7 @@ import os
 import sys
 import webbrowser
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 from comm.base_comm import BaseComm
@@ -28,6 +28,9 @@ from .ui_comm import (
     WorkingDirectoryParams,
 )
 from .utils import JsonData, JsonRecord, alias_home, is_local_html_file
+
+if TYPE_CHECKING:
+    from .positron_ipkernel import PositronIPyKernel
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +54,16 @@ class _InvalidParamsError(Exception):
     pass
 
 
-def _set_console_width(params: List[JsonData]) -> None:
+def _is_module_loaded(kernel: "PositronIPyKernel", params: List[JsonData]) -> None:
+    if not (isinstance(params, list) and len(params) == 1 and isinstance(params[0], str)):
+        raise _InvalidParamsError(f"Expected a module name, got: {params}")
+    # Consider: this is not a perfect check for a couple of reasons:
+    # 1. The module could be loaded under a different name
+    # 2. The user may have a variable with the same name as the module
+    return params[0] in kernel.shell.user_ns.keys()
+
+
+def _set_console_width(kernel: "PositronIPyKernel", params: List[JsonData]) -> None:
     if not (isinstance(params, list) and len(params) == 1 and isinstance(params[0], int)):
         raise _InvalidParamsError(f"Expected an integer width, got: {params}")
 
@@ -81,6 +93,7 @@ def _set_console_width(params: List[JsonData]) -> None:
 
 _RPC_METHODS: Dict[str, Callable[[List[JsonData]], JsonData]] = {
     "setConsoleWidth": _set_console_width,
+    "isModuleLoaded": _is_module_loaded,
 }
 
 
@@ -90,7 +103,9 @@ class UiService:
     Used for communication with the frontend, unscoped to any particular view.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, kernel: "PositronIPyKernel") -> None:
+        self.kernel = kernel
+
         self._comm: Optional[PositronComm] = None
 
         self._working_directory: Optional[Path] = None
@@ -157,7 +172,7 @@ class UiService:
             return logger.warning(f"Invalid frontend RPC request method: {rpc_request.method}")
 
         try:
-            result = func(rpc_request.params)
+            result = func(self.kernel, rpc_request.params)
         except _InvalidParamsError as exception:
             return logger.warning(
                 f"Invalid frontend RPC request params for method '{rpc_request.method}'. {exception}"

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -54,7 +54,7 @@ class _InvalidParamsError(Exception):
     pass
 
 
-def _is_module_loaded(kernel: "PositronIPyKernel", params: List[JsonData]) -> None:
+def _is_module_loaded(kernel: "PositronIPyKernel", params: List[JsonData]) -> bool:
     if not (isinstance(params, list) and len(params) == 1 and isinstance(params[0], str)):
         raise _InvalidParamsError(f"Expected a module name, got: {params}")
     # Consider: this is not a perfect check for a couple of reasons:

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -203,6 +203,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         }
     }
 
+    setWorkingDirectory(_dir: string): Thenable<void> {
+        return Promise.resolve();
+    }
+
     private async _installIpykernel(): Promise<void> {
         // Get the installer service
         const installer = this.serviceContainer.get<IInstaller>(IInstaller);

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -203,8 +203,32 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         }
     }
 
-    setWorkingDirectory(_dir: string): Thenable<void> {
-        return Promise.resolve();
+    async setWorkingDirectory(dir: string): Promise<void> {
+        if (this._kernel) {
+            // Check to see if the 'os' module is available in the kernel
+            const loaded = await this._kernel.callMethod('isModuleLoaded', 'os');
+            let code = '';
+            if (!loaded) {
+                code = 'import os; ';
+            }
+            // Escape backslashes in the directory path
+            dir = dir.replace(/\\/g, '\\\\');
+
+            // Escape single quotes in the directory path
+            dir = dir.replace(/'/g, "\\'");
+
+            // Set the working directory
+            code += `os.chdir('${dir}')`;
+
+            this._kernel.execute(
+                code,
+                createUniqueId(),
+                positron.RuntimeCodeExecutionMode.Interactive,
+                positron.RuntimeErrorBehavior.Continue,
+            );
+        } else {
+            throw new Error(`Cannot set working directory to ${dir}; kernel not started`);
+        }
     }
 
     private async _installIpykernel(): Promise<void> {
@@ -607,6 +631,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             }
         }
     }
+}
+
+export function createUniqueId(): string {
+    return Math.floor(Math.random() * 0x100000000).toString(16);
 }
 
 export function createJupyterKernelExtra(): undefined {

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -237,6 +237,9 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	 */
 	async setWorkingDirectory(dir: string): Promise<void> {
 		if (this._kernel) {
+			// Escape any backslashes in the directory path
+			dir = dir.replace(/\\/g, '\\\\');
+
 			// Escape any quotes in the directory path
 			dir = dir.replace(/"/g, '\\"');
 

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -230,6 +230,11 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		}
 	}
 
+	/**
+	 * Sets the working directory for the runtime.
+	 *
+	 * @param dir The working directory to set.
+	 */
 	async setWorkingDirectory(dir: string): Promise<void> {
 		if (this._kernel) {
 			// Escape any quotes in the directory path

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -230,6 +230,10 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		}
 	}
 
+	async setWorkingDirectory(dir: string): Promise<void> {
+		return Promise.reject(new Error('Not implemented.'));
+	}
+
 	async start(): Promise<positron.LanguageRuntimeInfo> {
 		if (!this._kernel) {
 			this._kernel = await this.createKernel();

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -231,7 +231,18 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	}
 
 	async setWorkingDirectory(dir: string): Promise<void> {
-		return Promise.reject(new Error('Not implemented.'));
+		if (this._kernel) {
+			// Escape any quotes in the directory path
+			dir = dir.replace(/"/g, '\\"');
+
+			// Tell the kernel to change the working directory
+			this._kernel.execute(`setwd("${dir}")`,
+				randomUUID(),
+				positron.RuntimeCodeExecutionMode.Interactive,
+				positron.RuntimeErrorBehavior.Continue);
+		} else {
+			throw new Error(`Cannot change to ${dir}; kernel not started`);
+		}
 	}
 
 	async start(): Promise<positron.LanguageRuntimeInfo> {

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -471,6 +471,10 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 		return this.pythonSession.replyToPrompt(id, reply);
 	}
 
+	public setWorkingDirectory(dir: string): Thenable<void> {
+		return this.pythonSession.setWorkingDirectory(dir);
+	}
+
 	public start() {
 		return this.pythonSession.start();
 	}

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -664,6 +664,19 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 	}
 
 	/**
+	 * Set the working directory for the kernel. This is a stub implementation since Jupyter
+	 * doesn't have a concept of a working directory.
+	 *
+	 * @param workingDirectory The working directory to set
+	 * @returns Nothing
+	 * @throws An error message indicating that this method is not implemented
+	 */
+	setWorkingDirectory(workingDirectory: string): Promise<void> {
+		return Promise.reject(
+			`Cannot change working directory to ${workingDirectory} (not implemented)`);
+	}
+
+	/**
 	 * Restores an existing session from the server.
 	 *
 	 * @param session The session to restore

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -724,7 +724,8 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 	async start(): Promise<positron.LanguageRuntimeInfo> {
 		try {
 			// Attempt to start the session
-			return this.tryStart();
+			const info = await this.tryStart();
+			return info;
 		} catch (err) {
 			if (err instanceof HttpError && err.statusCode === 500) {
 				// When the server returns a 500 error, it means the startup

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1073,6 +1073,16 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 	}
 
 	/**
+	 * Set the working directory for the kernel.
+	 *
+	 * @param workingDirectory The working directory to set
+	 */
+	public setWorkingDirectory(workingDirectory: string): Promise<void> {
+		this._ui?.changeDirectory(workingDirectory);
+		return Promise.resolve();
+	}
+
+	/**
 	 * Starts the runtime; returns a Thenable that resolves with information about the runtime.
 	 * @returns A Thenable that resolves with information about the runtime
 	 */

--- a/extensions/vscode-api-tests/src/singlefolder-tests/positron/runtime.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/positron/runtime.test.ts
@@ -56,6 +56,10 @@ class TestLanguageRuntimeSession implements positron.LanguageRuntimeSession {
 		throw new Error('Not implemented.');
 	}
 
+	setWorkingDirectory(_dir: string): Promise<void> {
+		throw new Error('Not implemented.');
+	}
+
 	async start(): Promise<positron.LanguageRuntimeInfo> {
 		throw new Error('Not implemented.');
 	}

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -819,6 +819,11 @@ declare module 'positron' {
 		replyToPrompt(id: string, reply: string): void;
 
 		/**
+		 * Set the current working directory of the session.
+		 */
+		setWorkingDirectory(dir: string): Thenable<void>;
+
+		/**
 		 * Start the session; returns a Thenable that resolves with information about the runtime.
 		 * If the runtime fails to start for any reason, the Thenable should reject with an error
 		 * object containing a `message` field with a human-readable error message and an optional

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -498,6 +498,10 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 		this._proxy.$replyToPrompt(this.handle, id, value);
 	}
 
+	setWorkingDirectory(dir: string): Promise<void> {
+		return this._proxy.$setWorkingDirectory(this.handle, dir);
+	}
+
 	async interrupt(): Promise<void> {
 		this._stateEmitter.fire(RuntimeState.Interrupting);
 		return this._proxy.$interruptLanguageRuntime(this.handle);

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -61,6 +61,7 @@ export interface ExtHostLanguageRuntimeShape {
 	$removeClient(handle: number, id: string): void;
 	$sendClientMessage(handle: number, client_id: string, message_id: string, message: any): void;
 	$replyToPrompt(handle: number, id: string, response: string): void;
+	$setWorkingDirectory(handle: number, directory: string): Promise<void>;
 	$interruptLanguageRuntime(handle: number): Promise<void>;
 	$restartSession(handle: number): Promise<void>;
 	$shutdownLanguageRuntime(handle: number, exitReason: RuntimeExitReason): Promise<void>;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -443,6 +443,13 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		this._runtimeSessions[handle].replyToPrompt(id, response);
 	}
 
+	$setWorkingDirectory(handle: number, dir: string): Promise<void> {
+		if (handle >= this._runtimeSessions.length) {
+			throw new Error(`Cannot set working directory: session handle '${handle}' not found or no longer valid.`);
+		}
+		return this._runtimeSessions[handle].setWorkingDirectory(dir);
+	}
+
 	/**
 	 * Discovers language runtimes and registers them with the main thread.
 	 */

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -453,7 +453,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 					resolve();
 				},
 				(err) => {
-					reject(err)
+					reject(err);
 				});
 		});
 	}

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -447,7 +447,15 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		if (handle >= this._runtimeSessions.length) {
 			throw new Error(`Cannot set working directory: session handle '${handle}' not found or no longer valid.`);
 		}
-		return this._runtimeSessions[handle].setWorkingDirectory(dir);
+		return new Promise((resolve, reject) => {
+			this._runtimeSessions[handle].setWorkingDirectory(dir).then(
+				() => {
+					resolve();
+				},
+				(err) => {
+					reject(err)
+				});
+		});
 	}
 
 	/**

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -676,7 +676,7 @@ registerAction2(class SetWorkingDirectoryCommand extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.setWorkingDirectory',
-			title: nls.localize2('setWorkingDirectory', "Set as Working Directory"),
+			title: nls.localize2('setWorkingDirectory', "Set as Working Directory in Active Console"),
 			category,
 			f1: true,
 			menu: [

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -683,6 +683,7 @@ registerAction2(class SetWorkingDirectoryCommand extends Action2 {
 				when: ContextKeyExpr.and(FilesExplorerFocusCondition, ExplorerFolderContext),
 				primary: KeyMod.Shift | KeyMod.Alt | KeyCode.KeyD,
 			},
+			f1: true,
 			menu: [
 				{
 					id: MenuId.ExplorerContext,

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -720,6 +720,13 @@ registerAction2(class SetWorkingDirectoryCommand extends Action2 {
 			}
 			resource = selection[0];
 		}
-		sessionService.foregroundSession?.setWorkingDirectory(resource?.fsPath);
+		if (!resource) {
+			return;
+		}
+		try {
+			session.setWorkingDirectory(resource.fsPath);
+		} catch (e) {
+			notificationService.error(e);
+		}
 	}
 });

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -22,7 +22,7 @@ import { IRuntimeStartupService } from 'vs/workbench/services/runtimeStartup/com
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { dispose } from 'vs/base/common/lifecycle';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
-import { ExplorerFolderContext, FilesExplorerFocusCondition } from 'vs/workbench/contrib/files/common/files';
+import { ExplorerFolderContext } from 'vs/workbench/contrib/files/common/files';
 import { URI } from 'vs/base/common/uri';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 
@@ -678,11 +678,6 @@ registerAction2(class SetWorkingDirectoryCommand extends Action2 {
 			id: 'workbench.action.setWorkingDirectory',
 			title: nls.localize2('setWorkingDirectory', "Set as Working Directory"),
 			category,
-			keybinding: {
-				weight: KeybindingWeight.WorkbenchContrib,
-				when: ContextKeyExpr.and(FilesExplorerFocusCondition, ExplorerFolderContext),
-				primary: KeyMod.Shift | KeyMod.Alt | KeyCode.KeyD,
-			},
 			f1: true,
 			menu: [
 				{

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -686,7 +686,7 @@ registerAction2(class SetWorkingDirectoryCommand extends Action2 {
 			menu: [
 				{
 					id: MenuId.ExplorerContext,
-					group: '4_search',
+					group: '2_workspace',
 					order: 10,
 					when: ContextKeyExpr.and(ExplorerFolderContext)
 				}
@@ -694,6 +694,13 @@ registerAction2(class SetWorkingDirectoryCommand extends Action2 {
 		});
 	}
 
+	/**
+	 * Invoke the command
+	 *
+	 * @param accessor The services accessor
+	 * @param resource The resource to set as the working directory, from the explorer. If not provided, the user will be prompted to select a folder.
+	 * @returns
+	 */
 	async run(accessor: ServicesAccessor, resource?: URI) {
 		const sessionService = accessor.get(IRuntimeSessionService);
 		const notificationService = accessor.get(INotificationService);
@@ -716,13 +723,20 @@ registerAction2(class SetWorkingDirectoryCommand extends Action2 {
 					'Set Directory')
 			});
 			if (!selection) {
+				// No folder was selected.
 				return;
 			}
+
+			// Use the first selected folder (there should only ever be one selected since we specified `canSelectMany: false`).
 			resource = selection[0];
 		}
+
+		// At this point we should have a resource.
 		if (!resource) {
 			return;
 		}
+
+		// Attempt to set the working directory to the selected folder.
 		try {
 			session.setWorkingDirectory(resource.fsPath);
 		} catch (e) {

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -165,6 +165,11 @@ export interface ILanguageRuntimeSession extends IDisposable {
 	 */
 	replyToPrompt(id: string, value: string): void;
 
+	/**
+	 * Set the runtime's working directory.
+	 */
+	setWorkingDirectory(directory: string): Thenable<void>;
+
 	start(): Thenable<ILanguageRuntimeInfo>;
 
 	/** Interrupt the runtime */

--- a/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
@@ -141,6 +141,10 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 		throw new Error('Not implemented.');
 	}
 
+	setWorkingDirectory(_dir: string): void {
+		throw new Error('Not implemented.');
+	}
+
 	async start(): Promise<ILanguageRuntimeInfo> {
 		this._onDidChangeRuntimeState.fire(RuntimeState.Starting);
 

--- a/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
@@ -141,7 +141,7 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 		throw new Error('Not implemented.');
 	}
 
-	setWorkingDirectory(_dir: string): void {
+	setWorkingDirectory(_dir: string): Promise<void> {
 		throw new Error('Not implemented.');
 	}
 


### PR DESCRIPTION
This change adds a "Set as Working Directory" affordance to the Explorer. 

<img width="453" alt="image" src="https://github.com/user-attachments/assets/4ed59ae6-8ef5-4697-81e4-059dfd59b81e">

This command sets the current working directory of the active Console to the folder by emitting the appropriate R or Python code. 

Addresses https://github.com/posit-dev/positron/issues/4444. 

The only complicated/annoying bit is that in Python, the idiomatic way to change the working directory is `os.chdir`, but that doesn't work unless you've done an `import os` at some point. So we also have to check to see if you have `os`, and if you haven't, tack on an `import os` to the command. 

I did not add an affordance going the other way (from the Console to the Explorer). That one will need more thought because the Explorer can't display folders outside your workspace, whereas the Console can enter any legal working directory.

### QA Notes

- If it's helpful for testing, I also added this to the Palette, under `Interpreter: Set as Working Directory`. 
- Directory names should be properly escaped.
