### PR TITLE
Data Explorer: Fix issues encountered with QA datasets; int64 overflows in statistics, histograms, add other group to frequency tables

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -58,7 +58,7 @@ import { Table, Vector } from 'apache-arrow';
 import { pathToFileURL } from 'url';
 
 // Set to true when doing development for better console logging
-const DEBUG_LOG = true;
+const DEBUG_LOG = false;
 
 class DuckDBInstance {
 	runningQuery: Promise<any> = Promise.resolve();


### PR DESCRIPTION
I also fixed a bug where the data explorer backend would get into a "stuck" state when a query fails (there is a `runningQuery` promise so that only one query is queued at a time so we can see execution times in the console logs). 

Additionally:

* Large INT64 values will not generate DuckDB overflows
* Added the "other" group to the frequency table output

Part of #5128 