### PR TITLE
Streamline session creation logging

### DIFF
--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -276,7 +276,8 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			interruptMode
 		};
 		await this._api.newSession(session);
-		this.log(`Session created: ${JSON.stringify(session)}`, vscode.LogLevel.Info);
+		this.log(`${kernelSpec.display_name} session '${this.metadata.sessionId}' created in ${workingDir} with command:`, vscode.LogLevel.Info);
+		this.log(args.join(' '), vscode.LogLevel.Info);
 		this._established.open();
 	}
 
@@ -711,7 +712,8 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 	async start(): Promise<positron.LanguageRuntimeInfo> {
 		try {
 			// Attempt to start the session
-			return this.tryStart();
+			const info = await this.tryStart();
+			return info;
 		} catch (err) {
 			if (err instanceof HttpError && err.statusCode === 500) {
 				// When the server returns a 500 error, it means the startup


### PR DESCRIPTION
This change simplifies the session creation logs:

- we no longer log all the metadata (it includes the environment, which can be sensitive)
- we do log a form of the command that can be copied and pasted to the terminal to simulate a kernel launch there (modulo swapping a real connection file, etc.)

Also fixes an error propagation issue at start, as a drive-by change.

Part of/related to https://github.com/posit-dev/positron/issues/5320. 

### QA Notes

Prior to this change, the metadata was logged at the beginning of the `Python A.B.C:  Console` output channel.
