### PR TITLE
Add more logging for Python interpreter discovery

### DIFF
--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -107,7 +107,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
 
         const interpreter = interpreterService.getInterpreters().find((i) => i.id === extraData.pythonEnvironmentId);
         if (!interpreter) {
-            throw new Error(`Interpreter not found: ${extraData.pythonEnvironmentId}`);
+            const interpreterIds = interpreterService.getInterpreters().map((i) => `${i.id}`);
+            throw new Error(
+                `Interpreter ${extraData.pythonEnvironmentId} not found in available Python interpreters: ${interpreterIds}`,
+            );
         }
         this.interpreter = interpreter;
 

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -107,9 +107,9 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
 
         const interpreter = interpreterService.getInterpreters().find((i) => i.id === extraData.pythonEnvironmentId);
         if (!interpreter) {
-            const interpreterIds = interpreterService.getInterpreters().map((i) => `${i.id}`);
+            const interpreterIds = interpreterService.getInterpreters().map((i) => `\n- ${i.id}`);
             throw new Error(
-                `Interpreter ${extraData.pythonEnvironmentId} not found in available Python interpreters: ${interpreterIds}`,
+                `Interpreter ${extraData.pythonEnvironmentId} (path: ${extraData.pythonPath}) not found in available Python interpreters: ${interpreterIds}`,
             );
         }
         this.interpreter = interpreter;


### PR DESCRIPTION
Addresses #5286 with some additional logging so we can start to understand why we sometimes see this failure in smoke tests

### QA Notes

No changes for when the right Python interpreter _is_ found from the `interpreterService`. If we again see this in tests, we should see something like this in the Developer Tools console:

> ERR Interpreter /Users/juliasilge/.pyenv/versions/3.11.7/envs/polars-testing/bin/python not found in available Python interpreters: /Users/juliasilge/.pyenv/versions/3.10.12/bin/python,/Users/juliasilge/.pyenv/versions/3.10.13/bin/python,/Users/juliasilge/.pyenv/versions/3.10.9/bin/python,/Users/juliasilge/.pyenv/versions/3.11.5/bin/python,/Users/juliasilge/.pyenv/versions/3.11.6/bin/python,/Users/juliasilge/.pyenv/versions/3.11.7/bin/python,/Users/juliasilge/.pyenv/versions/3.10.13/envs/bundle/bin/python,/Users/juliasilge/.pyenv/versions/3.10.12/envs/openai-testing/bin/python,/Users/juliasilge/.pyenv/versions/3.10.12/envs/positron/bin/python,/Users/juliasilge/.virtualenvs/r-tensorflow/bin/python,/usr/bin/python3,/Users/juliasilge/miniforge3/bin/python,/opt/homebrew/bin/python3.12,/Users/juliasilge/miniforge3/envs/emoji/bin/python,/Users/juliasilge/miniforge3/envs/keras-connect/bin/python,/Users/juliasilge/miniforge3/envs/my-first-pkg/bin/python,/Users/juliasilge/miniforge3/envs/pins-dev/bin/python,/Users/juliasilge/miniforge3/envs/test05-env/bin/python,/Users/juliasilge/miniforge3/envs/test06-env/bin/python,/Users/juliasilge/miniforge3/envs/tf_env/bin/python,/opt/homebrew/bin/python3.10,/opt/homebrew/bin/python3.11,/opt/homebrew/bin/python3.9,/Users/juliasilge/miniforge3/envs/another-test06-env/bin/python,/Users/juliasilge/.pyenv/versions/3.11.7/envs/positron-test-env/bin/python,

Kind of hard to read in a real situation, but seems like the best way for us to find out what's going wrong occasionally in the tests is to see all the interpreters the service thinks is there, plus what is was looking for.
