### PR TITLE
Remove `.qmd` and `.Rmd` from `R_DOCUMENT_SELECTORS`

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -23,8 +23,6 @@ export const R_DOCUMENT_SELECTORS = [
 	{ language: 'r', scheme: 'inmemory' },  // Console
 	{ language: 'r', pattern: '**/*.{r,R}' },
 	{ language: 'r', pattern: '**/*.{rprofile,Rprofile}' },
-	{ language: 'r', pattern: '**/*.{qmd,Qmd}' },
-	{ language: 'r', pattern: '**/*.{rmd,Rmd}' },
 ];
 
 /**


### PR DESCRIPTION
Addresses #3157

Having these kinds of files in `R_DOCUMENT_SELECTORS` does not actually do anything, since the R LSP cannot directly handle these kinds of files. Instead, we handle these files through the Quarto extension, which makes temporary `.R` virtual documents for us to deal with.

### QA Notes

The LSP should still correctly handle R Quarto and `.Rmd` files, for example, via statement range execution and hover help.
