### PR TITLE
fix global python interpreter filtering in Project Wizard

### DIFF
--- a/extensions/positron-python/src/client/common/constants.ts
+++ b/extensions/positron-python/src/client/common/constants.ts
@@ -80,6 +80,7 @@ export namespace Commands {
     export const Get_Create_Environment_Providers = 'python.getCreateEnvironmentProviders';
     export const Is_Conda_Installed = 'python.isCondaInstalled';
     export const Get_Conda_Python_Versions = 'python.getCondaPythonVersions';
+    export const Is_Global_Python = 'python.isGlobalPython';
     // --- End Positron ---
     export const InstallJupyter = 'python.installJupyter';
     export const InstallPython = 'python.installPython';

--- a/extensions/positron-python/src/client/positron/createEnvApi.ts
+++ b/extensions/positron-python/src/client/positron/createEnvApi.ts
@@ -76,9 +76,10 @@ export async function createEnvironmentAndRegister(
 
 /**
  * Checks if the given interpreter is a global python installation.
- * @param {string} interpreterPath : Interpreter path to check.
- * @returns {Promise<boolean>} : True if the interpreter is a global python installation, false if
- * it is not, and undefined if the check could not be performed.
+ * @param interpreterPath The interpreter path to check.
+ * @returns True if the interpreter is a global python installation, false if it is not, and
+ * undefined if the check could not be performed.
+ * Implementation is based on isGlobalPythonSelected in extensions/positron-python/src/client/pythonEnvironments/creation/common/createEnvTriggerUtils.ts
  */
 export async function isGlobalPython(interpreterPath: string): Promise<boolean | undefined> {
     const extension = getExtension<PythonExtension>(PVSC_EXTENSION_ID);

--- a/extensions/positron-python/src/client/positron/createEnvApi.ts
+++ b/extensions/positron-python/src/client/positron/createEnvApi.ts
@@ -13,6 +13,9 @@ import {
 } from '../pythonEnvironments/creation/proposed.createEnvApis';
 import { handleCreateEnvironmentCommand } from '../pythonEnvironments/creation/createEnvironment';
 import { IPythonRuntimeManager } from './manager';
+import { getExtension } from '../common/vscodeApis/extensionsApi';
+import { PythonExtension } from '../api/types';
+import { PVSC_EXTENSION_ID } from '../common/constants';
 
 /**
  * A simplified version of an environment provider that can be used in the Positron Project Wizard
@@ -69,4 +72,21 @@ export async function createEnvironmentAndRegister(
         return { ...result, metadata };
     }
     return result;
+}
+
+/**
+ * Checks if the given interpreter is a global python installation.
+ * @param {string} interpreterPath : Interpreter path to check.
+ * @returns {Promise<boolean>} : True if the interpreter is a global python installation, false if
+ * it is not, and undefined if the check could not be performed.
+ */
+export async function isGlobalPython(interpreterPath: string): Promise<boolean | undefined> {
+    const extension = getExtension<PythonExtension>(PVSC_EXTENSION_ID);
+    if (!extension) {
+        return undefined;
+    }
+    const extensionApi: PythonExtension = extension.exports as PythonExtension;
+    const interpreterDetails = await extensionApi.environments.resolveEnvironment(interpreterPath);
+    const isGlobal = interpreterDetails?.environment === undefined;
+    return isGlobal;
 }

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -26,7 +26,7 @@ import { CreateEnvironmentOptionsInternal } from './types';
 import { getCondaPythonVersions } from './provider/condaUtils';
 import { IPythonRuntimeManager } from '../../positron/manager';
 import { Conda } from '../common/environmentManagers/conda';
-import { createEnvironmentAndRegister, getCreateEnvironmentProviders } from '../../positron/createEnvApi';
+import { createEnvironmentAndRegister, getCreateEnvironmentProviders, isGlobalPython } from '../../positron/createEnvApi';
 // --- End Positron ---
 
 class CreateEnvironmentProviders {
@@ -109,6 +109,7 @@ export function registerCreateEnvironmentFeatures(
             },
         ),
         registerCommand(Commands.Get_Conda_Python_Versions, () => getCondaPythonVersions()),
+        registerCommand(Commands.Is_Global_Python, (interpreterPath: string) => isGlobalPython(interpreterPath)),
         // --- End Positron ---
         registerCreateEnvironmentProvider(new VenvCreationProvider(interpreterQuickPick)),
         registerCreateEnvironmentProvider(condaCreationProvider()),

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -26,7 +26,11 @@ import { CreateEnvironmentOptionsInternal } from './types';
 import { getCondaPythonVersions } from './provider/condaUtils';
 import { IPythonRuntimeManager } from '../../positron/manager';
 import { Conda } from '../common/environmentManagers/conda';
-import { createEnvironmentAndRegister, getCreateEnvironmentProviders, isGlobalPython } from '../../positron/createEnvApi';
+import {
+    createEnvironmentAndRegister,
+    getCreateEnvironmentProviders,
+    isGlobalPython,
+} from '../../positron/createEnvApi';
 // --- End Positron ---
 
 class CreateEnvironmentProviders {

--- a/src/vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/interfaces/newProjectWizardEnums.ts
@@ -35,11 +35,3 @@ export enum PythonEnvironmentProvider {
 	Venv = 'Venv',
 	Conda = 'Conda'
 }
-
-/**
- * PythonRuntimeFilter enum.
- */
-export enum PythonRuntimeFilter {
-	Global = 'Global',
-	Pyenv = 'Pyenv'
-}


### PR DESCRIPTION
### Addresses
- https://github.com/posit-dev/positron/issues/5341
- https://github.com/posit-dev/positron/issues/4270

### Implementation
- add new command `python.isGlobalPython` to the Python extension
    - Given a python interpreter path, return whether it is a global python interpreter
- remove `RuntimeFilter`, `PythonRuntimeFilter` and `runtimeSource` filtering logic from the Project Wizard, which would require an update to the appropriate enum every time we want to recognize a specific `runtimeSource` as a permitted "Global Python"
- rework `_getFilteredInterpreters()` to return all interpreters, only global interpreters, or undefined depending on the current state of the project wizard
- add/update log messages in the Project Wizard state handling methods

### QA Notes

On Windows, `MicrosoftStore`-installed Python versions should now show in the Project Wizard interpreter dropdown when creating a new Venv.

![image](https://github.com/user-attachments/assets/0e17cfab-ef97-4d73-b2da-4232c211bb0f)

On other operating systems, Global, Pyenv, Unknown and any other "Global" Python installations should show in the Project Wizard interpreter dropdown when creating a new Venv.

<img width="706" alt="image" src="https://github.com/user-attachments/assets/0ef25448-3df6-4c61-b0d0-f02440cdf6a9">
