### PR TITLE
Fix error propagation for supervisor

### DIFF
--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -711,7 +711,8 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 	async start(): Promise<positron.LanguageRuntimeInfo> {
 		try {
 			// Attempt to start the session
-			return this.tryStart();
+			const info = await this.tryStart();
+			return info;
 		} catch (err) {
 			if (err instanceof HttpError && err.statusCode === 500) {
 				// When the server returns a 500 error, it means the startup


### PR DESCRIPTION
This change improves the error message for some fairly generic-looking errors like "HTTP request failed" that are occasionally reported when kernels fail to start.

The change may look like a no-op, but it isn't; because of the way JS async exception handling works, we need to explicitly `await` the async expression in order to catch exceptions. What was happening here was that exceptions thrown from `tryStart()` in this codepath were not getting handled in the `try/catch` block (despite being thrown from inside the block). Instead, they were thrown directly by `start()`, with the result that none of the code intended to marshal API errors to the UI layer was running to summarize the error.

Partial backport of https://github.com/posit-dev/positron/pull/5490 for the 2024.11.1 branch.