### PR TITLE
Remove second copy of `positron.r.extraArguments` configuration

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -155,15 +155,6 @@
             "default": false,
             "description": "%r.configuration.restoreWorkspace.description%"
           },
-          "positron.r.extraArguments": {
-            "scope": "window",
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "default": [],
-            "description": "%r.configuration.extraArguments.description%"
-          },
           "positron.r.quietMode": {
             "scope": "window",
             "type": "boolean",


### PR DESCRIPTION
I noticed this while putting something else behind a feature flag. We've got 2 complete copies of the configuration for `positron.r.extraArguments`. It was introduced in #3950.

I had to decide which section to leave this in and decided it was advanced, but this is not a hill I will die on. I'm fine with keeping it in the not-advanced settings and removing from advanced, either way.