### PR TITLE
Fix scrolling in variables view for web

### DIFF
--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
@@ -7,7 +7,7 @@ import 'vs/css!./variablesInstance';
 import * as React from 'react';
 import { KeyboardEvent, useEffect, useRef, useState } from 'react'; // eslint-disable-line no-duplicate-imports
 import * as DOM from 'vs/base/browser/dom';
-import { isMacintosh } from 'vs/base/common/platform';
+import { isMacintosh, isWeb } from 'vs/base/common/platform';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { useStateRef } from 'vs/base/browser/ui/react/useStateRef';
 import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
@@ -512,6 +512,17 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 			return null;
 		}
 	};
+
+	// workaround for web disabling scrolling on the window to prevent URL navigation
+	useEffect(() => {
+		if (!isWeb) {
+			return;
+		}
+
+		outerRef.current?.addEventListener('wheel', (e: WheelEvent) => {
+			innerRef.current.parentElement?.scrollBy(e.deltaX, e.deltaY);
+		});
+	}, [innerRef]);
 
 	// Render.
 	return (

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
@@ -448,6 +448,15 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 		positronVariablesContext.reactComponentContainer.focusChanged?.(false);
 	};
 
+	// workaround for web disabling scrolling on the window to prevent URL navigation
+	const wheelHandler = (e: React.WheelEvent<HTMLDivElement>) => {
+		if (!isWeb) {
+			return;
+		}
+
+		innerRef.current.parentElement?.scrollBy(e.deltaX, e.deltaY);
+	};
+
 	/**
 	 * VariableEntry component.
 	 * @param index The index of the variable entry.
@@ -513,17 +522,6 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 		}
 	};
 
-	// workaround for web disabling scrolling on the window to prevent URL navigation
-	useEffect(() => {
-		if (!isWeb) {
-			return;
-		}
-
-		outerRef.current?.addEventListener('wheel', (e: WheelEvent) => {
-			innerRef.current.parentElement?.scrollBy(e.deltaX, e.deltaY);
-		});
-	}, [innerRef]);
-
 	// Render.
 	return (
 		<div
@@ -534,6 +532,7 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 			onKeyDown={keyDownHandler}
 			onFocus={focusHandler}
 			onBlur={blurHandler}
+			onWheel={wheelHandler}
 		>
 			{!variableEntries.length ?
 				<VariablesEmpty initializing={initializing} /> :


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

Address #5473

Adds a mouse wheel listener to the div containing list and forward it to the `List` component. I tried to wrap everything in a `Scrollable` but it would take more time to get everything working the same way. The `List` component does some extra list virtualization for performance that I didn't want to risk touching that the `Scrollable` would have to replace.

### QA Notes
Creating enough variables to fill more than the Variables view is one way to test. Another is creating a dataframe and expanding some of the data in it.

```python
#Python
a = 0
b = 0
c = 0
d = 0
e = 0
f = 0
```
```r
#R
df <- iris
```

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
