### PR TITLE
Data Explorer: Update Python kernel to latest comm definition, fix Optional logic error

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -1594,6 +1594,10 @@ class ReturnColumnProfilesParams(BaseModel):
         description="Array of individual column profile results",
     )
 
+    error_message: Optional[StrictStr] = Field(
+        description="Optional error message if something failed to compute",
+    )
+
 
 OpenDatasetResult.update_forward_refs()
 

--- a/positron/comms/data_explorer-frontend-openrpc.json
+++ b/positron/comms/data_explorer-frontend-openrpc.json
@@ -44,6 +44,7 @@
 				{
 					"name": "error_message",
 					"description": "Optional error message if something failed to compute",
+					"required": false,
 					"schema": {
 						"type": "string"
 					}

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -1058,10 +1058,17 @@ from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictI
 				yield `    """\n`;
 				yield `\n`;
 				for (const param of method.params) {
+					yield `    ${param.name}: `;
+					if (isOptional(param)) {
+						yield `Optional[`;
+					}
 					if (param.schema.enum) {
-						yield `    ${param.name}: ${snakeCaseToSentenceCase(method.name)}${snakeCaseToSentenceCase(param.name)}`;
+						yield `${snakeCaseToSentenceCase(method.name)}${snakeCaseToSentenceCase(param.name)}`;
 					} else {
-						yield `    ${param.name}: ${deriveType(contracts, PythonTypeMap, [param.name], param.schema)}`;
+						yield `${deriveType(contracts, PythonTypeMap, [param.name], param.schema)}`;
+					}
+					if (isOptional(param)) {
+						yield `]`;
 					}
 					yield ' = Field(\n';
 					yield `        description="${param.description}",\n`;
@@ -1315,7 +1322,11 @@ import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/co
 				yield '\t/**\n';
 				yield formatComment('\t * ', `${param.description}`);
 				yield '\t */\n';
-				yield `\t${param.name}: `;
+				yield `\t${param.name}`;
+				if (isOptional(param)) {
+					yield '?';
+				}
+				yield ': ';
 				if (param.schema.type === 'string' && param.schema.enum) {
 					yield `${snakeCaseToSentenceCase(method.name)}${snakeCaseToSentenceCase(param.name)}`;
 				} else {


### PR DESCRIPTION
Gardening related to #5128. Optional frontend method parameters were not handled in TypeScript or Python (but they were in Rust), so this has been fixed to be consistent.