### PR TITLE
Use data science appropriate examples for Problems filter placeholder

### DIFF
--- a/src/vs/workbench/contrib/markers/browser/messages.ts
+++ b/src/vs/workbench/contrib/markers/browser/messages.ts
@@ -37,7 +37,10 @@ export default class Messages {
 	public static MARKERS_PANEL_ACTION_TOOLTIP_FILTER: string = nls.localize('markers.panel.action.filter', "Filter Problems");
 	public static MARKERS_PANEL_ACTION_TOOLTIP_QUICKFIX: string = nls.localize('markers.panel.action.quickfix', "Show fixes");
 	public static MARKERS_PANEL_FILTER_ARIA_LABEL: string = nls.localize('markers.panel.filter.ariaLabel', "Filter Problems");
-	public static MARKERS_PANEL_FILTER_PLACEHOLDER: string = nls.localize('markers.panel.filter.placeholder', "Filter (e.g. text, **/*.ts, !**/node_modules/**)");
+	// --- Start Positron ---
+	// public static MARKERS_PANEL_FILTER_PLACEHOLDER: string = nls.localize('markers.panel.filter.placeholder', "Filter (e.g. text, **/*.ts, !**/node_modules/**)");
+	public static MARKERS_PANEL_FILTER_PLACEHOLDER: string = nls.localize('markers.panel.filter.placeholder', "Filter (e.g. text, **/*.py, *.R, !*.html, !data/**)");
+	// --- End Positron
 	public static MARKERS_PANEL_FILTER_ERRORS: string = nls.localize('markers.panel.filter.errors', "errors");
 	public static MARKERS_PANEL_FILTER_WARNINGS: string = nls.localize('markers.panel.filter.warnings', "warnings");
 	public static MARKERS_PANEL_FILTER_INFOS: string = nls.localize('markers.panel.filter.infos', "infos");


### PR DESCRIPTION
Addresses #5524


### QA Notes

We should now see more data science appropriate examples in the placeholder text for the Problems filter:

![Screenshot 2024-11-26 at 3 21 53 PM](https://github.com/user-attachments/assets/9d0acee9-1e84-478d-a837-12618048cbac)

