### PR TITLE
Bump ark to 0.1.156

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -667,7 +667,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.155"
+      "ark": "0.1.156"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
### Release Notes

#### New Features

- The variable pane now supports labels from the {haven} package (https://github.com/posit-dev/positron/issues/5327.

- The variable pane has improved support for formulas (https://github.com/posit-dev/positron/issues/4119).

#### Bug Fixes

- Assignments in function calls (e.g. `list(x <- 1)`) are now detected by the missing symbol linter to avoid false positive diagnostics (posit-dev/positron#3048). The flip side is that this causes false negatives when the assignment happens in a call with local scope, e.g. in `local()` or `test_that()`. In these cases the nested assignments will incorrectly overlast the end of the call. We prefer to be overly optimistic than overly cautious in these matters.

- The following environment variables are now set in the same way that R does:

  - `R_SHARE_DIR`
  - `R_INCLUDE_DIR`
  - `R_DOC_DIR`

  This solves a number of problems in situations that depend on these variables being defined (https://github.com/posit-dev/positron/issues/3637).

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

