### PR TITLE
Establish Ready listener before restarting

### DIFF
--- a/extensions/positron-r/src/util.ts
+++ b/extensions/positron-r/src/util.ts
@@ -8,12 +8,20 @@ import * as fs from 'fs';
 export class PromiseHandles<T> {
 	resolve!: (value: T | Promise<T>) => void;
 	reject!: (error: unknown) => void;
+	settled: boolean;
 	promise: Promise<T>;
 
 	constructor() {
+		this.settled = false;
 		this.promise = new Promise((resolve, reject) => {
-			this.resolve = resolve;
-			this.reject = reject;
+			this.resolve = (val) => {
+				this.settled = true;
+				resolve(val);
+			};
+			this.reject = (err) => {
+				this.settled = true;
+				reject(err);
+			};
 		});
 	}
 }


### PR DESCRIPTION
This change fixes an issue with the R package dev workflow introduced by the new supervisor. In particular, the new supervisor's `restart` API call does not return until the restart is finished, so waiting for the `Ready` state after the restart finishes results in waiting forever (it's _already_ `Ready`). 

Addresses https://github.com/posit-dev/positron/issues/5532.

### QA Notes

This is a minimal change that addresses the above issue, but while debugging the problem, I found another one: namely that you can do this "install and restart" thing only once or twice before it stops working. Requests to restart the kernel that are initiated from extensions are (... _sometimes_) resulting in multiple UI comms open, so RPCs called like `get_env_vars` appear to not return as they're sent to the wrong comm. So we've got more to do here, but I think this improvement is worth taking on its own.