### PR TITLE
e2e-test: upload logs

### DIFF
--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -206,6 +206,13 @@ jobs:
           path: blob-report
           retention-days: 14
 
+      - name: Upload logs
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-browser
+          path: test-logs
+
       - name: Clean up license files
         if: always()
         run: cd .. && rm -rf positron-license

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -192,6 +192,8 @@ jobs:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Preloading ensures the Node.js binary is fully built and ready before
+      # any parallel processes start, preventing runtime conflicts
       - name: Preload Node.js Binary
         run: yarn gulp node
 

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -133,7 +133,7 @@ jobs:
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CURRENTS_TAG: "electron"
         id: electron-tests
-        run: DISPLAY=:10 npx playwright test --project e2e-electron --workers 3
+        run: DISPLAY=:10 npx playwright test --project e2e-electron --workers 2
 
       - name: Upload blob report
         if: ${{ !cancelled() }}
@@ -149,6 +149,13 @@ jobs:
         with:
           name: junit-report-electron
           path: test-results/junit.xml
+
+      - name: Upload logs
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-electron
+          path: test-logs
 
   e2e-browser-tests:
     runs-on: ubuntu-latest-8x

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -185,6 +185,9 @@ jobs:
           aws-region: ${{ secrets.QA_AWS_REGION }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Preload Node.js Binary
+        run: yarn gulp node
+
       - name: Run Tests (Browser)
         env:
           POSITRON_PY_VER_SEL: 3.10.12

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -158,11 +158,11 @@ jobs:
             github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
             license-key: ${{ secrets.POSITRON_DEV_LICENSE }}
 
-        # one unit test needs this: Can list tables and fields from R connections
-        # - name: Setup R
-        #   uses: ./.github/actions/install-r
-        #   with:
-        #     version: "4.4.0"
+        # one integration test needs this: Connections pane works for R
+        - name: Setup R
+          uses: ./.github/actions/install-r
+          with:
+            version: "4.4.0"
 
         - name: Compile Integration Tests
           run: yarn --cwd test/integration/browser compile

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -131,7 +131,7 @@ jobs:
         run: DISPLAY=:10 yarn test-browser-no-install --browser chromium
 
   integration-tests:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-latest-4x
       timeout-minutes: 20
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -170,6 +170,16 @@ jobs:
         - name: Run Integration Tests (Electron)
           id: electron-integration-tests
           run: DISPLAY=:10 ./scripts/test-integration-pr.sh
+
+        - name: Run Integration Tests (Remote)
+          if: ${{ job.status != 'cancelled' && (success() || failure()) }}
+          id: electron-remote-integration-tests
+          run: DISPLAY=:10 ./scripts/test-remote-integration.sh
+
+        - name: Run Integration Tests (Browser, Chromium)
+          if: ${{ job.status != 'cancelled' && (success() || failure()) }}
+          id: browser-integration-tests
+          run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
 
   slack-notification:
     name: "Send Slack notification"

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -131,7 +131,7 @@ jobs:
         run: DISPLAY=:10 yarn test-browser-no-install --browser chromium
 
   integration-tests:
-      runs-on: ubuntu-latest-4x
+      runs-on: ubuntu-latest
       timeout-minutes: 20
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
 
-  unit-integration:
+  unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -118,21 +118,63 @@ jobs:
         with:
           version: "4.4.0"
 
-      - name: Compile Integration Tests
-        run: yarn --cwd test/integration/browser compile
+      - name: Run Unit Tests (Electron)
+        id: electron-unit-tests
+        run: DISPLAY=:10 ./scripts/test.sh
 
       - name: Run Unit Tests (node.js)
         id: nodejs-unit-tests
         run: yarn test-node
 
-      - name: Run Integration Tests (Electron)
-        id: electron-integration-tests
-        run: DISPLAY=:10 ./scripts/test-integration-pr.sh
+      - name: Run Unit Tests (Browser, Chromium)
+        id: browser-unit-tests
+        run: DISPLAY=:10 yarn test-browser-no-install --browser chromium
+
+  integration-tests:
+      runs-on: ubuntu-latest-4x
+      timeout-minutes: 20
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        POSITRON_BUILD_NUMBER: 0 # CI skips building releases
+        _R_CHECK_FUTURE_FILE_TIMESTAMPS_: false # this check can be flaky in the R pkg tests
+        _R_CHECK_CRAN_INCOMING_: false
+        _R_CHECK_SYSTEM_CLOCK_: false
+      steps:
+        - uses: actions/checkout@v4
+
+        - uses: actions/setup-node@v4
+          with:
+            node-version-file: .nvmrc
+
+        - name: Cache node_modules, build, extensions, and remote
+          uses: ./.github/actions/cache-multi-paths
+
+        - name: Setup Build and Compile
+          uses: ./.github/actions/setup-build-env
+
+        - name: Install Positron License
+          uses: ./.github/actions/install-license
+          with:
+            github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
+            license-key: ${{ secrets.POSITRON_DEV_LICENSE }}
+
+        # one unit test needs this: Can list tables and fields from R connections
+        # - name: Setup R
+        #   uses: ./.github/actions/install-r
+        #   with:
+        #     version: "4.4.0"
+
+        - name: Compile Integration Tests
+          run: yarn --cwd test/integration/browser compile
+
+        - name: Run Integration Tests (Electron)
+          id: electron-integration-tests
+          run: DISPLAY=:10 ./scripts/test-integration-pr.sh
 
   slack-notification:
     name: "Send Slack notification"
     runs-on: ubuntu-latest
-    needs: [unit-integration, e2e-electron]
+    needs: [unit-tests, integration-tests, e2e-electron]
     if: ${{ failure() && inputs.e2e_grep == '' }}
     steps:
       - name: "Send Slack notification"

--- a/test/automation/src/playwrightBrowser.ts
+++ b/test/automation/src/playwrightBrowser.ts
@@ -11,6 +11,9 @@ import { URI } from 'vscode-uri';
 import { Logger, measureAndLog } from './logger';
 import type { LaunchOptions } from './code';
 import { PlaywrightDriver } from './playwrightDriver';
+// --- Start Positron ---
+import * as fs from 'fs';
+// --- End Positron ---
 
 const root = join(__dirname, '..', '..', '..');
 
@@ -47,6 +50,7 @@ async function launchServer(options: LaunchOptions) {
 		...process.env,
 	};
 
+	const lockFilePath = join(agentFolder, 'node.lock');
 	const maxRetries = 10;
 	let serverProcess: ChildProcess | null = null;
 	let endpoint: string | undefined;
@@ -59,7 +63,13 @@ async function launchServer(options: LaunchOptions) {
 		logger.log(`Attempting to start server on port ${currentPort}`);
 		logger.log(`Command: '${serverLocation}' ${args.join(' ')}`);
 
+		let lockFile: fs.promises.FileHandle | null = null;
+
 		try {
+			// create and acquire the lock
+			lockFile = await fs.promises.open(lockFilePath, 'w'); // open lock file
+			await lockFile.write('locked'); // write to lock file to signal lock acquisition
+
 			serverProcess = await startServer(serverLocation, args, env, logger);
 			endpoint = await measureAndLog(
 				() => waitForEndpoint(serverProcess!, logger),
@@ -73,9 +83,20 @@ async function launchServer(options: LaunchOptions) {
 			if ((error as Error).message.includes('EADDRINUSE')) {
 				logger.log(`Port ${currentPort} is already in use. Retrying...`);
 				serverProcess?.kill();
+			} else if ((error as Error).message.includes('EBUSY')) {
+				logger.log('Node.js binary is busy. Waiting for lock...');
+				await new Promise(resolve => setTimeout(resolve, 500));
 			} else {
-				throw error; // Rethrow non-port-related errors
+				throw error;
 			}
+		} finally {
+			// ensure the lock file is properly closed and cleaned up
+			if (lockFile) {
+				await lockFile.close();
+			}
+			await fs.promises.unlink(lockFilePath).catch(() => {
+				logger.log(`Failed to remove lock file: ${lockFilePath}`);
+			});
 		}
 	}
 

--- a/test/smoke/src/areas/positron/_test.setup.ts
+++ b/test/smoke/src/areas/positron/_test.setup.ts
@@ -122,7 +122,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 		};
 
 		await use({ set: setInterpreter });
-	}, { scope: 'test', }],
+	}, { scope: 'test', timeout: 30000 }],
 
 	r: [
 		async ({ interpreter }, use) => {


### PR DESCRIPTION
### Summary
* upload logs artifacts for full test suite run
* turn on ALL unit and integration tests for PRs 😬 
* preload node binary for browser tests - it was causing a failure at startup due to parallelization conflict

<img width="347" alt="Screenshot 2024-12-02 at 7 35 54 AM" src="https://github.com/user-attachments/assets/fa66e860-e522-43be-9518-d6f7c9b91ae9">
