### PR TITLE
Simplify logic for switching runtimes for a notebook

### DIFF
--- a/extensions/positron-notebook-controllers/src/notebookController.ts
+++ b/extensions/positron-notebook-controllers/src/notebookController.ts
@@ -94,7 +94,7 @@ export class NotebookController implements vscode.Disposable {
 
 				await Promise.all([
 					updateNotebookLanguage(e.notebook, _runtimeMetadata.languageId),
-					this.startRuntimeSession(e.notebook),
+					this.selectRuntimeSession(e.notebook),
 				]);
 			} else {
 				await this._notebookSessionService.shutdownRuntimeSession(e.notebook.uri);
@@ -105,6 +105,16 @@ export class NotebookController implements vscode.Disposable {
 	/** The human-readable label of the controller. */
 	public get label(): string {
 		return this._runtimeMetadata.runtimeName;
+	}
+
+	private async selectRuntimeSession(notebook: vscode.NotebookDocument): Promise<void> {
+		// If there's an existing session from another runtime, shut it down.
+		if (this._notebookSessionService.hasStartingOrRunningNotebookSession(notebook.uri)) {
+			await this._notebookSessionService.shutdownRuntimeSession(notebook.uri);
+		}
+
+		// Start the new session.
+		await this.startRuntimeSession(notebook);
 	}
 
 	/**


### PR DESCRIPTION
A little refactor to simplify the logic for switching runtimes for a notebook.

When a user switches from one Positron notebook controller to another, two events are fired: one with `selected === true` and one with `selected === false`. The order of those events is not guaranteed, so we have to be careful about the order we request to shutdown the previous runtime and start the new one.

We previously worked around that by retrying the start request, but it's much simpler to shutdown any existing runtimes in the `selected === true` case.

### QA Notes

In a notebook, if you change the selected runtime a bunch of times you should be able to execute code in any selected runtime and there should not be any error notifications or console logs.