### PR TITLE
Use a global interrupt handler and handle interrupt edge cases

### DIFF
--- a/extensions/positron-notebook-controllers/src/test/testLanguageRuntimeSession.ts
+++ b/extensions/positron-notebook-controllers/src/test/testLanguageRuntimeSession.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { randomUUID } from 'crypto';
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+
+export class TestLanguageRuntimeSession implements Partial<positron.LanguageRuntimeSession> {
+	private _lastExecutionId?: string;
+	private readonly _onDidReceiveRuntimeMessage = new vscode.EventEmitter<positron.LanguageRuntimeMessage>();
+	private readonly _onDidExecute = new vscode.EventEmitter<string>();
+
+	public readonly onDidReceiveRuntimeMessage = this._onDidReceiveRuntimeMessage.event;
+	public readonly onDidExecute = this._onDidExecute.event;
+
+	public readonly metadata = {
+		sessionId: 'test-session',
+	} as positron.RuntimeSessionMetadata;
+
+	execute(_code: string, id: string, _mode: positron.RuntimeCodeExecutionMode, _errorBehavior: positron.RuntimeErrorBehavior) {
+		this._lastExecutionId = id;
+		this._onDidExecute.fire(id);
+	}
+
+	async interrupt(): Promise<void> {
+		if (this._lastExecutionId) {
+			this.fireErrorMessage(this._lastExecutionId);
+		}
+	}
+
+	dispose() {
+		this._onDidReceiveRuntimeMessage.dispose();
+	}
+
+	// Test helpers
+
+	public fireErrorMessage(parent_id: string) {
+		this._onDidReceiveRuntimeMessage.fire({
+			id: randomUUID(),
+			type: positron.LanguageRuntimeMessageType.Error,
+			parent_id,
+			when: new Date().toISOString(),
+			message: 'An error occurred.',
+			name: 'Error',
+			traceback: ['Traceback line 1', 'Traceback line 2'],
+		} as positron.LanguageRuntimeError);
+	}
+
+	public fireIdleMessage(parent_id: string) {
+		this._onDidReceiveRuntimeMessage.fire({
+			id: randomUUID(),
+			type: positron.LanguageRuntimeMessageType.State,
+			parent_id,
+			when: new Date().toISOString(),
+			state: positron.RuntimeOnlineState.Idle,
+		} as positron.LanguageRuntimeState);
+	}
+}

--- a/extensions/positron-notebook-controllers/src/test/testNotebookCellExecution.ts
+++ b/extensions/positron-notebook-controllers/src/test/testNotebookCellExecution.ts
@@ -9,6 +9,8 @@ export class TestNotebookCellExecution implements vscode.NotebookCellExecution {
 	token: vscode.CancellationToken;
 	executionOrder: number | undefined;
 
+	private readonly tokenSource = new vscode.CancellationTokenSource();
+
 	private _started = false;
 	private _startTime?: number;
 	private _ended = false;
@@ -18,8 +20,7 @@ export class TestNotebookCellExecution implements vscode.NotebookCellExecution {
 	constructor(
 		public readonly cell: vscode.NotebookCell,
 	) {
-		const tokenSource = new vscode.CancellationTokenSource();
-		this.token = tokenSource.token;
+		this.token = this.tokenSource.token;
 	}
 
 	start(startTime?: number): void {
@@ -67,6 +68,10 @@ export class TestNotebookCellExecution implements vscode.NotebookCellExecution {
 
 	get endTime() {
 		return this._endTime;
+	}
+
+	interrupt() {
+		this.tokenSource.cancel();
 	}
 
 	assertDidStart() {


### PR DESCRIPTION
Attempts to address #3805.

There are two parts to this:

1. Moved from using cell-level interrupt (`NotebookCellExecution.token`) to notebook-level interrupt (`NotebookController.interruptHandler`), which I believe is the correct approach when there is really a single global kernel backing executions. Cell-level interrupt also only let you interrupt once, and sometimes Python requires multiple interrupts.
2. Better handling for edge cases when interrupting such as the session having exited unexpectedly.

### QA Notes

Since the addressed issue is intermittent, it's hard to test. Opening and closing notebooks, and starting and interrupting executions in different ways should all be more stable with this PR.

Integration tests should also pass locally.