### PR TITLE
e2e-test: skip viewer test

### DIFF
--- a/test/smoke/src/areas/positron/viewer/viewer.test.ts
+++ b/test/smoke/src/areas/positron/viewer/viewer.test.ts
@@ -15,7 +15,9 @@ test.describe('Viewer', () => {
 		await app.workbench.positronViewer.clearViewer();
 	});
 
-	test('Python - Verify Viewer functionality with vetiver [C784887]', async function ({ app, logger, python }) {
+	test.skip('Python - Verify Viewer functionality with vetiver [C784887]', {
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5569' }]
+	}, async function ({ app, logger, python }) {
 		logger.log('Sending code to console');
 		await app.workbench.positronConsole.pasteCodeToConsole(pythonScript);
 		await app.workbench.positronConsole.sendEnterKey();


### PR DESCRIPTION
### QA Notes

Skipping viewer test for now until we understand why it's failing only in CI all of a sudden. Linked issue to test as well.