### PR TITLE
test: improve slack notifications

### DIFF
--- a/.github/actions/e2e-report/action.yml
+++ b/.github/actions/e2e-report/action.yml
@@ -13,12 +13,6 @@ inputs:
   blob-pattern:
     description: "Pattern to match blob reports"
     default: "blob-report-*"
-  repo-token:
-    description: "GitHub token for API calls"
-    required: true
-  slack-webhook:
-    description: "Slack webhook for notifications"
-    required: true
   testrail-api-key:
     description: "TestRail API Key"
     required: true
@@ -31,9 +25,6 @@ inputs:
   testrail-title:
     description: "Title for TestRail runs"
     default: "E2E Test Run"
-  upstream-failed:
-    description: "Status of upstream jobs (true if any failed)"
-    required: true
 
 runs:
   using: "composite"
@@ -107,12 +98,3 @@ runs:
         TESTRAIL_TITLE="$(date +'%Y-%m-%d') ${{ inputs.testrail-title }} - $GITHUB_REF_NAME"
         echo "TESTRAIL_TITLE=$TESTRAIL_TITLE" >> $GITHUB_ENV
         trcli --host "https://posit.testrail.io/" --project "${{ inputs.testrail-project }}" --username testrailautomation@posit.co --key "${{ inputs.testrail-api-key }}" parse_junit --file "./junit.xml" --case-matcher name --title "$TESTRAIL_TITLE" --close-run
-
-    - name: Send Slack Notification
-      uses: Gamesight/slack-workflow-status@master
-      if: inputs.upstream-failed == 'true'
-      with:
-        repo_token: ${{ inputs.repo-token }}
-        slack_webhook_url: ${{ inputs.slack-webhook }}
-        include_commit_message: true
-

--- a/.github/actions/e2e-report/action.yml
+++ b/.github/actions/e2e-report/action.yml
@@ -13,15 +13,12 @@ inputs:
   blob-pattern:
     description: "Pattern to match blob reports"
     default: "blob-report-*"
-  slack-token:
-    description: "Slack token for notifications"
+  repo-token:
+    description: "GitHub token for API calls"
     required: true
-  slack-channel:
-    description: "Slack channel for notifications"
+  slack-webhook:
+    description: "Slack webhook for notifications"
     required: true
-  slack-title:
-    description: "Slack title for the test suite"
-    default: "Test Suite Results"
   testrail-api-key:
     description: "TestRail API Key"
     required: true
@@ -34,6 +31,9 @@ inputs:
   testrail-title:
     description: "Title for TestRail runs"
     default: "E2E Test Run"
+  upstream-failed:
+    description: "Status of upstream jobs (true if any failed)"
+    required: true
 
 runs:
   using: "composite"
@@ -109,9 +109,10 @@ runs:
         trcli --host "https://posit.testrail.io/" --project "${{ inputs.testrail-project }}" --username testrailautomation@posit.co --key "${{ inputs.testrail-api-key }}" parse_junit --file "./junit.xml" --case-matcher name --title "$TESTRAIL_TITLE" --close-run
 
     - name: Send Slack Notification
-      uses: testlabauto/action-test-results-to-slack@v0.0.6
+      uses: Gamesight/slack-workflow-status@master
+      if: inputs.upstream-failed == 'true'
       with:
-        github_token: ${{ inputs.github-token }}
-        slack_token: ${{ inputs.slack-token }}
-        slack_channel: ${{ inputs.slack-channel }}
-        suite_name: ${{ inputs.slack-title }}
+        repo_token: ${{ inputs.repo-token }}
+        slack_webhook_url: ${{ inputs.slack-webhook }}
+        include_commit_message: true
+

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -3,15 +3,15 @@ description: "Installs necessary system dependencies."
 runs:
   using: "composite"
   steps:
-    - name: Install Build Dependencies
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          vim curl build-essential clang make cmake git \
-      # libsodium-dev libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb \
-      # libgtk-3-0 libgbm1 libnss3 libnspr4 libasound2 libkrb5-dev libcairo-dev \
-      # libsdl-pango-dev libjpeg-dev libgif-dev pandoc
+    # - name: Install Build Dependencies
+    #   shell: bash
+    #   run: |
+    #     sudo apt-get update
+    #     sudo apt-get install -y \
+    #       vim curl build-essential clang make cmake git \
+    #       libsodium-dev libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb \
+    #       libgtk-3-0 libgbm1 libnss3 libnspr4 libasound2 libkrb5-dev libcairo-dev \
+    #       libsdl-pango-dev libjpeg-dev libgif-dev pandoc
 
     - name: Execute yarn
       shell: bash

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -9,9 +9,9 @@ runs:
         sudo apt-get update
         sudo apt-get install -y \
           vim curl build-essential clang make cmake git \
-          libsodium-dev libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb \
-          libgtk-3-0 libgbm1 libnss3 libnspr4 libasound2 libkrb5-dev libcairo-dev \
-          libsdl-pango-dev libjpeg-dev libgif-dev pandoc
+      # libsodium-dev libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb \
+      # libgtk-3-0 libgbm1 libnss3 libnspr4 libasound2 libkrb5-dev libcairo-dev \
+      # libsdl-pango-dev libjpeg-dev libgif-dev pandoc
 
     - name: Execute yarn
       shell: bash

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -3,15 +3,15 @@ description: "Installs necessary system dependencies."
 runs:
   using: "composite"
   steps:
-    # - name: Install Build Dependencies
-    #   shell: bash
-    #   run: |
-    #     sudo apt-get update
-    #     sudo apt-get install -y \
-    #       vim curl build-essential clang make cmake git \
-    #       libsodium-dev libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb \
-    #       libgtk-3-0 libgbm1 libnss3 libnspr4 libasound2 libkrb5-dev libcairo-dev \
-    #       libsdl-pango-dev libjpeg-dev libgif-dev pandoc
+    - name: Install Build Dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          vim curl build-essential clang make cmake git \
+          libsodium-dev libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb \
+          libgtk-3-0 libgbm1 libnss3 libnspr4 libasound2 libkrb5-dev libcairo-dev \
+          libsdl-pango-dev libjpeg-dev libgif-dev pandoc
 
     - name: Execute yarn
       shell: bash

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -235,8 +235,8 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.48.0-jammy
     needs: [e2e-electron-tests, e2e-browser-tests, unit-tests, integration-tests]
-    permissions:
-      actions: 'read'
+    # permissions:
+    #   actions: 'read'
     env:
       REPORT_DIR: playwright-report-${{ github.run_id }}
       UPSTREAM_FAILED: ${{
@@ -256,19 +256,21 @@ jobs:
       - name: Debug Upstream Status
         shell: bash
         run: echo "UPSTREAM_FAILED=$UPSTREAM_FAILED"
-
-      - name: Slack Workflow Notification
-        uses: Gamesight/slack-workflow-status@master
-        with:
-          repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
-          include_commit_message: true
-
       - name: Run E2E Report
         uses: ./.github/actions/e2e-report
+        if: always()
         with:
           aws-s3-bucket: positron-test-reports
           aws-role: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
           testrail-api-key: ${{ secrets.TESTRAIL_API_KEY }}
           testrail-title: "E2E Electron Test Run"
+
+      - name: Slack Workflow Notification
+        # if: ${{ env.UPSTREAM_FAILED == 'true' }}
+        if: always()
+        uses: Gamesight/slack-workflow-status@master
+        with:
+          repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
+          include_commit_message: true
 

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -1,4 +1,4 @@
-name: "Positron: Full Test Suite"
+name: "Test: Full Suite (Ubuntu)"
 
 # Run tests daily at 4am UTC (11p EST) on weekdays for now, or manually
 on:
@@ -243,7 +243,8 @@ jobs:
         needs.unit-tests.result == 'failure' ||
         needs.integration-tests.result == 'failure' }}
     permissions:
-      contents: read
+        contents: write # required for S3 upload
+        actions: read   # required for Slack notifications
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -261,4 +261,4 @@ jobs:
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL }}
-          notify_on: "failure-only"
+          notify_on: "failure"

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -261,5 +261,4 @@ jobs:
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL }}
-          include_commit_message: true
           notify_on: "failure-only"

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -267,4 +267,5 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
           # channel: C07FR1JNZNJ # positron-test-results channel
           include_commit_message: true
-          notify_on: "fail-only"
+          # notify_on: "fail-only"
+          notify_on: "always"

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -235,6 +235,8 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.48.0-jammy
     needs: [e2e-electron-tests, e2e-browser-tests, unit-tests, integration-tests]
+    permissions:
+      actions: 'read'
     env:
       REPORT_DIR: playwright-report-${{ github.run_id }}
       UPSTREAM_FAILED: ${{
@@ -242,9 +244,6 @@ jobs:
         needs.e2e-browser-tests.result == 'failure' ||
         needs.unit-tests.result == 'failure' ||
         needs.integration-tests.result == 'failure' }}
-    permissions:
-        contents: write # required for S3 upload
-        actions: read   # required for Slack notifications
 
     steps:
       - uses: actions/checkout@v4
@@ -258,14 +257,18 @@ jobs:
         shell: bash
         run: echo "UPSTREAM_FAILED=$UPSTREAM_FAILED"
 
+      - name: Slack Workflow Notification
+        uses: Gamesight/slack-workflow-status@master
+        with:
+          repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
+          include_commit_message: true
+
       - name: Run E2E Report
         uses: ./.github/actions/e2e-report
         with:
           aws-s3-bucket: positron-test-reports
           aws-role: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
-          repo-token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          slack-webhook: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
           testrail-api-key: ${{ secrets.TESTRAIL_API_KEY }}
           testrail-title: "E2E Electron Test Run"
-          github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          upstream-failed: ${{ env.UPSTREAM_FAILED }}
+

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -246,10 +246,6 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: Debug Upstream Status
-        shell: bash
-        run: echo "UPSTREAM_FAILED=$UPSTREAM_FAILED"
-
       - name: Run E2E Report
         uses: ./.github/actions/e2e-report
         if: always()

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -237,6 +237,13 @@ jobs:
     needs: [e2e-electron-tests, e2e-browser-tests, unit-tests, integration-tests]
     env:
       REPORT_DIR: playwright-report-${{ github.run_id }}
+      UPSTREAM_FAILED: ${{
+        needs.e2e-electron-tests.result == 'failure' ||
+        needs.e2e-browser-tests.result == 'failure' ||
+        needs.unit-tests.result == 'failure' ||
+        needs.integration-tests.result == 'failure' }}
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -246,14 +253,18 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Debug Upstream Status
+        shell: bash
+        run: echo "UPSTREAM_FAILED=$UPSTREAM_FAILED"
+
       - name: Run E2E Report
         uses: ./.github/actions/e2e-report
         with:
           aws-s3-bucket: positron-test-reports
           aws-role: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
-          slack-token: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
-          slack-channel: C07FR1JNZNJ
-          slack-title: "Full Test Suite (Electron)"
+          repo-token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          slack-webhook: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
           testrail-api-key: ${{ secrets.TESTRAIL_API_KEY }}
           testrail-title: "E2E Electron Test Run"
           github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          upstream-failed: ${{ env.UPSTREAM_FAILED }}

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -260,8 +260,6 @@ jobs:
         if: always()
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
-          # channel: C07FR1JNZNJ # positron-test-results channel
+          slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL }}
           include_commit_message: true
-          # notify_on: "fail-only"
-          notify_on: "always"
+          notify_on: "failure-only"

--- a/.github/workflows/positron-full-test.yml
+++ b/.github/workflows/positron-full-test.yml
@@ -235,15 +235,8 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.48.0-jammy
     needs: [e2e-electron-tests, e2e-browser-tests, unit-tests, integration-tests]
-    # permissions:
-    #   actions: 'read'
     env:
       REPORT_DIR: playwright-report-${{ github.run_id }}
-      UPSTREAM_FAILED: ${{
-        needs.e2e-electron-tests.result == 'failure' ||
-        needs.e2e-browser-tests.result == 'failure' ||
-        needs.unit-tests.result == 'failure' ||
-        needs.integration-tests.result == 'failure' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -256,6 +249,7 @@ jobs:
       - name: Debug Upstream Status
         shell: bash
         run: echo "UPSTREAM_FAILED=$UPSTREAM_FAILED"
+
       - name: Run E2E Report
         uses: ./.github/actions/e2e-report
         if: always()
@@ -265,12 +259,12 @@ jobs:
           testrail-api-key: ${{ secrets.TESTRAIL_API_KEY }}
           testrail-title: "E2E Electron Test Run"
 
-      - name: Slack Workflow Notification
-        # if: ${{ env.UPSTREAM_FAILED == 'true' }}
+      - name: Send Slack Notification
+        uses: midleman/slack-workflow-status@master
         if: always()
-        uses: Gamesight/slack-workflow-status@master
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
+          # channel: C07FR1JNZNJ # positron-test-results channel
           include_commit_message: true
-
+          notify_on: "fail-only"

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -182,7 +182,8 @@ jobs:
           run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
 
   slack-notify:
-    if: ${{ failure() && inputs.e2e_grep == '' }}
+    # if: ${{ failure() && inputs.e2e_grep == '' }}
+    if: always()
     needs: [unit-tests, integration-tests, e2e-electron]
     runs-on: ubuntu-latest
     steps:
@@ -190,7 +191,8 @@ jobs:
         uses: midleman/slack-workflow-status@master
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL}}
-          notify_on: "on-failure"
+          slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL}}
+          include_jobs_time: 'false'
+          # notify_on: "on-failure"
 
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -183,7 +183,6 @@ jobs:
 
   slack-notify:
     # if: ${{ failure() && inputs.e2e_grep == '' }}
-    if: always()
     needs: [unit-tests, integration-tests, e2e-electron]
     runs-on: ubuntu-latest
     steps:
@@ -195,6 +194,6 @@ jobs:
           channel: C06DNFJSHPD
           # channel: C07FR1JNZNJ # positron-test-results channel
           include_commit_message: true
-          notify_on: 'always'
+          notify_on: 'on-failure'
 
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -191,7 +191,7 @@ jobs:
         uses: midleman/slack-workflow-status@master
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
+          slack_webhook_url: ${{ secrets.SLACK_QA_WEBHOOK_URL }}
           channel: C06DNFJSHPD
           # channel: C07FR1JNZNJ # positron-test-results channel
           include_commit_message: true

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -182,8 +182,7 @@ jobs:
           run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
 
   slack-notify:
-    # if: ${{ failure() && inputs.e2e_grep == '' }}
-    if: always()
+    if: ${{ failure() && inputs.e2e_grep == '' }}
     needs: [unit-tests, integration-tests, e2e-electron]
     runs-on: ubuntu-latest
     steps:
@@ -191,7 +190,7 @@ jobs:
         uses: midleman/slack-workflow-status@master
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
-          # notify_on: "on-failure"
+          slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL}}
+          notify_on: "on-failure"
 
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -182,7 +182,8 @@ jobs:
         #   run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
 
   slack-notify:
-    if: ${{ failure() && inputs.e2e_grep == '' }}
+    # if: ${{ failure() && inputs.e2e_grep == '' }}
+    if: always()
     needs: [unit-tests, integration-tests, e2e-electron]
     runs-on: ubuntu-latest
     steps:
@@ -193,6 +194,6 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
           # channel: C07FR1JNZNJ # positron-test-results channel
           include_commit_message: true
-          notify_on: 'fail-only'
+          notify_on: 'always'
 
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -182,7 +182,7 @@ jobs:
           run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
 
   slack-notify:
-    # if: ${{ failure() && inputs.e2e_grep == '' }}
+    if: ${{ failure() && inputs.e2e_grep == '' }}
     needs: [unit-tests, integration-tests, e2e-electron]
     runs-on: ubuntu-latest
     steps:
@@ -190,9 +190,7 @@ jobs:
         uses: midleman/slack-workflow-status@master
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          # slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL}}
-          slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
-          # notify_on: "on-failure"
-          include_jobs: "on-failure"
+          slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL}}
+          notify_on: "on-failure"
 
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -195,7 +195,7 @@ jobs:
         uses: Gamesight/slack-workflow-status@master
         with:
           # Required Input
-          repo_token: ${{ secrets.secrets.POSITRON_GITHUB_PAT }}
+          repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
           # Optional Input
           # channel: '#anthony-test-channel'

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -192,6 +192,7 @@ jobs:
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
+          channel: C06DNFJSHPD
           # channel: C07FR1JNZNJ # positron-test-results channel
           include_commit_message: true
           notify_on: 'always'

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -182,12 +182,11 @@ jobs:
         #   run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
 
   slack-notify:
-    # if: ${{ failure() && inputs.e2e_grep == '' }}
-    if: always()
+    if: ${{ failure() && inputs.e2e_grep == '' }}
     needs: [unit-tests, integration-tests, e2e-electron]
     runs-on: ubuntu-latest
     steps:
-      - name: Slack Workflow Notification
+      - name: Slack Slack Notification
         uses: midleman/slack-workflow-status@master
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -46,43 +46,43 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: Cache node_modules, build, extensions, and remote
-        uses: ./.github/actions/cache-multi-paths
+      # - name: Cache node_modules, build, extensions, and remote
+      #   uses: ./.github/actions/cache-multi-paths
 
-      - name: Setup Build and Compile
-        uses: ./.github/actions/setup-build-env
+      # - name: Setup Build and Compile
+      #   uses: ./.github/actions/setup-build-env
 
-      - name: Setup E2E Test Environment
-        uses: ./.github/actions/setup-test-env
-        with:
-          aws-role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
-          aws-region: ${{ secrets.QA_AWS_REGION }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Setup E2E Test Environment
+      #   uses: ./.github/actions/setup-test-env
+      #   with:
+      #     aws-role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
+      #     aws-region: ${{ secrets.QA_AWS_REGION }}
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Send HTML report URL to GitHub Summary
-        if: ${{ !cancelled() }}
-        run: |
-          REPORT_URL="https://d38p2avprg8il3.cloudfront.net/${{ env.REPORT_DIR }}/index.html"
-          echo "Report URL: $REPORT_URL"
-          echo "📄 [Playwright Report]($REPORT_URL) <br>" > $GITHUB_STEP_SUMMARY
+      # - name: Send HTML report URL to GitHub Summary
+      #   if: ${{ !cancelled() }}
+      #   run: |
+      #     REPORT_URL="https://d38p2avprg8il3.cloudfront.net/${{ env.REPORT_DIR }}/index.html"
+      #     echo "Report URL: $REPORT_URL"
+      #     echo "📄 [Playwright Report]($REPORT_URL) <br>" > $GITHUB_STEP_SUMMARY
 
-      - name: Run Playwright Tests (Electron)
-        env:
-          POSITRON_PY_VER_SEL: 3.10.12
-          POSITRON_R_VER_SEL: 4.4.0
-          CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
-          CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
-          COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
-          PWTEST_BLOB_DO_NOT_REMOVE: 1
-          CURRENTS_TAG: "electron,${{ inputs.e2e_grep }}"
-        id: e2e-playwright-tests
-        run: DISPLAY=:10 npx playwright test --project e2e-electron --workers 2 --grep=${{ env.E2E_GREP }}
+      # - name: Run Playwright Tests (Electron)
+      #   env:
+      #     POSITRON_PY_VER_SEL: 3.10.12
+      #     POSITRON_R_VER_SEL: 4.4.0
+      #     CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
+      #     CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+      #     COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
+      #     PWTEST_BLOB_DO_NOT_REMOVE: 1
+      #     CURRENTS_TAG: "electron,${{ inputs.e2e_grep }}"
+      #   id: e2e-playwright-tests
+      #   run: DISPLAY=:10 npx playwright test --project e2e-electron --workers 2 --grep=${{ env.E2E_GREP }}
 
-      - name: Upload Playwright Report to S3
-        if: ${{ success() || failure() }}
-        uses: ./.github/actions/upload-report-to-s3
-        with:
-          role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
+      # - name: Upload Playwright Report to S3
+      #   if: ${{ success() || failure() }}
+      #   uses: ./.github/actions/upload-report-to-s3
+      #   with:
+      #     role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -100,35 +100,35 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: Cache node_modules, build, extensions, and remote
-        uses: ./.github/actions/cache-multi-paths
+      # - name: Cache node_modules, build, extensions, and remote
+      #   uses: ./.github/actions/cache-multi-paths
 
-      - name: Setup Build and Compile
-        uses: ./.github/actions/setup-build-env
+      # - name: Setup Build and Compile
+      #   uses: ./.github/actions/setup-build-env
 
-      - name: Install Positron License
-        uses: ./.github/actions/install-license
-        with:
-          github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          license-key: ${{ secrets.POSITRON_DEV_LICENSE }}
+      # - name: Install Positron License
+      #   uses: ./.github/actions/install-license
+      #   with:
+      #     github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
+      #     license-key: ${{ secrets.POSITRON_DEV_LICENSE }}
 
-      # one unit test needs this: Can list tables and fields from R connections
-      - name: Setup R
-        uses: ./.github/actions/install-r
-        with:
-          version: "4.4.0"
+      # # one unit test needs this: Can list tables and fields from R connections
+      # - name: Setup R
+      #   uses: ./.github/actions/install-r
+      #   with:
+      #     version: "4.4.0"
 
-      - name: Run Unit Tests (Electron)
-        id: electron-unit-tests
-        run: DISPLAY=:10 ./scripts/test.sh
+      # - name: Run Unit Tests (Electron)
+      #   id: electron-unit-tests
+      #   run: DISPLAY=:10 ./scripts/test.sh
 
-      - name: Run Unit Tests (node.js)
-        id: nodejs-unit-tests
-        run: yarn test-node
+      # - name: Run Unit Tests (node.js)
+      #   id: nodejs-unit-tests
+      #   run: yarn test-node
 
-      - name: Run Unit Tests (Browser, Chromium)
-        id: browser-unit-tests
-        run: DISPLAY=:10 yarn test-browser-no-install --browser chromium
+      # - name: Run Unit Tests (Browser, Chromium)
+      #   id: browser-unit-tests
+      #   run: DISPLAY=:10 yarn test-browser-no-install --browser chromium
 
   integration-tests:
       runs-on: ubuntu-latest-4x
@@ -146,63 +146,53 @@ jobs:
           with:
             node-version-file: .nvmrc
 
-        - name: Cache node_modules, build, extensions, and remote
-          uses: ./.github/actions/cache-multi-paths
+        # - name: Cache node_modules, build, extensions, and remote
+        #   uses: ./.github/actions/cache-multi-paths
 
-        - name: Setup Build and Compile
-          uses: ./.github/actions/setup-build-env
+        # - name: Setup Build and Compile
+        #   uses: ./.github/actions/setup-build-env
 
-        - name: Install Positron License
-          uses: ./.github/actions/install-license
-          with:
-            github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
-            license-key: ${{ secrets.POSITRON_DEV_LICENSE }}
+        # - name: Install Positron License
+        #   uses: ./.github/actions/install-license
+        #   with:
+        #     github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
+        #     license-key: ${{ secrets.POSITRON_DEV_LICENSE }}
 
-        # one integration test needs this: Connections pane works for R
-        - name: Setup R
-          uses: ./.github/actions/install-r
-          with:
-            version: "4.4.0"
+        # # one integration test needs this: Connections pane works for R
+        # - name: Setup R
+        #   uses: ./.github/actions/install-r
+        #   with:
+        #     version: "4.4.0"
 
-        - name: Compile Integration Tests
-          run: yarn --cwd test/integration/browser compile
+        # - name: Compile Integration Tests
+        #   run: yarn --cwd test/integration/browser compile
 
-        - name: Run Integration Tests (Electron)
-          id: electron-integration-tests
-          run: DISPLAY=:10 ./scripts/test-integration-pr.sh
+        # - name: Run Integration Tests (Electron)
+        #   id: electron-integration-tests
+        #   run: DISPLAY=:10 ./scripts/test-integration-pr.sh
 
-        - name: Run Integration Tests (Remote)
-          if: ${{ job.status != 'cancelled' && (success() || failure()) }}
-          id: electron-remote-integration-tests
-          run: DISPLAY=:10 ./scripts/test-remote-integration.sh
+        # - name: Run Integration Tests (Remote)
+        #   if: ${{ job.status != 'cancelled' && (success() || failure()) }}
+        #   id: electron-remote-integration-tests
+        #   run: DISPLAY=:10 ./scripts/test-remote-integration.sh
 
-        - name: Run Integration Tests (Browser, Chromium)
-          if: ${{ job.status != 'cancelled' && (success() || failure()) }}
-          id: browser-integration-tests
-          run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
+        # - name: Run Integration Tests (Browser, Chromium)
+        #   if: ${{ job.status != 'cancelled' && (success() || failure()) }}
+        #   id: browser-integration-tests
+        #   run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
 
-  slack-workflow-status:
+  slack-notify:
     # if: ${{ failure() && inputs.e2e_grep == '' }}
     if: always()
-    needs:
-      - unit-tests
-      - integration-tests
-      - e2e-electron
+    needs: [unit-tests, integration-tests, e2e-electron]
     runs-on: ubuntu-latest
-    # permissions:
-    #   actions: 'read'
     steps:
       - name: Slack Workflow Notification
-        uses: Gamesight/slack-workflow-status@master
+        uses: midleman/slack-workflow-status@master
         with:
-          # Required Input
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
-          # Optional Input
           # channel: C07FR1JNZNJ # positron-test-results channel
-          # name: 'Test Status Bot'
-          # icon_emoji: ':poop:'
-          # icon_url: 'https://avatars0.githubusercontent.com/u/1701160?s=96&v=4'
           include_commit_message: true
 
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -192,7 +192,7 @@ jobs:
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL}}
-          include_jobs_time: 'false'
+          # include_jobs_time: 'false'
           # notify_on: "on-failure"
 
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -182,6 +182,7 @@ jobs:
           run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
 
   slack-workflow-status:
+    # if: ${{ failure() && inputs.e2e_grep == '' }}
     if: always()
     needs:
       - unit-tests
@@ -198,21 +199,10 @@ jobs:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
           # Optional Input
-          # channel: '#anthony-test-channel'
+          # channel: C07FR1JNZNJ # positron-test-results channel
           name: 'Test Status Bot'
           icon_emoji: ':poop:'
           icon_url: 'https://avatars0.githubusercontent.com/u/1701160?s=96&v=4'
+          include_commit_message: true
 
-  # slack-notification:
-  #   name: "Send Slack notification"
-  #   runs-on: ubuntu-latest
-  #   needs: [unit-tests, integration-tests, e2e-electron]
-  #   if: ${{ failure() && inputs.e2e_grep == '' }}
-  #   steps:
-  #     - name: "Send Slack notification"
-  #       uses: testlabauto/action-test-results-to-slack@v0.0.6
-  #       with:
-  #         github_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-  #         slack_token: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
-  #         slack_channel: C07FR1JNZNJ #positron-test-results channel
-  #         suite_name: Positron Merge to Main Test Suite
+

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -189,8 +189,8 @@ jobs:
       - integration-tests
       - e2e-electron
     runs-on: ubuntu-latest
-    permissions:
-      actions: 'read'
+    # permissions:
+    #   actions: 'read'
     steps:
       - name: Slack Workflow Notification
         uses: Gamesight/slack-workflow-status@master

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -146,6 +146,8 @@ jobs:
           with:
             node-version-file: .nvmrc
 
+        - run: exit 1
+
         # - name: Cache node_modules, build, extensions, and remote
         #   uses: ./.github/actions/cache-multi-paths
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -182,7 +182,7 @@ jobs:
           run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
 
   slack-notify:
-    if: ${{ failure() && inputs.e2e_grep == '' }}
+    # if: ${{ failure() && inputs.e2e_grep == '' }}
     needs: [unit-tests, integration-tests, e2e-electron]
     runs-on: ubuntu-latest
     steps:
@@ -190,7 +190,9 @@ jobs:
         uses: midleman/slack-workflow-status@master
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL}}
-          notify_on: "on-failure"
+          # slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL}}
+          slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
+          # notify_on: "on-failure"
+          include_jobs: "on-failure"
 
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -183,6 +183,7 @@ jobs:
 
   slack-notify:
     # if: ${{ failure() && inputs.e2e_grep == '' }}
+    if: always()
     needs: [unit-tests, integration-tests, e2e-electron]
     runs-on: ubuntu-latest
     steps:
@@ -190,9 +191,7 @@ jobs:
         uses: midleman/slack-workflow-status@master
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          slack_webhook_url: ${{ secrets.SLACK_QA_WEBHOOK_URL }}
-          channel: C06DNFJSHPD
-          # channel: C07FR1JNZNJ # positron-test-results channel
+          slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
           include_commit_message: true
           notify_on: 'on-failure'
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -46,43 +46,43 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      # - name: Cache node_modules, build, extensions, and remote
-      #   uses: ./.github/actions/cache-multi-paths
+      - name: Cache node_modules, build, extensions, and remote
+        uses: ./.github/actions/cache-multi-paths
 
-      # - name: Setup Build and Compile
-      #   uses: ./.github/actions/setup-build-env
+      - name: Setup Build and Compile
+        uses: ./.github/actions/setup-build-env
 
-      # - name: Setup E2E Test Environment
-      #   uses: ./.github/actions/setup-test-env
-      #   with:
-      #     aws-role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
-      #     aws-region: ${{ secrets.QA_AWS_REGION }}
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup E2E Test Environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          aws-role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
+          aws-region: ${{ secrets.QA_AWS_REGION }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Send HTML report URL to GitHub Summary
-      #   if: ${{ !cancelled() }}
-      #   run: |
-      #     REPORT_URL="https://d38p2avprg8il3.cloudfront.net/${{ env.REPORT_DIR }}/index.html"
-      #     echo "Report URL: $REPORT_URL"
-      #     echo "📄 [Playwright Report]($REPORT_URL) <br>" > $GITHUB_STEP_SUMMARY
+      - name: Send HTML report URL to GitHub Summary
+        if: ${{ !cancelled() }}
+        run: |
+          REPORT_URL="https://d38p2avprg8il3.cloudfront.net/${{ env.REPORT_DIR }}/index.html"
+          echo "Report URL: $REPORT_URL"
+          echo "📄 [Playwright Report]($REPORT_URL) <br>" > $GITHUB_STEP_SUMMARY
 
-      # - name: Run Playwright Tests (Electron)
-      #   env:
-      #     POSITRON_PY_VER_SEL: 3.10.12
-      #     POSITRON_R_VER_SEL: 4.4.0
-      #     CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
-      #     CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
-      #     COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
-      #     PWTEST_BLOB_DO_NOT_REMOVE: 1
-      #     CURRENTS_TAG: "electron,${{ inputs.e2e_grep }}"
-      #   id: e2e-playwright-tests
-      #   run: DISPLAY=:10 npx playwright test --project e2e-electron --workers 2 --grep=${{ env.E2E_GREP }}
+      - name: Run Playwright Tests (Electron)
+        env:
+          POSITRON_PY_VER_SEL: 3.10.12
+          POSITRON_R_VER_SEL: 4.4.0
+          CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
+          CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+          COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
+          PWTEST_BLOB_DO_NOT_REMOVE: 1
+          CURRENTS_TAG: "electron,${{ inputs.e2e_grep }}"
+        id: e2e-playwright-tests
+        run: DISPLAY=:10 npx playwright test --project e2e-electron --workers 2 --grep=${{ env.E2E_GREP }}
 
-      # - name: Upload Playwright Report to S3
-      #   if: ${{ success() || failure() }}
-      #   uses: ./.github/actions/upload-report-to-s3
-      #   with:
-      #     role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
+      - name: Upload Playwright Report to S3
+        if: ${{ success() || failure() }}
+        uses: ./.github/actions/upload-report-to-s3
+        with:
+          role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -100,35 +100,35 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      # - name: Cache node_modules, build, extensions, and remote
-      #   uses: ./.github/actions/cache-multi-paths
+      - name: Cache node_modules, build, extensions, and remote
+        uses: ./.github/actions/cache-multi-paths
 
-      # - name: Setup Build and Compile
-      #   uses: ./.github/actions/setup-build-env
+      - name: Setup Build and Compile
+        uses: ./.github/actions/setup-build-env
 
-      # - name: Install Positron License
-      #   uses: ./.github/actions/install-license
-      #   with:
-      #     github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
-      #     license-key: ${{ secrets.POSITRON_DEV_LICENSE }}
+      - name: Install Positron License
+        uses: ./.github/actions/install-license
+        with:
+          github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          license-key: ${{ secrets.POSITRON_DEV_LICENSE }}
 
-      # # one unit test needs this: Can list tables and fields from R connections
-      # - name: Setup R
-      #   uses: ./.github/actions/install-r
-      #   with:
-      #     version: "4.4.0"
+      # one unit test needs this: Can list tables and fields from R connections
+      - name: Setup R
+        uses: ./.github/actions/install-r
+        with:
+          version: "4.4.0"
 
-      # - name: Run Unit Tests (Electron)
-      #   id: electron-unit-tests
-      #   run: DISPLAY=:10 ./scripts/test.sh
+      - name: Run Unit Tests (Electron)
+        id: electron-unit-tests
+        run: DISPLAY=:10 ./scripts/test.sh
 
-      # - name: Run Unit Tests (node.js)
-      #   id: nodejs-unit-tests
-      #   run: yarn test-node
+      - name: Run Unit Tests (node.js)
+        id: nodejs-unit-tests
+        run: yarn test-node
 
-      # - name: Run Unit Tests (Browser, Chromium)
-      #   id: browser-unit-tests
-      #   run: DISPLAY=:10 yarn test-browser-no-install --browser chromium
+      - name: Run Unit Tests (Browser, Chromium)
+        id: browser-unit-tests
+        run: DISPLAY=:10 yarn test-browser-no-install --browser chromium
 
   integration-tests:
       runs-on: ubuntu-latest-4x

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -181,16 +181,38 @@ jobs:
           id: browser-integration-tests
           run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
 
-  slack-notification:
-    name: "Send Slack notification"
+  slack-workflow-status:
+    if: always()
+    needs:
+      - unit-tests
+      - integration-tests
+      - e2e-electron
     runs-on: ubuntu-latest
-    needs: [unit-tests, integration-tests, e2e-electron]
-    if: ${{ failure() && inputs.e2e_grep == '' }}
+    permissions:
+      actions: 'read'
     steps:
-      - name: "Send Slack notification"
-        uses: testlabauto/action-test-results-to-slack@v0.0.6
+      - name: Slack Workflow Notification
+        uses: Gamesight/slack-workflow-status@master
         with:
-          github_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          slack_token: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
-          slack_channel: C07FR1JNZNJ #positron-test-results channel
-          suite_name: Positron Merge to Main Test Suite
+          # Required Input
+          repo_token: ${{ secrets.secrets.POSITRON_GITHUB_PAT }}
+          slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
+          # Optional Input
+          # channel: '#anthony-test-channel'
+          name: 'Test Status Bot'
+          icon_emoji: ':poop:'
+          icon_url: 'https://avatars0.githubusercontent.com/u/1701160?s=96&v=4'
+
+  # slack-notification:
+  #   name: "Send Slack notification"
+  #   runs-on: ubuntu-latest
+  #   needs: [unit-tests, integration-tests, e2e-electron]
+  #   if: ${{ failure() && inputs.e2e_grep == '' }}
+  #   steps:
+  #     - name: "Send Slack notification"
+  #       uses: testlabauto/action-test-results-to-slack@v0.0.6
+  #       with:
+  #         github_token: ${{ secrets.POSITRON_GITHUB_PAT }}
+  #         slack_token: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
+  #         slack_channel: C07FR1JNZNJ #positron-test-results channel
+  #         suite_name: Positron Merge to Main Test Suite

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -146,42 +146,40 @@ jobs:
           with:
             node-version-file: .nvmrc
 
-        - run: exit 1
+        - name: Cache node_modules, build, extensions, and remote
+          uses: ./.github/actions/cache-multi-paths
 
-        # - name: Cache node_modules, build, extensions, and remote
-        #   uses: ./.github/actions/cache-multi-paths
+        - name: Setup Build and Compile
+          uses: ./.github/actions/setup-build-env
 
-        # - name: Setup Build and Compile
-        #   uses: ./.github/actions/setup-build-env
+        - name: Install Positron License
+          uses: ./.github/actions/install-license
+          with:
+            github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
+            license-key: ${{ secrets.POSITRON_DEV_LICENSE }}
 
-        # - name: Install Positron License
-        #   uses: ./.github/actions/install-license
-        #   with:
-        #     github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
-        #     license-key: ${{ secrets.POSITRON_DEV_LICENSE }}
+        # one integration test needs this: Connections pane works for R
+        - name: Setup R
+          uses: ./.github/actions/install-r
+          with:
+            version: "4.4.0"
 
-        # # one integration test needs this: Connections pane works for R
-        # - name: Setup R
-        #   uses: ./.github/actions/install-r
-        #   with:
-        #     version: "4.4.0"
+        - name: Compile Integration Tests
+          run: yarn --cwd test/integration/browser compile
 
-        # - name: Compile Integration Tests
-        #   run: yarn --cwd test/integration/browser compile
+        - name: Run Integration Tests (Electron)
+          id: electron-integration-tests
+          run: DISPLAY=:10 ./scripts/test-integration-pr.sh
 
-        # - name: Run Integration Tests (Electron)
-        #   id: electron-integration-tests
-        #   run: DISPLAY=:10 ./scripts/test-integration-pr.sh
+        - name: Run Integration Tests (Remote)
+          if: ${{ job.status != 'cancelled' && (success() || failure()) }}
+          id: electron-remote-integration-tests
+          run: DISPLAY=:10 ./scripts/test-remote-integration.sh
 
-        # - name: Run Integration Tests (Remote)
-        #   if: ${{ job.status != 'cancelled' && (success() || failure()) }}
-        #   id: electron-remote-integration-tests
-        #   run: DISPLAY=:10 ./scripts/test-remote-integration.sh
-
-        # - name: Run Integration Tests (Browser, Chromium)
-        #   if: ${{ job.status != 'cancelled' && (success() || failure()) }}
-        #   id: browser-integration-tests
-        #   run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
+        - name: Run Integration Tests (Browser, Chromium)
+          if: ${{ job.status != 'cancelled' && (success() || failure()) }}
+          id: browser-integration-tests
+          run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
 
   slack-notify:
     # if: ${{ failure() && inputs.e2e_grep == '' }}

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -192,6 +192,6 @@ jobs:
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
-          notify_on: "on-failure"
+          # notify_on: "on-failure"
 
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -200,9 +200,9 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
           # Optional Input
           # channel: C07FR1JNZNJ # positron-test-results channel
-          name: 'Test Status Bot'
-          icon_emoji: ':poop:'
-          icon_url: 'https://avatars0.githubusercontent.com/u/1701160?s=96&v=4'
+          # name: 'Test Status Bot'
+          # icon_emoji: ':poop:'
+          # icon_url: 'https://avatars0.githubusercontent.com/u/1701160?s=96&v=4'
           include_commit_message: true
 
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -194,5 +194,6 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
           # channel: C07FR1JNZNJ # positron-test-results channel
           include_commit_message: true
+          notify_on: 'fail-only'
 
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -187,12 +187,11 @@ jobs:
     needs: [unit-tests, integration-tests, e2e-electron]
     runs-on: ubuntu-latest
     steps:
-      - name: Slack Slack Notification
+      - name: Send Slack Notification
         uses: midleman/slack-workflow-status@master
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
-          include_commit_message: true
-          notify_on: 'on-failure'
+          notify_on: "on-failure"
 
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -182,8 +182,7 @@ jobs:
           run: DISPLAY=:10 ./scripts/test-web-integration.sh --browser chromium
 
   slack-notify:
-    # if: ${{ failure() && inputs.e2e_grep == '' }}
-    if: always()
+    if: ${{ failure() && inputs.e2e_grep == '' }}
     needs: [unit-tests, integration-tests, e2e-electron]
     runs-on: ubuntu-latest
     steps:
@@ -191,8 +190,7 @@ jobs:
         uses: midleman/slack-workflow-status@master
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL}}
-          # include_jobs_time: 'false'
-          # notify_on: "on-failure"
+          slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL}}
+          notify_on: "failure"
 
 

--- a/.github/workflows/positron-pull-requests.yml
+++ b/.github/workflows/positron-pull-requests.yml
@@ -1,4 +1,4 @@
-name: "Positron: CI - Pull Request"
+name: "Test: Pull Request"
 
 on:
   pull_request:

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -23,7 +23,6 @@ env:
 jobs:
   # Run full suite of upstream tests
   vscode-python-tests:
-    name: Upstream Python Tests
     # The value of runs-on is the OS of the current job (specified in the strategy matrix below) instead of being hardcoded.
     runs-on: ${{ matrix.os }}
     defaults:
@@ -85,8 +84,7 @@ jobs:
           path: ${{ github.workspace }}/${{ env.special-working-directory-relative }}/extensions/positron-python/python-unit-test-results.xml
 
   # Install the latest releases of test dependencies
-  positron-ipykernel-tests-latest:
-    name: Test latest Positron IPyKernel
+  ipykernel-tests-latest:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -131,7 +129,7 @@ jobs:
     if: always()
     name: 'Send Slack notification'
     runs-on: ubuntu-latest
-    needs: [vscode-python-tests, positron-ipykernel-tests-latest]
+    needs: [vscode-python-tests, ipykernel-tests-latest]
 
     steps:
     - name: Send Slack Notification

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -133,5 +133,5 @@ jobs:
         repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
         slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
         include_jobs: "status-only"
-        notify_on: "failure-only"
+        # notify_on: "failure-only"
 

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -139,6 +139,6 @@ jobs:
       with:
         repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
         slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
-        include_commit_message: true
+        include_jobs: "status-only"
         notify_on: "failure-only"
 

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -121,10 +121,10 @@ jobs:
           path: extensions/positron-python/python-test-results.xml
 
   slack-notification:
-    if: always()
     name: 'Send Slack notification'
     runs-on: ubuntu-latest
     needs: [vscode-python-tests, ipykernel-tests-latest]
+    if: always()
 
     steps:
     - name: Send Slack Notification
@@ -132,6 +132,6 @@ jobs:
       with:
         repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
         slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL }}
-        include_jobs_time: 'false'
+        include_jobs_time: "false"
         notify_on: "failure"
 

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -68,15 +68,8 @@ jobs:
       - name: Install test requirements
         run: python -m pip install -r build/test-requirements.txt
 
-      # - name: Run Python unit tests
-      #   run: python python_files/tests/run_all.py --junit-xml=python-unit-test-results.xml
       - name: Run Python unit tests
-        run: |
-          if [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.python }}" == "3.11" ]]; then
-            echo "Simulated failure for testing notifications" && exit 1
-          else
-            python python_files/tests/run_all.py --junit-xml=python-unit-test-results.xml
-          fi
+        run: python python_files/tests/run_all.py --junit-xml=python-unit-test-results.xml
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -68,8 +68,15 @@ jobs:
       - name: Install test requirements
         run: python -m pip install -r build/test-requirements.txt
 
+      # - name: Run Python unit tests
+      #   run: python python_files/tests/run_all.py --junit-xml=python-unit-test-results.xml
       - name: Run Python unit tests
-        run: python python_files/tests/run_all.py --junit-xml=python-unit-test-results.xml
+        run: |
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.python }}" == "3.11" ]]; then
+            echo "Simulated failure for testing notifications" && exit 1
+          else
+            python python_files/tests/run_all.py --junit-xml=python-unit-test-results.xml
+          fi
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -131,7 +131,7 @@ jobs:
       uses: midleman/slack-workflow-status@master
       with:
         repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-        slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL }}
+        slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
         include_commit_message: true
         notify_on: "failure-only"
 

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -133,5 +133,5 @@ jobs:
         repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
         slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL }}
         include_jobs_time: 'false'
-        notify_on: "failure-only"
+        notify_on: "failure"
 

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -132,6 +132,6 @@ jobs:
       with:
         repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
         slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL }}
-        include_jobs: "status-only"
+        include_jobs_time: 'false'
         notify_on: "failure-only"
 

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -131,7 +131,7 @@ jobs:
       uses: midleman/slack-workflow-status@master
       with:
         repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-        slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
+        slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL }}
         include_jobs: "status-only"
-        # notify_on: "failure-only"
+        notify_on: "failure-only"
 

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -130,8 +130,7 @@ jobs:
       uses: midleman/slack-workflow-status@master
       with:
         repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-        slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
-        # channel: C07FR1JNZNJ # positron-test-results channel
+        slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL }}
         include_commit_message: true
-        notify_on: "fail-only"
+        notify_on: "failure-only"
 

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -126,15 +126,12 @@ jobs:
     needs: [vscode-python-tests, positron-ipykernel-tests-latest]
 
     steps:
-      - name: Download test artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: test-artifacts
-
-      - name: 'Send Slack notification'
-        uses: automattic/action-test-results-to-slack@v0.3.1
-        with:
-          github_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          slack_token: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
-          slack_channel: C07FR1JNZNJ #positron-test-results channel
+    - name: Send Slack Notification
+      uses: midleman/slack-workflow-status@master
+      with:
+        repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
+        slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
+        # channel: C07FR1JNZNJ # positron-test-results channel
+        include_commit_message: true
+        notify_on: "fail-only"
 

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   # Run full suite of upstream tests
   vscode-python-tests:
+    name: 'vscode-python'
     # The value of runs-on is the OS of the current job (specified in the strategy matrix below) instead of being hardcoded.
     runs-on: ${{ matrix.os }}
     defaults:
@@ -85,6 +86,7 @@ jobs:
 
   # Install the latest releases of test dependencies
   ipykernel-tests-latest:
+    name: 'ipykernel'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/positron-windows-nightly.yml
+++ b/.github/workflows/positron-windows-nightly.yml
@@ -158,8 +158,6 @@ jobs:
         if: always()
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
-          slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
-          # channel: C07FR1JNZNJ # positron-test-results channel
+          slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL }}
           include_commit_message: true
-          # notify_on: "fail-only"
-          notify_on: "always"
+          notify_on: "failure-only"

--- a/.github/workflows/positron-windows-nightly.yml
+++ b/.github/workflows/positron-windows-nightly.yml
@@ -159,5 +159,4 @@ jobs:
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL }}
-          include_commit_message: true
           notify_on: "failure-only"

--- a/.github/workflows/positron-windows-nightly.yml
+++ b/.github/workflows/positron-windows-nightly.yml
@@ -161,4 +161,5 @@ jobs:
           slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
           # channel: C07FR1JNZNJ # positron-test-results channel
           include_commit_message: true
-          notify_on: "fail-only"
+          # notify_on: "fail-only"
+          notify_on: "always"

--- a/.github/workflows/positron-windows-nightly.yml
+++ b/.github/workflows/positron-windows-nightly.yml
@@ -146,12 +146,19 @@ jobs:
 
       - name: Run E2E Report
         uses: ./.github/actions/e2e-report
+        if: always()
         with:
           aws-s3-bucket: positron-test-reports
           aws-role: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
-          slack-token: ${{ secrets.SMOKE_TESTS_SLACK_TOKEN }}
-          slack-channel: C07FR1JNZNJ
-          slack-title: "Full Test Suite (Windows)"
           testrail-api-key: ${{ secrets.TESTRAIL_API_KEY }}
-          testrail-title: "E2E Windows Test Run"
-          github-token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          testrail-title: "E2E Electron Test Run"
+
+      - name: Send Slack Notification
+        uses: midleman/slack-workflow-status@master
+        if: always()
+        with:
+          repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
+          slack_webhook_url: ${{ secrets.SLACK_MARIE_WEBHOOK_URL }}
+          # channel: C07FR1JNZNJ # positron-test-results channel
+          include_commit_message: true
+          notify_on: "fail-only"

--- a/.github/workflows/positron-windows-nightly.yml
+++ b/.github/workflows/positron-windows-nightly.yml
@@ -159,4 +159,4 @@ jobs:
         with:
           repo_token: ${{ secrets.POSITRON_GITHUB_PAT }}
           slack_webhook_url: ${{ secrets.SLACK_TEST_RESULTS_WEBHOOK_URL }}
-          notify_on: "failure-only"
+          notify_on: "failure"

--- a/.github/workflows/positron-windows-nightly.yml
+++ b/.github/workflows/positron-windows-nightly.yml
@@ -1,4 +1,4 @@
-name: "Positron: Windows Full Test Suite"
+name: "Test: E2E Tests (Windows)"
 
 # Run tests daily at 4am UTC (11p EST) on weekdays for now, or manually
 on:

--- a/.github/workflows/slack-skipped-tests.yml
+++ b/.github/workflows/slack-skipped-tests.yml
@@ -14,4 +14,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Slack Skipped Tests Script
-        run: node scripts/slack-skipped-tests.js ${{ secrets.SLACK_E2E_TEST_WEBHOOK }}
+        run: node scripts/slack-skipped-tests.js ${{ secrets.SLACK_QA_WEBHOOK_URL }}


### PR DESCRIPTION
### QA Notes

This PR introduces the use of a [custom GitHub Action](https://github.com/midleman/slack-workflow-status) to enhance our Slack notifications for test statuses, offering improved context. Currently, all workflows are configured such that notifications are triggered **_only_** if any job in the workflow fails. 

Some key settings:
`notify_on`: always, failure
`include_jobs`: true, false, on-failure
`include_jobs_time`: true, false (handy for hiding on long job names, etc)

Confirmed it works with matrix jobs (tested both pass and fail scenarios):
<img width="675" alt="Screenshot 2024-12-04 at 6 01 08 AM" src="https://github.com/user-attachments/assets/cd11fe3e-f8ce-425a-9155-9ce30eef6ef8">

And of course just standard workflows:
<img width="560" alt="Screenshot 2024-12-04 at 5 57 58 AM" src="https://github.com/user-attachments/assets/51d06b3e-0ef4-4ccb-ba46-e19017fa5893">
