### PR TITLE
Fix R package installation commands after multiple restarts

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -97,7 +97,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.19"
+      "kallichore": "0.1.21"
     }
   },
   "dependencies": {

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -5,7 +5,7 @@
 
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Emitter, Event } from 'vs/base/common/event';
-import { IRuntimeClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
+import { IRuntimeClientInstance, RuntimeClientState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
 import { BusyEvent, ClearConsoleEvent, UiFrontendEvent, OpenEditorEvent, OpenWorkspaceEvent, PromptStateEvent, ShowMessageEvent, WorkingDirectoryEvent, ShowUrlEvent, SetEditorSelectionsEvent, ShowHtmlFileEvent, ClearWebviewPreloadsEvent } from './positronUiComm';
 import { PositronUiCommInstance } from 'vs/workbench/services/languageRuntime/common/positronUiCommInstance';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
@@ -242,5 +242,19 @@ export class UiClientInstance extends Disposable {
 		}
 
 		return uri;
+	}
+
+	/**
+	 * Get the ID of the underlying runtime client
+	 */
+	public getClientId(): string {
+		return this._client.getClientId();
+	}
+
+	/**
+	 * Get the state of the underlying runtime client
+	 */
+	public getClientState(): RuntimeClientState {
+		return this._client.clientState.get();
 	}
 }

--- a/src/vs/workbench/services/runtimeSession/common/activeRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/activeRuntimeSession.ts
@@ -1,0 +1,225 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DeferredPromise } from 'vs/base/common/async';
+import { Emitter } from 'vs/base/common/event';
+import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { ICommandService } from 'vs/platform/commands/common/commands';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { ILogService } from 'vs/platform/log/common/log';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { RuntimeClientState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeClientInstance';
+import { RuntimeState } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { IUiClientMessageInput, IUiClientMessageOutput, UiClientInstance } from 'vs/workbench/services/languageRuntime/common/languageRuntimeUiClient';
+import { UiFrontendEvent } from 'vs/workbench/services/languageRuntime/common/positronUiComm';
+import { ILanguageRuntimeGlobalEvent, ILanguageRuntimeSession, ILanguageRuntimeSessionManager, RuntimeClientType } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
+
+/**
+ * Utility class for tracking state changes in a language runtime session.
+ *
+ * We keep our own copy of the state so we can fire an event with both the old
+ * and new state values when the state changes.
+ */
+export class ActiveRuntimeSession extends Disposable {
+	public state: RuntimeState;
+
+	// The event emitter for the onDidReceiveRuntimeEvent event.
+	private readonly _onDidReceiveRuntimeEventEmitter =
+		this._register(new Emitter<ILanguageRuntimeGlobalEvent>());
+
+	/// The UI client instance, if it exists
+	private _uiClient: UiClientInstance | undefined;
+
+	private _startingUiClient: DeferredPromise<string> | undefined;
+
+	/**
+	 * Create a new LanguageRuntimeSessionInfo.
+	 *
+	 * @param session The session
+	 * @param manager The session's manager
+	 */
+	constructor(
+		public session: ILanguageRuntimeSession,
+		public manager: ILanguageRuntimeSessionManager,
+		private readonly _commandService: ICommandService,
+		private readonly _logService: ILogService,
+		private readonly _openerService: IOpenerService,
+		private readonly _configurationService: IConfigurationService
+	) {
+		super();
+		this.state = session.getRuntimeState();
+	}
+
+	/// An event that fires when a runtime receives a global event.
+	readonly onDidReceiveRuntimeEvent = this._onDidReceiveRuntimeEventEmitter.event;
+
+	/**
+	 * Register a disposable to be cleaned up when this object is disposed.
+	 * @param disposable
+	 */
+	public register(disposable: IDisposable): void {
+		this._register(disposable);
+	}
+
+	/**
+	 * Starts a UI client instance for the specified runtime session. The
+	 * UI client instance is used for two-way communication of
+	 * global state and events between the frontend and the backend.
+	 *
+	 * Resolves when the UI client instance is created, with the ID of the
+	 * newly created comm.
+	 */
+	public async startUiClient(): Promise<string> {
+		// If we already know the client ID, just return it.
+		if (this._uiClient) {
+			const clientState = this._uiClient.getClientState();
+			if (clientState === RuntimeClientState.Connected ||
+				clientState === RuntimeClientState.Opening) {
+				// This is an active client; we can use it
+				return this._uiClient.getClientId();
+			} else {
+				// This is not an active client; forget it and start a new one.
+				this._uiClient = undefined;
+			}
+		}
+
+		// If we're already starting a UI comm client, return that promise.
+		if (this._startingUiClient && !this._startingUiClient.isSettled) {
+			return this._startingUiClient.p;
+		}
+
+		// Save and return a promise that resolves when the client has started.
+		const promise = new DeferredPromise<string>();
+		this._startingUiClient = promise;
+		this.startUiClientImpl().then(clientId => {
+			promise.complete(clientId);
+		}).catch(err => {
+			promise.error(err);
+		});
+		return this._startingUiClient.p;
+	}
+
+	/**
+	 * Interior implementation of the UI client start method.
+	 */
+	private async startUiClientImpl(): Promise<string> {
+		// Create the frontend client. The second argument is empty for now; we
+		// could use this to pass in any initial state we want to pass to the
+		// frontend client (such as information on window geometry, etc.)
+		const client = await this.session.createClient<IUiClientMessageInput, IUiClientMessageOutput>
+			(RuntimeClientType.Ui, {});
+
+		// Create the UI client instance wrapping the client instance.
+		const uiClient = new UiClientInstance(client, this._commandService, this._logService, this._openerService, this._configurationService);
+		this._uiClient = uiClient;
+		this._register(this._uiClient);
+
+		const sessionId = this.session.sessionId;
+
+		// When the UI client instance emits an event, broadcast
+		// it to Positron with the corresponding runtime ID.
+		this._register(uiClient.onDidBusy(event => {
+			this._onDidReceiveRuntimeEventEmitter.fire({
+				session_id: sessionId,
+				event: {
+					name: UiFrontendEvent.Busy,
+					data: event
+				}
+			});
+		}));
+		this._register(uiClient.onDidClearConsole(event => {
+			this._onDidReceiveRuntimeEventEmitter.fire({
+				session_id: sessionId,
+				event: {
+					name: UiFrontendEvent.ClearConsole,
+					data: event
+				}
+			});
+		}));
+		this._register(uiClient.onDidSetEditorSelections(event => {
+			this._onDidReceiveRuntimeEventEmitter.fire({
+				session_id: sessionId,
+				event: {
+					name: UiFrontendEvent.SetEditorSelections,
+					data: event
+				}
+			});
+		}));
+		this._register(uiClient.onDidOpenEditor(event => {
+			this._onDidReceiveRuntimeEventEmitter.fire({
+				session_id: sessionId,
+				event: {
+					name: UiFrontendEvent.OpenEditor,
+					data: event
+				}
+			});
+		}));
+		this._register(uiClient.onDidOpenWorkspace(event => {
+			this._onDidReceiveRuntimeEventEmitter.fire({
+				session_id: sessionId,
+				event: {
+					name: UiFrontendEvent.OpenWorkspace,
+					data: event
+				}
+			});
+		}));
+		this._register(uiClient.onDidShowMessage(event => {
+			this._onDidReceiveRuntimeEventEmitter.fire({
+				session_id: sessionId,
+				event: {
+					name: UiFrontendEvent.ShowMessage,
+					data: event
+				}
+			});
+		}));
+		this._register(uiClient.onDidPromptState(event => {
+			this._onDidReceiveRuntimeEventEmitter.fire({
+				session_id: sessionId,
+				event: {
+					name: UiFrontendEvent.PromptState,
+					data: event
+				}
+			});
+		}));
+		this._register(uiClient.onDidWorkingDirectory(event => {
+			this._onDidReceiveRuntimeEventEmitter.fire({
+				session_id: sessionId,
+				event: {
+					name: UiFrontendEvent.WorkingDirectory,
+					data: event
+				}
+			});
+		}));
+		this._register(uiClient.onDidShowUrl(event => {
+			this._onDidReceiveRuntimeEventEmitter.fire({
+				session_id: sessionId,
+				event: {
+					name: UiFrontendEvent.ShowUrl,
+					data: event
+				}
+			});
+		}));
+		this._register(uiClient.onDidShowHtmlFile(event => {
+			this._onDidReceiveRuntimeEventEmitter.fire({
+				session_id: sessionId,
+				event: {
+					name: UiFrontendEvent.ShowHtmlFile,
+					data: event
+				}
+			});
+		}));
+		this._register(uiClient.onDidClearWebviewPreloads(event => {
+			this._onDidReceiveRuntimeEventEmitter.fire({
+				session_id: sessionId,
+				event: {
+					name: UiFrontendEvent.ClearWebviewPreloads,
+					data: event
+				}
+			});
+		}));
+
+		return client.getClientId();
+	}
+}

--- a/src/vs/workbench/services/runtimeSession/common/activeRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/activeRuntimeSession.ts
@@ -75,8 +75,7 @@ export class ActiveRuntimeSession extends Disposable {
 		// If we already know the client ID, just return it.
 		if (this._uiClient) {
 			const clientState = this._uiClient.getClientState();
-			if (clientState === RuntimeClientState.Connected ||
-				clientState === RuntimeClientState.Opening) {
+			if (clientState !== RuntimeClientState.Closed) {
 				// This is an active client; we can use it
 				return this._uiClient.getClientId();
 			} else {

--- a/src/vs/workbench/services/runtimeSession/common/activeRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/activeRuntimeSession.ts
@@ -17,10 +17,8 @@ import { UiFrontendEvent } from 'vs/workbench/services/languageRuntime/common/po
 import { ILanguageRuntimeGlobalEvent, ILanguageRuntimeSession, ILanguageRuntimeSessionManager, RuntimeClientType } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 
 /**
- * Utility class for tracking state changes in a language runtime session.
- *
- * We keep our own copy of the state so we can fire an event with both the old
- * and new state values when the state changes.
+ * Utility class for tracking the state and disposables associated with an
+ * active language runtime session.
  */
 export class ActiveRuntimeSession extends Disposable {
 	public state: RuntimeState;
@@ -32,10 +30,11 @@ export class ActiveRuntimeSession extends Disposable {
 	/// The UI client instance, if it exists
 	private _uiClient: UiClientInstance | undefined;
 
+	/// The promise that resolves when the UI client is started.
 	private _startingUiClient: DeferredPromise<string> | undefined;
 
 	/**
-	 * Create a new LanguageRuntimeSessionInfo.
+	 * Create a new ActiveRuntimeSession.
 	 *
 	 * @param session The session
 	 * @param manager The session's manager
@@ -49,6 +48,8 @@ export class ActiveRuntimeSession extends Disposable {
 		private readonly _configurationService: IConfigurationService
 	) {
 		super();
+
+		// Get the initial state from the session.
 		this.state = session.getRuntimeState();
 	}
 
@@ -64,9 +65,9 @@ export class ActiveRuntimeSession extends Disposable {
 	}
 
 	/**
-	 * Starts a UI client instance for the specified runtime session. The
-	 * UI client instance is used for two-way communication of
-	 * global state and events between the frontend and the backend.
+	 * Starts a UI client instance for the runtime session. The UI client
+	 * instance is used for two-way communication of global state and events
+	 * between the frontend and the backend.
 	 *
 	 * Resolves when the UI client instance is created, with the ID of the
 	 * newly created comm.

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -952,6 +952,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		const activeSession = new ActiveRuntimeSession(session, manager,
 			this._commandService, this._logService, this._openerService, this._configurationService);
 		this._activeSessionsBySessionId.set(session.sessionId, activeSession);
+		this._register(activeSession);
 		this._register(activeSession.onDidReceiveRuntimeEvent(evt => {
 			this._onDidReceiveRuntimeEventEmitter.fire(evt);
 		}));


### PR DESCRIPTION
This change addresses the remainder of issue https://github.com/posit-dev/positron/issues/5532.

The underlying problem turned out to be that in some circumstances (depending on timing) it is possible to get two UI comms to open at the same time. This happens when the _Ready_ status arrives multiple times. Since the _Ready_ status triggers the creation of the UI comm, and creating the comm is an async operation, receiving it multiple times can result in multiple in-flight requests to create the comm.

The fix has a few parts:

1. The fact that the _Ready_ status event happens multiple times can be traced upstream to the supervisor, which can mark the kernel Ready after getting the kernel info _and_ after the initial heartbeat. This fix updates to version 0.21 of the supervisor, which doesn't have this bug.
2. Even if the runtime fires multiple _Ready_ events, we should not create multiple UI comms. This fix adds re-entrancy guards to the part of the system that creates the comm, so that if we are asked to create one when one is already active, or we are in the process of creating one, we don't wind up with two.
3. Finally, I've done some light refactoring of the active session state to reduce the size of the runtime session service, and added a test for this bug.

### QA Notes

In order to test this, you'll want to be sure that the scenario in #5532 works at least 5 times in a row. I also recommend enabling the Runtime Sessions debug panel so you can check to see that the correct number of UI comms are in play as you test.
