### PR TITLE
E2E test: duck db sparklines

### DIFF
--- a/test/smoke/src/areas/positron/data-explorer/data-explorer-headless.test.ts
+++ b/test/smoke/src/areas/positron/data-explorer/data-explorer-headless.test.ts
@@ -14,7 +14,7 @@ test.use({
 test.describe('Headless Data Explorer - Large Data Frame', {
 	tag: ['@web']
 }, () => {
-	test.beforeEach(async function ({ app, python }) {
+	test.beforeEach(async function ({ app }) {
 		await app.workbench.positronLayouts.enterLayout('stacked');
 	});
 
@@ -33,6 +33,9 @@ test.describe('Headless Data Explorer - Large Data Frame', {
 
 async function testBody(app: Application, logger: Logger, fileName: string) {
 	const LAST_CELL_CONTENTS = '2013-09-30 08:00:00';
+
+	// if you immediately open the data file, the data explorer will be blank
+	await app.code.wait(5000);
 
 	await app.workbench.positronQuickaccess.openDataFile(join(app.workspacePathOrFolder, 'data-files', 'flights', fileName));
 

--- a/test/smoke/src/areas/positron/data-explorer/data-explorer-python-pandas.test.ts
+++ b/test/smoke/src/areas/positron/data-explorer/data-explorer-python-pandas.test.ts
@@ -100,19 +100,19 @@ df2 = pd.DataFrame(data)`;
 		await app.workbench.positronLayouts.enterLayout('notebook');
 
 		const col1ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(1);
-		expect(col1ProfileInfo).toStrictEqual({ 'Missing': '1', 'Min': '1.00', 'Median': '3.00', 'Mean': '3.00', 'Max': '5.00', 'SD': '1.83' });
+		expect(col1ProfileInfo.profileData).toStrictEqual({ 'Missing': '1', 'Min': '1.00', 'Median': '3.00', 'Mean': '3.00', 'Max': '5.00', 'SD': '1.83' });
 
 		const col2ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(2);
-		expect(col2ProfileInfo).toStrictEqual({ 'Missing': '2', 'Empty': '0', 'Unique': '3' });
+		expect(col2ProfileInfo.profileData).toStrictEqual({ 'Missing': '2', 'Empty': '0', 'Unique': '3' });
 
 		const col3ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(3);
-		expect(col3ProfileInfo).toStrictEqual({ 'Missing': '2', 'Min': '2.50', 'Median': '3.10', 'Mean': '3.47', 'Max': '4.80', 'SD': '1.19' });
+		expect(col3ProfileInfo.profileData).toStrictEqual({ 'Missing': '2', 'Min': '2.50', 'Median': '3.10', 'Mean': '3.47', 'Max': '4.80', 'SD': '1.19' });
 
 		const col4ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(4);
-		expect(col4ProfileInfo).toStrictEqual({ 'Missing': '3', 'Min': '2023-01-01 00:00:00', 'Median': 'NaT', 'Max': '2023-02-01 00:00:00', 'Timezone': 'None' });
+		expect(col4ProfileInfo.profileData).toStrictEqual({ 'Missing': '3', 'Min': '2023-01-01 00:00:00', 'Median': 'NaT', 'Max': '2023-02-01 00:00:00', 'Timezone': 'None' });
 
 		const col5ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(5);
-		expect(col5ProfileInfo).toStrictEqual({ 'Missing': '2', 'Empty': '0', 'Unique': '3' });
+		expect(col5ProfileInfo.profileData).toStrictEqual({ 'Missing': '2', 'Empty': '0', 'Unique': '3' });
 
 		await app.workbench.positronLayouts.enterLayout('stacked');
 		await app.workbench.positronSideBar.closeSecondarySideBar();

--- a/test/smoke/src/areas/positron/data-explorer/data-explorer-python-polars.test.ts
+++ b/test/smoke/src/areas/positron/data-explorer/data-explorer-python-polars.test.ts
@@ -55,22 +55,22 @@ test.describe('Data Explorer - Python Polars', {
 
 
 		const col1ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(1);
-		expect(col1ProfileInfo).toStrictEqual({ 'Missing': '0', 'Min': '1.00', 'Median': '2.00', 'Mean': '2.00', 'Max': '3.00', 'SD': '1.00' });
+		expect(col1ProfileInfo.profileData).toStrictEqual({ 'Missing': '0', 'Min': '1.00', 'Median': '2.00', 'Mean': '2.00', 'Max': '3.00', 'SD': '1.00' });
 
 		const col2ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(2);
-		expect(col2ProfileInfo).toStrictEqual({ 'Missing': '0', 'Min': '6.00', 'Median': '7.00', 'Mean': '7.00', 'Max': '8.00', 'SD': '1.00' });
+		expect(col2ProfileInfo.profileData).toStrictEqual({ 'Missing': '0', 'Min': '6.00', 'Median': '7.00', 'Mean': '7.00', 'Max': '8.00', 'SD': '1.00' });
 
 		const col3ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(3);
-		expect(col3ProfileInfo).toStrictEqual({ 'Missing': '0', 'Min': '2020-01-02', 'Median': '2021-03-04', 'Max': '2022-05-06' });
+		expect(col3ProfileInfo.profileData).toStrictEqual({ 'Missing': '0', 'Min': '2020-01-02', 'Median': '2021-03-04', 'Max': '2022-05-06' });
 
 		const col4ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(4);
-		expect(col4ProfileInfo).toStrictEqual({ 'Missing': '1', 'Min': '2.00', 'Median': '2.50', 'Mean': '2.50', 'Max': '3.00', 'SD': '0.7071' });
+		expect(col4ProfileInfo.profileData).toStrictEqual({ 'Missing': '1', 'Min': '2.00', 'Median': '2.50', 'Mean': '2.50', 'Max': '3.00', 'SD': '0.7071' });
 
 		const col5ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(5);
-		expect(col5ProfileInfo).toStrictEqual({ 'Missing': '1', 'Min': '0.5000', 'Median': '1.50', 'Mean': '1.50', 'Max': '2.50', 'SD': '1.41' });
+		expect(col5ProfileInfo.profileData).toStrictEqual({ 'Missing': '1', 'Min': '0.5000', 'Median': '1.50', 'Mean': '1.50', 'Max': '2.50', 'SD': '1.41' });
 
 		const col6ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(6);
-		expect(col6ProfileInfo).toStrictEqual({ 'Missing': '1', 'True': '1', 'False': '1' });
+		expect(col6ProfileInfo.profileData).toStrictEqual({ 'Missing': '1', 'True': '1', 'False': '1' });
 
 		await app.workbench.positronDataExplorer.collapseSummary();
 

--- a/test/smoke/src/areas/positron/data-explorer/data-explorer-r.test.ts
+++ b/test/smoke/src/areas/positron/data-explorer/data-explorer-r.test.ts
@@ -57,16 +57,16 @@ test.describe('Data Explorer - R ', {
 		await app.workbench.positronLayouts.enterLayout('notebook');
 
 		const col1ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(1);
-		expect(col1ProfileInfo).toStrictEqual({ 'Missing': '0', 'Empty': '0', 'Unique': '3' });
+		expect(col1ProfileInfo.profileData).toStrictEqual({ 'Missing': '0', 'Empty': '0', 'Unique': '3' });
 
 		const col2ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(2);
-		expect(col2ProfileInfo).toStrictEqual({ 'Missing': '1', 'Min': '100.00', 'Median': '110.00', 'Mean': '110.00', 'Max': '120.00', 'SD': '14.14' });
+		expect(col2ProfileInfo.profileData).toStrictEqual({ 'Missing': '1', 'Min': '100.00', 'Median': '110.00', 'Mean': '110.00', 'Max': '120.00', 'SD': '14.14' });
 
 		const col3ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(3);
-		expect(col3ProfileInfo).toStrictEqual({ 'Missing': '0', 'Min': '30.00', 'Median': '45.00', 'Mean': '45.00', 'Max': '60.00', 'SD': '15.00' });
+		expect(col3ProfileInfo.profileData).toStrictEqual({ 'Missing': '0', 'Min': '30.00', 'Median': '45.00', 'Mean': '45.00', 'Max': '60.00', 'SD': '15.00' });
 
 		const col4ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(4);
-		expect(col4ProfileInfo).toStrictEqual({ 'Missing': '2', 'Empty': '0', 'Unique': '2' });
+		expect(col4ProfileInfo.profileData).toStrictEqual({ 'Missing': '2', 'Empty': '0', 'Unique': '2' });
 
 		await app.workbench.positronLayouts.enterLayout('stacked');
 		await app.workbench.positronSideBar.closeSecondarySideBar();

--- a/test/smoke/src/areas/positron/data-explorer/duckdb-sparklines.test.ts
+++ b/test/smoke/src/areas/positron/data-explorer/duckdb-sparklines.test.ts
@@ -1,0 +1,121 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { test, expect } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Data Explorer - DuckDB Column Summary', {
+	tag: ['@web', '@win', '@pr']
+}, () => {
+	test('Verifies basic duckdb column summary functionality [C1053635]', async function ({ app }) {
+
+		// if you immediately open the data file, the data explorer will be blank
+		await app.code.wait(5000);
+
+		await app.workbench.positronQuickaccess.openDataFile(join(app.workspacePathOrFolder, 'data-files', '100x100', '100x100.parquet'));
+
+		await test.step('Verify some column missing percentages', async () => {
+			expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(1)).toBe('0%');
+			expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(2)).toBe('0%');
+			expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(3)).toBe('0%');
+			expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(4)).toBe('0%');
+			expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(5)).toBe('0%');
+		});
+
+		await app.workbench.positronLayouts.enterLayout('notebook');
+
+		await test.step('Verify some column profile info', async () => {
+			const col1ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(1);
+			expect(col1ProfileInfo.profileData).toStrictEqual({
+				'Missing': '0',
+				'Min': '0',
+				'Median': '0',
+				'Mean': '0',
+				'Max': '0',
+				'SD': '0'
+			});
+			expect(col1ProfileInfo.profileSparklineHeights).toStrictEqual(['50.0']);
+
+			const col2ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(2);
+			expect(col2ProfileInfo.profileData).toStrictEqual({
+				'Missing': '0',
+				'Empty': '0',
+				'Unique': '100'
+			});
+			expect(col2ProfileInfo.profileSparklineHeights).toStrictEqual([
+				'1.0',
+				'1.0',
+				'1.0',
+				'1.0',
+				'1.0',
+				'1.0',
+				'1.0',
+				'1.0',
+				'1.0',
+				'1.0',
+				'1.0',
+				'1.0',
+				'1.0',
+				'1.0',
+				'1.0',
+				'1.0',
+				'50.0',
+			]);
+
+			const col3ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(3);
+			expect(col3ProfileInfo.profileData).toStrictEqual({
+				'Missing': '0',
+				'True': '46',
+				'False': '54'
+			});
+			expect(col3ProfileInfo.profileSparklineHeights).toStrictEqual(['50.0', '42.6']);
+
+			const col4ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(4);
+			expect(col4ProfileInfo.profileData).toStrictEqual({
+				'Missing': '0',
+				'Min': '-125',
+				'Median': '-11',
+				'Mean': '-2.71',
+				'Max': '126',
+				'SD': '75.02'
+			});
+			expect(col4ProfileInfo.profileSparklineHeights).toStrictEqual([
+				'44.0',
+				'50.0',
+				'36.0',
+				'44.0',
+				'0.0',
+			]);
+
+			const col5ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(5);
+			expect(col5ProfileInfo.profileData).toStrictEqual({
+				'Missing': '0',
+				'Min': '-32403',
+				'Median': '-1357.50',
+				'Mean': '2138.13',
+				'Max': '32721',
+				'SD': '18186.19'
+			});
+			expect(col5ProfileInfo.profileSparklineHeights).toStrictEqual([
+				'28.3',
+				'47.8',
+				'50.0',
+				'43.5',
+				'0.0',
+			]);
+		});
+
+		await app.workbench.positronLayouts.enterLayout('stacked');
+		await app.workbench.positronSideBar.closeSecondarySideBar();
+
+		await app.workbench.positronDataExplorer.closeDataExplorer();
+		await app.workbench.positronVariables.toggleVariablesView();
+
+	});
+});

--- a/test/smoke/src/areas/positron/data-explorer/duckdb-sparklines.test.ts
+++ b/test/smoke/src/areas/positron/data-explorer/duckdb-sparklines.test.ts
@@ -20,6 +20,8 @@ test.describe('Data Explorer - DuckDB Column Summary', {
 
 		await app.workbench.positronQuickaccess.openDataFile(join(app.workspacePathOrFolder, 'data-files', '100x100', '100x100.parquet'));
 
+		await app.workbench.positronLayouts.enterLayout('notebook');
+
 		await test.step('Verify some column missing percentages', async () => {
 			expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(1)).toBe('0%');
 			expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(2)).toBe('0%');
@@ -27,8 +29,6 @@ test.describe('Data Explorer - DuckDB Column Summary', {
 			expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(4)).toBe('0%');
 			expect(await app.workbench.positronDataExplorer.getColumnMissingPercent(5)).toBe('0%');
 		});
-
-		await app.workbench.positronLayouts.enterLayout('notebook');
 
 		await test.step('Verify some column profile info', async () => {
 			const col1ProfileInfo = await app.workbench.positronDataExplorer.getColumnProfileInfo(1);


### PR DESCRIPTION
This test opens the qa-example-content file [100x100.parquet](https://github.com/posit-dev/qa-example-content/blob/main/data-files/100x100/100x100.parquet).  It then validates the empty percentages, the profile info and the heights of the rects in the expanded sparkline.

### QA Notes

All smoke tests should pass.
