### PR TITLE
Notebook variables pane sync

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeVariablesClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeVariablesClient.ts
@@ -232,16 +232,16 @@ export class VariablesClientInstance extends Disposable {
 	private connectClient(client: PositronVariablesComm) {
 		this._register(client);
 
-		this._comm.onDidRefresh((e: RefreshEvent) => {
+		this._register(this._comm.onDidRefresh((e: RefreshEvent) => {
 			this._onDidReceiveListEmitter.fire(new PositronVariablesList(
 				e.variables,
 				[], // No parent names; this is the top-level list
 				this._comm));
-		});
+		}));
 
-		this._comm.onDidUpdate((e: UpdateEvent) => {
+		this._register(this._comm.onDidUpdate((e: UpdateEvent) => {
 			this._onDidReceiveUpdateEmitter.fire(new PositronVariablesUpdate(
 				e, this._comm));
-		});
+		}));
 	}
 }

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -10,6 +10,7 @@ import { RuntimeItem } from 'vs/workbench/services/positronConsole/browser/class
 import { ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { ActivityItemPrompt } from 'vs/workbench/services/positronConsole/browser/classes/activityItemPrompt';
 import { RuntimeCodeExecutionMode, RuntimeErrorBehavior } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { IDisposable } from 'vs/base/common/lifecycle';
 
 // Create the decorator for the Positron console service (used in dependency injection).
 export const IPositronConsoleService = createDecorator<IPositronConsoleService>('positronConsoleService');
@@ -175,6 +176,12 @@ export interface IPositronConsoleInstance {
 	 * Last saved scroll top.
 	 */
 	lastScrollTop: number;
+
+	/**
+	 * Adds disposables that should be cleaned up when this instance is disposed.
+	 * @param disposables The disposables to add.
+	 */
+	addDisposables(disposables: IDisposable): void;
 
 	/**
 	 * The onFocusInput event.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -434,11 +434,11 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 		attachMode: SessionAttachMode
 	): IPositronConsoleInstance {
 		// Create the new Positron console instance.
-		const positronConsoleInstance = this._instantiationService.createInstance(
+		const positronConsoleInstance = this._register(this._instantiationService.createInstance(
 			PositronConsoleInstance,
 			session,
 			attachMode
-		);
+		));
 
 		// Add the Positron console instance.
 		this._positronConsoleInstancesByLanguageId.set(
@@ -522,7 +522,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * Gets or sets the disposable store. This contains things that are disposed when a runtime is
 	 * detached.
 	 */
-	private _runtimeDisposableStore = new DisposableStore();
+	private _runtimeDisposableStore = this._register(new DisposableStore());
 
 	/**
 	 * Gets or sets the runtime state.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -8,7 +8,7 @@ import { generateUuid } from 'vs/base/common/uuid';
 import { Event, Emitter } from 'vs/base/common/event';
 import { IEditor } from 'vs/editor/common/editorCommon';
 import { ILogService } from 'vs/platform/log/common/log';
-import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
 import { ISettableObservable, observableValue } from 'vs/base/common/observableInternal/base';
 import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -764,6 +764,14 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 		// Dispose of the runtime event handlers.
 		this._runtimeDisposableStore.dispose();
+	}
+
+	/**
+	 * Adds disposables that should be cleaned up when this instance is disposed.
+	 * @param disposables The disposables to add.
+	 */
+	addDisposables(disposables: IDisposable): void {
+		this._register(disposables);
 	}
 
 	//#endregion Constructor & Dispose

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -129,7 +129,7 @@ const formatTraceback = (traceback: string[]) => {
 /**
  * PositronConsoleService class.
  */
-class PositronConsoleService extends Disposable implements IPositronConsoleService {
+export class PositronConsoleService extends Disposable implements IPositronConsoleService {
 	//#region Private Properties
 
 	/**

--- a/src/vs/workbench/services/positronVariables/common/positronVariables.contribution.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariables.contribution.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Registry } from 'vs/platform/registry/common/platform';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
+import { localize } from 'vs/nls';
+
+// Register the configuration setting
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
+	.registerConfiguration({
+		properties: {
+			'positron.variables.followMode': {
+				type: 'boolean',
+				default: true,
+				description: localize('positron.variables.followMode', "Should the Positron variables pane automatically follows the active console or notebook."),
+			}
+		}
+	});

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
@@ -48,7 +48,7 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 	 * Gets or sets the runtime disposable store. This contains things that are disposed when a
 	 * runtime is detached.
 	 */
-	private _runtimeDisposableStore = new DisposableStore();
+	private _runtimeDisposableStore = this._register(new DisposableStore());
 
 	/**
 	 * Gets or sets the variable items map.

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesInstance.ts
@@ -474,8 +474,8 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 		// Try to create the runtime client.
 		try {
 			// Create the runtime client.
-			const client = await this._session.createClient<any, any>(
-				RuntimeClientType.Variables, {});
+			const client = this._register(await this._session.createClient<any, any>(
+				RuntimeClientType.Variables, {}));
 			this._variablesClient = new VariablesClientInstance(client);
 
 			// Add the onDidReceiveList event handler.
@@ -494,8 +494,9 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 
 			// Create an event handler for the client state.
 			const event = Event.fromObservable(
-				this._variablesClient.clientState, this._runtimeDisposableStore);
-			event(state => {
+				this._variablesClient.clientState, this._runtimeDisposableStore)
+
+			this._runtimeDisposableStore.add(event(state => {
 				// Clear all expanded paths if the client is closed.
 				if (state === RuntimeClientState.Closed) {
 					this._expandedPaths.clear();
@@ -503,8 +504,7 @@ export class PositronVariablesInstance extends Disposable implements IPositronVa
 
 				// Fire the onDidChangeState event.
 				this._onDidChangeStateEmitter.fire(state);
-			});
-
+			}));
 
 			// Add the runtime client to the runtime disposable store.
 			this._runtimeDisposableStore.add(this._variablesClient);

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -25,7 +25,7 @@ import { PositronNotebookEditorInput } from 'vs/workbench/contrib/positronNotebo
 /**
  * PositronVariablesService class.
  */
-class PositronVariablesService extends Disposable implements IPositronVariablesService {
+export class PositronVariablesService extends Disposable implements IPositronVariablesService {
 	//#region Private Properties
 
 	/**

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -18,6 +18,7 @@ import { isEqual } from 'vs/base/common/resources';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { NotebookEditorInput } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 /**
  * PositronVariablesService class.
@@ -65,13 +66,15 @@ class PositronVariablesService extends Disposable implements IPositronVariablesS
 	 * @param _notificationService The notification service.
 	 * @param _accessibilityService The accessibility service.
 	 * @param _editorService The editor service.
+	 * @param _configurationService The configuration service.
 	 */
 	constructor(
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
 		@ILogService private readonly _logService: ILogService,
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
-		@IEditorService private readonly _editorService: IEditorService
+		@IEditorService private readonly _editorService: IEditorService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService
 	) {
 		// Call the disposable constrcutor.
 		super();
@@ -109,8 +112,10 @@ class PositronVariablesService extends Disposable implements IPositronVariablesS
 		}));
 
 		this._register(this._editorService.onDidActiveEditorChange(() => {
-
 			// Check for feature flag for session following editor being on before proceeding
+			if (!this._configurationService.getValue('positron.variables.followsEditor')) {
+				return;
+			}
 
 			const editorInput = this._editorService.activeEditor;
 			if (editorInput instanceof NotebookEditorInput) {

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -87,7 +87,7 @@ class PositronVariablesService extends Disposable implements IPositronVariablesS
 				this._runtimeSessionService.foregroundSession.sessionId
 			);
 			if (positronVariablesInstance) {
-				this.setActivePositronVariablesInstance(positronVariablesInstance);
+				this._setActivePositronVariablesInstance(positronVariablesInstance);
 			}
 		}
 
@@ -106,7 +106,7 @@ class PositronVariablesService extends Disposable implements IPositronVariablesS
 		// Register the onDidChangeActiveRuntime event handler.
 		this._register(this._runtimeSessionService.onDidChangeForegroundSession(session => {
 			if (!session) {
-				this.setActivePositronVariablesInstance()
+				this._setActivePositronVariablesInstance()
 				return;
 			}
 
@@ -130,7 +130,7 @@ class PositronVariablesService extends Disposable implements IPositronVariablesS
 				// Revert to the most recent console session if we're not in a notebook editor
 				this._setActivePositronVariablesBySession(this._previousConsoleSession);
 			} else {
-				this.setActivePositronVariablesInstance()
+				this._setActivePositronVariablesInstance()
 			}
 		}));
 	}
@@ -171,7 +171,7 @@ class PositronVariablesService extends Disposable implements IPositronVariablesS
 			this._positronVariablesInstancesBySessionId.get(sessionId);
 		if (positronVariablesInstance) {
 			// Found it; make it active.
-			this.setActivePositronVariablesInstance(positronVariablesInstance);
+			this._setActivePositronVariablesInstance(positronVariablesInstance);
 		} else {
 			// Did not find it; log a warning.
 			this._logService.warn(
@@ -285,7 +285,7 @@ class PositronVariablesService extends Disposable implements IPositronVariablesS
 	 * Sets the active Positron variables instance.
 	 * @param positronVariablesInstance The Positron variables instance.
 	 */
-	private setActivePositronVariablesInstance(
+	private _setActivePositronVariablesInstance(
 		positronVariablesInstance?: IPositronVariablesInstance
 	) {
 		// Set the active instance and fire the onDidChangeActivePositronVariablesInstance event.
@@ -308,7 +308,7 @@ class PositronVariablesService extends Disposable implements IPositronVariablesS
 		);
 
 		if (positronVariablesInstance) {
-			this.setActivePositronVariablesInstance(positronVariablesInstance);
+			this._setActivePositronVariablesInstance(positronVariablesInstance);
 			return
 		}
 

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -20,6 +20,7 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { NotebookEditorInput } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
+import { PositronNotebookEditorInput } from 'vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput';
 
 /**
  * PositronVariablesService class.
@@ -131,12 +132,15 @@ class PositronVariablesService extends Disposable implements IPositronVariablesS
 			}
 
 			const editorInput = this._editorService.activeEditor;
-			if (editorInput instanceof NotebookEditorInput) {
-				// If this is a notebook editor. we should check to see if we have a
-				// variable session setup for it.
-				this._setActivePositronVariablesBySession(this._runtimeSessionService.activeSessions.find(
+			if (editorInput instanceof NotebookEditorInput || editorInput instanceof PositronNotebookEditorInput) {
+				// If this is a notebook editor try and set the active variables session to the one
+				// that corresponds with it.
+				const notebookSession = this._runtimeSessionService.activeSessions.find(
 					s => s.metadata.notebookUri && isEqual(s.metadata.notebookUri, editorInput.resource)
-				));
+				);
+				// If the editor is not for a jupyter notebook, just leave variables session as is.
+				if (!notebookSession) { return; }
+				this._setActivePositronVariablesBySession(notebookSession);
 			} else if (this._previousConsoleSession) {
 				// Revert to the most recent console session if we're not in a notebook editor
 				this._setActivePositronVariablesBySession(this._previousConsoleSession);

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter } from 'vs/base/common/event';
-import { Disposable } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableMap } from 'vs/base/common/lifecycle';
 import { ILogService } from 'vs/platform/log/common/log';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { PositronVariablesInstance } from 'vs/workbench/services/positronVariables/common/positronVariablesInstance';
@@ -32,7 +32,7 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 	 * Gets a map of the Positron variables instances by session ID.
 	 */
 	private readonly _positronVariablesInstancesBySessionId =
-		new Map<string, PositronVariablesInstance>();
+		this._register(new DisposableMap<string, PositronVariablesInstance>());
 
 	/**
 	 * Gets or sets the active Positron variables instance.
@@ -231,8 +231,7 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 			}
 
 			// Dispose the instance and remove it from our map
-			instance.dispose();
-			this._positronVariablesInstancesBySessionId.delete(sessionId);
+			this._positronVariablesInstancesBySessionId.deleteAndDispose(sessionId);
 		}
 	}
 
@@ -283,7 +282,7 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 
 		if (existingInstance) {
 			// Clean up the old session ID mapping
-			this._positronVariablesInstancesBySessionId.delete(existingInstance.session.sessionId);
+			this._positronVariablesInstancesBySessionId.deleteAndDispose(existingInstance.session.sessionId);
 
 			// Update the map of Positron variables instances by session ID.
 			this._positronVariablesInstancesBySessionId.set(

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -55,7 +55,7 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 	 * The previous console session. Used to restore variables pane to active session
 	 * when a notebook is hidden.
 	 */
-	private _previousConsoleSession?: ILanguageRuntimeSession;
+	private _activeConsoleSession?: ILanguageRuntimeSession;
 
 	//#endregion Private Properties
 
@@ -105,7 +105,7 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 			// If this is a console session, set it as the main console session that is
 			// used when the notebook is hidden.
 			if (e.session.metadata.sessionMode === LanguageRuntimeSessionMode.Console) {
-				this._previousConsoleSession = e.session;
+				this._activeConsoleSession = e.session;
 			}
 		}));
 
@@ -148,9 +148,9 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 				// If the editor is not for a jupyter notebook, just leave variables session as is.
 				if (!notebookSession) { return; }
 				this._setActivePositronVariablesBySession(notebookSession);
-			} else if (this._previousConsoleSession) {
+			} else if (this._activeConsoleSession) {
 				// Revert to the most recent console session if we're not in a notebook editor
-				this._setActivePositronVariablesBySession(this._previousConsoleSession);
+				this._setActivePositronVariablesBySession(this._activeConsoleSession);
 			} else {
 				// All else fails, just reset to the default
 				this._setActivePositronVariablesInstance()
@@ -226,8 +226,8 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 			}
 
 			// If this was the previous console session, clear it
-			if (this._previousConsoleSession === instance.session) {
-				this._previousConsoleSession = undefined;
+			if (this._activeConsoleSession === instance.session) {
+				this._activeConsoleSession = undefined;
 			}
 
 			// Dispose the instance and remove it from our map

--- a/src/vs/workbench/test/browser/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/positronWorkbenchTestServices.ts
@@ -26,8 +26,16 @@ import { IPositronWebviewPreloadService } from 'vs/workbench/services/positronWe
 import { createRuntimeServices } from 'vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
-import { workbenchInstantiationService as baseWorkbenchInstantiationService, TestViewsService } from 'vs/workbench/test/browser/workbenchTestServices';
+import { workbenchInstantiationService as baseWorkbenchInstantiationService, TestEditorService, TestViewsService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { TestNotebookService } from 'vs/workbench/test/common/positronWorkbenchTestServices';
+import { IPositronVariablesService } from 'vs/workbench/services/positronVariables/common/interfaces/positronVariablesService';
+import { PositronVariablesService } from 'vs/workbench/services/positronVariables/common/positronVariablesService';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
+import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
+import { IPositronConsoleService } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
+import { PositronConsoleService } from 'vs/workbench/services/positronConsole/browser/positronConsoleService';
 
 export function positronWorkbenchInstantiationService(
 	disposables: Pick<DisposableStore, 'add'> = new DisposableStore(),
@@ -48,6 +56,10 @@ export function positronWorkbenchInstantiationService(
 	instantiationService.stub(IPositronIPyWidgetsService, disposables.add(instantiationService.createInstance(PositronIPyWidgetsService)));
 	instantiationService.stub(IViewsService, new TestViewsService());
 	instantiationService.stub(IPositronPlotsService, disposables.add(instantiationService.createInstance(PositronPlotsService)));
+	instantiationService.stub(IEditorService, disposables.add(new TestEditorService()));
+	instantiationService.stub(IConfigurationService, new TestConfigurationService());
+	instantiationService.stub(IPositronConsoleService, disposables.add(instantiationService.createInstance(PositronConsoleService)));
+	instantiationService.stub(IPositronVariablesService, disposables.add(instantiationService.createInstance(PositronVariablesService)));
 
 	return instantiationService;
 }
@@ -59,5 +71,9 @@ export class PositronTestServiceAccessor {
 		@IPositronIPyWidgetsService public positronIPyWidgetsService: PositronIPyWidgetsService,
 		@IPositronPlotsService public positronPlotsService: IPositronPlotsService,
 		@IPositronWebviewPreloadService public positronWebviewPreloadService: PositronWebviewPreloadService,
+		@IPositronVariablesService public positronVariablesService: IPositronVariablesService,
+		@IEditorService public editorService: IEditorService,
+		@IConfigurationService public configurationService: IConfigurationService,
+		@IRuntimeSessionService public runtimeSessionService: IRuntimeSessionService,
 	) { }
 }

--- a/src/vs/workbench/test/browser/services/positronVariablesService.test.ts
+++ b/src/vs/workbench/test/browser/services/positronVariablesService.test.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { timeout } from 'vs/base/common/async';
+import { Emitter } from 'vs/base/common/event';
+import { URI } from 'vs/base/common/uri';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
+import { INotebookEditor } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorService';
+import { LanguageRuntimeSessionMode } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { IPositronVariablesService } from 'vs/workbench/services/positronVariables/common/interfaces/positronVariablesService';
+import { startTestLanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService';
+import { PositronTestServiceAccessor, positronWorkbenchInstantiationService } from 'vs/workbench/test/browser/positronWorkbenchTestServices';
+
+interface TestNotebookEditor extends INotebookEditor {
+	changeModel(uri: URI): void;
+}
+
+suite('Positron - PositronVariablesService', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let instantiationService: TestInstantiationService;
+	let accessor: PositronTestServiceAccessor;
+	let variablesService: IPositronVariablesService;
+	let notebookEditorService: INotebookEditorService;
+
+
+	setup(() => {
+		instantiationService = positronWorkbenchInstantiationService(disposables);
+		accessor = instantiationService.createInstance(PositronTestServiceAccessor);
+		variablesService = accessor.positronVariablesService;
+		notebookEditorService = accessor.notebookEditorService;
+	});
+
+	async function createNotebookInstance() {
+		const notebookUri = URI.file('test-notebook.ipynb');
+
+		// Add a mock notebook editor
+		const onDidChangeModel = disposables.add(new Emitter<NotebookTextModel | undefined>());
+		const notebookEditor = <TestNotebookEditor>{
+			getId() { return 'test-notebook-editor-id'; },
+			onDidChangeModel: onDidChangeModel.event,
+			textModel: { uri: notebookUri },
+			changeModel(uri) { onDidChangeModel.fire(<NotebookTextModel>{ uri }); },
+		};
+		notebookEditorService.addNotebookEditor(notebookEditor);
+
+		// Start a notebook session
+		const session = await startTestLanguageRuntimeSession(
+			instantiationService,
+			disposables,
+			{
+				sessionMode: LanguageRuntimeSessionMode.Notebook,
+				notebookUri
+			}
+		);
+
+		return {
+			notebookUri,
+			notebookEditor,
+			session
+		};
+	}
+
+	async function createConsoleInstance() {
+		// Start a console session
+		const session = await startTestLanguageRuntimeSession(
+			instantiationService,
+			disposables,
+			{
+				sessionMode: LanguageRuntimeSessionMode.Console
+			}
+		);
+
+		return { session };
+	}
+
+	test('should initialize with no active session', async () => {
+		assert.strictEqual(variablesService.activePositronVariablesInstance, undefined);
+	});
+
+	test('should create variables instance for new sessions', async () => {
+		const { session: notebookSession } = await createNotebookInstance();
+		const { session: consoleSession } = await createConsoleInstance();
+		await timeout(0);
+
+		// Both sessions should have variables instances
+		assert(variablesService.positronVariablesInstances.some(instance =>
+			instance.session.sessionId === notebookSession.sessionId));
+		assert(variablesService.positronVariablesInstances.some(instance =>
+			instance.session.sessionId === consoleSession.sessionId));
+	});
+
+});

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -183,7 +183,6 @@ import 'vs/workbench/contrib/encryption/electron-sandbox/encryption.contribution
 import 'vs/workbench/contrib/positronPreview/electron-sandbox/positronPreview.contribution';
 // Positron Variables
 import 'vs/workbench/services/positronVariables/common/positronVariables.contribution';
-import 'vs/workbench/services/positronVariables/common/positronVariablesService';
 // --- End Positron ---
 
 //#endregion

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -181,6 +181,9 @@ import 'vs/workbench/contrib/encryption/electron-sandbox/encryption.contribution
 
 // --- Start Positron ---
 import 'vs/workbench/contrib/positronPreview/electron-sandbox/positronPreview.contribution';
+// Positron Variables
+import 'vs/workbench/services/positronVariables/common/positronVariables.contribution';
+import 'vs/workbench/services/positronVariables/common/positronVariablesService';
 // --- End Positron ---
 
 //#endregion


### PR DESCRIPTION
Addresses #2452

This PR adds the ability for the variables pane to "follow" the user around as they work across different sessions (particularly useful for notebooks that have their own sessions.)

It works by automatically switching the variables pane in the following circumstances
- If the active editor tab is changed
  - If changed to a notebook, will switch variables to that notesbook session's variables
  - If changed to a non-notebook file such as a script, will switch the variables to the last-active console session.
- If code is run in the console the session backing the console's variables will be focused. 

https://github.com/user-attachments/assets/7fae8c0d-eea4-4cd4-a664-ee7cab902674

All of this behavior can be turned off by setting the `positron.variables.followMode` setting to false. (`src/vs/workbench/services/positronVariables/common/positronVariables.contribution.ts`)

### Annoyances
- Currently there's no real way to correlate a script like a `.R` or `.py` script with a session. In this case we go back to the most recent console session, but that could be confusing if you clicked onto an R session and your most recent console was a python session. I left this behavior as is because it's what _currently_ happens and it feels like the upcoming multi-session work will formalize behavior around this. 

### Code Refactoring:

* Renamed the method `setActivePositronVariablesInstance` to `_setActivePositronVariablesInstance` for consistency with other private methods. (`src/vs/workbench/services/positronVariables/common/positronVariablesService.ts`)


## QA notes:

Should be able to fiddle between different notebooks and consoles and the variables pane should go to where you expect it to. 