### PR TITLE
install python modules in Terminal when `python.installModulesInTerminal` enabled

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -837,6 +837,12 @@
                     "description": "%python.venvPath.description%",
                     "scope": "machine",
                     "type": "string"
+                },
+                "python.installModulesInTerminal": {
+                    "default": false,
+                    "markdownDescription": "%python.installModulesInTerminal.description%",
+                    "scope": "resource",
+                    "type": "boolean"
                 }
             },
             "title": "Python",

--- a/extensions/positron-python/package.nls.json
+++ b/extensions/positron-python/package.nls.json
@@ -104,6 +104,7 @@
     "python.testing.unittestEnabled.description": "Enable testing using unittest.",
     "python.venvFolders.description": "Folders in your home directory to look into for virtual environments (supports pyenv, direnv and virtualenvwrapper by default).",
     "python.venvPath.description": "Path to folder with a list of Virtual Environments (e.g. ~/.pyenv, ~/Envs, ~/.virtualenvs).",
+    "python.installModulesInTerminal.description": "Whether to install Python modules (such as `ipykernel`) in the Terminal, instead of in a background process. Installing modules in the Terminal allows you to see the output of the installation command.",
     "walkthrough.pythonWelcome.title": "Get Started with Python Development",
     "walkthrough.pythonWelcome.description": "Your first steps to set up a Python project with all the powerful tools and features that the Python extension has to offer!",
      "walkthrough.step.python.createPythonFile.title": "Create a Python file",

--- a/extensions/positron-python/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -282,6 +282,15 @@ suite('Module Installer', () => {
                             workspaceService
                                 .setup((w) => w.getConfiguration(TypeMoq.It.isValue('http')))
                                 .returns(() => http.object);
+                            // --- Start Positron ---
+                            const pythonConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
+                            pythonConfig
+                                .setup((p) => p.get(TypeMoq.It.isValue('installModulesInTerminal'), TypeMoq.It.isAny()))
+                                .returns(() => false);
+                            workspaceService
+                                .setup((w) => w.getConfiguration(TypeMoq.It.isValue('python')))
+                                .returns(() => pythonConfig.object);
+                            // --- End Positron ---
                             installer = new InstallerClass(serviceContainer.object);
                         });
                         teardown(() => {


### PR DESCRIPTION
### Summary

- Backports https://github.com/posit-dev/positron/pull/5529
- Addresses https://github.com/posit-dev/positron/issues/5506

### QA Notes

Please see notes in https://github.com/posit-dev/positron/pull/5529.