### PR TITLE
fix Run App for Gradio apps

### DIFF
--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -46,7 +46,7 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
         registerExecCommand(
             Commands.Exec_Gradio_In_Terminal,
             'Gradio',
-            (_runtime, document, urlPrefix) => getGradioDebugConfig(document, urlPrefix),
+            (_runtime, document, _urlPrefix) => getGradioDebugConfig(document),
             undefined,
             undefined,
             // Gradio url strings: https://github.com/gradio-app/gradio/blob/main/gradio/strings.py
@@ -100,7 +100,7 @@ export function activateWebAppCommands(serviceContainer: IServiceContainer, disp
         registerDebugCommand(
             Commands.Debug_Gradio_In_Terminal,
             'Gradio',
-            (_runtime, document, urlPrefix) => getGradioDebugConfig(document, urlPrefix),
+            (_runtime, document, _urlPrefix) => getGradioDebugConfig(document),
             undefined,
             undefined,
             // Gradio url strings: https://github.com/gradio-app/gradio/blob/main/gradio/strings.py
@@ -276,15 +276,8 @@ function getFlaskDebugConfig(document: vscode.TextDocument): DebugConfiguration 
     return { module: 'flask', args };
 }
 
-function getGradioDebugConfig(document: vscode.TextDocument, urlPrefix?: string): DebugConfiguration {
+function getGradioDebugConfig(document: vscode.TextDocument): DebugConfiguration {
     const env: { [key: string]: string } = {};
-    if (urlPrefix) {
-        // Gradio doc: https://www.gradio.app/guides/environment-variables#7-gradio-root-path
-        // Issue with Gradio not loading assets when Gradio is run via proxy:
-        //     https://github.com/gradio-app/gradio/issues/9529
-        // Gradio works if we use these versions: gradio==3.3.1 fastapi==0.85.2 httpx==0.24.1
-        env.GRADIO_ROOT_PATH = urlPrefix;
-    }
     return { program: document.uri.fsPath, env };
 }
 

--- a/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
@@ -220,7 +220,6 @@ suite('Web app commands', () => {
             Commands.Exec_Gradio_In_Terminal,
             {
                 commandLine: `${runtimePath} ${documentPath}`,
-                env: { GRADIO_ROOT_PATH: urlPrefix },
             },
             { urlPrefix },
         );
@@ -339,7 +338,7 @@ suite('Web app commands', () => {
                 jinja: true,
                 stopOnEntry: false,
                 program: documentPath,
-                env: { GRADIO_ROOT_PATH: urlPrefix },
+                env: {},
             },
             { urlPrefix },
         );

--- a/test/e2e/features/apps/python-apps.test.ts
+++ b/test/e2e/features/apps/python-apps.test.ts
@@ -57,9 +57,8 @@ test.describe('Python Applications', { tag: ['@pr'] }, () => {
 	});
 
 	// TODO: update for pop out to editor when issue resolved
-	test.skip('Python - Verify Basic Gradio App [C903307]', {
+	test('Python - Verify Basic Gradio App [C903307]', {
 		tag: ['@win'],
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5459' }]
 	}, async function ({ app, python }) {
 		const viewer = app.workbench.positronViewer;
 


### PR DESCRIPTION
### Summary

- Addresses https://github.com/posit-dev/positron/issues/5459
- Companion Gradio Issue https://github.com/gradio-app/gradio/issues/10093
- Companion Gradio PR https://github.com/gradio-app/gradio/pull/10094
- Re-enables `Python - Verify Basic Gradio App [C903307]`

#### localhost ValueError
https://github.com/gradio-app/gradio/pull/10094 addresses the following error described in #5459 

```
Traceback (most recent call last):
  File "/Users/christophermead/posit/qa-example-content/workspaces/python_apps/gradio_example/gradio_example.py", line 5, in <module>
    demo.launch()
  File "/Users/christophermead/.pyenv/versions/3.10.12/lib/python3.10/site-packages/gradio/blocks.py", line 2582, in launch
    raise ValueError(
ValueError: When localhost is not accessible, a shareable link must be created. Please set share=True or check your proxy settings to allow access to localhost.
```

We'll need to wait for [Gradio 5.8.0](https://github.com/gradio-app/gradio/pull/10082) before we can confirm that this error is fixed -- **edit: 5.8.0 has been released**! This error occurs before the [CSS styling issue](https://github.com/posit-dev/positron/issues/5459#issuecomment-2515466211) can be seen. A manual patch to gradio is currently needed in order to reach this second issue.

#### Failure to load styles
Our use of `GRADIO_ROOT_PATH` is no longer needed and also no longer works since the underlying issue was resolved in [Gradio 5.7.0](https://github.com/gradio-app/gradio/pull/9970), via https://github.com/gradio-app/gradio/pull/9822. The related code is being removed in this PR.

### QA Notes

The [gradio example app](https://github.com/posit-dev/qa-example-content/tree/main/workspaces/python_apps/gradio_example) should now work in Web and Desktop. 
