### PR TITLE
Use "positron" as the publisher for our extensions

### DIFF
--- a/extensions/jupyter-adapter/package.json
+++ b/extensions/jupyter-adapter/package.json
@@ -2,7 +2,7 @@
   "name": "jupyter-adapter",
   "displayName": "%displayName%",
   "description": "%description%",
-  "publisher": "vscode",
+  "publisher": "positron",
   "version": "0.0.1",
   "engines": {
     "vscode": "^1.61.0"

--- a/extensions/positron-code-cells/package.json
+++ b/extensions/positron-code-cells/package.json
@@ -2,7 +2,7 @@
   "name": "positron-code-cells",
   "displayName": "%displayName%",
   "description": "%description%",
-  "publisher": "vscode",
+  "publisher": "positron",
   "version": "0.0.1",
   "engines": {
     "vscode": "^1.65.0"

--- a/extensions/positron-code-cells/src/test/context.test.ts
+++ b/extensions/positron-code-cells/src/test/context.test.ts
@@ -11,7 +11,7 @@ import { closeAllEditors } from './utils';
 suite('Context', () => {
 	setup(async () => {
 		// Testing the context keys requires the extension to be activated.
-		await vscode.extensions.getExtension('vscode.positron-code-cells')!.activate();
+		await vscode.extensions.getExtension('positron.positron-code-cells')!.activate();
 	});
 	teardown(closeAllEditors);
 

--- a/extensions/positron-connections/package.json
+++ b/extensions/positron-connections/package.json
@@ -3,7 +3,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "0.0.1",
-  "publisher": "vscode",
+  "publisher": "positron",
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-connections/src/extension.ts
+++ b/extensions/positron-connections/src/extension.ts
@@ -131,7 +131,7 @@ export function activateImpl(context: vscode.ExtensionContext) {
 				connectionProvider.expandConnectionNodes(connectionTreeView);
 			}));
 
-	// this allows vscode.extensions.getExtension('vscode.positron-connections').exports
+	// this allows vscode.extensions.getExtension('positron.positron-connections').exports
 	// to acccess the ConnectionItemsProvider instance
 	return connectionProvider;
 }

--- a/extensions/positron-connections/src/test/connection.test.ts
+++ b/extensions/positron-connections/src/test/connection.test.ts
@@ -28,7 +28,7 @@ suite('Connections pane works for R', () => {
 			'con <- connections::connection_open(RSQLite::SQLite(), tempfile())',
 		);
 
-		const ext = vscode.extensions.getExtension<ConnectionItemsProvider>('vscode.positron-connections');
+		const ext = vscode.extensions.getExtension<ConnectionItemsProvider>('positron.positron-connections');
 		const provider = ext?.exports;
 		assert(provider !== undefined);
 

--- a/extensions/positron-duckdb/package.json
+++ b/extensions/positron-duckdb/package.json
@@ -3,7 +3,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "0.0.1",
-  "publisher": "vscode",
+  "publisher": "positron",
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -42,7 +42,7 @@ const DEFAULT_FORMAT_OPTIONS: FormatOptions = {
 // Not sure why it is not possible to use Mocha's 'before' for this
 async function activateExtension() {
 	// Ensure the extension is activated
-	await vscode.extensions.getExtension('vscode.positron-duckdb')?.activate();
+	await vscode.extensions.getExtension('positron.positron-duckdb')?.activate();
 }
 
 async function runQuery<Type>(query: string): Promise<Array<Type>> {

--- a/extensions/positron-ipywidgets/package.json
+++ b/extensions/positron-ipywidgets/package.json
@@ -3,7 +3,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "0.0.1",
-  "publisher": "vscode",
+  "publisher": "positron",
   "engines": {
     "vscode": "^1.75.0"
   },

--- a/extensions/positron-javascript/package.json
+++ b/extensions/positron-javascript/package.json
@@ -3,7 +3,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "0.0.1",
-  "publisher": "vscode",
+  "publisher": "positron",
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-notebook-controllers/package.json
+++ b/extensions/positron-notebook-controllers/package.json
@@ -2,7 +2,7 @@
   "name": "positron-notebook-controllers",
   "displayName": "Positron Notebook Controllers",
   "description": "Notebook Controllers for Positron Language Runtimes",
-  "publisher": "vscode",
+  "publisher": "positron",
   "version": "0.0.1",
   "engines": {
     "vscode": "^1.65.0"

--- a/extensions/positron-notebook-controllers/package.json
+++ b/extensions/positron-notebook-controllers/package.json
@@ -46,7 +46,7 @@
         {
           "command": "positron.restartKernel",
           "group": "navigation/execute@5",
-          "when": "notebookKernel =~ /^vscode.positron-notebook-controllers\\//"
+          "when": "notebookKernel =~ /^positron.positron-notebook-controllers\\//"
         }
       ]
     }

--- a/extensions/positron-notebooks/package.json
+++ b/extensions/positron-notebooks/package.json
@@ -3,7 +3,7 @@
   "displayName": "Positron Notebooks Helpers",
   "description": "Positron Notebook Helpers",
   "version": "1.0.0",
-  "publisher": "vscode",
+  "publisher": "positron",
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-proxy/package.json
+++ b/extensions/positron-proxy/package.json
@@ -3,7 +3,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.0",
-  "publisher": "vscode",
+  "publisher": "positron",
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -16,7 +16,7 @@
             "description": "Only Partial IntelliSense supported."
         }
     },
-    "publisher": "ms-python",
+    "publisher": "positron",
     "enabledApiProposals": [
         "positronResolveSymlinks",
         "contribEditorContentMenu",

--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -16,7 +16,7 @@
             "description": "Only Partial IntelliSense supported."
         }
     },
-    "publisher": "positron",
+    "publisher": "ms-python",
     "enabledApiProposals": [
         "positronResolveSymlinks",
         "contribEditorContentMenu",

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -470,7 +470,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         const config = vscode.workspace.getConfiguration('positronKernelSupervisor');
         if (config.get<boolean>('enable', true) && this.runtimeMetadata.runtimeId !== 'reticulate') {
             // Use the Positron kernel supervisor if enabled
-            const ext = vscode.extensions.getExtension('vscode.positron-supervisor');
+            const ext = vscode.extensions.getExtension('positron.positron-supervisor');
             if (!ext) {
                 throw new Error('Positron Supervisor extension not found');
             }
@@ -480,7 +480,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             this.adapterApi = ext?.exports as JupyterAdapterApi;
         } else {
             // Otherwise, connect to the Jupyter kernel directly
-            const ext = vscode.extensions.getExtension('vscode.jupyter-adapter');
+            const ext = vscode.extensions.getExtension('positron.jupyter-adapter');
             if (!ext) {
                 throw new Error('Jupyter Adapter extension not found');
             }
@@ -491,15 +491,15 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         }
         const kernel = this.kernelSpec
             ? // We have a kernel spec, so we're creating a new session
-              await this.adapterApi.createSession(
-                  this.runtimeMetadata,
-                  this.metadata,
-                  this.kernelSpec,
-                  this.dynState,
-                  createJupyterKernelExtra(),
-              )
+            await this.adapterApi.createSession(
+                this.runtimeMetadata,
+                this.metadata,
+                this.kernelSpec,
+                this.dynState,
+                createJupyterKernelExtra(),
+            )
             : // We don't have a kernel spec, so we're restoring a session
-              await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
+            await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
 
         kernel.onDidChangeRuntimeState((state) => {
             this._stateEmitter.fire(state);
@@ -622,10 +622,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             const regex = /^(\w*Error|Exception)\b/m;
             const errortext = regex.test(logFileContent)
                 ? vscode.l10n.t(
-                      '{0} exited unexpectedly with error: {1}',
-                      kernel.runtimeMetadata.runtimeName,
-                      logFileContent,
-                  )
+                    '{0} exited unexpectedly with error: {1}',
+                    kernel.runtimeMetadata.runtimeName,
+                    logFileContent,
+                )
                 : Console.consoleExitGeneric;
 
             const res = await showErrorMessage(errortext, vscode.l10n.t('Open Logs'));

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -491,15 +491,15 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         }
         const kernel = this.kernelSpec
             ? // We have a kernel spec, so we're creating a new session
-            await this.adapterApi.createSession(
-                this.runtimeMetadata,
-                this.metadata,
-                this.kernelSpec,
-                this.dynState,
-                createJupyterKernelExtra(),
-            )
+              await this.adapterApi.createSession(
+                  this.runtimeMetadata,
+                  this.metadata,
+                  this.kernelSpec,
+                  this.dynState,
+                  createJupyterKernelExtra(),
+              )
             : // We don't have a kernel spec, so we're restoring a session
-            await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
+              await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
 
         kernel.onDidChangeRuntimeState((state) => {
             this._stateEmitter.fire(state);
@@ -622,10 +622,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             const regex = /^(\w*Error|Exception)\b/m;
             const errortext = regex.test(logFileContent)
                 ? vscode.l10n.t(
-                    '{0} exited unexpectedly with error: {1}',
-                    kernel.runtimeMetadata.runtimeName,
-                    logFileContent,
-                )
+                      '{0} exited unexpectedly with error: {1}',
+                      kernel.runtimeMetadata.runtimeName,
+                      logFileContent,
+                  )
                 : Console.consoleExitGeneric;
 
             const res = await showErrorMessage(errortext, vscode.l10n.t('Open Logs'));

--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -360,9 +360,9 @@ async function getAppName(document: vscode.TextDocument, className: string): Pro
 
 /** Get the Positron Run App extension's API. */
 async function getPositronRunAppApi(): Promise<PositronRunApp> {
-    const runAppExt = vscode.extensions.getExtension<PositronRunApp>('vscode.positron-run-app');
+    const runAppExt = vscode.extensions.getExtension<PositronRunApp>('positron.positron-run-app');
     if (!runAppExt) {
-        throw new Error('vscode.positron-run-app extension not found');
+        throw new Error('positron.positron-run-app extension not found');
     }
     const runAppApi = await runAppExt.activate();
     return runAppApi;

--- a/extensions/positron-python/src/test/positron/session.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/session.unit.test.ts
@@ -114,7 +114,7 @@ suite('Python Runtime Session', () => {
         } as Partial<JupyterAdapterApi>) as JupyterAdapterApi;
 
         sinon.stub(vscode.extensions, 'getExtension').callsFake((extensionId) => {
-            if (extensionId === 'positron.positron-adapter' || extensionId === 'positron.jupyter-adapter') {
+            if (extensionId === 'positron.positron-supervisor' || extensionId === 'positron.jupyter-adapter') {
                 return {
                     id: '',
                     extensionPath: '',

--- a/extensions/positron-python/src/test/positron/session.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/session.unit.test.ts
@@ -114,7 +114,7 @@ suite('Python Runtime Session', () => {
         } as Partial<JupyterAdapterApi>) as JupyterAdapterApi;
 
         sinon.stub(vscode.extensions, 'getExtension').callsFake((extensionId) => {
-            if (extensionId === 'vscode.kallichore-adapter' || extensionId === 'vscode.jupyter-adapter') {
+            if (extensionId === 'positron.positron-adapter' || extensionId === 'positron.jupyter-adapter') {
                 return {
                     id: '',
                     extensionPath: '',

--- a/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
@@ -32,7 +32,7 @@ suite('Web app commands', () => {
     let isFastAPICliInstalled: boolean;
 
     setup(() => {
-        // Stub `vscode.extensions.getExtension('vscode.positron-run-app')` to return an extension
+        // Stub `vscode.extensions.getExtension('positron.positron-run-app')` to return an extension
         // with:
         // 1. `runApplication` that records the last `options` that it was called with.
         // 2. `debugApplication` that records the last `options` that it was called with.
@@ -49,7 +49,7 @@ suite('Web app commands', () => {
             },
         };
         sinon.stub(vscode.extensions, 'getExtension').callsFake((extensionId) => {
-            if (extensionId === 'vscode.positron-run-app') {
+            if (extensionId === 'positron.positron-run-app') {
                 return {
                     id: '',
                     extensionPath: '',

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -578,7 +578,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		const config = vscode.workspace.getConfiguration('positronKernelSupervisor');
 		if (config.get<boolean>('enable', true)) {
 			// Use the Positron kernel supervisor if enabled
-			const ext = vscode.extensions.getExtension('vscode.positron-supervisor');
+			const ext = vscode.extensions.getExtension('positron.positron-supervisor');
 			if (!ext) {
 				throw new Error('Positron Supervisor extension not found');
 			}
@@ -588,7 +588,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 			this.adapterApi = ext?.exports as JupyterAdapterApi;
 		} else {
 			// Otherwise, connect to the Jupyter kernel directly
-			const ext = vscode.extensions.getExtension('vscode.jupyter-adapter');
+			const ext = vscode.extensions.getExtension('positron.jupyter-adapter');
 			if (!ext) {
 				throw new Error('Jupyter Adapter extension not found');
 			}

--- a/extensions/positron-reticulate/package.json
+++ b/extensions/positron-reticulate/package.json
@@ -37,7 +37,7 @@
   "extensionDependencies": [
     "ms-python.python",
     "positron.positron-r",
-    "vscode.jupyter-adapter"
+    "positron.jupyter-adapter"
   ],
   "devDependencies": {
     "@types/glob": "^7.2.0",

--- a/extensions/positron-reticulate/package.json
+++ b/extensions/positron-reticulate/package.json
@@ -3,7 +3,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "0.0.1",
-  "publisher": "vscode",
+  "publisher": "positron",
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-rstudio-keymap/package.json
+++ b/extensions/positron-rstudio-keymap/package.json
@@ -3,7 +3,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "0.0.1",
-  "publisher": "vscode",
+  "publisher": "positron",
   "license": "SEE LICENSE IN LICENSE.md",
   "engines": {
     "vscode": "^1.75.0"

--- a/extensions/positron-run-app/package.json
+++ b/extensions/positron-run-app/package.json
@@ -3,7 +3,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "0.0.1",
-  "publisher": "vscode",
+  "publisher": "positron",
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-run-app/src/test/api.test.ts
+++ b/extensions/positron-run-app/src/test/api.test.ts
@@ -68,10 +68,10 @@ suite('PositronRunApp', () => {
 		sinon.stub(vscode.commands, 'executeCommand')
 			.withArgs('positronProxy.startPendingProxyServer')
 			.resolves({
-			proxyPath: '/proxy/path',
-			externalUri: vscode.Uri.parse('http://localhost:1234'),
-			finishProxySetup: () => {},
-		});
+				proxyPath: '/proxy/path',
+				externalUri: vscode.Uri.parse('http://localhost:1234'),
+				finishProxySetup: () => { },
+			});
 
 		// Stub the preview URL function.
 		previewUrlStub = sinon.stub(positron.window, 'previewUrl');
@@ -102,7 +102,7 @@ suite('PositronRunApp', () => {
 	});
 
 	async function getRunAppApi(): Promise<PositronRunAppApiImpl> {
-		const extension = vscode.extensions.getExtension<PositronRunAppApiImpl>('vscode.positron-run-app');
+		const extension = vscode.extensions.getExtension<PositronRunAppApiImpl>('positron.positron-run-app');
 		if (!extension) {
 			throw new Error('Could not find Positron Run App extension');
 		}

--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -2,7 +2,7 @@
   "name": "positron-supervisor",
   "displayName": "%displayName%",
   "description": "%description%",
-  "publisher": "vscode",
+  "publisher": "positron",
   "version": "0.0.1",
   "engines": {
     "vscode": "^1.61.0"

--- a/extensions/positron-viewer/package.json
+++ b/extensions/positron-viewer/package.json
@@ -6,7 +6,7 @@
     "externalUriOpener"
   ],
   "version": "1.0.0",
-  "publisher": "vscode",
+  "publisher": "positron",
   "engines": {
     "vscode": "^1.70.0"
   },

--- a/extensions/positron-zed/package.json
+++ b/extensions/positron-zed/package.json
@@ -3,7 +3,7 @@
   "displayName": "Zed",
   "description": "Positron Zed",
   "version": "1.0.0",
-  "publisher": "vscode",
+  "publisher": "positron",
   "engines": {
     "vscode": "^1.65.0"
   },

--- a/extensions/positron-zed/src/test/extension.test.ts
+++ b/extensions/positron-zed/src/test/extension.test.ts
@@ -29,7 +29,7 @@ suite('Zed Interpreter Extension Test Suite', () => {
 });
 
 async function activateZedExtension() {
-	const extension = vscode.extensions.getExtension('vscode.positron-zed');
+	const extension = vscode.extensions.getExtension('positron.positron-zed');
 	assert.ok(extension, 'Zed extension not found');
 	await extension.activate();
 	assert.ok(extension.isActive, 'Zed extension failed to activate');

--- a/extensions/theme-defaults/package.json
+++ b/extensions/theme-defaults/package.json
@@ -6,7 +6,7 @@
     "Themes"
   ],
   "version": "1.0.0",
-  "publisher": "positron",
+  "publisher": "vscode",
   "license": "MIT",
   "engines": {
     "vscode": "*"

--- a/extensions/theme-defaults/package.json
+++ b/extensions/theme-defaults/package.json
@@ -6,7 +6,7 @@
     "Themes"
   ],
   "version": "1.0.0",
-  "publisher": "vscode",
+  "publisher": "positron",
   "license": "MIT",
   "engines": {
     "vscode": "*"

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
@@ -596,7 +596,7 @@ export class KernelPickerMRUStrategy extends KernelPickerStrategyBase {
 						// --- Start Positron ---
 						// Enable kernel source action providers for Positron kernels
 						const kernel = all.find(kernel => kernel.id === `ms-toolsai.jupyter/${selectedKernelId}` ||
-							kernel.id === `vscode.positron-notebook-controllers/${selectedKernelId}`);
+							kernel.id === `positron.positron-notebook-controllers/${selectedKernelId}`);
 						// --- End Positron ---
 						if (kernel) {
 							await this._selecteKernel(notebook, kernel);
@@ -662,7 +662,7 @@ export class KernelPickerMRUStrategy extends KernelPickerStrategyBase {
 		// --- Start Positron ---
 		// Remove the "Positron Notebook Controllers" quickpick item in favor of kernel source action providers
 		const others = matchResult.all.filter(item => item.extension.value !== JUPYTER_EXTENSION_ID &&
-			item.extension.value !== 'vscode.positron-notebook-controllers');
+			item.extension.value !== 'positron.positron-notebook-controllers');
 		// --- End Positron ---
 		const quickPickItems: QuickPickInput<KernelQuickPickItem>[] = [];
 

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -81,8 +81,8 @@ export const ACCESSIBLE_NOTEBOOK_DISPLAY_ORDER: readonly string[] = [
  */
 export const RENDERER_EQUIVALENT_EXTENSIONS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
 	// --- Start Positron ---
-	// Use vscode.positron-ipywidgets renderer instead of ms-toolsai.jupyter.
-	['vscode.positron-ipywidgets', new Set(['jupyter-notebook', 'interactive'])],
+	// Use positron.positron-ipywidgets renderer instead of ms-toolsai.jupyter.
+	['positron.positron-ipywidgets', new Set(['jupyter-notebook', 'interactive'])],
 	// --- End Positron ---
 	['ms-toolsai.jupyter-renderers', new Set(['jupyter-notebook', 'interactive'])],
 ]);

--- a/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
@@ -63,7 +63,7 @@ class SelectPositronNotebookKernelAction extends Action2 {
 
 		const gatherKernelPicks = () => {
 			const kernelMatches = notebookKernelService.getMatchingKernel(notebook);
-			const positronKernels = kernelMatches.all.filter(k => k.extension.value === 'vscode.positron-notebook-controllers');
+			const positronKernels = kernelMatches.all.filter(k => k.extension.value === 'positron.positron-notebook-controllers');
 			if (positronKernels.length === 0) {
 				quickPick.busy = true;
 				quickPick.items = [{ label: localize('positronNotebookActions.selectKernel.noKernel', 'No Positron Notebook Kernel found'), picked: true }];

--- a/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
@@ -26,7 +26,7 @@ export class TestNotebookService implements Partial<INotebookService> {
 	getPreferredRenderer(_mimeType: string): NotebookOutputRendererInfo | undefined {
 		return <NotebookOutputRendererInfo>{
 			id: 'positron-ipywidgets',
-			extensionId: new ExtensionIdentifier('vscode.positron-ipywidgets'),
+			extensionId: new ExtensionIdentifier('positron.positron-ipywidgets'),
 		};
 	}
 


### PR DESCRIPTION
Addresses #5268

After experimenting with this, I believe we should _only_ update the publisher on extensions that we ourselves truly did make, not ones that we forked and made changes to. As an example, the Black formatter (which we bundle) depends on the `ms-python.python` extension ID; if we change our Python extension to be `positron.python` then we can no longer bundle the Black formatter.

### QA Notes

Most importantly, there should be no errors as the app comes up about extensions being activated, and both R and Python runtimes should start.

There are more implications for changing this publisher in the long term as outlined in #5268, but to confirm we have successfully updated it, you can look for some of the builtin extensions in the Extensions tab and see that they say they have the "positron" publisher:

![Screenshot 2024-12-03 at 5 27 04 PM](https://github.com/user-attachments/assets/05d98dc5-de39-43c6-a0f4-987e659000cf)

