### PR TITLE
Add RuntimeErrorBehavior to `runtime.executeCode()` in the API

### DIFF
--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -63,8 +63,8 @@ const HelpLines = [
 	'env rm X         - Removes X variables',
 	'env update X     - Updates X variables',
 	'error X Y Z      - Simulates an unsuccessful X line input with Y lines of error message and Z lines of traceback (where X >= 1 and Y >= 1 and Z >= 0)',
-	'exec silent X Y  - Executes a code snippet Y in the language X silently',
 	'exec X Y         - Executes a code snippet Y in the language X interactively',
+	'exec silent X Y  - Executes a code snippet Y in the language X silently',
 	'fancy            - Simulates fancy HTML output',
 	'flicker          - Simulates a flickering console prompt',
 	'help             - Shows this help',
@@ -386,13 +386,13 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 			// Execute code silently in another language.
 			const languageId = match[1];
 			const codeToExecute = match[2];
-			this.simulateCodeExecution(id, code, languageId, codeToExecute, positron.RuntimeCodeExecutionMode.Silent);
+			this.simulateCodeExecution(id, code, languageId, codeToExecute, positron.RuntimeCodeExecutionMode.Silent, positron.RuntimeErrorBehavior.Continue);
 			return;
 		} else if (match = code.match(/^exec ([a-zA-Z]+) (.+)/)) {
 			// Execute code in another language.
 			const languageId = match[1];
 			const codeToExecute = match[2];
-			this.simulateCodeExecution(id, code, languageId, codeToExecute, positron.RuntimeCodeExecutionMode.Interactive);
+			this.simulateCodeExecution(id, code, languageId, codeToExecute, positron.RuntimeCodeExecutionMode.Interactive, positron.RuntimeErrorBehavior.Continue);
 			return;
 		} else if (match = code.match(/^preview( .+)?/)) {
 			const command = (match.length > 1 && match[1]) ? match[1].trim() : 'default';
@@ -1605,12 +1605,14 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 	 * @param languageId The language identifier
 	 * @param codeToExecute The code to execute.
 	 * @param mode The execution mode to conform to.
+	 * @param errorBehavior The error behavior to conform to.
 	 */
 	private async simulateCodeExecution(parentId: string,
 		code: string,
 		languageId: string,
 		codeToExecute: string,
-		mode: positron.RuntimeCodeExecutionMode) {
+		mode: positron.RuntimeCodeExecutionMode,
+		errorBehavior: positron.RuntimeErrorBehavior) {
 		// Enter busy state and output the code.
 		this.simulateBusyState(parentId);
 		this.simulateInputMessage(parentId, code);
@@ -1622,7 +1624,7 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 		const focus = mode !== positron.RuntimeCodeExecutionMode.Silent;
 
 		// Perform the execution
-		const success = await positron.runtime.executeCode(languageId, codeToExecute, focus, true, mode);
+		const success = await positron.runtime.executeCode(languageId, codeToExecute, focus, true, mode, errorBehavior);
 		if (!success) {
 			this.simulateOutputMessage(parentId, `Failed; is there an active console for ${languageId}?`);
 		}

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1218,7 +1218,8 @@ declare module 'positron' {
 		 * @param focus Whether to focus the runtime's console
 		 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 		 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
-		* @param mode Possible code execution modes for a language runtime
+		 * @param mode Possible code execution mode for a language runtime
+		 * @param errorBehavior Possible error behavior for a language runtime
 		 * @returns A Thenable that resolves with true if the code was sent to a
 		 *   runtime successfully, false otherwise.
 		 */
@@ -1226,7 +1227,8 @@ declare module 'positron' {
 			code: string,
 			focus: boolean,
 			allowIncomplete?: boolean,
-			mode?: RuntimeCodeExecutionMode): Thenable<boolean>;
+			mode?: RuntimeCodeExecutionMode,
+			errorBehavior?: RuntimeErrorBehavior): Thenable<boolean>;
 
 		/**
 		 * Register a language runtime manager with Positron. Returns a

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -765,7 +765,15 @@ declare module 'positron' {
 		 */
 		openResource?(resource: vscode.Uri | string): Thenable<boolean>;
 
-		/** Execute code in the runtime */
+		/**
+		 * Execute code in the runtime
+		 *
+		 * @param code The code to execute
+		 * @param id The language ID of the code
+		 * @param mode The code execution mode
+		 * @param errorBehavior The code execution error behavior
+		 * Note: The errorBehavior parameter is currently ignored by kernels
+		 */
 		execute(code: string,
 			id: string,
 			mode: RuntimeCodeExecutionMode,

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1227,7 +1227,7 @@ declare module 'positron' {
 		 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 		 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
 		 * @param mode Possible code execution mode for a language runtime
-		 * @param errorBehavior Possible error behavior for a language runtime
+		 * @param errorBehavior Possible error behavior for a language runtime, currently ignored by kernels
 		 * @returns A Thenable that resolves with true if the code was sent to a
 		 *   runtime successfully, false otherwise.
 		 */

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1256,8 +1256,8 @@ export class MainThreadLanguageRuntime
 		}
 	}
 
-	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode): Promise<boolean> {
-		return this._positronConsoleService.executeCode(languageId, code, focus, allowIncomplete, mode);
+	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode, errorBehavior?: RuntimeErrorBehavior): Promise<boolean> {
+		return this._positronConsoleService.executeCode(languageId, code, focus, allowIncomplete, mode, errorBehavior);
 	}
 
 	public dispose(): void {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -76,8 +76,8 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 		// --- Start Positron ---
 		const runtime: typeof positron.runtime = {
-			executeCode(languageId, code, focus, allowIncomplete, mode): Thenable<boolean> {
-				return extHostLanguageRuntime.executeCode(languageId, code, focus, allowIncomplete, mode);
+			executeCode(languageId, code, focus, allowIncomplete, mode, errorBehavior): Thenable<boolean> {
+				return extHostLanguageRuntime.executeCode(languageId, code, focus, allowIncomplete, mode, errorBehavior);
 			},
 			registerLanguageRuntimeManager(
 				manager: positron.LanguageRuntimeManager): vscode.Disposable {

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -36,7 +36,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$startLanguageRuntime(runtimeId: string, sessionName: string, sessionMode: LanguageRuntimeSessionMode, notebookUri: URI | undefined): Promise<string>;
 	$completeLanguageRuntimeDiscovery(): void;
 	$unregisterLanguageRuntime(handle: number): void;
-	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode): Promise<boolean>;
+	$executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode, errorBehavior?: RuntimeErrorBehavior): Promise<boolean>;
 	$getPreferredRuntime(languageId: string): Promise<ILanguageRuntimeMetadata>;
 	$getForegroundSession(): Promise<string | undefined>;
 	$getNotebookSession(notebookUri: URI): Promise<string | undefined>;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -730,8 +730,8 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		});
 	}
 
-	public executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode): Promise<boolean> {
-		return this._proxy.$executeCode(languageId, code, focus, allowIncomplete, mode);
+	public executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode, errorBehavior?: RuntimeErrorBehavior): Promise<boolean> {
+		return this._proxy.$executeCode(languageId, code, focus, allowIncomplete, mode, errorBehavior);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -26,7 +26,7 @@ import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegis
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { NOTEBOOK_EDITOR_FOCUSED } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
-import { RuntimeCodeExecutionMode } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { RuntimeCodeExecutionMode, RuntimeErrorBehavior } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IExecutionHistoryService } from 'vs/workbench/contrib/executionHistory/common/executionHistoryService';
 import { IPositronModalDialogsService } from 'vs/workbench/services/positronModalDialogs/common/positronModalDialogs';
 import { IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID } from 'vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService';
@@ -271,6 +271,7 @@ export function registerPositronConsoleActions() {
 		 *   - languageId: Optionally, a language override for the code to execute. If `undefined`, the language of the active text editor is used. Useful for notebooks.
 		 *   - advance: Optionally, if the cursor should be advanced to the next statement. If `undefined`, fallbacks to `true`.
 		 *   - mode: Optionally, the code execution mode for a language runtime. If `undefined` fallbacks to `Interactive`.
+		 *   - errorBehavior: Optionally, the error behavior for a language runtime. If `undefined` fallbacks to `Continue`.
 		 */
 		async run(
 			accessor: ServicesAccessor,
@@ -279,6 +280,7 @@ export function registerPositronConsoleActions() {
 				languageId?: string;
 				advance?: boolean;
 				mode?: RuntimeCodeExecutionMode;
+				errorBehavior?: RuntimeErrorBehavior;
 			} = {}
 		) {
 			// Access services.
@@ -430,7 +432,7 @@ export function registerPositronConsoleActions() {
 
 			// Ask the Positron console service to execute the code. Do not focus the console as
 			// this will rip focus away from the editor.
-			if (!await positronConsoleService.executeCode(languageId, code, false, allowIncomplete, opts.mode)) {
+			if (!await positronConsoleService.executeCode(languageId, code, false, allowIncomplete, opts.mode, opts.errorBehavior)) {
 				const languageName = languageService.getLanguageName(languageId);
 				notificationService.notify({
 					severity: Severity.Info,

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -9,7 +9,7 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 import { RuntimeItem } from 'vs/workbench/services/positronConsole/browser/classes/runtimeItem';
 import { ILanguageRuntimeSession } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
 import { ActivityItemPrompt } from 'vs/workbench/services/positronConsole/browser/classes/activityItemPrompt';
-import { RuntimeCodeExecutionMode } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
+import { RuntimeCodeExecutionMode, RuntimeErrorBehavior } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 
 // Create the decorator for the Positron console service (used in dependency injection).
 export const IPositronConsoleService = createDecorator<IPositronConsoleService>('positronConsoleService');
@@ -90,9 +90,10 @@ export interface IPositronConsoleService {
 	 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 	 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
 	 * @param mode Possible code execution modes for a language runtime
+	 * @param errorBehavior Possible error behavior for a language runtime
 	 * @returns A value which indicates whether the code could be executed.
 	 */
-	executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode): Promise<boolean>;
+	executeCode(languageId: string, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode, errorBehavior?: RuntimeErrorBehavior): Promise<boolean>;
 }
 
 /**
@@ -121,6 +122,9 @@ export interface ILanguageRuntimeCodeExecutedEvent {
 
 	/* The mode used to execute the code in the language runtime session */
 	mode: RuntimeCodeExecutionMode;
+
+	/* The error disposition used to execute the code in the language runtime session */
+	errorBehavior: RuntimeErrorBehavior;
 }
 
 /**
@@ -310,6 +314,7 @@ export interface IPositronConsoleInstance {
 	 * @param allowIncomplete Whether to bypass runtime code completeness checks. If true, the `code`
 	 *   will be executed by the runtime even if it is incomplete or invalid. Defaults to false
 	 * @param mode Possible code execution modes for a language runtime.
+	 * @param errorBehavior Possible error behavior for a language runtime
 	 */
 	enqueueCode(code: string, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode): Promise<void>;
 
@@ -317,8 +322,9 @@ export interface IPositronConsoleInstance {
 	 * Executes code.
 	 * @param code The code to execute.
 	 * @param mode Possible code execution modes for a language runtime.
+	 * @param errorBehavior Possible error behavior for a language runtime
 	 */
-	executeCode(code: string, mode?: RuntimeCodeExecutionMode): void;
+	executeCode(code: string, mode?: RuntimeCodeExecutionMode, errorBehavior?: RuntimeErrorBehavior): void;
 
 	/**
 	 * Replies to a prompt.


### PR DESCRIPTION
### Description
This completes the ask from #4856. Support for `RuntimeCodeExecutionMode` was done in https://github.com/posit-dev/positron/pull/5450.

The positron API `executeCode` call takes in a `RuntimeErrorBehavior` value and propagates it down to the kernel. 
NOTEL The r and python kernel ignore the value for error behavior and default to stopping code execution on error.

### QA Notes
NOTE: There is no way to verify these changes end to end given that the kernels do not currently respect the value provided for the code execution error behavior. Regardless, the testing steps are provided below:

These changes would need to be tested in a dev build using the JavaScript runtime as we do not have a way to test the API for extensions in a release build:
```
var p = acquirePositronApi()

// multiple lines of code with error
var my_code_with_error = "c = 1 + 2\nd = 4 / 0\ne = 5 - 2"

// default
p.runtime.executeCode("python", my_code_with_error, false, false)

// specifying error behavior
p.runtime.executeCode("python", my_code_with_error, false, false, p.RuntimeCodeExecutionMode.Interactive, p.RuntimeErrorBehavior.Continue)
p.runtime.executeCode("python", my_code_with_error, false, false, p.RuntimeCodeExecutionMode.Interactive, p.RuntimeErrorBehavior.Stop)
```