### PR TITLE
E2E tests: use alternative wait method before assuming duckdb open will work

### DIFF
--- a/test/smoke/src/areas/positron/data-explorer/data-explorer-headless.test.ts
+++ b/test/smoke/src/areas/positron/data-explorer/data-explorer-headless.test.ts
@@ -14,7 +14,9 @@ test.use({
 test.describe('Headless Data Explorer - Large Data Frame', {
 	tag: ['@web']
 }, () => {
-	test.beforeEach(async function ({ app }) {
+	// python fixture not actually needed but serves as a long wait so that we can be sure
+	// headless/duckdb open will work
+	test.beforeEach(async function ({ app, python }) {
 		await app.workbench.positronLayouts.enterLayout('stacked');
 	});
 
@@ -33,9 +35,6 @@ test.describe('Headless Data Explorer - Large Data Frame', {
 
 async function testBody(app: Application, logger: Logger, fileName: string) {
 	const LAST_CELL_CONTENTS = '2013-09-30 08:00:00';
-
-	// if you immediately open the data file, the data explorer will be blank
-	await app.code.wait(5000);
 
 	await app.workbench.positronQuickaccess.openDataFile(join(app.workspacePathOrFolder, 'data-files', 'flights', fileName));
 

--- a/test/smoke/src/areas/positron/data-explorer/duckdb-sparklines.test.ts
+++ b/test/smoke/src/areas/positron/data-explorer/duckdb-sparklines.test.ts
@@ -13,10 +13,9 @@ test.use({
 test.describe('Data Explorer - DuckDB Column Summary', {
 	tag: ['@web', '@win', '@pr']
 }, () => {
-	test('Verifies basic duckdb column summary functionality [C1053635]', async function ({ app }) {
-
-		// if you immediately open the data file, the data explorer will be blank
-		await app.code.wait(5000);
+	// python fixture not actually needed but serves as a long wait so that we can be sure
+	// headless/duckdb open will work
+	test('Verifies basic duckdb column summary functionality [C1053635]', async function ({ app, python }) {
 
 		await app.workbench.positronQuickaccess.openDataFile(join(app.workspacePathOrFolder, 'data-files', '100x100', '100x100.parquet'));
 


### PR DESCRIPTION
Uses a slight hack (starting an interpreter thats not needed) to wait at app start up before trying to utilize headless/duckdb data explorer open.

### QA Notes

All smoke tests should pass.
