### PR TITLE
Merge upstream Python tool configuration & skip "magic trailing commas" for Positron Python files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -125,6 +125,13 @@
 	"[diff]": {
 		"files.trimTrailingWhitespace": false
 	},
+	"[python]": {
+		"editor.defaultFormatter": "charliermarsh.ruff",
+		"editor.formatOnSave": true,
+		"editor.codeActionsOnSave": {
+			"source.organizeImports": "explicit"
+		}
+	},
 	"rust-analyzer.linkedProjects": [
 		"cli/Cargo.toml"
 	],

--- a/extensions/positron-python/python_files/.vscode/settings.json
+++ b/extensions/positron-python/python_files/.vscode/settings.json
@@ -3,11 +3,13 @@
         "**/__pycache__/**": true,
         "**/**/*.pyc": true
     },
-    "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter",
-        "editor.formatOnSave": true,
-        "editor.rulers": [100],
-    },
+	"[python]": {
+		"editor.defaultFormatter": "charliermarsh.ruff",
+		"editor.formatOnSave": true,
+		"editor.codeActionsOnSave": {
+			"source.organizeImports": "explicit"
+		}
+	},
     "python.testing.pytestArgs": [
         "tests",
         "positron/positron_ipykernel/tests"

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/access_keys.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/access_keys.py
@@ -51,14 +51,18 @@ def decode_access_key(access_key: str) -> Any:
     if (
         not isinstance(json_data, dict)
         or not isinstance(json_data["type"], str)
-        or not isinstance(json_data["data"], (dict, list, str, int, float, bool, type(None)))
+        or not isinstance(
+            json_data["data"], (dict, list, str, int, float, bool, type(None))
+        )
     ):
         raise ValueError(f"Unexpected json data structure: {json_data}")
 
     # Get the inspector for this type.
     # TODO(pyright): cast shouldn't be necessary, recheck in a future version of pyright
     type_name = cast(str, json_data["type"])
-    inspector_key = _ACCESS_KEY_QUALNAME_TO_INSPECTOR_KEY.get(type_name, type_name)
+    inspector_key = _ACCESS_KEY_QUALNAME_TO_INSPECTOR_KEY.get(
+        type_name, type_name
+    )
     inspector_cls = INSPECTOR_CLASSES.get(inspector_key, PositronInspector)
 
     # Reconstruct the access key's original object using the deserialized JSON data.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -623,7 +623,10 @@ class SQLite3Connection(Connection):
                 "Path must include a schema and a table/view in this order.", f"Path: {path}"
             )
 
-        return pd_.read_sql(f"SELECT * FROM {schema.name}.{table.name} LIMIT 1000;", self.conn)
+        return pd_.read_sql(
+            f"SELECT * FROM {schema.name}.{table.name} LIMIT 1000;",
+            self.conn,
+        )
 
     def list_object_types(self):
         return {

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -623,10 +623,7 @@ class SQLite3Connection(Connection):
                 "Path must include a schema and a table/view in this order.", f"Path: {path}"
             )
 
-        return pd_.read_sql(
-            f"SELECT * FROM {schema.name}.{table.name} LIMIT 1000;",
-            self.conn,
-        )
+        return pd_.read_sql(f"SELECT * FROM {schema.name}.{table.name} LIMIT 1000;", self.conn)
 
     def list_object_types(self):
         return {

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections_comm.py
@@ -23,9 +23,13 @@ class ObjectSchema(BaseModel):
     ObjectSchema in Schemas
     """
 
-    name: StrictStr = Field(description="Name of the underlying object")
+    name: StrictStr = Field(
+        description="Name of the underlying object",
+    )
 
-    kind: StrictStr = Field(description="The object type (table, catalog, schema)")
+    kind: StrictStr = Field(
+        description="The object type (table, catalog, schema)",
+    )
 
 
 class FieldSchema(BaseModel):
@@ -33,9 +37,13 @@ class FieldSchema(BaseModel):
     FieldSchema in Schemas
     """
 
-    name: StrictStr = Field(description="Name of the field")
+    name: StrictStr = Field(
+        description="Name of the field",
+    )
 
-    dtype: StrictStr = Field(description="The field data type")
+    dtype: StrictStr = Field(
+        description="The field data type",
+    )
 
 
 class MetadataSchema(BaseModel):
@@ -43,18 +51,27 @@ class MetadataSchema(BaseModel):
     MetadataSchema in Schemas
     """
 
-    name: StrictStr = Field(description="Connection name")
-
-    language_id: StrictStr = Field(
-        description="Language ID for the connections. Essentially just R or python"
+    name: StrictStr = Field(
+        description="Connection name",
     )
 
-    host: Optional[StrictStr] = Field(default=None, description="Connection host")
+    language_id: StrictStr = Field(
+        description="Language ID for the connections. Essentially just R or python",
+    )
 
-    type: Optional[StrictStr] = Field(default=None, description="Connection type")
+    host: Optional[StrictStr] = Field(
+        default=None,
+        description="Connection host",
+    )
+
+    type: Optional[StrictStr] = Field(
+        default=None,
+        description="Connection type",
+    )
 
     code: Optional[StrictStr] = Field(
-        default=None, description="Code used to re-create the connection"
+        default=None,
+        description="Code used to re-create the connection",
     )
 
 
@@ -90,7 +107,7 @@ class ListObjectsParams(BaseModel):
     """
 
     path: List[ObjectSchema] = Field(
-        description="The path to object that we want to list children."
+        description="The path to object that we want to list children.",
     )
 
 
@@ -100,13 +117,18 @@ class ListObjectsRequest(BaseModel):
     and views.
     """
 
-    params: ListObjectsParams = Field(description="Parameters to the ListObjects method")
-
-    method: Literal[ConnectionsBackendRequest.ListObjects] = Field(
-        description="The JSON-RPC method name (list_objects)"
+    params: ListObjectsParams = Field(
+        description="Parameters to the ListObjects method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[ConnectionsBackendRequest.ListObjects] = Field(
+        description="The JSON-RPC method name (list_objects)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class ListFieldsParams(BaseModel):
@@ -114,7 +136,9 @@ class ListFieldsParams(BaseModel):
     List fields of an object, such as columns of a table or view.
     """
 
-    path: List[ObjectSchema] = Field(description="The path to object that we want to list fields.")
+    path: List[ObjectSchema] = Field(
+        description="The path to object that we want to list fields.",
+    )
 
 
 class ListFieldsRequest(BaseModel):
@@ -122,13 +146,18 @@ class ListFieldsRequest(BaseModel):
     List fields of an object, such as columns of a table or view.
     """
 
-    params: ListFieldsParams = Field(description="Parameters to the ListFields method")
-
-    method: Literal[ConnectionsBackendRequest.ListFields] = Field(
-        description="The JSON-RPC method name (list_fields)"
+    params: ListFieldsParams = Field(
+        description="Parameters to the ListFields method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[ConnectionsBackendRequest.ListFields] = Field(
+        description="The JSON-RPC method name (list_fields)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class ContainsDataParams(BaseModel):
@@ -137,7 +166,7 @@ class ContainsDataParams(BaseModel):
     """
 
     path: List[ObjectSchema] = Field(
-        description="The path to object that we want to check if it contains data."
+        description="The path to object that we want to check if it contains data.",
     )
 
 
@@ -146,13 +175,18 @@ class ContainsDataRequest(BaseModel):
     Check if an object contains data, such as a table or view.
     """
 
-    params: ContainsDataParams = Field(description="Parameters to the ContainsData method")
-
-    method: Literal[ConnectionsBackendRequest.ContainsData] = Field(
-        description="The JSON-RPC method name (contains_data)"
+    params: ContainsDataParams = Field(
+        description="Parameters to the ContainsData method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[ConnectionsBackendRequest.ContainsData] = Field(
+        description="The JSON-RPC method name (contains_data)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class GetIconParams(BaseModel):
@@ -160,7 +194,9 @@ class GetIconParams(BaseModel):
     Get icon of an object, such as a table or view.
     """
 
-    path: List[ObjectSchema] = Field(description="The path to object that we want to get the icon.")
+    path: List[ObjectSchema] = Field(
+        description="The path to object that we want to get the icon.",
+    )
 
 
 class GetIconRequest(BaseModel):
@@ -168,13 +204,18 @@ class GetIconRequest(BaseModel):
     Get icon of an object, such as a table or view.
     """
 
-    params: GetIconParams = Field(description="Parameters to the GetIcon method")
-
-    method: Literal[ConnectionsBackendRequest.GetIcon] = Field(
-        description="The JSON-RPC method name (get_icon)"
+    params: GetIconParams = Field(
+        description="Parameters to the GetIcon method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[ConnectionsBackendRequest.GetIcon] = Field(
+        description="The JSON-RPC method name (get_icon)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class PreviewObjectParams(BaseModel):
@@ -182,7 +223,9 @@ class PreviewObjectParams(BaseModel):
     Preview object data, such as a table or view.
     """
 
-    path: List[ObjectSchema] = Field(description="The path to object that we want to preview.")
+    path: List[ObjectSchema] = Field(
+        description="The path to object that we want to preview.",
+    )
 
 
 class PreviewObjectRequest(BaseModel):
@@ -190,13 +233,18 @@ class PreviewObjectRequest(BaseModel):
     Preview object data, such as a table or view.
     """
 
-    params: PreviewObjectParams = Field(description="Parameters to the PreviewObject method")
-
-    method: Literal[ConnectionsBackendRequest.PreviewObject] = Field(
-        description="The JSON-RPC method name (preview_object)"
+    params: PreviewObjectParams = Field(
+        description="Parameters to the PreviewObject method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[ConnectionsBackendRequest.PreviewObject] = Field(
+        description="The JSON-RPC method name (preview_object)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class GetMetadataParams(BaseModel):
@@ -205,7 +253,7 @@ class GetMetadataParams(BaseModel):
     """
 
     comm_id: StrictStr = Field(
-        description="The comm_id of the client we want to retrieve metdata for."
+        description="The comm_id of the client we want to retrieve metdata for.",
     )
 
 
@@ -214,13 +262,18 @@ class GetMetadataRequest(BaseModel):
     A connection has tied metadata such as an icon, the host, etc.
     """
 
-    params: GetMetadataParams = Field(description="Parameters to the GetMetadata method")
-
-    method: Literal[ConnectionsBackendRequest.GetMetadata] = Field(
-        description="The JSON-RPC method name (get_metadata)"
+    params: GetMetadataParams = Field(
+        description="Parameters to the GetMetadata method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[ConnectionsBackendRequest.GetMetadata] = Field(
+        description="The JSON-RPC method name (get_metadata)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class ConnectionsBackendMessageContent(BaseModel):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections_comm.py
@@ -23,13 +23,9 @@ class ObjectSchema(BaseModel):
     ObjectSchema in Schemas
     """
 
-    name: StrictStr = Field(
-        description="Name of the underlying object",
-    )
+    name: StrictStr = Field(description="Name of the underlying object")
 
-    kind: StrictStr = Field(
-        description="The object type (table, catalog, schema)",
-    )
+    kind: StrictStr = Field(description="The object type (table, catalog, schema)")
 
 
 class FieldSchema(BaseModel):
@@ -37,13 +33,9 @@ class FieldSchema(BaseModel):
     FieldSchema in Schemas
     """
 
-    name: StrictStr = Field(
-        description="Name of the field",
-    )
+    name: StrictStr = Field(description="Name of the field")
 
-    dtype: StrictStr = Field(
-        description="The field data type",
-    )
+    dtype: StrictStr = Field(description="The field data type")
 
 
 class MetadataSchema(BaseModel):
@@ -51,27 +43,18 @@ class MetadataSchema(BaseModel):
     MetadataSchema in Schemas
     """
 
-    name: StrictStr = Field(
-        description="Connection name",
-    )
+    name: StrictStr = Field(description="Connection name")
 
     language_id: StrictStr = Field(
-        description="Language ID for the connections. Essentially just R or python",
+        description="Language ID for the connections. Essentially just R or python"
     )
 
-    host: Optional[StrictStr] = Field(
-        default=None,
-        description="Connection host",
-    )
+    host: Optional[StrictStr] = Field(default=None, description="Connection host")
 
-    type: Optional[StrictStr] = Field(
-        default=None,
-        description="Connection type",
-    )
+    type: Optional[StrictStr] = Field(default=None, description="Connection type")
 
     code: Optional[StrictStr] = Field(
-        default=None,
-        description="Code used to re-create the connection",
+        default=None, description="Code used to re-create the connection"
     )
 
 
@@ -107,7 +90,7 @@ class ListObjectsParams(BaseModel):
     """
 
     path: List[ObjectSchema] = Field(
-        description="The path to object that we want to list children.",
+        description="The path to object that we want to list children."
     )
 
 
@@ -117,18 +100,13 @@ class ListObjectsRequest(BaseModel):
     and views.
     """
 
-    params: ListObjectsParams = Field(
-        description="Parameters to the ListObjects method",
-    )
+    params: ListObjectsParams = Field(description="Parameters to the ListObjects method")
 
     method: Literal[ConnectionsBackendRequest.ListObjects] = Field(
-        description="The JSON-RPC method name (list_objects)",
+        description="The JSON-RPC method name (list_objects)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class ListFieldsParams(BaseModel):
@@ -136,9 +114,7 @@ class ListFieldsParams(BaseModel):
     List fields of an object, such as columns of a table or view.
     """
 
-    path: List[ObjectSchema] = Field(
-        description="The path to object that we want to list fields.",
-    )
+    path: List[ObjectSchema] = Field(description="The path to object that we want to list fields.")
 
 
 class ListFieldsRequest(BaseModel):
@@ -146,18 +122,13 @@ class ListFieldsRequest(BaseModel):
     List fields of an object, such as columns of a table or view.
     """
 
-    params: ListFieldsParams = Field(
-        description="Parameters to the ListFields method",
-    )
+    params: ListFieldsParams = Field(description="Parameters to the ListFields method")
 
     method: Literal[ConnectionsBackendRequest.ListFields] = Field(
-        description="The JSON-RPC method name (list_fields)",
+        description="The JSON-RPC method name (list_fields)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class ContainsDataParams(BaseModel):
@@ -166,7 +137,7 @@ class ContainsDataParams(BaseModel):
     """
 
     path: List[ObjectSchema] = Field(
-        description="The path to object that we want to check if it contains data.",
+        description="The path to object that we want to check if it contains data."
     )
 
 
@@ -175,18 +146,13 @@ class ContainsDataRequest(BaseModel):
     Check if an object contains data, such as a table or view.
     """
 
-    params: ContainsDataParams = Field(
-        description="Parameters to the ContainsData method",
-    )
+    params: ContainsDataParams = Field(description="Parameters to the ContainsData method")
 
     method: Literal[ConnectionsBackendRequest.ContainsData] = Field(
-        description="The JSON-RPC method name (contains_data)",
+        description="The JSON-RPC method name (contains_data)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class GetIconParams(BaseModel):
@@ -194,9 +160,7 @@ class GetIconParams(BaseModel):
     Get icon of an object, such as a table or view.
     """
 
-    path: List[ObjectSchema] = Field(
-        description="The path to object that we want to get the icon.",
-    )
+    path: List[ObjectSchema] = Field(description="The path to object that we want to get the icon.")
 
 
 class GetIconRequest(BaseModel):
@@ -204,18 +168,13 @@ class GetIconRequest(BaseModel):
     Get icon of an object, such as a table or view.
     """
 
-    params: GetIconParams = Field(
-        description="Parameters to the GetIcon method",
-    )
+    params: GetIconParams = Field(description="Parameters to the GetIcon method")
 
     method: Literal[ConnectionsBackendRequest.GetIcon] = Field(
-        description="The JSON-RPC method name (get_icon)",
+        description="The JSON-RPC method name (get_icon)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class PreviewObjectParams(BaseModel):
@@ -223,9 +182,7 @@ class PreviewObjectParams(BaseModel):
     Preview object data, such as a table or view.
     """
 
-    path: List[ObjectSchema] = Field(
-        description="The path to object that we want to preview.",
-    )
+    path: List[ObjectSchema] = Field(description="The path to object that we want to preview.")
 
 
 class PreviewObjectRequest(BaseModel):
@@ -233,18 +190,13 @@ class PreviewObjectRequest(BaseModel):
     Preview object data, such as a table or view.
     """
 
-    params: PreviewObjectParams = Field(
-        description="Parameters to the PreviewObject method",
-    )
+    params: PreviewObjectParams = Field(description="Parameters to the PreviewObject method")
 
     method: Literal[ConnectionsBackendRequest.PreviewObject] = Field(
-        description="The JSON-RPC method name (preview_object)",
+        description="The JSON-RPC method name (preview_object)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class GetMetadataParams(BaseModel):
@@ -253,7 +205,7 @@ class GetMetadataParams(BaseModel):
     """
 
     comm_id: StrictStr = Field(
-        description="The comm_id of the client we want to retrieve metdata for.",
+        description="The comm_id of the client we want to retrieve metdata for."
     )
 
 
@@ -262,18 +214,13 @@ class GetMetadataRequest(BaseModel):
     A connection has tied metadata such as an icon, the host, etc.
     """
 
-    params: GetMetadataParams = Field(
-        description="Parameters to the GetMetadata method",
-    )
+    params: GetMetadataParams = Field(description="Parameters to the GetMetadata method")
 
     method: Literal[ConnectionsBackendRequest.GetMetadata] = Field(
-        description="The JSON-RPC method name (get_metadata)",
+        description="The JSON-RPC method name (get_metadata)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class ConnectionsBackendMessageContent(BaseModel):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections_comm.py
@@ -15,7 +15,14 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+from ._vendor.pydantic import (
+    BaseModel,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+)
 
 
 class ObjectSchema(BaseModel):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -23,7 +23,6 @@ from typing import (
 )
 
 import comm
-from IPython.core.error import UsageError
 
 from .access_keys import decode_access_key
 from .data_explorer_comm import (

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -188,7 +188,9 @@ class DataExplorerTableView(abc.ABC):
 
         self._set_sort_keys(state.sort_keys)
 
-        self._need_recompute = len(state.row_filters) > 0 or len(state.sort_keys) > 0
+        self._need_recompute = (
+            len(state.row_filters) > 0 or len(state.sort_keys) > 0
+        )
 
         # Array of selected ("true") indices using filters. If
         # there are also sort keys, we first filter the unsorted data,
@@ -210,7 +212,9 @@ class DataExplorerTableView(abc.ABC):
         # without having to recompute the search. If the search term
         # changes, we discard the last search result. We might add an
         # LRU cache here or something if it helps performance.
-        self._search_schema_last_result: Optional[Tuple[List[ColumnFilter], List[int]]] = None
+        self._search_schema_last_result: Optional[
+            Tuple[List[ColumnFilter], List[int]]
+        ] = None
 
         self._update_schema_cache()
 
@@ -221,9 +225,13 @@ class DataExplorerTableView(abc.ABC):
         # schema update. If the schema is large, then we don't cache
         # and where relevant we assume that the schema could have
         # changed.
-        if self._should_cache_schema(self.table) and self.state.schema_cache is None:
+        if (
+            self._should_cache_schema(self.table)
+            and self.state.schema_cache is None
+        ):
             self.state.schema_cache = [
-                self._get_single_column_schema(i) for i in range(self.table.shape[1])
+                self._get_single_column_schema(i)
+                for i in range(self.table.shape[1])
             ]
 
     @property
@@ -240,7 +248,8 @@ class DataExplorerTableView(abc.ABC):
         # We store the column schemas for each sort key to help with
         # eviction later during updates
         self._sort_key_schemas = [
-            self._get_single_column_schema(key.column_index) for key in self.state.sort_keys
+            self._get_single_column_schema(key.column_index)
+            for key in self.state.sort_keys
         ]
 
     def _recompute_if_needed(self) -> bool:
@@ -296,7 +305,11 @@ class DataExplorerTableView(abc.ABC):
 
         matches_slice = matches[start_index : start_index + max_results]
         return SearchSchemaResult(
-            matches=TableSchema(columns=[self._get_single_column_schema(i) for i in matches_slice]),
+            matches=TableSchema(
+                columns=[
+                    self._get_single_column_schema(i) for i in matches_slice
+                ]
+            ),
             total_num_matches=len(matches),
         ).dict()
 
@@ -367,7 +380,9 @@ class DataExplorerTableView(abc.ABC):
             request.params.format_options,
         )
 
-    def _get_row_labels(self, selection: ArraySelection, format_options: FormatOptions):
+    def _get_row_labels(
+        self, selection: ArraySelection, format_options: FormatOptions
+    ):
         # By default, the table has no row labels, so this will only
         # be implemented for pandas
         return {"row_labels": []}
@@ -413,7 +428,9 @@ class DataExplorerTableView(abc.ABC):
         else:
             raise NotImplementedError(f"Unknown data export: {kind}")
 
-    def _export_cell(self, row_index: int, column_index: int, fmt: ExportFormat):
+    def _export_cell(
+        self, row_index: int, column_index: int, fmt: ExportFormat
+    ):
         raise NotImplementedError
 
     def _export_tabular(self, row_selector, column_selector, fmt: ExportFormat):
@@ -440,7 +457,9 @@ class DataExplorerTableView(abc.ABC):
             # Simply reset if empty filter set passed
             self.filtered_indices = None
             self._update_row_view_indices()
-            return FilterResult(selected_num_rows=len(self.table), had_errors=False).dict()
+            return FilterResult(
+                selected_num_rows=len(self.table), had_errors=False
+            ).dict()
 
         # Evaluate all the filters and combine them using the
         # indicated conditions
@@ -475,12 +494,16 @@ class DataExplorerTableView(abc.ABC):
 
         self.filtered_indices = self._mask_to_indices(combined_mask)
         selected_num_rows = (
-            len(self.table) if self.filtered_indices is None else len(self.filtered_indices)
+            len(self.table)
+            if self.filtered_indices is None
+            else len(self.filtered_indices)
         )
 
         # Update the view indices, re-sorting if needed
         self._update_row_view_indices()
-        return FilterResult(selected_num_rows=selected_num_rows, had_errors=had_errors).dict()
+        return FilterResult(
+            selected_num_rows=selected_num_rows, had_errors=had_errors
+        ).dict()
 
     def _mask_to_indices(self, mask):
         raise NotImplementedError
@@ -540,7 +563,9 @@ class DataExplorerTableView(abc.ABC):
             if profile_type == ColumnProfileType.NullCount:
                 results["null_count"] = self._prof_null_count(column_index)
             elif profile_type == ColumnProfileType.SummaryStats:
-                results["summary_stats"] = self._prof_summary_stats(column_index, format_options)
+                results["summary_stats"] = self._prof_summary_stats(
+                    column_index, format_options
+                )
             elif profile_type == ColumnProfileType.SmallFrequencyTable:
                 assert isinstance(spec.params, ColumnFrequencyTableParams)
                 results["small_frequency_table"] = self._prof_freq_table(
@@ -587,7 +612,9 @@ class DataExplorerTableView(abc.ABC):
                 num_rows=filtered_num_rows,
                 num_columns=filtered_num_columns,
             ),
-            table_unfiltered_shape=TableShape(num_rows=num_rows, num_columns=num_columns),
+            table_unfiltered_shape=TableShape(
+                num_rows=num_rows, num_columns=num_columns
+            ),
             has_row_labels=self._has_row_labels,
             column_filters=self.state.column_filters,
             row_filters=self.state.row_filters,
@@ -688,7 +715,9 @@ class DataExplorerTableView(abc.ABC):
                     continue
             elif column_index in shifted_columns:
                 key.column_index = shifted_columns[column_index]
-            elif column_index in deleted_columns or prior_name != str(new_columns[column_index]):
+            elif column_index in deleted_columns or prior_name != str(
+                new_columns[column_index]
+            ):
                 # Column deleted
                 continue
 
@@ -801,7 +830,9 @@ class DataExplorerTableView(abc.ABC):
             support_status=SupportStatus.Unsupported,
             supported_types=[],
         ),
-        set_sort_columns=SetSortColumnsFeatures(support_status=SupportStatus.Unsupported),
+        set_sort_columns=SetSortColumnsFeatures(
+            support_status=SupportStatus.Unsupported
+        ),
         export_data_selection=ExportDataSelectionFeatures(
             support_status=SupportStatus.Unsupported,
             supported_formats=[],
@@ -825,14 +856,18 @@ def _box_number_stats(min_val, max_val, mean_val, median_val, std_val):
 def _box_string_stats(num_empty, num_unique):
     return ColumnSummaryStats(
         type_display=ColumnDisplayType.String,
-        string_stats=SummaryStatsString(num_empty=int(num_empty), num_unique=int(num_unique)),
+        string_stats=SummaryStatsString(
+            num_empty=int(num_empty), num_unique=int(num_unique)
+        ),
     )
 
 
 def _box_boolean_stats(true_count, false_count):
     return ColumnSummaryStats(
         type_display=ColumnDisplayType.Boolean,
-        boolean_stats=SummaryStatsBoolean(true_count=int(true_count), false_count=int(false_count)),
+        boolean_stats=SummaryStatsBoolean(
+            true_count=int(true_count), false_count=int(false_count)
+        ),
     )
 
 
@@ -852,7 +887,9 @@ def _box_date_stats(num_unique, min_date, mean_date, median_date, max_date):
     )
 
 
-def _box_datetime_stats(num_unique, min_date, mean_date, median_date, max_date, timezone):
+def _box_datetime_stats(
+    num_unique, min_date, mean_date, median_date, max_date, timezone
+):
     def format_date(x):
         return str(x)
 
@@ -1024,7 +1061,9 @@ def _pandas_summarize_date(col: "pd.Series", options: FormatOptions):
     median_date = _date_median(col_dttm)
     max_date = col.max()
     num_unique = col.nunique()
-    return _box_date_stats(num_unique, min_date, mean_date, median_date, max_date)
+    return _box_date_stats(
+        num_unique, min_date, mean_date, median_date, max_date
+    )
 
 
 def _pandas_summarize_datetime(col: "pd.Series", options: FormatOptions):
@@ -1050,7 +1089,9 @@ def _pandas_summarize_datetime(col: "pd.Series", options: FormatOptions):
         if len(timezones) > 2:
             timezone = timezone + f", ... ({len(timezones) - 2} more)"
 
-    return _box_datetime_stats(num_unique, min_date, mean_date, median_date, max_date, timezone)
+    return _box_datetime_stats(
+        num_unique, min_date, mean_date, median_date, max_date, timezone
+    )
 
 
 def _safe_stringify(x, max_length: int):
@@ -1105,7 +1146,10 @@ class PandasView(DataExplorerTableView):
     def _should_cache_schema(cls, table):
         num_rows, num_columns = table.shape
         num_cells = num_rows * num_columns
-        return num_columns < SCHEMA_CACHE_THRESHOLD and num_cells < PANDAS_CACHE_CELLS_THRESHOLD
+        return (
+            num_columns < SCHEMA_CACHE_THRESHOLD
+            and num_cells < PANDAS_CACHE_CELLS_THRESHOLD
+        )
 
     def _maybe_wrap(self, value):
         if isinstance(value, pd_.Series):
@@ -1118,7 +1162,8 @@ class PandasView(DataExplorerTableView):
 
     def get_updated_state(self, new_table) -> StateUpdate:
         filtered_columns = {
-            filt.column_schema.column_index: filt.column_schema for filt in self.state.row_filters
+            filt.column_schema.column_index: filt.column_schema
+            for filt in self.state.row_filters
         }
 
         new_state = DataExplorerState(self.state.name)
@@ -1160,7 +1205,9 @@ class PandasView(DataExplorerTableView):
                 for i, column_name in enumerate(self.table.columns):
                     column = self.table.iloc[:, i]
 
-                    new_schema = self._construct_schema(column, column_name, i, new_state)
+                    new_schema = self._construct_schema(
+                        column, column_name, i, new_state
+                    )
                     old_schema = self.state.schema_cache[i]
 
                     if (
@@ -1189,7 +1236,9 @@ class PandasView(DataExplorerTableView):
                             # for further analysis
                             continue
 
-                    schema_changes[i] = self._construct_schema(column, column_name, i, new_state)
+                    schema_changes[i] = self._construct_schema(
+                        column, column_name, i, new_state
+                    )
         else:
             # When computing the new display type of a column requires
             # calling infer_dtype, we are careful to only do it for
@@ -1273,7 +1322,9 @@ class PandasView(DataExplorerTableView):
         )
 
     @classmethod
-    def _get_inferred_dtype(cls, column, column_index: int, state: DataExplorerState):
+    def _get_inferred_dtype(
+        cls, column, column_index: int, state: DataExplorerState
+    ):
         from pandas.api.types import infer_dtype
 
         if len(column) > PANDAS_INFER_DTYPE_SIZE_LIMIT:
@@ -1395,7 +1446,9 @@ class PandasView(DataExplorerTableView):
             spec = selection.spec
             if isinstance(spec, DataSelectionRange):
                 if self.row_view_indices is not None:
-                    view_slice = self.row_view_indices[spec.first_index : spec.last_index + 1]
+                    view_slice = self.row_view_indices[
+                        spec.first_index : spec.last_index + 1
+                    ]
                     values = col.take(view_slice)
                 else:
                     # No filtering or sorting, just slice directly
@@ -1407,7 +1460,9 @@ class PandasView(DataExplorerTableView):
                     # No filtering or sorting, just slice directly
                     values = col.take(spec.indices)
 
-            formatted_columns.append(self._format_values(values, format_options))
+            formatted_columns.append(
+                self._format_values(values, format_options)
+            )
 
         # Bypass pydantic model for speed
         return {"columns": formatted_columns}
@@ -1415,13 +1470,19 @@ class PandasView(DataExplorerTableView):
     def _get_row_labels(self, selection: ArraySelection, _: FormatOptions):
         if isinstance(selection, DataSelectionRange):
             if self.row_view_indices is not None:
-                view_slice = self.row_view_indices[selection.first_index : selection.last_index + 1]
+                view_slice = self.row_view_indices[
+                    selection.first_index : selection.last_index + 1
+                ]
                 indices = self.table.index.take(view_slice)
             else:
-                indices = self.table.index[selection.first_index : selection.last_index + 1]
+                indices = self.table.index[
+                    selection.first_index : selection.last_index + 1
+                ]
         else:
             if self.row_view_indices is not None:
-                indices = self.table.index.take(self.row_view_indices.take(selection.indices))
+                indices = self.table.index.take(
+                    self.row_view_indices.take(selection.indices)
+                )
             else:
                 indices = self.table.index.take(selection.indices)
 
@@ -1434,7 +1495,9 @@ class PandasView(DataExplorerTableView):
         return {"row_labels": row_labels}
 
     @classmethod
-    def _format_values(cls, values, options: FormatOptions) -> List[ColumnValue]:
+    def _format_values(
+        cls, values, options: FormatOptions
+    ) -> List[ColumnValue]:
         NaT = pd_.NaT
         NA = pd_.NA
         float_format = _get_float_formatter(options)
@@ -1486,8 +1549,12 @@ class PandasView(DataExplorerTableView):
 
         return ExportedData(data=result, format=fmt).dict()
 
-    def _export_cell(self, row_index: int, column_index: int, fmt: ExportFormat):
-        return ExportedData(data=str(self.table.iat[row_index, column_index]), format=fmt).dict()
+    def _export_cell(
+        self, row_index: int, column_index: int, fmt: ExportFormat
+    ):
+        return ExportedData(
+            data=str(self.table.iat[row_index, column_index]), format=fmt
+        ).dict()
 
     def _mask_to_indices(self, mask):
         if mask is not None:
@@ -1507,8 +1574,12 @@ class PandasView(DataExplorerTableView):
         ):
             params = filt.params
             assert isinstance(params, FilterBetween)
-            left_value = self._coerce_value(params.left_value, dtype, inferred_type)
-            right_value = self._coerce_value(params.right_value, dtype, inferred_type)
+            left_value = self._coerce_value(
+                params.left_value, dtype, inferred_type
+            )
+            right_value = self._coerce_value(
+                params.right_value, dtype, inferred_type
+            )
             if filt.filter_type == RowFilterType.Between:
                 mask = (col >= left_value) & (col <= right_value)
             else:
@@ -1522,7 +1593,9 @@ class PandasView(DataExplorerTableView):
                 raise ValueError(f"Unsupported filter type: {params.op}")
             op = COMPARE_OPS[params.op]
             # pandas comparison filters return False for null values
-            mask = op(col, self._coerce_value(params.value, dtype, inferred_type))
+            mask = op(
+                col, self._coerce_value(params.value, dtype, inferred_type)
+            )
         elif filt.filter_type == RowFilterType.IsEmpty:
             mask = col.str.len() == 0
         elif filt.filter_type == RowFilterType.IsNull:
@@ -1540,7 +1613,10 @@ class PandasView(DataExplorerTableView):
             assert isinstance(params, FilterSetMembership)
 
             boxed_values = pd_.Series(
-                [self._coerce_value(val, dtype, inferred_type) for val in params.values]
+                [
+                    self._coerce_value(val, dtype, inferred_type)
+                    for val in params.values
+                ]
             )
             # IN
             mask = col.isin(boxed_values)
@@ -1632,7 +1708,9 @@ class PandasView(DataExplorerTableView):
                 self.row_view_indices = self.filtered_indices.take(sort_indexer)
             else:
                 # Data is not filtered
-                self.row_view_indices = nargsort(column, kind="mergesort", ascending=key.ascending)
+                self.row_view_indices = nargsort(
+                    column, kind="mergesort", ascending=key.ascending
+                )
         elif len(self.state.sort_keys) > 1:
             # Multiple sorting keys
             cols_to_sort = []
@@ -1709,7 +1787,9 @@ class PandasView(DataExplorerTableView):
 
         method = _get_histogram_method(params.method)
 
-        bin_counts, bin_edges = _get_histogram_numpy(data, params.num_bins, method=method)
+        bin_counts, bin_edges = _get_histogram_numpy(
+            data, params.num_bins, method=method
+        )
 
         if is_datetime64:
             # A bit hacky for now, but will replace this with
@@ -1798,7 +1878,9 @@ class PandasView(DataExplorerTableView):
                 ),
             ],
         ),
-        set_sort_columns=SetSortColumnsFeatures(support_status=SupportStatus.Supported),
+        set_sort_columns=SetSortColumnsFeatures(
+            support_status=SupportStatus.Supported
+        ),
         export_data_selection=ExportDataSelectionFeatures(
             support_status=SupportStatus.Supported,
             supported_formats=[
@@ -1850,7 +1932,9 @@ def _get_histogram_numpy(data, num_bins, method="fd"):
             #         519144975,  1384373326,  1974689646,   194821408, -1564699930],
             #         dtype=int32)
             # So we try again with the data converted to floating point as a fallback
-            return _get_histogram_numpy(data.astype(np_.float64), num_bins, method=method)
+            return _get_histogram_numpy(
+                data.astype(np_.float64), num_bins, method=method
+            )
 
         # If there are inf/-inf values in the dataset, ValueError is
         # raised. We catch it and try again to avoid paying the
@@ -1991,7 +2075,9 @@ def _polars_summarize_date(col: "pl.Series", _):
         int(as_int32.median()),  # type: ignore
         col.dtype,
     )
-    return _box_date_stats(num_unique, min_date, mean_date, median_date, max_date)
+    return _box_date_stats(
+        num_unique, min_date, mean_date, median_date, max_date
+    )
 
 
 def _polars_box_value(val, dtype):
@@ -2099,7 +2185,9 @@ class PolarsView(DataExplorerTableView):
 
             # The type changed
             schema_updated = True
-            schema_changes[old_index] = self._construct_schema(new_column, column_name, new_index)
+            schema_changes[old_index] = self._construct_schema(
+                new_column, column_name, new_index
+            )
 
         def schema_getter(column_name, column_index):
             return self._construct_schema(
@@ -2129,7 +2217,9 @@ class PolarsView(DataExplorerTableView):
             return self.schema_memo[column_index]
         else:
             column = self.table[:, column_index]
-            col_schema = self._construct_schema(column, column.name, column_index)
+            col_schema = self._construct_schema(
+                column, column.name, column_index
+            )
             self.schema_memo[column_index] = col_schema
             return col_schema
 
@@ -2201,23 +2291,31 @@ class PolarsView(DataExplorerTableView):
             spec = selection.spec
             if isinstance(spec, DataSelectionRange):
                 if self.row_view_indices is not None:
-                    view_slice = self.row_view_indices[spec.first_index : spec.last_index + 1]
+                    view_slice = self.row_view_indices[
+                        spec.first_index : spec.last_index + 1
+                    ]
                     values = col.gather(view_slice)
                 else:
                     # No filtering or sorting, just slice
                     values = col[spec.first_index : spec.last_index + 1]
             else:
                 if self.row_view_indices is not None:
-                    values = col.gather(self.row_view_indices.gather(spec.indices))
+                    values = col.gather(
+                        self.row_view_indices.gather(spec.indices)
+                    )
                 else:
                     values = col.gather(spec.indices)
-            formatted_columns.append(self._format_values(values, format_options))
+            formatted_columns.append(
+                self._format_values(values, format_options)
+            )
 
         # Bypass pydantic model for speed
         return {"columns": formatted_columns}
 
     @classmethod
-    def _format_values(cls, values, options: FormatOptions) -> List[ColumnValue]:
+    def _format_values(
+        cls, values, options: FormatOptions
+    ) -> List[ColumnValue]:
         float_format = _get_float_formatter(options)
         max_length = options.max_value_length
 
@@ -2239,7 +2337,11 @@ class PolarsView(DataExplorerTableView):
                     if is_valid_mask[i]:
                         inner_values = _format_series(v)
                         result.append(
-                            "[" + ", ".join("null" if v == 0 else v for v in inner_values) + "]"
+                            "["
+                            + ", ".join(
+                                "null" if v == 0 else v for v in inner_values
+                            )
+                            + "]"
                         )
                     else:
                         result.append(_VALUE_NULL)
@@ -2268,8 +2370,12 @@ class PolarsView(DataExplorerTableView):
 
         return ExportedData(data=result, format=fmt).dict()
 
-    def _export_cell(self, row_index: int, column_index: int, fmt: ExportFormat):
-        return ExportedData(data=str(self.table[row_index, column_index]), format=fmt).dict()
+    def _export_cell(
+        self, row_index: int, column_index: int, fmt: ExportFormat
+    ):
+        return ExportedData(
+            data=str(self.table[row_index, column_index]), format=fmt
+        ).dict()
 
     SUPPORTED_FILTERS = {
         RowFilterType.Between,
@@ -2304,8 +2410,12 @@ class PolarsView(DataExplorerTableView):
         ):
             params = filt.params
             assert isinstance(params, FilterBetween)
-            left_value = self._coerce_value(params.left_value, dtype, display_type)
-            right_value = self._coerce_value(params.right_value, dtype, display_type)
+            left_value = self._coerce_value(
+                params.left_value, dtype, display_type
+            )
+            right_value = self._coerce_value(
+                params.right_value, dtype, display_type
+            )
             mask = col.is_between(left_value, right_value)
             if filt.filter_type == RowFilterType.NotBetween:
                 mask = ~mask
@@ -2317,7 +2427,9 @@ class PolarsView(DataExplorerTableView):
                 raise ValueError(f"Unsupported filter type: {params.op}")
             op = COMPARE_OPS[params.op]
             # pandas comparison filters return False for null values
-            mask = op(col, self._coerce_value(params.value, dtype, display_type))
+            mask = op(
+                col, self._coerce_value(params.value, dtype, display_type)
+            )
         elif filt.filter_type == RowFilterType.IsEmpty:
             if col.dtype.is_(pl_.String):
                 mask = col.str.len_chars() == 0
@@ -2349,7 +2461,10 @@ class PolarsView(DataExplorerTableView):
             # Per https://github.com/pola-rs/polars/issues/17771, we
             # have to be really careful here because this can fail on
             # polars 1.x or 0.x
-            coerced_values = [self._coerce_value(val, dtype, display_type) for val in params.values]
+            coerced_values = [
+                self._coerce_value(val, dtype, display_type)
+                for val in params.values
+            ]
             try:
                 boxed_values = pl_.Series(coerced_values, dtype=col.dtype)
             except TypeError:
@@ -2439,7 +2554,9 @@ class PolarsView(DataExplorerTableView):
                 num_rows = len(self.table)
 
             # Do a stable sort of the indices using the columns as sort keys
-            to_sort = pl_.DataFrame([pl_.arange(num_rows, eager=True).alias(indexer_name)])
+            to_sort = pl_.DataFrame(
+                [pl_.arange(num_rows, eager=True).alias(indexer_name)]
+            )
 
             try:
                 to_sort = to_sort.select(
@@ -2451,12 +2568,16 @@ class PolarsView(DataExplorerTableView):
                 )
             except TypeError:
                 # Older versions of polars do not have maintain_order
-                to_sort = to_sort.select(pl_.all().sort_by(cols_to_sort, descending=directions))
+                to_sort = to_sort.select(
+                    pl_.all().sort_by(cols_to_sort, descending=directions)
+                )
 
             sort_indexer = to_sort[indexer_name]
             if self.filtered_indices is not None:
                 # Create the filtered, sorted virtual view indices
-                self.row_view_indices = self.filtered_indices.gather(sort_indexer)
+                self.row_view_indices = self.filtered_indices.gather(
+                    sort_indexer
+                )
             else:
                 self.row_view_indices = sort_indexer
         else:
@@ -2490,7 +2611,9 @@ class PolarsView(DataExplorerTableView):
         col = self._get_column(column_index).alias("values")
 
         col = col.filter(col.is_not_null())
-        counts = col.value_counts().sort(by=["count", "values"], descending=[True, False])
+        counts = col.value_counts().sort(
+            by=["count", "values"], descending=[True, False]
+        )
 
         top_counts = counts[: params.limit]
         other_count = int(counts[params.limit :, 1].sum())
@@ -2576,7 +2699,9 @@ class PolarsView(DataExplorerTableView):
             support_status=SupportStatus.Supported,
             supported_formats=[ExportFormat.Csv, ExportFormat.Tsv],
         ),
-        set_sort_columns=SetSortColumnsFeatures(support_status=SupportStatus.Supported),
+        set_sort_columns=SetSortColumnsFeatures(
+            support_status=SupportStatus.Supported
+        ),
     )
 
 
@@ -2590,7 +2715,9 @@ class PyArrowView(DataExplorerTableView):
 
 def _is_pandas(table):
     pandas = import_pandas()
-    if pandas is not None and isinstance(table, (pandas.DataFrame, pandas.Series)):
+    if pandas is not None and isinstance(
+        table, (pandas.DataFrame, pandas.Series)
+    ):
         # If pandas was installed after the kernel was started, pd_ will still be None.
         # Raise an error to inform the user to restart the kernel.
         if pd_ is None:
@@ -2604,7 +2731,9 @@ def _is_pandas(table):
 
 def _is_polars(table):
     polars = import_polars()
-    if polars is not None and isinstance(table, (polars.DataFrame, polars.Series)):
+    if polars is not None and isinstance(
+        table, (polars.DataFrame, polars.Series)
+    ):
         # If polars was installed after the kernel was started, pl_ will still be None.
         # Raise an error to inform the user to restart the kernel.
         if pl_ is None:
@@ -2798,7 +2927,9 @@ class DataExplorerService:
             for comm_id in list(self.path_to_comm_ids[path]):
                 self._update_explorer_for_comm(comm_id, path, new_variable)
 
-    def _update_explorer_for_comm(self, comm_id: str, path: PathKey, new_variable):
+    def _update_explorer_for_comm(
+        self, comm_id: str, path: PathKey, new_variable
+    ):
         """
         If a variable is updated, we have to handle the different scenarios:
 
@@ -2834,7 +2965,9 @@ class DataExplorerService:
         # data explorer open for a nested value, then we need to use
         # the same variables inspection logic to resolve it here.
         if len(path) > 1:
-            is_found, new_table = _resolve_value_from_path(new_variable, path[1:])
+            is_found, new_table = _resolve_value_from_path(
+                new_variable, path[1:]
+            )
             if not is_found:
                 raise KeyError(f"Path {full_title} not found in value")
         else:
@@ -2867,7 +3000,9 @@ class DataExplorerService:
         else:
             comm.send_event(DataExplorerFrontendEvent.DataUpdate.value, {})
 
-    def handle_msg(self, msg: CommMessage[DataExplorerBackendMessageContent], raw_msg):
+    def handle_msg(
+        self, msg: CommMessage[DataExplorerBackendMessageContent], raw_msg
+    ):
         """
         Handle messages received from the client via the
         positron.data_explorer comm.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -11,16 +11,7 @@ import logging
 import math
 import operator
 from datetime import datetime
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Set,
-    Tuple,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
 
 import comm
 
@@ -96,14 +87,7 @@ from .data_explorer_comm import (
     TextSearchType,
 )
 from .positron_comm import CommMessage, PositronComm
-from .third_party import (
-    RestartRequiredError,
-    import_pandas,
-    import_polars,
-    np_,
-    pd_,
-    pl_,
-)
+from .third_party import RestartRequiredError, import_pandas, import_polars, np_, pd_, pl_
 from .utils import BackgroundJobQueue, guid
 
 if TYPE_CHECKING:
@@ -172,11 +156,7 @@ class DataExplorerTableView(abc.ABC):
     """
 
     def __init__(
-        self,
-        table,
-        comm: PositronComm,
-        state: DataExplorerState,
-        job_queue: BackgroundJobQueue,
+        self, table, comm: PositronComm, state: DataExplorerState, job_queue: BackgroundJobQueue
     ):
         # Note: we must not ever modify the user's data
         self.table = table
@@ -355,17 +335,11 @@ class DataExplorerTableView(abc.ABC):
 
     def get_data_values(self, request: GetDataValuesRequest):
         self._recompute_if_needed()
-        return self._get_data_values(
-            request.params.columns,
-            request.params.format_options,
-        )
+        return self._get_data_values(request.params.columns, request.params.format_options)
 
     def get_row_labels(self, request: GetRowLabelsRequest):
         self._recompute_if_needed()
-        return self._get_row_labels(
-            request.params.selection,
-            request.params.format_options,
-        )
+        return self._get_row_labels(request.params.selection, request.params.format_options)
 
     def _get_row_labels(self, selection: ArraySelection, format_options: FormatOptions):
         # By default, the table has no row labels, so this will only
@@ -393,16 +367,12 @@ class DataExplorerTableView(abc.ABC):
         elif kind == TableSelectionKind.RowRange:
             assert isinstance(sel, DataSelectionRange)
             return self._export_tabular(
-                slice(sel.first_index, sel.last_index + 1),
-                slice(None),
-                fmt,
+                slice(sel.first_index, sel.last_index + 1), slice(None), fmt
             )
         elif kind == TableSelectionKind.ColumnRange:
             assert isinstance(sel, DataSelectionRange)
             return self._export_tabular(
-                slice(None),
-                slice(sel.first_index, sel.last_index + 1),
-                fmt,
+                slice(None), slice(sel.first_index, sel.last_index + 1), fmt
             )
         elif kind == TableSelectionKind.RowIndices:
             assert isinstance(sel, DataSelectionIndices)
@@ -512,9 +482,7 @@ class DataExplorerTableView(abc.ABC):
         for req in request.params.profiles:
             try:
                 result = self._compute_profiles(
-                    req.column_index,
-                    req.profiles,
-                    request.params.format_options,
+                    req.column_index, req.profiles, request.params.format_options
                 )
                 results.append(result.dict())
             except Exception as e:
@@ -529,10 +497,7 @@ class DataExplorerTableView(abc.ABC):
         )
 
     def _compute_profiles(
-        self,
-        column_index: int,
-        profiles: List[ColumnProfileSpec],
-        format_options: FormatOptions,
+        self, column_index: int, profiles: List[ColumnProfileSpec], format_options: FormatOptions
     ):
         results = {}
         for spec in profiles:
@@ -583,10 +548,7 @@ class DataExplorerTableView(abc.ABC):
 
         return BackendState(
             display_name=self.state.name,
-            table_shape=TableShape(
-                num_rows=filtered_num_rows,
-                num_columns=filtered_num_columns,
-            ),
+            table_shape=TableShape(num_rows=filtered_num_rows, num_columns=filtered_num_columns),
             table_unfiltered_shape=TableShape(num_rows=num_rows, num_columns=num_columns),
             has_row_labels=self._has_row_labels,
             column_filters=self.state.column_filters,
@@ -604,12 +566,7 @@ class DataExplorerTableView(abc.ABC):
         raise NotImplementedError
 
     def _get_adjusted_filters(
-        self,
-        new_columns,
-        schema_changes,
-        shifted_columns,
-        deleted_columns,
-        schema_getter,
+        self, new_columns, schema_changes, shifted_columns, deleted_columns, schema_getter
     ):
         # Shared by implementations of get_updated_state
         new_filters = []
@@ -637,10 +594,7 @@ class DataExplorerTableView(abc.ABC):
                         # Probably a new column that allows the old
                         # filter to become valid again if the type is
                         # compatible
-                        filt.column_schema = schema_getter(
-                            column_name,
-                            column_index,
-                        )
+                        filt.column_schema = schema_getter(column_name, column_index)
                     else:
                         is_deleted = True
             elif column_index in shifted_columns:
@@ -697,9 +651,7 @@ class DataExplorerTableView(abc.ABC):
         return new_sort_keys
 
     def _get_data_values(
-        self,
-        selections: List[ColumnSelection],
-        format_options: FormatOptions,
+        self, selections: List[ColumnSelection], format_options: FormatOptions
     ) -> dict:
         raise NotImplementedError
 
@@ -721,22 +673,13 @@ class DataExplorerTableView(abc.ABC):
         elif filt.filter_type == RowFilterType.Compare:
             params = filt.params
             assert isinstance(params, FilterComparison), str(params)
-            if params.op in [
-                FilterComparisonOp.Eq,
-                FilterComparisonOp.NotEq,
-            ]:
+            if params.op in [FilterComparisonOp.Eq, FilterComparisonOp.NotEq]:
                 return True
             else:
                 return display_type in _FILTER_RANGE_COMPARE_SUPPORTED
-        elif filt.filter_type in [
-            RowFilterType.Between,
-            RowFilterType.NotBetween,
-        ]:
+        elif filt.filter_type in [RowFilterType.Between, RowFilterType.NotBetween]:
             return display_type in _FILTER_RANGE_COMPARE_SUPPORTED
-        elif filt.filter_type in [
-            RowFilterType.IsTrue,
-            RowFilterType.IsFalse,
-        ]:
+        elif filt.filter_type in [RowFilterType.IsTrue, RowFilterType.IsFalse]:
             return display_type == ColumnDisplayType.Boolean
         else:
             # Filters always supported
@@ -769,25 +712,18 @@ class DataExplorerTableView(abc.ABC):
         raise NotImplementedError
 
     def _prof_freq_table(
-        self,
-        column_index: int,
-        params: ColumnFrequencyTableParams,
-        format_options: FormatOptions,
+        self, column_index: int, params: ColumnFrequencyTableParams, format_options: FormatOptions
     ) -> ColumnFrequencyTable:
         raise NotImplementedError
 
     def _prof_histogram(
-        self,
-        column_index: int,
-        params: ColumnHistogramParams,
-        format_options: FormatOptions,
+        self, column_index: int, params: ColumnHistogramParams, format_options: FormatOptions
     ) -> ColumnHistogram:
         raise NotImplementedError
 
     FEATURES = SupportedFeatures(
         search_schema=SearchSchemaFeatures(
-            support_status=SupportStatus.Unsupported,
-            supported_types=[],
+            support_status=SupportStatus.Unsupported, supported_types=[]
         ),
         set_column_filters=SetColumnFiltersFeatures(
             support_status=SupportStatus.Unsupported, supported_types=[]
@@ -798,13 +734,11 @@ class DataExplorerTableView(abc.ABC):
             supported_types=[],
         ),
         get_column_profiles=GetColumnProfilesFeatures(
-            support_status=SupportStatus.Unsupported,
-            supported_types=[],
+            support_status=SupportStatus.Unsupported, supported_types=[]
         ),
         set_sort_columns=SetSortColumnsFeatures(support_status=SupportStatus.Unsupported),
         export_data_selection=ExportDataSelectionFeatures(
-            support_status=SupportStatus.Unsupported,
-            supported_formats=[],
+            support_status=SupportStatus.Unsupported, supported_formats=[]
         ),
     )
 
@@ -813,11 +747,7 @@ def _box_number_stats(min_val, max_val, mean_val, median_val, std_val):
     return ColumnSummaryStats(
         type_display=ColumnDisplayType.Number,
         number_stats=SummaryStatsNumber(
-            min_value=min_val,
-            max_value=max_val,
-            mean=mean_val,
-            median=median_val,
-            stdev=std_val,
+            min_value=min_val, max_value=max_val, mean=mean_val, median=median_val, stdev=std_val
         ),
     )
 
@@ -995,13 +925,7 @@ def _pandas_summarize_number(col: "pd.Series", options: FormatOptions):
             min_val = float_format(min_val)
             max_val = float_format(max_val)
 
-    return _box_number_stats(
-        min_val,
-        max_val,
-        mean_val,
-        median_val,
-        std_val,
-    )
+    return _box_number_stats(min_val, max_val, mean_val, median_val, std_val)
 
 
 def _pandas_summarize_string(col: "pd.Series", options: FormatOptions):
@@ -1239,18 +1163,11 @@ class PandasView(DataExplorerTableView):
 
         def schema_getter(column_name, column_index):
             return self._construct_schema(
-                new_table.iloc[:, column_index],
-                column_name,
-                column_index,
-                new_state,
+                new_table.iloc[:, column_index], column_name, column_index, new_state
             )
 
         new_state.row_filters = self._get_adjusted_filters(
-            new_table.columns,
-            schema_changes,
-            shifted_columns,
-            deleted_columns,
-            schema_getter,
+            new_table.columns, schema_changes, shifted_columns, deleted_columns, schema_getter
         )
 
         new_state.sort_keys = self._get_adjusted_sort_keys(
@@ -1385,9 +1302,7 @@ class PandasView(DataExplorerTableView):
         return str(self.table.columns[index])
 
     def _get_data_values(
-        self,
-        selections: List[ColumnSelection],
-        format_options: FormatOptions,
+        self, selections: List[ColumnSelection], format_options: FormatOptions
     ) -> dict:
         formatted_columns = []
         for selection in selections:
@@ -1501,10 +1416,7 @@ class PandasView(DataExplorerTableView):
         inferred_type = self._get_inferred_dtype(col, column_index, self.state)
 
         mask = None
-        if filt.filter_type in (
-            RowFilterType.Between,
-            RowFilterType.NotBetween,
-        ):
+        if filt.filter_type in (RowFilterType.Between, RowFilterType.NotBetween):
             params = filt.params
             assert isinstance(params, FilterBetween)
             left_value = self._coerce_value(params.left_value, dtype, inferred_type)
@@ -1622,9 +1534,7 @@ class PandasView(DataExplorerTableView):
                 # the sorting indices). Mergesort is needed to make it
                 # stable
                 sort_indexer = nargsort(
-                    column.take(self.filtered_indices),
-                    kind="mergesort",
-                    ascending=key.ascending,
+                    column.take(self.filtered_indices), kind="mergesort", ascending=key.ascending
                 )
                 # Reorder the filtered_indices to provide the
                 # filtered, sorted virtual view for future data
@@ -1671,10 +1581,7 @@ class PandasView(DataExplorerTableView):
     }
 
     def _prof_freq_table(
-        self,
-        column_index: int,
-        params: ColumnFrequencyTableParams,
-        format_options: FormatOptions,
+        self, column_index: int, params: ColumnFrequencyTableParams, format_options: FormatOptions
     ) -> ColumnFrequencyTable:
         col = self._get_column(column_index)
         counts = col.value_counts()
@@ -1691,10 +1598,7 @@ class PandasView(DataExplorerTableView):
         )
 
     def _prof_histogram(
-        self,
-        column_index: int,
-        params: ColumnHistogramParams,
-        format_options: FormatOptions,
+        self, column_index: int, params: ColumnHistogramParams, format_options: FormatOptions
     ) -> ColumnHistogram:
         col = self._get_column(column_index)
 
@@ -1720,9 +1624,7 @@ class PandasView(DataExplorerTableView):
         formatted_edges = self._format_values(bin_edges, format_options)
 
         return ColumnHistogram(
-            bin_edges=formatted_edges,
-            bin_counts=[int(x) for x in bin_counts],
-            quantiles=[],
+            bin_edges=formatted_edges, bin_counts=[int(x) for x in bin_counts], quantiles=[]
         )
 
     SUPPORTED_FILTERS = {
@@ -1773,8 +1675,7 @@ class PandasView(DataExplorerTableView):
             support_status=SupportStatus.Supported,
             supported_types=[
                 ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.NullCount,
-                    support_status=SupportStatus.Supported,
+                    profile_type=ColumnProfileType.NullCount, support_status=SupportStatus.Supported
                 ),
                 ColumnProfileTypeSupportStatus(
                     profile_type=ColumnProfileType.SummaryStats,
@@ -1801,11 +1702,7 @@ class PandasView(DataExplorerTableView):
         set_sort_columns=SetSortColumnsFeatures(support_status=SupportStatus.Supported),
         export_data_selection=ExportDataSelectionFeatures(
             support_status=SupportStatus.Supported,
-            supported_formats=[
-                ExportFormat.Csv,
-                ExportFormat.Tsv,
-                ExportFormat.Html,
-            ],
+            supported_formats=[ExportFormat.Csv, ExportFormat.Tsv, ExportFormat.Html],
         ),
     )
 
@@ -1904,11 +1801,7 @@ def _possibly(f, otherwise=None):
         return otherwise
 
 
-_ISO_8601_FORMATS = [
-    "%Y-%m-%d %H:%M:%S",
-    "%Y-%m-%d %H:%M",
-    "%Y-%m-%d",
-]
+_ISO_8601_FORMATS = ["%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d"]
 
 
 def _parse_iso8601_like(x, tz=None):
@@ -1955,13 +1848,7 @@ def _polars_summarize_number(col: "pl.Series", options: FormatOptions):
         min_val = float_format(min_val)
         max_val = float_format(max_val)
 
-    return _box_number_stats(
-        min_val,
-        max_val,
-        mean_val,
-        median_val,
-        std_val,
-    )
+    return _box_number_stats(min_val, max_val, mean_val, median_val, std_val)
 
 
 def _polars_summarize_string(col: "pl.Series", _):
@@ -2033,9 +1920,7 @@ class PolarsView(DataExplorerTableView):
 
     def get_updated_state(self, new_table) -> StateUpdate:
         new_state = DataExplorerState(
-            self.state.name,
-            row_filters=self.state.row_filters,
-            sort_keys=self.state.sort_keys,
+            self.state.name, row_filters=self.state.row_filters, sort_keys=self.state.sort_keys
         )
 
         # As of June 2024, polars seems to be really slow for
@@ -2102,18 +1987,10 @@ class PolarsView(DataExplorerTableView):
             schema_changes[old_index] = self._construct_schema(new_column, column_name, new_index)
 
         def schema_getter(column_name, column_index):
-            return self._construct_schema(
-                new_table[:, column_index],
-                column_name,
-                column_index,
-            )
+            return self._construct_schema(new_table[:, column_index], column_name, column_index)
 
         new_state.row_filters = self._get_adjusted_filters(
-            new_columns,
-            schema_changes,
-            shifted_columns,
-            deleted_columns,
-            schema_getter,
+            new_columns, schema_changes, shifted_columns, deleted_columns, schema_getter
         )
 
         new_state.sort_keys = self._get_adjusted_sort_keys(
@@ -2137,12 +2014,7 @@ class PolarsView(DataExplorerTableView):
         return self.table[:, column_index].name
 
     @classmethod
-    def _construct_schema(
-        cls,
-        column: "pl.Series",
-        column_name: str,
-        column_index: int,
-    ):
+    def _construct_schema(cls, column: "pl.Series", column_name: str, column_index: int):
         type_display = cls._get_type_display(column.dtype)
 
         return ColumnSchema(
@@ -2191,9 +2063,7 @@ class PolarsView(DataExplorerTableView):
         raise NotImplementedError
 
     def _get_data_values(
-        self,
-        selections: List[ColumnSelection],
-        format_options: FormatOptions,
+        self, selections: List[ColumnSelection], format_options: FormatOptions
     ) -> dict:
         formatted_columns = []
         for selection in selections:
@@ -2298,10 +2168,7 @@ class PolarsView(DataExplorerTableView):
         display_type = self._get_type_display(dtype)
 
         mask = None
-        if filt.filter_type in (
-            RowFilterType.Between,
-            RowFilterType.NotBetween,
-        ):
+        if filt.filter_type in (RowFilterType.Between, RowFilterType.NotBetween):
             params = filt.params
             assert isinstance(params, FilterBetween)
             left_value = self._coerce_value(params.left_value, dtype, display_type)
@@ -2354,8 +2221,7 @@ class PolarsView(DataExplorerTableView):
                 boxed_values = pl_.Series(coerced_values, dtype=col.dtype)
             except TypeError:
                 boxed_values = pl_.Series(
-                    coerced_values,
-                    dtype=_polars_dtype_from_display(display_type),
+                    coerced_values, dtype=_polars_dtype_from_display(display_type)
                 )
             mask = col.is_in(boxed_values)
             if not params.inclusive:
@@ -2443,11 +2309,7 @@ class PolarsView(DataExplorerTableView):
 
             try:
                 to_sort = to_sort.select(
-                    pl_.all().sort_by(
-                        cols_to_sort,
-                        descending=directions,
-                        maintain_order=True,
-                    )
+                    pl_.all().sort_by(cols_to_sort, descending=directions, maintain_order=True)
                 )
             except TypeError:
                 # Older versions of polars do not have maintain_order
@@ -2482,10 +2344,7 @@ class PolarsView(DataExplorerTableView):
     }
 
     def _prof_freq_table(
-        self,
-        column_index: int,
-        params: ColumnFrequencyTableParams,
-        format_options: FormatOptions,
+        self, column_index: int, params: ColumnFrequencyTableParams, format_options: FormatOptions
     ) -> ColumnFrequencyTable:
         col = self._get_column(column_index).alias("values")
 
@@ -2504,10 +2363,7 @@ class PolarsView(DataExplorerTableView):
         )
 
     def _prof_histogram(
-        self,
-        column_index: int,
-        params: ColumnHistogramParams,
-        format_options: FormatOptions,
+        self, column_index: int, params: ColumnHistogramParams, format_options: FormatOptions
     ) -> ColumnHistogram:
         col = self._get_column(column_index)
 
@@ -2537,9 +2393,7 @@ class PolarsView(DataExplorerTableView):
         formatted_edges = self._format_values(bin_edges, format_options)
 
         return ColumnHistogram(
-            bin_edges=formatted_edges,
-            bin_counts=[int(x) for x in bin_counts],
-            quantiles=[],
+            bin_edges=formatted_edges, bin_counts=[int(x) for x in bin_counts], quantiles=[]
         )
 
     FEATURES = SupportedFeatures(
@@ -2563,8 +2417,7 @@ class PolarsView(DataExplorerTableView):
             support_status=SupportStatus.Supported,
             supported_types=[
                 ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.NullCount,
-                    support_status=SupportStatus.Supported,
+                    profile_type=ColumnProfileType.NullCount, support_status=SupportStatus.Supported
                 ),
                 ColumnProfileTypeSupportStatus(
                     profile_type=ColumnProfileType.SummaryStats,
@@ -2617,10 +2470,7 @@ def _is_polars(table):
 
 
 def _get_table_view(
-    table,
-    comm: PositronComm,
-    state: DataExplorerState,
-    job_queue: BackgroundJobQueue,
+    table, comm: PositronComm, state: DataExplorerState, job_queue: BackgroundJobQueue
 ):
     state.name = state.name or guid()
 
@@ -2669,13 +2519,7 @@ class DataExplorerService:
     def is_supported(self, value) -> bool:
         return value is not None and _value_type_is_supported(value)
 
-    def register_table(
-        self,
-        table,
-        title,
-        variable_path: Optional[List[str]] = None,
-        comm_id=None,
-    ):
+    def register_table(self, table, title, variable_path: Optional[List[str]] = None, comm_id=None):
         """
         Set up a new comm and data explorer table query wrapper to
         handle requests and manage state.
@@ -2707,9 +2551,7 @@ class DataExplorerService:
             comm_id = guid()
 
         base_comm = comm.create_comm(
-            target_name=self.comm_target,
-            comm_id=comm_id,
-            data={"title": title},
+            target_name=self.comm_target, comm_id=comm_id, data={"title": title}
         )
 
         def close_callback(_):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer.py
@@ -11,7 +11,16 @@ import logging
 import math
 import operator
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+)
 
 import comm
 
@@ -87,7 +96,14 @@ from .data_explorer_comm import (
     TextSearchType,
 )
 from .positron_comm import CommMessage, PositronComm
-from .third_party import RestartRequiredError, import_pandas, import_polars, np_, pd_, pl_
+from .third_party import (
+    RestartRequiredError,
+    import_pandas,
+    import_polars,
+    np_,
+    pd_,
+    pl_,
+)
 from .utils import BackgroundJobQueue, guid
 
 if TYPE_CHECKING:
@@ -156,7 +172,11 @@ class DataExplorerTableView(abc.ABC):
     """
 
     def __init__(
-        self, table, comm: PositronComm, state: DataExplorerState, job_queue: BackgroundJobQueue
+        self,
+        table,
+        comm: PositronComm,
+        state: DataExplorerState,
+        job_queue: BackgroundJobQueue,
     ):
         # Note: we must not ever modify the user's data
         self.table = table
@@ -335,11 +355,17 @@ class DataExplorerTableView(abc.ABC):
 
     def get_data_values(self, request: GetDataValuesRequest):
         self._recompute_if_needed()
-        return self._get_data_values(request.params.columns, request.params.format_options)
+        return self._get_data_values(
+            request.params.columns,
+            request.params.format_options,
+        )
 
     def get_row_labels(self, request: GetRowLabelsRequest):
         self._recompute_if_needed()
-        return self._get_row_labels(request.params.selection, request.params.format_options)
+        return self._get_row_labels(
+            request.params.selection,
+            request.params.format_options,
+        )
 
     def _get_row_labels(self, selection: ArraySelection, format_options: FormatOptions):
         # By default, the table has no row labels, so this will only
@@ -367,12 +393,16 @@ class DataExplorerTableView(abc.ABC):
         elif kind == TableSelectionKind.RowRange:
             assert isinstance(sel, DataSelectionRange)
             return self._export_tabular(
-                slice(sel.first_index, sel.last_index + 1), slice(None), fmt
+                slice(sel.first_index, sel.last_index + 1),
+                slice(None),
+                fmt,
             )
         elif kind == TableSelectionKind.ColumnRange:
             assert isinstance(sel, DataSelectionRange)
             return self._export_tabular(
-                slice(None), slice(sel.first_index, sel.last_index + 1), fmt
+                slice(None),
+                slice(sel.first_index, sel.last_index + 1),
+                fmt,
             )
         elif kind == TableSelectionKind.RowIndices:
             assert isinstance(sel, DataSelectionIndices)
@@ -482,7 +512,9 @@ class DataExplorerTableView(abc.ABC):
         for req in request.params.profiles:
             try:
                 result = self._compute_profiles(
-                    req.column_index, req.profiles, request.params.format_options
+                    req.column_index,
+                    req.profiles,
+                    request.params.format_options,
                 )
                 results.append(result.dict())
             except Exception as e:
@@ -497,7 +529,10 @@ class DataExplorerTableView(abc.ABC):
         )
 
     def _compute_profiles(
-        self, column_index: int, profiles: List[ColumnProfileSpec], format_options: FormatOptions
+        self,
+        column_index: int,
+        profiles: List[ColumnProfileSpec],
+        format_options: FormatOptions,
     ):
         results = {}
         for spec in profiles:
@@ -548,7 +583,10 @@ class DataExplorerTableView(abc.ABC):
 
         return BackendState(
             display_name=self.state.name,
-            table_shape=TableShape(num_rows=filtered_num_rows, num_columns=filtered_num_columns),
+            table_shape=TableShape(
+                num_rows=filtered_num_rows,
+                num_columns=filtered_num_columns,
+            ),
             table_unfiltered_shape=TableShape(num_rows=num_rows, num_columns=num_columns),
             has_row_labels=self._has_row_labels,
             column_filters=self.state.column_filters,
@@ -566,7 +604,12 @@ class DataExplorerTableView(abc.ABC):
         raise NotImplementedError
 
     def _get_adjusted_filters(
-        self, new_columns, schema_changes, shifted_columns, deleted_columns, schema_getter
+        self,
+        new_columns,
+        schema_changes,
+        shifted_columns,
+        deleted_columns,
+        schema_getter,
     ):
         # Shared by implementations of get_updated_state
         new_filters = []
@@ -594,7 +637,10 @@ class DataExplorerTableView(abc.ABC):
                         # Probably a new column that allows the old
                         # filter to become valid again if the type is
                         # compatible
-                        filt.column_schema = schema_getter(column_name, column_index)
+                        filt.column_schema = schema_getter(
+                            column_name,
+                            column_index,
+                        )
                     else:
                         is_deleted = True
             elif column_index in shifted_columns:
@@ -651,7 +697,9 @@ class DataExplorerTableView(abc.ABC):
         return new_sort_keys
 
     def _get_data_values(
-        self, selections: List[ColumnSelection], format_options: FormatOptions
+        self,
+        selections: List[ColumnSelection],
+        format_options: FormatOptions,
     ) -> dict:
         raise NotImplementedError
 
@@ -673,13 +721,22 @@ class DataExplorerTableView(abc.ABC):
         elif filt.filter_type == RowFilterType.Compare:
             params = filt.params
             assert isinstance(params, FilterComparison), str(params)
-            if params.op in [FilterComparisonOp.Eq, FilterComparisonOp.NotEq]:
+            if params.op in [
+                FilterComparisonOp.Eq,
+                FilterComparisonOp.NotEq,
+            ]:
                 return True
             else:
                 return display_type in _FILTER_RANGE_COMPARE_SUPPORTED
-        elif filt.filter_type in [RowFilterType.Between, RowFilterType.NotBetween]:
+        elif filt.filter_type in [
+            RowFilterType.Between,
+            RowFilterType.NotBetween,
+        ]:
             return display_type in _FILTER_RANGE_COMPARE_SUPPORTED
-        elif filt.filter_type in [RowFilterType.IsTrue, RowFilterType.IsFalse]:
+        elif filt.filter_type in [
+            RowFilterType.IsTrue,
+            RowFilterType.IsFalse,
+        ]:
             return display_type == ColumnDisplayType.Boolean
         else:
             # Filters always supported
@@ -712,18 +769,25 @@ class DataExplorerTableView(abc.ABC):
         raise NotImplementedError
 
     def _prof_freq_table(
-        self, column_index: int, params: ColumnFrequencyTableParams, format_options: FormatOptions
+        self,
+        column_index: int,
+        params: ColumnFrequencyTableParams,
+        format_options: FormatOptions,
     ) -> ColumnFrequencyTable:
         raise NotImplementedError
 
     def _prof_histogram(
-        self, column_index: int, params: ColumnHistogramParams, format_options: FormatOptions
+        self,
+        column_index: int,
+        params: ColumnHistogramParams,
+        format_options: FormatOptions,
     ) -> ColumnHistogram:
         raise NotImplementedError
 
     FEATURES = SupportedFeatures(
         search_schema=SearchSchemaFeatures(
-            support_status=SupportStatus.Unsupported, supported_types=[]
+            support_status=SupportStatus.Unsupported,
+            supported_types=[],
         ),
         set_column_filters=SetColumnFiltersFeatures(
             support_status=SupportStatus.Unsupported, supported_types=[]
@@ -734,11 +798,13 @@ class DataExplorerTableView(abc.ABC):
             supported_types=[],
         ),
         get_column_profiles=GetColumnProfilesFeatures(
-            support_status=SupportStatus.Unsupported, supported_types=[]
+            support_status=SupportStatus.Unsupported,
+            supported_types=[],
         ),
         set_sort_columns=SetSortColumnsFeatures(support_status=SupportStatus.Unsupported),
         export_data_selection=ExportDataSelectionFeatures(
-            support_status=SupportStatus.Unsupported, supported_formats=[]
+            support_status=SupportStatus.Unsupported,
+            supported_formats=[],
         ),
     )
 
@@ -747,7 +813,11 @@ def _box_number_stats(min_val, max_val, mean_val, median_val, std_val):
     return ColumnSummaryStats(
         type_display=ColumnDisplayType.Number,
         number_stats=SummaryStatsNumber(
-            min_value=min_val, max_value=max_val, mean=mean_val, median=median_val, stdev=std_val
+            min_value=min_val,
+            max_value=max_val,
+            mean=mean_val,
+            median=median_val,
+            stdev=std_val,
         ),
     )
 
@@ -925,7 +995,13 @@ def _pandas_summarize_number(col: "pd.Series", options: FormatOptions):
             min_val = float_format(min_val)
             max_val = float_format(max_val)
 
-    return _box_number_stats(min_val, max_val, mean_val, median_val, std_val)
+    return _box_number_stats(
+        min_val,
+        max_val,
+        mean_val,
+        median_val,
+        std_val,
+    )
 
 
 def _pandas_summarize_string(col: "pd.Series", options: FormatOptions):
@@ -1163,11 +1239,18 @@ class PandasView(DataExplorerTableView):
 
         def schema_getter(column_name, column_index):
             return self._construct_schema(
-                new_table.iloc[:, column_index], column_name, column_index, new_state
+                new_table.iloc[:, column_index],
+                column_name,
+                column_index,
+                new_state,
             )
 
         new_state.row_filters = self._get_adjusted_filters(
-            new_table.columns, schema_changes, shifted_columns, deleted_columns, schema_getter
+            new_table.columns,
+            schema_changes,
+            shifted_columns,
+            deleted_columns,
+            schema_getter,
         )
 
         new_state.sort_keys = self._get_adjusted_sort_keys(
@@ -1302,7 +1385,9 @@ class PandasView(DataExplorerTableView):
         return str(self.table.columns[index])
 
     def _get_data_values(
-        self, selections: List[ColumnSelection], format_options: FormatOptions
+        self,
+        selections: List[ColumnSelection],
+        format_options: FormatOptions,
     ) -> dict:
         formatted_columns = []
         for selection in selections:
@@ -1416,7 +1501,10 @@ class PandasView(DataExplorerTableView):
         inferred_type = self._get_inferred_dtype(col, column_index, self.state)
 
         mask = None
-        if filt.filter_type in (RowFilterType.Between, RowFilterType.NotBetween):
+        if filt.filter_type in (
+            RowFilterType.Between,
+            RowFilterType.NotBetween,
+        ):
             params = filt.params
             assert isinstance(params, FilterBetween)
             left_value = self._coerce_value(params.left_value, dtype, inferred_type)
@@ -1534,7 +1622,9 @@ class PandasView(DataExplorerTableView):
                 # the sorting indices). Mergesort is needed to make it
                 # stable
                 sort_indexer = nargsort(
-                    column.take(self.filtered_indices), kind="mergesort", ascending=key.ascending
+                    column.take(self.filtered_indices),
+                    kind="mergesort",
+                    ascending=key.ascending,
                 )
                 # Reorder the filtered_indices to provide the
                 # filtered, sorted virtual view for future data
@@ -1581,7 +1671,10 @@ class PandasView(DataExplorerTableView):
     }
 
     def _prof_freq_table(
-        self, column_index: int, params: ColumnFrequencyTableParams, format_options: FormatOptions
+        self,
+        column_index: int,
+        params: ColumnFrequencyTableParams,
+        format_options: FormatOptions,
     ) -> ColumnFrequencyTable:
         col = self._get_column(column_index)
         counts = col.value_counts()
@@ -1598,7 +1691,10 @@ class PandasView(DataExplorerTableView):
         )
 
     def _prof_histogram(
-        self, column_index: int, params: ColumnHistogramParams, format_options: FormatOptions
+        self,
+        column_index: int,
+        params: ColumnHistogramParams,
+        format_options: FormatOptions,
     ) -> ColumnHistogram:
         col = self._get_column(column_index)
 
@@ -1624,7 +1720,9 @@ class PandasView(DataExplorerTableView):
         formatted_edges = self._format_values(bin_edges, format_options)
 
         return ColumnHistogram(
-            bin_edges=formatted_edges, bin_counts=[int(x) for x in bin_counts], quantiles=[]
+            bin_edges=formatted_edges,
+            bin_counts=[int(x) for x in bin_counts],
+            quantiles=[],
         )
 
     SUPPORTED_FILTERS = {
@@ -1675,7 +1773,8 @@ class PandasView(DataExplorerTableView):
             support_status=SupportStatus.Supported,
             supported_types=[
                 ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.NullCount, support_status=SupportStatus.Supported
+                    profile_type=ColumnProfileType.NullCount,
+                    support_status=SupportStatus.Supported,
                 ),
                 ColumnProfileTypeSupportStatus(
                     profile_type=ColumnProfileType.SummaryStats,
@@ -1702,7 +1801,11 @@ class PandasView(DataExplorerTableView):
         set_sort_columns=SetSortColumnsFeatures(support_status=SupportStatus.Supported),
         export_data_selection=ExportDataSelectionFeatures(
             support_status=SupportStatus.Supported,
-            supported_formats=[ExportFormat.Csv, ExportFormat.Tsv, ExportFormat.Html],
+            supported_formats=[
+                ExportFormat.Csv,
+                ExportFormat.Tsv,
+                ExportFormat.Html,
+            ],
         ),
     )
 
@@ -1801,7 +1904,11 @@ def _possibly(f, otherwise=None):
         return otherwise
 
 
-_ISO_8601_FORMATS = ["%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d"]
+_ISO_8601_FORMATS = [
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%d %H:%M",
+    "%Y-%m-%d",
+]
 
 
 def _parse_iso8601_like(x, tz=None):
@@ -1848,7 +1955,13 @@ def _polars_summarize_number(col: "pl.Series", options: FormatOptions):
         min_val = float_format(min_val)
         max_val = float_format(max_val)
 
-    return _box_number_stats(min_val, max_val, mean_val, median_val, std_val)
+    return _box_number_stats(
+        min_val,
+        max_val,
+        mean_val,
+        median_val,
+        std_val,
+    )
 
 
 def _polars_summarize_string(col: "pl.Series", _):
@@ -1920,7 +2033,9 @@ class PolarsView(DataExplorerTableView):
 
     def get_updated_state(self, new_table) -> StateUpdate:
         new_state = DataExplorerState(
-            self.state.name, row_filters=self.state.row_filters, sort_keys=self.state.sort_keys
+            self.state.name,
+            row_filters=self.state.row_filters,
+            sort_keys=self.state.sort_keys,
         )
 
         # As of June 2024, polars seems to be really slow for
@@ -1987,10 +2102,18 @@ class PolarsView(DataExplorerTableView):
             schema_changes[old_index] = self._construct_schema(new_column, column_name, new_index)
 
         def schema_getter(column_name, column_index):
-            return self._construct_schema(new_table[:, column_index], column_name, column_index)
+            return self._construct_schema(
+                new_table[:, column_index],
+                column_name,
+                column_index,
+            )
 
         new_state.row_filters = self._get_adjusted_filters(
-            new_columns, schema_changes, shifted_columns, deleted_columns, schema_getter
+            new_columns,
+            schema_changes,
+            shifted_columns,
+            deleted_columns,
+            schema_getter,
         )
 
         new_state.sort_keys = self._get_adjusted_sort_keys(
@@ -2014,7 +2137,12 @@ class PolarsView(DataExplorerTableView):
         return self.table[:, column_index].name
 
     @classmethod
-    def _construct_schema(cls, column: "pl.Series", column_name: str, column_index: int):
+    def _construct_schema(
+        cls,
+        column: "pl.Series",
+        column_name: str,
+        column_index: int,
+    ):
         type_display = cls._get_type_display(column.dtype)
 
         return ColumnSchema(
@@ -2063,7 +2191,9 @@ class PolarsView(DataExplorerTableView):
         raise NotImplementedError
 
     def _get_data_values(
-        self, selections: List[ColumnSelection], format_options: FormatOptions
+        self,
+        selections: List[ColumnSelection],
+        format_options: FormatOptions,
     ) -> dict:
         formatted_columns = []
         for selection in selections:
@@ -2168,7 +2298,10 @@ class PolarsView(DataExplorerTableView):
         display_type = self._get_type_display(dtype)
 
         mask = None
-        if filt.filter_type in (RowFilterType.Between, RowFilterType.NotBetween):
+        if filt.filter_type in (
+            RowFilterType.Between,
+            RowFilterType.NotBetween,
+        ):
             params = filt.params
             assert isinstance(params, FilterBetween)
             left_value = self._coerce_value(params.left_value, dtype, display_type)
@@ -2221,7 +2354,8 @@ class PolarsView(DataExplorerTableView):
                 boxed_values = pl_.Series(coerced_values, dtype=col.dtype)
             except TypeError:
                 boxed_values = pl_.Series(
-                    coerced_values, dtype=_polars_dtype_from_display(display_type)
+                    coerced_values,
+                    dtype=_polars_dtype_from_display(display_type),
                 )
             mask = col.is_in(boxed_values)
             if not params.inclusive:
@@ -2309,7 +2443,11 @@ class PolarsView(DataExplorerTableView):
 
             try:
                 to_sort = to_sort.select(
-                    pl_.all().sort_by(cols_to_sort, descending=directions, maintain_order=True)
+                    pl_.all().sort_by(
+                        cols_to_sort,
+                        descending=directions,
+                        maintain_order=True,
+                    )
                 )
             except TypeError:
                 # Older versions of polars do not have maintain_order
@@ -2344,7 +2482,10 @@ class PolarsView(DataExplorerTableView):
     }
 
     def _prof_freq_table(
-        self, column_index: int, params: ColumnFrequencyTableParams, format_options: FormatOptions
+        self,
+        column_index: int,
+        params: ColumnFrequencyTableParams,
+        format_options: FormatOptions,
     ) -> ColumnFrequencyTable:
         col = self._get_column(column_index).alias("values")
 
@@ -2363,7 +2504,10 @@ class PolarsView(DataExplorerTableView):
         )
 
     def _prof_histogram(
-        self, column_index: int, params: ColumnHistogramParams, format_options: FormatOptions
+        self,
+        column_index: int,
+        params: ColumnHistogramParams,
+        format_options: FormatOptions,
     ) -> ColumnHistogram:
         col = self._get_column(column_index)
 
@@ -2393,7 +2537,9 @@ class PolarsView(DataExplorerTableView):
         formatted_edges = self._format_values(bin_edges, format_options)
 
         return ColumnHistogram(
-            bin_edges=formatted_edges, bin_counts=[int(x) for x in bin_counts], quantiles=[]
+            bin_edges=formatted_edges,
+            bin_counts=[int(x) for x in bin_counts],
+            quantiles=[],
         )
 
     FEATURES = SupportedFeatures(
@@ -2417,7 +2563,8 @@ class PolarsView(DataExplorerTableView):
             support_status=SupportStatus.Supported,
             supported_types=[
                 ColumnProfileTypeSupportStatus(
-                    profile_type=ColumnProfileType.NullCount, support_status=SupportStatus.Supported
+                    profile_type=ColumnProfileType.NullCount,
+                    support_status=SupportStatus.Supported,
                 ),
                 ColumnProfileTypeSupportStatus(
                     profile_type=ColumnProfileType.SummaryStats,
@@ -2470,7 +2617,10 @@ def _is_polars(table):
 
 
 def _get_table_view(
-    table, comm: PositronComm, state: DataExplorerState, job_queue: BackgroundJobQueue
+    table,
+    comm: PositronComm,
+    state: DataExplorerState,
+    job_queue: BackgroundJobQueue,
 ):
     state.name = state.name or guid()
 
@@ -2519,7 +2669,13 @@ class DataExplorerService:
     def is_supported(self, value) -> bool:
         return value is not None and _value_type_is_supported(value)
 
-    def register_table(self, table, title, variable_path: Optional[List[str]] = None, comm_id=None):
+    def register_table(
+        self,
+        table,
+        title,
+        variable_path: Optional[List[str]] = None,
+        comm_id=None,
+    ):
         """
         Set up a new comm and data explorer table query wrapper to
         handle requests and manage state.
@@ -2551,7 +2707,9 @@ class DataExplorerService:
             comm_id = guid()
 
         base_comm = comm.create_comm(
-            target_name=self.comm_target, comm_id=comm_id, data={"title": title}
+            target_name=self.comm_target,
+            comm_id=comm_id,
+            data={"title": title},
         )
 
         def close_callback(_):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -217,8 +217,7 @@ class OpenDatasetResult(BaseModel):
     """
 
     error_message: Optional[StrictStr] = Field(
-        default=None,
-        description="An error message if opening the dataset failed",
+        default=None, description="An error message if opening the dataset failed"
     )
 
 
@@ -228,11 +227,11 @@ class SearchSchemaResult(BaseModel):
     """
 
     matches: TableSchema = Field(
-        description="A schema containing matching columns up to the max_results limit",
+        description="A schema containing matching columns up to the max_results limit"
     )
 
     total_num_matches: StrictInt = Field(
-        description="The total number of columns matching the filter",
+        description="The total number of columns matching the filter"
     )
 
 
@@ -241,13 +240,9 @@ class ExportedData(BaseModel):
     Exported result
     """
 
-    data: StrictStr = Field(
-        description="Exported data as a string suitable for copy and paste",
-    )
+    data: StrictStr = Field(description="Exported data as a string suitable for copy and paste")
 
-    format: ExportFormat = Field(
-        description="The exported data format",
-    )
+    format: ExportFormat = Field(description="The exported data format")
 
 
 class FilterResult(BaseModel):
@@ -256,12 +251,11 @@ class FilterResult(BaseModel):
     """
 
     selected_num_rows: StrictInt = Field(
-        description="Number of rows in table after applying filters",
+        description="Number of rows in table after applying filters"
     )
 
     had_errors: Optional[StrictBool] = Field(
-        default=None,
-        description="Flag indicating if there were errors in evaluation",
+        default=None, description="Flag indicating if there were errors in evaluation"
     )
 
 
@@ -271,35 +265,29 @@ class BackendState(BaseModel):
     """
 
     display_name: StrictStr = Field(
-        description="Variable name or other string to display for tab name in UI",
+        description="Variable name or other string to display for tab name in UI"
     )
 
     table_shape: TableShape = Field(
-        description="Number of rows and columns in table with row/column filters applied",
+        description="Number of rows and columns in table with row/column filters applied"
     )
 
     table_unfiltered_shape: TableShape = Field(
-        description="Number of rows and columns in table without any filters applied",
+        description="Number of rows and columns in table without any filters applied"
     )
 
     has_row_labels: StrictBool = Field(
-        description="Indicates whether table has row labels or whether rows should be labeled by ordinal position",
+        description="Indicates whether table has row labels or whether rows should be labeled by ordinal position"
     )
 
-    column_filters: List[ColumnFilter] = Field(
-        description="The currently applied column filters",
-    )
+    column_filters: List[ColumnFilter] = Field(description="The currently applied column filters")
 
-    row_filters: List[RowFilter] = Field(
-        description="The currently applied row filters",
-    )
+    row_filters: List[RowFilter] = Field(description="The currently applied row filters")
 
-    sort_keys: List[ColumnSortKey] = Field(
-        description="The currently applied column sort keys",
-    )
+    sort_keys: List[ColumnSortKey] = Field(description="The currently applied column sort keys")
 
     supported_features: SupportedFeatures = Field(
-        description="The features currently supported by the backend instance",
+        description="The features currently supported by the backend instance"
     )
 
     connected: Optional[StrictBool] = Field(
@@ -318,50 +306,36 @@ class ColumnSchema(BaseModel):
     Schema for a column in a table
     """
 
-    column_name: StrictStr = Field(
-        description="Name of column as UTF-8 string",
-    )
+    column_name: StrictStr = Field(description="Name of column as UTF-8 string")
 
     column_index: StrictInt = Field(
-        description="The position of the column within the table without any column filters",
+        description="The position of the column within the table without any column filters"
     )
 
-    type_name: StrictStr = Field(
-        description="Exact name of data type used by underlying table",
-    )
+    type_name: StrictStr = Field(description="Exact name of data type used by underlying table")
 
     type_display: ColumnDisplayType = Field(
-        description="Canonical Positron display name of data type",
+        description="Canonical Positron display name of data type"
     )
 
     description: Optional[StrictStr] = Field(
-        default=None,
-        description="Column annotation / description",
+        default=None, description="Column annotation / description"
     )
 
     children: Optional[List[ColumnSchema]] = Field(
-        default=None,
-        description="Schema of nested child types",
+        default=None, description="Schema of nested child types"
     )
 
-    precision: Optional[StrictInt] = Field(
-        default=None,
-        description="Precision for decimal types",
-    )
+    precision: Optional[StrictInt] = Field(default=None, description="Precision for decimal types")
 
-    scale: Optional[StrictInt] = Field(
-        default=None,
-        description="Scale for decimal types",
-    )
+    scale: Optional[StrictInt] = Field(default=None, description="Scale for decimal types")
 
     timezone: Optional[StrictStr] = Field(
-        default=None,
-        description="Time zone for timestamp with time zone",
+        default=None, description="Time zone for timestamp with time zone"
     )
 
     type_size: Optional[StrictInt] = Field(
-        default=None,
-        description="Size parameter for fixed-size types (list, binary)",
+        default=None, description="Size parameter for fixed-size types (list, binary)"
     )
 
 
@@ -370,9 +344,7 @@ class TableData(BaseModel):
     Table values formatted as strings
     """
 
-    columns: List[List[ColumnValue]] = Field(
-        description="The columns of data",
-    )
+    columns: List[List[ColumnValue]] = Field(description="The columns of data")
 
 
 class TableRowLabels(BaseModel):
@@ -380,9 +352,7 @@ class TableRowLabels(BaseModel):
     Formatted table row labels formatted as strings
     """
 
-    row_labels: List[List[StrictStr]] = Field(
-        description="Zero or more arrays of row labels",
-    )
+    row_labels: List[List[StrictStr]] = Field(description="Zero or more arrays of row labels")
 
 
 class FormatOptions(BaseModel):
@@ -391,24 +361,23 @@ class FormatOptions(BaseModel):
     """
 
     large_num_digits: StrictInt = Field(
-        description="Fixed number of decimal places to display for numbers over 1, or in scientific notation",
+        description="Fixed number of decimal places to display for numbers over 1, or in scientific notation"
     )
 
     small_num_digits: StrictInt = Field(
-        description="Fixed number of decimal places to display for small numbers, and to determine lower threshold for switching to scientific notation",
+        description="Fixed number of decimal places to display for small numbers, and to determine lower threshold for switching to scientific notation"
     )
 
     max_integral_digits: StrictInt = Field(
-        description="Maximum number of integral digits to display before switching to scientific notation",
+        description="Maximum number of integral digits to display before switching to scientific notation"
     )
 
     max_value_length: StrictInt = Field(
-        description="Maximum size of formatted value, for truncating large strings or other large formatted values",
+        description="Maximum size of formatted value, for truncating large strings or other large formatted values"
     )
 
     thousands_sep: Optional[StrictStr] = Field(
-        default=None,
-        description="Thousands separator string",
+        default=None, description="Thousands separator string"
     )
 
 
@@ -417,9 +386,7 @@ class TableSchema(BaseModel):
     The schema for a table-like object
     """
 
-    columns: List[ColumnSchema] = Field(
-        description="Schema for each column in the table",
-    )
+    columns: List[ColumnSchema] = Field(description="Schema for each column in the table")
 
 
 class TableShape(BaseModel):
@@ -427,13 +394,9 @@ class TableShape(BaseModel):
     Provides number of rows and columns in a table
     """
 
-    num_rows: StrictInt = Field(
-        description="Numbers of rows in the table",
-    )
+    num_rows: StrictInt = Field(description="Numbers of rows in the table")
 
-    num_columns: StrictInt = Field(
-        description="Number of columns in the table",
-    )
+    num_columns: StrictInt = Field(description="Number of columns in the table")
 
 
 class RowFilter(BaseModel):
@@ -441,20 +404,14 @@ class RowFilter(BaseModel):
     Specifies a table row filter based on a single column's values
     """
 
-    filter_id: StrictStr = Field(
-        description="Unique identifier for this filter",
-    )
+    filter_id: StrictStr = Field(description="Unique identifier for this filter")
 
-    filter_type: RowFilterType = Field(
-        description="Type of row filter to apply",
-    )
+    filter_type: RowFilterType = Field(description="Type of row filter to apply")
 
-    column_schema: ColumnSchema = Field(
-        description="Column to apply filter to",
-    )
+    column_schema: ColumnSchema = Field(description="Column to apply filter to")
 
     condition: RowFilterCondition = Field(
-        description="The binary condition to use to combine with preceding row filters",
+        description="The binary condition to use to combine with preceding row filters"
     )
 
     is_valid: Optional[StrictBool] = Field(
@@ -463,13 +420,11 @@ class RowFilter(BaseModel):
     )
 
     error_message: Optional[StrictStr] = Field(
-        default=None,
-        description="Optional error message when the filter is invalid",
+        default=None, description="Optional error message when the filter is invalid"
     )
 
     params: Optional[RowFilterParams] = Field(
-        default=None,
-        description="The row filter type-specific parameters",
+        default=None, description="The row filter type-specific parameters"
     )
 
 
@@ -478,13 +433,9 @@ class RowFilterTypeSupportStatus(BaseModel):
     Support status for a row filter type
     """
 
-    row_filter_type: RowFilterType = Field(
-        description="Type of row filter",
-    )
+    row_filter_type: RowFilterType = Field(description="Type of row filter")
 
-    support_status: SupportStatus = Field(
-        description="The support status for this row filter type",
-    )
+    support_status: SupportStatus = Field(description="The support status for this row filter type")
 
 
 class FilterBetween(BaseModel):
@@ -492,13 +443,9 @@ class FilterBetween(BaseModel):
     Parameters for the 'between' and 'not_between' filter types
     """
 
-    left_value: StrictStr = Field(
-        description="The lower limit for filtering",
-    )
+    left_value: StrictStr = Field(description="The lower limit for filtering")
 
-    right_value: StrictStr = Field(
-        description="The upper limit for filtering",
-    )
+    right_value: StrictStr = Field(description="The upper limit for filtering")
 
 
 class FilterComparison(BaseModel):
@@ -506,13 +453,9 @@ class FilterComparison(BaseModel):
     Parameters for the 'compare' filter type
     """
 
-    op: FilterComparisonOp = Field(
-        description="String representation of a binary comparison",
-    )
+    op: FilterComparisonOp = Field(description="String representation of a binary comparison")
 
-    value: StrictStr = Field(
-        description="A stringified column value for a comparison filter",
-    )
+    value: StrictStr = Field(description="A stringified column value for a comparison filter")
 
 
 class FilterSetMembership(BaseModel):
@@ -520,12 +463,10 @@ class FilterSetMembership(BaseModel):
     Parameters for the 'set_membership' filter type
     """
 
-    values: List[StrictStr] = Field(
-        description="Array of values for a set membership filter",
-    )
+    values: List[StrictStr] = Field(description="Array of values for a set membership filter")
 
     inclusive: StrictBool = Field(
-        description="Filter by including only values passed (true) or excluding (false)",
+        description="Filter by including only values passed (true) or excluding (false)"
     )
 
 
@@ -534,16 +475,12 @@ class FilterTextSearch(BaseModel):
     Parameters for the 'search' filter type
     """
 
-    search_type: TextSearchType = Field(
-        description="Type of search to perform",
-    )
+    search_type: TextSearchType = Field(description="Type of search to perform")
 
-    term: StrictStr = Field(
-        description="String value/regex to search for",
-    )
+    term: StrictStr = Field(description="String value/regex to search for")
 
     case_sensitive: StrictBool = Field(
-        description="If true, do a case-sensitive search, otherwise case-insensitive",
+        description="If true, do a case-sensitive search, otherwise case-insensitive"
     )
 
 
@@ -552,9 +489,7 @@ class FilterMatchDataTypes(BaseModel):
     Parameters for the 'match_data_types' filter type
     """
 
-    display_types: List[ColumnDisplayType] = Field(
-        description="Column display types to match",
-    )
+    display_types: List[ColumnDisplayType] = Field(description="Column display types to match")
 
 
 class ColumnFilter(BaseModel):
@@ -563,13 +498,9 @@ class ColumnFilter(BaseModel):
     criteria
     """
 
-    filter_type: ColumnFilterType = Field(
-        description="Type of column filter to apply",
-    )
+    filter_type: ColumnFilterType = Field(description="Type of column filter to apply")
 
-    params: ColumnFilterParams = Field(
-        description="Parameters for column filter",
-    )
+    params: ColumnFilterParams = Field(description="Parameters for column filter")
 
 
 class ColumnFilterTypeSupportStatus(BaseModel):
@@ -577,12 +508,10 @@ class ColumnFilterTypeSupportStatus(BaseModel):
     Support status for a column filter type
     """
 
-    column_filter_type: ColumnFilterType = Field(
-        description="Type of column filter",
-    )
+    column_filter_type: ColumnFilterType = Field(description="Type of column filter")
 
     support_status: SupportStatus = Field(
-        description="The support status for this column filter type",
+        description="The support status for this column filter type"
     )
 
 
@@ -592,12 +521,10 @@ class ColumnProfileRequest(BaseModel):
     """
 
     column_index: StrictInt = Field(
-        description="The column index (absolute, relative to unfiltered table) to profile",
+        description="The column index (absolute, relative to unfiltered table) to profile"
     )
 
-    profiles: List[ColumnProfileSpec] = Field(
-        description="Column profiles needed",
-    )
+    profiles: List[ColumnProfileSpec] = Field(description="Column profiles needed")
 
 
 class ColumnProfileSpec(BaseModel):
@@ -605,13 +532,10 @@ class ColumnProfileSpec(BaseModel):
     Parameters for a single column profile for a request for profiles
     """
 
-    profile_type: ColumnProfileType = Field(
-        description="Type of column profile",
-    )
+    profile_type: ColumnProfileType = Field(description="Type of column profile")
 
     params: Optional[ColumnProfileParams] = Field(
-        default=None,
-        description="Extra parameters for different profile types",
+        default=None, description="Extra parameters for different profile types"
     )
 
 
@@ -620,12 +544,10 @@ class ColumnProfileTypeSupportStatus(BaseModel):
     Support status for a given column profile type
     """
 
-    profile_type: ColumnProfileType = Field(
-        description="The type of analytical column profile",
-    )
+    profile_type: ColumnProfileType = Field(description="The type of analytical column profile")
 
     support_status: SupportStatus = Field(
-        description="The support status for this column profile type",
+        description="The support status for this column profile type"
     )
 
 
@@ -635,33 +557,27 @@ class ColumnProfileResult(BaseModel):
     """
 
     null_count: Optional[StrictInt] = Field(
-        default=None,
-        description="Result from null_count request",
+        default=None, description="Result from null_count request"
     )
 
     summary_stats: Optional[ColumnSummaryStats] = Field(
-        default=None,
-        description="Results from summary_stats request",
+        default=None, description="Results from summary_stats request"
     )
 
     small_histogram: Optional[ColumnHistogram] = Field(
-        default=None,
-        description="Results from small histogram request",
+        default=None, description="Results from small histogram request"
     )
 
     large_histogram: Optional[ColumnHistogram] = Field(
-        default=None,
-        description="Results from large histogram request",
+        default=None, description="Results from large histogram request"
     )
 
     small_frequency_table: Optional[ColumnFrequencyTable] = Field(
-        default=None,
-        description="Results from small frequency_table request",
+        default=None, description="Results from small frequency_table request"
     )
 
     large_frequency_table: Optional[ColumnFrequencyTable] = Field(
-        default=None,
-        description="Results from large frequency_table request",
+        default=None, description="Results from large frequency_table request"
     )
 
 
@@ -672,32 +588,27 @@ class ColumnSummaryStats(BaseModel):
     """
 
     type_display: ColumnDisplayType = Field(
-        description="Canonical Positron display name of data type",
+        description="Canonical Positron display name of data type"
     )
 
     number_stats: Optional[SummaryStatsNumber] = Field(
-        default=None,
-        description="Statistics for a numeric data type",
+        default=None, description="Statistics for a numeric data type"
     )
 
     string_stats: Optional[SummaryStatsString] = Field(
-        default=None,
-        description="Statistics for a string-like data type",
+        default=None, description="Statistics for a string-like data type"
     )
 
     boolean_stats: Optional[SummaryStatsBoolean] = Field(
-        default=None,
-        description="Statistics for a boolean data type",
+        default=None, description="Statistics for a boolean data type"
     )
 
     date_stats: Optional[SummaryStatsDate] = Field(
-        default=None,
-        description="Statistics for a date data type",
+        default=None, description="Statistics for a date data type"
     )
 
     datetime_stats: Optional[SummaryStatsDatetime] = Field(
-        default=None,
-        description="Statistics for a datetime data type",
+        default=None, description="Statistics for a datetime data type"
     )
 
 
@@ -706,29 +617,18 @@ class SummaryStatsNumber(BaseModel):
     SummaryStatsNumber in Schemas
     """
 
-    min_value: Optional[StrictStr] = Field(
-        default=None,
-        description="Minimum value as string",
-    )
+    min_value: Optional[StrictStr] = Field(default=None, description="Minimum value as string")
 
-    max_value: Optional[StrictStr] = Field(
-        default=None,
-        description="Maximum value as string",
-    )
+    max_value: Optional[StrictStr] = Field(default=None, description="Maximum value as string")
 
-    mean: Optional[StrictStr] = Field(
-        default=None,
-        description="Average value as string",
-    )
+    mean: Optional[StrictStr] = Field(default=None, description="Average value as string")
 
     median: Optional[StrictStr] = Field(
-        default=None,
-        description="Sample median (50% value) value as string",
+        default=None, description="Sample median (50% value) value as string"
     )
 
     stdev: Optional[StrictStr] = Field(
-        default=None,
-        description="Sample standard deviation as a string",
+        default=None, description="Sample standard deviation as a string"
     )
 
 
@@ -737,13 +637,9 @@ class SummaryStatsBoolean(BaseModel):
     SummaryStatsBoolean in Schemas
     """
 
-    true_count: StrictInt = Field(
-        description="The number of non-null true values",
-    )
+    true_count: StrictInt = Field(description="The number of non-null true values")
 
-    false_count: StrictInt = Field(
-        description="The number of non-null false values",
-    )
+    false_count: StrictInt = Field(description="The number of non-null false values")
 
 
 class SummaryStatsString(BaseModel):
@@ -751,13 +647,9 @@ class SummaryStatsString(BaseModel):
     SummaryStatsString in Schemas
     """
 
-    num_empty: StrictInt = Field(
-        description="The number of empty / length-zero values",
-    )
+    num_empty: StrictInt = Field(description="The number of empty / length-zero values")
 
-    num_unique: StrictInt = Field(
-        description="The exact number of distinct values",
-    )
+    num_unique: StrictInt = Field(description="The exact number of distinct values")
 
 
 class SummaryStatsDate(BaseModel):
@@ -766,29 +658,18 @@ class SummaryStatsDate(BaseModel):
     """
 
     num_unique: Optional[StrictInt] = Field(
-        default=None,
-        description="The exact number of distinct values",
+        default=None, description="The exact number of distinct values"
     )
 
-    min_date: Optional[StrictStr] = Field(
-        default=None,
-        description="Minimum date value as string",
-    )
+    min_date: Optional[StrictStr] = Field(default=None, description="Minimum date value as string")
 
-    mean_date: Optional[StrictStr] = Field(
-        default=None,
-        description="Average date value as string",
-    )
+    mean_date: Optional[StrictStr] = Field(default=None, description="Average date value as string")
 
     median_date: Optional[StrictStr] = Field(
-        default=None,
-        description="Sample median (50% value) date value as string",
+        default=None, description="Sample median (50% value) date value as string"
     )
 
-    max_date: Optional[StrictStr] = Field(
-        default=None,
-        description="Maximum date value as string",
-    )
+    max_date: Optional[StrictStr] = Field(default=None, description="Maximum date value as string")
 
 
 class SummaryStatsDatetime(BaseModel):
@@ -797,33 +678,21 @@ class SummaryStatsDatetime(BaseModel):
     """
 
     num_unique: Optional[StrictInt] = Field(
-        default=None,
-        description="The exact number of distinct values",
+        default=None, description="The exact number of distinct values"
     )
 
-    min_date: Optional[StrictStr] = Field(
-        default=None,
-        description="Minimum date value as string",
-    )
+    min_date: Optional[StrictStr] = Field(default=None, description="Minimum date value as string")
 
-    mean_date: Optional[StrictStr] = Field(
-        default=None,
-        description="Average date value as string",
-    )
+    mean_date: Optional[StrictStr] = Field(default=None, description="Average date value as string")
 
     median_date: Optional[StrictStr] = Field(
-        default=None,
-        description="Sample median (50% value) date value as string",
+        default=None, description="Sample median (50% value) date value as string"
     )
 
-    max_date: Optional[StrictStr] = Field(
-        default=None,
-        description="Maximum date value as string",
-    )
+    max_date: Optional[StrictStr] = Field(default=None, description="Maximum date value as string")
 
     timezone: Optional[StrictStr] = Field(
-        default=None,
-        description="Time zone for timestamp with time zone",
+        default=None, description="Time zone for timestamp with time zone"
     )
 
 
@@ -832,13 +701,9 @@ class ColumnHistogramParams(BaseModel):
     Parameters for a column histogram profile request
     """
 
-    method: ColumnHistogramParamsMethod = Field(
-        description="Method for determining number of bins",
-    )
+    method: ColumnHistogramParamsMethod = Field(description="Method for determining number of bins")
 
-    num_bins: StrictInt = Field(
-        description="Maximum number of bins in the computed histogram.",
-    )
+    num_bins: StrictInt = Field(description="Maximum number of bins in the computed histogram.")
 
     quantiles: Optional[List[Union[StrictInt, StrictFloat]]] = Field(
         default=None,
@@ -852,15 +717,15 @@ class ColumnHistogram(BaseModel):
     """
 
     bin_edges: List[StrictStr] = Field(
-        description="String-formatted versions of the bin edges, there are N + 1 where N is the number of bins",
+        description="String-formatted versions of the bin edges, there are N + 1 where N is the number of bins"
     )
 
     bin_counts: List[StrictInt] = Field(
-        description="Absolute count of values in each histogram bin",
+        description="Absolute count of values in each histogram bin"
     )
 
     quantiles: List[ColumnQuantileValue] = Field(
-        description="Sample quantiles that were also requested",
+        description="Sample quantiles that were also requested"
     )
 
 
@@ -870,7 +735,7 @@ class ColumnFrequencyTableParams(BaseModel):
     """
 
     limit: StrictInt = Field(
-        description="Number of most frequently-occurring values to return. The K in TopK",
+        description="Number of most frequently-occurring values to return. The K in TopK"
     )
 
 
@@ -879,13 +744,9 @@ class ColumnFrequencyTable(BaseModel):
     Result from a frequency_table profile request
     """
 
-    values: List[StrictStr] = Field(
-        description="The formatted top values",
-    )
+    values: List[StrictStr] = Field(description="The formatted top values")
 
-    counts: List[StrictInt] = Field(
-        description="Counts of top values",
-    )
+    counts: List[StrictInt] = Field(description="Counts of top values")
 
     other_count: Optional[StrictInt] = Field(
         default=None,
@@ -899,15 +760,13 @@ class ColumnQuantileValue(BaseModel):
     """
 
     q: Union[StrictInt, StrictFloat] = Field(
-        description="Quantile number; a number between 0 and 1",
+        description="Quantile number; a number between 0 and 1"
     )
 
-    value: StrictStr = Field(
-        description="Stringified quantile value",
-    )
+    value: StrictStr = Field(description="Stringified quantile value")
 
     exact: StrictBool = Field(
-        description="Whether value is exact or approximate (computed from binned data or sketches)",
+        description="Whether value is exact or approximate (computed from binned data or sketches)"
     )
 
 
@@ -917,12 +776,10 @@ class ColumnSortKey(BaseModel):
     """
 
     column_index: StrictInt = Field(
-        description="Column index (absolute, relative to unfiltered table) to sort by",
+        description="Column index (absolute, relative to unfiltered table) to sort by"
     )
 
-    ascending: StrictBool = Field(
-        description="Sort order, ascending (true) or descending (false)",
-    )
+    ascending: StrictBool = Field(description="Sort order, ascending (true) or descending (false)")
 
 
 class SupportedFeatures(BaseModel):
@@ -931,27 +788,27 @@ class SupportedFeatures(BaseModel):
     """
 
     search_schema: SearchSchemaFeatures = Field(
-        description="Support for 'search_schema' RPC and its features",
+        description="Support for 'search_schema' RPC and its features"
     )
 
     set_column_filters: SetColumnFiltersFeatures = Field(
-        description="Support ofr 'set_column_filters' RPC and its features",
+        description="Support ofr 'set_column_filters' RPC and its features"
     )
 
     set_row_filters: SetRowFiltersFeatures = Field(
-        description="Support for 'set_row_filters' RPC and its features",
+        description="Support for 'set_row_filters' RPC and its features"
     )
 
     get_column_profiles: GetColumnProfilesFeatures = Field(
-        description="Support for 'get_column_profiles' RPC and its features",
+        description="Support for 'get_column_profiles' RPC and its features"
     )
 
     set_sort_columns: SetSortColumnsFeatures = Field(
-        description="Support for 'set_sort_columns' RPC and its features",
+        description="Support for 'set_sort_columns' RPC and its features"
     )
 
     export_data_selection: ExportDataSelectionFeatures = Field(
-        description="Support for 'export_data_selection' RPC and its features",
+        description="Support for 'export_data_selection' RPC and its features"
     )
 
 
@@ -960,12 +817,10 @@ class SearchSchemaFeatures(BaseModel):
     Feature flags for 'search_schema' RPC
     """
 
-    support_status: SupportStatus = Field(
-        description="The support status for this RPC method",
-    )
+    support_status: SupportStatus = Field(description="The support status for this RPC method")
 
     supported_types: List[ColumnFilterTypeSupportStatus] = Field(
-        description="A list of supported types",
+        description="A list of supported types"
     )
 
 
@@ -974,12 +829,10 @@ class SetColumnFiltersFeatures(BaseModel):
     Feature flags for 'set_column_filters' RPC
     """
 
-    support_status: SupportStatus = Field(
-        description="The support status for this RPC method",
-    )
+    support_status: SupportStatus = Field(description="The support status for this RPC method")
 
     supported_types: List[ColumnFilterTypeSupportStatus] = Field(
-        description="A list of supported types",
+        description="A list of supported types"
     )
 
 
@@ -988,16 +841,14 @@ class SetRowFiltersFeatures(BaseModel):
     Feature flags for 'set_row_filters' RPC
     """
 
-    support_status: SupportStatus = Field(
-        description="The support status for this RPC method",
-    )
+    support_status: SupportStatus = Field(description="The support status for this RPC method")
 
     supports_conditions: SupportStatus = Field(
-        description="Whether AND/OR filter conditions are supported",
+        description="Whether AND/OR filter conditions are supported"
     )
 
     supported_types: List[RowFilterTypeSupportStatus] = Field(
-        description="A list of supported types",
+        description="A list of supported types"
     )
 
 
@@ -1006,12 +857,10 @@ class GetColumnProfilesFeatures(BaseModel):
     Feature flags for 'get_column_profiles' RPC
     """
 
-    support_status: SupportStatus = Field(
-        description="The support status for this RPC method",
-    )
+    support_status: SupportStatus = Field(description="The support status for this RPC method")
 
     supported_types: List[ColumnProfileTypeSupportStatus] = Field(
-        description="A list of supported types",
+        description="A list of supported types"
     )
 
 
@@ -1020,13 +869,9 @@ class ExportDataSelectionFeatures(BaseModel):
     Feature flags for 'export_data_selction' RPC
     """
 
-    support_status: SupportStatus = Field(
-        description="The support status for this RPC method",
-    )
+    support_status: SupportStatus = Field(description="The support status for this RPC method")
 
-    supported_formats: List[ExportFormat] = Field(
-        description="Export formats supported",
-    )
+    supported_formats: List[ExportFormat] = Field(description="Export formats supported")
 
 
 class SetSortColumnsFeatures(BaseModel):
@@ -1034,9 +879,7 @@ class SetSortColumnsFeatures(BaseModel):
     Feature flags for 'set_sort_columns' RPC
     """
 
-    support_status: SupportStatus = Field(
-        description="The support status for this RPC method",
-    )
+    support_status: SupportStatus = Field(description="The support status for this RPC method")
 
 
 class TableSelection(BaseModel):
@@ -1046,12 +889,10 @@ class TableSelection(BaseModel):
     """
 
     kind: TableSelectionKind = Field(
-        description="Type of selection, all indices relative to filtered row/column indices",
+        description="Type of selection, all indices relative to filtered row/column indices"
     )
 
-    selection: Selection = Field(
-        description="A union of selection types",
-    )
+    selection: Selection = Field(description="A union of selection types")
 
 
 class DataSelectionSingleCell(BaseModel):
@@ -1059,13 +900,9 @@ class DataSelectionSingleCell(BaseModel):
     A selection that contains a single data cell
     """
 
-    row_index: StrictInt = Field(
-        description="The selected row index",
-    )
+    row_index: StrictInt = Field(description="The selected row index")
 
-    column_index: StrictInt = Field(
-        description="The selected column index",
-    )
+    column_index: StrictInt = Field(description="The selected column index")
 
 
 class DataSelectionCellRange(BaseModel):
@@ -1073,21 +910,15 @@ class DataSelectionCellRange(BaseModel):
     A selection that contains a rectangular range of data cells
     """
 
-    first_row_index: StrictInt = Field(
-        description="The starting selected row index (inclusive)",
-    )
+    first_row_index: StrictInt = Field(description="The starting selected row index (inclusive)")
 
-    last_row_index: StrictInt = Field(
-        description="The final selected row index (inclusive)",
-    )
+    last_row_index: StrictInt = Field(description="The final selected row index (inclusive)")
 
     first_column_index: StrictInt = Field(
-        description="The starting selected column index (inclusive)",
+        description="The starting selected column index (inclusive)"
     )
 
-    last_column_index: StrictInt = Field(
-        description="The final selected column index (inclusive)",
-    )
+    last_column_index: StrictInt = Field(description="The final selected column index (inclusive)")
 
 
 class DataSelectionRange(BaseModel):
@@ -1095,13 +926,9 @@ class DataSelectionRange(BaseModel):
     A contiguous selection bounded by inclusive start and end indices
     """
 
-    first_index: StrictInt = Field(
-        description="The starting selected index (inclusive)",
-    )
+    first_index: StrictInt = Field(description="The starting selected index (inclusive)")
 
-    last_index: StrictInt = Field(
-        description="The final selected index (inclusive)",
-    )
+    last_index: StrictInt = Field(description="The final selected index (inclusive)")
 
 
 class DataSelectionIndices(BaseModel):
@@ -1109,9 +936,7 @@ class DataSelectionIndices(BaseModel):
     A selection defined by a sequence of indices to include
     """
 
-    indices: List[StrictInt] = Field(
-        description="The selected indices",
-    )
+    indices: List[StrictInt] = Field(description="The selected indices")
 
 
 class ColumnSelection(BaseModel):
@@ -1120,31 +945,20 @@ class ColumnSelection(BaseModel):
     """
 
     column_index: StrictInt = Field(
-        description="Column index (relative to unfiltered schema) to select data from",
+        description="Column index (relative to unfiltered schema) to select data from"
     )
 
     spec: ArraySelection = Field(
-        description="Union of selection specifications for array_selection",
+        description="Union of selection specifications for array_selection"
     )
 
 
 # ColumnValue
-ColumnValue = Union[
-    StrictInt,
-    StrictStr,
-]
+ColumnValue = Union[StrictInt, StrictStr]
 # Union of row filter parameters
-RowFilterParams = Union[
-    FilterBetween,
-    FilterComparison,
-    FilterTextSearch,
-    FilterSetMembership,
-]
+RowFilterParams = Union[FilterBetween, FilterComparison, FilterTextSearch, FilterSetMembership]
 # Union of column filter type-specific parameters
-ColumnFilterParams = Union[
-    FilterTextSearch,
-    FilterMatchDataTypes,
-]
+ColumnFilterParams = Union[FilterTextSearch, FilterMatchDataTypes]
 # Extra parameters for different profile types
 ColumnProfileParams = Union[
     ColumnHistogramParams,
@@ -1154,16 +968,10 @@ ColumnProfileParams = Union[
 ]
 # A union of selection types
 Selection = Union[
-    DataSelectionSingleCell,
-    DataSelectionCellRange,
-    DataSelectionRange,
-    DataSelectionIndices,
+    DataSelectionSingleCell, DataSelectionCellRange, DataSelectionRange, DataSelectionIndices
 ]
 # Union of selection specifications for array_selection
-ArraySelection = Union[
-    DataSelectionRange,
-    DataSelectionIndices,
-]
+ArraySelection = Union[DataSelectionRange, DataSelectionIndices]
 
 
 @enum.unique
@@ -1211,9 +1019,7 @@ class OpenDatasetParams(BaseModel):
     Request to open a dataset given a URI
     """
 
-    uri: StrictStr = Field(
-        description="The resource locator or file path",
-    )
+    uri: StrictStr = Field(description="The resource locator or file path")
 
 
 class OpenDatasetRequest(BaseModel):
@@ -1221,18 +1027,13 @@ class OpenDatasetRequest(BaseModel):
     Request to open a dataset given a URI
     """
 
-    params: OpenDatasetParams = Field(
-        description="Parameters to the OpenDataset method",
-    )
+    params: OpenDatasetParams = Field(description="Parameters to the OpenDataset method")
 
     method: Literal[DataExplorerBackendRequest.OpenDataset] = Field(
-        description="The JSON-RPC method name (open_dataset)",
+        description="The JSON-RPC method name (open_dataset)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class GetSchemaParams(BaseModel):
@@ -1241,7 +1042,7 @@ class GetSchemaParams(BaseModel):
     """
 
     column_indices: List[StrictInt] = Field(
-        description="The column indices (relative to the filtered/selected columns) to fetch",
+        description="The column indices (relative to the filtered/selected columns) to fetch"
     )
 
 
@@ -1250,18 +1051,13 @@ class GetSchemaRequest(BaseModel):
     Request subset of column schemas for a table-like object
     """
 
-    params: GetSchemaParams = Field(
-        description="Parameters to the GetSchema method",
-    )
+    params: GetSchemaParams = Field(description="Parameters to the GetSchema method")
 
     method: Literal[DataExplorerBackendRequest.GetSchema] = Field(
-        description="The JSON-RPC method name (get_schema)",
+        description="The JSON-RPC method name (get_schema)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class SearchSchemaParams(BaseModel):
@@ -1270,16 +1066,14 @@ class SearchSchemaParams(BaseModel):
     more column filters
     """
 
-    filters: List[ColumnFilter] = Field(
-        description="Column filters to apply when searching",
-    )
+    filters: List[ColumnFilter] = Field(description="Column filters to apply when searching")
 
     start_index: StrictInt = Field(
-        description="Index (starting from zero) of first result to fetch (for paging)",
+        description="Index (starting from zero) of first result to fetch (for paging)"
     )
 
     max_results: StrictInt = Field(
-        description="Maximum number of resulting column schemas to fetch from the start index",
+        description="Maximum number of resulting column schemas to fetch from the start index"
     )
 
 
@@ -1289,18 +1083,13 @@ class SearchSchemaRequest(BaseModel):
     more column filters
     """
 
-    params: SearchSchemaParams = Field(
-        description="Parameters to the SearchSchema method",
-    )
+    params: SearchSchemaParams = Field(description="Parameters to the SearchSchema method")
 
     method: Literal[DataExplorerBackendRequest.SearchSchema] = Field(
-        description="The JSON-RPC method name (search_schema)",
+        description="The JSON-RPC method name (search_schema)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class GetDataValuesParams(BaseModel):
@@ -1308,12 +1097,10 @@ class GetDataValuesParams(BaseModel):
     Request data from table columns with values formatted as strings
     """
 
-    columns: List[ColumnSelection] = Field(
-        description="Array of column selections",
-    )
+    columns: List[ColumnSelection] = Field(description="Array of column selections")
 
     format_options: FormatOptions = Field(
-        description="Formatting options for returning data values as strings",
+        description="Formatting options for returning data values as strings"
     )
 
 
@@ -1322,18 +1109,13 @@ class GetDataValuesRequest(BaseModel):
     Request data from table columns with values formatted as strings
     """
 
-    params: GetDataValuesParams = Field(
-        description="Parameters to the GetDataValues method",
-    )
+    params: GetDataValuesParams = Field(description="Parameters to the GetDataValues method")
 
     method: Literal[DataExplorerBackendRequest.GetDataValues] = Field(
-        description="The JSON-RPC method name (get_data_values)",
+        description="The JSON-RPC method name (get_data_values)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class GetRowLabelsParams(BaseModel):
@@ -1341,12 +1123,10 @@ class GetRowLabelsParams(BaseModel):
     Request formatted row labels from table
     """
 
-    selection: ArraySelection = Field(
-        description="Selection of row labels",
-    )
+    selection: ArraySelection = Field(description="Selection of row labels")
 
     format_options: FormatOptions = Field(
-        description="Formatting options for returning labels as strings",
+        description="Formatting options for returning labels as strings"
     )
 
 
@@ -1355,18 +1135,13 @@ class GetRowLabelsRequest(BaseModel):
     Request formatted row labels from table
     """
 
-    params: GetRowLabelsParams = Field(
-        description="Parameters to the GetRowLabels method",
-    )
+    params: GetRowLabelsParams = Field(description="Parameters to the GetRowLabels method")
 
     method: Literal[DataExplorerBackendRequest.GetRowLabels] = Field(
-        description="The JSON-RPC method name (get_row_labels)",
+        description="The JSON-RPC method name (get_row_labels)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class ExportDataSelectionParams(BaseModel):
@@ -1375,13 +1150,9 @@ class ExportDataSelectionParams(BaseModel):
     HTML
     """
 
-    selection: TableSelection = Field(
-        description="The data selection",
-    )
+    selection: TableSelection = Field(description="The data selection")
 
-    format: ExportFormat = Field(
-        description="Result string format",
-    )
+    format: ExportFormat = Field(description="Result string format")
 
 
 class ExportDataSelectionRequest(BaseModel):
@@ -1391,17 +1162,14 @@ class ExportDataSelectionRequest(BaseModel):
     """
 
     params: ExportDataSelectionParams = Field(
-        description="Parameters to the ExportDataSelection method",
+        description="Parameters to the ExportDataSelection method"
     )
 
     method: Literal[DataExplorerBackendRequest.ExportDataSelection] = Field(
-        description="The JSON-RPC method name (export_data_selection)",
+        description="The JSON-RPC method name (export_data_selection)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class SetColumnFiltersParams(BaseModel):
@@ -1410,7 +1178,7 @@ class SetColumnFiltersParams(BaseModel):
     """
 
     filters: List[ColumnFilter] = Field(
-        description="Column filters to apply (or pass empty array to clear column filters)",
+        description="Column filters to apply (or pass empty array to clear column filters)"
     )
 
 
@@ -1419,18 +1187,13 @@ class SetColumnFiltersRequest(BaseModel):
     Set or clear column filters on table, replacing any previous filters
     """
 
-    params: SetColumnFiltersParams = Field(
-        description="Parameters to the SetColumnFilters method",
-    )
+    params: SetColumnFiltersParams = Field(description="Parameters to the SetColumnFilters method")
 
     method: Literal[DataExplorerBackendRequest.SetColumnFilters] = Field(
-        description="The JSON-RPC method name (set_column_filters)",
+        description="The JSON-RPC method name (set_column_filters)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class SetRowFiltersParams(BaseModel):
@@ -1438,9 +1201,7 @@ class SetRowFiltersParams(BaseModel):
     Row filters to apply (or pass empty array to clear row filters)
     """
 
-    filters: List[RowFilter] = Field(
-        description="Zero or more filters to apply",
-    )
+    filters: List[RowFilter] = Field(description="Zero or more filters to apply")
 
 
 class SetRowFiltersRequest(BaseModel):
@@ -1448,18 +1209,13 @@ class SetRowFiltersRequest(BaseModel):
     Row filters to apply (or pass empty array to clear row filters)
     """
 
-    params: SetRowFiltersParams = Field(
-        description="Parameters to the SetRowFilters method",
-    )
+    params: SetRowFiltersParams = Field(description="Parameters to the SetRowFilters method")
 
     method: Literal[DataExplorerBackendRequest.SetRowFilters] = Field(
-        description="The JSON-RPC method name (set_row_filters)",
+        description="The JSON-RPC method name (set_row_filters)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class SetSortColumnsParams(BaseModel):
@@ -1469,7 +1225,7 @@ class SetSortColumnsParams(BaseModel):
     """
 
     sort_keys: List[ColumnSortKey] = Field(
-        description="Pass zero or more keys to sort by. Clears any existing keys",
+        description="Pass zero or more keys to sort by. Clears any existing keys"
     )
 
 
@@ -1479,18 +1235,13 @@ class SetSortColumnsRequest(BaseModel):
     columns
     """
 
-    params: SetSortColumnsParams = Field(
-        description="Parameters to the SetSortColumns method",
-    )
+    params: SetSortColumnsParams = Field(description="Parameters to the SetSortColumns method")
 
     method: Literal[DataExplorerBackendRequest.SetSortColumns] = Field(
-        description="The JSON-RPC method name (set_sort_columns)",
+        description="The JSON-RPC method name (set_sort_columns)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class GetColumnProfilesParams(BaseModel):
@@ -1499,16 +1250,12 @@ class GetColumnProfilesParams(BaseModel):
     columns
     """
 
-    callback_id: StrictStr = Field(
-        description="Async callback unique identifier",
-    )
+    callback_id: StrictStr = Field(description="Async callback unique identifier")
 
-    profiles: List[ColumnProfileRequest] = Field(
-        description="Array of requested profiles",
-    )
+    profiles: List[ColumnProfileRequest] = Field(description="Array of requested profiles")
 
     format_options: FormatOptions = Field(
-        description="Formatting options for returning data values as strings",
+        description="Formatting options for returning data values as strings"
     )
 
 
@@ -1519,17 +1266,14 @@ class GetColumnProfilesRequest(BaseModel):
     """
 
     params: GetColumnProfilesParams = Field(
-        description="Parameters to the GetColumnProfiles method",
+        description="Parameters to the GetColumnProfiles method"
     )
 
     method: Literal[DataExplorerBackendRequest.GetColumnProfiles] = Field(
-        description="The JSON-RPC method name (get_column_profiles)",
+        description="The JSON-RPC method name (get_column_profiles)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class GetStateRequest(BaseModel):
@@ -1539,13 +1283,10 @@ class GetStateRequest(BaseModel):
     """
 
     method: Literal[DataExplorerBackendRequest.GetState] = Field(
-        description="The JSON-RPC method name (get_state)",
+        description="The JSON-RPC method name (get_state)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class DataExplorerBackendMessageContent(BaseModel):
@@ -1586,16 +1327,14 @@ class ReturnColumnProfilesParams(BaseModel):
     Return async result of get_column_profiles request
     """
 
-    callback_id: StrictStr = Field(
-        description="Async callback unique identifier",
-    )
+    callback_id: StrictStr = Field(description="Async callback unique identifier")
 
     profiles: List[ColumnProfileResult] = Field(
-        description="Array of individual column profile results",
+        description="Array of individual column profile results"
     )
 
     error_message: Optional[StrictStr] = Field(
-        description="Optional error message if something failed to compute",
+        description="Optional error message if something failed to compute"
     )
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -15,7 +15,14 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+from ._vendor.pydantic import (
+    BaseModel,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+)
 
 
 @enum.unique

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/data_explorer_comm.py
@@ -217,7 +217,8 @@ class OpenDatasetResult(BaseModel):
     """
 
     error_message: Optional[StrictStr] = Field(
-        default=None, description="An error message if opening the dataset failed"
+        default=None,
+        description="An error message if opening the dataset failed",
     )
 
 
@@ -227,11 +228,11 @@ class SearchSchemaResult(BaseModel):
     """
 
     matches: TableSchema = Field(
-        description="A schema containing matching columns up to the max_results limit"
+        description="A schema containing matching columns up to the max_results limit",
     )
 
     total_num_matches: StrictInt = Field(
-        description="The total number of columns matching the filter"
+        description="The total number of columns matching the filter",
     )
 
 
@@ -240,9 +241,13 @@ class ExportedData(BaseModel):
     Exported result
     """
 
-    data: StrictStr = Field(description="Exported data as a string suitable for copy and paste")
+    data: StrictStr = Field(
+        description="Exported data as a string suitable for copy and paste",
+    )
 
-    format: ExportFormat = Field(description="The exported data format")
+    format: ExportFormat = Field(
+        description="The exported data format",
+    )
 
 
 class FilterResult(BaseModel):
@@ -251,11 +256,12 @@ class FilterResult(BaseModel):
     """
 
     selected_num_rows: StrictInt = Field(
-        description="Number of rows in table after applying filters"
+        description="Number of rows in table after applying filters",
     )
 
     had_errors: Optional[StrictBool] = Field(
-        default=None, description="Flag indicating if there were errors in evaluation"
+        default=None,
+        description="Flag indicating if there were errors in evaluation",
     )
 
 
@@ -265,29 +271,35 @@ class BackendState(BaseModel):
     """
 
     display_name: StrictStr = Field(
-        description="Variable name or other string to display for tab name in UI"
+        description="Variable name or other string to display for tab name in UI",
     )
 
     table_shape: TableShape = Field(
-        description="Number of rows and columns in table with row/column filters applied"
+        description="Number of rows and columns in table with row/column filters applied",
     )
 
     table_unfiltered_shape: TableShape = Field(
-        description="Number of rows and columns in table without any filters applied"
+        description="Number of rows and columns in table without any filters applied",
     )
 
     has_row_labels: StrictBool = Field(
-        description="Indicates whether table has row labels or whether rows should be labeled by ordinal position"
+        description="Indicates whether table has row labels or whether rows should be labeled by ordinal position",
     )
 
-    column_filters: List[ColumnFilter] = Field(description="The currently applied column filters")
+    column_filters: List[ColumnFilter] = Field(
+        description="The currently applied column filters",
+    )
 
-    row_filters: List[RowFilter] = Field(description="The currently applied row filters")
+    row_filters: List[RowFilter] = Field(
+        description="The currently applied row filters",
+    )
 
-    sort_keys: List[ColumnSortKey] = Field(description="The currently applied column sort keys")
+    sort_keys: List[ColumnSortKey] = Field(
+        description="The currently applied column sort keys",
+    )
 
     supported_features: SupportedFeatures = Field(
-        description="The features currently supported by the backend instance"
+        description="The features currently supported by the backend instance",
     )
 
     connected: Optional[StrictBool] = Field(
@@ -306,36 +318,50 @@ class ColumnSchema(BaseModel):
     Schema for a column in a table
     """
 
-    column_name: StrictStr = Field(description="Name of column as UTF-8 string")
-
-    column_index: StrictInt = Field(
-        description="The position of the column within the table without any column filters"
+    column_name: StrictStr = Field(
+        description="Name of column as UTF-8 string",
     )
 
-    type_name: StrictStr = Field(description="Exact name of data type used by underlying table")
+    column_index: StrictInt = Field(
+        description="The position of the column within the table without any column filters",
+    )
+
+    type_name: StrictStr = Field(
+        description="Exact name of data type used by underlying table",
+    )
 
     type_display: ColumnDisplayType = Field(
-        description="Canonical Positron display name of data type"
+        description="Canonical Positron display name of data type",
     )
 
     description: Optional[StrictStr] = Field(
-        default=None, description="Column annotation / description"
+        default=None,
+        description="Column annotation / description",
     )
 
     children: Optional[List[ColumnSchema]] = Field(
-        default=None, description="Schema of nested child types"
+        default=None,
+        description="Schema of nested child types",
     )
 
-    precision: Optional[StrictInt] = Field(default=None, description="Precision for decimal types")
+    precision: Optional[StrictInt] = Field(
+        default=None,
+        description="Precision for decimal types",
+    )
 
-    scale: Optional[StrictInt] = Field(default=None, description="Scale for decimal types")
+    scale: Optional[StrictInt] = Field(
+        default=None,
+        description="Scale for decimal types",
+    )
 
     timezone: Optional[StrictStr] = Field(
-        default=None, description="Time zone for timestamp with time zone"
+        default=None,
+        description="Time zone for timestamp with time zone",
     )
 
     type_size: Optional[StrictInt] = Field(
-        default=None, description="Size parameter for fixed-size types (list, binary)"
+        default=None,
+        description="Size parameter for fixed-size types (list, binary)",
     )
 
 
@@ -344,7 +370,9 @@ class TableData(BaseModel):
     Table values formatted as strings
     """
 
-    columns: List[List[ColumnValue]] = Field(description="The columns of data")
+    columns: List[List[ColumnValue]] = Field(
+        description="The columns of data",
+    )
 
 
 class TableRowLabels(BaseModel):
@@ -352,7 +380,9 @@ class TableRowLabels(BaseModel):
     Formatted table row labels formatted as strings
     """
 
-    row_labels: List[List[StrictStr]] = Field(description="Zero or more arrays of row labels")
+    row_labels: List[List[StrictStr]] = Field(
+        description="Zero or more arrays of row labels",
+    )
 
 
 class FormatOptions(BaseModel):
@@ -361,23 +391,24 @@ class FormatOptions(BaseModel):
     """
 
     large_num_digits: StrictInt = Field(
-        description="Fixed number of decimal places to display for numbers over 1, or in scientific notation"
+        description="Fixed number of decimal places to display for numbers over 1, or in scientific notation",
     )
 
     small_num_digits: StrictInt = Field(
-        description="Fixed number of decimal places to display for small numbers, and to determine lower threshold for switching to scientific notation"
+        description="Fixed number of decimal places to display for small numbers, and to determine lower threshold for switching to scientific notation",
     )
 
     max_integral_digits: StrictInt = Field(
-        description="Maximum number of integral digits to display before switching to scientific notation"
+        description="Maximum number of integral digits to display before switching to scientific notation",
     )
 
     max_value_length: StrictInt = Field(
-        description="Maximum size of formatted value, for truncating large strings or other large formatted values"
+        description="Maximum size of formatted value, for truncating large strings or other large formatted values",
     )
 
     thousands_sep: Optional[StrictStr] = Field(
-        default=None, description="Thousands separator string"
+        default=None,
+        description="Thousands separator string",
     )
 
 
@@ -386,7 +417,9 @@ class TableSchema(BaseModel):
     The schema for a table-like object
     """
 
-    columns: List[ColumnSchema] = Field(description="Schema for each column in the table")
+    columns: List[ColumnSchema] = Field(
+        description="Schema for each column in the table",
+    )
 
 
 class TableShape(BaseModel):
@@ -394,9 +427,13 @@ class TableShape(BaseModel):
     Provides number of rows and columns in a table
     """
 
-    num_rows: StrictInt = Field(description="Numbers of rows in the table")
+    num_rows: StrictInt = Field(
+        description="Numbers of rows in the table",
+    )
 
-    num_columns: StrictInt = Field(description="Number of columns in the table")
+    num_columns: StrictInt = Field(
+        description="Number of columns in the table",
+    )
 
 
 class RowFilter(BaseModel):
@@ -404,14 +441,20 @@ class RowFilter(BaseModel):
     Specifies a table row filter based on a single column's values
     """
 
-    filter_id: StrictStr = Field(description="Unique identifier for this filter")
+    filter_id: StrictStr = Field(
+        description="Unique identifier for this filter",
+    )
 
-    filter_type: RowFilterType = Field(description="Type of row filter to apply")
+    filter_type: RowFilterType = Field(
+        description="Type of row filter to apply",
+    )
 
-    column_schema: ColumnSchema = Field(description="Column to apply filter to")
+    column_schema: ColumnSchema = Field(
+        description="Column to apply filter to",
+    )
 
     condition: RowFilterCondition = Field(
-        description="The binary condition to use to combine with preceding row filters"
+        description="The binary condition to use to combine with preceding row filters",
     )
 
     is_valid: Optional[StrictBool] = Field(
@@ -420,11 +463,13 @@ class RowFilter(BaseModel):
     )
 
     error_message: Optional[StrictStr] = Field(
-        default=None, description="Optional error message when the filter is invalid"
+        default=None,
+        description="Optional error message when the filter is invalid",
     )
 
     params: Optional[RowFilterParams] = Field(
-        default=None, description="The row filter type-specific parameters"
+        default=None,
+        description="The row filter type-specific parameters",
     )
 
 
@@ -433,9 +478,13 @@ class RowFilterTypeSupportStatus(BaseModel):
     Support status for a row filter type
     """
 
-    row_filter_type: RowFilterType = Field(description="Type of row filter")
+    row_filter_type: RowFilterType = Field(
+        description="Type of row filter",
+    )
 
-    support_status: SupportStatus = Field(description="The support status for this row filter type")
+    support_status: SupportStatus = Field(
+        description="The support status for this row filter type",
+    )
 
 
 class FilterBetween(BaseModel):
@@ -443,9 +492,13 @@ class FilterBetween(BaseModel):
     Parameters for the 'between' and 'not_between' filter types
     """
 
-    left_value: StrictStr = Field(description="The lower limit for filtering")
+    left_value: StrictStr = Field(
+        description="The lower limit for filtering",
+    )
 
-    right_value: StrictStr = Field(description="The upper limit for filtering")
+    right_value: StrictStr = Field(
+        description="The upper limit for filtering",
+    )
 
 
 class FilterComparison(BaseModel):
@@ -453,9 +506,13 @@ class FilterComparison(BaseModel):
     Parameters for the 'compare' filter type
     """
 
-    op: FilterComparisonOp = Field(description="String representation of a binary comparison")
+    op: FilterComparisonOp = Field(
+        description="String representation of a binary comparison",
+    )
 
-    value: StrictStr = Field(description="A stringified column value for a comparison filter")
+    value: StrictStr = Field(
+        description="A stringified column value for a comparison filter",
+    )
 
 
 class FilterSetMembership(BaseModel):
@@ -463,10 +520,12 @@ class FilterSetMembership(BaseModel):
     Parameters for the 'set_membership' filter type
     """
 
-    values: List[StrictStr] = Field(description="Array of values for a set membership filter")
+    values: List[StrictStr] = Field(
+        description="Array of values for a set membership filter",
+    )
 
     inclusive: StrictBool = Field(
-        description="Filter by including only values passed (true) or excluding (false)"
+        description="Filter by including only values passed (true) or excluding (false)",
     )
 
 
@@ -475,12 +534,16 @@ class FilterTextSearch(BaseModel):
     Parameters for the 'search' filter type
     """
 
-    search_type: TextSearchType = Field(description="Type of search to perform")
+    search_type: TextSearchType = Field(
+        description="Type of search to perform",
+    )
 
-    term: StrictStr = Field(description="String value/regex to search for")
+    term: StrictStr = Field(
+        description="String value/regex to search for",
+    )
 
     case_sensitive: StrictBool = Field(
-        description="If true, do a case-sensitive search, otherwise case-insensitive"
+        description="If true, do a case-sensitive search, otherwise case-insensitive",
     )
 
 
@@ -489,7 +552,9 @@ class FilterMatchDataTypes(BaseModel):
     Parameters for the 'match_data_types' filter type
     """
 
-    display_types: List[ColumnDisplayType] = Field(description="Column display types to match")
+    display_types: List[ColumnDisplayType] = Field(
+        description="Column display types to match",
+    )
 
 
 class ColumnFilter(BaseModel):
@@ -498,9 +563,13 @@ class ColumnFilter(BaseModel):
     criteria
     """
 
-    filter_type: ColumnFilterType = Field(description="Type of column filter to apply")
+    filter_type: ColumnFilterType = Field(
+        description="Type of column filter to apply",
+    )
 
-    params: ColumnFilterParams = Field(description="Parameters for column filter")
+    params: ColumnFilterParams = Field(
+        description="Parameters for column filter",
+    )
 
 
 class ColumnFilterTypeSupportStatus(BaseModel):
@@ -508,10 +577,12 @@ class ColumnFilterTypeSupportStatus(BaseModel):
     Support status for a column filter type
     """
 
-    column_filter_type: ColumnFilterType = Field(description="Type of column filter")
+    column_filter_type: ColumnFilterType = Field(
+        description="Type of column filter",
+    )
 
     support_status: SupportStatus = Field(
-        description="The support status for this column filter type"
+        description="The support status for this column filter type",
     )
 
 
@@ -521,10 +592,12 @@ class ColumnProfileRequest(BaseModel):
     """
 
     column_index: StrictInt = Field(
-        description="The column index (absolute, relative to unfiltered table) to profile"
+        description="The column index (absolute, relative to unfiltered table) to profile",
     )
 
-    profiles: List[ColumnProfileSpec] = Field(description="Column profiles needed")
+    profiles: List[ColumnProfileSpec] = Field(
+        description="Column profiles needed",
+    )
 
 
 class ColumnProfileSpec(BaseModel):
@@ -532,10 +605,13 @@ class ColumnProfileSpec(BaseModel):
     Parameters for a single column profile for a request for profiles
     """
 
-    profile_type: ColumnProfileType = Field(description="Type of column profile")
+    profile_type: ColumnProfileType = Field(
+        description="Type of column profile",
+    )
 
     params: Optional[ColumnProfileParams] = Field(
-        default=None, description="Extra parameters for different profile types"
+        default=None,
+        description="Extra parameters for different profile types",
     )
 
 
@@ -544,10 +620,12 @@ class ColumnProfileTypeSupportStatus(BaseModel):
     Support status for a given column profile type
     """
 
-    profile_type: ColumnProfileType = Field(description="The type of analytical column profile")
+    profile_type: ColumnProfileType = Field(
+        description="The type of analytical column profile",
+    )
 
     support_status: SupportStatus = Field(
-        description="The support status for this column profile type"
+        description="The support status for this column profile type",
     )
 
 
@@ -557,27 +635,33 @@ class ColumnProfileResult(BaseModel):
     """
 
     null_count: Optional[StrictInt] = Field(
-        default=None, description="Result from null_count request"
+        default=None,
+        description="Result from null_count request",
     )
 
     summary_stats: Optional[ColumnSummaryStats] = Field(
-        default=None, description="Results from summary_stats request"
+        default=None,
+        description="Results from summary_stats request",
     )
 
     small_histogram: Optional[ColumnHistogram] = Field(
-        default=None, description="Results from small histogram request"
+        default=None,
+        description="Results from small histogram request",
     )
 
     large_histogram: Optional[ColumnHistogram] = Field(
-        default=None, description="Results from large histogram request"
+        default=None,
+        description="Results from large histogram request",
     )
 
     small_frequency_table: Optional[ColumnFrequencyTable] = Field(
-        default=None, description="Results from small frequency_table request"
+        default=None,
+        description="Results from small frequency_table request",
     )
 
     large_frequency_table: Optional[ColumnFrequencyTable] = Field(
-        default=None, description="Results from large frequency_table request"
+        default=None,
+        description="Results from large frequency_table request",
     )
 
 
@@ -588,27 +672,32 @@ class ColumnSummaryStats(BaseModel):
     """
 
     type_display: ColumnDisplayType = Field(
-        description="Canonical Positron display name of data type"
+        description="Canonical Positron display name of data type",
     )
 
     number_stats: Optional[SummaryStatsNumber] = Field(
-        default=None, description="Statistics for a numeric data type"
+        default=None,
+        description="Statistics for a numeric data type",
     )
 
     string_stats: Optional[SummaryStatsString] = Field(
-        default=None, description="Statistics for a string-like data type"
+        default=None,
+        description="Statistics for a string-like data type",
     )
 
     boolean_stats: Optional[SummaryStatsBoolean] = Field(
-        default=None, description="Statistics for a boolean data type"
+        default=None,
+        description="Statistics for a boolean data type",
     )
 
     date_stats: Optional[SummaryStatsDate] = Field(
-        default=None, description="Statistics for a date data type"
+        default=None,
+        description="Statistics for a date data type",
     )
 
     datetime_stats: Optional[SummaryStatsDatetime] = Field(
-        default=None, description="Statistics for a datetime data type"
+        default=None,
+        description="Statistics for a datetime data type",
     )
 
 
@@ -617,18 +706,29 @@ class SummaryStatsNumber(BaseModel):
     SummaryStatsNumber in Schemas
     """
 
-    min_value: Optional[StrictStr] = Field(default=None, description="Minimum value as string")
+    min_value: Optional[StrictStr] = Field(
+        default=None,
+        description="Minimum value as string",
+    )
 
-    max_value: Optional[StrictStr] = Field(default=None, description="Maximum value as string")
+    max_value: Optional[StrictStr] = Field(
+        default=None,
+        description="Maximum value as string",
+    )
 
-    mean: Optional[StrictStr] = Field(default=None, description="Average value as string")
+    mean: Optional[StrictStr] = Field(
+        default=None,
+        description="Average value as string",
+    )
 
     median: Optional[StrictStr] = Field(
-        default=None, description="Sample median (50% value) value as string"
+        default=None,
+        description="Sample median (50% value) value as string",
     )
 
     stdev: Optional[StrictStr] = Field(
-        default=None, description="Sample standard deviation as a string"
+        default=None,
+        description="Sample standard deviation as a string",
     )
 
 
@@ -637,9 +737,13 @@ class SummaryStatsBoolean(BaseModel):
     SummaryStatsBoolean in Schemas
     """
 
-    true_count: StrictInt = Field(description="The number of non-null true values")
+    true_count: StrictInt = Field(
+        description="The number of non-null true values",
+    )
 
-    false_count: StrictInt = Field(description="The number of non-null false values")
+    false_count: StrictInt = Field(
+        description="The number of non-null false values",
+    )
 
 
 class SummaryStatsString(BaseModel):
@@ -647,9 +751,13 @@ class SummaryStatsString(BaseModel):
     SummaryStatsString in Schemas
     """
 
-    num_empty: StrictInt = Field(description="The number of empty / length-zero values")
+    num_empty: StrictInt = Field(
+        description="The number of empty / length-zero values",
+    )
 
-    num_unique: StrictInt = Field(description="The exact number of distinct values")
+    num_unique: StrictInt = Field(
+        description="The exact number of distinct values",
+    )
 
 
 class SummaryStatsDate(BaseModel):
@@ -658,18 +766,29 @@ class SummaryStatsDate(BaseModel):
     """
 
     num_unique: Optional[StrictInt] = Field(
-        default=None, description="The exact number of distinct values"
+        default=None,
+        description="The exact number of distinct values",
     )
 
-    min_date: Optional[StrictStr] = Field(default=None, description="Minimum date value as string")
+    min_date: Optional[StrictStr] = Field(
+        default=None,
+        description="Minimum date value as string",
+    )
 
-    mean_date: Optional[StrictStr] = Field(default=None, description="Average date value as string")
+    mean_date: Optional[StrictStr] = Field(
+        default=None,
+        description="Average date value as string",
+    )
 
     median_date: Optional[StrictStr] = Field(
-        default=None, description="Sample median (50% value) date value as string"
+        default=None,
+        description="Sample median (50% value) date value as string",
     )
 
-    max_date: Optional[StrictStr] = Field(default=None, description="Maximum date value as string")
+    max_date: Optional[StrictStr] = Field(
+        default=None,
+        description="Maximum date value as string",
+    )
 
 
 class SummaryStatsDatetime(BaseModel):
@@ -678,21 +797,33 @@ class SummaryStatsDatetime(BaseModel):
     """
 
     num_unique: Optional[StrictInt] = Field(
-        default=None, description="The exact number of distinct values"
+        default=None,
+        description="The exact number of distinct values",
     )
 
-    min_date: Optional[StrictStr] = Field(default=None, description="Minimum date value as string")
+    min_date: Optional[StrictStr] = Field(
+        default=None,
+        description="Minimum date value as string",
+    )
 
-    mean_date: Optional[StrictStr] = Field(default=None, description="Average date value as string")
+    mean_date: Optional[StrictStr] = Field(
+        default=None,
+        description="Average date value as string",
+    )
 
     median_date: Optional[StrictStr] = Field(
-        default=None, description="Sample median (50% value) date value as string"
+        default=None,
+        description="Sample median (50% value) date value as string",
     )
 
-    max_date: Optional[StrictStr] = Field(default=None, description="Maximum date value as string")
+    max_date: Optional[StrictStr] = Field(
+        default=None,
+        description="Maximum date value as string",
+    )
 
     timezone: Optional[StrictStr] = Field(
-        default=None, description="Time zone for timestamp with time zone"
+        default=None,
+        description="Time zone for timestamp with time zone",
     )
 
 
@@ -701,9 +832,13 @@ class ColumnHistogramParams(BaseModel):
     Parameters for a column histogram profile request
     """
 
-    method: ColumnHistogramParamsMethod = Field(description="Method for determining number of bins")
+    method: ColumnHistogramParamsMethod = Field(
+        description="Method for determining number of bins",
+    )
 
-    num_bins: StrictInt = Field(description="Maximum number of bins in the computed histogram.")
+    num_bins: StrictInt = Field(
+        description="Maximum number of bins in the computed histogram.",
+    )
 
     quantiles: Optional[List[Union[StrictInt, StrictFloat]]] = Field(
         default=None,
@@ -717,15 +852,15 @@ class ColumnHistogram(BaseModel):
     """
 
     bin_edges: List[StrictStr] = Field(
-        description="String-formatted versions of the bin edges, there are N + 1 where N is the number of bins"
+        description="String-formatted versions of the bin edges, there are N + 1 where N is the number of bins",
     )
 
     bin_counts: List[StrictInt] = Field(
-        description="Absolute count of values in each histogram bin"
+        description="Absolute count of values in each histogram bin",
     )
 
     quantiles: List[ColumnQuantileValue] = Field(
-        description="Sample quantiles that were also requested"
+        description="Sample quantiles that were also requested",
     )
 
 
@@ -735,7 +870,7 @@ class ColumnFrequencyTableParams(BaseModel):
     """
 
     limit: StrictInt = Field(
-        description="Number of most frequently-occurring values to return. The K in TopK"
+        description="Number of most frequently-occurring values to return. The K in TopK",
     )
 
 
@@ -744,9 +879,13 @@ class ColumnFrequencyTable(BaseModel):
     Result from a frequency_table profile request
     """
 
-    values: List[StrictStr] = Field(description="The formatted top values")
+    values: List[StrictStr] = Field(
+        description="The formatted top values",
+    )
 
-    counts: List[StrictInt] = Field(description="Counts of top values")
+    counts: List[StrictInt] = Field(
+        description="Counts of top values",
+    )
 
     other_count: Optional[StrictInt] = Field(
         default=None,
@@ -760,13 +899,15 @@ class ColumnQuantileValue(BaseModel):
     """
 
     q: Union[StrictInt, StrictFloat] = Field(
-        description="Quantile number; a number between 0 and 1"
+        description="Quantile number; a number between 0 and 1",
     )
 
-    value: StrictStr = Field(description="Stringified quantile value")
+    value: StrictStr = Field(
+        description="Stringified quantile value",
+    )
 
     exact: StrictBool = Field(
-        description="Whether value is exact or approximate (computed from binned data or sketches)"
+        description="Whether value is exact or approximate (computed from binned data or sketches)",
     )
 
 
@@ -776,10 +917,12 @@ class ColumnSortKey(BaseModel):
     """
 
     column_index: StrictInt = Field(
-        description="Column index (absolute, relative to unfiltered table) to sort by"
+        description="Column index (absolute, relative to unfiltered table) to sort by",
     )
 
-    ascending: StrictBool = Field(description="Sort order, ascending (true) or descending (false)")
+    ascending: StrictBool = Field(
+        description="Sort order, ascending (true) or descending (false)",
+    )
 
 
 class SupportedFeatures(BaseModel):
@@ -788,27 +931,27 @@ class SupportedFeatures(BaseModel):
     """
 
     search_schema: SearchSchemaFeatures = Field(
-        description="Support for 'search_schema' RPC and its features"
+        description="Support for 'search_schema' RPC and its features",
     )
 
     set_column_filters: SetColumnFiltersFeatures = Field(
-        description="Support ofr 'set_column_filters' RPC and its features"
+        description="Support ofr 'set_column_filters' RPC and its features",
     )
 
     set_row_filters: SetRowFiltersFeatures = Field(
-        description="Support for 'set_row_filters' RPC and its features"
+        description="Support for 'set_row_filters' RPC and its features",
     )
 
     get_column_profiles: GetColumnProfilesFeatures = Field(
-        description="Support for 'get_column_profiles' RPC and its features"
+        description="Support for 'get_column_profiles' RPC and its features",
     )
 
     set_sort_columns: SetSortColumnsFeatures = Field(
-        description="Support for 'set_sort_columns' RPC and its features"
+        description="Support for 'set_sort_columns' RPC and its features",
     )
 
     export_data_selection: ExportDataSelectionFeatures = Field(
-        description="Support for 'export_data_selection' RPC and its features"
+        description="Support for 'export_data_selection' RPC and its features",
     )
 
 
@@ -817,10 +960,12 @@ class SearchSchemaFeatures(BaseModel):
     Feature flags for 'search_schema' RPC
     """
 
-    support_status: SupportStatus = Field(description="The support status for this RPC method")
+    support_status: SupportStatus = Field(
+        description="The support status for this RPC method",
+    )
 
     supported_types: List[ColumnFilterTypeSupportStatus] = Field(
-        description="A list of supported types"
+        description="A list of supported types",
     )
 
 
@@ -829,10 +974,12 @@ class SetColumnFiltersFeatures(BaseModel):
     Feature flags for 'set_column_filters' RPC
     """
 
-    support_status: SupportStatus = Field(description="The support status for this RPC method")
+    support_status: SupportStatus = Field(
+        description="The support status for this RPC method",
+    )
 
     supported_types: List[ColumnFilterTypeSupportStatus] = Field(
-        description="A list of supported types"
+        description="A list of supported types",
     )
 
 
@@ -841,14 +988,16 @@ class SetRowFiltersFeatures(BaseModel):
     Feature flags for 'set_row_filters' RPC
     """
 
-    support_status: SupportStatus = Field(description="The support status for this RPC method")
+    support_status: SupportStatus = Field(
+        description="The support status for this RPC method",
+    )
 
     supports_conditions: SupportStatus = Field(
-        description="Whether AND/OR filter conditions are supported"
+        description="Whether AND/OR filter conditions are supported",
     )
 
     supported_types: List[RowFilterTypeSupportStatus] = Field(
-        description="A list of supported types"
+        description="A list of supported types",
     )
 
 
@@ -857,10 +1006,12 @@ class GetColumnProfilesFeatures(BaseModel):
     Feature flags for 'get_column_profiles' RPC
     """
 
-    support_status: SupportStatus = Field(description="The support status for this RPC method")
+    support_status: SupportStatus = Field(
+        description="The support status for this RPC method",
+    )
 
     supported_types: List[ColumnProfileTypeSupportStatus] = Field(
-        description="A list of supported types"
+        description="A list of supported types",
     )
 
 
@@ -869,9 +1020,13 @@ class ExportDataSelectionFeatures(BaseModel):
     Feature flags for 'export_data_selction' RPC
     """
 
-    support_status: SupportStatus = Field(description="The support status for this RPC method")
+    support_status: SupportStatus = Field(
+        description="The support status for this RPC method",
+    )
 
-    supported_formats: List[ExportFormat] = Field(description="Export formats supported")
+    supported_formats: List[ExportFormat] = Field(
+        description="Export formats supported",
+    )
 
 
 class SetSortColumnsFeatures(BaseModel):
@@ -879,7 +1034,9 @@ class SetSortColumnsFeatures(BaseModel):
     Feature flags for 'set_sort_columns' RPC
     """
 
-    support_status: SupportStatus = Field(description="The support status for this RPC method")
+    support_status: SupportStatus = Field(
+        description="The support status for this RPC method",
+    )
 
 
 class TableSelection(BaseModel):
@@ -889,10 +1046,12 @@ class TableSelection(BaseModel):
     """
 
     kind: TableSelectionKind = Field(
-        description="Type of selection, all indices relative to filtered row/column indices"
+        description="Type of selection, all indices relative to filtered row/column indices",
     )
 
-    selection: Selection = Field(description="A union of selection types")
+    selection: Selection = Field(
+        description="A union of selection types",
+    )
 
 
 class DataSelectionSingleCell(BaseModel):
@@ -900,9 +1059,13 @@ class DataSelectionSingleCell(BaseModel):
     A selection that contains a single data cell
     """
 
-    row_index: StrictInt = Field(description="The selected row index")
+    row_index: StrictInt = Field(
+        description="The selected row index",
+    )
 
-    column_index: StrictInt = Field(description="The selected column index")
+    column_index: StrictInt = Field(
+        description="The selected column index",
+    )
 
 
 class DataSelectionCellRange(BaseModel):
@@ -910,15 +1073,21 @@ class DataSelectionCellRange(BaseModel):
     A selection that contains a rectangular range of data cells
     """
 
-    first_row_index: StrictInt = Field(description="The starting selected row index (inclusive)")
-
-    last_row_index: StrictInt = Field(description="The final selected row index (inclusive)")
-
-    first_column_index: StrictInt = Field(
-        description="The starting selected column index (inclusive)"
+    first_row_index: StrictInt = Field(
+        description="The starting selected row index (inclusive)",
     )
 
-    last_column_index: StrictInt = Field(description="The final selected column index (inclusive)")
+    last_row_index: StrictInt = Field(
+        description="The final selected row index (inclusive)",
+    )
+
+    first_column_index: StrictInt = Field(
+        description="The starting selected column index (inclusive)",
+    )
+
+    last_column_index: StrictInt = Field(
+        description="The final selected column index (inclusive)",
+    )
 
 
 class DataSelectionRange(BaseModel):
@@ -926,9 +1095,13 @@ class DataSelectionRange(BaseModel):
     A contiguous selection bounded by inclusive start and end indices
     """
 
-    first_index: StrictInt = Field(description="The starting selected index (inclusive)")
+    first_index: StrictInt = Field(
+        description="The starting selected index (inclusive)",
+    )
 
-    last_index: StrictInt = Field(description="The final selected index (inclusive)")
+    last_index: StrictInt = Field(
+        description="The final selected index (inclusive)",
+    )
 
 
 class DataSelectionIndices(BaseModel):
@@ -936,7 +1109,9 @@ class DataSelectionIndices(BaseModel):
     A selection defined by a sequence of indices to include
     """
 
-    indices: List[StrictInt] = Field(description="The selected indices")
+    indices: List[StrictInt] = Field(
+        description="The selected indices",
+    )
 
 
 class ColumnSelection(BaseModel):
@@ -945,20 +1120,31 @@ class ColumnSelection(BaseModel):
     """
 
     column_index: StrictInt = Field(
-        description="Column index (relative to unfiltered schema) to select data from"
+        description="Column index (relative to unfiltered schema) to select data from",
     )
 
     spec: ArraySelection = Field(
-        description="Union of selection specifications for array_selection"
+        description="Union of selection specifications for array_selection",
     )
 
 
 # ColumnValue
-ColumnValue = Union[StrictInt, StrictStr]
+ColumnValue = Union[
+    StrictInt,
+    StrictStr,
+]
 # Union of row filter parameters
-RowFilterParams = Union[FilterBetween, FilterComparison, FilterTextSearch, FilterSetMembership]
+RowFilterParams = Union[
+    FilterBetween,
+    FilterComparison,
+    FilterTextSearch,
+    FilterSetMembership,
+]
 # Union of column filter type-specific parameters
-ColumnFilterParams = Union[FilterTextSearch, FilterMatchDataTypes]
+ColumnFilterParams = Union[
+    FilterTextSearch,
+    FilterMatchDataTypes,
+]
 # Extra parameters for different profile types
 ColumnProfileParams = Union[
     ColumnHistogramParams,
@@ -968,10 +1154,16 @@ ColumnProfileParams = Union[
 ]
 # A union of selection types
 Selection = Union[
-    DataSelectionSingleCell, DataSelectionCellRange, DataSelectionRange, DataSelectionIndices
+    DataSelectionSingleCell,
+    DataSelectionCellRange,
+    DataSelectionRange,
+    DataSelectionIndices,
 ]
 # Union of selection specifications for array_selection
-ArraySelection = Union[DataSelectionRange, DataSelectionIndices]
+ArraySelection = Union[
+    DataSelectionRange,
+    DataSelectionIndices,
+]
 
 
 @enum.unique
@@ -1019,7 +1211,9 @@ class OpenDatasetParams(BaseModel):
     Request to open a dataset given a URI
     """
 
-    uri: StrictStr = Field(description="The resource locator or file path")
+    uri: StrictStr = Field(
+        description="The resource locator or file path",
+    )
 
 
 class OpenDatasetRequest(BaseModel):
@@ -1027,13 +1221,18 @@ class OpenDatasetRequest(BaseModel):
     Request to open a dataset given a URI
     """
 
-    params: OpenDatasetParams = Field(description="Parameters to the OpenDataset method")
-
-    method: Literal[DataExplorerBackendRequest.OpenDataset] = Field(
-        description="The JSON-RPC method name (open_dataset)"
+    params: OpenDatasetParams = Field(
+        description="Parameters to the OpenDataset method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[DataExplorerBackendRequest.OpenDataset] = Field(
+        description="The JSON-RPC method name (open_dataset)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class GetSchemaParams(BaseModel):
@@ -1042,7 +1241,7 @@ class GetSchemaParams(BaseModel):
     """
 
     column_indices: List[StrictInt] = Field(
-        description="The column indices (relative to the filtered/selected columns) to fetch"
+        description="The column indices (relative to the filtered/selected columns) to fetch",
     )
 
 
@@ -1051,13 +1250,18 @@ class GetSchemaRequest(BaseModel):
     Request subset of column schemas for a table-like object
     """
 
-    params: GetSchemaParams = Field(description="Parameters to the GetSchema method")
-
-    method: Literal[DataExplorerBackendRequest.GetSchema] = Field(
-        description="The JSON-RPC method name (get_schema)"
+    params: GetSchemaParams = Field(
+        description="Parameters to the GetSchema method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[DataExplorerBackendRequest.GetSchema] = Field(
+        description="The JSON-RPC method name (get_schema)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class SearchSchemaParams(BaseModel):
@@ -1066,14 +1270,16 @@ class SearchSchemaParams(BaseModel):
     more column filters
     """
 
-    filters: List[ColumnFilter] = Field(description="Column filters to apply when searching")
+    filters: List[ColumnFilter] = Field(
+        description="Column filters to apply when searching",
+    )
 
     start_index: StrictInt = Field(
-        description="Index (starting from zero) of first result to fetch (for paging)"
+        description="Index (starting from zero) of first result to fetch (for paging)",
     )
 
     max_results: StrictInt = Field(
-        description="Maximum number of resulting column schemas to fetch from the start index"
+        description="Maximum number of resulting column schemas to fetch from the start index",
     )
 
 
@@ -1083,13 +1289,18 @@ class SearchSchemaRequest(BaseModel):
     more column filters
     """
 
-    params: SearchSchemaParams = Field(description="Parameters to the SearchSchema method")
-
-    method: Literal[DataExplorerBackendRequest.SearchSchema] = Field(
-        description="The JSON-RPC method name (search_schema)"
+    params: SearchSchemaParams = Field(
+        description="Parameters to the SearchSchema method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[DataExplorerBackendRequest.SearchSchema] = Field(
+        description="The JSON-RPC method name (search_schema)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class GetDataValuesParams(BaseModel):
@@ -1097,10 +1308,12 @@ class GetDataValuesParams(BaseModel):
     Request data from table columns with values formatted as strings
     """
 
-    columns: List[ColumnSelection] = Field(description="Array of column selections")
+    columns: List[ColumnSelection] = Field(
+        description="Array of column selections",
+    )
 
     format_options: FormatOptions = Field(
-        description="Formatting options for returning data values as strings"
+        description="Formatting options for returning data values as strings",
     )
 
 
@@ -1109,13 +1322,18 @@ class GetDataValuesRequest(BaseModel):
     Request data from table columns with values formatted as strings
     """
 
-    params: GetDataValuesParams = Field(description="Parameters to the GetDataValues method")
-
-    method: Literal[DataExplorerBackendRequest.GetDataValues] = Field(
-        description="The JSON-RPC method name (get_data_values)"
+    params: GetDataValuesParams = Field(
+        description="Parameters to the GetDataValues method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[DataExplorerBackendRequest.GetDataValues] = Field(
+        description="The JSON-RPC method name (get_data_values)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class GetRowLabelsParams(BaseModel):
@@ -1123,10 +1341,12 @@ class GetRowLabelsParams(BaseModel):
     Request formatted row labels from table
     """
 
-    selection: ArraySelection = Field(description="Selection of row labels")
+    selection: ArraySelection = Field(
+        description="Selection of row labels",
+    )
 
     format_options: FormatOptions = Field(
-        description="Formatting options for returning labels as strings"
+        description="Formatting options for returning labels as strings",
     )
 
 
@@ -1135,13 +1355,18 @@ class GetRowLabelsRequest(BaseModel):
     Request formatted row labels from table
     """
 
-    params: GetRowLabelsParams = Field(description="Parameters to the GetRowLabels method")
-
-    method: Literal[DataExplorerBackendRequest.GetRowLabels] = Field(
-        description="The JSON-RPC method name (get_row_labels)"
+    params: GetRowLabelsParams = Field(
+        description="Parameters to the GetRowLabels method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[DataExplorerBackendRequest.GetRowLabels] = Field(
+        description="The JSON-RPC method name (get_row_labels)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class ExportDataSelectionParams(BaseModel):
@@ -1150,9 +1375,13 @@ class ExportDataSelectionParams(BaseModel):
     HTML
     """
 
-    selection: TableSelection = Field(description="The data selection")
+    selection: TableSelection = Field(
+        description="The data selection",
+    )
 
-    format: ExportFormat = Field(description="Result string format")
+    format: ExportFormat = Field(
+        description="Result string format",
+    )
 
 
 class ExportDataSelectionRequest(BaseModel):
@@ -1162,14 +1391,17 @@ class ExportDataSelectionRequest(BaseModel):
     """
 
     params: ExportDataSelectionParams = Field(
-        description="Parameters to the ExportDataSelection method"
+        description="Parameters to the ExportDataSelection method",
     )
 
     method: Literal[DataExplorerBackendRequest.ExportDataSelection] = Field(
-        description="The JSON-RPC method name (export_data_selection)"
+        description="The JSON-RPC method name (export_data_selection)",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class SetColumnFiltersParams(BaseModel):
@@ -1178,7 +1410,7 @@ class SetColumnFiltersParams(BaseModel):
     """
 
     filters: List[ColumnFilter] = Field(
-        description="Column filters to apply (or pass empty array to clear column filters)"
+        description="Column filters to apply (or pass empty array to clear column filters)",
     )
 
 
@@ -1187,13 +1419,18 @@ class SetColumnFiltersRequest(BaseModel):
     Set or clear column filters on table, replacing any previous filters
     """
 
-    params: SetColumnFiltersParams = Field(description="Parameters to the SetColumnFilters method")
-
-    method: Literal[DataExplorerBackendRequest.SetColumnFilters] = Field(
-        description="The JSON-RPC method name (set_column_filters)"
+    params: SetColumnFiltersParams = Field(
+        description="Parameters to the SetColumnFilters method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[DataExplorerBackendRequest.SetColumnFilters] = Field(
+        description="The JSON-RPC method name (set_column_filters)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class SetRowFiltersParams(BaseModel):
@@ -1201,7 +1438,9 @@ class SetRowFiltersParams(BaseModel):
     Row filters to apply (or pass empty array to clear row filters)
     """
 
-    filters: List[RowFilter] = Field(description="Zero or more filters to apply")
+    filters: List[RowFilter] = Field(
+        description="Zero or more filters to apply",
+    )
 
 
 class SetRowFiltersRequest(BaseModel):
@@ -1209,13 +1448,18 @@ class SetRowFiltersRequest(BaseModel):
     Row filters to apply (or pass empty array to clear row filters)
     """
 
-    params: SetRowFiltersParams = Field(description="Parameters to the SetRowFilters method")
-
-    method: Literal[DataExplorerBackendRequest.SetRowFilters] = Field(
-        description="The JSON-RPC method name (set_row_filters)"
+    params: SetRowFiltersParams = Field(
+        description="Parameters to the SetRowFilters method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[DataExplorerBackendRequest.SetRowFilters] = Field(
+        description="The JSON-RPC method name (set_row_filters)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class SetSortColumnsParams(BaseModel):
@@ -1225,7 +1469,7 @@ class SetSortColumnsParams(BaseModel):
     """
 
     sort_keys: List[ColumnSortKey] = Field(
-        description="Pass zero or more keys to sort by. Clears any existing keys"
+        description="Pass zero or more keys to sort by. Clears any existing keys",
     )
 
 
@@ -1235,13 +1479,18 @@ class SetSortColumnsRequest(BaseModel):
     columns
     """
 
-    params: SetSortColumnsParams = Field(description="Parameters to the SetSortColumns method")
-
-    method: Literal[DataExplorerBackendRequest.SetSortColumns] = Field(
-        description="The JSON-RPC method name (set_sort_columns)"
+    params: SetSortColumnsParams = Field(
+        description="Parameters to the SetSortColumns method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[DataExplorerBackendRequest.SetSortColumns] = Field(
+        description="The JSON-RPC method name (set_sort_columns)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class GetColumnProfilesParams(BaseModel):
@@ -1250,12 +1499,16 @@ class GetColumnProfilesParams(BaseModel):
     columns
     """
 
-    callback_id: StrictStr = Field(description="Async callback unique identifier")
+    callback_id: StrictStr = Field(
+        description="Async callback unique identifier",
+    )
 
-    profiles: List[ColumnProfileRequest] = Field(description="Array of requested profiles")
+    profiles: List[ColumnProfileRequest] = Field(
+        description="Array of requested profiles",
+    )
 
     format_options: FormatOptions = Field(
-        description="Formatting options for returning data values as strings"
+        description="Formatting options for returning data values as strings",
     )
 
 
@@ -1266,14 +1519,17 @@ class GetColumnProfilesRequest(BaseModel):
     """
 
     params: GetColumnProfilesParams = Field(
-        description="Parameters to the GetColumnProfiles method"
+        description="Parameters to the GetColumnProfiles method",
     )
 
     method: Literal[DataExplorerBackendRequest.GetColumnProfiles] = Field(
-        description="The JSON-RPC method name (get_column_profiles)"
+        description="The JSON-RPC method name (get_column_profiles)",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class GetStateRequest(BaseModel):
@@ -1283,10 +1539,13 @@ class GetStateRequest(BaseModel):
     """
 
     method: Literal[DataExplorerBackendRequest.GetState] = Field(
-        description="The JSON-RPC method name (get_state)"
+        description="The JSON-RPC method name (get_state)",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class DataExplorerBackendMessageContent(BaseModel):
@@ -1327,14 +1586,16 @@ class ReturnColumnProfilesParams(BaseModel):
     Return async result of get_column_profiles request
     """
 
-    callback_id: StrictStr = Field(description="Async callback unique identifier")
+    callback_id: StrictStr = Field(
+        description="Async callback unique identifier",
+    )
 
     profiles: List[ColumnProfileResult] = Field(
-        description="Array of individual column profile results"
+        description="Array of individual column profile results",
     )
 
     error_message: Optional[StrictStr] = Field(
-        description="Optional error message if something failed to compute"
+        description="Optional error message if something failed to compute",
     )
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/docstrings/__init__.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/docstrings/__init__.py
@@ -2,7 +2,10 @@
 # Copyright (C) 2023 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
-from .._vendor.docstring_to_markdown.google import google_to_markdown, looks_like_google
+from .._vendor.docstring_to_markdown.google import (
+    google_to_markdown,
+    looks_like_google,
+)
 from .._vendor.docstring_to_markdown.rst import rst_to_markdown
 from .epytext import epytext_to_markdown, looks_like_epytext
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/docstrings/epytext.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/docstrings/epytext.py
@@ -10,7 +10,7 @@ from typing import List
 # from markdown_to_docstring.google.ESCAPE_RULES
 ESCAPE_RULES = {
     # Avoid Markdown in magic methods or filenames like __init__.py
-    r"__(?P<text>\S+)__": r"\_\_\g<text>\_\_",
+    r"__(?P<text>\S+)__": r"\_\_\g<text>\_\_"
 }
 
 EPYTEXT_FIELDS: List[str] = [

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/docstrings/epytext.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/docstrings/epytext.py
@@ -10,7 +10,7 @@ from typing import List
 # from markdown_to_docstring.google.ESCAPE_RULES
 ESCAPE_RULES = {
     # Avoid Markdown in magic methods or filenames like __init__.py
-    r"__(?P<text>\S+)__": r"\_\_\g<text>\_\_"
+    r"__(?P<text>\S+)__": r"\_\_\g<text>\_\_",
 }
 
 EPYTEXT_FIELDS: List[str] = [

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/docstrings/epytext.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/docstrings/epytext.py
@@ -59,7 +59,11 @@ class Section:
         # in either case, we can split on the first " "
         split = name[1:].split(" ", 1)
 
-        self.name = split[0].capitalize() if split[0].endswith(":") else split[0].capitalize() + ":"
+        self.name = (
+            split[0].capitalize()
+            if split[0].endswith(":")
+            else split[0].capitalize() + ":"
+        )
         self.content = ""
 
         # epytext should only ever have 1 arg name per section
@@ -119,7 +123,9 @@ class Section:
                     # --- Start Positron ---
                     # arg and description are on the same line
                     # for epytext docstrings
-                    self.content += "- `{}`: {}".format(arg, description).rstrip()
+                    self.content += "- `{}`: {}".format(
+                        arg, description
+                    ).rstrip()
                     skip_first = True
                 else:
                     self.content += " {}\n".format(arg)
@@ -201,20 +207,22 @@ class EpytextDocstring:
             content = section.content
 
             if name == "Type:":
-                type_sections[section.arg_name] = content.split(f"`{section.arg_name}`: ", 1)[1]
+                type_sections[section.arg_name] = content.split(
+                    f"`{section.arg_name}`: ", 1
+                )[1]
             elif name == "Rtype:":
                 unique_sections[
                     "Return:"
-                ].content = f"({content.rstrip()}) {unique_sections['Return:'].content}"
+                ].content = (
+                    f"({content.rstrip()}) {unique_sections['Return:'].content}"
+                )
             else:
                 matching_type = type_sections.get(str(section.arg_name))
 
                 if matching_type:
                     content_split = content.split(":", 1)
                     # replace the : we split on, add type name, then content
-                    section.content = (
-                        f"- `{section.arg_name}` ({matching_type.rstrip()}):{content_split[1]}"
-                    )
+                    section.content = f"- `{section.arg_name}` ({matching_type.rstrip()}):{content_split[1]}"
                 if name in unique_sections:
                     # Append the description if the section heading is already present
                     unique_sections[name].content += "\n" + section.content

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/help.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/help.py
@@ -67,10 +67,7 @@ class HelpService:
 
     # Not sure why, but some qualified names cause errors in pydoc. Manually replace these with
     # names that are known to work.
-    _QUALNAME_OVERRIDES = {
-        "pandas.core.frame": "pandas",
-        "pandas.core.series": "pandas",
-    }
+    _QUALNAME_OVERRIDES = {"pandas.core.frame": "pandas", "pandas.core.series": "pandas"}
 
     def __init__(self):
         self._comm: Optional[PositronComm] = None

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/help.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/help.py
@@ -57,7 +57,9 @@ def help(topic="help"):
         kernel = PositronIPyKernel.instance()
         kernel.help_service.show_help(topic)
     else:
-        raise Exception("Unexpected error. No PositronIPyKernel has been initialized.")
+        raise Exception(
+            "Unexpected error. No PositronIPyKernel has been initialized."
+        )
 
 
 class HelpService:
@@ -80,7 +82,9 @@ class HelpService:
         self._comm = PositronComm(comm)
         self._comm.on_msg(self.handle_msg, HelpBackendMessageContent)
 
-    def handle_msg(self, msg: CommMessage[HelpBackendMessageContent], raw_msg: JsonRecord) -> None:
+    def handle_msg(
+        self, msg: CommMessage[HelpBackendMessageContent], raw_msg: JsonRecord
+    ) -> None:
         """
         Handle messages received from the client via the positron.help comm.
         """
@@ -112,7 +116,9 @@ class HelpService:
 
     def show_help(self, request: Optional[Union[str, Any]]) -> None:
         if self._pydoc_thread is None or not self._pydoc_thread.serving:
-            logger.warning("Ignoring help request, the pydoc server is not serving")
+            logger.warning(
+                "Ignoring help request, the pydoc server is not serving"
+            )
             return
 
         # Map from the object to the URL for the pydoc server.
@@ -143,4 +149,6 @@ class HelpService:
         # Submit the event to the frontend service
         event = ShowHelpParams(content=url, kind=ShowHelpKind.Url, focus=True)
         if self._comm is not None:
-            self._comm.send_event(name=HelpFrontendEvent.ShowHelp.value, payload=event.dict())
+            self._comm.send_event(
+                name=HelpFrontendEvent.ShowHelp.value, payload=event.dict()
+            )

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/help.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/help.py
@@ -67,7 +67,10 @@ class HelpService:
 
     # Not sure why, but some qualified names cause errors in pydoc. Manually replace these with
     # names that are known to work.
-    _QUALNAME_OVERRIDES = {"pandas.core.frame": "pandas", "pandas.core.series": "pandas"}
+    _QUALNAME_OVERRIDES = {
+        "pandas.core.frame": "pandas",
+        "pandas.core.series": "pandas",
+    }
 
     def __init__(self):
         self._comm: Optional[PositronComm] = None

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/help_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/help_comm.py
@@ -49,7 +49,9 @@ class ShowHelpTopicParams(BaseModel):
     delivered.
     """
 
-    topic: StrictStr = Field(description="The help topic to show")
+    topic: StrictStr = Field(
+        description="The help topic to show",
+    )
 
 
 class ShowHelpTopicRequest(BaseModel):
@@ -60,13 +62,18 @@ class ShowHelpTopicRequest(BaseModel):
     delivered.
     """
 
-    params: ShowHelpTopicParams = Field(description="Parameters to the ShowHelpTopic method")
-
-    method: Literal[HelpBackendRequest.ShowHelpTopic] = Field(
-        description="The JSON-RPC method name (show_help_topic)"
+    params: ShowHelpTopicParams = Field(
+        description="Parameters to the ShowHelpTopic method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[HelpBackendRequest.ShowHelpTopic] = Field(
+        description="The JSON-RPC method name (show_help_topic)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class HelpBackendMessageContent(BaseModel):
@@ -89,12 +96,16 @@ class ShowHelpParams(BaseModel):
     Request to show help in the frontend
     """
 
-    content: StrictStr = Field(description="The help content to show")
+    content: StrictStr = Field(
+        description="The help content to show",
+    )
 
-    kind: ShowHelpKind = Field(description="The type of content to show")
+    kind: ShowHelpKind = Field(
+        description="The type of content to show",
+    )
 
     focus: StrictBool = Field(
-        description="Whether to focus the Help pane when the content is displayed."
+        description="Whether to focus the Help pane when the content is displayed.",
     )
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/help_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/help_comm.py
@@ -49,9 +49,7 @@ class ShowHelpTopicParams(BaseModel):
     delivered.
     """
 
-    topic: StrictStr = Field(
-        description="The help topic to show",
-    )
+    topic: StrictStr = Field(description="The help topic to show")
 
 
 class ShowHelpTopicRequest(BaseModel):
@@ -62,18 +60,13 @@ class ShowHelpTopicRequest(BaseModel):
     delivered.
     """
 
-    params: ShowHelpTopicParams = Field(
-        description="Parameters to the ShowHelpTopic method",
-    )
+    params: ShowHelpTopicParams = Field(description="Parameters to the ShowHelpTopic method")
 
     method: Literal[HelpBackendRequest.ShowHelpTopic] = Field(
-        description="The JSON-RPC method name (show_help_topic)",
+        description="The JSON-RPC method name (show_help_topic)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class HelpBackendMessageContent(BaseModel):
@@ -96,16 +89,12 @@ class ShowHelpParams(BaseModel):
     Request to show help in the frontend
     """
 
-    content: StrictStr = Field(
-        description="The help content to show",
-    )
+    content: StrictStr = Field(description="The help content to show")
 
-    kind: ShowHelpKind = Field(
-        description="The type of content to show",
-    )
+    kind: ShowHelpKind = Field(description="The type of content to show")
 
     focus: StrictBool = Field(
-        description="Whether to focus the Help pane when the content is displayed.",
+        description="Whether to focus the Help pane when the content is displayed."
     )
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/help_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/help_comm.py
@@ -15,7 +15,14 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+from ._vendor.pydantic import (
+    BaseModel,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+)
 
 
 @enum.unique

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -141,10 +141,14 @@ class PositronInspector(Generic[T]):
         return False
 
     def get_child(self, key: Any) -> Any:
-        raise TypeError(f"get_child() is not implemented for type: {type(self.value)}")
+        raise TypeError(
+            f"get_child() is not implemented for type: {type(self.value)}"
+        )
 
     def get_children(self) -> Iterable[Any]:
-        raise TypeError(f"get_children() is not implemented for type: {type(self.value)}")
+        raise TypeError(
+            f"get_children() is not implemented for type: {type(self.value)}"
+        )
 
     def has_viewer(self) -> bool:
         return False
@@ -173,7 +177,9 @@ class PositronInspector(Generic[T]):
         deepcopying, sub-classes must override `deepcopy`.
         """
         if self.is_mutable():
-            raise copy.Error(f"Deepcopying is not supported for type: {type(self.value)}")
+            raise copy.Error(
+                f"Deepcopying is not supported for type: {type(self.value)}"
+            )
         # If the value is immutable, the deepcopy may reference the same value.
         return self.value
 
@@ -200,10 +206,14 @@ class PositronInspector(Generic[T]):
             raise ValueError(f"Expected json_data to be dict, got {json_data}")
 
         if not isinstance(json_data["type"], str):
-            raise ValueError(f"Expected json_data['type'] to be str, got {json_data['type']}")
+            raise ValueError(
+                f"Expected json_data['type'] to be str, got {json_data['type']}"
+            )
 
         # TODO(pyright): cast shouldn't be necessary, recheck in a future version of pyright
-        return cls.value_from_json(cast(str, json_data["type"]), json_data["data"])
+        return cls.value_from_json(
+            cast(str, json_data["type"]), json_data["data"]
+        )
 
     @classmethod
     def value_from_json(cls, type_name: str, data: JsonData) -> T:
@@ -392,7 +402,9 @@ class NumberInspector(PositronInspector[NT], ABC):
         return super().value_to_json()
 
     @classmethod
-    def value_from_json(cls, type_name: str, data: JsonData) -> Union[NT, numbers.Number]:
+    def value_from_json(
+        cls, type_name: str, data: JsonData
+    ) -> Union[NT, numbers.Number]:
         if type_name == "int":
             if not isinstance(data, numbers.Integral):
                 raise ValueError(f"Expected data to be int, got {data}")
@@ -434,7 +446,9 @@ class StringInspector(PositronInspector[str]):
         truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
         # Ignore print_width for strings
-        display_value, is_truncated = super().get_display_value(None, truncate_at)
+        display_value, is_truncated = super().get_display_value(
+            None, truncate_at
+        )
 
         # Use repr() to show quotes around strings
         return repr(display_value), is_truncated
@@ -527,7 +541,9 @@ class _BaseCollectionInspector(PositronInspector[CT], ABC):
     def get_child(self, key: int) -> Any:
         # Don't allow indexing into ranges or sets.
         if isinstance(self.value, (range, Set, FrozenSet)):
-            raise TypeError(f"get_child() is not implemented for type: {type(self.value)}")
+            raise TypeError(
+                f"get_child() is not implemented for type: {type(self.value)}"
+            )
 
         # TODO(pyright): type should be narrowed to exclude frozen set, retry in a future version of pyright
         return self.value[key]  # type: ignore
@@ -583,13 +599,19 @@ class CollectionInspector(_BaseCollectionInspector[CollectionT]):
                 raise ValueError(f"Expected data to be dict, got {data}")
 
             if not isinstance(data["start"], int):
-                raise ValueError(f"Expected data['start'] to be int, got {data['start']}")
+                raise ValueError(
+                    f"Expected data['start'] to be int, got {data['start']}"
+                )
 
             if not isinstance(data["stop"], int):
-                raise ValueError(f"Expected data['stop'] to be int, got {data['stop']}")
+                raise ValueError(
+                    f"Expected data['stop'] to be int, got {data['stop']}"
+                )
 
             if not isinstance(data["step"], int):
-                raise ValueError(f"Expected data['step'] to be int, got {data['step']}")
+                raise ValueError(
+                    f"Expected data['step'] to be int, got {data['step']}"
+                )
 
             # TODO(pyright): cast shouldn't be necessary, recheck in a future version of pyright
             return range(
@@ -908,7 +930,9 @@ class PolarsSeriesInspector(BaseColumnInspector["pl.Series"]):
     def equals(self, value: pl.Series) -> bool:
         try:
             return self.value.equals(value)
-        except AttributeError:  # polars.Series.equals was introduced in v0.19.16
+        except (
+            AttributeError
+        ):  # polars.Series.equals was introduced in v0.19.16
             return self.value.series_equal(value)  # type: ignore
 
     def deepcopy(self) -> pl.Series:
@@ -959,7 +983,9 @@ class BaseTableInspector(_BaseMapInspector[Table], Generic[Table, Column], ABC):
         display_value = _get_class_display(self.value)
         if hasattr(self.value, "shape"):
             shape = self.value.shape
-            display_value = f"[{shape[0]} rows x {shape[1]} columns] {display_value}"
+            display_value = (
+                f"[{shape[0]} rows x {shape[1]} columns] {display_value}"
+            )
 
         return (display_value, True)
 
@@ -1021,7 +1047,9 @@ class PolarsDataFrameInspector(BaseTableInspector["pl.DataFrame", "pl.Series"]):
     def equals(self, value: pl.DataFrame) -> bool:
         try:
             return self.value.equals(value)
-        except AttributeError:  # polars.DataFrame.equals was introduced in v0.19.16
+        except (
+            AttributeError
+        ):  # polars.DataFrame.equals was introduced in v0.19.16
             return self.value.frame_equal(value)  # type: ignore
 
     def deepcopy(self) -> pl.DataFrame:
@@ -1080,18 +1108,26 @@ class SQLAlchemyEngineInspector(BaseConnectionInspector):
 
 
 INSPECTOR_CLASSES: Dict[str, Type[PositronInspector]] = {
-    **dict.fromkeys(PandasDataFrameInspector.CLASS_QNAME, PandasDataFrameInspector),
+    **dict.fromkeys(
+        PandasDataFrameInspector.CLASS_QNAME, PandasDataFrameInspector
+    ),
     **dict.fromkeys(PandasSeriesInspector.CLASS_QNAME, PandasSeriesInspector),
     **dict.fromkeys(PandasIndexInspector.CLASS_QNAME, PandasIndexInspector),
     PandasTimestampInspector.CLASS_QNAME: PandasTimestampInspector,
     **dict.fromkeys(NumpyNumberInspector.CLASS_QNAME, NumpyNumberInspector),
     NumpyNdarrayInspector.CLASS_QNAME: NumpyNdarrayInspector,
     TorchTensorInspector.CLASS_QNAME: TorchTensorInspector,
-    **dict.fromkeys(PolarsDataFrameInspector.CLASS_QNAME, PolarsDataFrameInspector),
+    **dict.fromkeys(
+        PolarsDataFrameInspector.CLASS_QNAME, PolarsDataFrameInspector
+    ),
     **dict.fromkeys(PolarsSeriesInspector.CLASS_QNAME, PolarsSeriesInspector),
     DatetimeInspector.CLASS_QNAME: DatetimeInspector,
-    **dict.fromkeys(SQLiteConnectionInspector.CLASS_QNAME, SQLiteConnectionInspector),
-    **dict.fromkeys(SQLAlchemyEngineInspector.CLASS_QNAME, SQLAlchemyEngineInspector),
+    **dict.fromkeys(
+        SQLiteConnectionInspector.CLASS_QNAME, SQLiteConnectionInspector
+    ),
+    **dict.fromkeys(
+        SQLAlchemyEngineInspector.CLASS_QNAME, SQLAlchemyEngineInspector
+    ),
     "boolean": BooleanInspector,
     "bytes": BytesInspector,
     "class": ClassInspector,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -14,14 +14,7 @@ import re
 import sys
 import types
 from abc import ABC, abstractmethod
-from collections.abc import (
-    Mapping,
-    MutableMapping,
-    MutableSequence,
-    MutableSet,
-    Sequence,
-    Set,
-)
+from collections.abc import Mapping, MutableMapping, MutableSequence, MutableSet, Sequence, Set
 from inspect import getattr_static
 from typing import (
     TYPE_CHECKING,
@@ -107,9 +100,7 @@ class PositronInspector(Generic[T]):
         return str(key)
 
     def get_display_value(
-        self,
-        print_width: Optional[int] = PRINT_WIDTH,
-        truncate_at: int = TRUNCATE_AT,
+        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
     ) -> Tuple[str, bool]:
         return pretty_format(self.value, print_width, truncate_at)
 
@@ -252,9 +243,7 @@ class BytesInspector(PositronInspector[bytes]):
         return super().deepcopy()
 
     def get_display_value(
-        self,
-        print_width: Optional[int] = PRINT_WIDTH,
-        truncate_at: int = TRUNCATE_AT,
+        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
     ) -> Tuple[str, bool]:
         # Ignore print_width for strings
         return super().get_display_value(None, truncate_at)
@@ -335,9 +324,7 @@ class FunctionInspector(PositronInspector[Callable]):
         return False
 
     def get_display_value(
-        self,
-        print_width: Optional[int] = PRINT_WIDTH,
-        truncate_at: int = TRUNCATE_AT,
+        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
     ) -> Tuple[str, bool]:
         if callable(self.value):
             sig = inspect.signature(self.value)
@@ -415,9 +402,7 @@ class NumpyNumberInspector(NumberInspector["np.number"]):
     CLASS_QNAME = numpy_numeric_scalars
 
     def get_display_value(
-        self,
-        print_width: Optional[int] = PRINT_WIDTH,
-        truncate_at: int = TRUNCATE_AT,
+        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
     ) -> Tuple[str, bool]:
         # numpy numbers do not print cleanly as of numpy 2.0
         # use the self.value.item() to retrieve the actual number
@@ -429,9 +414,7 @@ class StringInspector(PositronInspector[str]):
         return False
 
     def get_display_value(
-        self,
-        print_width: Optional[int] = PRINT_WIDTH,
-        truncate_at: int = TRUNCATE_AT,
+        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
     ) -> Tuple[str, bool]:
         # Ignore print_width for strings
         display_value, is_truncated = super().get_display_value(None, truncate_at)
@@ -568,11 +551,7 @@ class CollectionInspector(_BaseCollectionInspector[CollectionT]):
 
     def value_to_json(self) -> JsonData:
         if isinstance(self.value, range):
-            return {
-                "start": self.value.start,
-                "stop": self.value.stop,
-                "step": self.value.step,
-            }
+            return {"start": self.value.start, "stop": self.value.stop, "step": self.value.step}
 
         return super().value_to_json()
 
@@ -592,11 +571,7 @@ class CollectionInspector(_BaseCollectionInspector[CollectionT]):
                 raise ValueError(f"Expected data['step'] to be int, got {data['step']}")
 
             # TODO(pyright): cast shouldn't be necessary, recheck in a future version of pyright
-            return range(
-                cast(int, data["start"]),
-                cast(int, data["stop"]),
-                cast(int, data["step"]),
-            )
+            return range(cast(int, data["start"]), cast(int, data["stop"]), cast(int, data["step"]))
 
         return super().value_from_json(type_name, data)
 
@@ -663,9 +638,7 @@ class NumpyNdarrayInspector(_BaseArrayInspector["np.ndarray"]):
     CLASS_QNAME = "numpy.ndarray"
 
     def get_display_value(
-        self,
-        print_width: Optional[int] = PRINT_WIDTH,
-        truncate_at: int = TRUNCATE_AT,
+        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
     ) -> Tuple[str, bool]:
         return (
             not_none(np_).array2string(
@@ -691,9 +664,7 @@ class TorchTensorInspector(_BaseArrayInspector["torch.Tensor"]):
     CLASS_QNAME = "torch.Tensor"
 
     def get_display_value(
-        self,
-        print_width: Optional[int] = PRINT_WIDTH,
-        truncate_at: int = TRUNCATE_AT,
+        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
     ) -> Tuple[str, bool]:
         # NOTE:
         # Once https://github.com/pytorch/pytorch/commit/e03800a93af55ef61f2e610d65ac7194c0614edc
@@ -744,15 +715,7 @@ class TorchTensorInspector(_BaseArrayInspector["torch.Tensor"]):
 #
 
 
-MT = TypeVar(
-    "MT",
-    Mapping,
-    "pd.DataFrame",
-    "pl.DataFrame",
-    "pd.Series",
-    "pl.Series",
-    "pd.Index",
-)
+MT = TypeVar("MT", Mapping, "pd.DataFrame", "pl.DataFrame", "pd.Series", "pl.Series", "pd.Index")
 
 
 class _BaseMapInspector(PositronInspector[MT], ABC):
@@ -801,9 +764,7 @@ class BaseColumnInspector(_BaseMapInspector[Column], ABC):
         return f"{self.value.dtype} [{self.get_length()}]"
 
     def get_display_value(
-        self,
-        print_width: Optional[int] = PRINT_WIDTH,
-        truncate_at: int = TRUNCATE_AT,
+        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
     ) -> Tuple[str, bool]:
         display_value = _get_class_display(self.value)
         column_values = str(cast(Column, self.value[:100]).to_list())
@@ -821,10 +782,7 @@ class BaseColumnInspector(_BaseMapInspector[Column], ABC):
 
 
 class PandasSeriesInspector(BaseColumnInspector["pd.Series"]):
-    CLASS_QNAME = [
-        "pandas.core.series.Series",
-        "geopandas.geoseries.GeoSeries",
-    ]
+    CLASS_QNAME = ["pandas.core.series.Series", "geopandas.geoseries.GeoSeries"]
 
     def get_display_name(self, key: int) -> str:
         return str(self.value.index[key])
@@ -869,9 +827,7 @@ class PandasIndexInspector(BaseColumnInspector["pd.Index"]):
         return False
 
     def get_display_value(
-        self,
-        print_width: Optional[int] = PRINT_WIDTH,
-        truncate_at: int = TRUNCATE_AT,
+        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
     ) -> Tuple[str, bool]:
         # RangeIndexes don't need to be truncated.
         if isinstance(self.value, not_none(pd_).RangeIndex):
@@ -900,10 +856,7 @@ class PandasIndexInspector(BaseColumnInspector["pd.Index"]):
 
 
 class PolarsSeriesInspector(BaseColumnInspector["pl.Series"]):
-    CLASS_QNAME = [
-        "polars.series.series.Series",
-        "polars.internals.series.series.Series",
-    ]
+    CLASS_QNAME = ["polars.series.series.Series", "polars.internals.series.series.Series"]
 
     def equals(self, value: pl.Series) -> bool:
         try:
@@ -952,9 +905,7 @@ class BaseTableInspector(_BaseMapInspector[Table], Generic[Table, Column], ABC):
         return True
 
     def get_display_value(
-        self,
-        print_width: Optional[int] = PRINT_WIDTH,
-        truncate_at: int = TRUNCATE_AT,
+        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
     ) -> Tuple[str, bool]:
         display_value = _get_class_display(self.value)
         if hasattr(self.value, "shape"):
@@ -970,10 +921,7 @@ class BaseTableInspector(_BaseMapInspector[Table], Generic[Table, Column], ABC):
 
 
 class PandasDataFrameInspector(BaseTableInspector["pd.DataFrame", "pd.Series"]):
-    CLASS_QNAME = [
-        "pandas.core.frame.DataFrame",
-        "geopandas.geodataframe.GeoDataFrame",
-    ]
+    CLASS_QNAME = ["pandas.core.frame.DataFrame", "geopandas.geodataframe.GeoDataFrame"]
 
     def get_display_name(self, key: int) -> str:
         return str(self.value.columns[key])
@@ -1000,18 +948,13 @@ class PandasDataFrameInspector(BaseTableInspector["pd.DataFrame", "pd.Series"]):
 
 
 class PolarsDataFrameInspector(BaseTableInspector["pl.DataFrame", "pl.Series"]):
-    CLASS_QNAME = [
-        "polars.dataframe.frame.DataFrame",
-        "polars.internals.dataframe.frame.DataFrame",
-    ]
+    CLASS_QNAME = ["polars.dataframe.frame.DataFrame", "polars.internals.dataframe.frame.DataFrame"]
 
     def get_children(self):
         return self.value.columns
 
     def get_display_value(
-        self,
-        print_width: Optional[int] = PRINT_WIDTH,
-        truncate_at: int = TRUNCATE_AT,
+        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
     ) -> Tuple[str, bool]:
         qualname = _get_class_display(self.value)
         shape = self.value.shape

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -14,7 +14,14 @@ import re
 import sys
 import types
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, MutableMapping, MutableSequence, MutableSet, Sequence, Set
+from collections.abc import (
+    Mapping,
+    MutableMapping,
+    MutableSequence,
+    MutableSet,
+    Sequence,
+    Set,
+)
 from inspect import getattr_static
 from typing import (
     TYPE_CHECKING,
@@ -100,7 +107,9 @@ class PositronInspector(Generic[T]):
         return str(key)
 
     def get_display_value(
-        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
+        self,
+        print_width: Optional[int] = PRINT_WIDTH,
+        truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
         return pretty_format(self.value, print_width, truncate_at)
 
@@ -243,7 +252,9 @@ class BytesInspector(PositronInspector[bytes]):
         return super().deepcopy()
 
     def get_display_value(
-        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
+        self,
+        print_width: Optional[int] = PRINT_WIDTH,
+        truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
         # Ignore print_width for strings
         return super().get_display_value(None, truncate_at)
@@ -324,7 +335,9 @@ class FunctionInspector(PositronInspector[Callable]):
         return False
 
     def get_display_value(
-        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
+        self,
+        print_width: Optional[int] = PRINT_WIDTH,
+        truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
         if callable(self.value):
             sig = inspect.signature(self.value)
@@ -402,7 +415,9 @@ class NumpyNumberInspector(NumberInspector["np.number"]):
     CLASS_QNAME = numpy_numeric_scalars
 
     def get_display_value(
-        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
+        self,
+        print_width: Optional[int] = PRINT_WIDTH,
+        truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
         # numpy numbers do not print cleanly as of numpy 2.0
         # use the self.value.item() to retrieve the actual number
@@ -414,7 +429,9 @@ class StringInspector(PositronInspector[str]):
         return False
 
     def get_display_value(
-        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
+        self,
+        print_width: Optional[int] = PRINT_WIDTH,
+        truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
         # Ignore print_width for strings
         display_value, is_truncated = super().get_display_value(None, truncate_at)
@@ -551,7 +568,11 @@ class CollectionInspector(_BaseCollectionInspector[CollectionT]):
 
     def value_to_json(self) -> JsonData:
         if isinstance(self.value, range):
-            return {"start": self.value.start, "stop": self.value.stop, "step": self.value.step}
+            return {
+                "start": self.value.start,
+                "stop": self.value.stop,
+                "step": self.value.step,
+            }
 
         return super().value_to_json()
 
@@ -571,7 +592,11 @@ class CollectionInspector(_BaseCollectionInspector[CollectionT]):
                 raise ValueError(f"Expected data['step'] to be int, got {data['step']}")
 
             # TODO(pyright): cast shouldn't be necessary, recheck in a future version of pyright
-            return range(cast(int, data["start"]), cast(int, data["stop"]), cast(int, data["step"]))
+            return range(
+                cast(int, data["start"]),
+                cast(int, data["stop"]),
+                cast(int, data["step"]),
+            )
 
         return super().value_from_json(type_name, data)
 
@@ -638,7 +663,9 @@ class NumpyNdarrayInspector(_BaseArrayInspector["np.ndarray"]):
     CLASS_QNAME = "numpy.ndarray"
 
     def get_display_value(
-        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
+        self,
+        print_width: Optional[int] = PRINT_WIDTH,
+        truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
         return (
             not_none(np_).array2string(
@@ -664,7 +691,9 @@ class TorchTensorInspector(_BaseArrayInspector["torch.Tensor"]):
     CLASS_QNAME = "torch.Tensor"
 
     def get_display_value(
-        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
+        self,
+        print_width: Optional[int] = PRINT_WIDTH,
+        truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
         # NOTE:
         # Once https://github.com/pytorch/pytorch/commit/e03800a93af55ef61f2e610d65ac7194c0614edc
@@ -715,7 +744,15 @@ class TorchTensorInspector(_BaseArrayInspector["torch.Tensor"]):
 #
 
 
-MT = TypeVar("MT", Mapping, "pd.DataFrame", "pl.DataFrame", "pd.Series", "pl.Series", "pd.Index")
+MT = TypeVar(
+    "MT",
+    Mapping,
+    "pd.DataFrame",
+    "pl.DataFrame",
+    "pd.Series",
+    "pl.Series",
+    "pd.Index",
+)
 
 
 class _BaseMapInspector(PositronInspector[MT], ABC):
@@ -764,7 +801,9 @@ class BaseColumnInspector(_BaseMapInspector[Column], ABC):
         return f"{self.value.dtype} [{self.get_length()}]"
 
     def get_display_value(
-        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
+        self,
+        print_width: Optional[int] = PRINT_WIDTH,
+        truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
         display_value = _get_class_display(self.value)
         column_values = str(cast(Column, self.value[:100]).to_list())
@@ -782,7 +821,10 @@ class BaseColumnInspector(_BaseMapInspector[Column], ABC):
 
 
 class PandasSeriesInspector(BaseColumnInspector["pd.Series"]):
-    CLASS_QNAME = ["pandas.core.series.Series", "geopandas.geoseries.GeoSeries"]
+    CLASS_QNAME = [
+        "pandas.core.series.Series",
+        "geopandas.geoseries.GeoSeries",
+    ]
 
     def get_display_name(self, key: int) -> str:
         return str(self.value.index[key])
@@ -827,7 +869,9 @@ class PandasIndexInspector(BaseColumnInspector["pd.Index"]):
         return False
 
     def get_display_value(
-        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
+        self,
+        print_width: Optional[int] = PRINT_WIDTH,
+        truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
         # RangeIndexes don't need to be truncated.
         if isinstance(self.value, not_none(pd_).RangeIndex):
@@ -856,7 +900,10 @@ class PandasIndexInspector(BaseColumnInspector["pd.Index"]):
 
 
 class PolarsSeriesInspector(BaseColumnInspector["pl.Series"]):
-    CLASS_QNAME = ["polars.series.series.Series", "polars.internals.series.series.Series"]
+    CLASS_QNAME = [
+        "polars.series.series.Series",
+        "polars.internals.series.series.Series",
+    ]
 
     def equals(self, value: pl.Series) -> bool:
         try:
@@ -905,7 +952,9 @@ class BaseTableInspector(_BaseMapInspector[Table], Generic[Table, Column], ABC):
         return True
 
     def get_display_value(
-        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
+        self,
+        print_width: Optional[int] = PRINT_WIDTH,
+        truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
         display_value = _get_class_display(self.value)
         if hasattr(self.value, "shape"):
@@ -921,7 +970,10 @@ class BaseTableInspector(_BaseMapInspector[Table], Generic[Table, Column], ABC):
 
 
 class PandasDataFrameInspector(BaseTableInspector["pd.DataFrame", "pd.Series"]):
-    CLASS_QNAME = ["pandas.core.frame.DataFrame", "geopandas.geodataframe.GeoDataFrame"]
+    CLASS_QNAME = [
+        "pandas.core.frame.DataFrame",
+        "geopandas.geodataframe.GeoDataFrame",
+    ]
 
     def get_display_name(self, key: int) -> str:
         return str(self.value.columns[key])
@@ -948,13 +1000,18 @@ class PandasDataFrameInspector(BaseTableInspector["pd.DataFrame", "pd.Series"]):
 
 
 class PolarsDataFrameInspector(BaseTableInspector["pl.DataFrame", "pl.Series"]):
-    CLASS_QNAME = ["polars.dataframe.frame.DataFrame", "polars.internals.dataframe.frame.DataFrame"]
+    CLASS_QNAME = [
+        "polars.dataframe.frame.DataFrame",
+        "polars.internals.dataframe.frame.DataFrame",
+    ]
 
     def get_children(self):
         return self.value.columns
 
     def get_display_value(
-        self, print_width: Optional[int] = PRINT_WIDTH, truncate_at: int = TRUNCATE_AT
+        self,
+        print_width: Optional[int] = PRINT_WIDTH,
+        truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
         qualname = _get_class_display(self.value)
         shape = self.value.shape

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/jedi.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/jedi.py
@@ -16,6 +16,7 @@ from ._vendor.jedi.api.completion import (
 from ._vendor.jedi.api.completion import (
     _extract_string_while_in_string,
     _remove_duplicates,
+    extract_imported_names,
     filter_names,
 )
 from ._vendor.jedi.api.file_name import complete_file_name

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/jedi.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/jedi.py
@@ -8,7 +8,9 @@ from typing import Any, Tuple
 from ._vendor.jedi import cache, debug
 from ._vendor.jedi.api import Interpreter
 from ._vendor.jedi.api.classes import Completion
-from ._vendor.jedi.api.completion import Completion as CompletionAPI
+from ._vendor.jedi.api.completion import (
+    Completion as CompletionAPI,
+)
 
 # Rename to avoid conflict with classes.Completion
 from ._vendor.jedi.api.completion import (
@@ -91,7 +93,10 @@ class PositronInterpreter(Interpreter):
         )
         # --- Start Positron ---
         # Use our custom module context class.
-        return PositronMixedModuleContext(tree_module_value, self.namespaces)
+        return PositronMixedModuleContext(
+            tree_module_value,
+            self.namespaces,
+        )
         # --- End Positron ---
 
     def complete(self, line=None, column=None, *, fuzzy=False):
@@ -283,7 +288,11 @@ def _completions_for_dicts(inference_state, dicts, literal_string, cut_end_quote
     for name in sorted(_get_python_keys(inference_state, dicts), key=lambda x: repr(x.string_name)):
         # --- End Positron ---
         yield Completion(
-            inference_state, name, stack=None, like_name_length=len(literal_string), is_fuzzy=fuzzy
+            inference_state,
+            name,
+            stack=None,
+            like_name_length=len(literal_string),
+            is_fuzzy=fuzzy,
         )
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/jedi.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/jedi.py
@@ -122,7 +122,9 @@ class PositronCompletion(CompletionAPI):
         leaf = self._module_node.get_leaf_for_position(
             self._original_position, include_prefixes=True
         )
-        string, start_leaf, quote = _extract_string_while_in_string(leaf, self._original_position)
+        string, start_leaf, quote = _extract_string_while_in_string(
+            leaf, self._original_position
+        )
 
         prefixed_completions = complete_dict(
             self._module_context,
@@ -151,13 +153,18 @@ class PositronCompletion(CompletionAPI):
         if string is not None:
             if not prefixed_completions and "\n" in string:
                 # Complete only multi line strings
-                prefixed_completions = self._complete_in_string(start_leaf, string)
+                prefixed_completions = self._complete_in_string(
+                    start_leaf, string
+                )
             return prefixed_completions
 
         cached_name, completion_names = self._complete_python(leaf)
 
         imported_names = []
-        if leaf.parent is not None and leaf.parent.type in ["import_as_names", "dotted_as_names"]:
+        if leaf.parent is not None and leaf.parent.type in [
+            "import_as_names",
+            "dotted_as_names",
+        ]:
             imported_names.extend(extract_imported_names(leaf.parent))  # type: ignore
 
         completions = list(
@@ -255,7 +262,9 @@ def complete_dict(module_context, code_lines, leaf, position, string, fuzzy):
 
     cut_end_quote = ""
     if string:
-        cut_end_quote = get_quote_ending(string, code_lines, position, invert_result=True)
+        cut_end_quote = get_quote_ending(
+            string, code_lines, position, invert_result=True
+        )
 
     if bracket_leaf == "[":
         if string is None and leaf is not bracket_leaf:
@@ -281,11 +290,16 @@ def complete_dict(module_context, code_lines, leaf, position, string, fuzzy):
 
 
 # Adapted from jedi.api.strings._completions_for_dicts.
-def _completions_for_dicts(inference_state, dicts, literal_string, cut_end_quote, fuzzy):
+def _completions_for_dicts(
+    inference_state, dicts, literal_string, cut_end_quote, fuzzy
+):
     # --- Start Positron ---
     # Since we've modified _get_python_keys to return Names, sort by yielded value's string_name
     # instead of the yielded value itself.
-    for name in sorted(_get_python_keys(inference_state, dicts), key=lambda x: repr(x.string_name)):
+    for name in sorted(
+        _get_python_keys(inference_state, dicts),
+        key=lambda x: repr(x.string_name),
+    ):
         # --- End Positron ---
         yield Completion(
             inference_state,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/jedi.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/jedi.py
@@ -8,9 +8,7 @@ from typing import Any, Tuple
 from ._vendor.jedi import cache, debug
 from ._vendor.jedi.api import Interpreter
 from ._vendor.jedi.api.classes import Completion
-from ._vendor.jedi.api.completion import (
-    Completion as CompletionAPI,
-)
+from ._vendor.jedi.api.completion import Completion as CompletionAPI
 
 # Rename to avoid conflict with classes.Completion
 from ._vendor.jedi.api.completion import (
@@ -93,10 +91,7 @@ class PositronInterpreter(Interpreter):
         )
         # --- Start Positron ---
         # Use our custom module context class.
-        return PositronMixedModuleContext(
-            tree_module_value,
-            self.namespaces,
-        )
+        return PositronMixedModuleContext(tree_module_value, self.namespaces)
         # --- End Positron ---
 
     def complete(self, line=None, column=None, *, fuzzy=False):
@@ -288,11 +283,7 @@ def _completions_for_dicts(inference_state, dicts, literal_string, cut_end_quote
     for name in sorted(_get_python_keys(inference_state, dicts), key=lambda x: repr(x.string_name)):
         # --- End Positron ---
         yield Completion(
-            inference_state,
-            name,
-            stack=None,
-            like_name_length=len(literal_string),
-            is_fuzzy=fuzzy,
+            inference_state, name, stack=None, like_name_length=len(literal_string), is_fuzzy=fuzzy
         )
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/lsp.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/lsp.py
@@ -45,11 +45,15 @@ class LSPService:
 
         host, port = self._split_address(client_address)
         if host is None or port is None:
-            logger.warning(f"Could not parse host and port from client address: {client_address}")
+            logger.warning(
+                f"Could not parse host and port from client address: {client_address}"
+            )
             return
 
         # Start the language server thread
-        POSITRON.start(lsp_host=host, lsp_port=port, shell=self._kernel.shell, comm=comm)
+        POSITRON.start(
+            lsp_host=host, lsp_port=port, shell=self._kernel.shell, comm=comm
+        )
 
     def _receive_message(self, msg: Dict[str, Any]) -> None:
         """
@@ -67,7 +71,9 @@ class LSPService:
             except Exception:
                 pass
 
-    def _split_address(self, client_address: str) -> Tuple[Optional[str], Optional[int]]:
+    def _split_address(
+        self, client_address: str
+    ) -> Tuple[Optional[str], Optional[int]]:
         """
         Split an address of the form "host:port" into a tuple of (host, port).
         """

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/matplotlib_backend.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/matplotlib_backend.py
@@ -189,10 +189,7 @@ class FigureCanvasPositron(FigureCanvasAgg):
         # Render the canvas.
         with io.BytesIO() as figure_buffer:
             self.print_figure(
-                figure_buffer,
-                format=format,
-                dpi=self.figure.dpi,
-                bbox_inches=bbox_inches,
+                figure_buffer, format=format, dpi=self.figure.dpi, bbox_inches=bbox_inches
             )
             rendered = figure_buffer.getvalue()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/matplotlib_backend.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/matplotlib_backend.py
@@ -61,8 +61,12 @@ class FigureManagerPositron(FigureManagerBase):
         super().__init__(canvas, num)
 
         # Create the plot instance via the plots service.
-        self._plots_service = cast(PositronIPyKernel, PositronIPyKernel.instance()).plots_service
-        self._plot = self._plots_service.create_plot(canvas.render, canvas.intrinsic_size)
+        self._plots_service = cast(
+            PositronIPyKernel, PositronIPyKernel.instance()
+        ).plots_service
+        self._plot = self._plots_service.create_plot(
+            canvas.render, canvas.intrinsic_size
+        )
 
     @property
     def closed(self) -> bool:
@@ -159,7 +163,9 @@ class FigureCanvasPositron(FigureCanvasAgg):
             logger.debug("Canvas: hash changed, requesting an update")
             self.manager.update()
 
-    def render(self, size: Optional[PlotSize], pixel_ratio: float, format: str) -> bytes:
+    def render(
+        self, size: Optional[PlotSize], pixel_ratio: float, format: str
+    ) -> bytes:
         # Set the device pixel ratio to the requested value.
         self._set_device_pixel_ratio(pixel_ratio)  # type: ignore
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/matplotlib_backend.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/matplotlib_backend.py
@@ -189,7 +189,10 @@ class FigureCanvasPositron(FigureCanvasAgg):
         # Render the canvas.
         with io.BytesIO() as figure_buffer:
             self.print_figure(
-                figure_buffer, format=format, dpi=self.figure.dpi, bbox_inches=bbox_inches
+                figure_buffer,
+                format=format,
+                dpi=self.figure.dpi,
+                bbox_inches=bbox_inches,
             )
             rendered = figure_buffer.getvalue()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/patch/holoviews.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/patch/holoviews.py
@@ -25,7 +25,9 @@ def set_holoviews_extension(ui_service: UiService) -> None:
     else:
         if holoviews.extension == holoviews.ipython.notebook_extension:
 
-            class positron_notebook_extension(holoviews.ipython.notebook_extension):
+            class positron_notebook_extension(
+                holoviews.ipython.notebook_extension
+            ):
                 """
                 Custom notebook extension for HoloViews that notifies the frontend
                 of new extension loads.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
@@ -51,21 +51,13 @@ class IntrinsicSize(BaseModel):
     The intrinsic size of a plot, if known
     """
 
-    width: Union[StrictInt, StrictFloat] = Field(
-        description="The width of the plot",
-    )
+    width: Union[StrictInt, StrictFloat] = Field(description="The width of the plot")
 
-    height: Union[StrictInt, StrictFloat] = Field(
-        description="The height of the plot",
-    )
+    height: Union[StrictInt, StrictFloat] = Field(description="The height of the plot")
 
-    unit: PlotUnit = Field(
-        description="The unit of measurement of the plot's dimensions",
-    )
+    unit: PlotUnit = Field(description="The unit of measurement of the plot's dimensions")
 
-    source: StrictStr = Field(
-        description="The source of the intrinsic size e.g. 'Matplotlib'",
-    )
+    source: StrictStr = Field(description="The source of the intrinsic size e.g. 'Matplotlib'")
 
 
 class PlotResult(BaseModel):
@@ -73,13 +65,9 @@ class PlotResult(BaseModel):
     A rendered plot
     """
 
-    data: StrictStr = Field(
-        description="The plot data, as a base64-encoded string",
-    )
+    data: StrictStr = Field(description="The plot data, as a base64-encoded string")
 
-    mime_type: StrictStr = Field(
-        description="The MIME type of the plot data",
-    )
+    mime_type: StrictStr = Field(description="The MIME type of the plot data")
 
 
 class PlotSize(BaseModel):
@@ -87,13 +75,9 @@ class PlotSize(BaseModel):
     The size of a plot
     """
 
-    height: StrictInt = Field(
-        description="The plot's height, in pixels",
-    )
+    height: StrictInt = Field(description="The plot's height, in pixels")
 
-    width: StrictInt = Field(
-        description="The plot's width, in pixels",
-    )
+    width: StrictInt = Field(description="The plot's width, in pixels")
 
 
 @enum.unique
@@ -116,13 +100,10 @@ class GetIntrinsicSizeRequest(BaseModel):
     """
 
     method: Literal[PlotBackendRequest.GetIntrinsicSize] = Field(
-        description="The JSON-RPC method name (get_intrinsic_size)",
+        description="The JSON-RPC method name (get_intrinsic_size)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class RenderParams(BaseModel):
@@ -137,12 +118,10 @@ class RenderParams(BaseModel):
     )
 
     pixel_ratio: Union[StrictInt, StrictFloat] = Field(
-        description="The pixel ratio of the display device",
+        description="The pixel ratio of the display device"
     )
 
-    format: RenderFormat = Field(
-        description="The requested plot format",
-    )
+    format: RenderFormat = Field(description="The requested plot format")
 
 
 class RenderRequest(BaseModel):
@@ -151,26 +130,18 @@ class RenderRequest(BaseModel):
     base64-encoded string.
     """
 
-    params: RenderParams = Field(
-        description="Parameters to the Render method",
-    )
+    params: RenderParams = Field(description="Parameters to the Render method")
 
     method: Literal[PlotBackendRequest.Render] = Field(
-        description="The JSON-RPC method name (render)",
+        description="The JSON-RPC method name (render)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class PlotBackendMessageContent(BaseModel):
     comm_id: str
-    data: Union[
-        GetIntrinsicSizeRequest,
-        RenderRequest,
-    ] = Field(..., discriminator="method")
+    data: Union[GetIntrinsicSizeRequest, RenderRequest] = Field(..., discriminator="method")
 
 
 @enum.unique

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
@@ -15,7 +15,14 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+from ._vendor.pydantic import (
+    BaseModel,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+)
 
 
 @enum.unique

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plot_comm.py
@@ -51,13 +51,21 @@ class IntrinsicSize(BaseModel):
     The intrinsic size of a plot, if known
     """
 
-    width: Union[StrictInt, StrictFloat] = Field(description="The width of the plot")
+    width: Union[StrictInt, StrictFloat] = Field(
+        description="The width of the plot",
+    )
 
-    height: Union[StrictInt, StrictFloat] = Field(description="The height of the plot")
+    height: Union[StrictInt, StrictFloat] = Field(
+        description="The height of the plot",
+    )
 
-    unit: PlotUnit = Field(description="The unit of measurement of the plot's dimensions")
+    unit: PlotUnit = Field(
+        description="The unit of measurement of the plot's dimensions",
+    )
 
-    source: StrictStr = Field(description="The source of the intrinsic size e.g. 'Matplotlib'")
+    source: StrictStr = Field(
+        description="The source of the intrinsic size e.g. 'Matplotlib'",
+    )
 
 
 class PlotResult(BaseModel):
@@ -65,9 +73,13 @@ class PlotResult(BaseModel):
     A rendered plot
     """
 
-    data: StrictStr = Field(description="The plot data, as a base64-encoded string")
+    data: StrictStr = Field(
+        description="The plot data, as a base64-encoded string",
+    )
 
-    mime_type: StrictStr = Field(description="The MIME type of the plot data")
+    mime_type: StrictStr = Field(
+        description="The MIME type of the plot data",
+    )
 
 
 class PlotSize(BaseModel):
@@ -75,9 +87,13 @@ class PlotSize(BaseModel):
     The size of a plot
     """
 
-    height: StrictInt = Field(description="The plot's height, in pixels")
+    height: StrictInt = Field(
+        description="The plot's height, in pixels",
+    )
 
-    width: StrictInt = Field(description="The plot's width, in pixels")
+    width: StrictInt = Field(
+        description="The plot's width, in pixels",
+    )
 
 
 @enum.unique
@@ -100,10 +116,13 @@ class GetIntrinsicSizeRequest(BaseModel):
     """
 
     method: Literal[PlotBackendRequest.GetIntrinsicSize] = Field(
-        description="The JSON-RPC method name (get_intrinsic_size)"
+        description="The JSON-RPC method name (get_intrinsic_size)",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class RenderParams(BaseModel):
@@ -118,10 +137,12 @@ class RenderParams(BaseModel):
     )
 
     pixel_ratio: Union[StrictInt, StrictFloat] = Field(
-        description="The pixel ratio of the display device"
+        description="The pixel ratio of the display device",
     )
 
-    format: RenderFormat = Field(description="The requested plot format")
+    format: RenderFormat = Field(
+        description="The requested plot format",
+    )
 
 
 class RenderRequest(BaseModel):
@@ -130,18 +151,26 @@ class RenderRequest(BaseModel):
     base64-encoded string.
     """
 
-    params: RenderParams = Field(description="Parameters to the Render method")
-
-    method: Literal[PlotBackendRequest.Render] = Field(
-        description="The JSON-RPC method name (render)"
+    params: RenderParams = Field(
+        description="Parameters to the Render method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[PlotBackendRequest.Render] = Field(
+        description="The JSON-RPC method name (render)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class PlotBackendMessageContent(BaseModel):
     comm_id: str
-    data: Union[GetIntrinsicSizeRequest, RenderRequest] = Field(..., discriminator="method")
+    data: Union[
+        GetIntrinsicSizeRequest,
+        RenderRequest,
+    ] = Field(..., discriminator="method")
 
 
 @enum.unique

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
@@ -51,7 +51,10 @@ class Plot:
     """
 
     def __init__(
-        self, comm: PositronComm, render: Renderer, intrinsic_size: Tuple[int, int]
+        self,
+        comm: PositronComm,
+        render: Renderer,
+        intrinsic_size: Tuple[int, int],
     ) -> None:
         self._comm = comm
         self._render = render
@@ -112,14 +115,21 @@ class Plot:
         request = msg.content.data
         if isinstance(request, RenderRequest):
             self._handle_render(
-                request.params.size, request.params.pixel_ratio, request.params.format
+                request.params.size,
+                request.params.pixel_ratio,
+                request.params.format,
             )
         elif isinstance(request, GetIntrinsicSizeRequest):
             self._handle_get_intrinsic_size()
         else:
             logger.warning(f"Unhandled request: {request}")
 
-    def _handle_render(self, size: Optional[PlotSize], pixel_ratio: float, format: str) -> None:
+    def _handle_render(
+        self,
+        size: Optional[PlotSize],
+        pixel_ratio: float,
+        format: str,
+    ) -> None:
         rendered = self._render(size, pixel_ratio, format)
         data = base64.b64encode(rendered).decode()
         result = PlotResult(data=data, mime_type=MIME_TYPE[format]).dict()

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
@@ -111,7 +111,9 @@ class Plot:
         else:
             self._comm.send_event(PlotFrontendEvent.Update, {})
 
-    def _handle_msg(self, msg: CommMessage[PlotBackendMessageContent], raw_msg: JsonRecord) -> None:
+    def _handle_msg(
+        self, msg: CommMessage[PlotBackendMessageContent], raw_msg: JsonRecord
+    ) -> None:
         request = msg.content.data
         if isinstance(request, RenderRequest):
             self._handle_render(
@@ -156,7 +158,9 @@ class Renderer(Protocol):
     A callable that renders a plot. See `plot_comm.RenderRequest` for parameter details.
     """
 
-    def __call__(self, size: Optional[PlotSize], pixel_ratio: float, format: str) -> bytes: ...
+    def __call__(
+        self, size: Optional[PlotSize], pixel_ratio: float, format: str
+    ) -> bytes: ...
 
 
 class PlotsService:
@@ -177,7 +181,9 @@ class PlotsService:
 
         self._plots: List[Plot] = []
 
-    def create_plot(self, render: Renderer, intrinsic_size: Tuple[int, int]) -> Plot:
+    def create_plot(
+        self, render: Renderer, intrinsic_size: Tuple[int, int]
+    ) -> Plot:
         """
         Create a plot.
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/plots.py
@@ -51,10 +51,7 @@ class Plot:
     """
 
     def __init__(
-        self,
-        comm: PositronComm,
-        render: Renderer,
-        intrinsic_size: Tuple[int, int],
+        self, comm: PositronComm, render: Renderer, intrinsic_size: Tuple[int, int]
     ) -> None:
         self._comm = comm
         self._render = render
@@ -115,21 +112,14 @@ class Plot:
         request = msg.content.data
         if isinstance(request, RenderRequest):
             self._handle_render(
-                request.params.size,
-                request.params.pixel_ratio,
-                request.params.format,
+                request.params.size, request.params.pixel_ratio, request.params.format
             )
         elif isinstance(request, GetIntrinsicSizeRequest):
             self._handle_get_intrinsic_size()
         else:
             logger.warning(f"Unhandled request: {request}")
 
-    def _handle_render(
-        self,
-        size: Optional[PlotSize],
-        pixel_ratio: float,
-        format: str,
-    ) -> None:
+    def _handle_render(self, size: Optional[PlotSize], pixel_ratio: float, format: str) -> None:
         rendered = self._render(size, pixel_ratio, format)
         data = base64.b64encode(rendered).decode()
         result = PlotResult(data=data, mime_type=MIME_TYPE[format]).dict()

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_comm.py
@@ -12,7 +12,14 @@ from typing import Callable, Generic, Optional, Type, TypeVar
 
 import comm
 
-from . import connections_comm, data_explorer_comm, help_comm, plot_comm, ui_comm, variables_comm
+from . import (
+    connections_comm,
+    data_explorer_comm,
+    help_comm,
+    plot_comm,
+    ui_comm,
+    variables_comm,
+)
 from ._vendor.pydantic import ValidationError
 from ._vendor.pydantic.generics import GenericModel
 from .utils import JsonData, JsonRecord
@@ -138,7 +145,9 @@ class PositronComm:
             The Pydantic model to parse the message with.
         """
 
-        def _handle_msg(raw_msg: JsonRecord) -> None:
+        def _handle_msg(
+            raw_msg: JsonRecord,
+        ) -> None:
             try:
                 comm_msg = CommMessage[content_cls].parse_obj(raw_msg)
             except ValidationError as exception:
@@ -154,7 +163,8 @@ class PositronComm:
                     ):
                         method = error["ctx"]["discriminator_value"]
                         self.send_error(
-                            JsonRpcErrorCode.METHOD_NOT_FOUND, f"Unknown method '{method}'"
+                            JsonRpcErrorCode.METHOD_NOT_FOUND,
+                            f"Unknown method '{method}'",
                         )
                         return
 
@@ -165,11 +175,15 @@ class PositronComm:
                     ):
                         method = error["ctx"]["given"]
                         self.send_error(
-                            JsonRpcErrorCode.METHOD_NOT_FOUND, f"Unknown method '{method}'"
+                            JsonRpcErrorCode.METHOD_NOT_FOUND,
+                            f"Unknown method '{method}'",
                         )
                         return
 
-                self.send_error(JsonRpcErrorCode.INVALID_REQUEST, f"Invalid request: {exception}")
+                self.send_error(
+                    JsonRpcErrorCode.INVALID_REQUEST,
+                    f"Invalid request: {exception}",
+                )
                 return
 
             callback(comm_msg, raw_msg)
@@ -209,8 +223,15 @@ class PositronComm:
         metadata
             The metadata to send with the result.
         """
-        result = dict(jsonrpc="2.0", result=data)
-        self.comm.send(data=result, metadata=metadata, buffers=None)
+        result = dict(
+            jsonrpc="2.0",
+            result=data,
+        )
+        self.comm.send(
+            data=result,
+            metadata=metadata,
+            buffers=None,
+        )
 
     def send_event(self, name: str, payload: JsonRecord) -> None:
         """
@@ -223,7 +244,11 @@ class PositronComm:
         payload
             The payload of the event.
         """
-        event = dict(jsonrpc="2.0", method=name, params=payload)
+        event = dict(
+            jsonrpc="2.0",
+            method=name,
+            params=payload,
+        )
         with self.send_lock:
             self.comm.send(data=event)
 
@@ -238,8 +263,18 @@ class PositronComm:
         message
             The error message to send.
         """
-        error = dict(jsonrpc="2.0", error=dict(code=code.value, message=message))
-        self.comm.send(data=error, metadata=None, buffers=None)
+        error = dict(
+            jsonrpc="2.0",
+            error=dict(
+                code=code.value,
+                message=message,
+            ),
+        )
+        self.comm.send(
+            data=error,
+            metadata=None,
+            buffers=None,
+        )
 
     def close(self) -> None:
         """

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_comm.py
@@ -12,14 +12,7 @@ from typing import Callable, Generic, Optional, Type, TypeVar
 
 import comm
 
-from . import (
-    connections_comm,
-    data_explorer_comm,
-    help_comm,
-    plot_comm,
-    ui_comm,
-    variables_comm,
-)
+from . import connections_comm, data_explorer_comm, help_comm, plot_comm, ui_comm, variables_comm
 from ._vendor.pydantic import ValidationError
 from ._vendor.pydantic.generics import GenericModel
 from .utils import JsonData, JsonRecord
@@ -145,9 +138,7 @@ class PositronComm:
             The Pydantic model to parse the message with.
         """
 
-        def _handle_msg(
-            raw_msg: JsonRecord,
-        ) -> None:
+        def _handle_msg(raw_msg: JsonRecord) -> None:
             try:
                 comm_msg = CommMessage[content_cls].parse_obj(raw_msg)
             except ValidationError as exception:
@@ -163,8 +154,7 @@ class PositronComm:
                     ):
                         method = error["ctx"]["discriminator_value"]
                         self.send_error(
-                            JsonRpcErrorCode.METHOD_NOT_FOUND,
-                            f"Unknown method '{method}'",
+                            JsonRpcErrorCode.METHOD_NOT_FOUND, f"Unknown method '{method}'"
                         )
                         return
 
@@ -175,15 +165,11 @@ class PositronComm:
                     ):
                         method = error["ctx"]["given"]
                         self.send_error(
-                            JsonRpcErrorCode.METHOD_NOT_FOUND,
-                            f"Unknown method '{method}'",
+                            JsonRpcErrorCode.METHOD_NOT_FOUND, f"Unknown method '{method}'"
                         )
                         return
 
-                self.send_error(
-                    JsonRpcErrorCode.INVALID_REQUEST,
-                    f"Invalid request: {exception}",
-                )
+                self.send_error(JsonRpcErrorCode.INVALID_REQUEST, f"Invalid request: {exception}")
                 return
 
             callback(comm_msg, raw_msg)
@@ -223,15 +209,8 @@ class PositronComm:
         metadata
             The metadata to send with the result.
         """
-        result = dict(
-            jsonrpc="2.0",
-            result=data,
-        )
-        self.comm.send(
-            data=result,
-            metadata=metadata,
-            buffers=None,
-        )
+        result = dict(jsonrpc="2.0", result=data)
+        self.comm.send(data=result, metadata=metadata, buffers=None)
 
     def send_event(self, name: str, payload: JsonRecord) -> None:
         """
@@ -244,11 +223,7 @@ class PositronComm:
         payload
             The payload of the event.
         """
-        event = dict(
-            jsonrpc="2.0",
-            method=name,
-            params=payload,
-        )
+        event = dict(jsonrpc="2.0", method=name, params=payload)
         with self.send_lock:
             self.comm.send(data=event)
 
@@ -263,18 +238,8 @@ class PositronComm:
         message
             The error message to send.
         """
-        error = dict(
-            jsonrpc="2.0",
-            error=dict(
-                code=code.value,
-                message=message,
-            ),
-        )
-        self.comm.send(
-            data=error,
-            metadata=None,
-            buffers=None,
-        )
+        error = dict(jsonrpc="2.0", error=dict(code=code.value, message=message))
+        self.comm.send(data=error, metadata=None, buffers=None)
 
     def close(self) -> None:
         """

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_comm.py
@@ -158,7 +158,8 @@ class PositronComm:
                     if (
                         # Comms with multiple backend request methods will have a discriminated_union error
                         error["loc"] == ("content", "data")
-                        and error["type"] == "value_error.discriminated_union.invalid_discriminator"
+                        and error["type"]
+                        == "value_error.discriminated_union.invalid_discriminator"
                         and error["ctx"]["discriminator_key"] == "method"
                     ):
                         method = error["ctx"]["discriminator_value"]
@@ -212,7 +213,9 @@ class PositronComm:
         """
         return getattr(self.comm, "messages")
 
-    def send_result(self, data: JsonData = None, metadata: Optional[JsonRecord] = None) -> None:
+    def send_result(
+        self, data: JsonData = None, metadata: Optional[JsonRecord] = None
+    ) -> None:
         """
         Send a JSON-RPC result to the frontend-side version of this comm.
 
@@ -252,7 +255,9 @@ class PositronComm:
         with self.send_lock:
             self.comm.send(data=event)
 
-    def send_error(self, code: JsonRpcErrorCode, message: Optional[str] = None) -> None:
+    def send_error(
+        self, code: JsonRpcErrorCode, message: Optional[str] = None
+    ) -> None:
         """
         Send a JSON-RPC result to the frontend-side version of this comm.
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -168,7 +168,9 @@ class PositronMagics(Magics):
                 obj, title, variable_path=[encode_access_key(args.object)]
             )
         except TypeError:
-            raise UsageError(f"cannot view object of type '{get_qualname(obj)}'")
+            raise UsageError(
+                f"cannot view object of type '{get_qualname(obj)}'"
+            )
         except RestartRequiredError as error:
             raise UsageError(*error.args)
 
@@ -192,7 +194,9 @@ class PositronMagics(Magics):
                 info.obj, variable_path=args.object
             )
         except TypeError:
-            raise UsageError(f"cannot show object of type '{get_qualname(info.obj)}'")
+            raise UsageError(
+                f"cannot show object of type '{get_qualname(info.obj)}'"
+            )
 
 
 _traceback_file_link_re = re.compile(r"^(File \x1b\[\d+;\d+m)(.+):(\d+)")
@@ -312,7 +316,9 @@ class PositronShell(ZMQInteractiveShell):
 
     def show_usage(self):
         """Show a usage message"""
-        self.kernel.help_service.show_help("positron_ipykernel.utils.positron_ipykernel_usage")
+        self.kernel.help_service.show_help(
+            "positron_ipykernel.utils.positron_ipykernel_usage"
+        )
 
     @traitlets.observe("exit_now")
     def _update_exit_now(self, change):
@@ -412,18 +418,28 @@ class PositronIPyKernel(IPythonKernel):
         self.job_queue = BackgroundJobQueue()
 
         # Create Positron services
-        self.data_explorer_service = DataExplorerService(_CommTarget.DataExplorer, self.job_queue)
+        self.data_explorer_service = DataExplorerService(
+            _CommTarget.DataExplorer, self.job_queue
+        )
         self.plots_service = PlotsService(_CommTarget.Plot, self.session_mode)
         self.ui_service = UiService(self)
         self.help_service = HelpService()
         self.lsp_service = LSPService(self)
         self.variables_service = VariablesService(self)
-        self.connections_service = ConnectionsService(self, _CommTarget.Connections)
+        self.connections_service = ConnectionsService(
+            self, _CommTarget.Connections
+        )
 
         # Register comm targets
-        self.comm_manager.register_target(_CommTarget.Lsp, self.lsp_service.on_comm_open)
-        self.comm_manager.register_target(_CommTarget.Ui, self.ui_service.on_comm_open)
-        self.comm_manager.register_target(_CommTarget.Help, self.help_service.on_comm_open)
+        self.comm_manager.register_target(
+            _CommTarget.Lsp, self.lsp_service.on_comm_open
+        )
+        self.comm_manager.register_target(
+            _CommTarget.Ui, self.ui_service.on_comm_open
+        )
+        self.comm_manager.register_target(
+            _CommTarget.Help, self.help_service.on_comm_open
+        )
         self.comm_manager.register_target(
             _CommTarget.Variables, self.variables_service.on_comm_open
         )
@@ -510,7 +526,9 @@ class PositronIPyKernel(IPythonKernel):
 
     # monkey patching warning.showwarning is recommended by the official documentation
     # https://docs.python.org/3/library/warnings.html#warnings.showwarning
-    def _showwarning(self, message, category, filename, lineno, file=None, line=None):
+    def _showwarning(
+        self, message, category, filename, lineno, file=None, line=None
+    ):
         # if coming from one of our files, log and don't send to user
         positron_files_path = Path(__file__).parent
 
@@ -530,9 +548,13 @@ class PositronIPyKernel(IPythonKernel):
             logger.warning(msg)
             return
 
-        msg = warnings.WarningMessage(message, category, filename, lineno, file, line)
+        msg = warnings.WarningMessage(
+            message, category, filename, lineno, file, line
+        )
 
-        return original_showwarning(message, category, filename, lineno, file, line)  # type: ignore reportAttributeAccessIssue
+        return original_showwarning(
+            message, category, filename, lineno, file, line
+        )  # type: ignore reportAttributeAccessIssue
 
 
 class PositronIPKernelApp(IPKernelApp):
@@ -551,7 +573,9 @@ class PositronIPKernelApp(IPKernelApp):
             # Matplotlib uses the MPLBACKEND environment variable to determine the backend to use.
             # It imports the backend module when it's first needed.
             if not os.environ.get("MPLBACKEND"):
-                os.environ["MPLBACKEND"] = "module://positron_ipykernel.matplotlib_backend"
+                os.environ["MPLBACKEND"] = (
+                    "module://positron_ipykernel.matplotlib_backend"
+                )
 
         return super().init_gui_pylab()
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -83,7 +83,13 @@ class PositronIPythonInspector(oinspect.Inspector):
         if fname is None:
             # If we couldn't get a filename, fall back to the default implementation.
             return super().pinfo(
-                obj, oname, formatter, info, detail_level, enable_html_pager, omit_sections
+                obj,
+                oname,
+                formatter,
+                info,
+                detail_level,
+                enable_html_pager,
+                omit_sections,
             )
 
         # If we got a filename, try to get the line number and open an editor.
@@ -105,7 +111,10 @@ class PositronMagics(Magics):
         self.shell.kernel.ui_service.clear_console()
 
     @magic_arguments.magic_arguments()
-    @magic_arguments.argument("object", help="The object to view.")
+    @magic_arguments.argument(
+        "object",
+        help="The object to view.",
+    )
     @magic_arguments.argument(
         "title",
         nargs="?",
@@ -164,7 +173,10 @@ class PositronMagics(Magics):
             raise UsageError(*error.args)
 
     @magic_arguments.magic_arguments()
-    @magic_arguments.argument("object", help="The connection object to show.")
+    @magic_arguments.argument(
+        "object",
+        help="The connection object to show.",
+    )
     @line_magic
     def connection_show(self, line: str) -> None:
         """Show a connection object in the Positron Connections Pane."""
@@ -440,7 +452,11 @@ class PositronIPyKernel(IPythonKernel):
         # Patch bokeh to generate html in tempfile
         patch_bokeh_no_access()
 
-    def publish_execute_input(self, code: str, parent: JsonRecord) -> None:
+    def publish_execute_input(
+        self,
+        code: str,
+        parent: JsonRecord,
+    ) -> None:
         self._publish_execute_input(code, parent, self.execution_count - 1)
 
     def start(self) -> None:
@@ -487,7 +503,9 @@ class PositronIPyKernel(IPythonKernel):
                     child.wait(timeout=0)
                 except psutil.TimeoutExpired as exception:
                     self.log.warning(
-                        "Error while reaping zombie subprocess %s: %s", child, exception
+                        "Error while reaping zombie subprocess %s: %s",
+                        child,
+                        exception,
                     )
 
     # monkey patching warning.showwarning is recommended by the official documentation

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_ipkernel.py
@@ -83,13 +83,7 @@ class PositronIPythonInspector(oinspect.Inspector):
         if fname is None:
             # If we couldn't get a filename, fall back to the default implementation.
             return super().pinfo(
-                obj,
-                oname,
-                formatter,
-                info,
-                detail_level,
-                enable_html_pager,
-                omit_sections,
+                obj, oname, formatter, info, detail_level, enable_html_pager, omit_sections
             )
 
         # If we got a filename, try to get the line number and open an editor.
@@ -111,10 +105,7 @@ class PositronMagics(Magics):
         self.shell.kernel.ui_service.clear_console()
 
     @magic_arguments.magic_arguments()
-    @magic_arguments.argument(
-        "object",
-        help="The object to view.",
-    )
+    @magic_arguments.argument("object", help="The object to view.")
     @magic_arguments.argument(
         "title",
         nargs="?",
@@ -173,10 +164,7 @@ class PositronMagics(Magics):
             raise UsageError(*error.args)
 
     @magic_arguments.magic_arguments()
-    @magic_arguments.argument(
-        "object",
-        help="The connection object to show.",
-    )
+    @magic_arguments.argument("object", help="The connection object to show.")
     @line_magic
     def connection_show(self, line: str) -> None:
         """Show a connection object in the Positron Connections Pane."""
@@ -452,11 +440,7 @@ class PositronIPyKernel(IPythonKernel):
         # Patch bokeh to generate html in tempfile
         patch_bokeh_no_access()
 
-    def publish_execute_input(
-        self,
-        code: str,
-        parent: JsonRecord,
-    ) -> None:
+    def publish_execute_input(self, code: str, parent: JsonRecord) -> None:
         self._publish_execute_input(code, parent, self.execution_count - 1)
 
     def start(self) -> None:
@@ -503,9 +487,7 @@ class PositronIPyKernel(IPythonKernel):
                     child.wait(timeout=0)
                 except psutil.TimeoutExpired as exception:
                     self.log.warning(
-                        "Error while reaping zombie subprocess %s: %s",
-                        child,
-                        exception,
+                        "Error while reaping zombie subprocess %s: %s", child, exception
                     )
 
     # monkey patching warning.showwarning is recommended by the official documentation

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_jedilsp.py
@@ -15,7 +15,8 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Uni
 from comm.base_comm import BaseComm
 
 from ._vendor import attrs
-from ._vendor.jedi.api import Interpreter, Project
+from ._vendor.jedi.api import Interpreter
+from ._vendor.jedi.api.project import Project
 from ._vendor.jedi_language_server import jedi_utils, pygls_utils
 from ._vendor.jedi_language_server.server import (
     JediLanguageServer,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_jedilsp.py
@@ -344,9 +344,7 @@ def positron_completion(
         )
         markup_kind = _choose_markup(server)
         is_import_context = jedi_utils.is_import(
-            script_=jedi_script,
-            line=jedi_lines[0],
-            column=jedi_lines[1],
+            script_=jedi_script, line=jedi_lines[0], column=jedi_lines[1]
         )
         enable_snippets = snippet_support and not snippet_disable and not is_import_context
         char_before_cursor = pygls_utils.char_before_cursor(
@@ -433,10 +431,7 @@ def positron_completion(
 
 
 def _magic_completion_item(
-    name: str,
-    magic_type: _MagicType,
-    chars_before_cursor: str,
-    func: Callable,
+    name: str, magic_type: _MagicType, chars_before_cursor: str, func: Callable
 ) -> CompletionItem:
     """
     Create a completion item for a magic command.
@@ -514,10 +509,7 @@ def positron_completion_item_resolve(
     return completion_item_resolve(server, params)
 
 
-@POSITRON.feature(
-    TEXT_DOCUMENT_SIGNATURE_HELP,
-    SignatureHelpOptions(trigger_characters=["(", ","]),
-)
+@POSITRON.feature(TEXT_DOCUMENT_SIGNATURE_HELP, SignatureHelpOptions(trigger_characters=["(", ","]))
 def positron_signature_help(
     server: PositronJediLanguageServer, params: TextDocumentPositionParams
 ) -> Optional[SignatureHelp]:
@@ -611,10 +603,7 @@ def positron_help_topic_request(
 @POSITRON.feature(
     TEXT_DOCUMENT_CODE_ACTION,
     CodeActionOptions(
-        code_action_kinds=[
-            CodeActionKind.RefactorInline,
-            CodeActionKind.RefactorExtract,
-        ],
+        code_action_kinds=[CodeActionKind.RefactorInline, CodeActionKind.RefactorExtract]
     ),
 )
 def positron_code_action(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/positron_jedilsp.py
@@ -344,7 +344,9 @@ def positron_completion(
         )
         markup_kind = _choose_markup(server)
         is_import_context = jedi_utils.is_import(
-            script_=jedi_script, line=jedi_lines[0], column=jedi_lines[1]
+            script_=jedi_script,
+            line=jedi_lines[0],
+            column=jedi_lines[1],
         )
         enable_snippets = snippet_support and not snippet_disable and not is_import_context
         char_before_cursor = pygls_utils.char_before_cursor(
@@ -431,7 +433,10 @@ def positron_completion(
 
 
 def _magic_completion_item(
-    name: str, magic_type: _MagicType, chars_before_cursor: str, func: Callable
+    name: str,
+    magic_type: _MagicType,
+    chars_before_cursor: str,
+    func: Callable,
 ) -> CompletionItem:
     """
     Create a completion item for a magic command.
@@ -509,7 +514,10 @@ def positron_completion_item_resolve(
     return completion_item_resolve(server, params)
 
 
-@POSITRON.feature(TEXT_DOCUMENT_SIGNATURE_HELP, SignatureHelpOptions(trigger_characters=["(", ","]))
+@POSITRON.feature(
+    TEXT_DOCUMENT_SIGNATURE_HELP,
+    SignatureHelpOptions(trigger_characters=["(", ","]),
+)
 def positron_signature_help(
     server: PositronJediLanguageServer, params: TextDocumentPositionParams
 ) -> Optional[SignatureHelp]:
@@ -603,7 +611,10 @@ def positron_help_topic_request(
 @POSITRON.feature(
     TEXT_DOCUMENT_CODE_ACTION,
     CodeActionOptions(
-        code_action_kinds=[CodeActionKind.RefactorInline, CodeActionKind.RefactorExtract]
+        code_action_kinds=[
+            CodeActionKind.RefactorInline,
+            CodeActionKind.RefactorExtract,
+        ],
     ),
 )
 def positron_code_action(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/pydoc.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/pydoc.py
@@ -170,16 +170,7 @@ def _tabulate_attrs(attrs: List[_Attr], cls_name: Optional[str] = None) -> List[
         argspec = _compact_signature(attr.value, attr.name) or ""
         link = f'<a href="{full_name}"><code>{attr.name}</code></a>{argspec}'
         summary = _get_summary(attr.value) or ""
-        row_lines = [
-            "<tr>",
-            "<td>",
-            link,
-            "</td>",
-            "<td>",
-            summary,
-            "</td>",
-            "</tr>",
-        ]
+        row_lines = ["<tr>", "<td>", link, "</td>", "<td>", summary, "</td>", "</tr>"]
         result.extend(row_lines)
     result.append("</tbody>")
     result.append("</table>")
@@ -256,11 +247,7 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
 <meta charset="utf-8">
 <title>Pydoc: %s</title>
 %s</head><body>%s</div>
-</body></html>""" % (
-            title,
-            css_link,
-            contents,
-        )
+</body></html>""" % (title, css_link, contents)
         # --- End Positron ---
 
     def heading(self, title: str, extras="") -> str:  # type: ignore ReportIncompatibleMethodOverride
@@ -273,14 +260,7 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
         return result
 
     def section(  # type: ignore ReportIncompatibleMethodOverride
-        self,
-        title: str,
-        cls: str,
-        contents: str,
-        width=None,
-        prelude="",
-        marginalia=None,
-        gap=None,
+        self, title: str, cls: str, contents: str, width=None, prelude="", marginalia=None, gap=None
     ) -> str:
         """Format a section with a heading."""
         # Simplified version of pydoc.HTMLDoc.section that doesn't use tables
@@ -293,10 +273,7 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
         if gap:
             logger.debug(f"Ignoring gap: {gap}")
 
-        lines = [
-            f'<section class="{cls}">',
-            f"<h2>{title}</h2>",
-        ]
+        lines = [f'<section class="{cls}">', f"<h2>{title}</h2>"]
         if prelude:
             lines.append(prelude)
         lines.append(contents)
@@ -436,14 +413,7 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
 
     # as is from pydoc.HTMLDoc to port Python 3.11 breaking CSS changes
     def docroutine(
-        self,
-        object: Any,
-        name=None,
-        mod=None,
-        funcs={},
-        classes={},
-        methods={},
-        cl=None,
+        self, object: Any, name=None, mod=None, funcs={}, classes={}, methods={}, cl=None
     ):
         """Produce HTML documentation for a function or method object."""
         realname = object.__name__
@@ -604,9 +574,7 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
             return '<a href="%s.html">%s</a>' % (name, name)
 
         results = []
-        heading = self.heading(
-            '<strong class="title">Search Results</strong>',
-        )
+        heading = self.heading('<strong class="title">Search Results</strong>')
         for name, desc in search_result:
             results.append(bltinlink(name) + desc)
         contents = heading + self.bigsection("key = %s" % key, "index", "<br>".join(results))
@@ -632,9 +600,7 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
         def bltinlink(name):
             return '<a href="topic?key=%s">%s</a>' % (name, name)
 
-        heading = self.heading(
-            '<strong class="title">INDEX</strong>',
-        )
+        heading = self.heading('<strong class="title">INDEX</strong>')
         # --- Start Positron ---
         names = sorted(PositronHelper.topics.keys())
         # --- End Positron ---
@@ -646,9 +612,7 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
     # as is from pydoc._url_handler to port Python 3.11 breaking CSS changes
     def html_keywords(self):
         """Index of keywords."""
-        heading = self.heading(
-            '<strong class="title">INDEX</strong>',
-        )
+        heading = self.heading('<strong class="title">INDEX</strong>')
         # --- Start Positron ---
         names = sorted(PositronHelper.keywords.keys())
         # --- End Positron ---
@@ -672,9 +636,7 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
             title = "KEYWORD"
         else:
             title = "TOPIC"
-        heading = self.heading(
-            '<strong class="title">%s</strong>' % title,
-        )
+        heading = self.heading('<strong class="title">%s</strong>' % title)
         contents = "<pre>%s</pre>" % self.markup(contents)
         contents = self.bigsection(topic, "index", contents)
         if xrefs:
@@ -689,9 +651,7 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
 
     # as is from pydoc._url_handler to port Python 3.11 breaking CSS changes
     def html_error(self, url, exc):
-        heading = self.heading(
-            '<strong class="title">Not found</strong>',
-        )
+        heading = self.heading('<strong class="title">Not found</strong>')
         contents = "<br>".join(self.escape(line) for line in format_exception_only(type(exc), exc))
         # --- Start Positron ---
         contents = heading + self.bigsection("", "error", contents)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/pydoc.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/pydoc.py
@@ -143,7 +143,9 @@ def _untyped_signature(obj: Any) -> Optional[str]:
         for name, param in signature.parameters.items()
         if name != "self"
     ]
-    signature = signature.replace(parameters=untyped_params, return_annotation=signature.empty)
+    signature = signature.replace(
+        parameters=untyped_params, return_annotation=signature.empty
+    )
     result = str(signature)
     return result
 
@@ -156,7 +158,9 @@ def _get_summary(object: Any) -> Optional[str]:
     return doc.split("\n\n", 1)[0]
 
 
-def _tabulate_attrs(attrs: List[_Attr], cls_name: Optional[str] = None) -> List[str]:
+def _tabulate_attrs(
+    attrs: List[_Attr], cls_name: Optional[str] = None
+) -> List[str]:
     """
     Create an HTML table of attribute signatures and summaries.
     """
@@ -246,7 +250,9 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
         # update path for positron file system
         css_path = "_pydoc.css"
 
-        css_link = '<link rel="stylesheet" type="text/css" href="%s">' % css_path
+        css_link = (
+            '<link rel="stylesheet" type="text/css" href="%s">' % css_path
+        )
 
         # removed html_navbar() for aesthetics
         return """\
@@ -374,7 +380,9 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
 
         if funcs:
             contents = _tabulate_attrs(funcs, obj_name)
-            result += self.bigsection("Functions", "functions", "\n".join(contents))
+            result += self.bigsection(
+                "Functions", "functions", "\n".join(contents)
+            )
 
         if data:
             contents = _tabulate_attrs(data, obj_name)
@@ -426,11 +434,15 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
         # Add the object's members to the page
         if attributes:
             contents = _tabulate_attrs(attributes, obj_name)
-            result += self.bigsection("Attributes", "attributes", "\n".join(contents))
+            result += self.bigsection(
+                "Attributes", "attributes", "\n".join(contents)
+            )
 
         if methods:
             contents = _tabulate_attrs(methods, obj_name)
-            result += self.bigsection("Methods", "functions", "\n".join(contents))
+            result += self.bigsection(
+                "Methods", "functions", "\n".join(contents)
+            )
 
         return result
 
@@ -458,11 +470,15 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
                     note = " from " + self.classlink(imclass, mod)  # type: ignore
             else:
                 if object.__self__ is not None:
-                    note = " method of %s instance" % self.classlink(object.__self__.__class__, mod)  # type: ignore
+                    note = " method of %s instance" % self.classlink(
+                        object.__self__.__class__, mod
+                    )  # type: ignore
                 else:
                     note = " unbound %s method" % self.classlink(imclass, mod)  # type: ignore
 
-        if inspect.iscoroutinefunction(object) or inspect.isasyncgenfunction(object):
+        if inspect.iscoroutinefunction(object) or inspect.isasyncgenfunction(
+            object
+        ):
             asyncqualifier = "async "
         else:
             asyncqualifier = ""
@@ -471,11 +487,18 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
             title = '<a name="%s"><strong>%s</strong></a>' % (anchor, realname)
         else:
             if cl and inspect.getattr_static(cl, realname, []) is object:
-                reallink = '<a href="#%s">%s</a>' % (cl.__name__ + "-" + realname, realname)
+                reallink = '<a href="#%s">%s</a>' % (
+                    cl.__name__ + "-" + realname,
+                    realname,
+                )
                 skipdocs = 1
             else:
                 reallink = realname
-            title = '<a name="%s"><strong>%s</strong></a> = %s' % (anchor, name, reallink)
+            title = '<a name="%s"><strong>%s</strong></a> = %s' % (
+                anchor,
+                name,
+                reallink,
+            )
         argspec = None
         if inspect.isroutine(object):
             try:
@@ -497,13 +520,18 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
             asyncqualifier
             + title
             + self.escape(argspec)
-            + (note and self.grey('<span class="heading-text">%s</span>' % note))
+            + (
+                note
+                and self.grey('<span class="heading-text">%s</span>' % note)
+            )
         )
 
         if skipdocs:
             return "<dl><dt>%s</dt></dl>\n" % decl
         else:
-            doc = self.markup(_getdoc(object), self.preformat, funcs, classes, methods)
+            doc = self.markup(
+                _getdoc(object), self.preformat, funcs, classes, methods
+            )
             # --- Start Positron ---
             # Remove <span class="code">
             # doc = doc and '<dd><span class="code">%s</span></dd>' % doc
@@ -565,10 +593,17 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
         def bltinlink(name):
             return '<a href="%s.html">%s</a>' % (name, name)
 
-        heading = self.heading('<strong class="title">Index of Modules</strong>')
-        names = [name for name in sys.builtin_module_names if name != "__main__"]
+        heading = self.heading(
+            '<strong class="title">Index of Modules</strong>'
+        )
+        names = [
+            name for name in sys.builtin_module_names if name != "__main__"
+        ]
         contents = self.multicolumn(names, bltinlink)
-        contents = [heading, "<p>" + self.bigsection("Built-in Modules", "index", contents)]
+        contents = [
+            heading,
+            "<p>" + self.bigsection("Built-in Modules", "index", contents),
+        ]
 
         seen = {}
         for dir in sys.path:
@@ -609,7 +644,9 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
         )
         for name, desc in search_result:
             results.append(bltinlink(name) + desc)
-        contents = heading + self.bigsection("key = %s" % key, "index", "<br>".join(results))
+        contents = heading + self.bigsection(
+            "key = %s" % key, "index", "<br>".join(results)
+        )
         return "Search Results", contents
 
     # as is from pydoc._url_handler to port Python 3.11 breaking CSS changes
@@ -692,7 +729,9 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
         heading = self.heading(
             '<strong class="title">Not found</strong>',
         )
-        contents = "<br>".join(self.escape(line) for line in format_exception_only(type(exc), exc))
+        contents = "<br>".join(
+            self.escape(line) for line in format_exception_only(type(exc), exc)
+        )
         # --- Start Positron ---
         contents = heading + self.bigsection("", "error", contents)
         return "Error", contents
@@ -951,7 +990,9 @@ def _rst_to_html(docstring: str, object: Any) -> str:
 
     markdown = _linkify(markdown, object)
 
-    md = MarkdownIt("commonmark", {"html": True, "highlight": _highlight}).enable(["table"])
+    md = MarkdownIt(
+        "commonmark", {"html": True, "highlight": _highlight}
+    ).enable(["table"])
 
     html = md.render(markdown)
 
@@ -995,7 +1036,9 @@ def start_server(port: int = 0):
     thread = pydoc._start_server(_url_handler, hostname="localhost", port=port)  # type: ignore
 
     if thread.error:
-        logger.error(f"Could not start the pydoc help server. Error: {thread.error}")
+        logger.error(
+            f"Could not start the pydoc help server. Error: {thread.error}"
+        )
         return
     elif thread.serving:
         logger.info(f"Pydoc server ready at: {thread.url}")

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/pydoc.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/pydoc.py
@@ -471,8 +471,9 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
             else:
                 if object.__self__ is not None:
                     note = " method of %s instance" % self.classlink(
-                        object.__self__.__class__, mod
-                    )  # type: ignore
+                        object.__self__.__class__,
+                        mod,  # type: ignore
+                    )
                 else:
                     note = " unbound %s method" % self.classlink(imclass, mod)  # type: ignore
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/pydoc.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/pydoc.py
@@ -170,7 +170,16 @@ def _tabulate_attrs(attrs: List[_Attr], cls_name: Optional[str] = None) -> List[
         argspec = _compact_signature(attr.value, attr.name) or ""
         link = f'<a href="{full_name}"><code>{attr.name}</code></a>{argspec}'
         summary = _get_summary(attr.value) or ""
-        row_lines = ["<tr>", "<td>", link, "</td>", "<td>", summary, "</td>", "</tr>"]
+        row_lines = [
+            "<tr>",
+            "<td>",
+            link,
+            "</td>",
+            "<td>",
+            summary,
+            "</td>",
+            "</tr>",
+        ]
         result.extend(row_lines)
     result.append("</tbody>")
     result.append("</table>")
@@ -247,7 +256,11 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
 <meta charset="utf-8">
 <title>Pydoc: %s</title>
 %s</head><body>%s</div>
-</body></html>""" % (title, css_link, contents)
+</body></html>""" % (
+            title,
+            css_link,
+            contents,
+        )
         # --- End Positron ---
 
     def heading(self, title: str, extras="") -> str:  # type: ignore ReportIncompatibleMethodOverride
@@ -260,7 +273,14 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
         return result
 
     def section(  # type: ignore ReportIncompatibleMethodOverride
-        self, title: str, cls: str, contents: str, width=None, prelude="", marginalia=None, gap=None
+        self,
+        title: str,
+        cls: str,
+        contents: str,
+        width=None,
+        prelude="",
+        marginalia=None,
+        gap=None,
     ) -> str:
         """Format a section with a heading."""
         # Simplified version of pydoc.HTMLDoc.section that doesn't use tables
@@ -273,7 +293,10 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
         if gap:
             logger.debug(f"Ignoring gap: {gap}")
 
-        lines = [f'<section class="{cls}">', f"<h2>{title}</h2>"]
+        lines = [
+            f'<section class="{cls}">',
+            f"<h2>{title}</h2>",
+        ]
         if prelude:
             lines.append(prelude)
         lines.append(contents)
@@ -413,7 +436,14 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
 
     # as is from pydoc.HTMLDoc to port Python 3.11 breaking CSS changes
     def docroutine(
-        self, object: Any, name=None, mod=None, funcs={}, classes={}, methods={}, cl=None
+        self,
+        object: Any,
+        name=None,
+        mod=None,
+        funcs={},
+        classes={},
+        methods={},
+        cl=None,
     ):
         """Produce HTML documentation for a function or method object."""
         realname = object.__name__
@@ -574,7 +604,9 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
             return '<a href="%s.html">%s</a>' % (name, name)
 
         results = []
-        heading = self.heading('<strong class="title">Search Results</strong>')
+        heading = self.heading(
+            '<strong class="title">Search Results</strong>',
+        )
         for name, desc in search_result:
             results.append(bltinlink(name) + desc)
         contents = heading + self.bigsection("key = %s" % key, "index", "<br>".join(results))
@@ -600,7 +632,9 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
         def bltinlink(name):
             return '<a href="topic?key=%s">%s</a>' % (name, name)
 
-        heading = self.heading('<strong class="title">INDEX</strong>')
+        heading = self.heading(
+            '<strong class="title">INDEX</strong>',
+        )
         # --- Start Positron ---
         names = sorted(PositronHelper.topics.keys())
         # --- End Positron ---
@@ -612,7 +646,9 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
     # as is from pydoc._url_handler to port Python 3.11 breaking CSS changes
     def html_keywords(self):
         """Index of keywords."""
-        heading = self.heading('<strong class="title">INDEX</strong>')
+        heading = self.heading(
+            '<strong class="title">INDEX</strong>',
+        )
         # --- Start Positron ---
         names = sorted(PositronHelper.keywords.keys())
         # --- End Positron ---
@@ -636,7 +672,9 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
             title = "KEYWORD"
         else:
             title = "TOPIC"
-        heading = self.heading('<strong class="title">%s</strong>' % title)
+        heading = self.heading(
+            '<strong class="title">%s</strong>' % title,
+        )
         contents = "<pre>%s</pre>" % self.markup(contents)
         contents = self.bigsection(topic, "index", contents)
         if xrefs:
@@ -651,7 +689,9 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
 
     # as is from pydoc._url_handler to port Python 3.11 breaking CSS changes
     def html_error(self, url, exc):
-        heading = self.heading('<strong class="title">Not found</strong>')
+        heading = self.heading(
+            '<strong class="title">Not found</strong>',
+        )
         contents = "<br>".join(self.escape(line) for line in format_exception_only(type(exc), exc))
         # --- Start Positron ---
         contents = heading + self.bigsection("", "error", contents)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/conftest.py
@@ -155,42 +155,54 @@ def session(kernel) -> TestSession:
 
 
 @pytest.fixture
-def mock_connections_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
+def mock_connections_service(
+    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
+) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell.kernel, "connections_service", mock)
     return mock
 
 
 @pytest.fixture
-def mock_dataexplorer_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
+def mock_dataexplorer_service(
+    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
+) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell.kernel, "data_explorer_service", mock)
     return mock
 
 
 @pytest.fixture
-def mock_ui_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
+def mock_ui_service(
+    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
+) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell.kernel, "ui_service", mock)
     return mock
 
 
 @pytest.fixture
-def mock_help_service(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
+def mock_help_service(
+    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
+) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell.kernel, "help_service", mock)
     return mock
 
 
 @pytest.fixture
-def mock_displayhook(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
+def mock_displayhook(
+    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
+) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell, "displayhook", mock)
     return mock
 
 
 @pytest.fixture
-def mock_display_pub(shell: PositronShell, monkeypatch: pytest.MonkeyPatch) -> Mock:
+def mock_display_pub(
+    shell: PositronShell, monkeypatch: pytest.MonkeyPatch
+) -> Mock:
     mock = Mock()
     monkeypatch.setattr(shell, "display_pub", mock)
     return mock

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/data.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/data.py
@@ -30,7 +30,15 @@ STRING_CASES = [
 
 # Python 3 ints are unbounded, but we include a few large numbers
 # for basic test cases
-INT_CASES = [-sys.maxsize * 100, -sys.maxsize, -1, 0, 1, sys.maxsize, sys.maxsize * 100]
+INT_CASES = [
+    -sys.maxsize * 100,
+    -sys.maxsize,
+    -1,
+    0,
+    1,
+    sys.maxsize,
+    sys.maxsize * 100,
+]
 
 
 NUMPY_SCALAR_CASES = [
@@ -88,4 +96,7 @@ RANGE_CASES = [
 ]
 
 
-TIMESTAMP_CASES = [pd.Timestamp("2021-01-01 01:23:45"), datetime.datetime(2021, 1, 1, 1, 23, 45)]
+TIMESTAMP_CASES = [
+    pd.Timestamp("2021-01-01 01:23:45"),
+    datetime.datetime(2021, 1, 1, 1, 23, 45),
+]

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/data.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/data.py
@@ -30,15 +30,7 @@ STRING_CASES = [
 
 # Python 3 ints are unbounded, but we include a few large numbers
 # for basic test cases
-INT_CASES = [
-    -sys.maxsize * 100,
-    -sys.maxsize,
-    -1,
-    0,
-    1,
-    sys.maxsize,
-    sys.maxsize * 100,
-]
+INT_CASES = [-sys.maxsize * 100, -sys.maxsize, -1, 0, 1, sys.maxsize, sys.maxsize * 100]
 
 
 NUMPY_SCALAR_CASES = [
@@ -96,7 +88,4 @@ RANGE_CASES = [
 ]
 
 
-TIMESTAMP_CASES = [
-    pd.Timestamp("2021-01-01 01:23:45"),
-    datetime.datetime(2021, 1, 1, 1, 23, 45),
-]
+TIMESTAMP_CASES = [pd.Timestamp("2021-01-01 01:23:45"), datetime.datetime(2021, 1, 1, 1, 23, 45)]

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/data.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/data.py
@@ -87,11 +87,21 @@ RANGE_CASES = [
     range(1),  # Range with positive start, 1 element
     range(-1, 0),  # Range with negative start, 1 element
     range(-2, 3),  # Range with negative start, positive stop
-    range(10, 21, 2),  # Range with positive start, positive stop, and positive step
-    range(20, 9, -2),  # Range with positive start, positive stop, and negative step
-    range(2, -10, -2),  # Range with positive start, negative stop, and negative step
-    range(-20, -9, 2),  # Range with negative start, negative stop, and positive step
-    range(-10, 3, 2),  # Range with negative start, positive stop, and positive step
+    range(
+        10, 21, 2
+    ),  # Range with positive start, positive stop, and positive step
+    range(
+        20, 9, -2
+    ),  # Range with positive start, positive stop, and negative step
+    range(
+        2, -10, -2
+    ),  # Range with positive start, negative stop, and negative step
+    range(
+        -20, -9, 2
+    ),  # Range with negative start, negative stop, and positive step
+    range(
+        -10, 3, 2
+    ),  # Range with negative start, positive stop, and positive step
     range(1, 5000),  # Large Range (compact display, does not show elements)
 ]
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_access_keys.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_access_keys.py
@@ -80,13 +80,7 @@ def test_encode_access_key_not_hashable_error(case: Any) -> None:
         encode_access_key(case)
 
 
-@pytest.mark.parametrize(
-    "case",
-    [
-        torch.tensor([]) if torch else None,
-        lambda x: x,
-    ],
-)
+@pytest.mark.parametrize("case", [torch.tensor([]) if torch else None, lambda x: x])
 def test_encode_access_key_not_implemented_error(case: Any) -> None:
     """
     Encoding an access key of an unsupported type raises an error.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_access_keys.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_access_keys.py
@@ -80,7 +80,13 @@ def test_encode_access_key_not_hashable_error(case: Any) -> None:
         encode_access_key(case)
 
 
-@pytest.mark.parametrize("case", [torch.tensor([]) if torch else None, lambda x: x])
+@pytest.mark.parametrize(
+    "case",
+    [
+        torch.tensor([]) if torch else None,
+        lambda x: x,
+    ],
+)
 def test_encode_access_key_not_implemented_error(case: Any) -> None:
     """
     Encoding an access key of an unsupported type raises an error.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_connections.py
@@ -65,11 +65,7 @@ class TestSQLiteConnectionsService:
         assert comm_id in connections_service.comms
 
     @pytest.mark.parametrize(
-        "path,expected",
-        [
-            ([], False),
-            ([{"kind": "schema", "name": "main"}], True),
-        ],
+        "path,expected", [([], False), ([{"kind": "schema", "name": "main"}], True)]
     )
     def test_contains_data(
         self, connections_comm: Tuple[ConnectionsService, DummyComm], path, expected
@@ -83,11 +79,7 @@ class TestSQLiteConnectionsService:
         assert result is False
 
     @pytest.mark.parametrize(
-        "path,expected",
-        [
-            ([], ""),
-            ([{"kind": "schema", "name": "main"}], ""),
-        ],
+        "path,expected", [([], ""), ([{"kind": "schema", "name": "main"}], "")]
     )
     def test_get_icon(self, connections_comm: Tuple[ConnectionsService, DummyComm], path, expected):
         _, comm = connections_comm

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_connections.py
@@ -65,7 +65,11 @@ class TestSQLiteConnectionsService:
         assert comm_id in connections_service.comms
 
     @pytest.mark.parametrize(
-        "path,expected", [([], False), ([{"kind": "schema", "name": "main"}], True)]
+        "path,expected",
+        [
+            ([], False),
+            ([{"kind": "schema", "name": "main"}], True),
+        ],
     )
     def test_contains_data(
         self, connections_comm: Tuple[ConnectionsService, DummyComm], path, expected
@@ -79,7 +83,11 @@ class TestSQLiteConnectionsService:
         assert result is False
 
     @pytest.mark.parametrize(
-        "path,expected", [([], ""), ([{"kind": "schema", "name": "main"}], "")]
+        "path,expected",
+        [
+            ([], ""),
+            ([{"kind": "schema", "name": "main"}], ""),
+        ],
     )
     def test_get_icon(self, connections_comm: Tuple[ConnectionsService, DummyComm], path, expected):
         _, comm = connections_comm

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_connections.py
@@ -60,7 +60,9 @@ def connections_comm(
 
 @pytest.mark.parametrize("con", get_sqlite_connections())
 class TestSQLiteConnectionsService:
-    def test_register_connection(self, connections_service: ConnectionsService, con):
+    def test_register_connection(
+        self, connections_service: ConnectionsService, con
+    ):
         comm_id = connections_service.register_connection(con)
         assert comm_id in connections_service.comms
 
@@ -72,11 +74,16 @@ class TestSQLiteConnectionsService:
         ],
     )
     def test_contains_data(
-        self, connections_comm: Tuple[ConnectionsService, DummyComm], path, expected
+        self,
+        connections_comm: Tuple[ConnectionsService, DummyComm],
+        path,
+        expected,
     ):
         _, comm = connections_comm
 
-        msg = _make_msg(params={"path": path}, method="contains_data", comm_id=comm.comm_id)
+        msg = _make_msg(
+            params={"path": path}, method="contains_data", comm_id=comm.comm_id
+        )
         comm.handle_msg(msg)
 
         result = comm.messages[0]["data"]["result"]
@@ -89,10 +96,17 @@ class TestSQLiteConnectionsService:
             ([{"kind": "schema", "name": "main"}], ""),
         ],
     )
-    def test_get_icon(self, connections_comm: Tuple[ConnectionsService, DummyComm], path, expected):
+    def test_get_icon(
+        self,
+        connections_comm: Tuple[ConnectionsService, DummyComm],
+        path,
+        expected,
+    ):
         _, comm = connections_comm
 
-        msg = _make_msg(params={"path": path}, method="get_icon", comm_id=comm.comm_id)
+        msg = _make_msg(
+            params={"path": path}, method="get_icon", comm_id=comm.comm_id
+        )
         comm.handle_msg(msg)
         result = comm.messages[0]["data"]["result"]
         assert result == expected
@@ -101,27 +115,40 @@ class TestSQLiteConnectionsService:
         "path,expected",
         [
             ([], [{"kind": "schema", "name": "main"}]),
-            ([{"kind": "schema", "name": "main"}], [{"kind": "table", "name": "movie"}]),
+            (
+                [{"kind": "schema", "name": "main"}],
+                [{"kind": "table", "name": "movie"}],
+            ),
         ],
     )
     def test_list_objects(
-        self, connections_comm: Tuple[ConnectionsService, DummyComm], path, expected
+        self,
+        connections_comm: Tuple[ConnectionsService, DummyComm],
+        path,
+        expected,
     ):
         _, comm = connections_comm
 
-        msg = _make_msg(params={"path": path}, method="list_objects", comm_id=comm.comm_id)
+        msg = _make_msg(
+            params={"path": path}, method="list_objects", comm_id=comm.comm_id
+        )
 
         comm.handle_msg(msg)
         result = comm.messages[0]["data"]["result"]
         assert len(result) == 1
         assert result == expected
 
-    def test_list_fields(self, connections_comm: Tuple[ConnectionsService, DummyComm]):
+    def test_list_fields(
+        self, connections_comm: Tuple[ConnectionsService, DummyComm]
+    ):
         _, comm = connections_comm
 
         msg = _make_msg(
             params={
-                "path": [{"kind": "schema", "name": "main"}, {"kind": "table", "name": "movie"}]
+                "path": [
+                    {"kind": "schema", "name": "main"},
+                    {"kind": "table", "name": "movie"},
+                ]
             },
             method="list_fields",
             comm_id=comm.comm_id,
@@ -133,12 +160,17 @@ class TestSQLiteConnectionsService:
         assert result[1] == {"name": "year", "dtype": "INTEGER"}
         assert result[2] == {"name": "score", "dtype": "NUMERIC"}
 
-    def test_preview_object(self, connections_comm: Tuple[ConnectionsService, DummyComm]):
+    def test_preview_object(
+        self, connections_comm: Tuple[ConnectionsService, DummyComm]
+    ):
         service, comm = connections_comm
 
         msg = _make_msg(
             params={
-                "path": [{"kind": "schema", "name": "main"}, {"kind": "table", "name": "movie"}]
+                "path": [
+                    {"kind": "schema", "name": "main"},
+                    {"kind": "table", "name": "movie"},
+                ]
             },
             method="preview_object",
             comm_id=comm.comm_id,
@@ -218,7 +250,9 @@ class TestVariablePaneIntegration:
         assert connections_service.path_to_comm_ids.get(path) is None
 
     # TODO: reuse code from test_data_explorer.py
-    def _assign_variables(self, shell: PositronShell, variables_comm: DummyComm, **variables):
+    def _assign_variables(
+        self, shell: PositronShell, variables_comm: DummyComm, **variables
+    ):
         # A hack to make sure that change events are fired when we
         # manipulate user_ns
         shell.kernel.variables_service.snapshot_user_ns()
@@ -226,7 +260,9 @@ class TestVariablePaneIntegration:
         shell.kernel.variables_service.poll_variables()
         variables_comm.messages.clear()
 
-    def _delete_variables(self, shell: PositronShell, variables_comm: DummyComm, names):
+    def _delete_variables(
+        self, shell: PositronShell, variables_comm: DummyComm, names
+    ):
         for nm in names:
             shell.run_cell(f"del {nm}")
 
@@ -235,7 +271,9 @@ class TestVariablePaneIntegration:
 
     def _view_in_connections_pane(self, variables_comm: DummyComm, path):
         encoded_paths = [encode_access_key(p) for p in path]
-        msg = _make_msg("view", {"path": encoded_paths}, comm_id="dummy_comm_id")
+        msg = _make_msg(
+            "view", {"path": encoded_paths}, comm_id="dummy_comm_id"
+        )
         variables_comm.handle_msg(msg)
         assert variables_comm.messages == [json_rpc_response({})]
         variables_comm.messages.clear()

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -69,7 +69,10 @@ def supports_keyword(func, keyword):
 
 
 def get_new_comm(
-    de_service: DataExplorerService, table: Any, title: str, comm_id: Optional[str] = None
+    de_service: DataExplorerService,
+    table: Any,
+    title: str,
+    comm_id: Optional[str] = None,
 ) -> DummyComm:
     """
 
@@ -149,7 +152,9 @@ def _open_viewer(variables_comm, path):
 
 
 def test_explorer_open_close_delete(
-    shell: PositronShell, de_service: DataExplorerService, variables_comm: DummyComm
+    shell: PositronShell,
+    de_service: DataExplorerService,
+    variables_comm: DummyComm,
 ):
     _assign_variables(
         shell,
@@ -188,7 +193,9 @@ def _assign_variables(shell: PositronShell, variables_comm: DummyComm, **variabl
 
 
 def test_explorer_delete_variable(
-    shell: PositronShell, de_service: DataExplorerService, variables_comm: DummyComm
+    shell: PositronShell,
+    de_service: DataExplorerService,
+    variables_comm: DummyComm,
 ):
     _assign_variables(
         shell,
@@ -342,7 +349,10 @@ DEFAULT_FORMAT = FormatOptions(
 
 class DataExplorerFixture:
     def __init__(
-        self, shell: PositronShell, de_service: DataExplorerService, variables_comm: DummyComm
+        self,
+        shell: PositronShell,
+        de_service: DataExplorerService,
+        variables_comm: DummyComm,
     ):
         self.shell = shell
         self.de_service = de_service
@@ -376,7 +386,10 @@ class DataExplorerFixture:
                 self.de_service._close_explorer(old_comm_id)
 
         self.de_service.register_table(
-            table, table_name, comm_id=comm_id, variable_path=[encode_access_key(table_name)]
+            table,
+            table_name,
+            comm_id=comm_id,
+            variable_path=[encode_access_key(table_name)],
         )
 
     def get_schema_for(self, df):
@@ -392,7 +405,11 @@ class DataExplorerFixture:
     def do_json_rpc(self, table_name, method, **params):
         comm_id = self._get_comm_id(table_name)
 
-        request = json_rpc_request(method, params=params, comm_id=comm_id)
+        request = json_rpc_request(
+            method,
+            params=params,
+            comm_id=comm_id,
+        )
         self.de_service.comms[comm_id].comm.handle_msg(request)
         response = get_last_message(self.de_service, comm_id)
         data = response["data"]
@@ -402,7 +419,11 @@ class DataExplorerFixture:
         if column_indices is None:
             column_indices = list(range(self.get_state(table_name)["table_shape"]["num_columns"]))
 
-        return self.do_json_rpc(table_name, "get_schema", column_indices=column_indices)["columns"]
+        return self.do_json_rpc(
+            table_name,
+            "get_schema",
+            column_indices=column_indices,
+        )["columns"]
 
     def search_schema(self, table_name, filters, start_index, max_results):
         return self.do_json_rpc(
@@ -418,17 +439,26 @@ class DataExplorerFixture:
 
     def get_data_values(self, table_name, format_options=DEFAULT_FORMAT, columns=None):
         return self.do_json_rpc(
-            table_name, "get_data_values", format_options=format_options, columns=columns
+            table_name,
+            "get_data_values",
+            format_options=format_options,
+            columns=columns,
         )
 
     def get_row_labels(self, table_name, selection, format_options=DEFAULT_FORMAT):
         return self.do_json_rpc(
-            table_name, "get_row_labels", format_options=format_options, selection=selection
+            table_name,
+            "get_row_labels",
+            format_options=format_options,
+            selection=selection,
         )
 
     def export_data_selection(self, table_name, selection, format="csv"):
         return self.do_json_rpc(
-            table_name, "export_data_selection", selection=selection, format=format
+            table_name,
+            "export_data_selection",
+            selection=selection,
+            format=format,
         )
 
     def set_row_filters(self, table_name, filters=None):
@@ -468,7 +498,10 @@ class DataExplorerFixture:
             pprint.pprint(state["row_filters"])
             raise
 
-        assert state["table_shape"] == {"num_rows": ex_num_rows, "num_columns": len(table.columns)}
+        assert state["table_shape"] == {
+            "num_rows": ex_num_rows,
+            "num_columns": len(table.columns),
+        }
         assert state["table_unfiltered_shape"] == {
             "num_rows": len(table),
             "num_columns": len(table.columns),
@@ -535,13 +568,23 @@ def get_column_profile_result(de_service: DataExplorerService, comm_id: str, cal
 
 def _select_all(num_rows, num_columns):
     return [
-        {"column_index": i, "spec": {"first_index": 0, "last_index": num_rows - 1}}
+        {
+            "column_index": i,
+            "spec": {
+                "first_index": 0,
+                "last_index": num_rows - 1,
+            },
+        }
         for i in range(num_columns)
     ]
 
 
 @pytest.fixture
-def dxf(shell: PositronShell, de_service: DataExplorerService, variables_comm: DummyComm):
+def dxf(
+    shell: PositronShell,
+    de_service: DataExplorerService,
+    variables_comm: DummyComm,
+):
     fixture = DataExplorerFixture(shell, de_service, variables_comm)
     yield fixture
 
@@ -565,8 +608,14 @@ def test_pandas_get_state(dxf: DataExplorerFixture):
 
     schema = dxf.get_schema("simple")
 
-    sort_keys = [{"column_index": 0, "ascending": True}, {"column_index": 1, "ascending": False}]
-    filters = [_compare_filter(schema[0], ">", 2), _compare_filter(schema[0], "<", 5)]
+    sort_keys = [
+        {"column_index": 0, "ascending": True},
+        {"column_index": 1, "ascending": False},
+    ]
+    filters = [
+        _compare_filter(schema[0], ">", 2),
+        _compare_filter(schema[0], "<", 5),
+    ]
     dxf.set_sort_columns("simple", sort_keys=sort_keys)
     dxf.set_row_filters("simple", filters=filters)
 
@@ -627,19 +676,24 @@ def test_pandas_supported_features(dxf: DataExplorerFixture):
             profile_type="null_count", support_status=SupportStatus.Supported
         ),
         ColumnProfileTypeSupportStatus(
-            profile_type="summary_stats", support_status=SupportStatus.Supported
+            profile_type="summary_stats",
+            support_status=SupportStatus.Supported,
         ),
         ColumnProfileTypeSupportStatus(
-            profile_type="small_histogram", support_status=SupportStatus.Supported
+            profile_type="small_histogram",
+            support_status=SupportStatus.Supported,
         ),
         ColumnProfileTypeSupportStatus(
-            profile_type="large_histogram", support_status=SupportStatus.Supported
+            profile_type="large_histogram",
+            support_status=SupportStatus.Supported,
         ),
         ColumnProfileTypeSupportStatus(
-            profile_type="small_frequency_table", support_status=SupportStatus.Supported
+            profile_type="small_frequency_table",
+            support_status=SupportStatus.Supported,
         ),
         ColumnProfileTypeSupportStatus(
-            profile_type="large_frequency_table", support_status=SupportStatus.Supported
+            profile_type="large_frequency_table",
+            support_status=SupportStatus.Supported,
         ),
     ]
     for tp in profile_types:
@@ -651,8 +705,16 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
         ([1, 2, 3, 4, 5], "int64", "number"),
         ([True, False, True, None, True], "bool", "boolean"),
         (["foo", "bar", None, "bar", "None"], "string", "string"),
-        (np.array([0, 1.2, -4.5, 6, np.nan], dtype=np.float16), "float16", "number"),
-        (np.array([0, 1.2, -4.5, 6, np.nan], dtype=np.float32), "float32", "number"),
+        (
+            np.array([0, 1.2, -4.5, 6, np.nan], dtype=np.float16),
+            "float16",
+            "number",
+        ),
+        (
+            np.array([0, 1.2, -4.5, 6, np.nan], dtype=np.float32),
+            "float32",
+            "number",
+        ),
         ([0, 1.2, -4.5, 6, np.nan], "float64", "number"),
         (
             pd.to_datetime(
@@ -687,13 +749,27 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
         (pd.Series([1, 2, None, 3, 4], dtype="Float32"), "Float32", "number"),
         (pd.Series([1, 2, None, 3, 4], dtype="Float64"), "Float64", "number"),
         # NA boolean
-        (pd.Series([True, False, None, None, True], dtype="boolean"), "boolean", "boolean"),
+        (
+            pd.Series([True, False, None, None, True], dtype="boolean"),
+            "boolean",
+            "boolean",
+        ),
         # NA string
-        (pd.Series(["foo", "bar", None, "baz", "qux"], dtype="string"), "string", "string"),
+        (
+            pd.Series(["foo", "bar", None, "baz", "qux"], dtype="string"),
+            "string",
+            "string",
+        ),
         # datetimetz
         (
             pd.Series(
-                ["2000-01-01", "2000-01-02", None, "2000-01-04", "2000-01-05"],
+                [
+                    "2000-01-01",
+                    "2000-01-02",
+                    None,
+                    "2000-01-04",
+                    "2000-01-05",
+                ],
                 dtype=pd.DatetimeTZDtype(tz="US/Eastern"),
             ),
             "datetime64[ns, US/Eastern]",
@@ -705,7 +781,10 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
         # Windows doesn't have complex256
         cases.append(
             (
-                np.array([1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, 5 + 5j], dtype="complex256"),
+                np.array(
+                    [1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, 5 + 5j],
+                    dtype="complex256",
+                ),
                 "complex256",
                 "number",
             )
@@ -760,7 +839,14 @@ def test_pandas_get_schema_inference_limit(dxf: DataExplorerFixture):
 
     assert dxf.get_schema_for(df) == _wrap_json(
         ColumnSchema,
-        [{"column_name": "c0", "column_index": 0, "type_name": "empty", "type_display": "unknown"}],
+        [
+            {
+                "column_name": "c0",
+                "column_index": 0,
+                "type_name": "empty",
+                "type_display": "unknown",
+            }
+        ],
     )
 
 
@@ -772,7 +858,14 @@ def test_pandas_series(dxf: DataExplorerFixture):
     schema = dxf.get_schema("series")
     assert schema == _wrap_json(
         ColumnSchema,
-        [{"column_name": "a", "column_index": 0, "type_name": "int64", "type_display": "number"}],
+        [
+            {
+                "column_name": "a",
+                "column_index": 0,
+                "type_name": "int64",
+                "type_display": "number",
+            },
+        ],
     )
 
     dxf.compare_tables("series", "expected", (len(series), 1))
@@ -790,7 +883,7 @@ def test_pandas_series(dxf: DataExplorerFixture):
                 "column_index": 0,
                 "type_name": "int64",
                 "type_display": "number",
-            }
+            },
         ],
     )
 
@@ -807,7 +900,8 @@ def test_pandas_wide_schemas(dxf: DataExplorerFixture):
     for chunk_index in range(ncols // chunk_size):
         start_index = chunk_index * chunk_size
         dxf.register_table(
-            f"wide_df_{chunk_index}", df.iloc[:, start_index : (chunk_index + 1) * chunk_size]
+            f"wide_df_{chunk_index}",
+            df.iloc[:, start_index : (chunk_index + 1) * chunk_size],
         )
 
         schema_slice = dxf.get_schema("wide_df", list(range(start_index, start_index + chunk_size)))
@@ -821,7 +915,11 @@ def test_pandas_wide_schemas(dxf: DataExplorerFixture):
 def _text_search_filter(term, match="contains", case_sensitive=False):
     return {
         "filter_type": "text_search",
-        "params": {"search_type": match, "term": term, "case_sensitive": case_sensitive},
+        "params": {
+            "search_type": match,
+            "term": term,
+            "case_sensitive": case_sensitive,
+        },
     }
 
 
@@ -903,7 +1001,13 @@ def test_search_schema(dxf: DataExplorerFixture):
             ([ddd_filter], 0, 10, 10, full_schema[1150:1160]),
         ]
 
-        for filters, start_index, max_results, ex_total, ex_matches in cases:
+        for (
+            filters,
+            start_index,
+            max_results,
+            ex_total,
+            ex_matches,
+        ) in cases:
             result = dxf.search_schema(name, filters, start_index, max_results)
 
             assert result["total_num_matches"] == ex_total
@@ -952,7 +1056,8 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
 
     # Edge cases: request beyond end of table
     response = dxf.get_data_values(
-        "simple", columns=[{"column_index": 0, "spec": {"first_index": 5, "last_index": 14}}]
+        "simple",
+        columns=[{"column_index": 0, "spec": {"first_index": 5, "last_index": 14}}],
     )
     assert response["columns"] == [[]]
 
@@ -972,7 +1077,9 @@ def _check_format_cases(dxf, table_name, cases):
 
     for options, expected in cases:
         result = dxf.get_data_values(
-            table_name, columns=_select_all(num_rows, num_columns), format_options=options
+            table_name,
+            columns=_select_all(num_rows, num_columns),
+            format_options=options,
         )
 
         assert result["columns"] == expected
@@ -1053,10 +1160,25 @@ def test_get_data_values_max_value_length(dxf: DataExplorerFixture):
 
     # (FormatOptions, expected results)
     cases = [
-        (DEFAULT_FORMAT.copy(update={"max_value_length": 50}), [["a" * 50, "b" * 50, "c" * 50]]),
+        (
+            DEFAULT_FORMAT.copy(update={"max_value_length": 50}),
+            [
+                [
+                    "a" * 50,
+                    "b" * 50,
+                    "c" * 50,
+                ]
+            ],
+        ),
         (
             DEFAULT_FORMAT.copy(update={"max_value_length": 1001}),
-            [["a" * 100, "b" * 1000, "c" * 1001]],
+            [
+                [
+                    "a" * 100,
+                    "b" * 1000,
+                    "c" * 1001,
+                ]
+            ],
         ),
     ]
 
@@ -1124,7 +1246,10 @@ def test_pandas_extension_dtypes(dxf: DataExplorerFixture):
 def test_pandas_leading_whitespace(dxf: DataExplorerFixture):
     # See GH#3138
     df = pd.DataFrame(
-        {"a": ["   foo", "  bar", " baz", "qux", "potato"], "c": [True, False, True, False, True]}
+        {
+            "a": ["   foo", "  bar", " baz", "qux", "potato"],
+            "c": [True, False, True, False, True],
+        }
     )
 
     dxf.register_table("ws", df)
@@ -1166,33 +1291,56 @@ def _between_filter(column_schema, left_value, right_value, op="between", condit
         op,
         column_schema,
         condition=condition,
-        params={"left_value": str(left_value), "right_value": str(right_value)},
+        params={
+            "left_value": str(left_value),
+            "right_value": str(right_value),
+        },
     )
 
 
 def _not_between_filter(column_schema, left_value, right_value, condition="and"):
     return _between_filter(
-        column_schema, left_value, right_value, op="not_between", condition=condition
+        column_schema,
+        left_value,
+        right_value,
+        op="not_between",
+        condition=condition,
     )
 
 
 def _search_filter(
-    column_schema, term, case_sensitive=False, search_type="contains", condition="and"
+    column_schema,
+    term,
+    case_sensitive=False,
+    search_type="contains",
+    condition="and",
 ):
     return _filter(
         "search",
         column_schema,
         condition=condition,
-        params={"search_type": search_type, "term": term, "case_sensitive": case_sensitive},
+        params={
+            "search_type": search_type,
+            "term": term,
+            "case_sensitive": case_sensitive,
+        },
     )
 
 
-def _set_member_filter(column_schema, values, inclusive=True, condition="and"):
+def _set_member_filter(
+    column_schema,
+    values,
+    inclusive=True,
+    condition="and",
+):
     return _filter(
         "set_membership",
         column_schema,
         condition=condition,
-        params={"values": [str(x) for x in values], "inclusive": inclusive},
+        params={
+            "values": [str(x) for x in values],
+            "inclusive": inclusive,
+        },
     )
 
 
@@ -1212,7 +1360,9 @@ def test_pandas_filter_between(dxf: DataExplorerFixture):
         ex_not_between = df[(col < left_value) | (col > right_value)]
 
         dxf.check_filter_case(
-            df, [_between_filter(column_schema, str(left_value), str(right_value))], ex_between
+            df,
+            [_between_filter(column_schema, str(left_value), str(right_value))],
+            ex_between,
         )
         dxf.check_filter_case(
             df,
@@ -1237,7 +1387,9 @@ def test_pandas_filter_conditions(dxf: DataExplorerFixture):
     dxf.check_filter_case(df, filters, expected_df)
 
     # Test a single condition with or set
-    filters = [_compare_filter(schema[0], ">=", 3, condition="or")]
+    filters = [
+        _compare_filter(schema[0], ">=", 3, condition="or"),
+    ]
     dxf.check_filter_case(df, filters, df[df["a"] >= 3])
 
 
@@ -1257,7 +1409,11 @@ def test_pandas_filter_compare(dxf: DataExplorerFixture):
 def test_pandas_filter_datetimetz(dxf: DataExplorerFixture):
     tz = pytz.timezone("US/Eastern")
 
-    df = pd.DataFrame({"date": pd.date_range("2000-01-01", periods=5, tz="US/Eastern")})
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2000-01-01", periods=5, tz="US/Eastern"),
+        }
+    )
     dxf.register_table("dtz", df)
     schema = dxf.get_schema("dtz")
 
@@ -1299,7 +1455,10 @@ def test_pandas_filter_reset(dxf: DataExplorerFixture):
 
 
 def test_pandas_polars_filter_value_coercion(dxf: DataExplorerFixture):
-    data = {"a": [1, 2, 3, 4, 5], "b": pd.date_range("2000-01-01", freq="D", periods=5)}
+    data = {
+        "a": [1, 2, 3, 4, 5],
+        "b": pd.date_range("2000-01-01", freq="D", periods=5),
+    }
 
     df = pd.DataFrame(data)
     pdf = pl.DataFrame(data)
@@ -1365,7 +1524,11 @@ def test_pandas_filter_empty(dxf: DataExplorerFixture):
 
 
 def test_pandas_filter_boolean(dxf: DataExplorerFixture):
-    df = pd.DataFrame({"a": [True, True, None, False, False, False, True, True]})
+    df = pd.DataFrame(
+        {
+            "a": [True, True, None, False, False, False, True, True],
+        }
+    )
 
     schema = dxf.get_schema_for(df)
 
@@ -1396,10 +1559,19 @@ def test_pandas_filter_set_membership(dxf: DataExplorerFixture):
 
     cases = [
         [[_set_member_filter(schema[0], [2, 4])], df[df["a"].isin([2, 4])]],
-        [[_set_member_filter(schema[0], [2.0, 3.5, 4])], df[df["a"].isin([2.0, 3.5, 4])]],
-        [[_set_member_filter(schema[2], ["bar", "foo"])], df[df["c"].isin(["bar", "foo"])]],
+        [
+            [_set_member_filter(schema[0], [2.0, 3.5, 4])],
+            df[df["a"].isin([2.0, 3.5, 4])],
+        ],
+        [
+            [_set_member_filter(schema[2], ["bar", "foo"])],
+            df[df["c"].isin(["bar", "foo"])],
+        ],
         [[_set_member_filter(schema[2], [])], df[df["c"].isin([])]],
-        [[_set_member_filter(schema[2], ["bar"], False)], df[~df["c"].isin(["bar"])]],
+        [
+            [_set_member_filter(schema[2], ["bar"], False)],
+            df[~df["c"].isin(["bar"])],
+        ],
         [[_set_member_filter(schema[2], [], False)], df],
     ]
 
@@ -1420,7 +1592,13 @@ def test_pandas_filter_search(dxf: DataExplorerFixture):
 
     # (search_type, column_schema, term, case_sensitive, boolean mask)
     cases = [
-        ("contains", schema[0], "foo", False, df["a"].str.lower().str.contains("foo")),
+        (
+            "contains",
+            schema[0],
+            "foo",
+            False,
+            df["a"].str.lower().str.contains("foo"),
+        ),
         ("contains", schema[0], "foo", True, df["a"].str.contains("foo")),
         (
             "not_contains",
@@ -1429,13 +1607,55 @@ def test_pandas_filter_search(dxf: DataExplorerFixture):
             False,
             ~df["a"].str.lower().str.contains("foo", na=True),
         ),
-        ("not_contains", schema[0], "foo", True, ~df["a"].str.contains("foo", na=True)),
-        ("starts_with", schema[0], "foo", False, df["a"].str.lower().str.startswith("foo")),
-        ("starts_with", schema[0], "foo", True, df["a"].str.startswith("foo")),
-        ("ends_with", schema[0], "foo", False, df["a"].str.lower().str.endswith("foo")),
-        ("ends_with", schema[0], "foo", True, df["a"].str.endswith("foo")),
-        ("regex_match", schema[0], "f[o]+", False, df["a"].str.match("f[o]+", case=False)),
-        ("regex_match", schema[0], "f[o]+[^o]*", True, df["a"].str.match("f[o]+[^o]*", case=True)),
+        (
+            "not_contains",
+            schema[0],
+            "foo",
+            True,
+            ~df["a"].str.contains("foo", na=True),
+        ),
+        (
+            "starts_with",
+            schema[0],
+            "foo",
+            False,
+            df["a"].str.lower().str.startswith("foo"),
+        ),
+        (
+            "starts_with",
+            schema[0],
+            "foo",
+            True,
+            df["a"].str.startswith("foo"),
+        ),
+        (
+            "ends_with",
+            schema[0],
+            "foo",
+            False,
+            df["a"].str.lower().str.endswith("foo"),
+        ),
+        (
+            "ends_with",
+            schema[0],
+            "foo",
+            True,
+            df["a"].str.endswith("foo"),
+        ),
+        (
+            "regex_match",
+            schema[0],
+            "f[o]+",
+            False,
+            df["a"].str.match("f[o]+", case=False),
+        ),
+        (
+            "regex_match",
+            schema[0],
+            "f[o]+[^o]*",
+            True,
+            df["a"].str.match("f[o]+[^o]*", case=True),
+        ),
     ]
 
     for search_type, column_schema, term, cs, mask in cases:
@@ -1443,7 +1663,14 @@ def test_pandas_filter_search(dxf: DataExplorerFixture):
         ex_table = df[mask.astype(bool)]
         dxf.check_filter_case(
             df,
-            [_search_filter(column_schema, term, case_sensitive=cs, search_type=search_type)],
+            [
+                _search_filter(
+                    column_schema,
+                    term,
+                    case_sensitive=cs,
+                    search_type=search_type,
+                )
+            ],
             ex_table,
         )
 
@@ -1653,7 +1880,11 @@ def test_schema_change_scenario1(ssf: SchemaChangeFixture):
     ssf.check_scenario("df", scenario1, "df['a'] = df['a'].astype(str)")
 
     # polars
-    ssf.check_scenario("dfp", scenario1, "dfp = dfp.with_columns(pl.col('a').cast(pl.String))")
+    ssf.check_scenario(
+        "dfp",
+        scenario1,
+        "dfp = dfp.with_columns(pl.col('a').cast(pl.String))",
+    )
 
 
 def test_schema_change_scenario2(ssf: SchemaChangeFixture):
@@ -1717,14 +1948,20 @@ def test_schema_change_scenario5(ssf: SchemaChangeFixture):
     # Scenario 5: replace a column in place with a new name
     def scenario5(fixture: DataExplorerFixture, table_id):
         schema = fixture.get_schema(table_id)
-        return {"filters": [(_compare_filter(schema[1], "=", "foo"), False)]}
+        return {
+            "filters": [
+                (_compare_filter(schema[1], "=", "foo"), False),
+            ]
+        }
 
     # pandas
     ssf.check_scenario("df", scenario5, "df.insert(1, 'b2', df.pop('b'))")
 
     # polars
     ssf.check_scenario(
-        "dfp", scenario5, "dfp = dfp.drop('b').insert_column(1, dfp['b'].alias('b2'))"
+        "dfp",
+        scenario5,
+        "dfp = dfp.drop('b').insert_column(1, dfp['b'].alias('b2'))",
     )
 
 
@@ -1750,7 +1987,11 @@ def test_schema_change_scenario7(ssf: SchemaChangeFixture, dxf: DataExplorerFixt
     # Scenario 7: delete column, then restore it and check that the
     def scenario7(fixture: DataExplorerFixture, table_id):
         schema = fixture.get_schema(table_id)
-        return {"filters": [(_compare_filter(schema[0], "<", "4"), False)]}
+        return {
+            "filters": [
+                (_compare_filter(schema[0], "<", "4"), False),
+            ]
+        }
 
     ## pandas
 
@@ -1780,7 +2021,10 @@ def test_schema_change_scenario7(ssf: SchemaChangeFixture, dxf: DataExplorerFixt
 def test_schema_change_scenario8(ssf: SchemaChangeFixture):
     # Scenario 8: Delete sorted column in middle of table
     def scenario8(fixture: DataExplorerFixture, table_id):
-        return {"sort_keys": [{"column_index": 1, "ascending": False}], "updated_sort_keys": []}
+        return {
+            "sort_keys": [{"column_index": 1, "ascending": False}],
+            "updated_sort_keys": [],
+        }
 
     # pandas
     ssf.check_scenario("df", scenario8, "del df['b']")
@@ -1811,7 +2055,11 @@ def test_pandas_set_sort_columns(dxf: DataExplorerFixture):
         ("df2", [(1, True)], {"by": "b"}),
         ("df2", [(2, True)], {"by": "c"}),
         ("df2", [(0, True), (1, True)], {"by": ["a", "b"]}),
-        ("df2", [(0, True), (1, False)], {"by": ["a", "b"], "ascending": [True, False]}),
+        (
+            "df2",
+            [(0, True), (1, False)],
+            {"by": ["a", "b"], "ascending": [True, False]},
+        ),
         (
             "df2",
             [(2, False), (1, True), (0, False)],
@@ -1860,7 +2108,11 @@ def test_pandas_change_schema_after_sort(
     # Sort a column that is out of bounds for the table after the
     # schema change below
     dxf.set_sort_columns(
-        "df", [{"column_index": 4, "ascending": True}, {"column_index": 0, "ascending": False}]
+        "df",
+        [
+            {"column_index": 4, "ascending": True},
+            {"column_index": 0, "ascending": False},
+        ],
     )
 
     expected_df = df[["b", "a"]].sort_values("a", ascending=False)  # type: ignore
@@ -1882,7 +2134,11 @@ def test_pandas_updated_with_sort_keys(dxf: DataExplorerFixture):
     # GitHub #3044, PandasView gets into an inconsistent state when a
     # dataset with sort keys set is updated (or the view is refreshed
     # because the dataset is large)
-    arrays = [[1, 2, 3, 4, 5], [True, False, True, None, True], ["foo", "bar", None, "bar", "None"]]
+    arrays = [
+        [1, 2, 3, 4, 5],
+        [True, False, True, None, True],
+        ["foo", "bar", None, "bar", "None"],
+    ]
     df = pd.DataFrame({"f0": arrays[0], "f1": arrays[1], "f2": arrays[2]})
 
     wide_df = _replicate_df_columns(df, 10000)
@@ -1914,11 +2170,17 @@ def test_pandas_updated_with_sort_keys(dxf: DataExplorerFixture):
 
 
 def _select_single_cell(row_index: int, col_index: int):
-    return {"kind": "single_cell", "selection": {"row_index": row_index, "column_index": col_index}}
+    return {
+        "kind": "single_cell",
+        "selection": {"row_index": row_index, "column_index": col_index},
+    }
 
 
 def _select_cell_range(
-    first_row_index: int, last_row_index: int, first_col_index: int, last_col_index: int
+    first_row_index: int,
+    last_row_index: int,
+    first_col_index: int,
+    last_col_index: int,
 ):
     return {
         "kind": "cell_range",
@@ -1932,7 +2194,10 @@ def _select_cell_range(
 
 
 def _select_range(first_index: int, last_index: int, kind: str):
-    return {"kind": kind, "selection": {"first_index": first_index, "last_index": last_index}}
+    return {
+        "kind": kind,
+        "selection": {"first_index": first_index, "last_index": last_index},
+    }
 
 
 def _select_column_range(first_index: int, last_index: int):
@@ -1944,7 +2209,10 @@ def _select_row_range(first_index: int, last_index: int):
 
 
 def _select_indices(indices: List[int], kind: str):
-    return {"kind": kind, "selection": {"indices": indices}}
+    return {
+        "kind": kind,
+        "selection": {"indices": indices},
+    }
 
 
 def _select_column_indices(indices: List[int]):
@@ -2029,7 +2297,10 @@ def test_export_data_selection(dxf: DataExplorerFixture):
         ("dfp", polars_export_cell, polars_export_table, polars_iloc),
     }
 
-    data = {"df": (df, df[df.iloc[:, 0] > 0]), "dfp": (dfp, dfp.filter(dfp[:, 0] > 0))}
+    data = {
+        "df": (df, df[df.iloc[:, 0] > 0]),
+        "dfp": (dfp, dfp.filter(dfp[:, 0] > 0)),
+    }
 
     for name, export_cell, export_table, iloc in data_cases:
         unfiltered, filtered = data[name]
@@ -2077,13 +2348,24 @@ def _get_null_count(column_index):
 def _get_histogram(column_index, bins=2000, method="fixed"):
     return _profile_request(
         column_index,
-        [{"profile_type": "small_histogram", "params": {"method": method, "num_bins": bins}}],
+        [
+            {
+                "profile_type": "small_histogram",
+                "params": {"method": method, "num_bins": bins},
+            }
+        ],
     )
 
 
 def _get_frequency_table(column_index, limit):
     return _profile_request(
-        column_index, [{"profile_type": "small_frequency_table", "params": {"limit": limit}}]
+        column_index,
+        [
+            {
+                "profile_type": "small_frequency_table",
+                "params": {"limit": limit},
+            }
+        ],
     )
 
 
@@ -2106,13 +2388,27 @@ def test_pandas_profile_null_counts(dxf: DataExplorerFixture):
         dxf.register_table(name, df)
 
     # tuples like (table_name, [ColumnProfileRequest], [results])
-    all_profiles = [_get_null_count(0), _get_null_count(1), _get_null_count(2), _get_null_count(3)]
+    all_profiles = [
+        _get_null_count(0),
+        _get_null_count(1),
+        _get_null_count(2),
+        _get_null_count(3),
+    ]
     cases = [
         ("df1", [], []),
-        ("df1", [_get_null_count(3)], [0]),
         (
             "df1",
-            [_get_null_count(0), _get_null_count(1), _get_null_count(2), _get_null_count(3)],
+            [_get_null_count(3)],
+            [0],
+        ),
+        (
+            "df1",
+            [
+                _get_null_count(0),
+                _get_null_count(1),
+                _get_null_count(2),
+                _get_null_count(3),
+            ],
             [2, 3, 4, 0],
         ),
     ]
@@ -2129,7 +2425,12 @@ def test_pandas_profile_null_counts(dxf: DataExplorerFixture):
     # Test profiling with filter
     # format: (table, filters, filtered_table, profiles)
     filter_cases = [
-        (df1, [_filter("not_null", df1_schema[0])], df1[df1["a"].notnull()], all_profiles)
+        (
+            df1,
+            [_filter("not_null", df1_schema[0])],
+            df1[df1["a"].notnull()],
+            all_profiles,
+        )
     ]
     for table, filters, filtered_table, profiles in filter_cases:
         table_id = guid()
@@ -2221,7 +2522,19 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             "f0": arr,
             "f1": arr_with_nulls,
             "f2": [False, False, False, True, None] * 20,
-            "f3": ["foo", "", "baz", "qux", "foo", None, "bar", "", "bar", "zzz"] * 10,
+            "f3": [
+                "foo",
+                "",
+                "baz",
+                "qux",
+                "foo",
+                None,
+                "bar",
+                "",
+                "bar",
+                "zzz",
+            ]
+            * 10,
             "f4": getattr(
                 pd.date_range("2000-01-01", freq="D", periods=100), "date"
             ),  # date column
@@ -2242,7 +2555,14 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="US/Eastern")}
             ),
             pd.DataFrame(
-                {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="Asia/Hong_Kong")}
+                {
+                    "x": pd.date_range(
+                        "2000-01-01",
+                        freq="2h",
+                        periods=50,
+                        tz="Asia/Hong_Kong",
+                    )
+                }
             ),
         ]
     )
@@ -2254,7 +2574,14 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="US/Eastern")}
             ),
             pd.DataFrame(
-                {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="Asia/Hong_Kong")}
+                {
+                    "x": pd.date_range(
+                        "2000-01-01",
+                        freq="2h",
+                        periods=50,
+                        tz="Asia/Hong_Kong",
+                    )
+                }
             ),
         ]
     )
@@ -2295,8 +2622,16 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 "median": _format_float(df1["f1"].median()),
             },
         ),
-        ("df1", 2, {"true_count": 20, "false_count": 60}),
-        ("df1", 3, {"num_empty": 20, "num_unique": 6}),
+        (
+            "df1",
+            2,
+            {"true_count": 20, "false_count": 60},
+        ),
+        (
+            "df1",
+            3,
+            {"num_empty": 20, "num_unique": 6},
+        ),
         (
             "df1",
             4,
@@ -2332,9 +2667,21 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 "timezone": "US/Eastern",
             },
         ),
-        ("df1", 7, {"mean": "2.50+2.50j", "median": "2.50+2.50j"}),
-        ("df1", 8, {"min_value": "-INF", "max_value": "INF"}),
-        ("df1", 9, {}),
+        (
+            "df1",
+            7,
+            {"mean": "2.50+2.50j", "median": "2.50+2.50j"},
+        ),
+        (
+            "df1",
+            8,
+            {"min_value": "-INF", "max_value": "INF"},
+        ),
+        (
+            "df1",
+            9,
+            {},
+        ),
         (
             "df_mixed_tz1",
             0,
@@ -2429,7 +2776,15 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
         (
             _get_histogram(2, bins=6),
             {
-                "bin_edges": ["-10.00", "-6.67", "-3.33", "0.00", "3.33", "6.67", "10.00"],
+                "bin_edges": [
+                    "-10.00",
+                    "-6.67",
+                    "-3.33",
+                    "0.00",
+                    "3.33",
+                    "6.67",
+                    "10.00",
+                ],
                 "bin_counts": [1, 1, 1, 3, 2, 1],
                 "quantiles": [],
             },
@@ -2437,7 +2792,13 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
         (
             _get_histogram(3, bins=4),
             {
-                "bin_edges": ["0.00", "2.50", "5.00", "7.50", "10.00"],
+                "bin_edges": [
+                    "0.00",
+                    "2.50",
+                    "5.00",
+                    "7.50",
+                    "10.00",
+                ],
                 "bin_counts": [5, 0, 0, 6],
                 "quantiles": [],
             },
@@ -2452,15 +2813,27 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
         ),
         (
             _get_histogram(5, method="sturges"),
-            {"bin_edges": ["0.5000", "1.50"], "bin_counts": [11], "quantiles": []},
+            {
+                "bin_edges": ["0.5000", "1.50"],
+                "bin_counts": [11],
+                "quantiles": [],
+            },
         ),
         (
             _get_histogram(5, method="freedman_diaconis"),
-            {"bin_edges": ["0.5000", "1.50"], "bin_counts": [11], "quantiles": []},
+            {
+                "bin_edges": ["0.5000", "1.50"],
+                "bin_counts": [11],
+                "quantiles": [],
+            },
         ),
         (
             _get_histogram(5, method="scott"),
-            {"bin_edges": ["0.5000", "1.50"], "bin_counts": [11], "quantiles": []},
+            {
+                "bin_edges": ["0.5000", "1.50"],
+                "bin_counts": [11],
+                "quantiles": [],
+            },
         ),
         (
             _get_histogram(0, bins=50),
@@ -2488,7 +2861,18 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
 def test_pandas_polars_profile_frequency_table(dxf: DataExplorerFixture):
     data = {
         "a": [0, 0, 0, 1, 1, 2, 2, 3, 4, 5],
-        "b": ["foo", "foo", "foo", "foo", "b0", "b0", "b1", "b2", "b3", None],
+        "b": [
+            "foo",
+            "foo",
+            "foo",
+            "foo",
+            "b0",
+            "b0",
+            "b1",
+            "b2",
+            "b3",
+            None,
+        ],
     }
     dxf.register_table("df", pd.DataFrame(data))
     dxf.register_table("dfp", pl.DataFrame(data))
@@ -2496,11 +2880,19 @@ def test_pandas_polars_profile_frequency_table(dxf: DataExplorerFixture):
     cases = [
         (
             _get_frequency_table(0, 3),
-            {"values": ["0", "1", "2"], "counts": [3, 2, 2], "other_count": 3},
+            {
+                "values": ["0", "1", "2"],
+                "counts": [3, 2, 2],
+                "other_count": 3,
+            },
         ),
         (
             _get_frequency_table(1, 3),
-            {"values": ["foo", "b0", "b1"], "counts": [4, 2, 1], "other_count": 2},
+            {
+                "values": ["foo", "b0", "b1"],
+                "counts": [4, 2, 1],
+                "other_count": 2,
+            },
         ),
     ]
 
@@ -2545,14 +2937,24 @@ POLARS_TYPE_EXAMPLES = [
     (pl.Int8, [-1, 2, 3, None], "Int8", "number"),
     (pl.Int16, [-10000, 20000, 30000, None], "Int16", "number"),
     (pl.Int32, [-10000000, 20000000, 30000000, None], "Int32", "number"),
-    (pl.Int64, [-10000000000, 20000000000, 30000000000, None], "Int64", "number"),
+    (
+        pl.Int64,
+        [-10000000000, 20000000000, 30000000000, None],
+        "Int64",
+        "number",
+    ),
     (pl.UInt8, [0, 2, 3, None], "UInt8", "number"),
     (pl.UInt16, [0, 2000, 3000, None], "UInt16", "number"),
     (pl.UInt32, [0, 2000000, 3000000, None], "UInt32", "number"),
     (pl.UInt64, [0, 2000000000, 3000000000, None], "UInt64", "number"),
     (pl.Float32, [-0.01234, 2.56789, 3.012345, None], "Float32", "number"),
     (pl.Float64, [-0.01234, 2.56789, 3.012345, None], "Float64", "number"),
-    (pl.Binary, [b"testing", b"some", b"strings", None], "Binary", "string"),
+    (
+        pl.Binary,
+        [b"testing", b"some", b"strings", None],
+        "Binary",
+        "string",
+    ),
     (pl.String, ["tésting", "söme", "strîngs", None], "String", "string"),
     (pl.Time, [0, 14400000000000, 40271000000000, None], "Time", "time"),
     (
@@ -2568,10 +2970,20 @@ POLARS_TYPE_EXAMPLES = [
         "datetime",
     ),
     (pl.Date, [130120, 0, -1, None], "Date", "date"),
-    (pl.Duration("ms"), [0, 1000, 2000, None], "Duration(time_unit='ms')", "unknown"),
+    (
+        pl.Duration("ms"),
+        [0, 1000, 2000, None],
+        "Duration(time_unit='ms')",
+        "unknown",
+    ),
     (
         pl.Decimal(12, 4),
-        [Decimal("123.4501"), Decimal("0.0000"), Decimal("12345678.4501"), None],
+        [
+            Decimal("123.4501"),
+            Decimal("0.0000"),
+            Decimal("12345678.4501"),
+            None,
+        ],
         "Decimal(precision=12, scale=4)",
         "number",
     ),
@@ -2670,7 +3082,8 @@ def test_polars_get_state(dxf: DataExplorerFixture):
             profile_type="null_count", support_status=SupportStatus.Supported
         ),
         ColumnProfileTypeSupportStatus(
-            profile_type="summary_stats", support_status=SupportStatus.Supported
+            profile_type="summary_stats",
+            support_status=SupportStatus.Supported,
         ),
     ]
 
@@ -2739,7 +3152,13 @@ def test_polars_get_data_values(dxf: DataExplorerFixture):
     result = dxf.get_data_values(
         name,
         columns=[
-            {"column_index": i, "spec": {"first_index": 2, "last_index": 11}}
+            {
+                "column_index": i,
+                "spec": {
+                    "first_index": 2,
+                    "last_index": 11,
+                },
+            }
             for i in range(15, df.shape[1])
         ],
     )
@@ -2765,7 +3184,9 @@ def test_polars_filter_between(dxf: DataExplorerFixture):
         ex_not_between = df.filter((col < left_value) | (col > right_value))
 
         dxf.check_filter_case(
-            df, [_between_filter(column_schema, str(left_value), str(right_value))], ex_between
+            df,
+            [_between_filter(column_schema, str(left_value), str(right_value))],
+            ex_between,
         )
         dxf.check_filter_case(
             df,
@@ -2832,10 +3253,14 @@ def test_polars_filter_empty(dxf: DataExplorerFixture):
     schema = dxf.get_schema_for(df)
 
     dxf.check_filter_case(
-        df, [_filter("is_empty", schema[0])], df.filter(df["a"].str.len_chars() == 0)
+        df,
+        [_filter("is_empty", schema[0])],
+        df.filter(df["a"].str.len_chars() == 0),
     )
     dxf.check_filter_case(
-        df, [_filter("not_empty", schema[0])], df.filter(df["a"].str.len_chars() != 0)
+        df,
+        [_filter("not_empty", schema[0])],
+        df.filter(df["a"].str.len_chars() != 0),
     )
     dxf.check_filter_case(
         df,
@@ -2850,7 +3275,11 @@ def test_polars_filter_empty(dxf: DataExplorerFixture):
 
 
 def test_polars_filter_boolean(dxf: DataExplorerFixture):
-    df = pl.DataFrame({"a": [True, True, None, False, False, False, True, True]})
+    df = pl.DataFrame(
+        {
+            "a": [True, True, None, False, False, False, True, True],
+        }
+    )
 
     schema = dxf.get_schema_for(df)
 
@@ -2884,34 +3313,90 @@ def test_polars_filter_reset(dxf: DataExplorerFixture):
 
 
 def test_polars_filter_search(dxf: DataExplorerFixture):
-    df = pl.DataFrame({"a": ["foo1", "foo2", None, "2FOO", "FOO3", "bar1", "2BAR"]})
+    df = pl.DataFrame(
+        {
+            "a": ["foo1", "foo2", None, "2FOO", "FOO3", "bar1", "2BAR"],
+        }
+    )
 
     dxf.register_table("df", df)
     schema = dxf.get_schema("df")
 
     # (search_type, column_schema, term, case_sensitive, boolean mask)
     cases = [
-        ("contains", schema[0], "foo", False, df["a"].str.to_lowercase().str.contains("foo")),
+        (
+            "contains",
+            schema[0],
+            "foo",
+            False,
+            df["a"].str.to_lowercase().str.contains("foo"),
+        ),
         ("contains", schema[0], "foo", True, df["a"].str.contains("foo")),
-        ("starts_with", schema[0], "foo", False, df["a"].str.to_lowercase().str.starts_with("foo")),
-        ("starts_with", schema[0], "foo", True, df["a"].str.starts_with("foo")),
-        ("ends_with", schema[0], "foo", False, df["a"].str.to_lowercase().str.ends_with("foo")),
-        ("ends_with", schema[0], "foo", True, df["a"].str.ends_with("foo")),
-        ("regex_match", schema[0], "f[o]+", False, df["a"].str.contains("(?i)f[o]+")),
-        ("regex_match", schema[0], "f[o]+[^o]*", True, df["a"].str.contains("f[o]+[^o]*")),
+        (
+            "starts_with",
+            schema[0],
+            "foo",
+            False,
+            df["a"].str.to_lowercase().str.starts_with("foo"),
+        ),
+        (
+            "starts_with",
+            schema[0],
+            "foo",
+            True,
+            df["a"].str.starts_with("foo"),
+        ),
+        (
+            "ends_with",
+            schema[0],
+            "foo",
+            False,
+            df["a"].str.to_lowercase().str.ends_with("foo"),
+        ),
+        (
+            "ends_with",
+            schema[0],
+            "foo",
+            True,
+            df["a"].str.ends_with("foo"),
+        ),
+        (
+            "regex_match",
+            schema[0],
+            "f[o]+",
+            False,
+            df["a"].str.contains("(?i)f[o]+"),
+        ),
+        (
+            "regex_match",
+            schema[0],
+            "f[o]+[^o]*",
+            True,
+            df["a"].str.contains("f[o]+[^o]*"),
+        ),
     ]
 
     for search_type, column_schema, term, cs, mask in cases:
         dxf.check_filter_case(
             df,
-            [_search_filter(column_schema, term, case_sensitive=cs, search_type=search_type)],
+            [
+                _search_filter(
+                    column_schema,
+                    term,
+                    case_sensitive=cs,
+                    search_type=search_type,
+                )
+            ],
             df.filter(mask),
         )
 
 
 def test_polars_filter_set_membership(dxf: DataExplorerFixture):
     df = pl.DataFrame(
-        {"a": [1, 2, 3, 4, None, 5, 6], "b": ["foo", "bar", None, "baz", "foo", None, "qux"]}
+        {
+            "a": [1, 2, 3, 4, None, 5, 6],
+            "b": ["foo", "bar", None, "baz", "foo", None, "qux"],
+        }
     )
     schema = dxf.get_schema_for(df)
 
@@ -2923,11 +3408,23 @@ def test_polars_filter_set_membership(dxf: DataExplorerFixture):
             [_set_member_filter(schema[0], [2, 3.5, 4.0, 5, 6.5])],
             df.filter(df["a"].is_in(pl.Series([2, 3.5, 4.0, 5, 6.5], dtype=pl.Float64))),
         ),
-        ([_set_member_filter(schema[0], [2, 4])], df.filter(df["a"].is_in([2, 4]))),
-        ([_set_member_filter(schema[1], ["bar", "foo"])], df.filter(df["b"].is_in(["bar", "foo"]))),
+        (
+            [_set_member_filter(schema[0], [2, 4])],
+            df.filter(df["a"].is_in([2, 4])),
+        ),
+        (
+            [_set_member_filter(schema[1], ["bar", "foo"])],
+            df.filter(df["b"].is_in(["bar", "foo"])),
+        ),
         ([_set_member_filter(schema[1], [])], df.filter(df["b"].is_in([]))),
-        ([_set_member_filter(schema[1], ["bar"], False)], df.filter(~df["b"].is_in(["bar"]))),
-        ([_set_member_filter(schema[1], [], False)], df.filter(~df["b"].is_in([]))),
+        (
+            [_set_member_filter(schema[1], ["bar"], False)],
+            df.filter(~df["b"].is_in(["bar"])),
+        ),
+        (
+            [_set_member_filter(schema[1], [], False)],
+            df.filter(~df["b"].is_in([])),
+        ),
     ]
 
     for filter_set, expected_df in cases:
@@ -2960,7 +3457,11 @@ def test_polars_set_sort_columns(dxf: DataExplorerFixture):
         ("df2", [(1, True)], {"by": "b"}),
         ("df2", [(2, True)], {"by": "c"}),
         ("df2", [(0, True), (1, True)], {"by": ["a", "b"]}),
-        ("df2", [(0, True), (1, False)], {"by": ["a", "b"], "descending": [False, True]}),
+        (
+            "df2",
+            [(0, True), (1, False)],
+            {"by": ["a", "b"], "descending": [False, True]},
+        ),
         (
             "df2",
             [(2, False), (1, True), (0, False)],
@@ -2970,7 +3471,12 @@ def test_polars_set_sort_columns(dxf: DataExplorerFixture):
 
     # Test sort AND filter
     filter_cases = {
-        "df2": [(lambda x: x.filter(x["a"] > 0), [_compare_filter(df2_schema[0], ">", 0)])]
+        "df2": [
+            (
+                lambda x: x.filter(x["a"] > 0),
+                [_compare_filter(df2_schema[0], ">", 0)],
+            )
+        ]
     }
 
     for df_name, sort_keys, expected_params in cases:
@@ -2980,7 +3486,10 @@ def test_polars_set_sort_columns(dxf: DataExplorerFixture):
         ]
 
         args = (expected_params["by"],)
-        kwds = {"descending": expected_params.get("descending", False), "maintain_order": True}
+        kwds = {
+            "descending": expected_params.get("descending", False),
+            "maintain_order": True,
+        }
 
         expected_df = df.sort(*args, **kwds)
         dxf.check_sort_case(df, wrapped_keys, expected_df)
@@ -3006,10 +3515,19 @@ def test_polars_profile_null_counts(dxf: DataExplorerFixture):
     # tuples like (table_name, [ColumnProfileRequest], [results])
     cases = [
         (name, [], []),
-        (name, [_get_null_count(3)], [0]),
         (
             name,
-            [_get_null_count(0), _get_null_count(1), _get_null_count(2), _get_null_count(3)],
+            [_get_null_count(3)],
+            [0],
+        ),
+        (
+            name,
+            [
+                _get_null_count(0),
+                _get_null_count(1),
+                _get_null_count(2),
+                _get_null_count(3),
+            ],
             [2, 3, 4, 0],
         ),
     ]
@@ -3033,12 +3551,26 @@ def test_polars_profile_summary_stats(dxf: DataExplorerFixture):
             "f0": arr,
             "f1": arr_with_nulls,
             "f2": [False, False, False, True, None] * 20,
-            "f3": ["foo", "", "baz", "qux", "foo", None, "bar", "", "bar", "zzz"] * 10,
+            "f3": [
+                "foo",
+                "",
+                "baz",
+                "qux",
+                "foo",
+                None,
+                "bar",
+                "",
+                "bar",
+                "zzz",
+            ]
+            * 10,
             "f4": pl.Series(
-                pd.date_range("2000-01-01", freq="D", periods=100), dtype=pl.Date
+                pd.date_range("2000-01-01", freq="D", periods=100),
+                dtype=pl.Date,
             ),  # date column
             "f5": pl.Series(
-                list(pd.date_range("2000-01-01", freq="2h", periods=100)), dtype=pl.Datetime("us")
+                list(pd.date_range("2000-01-01", freq="2h", periods=100)),
+                dtype=pl.Datetime("us"),
             ),  # datetime no tz
             "f6": pl.Series(
                 [
@@ -3086,8 +3618,16 @@ def test_polars_profile_summary_stats(dxf: DataExplorerFixture):
                 "median": _format_float(df1["f1"].median()),
             },
         ),
-        ("df1", 2, {"true_count": 20, "false_count": 60}),
-        ("df1", 3, {"num_empty": 20, "num_unique": 7}),
+        (
+            "df1",
+            2,
+            {"true_count": 20, "false_count": 60},
+        ),
+        (
+            "df1",
+            3,
+            {"num_empty": 20, "num_unique": 7},
+        ),
         (
             "df1",
             4,
@@ -3123,8 +3663,16 @@ def test_polars_profile_summary_stats(dxf: DataExplorerFixture):
                 "timezone": "UTC",
             },
         ),
-        ("df1", 7, {"min_value": "-INF", "max_value": "INF"}),
-        ("df1", 8, {}),
+        (
+            "df1",
+            7,
+            {"min_value": "-INF", "max_value": "INF"},
+        ),
+        (
+            "df1",
+            8,
+            {},
+        ),
     ]
 
     for table_name, col_index, ex_result in cases:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -69,10 +69,7 @@ def supports_keyword(func, keyword):
 
 
 def get_new_comm(
-    de_service: DataExplorerService,
-    table: Any,
-    title: str,
-    comm_id: Optional[str] = None,
+    de_service: DataExplorerService, table: Any, title: str, comm_id: Optional[str] = None
 ) -> DummyComm:
     """
 
@@ -152,9 +149,7 @@ def _open_viewer(variables_comm, path):
 
 
 def test_explorer_open_close_delete(
-    shell: PositronShell,
-    de_service: DataExplorerService,
-    variables_comm: DummyComm,
+    shell: PositronShell, de_service: DataExplorerService, variables_comm: DummyComm
 ):
     _assign_variables(
         shell,
@@ -193,9 +188,7 @@ def _assign_variables(shell: PositronShell, variables_comm: DummyComm, **variabl
 
 
 def test_explorer_delete_variable(
-    shell: PositronShell,
-    de_service: DataExplorerService,
-    variables_comm: DummyComm,
+    shell: PositronShell, de_service: DataExplorerService, variables_comm: DummyComm
 ):
     _assign_variables(
         shell,
@@ -349,10 +342,7 @@ DEFAULT_FORMAT = FormatOptions(
 
 class DataExplorerFixture:
     def __init__(
-        self,
-        shell: PositronShell,
-        de_service: DataExplorerService,
-        variables_comm: DummyComm,
+        self, shell: PositronShell, de_service: DataExplorerService, variables_comm: DummyComm
     ):
         self.shell = shell
         self.de_service = de_service
@@ -386,10 +376,7 @@ class DataExplorerFixture:
                 self.de_service._close_explorer(old_comm_id)
 
         self.de_service.register_table(
-            table,
-            table_name,
-            comm_id=comm_id,
-            variable_path=[encode_access_key(table_name)],
+            table, table_name, comm_id=comm_id, variable_path=[encode_access_key(table_name)]
         )
 
     def get_schema_for(self, df):
@@ -405,11 +392,7 @@ class DataExplorerFixture:
     def do_json_rpc(self, table_name, method, **params):
         comm_id = self._get_comm_id(table_name)
 
-        request = json_rpc_request(
-            method,
-            params=params,
-            comm_id=comm_id,
-        )
+        request = json_rpc_request(method, params=params, comm_id=comm_id)
         self.de_service.comms[comm_id].comm.handle_msg(request)
         response = get_last_message(self.de_service, comm_id)
         data = response["data"]
@@ -419,11 +402,7 @@ class DataExplorerFixture:
         if column_indices is None:
             column_indices = list(range(self.get_state(table_name)["table_shape"]["num_columns"]))
 
-        return self.do_json_rpc(
-            table_name,
-            "get_schema",
-            column_indices=column_indices,
-        )["columns"]
+        return self.do_json_rpc(table_name, "get_schema", column_indices=column_indices)["columns"]
 
     def search_schema(self, table_name, filters, start_index, max_results):
         return self.do_json_rpc(
@@ -439,26 +418,17 @@ class DataExplorerFixture:
 
     def get_data_values(self, table_name, format_options=DEFAULT_FORMAT, columns=None):
         return self.do_json_rpc(
-            table_name,
-            "get_data_values",
-            format_options=format_options,
-            columns=columns,
+            table_name, "get_data_values", format_options=format_options, columns=columns
         )
 
     def get_row_labels(self, table_name, selection, format_options=DEFAULT_FORMAT):
         return self.do_json_rpc(
-            table_name,
-            "get_row_labels",
-            format_options=format_options,
-            selection=selection,
+            table_name, "get_row_labels", format_options=format_options, selection=selection
         )
 
     def export_data_selection(self, table_name, selection, format="csv"):
         return self.do_json_rpc(
-            table_name,
-            "export_data_selection",
-            selection=selection,
-            format=format,
+            table_name, "export_data_selection", selection=selection, format=format
         )
 
     def set_row_filters(self, table_name, filters=None):
@@ -498,10 +468,7 @@ class DataExplorerFixture:
             pprint.pprint(state["row_filters"])
             raise
 
-        assert state["table_shape"] == {
-            "num_rows": ex_num_rows,
-            "num_columns": len(table.columns),
-        }
+        assert state["table_shape"] == {"num_rows": ex_num_rows, "num_columns": len(table.columns)}
         assert state["table_unfiltered_shape"] == {
             "num_rows": len(table),
             "num_columns": len(table.columns),
@@ -568,23 +535,13 @@ def get_column_profile_result(de_service: DataExplorerService, comm_id: str, cal
 
 def _select_all(num_rows, num_columns):
     return [
-        {
-            "column_index": i,
-            "spec": {
-                "first_index": 0,
-                "last_index": num_rows - 1,
-            },
-        }
+        {"column_index": i, "spec": {"first_index": 0, "last_index": num_rows - 1}}
         for i in range(num_columns)
     ]
 
 
 @pytest.fixture
-def dxf(
-    shell: PositronShell,
-    de_service: DataExplorerService,
-    variables_comm: DummyComm,
-):
+def dxf(shell: PositronShell, de_service: DataExplorerService, variables_comm: DummyComm):
     fixture = DataExplorerFixture(shell, de_service, variables_comm)
     yield fixture
 
@@ -608,14 +565,8 @@ def test_pandas_get_state(dxf: DataExplorerFixture):
 
     schema = dxf.get_schema("simple")
 
-    sort_keys = [
-        {"column_index": 0, "ascending": True},
-        {"column_index": 1, "ascending": False},
-    ]
-    filters = [
-        _compare_filter(schema[0], ">", 2),
-        _compare_filter(schema[0], "<", 5),
-    ]
+    sort_keys = [{"column_index": 0, "ascending": True}, {"column_index": 1, "ascending": False}]
+    filters = [_compare_filter(schema[0], ">", 2), _compare_filter(schema[0], "<", 5)]
     dxf.set_sort_columns("simple", sort_keys=sort_keys)
     dxf.set_row_filters("simple", filters=filters)
 
@@ -676,24 +627,19 @@ def test_pandas_supported_features(dxf: DataExplorerFixture):
             profile_type="null_count", support_status=SupportStatus.Supported
         ),
         ColumnProfileTypeSupportStatus(
-            profile_type="summary_stats",
-            support_status=SupportStatus.Supported,
+            profile_type="summary_stats", support_status=SupportStatus.Supported
         ),
         ColumnProfileTypeSupportStatus(
-            profile_type="small_histogram",
-            support_status=SupportStatus.Supported,
+            profile_type="small_histogram", support_status=SupportStatus.Supported
         ),
         ColumnProfileTypeSupportStatus(
-            profile_type="large_histogram",
-            support_status=SupportStatus.Supported,
+            profile_type="large_histogram", support_status=SupportStatus.Supported
         ),
         ColumnProfileTypeSupportStatus(
-            profile_type="small_frequency_table",
-            support_status=SupportStatus.Supported,
+            profile_type="small_frequency_table", support_status=SupportStatus.Supported
         ),
         ColumnProfileTypeSupportStatus(
-            profile_type="large_frequency_table",
-            support_status=SupportStatus.Supported,
+            profile_type="large_frequency_table", support_status=SupportStatus.Supported
         ),
     ]
     for tp in profile_types:
@@ -705,16 +651,8 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
         ([1, 2, 3, 4, 5], "int64", "number"),
         ([True, False, True, None, True], "bool", "boolean"),
         (["foo", "bar", None, "bar", "None"], "string", "string"),
-        (
-            np.array([0, 1.2, -4.5, 6, np.nan], dtype=np.float16),
-            "float16",
-            "number",
-        ),
-        (
-            np.array([0, 1.2, -4.5, 6, np.nan], dtype=np.float32),
-            "float32",
-            "number",
-        ),
+        (np.array([0, 1.2, -4.5, 6, np.nan], dtype=np.float16), "float16", "number"),
+        (np.array([0, 1.2, -4.5, 6, np.nan], dtype=np.float32), "float32", "number"),
         ([0, 1.2, -4.5, 6, np.nan], "float64", "number"),
         (
             pd.to_datetime(
@@ -749,27 +687,13 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
         (pd.Series([1, 2, None, 3, 4], dtype="Float32"), "Float32", "number"),
         (pd.Series([1, 2, None, 3, 4], dtype="Float64"), "Float64", "number"),
         # NA boolean
-        (
-            pd.Series([True, False, None, None, True], dtype="boolean"),
-            "boolean",
-            "boolean",
-        ),
+        (pd.Series([True, False, None, None, True], dtype="boolean"), "boolean", "boolean"),
         # NA string
-        (
-            pd.Series(["foo", "bar", None, "baz", "qux"], dtype="string"),
-            "string",
-            "string",
-        ),
+        (pd.Series(["foo", "bar", None, "baz", "qux"], dtype="string"), "string", "string"),
         # datetimetz
         (
             pd.Series(
-                [
-                    "2000-01-01",
-                    "2000-01-02",
-                    None,
-                    "2000-01-04",
-                    "2000-01-05",
-                ],
+                ["2000-01-01", "2000-01-02", None, "2000-01-04", "2000-01-05"],
                 dtype=pd.DatetimeTZDtype(tz="US/Eastern"),
             ),
             "datetime64[ns, US/Eastern]",
@@ -781,10 +705,7 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
         # Windows doesn't have complex256
         cases.append(
             (
-                np.array(
-                    [1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, 5 + 5j],
-                    dtype="complex256",
-                ),
+                np.array([1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, 5 + 5j], dtype="complex256"),
                 "complex256",
                 "number",
             )
@@ -839,14 +760,7 @@ def test_pandas_get_schema_inference_limit(dxf: DataExplorerFixture):
 
     assert dxf.get_schema_for(df) == _wrap_json(
         ColumnSchema,
-        [
-            {
-                "column_name": "c0",
-                "column_index": 0,
-                "type_name": "empty",
-                "type_display": "unknown",
-            }
-        ],
+        [{"column_name": "c0", "column_index": 0, "type_name": "empty", "type_display": "unknown"}],
     )
 
 
@@ -858,14 +772,7 @@ def test_pandas_series(dxf: DataExplorerFixture):
     schema = dxf.get_schema("series")
     assert schema == _wrap_json(
         ColumnSchema,
-        [
-            {
-                "column_name": "a",
-                "column_index": 0,
-                "type_name": "int64",
-                "type_display": "number",
-            },
-        ],
+        [{"column_name": "a", "column_index": 0, "type_name": "int64", "type_display": "number"}],
     )
 
     dxf.compare_tables("series", "expected", (len(series), 1))
@@ -883,7 +790,7 @@ def test_pandas_series(dxf: DataExplorerFixture):
                 "column_index": 0,
                 "type_name": "int64",
                 "type_display": "number",
-            },
+            }
         ],
     )
 
@@ -900,8 +807,7 @@ def test_pandas_wide_schemas(dxf: DataExplorerFixture):
     for chunk_index in range(ncols // chunk_size):
         start_index = chunk_index * chunk_size
         dxf.register_table(
-            f"wide_df_{chunk_index}",
-            df.iloc[:, start_index : (chunk_index + 1) * chunk_size],
+            f"wide_df_{chunk_index}", df.iloc[:, start_index : (chunk_index + 1) * chunk_size]
         )
 
         schema_slice = dxf.get_schema("wide_df", list(range(start_index, start_index + chunk_size)))
@@ -915,11 +821,7 @@ def test_pandas_wide_schemas(dxf: DataExplorerFixture):
 def _text_search_filter(term, match="contains", case_sensitive=False):
     return {
         "filter_type": "text_search",
-        "params": {
-            "search_type": match,
-            "term": term,
-            "case_sensitive": case_sensitive,
-        },
+        "params": {"search_type": match, "term": term, "case_sensitive": case_sensitive},
     }
 
 
@@ -1001,13 +903,7 @@ def test_search_schema(dxf: DataExplorerFixture):
             ([ddd_filter], 0, 10, 10, full_schema[1150:1160]),
         ]
 
-        for (
-            filters,
-            start_index,
-            max_results,
-            ex_total,
-            ex_matches,
-        ) in cases:
+        for filters, start_index, max_results, ex_total, ex_matches in cases:
             result = dxf.search_schema(name, filters, start_index, max_results)
 
             assert result["total_num_matches"] == ex_total
@@ -1056,8 +952,7 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
 
     # Edge cases: request beyond end of table
     response = dxf.get_data_values(
-        "simple",
-        columns=[{"column_index": 0, "spec": {"first_index": 5, "last_index": 14}}],
+        "simple", columns=[{"column_index": 0, "spec": {"first_index": 5, "last_index": 14}}]
     )
     assert response["columns"] == [[]]
 
@@ -1077,9 +972,7 @@ def _check_format_cases(dxf, table_name, cases):
 
     for options, expected in cases:
         result = dxf.get_data_values(
-            table_name,
-            columns=_select_all(num_rows, num_columns),
-            format_options=options,
+            table_name, columns=_select_all(num_rows, num_columns), format_options=options
         )
 
         assert result["columns"] == expected
@@ -1160,25 +1053,10 @@ def test_get_data_values_max_value_length(dxf: DataExplorerFixture):
 
     # (FormatOptions, expected results)
     cases = [
-        (
-            DEFAULT_FORMAT.copy(update={"max_value_length": 50}),
-            [
-                [
-                    "a" * 50,
-                    "b" * 50,
-                    "c" * 50,
-                ]
-            ],
-        ),
+        (DEFAULT_FORMAT.copy(update={"max_value_length": 50}), [["a" * 50, "b" * 50, "c" * 50]]),
         (
             DEFAULT_FORMAT.copy(update={"max_value_length": 1001}),
-            [
-                [
-                    "a" * 100,
-                    "b" * 1000,
-                    "c" * 1001,
-                ]
-            ],
+            [["a" * 100, "b" * 1000, "c" * 1001]],
         ),
     ]
 
@@ -1246,10 +1124,7 @@ def test_pandas_extension_dtypes(dxf: DataExplorerFixture):
 def test_pandas_leading_whitespace(dxf: DataExplorerFixture):
     # See GH#3138
     df = pd.DataFrame(
-        {
-            "a": ["   foo", "  bar", " baz", "qux", "potato"],
-            "c": [True, False, True, False, True],
-        }
+        {"a": ["   foo", "  bar", " baz", "qux", "potato"], "c": [True, False, True, False, True]}
     )
 
     dxf.register_table("ws", df)
@@ -1291,56 +1166,33 @@ def _between_filter(column_schema, left_value, right_value, op="between", condit
         op,
         column_schema,
         condition=condition,
-        params={
-            "left_value": str(left_value),
-            "right_value": str(right_value),
-        },
+        params={"left_value": str(left_value), "right_value": str(right_value)},
     )
 
 
 def _not_between_filter(column_schema, left_value, right_value, condition="and"):
     return _between_filter(
-        column_schema,
-        left_value,
-        right_value,
-        op="not_between",
-        condition=condition,
+        column_schema, left_value, right_value, op="not_between", condition=condition
     )
 
 
 def _search_filter(
-    column_schema,
-    term,
-    case_sensitive=False,
-    search_type="contains",
-    condition="and",
+    column_schema, term, case_sensitive=False, search_type="contains", condition="and"
 ):
     return _filter(
         "search",
         column_schema,
         condition=condition,
-        params={
-            "search_type": search_type,
-            "term": term,
-            "case_sensitive": case_sensitive,
-        },
+        params={"search_type": search_type, "term": term, "case_sensitive": case_sensitive},
     )
 
 
-def _set_member_filter(
-    column_schema,
-    values,
-    inclusive=True,
-    condition="and",
-):
+def _set_member_filter(column_schema, values, inclusive=True, condition="and"):
     return _filter(
         "set_membership",
         column_schema,
         condition=condition,
-        params={
-            "values": [str(x) for x in values],
-            "inclusive": inclusive,
-        },
+        params={"values": [str(x) for x in values], "inclusive": inclusive},
     )
 
 
@@ -1360,9 +1212,7 @@ def test_pandas_filter_between(dxf: DataExplorerFixture):
         ex_not_between = df[(col < left_value) | (col > right_value)]
 
         dxf.check_filter_case(
-            df,
-            [_between_filter(column_schema, str(left_value), str(right_value))],
-            ex_between,
+            df, [_between_filter(column_schema, str(left_value), str(right_value))], ex_between
         )
         dxf.check_filter_case(
             df,
@@ -1387,9 +1237,7 @@ def test_pandas_filter_conditions(dxf: DataExplorerFixture):
     dxf.check_filter_case(df, filters, expected_df)
 
     # Test a single condition with or set
-    filters = [
-        _compare_filter(schema[0], ">=", 3, condition="or"),
-    ]
+    filters = [_compare_filter(schema[0], ">=", 3, condition="or")]
     dxf.check_filter_case(df, filters, df[df["a"] >= 3])
 
 
@@ -1409,11 +1257,7 @@ def test_pandas_filter_compare(dxf: DataExplorerFixture):
 def test_pandas_filter_datetimetz(dxf: DataExplorerFixture):
     tz = pytz.timezone("US/Eastern")
 
-    df = pd.DataFrame(
-        {
-            "date": pd.date_range("2000-01-01", periods=5, tz="US/Eastern"),
-        }
-    )
+    df = pd.DataFrame({"date": pd.date_range("2000-01-01", periods=5, tz="US/Eastern")})
     dxf.register_table("dtz", df)
     schema = dxf.get_schema("dtz")
 
@@ -1455,10 +1299,7 @@ def test_pandas_filter_reset(dxf: DataExplorerFixture):
 
 
 def test_pandas_polars_filter_value_coercion(dxf: DataExplorerFixture):
-    data = {
-        "a": [1, 2, 3, 4, 5],
-        "b": pd.date_range("2000-01-01", freq="D", periods=5),
-    }
+    data = {"a": [1, 2, 3, 4, 5], "b": pd.date_range("2000-01-01", freq="D", periods=5)}
 
     df = pd.DataFrame(data)
     pdf = pl.DataFrame(data)
@@ -1524,11 +1365,7 @@ def test_pandas_filter_empty(dxf: DataExplorerFixture):
 
 
 def test_pandas_filter_boolean(dxf: DataExplorerFixture):
-    df = pd.DataFrame(
-        {
-            "a": [True, True, None, False, False, False, True, True],
-        }
-    )
+    df = pd.DataFrame({"a": [True, True, None, False, False, False, True, True]})
 
     schema = dxf.get_schema_for(df)
 
@@ -1559,19 +1396,10 @@ def test_pandas_filter_set_membership(dxf: DataExplorerFixture):
 
     cases = [
         [[_set_member_filter(schema[0], [2, 4])], df[df["a"].isin([2, 4])]],
-        [
-            [_set_member_filter(schema[0], [2.0, 3.5, 4])],
-            df[df["a"].isin([2.0, 3.5, 4])],
-        ],
-        [
-            [_set_member_filter(schema[2], ["bar", "foo"])],
-            df[df["c"].isin(["bar", "foo"])],
-        ],
+        [[_set_member_filter(schema[0], [2.0, 3.5, 4])], df[df["a"].isin([2.0, 3.5, 4])]],
+        [[_set_member_filter(schema[2], ["bar", "foo"])], df[df["c"].isin(["bar", "foo"])]],
         [[_set_member_filter(schema[2], [])], df[df["c"].isin([])]],
-        [
-            [_set_member_filter(schema[2], ["bar"], False)],
-            df[~df["c"].isin(["bar"])],
-        ],
+        [[_set_member_filter(schema[2], ["bar"], False)], df[~df["c"].isin(["bar"])]],
         [[_set_member_filter(schema[2], [], False)], df],
     ]
 
@@ -1592,13 +1420,7 @@ def test_pandas_filter_search(dxf: DataExplorerFixture):
 
     # (search_type, column_schema, term, case_sensitive, boolean mask)
     cases = [
-        (
-            "contains",
-            schema[0],
-            "foo",
-            False,
-            df["a"].str.lower().str.contains("foo"),
-        ),
+        ("contains", schema[0], "foo", False, df["a"].str.lower().str.contains("foo")),
         ("contains", schema[0], "foo", True, df["a"].str.contains("foo")),
         (
             "not_contains",
@@ -1607,55 +1429,13 @@ def test_pandas_filter_search(dxf: DataExplorerFixture):
             False,
             ~df["a"].str.lower().str.contains("foo", na=True),
         ),
-        (
-            "not_contains",
-            schema[0],
-            "foo",
-            True,
-            ~df["a"].str.contains("foo", na=True),
-        ),
-        (
-            "starts_with",
-            schema[0],
-            "foo",
-            False,
-            df["a"].str.lower().str.startswith("foo"),
-        ),
-        (
-            "starts_with",
-            schema[0],
-            "foo",
-            True,
-            df["a"].str.startswith("foo"),
-        ),
-        (
-            "ends_with",
-            schema[0],
-            "foo",
-            False,
-            df["a"].str.lower().str.endswith("foo"),
-        ),
-        (
-            "ends_with",
-            schema[0],
-            "foo",
-            True,
-            df["a"].str.endswith("foo"),
-        ),
-        (
-            "regex_match",
-            schema[0],
-            "f[o]+",
-            False,
-            df["a"].str.match("f[o]+", case=False),
-        ),
-        (
-            "regex_match",
-            schema[0],
-            "f[o]+[^o]*",
-            True,
-            df["a"].str.match("f[o]+[^o]*", case=True),
-        ),
+        ("not_contains", schema[0], "foo", True, ~df["a"].str.contains("foo", na=True)),
+        ("starts_with", schema[0], "foo", False, df["a"].str.lower().str.startswith("foo")),
+        ("starts_with", schema[0], "foo", True, df["a"].str.startswith("foo")),
+        ("ends_with", schema[0], "foo", False, df["a"].str.lower().str.endswith("foo")),
+        ("ends_with", schema[0], "foo", True, df["a"].str.endswith("foo")),
+        ("regex_match", schema[0], "f[o]+", False, df["a"].str.match("f[o]+", case=False)),
+        ("regex_match", schema[0], "f[o]+[^o]*", True, df["a"].str.match("f[o]+[^o]*", case=True)),
     ]
 
     for search_type, column_schema, term, cs, mask in cases:
@@ -1663,14 +1443,7 @@ def test_pandas_filter_search(dxf: DataExplorerFixture):
         ex_table = df[mask.astype(bool)]
         dxf.check_filter_case(
             df,
-            [
-                _search_filter(
-                    column_schema,
-                    term,
-                    case_sensitive=cs,
-                    search_type=search_type,
-                )
-            ],
+            [_search_filter(column_schema, term, case_sensitive=cs, search_type=search_type)],
             ex_table,
         )
 
@@ -1880,11 +1653,7 @@ def test_schema_change_scenario1(ssf: SchemaChangeFixture):
     ssf.check_scenario("df", scenario1, "df['a'] = df['a'].astype(str)")
 
     # polars
-    ssf.check_scenario(
-        "dfp",
-        scenario1,
-        "dfp = dfp.with_columns(pl.col('a').cast(pl.String))",
-    )
+    ssf.check_scenario("dfp", scenario1, "dfp = dfp.with_columns(pl.col('a').cast(pl.String))")
 
 
 def test_schema_change_scenario2(ssf: SchemaChangeFixture):
@@ -1948,20 +1717,14 @@ def test_schema_change_scenario5(ssf: SchemaChangeFixture):
     # Scenario 5: replace a column in place with a new name
     def scenario5(fixture: DataExplorerFixture, table_id):
         schema = fixture.get_schema(table_id)
-        return {
-            "filters": [
-                (_compare_filter(schema[1], "=", "foo"), False),
-            ]
-        }
+        return {"filters": [(_compare_filter(schema[1], "=", "foo"), False)]}
 
     # pandas
     ssf.check_scenario("df", scenario5, "df.insert(1, 'b2', df.pop('b'))")
 
     # polars
     ssf.check_scenario(
-        "dfp",
-        scenario5,
-        "dfp = dfp.drop('b').insert_column(1, dfp['b'].alias('b2'))",
+        "dfp", scenario5, "dfp = dfp.drop('b').insert_column(1, dfp['b'].alias('b2'))"
     )
 
 
@@ -1987,11 +1750,7 @@ def test_schema_change_scenario7(ssf: SchemaChangeFixture, dxf: DataExplorerFixt
     # Scenario 7: delete column, then restore it and check that the
     def scenario7(fixture: DataExplorerFixture, table_id):
         schema = fixture.get_schema(table_id)
-        return {
-            "filters": [
-                (_compare_filter(schema[0], "<", "4"), False),
-            ]
-        }
+        return {"filters": [(_compare_filter(schema[0], "<", "4"), False)]}
 
     ## pandas
 
@@ -2021,10 +1780,7 @@ def test_schema_change_scenario7(ssf: SchemaChangeFixture, dxf: DataExplorerFixt
 def test_schema_change_scenario8(ssf: SchemaChangeFixture):
     # Scenario 8: Delete sorted column in middle of table
     def scenario8(fixture: DataExplorerFixture, table_id):
-        return {
-            "sort_keys": [{"column_index": 1, "ascending": False}],
-            "updated_sort_keys": [],
-        }
+        return {"sort_keys": [{"column_index": 1, "ascending": False}], "updated_sort_keys": []}
 
     # pandas
     ssf.check_scenario("df", scenario8, "del df['b']")
@@ -2055,11 +1811,7 @@ def test_pandas_set_sort_columns(dxf: DataExplorerFixture):
         ("df2", [(1, True)], {"by": "b"}),
         ("df2", [(2, True)], {"by": "c"}),
         ("df2", [(0, True), (1, True)], {"by": ["a", "b"]}),
-        (
-            "df2",
-            [(0, True), (1, False)],
-            {"by": ["a", "b"], "ascending": [True, False]},
-        ),
+        ("df2", [(0, True), (1, False)], {"by": ["a", "b"], "ascending": [True, False]}),
         (
             "df2",
             [(2, False), (1, True), (0, False)],
@@ -2108,11 +1860,7 @@ def test_pandas_change_schema_after_sort(
     # Sort a column that is out of bounds for the table after the
     # schema change below
     dxf.set_sort_columns(
-        "df",
-        [
-            {"column_index": 4, "ascending": True},
-            {"column_index": 0, "ascending": False},
-        ],
+        "df", [{"column_index": 4, "ascending": True}, {"column_index": 0, "ascending": False}]
     )
 
     expected_df = df[["b", "a"]].sort_values("a", ascending=False)  # type: ignore
@@ -2134,11 +1882,7 @@ def test_pandas_updated_with_sort_keys(dxf: DataExplorerFixture):
     # GitHub #3044, PandasView gets into an inconsistent state when a
     # dataset with sort keys set is updated (or the view is refreshed
     # because the dataset is large)
-    arrays = [
-        [1, 2, 3, 4, 5],
-        [True, False, True, None, True],
-        ["foo", "bar", None, "bar", "None"],
-    ]
+    arrays = [[1, 2, 3, 4, 5], [True, False, True, None, True], ["foo", "bar", None, "bar", "None"]]
     df = pd.DataFrame({"f0": arrays[0], "f1": arrays[1], "f2": arrays[2]})
 
     wide_df = _replicate_df_columns(df, 10000)
@@ -2170,17 +1914,11 @@ def test_pandas_updated_with_sort_keys(dxf: DataExplorerFixture):
 
 
 def _select_single_cell(row_index: int, col_index: int):
-    return {
-        "kind": "single_cell",
-        "selection": {"row_index": row_index, "column_index": col_index},
-    }
+    return {"kind": "single_cell", "selection": {"row_index": row_index, "column_index": col_index}}
 
 
 def _select_cell_range(
-    first_row_index: int,
-    last_row_index: int,
-    first_col_index: int,
-    last_col_index: int,
+    first_row_index: int, last_row_index: int, first_col_index: int, last_col_index: int
 ):
     return {
         "kind": "cell_range",
@@ -2194,10 +1932,7 @@ def _select_cell_range(
 
 
 def _select_range(first_index: int, last_index: int, kind: str):
-    return {
-        "kind": kind,
-        "selection": {"first_index": first_index, "last_index": last_index},
-    }
+    return {"kind": kind, "selection": {"first_index": first_index, "last_index": last_index}}
 
 
 def _select_column_range(first_index: int, last_index: int):
@@ -2209,10 +1944,7 @@ def _select_row_range(first_index: int, last_index: int):
 
 
 def _select_indices(indices: List[int], kind: str):
-    return {
-        "kind": kind,
-        "selection": {"indices": indices},
-    }
+    return {"kind": kind, "selection": {"indices": indices}}
 
 
 def _select_column_indices(indices: List[int]):
@@ -2297,10 +2029,7 @@ def test_export_data_selection(dxf: DataExplorerFixture):
         ("dfp", polars_export_cell, polars_export_table, polars_iloc),
     }
 
-    data = {
-        "df": (df, df[df.iloc[:, 0] > 0]),
-        "dfp": (dfp, dfp.filter(dfp[:, 0] > 0)),
-    }
+    data = {"df": (df, df[df.iloc[:, 0] > 0]), "dfp": (dfp, dfp.filter(dfp[:, 0] > 0))}
 
     for name, export_cell, export_table, iloc in data_cases:
         unfiltered, filtered = data[name]
@@ -2348,24 +2077,13 @@ def _get_null_count(column_index):
 def _get_histogram(column_index, bins=2000, method="fixed"):
     return _profile_request(
         column_index,
-        [
-            {
-                "profile_type": "small_histogram",
-                "params": {"method": method, "num_bins": bins},
-            }
-        ],
+        [{"profile_type": "small_histogram", "params": {"method": method, "num_bins": bins}}],
     )
 
 
 def _get_frequency_table(column_index, limit):
     return _profile_request(
-        column_index,
-        [
-            {
-                "profile_type": "small_frequency_table",
-                "params": {"limit": limit},
-            }
-        ],
+        column_index, [{"profile_type": "small_frequency_table", "params": {"limit": limit}}]
     )
 
 
@@ -2388,27 +2106,13 @@ def test_pandas_profile_null_counts(dxf: DataExplorerFixture):
         dxf.register_table(name, df)
 
     # tuples like (table_name, [ColumnProfileRequest], [results])
-    all_profiles = [
-        _get_null_count(0),
-        _get_null_count(1),
-        _get_null_count(2),
-        _get_null_count(3),
-    ]
+    all_profiles = [_get_null_count(0), _get_null_count(1), _get_null_count(2), _get_null_count(3)]
     cases = [
         ("df1", [], []),
+        ("df1", [_get_null_count(3)], [0]),
         (
             "df1",
-            [_get_null_count(3)],
-            [0],
-        ),
-        (
-            "df1",
-            [
-                _get_null_count(0),
-                _get_null_count(1),
-                _get_null_count(2),
-                _get_null_count(3),
-            ],
+            [_get_null_count(0), _get_null_count(1), _get_null_count(2), _get_null_count(3)],
             [2, 3, 4, 0],
         ),
     ]
@@ -2425,12 +2129,7 @@ def test_pandas_profile_null_counts(dxf: DataExplorerFixture):
     # Test profiling with filter
     # format: (table, filters, filtered_table, profiles)
     filter_cases = [
-        (
-            df1,
-            [_filter("not_null", df1_schema[0])],
-            df1[df1["a"].notnull()],
-            all_profiles,
-        )
+        (df1, [_filter("not_null", df1_schema[0])], df1[df1["a"].notnull()], all_profiles)
     ]
     for table, filters, filtered_table, profiles in filter_cases:
         table_id = guid()
@@ -2522,19 +2221,7 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             "f0": arr,
             "f1": arr_with_nulls,
             "f2": [False, False, False, True, None] * 20,
-            "f3": [
-                "foo",
-                "",
-                "baz",
-                "qux",
-                "foo",
-                None,
-                "bar",
-                "",
-                "bar",
-                "zzz",
-            ]
-            * 10,
+            "f3": ["foo", "", "baz", "qux", "foo", None, "bar", "", "bar", "zzz"] * 10,
             "f4": getattr(
                 pd.date_range("2000-01-01", freq="D", periods=100), "date"
             ),  # date column
@@ -2555,14 +2242,7 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="US/Eastern")}
             ),
             pd.DataFrame(
-                {
-                    "x": pd.date_range(
-                        "2000-01-01",
-                        freq="2h",
-                        periods=50,
-                        tz="Asia/Hong_Kong",
-                    )
-                }
+                {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="Asia/Hong_Kong")}
             ),
         ]
     )
@@ -2574,14 +2254,7 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="US/Eastern")}
             ),
             pd.DataFrame(
-                {
-                    "x": pd.date_range(
-                        "2000-01-01",
-                        freq="2h",
-                        periods=50,
-                        tz="Asia/Hong_Kong",
-                    )
-                }
+                {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="Asia/Hong_Kong")}
             ),
         ]
     )
@@ -2622,16 +2295,8 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 "median": _format_float(df1["f1"].median()),
             },
         ),
-        (
-            "df1",
-            2,
-            {"true_count": 20, "false_count": 60},
-        ),
-        (
-            "df1",
-            3,
-            {"num_empty": 20, "num_unique": 6},
-        ),
+        ("df1", 2, {"true_count": 20, "false_count": 60}),
+        ("df1", 3, {"num_empty": 20, "num_unique": 6}),
         (
             "df1",
             4,
@@ -2667,21 +2332,9 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
                 "timezone": "US/Eastern",
             },
         ),
-        (
-            "df1",
-            7,
-            {"mean": "2.50+2.50j", "median": "2.50+2.50j"},
-        ),
-        (
-            "df1",
-            8,
-            {"min_value": "-INF", "max_value": "INF"},
-        ),
-        (
-            "df1",
-            9,
-            {},
-        ),
+        ("df1", 7, {"mean": "2.50+2.50j", "median": "2.50+2.50j"}),
+        ("df1", 8, {"min_value": "-INF", "max_value": "INF"}),
+        ("df1", 9, {}),
         (
             "df_mixed_tz1",
             0,
@@ -2776,15 +2429,7 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
         (
             _get_histogram(2, bins=6),
             {
-                "bin_edges": [
-                    "-10.00",
-                    "-6.67",
-                    "-3.33",
-                    "0.00",
-                    "3.33",
-                    "6.67",
-                    "10.00",
-                ],
+                "bin_edges": ["-10.00", "-6.67", "-3.33", "0.00", "3.33", "6.67", "10.00"],
                 "bin_counts": [1, 1, 1, 3, 2, 1],
                 "quantiles": [],
             },
@@ -2792,13 +2437,7 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
         (
             _get_histogram(3, bins=4),
             {
-                "bin_edges": [
-                    "0.00",
-                    "2.50",
-                    "5.00",
-                    "7.50",
-                    "10.00",
-                ],
+                "bin_edges": ["0.00", "2.50", "5.00", "7.50", "10.00"],
                 "bin_counts": [5, 0, 0, 6],
                 "quantiles": [],
             },
@@ -2813,27 +2452,15 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
         ),
         (
             _get_histogram(5, method="sturges"),
-            {
-                "bin_edges": ["0.5000", "1.50"],
-                "bin_counts": [11],
-                "quantiles": [],
-            },
+            {"bin_edges": ["0.5000", "1.50"], "bin_counts": [11], "quantiles": []},
         ),
         (
             _get_histogram(5, method="freedman_diaconis"),
-            {
-                "bin_edges": ["0.5000", "1.50"],
-                "bin_counts": [11],
-                "quantiles": [],
-            },
+            {"bin_edges": ["0.5000", "1.50"], "bin_counts": [11], "quantiles": []},
         ),
         (
             _get_histogram(5, method="scott"),
-            {
-                "bin_edges": ["0.5000", "1.50"],
-                "bin_counts": [11],
-                "quantiles": [],
-            },
+            {"bin_edges": ["0.5000", "1.50"], "bin_counts": [11], "quantiles": []},
         ),
         (
             _get_histogram(0, bins=50),
@@ -2861,18 +2488,7 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
 def test_pandas_polars_profile_frequency_table(dxf: DataExplorerFixture):
     data = {
         "a": [0, 0, 0, 1, 1, 2, 2, 3, 4, 5],
-        "b": [
-            "foo",
-            "foo",
-            "foo",
-            "foo",
-            "b0",
-            "b0",
-            "b1",
-            "b2",
-            "b3",
-            None,
-        ],
+        "b": ["foo", "foo", "foo", "foo", "b0", "b0", "b1", "b2", "b3", None],
     }
     dxf.register_table("df", pd.DataFrame(data))
     dxf.register_table("dfp", pl.DataFrame(data))
@@ -2880,19 +2496,11 @@ def test_pandas_polars_profile_frequency_table(dxf: DataExplorerFixture):
     cases = [
         (
             _get_frequency_table(0, 3),
-            {
-                "values": ["0", "1", "2"],
-                "counts": [3, 2, 2],
-                "other_count": 3,
-            },
+            {"values": ["0", "1", "2"], "counts": [3, 2, 2], "other_count": 3},
         ),
         (
             _get_frequency_table(1, 3),
-            {
-                "values": ["foo", "b0", "b1"],
-                "counts": [4, 2, 1],
-                "other_count": 2,
-            },
+            {"values": ["foo", "b0", "b1"], "counts": [4, 2, 1], "other_count": 2},
         ),
     ]
 
@@ -2937,24 +2545,14 @@ POLARS_TYPE_EXAMPLES = [
     (pl.Int8, [-1, 2, 3, None], "Int8", "number"),
     (pl.Int16, [-10000, 20000, 30000, None], "Int16", "number"),
     (pl.Int32, [-10000000, 20000000, 30000000, None], "Int32", "number"),
-    (
-        pl.Int64,
-        [-10000000000, 20000000000, 30000000000, None],
-        "Int64",
-        "number",
-    ),
+    (pl.Int64, [-10000000000, 20000000000, 30000000000, None], "Int64", "number"),
     (pl.UInt8, [0, 2, 3, None], "UInt8", "number"),
     (pl.UInt16, [0, 2000, 3000, None], "UInt16", "number"),
     (pl.UInt32, [0, 2000000, 3000000, None], "UInt32", "number"),
     (pl.UInt64, [0, 2000000000, 3000000000, None], "UInt64", "number"),
     (pl.Float32, [-0.01234, 2.56789, 3.012345, None], "Float32", "number"),
     (pl.Float64, [-0.01234, 2.56789, 3.012345, None], "Float64", "number"),
-    (
-        pl.Binary,
-        [b"testing", b"some", b"strings", None],
-        "Binary",
-        "string",
-    ),
+    (pl.Binary, [b"testing", b"some", b"strings", None], "Binary", "string"),
     (pl.String, ["tésting", "söme", "strîngs", None], "String", "string"),
     (pl.Time, [0, 14400000000000, 40271000000000, None], "Time", "time"),
     (
@@ -2970,20 +2568,10 @@ POLARS_TYPE_EXAMPLES = [
         "datetime",
     ),
     (pl.Date, [130120, 0, -1, None], "Date", "date"),
-    (
-        pl.Duration("ms"),
-        [0, 1000, 2000, None],
-        "Duration(time_unit='ms')",
-        "unknown",
-    ),
+    (pl.Duration("ms"), [0, 1000, 2000, None], "Duration(time_unit='ms')", "unknown"),
     (
         pl.Decimal(12, 4),
-        [
-            Decimal("123.4501"),
-            Decimal("0.0000"),
-            Decimal("12345678.4501"),
-            None,
-        ],
+        [Decimal("123.4501"), Decimal("0.0000"), Decimal("12345678.4501"), None],
         "Decimal(precision=12, scale=4)",
         "number",
     ),
@@ -3082,8 +2670,7 @@ def test_polars_get_state(dxf: DataExplorerFixture):
             profile_type="null_count", support_status=SupportStatus.Supported
         ),
         ColumnProfileTypeSupportStatus(
-            profile_type="summary_stats",
-            support_status=SupportStatus.Supported,
+            profile_type="summary_stats", support_status=SupportStatus.Supported
         ),
     ]
 
@@ -3152,13 +2739,7 @@ def test_polars_get_data_values(dxf: DataExplorerFixture):
     result = dxf.get_data_values(
         name,
         columns=[
-            {
-                "column_index": i,
-                "spec": {
-                    "first_index": 2,
-                    "last_index": 11,
-                },
-            }
+            {"column_index": i, "spec": {"first_index": 2, "last_index": 11}}
             for i in range(15, df.shape[1])
         ],
     )
@@ -3184,9 +2765,7 @@ def test_polars_filter_between(dxf: DataExplorerFixture):
         ex_not_between = df.filter((col < left_value) | (col > right_value))
 
         dxf.check_filter_case(
-            df,
-            [_between_filter(column_schema, str(left_value), str(right_value))],
-            ex_between,
+            df, [_between_filter(column_schema, str(left_value), str(right_value))], ex_between
         )
         dxf.check_filter_case(
             df,
@@ -3253,14 +2832,10 @@ def test_polars_filter_empty(dxf: DataExplorerFixture):
     schema = dxf.get_schema_for(df)
 
     dxf.check_filter_case(
-        df,
-        [_filter("is_empty", schema[0])],
-        df.filter(df["a"].str.len_chars() == 0),
+        df, [_filter("is_empty", schema[0])], df.filter(df["a"].str.len_chars() == 0)
     )
     dxf.check_filter_case(
-        df,
-        [_filter("not_empty", schema[0])],
-        df.filter(df["a"].str.len_chars() != 0),
+        df, [_filter("not_empty", schema[0])], df.filter(df["a"].str.len_chars() != 0)
     )
     dxf.check_filter_case(
         df,
@@ -3275,11 +2850,7 @@ def test_polars_filter_empty(dxf: DataExplorerFixture):
 
 
 def test_polars_filter_boolean(dxf: DataExplorerFixture):
-    df = pl.DataFrame(
-        {
-            "a": [True, True, None, False, False, False, True, True],
-        }
-    )
+    df = pl.DataFrame({"a": [True, True, None, False, False, False, True, True]})
 
     schema = dxf.get_schema_for(df)
 
@@ -3313,90 +2884,34 @@ def test_polars_filter_reset(dxf: DataExplorerFixture):
 
 
 def test_polars_filter_search(dxf: DataExplorerFixture):
-    df = pl.DataFrame(
-        {
-            "a": ["foo1", "foo2", None, "2FOO", "FOO3", "bar1", "2BAR"],
-        }
-    )
+    df = pl.DataFrame({"a": ["foo1", "foo2", None, "2FOO", "FOO3", "bar1", "2BAR"]})
 
     dxf.register_table("df", df)
     schema = dxf.get_schema("df")
 
     # (search_type, column_schema, term, case_sensitive, boolean mask)
     cases = [
-        (
-            "contains",
-            schema[0],
-            "foo",
-            False,
-            df["a"].str.to_lowercase().str.contains("foo"),
-        ),
+        ("contains", schema[0], "foo", False, df["a"].str.to_lowercase().str.contains("foo")),
         ("contains", schema[0], "foo", True, df["a"].str.contains("foo")),
-        (
-            "starts_with",
-            schema[0],
-            "foo",
-            False,
-            df["a"].str.to_lowercase().str.starts_with("foo"),
-        ),
-        (
-            "starts_with",
-            schema[0],
-            "foo",
-            True,
-            df["a"].str.starts_with("foo"),
-        ),
-        (
-            "ends_with",
-            schema[0],
-            "foo",
-            False,
-            df["a"].str.to_lowercase().str.ends_with("foo"),
-        ),
-        (
-            "ends_with",
-            schema[0],
-            "foo",
-            True,
-            df["a"].str.ends_with("foo"),
-        ),
-        (
-            "regex_match",
-            schema[0],
-            "f[o]+",
-            False,
-            df["a"].str.contains("(?i)f[o]+"),
-        ),
-        (
-            "regex_match",
-            schema[0],
-            "f[o]+[^o]*",
-            True,
-            df["a"].str.contains("f[o]+[^o]*"),
-        ),
+        ("starts_with", schema[0], "foo", False, df["a"].str.to_lowercase().str.starts_with("foo")),
+        ("starts_with", schema[0], "foo", True, df["a"].str.starts_with("foo")),
+        ("ends_with", schema[0], "foo", False, df["a"].str.to_lowercase().str.ends_with("foo")),
+        ("ends_with", schema[0], "foo", True, df["a"].str.ends_with("foo")),
+        ("regex_match", schema[0], "f[o]+", False, df["a"].str.contains("(?i)f[o]+")),
+        ("regex_match", schema[0], "f[o]+[^o]*", True, df["a"].str.contains("f[o]+[^o]*")),
     ]
 
     for search_type, column_schema, term, cs, mask in cases:
         dxf.check_filter_case(
             df,
-            [
-                _search_filter(
-                    column_schema,
-                    term,
-                    case_sensitive=cs,
-                    search_type=search_type,
-                )
-            ],
+            [_search_filter(column_schema, term, case_sensitive=cs, search_type=search_type)],
             df.filter(mask),
         )
 
 
 def test_polars_filter_set_membership(dxf: DataExplorerFixture):
     df = pl.DataFrame(
-        {
-            "a": [1, 2, 3, 4, None, 5, 6],
-            "b": ["foo", "bar", None, "baz", "foo", None, "qux"],
-        }
+        {"a": [1, 2, 3, 4, None, 5, 6], "b": ["foo", "bar", None, "baz", "foo", None, "qux"]}
     )
     schema = dxf.get_schema_for(df)
 
@@ -3408,23 +2923,11 @@ def test_polars_filter_set_membership(dxf: DataExplorerFixture):
             [_set_member_filter(schema[0], [2, 3.5, 4.0, 5, 6.5])],
             df.filter(df["a"].is_in(pl.Series([2, 3.5, 4.0, 5, 6.5], dtype=pl.Float64))),
         ),
-        (
-            [_set_member_filter(schema[0], [2, 4])],
-            df.filter(df["a"].is_in([2, 4])),
-        ),
-        (
-            [_set_member_filter(schema[1], ["bar", "foo"])],
-            df.filter(df["b"].is_in(["bar", "foo"])),
-        ),
+        ([_set_member_filter(schema[0], [2, 4])], df.filter(df["a"].is_in([2, 4]))),
+        ([_set_member_filter(schema[1], ["bar", "foo"])], df.filter(df["b"].is_in(["bar", "foo"]))),
         ([_set_member_filter(schema[1], [])], df.filter(df["b"].is_in([]))),
-        (
-            [_set_member_filter(schema[1], ["bar"], False)],
-            df.filter(~df["b"].is_in(["bar"])),
-        ),
-        (
-            [_set_member_filter(schema[1], [], False)],
-            df.filter(~df["b"].is_in([])),
-        ),
+        ([_set_member_filter(schema[1], ["bar"], False)], df.filter(~df["b"].is_in(["bar"]))),
+        ([_set_member_filter(schema[1], [], False)], df.filter(~df["b"].is_in([]))),
     ]
 
     for filter_set, expected_df in cases:
@@ -3457,11 +2960,7 @@ def test_polars_set_sort_columns(dxf: DataExplorerFixture):
         ("df2", [(1, True)], {"by": "b"}),
         ("df2", [(2, True)], {"by": "c"}),
         ("df2", [(0, True), (1, True)], {"by": ["a", "b"]}),
-        (
-            "df2",
-            [(0, True), (1, False)],
-            {"by": ["a", "b"], "descending": [False, True]},
-        ),
+        ("df2", [(0, True), (1, False)], {"by": ["a", "b"], "descending": [False, True]}),
         (
             "df2",
             [(2, False), (1, True), (0, False)],
@@ -3471,12 +2970,7 @@ def test_polars_set_sort_columns(dxf: DataExplorerFixture):
 
     # Test sort AND filter
     filter_cases = {
-        "df2": [
-            (
-                lambda x: x.filter(x["a"] > 0),
-                [_compare_filter(df2_schema[0], ">", 0)],
-            )
-        ]
+        "df2": [(lambda x: x.filter(x["a"] > 0), [_compare_filter(df2_schema[0], ">", 0)])]
     }
 
     for df_name, sort_keys, expected_params in cases:
@@ -3486,10 +2980,7 @@ def test_polars_set_sort_columns(dxf: DataExplorerFixture):
         ]
 
         args = (expected_params["by"],)
-        kwds = {
-            "descending": expected_params.get("descending", False),
-            "maintain_order": True,
-        }
+        kwds = {"descending": expected_params.get("descending", False), "maintain_order": True}
 
         expected_df = df.sort(*args, **kwds)
         dxf.check_sort_case(df, wrapped_keys, expected_df)
@@ -3515,19 +3006,10 @@ def test_polars_profile_null_counts(dxf: DataExplorerFixture):
     # tuples like (table_name, [ColumnProfileRequest], [results])
     cases = [
         (name, [], []),
+        (name, [_get_null_count(3)], [0]),
         (
             name,
-            [_get_null_count(3)],
-            [0],
-        ),
-        (
-            name,
-            [
-                _get_null_count(0),
-                _get_null_count(1),
-                _get_null_count(2),
-                _get_null_count(3),
-            ],
+            [_get_null_count(0), _get_null_count(1), _get_null_count(2), _get_null_count(3)],
             [2, 3, 4, 0],
         ),
     ]
@@ -3551,26 +3033,12 @@ def test_polars_profile_summary_stats(dxf: DataExplorerFixture):
             "f0": arr,
             "f1": arr_with_nulls,
             "f2": [False, False, False, True, None] * 20,
-            "f3": [
-                "foo",
-                "",
-                "baz",
-                "qux",
-                "foo",
-                None,
-                "bar",
-                "",
-                "bar",
-                "zzz",
-            ]
-            * 10,
+            "f3": ["foo", "", "baz", "qux", "foo", None, "bar", "", "bar", "zzz"] * 10,
             "f4": pl.Series(
-                pd.date_range("2000-01-01", freq="D", periods=100),
-                dtype=pl.Date,
+                pd.date_range("2000-01-01", freq="D", periods=100), dtype=pl.Date
             ),  # date column
             "f5": pl.Series(
-                list(pd.date_range("2000-01-01", freq="2h", periods=100)),
-                dtype=pl.Datetime("us"),
+                list(pd.date_range("2000-01-01", freq="2h", periods=100)), dtype=pl.Datetime("us")
             ),  # datetime no tz
             "f6": pl.Series(
                 [
@@ -3618,16 +3086,8 @@ def test_polars_profile_summary_stats(dxf: DataExplorerFixture):
                 "median": _format_float(df1["f1"].median()),
             },
         ),
-        (
-            "df1",
-            2,
-            {"true_count": 20, "false_count": 60},
-        ),
-        (
-            "df1",
-            3,
-            {"num_empty": 20, "num_unique": 7},
-        ),
+        ("df1", 2, {"true_count": 20, "false_count": 60}),
+        ("df1", 3, {"num_empty": 20, "num_unique": 7}),
         (
             "df1",
             4,
@@ -3663,16 +3123,8 @@ def test_polars_profile_summary_stats(dxf: DataExplorerFixture):
                 "timezone": "UTC",
             },
         ),
-        (
-            "df1",
-            7,
-            {"min_value": "-INF", "max_value": "INF"},
-        ),
-        (
-            "df1",
-            8,
-            {},
-        ),
+        ("df1", 7, {"min_value": "-INF", "max_value": "INF"}),
+        ("df1", 8, {}),
     ]
 
     for table_name, col_index, ex_result in cases:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_data_explorer.py
@@ -183,7 +183,9 @@ def test_explorer_open_close_delete(
     assert len(de_service.table_views) == 0
 
 
-def _assign_variables(shell: PositronShell, variables_comm: DummyComm, **variables):
+def _assign_variables(
+    shell: PositronShell, variables_comm: DummyComm, **variables
+):
     # A hack to make sure that change events are fired when we
     # manipulate user_ns
     shell.kernel.variables_service.snapshot_user_ns()
@@ -224,7 +226,9 @@ def test_explorer_delete_variable(
         assert len(paths) > 0
 
         comms = [
-            de_service.comms[comm_id] for p in paths for comm_id in de_service.path_to_comm_ids[p]
+            de_service.comms[comm_id]
+            for p in paths
+            for comm_id in de_service.path_to_comm_ids[p]
         ]
         variables_comm.handle_msg(msg)
 
@@ -256,7 +260,11 @@ def _get_comms_for_name(de_service, name):
     paths = de_service.get_paths_for_variable(name)
     assert len(paths) > 0
 
-    return [de_service.comms[comm_id] for p in paths for comm_id in de_service.path_to_comm_ids[p]]
+    return [
+        de_service.comms[comm_id]
+        for p in paths
+        for comm_id in de_service.path_to_comm_ids[p]
+    ]
 
 
 def _check_update_variable(de_service, name, update_type="schema"):
@@ -316,7 +324,8 @@ def test_register_table_after_installing_dependency(
     monkeypatch.setattr(data_explorer, import_name, None)
 
     with pytest.raises(
-        RestartRequiredError, match=f"^{title} was installed after the session started."
+        RestartRequiredError,
+        match=f"^{title} was installed after the session started.",
     ):
         de_service.register_table(table, "test_table")
 
@@ -417,7 +426,9 @@ class DataExplorerFixture:
 
     def get_schema(self, table_name, column_indices=None):
         if column_indices is None:
-            column_indices = list(range(self.get_state(table_name)["table_shape"]["num_columns"]))
+            column_indices = list(
+                range(self.get_state(table_name)["table_shape"]["num_columns"])
+            )
 
         return self.do_json_rpc(
             table_name,
@@ -437,7 +448,9 @@ class DataExplorerFixture:
     def get_state(self, table_name):
         return self.do_json_rpc(table_name, "get_state")
 
-    def get_data_values(self, table_name, format_options=DEFAULT_FORMAT, columns=None):
+    def get_data_values(
+        self, table_name, format_options=DEFAULT_FORMAT, columns=None
+    ):
         return self.do_json_rpc(
             table_name,
             "get_data_values",
@@ -445,7 +458,9 @@ class DataExplorerFixture:
             columns=columns,
         )
 
-    def get_row_labels(self, table_name, selection, format_options=DEFAULT_FORMAT):
+    def get_row_labels(
+        self, table_name, selection, format_options=DEFAULT_FORMAT
+    ):
         return self.do_json_rpc(
             table_name,
             "get_row_labels",
@@ -465,9 +480,13 @@ class DataExplorerFixture:
         return self.do_json_rpc(table_name, "set_row_filters", filters=filters)
 
     def set_sort_columns(self, table_name, sort_keys=None):
-        return self.do_json_rpc(table_name, "set_sort_columns", sort_keys=sort_keys)
+        return self.do_json_rpc(
+            table_name, "set_sort_columns", sort_keys=sort_keys
+        )
 
-    def get_column_profiles(self, table_name, profiles, format_options=DEFAULT_FORMAT):
+    def get_column_profiles(
+        self, table_name, profiles, format_options=DEFAULT_FORMAT
+    ):
         callback_id = guid()
         result = self.do_json_rpc(
             table_name,
@@ -493,7 +512,9 @@ class DataExplorerFixture:
 
         ex_num_rows = len(expected_table)
         try:
-            assert response == FilterResult(selected_num_rows=ex_num_rows, had_errors=False)
+            assert response == FilterResult(
+                selected_num_rows=ex_num_rows, had_errors=False
+            )
         except Exception:
             pprint.pprint(state["row_filters"])
             raise
@@ -530,7 +551,9 @@ class DataExplorerFixture:
         assert response is None
         self.compare_tables(table_id, ex_unsorted_id, table.shape)
 
-    def compare_tables(self, table_id: str, expected_id: str, table_shape: tuple):
+    def compare_tables(
+        self, table_id: str, expected_id: str, table_shape: tuple
+    ):
         state = self.get_state(table_id)
         ex_state = self.get_state(expected_id)
 
@@ -550,10 +573,14 @@ class DataExplorerFixture:
             mask = left == right
             different_indices = (~mask).nonzero()[0]
             if len(different_indices) > 0:
-                raise AssertionError(f"Indices differ at {str(different_indices)}")
+                raise AssertionError(
+                    f"Indices differ at {str(different_indices)}"
+                )
 
 
-def get_column_profile_result(de_service: DataExplorerService, comm_id: str, callback_id: str):
+def get_column_profile_result(
+    de_service: DataExplorerService, comm_id: str, callback_id: str
+):
     comm = cast(DummyComm, de_service.comms[comm_id].comm)
     for message in comm.messages:
         data = message["data"]
@@ -664,7 +691,9 @@ def test_pandas_supported_features(dxf: DataExplorerFixture):
     ]
     for tp in row_filter_types:
         assert (
-            RowFilterTypeSupportStatus(row_filter_type=tp, support_status=SupportStatus.Supported)
+            RowFilterTypeSupportStatus(
+                row_filter_type=tp, support_status=SupportStatus.Supported
+            )
             in row_filters["supported_types"]
         )
     assert len(row_filter_types) == len(row_filters["supported_types"])
@@ -731,7 +760,9 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
         ),
         ([None, MyData(5), MyData(-1), None, None], "mixed", "object"),
         (
-            np.array([1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, 5 + 5j], dtype="complex64"),
+            np.array(
+                [1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, 5 + 5j], dtype="complex64"
+            ),
             "complex64",
             "number",
         ),
@@ -904,8 +935,12 @@ def test_pandas_wide_schemas(dxf: DataExplorerFixture):
             df.iloc[:, start_index : (chunk_index + 1) * chunk_size],
         )
 
-        schema_slice = dxf.get_schema("wide_df", list(range(start_index, start_index + chunk_size)))
-        expected = dxf.get_schema(f"wide_df_{chunk_index}", list(range(0, chunk_size)))
+        schema_slice = dxf.get_schema(
+            "wide_df", list(range(start_index, start_index + chunk_size))
+        )
+        expected = dxf.get_schema(
+            f"wide_df_{chunk_index}", list(range(0, chunk_size))
+        )
 
         for left, right in zip(schema_slice, expected):
             right["column_index"] = right["column_index"] + start_index
@@ -926,7 +961,9 @@ def _text_search_filter(term, match="contains", case_sensitive=False):
 def _match_types_filter(data_types):
     return {
         "filter_type": "match_data_types",
-        "params": {"display_types": [getattr(x, "value", x) for x in data_types]},
+        "params": {
+            "display_types": [getattr(x, "value", x) for x in data_types]
+        },
     }
 
 
@@ -955,7 +992,8 @@ def test_search_schema(dxf: DataExplorerFixture):
     }
 
     frame_data = {
-        name: data_examples[i % len(data_examples)] for i, name in enumerate(column_names)
+        name: data_examples[i % len(data_examples)]
+        for i, name in enumerate(column_names)
     }
 
     # Make a data frame with those column names
@@ -986,12 +1024,18 @@ def test_search_schema(dxf: DataExplorerFixture):
             (
                 [
                     aaa_filter,
-                    _match_types_filter([ColumnDisplayType.Boolean, ColumnDisplayType.Number]),
+                    _match_types_filter(
+                        [ColumnDisplayType.Boolean, ColumnDisplayType.Number]
+                    ),
                 ],
                 0,
                 120,
                 600,
-                [x for i, x in enumerate(full_schema[:200]) if i % 5 in (0, 2, 3)],
+                [
+                    x
+                    for i, x in enumerate(full_schema[:200])
+                    if i % 5 in (0, 2, 3)
+                ],
             ),
             ([aaa_filter], 100, 100, 1000, full_schema[100:200]),
             ([aaa_filter], 950, 100, 1000, full_schema[950:1000]),
@@ -1048,16 +1092,22 @@ def test_pandas_get_data_values(dxf: DataExplorerFixture):
     indices = [0, 2, 4]
     result = dxf.get_data_values(
         "simple",
-        columns=[{"column_index": i, "spec": {"indices": indices}} for i in list(range(8))],
+        columns=[
+            {"column_index": i, "spec": {"indices": indices}}
+            for i in list(range(8))
+        ],
     )
     assert result["columns"] == [
-        [x for i, x in enumerate(col) if i in indices] for col in expected_columns
+        [x for i, x in enumerate(col) if i in indices]
+        for col in expected_columns
     ]
 
     # Edge cases: request beyond end of table
     response = dxf.get_data_values(
         "simple",
-        columns=[{"column_index": 0, "spec": {"first_index": 5, "last_index": 14}}],
+        columns=[
+            {"column_index": 0, "spec": {"first_index": 5, "last_index": 14}}
+        ],
     )
     assert response["columns"] == [[]]
 
@@ -1129,7 +1179,9 @@ def test_pandas_float_formatting(dxf: DataExplorerFixture):
             ],
         ),
         (
-            DEFAULT_FORMAT.copy(update={"thousands_sep": "_", "large_num_digits": 3}),
+            DEFAULT_FORMAT.copy(
+                update={"thousands_sep": "_", "large_num_digits": 3}
+            ),
             [
                 [
                     "0.000",
@@ -1192,8 +1244,12 @@ def test_get_data_values_max_value_length(dxf: DataExplorerFixture):
 def test_pandas_extension_dtypes(dxf: DataExplorerFixture):
     df = pd.DataFrame(
         {
-            "datetime_tz": pd.date_range("2000-01-01", periods=5, tz="US/Eastern"),
-            "arrow_bools": pd.Series([False, None, True, False, None], dtype=pd.BooleanDtype()),
+            "datetime_tz": pd.date_range(
+                "2000-01-01", periods=5, tz="US/Eastern"
+            ),
+            "arrow_bools": pd.Series(
+                [False, None, True, False, None], dtype=pd.BooleanDtype()
+            ),
             "arrow_strings": pd.Series(
                 ["foo", "bar", "baz", None, "quuuux"], dtype=pd.StringDtype()
             ),
@@ -1263,7 +1319,9 @@ def test_pandas_leading_whitespace(dxf: DataExplorerFixture):
     assert result["columns"] == expected_columns
 
 
-def _filter(filter_type, column_schema, condition="and", is_valid=None, **kwargs):
+def _filter(
+    filter_type, column_schema, condition="and", is_valid=None, **kwargs
+):
     kwargs.update(
         {
             "filter_id": guid(),
@@ -1286,7 +1344,9 @@ def _compare_filter(column_schema, op, value, condition="and", is_valid=None):
     )
 
 
-def _between_filter(column_schema, left_value, right_value, op="between", condition="and"):
+def _between_filter(
+    column_schema, left_value, right_value, op="between", condition="and"
+):
     return _filter(
         op,
         column_schema,
@@ -1298,7 +1358,9 @@ def _between_filter(column_schema, left_value, right_value, op="between", condit
     )
 
 
-def _not_between_filter(column_schema, left_value, right_value, condition="and"):
+def _not_between_filter(
+    column_schema, left_value, right_value, condition="and"
+):
     return _between_filter(
         column_schema,
         left_value,
@@ -1366,7 +1428,11 @@ def test_pandas_filter_between(dxf: DataExplorerFixture):
         )
         dxf.check_filter_case(
             df,
-            [_not_between_filter(column_schema, str(left_value), str(right_value))],
+            [
+                _not_between_filter(
+                    column_schema, str(left_value), str(right_value)
+                )
+            ],
             ex_not_between,
         )
 
@@ -1517,10 +1583,18 @@ def test_pandas_filter_empty(dxf: DataExplorerFixture):
 
     schema = dxf.get_schema_for(df)
 
-    dxf.check_filter_case(df, [_filter("is_empty", schema[0])], df[df["a"].str.len() == 0])
-    dxf.check_filter_case(df, [_filter("not_empty", schema[0])], df[df["a"].str.len() != 0])
-    dxf.check_filter_case(df, [_filter("is_empty", schema[1])], df[df["b"].str.len() == 0])
-    dxf.check_filter_case(df, [_filter("not_empty", schema[1])], df[df["b"].str.len() != 0])
+    dxf.check_filter_case(
+        df, [_filter("is_empty", schema[0])], df[df["a"].str.len() == 0]
+    )
+    dxf.check_filter_case(
+        df, [_filter("not_empty", schema[0])], df[df["a"].str.len() != 0]
+    )
+    dxf.check_filter_case(
+        df, [_filter("is_empty", schema[1])], df[df["b"].str.len() == 0]
+    )
+    dxf.check_filter_case(
+        df, [_filter("not_empty", schema[1])], df[df["b"].str.len() != 0]
+    )
 
 
 def test_pandas_filter_boolean(dxf: DataExplorerFixture):
@@ -1532,8 +1606,12 @@ def test_pandas_filter_boolean(dxf: DataExplorerFixture):
 
     schema = dxf.get_schema_for(df)
 
-    dxf.check_filter_case(df, [_filter("is_true", schema[0])], df[df["a"] == True])  # noqa: E712
-    dxf.check_filter_case(df, [_filter("is_false", schema[0])], df[df["a"] == False])  # noqa: E712
+    dxf.check_filter_case(
+        df, [_filter("is_true", schema[0])], df[df["a"] == True]
+    )  # noqa: E712
+    dxf.check_filter_case(
+        df, [_filter("is_false", schema[0])], df[df["a"] == False]
+    )  # noqa: E712
 
 
 def test_pandas_filter_is_null_not_null(dxf: DataExplorerFixture):
@@ -1681,7 +1759,10 @@ def _replicate_df_columns(df, new_width):
     # unique
     ncols = df.shape[1]
     return pd.DataFrame(
-        {f"{df.columns[i % ncols]}_{i}": df.iloc[:, i % ncols] for i in range(new_width)}
+        {
+            f"{df.columns[i % ncols]}_{i}": df.iloc[:, i % ncols]
+            for i in range(new_width)
+        }
     )
 
 
@@ -1744,7 +1825,9 @@ def test_variable_updates(
         assert new_state["display_name"] == name
         assert new_state["table_shape"]["num_rows"] == 5
         assert new_state["table_shape"]["num_columns"] == 1
-        assert new_state["sort_keys"] == [ColumnSortKey(**k) for k in x_sort_keys]
+        assert new_state["sort_keys"] == [
+            ColumnSortKey(**k) for k in x_sort_keys
+        ]
 
     # Execute code that triggers a schema update events for large data
     # frames
@@ -1813,7 +1896,9 @@ class SchemaChangeFixture:
             self.dxf.set_sort_columns(table_id, sort_keys=scenario["sort_keys"])
 
         if len(filter_spec) > 0:
-            self.dxf.set_row_filters(table_id, filters=list(zip(*filter_spec))[0])
+            self.dxf.set_row_filters(
+                table_id, filters=list(zip(*filter_spec))[0]
+            )
 
         self.dxf.execute_code(code)
 
@@ -1903,7 +1988,9 @@ def test_schema_change_scenario2(ssf: SchemaChangeFixture):
     ssf.check_scenario("df", scenario2, "df['a'] = df['a'].astype('int16')")
 
     # polars
-    ssf.check_scenario("dfp", scenario2, "dfp = dfp.with_columns(pl.col('a').cast(pl.Int16))")
+    ssf.check_scenario(
+        "dfp", scenario2, "dfp = dfp.with_columns(pl.col('a').cast(pl.Int16))"
+    )
 
 
 def test_schema_change_scenario3(ssf: SchemaChangeFixture):
@@ -1980,10 +2067,14 @@ def test_schema_change_scenario6(ssf: SchemaChangeFixture):
     ssf.check_scenario("df", scenario6, "df['b2'] = df['b']")
 
     # polars
-    ssf.check_scenario("dfp", scenario6, "dfp = dfp.with_columns(dfp['b'].alias('b2'))")
+    ssf.check_scenario(
+        "dfp", scenario6, "dfp = dfp.with_columns(dfp['b'].alias('b2'))"
+    )
 
 
-def test_schema_change_scenario7(ssf: SchemaChangeFixture, dxf: DataExplorerFixture):
+def test_schema_change_scenario7(
+    ssf: SchemaChangeFixture, dxf: DataExplorerFixture
+):
     # Scenario 7: delete column, then restore it and check that the
     def scenario7(fixture: DataExplorerFixture, table_id):
         schema = fixture.get_schema(table_id)
@@ -2068,12 +2159,17 @@ def test_pandas_set_sort_columns(dxf: DataExplorerFixture):
     ]
 
     # Test sort AND filter
-    filter_cases = {"df2": [(lambda x: x[x["a"] > 0], [_compare_filter(df2_schema[0], ">", 0)])]}
+    filter_cases = {
+        "df2": [
+            (lambda x: x[x["a"] > 0], [_compare_filter(df2_schema[0], ">", 0)])
+        ]
+    }
 
     for df_name, sort_keys, expected_params in cases:
         df = tables[df_name]
         wrapped_keys = [
-            {"column_index": index, "ascending": ascending} for index, ascending in sort_keys
+            {"column_index": index, "ascending": ascending}
+            for index, ascending in sort_keys
         ]
 
         expected_params["kind"] = "mergesort"
@@ -2084,7 +2180,9 @@ def test_pandas_set_sort_columns(dxf: DataExplorerFixture):
 
         for filter_f, filters in filter_cases.get(df_name, []):
             expected_filtered = filter_f(df).sort_values(**expected_params)
-            dxf.check_sort_case(df, wrapped_keys, expected_filtered, filters=filters)
+            dxf.check_sort_case(
+                df, wrapped_keys, expected_filtered, filters=filters
+            )
 
 
 def test_pandas_change_schema_after_sort(
@@ -2153,7 +2251,9 @@ def test_pandas_updated_with_sort_keys(dxf: DataExplorerFixture):
         new_view = PandasView(
             table,
             None,  # type: ignore
-            DataExplorerState(name, row_filters=state.row_filters, sort_keys=state.sort_keys),
+            DataExplorerState(
+                name, row_filters=state.row_filters, sort_keys=state.sort_keys
+            ),
             dxf.de_service.job_queue,
         )
 
@@ -2228,9 +2328,13 @@ def test_export_data_selection(dxf: DataExplorerFixture):
     ncols = 20
 
     np.random.seed(12345)
-    df = pd.DataFrame({f"a{i}": np.random.standard_normal(length) for i in range(ncols)})
+    df = pd.DataFrame(
+        {f"a{i}": np.random.standard_normal(length) for i in range(ncols)}
+    )
 
-    dfp = pl.DataFrame({f"a{i}": np.random.standard_normal(length) for i in range(ncols)})
+    dfp = pl.DataFrame(
+        {f"a{i}": np.random.standard_normal(length) for i in range(ncols)}
+    )
 
     pandas_name = "df"
     polars_name = "dfp"
@@ -2242,7 +2346,9 @@ def test_export_data_selection(dxf: DataExplorerFixture):
 
     for name in ["df_filtered", "dfp_filtered"]:
         schema = dxf.get_schema(name)
-        dxf.set_row_filters(name, filters=[_compare_filter(schema[0], ">", "0")])
+        dxf.set_row_filters(
+            name, filters=[_compare_filter(schema[0], ">", "0")]
+        )
 
     # Test exporting single cells
     single_cell_cases = [(0, 0), (5, 10), (25, 15), (99, 19)]
@@ -2313,7 +2419,9 @@ def test_export_data_selection(dxf: DataExplorerFixture):
 
             filt_row_index = min(row_index, len(filtered) - 1)
             filt_selection = _select_single_cell(filt_row_index, col_index)
-            filt_result = dxf.export_data_selection(f"{name}_filtered", filt_selection, "csv")
+            filt_result = dxf.export_data_selection(
+                f"{name}_filtered", filt_selection, "csv"
+            )
             filt_expected = export_cell(filtered, filt_row_index, col_index)
             assert filt_result["data"] == filt_expected
 
@@ -2332,7 +2440,9 @@ def test_export_data_selection(dxf: DataExplorerFixture):
                 assert df_result["data"] == df_expected
                 assert df_result["format"] == fmt
 
-                filt_result = dxf.export_data_selection(f"{name}_filtered", rpc_selection, fmt)
+                filt_result = dxf.export_data_selection(
+                    f"{name}_filtered", rpc_selection, fmt
+                )
                 filt_expected = export_table(filtered_selected, fmt)
                 assert filt_result["data"] == filt_expected
 
@@ -2416,7 +2526,9 @@ def test_pandas_profile_null_counts(dxf: DataExplorerFixture):
     for table_name, profiles, ex_results in cases:
         results = dxf.get_column_profiles(table_name, profiles)
 
-        ex_results = [ColumnProfileResult(null_count=count) for count in ex_results]
+        ex_results = [
+            ColumnProfileResult(null_count=count) for count in ex_results
+        ]
 
         assert results == ex_results
 
@@ -2486,7 +2598,9 @@ def _assert_numeric_stats_equal(expected, actual):
     # for stats that weren't expected, check that there isn't an
     # unexpected value
     for not_expected_stat in all_stats:
-        assert not_expected_stat not in actual or actual[not_expected_stat] is None
+        assert (
+            not_expected_stat not in actual or actual[not_expected_stat] is None
+        )
 
 
 def _assert_string_stats_equal(expected, actual):
@@ -2538,7 +2652,9 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             "f4": getattr(
                 pd.date_range("2000-01-01", freq="D", periods=100), "date"
             ),  # date column
-            "f5": pd.date_range("2000-01-01", freq="2h", periods=100),  # datetime no tz
+            "f5": pd.date_range(
+                "2000-01-01", freq="2h", periods=100
+            ),  # datetime no tz
             "f6": pd.date_range(
                 "2000-01-01", freq="2h", periods=100, tz="US/Eastern"
             ),  # datetime single tz
@@ -2550,9 +2666,15 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
 
     df_mixed_tz1 = pd.concat(
         [
-            pd.DataFrame({"x": pd.date_range("2000-01-01", freq="2h", periods=50)}),
             pd.DataFrame(
-                {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="US/Eastern")}
+                {"x": pd.date_range("2000-01-01", freq="2h", periods=50)}
+            ),
+            pd.DataFrame(
+                {
+                    "x": pd.date_range(
+                        "2000-01-01", freq="2h", periods=50, tz="US/Eastern"
+                    )
+                }
             ),
             pd.DataFrame(
                 {
@@ -2571,7 +2693,11 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
     df_mixed_tz2 = pd.concat(
         [
             pd.DataFrame(
-                {"x": pd.date_range("2000-01-01", freq="2h", periods=50, tz="US/Eastern")}
+                {
+                    "x": pd.date_range(
+                        "2000-01-01", freq="2h", periods=50, tz="US/Eastern"
+                    )
+                }
             ),
             pd.DataFrame(
                 {
@@ -2710,7 +2836,9 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
 
     for table_name, col_index, ex_result in cases:
         profiles = [_get_summary_stats(col_index)]
-        results = dxf.get_column_profiles(table_name, profiles, format_options=format_options)
+        results = dxf.get_column_profiles(
+            table_name, profiles, format_options=format_options
+        )
 
         stats = results[0]["summary_stats"]
         assert_summary_stats_equal(stats["type_display"], stats, ex_result)
@@ -2838,7 +2966,9 @@ def test_pandas_polars_profile_histogram(dxf: DataExplorerFixture):
         (
             _get_histogram(0, bins=50),
             {
-                "bin_edges": [_format_float(x) for x in np.linspace(0.0, 10.0, 12)],
+                "bin_edges": [
+                    _format_float(x) for x in np.linspace(0.0, 10.0, 12)
+                ],
                 "bin_counts": [1] * 11,
                 "quantiles": [],
             },
@@ -3006,7 +3136,9 @@ POLARS_TYPE_EXAMPLES = [
 def example_polars_df():
     full_schema = []
     full_data = []
-    for i, (dtype, data, type_name, type_display) in enumerate(POLARS_TYPE_EXAMPLES):
+    for i, (dtype, data, type_name, type_display) in enumerate(
+        POLARS_TYPE_EXAMPLES
+    ):
         name = f"f{i}"
         s = pl.Series(name=name, values=data, dtype=dtype)
         full_data.append(s)
@@ -3065,15 +3197,25 @@ def test_polars_get_state(dxf: DataExplorerFixture):
     assert not state["has_row_labels"]
 
     features = state["supported_features"]
-    assert features["search_schema"]["support_status"] == SupportStatus.Unsupported
-    assert features["set_row_filters"]["support_status"] == SupportStatus.Supported
+    assert (
+        features["search_schema"]["support_status"] == SupportStatus.Unsupported
+    )
+    assert (
+        features["set_row_filters"]["support_status"] == SupportStatus.Supported
+    )
 
     column_filters = features["set_column_filters"]
     assert column_filters["support_status"] == SupportStatus.Unsupported
     assert column_filters["supported_types"] == []
 
-    assert features["set_sort_columns"]["support_status"] == SupportStatus.Supported
-    assert features["get_column_profiles"]["support_status"] == SupportStatus.Supported
+    assert (
+        features["set_sort_columns"]["support_status"]
+        == SupportStatus.Supported
+    )
+    assert (
+        features["get_column_profiles"]["support_status"]
+        == SupportStatus.Supported
+    )
     export_data = features["export_data_selection"]
     assert export_data["support_status"] == SupportStatus.Supported
     assert export_data["supported_formats"] == ["csv", "tsv"]
@@ -3142,10 +3284,14 @@ def test_polars_get_data_values(dxf: DataExplorerFixture):
     indices = [0, 1, 3]
     result = dxf.get_data_values(
         name,
-        columns=[{"column_index": i, "spec": {"indices": indices}} for i in range(df.shape[1])],
+        columns=[
+            {"column_index": i, "spec": {"indices": indices}}
+            for i in range(df.shape[1])
+        ],
     )
     assert result["columns"] == [
-        [x for i, x in enumerate(col) if i in indices] for col in expected_columns
+        [x for i, x in enumerate(col) if i in indices]
+        for col in expected_columns
     ]
 
     # Select subset range
@@ -3190,7 +3336,11 @@ def test_polars_filter_between(dxf: DataExplorerFixture):
         )
         dxf.check_filter_case(
             df,
-            [_not_between_filter(column_schema, str(left_value), str(right_value))],
+            [
+                _not_between_filter(
+                    column_schema, str(left_value), str(right_value)
+                )
+            ],
             ex_not_between,
         )
 
@@ -3283,15 +3433,23 @@ def test_polars_filter_boolean(dxf: DataExplorerFixture):
 
     schema = dxf.get_schema_for(df)
 
-    dxf.check_filter_case(df, [_filter("is_true", schema[0])], df.filter(df["a"]))
-    dxf.check_filter_case(df, [_filter("is_false", schema[0])], df.filter(~df["a"]))
+    dxf.check_filter_case(
+        df, [_filter("is_true", schema[0])], df.filter(df["a"])
+    )
+    dxf.check_filter_case(
+        df, [_filter("is_false", schema[0])], df.filter(~df["a"])
+    )
 
 
 def test_polars_filter_is_null_not_null(dxf: DataExplorerFixture):
     df, schema = example_polars_df()
     for i, col in enumerate(schema):
-        dxf.check_filter_case(df, [_filter("is_null", col)], df.filter(df[:, i].is_null()))
-        dxf.check_filter_case(df, [_filter("not_null", col)], df.filter(~df[:, i].is_null()))
+        dxf.check_filter_case(
+            df, [_filter("is_null", col)], df.filter(df[:, i].is_null())
+        )
+        dxf.check_filter_case(
+            df, [_filter("not_null", col)], df.filter(~df[:, i].is_null())
+        )
 
 
 def test_polars_filter_reset(dxf: DataExplorerFixture):
@@ -3406,7 +3564,11 @@ def test_polars_filter_set_membership(dxf: DataExplorerFixture):
         # resolution.
         (
             [_set_member_filter(schema[0], [2, 3.5, 4.0, 5, 6.5])],
-            df.filter(df["a"].is_in(pl.Series([2, 3.5, 4.0, 5, 6.5], dtype=pl.Float64))),
+            df.filter(
+                df["a"].is_in(
+                    pl.Series([2, 3.5, 4.0, 5, 6.5], dtype=pl.Float64)
+                )
+            ),
         ),
         (
             [_set_member_filter(schema[0], [2, 4])],
@@ -3482,7 +3644,8 @@ def test_polars_set_sort_columns(dxf: DataExplorerFixture):
     for df_name, sort_keys, expected_params in cases:
         df = tables[df_name]
         wrapped_keys = [
-            {"column_index": index, "ascending": ascending} for index, ascending in sort_keys
+            {"column_index": index, "ascending": ascending}
+            for index, ascending in sort_keys
         ]
 
         args = (expected_params["by"],)
@@ -3496,7 +3659,9 @@ def test_polars_set_sort_columns(dxf: DataExplorerFixture):
 
         for filter_f, filters in filter_cases.get(df_name, []):
             expected_filtered = filter_f(df).sort(*args, **kwds)
-            dxf.check_sort_case(df, wrapped_keys, expected_filtered, filters=filters)
+            dxf.check_sort_case(
+                df, wrapped_keys, expected_filtered, filters=filters
+            )
 
 
 def test_polars_profile_null_counts(dxf: DataExplorerFixture):
@@ -3535,7 +3700,9 @@ def test_polars_profile_null_counts(dxf: DataExplorerFixture):
     for table_name, profiles, ex_results in cases:
         results = dxf.get_column_profiles(table_name, profiles)
 
-        ex_results = [ColumnProfileResult(null_count=count) for count in ex_results]
+        ex_results = [
+            ColumnProfileResult(null_count=count) for count in ex_results
+        ]
 
         assert results == ex_results
 
@@ -3677,7 +3844,9 @@ def test_polars_profile_summary_stats(dxf: DataExplorerFixture):
 
     for table_name, col_index, ex_result in cases:
         profiles = [_get_summary_stats(col_index)]
-        results = dxf.get_column_profiles(table_name, profiles, format_options=format_options)
+        results = dxf.get_column_profiles(
+            table_name, profiles, format_options=format_options
+        )
 
         stats = results[0]["summary_stats"]
         assert_summary_stats_equal(stats["type_display"], stats, ex_result)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_docstrings_epytext.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_docstrings_epytext.py
@@ -89,9 +89,18 @@ MULTILINE_ARG_DESCRIPTION_MD = """Example of epytext docstring.
 """
 
 EPYTEXT_CASES = {
-    "basic example": {"epytext": BASIC_EXAMPLE, "md": BASIC_EXAMPLE_MD},
-    "escape magic method": {"epytext": ESCAPE_MAGIC_METHOD, "md": ESCAPE_MAGIC_METHOD_MD},
-    "plain section": {"epytext": PLAIN_SECTION, "md": PLAIN_SECTION_MD},
+    "basic example": {
+        "epytext": BASIC_EXAMPLE,
+        "md": BASIC_EXAMPLE_MD,
+    },
+    "escape magic method": {
+        "epytext": ESCAPE_MAGIC_METHOD,
+        "md": ESCAPE_MAGIC_METHOD_MD,
+    },
+    "plain section": {
+        "epytext": PLAIN_SECTION,
+        "md": PLAIN_SECTION_MD,
+    },
     "multiline arg description": {
         "epytext": MULTILINE_ARG_DESCRIPTION,
         "md": MULTILINE_ARG_DESCRIPTION_MD,
@@ -100,7 +109,9 @@ EPYTEXT_CASES = {
 
 
 @pytest.mark.parametrize(
-    "epytext", [case["epytext"] for case in EPYTEXT_CASES.values()], ids=EPYTEXT_CASES.keys()
+    "epytext",
+    [case["epytext"] for case in EPYTEXT_CASES.values()],
+    ids=EPYTEXT_CASES.keys(),
 )
 def test_looks_like_epytext_recognises_epytext(epytext):
     assert looks_like_epytext(epytext)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_docstrings_epytext.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_docstrings_epytext.py
@@ -5,7 +5,10 @@
 
 import pytest
 
-from positron_ipykernel.docstrings import epytext_to_markdown, looks_like_epytext
+from positron_ipykernel.docstrings import (
+    epytext_to_markdown,
+    looks_like_epytext,
+)
 
 BASIC_EXAMPLE = """Example of epytext docstring.
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_docstrings_epytext.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_docstrings_epytext.py
@@ -89,18 +89,9 @@ MULTILINE_ARG_DESCRIPTION_MD = """Example of epytext docstring.
 """
 
 EPYTEXT_CASES = {
-    "basic example": {
-        "epytext": BASIC_EXAMPLE,
-        "md": BASIC_EXAMPLE_MD,
-    },
-    "escape magic method": {
-        "epytext": ESCAPE_MAGIC_METHOD,
-        "md": ESCAPE_MAGIC_METHOD_MD,
-    },
-    "plain section": {
-        "epytext": PLAIN_SECTION,
-        "md": PLAIN_SECTION_MD,
-    },
+    "basic example": {"epytext": BASIC_EXAMPLE, "md": BASIC_EXAMPLE_MD},
+    "escape magic method": {"epytext": ESCAPE_MAGIC_METHOD, "md": ESCAPE_MAGIC_METHOD_MD},
+    "plain section": {"epytext": PLAIN_SECTION, "md": PLAIN_SECTION_MD},
     "multiline arg description": {
         "epytext": MULTILINE_ARG_DESCRIPTION,
         "md": MULTILINE_ARG_DESCRIPTION_MD,
@@ -109,9 +100,7 @@ EPYTEXT_CASES = {
 
 
 @pytest.mark.parametrize(
-    "epytext",
-    [case["epytext"] for case in EPYTEXT_CASES.values()],
-    ids=EPYTEXT_CASES.keys(),
+    "epytext", [case["epytext"] for case in EPYTEXT_CASES.values()], ids=EPYTEXT_CASES.keys()
 )
 def test_looks_like_epytext_recognises_epytext(epytext):
     assert looks_like_epytext(epytext)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_help.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_help.py
@@ -12,7 +12,11 @@ import pandas as pd
 import pytest
 
 from positron_ipykernel.help import HelpService, help
-from positron_ipykernel.help_comm import HelpBackendRequest, HelpFrontendEvent, ShowHelpKind
+from positron_ipykernel.help_comm import (
+    HelpBackendRequest,
+    HelpFrontendEvent,
+    ShowHelpKind,
+)
 
 from .conftest import DummyComm
 from .utils import json_rpc_notification, json_rpc_request, json_rpc_response
@@ -92,7 +96,8 @@ def test_pydoc_server_styling(running_help_service: HelpService):
 
 def show_help_event(content: str, kind=ShowHelpKind.Url, focus=True):
     return json_rpc_notification(
-        HelpFrontendEvent.ShowHelp.value, {"kind": kind, "focus": focus, "content": content}
+        HelpFrontendEvent.ShowHelp.value,
+        {"kind": kind, "focus": focus, "content": content},
     )
 
 
@@ -124,7 +129,11 @@ def show_help_event(content: str, kind=ShowHelpKind.Url, focus=True):
     ],
 )
 def test_show_help(
-    obj: Any, expected_path: str, help_service: HelpService, help_comm, mock_pydoc_thread
+    obj: Any,
+    expected_path: str,
+    help_service: HelpService,
+    help_comm,
+    mock_pydoc_thread,
 ):
     """
     Calling `show_help` should resolve an object to a url and send a `ShowHelp` event over the comm.
@@ -138,7 +147,9 @@ def test_show_help(
 
 def test_handle_show_help_topic(help_comm, mock_pydoc_thread) -> None:
     msg = json_rpc_request(
-        HelpBackendRequest.ShowHelpTopic, {"topic": "logging"}, comm_id="dummy_comm_id"
+        HelpBackendRequest.ShowHelpTopic,
+        {"topic": "logging"},
+        comm_id="dummy_comm_id",
     )
     help_comm.handle_msg(msg)
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
@@ -19,7 +19,11 @@ import pytest
 from fastcore.foundation import L
 from shapely.geometry import Polygon
 
-from positron_ipykernel.inspectors import PRINT_WIDTH, TRUNCATE_AT, get_inspector
+from positron_ipykernel.inspectors import (
+    PRINT_WIDTH,
+    TRUNCATE_AT,
+    get_inspector,
+)
 from positron_ipykernel.utils import get_qualname
 from positron_ipykernel.variables_comm import VariableKind
 
@@ -272,7 +276,12 @@ def test_inspect_bytes(value: bytes) -> None:
     )
 
 
-BYTEARRAY_CASES = [bytearray(), bytearray(0), bytearray(1), bytearray(b"\x41\x42\x43")]
+BYTEARRAY_CASES = [
+    bytearray(),
+    bytearray(0),
+    bytearray(1),
+    bytearray(b"\x41\x42\x43"),
+]
 
 
 @pytest.mark.parametrize("value", BYTEARRAY_CASES)
@@ -641,7 +650,12 @@ def test_inspect_numpy_array(value: np.ndarray) -> None:
     )
 
 
-@pytest.mark.parametrize("value", [np.array(1, dtype=np.int64)])
+@pytest.mark.parametrize(
+    "value",
+    [
+        np.array(1, dtype=np.int64),
+    ],
+)
 def test_inspect_numpy_array_0d(value: np.ndarray) -> None:
     verify_inspector(
         value=value,
@@ -852,7 +866,10 @@ def test_inspect_polars_series() -> None:
         (pd.DataFrame({"a": [1, 2], "b": ["3", "4"]}), range(2)),
         (pl.DataFrame({"a": [1, 2], "b": ["3", "4"]}), ["a", "b"]),
         (pd.Index([0, 1]), range(0, 2)),
-        (pd.Index([datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2)]), range(0, 2)),
+        (
+            pd.Index([datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2)]),
+            range(0, 2),
+        ),
         (np.array([0, 1]), range(0, 2)),  # 1D
         (np.array([[0, 1], [2, 3]]), range(0, 2)),  # 2D
     ],
@@ -872,8 +889,16 @@ def test_get_children(data: Any, expected: Iterable) -> None:
         (helper, "fn_no_args", helper.fn_no_args),
         (pd.Series({"a": 0, "b": 1}), 0, 0),
         (pl.Series([0, 1]), 0, 0),
-        (pd.DataFrame({"a": [1, 2], "b": ["3", "4"]}), 0, pd.Series([1, 2], name="a")),
-        (pl.DataFrame({"a": [1, 2], "b": ["3", "4"]}), "a", pl.Series(values=[1, 2], name="a")),
+        (
+            pd.DataFrame({"a": [1, 2], "b": ["3", "4"]}),
+            0,
+            pd.Series([1, 2], name="a"),
+        ),
+        (
+            pl.DataFrame({"a": [1, 2], "b": ["3", "4"]}),
+            "a",
+            pl.Series(values=[1, 2], name="a"),
+        ),
         (pd.Index([0, 1]), 0, 0),
         (
             pd.Index([datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2)]),

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
@@ -19,11 +19,7 @@ import pytest
 from fastcore.foundation import L
 from shapely.geometry import Polygon
 
-from positron_ipykernel.inspectors import (
-    PRINT_WIDTH,
-    TRUNCATE_AT,
-    get_inspector,
-)
+from positron_ipykernel.inspectors import PRINT_WIDTH, TRUNCATE_AT, get_inspector
 from positron_ipykernel.utils import get_qualname
 from positron_ipykernel.variables_comm import VariableKind
 
@@ -276,12 +272,7 @@ def test_inspect_bytes(value: bytes) -> None:
     )
 
 
-BYTEARRAY_CASES = [
-    bytearray(),
-    bytearray(0),
-    bytearray(1),
-    bytearray(b"\x41\x42\x43"),
-]
+BYTEARRAY_CASES = [bytearray(), bytearray(0), bytearray(1), bytearray(b"\x41\x42\x43")]
 
 
 @pytest.mark.parametrize("value", BYTEARRAY_CASES)
@@ -650,12 +641,7 @@ def test_inspect_numpy_array(value: np.ndarray) -> None:
     )
 
 
-@pytest.mark.parametrize(
-    "value",
-    [
-        np.array(1, dtype=np.int64),
-    ],
-)
+@pytest.mark.parametrize("value", [np.array(1, dtype=np.int64)])
 def test_inspect_numpy_array_0d(value: np.ndarray) -> None:
     verify_inspector(
         value=value,
@@ -866,10 +852,7 @@ def test_inspect_polars_series() -> None:
         (pd.DataFrame({"a": [1, 2], "b": ["3", "4"]}), range(2)),
         (pl.DataFrame({"a": [1, 2], "b": ["3", "4"]}), ["a", "b"]),
         (pd.Index([0, 1]), range(0, 2)),
-        (
-            pd.Index([datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2)]),
-            range(0, 2),
-        ),
+        (pd.Index([datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2)]), range(0, 2)),
         (np.array([0, 1]), range(0, 2)),  # 1D
         (np.array([[0, 1], [2, 3]]), range(0, 2)),  # 2D
     ],
@@ -889,16 +872,8 @@ def test_get_children(data: Any, expected: Iterable) -> None:
         (helper, "fn_no_args", helper.fn_no_args),
         (pd.Series({"a": 0, "b": 1}), 0, 0),
         (pl.Series([0, 1]), 0, 0),
-        (
-            pd.DataFrame({"a": [1, 2], "b": ["3", "4"]}),
-            0,
-            pd.Series([1, 2], name="a"),
-        ),
-        (
-            pl.DataFrame({"a": [1, 2], "b": ["3", "4"]}),
-            "a",
-            pl.Series(values=[1, 2], name="a"),
-        ),
+        (pd.DataFrame({"a": [1, 2], "b": ["3", "4"]}), 0, pd.Series([1, 2], name="a")),
+        (pl.DataFrame({"a": [1, 2], "b": ["3", "4"]}), "a", pl.Series(values=[1, 2], name="a")),
         (pd.Index([0, 1]), 0, 0),
         (
             pd.Index([datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2)]),

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
@@ -406,7 +406,9 @@ def test_inspect_set_truncated() -> None:
     length = len(value)
     verify_inspector(
         value=value,
-        display_value=pprint.pformat(value, width=PRINT_WIDTH, compact=True)[:TRUNCATE_AT],
+        display_value=pprint.pformat(value, width=PRINT_WIDTH, compact=True)[
+            :TRUNCATE_AT
+        ],
         kind=VariableKind.Collection,
         display_type=f"set {{{length}}}",
         type_info="set",
@@ -453,7 +455,9 @@ def test_inspect_list_truncated() -> None:
     length = len(value)
     verify_inspector(
         value=value,
-        display_value=pprint.pformat(value, width=PRINT_WIDTH, compact=True)[:TRUNCATE_AT],
+        display_value=pprint.pformat(value, width=PRINT_WIDTH, compact=True)[
+            :TRUNCATE_AT
+        ],
         kind=VariableKind.Collection,
         display_type=f"list [{length}]",
         type_info="list",
@@ -568,7 +572,9 @@ FUNCTION_CASES = [
 
 @pytest.mark.parametrize("value", FUNCTION_CASES)
 def test_inspect_function(value: Callable) -> None:
-    expected_type = "method" if isinstance(value, types.MethodType) else "function"
+    expected_type = (
+        "method" if isinstance(value, types.MethodType) else "function"
+    )
     verify_inspector(
         value=value,
         length=0,
@@ -703,7 +709,9 @@ def test_inspect_geopandas_dataframe() -> None:
     p2 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
     p3 = Polygon([(2, 0), (3, 0), (3, 1), (2, 1)])
 
-    value = geopandas.GeoDataFrame({"g": geopandas.GeoSeries([p1, p2, p3]), "data": [0, 1, 2]})
+    value = geopandas.GeoDataFrame(
+        {"g": geopandas.GeoSeries([p1, p2, p3]), "data": [0, 1, 2]}
+    )
 
     rows, cols = value.shape
 
@@ -867,7 +875,9 @@ def test_inspect_polars_series() -> None:
         (pl.DataFrame({"a": [1, 2], "b": ["3", "4"]}), ["a", "b"]),
         (pd.Index([0, 1]), range(0, 2)),
         (
-            pd.Index([datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2)]),
+            pd.Index(
+                [datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2)]
+            ),
             range(0, 2),
         ),
         (np.array([0, 1]), range(0, 2)),  # 1D
@@ -901,7 +911,9 @@ def test_get_children(data: Any, expected: Iterable) -> None:
         ),
         (pd.Index([0, 1]), 0, 0),
         (
-            pd.Index([datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2)]),
+            pd.Index(
+                [datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2)]
+            ),
             0,
             datetime.datetime(2021, 1, 1),
         ),

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_patch/test_bokeh.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_patch/test_bokeh.py
@@ -13,7 +13,9 @@ MIME_TYPE_POSITRON_WEBVIEW_FLAG = "application/positron-webview-load.v0+json"
 
 
 def test_bokeh_mime_tagging(
-    shell: PositronShell, mock_display_pub: Mock, enable_bokeh_output_notebook: None
+    shell: PositronShell,
+    mock_display_pub: Mock,
+    enable_bokeh_output_notebook: None,
 ):
     """
     Test to make sure that the send message function in bokeh is patched to append a mime-type
@@ -56,4 +58,7 @@ p
     )
 
     # Assert that none of the messages have a text/html mime type
-    assert not any("text/html" in message["content"]["data"] for message in session.messages)
+    assert not any(
+        "text/html" in message["content"]["data"]
+        for message in session.messages
+    )

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
@@ -95,7 +95,11 @@ def _do_render(
 ) -> Dict[str, Any]:
     msg = json_rpc_request(
         "render",
-        {"size": size.dict() if size else None, "pixel_ratio": pixel_ratio, "format": format},
+        {
+            "size": size.dict() if size else None,
+            "pixel_ratio": pixel_ratio,
+            "format": format,
+        },
         comm_id="dummy_comm_id",
     )
     plot_comm.handle_msg(msg)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_plots.py
@@ -95,11 +95,7 @@ def _do_render(
 ) -> Dict[str, Any]:
     msg = json_rpc_request(
         "render",
-        {
-            "size": size.dict() if size else None,
-            "pixel_ratio": pixel_ratio,
-            "format": format,
-        },
+        {"size": size.dict() if size else None, "pixel_ratio": pixel_ratio, "format": format},
         comm_id="dummy_comm_id",
     )
     plot_comm.handle_msg(msg)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_ipkernel.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_ipkernel.py
@@ -33,7 +33,11 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture
 def warning_kwargs():
-    return {"message": "this is a warning", "category": UserWarning, "lineno": 3}
+    return {
+        "message": "this is a warning",
+        "category": UserWarning,
+        "lineno": 3,
+    }
 
 
 def test_override_help(shell: PositronShell) -> None:
@@ -47,26 +51,38 @@ def test_override_help(shell: PositronShell) -> None:
 def test_view(shell: PositronShell, mock_dataexplorer_service: Mock) -> None:
     name = "x"
     shell.run_cell(f"{name} = object()\n%view {name}")
-    assert_register_table_called(mock_dataexplorer_service, shell.user_ns[name], name)
+    assert_register_table_called(
+        mock_dataexplorer_service, shell.user_ns[name], name
+    )
 
 
-def test_view_with_title(shell: PositronShell, mock_dataexplorer_service: Mock) -> None:
+def test_view_with_title(
+    shell: PositronShell, mock_dataexplorer_service: Mock
+) -> None:
     name = "xt"
     title = "A custom title"
     path = [encode_access_key(name)]
 
     shell.run_cell(f'{name} = object()\n%view {name} "{title}"')
-    assert_register_table_called(mock_dataexplorer_service, shell.user_ns[name], title, path)
+    assert_register_table_called(
+        mock_dataexplorer_service, shell.user_ns[name], title, path
+    )
 
 
-def test_view_undefined(shell: PositronShell, mock_dataexplorer_service: Mock, capsys) -> None:
+def test_view_undefined(
+    shell: PositronShell, mock_dataexplorer_service: Mock, capsys
+) -> None:
     name = "x"
     shell.run_cell(f"%view {name}")
     mock_dataexplorer_service.register_table.assert_not_called()
-    assert capsys.readouterr().err == f"UsageError: name '{name}' is not defined\n"
+    assert (
+        capsys.readouterr().err == f"UsageError: name '{name}' is not defined\n"
+    )
 
 
-def test_view_title_unquoted(shell: PositronShell, mock_dataexplorer_service: Mock, capsys) -> None:
+def test_view_title_unquoted(
+    shell: PositronShell, mock_dataexplorer_service: Mock, capsys
+) -> None:
     shell.run_cell("%view x A custom title")
     mock_dataexplorer_service.register_table.assert_not_called()
     assert (
@@ -83,11 +99,18 @@ def test_view_unsupported_type(
 
     shell.run_cell(f"{name} = object()\n%view {name}")
 
-    assert_register_table_called(mock_dataexplorer_service, shell.user_ns[name], name)
-    assert capsys.readouterr().err == "UsageError: cannot view object of type 'object'\n"
+    assert_register_table_called(
+        mock_dataexplorer_service, shell.user_ns[name], name
+    )
+    assert (
+        capsys.readouterr().err
+        == "UsageError: cannot view object of type 'object'\n"
+    )
 
 
-def assert_register_connection_called(mock_connections_service: Mock, obj: Any) -> None:
+def assert_register_connection_called(
+    mock_connections_service: Mock, obj: Any
+) -> None:
     call_args_list = mock_connections_service.register_connection.call_args_list
     assert len(call_args_list) == 1
 
@@ -95,10 +118,14 @@ def assert_register_connection_called(mock_connections_service: Mock, obj: Any) 
     assert passed_connection is obj
 
 
-def test_connection_show(shell: PositronShell, mock_connections_service: Mock) -> None:
+def test_connection_show(
+    shell: PositronShell, mock_connections_service: Mock
+) -> None:
     name = "x"
     shell.run_cell(f"{name} = object()\n%connection_show {name}")
-    assert_register_connection_called(mock_connections_service, shell.user_ns[name])
+    assert_register_connection_called(
+        mock_connections_service, shell.user_ns[name]
+    )
 
 
 def test_connection_show_undefined(
@@ -107,7 +134,9 @@ def test_connection_show_undefined(
     name = "x"
     shell.run_cell(f"%connection_show {name}")
     mock_connections_service.register_connection.assert_not_called()
-    assert capsys.readouterr().err == f"UsageError: name '{name}' is not defined\n"
+    assert (
+        capsys.readouterr().err == f"UsageError: name '{name}' is not defined\n"
+    )
 
 
 def test_connection_show_unsupported_type(
@@ -118,8 +147,13 @@ def test_connection_show_unsupported_type(
 
     shell.run_cell(f"{name} = object()\n%connection_show {name}")
 
-    assert_register_connection_called(mock_connections_service, shell.user_ns[name])
-    assert capsys.readouterr().err == "UsageError: cannot show object of type 'object'\n"
+    assert_register_connection_called(
+        mock_connections_service, shell.user_ns[name]
+    )
+    assert (
+        capsys.readouterr().err
+        == "UsageError: cannot show object of type 'object'\n"
+    )
 
 
 code = """def f():
@@ -209,8 +243,12 @@ def test_console_traceback(
     assert len(traceback) == 2
 
     # Check the beginning of each frame.
-    assert_ansi_string_startswith(traceback[0], traceback_frame_header.format(line=5, func="g"))
-    assert_ansi_string_startswith(traceback[1], traceback_frame_header.format(line=2, func="f"))
+    assert_ansi_string_startswith(
+        traceback[0], traceback_frame_header.format(line=5, func="g")
+    )
+    assert_ansi_string_startswith(
+        traceback[1], traceback_frame_header.format(line=2, func="f")
+    )
 
     # Check the exception name.
     assert exc_content["ename"] == "Exception"
@@ -282,7 +320,9 @@ def test_pinfo(shell: PositronShell, mock_help_service: Mock) -> None:
     mock_help_service.show_help.assert_called_once_with(object)
 
 
-def test_pinfo_2(shell: PositronShell, tmp_path: Path, mock_ui_service: Mock) -> None:
+def test_pinfo_2(
+    shell: PositronShell, tmp_path: Path, mock_ui_service: Mock
+) -> None:
     """
     Redirect `object??` to the Positron UI service's `open_editor` method.
     """
@@ -310,7 +350,9 @@ def test_clear(shell: PositronShell, mock_ui_service: Mock) -> None:
     mock_ui_service.clear_console.assert_called_once_with()
 
 
-def test_question_mark_help(shell: PositronShell, mock_help_service: Mock) -> None:
+def test_question_mark_help(
+    shell: PositronShell, mock_help_service: Mock
+) -> None:
     """
     Redirect `?` to the Positron Help service.
     """

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_jedilsp.py
@@ -21,7 +21,9 @@ from positron_ipykernel._vendor.lsprotocol.types import (
     Position,
     TextDocumentIdentifier,
 )
-from positron_ipykernel._vendor.pygls.workspace.text_document import TextDocument
+from positron_ipykernel._vendor.pygls.workspace.text_document import (
+    TextDocument,
+)
 from positron_ipykernel.help_comm import ShowHelpTopicParams
 from positron_ipykernel.jedi import PositronInterpreter
 from positron_ipykernel.positron_jedilsp import (
@@ -71,7 +73,9 @@ def test_positron_help_topic_request(
     namespace: Dict[str, Any],
     expected_topic: Optional[str],
 ) -> None:
-    params = HelpTopicParams(TextDocumentIdentifier("file:///foo.py"), Position(0, 0))
+    params = HelpTopicParams(
+        TextDocumentIdentifier("file:///foo.py"), Position(0, 0)
+    )
     server = mock_server(params.text_document.uri, source, namespace)
 
     topic = positron_help_topic_request(server, params)
@@ -98,7 +102,9 @@ def _completions(
     lines = source.splitlines()
     line = len(lines) - 1
     character = len(lines[line])
-    params = CompletionParams(TextDocumentIdentifier("file:///foo.py"), Position(line, character))
+    params = CompletionParams(
+        TextDocumentIdentifier("file:///foo.py"), Position(line, character)
+    )
     server = mock_server(params.text_document.uri, source, namespace)
 
     completion_list = positron_completion(server, params)
@@ -167,28 +173,36 @@ _pl_df = pl.DataFrame({"a": [0]})
             'x["',
             {"x": {"a": _object_with_property.prop}},
             "instance str(object='', /) -> str",
-            jedi_utils.convert_docstring(cast(str, str.__doc__), MarkupKind.Markdown),
+            jedi_utils.convert_docstring(
+                cast(str, str.__doc__), MarkupKind.Markdown
+            ),
         ),
         # Dict key mapping to an int.
         (
             'x["',
             {"x": {"a": 0}},
             "instance int(x=None, /) -> int",
-            jedi_utils.convert_docstring(cast(str, int.__doc__), MarkupKind.Markdown),
+            jedi_utils.convert_docstring(
+                cast(str, int.__doc__), MarkupKind.Markdown
+            ),
         ),
         # Integer, to sanity check for a basic value.
         (
             "x",
             {"x": 0},
             "instance int(x=None, /) -> int",
-            jedi_utils.convert_docstring(cast(str, int.__doc__), MarkupKind.Markdown),
+            jedi_utils.convert_docstring(
+                cast(str, int.__doc__), MarkupKind.Markdown
+            ),
         ),
         # Dict literal key mapping to an int.
         (
             '{"a": 0}["',
             {},
             "instance int(x=None, /) -> int",
-            jedi_utils.convert_docstring(cast(str, int.__doc__), MarkupKind.Markdown),
+            jedi_utils.convert_docstring(
+                cast(str, int.__doc__), MarkupKind.Markdown
+            ),
         ),
         # Pandas dataframe.
         (
@@ -246,10 +260,14 @@ def test_positron_completion_item_resolve(
     lines = source.splitlines()
     line = len(lines)
     character = len(lines[line - 1])
-    completions = PositronInterpreter(source, namespaces=[namespace]).complete(line, character)
+    completions = PositronInterpreter(source, namespaces=[namespace]).complete(
+        line, character
+    )
     assert len(completions) == 1, "Test cases must have exactly one completion"
     [completion] = completions
-    monkeypatch.setattr(jedi_utils, "_MOST_RECENT_COMPLETIONS", {"label": completion})
+    monkeypatch.setattr(
+        jedi_utils, "_MOST_RECENT_COMPLETIONS", {"label": completion}
+    )
 
     server = mock_server("", source, namespace)
     params = CompletionItem("label")

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_jedilsp.py
@@ -67,9 +67,7 @@ def mock_server(uri: str, source: str, namespace: Dict[str, Any]) -> Mock:
     ],
 )
 def test_positron_help_topic_request(
-    source: str,
-    namespace: Dict[str, Any],
-    expected_topic: Optional[str],
+    source: str, namespace: Dict[str, Any], expected_topic: Optional[str]
 ) -> None:
     params = HelpTopicParams(TextDocumentIdentifier("file:///foo.py"), Position(0, 0))
     server = mock_server(params.text_document.uri, source, namespace)
@@ -91,10 +89,7 @@ class _ObjectWithProperty:
 _object_with_property = _ObjectWithProperty()
 
 
-def _completions(
-    source: str,
-    namespace: Dict[str, Any],
-) -> List[CompletionItem]:
+def _completions(source: str, namespace: Dict[str, Any]) -> List[CompletionItem]:
     lines = source.splitlines()
     line = len(lines) - 1
     character = len(lines[line])
@@ -128,9 +123,7 @@ def _completions(
     ],
 )
 def test_positron_completion_exact(
-    source: str,
-    namespace: Dict[str, Any],
-    expected_labels: List[str],
+    source: str, namespace: Dict[str, Any], expected_labels: List[str]
 ) -> None:
     completions = _completions(source, namespace)
     completion_labels = [completion.label for completion in completions]
@@ -142,13 +135,11 @@ def test_positron_completion_exact(
     [
         # Pandas dataframe - attribute access.
         # Note that polars dataframes don't support accessing columns as attributes.
-        ("x.a", {"x": pd.DataFrame({"a": []})}, "a"),
+        ("x.a", {"x": pd.DataFrame({"a": []})}, "a")
     ],
 )
 def test_positron_completion_contains(
-    source: str,
-    namespace: Dict[str, Any],
-    expected_label: str,
+    source: str, namespace: Dict[str, Any], expected_label: str
 ) -> None:
     completions = _completions(source, namespace)
     completion_labels = [completion.label for completion in completions]
@@ -198,12 +189,7 @@ _pl_df = pl.DataFrame({"a": [0]})
             f"```text\n{_pd_df}\n```",
         ),
         # Pandas dataframe column - dict key access.
-        (
-            'x["',
-            {"x": _pd_df},
-            f"int64 [{_pd_df['a'].shape[0]}]",
-            f"```text\n{_pd_df['a']}\n```",
-        ),
+        ('x["', {"x": _pd_df}, f"int64 [{_pd_df['a'].shape[0]}]", f"```text\n{_pd_df['a']}\n```"),
         # Pandas series.
         (
             "x",
@@ -219,12 +205,7 @@ _pl_df = pl.DataFrame({"a": [0]})
             f"```text\n{_pl_df}\n```",
         ),
         # Polars dataframe column - dict key access.
-        (
-            'x["',
-            {"x": _pl_df},
-            f"Int64 [{_pl_df['a'].shape[0]}]",
-            f"```text\n{_pl_df['a']}\n```",
-        ),
+        ('x["', {"x": _pl_df}, f"Int64 [{_pl_df['a'].shape[0]}]", f"```text\n{_pl_df['a']}\n```"),
         # Polars series.
         (
             "x",

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_jedilsp.py
@@ -67,7 +67,9 @@ def mock_server(uri: str, source: str, namespace: Dict[str, Any]) -> Mock:
     ],
 )
 def test_positron_help_topic_request(
-    source: str, namespace: Dict[str, Any], expected_topic: Optional[str]
+    source: str,
+    namespace: Dict[str, Any],
+    expected_topic: Optional[str],
 ) -> None:
     params = HelpTopicParams(TextDocumentIdentifier("file:///foo.py"), Position(0, 0))
     server = mock_server(params.text_document.uri, source, namespace)
@@ -89,7 +91,10 @@ class _ObjectWithProperty:
 _object_with_property = _ObjectWithProperty()
 
 
-def _completions(source: str, namespace: Dict[str, Any]) -> List[CompletionItem]:
+def _completions(
+    source: str,
+    namespace: Dict[str, Any],
+) -> List[CompletionItem]:
     lines = source.splitlines()
     line = len(lines) - 1
     character = len(lines[line])
@@ -123,7 +128,9 @@ def _completions(source: str, namespace: Dict[str, Any]) -> List[CompletionItem]
     ],
 )
 def test_positron_completion_exact(
-    source: str, namespace: Dict[str, Any], expected_labels: List[str]
+    source: str,
+    namespace: Dict[str, Any],
+    expected_labels: List[str],
 ) -> None:
     completions = _completions(source, namespace)
     completion_labels = [completion.label for completion in completions]
@@ -135,11 +142,13 @@ def test_positron_completion_exact(
     [
         # Pandas dataframe - attribute access.
         # Note that polars dataframes don't support accessing columns as attributes.
-        ("x.a", {"x": pd.DataFrame({"a": []})}, "a")
+        ("x.a", {"x": pd.DataFrame({"a": []})}, "a"),
     ],
 )
 def test_positron_completion_contains(
-    source: str, namespace: Dict[str, Any], expected_label: str
+    source: str,
+    namespace: Dict[str, Any],
+    expected_label: str,
 ) -> None:
     completions = _completions(source, namespace)
     completion_labels = [completion.label for completion in completions]
@@ -189,7 +198,12 @@ _pl_df = pl.DataFrame({"a": [0]})
             f"```text\n{_pd_df}\n```",
         ),
         # Pandas dataframe column - dict key access.
-        ('x["', {"x": _pd_df}, f"int64 [{_pd_df['a'].shape[0]}]", f"```text\n{_pd_df['a']}\n```"),
+        (
+            'x["',
+            {"x": _pd_df},
+            f"int64 [{_pd_df['a'].shape[0]}]",
+            f"```text\n{_pd_df['a']}\n```",
+        ),
         # Pandas series.
         (
             "x",
@@ -205,7 +219,12 @@ _pl_df = pl.DataFrame({"a": [0]})
             f"```text\n{_pl_df}\n```",
         ),
         # Polars dataframe column - dict key access.
-        ('x["', {"x": _pl_df}, f"Int64 [{_pl_df['a'].shape[0]}]", f"```text\n{_pl_df['a']}\n```"),
+        (
+            'x["',
+            {"x": _pl_df},
+            f"Int64 [{_pl_df['a'].shape[0]}]",
+            f"```text\n{_pl_df['a']}\n```",
+        ),
         # Polars series.
         (
             "x",

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_positron_jedilsp.py
@@ -11,7 +11,7 @@ import pandas as pd
 import polars as pl
 import pytest
 
-from positron_ipykernel._vendor.jedi import Project
+from positron_ipykernel._vendor.jedi.api.project import Project
 from positron_ipykernel._vendor.jedi_language_server import jedi_utils
 from positron_ipykernel._vendor.lsprotocol.types import (
     CompletionItem,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_pydoc.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_pydoc.py
@@ -327,9 +327,7 @@ def test_tabulate_attrs(attrs: List[_Attr], expected: List[str]) -> None:
 
 @pytest.mark.parametrize(
     ("obj", "expected"),
-    [
-        (pd.DataFrame, "Two-dimensional, size-mutable, potentially heterogeneous tabular data."),
-    ],
+    [(pd.DataFrame, "Two-dimensional, size-mutable, potentially heterogeneous tabular data.")],
 )
 def test_get_summary(obj: Any, expected: str) -> None:
     result = _get_summary(obj)
@@ -480,25 +478,13 @@ def test_resolve(target: str, from_obj: Any, expected: Any) -> None:
     ("object", "expected"),
     [
         # Does not link item names/types in Arguments section, but does link descriptions.
-        (
-            _test_getdoc_links_arguments_section,
-            _TEST_GETDOC_LINKS_ARGS_SECTION_OUTPUT,
-        ),
+        (_test_getdoc_links_arguments_section, _TEST_GETDOC_LINKS_ARGS_SECTION_OUTPUT),
         # Same as previous but using markdown link format.
-        (
-            _test_getdoc_md_links_arguments_section,
-            _TEST_GETDOC_LINKS_ARGS_SECTION_OUTPUT,
-        ),
+        (_test_getdoc_md_links_arguments_section, _TEST_GETDOC_LINKS_ARGS_SECTION_OUTPUT),
         # Links items in the list under the See Also section.
-        (
-            _test_getdoc_links_see_also_section,
-            _TEST_GETDOC_LINKS_SEE_ALSO_SECTION_OUTPUT,
-        ),
+        (_test_getdoc_links_see_also_section, _TEST_GETDOC_LINKS_SEE_ALSO_SECTION_OUTPUT),
         # Same as previous but using markdown link format.
-        (
-            _test_getdoc_md_links_see_also_section,
-            _TEST_GETDOC_LINKS_SEE_ALSO_SECTION_OUTPUT,
-        ),
+        (_test_getdoc_md_links_see_also_section, _TEST_GETDOC_LINKS_SEE_ALSO_SECTION_OUTPUT),
         # Highlights code blocks.
         # Inputs and outputs are split into separate html elements.
         (

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_pydoc.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_pydoc.py
@@ -189,7 +189,9 @@ _html = _PositronHTMLDoc()
         (_html.html_topics, ()),
     ],
 )
-def test_pydoc_py311_breaking_changes(func: Callable, args: Tuple[Any, ...]) -> None:
+def test_pydoc_py311_breaking_changes(
+    func: Callable, args: Tuple[Any, ...]
+) -> None:
     """
     Python 3.11 introduced a breaking change into pydoc.HTMLDoc methods: heading, section, and
     bigsection. Ensure that we've patched these to work in all versions from 3.8+.
@@ -221,11 +223,15 @@ def _only_optional_args(index=None, name=None):
     pass
 
 
-def _keyword_only_required_and_optional_args(*, columns, index=None, values=None):
+def _keyword_only_required_and_optional_args(
+    *, columns, index=None, values=None
+):
     pass
 
 
-def _keyword_only_optional_args(*, axis=None, inplace=None, limit=None, downcast=None):
+def _keyword_only_optional_args(
+    *, axis=None, inplace=None, limit=None, downcast=None
+):
     pass
 
 
@@ -245,11 +251,15 @@ def _variadic_positional_and_optional_keyword_args(*args, copy=None):
     pass
 
 
-def _truncated_1(other, join=None, overwrite=None, filter_func=None, errors=None):
+def _truncated_1(
+    other, join=None, overwrite=None, filter_func=None, errors=None
+):
     pass
 
 
-def _truncated_2(subset=None, normalize=None, sort=None, ascending=None, dropna=None):
+def _truncated_2(
+    subset=None, normalize=None, sort=None, ascending=None, dropna=None
+):
     pass
 
 
@@ -265,7 +275,10 @@ def _truncated_3(subset=None, *, keep, inplace, ignore_index):
         (_two_args, "(loc, value)"),
         (_required_and_optional_args, "(other[, axis, level])"),
         (_only_optional_args, "([index, name])"),
-        (_keyword_only_required_and_optional_args, "(*, columns[, index, values])"),
+        (
+            _keyword_only_required_and_optional_args,
+            "(*, columns[, index, values])",
+        ),
         (_keyword_only_optional_args, "(*[, axis, inplace, limit, downcast])"),
         (_required_and_keyword_only_optional_args, "(labels, *[, axis, copy])"),
         (_variadic_positional_and_keyword_args, "(func, *args, **kwargs)"),
@@ -286,7 +299,10 @@ def test_compact_signature(func: Callable, expected: str) -> None:
 @pytest.mark.parametrize(
     ("func", "expected"),
     [
-        (pd.DataFrame, "(data=None, index=None, columns=None, dtype=None, copy=None)"),
+        (
+            pd.DataFrame,
+            "(data=None, index=None, columns=None, dtype=None, copy=None)",
+        ),
         (_test_func, "(a, b, c=1, *args, **kwargs)"),
     ],
 )
@@ -299,7 +315,10 @@ def test_untyped_signature(func: Callable, expected: str) -> None:
     ("attrs", "expected"),
     [
         # Empty
-        ([], ['<table class="autosummary">', "<tbody>", "</tbody>", "</table>"]),
+        (
+            [],
+            ['<table class="autosummary">', "<tbody>", "</tbody>", "</table>"],
+        ),
         # One attr
         (
             [_Attr(name="attr", cls=_A, value=_DummyAttribute)],
@@ -328,7 +347,10 @@ def test_tabulate_attrs(attrs: List[_Attr], expected: List[str]) -> None:
 @pytest.mark.parametrize(
     ("obj", "expected"),
     [
-        (pd.DataFrame, "Two-dimensional, size-mutable, potentially heterogeneous tabular data."),
+        (
+            pd.DataFrame,
+            "Two-dimensional, size-mutable, potentially heterogeneous tabular data.",
+        ),
     ],
 )
 def test_get_summary(obj: Any, expected: str) -> None:

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_pydoc.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_pydoc.py
@@ -327,7 +327,9 @@ def test_tabulate_attrs(attrs: List[_Attr], expected: List[str]) -> None:
 
 @pytest.mark.parametrize(
     ("obj", "expected"),
-    [(pd.DataFrame, "Two-dimensional, size-mutable, potentially heterogeneous tabular data.")],
+    [
+        (pd.DataFrame, "Two-dimensional, size-mutable, potentially heterogeneous tabular data."),
+    ],
 )
 def test_get_summary(obj: Any, expected: str) -> None:
     result = _get_summary(obj)
@@ -478,13 +480,25 @@ def test_resolve(target: str, from_obj: Any, expected: Any) -> None:
     ("object", "expected"),
     [
         # Does not link item names/types in Arguments section, but does link descriptions.
-        (_test_getdoc_links_arguments_section, _TEST_GETDOC_LINKS_ARGS_SECTION_OUTPUT),
+        (
+            _test_getdoc_links_arguments_section,
+            _TEST_GETDOC_LINKS_ARGS_SECTION_OUTPUT,
+        ),
         # Same as previous but using markdown link format.
-        (_test_getdoc_md_links_arguments_section, _TEST_GETDOC_LINKS_ARGS_SECTION_OUTPUT),
+        (
+            _test_getdoc_md_links_arguments_section,
+            _TEST_GETDOC_LINKS_ARGS_SECTION_OUTPUT,
+        ),
         # Links items in the list under the See Also section.
-        (_test_getdoc_links_see_also_section, _TEST_GETDOC_LINKS_SEE_ALSO_SECTION_OUTPUT),
+        (
+            _test_getdoc_links_see_also_section,
+            _TEST_GETDOC_LINKS_SEE_ALSO_SECTION_OUTPUT,
+        ),
         # Same as previous but using markdown link format.
-        (_test_getdoc_md_links_see_also_section, _TEST_GETDOC_LINKS_SEE_ALSO_SECTION_OUTPUT),
+        (
+            _test_getdoc_md_links_see_also_section,
+            _TEST_GETDOC_LINKS_SEE_ALSO_SECTION_OUTPUT,
+        ),
         # Highlights code blocks.
         # Inputs and outputs are split into separate html elements.
         (

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
@@ -93,7 +93,12 @@ def test_set_console_width(ui_comm: DummyComm) -> None:
     """
     width = 118
     msg = json_rpc_request(
-        "call_method", {"method": "setConsoleWidth", "params": [width]}, comm_id="dummy_comm_id"
+        "call_method",
+        {
+            "method": "setConsoleWidth",
+            "params": [width],
+        },
+        comm_id="dummy_comm_id",
     )
     ui_comm.handle_msg(msg)
 
@@ -124,7 +129,12 @@ def test_is_module_loaded(ui_comm: DummyComm) -> None:
     """
     module = "fallingStars"
     msg = json_rpc_request(
-        "call_method", {"method": "isModuleLoaded", "params": [module]}, comm_id="dummy_comm_id"
+        "call_method",
+        {
+            "method": "isModuleLoaded",
+            "params": [module],
+        },
+        comm_id="dummy_comm_id",
     )
     ui_comm.handle_msg(msg)
 
@@ -206,7 +216,10 @@ webbrowser.open({repr(url)})
     assert ui_comm.messages == expected
 
 
-def test_bokeh_show_sends_events(shell: PositronShell, ui_comm: DummyComm) -> None:
+def test_bokeh_show_sends_events(
+    shell: PositronShell,
+    ui_comm: DummyComm,
+) -> None:
     """
     Test that showing a Bokeh plot sends the expected UI events.
     """
@@ -250,7 +263,9 @@ def test_holoview_extension_sends_events(shell: PositronShell, ui_comm: DummyCom
 
 
 def test_plotly_show_sends_events(
-    shell: PositronShell, ui_comm: DummyComm, mock_handle_request: Mock
+    shell: PositronShell,
+    ui_comm: DummyComm,
+    mock_handle_request: Mock,
 ) -> None:
     """
     Test that showing a Plotly plot sends the expected UI events when using `fig.show()` and `fig`.
@@ -284,7 +299,10 @@ fig
     assert params["height"] == 0
 
 
-def test_is_not_plot_url_events(shell: PositronShell, ui_comm: DummyComm) -> None:
+def test_is_not_plot_url_events(
+    shell: PositronShell,
+    ui_comm: DummyComm,
+) -> None:
     """
     Test that opening a URL that is not a plot sends the expected UI events.
     Checks that the `is_plot` parameter is not sent or is `False`.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
@@ -93,12 +93,7 @@ def test_set_console_width(ui_comm: DummyComm) -> None:
     """
     width = 118
     msg = json_rpc_request(
-        "call_method",
-        {
-            "method": "setConsoleWidth",
-            "params": [width],
-        },
-        comm_id="dummy_comm_id",
+        "call_method", {"method": "setConsoleWidth", "params": [width]}, comm_id="dummy_comm_id"
     )
     ui_comm.handle_msg(msg)
 
@@ -129,12 +124,7 @@ def test_is_module_loaded(ui_comm: DummyComm) -> None:
     """
     module = "fallingStars"
     msg = json_rpc_request(
-        "call_method",
-        {
-            "method": "isModuleLoaded",
-            "params": [module],
-        },
-        comm_id="dummy_comm_id",
+        "call_method", {"method": "isModuleLoaded", "params": [module]}, comm_id="dummy_comm_id"
     )
     ui_comm.handle_msg(msg)
 
@@ -216,10 +206,7 @@ webbrowser.open({repr(url)})
     assert ui_comm.messages == expected
 
 
-def test_bokeh_show_sends_events(
-    shell: PositronShell,
-    ui_comm: DummyComm,
-) -> None:
+def test_bokeh_show_sends_events(shell: PositronShell, ui_comm: DummyComm) -> None:
     """
     Test that showing a Bokeh plot sends the expected UI events.
     """
@@ -263,9 +250,7 @@ def test_holoview_extension_sends_events(shell: PositronShell, ui_comm: DummyCom
 
 
 def test_plotly_show_sends_events(
-    shell: PositronShell,
-    ui_comm: DummyComm,
-    mock_handle_request: Mock,
+    shell: PositronShell, ui_comm: DummyComm, mock_handle_request: Mock
 ) -> None:
     """
     Test that showing a Plotly plot sends the expected UI events when using `fig.show()` and `fig`.
@@ -299,10 +284,7 @@ fig
     assert params["height"] == 0
 
 
-def test_is_not_plot_url_events(
-    shell: PositronShell,
-    ui_comm: DummyComm,
-) -> None:
+def test_is_not_plot_url_events(shell: PositronShell, ui_comm: DummyComm) -> None:
     """
     Test that opening a URL that is not a plot sends the expected UI events.
     Checks that the `is_plot` parameter is not sent or is `False`.

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
@@ -14,7 +14,10 @@ import pandas as pd
 import polars as pl
 import pytest
 
-from positron_ipykernel.positron_ipkernel import PositronIPyKernel, PositronShell
+from positron_ipykernel.positron_ipkernel import (
+    PositronIPyKernel,
+    PositronShell,
+)
 from positron_ipykernel.ui import UiService
 from positron_ipykernel.utils import alias_home
 
@@ -62,7 +65,9 @@ def ui_comm(ui_service: UiService) -> DummyComm:
 
 
 def working_directory_event() -> Dict[str, Any]:
-    return json_rpc_notification("working_directory", {"directory": str(alias_home(Path.cwd()))})
+    return json_rpc_notification(
+        "working_directory", {"directory": str(alias_home(Path.cwd()))}
+    )
 
 
 def show_url_event(url: str) -> Dict[str, Any]:
@@ -71,7 +76,8 @@ def show_url_event(url: str) -> Dict[str, Any]:
 
 def show_html_file_event(path: str, is_plot: bool) -> Dict[str, Any]:
     return json_rpc_notification(
-        "show_html_file", {"path": path, "is_plot": is_plot, "height": 0, "title": ""}
+        "show_html_file",
+        {"path": path, "is_plot": is_plot, "height": 0, "title": ""},
     )
 
 
@@ -84,7 +90,10 @@ def test_comm_open(ui_service: UiService) -> None:
     ui_service.on_comm_open(ui_comm, {})
 
     # Check that the comm_open and initial working_directory messages are sent
-    assert ui_comm.messages == [comm_open_message(TARGET_NAME), working_directory_event()]
+    assert ui_comm.messages == [
+        comm_open_message(TARGET_NAME),
+        working_directory_event(),
+    ]
 
 
 def test_set_console_width(ui_comm: DummyComm) -> None:
@@ -119,7 +128,9 @@ def test_open_editor(ui_service: UiService, ui_comm: DummyComm) -> None:
     ui_service.open_editor(file, line, column)
 
     assert ui_comm.messages == [
-        json_rpc_notification("open_editor", {"file": file, "line": line, "column": column})
+        json_rpc_notification(
+            "open_editor", {"file": file, "line": line, "column": column}
+        )
     ]
 
 
@@ -148,7 +159,9 @@ def test_clear_console(ui_service: UiService, ui_comm: DummyComm) -> None:
     assert ui_comm.messages == [json_rpc_notification("clear_console", {})]
 
 
-def test_poll_working_directory(shell: PositronShell, ui_comm: DummyComm) -> None:
+def test_poll_working_directory(
+    shell: PositronShell, ui_comm: DummyComm
+) -> None:
     # If a cell execution does not change the working directory, no comm messages should be sent.
     shell.run_cell("print()")
 
@@ -188,7 +201,11 @@ def test_shutdown(ui_service: UiService, ui_comm: DummyComm) -> None:
         # Windows path
         (
             "file:///C:/Users/username/Documents/index.htm",
-            [show_html_file_event("file:///C:/Users/username/Documents/index.htm", False)],
+            [
+                show_html_file_event(
+                    "file:///C:/Users/username/Documents/index.htm", False
+                )
+            ],
         ),
         # Not a local html file
         ("http://example.com/page.html", []),
@@ -249,8 +266,12 @@ show(p)
     assert tempfile.gettempdir() in params["path"]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires Python 3.9 or higher")
-def test_holoview_extension_sends_events(shell: PositronShell, ui_comm: DummyComm) -> None:
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="requires Python 3.9 or higher"
+)
+def test_holoview_extension_sends_events(
+    shell: PositronShell, ui_comm: DummyComm
+) -> None:
     """
     Running holoviews/holoviz code that sets an extension will trigger an event on the ui comm that
     can be used on the front end to react appropriately.
@@ -259,7 +280,9 @@ def test_holoview_extension_sends_events(shell: PositronShell, ui_comm: DummyCom
     shell.run_cell("import holoviews as hv; hv.extension('plotly')")
 
     assert len(ui_comm.messages) == 1
-    assert ui_comm.messages[0] == json_rpc_notification("clear_webview_preloads", {})
+    assert ui_comm.messages[0] == json_rpc_notification(
+        "clear_webview_preloads", {}
+    )
 
 
 def test_plotly_show_sends_events(
@@ -323,5 +346,9 @@ webbrowser.open("file://file.html")
     assert "is_plot" not in params
 
     params = ui_comm.messages[1]["data"]["params"]
-    assert params["path"] == "file.html" if sys.platform == "win32" else "file://file.html"
+    assert (
+        params["path"] == "file.html"
+        if sys.platform == "win32"
+        else "file://file.html"
+    )
     assert params["is_plot"] is False

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
@@ -50,7 +50,9 @@ def test_comm_open(kernel: PositronIPyKernel) -> None:
     # Check that the comm_open and empty refresh messages were sent
     assert variables_comm.messages == [
         comm_open_message(TARGET_NAME),
-        json_rpc_notification("refresh", {"variables": [], "length": 0, "version": 0}),
+        json_rpc_notification(
+            "refresh", {"variables": [], "length": 0, "version": 0}
+        ),
     ]
 
 
@@ -113,7 +115,9 @@ def test_change_detection(
         _assert_assigned(shell, value_code, variables_comm)
 
 
-def _assert_assigned(shell: PositronShell, value_code: str, variables_comm: DummyComm):
+def _assert_assigned(
+    shell: PositronShell, value_code: str, variables_comm: DummyComm
+):
     # Test that the expected `update` message was sent with the
     # expected `assigned` value.
     with patch("positron_ipykernel.variables.timestamp", return_value=0):
@@ -166,12 +170,16 @@ def _assert_assigned(shell: PositronShell, value_code: str, variables_comm: Dumm
 def _import_library(shell: PositronShell, import_code: str):
     # Import the necessary library.
     if import_code:
-        if import_code.endswith("torch"):  # temporary workaround for python 3.12
+        if import_code.endswith(
+            "torch"
+        ):  # temporary workaround for python 3.12
             pytest.skip()
         shell.run_cell(import_code)
 
 
-def test_change_detection_over_limit(shell: PositronShell, variables_comm: DummyComm):
+def test_change_detection_over_limit(
+    shell: PositronShell, variables_comm: DummyComm
+):
     _import_library(shell, "import numpy as np")
 
     big_array = f"x = np.arange({BIG_ARRAY_LENGTH})"
@@ -200,7 +208,9 @@ def _do_list(variables_comm: DummyComm):
     ]
 
     result = variables_comm.messages[0]["data"]["result"]
-    result["variables"] = [Variable.parse_obj(variable) for variable in result["variables"]]
+    result["variables"] = [
+        Variable.parse_obj(variable) for variable in result["variables"]
+    ]
 
     variables_comm.messages.clear()
 
@@ -296,7 +306,9 @@ def test_update_max_items_plus_one(
 
     # Spot check the first and last variables display values
     assert variables[0].get("display_value") == str(add_value)
-    assert variables[variables_len - 1].get("display_value") == str(variables_len - 1 + add_value)
+    assert variables[variables_len - 1].get("display_value") == str(
+        variables_len - 1 + add_value
+    )
 
 
 def create_and_update_n_vars(
@@ -332,7 +344,9 @@ async def test_clear(
 ) -> None:
     shell.user_ns.update({"x": 3, "y": 5})
 
-    msg = json_rpc_request("clear", {"include_hidden_objects": False}, comm_id="dummy_comm_id")
+    msg = json_rpc_request(
+        "clear", {"include_hidden_objects": False}, comm_id="dummy_comm_id"
+    )
     variables_comm.handle_msg(msg)
 
     # Wait until all resulting kernel tasks are processed
@@ -350,7 +364,9 @@ async def test_clear(
                 "version": 0,
             },
         ),
-        json_rpc_notification("refresh", {"length": 0, "variables": [], "version": 0}),
+        json_rpc_notification(
+            "refresh", {"length": 0, "variables": [], "version": 0}
+        ),
     ]
 
     # All user variables are removed
@@ -382,7 +398,9 @@ def test_delete_error(variables_comm: DummyComm) -> None:
 
 
 # TODO(seem): encoded_path should be typed as List[str] but that makes pyright unhappy; might be a pyright bug
-def _do_inspect(encoded_path: List[JsonData], variables_comm: DummyComm) -> List[Variable]:
+def _do_inspect(
+    encoded_path: List[JsonData], variables_comm: DummyComm
+) -> List[Variable]:
     msg = json_rpc_request(
         "inspect",
         {"path": encoded_path},
@@ -423,7 +441,9 @@ class TestClass:
 _test_obj = TestClass()
 
 
-def variable(display_name: str, display_value: str, children: List[Dict[str, Any]] = []):
+def variable(
+    display_name: str, display_value: str, children: List[Dict[str, Any]] = []
+):
     return {
         "display_name": display_name,
         "display_value": display_value,
@@ -542,10 +562,18 @@ def variable(display_name: str, display_value: str, children: List[Dict[str, Any
                 "root",
                 "[1 rows x 4 columns] pandas.DataFrame",
                 children=[
-                    variable("a", "pandas.Series [0]", children=[variable("0", "0")]),
-                    variable("b", "pandas.Series [1]", children=[variable("0", "1")]),
-                    variable("a", "pandas.Series [2]", children=[variable("0", "2")]),
-                    variable("b", "pandas.Series [3]", children=[variable("0", "3")]),
+                    variable(
+                        "a", "pandas.Series [0]", children=[variable("0", "0")]
+                    ),
+                    variable(
+                        "b", "pandas.Series [1]", children=[variable("0", "1")]
+                    ),
+                    variable(
+                        "a", "pandas.Series [2]", children=[variable("0", "2")]
+                    ),
+                    variable(
+                        "b", "pandas.Series [3]", children=[variable("0", "3")]
+                    ),
                 ],
             ),
         ),
@@ -629,10 +657,17 @@ def _verify_inspect(
             # the UI.
             child_path = encoded_path + [child.access_key]
             child_children = _do_inspect(child_path, variables_comm)
-            _verify_inspect(child_path, child_children, expected_child_children, variables_comm)
+            _verify_inspect(
+                child_path,
+                child_children,
+                expected_child_children,
+                variables_comm,
+            )
 
 
-def test_inspect_large_object(shell: PositronShell, variables_comm: DummyComm) -> None:
+def test_inspect_large_object(
+    shell: PositronShell, variables_comm: DummyComm
+) -> None:
     # Inspecting large objects should not trigger update messages: https://github.com/posit-dev/positron/issues/2308.
     shell.user_ns["x"] = np.arange(BIG_ARRAY_LENGTH)
 
@@ -655,7 +690,9 @@ def test_inspect_error(variables_comm: DummyComm) -> None:
     ]
 
 
-def test_clipboard_format(shell: PositronShell, variables_comm: DummyComm) -> None:
+def test_clipboard_format(
+    shell: PositronShell, variables_comm: DummyComm
+) -> None:
     shell.user_ns.update({"x": 3, "y": 5})
 
     msg = json_rpc_request(
@@ -753,7 +790,9 @@ def test_view_error(variables_comm: DummyComm) -> None:
 
 
 def test_view_error_when_pandas_not_loaded(
-    shell: PositronShell, variables_comm: DummyComm, mock_dataexplorer_service: Mock
+    shell: PositronShell,
+    variables_comm: DummyComm,
+    mock_dataexplorer_service: Mock,
 ) -> None:
     # regression test for https://github.com/posit-dev/positron/issues/3653
     shell.user_ns["x"] = pd.DataFrame({"a": [0]})
@@ -805,7 +844,9 @@ def test_unknown_method(variables_comm: DummyComm) -> None:
 
 
 @pytest.mark.asyncio
-async def test_shutdown(variables_service: VariablesService, variables_comm: DummyComm) -> None:
+async def test_shutdown(
+    variables_service: VariablesService, variables_comm: DummyComm
+) -> None:
     # Double-check that the comm is not yet closed
     assert not variables_comm._closed
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_variables.py
@@ -63,35 +63,23 @@ def test_comm_open(kernel: PositronIPyKernel) -> None:
         ("import numpy as np", [f"x = np.array({x})" for x in [3, [3], [[3]]]]),
         ("import torch", [f"x = torch.tensor({x})" for x in [3, [3], [[3]]]]),
         pytest.param(
-            "import pandas as pd",
-            [f"x = pd.Series({x})" for x in [[], [3], [3, 3], ["3"]]],
+            "import pandas as pd", [f"x = pd.Series({x})" for x in [[], [3], [3, 3], ["3"]]]
         ),
         pytest.param(
-            "import polars as pl",
-            [f"x = pl.Series({x})" for x in [[], [3], [3, 3], ["3"]]],
+            "import polars as pl", [f"x = pl.Series({x})" for x in [[], [3], [3, 3], ["3"]]]
         ),
         (
             "import pandas as pd",
             [
                 f"x = pd.DataFrame({x})"
-                for x in [
-                    {"a": []},
-                    {"a": [3]},
-                    {"a": ["3"]},
-                    {"a": [3], "b": [3]},
-                ]
+                for x in [{"a": []}, {"a": [3]}, {"a": ["3"]}, {"a": [3], "b": [3]}]
             ],
         ),
         (
             "import polars as pl",
             [
                 f"x = pl.DataFrame({x})"
-                for x in [
-                    {"a": []},
-                    {"a": [3]},
-                    {"a": ["3"]},
-                    {"a": [3], "b": [3]},
-                ]
+                for x in [{"a": []}, {"a": [3]}, {"a": ["3"]}, {"a": [3], "b": [3]}]
             ],
         ),
         # Nested mutable types
@@ -100,10 +88,7 @@ def test_comm_open(kernel: PositronIPyKernel) -> None:
     ],
 )
 def test_change_detection(
-    import_code: str,
-    value_codes: List[str],
-    shell: PositronShell,
-    variables_comm: DummyComm,
+    import_code: str, value_codes: List[str], shell: PositronShell, variables_comm: DummyComm
 ) -> None:
     """
     Test change detection when updating the value of the same name.
@@ -150,12 +135,7 @@ def _assert_assigned(shell: PositronShell, value_code: str, variables_comm: Dumm
         assert variables_comm.messages == [
             json_rpc_notification(
                 "update",
-                {
-                    "assigned": assigned,
-                    "removed": [],
-                    "unevaluated": unevaluated,
-                    "version": 0,
-                },
+                {"assigned": assigned, "removed": [], "unevaluated": unevaluated, "version": 0},
             )
         ]
 
@@ -190,13 +170,7 @@ def _do_list(variables_comm: DummyComm):
 
     # Check the structure of the message but let the caller verify the contents.
     assert variables_comm.messages == [
-        json_rpc_response(
-            {
-                "variables": ANY,
-                "length": ANY,
-                "version": 0,
-            }
-        )
+        json_rpc_response({"variables": ANY, "length": ANY, "version": 0})
     ]
 
     result = variables_comm.messages[0]["data"]["result"]
@@ -326,9 +300,7 @@ def _encode_path(path: List[Any]) -> List[JsonData]:
 
 @pytest.mark.asyncio
 async def test_clear(
-    shell: PositronShell,
-    variables_service: VariablesService,
-    variables_comm: DummyComm,
+    shell: PositronShell, variables_service: VariablesService, variables_comm: DummyComm
 ) -> None:
     shell.user_ns.update({"x": 3, "y": 5})
 
@@ -343,12 +315,7 @@ async def test_clear(
         json_rpc_response({}),
         json_rpc_notification(
             "update",
-            {
-                "assigned": [],
-                "removed": _encode_path(["x", "y"]),
-                "unevaluated": [],
-                "version": 0,
-            },
+            {"assigned": [], "removed": _encode_path(["x", "y"]), "unevaluated": [], "version": 0},
         ),
         json_rpc_notification("refresh", {"length": 0, "variables": [], "version": 0}),
     ]
@@ -368,9 +335,7 @@ def test_delete(shell: PositronShell, variables_comm: DummyComm) -> None:
     assert "x" not in shell.user_ns
     assert "y" in shell.user_ns
 
-    assert variables_comm.messages == [
-        json_rpc_response(_encode_path(["x"])),
-    ]
+    assert variables_comm.messages == [json_rpc_response(_encode_path(["x"]))]
 
 
 def test_delete_error(variables_comm: DummyComm) -> None:
@@ -383,24 +348,13 @@ def test_delete_error(variables_comm: DummyComm) -> None:
 
 # TODO(seem): encoded_path should be typed as List[str] but that makes pyright unhappy; might be a pyright bug
 def _do_inspect(encoded_path: List[JsonData], variables_comm: DummyComm) -> List[Variable]:
-    msg = json_rpc_request(
-        "inspect",
-        {"path": encoded_path},
-        comm_id="dummy_comm_id",
-    )
+    msg = json_rpc_request("inspect", {"path": encoded_path}, comm_id="dummy_comm_id")
 
     with patch("positron_ipykernel.variables.timestamp", return_value=0):
         variables_comm.handle_msg(msg)
 
     # Check the structure of the message but let the caller verify the contents.
-    assert variables_comm.messages == [
-        json_rpc_response(
-            {
-                "children": ANY,
-                "length": ANY,
-            }
-        )
-    ]
+    assert variables_comm.messages == [json_rpc_response({"children": ANY, "length": ANY})]
 
     children = [
         Variable.parse_obj(child)
@@ -424,11 +378,7 @@ _test_obj = TestClass()
 
 
 def variable(display_name: str, display_value: str, children: List[Dict[str, Any]] = []):
-    return {
-        "display_name": display_name,
-        "display_value": display_value,
-        "children": children,
-    }
+    return {"display_name": display_name, "display_value": display_value, "children": children}
 
 
 @pytest.mark.parametrize(
@@ -438,17 +388,13 @@ def variable(display_name: str, display_value: str, children: List[Dict[str, Any
         (
             pd.Series([1, 2]),
             variable(
-                "root",
-                "pandas.Series [1, 2]",
-                children=[variable("0", "1"), variable("1", "2")],
+                "root", "pandas.Series [1, 2]", children=[variable("0", "1"), variable("1", "2")]
             ),
         ),
         (
             pl.Series([1, 2]),
             variable(
-                "root",
-                "polars.Series [1, 2]",
-                children=[variable("0", "1"), variable("1", "2")],
+                "root", "polars.Series [1, 2]", children=[variable("0", "1"), variable("1", "2")]
             ),
         ),
         # DataFrames
@@ -497,16 +443,8 @@ def variable(display_name: str, display_value: str, children: List[Dict[str, Any
                 "root",
                 "[[0,1],\n [2,3]]",
                 children=[
-                    variable(
-                        "0",
-                        "[0,1]",
-                        children=[variable("0", "0"), variable("1", "1")],
-                    ),
-                    variable(
-                        "1",
-                        "[2,3]",
-                        children=[variable("0", "2"), variable("1", "3")],
-                    ),
+                    variable("0", "[0,1]", children=[variable("0", "0"), variable("1", "1")]),
+                    variable("1", "[2,3]", children=[variable("0", "2"), variable("1", "3")]),
                 ],
             ),
         ),
@@ -516,10 +454,7 @@ def variable(display_name: str, display_value: str, children: List[Dict[str, Any
             variable(
                 "root",
                 repr(_test_obj),
-                children=[
-                    variable("x", "0"),
-                    variable("x_plus_one", repr(TestClass.x_plus_one)),
-                ],
+                children=[variable("x", "0"), variable("x_plus_one", repr(TestClass.x_plus_one))],
             ),
         ),
         # Children with duplicate keys
@@ -552,24 +487,12 @@ def variable(display_name: str, display_value: str, children: List[Dict[str, Any
         # Children with unique keys that have the same display_name
         (
             {0: 0, "0": 1},
-            variable(
-                "root",
-                "{0: 0, '0': 1}",
-                children=[
-                    variable("0", "0"),
-                    variable("0", "1"),
-                ],
-            ),
+            variable("root", "{0: 0, '0': 1}", children=[variable("0", "0"), variable("0", "1")]),
         ),
         (
             pd.Series({0: 0, "0": 1}),
             variable(
-                "root",
-                "pandas.Series [0, 1]",
-                children=[
-                    variable("0", "0"),
-                    variable("0", "1"),
-                ],
+                "root", "pandas.Series [0, 1]", children=[variable("0", "0"), variable("0", "1")]
             ),
         ),
         (
@@ -578,16 +501,8 @@ def variable(display_name: str, display_value: str, children: List[Dict[str, Any
                 "root",
                 "[1 rows x 2 columns] pandas.DataFrame",
                 children=[
-                    variable(
-                        "0",
-                        "pandas.Series [0]",
-                        children=[variable("0", "0")],
-                    ),
-                    variable(
-                        "0",
-                        "pandas.Series [1]",
-                        children=[variable("0", "1")],
-                    ),
+                    variable("0", "pandas.Series [0]", children=[variable("0", "0")]),
+                    variable("0", "pandas.Series [1]", children=[variable("0", "1")]),
                 ],
             ),
         ),
@@ -649,8 +564,7 @@ def test_inspect_error(variables_comm: DummyComm) -> None:
     # An error message is sent
     assert variables_comm.messages == [
         json_rpc_error(
-            JsonRpcErrorCode.INVALID_PARAMS,
-            f"Cannot find variable at '{path}' to inspect",
+            JsonRpcErrorCode.INVALID_PARAMS, f"Cannot find variable at '{path}' to inspect"
         )
     ]
 
@@ -660,10 +574,7 @@ def test_clipboard_format(shell: PositronShell, variables_comm: DummyComm) -> No
 
     msg = json_rpc_request(
         "clipboard_format",
-        {
-            "path": _encode_path(["x"]),
-            "format": "text/plain",
-        },
+        {"path": _encode_path(["x"]), "format": "text/plain"},
         comm_id="dummy_comm_id",
     )
     variables_comm.handle_msg(msg)
@@ -684,17 +595,13 @@ def test_clipboard_format_error(variables_comm: DummyComm) -> None:
     # An error message is sent
     assert variables_comm.messages == [
         json_rpc_error(
-            JsonRpcErrorCode.INVALID_PARAMS,
-            f"Cannot find variable at '{path}' to format",
+            JsonRpcErrorCode.INVALID_PARAMS, f"Cannot find variable at '{path}' to format"
         )
     ]
 
 
 def _do_view(
-    name: str,
-    shell: PositronShell,
-    variables_comm: DummyComm,
-    mock_dataexplorer_service: Mock,
+    name: str, shell: PositronShell, variables_comm: DummyComm, mock_dataexplorer_service: Mock
 ):
     path = _encode_path([name])
     msg = json_rpc_request("view", {"path": path}, comm_id="dummy_comm_id")
@@ -710,9 +617,7 @@ def _do_view(
 
 
 def test_view(
-    shell: PositronShell,
-    variables_comm: DummyComm,
-    mock_dataexplorer_service: Mock,
+    shell: PositronShell, variables_comm: DummyComm, mock_dataexplorer_service: Mock
 ) -> None:
     name = "dfx"
     shell.user_ns[name] = pd.DataFrame({"a": [0]})
@@ -721,10 +626,7 @@ def test_view(
 
 
 def test_view_with_sqlalchemy_v1_3(
-    shell: PositronShell,
-    variables_comm: DummyComm,
-    mock_dataexplorer_service: Mock,
-    monkeypatch,
+    shell: PositronShell, variables_comm: DummyComm, mock_dataexplorer_service: Mock, monkeypatch
 ) -> None:
     # Simulate sqlalchemy<=1.3 where `sqlalchemy.Engine` does not exist.
     import sqlalchemy
@@ -745,10 +647,7 @@ def test_view_error(variables_comm: DummyComm) -> None:
 
     # An error message is sent
     assert variables_comm.messages == [
-        json_rpc_error(
-            JsonRpcErrorCode.INVALID_PARAMS,
-            f"Cannot find variable at '{path}' to view",
-        )
+        json_rpc_error(JsonRpcErrorCode.INVALID_PARAMS, f"Cannot find variable at '{path}' to view")
     ]
 
 
@@ -797,10 +696,7 @@ def test_unknown_method(variables_comm: DummyComm) -> None:
     variables_comm.handle_msg(msg, raise_errors=False)
 
     assert variables_comm.messages == [
-        json_rpc_error(
-            JsonRpcErrorCode.METHOD_NOT_FOUND,
-            "Unknown method 'unknown_method'",
-        )
+        json_rpc_error(JsonRpcErrorCode.METHOD_NOT_FOUND, "Unknown method 'unknown_method'")
     ]
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/utils.py
@@ -49,17 +49,10 @@ def assert_register_table_called(
         assert passed_variable_path[0] == variable_path[0]
 
 
-def comm_message(
-    data: Optional[JsonRecord] = None,
-) -> JsonRecord:
+def comm_message(data: Optional[JsonRecord] = None) -> JsonRecord:
     if data is None:
         data = {}
-    return {
-        "data": data,
-        "metadata": None,
-        "buffers": None,
-        "msg_type": "comm_msg",
-    }
+    return {"data": data, "metadata": None, "buffers": None, "msg_type": "comm_msg"}
 
 
 def comm_request(data: JsonRecord, **kwargs) -> JsonRecord:
@@ -76,60 +69,31 @@ def comm_open_message(target_name: str, data: Optional[JsonRecord] = None) -> Js
 
 
 def comm_close_message() -> JsonRecord:
-    return {
-        **comm_message(),
-        "msg_type": "comm_close",
-    }
+    return {**comm_message(), "msg_type": "comm_close"}
 
 
 def json_rpc_error(code: int, message: str) -> JsonRecord:
-    return comm_message(
-        {
-            "jsonrpc": "2.0",
-            "error": {
-                "code": code,
-                "message": message,
-            },
-        }
-    )
+    return comm_message({"jsonrpc": "2.0", "error": {"code": code, "message": message}})
 
 
 def json_rpc_notification(method: str, params: Optional[JsonRecord] = None) -> JsonRecord:
     return comm_message(
-        {
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": {} if params is None else params,
-        }
+        {"jsonrpc": "2.0", "method": method, "params": {} if params is None else params}
     )
 
 
 def json_rpc_request(
-    method: str,
-    params: Optional[JsonRecord] = None,
-    **content: JsonData,
+    method: str, params: Optional[JsonRecord] = None, **content: JsonData
 ) -> JsonRecord:
     data = {"params": params} if params else {}
     return {
-        "content": {
-            "data": {
-                "jsonrpc": "2.0",
-                "method": method,
-                **data,
-            },
-            **content,
-        },
+        "content": {"data": {"jsonrpc": "2.0", "method": method, **data}, **content},
         "header": {},
     }
 
 
 def json_rpc_response(result: JsonData) -> JsonRecord:
-    return comm_message(
-        {
-            "jsonrpc": "2.0",
-            "result": result,
-        }
-    )
+    return comm_message({"jsonrpc": "2.0", "result": result})
 
 
 # remove "<class '...'>" from value

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/utils.py
@@ -13,7 +13,9 @@ from positron_ipykernel._vendor.pydantic import BaseModel
 from positron_ipykernel.utils import JsonData, JsonRecord
 
 
-def assert_pydantic_model_equal(actual: BaseModel, expected: BaseModel, exclude: Set[str]) -> None:
+def assert_pydantic_model_equal(
+    actual: BaseModel, expected: BaseModel, exclude: Set[str]
+) -> None:
     actual_dict = actual.dict(exclude=exclude)
     expected_dict = expected.dict(exclude=exclude)
     assert actual_dict == expected_dict
@@ -32,7 +34,10 @@ def preserve_working_directory():
 
 
 def assert_register_table_called(
-    mock_dataexplorer_service: Mock, obj: Any, title: str, variable_path: Optional[List[str]] = None
+    mock_dataexplorer_service: Mock,
+    obj: Any,
+    title: str,
+    variable_path: Optional[List[str]] = None,
 ) -> None:
     call_args_list = mock_dataexplorer_service.register_table.call_args_list
     assert len(call_args_list) == 1
@@ -66,7 +71,9 @@ def comm_request(data: JsonRecord, **kwargs) -> JsonRecord:
     return {"content": {"data": data, **kwargs.pop("content", {})}, **kwargs}
 
 
-def comm_open_message(target_name: str, data: Optional[JsonRecord] = None) -> JsonRecord:
+def comm_open_message(
+    target_name: str, data: Optional[JsonRecord] = None
+) -> JsonRecord:
     return {
         **comm_message(data),
         "target_name": target_name,
@@ -94,7 +101,9 @@ def json_rpc_error(code: int, message: str) -> JsonRecord:
     )
 
 
-def json_rpc_notification(method: str, params: Optional[JsonRecord] = None) -> JsonRecord:
+def json_rpc_notification(
+    method: str, params: Optional[JsonRecord] = None
+) -> JsonRecord:
     return comm_message(
         {
             "jsonrpc": "2.0",

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/utils.py
@@ -49,10 +49,17 @@ def assert_register_table_called(
         assert passed_variable_path[0] == variable_path[0]
 
 
-def comm_message(data: Optional[JsonRecord] = None) -> JsonRecord:
+def comm_message(
+    data: Optional[JsonRecord] = None,
+) -> JsonRecord:
     if data is None:
         data = {}
-    return {"data": data, "metadata": None, "buffers": None, "msg_type": "comm_msg"}
+    return {
+        "data": data,
+        "metadata": None,
+        "buffers": None,
+        "msg_type": "comm_msg",
+    }
 
 
 def comm_request(data: JsonRecord, **kwargs) -> JsonRecord:
@@ -69,31 +76,60 @@ def comm_open_message(target_name: str, data: Optional[JsonRecord] = None) -> Js
 
 
 def comm_close_message() -> JsonRecord:
-    return {**comm_message(), "msg_type": "comm_close"}
+    return {
+        **comm_message(),
+        "msg_type": "comm_close",
+    }
 
 
 def json_rpc_error(code: int, message: str) -> JsonRecord:
-    return comm_message({"jsonrpc": "2.0", "error": {"code": code, "message": message}})
+    return comm_message(
+        {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": code,
+                "message": message,
+            },
+        }
+    )
 
 
 def json_rpc_notification(method: str, params: Optional[JsonRecord] = None) -> JsonRecord:
     return comm_message(
-        {"jsonrpc": "2.0", "method": method, "params": {} if params is None else params}
+        {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": {} if params is None else params,
+        }
     )
 
 
 def json_rpc_request(
-    method: str, params: Optional[JsonRecord] = None, **content: JsonData
+    method: str,
+    params: Optional[JsonRecord] = None,
+    **content: JsonData,
 ) -> JsonRecord:
     data = {"params": params} if params else {}
     return {
-        "content": {"data": {"jsonrpc": "2.0", "method": method, **data}, **content},
+        "content": {
+            "data": {
+                "jsonrpc": "2.0",
+                "method": method,
+                **data,
+            },
+            **content,
+        },
         "header": {},
     }
 
 
 def json_rpc_response(result: JsonData) -> JsonRecord:
-    return comm_message({"jsonrpc": "2.0", "result": result})
+    return comm_message(
+        {
+            "jsonrpc": "2.0",
+            "result": result,
+        }
+    )
 
 
 # remove "<class '...'>" from value

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -115,7 +115,12 @@ class UiService:
         self._comm.on_msg(self.handle_msg, UiBackendMessageContent)
 
         self.browser = PositronViewerBrowser(comm=self._comm)
-        webbrowser.register(self.browser.name, PositronViewerBrowser, self.browser, preferred=True)
+        webbrowser.register(
+            self.browser.name,
+            PositronViewerBrowser,
+            self.browser,
+            preferred=True,
+        )
 
         # Clear the current working directory to generate an event for the new
         # client (i.e. after a reconnect)
@@ -193,7 +198,11 @@ class UiService:
 class PositronViewerBrowser(webbrowser.BaseBrowser):
     """Launcher class for Positron Viewer browsers."""
 
-    def __init__(self, name: str = "positron_viewer", comm: Optional[PositronComm] = None):
+    def __init__(
+        self,
+        name: str = "positron_viewer",
+        comm: Optional[PositronComm] = None,
+    ):
         self.name = name
         self._comm = comm
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -115,12 +115,7 @@ class UiService:
         self._comm.on_msg(self.handle_msg, UiBackendMessageContent)
 
         self.browser = PositronViewerBrowser(comm=self._comm)
-        webbrowser.register(
-            self.browser.name,
-            PositronViewerBrowser,
-            self.browser,
-            preferred=True,
-        )
+        webbrowser.register(self.browser.name, PositronViewerBrowser, self.browser, preferred=True)
 
         # Clear the current working directory to generate an event for the new
         # client (i.e. after a reconnect)
@@ -198,11 +193,7 @@ class UiService:
 class PositronViewerBrowser(webbrowser.BaseBrowser):
     """Launcher class for Positron Viewer browsers."""
 
-    def __init__(
-        self,
-        name: str = "positron_viewer",
-        comm: Optional[PositronComm] = None,
-    ):
+    def __init__(self, name: str = "positron_viewer", comm: Optional[PositronComm] = None):
         self.name = name
         self._comm = comm
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui.py
@@ -54,8 +54,14 @@ class _InvalidParamsError(Exception):
     pass
 
 
-def _is_module_loaded(kernel: "PositronIPyKernel", params: List[JsonData]) -> bool:
-    if not (isinstance(params, list) and len(params) == 1 and isinstance(params[0], str)):
+def _is_module_loaded(
+    kernel: "PositronIPyKernel", params: List[JsonData]
+) -> bool:
+    if not (
+        isinstance(params, list)
+        and len(params) == 1
+        and isinstance(params[0], str)
+    ):
         raise _InvalidParamsError(f"Expected a module name, got: {params}")
     # Consider: this is not a perfect check for a couple of reasons:
     # 1. The module could be loaded under a different name
@@ -63,8 +69,14 @@ def _is_module_loaded(kernel: "PositronIPyKernel", params: List[JsonData]) -> bo
     return params[0] in kernel.shell.user_ns.keys()
 
 
-def _set_console_width(kernel: "PositronIPyKernel", params: List[JsonData]) -> None:
-    if not (isinstance(params, list) and len(params) == 1 and isinstance(params[0], int)):
+def _set_console_width(
+    kernel: "PositronIPyKernel", params: List[JsonData]
+) -> None:
+    if not (
+        isinstance(params, list)
+        and len(params) == 1
+        and isinstance(params[0], int)
+    ):
         raise _InvalidParamsError(f"Expected an integer width, got: {params}")
 
     width = params[0]
@@ -91,7 +103,9 @@ def _set_console_width(kernel: "PositronIPyKernel", params: List[JsonData]) -> N
         torch_.set_printoptions(linewidth=width)
 
 
-_RPC_METHODS: Dict[str, Callable[["PositronIPyKernel", List[JsonData]], Optional[JsonData]]] = {
+_RPC_METHODS: Dict[
+    str, Callable[["PositronIPyKernel", List[JsonData]], Optional[JsonData]]
+] = {
     "setConsoleWidth": _set_console_width,
     "isModuleLoaded": _is_module_loaded,
 }
@@ -143,8 +157,12 @@ class UiService:
             self._working_directory = current_dir
             # Deliver event to client
             if self._comm is not None:
-                event = WorkingDirectoryParams(directory=str(alias_home(current_dir)))
-                self._send_event(name=UiFrontendEvent.WorkingDirectory, payload=event)
+                event = WorkingDirectoryParams(
+                    directory=str(alias_home(current_dir))
+                )
+                self._send_event(
+                    name=UiFrontendEvent.WorkingDirectory, payload=event
+                )
 
     def open_editor(self, file: str, line: int, column: int) -> None:
         event = OpenEditorParams(file=file, line=line, column=column)
@@ -156,7 +174,9 @@ class UiService:
     def clear_webview_preloads(self) -> None:
         self._send_event(name=UiFrontendEvent.ClearWebviewPreloads, payload={})
 
-    def handle_msg(self, msg: CommMessage[UiBackendMessageContent], raw_msg: JsonRecord) -> None:
+    def handle_msg(
+        self, msg: CommMessage[UiBackendMessageContent], raw_msg: JsonRecord
+    ) -> None:
         request = msg.content.data
 
         if isinstance(request, CallMethodRequest):
@@ -169,7 +189,9 @@ class UiService:
     def _call_method(self, rpc_request: CallMethodParams) -> None:
         func = _RPC_METHODS.get(rpc_request.method, None)
         if func is None:
-            return logger.warning(f"Invalid frontend RPC request method: {rpc_request.method}")
+            return logger.warning(
+                f"Invalid frontend RPC request method: {rpc_request.method}"
+            )
 
         try:
             result = func(self.kernel, rpc_request.params)
@@ -188,7 +210,9 @@ class UiService:
             except Exception:
                 pass
 
-    def _send_event(self, name: str, payload: Union[BaseModel, JsonRecord]) -> None:
+    def _send_event(
+        self, name: str, payload: Union[BaseModel, JsonRecord]
+    ) -> None:
         if self._comm is not None:
             if isinstance(payload, BaseModel):
                 payload = payload.dict()
@@ -227,20 +251,25 @@ class PositronViewerBrowser(webbrowser.BaseBrowser):
                     return self._send_show_html_event(url, is_plot)
                 else:
                     event = ShowUrlParams(url=url)
-                    self._comm.send_event(name=UiFrontendEvent.ShowUrl, payload=event.dict())
+                    self._comm.send_event(
+                        name=UiFrontendEvent.ShowUrl, payload=event.dict()
+                    )
 
                 return True
         # pass back to webbrowser's list of browsers to open up the link
         return False
 
     @staticmethod
-    def _is_module_function(module_name: str, function_name: Union[str, None] = None) -> bool:
+    def _is_module_function(
+        module_name: str, function_name: Union[str, None] = None
+    ) -> bool:
         module = sys.modules.get(module_name)
         if module:
             for frame_info in inspect.stack():
                 if function_name:
                     if (
-                        inspect.getmodule(frame_info.frame, frame_info.filename) == module
+                        inspect.getmodule(frame_info.frame, frame_info.filename)
+                        == module
                         and frame_info.function == function_name
                     ):
                         return True

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui_comm.py
@@ -26,13 +26,21 @@ class EditorContext(BaseModel):
     Editor metadata
     """
 
-    document: TextDocument = Field(description="Document metadata")
+    document: TextDocument = Field(
+        description="Document metadata",
+    )
 
-    contents: List[StrictStr] = Field(description="Document contents")
+    contents: List[StrictStr] = Field(
+        description="Document contents",
+    )
 
-    selection: Selection = Field(description="The primary selection, i.e. selections[0]")
+    selection: Selection = Field(
+        description="The primary selection, i.e. selections[0]",
+    )
 
-    selections: List[Selection] = Field(description="The selections in this text editor.")
+    selections: List[Selection] = Field(
+        description="The selections in this text editor.",
+    )
 
 
 class TextDocument(BaseModel):
@@ -40,21 +48,37 @@ class TextDocument(BaseModel):
     Document metadata
     """
 
-    path: StrictStr = Field(description="URI of the resource viewed in the editor")
+    path: StrictStr = Field(
+        description="URI of the resource viewed in the editor",
+    )
 
-    eol: StrictStr = Field(description="End of line sequence")
+    eol: StrictStr = Field(
+        description="End of line sequence",
+    )
 
-    is_closed: StrictBool = Field(description="Whether the document has been closed")
+    is_closed: StrictBool = Field(
+        description="Whether the document has been closed",
+    )
 
-    is_dirty: StrictBool = Field(description="Whether the document has been modified")
+    is_dirty: StrictBool = Field(
+        description="Whether the document has been modified",
+    )
 
-    is_untitled: StrictBool = Field(description="Whether the document is untitled")
+    is_untitled: StrictBool = Field(
+        description="Whether the document is untitled",
+    )
 
-    language_id: StrictStr = Field(description="Language identifier")
+    language_id: StrictStr = Field(
+        description="Language identifier",
+    )
 
-    line_count: StrictInt = Field(description="Number of lines in the document")
+    line_count: StrictInt = Field(
+        description="Number of lines in the document",
+    )
 
-    version: StrictInt = Field(description="Version number of the document")
+    version: StrictInt = Field(
+        description="Version number of the document",
+    )
 
 
 class Position(BaseModel):
@@ -63,10 +87,12 @@ class Position(BaseModel):
     """
 
     character: StrictInt = Field(
-        description="The zero-based character value, as a Unicode code point offset."
+        description="The zero-based character value, as a Unicode code point offset.",
     )
 
-    line: StrictInt = Field(description="The zero-based line value.")
+    line: StrictInt = Field(
+        description="The zero-based line value.",
+    )
 
 
 class Selection(BaseModel):
@@ -74,13 +100,21 @@ class Selection(BaseModel):
     Selection metadata
     """
 
-    active: Position = Field(description="Position of the cursor.")
+    active: Position = Field(
+        description="Position of the cursor.",
+    )
 
-    start: Position = Field(description="Start position of the selection")
+    start: Position = Field(
+        description="Start position of the selection",
+    )
 
-    end: Position = Field(description="End position of the selection")
+    end: Position = Field(
+        description="End position of the selection",
+    )
 
-    text: StrictStr = Field(description="Text of the selection")
+    text: StrictStr = Field(
+        description="Text of the selection",
+    )
 
 
 class Range(BaseModel):
@@ -88,9 +122,13 @@ class Range(BaseModel):
     Selection range
     """
 
-    start: Position = Field(description="Start position of the selection")
+    start: Position = Field(
+        description="Start position of the selection",
+    )
 
-    end: Position = Field(description="End position of the selection")
+    end: Position = Field(
+        description="End position of the selection",
+    )
 
 
 @enum.unique
@@ -110,9 +148,13 @@ class CallMethodParams(BaseModel):
     an implementation-defined serialization scheme.
     """
 
-    method: StrictStr = Field(description="The method to call inside the interpreter")
+    method: StrictStr = Field(
+        description="The method to call inside the interpreter",
+    )
 
-    params: List[Param] = Field(description="The parameters for `method`")
+    params: List[Param] = Field(
+        description="The parameters for `method`",
+    )
 
 
 class CallMethodRequest(BaseModel):
@@ -122,13 +164,18 @@ class CallMethodRequest(BaseModel):
     an implementation-defined serialization scheme.
     """
 
-    params: CallMethodParams = Field(description="Parameters to the CallMethod method")
-
-    method: Literal[UiBackendRequest.CallMethod] = Field(
-        description="The JSON-RPC method name (call_method)"
+    params: CallMethodParams = Field(
+        description="Parameters to the CallMethod method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[UiBackendRequest.CallMethod] = Field(
+        description="The JSON-RPC method name (call_method)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class UiBackendMessageContent(BaseModel):
@@ -181,7 +228,9 @@ class BusyParams(BaseModel):
     Change in backend's busy/idle status
     """
 
-    busy: StrictBool = Field(description="Whether the backend is busy")
+    busy: StrictBool = Field(
+        description="Whether the backend is busy",
+    )
 
 
 class OpenEditorParams(BaseModel):
@@ -189,11 +238,17 @@ class OpenEditorParams(BaseModel):
     Open an editor
     """
 
-    file: StrictStr = Field(description="The path of the file to open")
+    file: StrictStr = Field(
+        description="The path of the file to open",
+    )
 
-    line: StrictInt = Field(description="The line number to jump to")
+    line: StrictInt = Field(
+        description="The line number to jump to",
+    )
 
-    column: StrictInt = Field(description="The column number to jump to")
+    column: StrictInt = Field(
+        description="The column number to jump to",
+    )
 
 
 class NewDocumentParams(BaseModel):
@@ -201,9 +256,13 @@ class NewDocumentParams(BaseModel):
     Create a new document with text contents
     """
 
-    contents: StrictStr = Field(description="Document contents")
+    contents: StrictStr = Field(
+        description="Document contents",
+    )
 
-    language_id: StrictStr = Field(description="Language identifier")
+    language_id: StrictStr = Field(
+        description="Language identifier",
+    )
 
 
 class ShowMessageParams(BaseModel):
@@ -211,7 +270,9 @@ class ShowMessageParams(BaseModel):
     Show a message
     """
 
-    message: StrictStr = Field(description="The message to show to the user.")
+    message: StrictStr = Field(
+        description="The message to show to the user.",
+    )
 
 
 class ShowQuestionParams(BaseModel):
@@ -219,13 +280,21 @@ class ShowQuestionParams(BaseModel):
     Show a question
     """
 
-    title: StrictStr = Field(description="The title of the dialog")
+    title: StrictStr = Field(
+        description="The title of the dialog",
+    )
 
-    message: StrictStr = Field(description="The message to display in the dialog")
+    message: StrictStr = Field(
+        description="The message to display in the dialog",
+    )
 
-    ok_button_title: StrictStr = Field(description="The title of the OK button")
+    ok_button_title: StrictStr = Field(
+        description="The title of the OK button",
+    )
 
-    cancel_button_title: StrictStr = Field(description="The title of the Cancel button")
+    cancel_button_title: StrictStr = Field(
+        description="The title of the Cancel button",
+    )
 
 
 class ShowDialogParams(BaseModel):
@@ -233,9 +302,13 @@ class ShowDialogParams(BaseModel):
     Show a dialog
     """
 
-    title: StrictStr = Field(description="The title of the dialog")
+    title: StrictStr = Field(
+        description="The title of the dialog",
+    )
 
-    message: StrictStr = Field(description="The message to display in the dialog")
+    message: StrictStr = Field(
+        description="The message to display in the dialog",
+    )
 
 
 class PromptStateParams(BaseModel):
@@ -243,9 +316,13 @@ class PromptStateParams(BaseModel):
     New state of the primary and secondary prompts
     """
 
-    input_prompt: StrictStr = Field(description="Prompt for primary input.")
+    input_prompt: StrictStr = Field(
+        description="Prompt for primary input.",
+    )
 
-    continuation_prompt: StrictStr = Field(description="Prompt for incomplete input.")
+    continuation_prompt: StrictStr = Field(
+        description="Prompt for incomplete input.",
+    )
 
 
 class WorkingDirectoryParams(BaseModel):
@@ -253,7 +330,9 @@ class WorkingDirectoryParams(BaseModel):
     Change the displayed working directory
     """
 
-    directory: StrictStr = Field(description="The new working directory")
+    directory: StrictStr = Field(
+        description="The new working directory",
+    )
 
 
 class DebugSleepParams(BaseModel):
@@ -261,7 +340,9 @@ class DebugSleepParams(BaseModel):
     Sleep for n seconds
     """
 
-    ms: Union[StrictInt, StrictFloat] = Field(description="Duration in milliseconds")
+    ms: Union[StrictInt, StrictFloat] = Field(
+        description="Duration in milliseconds",
+    )
 
 
 class ExecuteCommandParams(BaseModel):
@@ -269,7 +350,9 @@ class ExecuteCommandParams(BaseModel):
     Execute a Positron command
     """
 
-    command: StrictStr = Field(description="The command to execute")
+    command: StrictStr = Field(
+        description="The command to execute",
+    )
 
 
 class EvaluateWhenClauseParams(BaseModel):
@@ -277,7 +360,9 @@ class EvaluateWhenClauseParams(BaseModel):
     Get a logical for a `when` clause (a set of context keys)
     """
 
-    when_clause: StrictStr = Field(description="The values for context keys, as a `when` clause")
+    when_clause: StrictStr = Field(
+        description="The values for context keys, as a `when` clause",
+    )
 
 
 class ExecuteCodeParams(BaseModel):
@@ -285,14 +370,20 @@ class ExecuteCodeParams(BaseModel):
     Execute code in a Positron runtime
     """
 
-    language_id: StrictStr = Field(description="The language ID of the code to execute")
+    language_id: StrictStr = Field(
+        description="The language ID of the code to execute",
+    )
 
-    code: StrictStr = Field(description="The code to execute")
+    code: StrictStr = Field(
+        description="The code to execute",
+    )
 
-    focus: StrictBool = Field(description="Whether to focus the runtime's console")
+    focus: StrictBool = Field(
+        description="Whether to focus the runtime's console",
+    )
 
     allow_incomplete: StrictBool = Field(
-        description="Whether to bypass runtime code completeness checks"
+        description="Whether to bypass runtime code completeness checks",
     )
 
 
@@ -301,9 +392,13 @@ class OpenWorkspaceParams(BaseModel):
     Open a workspace
     """
 
-    path: StrictStr = Field(description="The path for the workspace to be opened")
+    path: StrictStr = Field(
+        description="The path for the workspace to be opened",
+    )
 
-    new_window: StrictBool = Field(description="Should the workspace be opened in a new window?")
+    new_window: StrictBool = Field(
+        description="Should the workspace be opened in a new window?",
+    )
 
 
 class SetEditorSelectionsParams(BaseModel):
@@ -312,7 +407,7 @@ class SetEditorSelectionsParams(BaseModel):
     """
 
     selections: List[Range] = Field(
-        description="The selections (really, ranges) to set in the document"
+        description="The selections (really, ranges) to set in the document",
     )
 
 
@@ -322,10 +417,12 @@ class ModifyEditorSelectionsParams(BaseModel):
     """
 
     selections: List[Range] = Field(
-        description="The selections (really, ranges) to set in the document"
+        description="The selections (really, ranges) to set in the document",
     )
 
-    values: List[StrictStr] = Field(description="The text values to insert at the selections")
+    values: List[StrictStr] = Field(
+        description="The text values to insert at the selections",
+    )
 
 
 class ShowUrlParams(BaseModel):
@@ -333,7 +430,9 @@ class ShowUrlParams(BaseModel):
     Show a URL in Positron's Viewer pane
     """
 
-    url: StrictStr = Field(description="The URL to display")
+    url: StrictStr = Field(
+        description="The URL to display",
+    )
 
 
 class ShowHtmlFileParams(BaseModel):
@@ -342,17 +441,19 @@ class ShowHtmlFileParams(BaseModel):
     """
 
     path: StrictStr = Field(
-        description="The fully qualified filesystem path to the HTML file to display"
+        description="The fully qualified filesystem path to the HTML file to display",
     )
 
     title: StrictStr = Field(
-        description="A title to be displayed in the viewer. May be empty, and can be superseded by the title in the HTML file."
+        description="A title to be displayed in the viewer. May be empty, and can be superseded by the title in the HTML file.",
     )
 
-    is_plot: StrictBool = Field(description="Whether the HTML file is a plot-like object")
+    is_plot: StrictBool = Field(
+        description="Whether the HTML file is a plot-like object",
+    )
 
     height: StrictInt = Field(
-        description="The desired height of the HTML viewer, in pixels. The special value 0 indicates that no particular height is desired, and -1 indicates that the viewer should be as tall as possible."
+        description="The desired height of the HTML viewer, in pixels. The special value 0 indicates that no particular height is desired, and -1 indicates that the viewer should be as tall as possible.",
     )
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui_comm.py
@@ -15,7 +15,14 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+from ._vendor.pydantic import (
+    BaseModel,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+)
 
 Param = Any
 CallMethodResult = Any

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/ui_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/ui_comm.py
@@ -26,21 +26,13 @@ class EditorContext(BaseModel):
     Editor metadata
     """
 
-    document: TextDocument = Field(
-        description="Document metadata",
-    )
+    document: TextDocument = Field(description="Document metadata")
 
-    contents: List[StrictStr] = Field(
-        description="Document contents",
-    )
+    contents: List[StrictStr] = Field(description="Document contents")
 
-    selection: Selection = Field(
-        description="The primary selection, i.e. selections[0]",
-    )
+    selection: Selection = Field(description="The primary selection, i.e. selections[0]")
 
-    selections: List[Selection] = Field(
-        description="The selections in this text editor.",
-    )
+    selections: List[Selection] = Field(description="The selections in this text editor.")
 
 
 class TextDocument(BaseModel):
@@ -48,37 +40,21 @@ class TextDocument(BaseModel):
     Document metadata
     """
 
-    path: StrictStr = Field(
-        description="URI of the resource viewed in the editor",
-    )
+    path: StrictStr = Field(description="URI of the resource viewed in the editor")
 
-    eol: StrictStr = Field(
-        description="End of line sequence",
-    )
+    eol: StrictStr = Field(description="End of line sequence")
 
-    is_closed: StrictBool = Field(
-        description="Whether the document has been closed",
-    )
+    is_closed: StrictBool = Field(description="Whether the document has been closed")
 
-    is_dirty: StrictBool = Field(
-        description="Whether the document has been modified",
-    )
+    is_dirty: StrictBool = Field(description="Whether the document has been modified")
 
-    is_untitled: StrictBool = Field(
-        description="Whether the document is untitled",
-    )
+    is_untitled: StrictBool = Field(description="Whether the document is untitled")
 
-    language_id: StrictStr = Field(
-        description="Language identifier",
-    )
+    language_id: StrictStr = Field(description="Language identifier")
 
-    line_count: StrictInt = Field(
-        description="Number of lines in the document",
-    )
+    line_count: StrictInt = Field(description="Number of lines in the document")
 
-    version: StrictInt = Field(
-        description="Version number of the document",
-    )
+    version: StrictInt = Field(description="Version number of the document")
 
 
 class Position(BaseModel):
@@ -87,12 +63,10 @@ class Position(BaseModel):
     """
 
     character: StrictInt = Field(
-        description="The zero-based character value, as a Unicode code point offset.",
+        description="The zero-based character value, as a Unicode code point offset."
     )
 
-    line: StrictInt = Field(
-        description="The zero-based line value.",
-    )
+    line: StrictInt = Field(description="The zero-based line value.")
 
 
 class Selection(BaseModel):
@@ -100,21 +74,13 @@ class Selection(BaseModel):
     Selection metadata
     """
 
-    active: Position = Field(
-        description="Position of the cursor.",
-    )
+    active: Position = Field(description="Position of the cursor.")
 
-    start: Position = Field(
-        description="Start position of the selection",
-    )
+    start: Position = Field(description="Start position of the selection")
 
-    end: Position = Field(
-        description="End position of the selection",
-    )
+    end: Position = Field(description="End position of the selection")
 
-    text: StrictStr = Field(
-        description="Text of the selection",
-    )
+    text: StrictStr = Field(description="Text of the selection")
 
 
 class Range(BaseModel):
@@ -122,13 +88,9 @@ class Range(BaseModel):
     Selection range
     """
 
-    start: Position = Field(
-        description="Start position of the selection",
-    )
+    start: Position = Field(description="Start position of the selection")
 
-    end: Position = Field(
-        description="End position of the selection",
-    )
+    end: Position = Field(description="End position of the selection")
 
 
 @enum.unique
@@ -148,13 +110,9 @@ class CallMethodParams(BaseModel):
     an implementation-defined serialization scheme.
     """
 
-    method: StrictStr = Field(
-        description="The method to call inside the interpreter",
-    )
+    method: StrictStr = Field(description="The method to call inside the interpreter")
 
-    params: List[Param] = Field(
-        description="The parameters for `method`",
-    )
+    params: List[Param] = Field(description="The parameters for `method`")
 
 
 class CallMethodRequest(BaseModel):
@@ -164,18 +122,13 @@ class CallMethodRequest(BaseModel):
     an implementation-defined serialization scheme.
     """
 
-    params: CallMethodParams = Field(
-        description="Parameters to the CallMethod method",
-    )
+    params: CallMethodParams = Field(description="Parameters to the CallMethod method")
 
     method: Literal[UiBackendRequest.CallMethod] = Field(
-        description="The JSON-RPC method name (call_method)",
+        description="The JSON-RPC method name (call_method)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class UiBackendMessageContent(BaseModel):
@@ -228,9 +181,7 @@ class BusyParams(BaseModel):
     Change in backend's busy/idle status
     """
 
-    busy: StrictBool = Field(
-        description="Whether the backend is busy",
-    )
+    busy: StrictBool = Field(description="Whether the backend is busy")
 
 
 class OpenEditorParams(BaseModel):
@@ -238,17 +189,11 @@ class OpenEditorParams(BaseModel):
     Open an editor
     """
 
-    file: StrictStr = Field(
-        description="The path of the file to open",
-    )
+    file: StrictStr = Field(description="The path of the file to open")
 
-    line: StrictInt = Field(
-        description="The line number to jump to",
-    )
+    line: StrictInt = Field(description="The line number to jump to")
 
-    column: StrictInt = Field(
-        description="The column number to jump to",
-    )
+    column: StrictInt = Field(description="The column number to jump to")
 
 
 class NewDocumentParams(BaseModel):
@@ -256,13 +201,9 @@ class NewDocumentParams(BaseModel):
     Create a new document with text contents
     """
 
-    contents: StrictStr = Field(
-        description="Document contents",
-    )
+    contents: StrictStr = Field(description="Document contents")
 
-    language_id: StrictStr = Field(
-        description="Language identifier",
-    )
+    language_id: StrictStr = Field(description="Language identifier")
 
 
 class ShowMessageParams(BaseModel):
@@ -270,9 +211,7 @@ class ShowMessageParams(BaseModel):
     Show a message
     """
 
-    message: StrictStr = Field(
-        description="The message to show to the user.",
-    )
+    message: StrictStr = Field(description="The message to show to the user.")
 
 
 class ShowQuestionParams(BaseModel):
@@ -280,21 +219,13 @@ class ShowQuestionParams(BaseModel):
     Show a question
     """
 
-    title: StrictStr = Field(
-        description="The title of the dialog",
-    )
+    title: StrictStr = Field(description="The title of the dialog")
 
-    message: StrictStr = Field(
-        description="The message to display in the dialog",
-    )
+    message: StrictStr = Field(description="The message to display in the dialog")
 
-    ok_button_title: StrictStr = Field(
-        description="The title of the OK button",
-    )
+    ok_button_title: StrictStr = Field(description="The title of the OK button")
 
-    cancel_button_title: StrictStr = Field(
-        description="The title of the Cancel button",
-    )
+    cancel_button_title: StrictStr = Field(description="The title of the Cancel button")
 
 
 class ShowDialogParams(BaseModel):
@@ -302,13 +233,9 @@ class ShowDialogParams(BaseModel):
     Show a dialog
     """
 
-    title: StrictStr = Field(
-        description="The title of the dialog",
-    )
+    title: StrictStr = Field(description="The title of the dialog")
 
-    message: StrictStr = Field(
-        description="The message to display in the dialog",
-    )
+    message: StrictStr = Field(description="The message to display in the dialog")
 
 
 class PromptStateParams(BaseModel):
@@ -316,13 +243,9 @@ class PromptStateParams(BaseModel):
     New state of the primary and secondary prompts
     """
 
-    input_prompt: StrictStr = Field(
-        description="Prompt for primary input.",
-    )
+    input_prompt: StrictStr = Field(description="Prompt for primary input.")
 
-    continuation_prompt: StrictStr = Field(
-        description="Prompt for incomplete input.",
-    )
+    continuation_prompt: StrictStr = Field(description="Prompt for incomplete input.")
 
 
 class WorkingDirectoryParams(BaseModel):
@@ -330,9 +253,7 @@ class WorkingDirectoryParams(BaseModel):
     Change the displayed working directory
     """
 
-    directory: StrictStr = Field(
-        description="The new working directory",
-    )
+    directory: StrictStr = Field(description="The new working directory")
 
 
 class DebugSleepParams(BaseModel):
@@ -340,9 +261,7 @@ class DebugSleepParams(BaseModel):
     Sleep for n seconds
     """
 
-    ms: Union[StrictInt, StrictFloat] = Field(
-        description="Duration in milliseconds",
-    )
+    ms: Union[StrictInt, StrictFloat] = Field(description="Duration in milliseconds")
 
 
 class ExecuteCommandParams(BaseModel):
@@ -350,9 +269,7 @@ class ExecuteCommandParams(BaseModel):
     Execute a Positron command
     """
 
-    command: StrictStr = Field(
-        description="The command to execute",
-    )
+    command: StrictStr = Field(description="The command to execute")
 
 
 class EvaluateWhenClauseParams(BaseModel):
@@ -360,9 +277,7 @@ class EvaluateWhenClauseParams(BaseModel):
     Get a logical for a `when` clause (a set of context keys)
     """
 
-    when_clause: StrictStr = Field(
-        description="The values for context keys, as a `when` clause",
-    )
+    when_clause: StrictStr = Field(description="The values for context keys, as a `when` clause")
 
 
 class ExecuteCodeParams(BaseModel):
@@ -370,20 +285,14 @@ class ExecuteCodeParams(BaseModel):
     Execute code in a Positron runtime
     """
 
-    language_id: StrictStr = Field(
-        description="The language ID of the code to execute",
-    )
+    language_id: StrictStr = Field(description="The language ID of the code to execute")
 
-    code: StrictStr = Field(
-        description="The code to execute",
-    )
+    code: StrictStr = Field(description="The code to execute")
 
-    focus: StrictBool = Field(
-        description="Whether to focus the runtime's console",
-    )
+    focus: StrictBool = Field(description="Whether to focus the runtime's console")
 
     allow_incomplete: StrictBool = Field(
-        description="Whether to bypass runtime code completeness checks",
+        description="Whether to bypass runtime code completeness checks"
     )
 
 
@@ -392,13 +301,9 @@ class OpenWorkspaceParams(BaseModel):
     Open a workspace
     """
 
-    path: StrictStr = Field(
-        description="The path for the workspace to be opened",
-    )
+    path: StrictStr = Field(description="The path for the workspace to be opened")
 
-    new_window: StrictBool = Field(
-        description="Should the workspace be opened in a new window?",
-    )
+    new_window: StrictBool = Field(description="Should the workspace be opened in a new window?")
 
 
 class SetEditorSelectionsParams(BaseModel):
@@ -407,7 +312,7 @@ class SetEditorSelectionsParams(BaseModel):
     """
 
     selections: List[Range] = Field(
-        description="The selections (really, ranges) to set in the document",
+        description="The selections (really, ranges) to set in the document"
     )
 
 
@@ -417,12 +322,10 @@ class ModifyEditorSelectionsParams(BaseModel):
     """
 
     selections: List[Range] = Field(
-        description="The selections (really, ranges) to set in the document",
+        description="The selections (really, ranges) to set in the document"
     )
 
-    values: List[StrictStr] = Field(
-        description="The text values to insert at the selections",
-    )
+    values: List[StrictStr] = Field(description="The text values to insert at the selections")
 
 
 class ShowUrlParams(BaseModel):
@@ -430,9 +333,7 @@ class ShowUrlParams(BaseModel):
     Show a URL in Positron's Viewer pane
     """
 
-    url: StrictStr = Field(
-        description="The URL to display",
-    )
+    url: StrictStr = Field(description="The URL to display")
 
 
 class ShowHtmlFileParams(BaseModel):
@@ -441,19 +342,17 @@ class ShowHtmlFileParams(BaseModel):
     """
 
     path: StrictStr = Field(
-        description="The fully qualified filesystem path to the HTML file to display",
+        description="The fully qualified filesystem path to the HTML file to display"
     )
 
     title: StrictStr = Field(
-        description="A title to be displayed in the viewer. May be empty, and can be superseded by the title in the HTML file.",
+        description="A title to be displayed in the viewer. May be empty, and can be superseded by the title in the HTML file."
     )
 
-    is_plot: StrictBool = Field(
-        description="Whether the HTML file is a plot-like object",
-    )
+    is_plot: StrictBool = Field(description="Whether the HTML file is a plot-like object")
 
     height: StrictInt = Field(
-        description="The desired height of the HTML viewer, in pixels. The special value 0 indicates that no particular height is desired, and -1 indicates that the viewer should be as tall as possible.",
+        description="The desired height of the HTML viewer, in pixels. The special value 0 indicates that no particular height is desired, and -1 indicates that the viewer should be as tall as possible."
     )
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
@@ -15,7 +15,18 @@ import uuid
 from binascii import b2a_base64
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Coroutine, Dict, List, Optional, Set, Tuple, TypeVar, Union, cast
+from typing import (
+    Any,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
 from urllib.parse import unquote, urlparse
 
 JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool, None]
@@ -110,7 +121,9 @@ def is_numpy_ufunc(object: Any) -> bool:
 
 
 def pretty_format(
-    value, print_width: Optional[int] = None, truncate_at: Optional[int] = None
+    value,
+    print_width: Optional[int] = None,
+    truncate_at: Optional[int] = None,
 ) -> Tuple[str, bool]:
     if print_width is not None:
         s = pprint.pformat(value, width=print_width, compact=True)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
@@ -15,18 +15,7 @@ import uuid
 from binascii import b2a_base64
 from datetime import datetime
 from pathlib import Path
-from typing import (
-    Any,
-    Coroutine,
-    Dict,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Coroutine, Dict, List, Optional, Set, Tuple, TypeVar, Union, cast
 from urllib.parse import unquote, urlparse
 
 JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool, None]
@@ -121,9 +110,7 @@ def is_numpy_ufunc(object: Any) -> bool:
 
 
 def pretty_format(
-    value,
-    print_width: Optional[int] = None,
-    truncate_at: Optional[int] = None,
+    value, print_width: Optional[int] = None, truncate_at: Optional[int] = None
 ) -> Tuple[str, bool]:
     if print_width is not None:
         s = pprint.pformat(value, width=print_width, compact=True)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/utils.py
@@ -29,7 +29,9 @@ from typing import (
 )
 from urllib.parse import unquote, urlparse
 
-JsonData = Union[Dict[str, "JsonData"], List["JsonData"], str, int, float, bool, None]
+JsonData = Union[
+    Dict[str, "JsonData"], List["JsonData"], str, int, float, bool, None
+]
 JsonRecord = Dict[str, JsonData]
 
 
@@ -219,7 +221,9 @@ def json_clean(obj):
     raise ValueError("Can't clean for JSON: %r" % obj)
 
 
-def create_task(coro: Coroutine, pending_tasks: Set[asyncio.Task], **kwargs) -> asyncio.Task:
+def create_task(
+    coro: Coroutine, pending_tasks: Set[asyncio.Task], **kwargs
+) -> asyncio.Task:
     """
     Create a strongly referenced task to avoid it being garbage collected.
 
@@ -252,7 +256,9 @@ class BackgroundJobQueue:
     def __init__(self, max_workers=None):
         # Initialize the ThreadPoolExecutor with the specified number
         # of workers
-        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+        self.executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_workers
+        )
         self.pending_futures = set()
         self.lock = threading.Lock()
 
@@ -285,7 +291,9 @@ class BackgroundJobQueue:
         self.executor.shutdown(wait=wait)
 
 
-def safe_isinstance(obj: Any, module: str, class_name: str, *attrs: str) -> bool:
+def safe_isinstance(
+    obj: Any, module: str, class_name: str, *attrs: str
+) -> bool:
     """
     Check if `obj` is an instance of module.class_name if loaded.
 
@@ -296,7 +304,9 @@ def safe_isinstance(obj: Any, module: str, class_name: str, *attrs: str) -> bool
         for attr in [class_name, *attrs]:
             m = getattr(m, attr)
         if not isinstance(m, type):
-            raise ValueError(f"{module}.{class_name}.{'.'.join(attrs)} is not a type")
+            raise ValueError(
+                f"{module}.{class_name}.{'.'.join(attrs)} is not a type"
+            )
         return isinstance(obj, m)
     return False
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -17,13 +17,7 @@ from comm.base_comm import BaseComm
 from .access_keys import decode_access_key, encode_access_key
 from .inspectors import get_inspector
 from .positron_comm import CommMessage, JsonRpcErrorCode, PositronComm
-from .utils import (
-    JsonData,
-    JsonRecord,
-    cancel_tasks,
-    create_task,
-    get_qualname,
-)
+from .utils import JsonData, JsonRecord, cancel_tasks, create_task, get_qualname
 from .variables_comm import (
     ClearRequest,
     ClipboardFormatFormat,
@@ -113,9 +107,7 @@ class VariablesService:
         self.send_refresh_event()
 
     def handle_msg(
-        self,
-        msg: CommMessage[VariablesBackendMessageContent],
-        raw_msg: JsonRecord,
+        self, msg: CommMessage[VariablesBackendMessageContent], raw_msg: JsonRecord
     ) -> None:
         """
         Handle messages received from the client via the positron.variables comm.
@@ -144,10 +136,7 @@ class VariablesService:
             logger.warning(f"Unhandled request: {request}")
 
     def _send_update(
-        self,
-        assigned: Mapping[str, Any],
-        unevaluated: Mapping[str, Any],
-        removed: Set[str],
+        self, assigned: Mapping[str, Any], unevaluated: Mapping[str, Any], removed: Set[str]
     ) -> None:
         """
         Sends the list of variables that have changed in the current
@@ -239,11 +228,7 @@ class VariablesService:
         variables = self._get_filtered_vars()
         filtered_variables = _summarize_children(variables, MAX_ITEMS)
 
-        msg = RefreshParams(
-            variables=filtered_variables,
-            length=len(filtered_variables),
-            version=0,
-        )
+        msg = RefreshParams(variables=filtered_variables, length=len(filtered_variables), version=0)
         self._send_event(VariablesFrontendEvent.Refresh.value, msg.dict())
 
     async def shutdown(self) -> None:
@@ -335,9 +320,7 @@ class VariablesService:
         copied = repr(list(self._snapshot["mutable_copied"].keys()))
         logger.debug(f"Variables copied: {copied}")
 
-    def _compare_user_ns(
-        self,
-    ) -> Tuple[Dict[str, Any], Dict[str, Any], Set[str]]:
+    def _compare_user_ns(self) -> Tuple[Dict[str, Any], Dict[str, Any], Set[str]]:
         """
         Attempts to detect changes to variables in the user's environment.
 
@@ -464,11 +447,7 @@ class VariablesService:
 
     def _send_list(self) -> None:
         filtered_variables = self._list_all_vars()
-        msg = VariableList(
-            variables=filtered_variables,
-            length=len(filtered_variables),
-            version=0,
-        )
+        msg = VariableList(variables=filtered_variables, length=len(filtered_variables), version=0)
         self._send_result(msg.dict())
 
     def _delete_all_vars(self, parent: Dict[str, Any]) -> None:
@@ -557,8 +536,7 @@ class VariablesService:
             self._send_details(path, value)
         else:
             self._send_error(
-                JsonRpcErrorCode.INVALID_PARAMS,
-                f"Cannot find variable at '{path}' to inspect",
+                JsonRpcErrorCode.INVALID_PARAMS, f"Cannot find variable at '{path}' to inspect"
             )
 
     def _perform_view_action(self, path: List[str]) -> None:
@@ -572,8 +550,7 @@ class VariablesService:
         is_known, value = self._find_var(path)
         if not is_known:
             return self._send_error(
-                JsonRpcErrorCode.INVALID_PARAMS,
-                f"Cannot find variable at '{path}' to view",
+                JsonRpcErrorCode.INVALID_PARAMS, f"Cannot find variable at '{path}' to view"
             )
 
         try:
@@ -666,8 +643,7 @@ class VariablesService:
             self._send_result(msg.dict())
         else:
             self._send_error(
-                JsonRpcErrorCode.INVALID_PARAMS,
-                f"Cannot find variable at '{path}' to format",
+                JsonRpcErrorCode.INVALID_PARAMS, f"Cannot find variable at '{path}' to format"
             )
 
     def _send_details(self, path: List[str], value: Any = None):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -17,7 +17,13 @@ from comm.base_comm import BaseComm
 from .access_keys import decode_access_key, encode_access_key
 from .inspectors import get_inspector
 from .positron_comm import CommMessage, JsonRpcErrorCode, PositronComm
-from .utils import JsonData, JsonRecord, cancel_tasks, create_task, get_qualname
+from .utils import (
+    JsonData,
+    JsonRecord,
+    cancel_tasks,
+    create_task,
+    get_qualname,
+)
 from .variables_comm import (
     ClearRequest,
     ClipboardFormatFormat,
@@ -107,7 +113,9 @@ class VariablesService:
         self.send_refresh_event()
 
     def handle_msg(
-        self, msg: CommMessage[VariablesBackendMessageContent], raw_msg: JsonRecord
+        self,
+        msg: CommMessage[VariablesBackendMessageContent],
+        raw_msg: JsonRecord,
     ) -> None:
         """
         Handle messages received from the client via the positron.variables comm.
@@ -136,7 +144,10 @@ class VariablesService:
             logger.warning(f"Unhandled request: {request}")
 
     def _send_update(
-        self, assigned: Mapping[str, Any], unevaluated: Mapping[str, Any], removed: Set[str]
+        self,
+        assigned: Mapping[str, Any],
+        unevaluated: Mapping[str, Any],
+        removed: Set[str],
     ) -> None:
         """
         Sends the list of variables that have changed in the current
@@ -228,7 +239,11 @@ class VariablesService:
         variables = self._get_filtered_vars()
         filtered_variables = _summarize_children(variables, MAX_ITEMS)
 
-        msg = RefreshParams(variables=filtered_variables, length=len(filtered_variables), version=0)
+        msg = RefreshParams(
+            variables=filtered_variables,
+            length=len(filtered_variables),
+            version=0,
+        )
         self._send_event(VariablesFrontendEvent.Refresh.value, msg.dict())
 
     async def shutdown(self) -> None:
@@ -320,7 +335,9 @@ class VariablesService:
         copied = repr(list(self._snapshot["mutable_copied"].keys()))
         logger.debug(f"Variables copied: {copied}")
 
-    def _compare_user_ns(self) -> Tuple[Dict[str, Any], Dict[str, Any], Set[str]]:
+    def _compare_user_ns(
+        self,
+    ) -> Tuple[Dict[str, Any], Dict[str, Any], Set[str]]:
         """
         Attempts to detect changes to variables in the user's environment.
 
@@ -447,7 +464,11 @@ class VariablesService:
 
     def _send_list(self) -> None:
         filtered_variables = self._list_all_vars()
-        msg = VariableList(variables=filtered_variables, length=len(filtered_variables), version=0)
+        msg = VariableList(
+            variables=filtered_variables,
+            length=len(filtered_variables),
+            version=0,
+        )
         self._send_result(msg.dict())
 
     def _delete_all_vars(self, parent: Dict[str, Any]) -> None:
@@ -536,7 +557,8 @@ class VariablesService:
             self._send_details(path, value)
         else:
             self._send_error(
-                JsonRpcErrorCode.INVALID_PARAMS, f"Cannot find variable at '{path}' to inspect"
+                JsonRpcErrorCode.INVALID_PARAMS,
+                f"Cannot find variable at '{path}' to inspect",
             )
 
     def _perform_view_action(self, path: List[str]) -> None:
@@ -550,7 +572,8 @@ class VariablesService:
         is_known, value = self._find_var(path)
         if not is_known:
             return self._send_error(
-                JsonRpcErrorCode.INVALID_PARAMS, f"Cannot find variable at '{path}' to view"
+                JsonRpcErrorCode.INVALID_PARAMS,
+                f"Cannot find variable at '{path}' to view",
             )
 
         try:
@@ -643,7 +666,8 @@ class VariablesService:
             self._send_result(msg.dict())
         else:
             self._send_error(
-                JsonRpcErrorCode.INVALID_PARAMS, f"Cannot find variable at '{path}' to format"
+                JsonRpcErrorCode.INVALID_PARAMS,
+                f"Cannot find variable at '{path}' to format",
             )
 
     def _send_details(self, path: List[str], value: Any = None):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables.py
@@ -206,7 +206,9 @@ class VariablesService:
         # Filter out hidden removed variables and encode access keys
         hidden = self._get_user_ns_hidden()
         filtered_removed = [
-            encode_access_key(name) for name in sorted(removed) if name not in hidden
+            encode_access_key(name)
+            for name in sorted(removed)
+            if name not in hidden
         ]
 
         if filtered_assigned or filtered_unevaluated or filtered_removed:
@@ -367,7 +369,9 @@ class VariablesService:
             inspector1 = get_inspector(v1)
             inspector2 = get_inspector(v2)
 
-            return type(inspector1) is not type(inspector2) or not inspector1.equals(v2)
+            return type(inspector1) is not type(
+                inspector2
+            ) or not inspector1.equals(v2)
 
         def _compare_always_different(v1, v2):
             return True
@@ -398,7 +402,9 @@ class VariablesService:
 
         _check_ns_subset(snapshot["immutable"], True, _compare_immutable)
         _check_ns_subset(snapshot["mutable_copied"], True, _compare_mutable)
-        _check_ns_subset(snapshot["mutable_excluded"], False, _compare_always_different)
+        _check_ns_subset(
+            snapshot["mutable_excluded"], False, _compare_always_different
+        )
 
         for key, value in after.items():
             if key in hidden:
@@ -420,7 +426,9 @@ class VariablesService:
 
     # -- Private Methods --
 
-    def _get_filtered_vars(self, variables: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
+    def _get_filtered_vars(
+        self, variables: Optional[Mapping[str, Any]] = None
+    ) -> Dict[str, Any]:
         """
         Returns
         -------
@@ -502,7 +510,9 @@ class VariablesService:
         # Refresh the client state
         self.send_refresh_event()
 
-    def _delete_vars(self, names: Iterable[str], parent: Dict[str, Any]) -> None:
+    def _delete_vars(
+        self, names: Iterable[str], parent: Dict[str, Any]
+    ) -> None:
         """
         Deletes the requested variables by name from the current user session.
 
@@ -601,14 +611,18 @@ class VariablesService:
         access_key = path[-1]
 
         title = str(decode_access_key(access_key))
-        comm_id = self.kernel.data_explorer_service.register_table(value, title, variable_path=path)
+        comm_id = self.kernel.data_explorer_service.register_table(
+            value, title, variable_path=path
+        )
         self._send_result(comm_id)
 
     def _open_connections_pane(self, path: List[str], value: Any) -> None:
         """Opens a Connections comm for the variable at the requested
         path in the current user session.
         """
-        self.kernel.connections_service.register_connection(value, variable_path=path)
+        self.kernel.connections_service.register_connection(
+            value, variable_path=path
+        )
         self._send_result({})
 
     def _send_event(self, name: str, payload: JsonRecord) -> None:
@@ -627,7 +641,9 @@ class VariablesService:
         if self._comm is not None:
             self._comm.send_error(code, message)
         else:
-            logger.warning(f"Cannot send error {message} (code {code}): comm is not open)")
+            logger.warning(
+                f"Cannot send error {message} (code {code}): comm is not open)"
+            )
 
     def _send_result(self, data: JsonData = None) -> None:
         """
@@ -796,7 +812,9 @@ def _summarize_variable(
         )
 
 
-def _summarize_children(parent: Any, limit: int = MAX_CHILDREN) -> List[Variable]:
+def _summarize_children(
+    parent: Any, limit: int = MAX_CHILDREN
+) -> List[Variable]:
     inspector = get_inspector(parent)
     children = inspector.get_children()
     summaries = []

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables_comm.py
@@ -67,17 +67,14 @@ class VariableList(BaseModel):
     A view containing a list of variables in the session.
     """
 
-    variables: List[Variable] = Field(
-        description="A list of variables in the session.",
-    )
+    variables: List[Variable] = Field(description="A list of variables in the session.")
 
     length: StrictInt = Field(
-        description="The total number of variables in the session. This may be greater than the number of variables in the 'variables' array if the array is truncated.",
+        description="The total number of variables in the session. This may be greater than the number of variables in the 'variables' array if the array is truncated."
     )
 
     version: Optional[StrictInt] = Field(
-        default=None,
-        description="The version of the view (incremented with each update)",
+        default=None, description="The version of the view (incremented with each update)"
     )
 
 
@@ -86,12 +83,10 @@ class InspectedVariable(BaseModel):
     An inspected variable.
     """
 
-    children: List[Variable] = Field(
-        description="The children of the inspected variable.",
-    )
+    children: List[Variable] = Field(description="The children of the inspected variable.")
 
     length: StrictInt = Field(
-        description="The total number of children. This may be greater than the number of children in the 'children' array if the array is truncated.",
+        description="The total number of children. This may be greater than the number of children in the 'children' array if the array is truncated."
     )
 
 
@@ -100,9 +95,7 @@ class FormattedVariable(BaseModel):
     An object formatted for copying to the clipboard.
     """
 
-    content: StrictStr = Field(
-        description="The formatted content of the variable.",
-    )
+    content: StrictStr = Field(description="The formatted content of the variable.")
 
 
 class Variable(BaseModel):
@@ -111,51 +104,41 @@ class Variable(BaseModel):
     """
 
     access_key: StrictStr = Field(
-        description="A key that uniquely identifies the variable within the runtime and can be used to access the variable in `inspect` requests",
+        description="A key that uniquely identifies the variable within the runtime and can be used to access the variable in `inspect` requests"
     )
 
-    display_name: StrictStr = Field(
-        description="The name of the variable, formatted for display",
-    )
+    display_name: StrictStr = Field(description="The name of the variable, formatted for display")
 
     display_value: StrictStr = Field(
-        description="A string representation of the variable's value, formatted for display and possibly truncated",
+        description="A string representation of the variable's value, formatted for display and possibly truncated"
     )
 
-    display_type: StrictStr = Field(
-        description="The variable's type, formatted for display",
-    )
+    display_type: StrictStr = Field(description="The variable's type, formatted for display")
 
-    type_info: StrictStr = Field(
-        description="Extended information about the variable's type",
-    )
+    type_info: StrictStr = Field(description="Extended information about the variable's type")
 
-    size: StrictInt = Field(
-        description="The size of the variable's value in bytes",
-    )
+    size: StrictInt = Field(description="The size of the variable's value in bytes")
 
     kind: VariableKind = Field(
-        description="The kind of value the variable represents, such as 'string' or 'number'",
+        description="The kind of value the variable represents, such as 'string' or 'number'"
     )
 
     length: StrictInt = Field(
-        description="The number of elements in the variable, if it is a collection",
+        description="The number of elements in the variable, if it is a collection"
     )
 
-    has_children: StrictBool = Field(
-        description="Whether the variable has child variables",
-    )
+    has_children: StrictBool = Field(description="Whether the variable has child variables")
 
     has_viewer: StrictBool = Field(
-        description="True if there is a viewer available for this variable (i.e. the runtime can handle a 'view' request for this variable)",
+        description="True if there is a viewer available for this variable (i.e. the runtime can handle a 'view' request for this variable)"
     )
 
     is_truncated: StrictBool = Field(
-        description="True if the 'value' field is a truncated representation of the variable's value",
+        description="True if the 'value' field is a truncated representation of the variable's value"
     )
 
     updated_time: StrictInt = Field(
-        description="The time the variable was created or updated, in milliseconds since the epoch, or 0 if unknown.",
+        description="The time the variable was created or updated, in milliseconds since the epoch, or 0 if unknown."
     )
 
 
@@ -190,13 +173,10 @@ class ListRequest(BaseModel):
     """
 
     method: Literal[VariablesBackendRequest.List] = Field(
-        description="The JSON-RPC method name (list)",
+        description="The JSON-RPC method name (list)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class ClearParams(BaseModel):
@@ -205,7 +185,7 @@ class ClearParams(BaseModel):
     """
 
     include_hidden_objects: StrictBool = Field(
-        description="Whether to clear hidden objects in addition to normal variables",
+        description="Whether to clear hidden objects in addition to normal variables"
     )
 
 
@@ -214,18 +194,13 @@ class ClearRequest(BaseModel):
     Clears (deletes) all variables in the current session.
     """
 
-    params: ClearParams = Field(
-        description="Parameters to the Clear method",
-    )
+    params: ClearParams = Field(description="Parameters to the Clear method")
 
     method: Literal[VariablesBackendRequest.Clear] = Field(
-        description="The JSON-RPC method name (clear)",
+        description="The JSON-RPC method name (clear)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class DeleteParams(BaseModel):
@@ -233,9 +208,7 @@ class DeleteParams(BaseModel):
     Deletes the named variables from the current session.
     """
 
-    names: List[StrictStr] = Field(
-        description="The names of the variables to delete.",
-    )
+    names: List[StrictStr] = Field(description="The names of the variables to delete.")
 
 
 class DeleteRequest(BaseModel):
@@ -243,18 +216,13 @@ class DeleteRequest(BaseModel):
     Deletes the named variables from the current session.
     """
 
-    params: DeleteParams = Field(
-        description="Parameters to the Delete method",
-    )
+    params: DeleteParams = Field(description="Parameters to the Delete method")
 
     method: Literal[VariablesBackendRequest.Delete] = Field(
-        description="The JSON-RPC method name (delete)",
+        description="The JSON-RPC method name (delete)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class InspectParams(BaseModel):
@@ -263,7 +231,7 @@ class InspectParams(BaseModel):
     """
 
     path: List[StrictStr] = Field(
-        description="The path to the variable to inspect, as an array of access keys.",
+        description="The path to the variable to inspect, as an array of access keys."
     )
 
 
@@ -272,18 +240,13 @@ class InspectRequest(BaseModel):
     Returns the children of a variable, as an array of variables.
     """
 
-    params: InspectParams = Field(
-        description="Parameters to the Inspect method",
-    )
+    params: InspectParams = Field(description="Parameters to the Inspect method")
 
     method: Literal[VariablesBackendRequest.Inspect] = Field(
-        description="The JSON-RPC method name (inspect)",
+        description="The JSON-RPC method name (inspect)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class ClipboardFormatParams(BaseModel):
@@ -293,11 +256,11 @@ class ClipboardFormatParams(BaseModel):
     """
 
     path: List[StrictStr] = Field(
-        description="The path to the variable to format, as an array of access keys.",
+        description="The path to the variable to format, as an array of access keys."
     )
 
     format: ClipboardFormatFormat = Field(
-        description="The requested format for the variable, as a MIME type",
+        description="The requested format for the variable, as a MIME type"
     )
 
 
@@ -307,18 +270,13 @@ class ClipboardFormatRequest(BaseModel):
     clipboard.
     """
 
-    params: ClipboardFormatParams = Field(
-        description="Parameters to the ClipboardFormat method",
-    )
+    params: ClipboardFormatParams = Field(description="Parameters to the ClipboardFormat method")
 
     method: Literal[VariablesBackendRequest.ClipboardFormat] = Field(
-        description="The JSON-RPC method name (clipboard_format)",
+        description="The JSON-RPC method name (clipboard_format)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class ViewParams(BaseModel):
@@ -328,7 +286,7 @@ class ViewParams(BaseModel):
     """
 
     path: List[StrictStr] = Field(
-        description="The path to the variable to view, as an array of access keys.",
+        description="The path to the variable to view, as an array of access keys."
     )
 
 
@@ -338,18 +296,13 @@ class ViewRequest(BaseModel):
     variable.
     """
 
-    params: ViewParams = Field(
-        description="Parameters to the View method",
-    )
+    params: ViewParams = Field(description="Parameters to the View method")
 
     method: Literal[VariablesBackendRequest.View] = Field(
-        description="The JSON-RPC method name (view)",
+        description="The JSON-RPC method name (view)"
     )
 
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
+    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
 
 
 class VariablesBackendMessageContent(BaseModel):
@@ -383,19 +336,19 @@ class UpdateParams(BaseModel):
     """
 
     assigned: List[Variable] = Field(
-        description="An array of variables that have been newly assigned.",
+        description="An array of variables that have been newly assigned."
     )
 
     unevaluated: List[Variable] = Field(
-        description="An array of variables that were not evaluated for value updates.",
+        description="An array of variables that were not evaluated for value updates."
     )
 
     removed: List[StrictStr] = Field(
-        description="An array of variable names that have been removed.",
+        description="An array of variable names that have been removed."
     )
 
     version: StrictInt = Field(
-        description="The version of the view (incremented with each update), or 0 if the backend doesn't track versions.",
+        description="The version of the view (incremented with each update), or 0 if the backend doesn't track versions."
     )
 
 
@@ -405,15 +358,13 @@ class RefreshParams(BaseModel):
     """
 
     variables: List[Variable] = Field(
-        description="An array listing all the variables in the current session.",
+        description="An array listing all the variables in the current session."
     )
 
-    length: StrictInt = Field(
-        description="The number of variables in the current session.",
-    )
+    length: StrictInt = Field(description="The number of variables in the current session.")
 
     version: StrictInt = Field(
-        description="The version of the view (incremented with each update), or 0 if the backend doesn't track versions.",
+        description="The version of the view (incremented with each update), or 0 if the backend doesn't track versions."
     )
 
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables_comm.py
@@ -15,7 +15,14 @@ from __future__ import annotations
 import enum
 from typing import Any, List, Literal, Optional, Union
 
-from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+from ._vendor.pydantic import (
+    BaseModel,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+)
 
 
 @enum.unique

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/variables_comm.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/variables_comm.py
@@ -67,14 +67,17 @@ class VariableList(BaseModel):
     A view containing a list of variables in the session.
     """
 
-    variables: List[Variable] = Field(description="A list of variables in the session.")
+    variables: List[Variable] = Field(
+        description="A list of variables in the session.",
+    )
 
     length: StrictInt = Field(
-        description="The total number of variables in the session. This may be greater than the number of variables in the 'variables' array if the array is truncated."
+        description="The total number of variables in the session. This may be greater than the number of variables in the 'variables' array if the array is truncated.",
     )
 
     version: Optional[StrictInt] = Field(
-        default=None, description="The version of the view (incremented with each update)"
+        default=None,
+        description="The version of the view (incremented with each update)",
     )
 
 
@@ -83,10 +86,12 @@ class InspectedVariable(BaseModel):
     An inspected variable.
     """
 
-    children: List[Variable] = Field(description="The children of the inspected variable.")
+    children: List[Variable] = Field(
+        description="The children of the inspected variable.",
+    )
 
     length: StrictInt = Field(
-        description="The total number of children. This may be greater than the number of children in the 'children' array if the array is truncated."
+        description="The total number of children. This may be greater than the number of children in the 'children' array if the array is truncated.",
     )
 
 
@@ -95,7 +100,9 @@ class FormattedVariable(BaseModel):
     An object formatted for copying to the clipboard.
     """
 
-    content: StrictStr = Field(description="The formatted content of the variable.")
+    content: StrictStr = Field(
+        description="The formatted content of the variable.",
+    )
 
 
 class Variable(BaseModel):
@@ -104,41 +111,51 @@ class Variable(BaseModel):
     """
 
     access_key: StrictStr = Field(
-        description="A key that uniquely identifies the variable within the runtime and can be used to access the variable in `inspect` requests"
+        description="A key that uniquely identifies the variable within the runtime and can be used to access the variable in `inspect` requests",
     )
 
-    display_name: StrictStr = Field(description="The name of the variable, formatted for display")
+    display_name: StrictStr = Field(
+        description="The name of the variable, formatted for display",
+    )
 
     display_value: StrictStr = Field(
-        description="A string representation of the variable's value, formatted for display and possibly truncated"
+        description="A string representation of the variable's value, formatted for display and possibly truncated",
     )
 
-    display_type: StrictStr = Field(description="The variable's type, formatted for display")
+    display_type: StrictStr = Field(
+        description="The variable's type, formatted for display",
+    )
 
-    type_info: StrictStr = Field(description="Extended information about the variable's type")
+    type_info: StrictStr = Field(
+        description="Extended information about the variable's type",
+    )
 
-    size: StrictInt = Field(description="The size of the variable's value in bytes")
+    size: StrictInt = Field(
+        description="The size of the variable's value in bytes",
+    )
 
     kind: VariableKind = Field(
-        description="The kind of value the variable represents, such as 'string' or 'number'"
+        description="The kind of value the variable represents, such as 'string' or 'number'",
     )
 
     length: StrictInt = Field(
-        description="The number of elements in the variable, if it is a collection"
+        description="The number of elements in the variable, if it is a collection",
     )
 
-    has_children: StrictBool = Field(description="Whether the variable has child variables")
+    has_children: StrictBool = Field(
+        description="Whether the variable has child variables",
+    )
 
     has_viewer: StrictBool = Field(
-        description="True if there is a viewer available for this variable (i.e. the runtime can handle a 'view' request for this variable)"
+        description="True if there is a viewer available for this variable (i.e. the runtime can handle a 'view' request for this variable)",
     )
 
     is_truncated: StrictBool = Field(
-        description="True if the 'value' field is a truncated representation of the variable's value"
+        description="True if the 'value' field is a truncated representation of the variable's value",
     )
 
     updated_time: StrictInt = Field(
-        description="The time the variable was created or updated, in milliseconds since the epoch, or 0 if unknown."
+        description="The time the variable was created or updated, in milliseconds since the epoch, or 0 if unknown.",
     )
 
 
@@ -173,10 +190,13 @@ class ListRequest(BaseModel):
     """
 
     method: Literal[VariablesBackendRequest.List] = Field(
-        description="The JSON-RPC method name (list)"
+        description="The JSON-RPC method name (list)",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class ClearParams(BaseModel):
@@ -185,7 +205,7 @@ class ClearParams(BaseModel):
     """
 
     include_hidden_objects: StrictBool = Field(
-        description="Whether to clear hidden objects in addition to normal variables"
+        description="Whether to clear hidden objects in addition to normal variables",
     )
 
 
@@ -194,13 +214,18 @@ class ClearRequest(BaseModel):
     Clears (deletes) all variables in the current session.
     """
 
-    params: ClearParams = Field(description="Parameters to the Clear method")
-
-    method: Literal[VariablesBackendRequest.Clear] = Field(
-        description="The JSON-RPC method name (clear)"
+    params: ClearParams = Field(
+        description="Parameters to the Clear method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[VariablesBackendRequest.Clear] = Field(
+        description="The JSON-RPC method name (clear)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class DeleteParams(BaseModel):
@@ -208,7 +233,9 @@ class DeleteParams(BaseModel):
     Deletes the named variables from the current session.
     """
 
-    names: List[StrictStr] = Field(description="The names of the variables to delete.")
+    names: List[StrictStr] = Field(
+        description="The names of the variables to delete.",
+    )
 
 
 class DeleteRequest(BaseModel):
@@ -216,13 +243,18 @@ class DeleteRequest(BaseModel):
     Deletes the named variables from the current session.
     """
 
-    params: DeleteParams = Field(description="Parameters to the Delete method")
-
-    method: Literal[VariablesBackendRequest.Delete] = Field(
-        description="The JSON-RPC method name (delete)"
+    params: DeleteParams = Field(
+        description="Parameters to the Delete method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[VariablesBackendRequest.Delete] = Field(
+        description="The JSON-RPC method name (delete)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class InspectParams(BaseModel):
@@ -231,7 +263,7 @@ class InspectParams(BaseModel):
     """
 
     path: List[StrictStr] = Field(
-        description="The path to the variable to inspect, as an array of access keys."
+        description="The path to the variable to inspect, as an array of access keys.",
     )
 
 
@@ -240,13 +272,18 @@ class InspectRequest(BaseModel):
     Returns the children of a variable, as an array of variables.
     """
 
-    params: InspectParams = Field(description="Parameters to the Inspect method")
-
-    method: Literal[VariablesBackendRequest.Inspect] = Field(
-        description="The JSON-RPC method name (inspect)"
+    params: InspectParams = Field(
+        description="Parameters to the Inspect method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[VariablesBackendRequest.Inspect] = Field(
+        description="The JSON-RPC method name (inspect)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class ClipboardFormatParams(BaseModel):
@@ -256,11 +293,11 @@ class ClipboardFormatParams(BaseModel):
     """
 
     path: List[StrictStr] = Field(
-        description="The path to the variable to format, as an array of access keys."
+        description="The path to the variable to format, as an array of access keys.",
     )
 
     format: ClipboardFormatFormat = Field(
-        description="The requested format for the variable, as a MIME type"
+        description="The requested format for the variable, as a MIME type",
     )
 
 
@@ -270,13 +307,18 @@ class ClipboardFormatRequest(BaseModel):
     clipboard.
     """
 
-    params: ClipboardFormatParams = Field(description="Parameters to the ClipboardFormat method")
-
-    method: Literal[VariablesBackendRequest.ClipboardFormat] = Field(
-        description="The JSON-RPC method name (clipboard_format)"
+    params: ClipboardFormatParams = Field(
+        description="Parameters to the ClipboardFormat method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[VariablesBackendRequest.ClipboardFormat] = Field(
+        description="The JSON-RPC method name (clipboard_format)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class ViewParams(BaseModel):
@@ -286,7 +328,7 @@ class ViewParams(BaseModel):
     """
 
     path: List[StrictStr] = Field(
-        description="The path to the variable to view, as an array of access keys."
+        description="The path to the variable to view, as an array of access keys.",
     )
 
 
@@ -296,13 +338,18 @@ class ViewRequest(BaseModel):
     variable.
     """
 
-    params: ViewParams = Field(description="Parameters to the View method")
-
-    method: Literal[VariablesBackendRequest.View] = Field(
-        description="The JSON-RPC method name (view)"
+    params: ViewParams = Field(
+        description="Parameters to the View method",
     )
 
-    jsonrpc: str = Field(default="2.0", description="The JSON-RPC version specifier")
+    method: Literal[VariablesBackendRequest.View] = Field(
+        description="The JSON-RPC method name (view)",
+    )
+
+    jsonrpc: str = Field(
+        default="2.0",
+        description="The JSON-RPC version specifier",
+    )
 
 
 class VariablesBackendMessageContent(BaseModel):
@@ -336,19 +383,19 @@ class UpdateParams(BaseModel):
     """
 
     assigned: List[Variable] = Field(
-        description="An array of variables that have been newly assigned."
+        description="An array of variables that have been newly assigned.",
     )
 
     unevaluated: List[Variable] = Field(
-        description="An array of variables that were not evaluated for value updates."
+        description="An array of variables that were not evaluated for value updates.",
     )
 
     removed: List[StrictStr] = Field(
-        description="An array of variable names that have been removed."
+        description="An array of variable names that have been removed.",
     )
 
     version: StrictInt = Field(
-        description="The version of the view (incremented with each update), or 0 if the backend doesn't track versions."
+        description="The version of the view (incremented with each update), or 0 if the backend doesn't track versions.",
     )
 
 
@@ -358,13 +405,15 @@ class RefreshParams(BaseModel):
     """
 
     variables: List[Variable] = Field(
-        description="An array listing all the variables in the current session."
+        description="An array listing all the variables in the current session.",
     )
 
-    length: StrictInt = Field(description="The number of variables in the current session.")
+    length: StrictInt = Field(
+        description="The number of variables in the current session.",
+    )
 
     version: StrictInt = Field(
-        description="The version of the view (incremented with each update), or 0 if the backend doesn't track versions."
+        description="The version of the view (incremented with each update), or 0 if the backend doesn't track versions.",
     )
 
 

--- a/extensions/positron-python/python_files/positron/positron_language_server.py
+++ b/extensions/positron-python/python_files/positron/positron_language_server.py
@@ -138,7 +138,9 @@ if __name__ == "__main__":
 
     # IPyKernel uses Tornado which (as of version 5.0) shares the same event
     # loop as asyncio.
-    loop: asyncio.events.AbstractEventLoop = asyncio.get_event_loop_policy().get_event_loop()
+    loop: asyncio.events.AbstractEventLoop = (
+        asyncio.get_event_loop_policy().get_event_loop()
+    )
 
     # Enable asyncio debug mode.
     if args.loglevel == "DEBUG":

--- a/extensions/positron-python/python_files/positron/positron_language_server.py
+++ b/extensions/positron-python/python_files/positron/positron_language_server.py
@@ -29,8 +29,17 @@ def parse_args() -> argparse.Namespace:
         description="Positron Jedi language server: an LSP wrapper for jedi.",
     )
 
-    parser.add_argument("--debugport", help="port for debugpy debugger", type=int, default=None)
-    parser.add_argument("--logfile", help="redirect logs to file specified", type=str)
+    parser.add_argument(
+        "--debugport",
+        help="port for debugpy debugger",
+        type=int,
+        default=None,
+    )
+    parser.add_argument(
+        "--logfile",
+        help="redirect logs to file specified",
+        type=str,
+    )
     parser.add_argument(
         "--loglevel",
         help="logging level",
@@ -39,10 +48,16 @@ def parse_args() -> argparse.Namespace:
         choices=["critical", "error", "warn", "info", "debug"],
     )
     parser.add_argument(
-        "-f", "--connection-file", help="location of the IPyKernel connection file", type=str
+        "-f",
+        "--connection-file",
+        help="location of the IPyKernel connection file",
+        type=str,
     )
     parser.add_argument(
-        "-q", "--quiet", help="Suppress console startup banner information", action="store_true"
+        "-q",
+        "--quiet",
+        help="Suppress console startup banner information",
+        action="store_true",
     )
     parser.add_argument(
         "--session-mode",
@@ -78,8 +93,14 @@ if __name__ == "__main__":
     handlers = ["console"] if args.logfile is None else ["file"]
     logging_config = {
         "loggers": {
-            "": {"level": args.loglevel, "handlers": handlers},
-            "PositronIPKernelApp": {"level": args.loglevel, "handlers": handlers},
+            "": {
+                "level": args.loglevel,
+                "handlers": handlers,
+            },
+            "PositronIPKernelApp": {
+                "level": args.loglevel,
+                "handlers": handlers,
+            },
         }
     }
     if args.logfile is not None:

--- a/extensions/positron-python/python_files/positron/positron_language_server.py
+++ b/extensions/positron-python/python_files/positron/positron_language_server.py
@@ -29,17 +29,8 @@ def parse_args() -> argparse.Namespace:
         description="Positron Jedi language server: an LSP wrapper for jedi.",
     )
 
-    parser.add_argument(
-        "--debugport",
-        help="port for debugpy debugger",
-        type=int,
-        default=None,
-    )
-    parser.add_argument(
-        "--logfile",
-        help="redirect logs to file specified",
-        type=str,
-    )
+    parser.add_argument("--debugport", help="port for debugpy debugger", type=int, default=None)
+    parser.add_argument("--logfile", help="redirect logs to file specified", type=str)
     parser.add_argument(
         "--loglevel",
         help="logging level",
@@ -48,16 +39,10 @@ def parse_args() -> argparse.Namespace:
         choices=["critical", "error", "warn", "info", "debug"],
     )
     parser.add_argument(
-        "-f",
-        "--connection-file",
-        help="location of the IPyKernel connection file",
-        type=str,
+        "-f", "--connection-file", help="location of the IPyKernel connection file", type=str
     )
     parser.add_argument(
-        "-q",
-        "--quiet",
-        help="Suppress console startup banner information",
-        action="store_true",
+        "-q", "--quiet", help="Suppress console startup banner information", action="store_true"
     )
     parser.add_argument(
         "--session-mode",
@@ -93,14 +78,8 @@ if __name__ == "__main__":
     handlers = ["console"] if args.logfile is None else ["file"]
     logging_config = {
         "loggers": {
-            "": {
-                "level": args.loglevel,
-                "handlers": handlers,
-            },
-            "PositronIPKernelApp": {
-                "level": args.loglevel,
-                "handlers": handlers,
-            },
+            "": {"level": args.loglevel, "handlers": handlers},
+            "PositronIPKernelApp": {"level": args.loglevel, "handlers": handlers},
         }
     }
     if args.logfile is not None:

--- a/extensions/positron-python/python_files/positron/pyproject.toml
+++ b/extensions/positron-python/python_files/positron/pyproject.toml
@@ -1,5 +1,11 @@
 [tool.ruff]
+line-length = 100
+target-version = "py38"
 exclude = [
     # Ignore vendored dependencies
     'positron_ipykernel/_vendor/',
 ]
+
+[tool.ruff.format]
+docstring-code-format = true
+skip-magic-trailing-comma = true

--- a/extensions/positron-python/python_files/positron/pyproject.toml
+++ b/extensions/positron-python/python_files/positron/pyproject.toml
@@ -1,11 +1,5 @@
 [tool.ruff]
-line-length = 100
-target-version = "py38"
 exclude = [
     # Ignore vendored dependencies
     'positron_ipykernel/_vendor/',
 ]
-
-[tool.ruff.format]
-docstring-code-format = true
-skip-magic-trailing-comma = true

--- a/extensions/positron-python/python_files/positron/pyproject.toml
+++ b/extensions/positron-python/python_files/positron/pyproject.toml
@@ -1,5 +1,10 @@
 [tool.ruff]
+line-length = 80
+target-version = "py38"
 exclude = [
     # Ignore vendored dependencies
     'positron_ipykernel/_vendor/',
 ]
+
+[tool.ruff.format]
+docstring-code-format = true

--- a/extensions/positron-python/python_files/positron/pyproject.toml
+++ b/extensions/positron-python/python_files/positron/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.ruff]
+exclude = [
+    # Ignore vendored dependencies
+    'positron_ipykernel/_vendor/',
+]

--- a/extensions/positron-python/python_files/pyproject.toml
+++ b/extensions/positron-python/python_files/pyproject.toml
@@ -1,45 +1,19 @@
-[tool.autopep8]
-max_line_length = 100
-
-[tool.black]
-include = 'positron\/.*.py$|positron\/positron_ipykernel\/.*.py$|positron\/positron_ipykernel\/test_positron_.*.py$'
-exclude = '''
-
-(
-  /(
-    .data
-    | .vscode
-    | lib
-    | positron/positron_ipykernel/_vendor
-  )/
-)
-'''
-line-length = 100
-
-[tool.isort]
-profile = "black"
-extend_skip = ['positron/positron_ipykernel/_vendor']
-known_first_party = ['positron_ipykernel']
-known_third_party = ['positron_ipykernel._vendor']
-
 [tool.pyright]
+# --- Start Positron ---
+# Exclude vendored positron_ipykernel dependencies as well.
 exclude = ['lib', 'positron/positron_ipykernel/_vendor']
-extraPaths = ['lib/python', 'positron/positron_ipykernel/_vendor']
+extraPaths = ['lib', 'positron/positron_ipykernel/_vendor']
+# --- End Positron ---
 ignore = [
     # Ignore all pre-existing code with issues
     'get-pip.py',
-    'install_debugpy.py',
-    'normalizeSelection.py',
     'tensorboard_launcher.py',
     'testlauncher.py',
     'visualstudio_py_testlauncher.py',
     'testing_tools/unittest_discovery.py',
-    'testing_tools/adapter/report.py',
     'testing_tools/adapter/util.py',
     'testing_tools/adapter/pytest/_discovery.py',
     'testing_tools/adapter/pytest/_pytest_item.py',
-    'tests/debug_adapter/test_install_debugpy.py',
-    'tests/unittestadapter/helpers.py',
     'tests/testing_tools/adapter/.data',
     'tests/testing_tools/adapter/test___main__.py',
     'tests/testing_tools/adapter/test_discovery.py',
@@ -48,75 +22,65 @@ ignore = [
     'tests/testing_tools/adapter/test_util.py',
     'tests/testing_tools/adapter/pytest/test_cli.py',
     'tests/testing_tools/adapter/pytest/test_discovery.py',
-    'tests/unittestadapter/.data/unittest_skip/unittest_skip_function.py',
-    'tests/pytestadapter/helpers.py'
 ]
 
 [tool.ruff]
 line-length = 100
+target-version = "py38"
 exclude = [
-    "tests/testing_tools/adapter/.data",
-    "tests/unittestadapter/.data",
-    # --- Start Positron ---
-    # Ignore upstream files with format errors
-    "tests/pytestadapter",
-    # Ignore vendored dependencies
-    'lib/',
-    'positron/positron_ipykernel/_vendor/',
-    # --- End Positron ---
+    "**/.data",
+    "lib",
 ]
 
 [tool.ruff.format]
 docstring-code-format = true
 
-# --- Start Positron ---
 [tool.ruff.lint]
 # Ruff's defaults are F and a subset of E.
 # https://docs.astral.sh/ruff/rules/#rules
 # Compatible w/ ruff formatter. https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
 # Up-to-date as of Ruff 0.5.0.
 select = [
-#    "A",  # flake8-builtins
-#    "ARG",  # flake8-unused-argument
+    "A",  # flake8-builtins
+    "ARG",  # flake8-unused-argument
     "ASYNC",  # flake8-async
-#    "B",  # flake8-bugbear
-#    "C4",  # flake8-comprehensions
-#    "D2", "D400", "D403", "D419",  # pydocstyle
-#    "DJ",  # flake8-django
-#    "DTZ",  # flake8-dasetimez
-#    "E4", "E7", "E9",  # pycodestyle (errors)
-#    "EXE",  # flake8-executable
-#    "F",  # Pyflakes
-#    "FBT",  # flake8-boolean-trap
-#    "FLY",  # flynt
-#    "FURB",  # refurb
-#    "I",  # isort
-#    "INP",  # flake8-no-pep420
+    "B",  # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "D2", "D400", "D403", "D419",  # pydocstyle
+    "DJ",  # flake8-django
+    "DTZ",  # flake8-dasetimez
+    "E4", "E7", "E9",  # pycodestyle (errors)
+    "EXE",  # flake8-executable
+    "F",  # Pyflakes
+    "FBT",  # flake8-boolean-trap
+    "FLY",  # flynt
+    "FURB",  # refurb
+    "I",  # isort
+    "INP",  # flake8-no-pep420
     "INT",  # flake8-gettext
     "LOG",  # flake8-logging
-#    "N",  # pep8-naming
-#    "NPY",  # NumPy-specific rules
-#    "PD",  # pandas-vet
-#    "PERF",  # Perflint
-#    "PIE",  # flake8-pie
-#    "PTH",  # flake8-pathlib
+    "N",  # pep8-naming
+    "NPY",  # NumPy-specific rules
+    "PD",  # pandas-vet
+    "PERF",  # Perflint
+    "PIE",  # flake8-pie
+    "PTH",  # flake8-pathlib
     # flake8-pytest-style
-#    "PT006", "PT007", "PT009", "PT012", "PT014", "PT015", "PT016", "PT017", "PT018", "PT019",
-#    "PT020", "PT021", "PT022", "PT024", "PT025", "PT026", "PT027",
-#    "PYI",  # flake8-pyi
+    "PT006", "PT007", "PT009", "PT012", "PT014", "PT015", "PT016", "PT017", "PT018", "PT019",
+    "PT020", "PT021", "PT022", "PT024", "PT025", "PT026", "PT027",
+    "PYI",  # flake8-pyi
     "Q",  # flake8-quotes
-#    "RET502", "RET503", "RET504",  # flake8-return
-#    "RSE",  # flake8-raise
-#    "RUF",  # Ruff-specific rules
-#    "SIM",  # flake8-simplify
-#    "SLF",  # flake8-self
-#    "SLOT",  # flake8-slots
-#    "TCH",  # flake8-type-checking
-#    "UP",  # pyupgrade
-#    "W",  # pycodestyle (warnings)
+    "RET502", "RET503", "RET504",  # flake8-return
+    "RSE",  # flake8-raise
+    "RUF",  # Ruff-specific rules
+    "SIM",  # flake8-simplify
+    "SLF",  # flake8-self
+    "SLOT",  # flake8-slots
+    "TCH",  # flake8-type-checking
+    "UP",  # pyupgrade
+    "W",  # pycodestyle (warnings)
     "YTT",  # flake8-2020
 ]
-# --- End Positron ---
 
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"

--- a/extensions/positron-python/python_files/pyproject.toml
+++ b/extensions/positron-python/python_files/pyproject.toml
@@ -2,7 +2,7 @@
 # --- Start Positron ---
 # Exclude vendored positron_ipykernel dependencies as well.
 exclude = ['lib', 'positron/positron_ipykernel/_vendor']
-extraPaths = ['lib', 'positron/positron_ipykernel/_vendor']
+extraPaths = ['lib/python', 'positron/positron_ipykernel/_vendor']
 # --- End Positron ---
 ignore = [
     # Ignore all pre-existing code with issues

--- a/extensions/positron-python/python_files/tests/test_smart_selection.py
+++ b/extensions/positron-python/python_files/tests/test_smart_selection.py
@@ -378,7 +378,7 @@ def test_positron_comment():
         1
         """
     )
-    result = normalizeSelection.traverse_file(src, 1, 1, False)
+    result = normalizeSelection.traverse_file(src, 1, 1, was_highlighted=False)
     assert result["normalized_smart_result"] == expected
 
 

--- a/extensions/positron-python/python_files/visualstudio_py_testlauncher.py
+++ b/extensions/positron-python/python_files/visualstudio_py_testlauncher.py
@@ -130,7 +130,7 @@ class _IpcChannel:
             body = {"type": "event", "seq": self.seq, "event": name, "body": args}
             self.seq += 1
             content = json.dumps(body).encode("utf8")
-            headers = ("Content-Length: %d\n\n" % (len(content),)).encode("utf8")
+            headers = f"Content-Length: {len(content)}\n\n".encode()
             self.socket.send(headers)
             self.socket.send(content)
 


### PR DESCRIPTION
This PR is one potential solution to the problem identified in https://github.com/posit-dev/positron/pull/5599#discussion_r1868913568: if a developer works locally at a lower line length than the agreed project line length of 100, they'll end up committing unnecessary changes.

Ruff supports hierarchical configuration which lets us use our own formatting config for files in the `python_files/positron` folder. I've enabled the `skip-magic-trailing-commas` setting so that expressions that span multiple lines are _always_ collapsed to a single line if it fits the line length.

I personally don't like this setting since some expressions are more readable over multiple lines. It's nice to have that flexibility e.g. I find argparse arguments more readable if they're all multiline:

https://github.com/posit-dev/positron/blob/3bd7d7de01af1cc46d2b4cdfafb0dbd7f0442c2f/extensions/positron-python/python_files/positron/positron_language_server.py#L32-L40

Since we now know that hierarchical config is an option, what do folks think about lowering the line length to 80? I don't really mind between 80 vs 100, and I'd rather take 80 if it means we could leave `skip-magic-trailing-commas` disabled.

---

Since I was already working with these files, I also merged some upstream `main` changes to the config files so we'll get less of a diff there in the next upstream merge.