### PR TITLE
Use data science appropriate examples for Search filter placeholder

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -519,7 +519,10 @@ export class SearchView extends ViewPane {
 
 		this.inputPatternIncludes = this._register(this.instantiationService.createInstance(IncludePatternInputWidget, folderIncludesList, this.contextViewService, {
 			ariaLabel: filesToIncludeTitle,
-			placeholder: nls.localize('placeholder.includes', "e.g. *.ts, src/**/include"),
+			// --- Start Positron ---
+			// placeholder: nls.localize('placeholder.includes', "e.g. *.ts, src/**/include"),
+			placeholder: nls.localize('placeholder.includes', "e.g. *.py, tests/testthat/*.R"),
+			// --- End Positron
 			showPlaceholderOnFocus: true,
 			history: patternIncludesHistory,
 			inputBoxStyles: defaultInputBoxStyles

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -544,7 +544,7 @@ export class SearchView extends ViewPane {
 			ariaLabel: excludesTitle,
 			// --- Start Positron ---
 			// placeholder: nls.localize('placeholder.excludes', "e.g. *.ts, src/**/exclude"),
-			placeholder: nls.localize('placeholder.excludes', "e.g. *.html, man/**/*.md"),
+			placeholder: nls.localize('placeholder.excludes', "e.g. *.html, *.Rd, man/**/*.md"),
 			// --- End Positron
 			showPlaceholderOnFocus: true,
 			history: patternExclusionsHistory,

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -542,7 +542,10 @@ export class SearchView extends ViewPane {
 		dom.append(excludesList, $('h4', undefined, excludesTitle));
 		this.inputPatternExcludes = this._register(this.instantiationService.createInstance(ExcludePatternInputWidget, excludesList, this.contextViewService, {
 			ariaLabel: excludesTitle,
-			placeholder: nls.localize('placeholder.excludes', "e.g. *.ts, src/**/exclude"),
+			// --- Start Positron ---
+			// placeholder: nls.localize('placeholder.excludes', "e.g. *.ts, src/**/exclude"),
+			placeholder: nls.localize('placeholder.excludes', "e.g. *.html, man/**/*.md"),
+			// --- End Positron
 			showPlaceholderOnFocus: true,
 			history: patternExclusionsHistory,
 			inputBoxStyles: defaultInputBoxStyles


### PR DESCRIPTION
Similar to #5528 but for the placeholder text in the Search panel

We don't currently have a way to provide pre-defined options here (like RStudio provides) but we can at least update the placeholder text easily to be more appropriate for our users.

### QA Notes

We should now see more data science appropriate examples in the placeholder text for the Search filters:

![Screenshot 2024-12-04 at 3 13 53 PM](https://github.com/user-attachments/assets/01531ab5-de16-4336-8578-352463157a03)

![Screenshot 2024-12-05 at 11 53 38 AM](https://github.com/user-attachments/assets/ac37bc09-0cab-4a5e-bbb0-d20d2bd77ac5)


