### PR TITLE
Python: Do not execute Ibis expressions when ibis.options.interactive is True

### DIFF
--- a/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
@@ -5,6 +5,7 @@ geopandas==0.13.2; python_version < '3.9'
 geopandas==1.0.1; python_version >= '3.9'
 hvplot==0.10.0 ; python_version >= '3.9'
 hvplot==0.8.0 ; python_version < '3.9'
+ibis-framework[duckdb]==9.5.0
 ipykernel==6.29.5
 ipywidgets==8.1.5
 matplotlib==3.9.2; python_version >= '3.9'

--- a/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
@@ -5,7 +5,7 @@ geopandas==0.13.2; python_version < '3.9'
 geopandas==1.0.1; python_version >= '3.9'
 hvplot==0.10.0 ; python_version >= '3.9'
 hvplot==0.8.0 ; python_version < '3.9'
-ibis-framework[duckdb]==9.5.0
+ibis-framework[duckdb]==9.5.0; python_version >= '3.10'
 ipykernel==6.29.5
 ipywidgets==8.1.5
 matplotlib==3.9.2; python_version >= '3.9'

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -1123,10 +1123,17 @@ class IbisExprInspector(PositronInspector["ibis.Expr"]):
         truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
         # Just use the default object.__repr__ for now
-        return pretty_format(type(self.value), print_width, truncate_at)
+        simplified_name = get_qualname(self.value)
+        return (f"{simplified_name}", True)
 
     def get_display_type(self) -> str:
-        return type(self.value).__name__
+        return "ibis.Expr"
+
+    def to_html(self) -> str:
+        return self.get_display_value()[0]
+
+    def to_plaintext(self) -> str:
+        return self.get_display_value()[0]
 
 
 INSPECTOR_CLASSES: Dict[str, Type[PositronInspector]] = {

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -1108,8 +1108,8 @@ class SQLAlchemyEngineInspector(BaseConnectionInspector):
 
 
 class IbisExprInspector(PositronInspector["ibis.Expr"]):
-    def get_display_name(self, key: Any) -> str:
-        return str(key)
+    def is_mutable(self):
+        return False
 
     def get_display_value(
         self,

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -61,6 +61,12 @@ if TYPE_CHECKING:
     except ImportError:
         pass
 
+    try:
+        import ibis  # python >= 3.10
+    except ImportError:
+        pass
+
+
 # General display settings
 TRUNCATE_AT: int = 1024
 PRINT_WIDTH: int = 100

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -1108,6 +1108,12 @@ class SQLAlchemyEngineInspector(BaseConnectionInspector):
 
 
 class IbisExprInspector(PositronInspector["ibis.Expr"]):
+    def has_children(self) -> bool:
+        return False
+
+    def get_length(self) -> int:
+        return 0
+
     def is_mutable(self):
         return False
 
@@ -1117,7 +1123,7 @@ class IbisExprInspector(PositronInspector["ibis.Expr"]):
         truncate_at: int = TRUNCATE_AT,
     ) -> Tuple[str, bool]:
         # Just use the default object.__repr__ for now
-        return pretty_format(object.__repr__(self.value), print_width, truncate_at)
+        return pretty_format(type(self.value), print_width, truncate_at)
 
     def get_display_type(self) -> str:
         return type(self.value).__name__

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
@@ -919,7 +919,12 @@ def test_get_child(value: Any, key: Any, expected: Any) -> None:
 def test_inspect_ibis_exprs() -> None:
     import ibis
 
-    t = ibis.table({"a": "int64", "b": "string"})
+    # Make sure we don't return an executed repr
+    ibis.options.interactive = True
+
+    df = pd.DataFrame({"a": [1, 2, 1, 1, 2], "b": ["foo", "bar", "baz", "qux", None]})
+
+    t = ibis.memtable(df, name="df")
     table_type = "ibis.expr.types.relations.Table"
 
     verify_inspector(

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
@@ -8,6 +8,7 @@ import inspect
 import pprint
 import random
 import string
+import sys
 import types
 from typing import Any, Callable, Iterable, Optional, Tuple
 
@@ -914,6 +915,7 @@ def test_get_child(value: Any, key: Any, expected: Any) -> None:
     assert get_inspector(child).equals(expected)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires Python 3.10 or higher")
 def test_inspect_ibis_exprs() -> None:
     import ibis
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
@@ -914,6 +914,40 @@ def test_get_child(value: Any, key: Any, expected: Any) -> None:
     assert get_inspector(child).equals(expected)
 
 
+def test_inspect_ibis_exprs() -> None:
+    import ibis
+
+    t = ibis.table({"a": "int64", "b": "string"})
+    table_type = "ibis.expr.types.relations.Table"
+
+    verify_inspector(
+        value=t,
+        display_value=table_type,
+        kind=VariableKind.Other,
+        display_type=f"ibis.Expr",
+        type_info=get_type_as_str(t),
+        has_children=False,
+        is_truncated=True,
+        length=0,
+        mutable=False,
+    )
+
+    a_sum = t["a"].sum()  # type: ignore
+    int_type = "ibis.expr.types.numeric.IntegerScalar"
+
+    verify_inspector(
+        value=a_sum,
+        display_value=int_type,
+        kind=VariableKind.Other,
+        display_type=f"ibis.Expr",
+        type_info=get_type_as_str(a_sum),
+        has_children=False,
+        is_truncated=True,
+        length=0,
+        mutable=False,
+    )
+
+
 # TODO(wesm): these size values are only currently used for computing
 # comparison costs. We should align on # of cells vs. # of bytes for
 # these comparisons (possibly based on more experiments)

--- a/extensions/positron-python/python_files/positron/test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/test-requirements.txt
@@ -2,7 +2,7 @@ bokeh
 fastcore
 geopandas
 holoviews
-ibis-framework[duckdb]
+ibis-framework[duckdb]; python_version >= '3.10'
 ipykernel
 ipywidgets
 matplotlib

--- a/extensions/positron-python/python_files/positron/test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/test-requirements.txt
@@ -2,6 +2,7 @@ bokeh
 fastcore
 geopandas
 holoviews
+ibis-framework[duckdb]
 ipykernel
 ipywidgets
 matplotlib


### PR DESCRIPTION
Addresses #5499 by adding a custom inspector for Ibis expressions. This is very basic, and per #5573 should perhaps live eventually in Ibis itself. 

Ibis is a bit unusual in that its interactive mode causes computation to be executed when running the `__repr__` method, for nice interactivity in the console and in Jupyter notebooks. So here we avoid running the `__repr__` method so we don't accidentally fire off a BigQuery, Snowflake, or other query which might have unwanted costs or side effects.

There is a unit test -- Ibis with DuckDB is a minor dependency to pull in relative to the rest of our test dependencies so I do not think this is too onerous. 