### PR TITLE
Fix inconsistency when concurrently starting a session and `session.start()` rejects

### DIFF
--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -515,11 +515,12 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// Actually reconnect the session.
 		try {
 			await this.doStartRuntimeSession(session, sessionManager, false);
-		} catch (err) {
-			// Do nothing
-		} finally {
 			startPromise.complete(sessionMetadata.sessionId);
+		} catch (err) {
+			startPromise.error(err);
 		}
+
+		return startPromise.p.then(() => { });
 	}
 
 	/**
@@ -871,13 +872,12 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// Actually start the session.
 		try {
 			await this.doStartRuntimeSession(session, sessionManager, true);
-		} catch (err) {
-			// Do nothing
-		} finally {
 			startPromise.complete(sessionId);
+		} catch (err) {
+			startPromise.error(err);
 		}
 
-		return sessionId;
+		return startPromise.p;
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -515,9 +515,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// Actually reconnect the session.
 		try {
 			await this.doStartRuntimeSession(session, sessionManager, false);
-			startPromise.complete(sessionMetadata.sessionId);
 		} catch (err) {
-			startPromise.error(err);
+			// Do nothing
+		} finally {
+			startPromise.complete(sessionMetadata.sessionId);
 		}
 	}
 
@@ -870,9 +871,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// Actually start the session.
 		try {
 			await this.doStartRuntimeSession(session, sessionManager, true);
-			startPromise.complete(sessionId);
 		} catch (err) {
-			startPromise.error(err);
+			// Do nothing
+		} finally {
+			startPromise.complete(sessionId);
 		}
 
 		return sessionId;


### PR DESCRIPTION
Related to #2671.

I didn't encounter this in practice but noticed the inconsistency while working with the code.

I assume it is intended for the outer call to _not_ reject when `session.start()` rejects, so concurrent calls probably also shouldn't reject.