### PR TITLE
e2e-test: update python notebook test for "interrupt"

### DIFF
--- a/test/smoke/src/areas/positron/notebook/notebook-large-python.test.ts
+++ b/test/smoke/src/areas/positron/notebook/notebook-large-python.test.ts
@@ -14,6 +14,7 @@ test.use({
 // Note that this test is too heavy to pass on web and windows
 test.describe('Large Python Notebook', {
 	annotation: [{ type: 'issue', description: 'This test is too heavy to run in CICD due to snapshots on the excessive scrolling.' }],
+	tag: ['@pr']
 }, () => {
 
 	test('Python - Large notebook execution [C983592]', async function ({ app, python }) {

--- a/test/smoke/src/areas/positron/notebook/notebook-large-python.test.ts
+++ b/test/smoke/src/areas/positron/notebook/notebook-large-python.test.ts
@@ -24,9 +24,9 @@ test.describe('Large Python Notebook', {
 		await app.workbench.positronQuickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'large_py_notebook', 'spotify.ipynb'));
 		await notebooks.selectInterpreter('Python Environments', process.env.POSITRON_PY_VER_SEL!);
 
-		await app.code.driver.page.getByText('Run All').click();
+		await app.code.driver.page.getByLabel('Run All').click();
 
-		const stopExecutionLocator = app.code.driver.page.locator('a').filter({ hasText: 'Stop Execution' });
+		const stopExecutionLocator = app.code.driver.page.locator('a').filter({ hasText: /Stop Execution|Interrupt/ });
 		await expect(stopExecutionLocator).toBeVisible();
 		await expect(stopExecutionLocator).not.toBeVisible({ timeout: 120000 });
 

--- a/test/smoke/src/areas/positron/notebook/notebook-large-python.test.ts
+++ b/test/smoke/src/areas/positron/notebook/notebook-large-python.test.ts
@@ -14,7 +14,6 @@ test.use({
 // Note that this test is too heavy to pass on web and windows
 test.describe('Large Python Notebook', {
 	annotation: [{ type: 'issue', description: 'This test is too heavy to run in CICD due to snapshots on the excessive scrolling.' }],
-	tag: ['@pr']
 }, () => {
 
 	test('Python - Large notebook execution [C983592]', async function ({ app, python }) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will 
  automatically close the issue. If there are any details about your 
  approach that are unintuitive or you want to draw attention to, please 
  describe them here.
-->

### QA Notes

A [recent change](https://github.com/posit-dev/positron/commit/f86d31406b7731972ac996a7699bfe0f8a412b59) updated the text on the “stop cell execution” button from Stop Execution to Interrupt. This PR updates the test to reflect the new behavior.

I ran test 2x on PR - it passed both times.