### PR TITLE
viewer: bring focus to editor if it already exists

### DIFF
--- a/extensions/positron-proxy/package.json
+++ b/extensions/positron-proxy/package.json
@@ -22,14 +22,14 @@
     "menus": {
       "explorer/context": [
         {
-          "when": "resourceLangId == html",
+          "when": "resourceLangId == html && resourceScheme == file",
           "command": "positronProxy.showHtmlPreview",
           "group": "navigation"
         }
       ],
       "editor/title": [
         {
-          "when": "resourceLangId == html",
+          "when": "resourceLangId == html  && resourceScheme == file",
           "command": "positronProxy.showHtmlPreview",
           "group": "navigation"
         }

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -511,7 +511,8 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 
 	public async openEditor(uri: URI, title?: string): Promise<void> {
 		// Create and store webview overlay for editor
-		const previewId = `editorPreview.${PositronPreviewService._previewIdCounter++}`;
+		// We use the URI to try to attempt to open the same editor, if possible
+		const previewId = `editorPreview.${uri.toString()}`;
 		this._editors.set(previewId, {
 			uri: uri,
 			webview: this.createPreviewUrl(previewId, undefined, uri),

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -511,7 +511,7 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 
 	public async openEditor(uri: URI, title?: string): Promise<void> {
 		// Create and store webview overlay for editor
-		// We use the URI to try to attempt to open the same editor, if possible
+		// We use the URI to attempt to bring focus to an editor if it already exists
 		const previewId = `editorPreview.${uri.toString()}`;
 		this._editors.set(previewId, {
 			uri: uri,


### PR DESCRIPTION
Previously, a new editor pane populated each time you opened it from the Viewer.


Note: if you 
- open an HTML file in Viewer
- open in an editor
- close file in Viewer
- reopen in Viewer
- open in an editor _again_

it WILL open a new tab since the url to open HTML files is regenerated each time. I thought about using the file name instead, but it does not include directories, eg, `index.html` and `files/index.html` would be considered identical. I can look into something more elegant if we want to handle for the above situation, but I'm not sure how often it will happen/if this behaviour is actually desired.

### QA Notes

Clicking `Open the content in an editor pane.` multiple times will bring focus to opened tab rather than opening new ones.


