### PR TITLE
Retrieve notebook sessions via the `positron.runtime` API

### DIFF
--- a/extensions/positron-notebook-controllers/src/commands.ts
+++ b/extensions/positron-notebook-controllers/src/commands.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { NotebookSessionService } from './notebookSessionService';
-import { getRunningNotebookSession } from './utils';
+import { getNotebookSession } from './utils';
 
 export function registerCommands(context: vscode.ExtensionContext, notebookSessionService: NotebookSessionService): void {
 	context.subscriptions.push(vscode.commands.registerCommand('positron.restartKernel', async () => {
@@ -16,7 +16,7 @@ export function registerCommands(context: vscode.ExtensionContext, notebookSessi
 		}
 
 		// Get the session for the active notebook.
-		const session = await getRunningNotebookSession(notebook.uri);
+		const session = await getNotebookSession(notebook.uri);
 		if (!session) {
 			throw new Error('No session found for active notebook. This command should only be available when a session is running.');
 		}

--- a/extensions/positron-notebook-controllers/src/commands.ts
+++ b/extensions/positron-notebook-controllers/src/commands.ts
@@ -3,9 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { NotebookSessionService } from './notebookSessionService';
+import { getRunningNotebookSession } from './utils';
 
 export function registerCommands(context: vscode.ExtensionContext, notebookSessionService: NotebookSessionService): void {
 	context.subscriptions.push(vscode.commands.registerCommand('positron.restartKernel', async () => {
@@ -16,7 +16,7 @@ export function registerCommands(context: vscode.ExtensionContext, notebookSessi
 		}
 
 		// Get the session for the active notebook.
-		const session = await positron.runtime.getNotebookSession(notebook.uri);
+		const session = await getRunningNotebookSession(notebook.uri);
 		if (!session) {
 			throw new Error('No session found for active notebook. This command should only be available when a session is running.');
 		}

--- a/extensions/positron-notebook-controllers/src/commands.ts
+++ b/extensions/positron-notebook-controllers/src/commands.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import { NotebookSessionService } from './notebookSessionService';
+import { getRunningNotebookSession } from './utils';
 
 export function registerCommands(context: vscode.ExtensionContext, notebookSessionService: NotebookSessionService): void {
 	context.subscriptions.push(vscode.commands.registerCommand('positron.restartKernel', async () => {
@@ -15,7 +16,7 @@ export function registerCommands(context: vscode.ExtensionContext, notebookSessi
 		}
 
 		// Get the session for the active notebook.
-		const session = notebookSessionService.getNotebookSession(notebook.uri);
+		const session = await getRunningNotebookSession(notebook.uri);
 		if (!session) {
 			throw new Error('No session found for active notebook. This command should only be available when a session is running.');
 		}

--- a/extensions/positron-notebook-controllers/src/commands.ts
+++ b/extensions/positron-notebook-controllers/src/commands.ts
@@ -3,9 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { NotebookSessionService } from './notebookSessionService';
-import { getRunningNotebookSession } from './utils';
 
 export function registerCommands(context: vscode.ExtensionContext, notebookSessionService: NotebookSessionService): void {
 	context.subscriptions.push(vscode.commands.registerCommand('positron.restartKernel', async () => {
@@ -16,7 +16,7 @@ export function registerCommands(context: vscode.ExtensionContext, notebookSessi
 		}
 
 		// Get the session for the active notebook.
-		const session = await getRunningNotebookSession(notebook.uri);
+		const session = await positron.runtime.getNotebookSession(notebook.uri);
 		if (!session) {
 			throw new Error('No session found for active notebook. This command should only be available when a session is running.');
 		}

--- a/extensions/positron-notebook-controllers/src/extension.ts
+++ b/extensions/positron-notebook-controllers/src/extension.ts
@@ -20,9 +20,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	// Shutdown any running sessions when a notebook is closed.
 	context.subscriptions.push(vscode.workspace.onDidCloseNotebookDocument(async (notebook) => {
 		log.debug(`Notebook closed: ${notebook.uri.path}`);
-		if (notebookSessionService.hasStartingOrRunningNotebookSession(notebook.uri)) {
-			await notebookSessionService.shutdownRuntimeSession(notebook.uri);
-		}
+		await notebookSessionService.shutdownRuntimeSession(notebook.uri);
 	}));
 
 	const manager = new NotebookControllerManager(notebookSessionService);

--- a/extensions/positron-notebook-controllers/src/extension.ts
+++ b/extensions/positron-notebook-controllers/src/extension.ts
@@ -10,6 +10,7 @@ import { NotebookSessionService } from './notebookSessionService';
 import { registerCommands } from './commands';
 import { JUPYTER_NOTEBOOK_TYPE } from './constants';
 import { registerExecutionInfoStatusBar } from './statusBar';
+import { getRunningNotebookSession } from './utils';
 
 export const log = vscode.window.createOutputChannel('Positron Notebook Controllers', { log: true });
 
@@ -52,7 +53,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 	// Set the hasRunningNotebookSession context when the active notebook editor changes.
 	context.subscriptions.push(vscode.window.onDidChangeActiveNotebookEditor(async (editor) => {
-		const session = editor && await positron.runtime.getNotebookSession(editor?.notebook.uri);
+		const session = editor && await getRunningNotebookSession(editor?.notebook.uri);
 		setHasRunningNotebookSessionContext(Boolean(session));
 	}));
 

--- a/extensions/positron-notebook-controllers/src/extension.ts
+++ b/extensions/positron-notebook-controllers/src/extension.ts
@@ -53,13 +53,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	// Set the hasRunningNotebookSession context when the active notebook editor changes.
 	context.subscriptions.push(vscode.window.onDidChangeActiveNotebookEditor(async (editor) => {
 		const session = editor && await positron.runtime.getNotebookSession(editor?.notebook.uri);
-		setHasRunningNotebookSessionContext(!!session);
+		setHasRunningNotebookSessionContext(Boolean(session));
 	}));
 
 	// Set the hasRunningNotebookSession context when a session is started/shutdown for the active notebook.
 	context.subscriptions.push(notebookSessionService.onDidChangeNotebookSession((e) => {
 		if (e.notebookUri === vscode.window.activeNotebookEditor?.notebook.uri) {
-			setHasRunningNotebookSessionContext(!!e.session);
+			setHasRunningNotebookSessionContext(Boolean(e.session));
 		}
 	}));
 

--- a/extensions/positron-notebook-controllers/src/extension.ts
+++ b/extensions/positron-notebook-controllers/src/extension.ts
@@ -10,6 +10,7 @@ import { NotebookSessionService } from './notebookSessionService';
 import { registerCommands } from './commands';
 import { JUPYTER_NOTEBOOK_TYPE } from './constants';
 import { registerExecutionInfoStatusBar } from './statusBar';
+import { getRunningNotebookSession } from './utils';
 
 export const log = vscode.window.createOutputChannel('Positron Notebook Controllers', { log: true });
 
@@ -53,9 +54,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	}
 
 	// Set the hasRunningNotebookSession context when the active notebook editor changes.
-	context.subscriptions.push(vscode.window.onDidChangeActiveNotebookEditor((editor) => {
-		const value = notebookSessionService.hasRunningNotebookSession(editor?.notebook.uri);
-		setHasRunningNotebookSessionContext(value);
+	context.subscriptions.push(vscode.window.onDidChangeActiveNotebookEditor(async (editor) => {
+		const session = editor && await getRunningNotebookSession(editor?.notebook.uri);
+		setHasRunningNotebookSessionContext(!!session);
 	}));
 
 	// Set the hasRunningNotebookSession context when a session is started/shutdown for the active notebook.

--- a/extensions/positron-notebook-controllers/src/extension.ts
+++ b/extensions/positron-notebook-controllers/src/extension.ts
@@ -10,7 +10,7 @@ import { NotebookSessionService } from './notebookSessionService';
 import { registerCommands } from './commands';
 import { JUPYTER_NOTEBOOK_TYPE } from './constants';
 import { registerExecutionInfoStatusBar } from './statusBar';
-import { getRunningNotebookSession } from './utils';
+import { getNotebookSession } from './utils';
 
 export const log = vscode.window.createOutputChannel('Positron Notebook Controllers', { log: true });
 
@@ -53,13 +53,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 	// Set the hasRunningNotebookSession context when the active notebook editor changes.
 	context.subscriptions.push(vscode.window.onDidChangeActiveNotebookEditor(async (editor) => {
-		const session = editor && await getRunningNotebookSession(editor?.notebook.uri);
+		const session = editor && await getNotebookSession(editor.notebook.uri);
 		setHasRunningNotebookSessionContext(Boolean(session));
 	}));
 
 	// Set the hasRunningNotebookSession context when a session is started/shutdown for the active notebook.
 	context.subscriptions.push(notebookSessionService.onDidChangeNotebookSession((e) => {
-		if (e.notebookUri === vscode.window.activeNotebookEditor?.notebook.uri) {
+		if (e.notebookUri.toString() === vscode.window.activeNotebookEditor?.notebook.uri.toString()) {
 			setHasRunningNotebookSessionContext(Boolean(e.session));
 		}
 	}));

--- a/extensions/positron-notebook-controllers/src/extension.ts
+++ b/extensions/positron-notebook-controllers/src/extension.ts
@@ -10,7 +10,6 @@ import { NotebookSessionService } from './notebookSessionService';
 import { registerCommands } from './commands';
 import { JUPYTER_NOTEBOOK_TYPE } from './constants';
 import { registerExecutionInfoStatusBar } from './statusBar';
-import { getRunningNotebookSession } from './utils';
 
 export const log = vscode.window.createOutputChannel('Positron Notebook Controllers', { log: true });
 
@@ -55,7 +54,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 	// Set the hasRunningNotebookSession context when the active notebook editor changes.
 	context.subscriptions.push(vscode.window.onDidChangeActiveNotebookEditor(async (editor) => {
-		const session = editor && await getRunningNotebookSession(editor?.notebook.uri);
+		const session = editor && await positron.runtime.getNotebookSession(editor?.notebook.uri);
 		setHasRunningNotebookSessionContext(!!session);
 	}));
 

--- a/extensions/positron-notebook-controllers/src/notebookController.ts
+++ b/extensions/positron-notebook-controllers/src/notebookController.ts
@@ -8,7 +8,6 @@ import { NotebookSessionService } from './notebookSessionService';
 import { JUPYTER_NOTEBOOK_TYPE } from './constants';
 import { log } from './extension';
 import { ResourceMap } from './map';
-import { getRunningNotebookSession } from './utils';
 
 /** The type of a Jupyter notebook cell output. */
 enum NotebookCellOutputType {
@@ -167,7 +166,7 @@ export class NotebookController implements vscode.Disposable {
 	 */
 	private async interruptRuntimeSession(notebook: vscode.NotebookDocument): Promise<void> {
 		// If the notebook has a session, interrupt it.
-		const session = await getRunningNotebookSession(notebook.uri);
+		const session = await positron.runtime.getNotebookSession(notebook.uri);
 		if (session) {
 			await session.interrupt();
 			return;
@@ -268,7 +267,7 @@ export class NotebookController implements vscode.Disposable {
 		await this._notebookSessionService.waitForNotebookSessionToRestart(notebook.uri);
 
 		// Get the notebook's session.
-		let session = await getRunningNotebookSession(notebook.uri);
+		let session = await positron.runtime.getNotebookSession(notebook.uri);
 
 		// No session has been started for this notebook, start one.
 		if (!session) {

--- a/extensions/positron-notebook-controllers/src/notebookController.ts
+++ b/extensions/positron-notebook-controllers/src/notebookController.ts
@@ -208,7 +208,7 @@ export class NotebookController implements vscode.Disposable {
 		try {
 			await Promise.all(cells.map(cell => this.queueCellExecution(cell, notebook, tokenSource.token)));
 		} catch (err) {
-			log.debug(`Error executing cells: ${err}`);
+			log.debug(`Error executing cells: ${err.stack ?? err}`);
 		} finally {
 			// Clean up the cancellation token source for this execution.
 			if (this._executionTokenSourceByNotebookUri.get(notebook.uri) === tokenSource) {
@@ -260,6 +260,9 @@ export class NotebookController implements vscode.Disposable {
 			// Don't try to execute raw cells; they're often used to define metadata e.g in Quarto notebooks.
 			return;
 		}
+
+		// If a session is shutting down for this notebook, wait for it to finish.
+		await this._notebookSessionService.waitForNotebookSessionToShutdown(notebook.uri);
 
 		// If a session is restarting for this notebook, wait for it to finish.
 		await this._notebookSessionService.waitForNotebookSessionToRestart(notebook.uri);

--- a/extensions/positron-notebook-controllers/src/notebookController.ts
+++ b/extensions/positron-notebook-controllers/src/notebookController.ts
@@ -8,6 +8,7 @@ import { NotebookSessionService } from './notebookSessionService';
 import { JUPYTER_NOTEBOOK_TYPE } from './constants';
 import { log } from './extension';
 import { ResourceMap } from './map';
+import { getRunningNotebookSession } from './utils';
 
 /** The type of a Jupyter notebook cell output. */
 enum NotebookCellOutputType {
@@ -166,7 +167,7 @@ export class NotebookController implements vscode.Disposable {
 	 */
 	private async interruptRuntimeSession(notebook: vscode.NotebookDocument): Promise<void> {
 		// If the notebook has a session, interrupt it.
-		const session = this._notebookSessionService.getNotebookSession(notebook.uri);
+		const session = await getRunningNotebookSession(notebook.uri);
 		if (session) {
 			await session.interrupt();
 			return;
@@ -264,7 +265,7 @@ export class NotebookController implements vscode.Disposable {
 		await this._notebookSessionService.waitForNotebookSessionToRestart(notebook.uri);
 
 		// Get the notebook's session.
-		let session = this._notebookSessionService.getNotebookSession(notebook.uri);
+		let session = await getRunningNotebookSession(notebook.uri);
 
 		// No session has been started for this notebook, start one.
 		if (!session) {

--- a/extensions/positron-notebook-controllers/src/notebookController.ts
+++ b/extensions/positron-notebook-controllers/src/notebookController.ts
@@ -8,6 +8,7 @@ import { NotebookSessionService } from './notebookSessionService';
 import { JUPYTER_NOTEBOOK_TYPE } from './constants';
 import { log } from './extension';
 import { ResourceMap } from './map';
+import { getRunningNotebookSession } from './utils';
 
 /** The type of a Jupyter notebook cell output. */
 enum NotebookCellOutputType {
@@ -164,7 +165,7 @@ export class NotebookController implements vscode.Disposable {
 	 */
 	private async interruptRuntimeSession(notebook: vscode.NotebookDocument): Promise<void> {
 		// If the notebook has a session, interrupt it.
-		const session = await positron.runtime.getNotebookSession(notebook.uri);
+		const session = await getRunningNotebookSession(notebook.uri);
 		if (session) {
 			await session.interrupt();
 			return;
@@ -265,7 +266,7 @@ export class NotebookController implements vscode.Disposable {
 		await this._notebookSessionService.waitForNotebookSessionToRestart(notebook.uri);
 
 		// Get the notebook's session.
-		let session = await positron.runtime.getNotebookSession(notebook.uri);
+		let session = await getRunningNotebookSession(notebook.uri);
 
 		// No session has been started for this notebook, start one.
 		if (!session) {

--- a/extensions/positron-notebook-controllers/src/notebookController.ts
+++ b/extensions/positron-notebook-controllers/src/notebookController.ts
@@ -121,9 +121,7 @@ export class NotebookController implements vscode.Disposable {
 
 	private async selectRuntimeSession(notebook: vscode.NotebookDocument): Promise<void> {
 		// If there's an existing session from another runtime, shut it down.
-		if (this._notebookSessionService.hasStartingOrRunningNotebookSession(notebook.uri)) {
-			await this._notebookSessionService.shutdownRuntimeSession(notebook.uri);
-		}
+		await this._notebookSessionService.shutdownRuntimeSession(notebook.uri);
 
 		// Start the new session.
 		await this.startRuntimeSession(notebook);

--- a/extensions/positron-notebook-controllers/src/notebookController.ts
+++ b/extensions/positron-notebook-controllers/src/notebookController.ts
@@ -8,7 +8,7 @@ import { NotebookSessionService } from './notebookSessionService';
 import { JUPYTER_NOTEBOOK_TYPE } from './constants';
 import { log } from './extension';
 import { ResourceMap } from './map';
-import { getRunningNotebookSession } from './utils';
+import { getNotebookSession } from './utils';
 
 /** The type of a Jupyter notebook cell output. */
 enum NotebookCellOutputType {
@@ -165,7 +165,7 @@ export class NotebookController implements vscode.Disposable {
 	 */
 	private async interruptRuntimeSession(notebook: vscode.NotebookDocument): Promise<void> {
 		// If the notebook has a session, interrupt it.
-		const session = await getRunningNotebookSession(notebook.uri);
+		const session = await getNotebookSession(notebook.uri);
 		if (session) {
 			await session.interrupt();
 			return;
@@ -266,7 +266,7 @@ export class NotebookController implements vscode.Disposable {
 		await this._notebookSessionService.waitForNotebookSessionToRestart(notebook.uri);
 
 		// Get the notebook's session.
-		let session = await getRunningNotebookSession(notebook.uri);
+		let session = await getNotebookSession(notebook.uri, this._runtimeMetadata.runtimeId);
 
 		// No session has been started for this notebook, start one.
 		if (!session) {

--- a/extensions/positron-notebook-controllers/src/notebookSessionService.ts
+++ b/extensions/positron-notebook-controllers/src/notebookSessionService.ts
@@ -74,12 +74,8 @@ export class NotebookSessionService implements vscode.Disposable {
 	 * @param notebookUri The notebook URI to wait for.
 	 * @returns A promise that resolves when the session has completed the restart sequence.
 	 */
-	async waitForNotebookSessionToRestart(notebookUri: vscode.Uri): Promise<positron.LanguageRuntimeSession> {
-		const restartingSessionPromise = this._restartingSessionsByNotebookUri.get(notebookUri);
-		if (!restartingSessionPromise) {
-			throw new Error(`No session is restarting for notebook ${notebookUri.path}`);
-		}
-		return restartingSessionPromise;
+	async waitForNotebookSessionToRestart(notebookUri: vscode.Uri): Promise<void> {
+		await this._restartingSessionsByNotebookUri.get(notebookUri);
 	}
 
 	/**

--- a/extensions/positron-notebook-controllers/src/notebookSessionService.ts
+++ b/extensions/positron-notebook-controllers/src/notebookSessionService.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { log } from './extension';
 import { ResourceMap } from './map';
+import { getRunningNotebookSession } from './utils';
 
 export interface INotebookSessionDidChangeEvent {
 	/** The URI of the notebook corresponding to the session. */
@@ -214,7 +215,7 @@ export class NotebookSessionService implements vscode.Disposable {
 
 	private async getExistingOrPendingSession(notebookUri: vscode.Uri): Promise<positron.LanguageRuntimeSession | undefined> {
 		// Check for an active session first.
-		const activeSession = await positron.runtime.getNotebookSession(notebookUri);
+		const activeSession = await getRunningNotebookSession(notebookUri);
 		if (activeSession) {
 			return activeSession;
 		}
@@ -270,7 +271,7 @@ export class NotebookSessionService implements vscode.Disposable {
 
 	async doRestartRuntimeSession(notebookUri: vscode.Uri): Promise<positron.LanguageRuntimeSession> {
 		// Get the notebook's session.
-		const session = await positron.runtime.getNotebookSession(notebookUri);
+		const session = await getRunningNotebookSession(notebookUri);
 		if (!session) {
 			throw new Error(`Tried to restart runtime for notebook without a running runtime: ${notebookUri.path}`);
 		}

--- a/extensions/positron-notebook-controllers/src/notebookSessionService.ts
+++ b/extensions/positron-notebook-controllers/src/notebookSessionService.ts
@@ -141,7 +141,7 @@ export class NotebookSessionService implements vscode.Disposable {
 			}
 		}
 
-		// If we couldn't restore a session, start a new one.
+		// Start the session.
 		try {
 			const session = await positron.runtime.startLanguageRuntime(
 				runtimeId,

--- a/extensions/positron-notebook-controllers/src/notebookSessionService.ts
+++ b/extensions/positron-notebook-controllers/src/notebookSessionService.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { log } from './extension';
 import { ResourceMap } from './map';
-import { getRunningNotebookSession } from './utils';
+import { getNotebookSession } from './utils';
 
 export interface INotebookSessionDidChangeEvent {
 	/** The URI of the notebook corresponding to the session. */
@@ -215,7 +215,7 @@ export class NotebookSessionService implements vscode.Disposable {
 
 	private async getExistingOrPendingSession(notebookUri: vscode.Uri): Promise<positron.LanguageRuntimeSession | undefined> {
 		// Check for an active session first.
-		const activeSession = await getRunningNotebookSession(notebookUri);
+		const activeSession = await getNotebookSession(notebookUri);
 		if (activeSession) {
 			return activeSession;
 		}
@@ -271,7 +271,7 @@ export class NotebookSessionService implements vscode.Disposable {
 
 	async doRestartRuntimeSession(notebookUri: vscode.Uri): Promise<positron.LanguageRuntimeSession> {
 		// Get the notebook's session.
-		const session = await getRunningNotebookSession(notebookUri);
+		const session = await getNotebookSession(notebookUri);
 		if (!session) {
 			throw new Error(`Tried to restart runtime for notebook without a running runtime: ${notebookUri.path}`);
 		}

--- a/extensions/positron-notebook-controllers/src/notebookSessionService.ts
+++ b/extensions/positron-notebook-controllers/src/notebookSessionService.ts
@@ -87,6 +87,16 @@ export class NotebookSessionService implements vscode.Disposable {
 	}
 
 	/**
+	 * Wait for a notebook session to complete a shutdown sequence.
+	 *
+	 * @param notebookUri The notebook URI to wait for.
+	 * @returns A promise that resolves when the session has completed the shutdown sequence.
+	 */
+	async waitForNotebookSessionToShutdown(notebookUri: vscode.Uri): Promise<void> {
+		await this._shuttingDownSessionsByNotebookUri.get(notebookUri);
+	}
+
+	/**
 	 * Wait for a notebook session to complete a restart sequence.
 	 *
 	 * @param notebookUri The notebook URI to wait for.

--- a/extensions/positron-notebook-controllers/src/notebookSessionService.ts
+++ b/extensions/positron-notebook-controllers/src/notebookSessionService.ts
@@ -8,7 +8,6 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { log } from './extension';
 import { ResourceMap } from './map';
-import { getRunningNotebookSession } from './utils';
 
 export interface INotebookSessionDidChangeEvent {
 	/** The URI of the notebook corresponding to the session. */
@@ -68,7 +67,7 @@ export class NotebookSessionService implements vscode.Disposable {
 	hasStartingOrRunningNotebookSession(notebookUri: vscode.Uri): boolean {
 		return this._startingSessionsByNotebookUri.has(notebookUri) ||
 			this._restartingSessionsByNotebookUri.has(notebookUri) ||
-			getRunningNotebookSession(notebookUri) !== undefined;
+			positron.runtime.getNotebookSession(notebookUri) !== undefined;
 	}
 
 	/**
@@ -231,7 +230,7 @@ export class NotebookSessionService implements vscode.Disposable {
 
 	private async getExistingOrPendingSession(notebookUri: vscode.Uri): Promise<positron.LanguageRuntimeSession | undefined> {
 		// Check for an active session first.
-		const activeSession = await getRunningNotebookSession(notebookUri);
+		const activeSession = await positron.runtime.getNotebookSession(notebookUri);
 		if (activeSession) {
 			return activeSession;
 		}
@@ -287,7 +286,7 @@ export class NotebookSessionService implements vscode.Disposable {
 
 	async doRestartRuntimeSession(notebookUri: vscode.Uri): Promise<positron.LanguageRuntimeSession> {
 		// Get the notebook's session.
-		const session = await getRunningNotebookSession(notebookUri);
+		const session = await positron.runtime.getNotebookSession(notebookUri);
 		if (!session) {
 			throw new Error(`Tried to restart runtime for notebook without a running runtime: ${notebookUri.path}`);
 		}

--- a/extensions/positron-notebook-controllers/src/notebookSessionService.ts
+++ b/extensions/positron-notebook-controllers/src/notebookSessionService.ts
@@ -97,16 +97,6 @@ export class NotebookSessionService implements vscode.Disposable {
 	}
 
 	/**
-	 * Get the running notebook session for the given notebook URI, if one exists.
-	 *
-	 * @param notebookUri The notebook URI of the session to retrieve.
-	 * @returns The running notebook session for the given notebook URI, if one exists.
-	 */
-	getNotebookSession(notebookUri: vscode.Uri): positron.LanguageRuntimeSession | undefined {
-		return this._notebookSessionsByNotebookUri.get(notebookUri);
-	}
-
-	/**
 	 * Set a notebook session for a notebook URI.
 	 *
 	 * @param notebookUri The notebook URI of the session to set.

--- a/extensions/positron-notebook-controllers/src/notebookSessionService.ts
+++ b/extensions/positron-notebook-controllers/src/notebookSessionService.ts
@@ -59,18 +59,6 @@ export class NotebookSessionService implements vscode.Disposable {
 	}
 
 	/**
-	 * Checks for a starting or running notebook for the given notebook URI.
-	 *
-	 * @param notebookUri The notebook URI to check for.
-	 * @returns True if a starting or running notebook session exists for the given notebook URI.
-	 */
-	hasStartingOrRunningNotebookSession(notebookUri: vscode.Uri): boolean {
-		return this._startingSessionsByNotebookUri.has(notebookUri) ||
-			this._restartingSessionsByNotebookUri.has(notebookUri) ||
-			positron.runtime.getNotebookSession(notebookUri) !== undefined;
-	}
-
-	/**
 	 * Wait for a notebook session to complete a shutdown sequence.
 	 *
 	 * @param notebookUri The notebook URI to wait for.

--- a/extensions/positron-notebook-controllers/src/test/notebookController.test.ts
+++ b/extensions/positron-notebook-controllers/src/test/notebookController.test.ts
@@ -80,8 +80,9 @@ suite('NotebookController', () => {
 
 		// Create a test session.
 		session = new TestLanguageRuntimeSession();
+		session.setRuntimeState(positron.RuntimeState.Idle);
 		disposables.push(session);
-		notebookSessionService.getNotebookSession.withArgs(notebook.uri).returns(session as any);
+		sinon.stub(positron.runtime, 'getNotebookSession').withArgs(notebook.uri).resolves(session as any);
 
 		// Stub the notebook controller to return a test cell execution.
 		executions = [];
@@ -244,8 +245,8 @@ suite('NotebookController', () => {
 			const executionEndedPromise = executeNotebook([0]);
 			await executionStartedPromise;
 
-			// Simulate the session exiting.
-			notebookSessionService.getNotebookSession.withArgs(notebook.uri).returns(undefined);
+			// Exit the session.
+			session.setRuntimeState(positron.RuntimeState.Exited);
 
 			// Interrupt and wait for the execution to end.
 			await interruptNotebook();

--- a/extensions/positron-notebook-controllers/src/test/notebookController.test.ts
+++ b/extensions/positron-notebook-controllers/src/test/notebookController.test.ts
@@ -80,7 +80,7 @@ suite('NotebookController', () => {
 		} as vscode.NotebookCell];
 
 		// Create a test session.
-		session = new TestLanguageRuntimeSession();
+		session = new TestLanguageRuntimeSession(runtime);
 		disposables.push(session);
 		getNotebookSessionStub = sinon.stub(positron.runtime, 'getNotebookSession')
 			.withArgs(notebook.uri).resolves(session as any);

--- a/extensions/positron-notebook-controllers/src/test/notebookController.test.ts
+++ b/extensions/positron-notebook-controllers/src/test/notebookController.test.ts
@@ -80,7 +80,6 @@ suite('NotebookController', () => {
 
 		// Create a test session.
 		session = new TestLanguageRuntimeSession();
-		session.setRuntimeState(positron.RuntimeState.Idle);
 		disposables.push(session);
 		sinon.stub(positron.runtime, 'getNotebookSession').withArgs(notebook.uri).resolves(session as any);
 

--- a/extensions/positron-notebook-controllers/src/test/testLanguageRuntimeSession.ts
+++ b/extensions/positron-notebook-controllers/src/test/testLanguageRuntimeSession.ts
@@ -8,6 +8,7 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 
 export class TestLanguageRuntimeSession implements Partial<positron.LanguageRuntimeSession> {
+	private _state = positron.RuntimeState.Uninitialized;
 	private _lastExecutionId?: string;
 	private readonly _onDidReceiveRuntimeMessage = new vscode.EventEmitter<positron.LanguageRuntimeMessage>();
 	private readonly _onDidExecute = new vscode.EventEmitter<string>();
@@ -18,6 +19,10 @@ export class TestLanguageRuntimeSession implements Partial<positron.LanguageRunt
 	public readonly metadata = {
 		sessionId: 'test-session',
 	} as positron.RuntimeSessionMetadata;
+
+	get state(): positron.RuntimeState {
+		return this._state;
+	}
 
 	execute(_code: string, id: string, _mode: positron.RuntimeCodeExecutionMode, _errorBehavior: positron.RuntimeErrorBehavior) {
 		this._lastExecutionId = id;
@@ -35,6 +40,10 @@ export class TestLanguageRuntimeSession implements Partial<positron.LanguageRunt
 	}
 
 	// Test helpers
+
+	public setRuntimeState(state: positron.RuntimeState) {
+		this._state = state;
+	}
 
 	public fireErrorMessage(parent_id: string) {
 		this._onDidReceiveRuntimeMessage.fire({

--- a/extensions/positron-notebook-controllers/src/test/testLanguageRuntimeSession.ts
+++ b/extensions/positron-notebook-controllers/src/test/testLanguageRuntimeSession.ts
@@ -8,7 +8,6 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 
 export class TestLanguageRuntimeSession implements Partial<positron.LanguageRuntimeSession> {
-	private _state = positron.RuntimeState.Uninitialized;
 	private _lastExecutionId?: string;
 	private readonly _onDidReceiveRuntimeMessage = new vscode.EventEmitter<positron.LanguageRuntimeMessage>();
 	private readonly _onDidExecute = new vscode.EventEmitter<string>();
@@ -19,10 +18,6 @@ export class TestLanguageRuntimeSession implements Partial<positron.LanguageRunt
 	public readonly metadata = {
 		sessionId: 'test-session',
 	} as positron.RuntimeSessionMetadata;
-
-	get state(): positron.RuntimeState {
-		return this._state;
-	}
 
 	execute(_code: string, id: string, _mode: positron.RuntimeCodeExecutionMode, _errorBehavior: positron.RuntimeErrorBehavior) {
 		this._lastExecutionId = id;
@@ -40,10 +35,6 @@ export class TestLanguageRuntimeSession implements Partial<positron.LanguageRunt
 	}
 
 	// Test helpers
-
-	public setRuntimeState(state: positron.RuntimeState) {
-		this._state = state;
-	}
 
 	public fireErrorMessage(parent_id: string) {
 		this._onDidReceiveRuntimeMessage.fire({

--- a/extensions/positron-notebook-controllers/src/test/testLanguageRuntimeSession.ts
+++ b/extensions/positron-notebook-controllers/src/test/testLanguageRuntimeSession.ts
@@ -19,6 +19,10 @@ export class TestLanguageRuntimeSession implements Partial<positron.LanguageRunt
 		sessionId: 'test-session',
 	} as positron.RuntimeSessionMetadata;
 
+	constructor(
+		public readonly runtimeMetadata: positron.LanguageRuntimeMetadata,
+	) { }
+
 	execute(_code: string, id: string, _mode: positron.RuntimeCodeExecutionMode, _errorBehavior: positron.RuntimeErrorBehavior) {
 		this._lastExecutionId = id;
 		this._onDidExecute.fire(id);

--- a/extensions/positron-notebook-controllers/src/utils.ts
+++ b/extensions/positron-notebook-controllers/src/utils.ts
@@ -19,13 +19,13 @@ export function formatCount(count: number, unit: string): string {
 
 export async function getRunningNotebookSession(notebookUri: vscode.Uri): Promise<positron.LanguageRuntimeSession | undefined> {
 	// TODO: Use getSessions()?
-	const session = await positron.runtime.getNotebookSession(notebookUri);
-	// TODO: Check that it's the expected runtime.
-	const state = session?.state;
-	if (state === positron.RuntimeState.Uninitialized
-		|| state === positron.RuntimeState.Exiting
-		|| state === positron.RuntimeState.Exited) {
-		return undefined;
-	}
-	return session;
+	// TODO: Check that it's the expected runtime?
+	return positron.runtime.getNotebookSession(notebookUri);
+	// const state = session?.state;
+	// if (state === positron.RuntimeState.Uninitialized
+	// 	|| state === positron.RuntimeState.Exiting
+	// 	|| state === positron.RuntimeState.Exited) {
+	// 	return undefined;
+	// }
+	// return session;
 }

--- a/extensions/positron-notebook-controllers/src/utils.ts
+++ b/extensions/positron-notebook-controllers/src/utils.ts
@@ -3,6 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+
 export function delay(ms: number) {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -12,4 +15,17 @@ export function formatCount(count: number, unit: string): string {
 		return `${count} ${unit}`;
 	}
 	return `${count} ${unit}s`;
+}
+
+export async function getRunningNotebookSession(notebookUri: vscode.Uri): Promise<positron.LanguageRuntimeSession | undefined> {
+	// TODO: Use getSessions()?
+	const session = await positron.runtime.getNotebookSession(notebookUri);
+	// TODO: Check that it's the expected runtime.
+	const state = session?.state;
+	if (state === positron.RuntimeState.Uninitialized
+		|| state === positron.RuntimeState.Exiting
+		|| state === positron.RuntimeState.Exited) {
+		return undefined;
+	}
+	return session;
 }

--- a/extensions/positron-notebook-controllers/src/utils.ts
+++ b/extensions/positron-notebook-controllers/src/utils.ts
@@ -5,6 +5,7 @@
 
 import * as positron from 'positron';
 import * as vscode from 'vscode';
+import { log } from './extension';
 
 export function delay(ms: number) {
 	return new Promise(resolve => setTimeout(resolve, ms));
@@ -35,6 +36,8 @@ export async function getNotebookSession(
 
 	// Ensure that the session is for the requested runtime.
 	if (runtimeId && session.runtimeMetadata.runtimeId !== runtimeId) {
+		log.warn(`Expected session for notebook ${notebookUri} to be for runtime ${runtimeId}, ` +
+			`but it is for runtime ${session.runtimeMetadata.runtimeId}`);
 		return undefined;
 	}
 

--- a/extensions/positron-notebook-controllers/src/utils.ts
+++ b/extensions/positron-notebook-controllers/src/utils.ts
@@ -17,15 +17,26 @@ export function formatCount(count: number, unit: string): string {
 	return `${count} ${unit}s`;
 }
 
-export async function getRunningNotebookSession(notebookUri: vscode.Uri): Promise<positron.LanguageRuntimeSession | undefined> {
-	// TODO: Use getSessions()?
-	// TODO: Check that it's the expected runtime?
-	return positron.runtime.getNotebookSession(notebookUri);
-	// const state = session?.state;
-	// if (state === positron.RuntimeState.Uninitialized
-	// 	|| state === positron.RuntimeState.Exiting
-	// 	|| state === positron.RuntimeState.Exited) {
-	// 	return undefined;
-	// }
-	// return session;
+/**
+ * Get the language runtime session for a notebook.
+ *
+ * @param notebookUri The URI of the notebook.
+ * @param runtimeId Optional runtime ID to filter the session by.
+ * @returns Promise that resolves with the language runtime session, or `undefined` if no session is found.
+ */
+export async function getNotebookSession(
+	notebookUri: vscode.Uri, runtimeId?: string,
+): Promise<positron.LanguageRuntimeSession | undefined> {
+	// Get the session for the notebook.
+	const session = await positron.runtime.getNotebookSession(notebookUri);
+	if (!session) {
+		return undefined;
+	}
+
+	// Ensure that the session is for the requested runtime.
+	if (runtimeId && session.runtimeMetadata.runtimeId !== runtimeId) {
+		return undefined;
+	}
+
+	return session;
 }

--- a/extensions/positron-notebook-controllers/src/utils.ts
+++ b/extensions/positron-notebook-controllers/src/utils.ts
@@ -3,9 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as positron from 'positron';
-import * as vscode from 'vscode';
-
 export function delay(ms: number) {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -15,17 +12,4 @@ export function formatCount(count: number, unit: string): string {
 		return `${count} ${unit}`;
 	}
 	return `${count} ${unit}s`;
-}
-
-export async function getRunningNotebookSession(notebookUri: vscode.Uri): Promise<positron.LanguageRuntimeSession | undefined> {
-	// TODO: Use getSessions()?
-	// TODO: Check that it's the expected runtime?
-	return positron.runtime.getNotebookSession(notebookUri);
-	// const state = session?.state;
-	// if (state === positron.RuntimeState.Uninitialized
-	// 	|| state === positron.RuntimeState.Exiting
-	// 	|| state === positron.RuntimeState.Exited) {
-	// 	return undefined;
-	// }
-	// return session;
 }

--- a/extensions/positron-notebook-controllers/src/utils.ts
+++ b/extensions/positron-notebook-controllers/src/utils.ts
@@ -3,6 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+
 export function delay(ms: number) {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -12,4 +15,17 @@ export function formatCount(count: number, unit: string): string {
 		return `${count} ${unit}`;
 	}
 	return `${count} ${unit}s`;
+}
+
+export async function getRunningNotebookSession(notebookUri: vscode.Uri): Promise<positron.LanguageRuntimeSession | undefined> {
+	// TODO: Use getSessions()?
+	// TODO: Check that it's the expected runtime?
+	return positron.runtime.getNotebookSession(notebookUri);
+	// const state = session?.state;
+	// if (state === positron.RuntimeState.Uninitialized
+	// 	|| state === positron.RuntimeState.Exiting
+	// 	|| state === positron.RuntimeState.Exited) {
+	// 	return undefined;
+	// }
+	// return session;
 }

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -93,11 +93,20 @@ declare module 'positron' {
 		/** The runtime is busy executing code. */
 		Busy = 'busy',
 
+		/** The runtime is in the process of restarting. */
+		Restarting = 'restarting',
+
+		/** The runtime is in the process of shutting down. */
+		Exiting = 'exiting',
+
 		/** The runtime's host process has ended. */
 		Exited = 'exited',
 
 		/** The runtime is not responding to heartbeats and is presumed offline. */
 		Offline = 'offline',
+
+		/** The user has interrupted a busy runtime, but the runtime is not idle yet. */
+		Interrupting = 'interrupting',
 	}
 
 	/**


### PR DESCRIPTION
The goal of this PR is to stop relying on the positron-notebook-controller extension's notebook session service tracking the running notebook sessions and instead use the existing `positron.runtime.getNotebookSession` method. It's another step toward removing the notebook session service altogether.

Related to #2671

### QA Notes

Tests should continue to pass and opening/closing/restarting/executing notebooks should feel stable in general.