### PR TITLE
e2e-test: update r-pkg test to check for `library()`

### DIFF
--- a/test/e2e/features/r-pkg-development/r-pkg-development.test.ts
+++ b/test/e2e/features/r-pkg-development/r-pkg-development.test.ts
@@ -69,6 +69,10 @@ test.describe('R Package Development', { tag: ['@web'] }, () => {
 				await expect(app.workbench.positronConsole.activeConsole.getByText('restarted')).toBeVisible({ timeout: 30000 });
 				await expect(app.workbench.positronConsole.activeConsole.getByText('library(testfun)')).toBeVisible();
 			}).toPass({ timeout: 70000 });
+
+			await app.workbench.positronConsole.pasteCodeToConsole('(.packages())');
+			await app.workbench.positronConsole.sendEnterKey();
+			await expect(app.workbench.positronConsole.activeConsole.getByText('"testfun"')).toBeVisible();
 		});
 	});
 });

--- a/test/e2e/features/r-pkg-development/r-pkg-development.test.ts
+++ b/test/e2e/features/r-pkg-development/r-pkg-development.test.ts
@@ -27,40 +27,48 @@ test.describe('R Package Development', { tag: ['@web'] }, () => {
 	test('R Package Development Tasks [C809821]', async function ({ app, logger }) {
 		test.slow();
 
-		await expect(async () => {
-			// Navigate to https://github.com/posit-dev/qa-example-content/tree/main/workspaces/r_testing
-			// This is an R package embedded in qa-example-content
-			await app.workbench.quickaccess.runCommand('workbench.action.files.openFolder', { keepOpen: true });
-			await app.workbench.quickinput.waitForQuickInputOpened();
-			await app.workbench.quickinput.type(path.join(app.workspacePathOrFolder, 'workspaces', 'r_testing'));
-			// Had to add a positron class, because Microsoft did not have this:
-			await app.workbench.quickinput.clickOkOnQuickInput();
+		await test.step('Open R Package', async () => {
+			await expect(async () => {
+				// Navigate to https://github.com/posit-dev/qa-example-content/tree/main/workspaces/r_testing
+				// This is an R package embedded in qa-example-content
+				await app.workbench.quickaccess.runCommand('workbench.action.files.openFolder', { keepOpen: true });
+				await app.workbench.quickinput.waitForQuickInputOpened();
+				await app.workbench.quickinput.type(path.join(app.workspacePathOrFolder, 'workspaces', 'r_testing'));
+				await app.workbench.quickinput.clickOkOnQuickInput();
 
-			// Wait for the console to be ready
-			await app.workbench.positronConsole.waitForReady('>', 10000);
-		}).toPass({ timeout: 70000 });
+				// Wait for the console to be ready
+				await app.workbench.positronConsole.waitForReady('>', 10000);
+			}).toPass({ timeout: 70000 });
+		});
 
-		logger.log('Test R Package');
-		await app.workbench.quickaccess.runCommand('r.packageTest');
-		await expect(async () => {
-			await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.startsWith('[ FAIL 1 | WARN 0 | SKIP 0 | PASS 16 ]')));
-			await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.includes('Terminal will be reused by tasks')));
-		}).toPass({ timeout: 70000 });
+		await test.step('Test R Package', async () => {
+			logger.log('Test R Package');
+			await app.workbench.quickaccess.runCommand('r.packageTest');
+			await expect(async () => {
+				await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.startsWith('[ FAIL 1 | WARN 0 | SKIP 0 | PASS 16 ]')));
+				await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.includes('Terminal will be reused by tasks')));
+			}).toPass({ timeout: 70000 });
+		});
 
-		logger.log('Check R Package');
-		await app.workbench.quickaccess.runCommand('workbench.action.terminal.clear');
-		await app.workbench.quickaccess.runCommand('r.packageCheck');
-		await expect(async () => {
-			await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.startsWith('Error: R CMD check found ERRORs')));
-			await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.includes('Terminal will be reused by tasks')));
-		}).toPass({ timeout: 70000 });
+		await test.step('Check R Package', async () => {
+			logger.log('Check R Package');
+			await app.workbench.quickaccess.runCommand('workbench.action.terminal.clear');
+			await app.workbench.quickaccess.runCommand('r.packageCheck');
+			await expect(async () => {
+				await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.startsWith('Error: R CMD check found ERRORs')));
+				await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.includes('Terminal will be reused by tasks')));
+			}).toPass({ timeout: 70000 });
+		});
 
-		logger.log('Install R Package and Restart R');
-		await app.workbench.quickaccess.runCommand('r.packageInstall');
-		await expect(async () => {
+		await test.step('Install R Package and Restart R', async () => {
+			logger.log('Install R Package and Restart R');
+			await app.workbench.quickaccess.runCommand('r.packageInstall');
 			await app.workbench.terminal.waitForTerminalText(buffer => buffer.some(line => line.startsWith('✔ Installed testfun 0.0.0.9000')));
-			await app.workbench.positronConsole.waitForReady('>');
-			await expect(app.workbench.positronConsole.activeConsole.getByText('restarted')).toBeVisible({ timeout: 30000 });
-		}).toPass({ timeout: 70000 });
+			await expect(async () => {
+				await app.workbench.positronConsole.waitForReady('>');
+				await expect(app.workbench.positronConsole.activeConsole.getByText('restarted')).toBeVisible({ timeout: 30000 });
+				await expect(app.workbench.positronConsole.activeConsole.getByText('library(testfun)')).toBeVisible();
+			}).toPass({ timeout: 70000 });
+		});
 	});
 });


### PR DESCRIPTION
### Intent
As outlined in [this issue](https://github.com/posit-dev/positron/issues/5532), the goal is to ensure that `library()` is called in the console after a package install & restart.

### Approach
- Added test steps to provide better clarity in the test report.
- Updated the test to verify that `library()` appears in the console following package installation & restart.

### QA Notes
- Verified that the updated test runs successfully (web & electron) locally without issues.