### PR TITLE
Do not error in comm code generator when 'name' property present in object that has enum

### DIFF
--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -314,7 +314,7 @@ function* enumVisitor(
 	} else if (typeof contract === 'object') {
 		// If this object is an object, recurse into each property
 		for (const key of Object.keys(contract)) {
-			if (contract['name']) {
+			if (contract['name'] && typeof contract['name'] === 'string') {
 				// If this is a named object, push the name onto the context
 				// and recurse
 				yield* enumVisitor(


### PR DESCRIPTION
Addresses #2139. This isn't causing active harm, but a sharp edge that will hit comm developers with a confusing error message when an object property is called "name" and there is another property that is an enum. I tested this out with the example from the linked issue and it works correctly. I also checked that this change does not impact any of the generated comm code. 