### PR TITLE
Track reasons for R discovery and rejection and do stuff with them

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -109,7 +109,7 @@ export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRun
 			LOGGER.warn('Learn more about R discovery at https://positron.posit.co/r-installations.html');
 			const showLog = await positron.window.showSimpleModalDialogPrompt(
 				vscode.l10n.t('All discovered R installations are unusable by Positron.'),
-				vscode.l10n.t('Learn more about R discovery at <https://positron.posit.co/r-installations.html>'),
+				vscode.l10n.t('Learn more about R discovery at <br><a href="https://positron.posit.co/r-installations.html">https://positron.posit.co/r-installations.html</a>'),
 				vscode.l10n.t('View the logs for R discovery'),
 				vscode.l10n.t('Dismiss')
 			);

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -107,14 +107,15 @@ export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRun
 		if (rInstallations.length === 0) {
 			LOGGER.warn(`All discovered R installations are unusable by Positron.`);
 			LOGGER.warn('Learn more about R discovery at https://positron.posit.co/r-installations.html');
-			vscode.window.showWarningMessage(
-				`All discovered R installations are unusable by Positron.`,
-				{ modal: true }, 'See the log file')
-				.then(selection => {
-					if (selection === 'See the log file') {
-						LOGGER.show();
-					}
-				});
+			const showLog = await positron.window.showSimpleModalDialogPrompt(
+				vscode.l10n.t('All discovered R installations are unusable by Positron.'),
+				vscode.l10n.t('Learn more about R discovery at <https://positron.posit.co/r-installations.html>'),
+				vscode.l10n.t('View the logs for R discovery'),
+				vscode.l10n.t('Dismiss')
+			);
+			if (showLog) {
+				LOGGER.show();
+			}
 		} else {
 			LOGGER.warn(`Some discovered R installations are unusable by Positron.`);
 			LOGGER.warn('Learn more about R discovery at https://positron.posit.co/r-installations.html');

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -106,10 +106,10 @@ export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRun
 	if (rejectedRInstallations.length > 0) {
 		if (rInstallations.length === 0) {
 			LOGGER.warn(`All discovered R installations are unusable by Positron.`);
-			LOGGER.warn('Learn more about R discovery at https://positron.posit.co/r-installations.html');
+			LOGGER.warn('Learn more about R discovery at https://positron.posit.co/r-installations');
 			const showLog = await positron.window.showSimpleModalDialogPrompt(
 				vscode.l10n.t('No usable R installations'),
-				vscode.l10n.t('All discovered R installations are unusable by Positron. Learn more about R discovery at <br><a href="https://positron.posit.co/r-installations.html">https://positron.posit.co/r-installations.html</a>'),
+				vscode.l10n.t('All discovered R installations are unusable by Positron. Learn more about R discovery at <br><a href="https://positron.posit.co/r-installations">https://positron.posit.co/r-installations</a>'),
 				vscode.l10n.t('View logs'),
 				vscode.l10n.t('Dismiss')
 			);
@@ -118,7 +118,7 @@ export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRun
 			}
 		} else {
 			LOGGER.warn(`Some discovered R installations are unusable by Positron.`);
-			LOGGER.warn('Learn more about R discovery at https://positron.posit.co/r-installations.html');
+			LOGGER.warn('Learn more about R discovery at https://positron.posit.co/r-installations');
 		}
 	}
 

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -110,7 +110,7 @@ export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRun
 			const showLog = await positron.window.showSimpleModalDialogPrompt(
 				vscode.l10n.t('All discovered R installations are unusable by Positron.'),
 				vscode.l10n.t('Learn more about R discovery at <br><a href="https://positron.posit.co/r-installations.html">https://positron.posit.co/r-installations.html</a>'),
-				vscode.l10n.t('View the logs for R discovery'),
+				vscode.l10n.t('View logs'),
 				vscode.l10n.t('Dismiss')
 			);
 			if (showLog) {

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -12,7 +12,7 @@ import * as which from 'which';
 import * as positron from 'positron';
 import * as crypto from 'crypto';
 
-import { RInstallation, RMetadataExtra, getRHomePath } from './r-installation';
+import { RInstallation, RMetadataExtra, getRHomePath, ReasonDiscovered, friendlyReason } from './r-installation';
 import { LOGGER } from './extension';
 import { EXTENSION_ROOT_DIR, MINIMUM_R_VERSION } from './constants';
 
@@ -25,123 +25,101 @@ export const R_DOCUMENT_SELECTORS = [
 	{ language: 'r', pattern: '**/*.{rprofile,Rprofile}' },
 ];
 
-/**
- * Enum represents the source from which an R binary was discovered.
- */
-enum BinarySource {
-	/* eslint-disable-next-line @typescript-eslint/naming-convention */
-	HQ = 'HQ',
-	adHoc = 'ad hoc location',
-	registry = 'Windows registry',
-	/* eslint-disable-next-line @typescript-eslint/naming-convention */
-	PATH = 'PATH',
-	user = 'user-specified directory'
+export interface RBinary {
+	path: string;
+	reasons: ReasonDiscovered[]
 }
 
 /**
- * Discovers R language runtimes for Positron; implements
- * positron.LanguageRuntimeDiscoverer.
+ * Discovers R language runtimes for Positron; implements positron.LanguageRuntimeDiscoverer.
  *
  * @param context The extension context.
  */
 export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRuntimeMetadata> {
-	let rInstallations: Array<RInstallation> = [];
-	const binaries = new Map<string, BinarySource>();
+	const binaries = new Map<string, RBinary>();
 
-	// look for R executables in the well-known place(s) for R installations on this OS
+	function updateBinaries(binary: RBinary | RBinary[] | undefined): void {
+		if (!binary) {
+			return;
+		}
+		const input = Array.isArray(binary) ? binary : [binary];
+		for (const binary of input) {
+			if (binaries.has(binary.path)) {
+				const reasons = new Set(binaries.get(binary.path)!.reasons.concat(binary.reasons));
+				binaries.get(binary.path)!.reasons = Array.from(reasons);
+			} else {
+				binaries.set(binary.path, binary);
+			}
+		}
+	}
+
+	// Find the current R binary(ies) for various definitions of "current".
+	// The first item here will eventually be marked as The Current R Binary.
+	const currentBinaries = await currentRBinaryCandidates();
+	updateBinaries(currentBinaries);
+
+	// Now we scour the system for all R binaries we can find.
 	const systemHqBinaries = discoverHQBinaries(rHeadquarters());
-	for (const b of systemHqBinaries) {
-		binaries.set(b, BinarySource.HQ);
-	}
+	updateBinaries(systemHqBinaries);
 
-	// consult user-specified, HQ-like directories
-	const userHqBinaries = discoverHQBinaries(userRHeadquarters());
-	for (const b of userHqBinaries) {
-		binaries.set(b, BinarySource.user);
-	}
+	const registryBinaries = await discoverRegistryBinaries();
+	updateBinaries(registryBinaries);
 
-	// other conventional places we might find an R binary (or a symlink to one)
-	const possibleBinaries = [
+	const moreBinaries = discoverAdHocBinaries([
 		'/usr/bin/R',
 		'/usr/local/bin/R',
 		'/opt/local/bin/R',
 		'/opt/homebrew/bin/R'
-	];
-	const moreBinaries = possibleBinaries
-		.filter(b => fs.existsSync(b))
-		.map(b => fs.realpathSync(b));
-	for (const b of moreBinaries) {
-		if (!binaries.has(b)) {
-			binaries.set(b, BinarySource.adHoc);
-		}
+	]);
+	updateBinaries(moreBinaries);
+
+	// Optional, user-specified root directories or binaries
+	const userHqBinaries = discoverHQBinaries(userRHeadquarters());
+	updateBinaries(userHqBinaries);
+
+	const userMoreBinaries = discoverAdHocBinaries(userRBinaries());
+	updateBinaries(userMoreBinaries);
+
+	// (Try to) promote each RBinary to a proper RInstallation
+	let rInstallations: Array<RInstallation> = [];
+	if (currentBinaries.length > 0) {
+		const currentBinary = currentBinaries[0];
+		rInstallations.push(new RInstallation(currentBinary.path, true, currentBinary.reasons));
+		binaries.delete(currentBinary.path);
 	}
 
-	// same as above but user-specified, ad hoc binaries
-	const userPossibleBinaries = userRBinaries();
-	const userMoreBinaries = userPossibleBinaries
-		.filter(b => fs.existsSync(b))
-		.map(b => fs.realpathSync(b));
-	for (const b of userMoreBinaries) {
-		if (!binaries.has(b)) {
-			binaries.set(b, BinarySource.user);
-		}
-	}
-
-	const registryBinaries = await discoverRegistryBinaries();
-	for (const b of registryBinaries) {
-		if (!binaries.has(b)) {
-			binaries.set(b, BinarySource.registry);
-		}
-	}
-
-	const pathBinary = await findRBinaryFromPATH();
-	if (pathBinary && !binaries.has(pathBinary)) {
-		binaries.set(pathBinary, BinarySource.PATH);
-	}
-
-	// make sure we include the "current" version of R, for some definition of "current"
-	// we've probably already discovered it, but we still want to single it out, so that we mark
-	// that particular R installation as the current one
-	const curBin = await findCurrentRBinary();
-	if (curBin) {
-		rInstallations.push(new RInstallation(curBin, true));
-		binaries.delete(curBin);
-	}
-
-	binaries.forEach((source, bin) => {
-		rInstallations.push(new RInstallation(bin));
+	binaries.forEach(rbin => {
+		rInstallations.push(new RInstallation(rbin.path, false, rbin.reasons));
 	});
 
-	// TODO: possible location to tell the user why certain R installations are being omitted from
-	// the interpreter drop-down and, in some cases, offer to help fix the situation:
-	// * version < minimum R version supported by positron-r
-	// * (macOS only) version is not orthogonal and is not the current version of R
-	// * invalid R installation
+	const rejectedRInstallations: Array<RInstallation> = [];
 	rInstallations = rInstallations
 		.filter(r => {
-			if (!r.valid) {
-				LOGGER.info(`Filtering out ${r.binpath}: invalid R installation.`);
-				return false;
-			}
-			return true;
-		})
-		.filter(r => {
-			if (!(r.current || r.orthogonal)) {
-				LOGGER.info(`Filtering out ${r.binpath}: not current and also not orthogonal.`);
-				return false;
-			}
-			return true;
-		})
-		.filter(r => {
-			if (!r.supported) {
-				LOGGER.info(`Filtering out ${r.binpath}: version is < ${MINIMUM_R_VERSION}`);
+			if (!r.usable) {
+				LOGGER.info(`Filtering out ${r.binpath}, reason: ${friendlyReason(r.reasonRejected)}.`);
+				rejectedRInstallations.push(r);
 				return false;
 			}
 			return true;
 		});
 
-	// FIXME? should I explicitly check that there is <= 1 R installation
-	// marked as 'current'?
+	if (rejectedRInstallations.length > 0) {
+		if (rInstallations.length === 0) {
+			LOGGER.warn(`All discovered R installations are unusable by Positron.`);
+			LOGGER.warn('Learn more about R discovery at https://positron.posit.co/r-installations.html');
+			vscode.window.showWarningMessage(
+				`All discovered R installations are unusable by Positron.`,
+				{ modal: true }, 'See the log file')
+				.then(selection => {
+					if (selection === 'See the log file') {
+						LOGGER.show();
+					}
+				});
+		} else {
+			LOGGER.warn(`Some discovered R installations are unusable by Positron.`);
+			LOGGER.warn('Learn more about R discovery at https://positron.posit.co/r-installations.html');
+		}
+	}
 
 	rInstallations.sort((a, b) => {
 		if (a.current || b.current) {
@@ -233,7 +211,8 @@ export async function makeMetadata(
 	const extraRuntimeData: RMetadataExtra = {
 		homepath: rInst.homepath,
 		binpath: rInst.binpath,
-		current: rInst.current
+		current: rInst.current,
+		reasonDiscovered: rInst.reasonDiscovered,
 	};
 
 	const metadata: positron.LanguageRuntimeMetadata = {
@@ -257,6 +236,279 @@ export async function makeMetadata(
 
 	return metadata;
 }
+
+// functions relating to the current R binary
+let cachedRBinaryCurrent: RBinary | undefined;
+
+export async function currentRBinary(): Promise<RBinary | undefined> {
+	if (cachedRBinaryCurrent !== undefined) {
+		return cachedRBinaryCurrent;
+	}
+
+	const candidates = await currentRBinaryCandidates();
+	if (candidates.length === 0) {
+		return undefined;
+	} else {
+		cachedRBinaryCurrent = candidates[0];
+		return cachedRBinaryCurrent;
+	}
+}
+
+async function currentRBinaryCandidates(): Promise<RBinary[]> {
+	const candidates: RBinary[] = [];
+	let candidate: RBinary | undefined;
+
+	if (os.platform() === 'win32') {
+		candidate = await currentRBinaryFromRegistry();
+		if (candidate) {
+			candidates.push(candidate);
+		}
+	}
+
+	candidate = await currentRBinaryFromPATH();
+	if (candidate) {
+		candidates.push(candidate);
+	}
+
+	if (os.platform() !== 'win32') {
+		candidate = currentRBinaryFromHq(rHeadquarters());
+		if (candidate) {
+			candidates.push(candidate);
+		}
+	}
+
+	return candidates;
+}
+
+let cachedRBinaryFromRegistry: RBinary | undefined;
+
+async function currentRBinaryFromRegistry(): Promise<RBinary | undefined> {
+	if (os.platform() !== 'win32') {
+		LOGGER.info('Skipping registry check on non-Windows platform');
+		return undefined;
+	}
+
+	if (cachedRBinaryFromRegistry !== undefined) {
+		return cachedRBinaryFromRegistry;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	const Registry = await import('@vscode/windows-registry');
+
+	const hives: any[] = ['HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE'];
+	const wows = ['', 'WOW6432Node'];
+
+	let installPath = undefined;
+
+	for (const hive of hives) {
+		for (const wow of wows) {
+			const R64_KEY: string = `SOFTWARE\\${wow ? wow + '\\' : ''}R-core\\R64`;
+			try {
+				const key = Registry.GetStringRegKey(hive, R64_KEY, 'InstallPath');
+				if (key) {
+					installPath = key;
+					LOGGER.info(`Registry key ${hive}\\${R64_KEY}\\InstallPath reports the current R installation is at ${key}`);
+					break;
+				}
+			} catch { }
+		}
+	}
+
+	if (installPath === undefined) {
+		LOGGER.info('Cannot determine current version of R from the registry.');
+		return undefined;
+	}
+
+	const binPath = firstExisting(installPath, binFragments());
+	if (!binPath) {
+		return undefined;
+	}
+
+	LOGGER.info(`Identified the current R binary: ${binPath}`);
+	cachedRBinaryFromRegistry = { path: binPath, reasons: [ReasonDiscovered.registry] };
+	return cachedRBinaryFromRegistry;
+}
+
+let cachedRBinaryFromPATH: RBinary | undefined;
+
+async function currentRBinaryFromPATH(): Promise<RBinary | undefined> {
+	if (cachedRBinaryFromPATH !== undefined) {
+		return cachedRBinaryFromPATH;
+	}
+
+	const whichR = await which('R', { nothrow: true }) as string;
+	if (whichR) {
+		LOGGER.info(`Possibly found R on PATH: ${whichR}.`);
+		if (os.platform() === 'win32') {
+			cachedRBinaryFromPATH = await currentRBinaryFromPATHWindows(whichR);
+		} else {
+			cachedRBinaryFromPATH = await currentRBinaryFromPATHNotWindows(whichR);
+		}
+	} else {
+		cachedRBinaryFromPATH = undefined;
+	}
+
+	return cachedRBinaryFromPATH;
+}
+
+export async function currentRBinaryFromPATHWindows(whichR: string): Promise<RBinary | undefined> {
+	// The CRAN Windows installer does NOT put R on the PATH.
+	// If we are here, it is because the user has arranged it so.
+	const ext = path.extname(whichR).toLowerCase();
+	if (ext !== '.exe') {
+		// rig can put put something on the PATH that results in whichR being 'a/path/to/R.bat'
+		// but we aren't going to handle that.
+		LOGGER.info(`Unsupported extension: ${ext}.`);
+		return undefined;
+	}
+
+	// Overall idea: a discovered binpath --> homepath --> our preferred binpath
+	// This might just be a no-op.
+	// But if the input binpath is this:
+	// "C:\Program Files\R\R-4.3.2\bin\R.exe"
+	// we want to convert it to this, if it exists:
+	// "C:\Program Files\R\R-4.3.2\bin\x64\R.exe"
+	// It typically does exist for x86_64 R installations.
+	// It will not exist for arm64 R installations.
+	const whichRHome = getRHomePath(whichR);
+	if (!whichRHome) {
+		LOGGER.info(`Failed to get R home path from ${whichR}.`);
+		return undefined;
+	}
+	const binpathNormalized = firstExisting(whichRHome, binFragments());
+	if (binpathNormalized) {
+		LOGGER.info(`Resolved R binary at ${binpathNormalized}.`);
+		return { path: binpathNormalized, reasons: [ReasonDiscovered.PATH] };
+	} else {
+		LOGGER.info(`Can't find R binary within ${whichRHome}.`);
+		return undefined;
+	}
+}
+
+async function currentRBinaryFromPATHNotWindows(whichR: string): Promise<RBinary | undefined> {
+	const whichRCanonical = fs.realpathSync(whichR);
+	LOGGER.info(`Resolved R binary at ${whichRCanonical}`);
+	return { path: whichRCanonical, reasons: [ReasonDiscovered.PATH] };
+}
+
+function currentRBinaryFromHq(hqDirs: string[]): RBinary | undefined {
+	// this is not relevant on Windows
+	if (os.platform() === 'win32') {
+		return undefined;
+	}
+
+	// and, on not-Windows, hqDirs is expected to be a singleton
+	if (hqDirs.length > 1) {
+		LOGGER.error('Expected exactly one R HQ directory on this platform.');
+	}
+	const hqDir = hqDirs[0];
+
+	if (!fs.existsSync(hqDir)) {
+		return undefined;
+	}
+
+	const currentDirs = fs.readdirSync(hqDir)
+		.map(file => path.join(hqDir, file))
+		// macOS: 'Current' (uppercase 'C'), if it exists, is a symlink to an actual version
+		// linux: 'current' (lowercase 'c'), if it exists, is a symlink to an actual version
+		.filter(path => path.toLowerCase().endsWith('current'));
+
+	if (currentDirs.length !== 1) {
+		return undefined;
+	}
+	const currentDir = currentDirs[0];
+
+	const binpath = firstExisting(currentDir, binFragments());
+	if (!binpath) {
+		return undefined;
+	}
+
+	const binary = { path: fs.realpathSync(binpath), reasons: [ReasonDiscovered.HQ] };
+	return binary;
+}
+
+// Consult various sources of other, perhaps non-current, R binaries
+function discoverHQBinaries(hqDirs: string[]): RBinary[] {
+	const existingHqDirs = hqDirs.filter(dir => fs.existsSync(dir));
+	if (existingHqDirs.length === 0) {
+		return [];
+	}
+
+	const versionDirs = existingHqDirs
+		.map(hqDir => fs.readdirSync(hqDir).map(file => path.join(hqDir, file)))
+		// Windows: rig creates 'bin/', which is a directory of .bat files (at least, for now)
+		// https://github.com/r-lib/rig/issues/189
+		.map(listing => listing.filter(path => !path.endsWith('bin')))
+		// macOS: 'Current' (uppercase 'C'), if it exists, is a symlink to an actual version
+		// linux: 'current' (lowercase 'c'), if it exists, is a symlink to an actual version
+		.map(listing => listing.filter(path => !path.toLowerCase().endsWith('current')));
+
+	// On Windows:
+	// In the case that both (1) and (2) exist we prefer (1).
+	// (1) C:\Program Files\R\R-4.3.2\bin\x64\R.exe
+	// (2) C:\Program Files\R\R-4.3.2\bin\R.exe
+	// Because we require R >= 4.2, we don't need to consider bin\i386\R.exe.
+	const binaries = versionDirs
+		.map(vd => vd.map(x => firstExisting(x, binFragments())))
+		.flat()
+		// macOS: By default, the CRAN installer deletes previous R installations, but sometimes
+		// it doesn't do a thorough job of it and a nearly-empty version directory lingers on.
+		.filter(b => fs.existsSync(b))
+		.map(b => ({ path: b, reasons: [ReasonDiscovered.HQ] }));
+	return binaries;
+}
+
+async function discoverRegistryBinaries(): Promise<RBinary[]> {
+	if (os.platform() !== 'win32') {
+		LOGGER.info('Skipping registry check on non-Windows platform');
+		return [];
+	}
+
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	const Registry = await import('@vscode/windows-registry');
+
+	const hives: any[] = ['HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE'];
+	// R's install path is written to a WOW (Windows on Windows) node when e.g. an x86 build of
+	// R is installed on an ARM version of Windows.
+	const wows = ['', 'WOW6432Node'];
+
+	// The @vscode/windows-registry module is so minimalistic that it can't list the registry.
+	// Therefore we explicitly generate the R versions that might be there and check for each one.
+	const versions = generateVersions();
+
+	const discoveredKeys: string[] = [];
+
+	for (const hive of hives) {
+		for (const wow of wows) {
+			for (const version of versions) {
+				const R64_KEY: string = `SOFTWARE\\${wow ? wow + '\\' : ''}R-core\\R64\\${version}`;
+				try {
+					const key = Registry.GetStringRegKey(hive, R64_KEY, 'InstallPath');
+					if (key) {
+						LOGGER.info(`Registry key ${hive}\\${R64_KEY}\\InstallPath reports an R installation at ${key}`);
+						discoveredKeys.push(key);
+					}
+				} catch { }
+			}
+		}
+	}
+
+	const binPaths = discoveredKeys
+		.map(installPath => firstExisting(installPath, binFragments()))
+		.filter(binPath => binPath !== undefined)
+		.map(binPath => ({ path: binPath, reasons: [ReasonDiscovered.registry] }));
+
+	return binPaths;
+}
+
+function discoverAdHocBinaries(paths: string[]): RBinary[] {
+	return paths
+		.filter(b => fs.existsSync(b))
+		.map(b => fs.realpathSync(b))
+		.map(b => ({ path: b, reasons: [ReasonDiscovered.adHoc] }));
+}
+
+// R discovery helpers
 
 // directory(ies) where this OS is known to keep its R installations
 function rHeadquarters(): string[] {
@@ -311,35 +563,6 @@ function firstExisting(base: string, fragments: string[]): string {
 	return existingPath || '';
 }
 
-function discoverHQBinaries(hqDirs: string[]): string[] {
-	const existingHqDirs = hqDirs.filter(dir => fs.existsSync(dir));
-	if (existingHqDirs.length === 0) {
-		return [];
-	}
-
-	const versionDirs = existingHqDirs
-		.map(hqDir => fs.readdirSync(hqDir).map(file => path.join(hqDir, file)))
-		// Windows: rig creates 'bin/', which is a directory of .bat files (at least, for now)
-		// https://github.com/r-lib/rig/issues/189
-		.map(listing => listing.filter(path => !path.endsWith('bin')))
-		// macOS: 'Current' (uppercase 'C'), if it exists, is a symlink to an actual version
-		// linux: 'current' (lowercase 'c'), if it exists, is a symlink to an actual version
-		.map(listing => listing.filter(path => !path.toLowerCase().endsWith('current')));
-
-	// On Windows:
-	// In the case that both (1) and (2) exist we prefer (1).
-	// (1) C:\Program Files\R\R-4.3.2\bin\x64\R.exe
-	// (2) C:\Program Files\R\R-4.3.2\bin\R.exe
-	// Because we require R >= 4.2, we don't need to consider bin\i386\R.exe.
-	const binaries = versionDirs
-		.map(vd => vd.map(x => firstExisting(x, binFragments())))
-		.flat()
-		// macOS: By default, the CRAN installer deletes previous R installations, but sometimes
-		// it doesn't do a thorough job of it and a nearly-empty version directory lingers on.
-		.filter(b => fs.existsSync(b));
-	return binaries;
-}
-
 function binFragments(): string[] {
 	switch (process.platform) {
 		case 'darwin':
@@ -382,174 +605,6 @@ function generateVersions(): string[] {
 	return versions;
 }
 
-async function discoverRegistryBinaries(): Promise<string[]> {
-	if (os.platform() !== 'win32') {
-		LOGGER.info('Skipping registry check on non-Windows platform');
-		return [];
-	}
-
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	const Registry = await import('@vscode/windows-registry');
-
-	const hives: any[] = ['HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE'];
-	// R's install path is written to a WOW (Windows on Windows) node when e.g. an x86 build of
-	// R is installed on an ARM version of Windows.
-	const wows = ['', 'WOW6432Node'];
-
-	// The @vscode/windows-registry module is so minimalistic that it can't list the registry.
-	// Therefore we explicitly generate the R versions that might be there and check for each one.
-	const versions = generateVersions();
-
-	const discoveredKeys: string[] = [];
-
-	for (const hive of hives) {
-		for (const wow of wows) {
-			for (const version of versions) {
-				const R64_KEY: string = `SOFTWARE\\${wow ? wow + '\\' : ''}R-core\\R64\\${version}`;
-				try {
-					const key = Registry.GetStringRegKey(hive, R64_KEY, 'InstallPath');
-					if (key) {
-						LOGGER.info(`Registry key ${hive}\\${R64_KEY}\\InstallPath reports an R installation at ${key}`);
-						discoveredKeys.push(key);
-					}
-				} catch { }
-			}
-		}
-	}
-
-	const binPaths = discoveredKeys
-		.map(installPath => firstExisting(installPath, binFragments()))
-		.filter(binPath => binPath !== undefined);
-
-	return binPaths;
-}
-
-let cachedRBinary: string | undefined;
-
-export async function findCurrentRBinary(): Promise<string | undefined> {
-	if (cachedRBinary !== undefined) {
-		return cachedRBinary;
-	}
-
-	if (os.platform() === 'win32') {
-		const registryBinary = await findCurrentRBinaryFromRegistry();
-		if (registryBinary) {
-			cachedRBinary = registryBinary;
-			return registryBinary;
-		}
-	}
-
-	// TODO: for macOS, this should arguably be whatever
-	// /Library/Frameworks/R.framework/Versions/Current/ resolves to
-	// that would remove overlap between `findCurrentBinary()` and `findRBinaryFromPATH()`
-
-	cachedRBinary = await findRBinaryFromPATH();
-	return cachedRBinary;
-}
-
-let cachedRBinaryFromPATH: string | undefined;
-
-async function findRBinaryFromPATH(): Promise<string | undefined> {
-	if (cachedRBinaryFromPATH !== undefined) {
-		return cachedRBinaryFromPATH;
-	}
-
-	const whichR = await which('R', { nothrow: true }) as string;
-	if (whichR) {
-		LOGGER.info(`Possibly found R on PATH: ${whichR}.`);
-		if (os.platform() === 'win32') {
-			cachedRBinaryFromPATH = await findRBinaryFromPATHWindows(whichR);
-		} else {
-			cachedRBinaryFromPATH = await findRBinaryFromPATHNotWindows(whichR);
-		}
-	} else {
-		cachedRBinaryFromPATH = undefined;
-	}
-
-	return cachedRBinaryFromPATH;
-}
-
-export async function findRBinaryFromPATHWindows(whichR: string): Promise<string | undefined> {
-	// The CRAN Windows installer does NOT put R on the PATH.
-	// If we are here, it is because the user has arranged it so.
-	const ext = path.extname(whichR).toLowerCase();
-	if (ext !== '.exe') {
-		// rig can put put something on the PATH that results in whichR being 'a/path/to/R.bat'
-		// but we aren't going to handle that.
-		LOGGER.info(`Unsupported extension: ${ext}.`);
-		return undefined;
-	}
-
-	// Overall idea: a discovered binpath --> homepath --> our preferred binpath
-	// This might just be a no-op.
-	// But if the input binpath is this:
-	// "C:\Program Files\R\R-4.3.2\bin\R.exe"
-	// we want to convert it to this, if it exists:
-	// "C:\Program Files\R\R-4.3.2\bin\x64\R.exe"
-	// It typically does exist for x86_64 R installations.
-	// It will not exist for arm64 R installations.
-	const whichRHome = getRHomePath(whichR);
-	if (!whichRHome) {
-		LOGGER.info(`Failed to get R home path from ${whichR}.`);
-		return undefined;
-	}
-	const binpathNormalized = firstExisting(whichRHome, binFragments());
-	if (binpathNormalized) {
-		LOGGER.info(`Resolved R binary at ${binpathNormalized}.`);
-		return binpathNormalized;
-	} else {
-		LOGGER.info(`Can't find R binary within ${whichRHome}.`);
-		return undefined;
-	}
-}
-
-async function findRBinaryFromPATHNotWindows(whichR: string): Promise<string | undefined> {
-	const whichRCanonical = fs.realpathSync(whichR);
-	LOGGER.info(`Resolved R binary at ${whichRCanonical}`);
-	return whichRCanonical;
-}
-
-async function findCurrentRBinaryFromRegistry(): Promise<string | undefined> {
-	if (os.platform() !== 'win32') {
-		LOGGER.info('Skipping registry check on non-Windows platform');
-		return undefined;
-	}
-
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	const Registry = await import('@vscode/windows-registry');
-
-	const hives: any[] = ['HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE'];
-	const wows = ['', 'WOW6432Node'];
-
-	let installPath = undefined;
-
-	for (const hive of hives) {
-		for (const wow of wows) {
-			const R64_KEY: string = `SOFTWARE\\${wow ? wow + '\\' : ''}R-core\\R64`;
-			try {
-				const key = Registry.GetStringRegKey(hive, R64_KEY, 'InstallPath');
-				if (key) {
-					installPath = key;
-					LOGGER.info(`Registry key ${hive}\\${R64_KEY}\\InstallPath reports the current R installation is at ${key}`);
-					break;
-				}
-			} catch { }
-		}
-	}
-
-	if (installPath === undefined) {
-		LOGGER.info('Cannot determine current version of R from the registry.');
-		return undefined;
-	}
-
-	const binPath = firstExisting(installPath, binFragments());
-	if (!binPath) {
-		return undefined;
-	}
-	LOGGER.info(`Identified the current R binary: ${binPath}`);
-
-	return binPath;
-}
 
 // Should we recommend an R runtime for the workspace?
 async function shouldRecommendForWorkspace(): Promise<boolean> {

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -108,8 +108,8 @@ export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRun
 			LOGGER.warn(`All discovered R installations are unusable by Positron.`);
 			LOGGER.warn('Learn more about R discovery at https://positron.posit.co/r-installations.html');
 			const showLog = await positron.window.showSimpleModalDialogPrompt(
-				vscode.l10n.t('All discovered R installations are unusable by Positron.'),
-				vscode.l10n.t('Learn more about R discovery at <br><a href="https://positron.posit.co/r-installations.html">https://positron.posit.co/r-installations.html</a>'),
+				vscode.l10n.t('No usable R installations'),
+				vscode.l10n.t('All discovered R installations are unusable by Positron. Learn more about R discovery at <br><a href="https://positron.posit.co/r-installations.html">https://positron.posit.co/r-installations.html</a>'),
 				vscode.l10n.t('View logs'),
 				vscode.l10n.t('Dismiss')
 			);

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -36,23 +36,23 @@ export interface RMetadataExtra {
  * Enum represents how we discovered an R binary.
  */
 export enum ReasonDiscovered {
-	affiliated,
-	registry,
+	affiliated = "affiliated",
+	registry = "registry",
 	/* eslint-disable @typescript-eslint/naming-convention */
-	PATH,
-	HQ,
+	PATH = "PATH",
+	HQ = "HQ",
 	/* eslint-enable @typescript-eslint/naming-convention */
-	adHoc,
-	user
+	adHoc = "adHoc",
+	user = "user"
 }
 
 /**
  * Enum represents why we rejected an R binary.
  */
 export enum ReasonRejected {
-	invalid,
-	unsupported,
-	nonOrthogonal
+	invalid = "invalid",
+	unsupported = "unsupported",
+	nonOrthogonal = "nonOrthogonal"
 }
 
 export function friendlyReason(reason: ReasonDiscovered | ReasonRejected | null): string {

--- a/extensions/positron-r/src/test/discovery.test.ts
+++ b/extensions/positron-r/src/test/discovery.test.ts
@@ -66,7 +66,7 @@ suite('Discovery', () => {
 
 		test('Find R on Windows path', async () => {
 			const result = await currentRBinaryFromPATHWindows(r432);
-			assert.strictEqual(result, r432);
+			assert.strictEqual(result?.path, r432);
 		});
 	});
 
@@ -103,7 +103,7 @@ suite('Discovery', () => {
 
 		test('Find R on Windows path', async () => {
 			const result = await currentRBinaryFromPATHWindows(smartshim);
-			assert.strictEqual(result, x64);
+			assert.strictEqual(result?.path, x64);
 		});
 	});
 });

--- a/extensions/positron-r/src/test/discovery.test.ts
+++ b/extensions/positron-r/src/test/discovery.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import * as Fs from "fs"
 import * as Sinon from 'sinon';
-import { findRBinaryFromPATHWindows } from '../provider';
+import { currentRBinaryFromPATHWindows } from '../provider';
 import path = require('path');
 
 
@@ -65,7 +65,7 @@ suite('Discovery', () => {
 		});
 
 		test('Find R on Windows path', async () => {
-			const result = await findRBinaryFromPATHWindows(r432);
+			const result = await currentRBinaryFromPATHWindows(r432);
 			assert.strictEqual(result, r432);
 		});
 	});
@@ -83,7 +83,7 @@ suite('Discovery', () => {
 		});
 
 		test('Find R on Windows path', async () => {
-			const result = await findRBinaryFromPATHWindows(rbat);
+			const result = await currentRBinaryFromPATHWindows(rbat);
 			assert.strictEqual(result, undefined);
 		});
 	});
@@ -102,7 +102,7 @@ suite('Discovery', () => {
 		});
 
 		test('Find R on Windows path', async () => {
-			const result = await findRBinaryFromPATHWindows(smartshim);
+			const result = await currentRBinaryFromPATHWindows(smartshim);
 			assert.strictEqual(result, x64);
 		});
 	});

--- a/extensions/positron-r/src/util.ts
+++ b/extensions/positron-r/src/util.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fs from 'fs';
+import { LOGGER } from './extension';
 
 export class PromiseHandles<T> {
 	resolve!: (value: T | Promise<T>) => void;
@@ -42,8 +43,13 @@ export function timeout(ms: number, reason: string) {
 }
 
 export function readLines(pth: string): Array<string> {
-	const bigString = fs.readFileSync(pth, 'utf8');
-	return bigString.split(/\r?\n/);
+	try {
+		const bigString = fs.readFileSync(pth, 'utf8');
+		return bigString.split(/\r?\n/);
+	} catch (error) {
+		LOGGER.error(`Error reading file: "${error}"`);
+		return [];
+	}
 }
 
 // extractValue('KEY=VALUE', 'KEY')      --> 'VALUE'


### PR DESCRIPTION
Addresses #1397 
Addresses #5220 
Continued preparation for #5223

A lot of the changes are very internal, but there are also user-facing improvements:

* Even more effort to track the reasons (plural) why we've discovered an R installation and, perhaps, the reason an R installation can't be used with Positron. The richer information appears in the Positron R Extension output channel.
* If we discover at least one R installations, but there is no usable R installation, we put a pop-up warning. The exact details of this will be good to discuss in the next R meeting.

### QA Notes

To experience this, you need to have at least 1 unusable R installation around and 0 usable ones.

For rig-installed R, use `rig rm release` (or similar) to remove an R installation. Repeat as necessary, until all usable R is gone!

Older R installers are here for macOS arm64: https://cran.rstudio.com/bin/macosx/big-sur-arm64/base/. This makes it easy to get R 4.1, for example, which is below our minimum supported version.

You should see a modal telling you that all R installations are unusable, allowing you to look at the Positron R Extension output channel or dismiss.