### PR TITLE
Fix flakiness of new project renv test

### DIFF
--- a/test/e2e/features/new-project-wizard/new-project-r-jupyter.test.ts
+++ b/test/e2e/features/new-project-wizard/new-project-r-jupyter.test.ts
@@ -47,8 +47,7 @@ test.describe('R - New Project Wizard', () => {
 		await pw.rConfigurationStep.renvCheckbox.click();
 		await pw.navigate(ProjectWizardNavigateAction.CREATE);
 		await pw.currentOrNewWindowSelectionModal.currentWindowButton.click();
-		await app.workbench.positronLayouts.enterLayout("fullSizedSidebar");
-		await expect(app.code.driver.page.getByRole('button', { name: `Explorer Section: ${defaultProjectName + projSuffix}` })).toBeVisible({ timeout: 15000 });
+
 		// Interact with the modal to install renv
 		await app.workbench.positronPopups.installRenv();
 
@@ -64,6 +63,8 @@ test.describe('R - New Project Wizard', () => {
 		// await app.workbench.positronConsole.typeToConsole('y');
 		// await app.workbench.positronConsole.sendEnterKey();
 
+		await app.workbench.positronLayouts.enterLayout("fullSizedSidebar");
+		await expect(app.code.driver.page.getByRole('button', { name: `Explorer Section: ${defaultProjectName + projSuffix}` })).toBeVisible({ timeout: 15000 });
 		// Verify renv files are present
 		await expect(async () => {
 			const projectFiles = await app.workbench.positronExplorer.getExplorerProjectFiles();


### PR DESCRIPTION
## Intent

New project renv test occasinoally fails or is flaky

## Approach
I noticed in the fails, the popup to install was appearing before the quick input command had finished.. blocking it.
So I moved the quickinput to make the auxbar bigger after the renv install.

## QA Notes

The test passes in CI