### PR TITLE
Data Explorer: Visually distinguish column names with leading/trailing whitespace or empty string

### DIFF
--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.css
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.css
@@ -87,6 +87,14 @@
 .data-grid-column-header
 .content
 .title-description
+.title
+.whitespace {
+	opacity: 50%;
+}
+
+.data-grid-column-header
+.content
+.title-description
 .description {
 	opacity: 80%;
 	overflow: hidden;

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -17,6 +17,7 @@ import { selectionType } from '../utilities/mouseUtilities.js';
 import { VerticalSplitter } from '../../../../base/browser/ui/positronComponents/splitters/verticalSplitter.js';
 import { ColumnSelectionState } from '../classes/dataGridInstance.js';
 import { usePositronDataGridContext } from '../positronDataGridContext.js';
+import { getDisplayedColumnName } from '../../../services/positronDataExplorer/common/utils.js';
 
 /**
  * Constants.
@@ -103,6 +104,8 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 	// Determine whether the column is selected.
 	const selected = (columnSelectionState & ColumnSelectionState.Selected) !== 0;
 
+	const displayedColumnName = getDisplayedColumnName(props.column?.name);
+
 	// Render.
 	return (
 		<div
@@ -137,7 +140,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 				}}
 			>
 				<div className='title-description'>
-					<div className='title'>{props.column?.name}</div>
+					<div className='title'>{displayedColumnName}</div>
 					{props.column?.description &&
 						<div className='description'>{props.column.description}</div>
 					}

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -17,7 +17,7 @@ import { selectionType } from '../utilities/mouseUtilities.js';
 import { VerticalSplitter } from '../../../../base/browser/ui/positronComponents/splitters/verticalSplitter.js';
 import { ColumnSelectionState } from '../classes/dataGridInstance.js';
 import { usePositronDataGridContext } from '../positronDataGridContext.js';
-import { getDisplayedColumnName } from '../../../services/positronDataExplorer/common/utils.js';
+import { renderLeadingTrailingWhitespace } from '../../../services/positronDataExplorer/browser/components/tableDataCell.js';
 
 /**
  * Constants.
@@ -104,7 +104,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 	// Determine whether the column is selected.
 	const selected = (columnSelectionState & ColumnSelectionState.Selected) !== 0;
 
-	const displayedColumnName = getDisplayedColumnName(props.column?.name);
+	const renderedColumn = renderLeadingTrailingWhitespace(props.column?.name);
 
 	// Render.
 	return (
@@ -140,7 +140,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 				}}
 			>
 				<div className='title-description'>
-					<div className='title'>{displayedColumnName}</div>
+					<div className='title'>{renderedColumn}</div>
 					{props.column?.description &&
 						<div className='description'>{props.column.description}</div>
 					}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.css
@@ -91,6 +91,10 @@
 	grid-column: title / sparkline;
 }
 
+.data-grid-row-cell .content .column-summary .basic-info .column-name .whitespace {
+	opacity: 50%;
+}
+
 /* column-sparkline */
 
 .data-grid-row-cell .content .column-summary .basic-info .column-sparkline {

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -24,6 +24,7 @@ import { ColumnProfileDatetime } from './columnProfileDatetime.js';
 import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js';
 import { ColumnDisplayType, ColumnProfileType, ColumnSchema } from '../../../languageRuntime/common/positronDataExplorerComm.js';
 import { dataExplorerExperimentalFeatureEnabled } from '../../common/positronDataExplorerExperimentalConfig.js';
+import { getDisplayedColumnName } from '../../common/utils.js';
 
 /**
  * Constants.
@@ -413,7 +414,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 					onMouseLeave={() => props.hoverService.hideHover()}
 				/>
 				<div className='column-name'>
-					{props.columnSchema.column_name}
+					{getDisplayedColumnName(props.columnSchema.column_name)}
 				</div>
 				{!expanded && <ColumnSparkline />}
 				<ColumnNullPercent />

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -24,7 +24,7 @@ import { ColumnProfileDatetime } from './columnProfileDatetime.js';
 import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js';
 import { ColumnDisplayType, ColumnProfileType, ColumnSchema } from '../../../languageRuntime/common/positronDataExplorerComm.js';
 import { dataExplorerExperimentalFeatureEnabled } from '../../common/positronDataExplorerExperimentalConfig.js';
-import { getDisplayedColumnName } from '../../common/utils.js';
+import { renderLeadingTrailingWhitespace } from './tableDataCell.js';
 
 /**
  * Constants.
@@ -355,6 +355,8 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			break;
 	}
 
+	const renderedColumn = renderLeadingTrailingWhitespace(props.columnSchema.column_name);
+
 	// Determine whether this is the cursor.
 	const cursor = props.columnIndex === props.instance.cursorRowIndex;
 
@@ -414,7 +416,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 					onMouseLeave={() => props.hoverService.hideHover()}
 				/>
 				<div className='column-name'>
-					{getDisplayedColumnName(props.columnSchema.column_name)}
+					{renderedColumn}
 				</div>
 				{!expanded && <ColumnSparkline />}
 				<ColumnNullPercent />

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/tableDataCell.tsx
@@ -23,33 +23,28 @@ interface TableDataCellProps {
 	dataCell: DataCell;
 }
 
-/**
- * TableDataCell component.
- * @param props A TableDataCellProps that contains the component properties.
- * @returns The rendered component.
- */
-export const TableDataCell = (props: TableDataCellProps) => {
+export function renderLeadingTrailingWhitespace(text: string | undefined) {
+	const parts: (string | JSX.Element)[] = [];
+
+	text = text ?? '';
+
+	if (text === '') {
+		// TODO: is this what we want?
+		return [<span className='whitespace'>{'<empty>'}</span>];
+	}
+
 	const EMPTY_SPACE_SYMBOL = '\u00B7';
 
-	let isSpecialValue = props.dataCell.kind !== DataCellKind.NON_NULL;
-
-	// Render empty strings as special value
-	// Initialize rendered output parts
-	const parts: (string | JSX.Element)[] = [];
-	const formattedText = props.dataCell.formatted
-		.replace(/\r/g, '\\r')
-		.replace(/\n/g, '\\n');
-
 	// Handle text that is only whitespace
-	if (formattedText.trim() === '') {
+	if (text.trim() === '') {
 		parts.push(
 			<span className='whitespace'>
-				{EMPTY_SPACE_SYMBOL.repeat(formattedText.length)}
+				{EMPTY_SPACE_SYMBOL.repeat(text.length)}
 			</span>
 		);
 	} else {
 		// Handle leading whitespace
-		const leadingMatch = formattedText.match(/^\s+/);
+		const leadingMatch = text.match(/^\s+/);
 		if (leadingMatch) {
 			parts.push(
 				<span className='whitespace'>
@@ -59,11 +54,11 @@ export const TableDataCell = (props: TableDataCellProps) => {
 		}
 
 		// Add the main content
-		const mainContent = formattedText.trim();
+		const mainContent = text.trim();
 		parts.push(mainContent);
 
 		// Handle trailing whitespace
-		const trailingMatch = formattedText.match(/\s+$/);
+		const trailingMatch = text.match(/\s+$/);
 		if (trailingMatch) {
 			parts.push(
 				<span className='whitespace'>
@@ -72,6 +67,26 @@ export const TableDataCell = (props: TableDataCellProps) => {
 			);
 		}
 	}
+
+	return parts;
+}
+
+/**
+ * TableDataCell component.
+ * @param props A TableDataCellProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const TableDataCell = (props: TableDataCellProps) => {
+	// Render empty strings as special value
+	// Initialize rendered output parts
+	const formattedText = props.dataCell.formatted
+		.replace(/\r/g, '\\r')
+		.replace(/\n/g, '\\n');
+
+	const parts = renderLeadingTrailingWhitespace(formattedText);
+
+	let isSpecialValue = props.dataCell.kind !== DataCellKind.NON_NULL;
+
 	let renderedOutput = parts;
 	if (props.dataCell.kind === DataCellKind.NON_NULL && formattedText === '') {
 		isSpecialValue = true;

--- a/src/vs/workbench/services/positronDataExplorer/common/utils.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/utils.ts
@@ -29,3 +29,21 @@ export const arrayFromIndexRange = (startIndex: number, endIndex: number) =>
  */
 export const linearConversion = (value: number, from: Range, to: Range) =>
 	((value - from.min) / (from.max - from.min)) * (to.max - to.min) + to.min;
+
+
+/**
+ * Add quoting to column name in case it is an empty string or contains leading whitespace.
+ * @param name The column name from the backend
+ * @returns A modified column name that helps distinguish whitespace
+ */
+export function getDisplayedColumnName(name: string | undefined) {
+	let result = name ?? '';
+
+	const EMPTY_SPACE_SYMBOL = '\u2423';
+	// If a column name is an empty string (allowed by pandas, at least) or contains
+	// leading whitespace, then we surround the column name with quotations.
+	if (result === '' || result.match(/^\s/)) {
+		result = `"${result}"`.replace(/ /g, EMPTY_SPACE_SYMBOL);
+	}
+	return result;
+}

--- a/src/vs/workbench/services/positronDataExplorer/common/utils.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/utils.ts
@@ -29,4 +29,3 @@ export const arrayFromIndexRange = (startIndex: number, endIndex: number) =>
  */
 export const linearConversion = (value: number, from: Range, to: Range) =>
 	((value - from.min) / (from.max - from.min)) * (to.max - to.min) + to.min;
-

--- a/src/vs/workbench/services/positronDataExplorer/common/utils.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/utils.ts
@@ -30,20 +30,3 @@ export const arrayFromIndexRange = (startIndex: number, endIndex: number) =>
 export const linearConversion = (value: number, from: Range, to: Range) =>
 	((value - from.min) / (from.max - from.min)) * (to.max - to.min) + to.min;
 
-
-/**
- * Add quoting to column name in case it is an empty string or contains leading whitespace.
- * @param name The column name from the backend
- * @returns A modified column name that helps distinguish whitespace
- */
-export function getDisplayedColumnName(name: string | undefined) {
-	let result = name ?? '';
-
-	const EMPTY_SPACE_SYMBOL = '\u2423';
-	// If a column name is an empty string (allowed by pandas, at least) or contains
-	// leading whitespace, then we surround the column name with quotations.
-	if (result === '' || result.match(/^\s/)) {
-		result = `"${result}"`.replace(/ /g, EMPTY_SPACE_SYMBOL);
-	}
-	return result;
-}


### PR DESCRIPTION
Aims to address #3084, #3089. Related to #5652, we also cannot distinguish empty strings or strings with leading whitespace in column names both in the data grid headers and the summary panel. 

This PR applies the same approach we used for data cells to format column names in the grid headers and the summary pane. The appearance is could potentially be a bit odd because we use non-fixed-width fonts.

![image](https://github.com/user-attachments/assets/a6e8bfe1-04c8-445c-9159-f2d185e830b4)

e2e: @:data-explorer