### PR TITLE
Data Explorer: When a table has row labels, do not return an incorrect row label while RPC is pending

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/common/tableDataCache.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/tableDataCache.ts
@@ -149,6 +149,11 @@ export class TableDataCache extends Disposable {
 	private _rows = 0;
 
 	/**
+	 * Flag if table has row labels
+	 */
+	private _hasRowLabels = false;
+
+	/**
 	 * Gets or sets the width calculators.
 	 */
 	private _widthCalculators?: WidthCalculators;
@@ -376,6 +381,7 @@ export class TableDataCache extends Disposable {
 		const tableState = await this._dataExplorerClientInstance.getBackendState();
 		this._columns = tableState.table_shape.num_columns;
 		this._rows = tableState.table_shape.num_rows;
+		this._hasRowLabels = tableState.has_row_labels;
 
 		// Set the start column index and the end column index of the columns to cache.
 		const overscanColumns = screenColumns * OVERSCAN_FACTOR;
@@ -673,7 +679,11 @@ export class TableDataCache extends Disposable {
 	 * @returns The row label for the specified column index.
 	 */
 	getRowLabel(rowIndex: number) {
-		return this._rowLabelCache.get(rowIndex) ?? `${rowIndex}`;
+		if (this._hasRowLabels) {
+			return this._rowLabelCache.get(rowIndex) ?? `...`;
+		} else {
+			return `${rowIndex}`;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Addresses issue described in #5230. When the row label cache has not been updated yet (the backend getRowLabels RPC is pending), the data cache was falling back on returning the row index, causing the row label to appear to be temporarily wrong. There are videos in #5230 showing exactly this.

Now the string `...` is showed momentarily to indicate that the row labels are still loading. This seems less misleading:

https://github.com/user-attachments/assets/be14c456-ab0a-42b1-8027-ec4624b24e90