### PR TITLE
Data Explorer: Retry positron-duckdb.dataExplorerRpc if it has not been registered yet

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
@@ -118,7 +118,7 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 		const commandName = 'positron-duckdb.dataExplorerRpc';
 		if (CommandsRegistry.getCommand(commandName) === undefined) {
 			await (new Promise<void>((resolve, reject) => {
-				// Set up the timeout
+				// Reject if command not registered within 30 seconds
 				const timeoutId = setTimeout(() => {
 					reject(new Error(`${commandName} not registered within 30 seconds`));
 				}, 30000);

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerDuckDBBackend.ts
@@ -38,8 +38,7 @@ import {
 	TableSchema,
 	TableSelection
 } from 'vs/workbench/services/languageRuntime/common/positronDataExplorerComm';
-import { ICommandService } from 'vs/platform/commands/common/commands';
-
+import { ICommandService, CommandsRegistry } from 'vs/platform/commands/common/commands';
 
 /**
  * Descriptor for backend method invocation in via extension command.
@@ -116,39 +115,34 @@ export class PositronDataExplorerDuckDBBackend extends Disposable implements IDa
 	private async _execRpc<Type>(rpc: DataExplorerRpc): Promise<Type> {
 		await this.initialSetup;
 
-		// Wait for command to become available (retry up to 30 times with 1 second delay)
-		const maxRetries = 30;
-		const retryDelay = 1000;
+		const commandName = 'positron-duckdb.dataExplorerRpc';
+		if (CommandsRegistry.getCommand(commandName) === undefined) {
+			await (new Promise<void>((resolve, reject) => {
+				// Set up the timeout
+				const timeoutId = setTimeout(() => {
+					reject(new Error(`${commandName} not registered within 30 seconds`));
+				}, 30000);
 
-		for (let i = 0; i < maxRetries; i++) {
-			try {
-				const response = await this._commandService.executeCommand(
-					'positron-duckdb.dataExplorerRpc', rpc
-				);
-
-				if (response === undefined) {
-					return Promise.reject(
-						new Error('Sending request to positron-duckdb failed for unknown reason')
-					);
-				} else if ('error_message' in response) {
-					return Promise.reject(new Error(response.error_message));
-				} else {
-					return response.result;
-				}
-			} catch (error) {
-				if (error.message?.includes('command \'positron-duckdb.dataExplorerRpc\' not found')) {
-					if (i === maxRetries - 1) {
-						return Promise.reject(new Error('Timeout waiting for positron-duckdb extension to load'));
+				CommandsRegistry.onDidRegisterCommand((id: string) => {
+					if (id === commandName) {
+						clearTimeout(timeoutId);
+						resolve();
 					}
-					await new Promise(resolve => setTimeout(resolve, retryDelay));
-					continue;
-				}
-				throw error; // Re-throw if it's a different kind of error
-			}
+				});
+			}));
 		}
 
-		// This should never be reached due to the rejection in the loop
-		return Promise.reject(new Error('Unexpected error waiting for positron-duckdb extension'));
+		const response = await this._commandService.executeCommand(commandName, rpc);
+
+		if (response === undefined) {
+			return Promise.reject(
+				new Error('Sending request to positron-duckdb failed for unknown reason')
+			);
+		} else if ('error_message' in response) {
+			return Promise.reject(new Error(response.error_message));
+		} else {
+			return response.result;
+		}
 	}
 
 	async openDataset() {


### PR DESCRIPTION
Addresses #5655. Currently if you click on a data file while Positron is loading, it will open a broken data explorer. This awaits the command becoming available using the CommandsRegistry events and fails after 30 seconds if the command is not registered at that point.

https://github.com/user-attachments/assets/07460b8b-ef06-4c75-9b47-d93562e7690d
