### PR TITLE
Bump ark to 0.1.158

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -686,7 +686,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.157"
+      "ark": "0.1.158"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
Waiting on https://github.com/posit-dev/ark/actions/runs/12239460144

- https://github.com/posit-dev/ark/pull/642
- https://github.com/posit-dev/ark/pull/638

### Positron Release Notes

#### New Features

- N/A

#### Bug Fixes

- `Cmd/Ctrl + Enter` now works as expected with expressions separated by semi-colons on a single line.
   https://github.com/posit-dev/positron/issues/4317
