### PR TITLE
Refactor file/folder creation modals to be more platform-aware

### DIFF
--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -133,6 +133,7 @@ export class PositronNewFolderAction extends Action2 {
 			accessor.get(IKeybindingService),
 			accessor.get(ILabelService),
 			accessor.get(IWorkbenchLayoutService),
+			accessor.get(IPathService),
 		);
 	}
 }
@@ -184,6 +185,7 @@ export class PositronNewFolderFromGitAction extends Action2 {
 			accessor.get(IKeybindingService),
 			accessor.get(ILabelService),
 			accessor.get(IWorkbenchLayoutService),
+			accessor.get(IPathService),
 		);
 	}
 }

--- a/src/vs/workbench/browser/actions/positronActions.ts
+++ b/src/vs/workbench/browser/actions/positronActions.ts
@@ -27,6 +27,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IPositronNewProjectService } from 'vs/workbench/services/positronNewProject/common/positronNewProject';
 import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
+import { ILabelService } from 'vs/platform/label/common/label';
 
 /**
  * The PositronNewProjectAction.
@@ -74,6 +75,7 @@ export class PositronNewProjectAction extends Action2 {
 			accessor.get(IFileDialogService),
 			accessor.get(IFileService),
 			accessor.get(IKeybindingService),
+			accessor.get(ILabelService),
 			accessor.get(ILanguageRuntimeService),
 			accessor.get(IWorkbenchLayoutService),
 			accessor.get(ILogService),
@@ -82,7 +84,7 @@ export class PositronNewProjectAction extends Action2 {
 			accessor.get(IPositronNewProjectService),
 			accessor.get(IRuntimeSessionService),
 			accessor.get(IRuntimeStartupService),
-			accessor.get(IWorkspaceTrustManagementService)
+			accessor.get(IWorkspaceTrustManagementService),
 		);
 	}
 }
@@ -129,6 +131,7 @@ export class PositronNewFolderAction extends Action2 {
 			accessor.get(IFileDialogService),
 			accessor.get(IFileService),
 			accessor.get(IKeybindingService),
+			accessor.get(ILabelService),
 			accessor.get(IWorkbenchLayoutService),
 		);
 	}
@@ -179,6 +182,7 @@ export class PositronNewFolderFromGitAction extends Action2 {
 			accessor.get(IConfigurationService),
 			accessor.get(IFileDialogService),
 			accessor.get(IKeybindingService),
+			accessor.get(ILabelService),
 			accessor.get(IWorkbenchLayoutService),
 		);
 	}

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
@@ -68,11 +68,17 @@ export const showNewFolderFromGitModalDialog = async (
 						kGitOpenAfterClone,
 						result.newWindow ? 'alwaysNewWindow' : 'always'
 					);
+					// The Git clone command works with a path string instead of a URI. We need to
+					// convert the folder URI to an OS-aware path string using the label service.
+					const parentFolder = labelService.getUriLabel(
+						result.parentFolder,
+						{ noPrefix: true }
+					);
 					try {
 						await commandService.executeCommand(
 							'git.clone',
 							result.repo,
-							result.parentFolder.fsPath
+							parentFolder
 						);
 					} finally {
 						configurationService.updateValue(kGitOpenAfterClone, prevOpenAfterClone);

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
@@ -207,7 +207,7 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 					))()}
 					value={parentFolderLabel}
 					onBrowse={browseHandler}
-					onChange={async (e) => onChangeParentFolder(e.target.value)}
+					onChange={e => onChangeParentFolder(e.target.value)}
 				/>
 			</VerticalStack>
 			<VerticalSpacer>

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
@@ -124,6 +124,9 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 	const folderNameRef = useRef<HTMLInputElement>(undefined!);
 
 	// State hooks.
+	const [parentFolderLabel, setParentFolderLabel] = useState(
+		() => pathUriToLabel(props.parentFolder, props.labelService)
+	);
 	const [result, setResult] = useState<NewFolderFromGitResult>({
 		repo: '',
 		parentFolder: props.parentFolder,
@@ -132,18 +135,38 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 
 	// The browse handler.
 	const browseHandler = async () => {
+		// Construct the parent folder URI.
+		const parentFolderUri = await combineLabelWithPathUri(
+			parentFolderLabel,
+			props.parentFolder,
+			props.pathService
+		);
+
 		// Show the open dialog.
 		const uri = await props.fileDialogService.showOpenDialog({
-			defaultUri: result.parentFolder ? result.parentFolder : await props.fileDialogService.defaultFolderPath(),
+			defaultUri: parentFolderUri,
 			canSelectFiles: false,
 			canSelectFolders: true
 		});
 
 		// If the user made a selection, set the parent directory.
 		if (uri?.length) {
+			const pathLabel = pathUriToLabel(uri[0], props.labelService);
+			setParentFolderLabel(pathLabel);
 			setResult({ ...result, parentFolder: uri[0] });
 			folderNameRef.current.focus();
 		}
+	};
+
+	// Update the parent folder.
+	const onChangeParentFolder = async (folder: string) => {
+		setParentFolderLabel(folder);
+		const parentFolderUri = await combineLabelWithPathUri(
+			folder,
+			props.parentFolder,
+			props.pathService
+		);
+		setResult({ ...result, parentFolder: parentFolderUri });
 	};
 
 	// Render.
@@ -182,16 +205,9 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 						'positron.createFolderAsSubfolderOf',
 						"Create folder as subfolder of"
 					))()}
-					value={pathUriToLabel(result.parentFolder, props.labelService)}
+					value={parentFolderLabel}
 					onBrowse={browseHandler}
-					onChange={async (e) => setResult({
-						...result,
-						parentFolder: await combineLabelWithPathUri(
-							e.target.value,
-							result.parentFolder,
-							props.pathService
-						)
-					})}
+					onChange={async (e) => onChangeParentFolder(e.target.value)}
 				/>
 			</VerticalStack>
 			<VerticalSpacer>

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
@@ -171,7 +171,7 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 						'positron.createFolderAsSubfolderOf',
 						"Create folder as subfolder of"
 					))()}
-					value={props.labelService.getUriLabel(result.parentFolder)}
+					value={props.labelService.getUriLabel(result.parentFolder, { noPrefix: true })}
 					onBrowse={browseHandler}
 					onChange={e => setResult({ ...result, parentFolder: result.parentFolder.with({ path: e.target.value }) })}
 				/>

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
@@ -26,6 +26,7 @@ import { LabeledTextInput } from 'vs/workbench/browser/positronComponents/positr
 import { OKCancelModalDialog } from 'vs/workbench/browser/positronComponents/positronModalDialog/positronOKCancelModalDialog';
 import { LabeledFolderInput } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/labeledFolderInput';
 import { isInputEmpty } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators';
+import { ILabelService } from 'vs/platform/label/common/label';
 
 /**
  * Shows the new folder from Git modal dialog.
@@ -40,6 +41,7 @@ export const showNewFolderFromGitModalDialog = async (
 	configurationService: IConfigurationService,
 	fileDialogService: IFileDialogService,
 	keybindingService: IKeybindingService,
+	labelService: ILabelService,
 	layoutService: IWorkbenchLayoutService,
 ): Promise<void> => {
 	// Create the renderer.
@@ -53,6 +55,7 @@ export const showNewFolderFromGitModalDialog = async (
 	renderer.render(
 		<NewFolderFromGitModalDialog
 			fileDialogService={fileDialogService}
+			labelService={labelService}
 			renderer={renderer}
 			parentFolder={await fileDialogService.defaultFolderPath()}
 			createFolder={async result => {
@@ -94,6 +97,7 @@ interface NewFolderFromGitResult {
  */
 interface NewFolderFromGitModalDialogProps {
 	fileDialogService: IFileDialogService;
+	labelService: ILabelService;
 	renderer: PositronModalReactRenderer;
 	parentFolder: URI;
 	createFolder: (result: NewFolderFromGitResult) => Promise<void>;
@@ -167,7 +171,7 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 						'positron.createFolderAsSubfolderOf',
 						"Create folder as subfolder of"
 					))()}
-					value={result.parentFolder.fsPath}
+					value={props.labelService.getUriLabel(result.parentFolder)}
 					onBrowse={browseHandler}
 					onChange={e => setResult({ ...result, parentFolder: result.parentFolder.with({ path: e.target.value }) })}
 				/>

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
@@ -26,7 +26,6 @@ import { LabeledTextInput } from 'vs/workbench/browser/positronComponents/positr
 import { OKCancelModalDialog } from 'vs/workbench/browser/positronComponents/positronModalDialog/positronOKCancelModalDialog';
 import { LabeledFolderInput } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/labeledFolderInput';
 import { checkIfPathValid, isInputEmpty } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators';
-import { normalizePath } from 'vs/base/common/resources';
 import { ILabelService } from 'vs/platform/label/common/label';
 
 /**
@@ -52,18 +51,13 @@ export const showNewFolderModalDialog = async (
 		container: layoutService.activeContainer
 	});
 
-	// Construct the parentFolder URI, normalized to the correct format, whether running in Desktop,
-	// Web and/or remotely.
-	const defaultFolder = await fileDialogService.defaultFolderPath();
-	const parentFolder = normalizePath(defaultFolder);
-
 	// Show the new folder modal dialog.
 	renderer.render(
 		<NewFolderModalDialog
 			fileDialogService={fileDialogService}
 			labelService={labelService}
 			renderer={renderer}
-			parentFolder={parentFolder}
+			parentFolder={await fileDialogService.defaultFolderPath()}
 			createFolder={async result => {
 				// Create the folder path.
 				const folderURI = URI.joinPath(result.parentFolder, result.folder);

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
@@ -26,6 +26,8 @@ import { LabeledTextInput } from 'vs/workbench/browser/positronComponents/positr
 import { OKCancelModalDialog } from 'vs/workbench/browser/positronComponents/positronModalDialog/positronOKCancelModalDialog';
 import { LabeledFolderInput } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/labeledFolderInput';
 import { checkIfPathValid, isInputEmpty } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators';
+import { normalizePath } from 'vs/base/common/resources';
+import { ILabelService } from 'vs/platform/label/common/label';
 
 /**
  * Shows the new folder modal dialog.
@@ -40,6 +42,7 @@ export const showNewFolderModalDialog = async (
 	fileDialogService: IFileDialogService,
 	fileService: IFileService,
 	keybindingService: IKeybindingService,
+	labelService: ILabelService,
 	layoutService: IWorkbenchLayoutService,
 ): Promise<void> => {
 	// Create the renderer.
@@ -49,12 +52,18 @@ export const showNewFolderModalDialog = async (
 		container: layoutService.activeContainer
 	});
 
+	// Construct the parentFolder URI, normalized to the correct format, whether running in Desktop,
+	// Web and/or remotely.
+	const defaultFolder = await fileDialogService.defaultFolderPath();
+	const parentFolder = normalizePath(defaultFolder);
+
 	// Show the new folder modal dialog.
 	renderer.render(
 		<NewFolderModalDialog
 			fileDialogService={fileDialogService}
+			labelService={labelService}
 			renderer={renderer}
-			parentFolder={await fileDialogService.defaultFolderPath()}
+			parentFolder={parentFolder}
 			createFolder={async result => {
 				// Create the folder path.
 				const folderURI = URI.joinPath(result.parentFolder, result.folder);
@@ -92,6 +101,7 @@ interface NewFolderResult {
  */
 interface NewFolderModalDialogProps {
 	fileDialogService: IFileDialogService;
+	labelService: ILabelService;
 	renderer: PositronModalReactRenderer;
 	parentFolder: URI;
 	createFolder: (result: NewFolderResult) => Promise<void>;
@@ -159,7 +169,7 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 						'positron.createFolderAsSubfolderOf',
 						"Create folder as subfolder of"
 					))()}
-					value={result.parentFolder.fsPath}
+					value={props.labelService.getUriLabel(result.parentFolder)}
 					onBrowse={browseHandler}
 					onChange={e => setResult({ ...result, parentFolder: result.parentFolder.with({ path: e.target.value }) })}
 				/>

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
@@ -169,7 +169,7 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 						'positron.createFolderAsSubfolderOf',
 						"Create folder as subfolder of"
 					))()}
-					value={props.labelService.getUriLabel(result.parentFolder)}
+					value={props.labelService.getUriLabel(result.parentFolder, { noPrefix: true })}
 					onBrowse={browseHandler}
 					onChange={e => setResult({ ...result, parentFolder: result.parentFolder.with({ path: e.target.value }) })}
 				/>

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -219,7 +219,7 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 							'projectNameLocationSubStep.parentDirectory.description',
 							"Select a directory to create your project in"
 						))()}
-					value={labelService.getUriLabel(parentFolder)}
+					value={labelService.getUriLabel(parentFolder, { noPrefix: true })}
 					onBrowse={browseHandler}
 					error={Boolean(parentPathErrorMsg)}
 					skipValidation

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -25,6 +25,7 @@ import { NewProjectType } from 'vs/workbench/services/positronNewProject/common/
 import { checkIfPathValid, checkIfURIExists } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/fileInputValidators';
 import { PathDisplay } from 'vs/workbench/browser/positronNewProjectWizard/components/pathDisplay';
 import { useDebouncedValidator } from 'vs/workbench/browser/positronComponents/positronModalDialog/components/useDebouncedValidator';
+import { combineLabelWithPathUri, pathUriToLabel } from 'vs/workbench/browser/utils/path';
 
 /**
  * The ProjectNameLocationStep component is the second step in the new project wizard.
@@ -229,11 +230,13 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 							'projectNameLocationSubStep.parentDirectory.description',
 							"Select a directory to create your project in"
 						))()}
-					value={labelService.getUriLabel(parentFolder, { noPrefix: true })}
+					value={pathUriToLabel(parentFolder, labelService)}
 					onBrowse={browseHandler}
 					error={Boolean(parentPathErrorMsg)}
 					skipValidation
-					onChange={(e) => onChangeParentFolder(parentFolder.with({ path: e.target.value }))}
+					onChange={async (e) => onChangeParentFolder(
+						await combineLabelWithPathUri(e.target.value, parentFolder, pathService)
+					)}
 				/>
 			</PositronWizardSubStep>
 			<PositronWizardSubStep

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -36,7 +36,7 @@ import { useDebouncedValidator } from 'vs/workbench/browser/positronComponents/p
 export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizardStepProps>) => {
 	// State.
 	const context = useNewProjectWizardContext();
-	const { fileDialogService, fileService, logService, pathService } = context.services;
+	const { fileDialogService, fileService, labelService, logService, pathService } = context.services;
 
 	// Hooks.
 	const [projectName, setProjectName] = useState(context.projectName);
@@ -219,7 +219,7 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 							'projectNameLocationSubStep.parentDirectory.description',
 							"Select a directory to create your project in"
 						))()}
-					value={parentFolder.fsPath}
+					value={labelService.getUriLabel(parentFolder)}
 					onBrowse={browseHandler}
 					error={Boolean(parentPathErrorMsg)}
 					skipValidation

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -93,7 +93,6 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 		context.projectNameFeedback = await checkProjectName(
 			name,
 			parentFolder,
-			pathService,
 			fileService
 		);
 	};
@@ -104,7 +103,6 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 		context.projectNameFeedback = await checkProjectName(
 			projectName,
 			folder,
-			pathService,
 			fileService
 		);
 	};

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -207,7 +207,10 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 									"Your project will be created at: "
 								))()}
 							<PathDisplay
-								pathComponents={[parentFolder.fsPath, projectName]}
+								pathComponents={[
+									labelService.getUriLabel(parentFolder, { noPrefix: true }),
+									projectName
+								]}
 								pathService={pathService}
 							/>
 						</WizardFormattedText>

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -259,7 +259,7 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 					onBrowse={browseHandler}
 					error={Boolean(parentPathErrorMsg)}
 					skipValidation
-					onChange={async (e) => onChangeParentFolder(e.target.value)}
+					onChange={(e) => onChangeParentFolder(e.target.value)}
 				/>
 			</PositronWizardSubStep>
 			<PositronWizardSubStep

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -70,6 +70,7 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 			setProjectName(context.projectName);
 			setProjectNameFeedback(context.projectNameFeedback);
 			setMaxProjectPathLength(() => getMaxProjectPathLength(context.parentFolder.path.length));
+			// The parent folder state is local to this component, so we don't update it here.
 		}));
 
 		// Return the cleanup function that will dispose of the event handlers.
@@ -117,7 +118,11 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 
 	// Update the parent folder and the project name feedback.
 	const onChangeParentFolder = async (folder: string) => {
+		// Update the parent folder component state. The parent folder URI will be updated in the
+		// project wizard context when the user navigates to the next step.
 		setParentFolder(folder);
+
+		// Check that the project name is still valid.
 		const parentFolderUri = await combineLabelWithPathUri(
 			folder,
 			context.parentFolder,
@@ -132,7 +137,12 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 
 	// Navigate to the next step in the wizard, based on the selected project type.
 	const nextStep = async () => {
-		context.parentFolder = await combineLabelWithPathUri(parentFolder, context.parentFolder, pathService)
+		// Update the parent folder URI in the context before navigating to the next step.
+		context.parentFolder = await combineLabelWithPathUri(
+			parentFolder,
+			context.parentFolder,
+			pathService
+		);
 
 		switch (context.projectType) {
 			case NewProjectType.RProject:

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectTypeStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectTypeStep.tsx
@@ -56,7 +56,6 @@ export const ProjectTypeStep = (props: PropsWithChildren<NewProjectWizardStepPro
 			context.projectNameFeedback = await checkProjectName(
 				defaultProjectName,
 				context.parentFolder,
-				context.services.pathService,
 				context.services.fileService
 			);
 		}

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -123,6 +123,7 @@ export const showNewProjectModalDialog = async (
 					// Create the new project configuration.
 					const newProjectConfig: NewProjectConfiguration = {
 						folderScheme: folder.scheme,
+						folderAuthority: folder.authority,
 						runtimeMetadata: result.selectedRuntime || undefined,
 						projectType: result.projectType || '',
 						projectFolder: folder.path,

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -30,6 +30,7 @@ import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/w
 import { showChooseNewProjectWindowModalDialog } from 'vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { URI } from 'vs/base/common/uri';
+import { ILabelService } from 'vs/platform/label/common/label';
 
 /**
  * Shows the NewProjectModalDialog.
@@ -40,6 +41,7 @@ export const showNewProjectModalDialog = async (
 	fileDialogService: IFileDialogService,
 	fileService: IFileService,
 	keybindingService: IKeybindingService,
+	labelService: ILabelService,
 	languageRuntimeService: ILanguageRuntimeService,
 	layoutService: IWorkbenchLayoutService,
 	logService: ILogService,
@@ -48,7 +50,7 @@ export const showNewProjectModalDialog = async (
 	positronNewProjectService: IPositronNewProjectService,
 	runtimeSessionService: IRuntimeSessionService,
 	runtimeStartupService: IRuntimeStartupService,
-	workspaceTrustManagementService: IWorkspaceTrustManagementService
+	workspaceTrustManagementService: IWorkspaceTrustManagementService,
 ): Promise<void> => {
 	// Create the renderer.
 	const renderer = new PositronModalReactRenderer({
@@ -66,6 +68,7 @@ export const showNewProjectModalDialog = async (
 				fileDialogService,
 				fileService,
 				keybindingService,
+				labelService,
 				languageRuntimeService,
 				layoutService,
 				logService,

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -121,11 +121,12 @@ export const showNewProjectModalDialog = async (
 					}
 
 					// Create the new project configuration.
+					const folderPath = labelService.getUriLabel(folder, { noPrefix: true });
 					const newProjectConfig: NewProjectConfiguration = {
 						folderScheme: folder.scheme,
 						runtimeMetadata: result.selectedRuntime || undefined,
 						projectType: result.projectType || '',
-						projectFolder: folder.fsPath,
+						projectFolder: folderPath,
 						projectName: result.projectName,
 						initGitRepo: result.initGitRepo,
 						pythonEnvProviderId: result.pythonEnvProviderId,

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -121,12 +121,11 @@ export const showNewProjectModalDialog = async (
 					}
 
 					// Create the new project configuration.
-					const folderPath = labelService.getUriLabel(folder, { noPrefix: true });
 					const newProjectConfig: NewProjectConfiguration = {
 						folderScheme: folder.scheme,
 						runtimeMetadata: result.selectedRuntime || undefined,
 						projectType: result.projectType || '',
-						projectFolder: folderPath,
+						projectFolder: folder.path,
 						projectName: result.projectName,
 						initGitRepo: result.initGitRepo,
 						pythonEnvProviderId: result.pythonEnvProviderId,

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardState.ts
@@ -24,6 +24,7 @@ import { LanguageIds, NewProjectType } from 'vs/workbench/services/positronNewPr
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { CondaPythonVersionInfo, EMPTY_CONDA_PYTHON_VERSION_INFO } from 'vs/workbench/browser/positronNewProjectWizard/utilities/condaUtils';
 import { URI } from 'vs/base/common/uri';
+import { ILabelService } from 'vs/platform/label/common/label';
 
 /**
  * NewProjectWizardServices interface.
@@ -35,6 +36,7 @@ interface NewProjectWizardServices {
 	readonly fileDialogService: IFileDialogService;
 	readonly fileService: IFileService;
 	readonly keybindingService: IKeybindingService;
+	readonly labelService: ILabelService;
 	readonly languageRuntimeService: ILanguageRuntimeService;
 	readonly layoutService: IWorkbenchLayoutService;
 	readonly logService: ILogService;

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils.ts
@@ -7,7 +7,6 @@ import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { IFileService } from 'vs/platform/files/common/files';
 import { WizardFormattedTextType } from 'vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText';
-import { IPathService } from 'vs/workbench/services/path/common/pathService';
 
 /**
  * Checks the project name to ensure it is valid.
@@ -20,7 +19,6 @@ import { IPathService } from 'vs/workbench/services/path/common/pathService';
 export const checkProjectName = async (
 	projectName: string,
 	parentFolder: URI,
-	pathService: IPathService,
 	fileService: IFileService
 ) => {
 	// The project name can't be empty.
@@ -37,10 +35,7 @@ export const checkProjectName = async (
 	// TODO: Additional project name validation (i.e. unsupported characters, length, etc.)
 
 	// The project directory can't already exist.
-	const pathBuilder = await pathService.path;
-	const folderPath = parentFolder.with({
-		path: pathBuilder.join(parentFolder.path, projectName)
-	});
+	const folderPath = URI.joinPath(parentFolder, projectName);
 	if (await fileService.exists(folderPath)) {
 		return {
 			type: WizardFormattedTextType.Error,

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils.ts
@@ -37,7 +37,10 @@ export const checkProjectName = async (
 	// TODO: Additional project name validation (i.e. unsupported characters, length, etc.)
 
 	// The project directory can't already exist.
-	const folderPath = parentFolder.with({ path: (await pathService.path).join(parentFolder.fsPath, projectName) });
+	const pathBuilder = await pathService.path;
+	const folderPath = parentFolder.with({
+		path: pathBuilder.join(parentFolder.path, projectName)
+	});
 	if (await fileService.exists(folderPath)) {
 		return {
 			type: WizardFormattedTextType.Error,

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils.ts
@@ -9,6 +9,12 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { WizardFormattedTextType } from 'vs/workbench/browser/positronNewProjectWizard/components/wizardFormattedText';
 
 /**
+ * The maximum length of a project path, which is the full path when joining a parent folder with
+ * the project name.
+ */
+export const MAX_LENGTH_PROJECT_PATH = 255;
+
+/**
  * Checks the project name to ensure it is valid.
  * @param projectName The project name to check.
  * @param parentFolder The parent folder of the project.

--- a/src/vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils.ts
+++ b/src/vs/workbench/browser/positronNewProjectWizard/utilities/projectNameUtils.ts
@@ -12,7 +12,15 @@ import { WizardFormattedTextType } from 'vs/workbench/browser/positronNewProject
  * The maximum length of a project path, which is the full path when joining a parent folder with
  * the project name.
  */
-export const MAX_LENGTH_PROJECT_PATH = 255;
+const MAX_LENGTH_PROJECT_PATH = 255;
+
+/**
+ * Calculates the maximum length of a project name based on the maximum length of a project path and
+ * the length of the parent folder path.
+ * @param parentFolderLength The length of the parent folder path string.
+ * @returns The maximum length of a project name.
+ */
+export const getMaxProjectPathLength = (parentFolderLength: number) => MAX_LENGTH_PROJECT_PATH + 1 - parentFolderLength;
 
 /**
  * Checks the project name to ensure it is valid.

--- a/src/vs/workbench/browser/utils/path.ts
+++ b/src/vs/workbench/browser/utils/path.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from 'vs/base/common/uri';
+import { ILabelService } from 'vs/platform/label/common/label';
+import { IPathService } from 'vs/workbench/services/path/common/pathService';
+
+/**
+ * Converts a URI path to a label, with awareness of the operating system that the positron server
+ * is running on. The path is formatted according to the platform on which the server is running,
+ * which will be the platform that the path exists on.
+ * @param path The URI path to convert to a label.
+ * @param labelService The label service.
+ * @returns The label.
+ */
+export const pathUriToLabel = (path: URI, labelService: ILabelService): string => {
+	return labelService.getUriLabel(path, { noPrefix: true });
+};
+
+/**
+ * Combines a label with a URI path, ensuring that the label is not empty and that the URI path
+ * has a leading slash if it has an authority.
+ * @param label The label to combine with the URI path. This string is expected to have been created
+ * via the label service.
+ * @param uri The URI to combine with the label.
+ * @param pathService The path service.
+ * @returns A promise that resolves to the combined URI.
+ */
+export const combineLabelWithPathUri = async (
+	label: string,
+	uri: URI,
+	pathService: IPathService
+): Promise<URI> => {
+	let labelUpdated = label.trim();
+
+	// If the label is empty, return the original URI
+	if (labelUpdated === '') {
+		return uri;
+	}
+
+	// URIs with authority need to have a path with a leading slash
+	if (uri.authority) {
+		const pathBuilder = await pathService.path;
+		if (!labelUpdated.startsWith(pathBuilder.sep)) {
+			labelUpdated = pathBuilder.sep + labelUpdated;
+		}
+	}
+	return uri.with({ path: labelUpdated });
+};

--- a/src/vs/workbench/browser/utils/path.ts
+++ b/src/vs/workbench/browser/utils/path.ts
@@ -35,7 +35,7 @@ export const combineLabelWithPathUri = async (
 ): Promise<URI> => {
 	let labelUpdated = label.trim();
 
-	// If the label is empty, return the original URI
+	// If the label is empty, return the original URI with the path cleared.
 	if (labelUpdated === '') {
 		return uri.with({ path: '' });
 	}

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -31,6 +31,7 @@ import { PlotSizingPolicyIntrinsic } from 'vs/workbench/services/positronPlots/c
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IRenderedPlot } from 'vs/workbench/services/languageRuntime/common/positronPlotCommProxy';
 import { IPositronModalDialogsService } from 'vs/workbench/services/positronModalDialogs/common/positronModalDialogs';
+import { ILabelService } from 'vs/platform/label/common/label';
 
 export interface SavePlotOptions {
 	uri: string;
@@ -64,6 +65,7 @@ export const showSavePlotModalDialog = (
 	fileDialogService: IFileDialogService,
 	logService: ILogService,
 	notificationService: INotificationService,
+	labelService: ILabelService,
 	plotClient: PlotClientInstance,
 	savePlotCallback: (options: SavePlotOptions) => void,
 	suggestedPath?: URI,
@@ -84,6 +86,7 @@ export const showSavePlotModalDialog = (
 			keybindingService={keybindingService}
 			logService={logService}
 			notificationService={notificationService}
+			labelService={labelService}
 			renderer={renderer}
 			enableIntrinsicSize={selectedSizingPolicy instanceof PlotSizingPolicyIntrinsic}
 			plotSize={plotClient.lastRender?.size}
@@ -103,6 +106,7 @@ interface SavePlotModalDialogProps {
 	logService: ILogService;
 	notificationService: INotificationService;
 	keybindingService: IKeybindingService;
+	labelService: ILabelService;
 	renderer: PositronModalReactRenderer;
 	enableIntrinsicSize: boolean;
 	plotSize: IPlotSize | undefined;
@@ -300,7 +304,7 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 									'positron.savePlotModalDialog.directory',
 									"Directory"
 								))()}
-								value={directory.value.fsPath}
+								value={props.labelService.getUriLabel(directory.value, { noPrefix: true })}
 								onChange={e => updatePath(directory.value.with({ path: e.target.value }))}
 								onBrowse={browseHandler}
 								readOnlyInput={false}

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -48,6 +48,7 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { URI } from 'vs/base/common/uri';
 import { PositronPlotCommProxy } from 'vs/workbench/services/languageRuntime/common/positronPlotCommProxy';
 import { IPositronModalDialogsService } from 'vs/workbench/services/positronModalDialogs/common/positronModalDialogs';
+import { ILabelService } from 'vs/platform/label/common/label';
 
 /** The maximum number of recent executions to store. */
 const MaxRecentExecutions = 10;
@@ -160,7 +161,8 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@ILogService private readonly _logService: ILogService,
 		@INotificationService private readonly _notificationService: INotificationService,
-		@IEditorService private readonly _editorService: IEditorService
+		@IEditorService private readonly _editorService: IEditorService,
+		@ILabelService private readonly _labelService: ILabelService,
 	) {
 		super();
 
@@ -853,6 +855,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 								this._fileDialogService,
 								this._logService,
 								this._notificationService,
+								this._labelService,
 								plot,
 								this.savePlotAs,
 								suggestedPath

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -49,6 +49,7 @@ import { URI } from 'vs/base/common/uri';
 import { PositronPlotCommProxy } from 'vs/workbench/services/languageRuntime/common/positronPlotCommProxy';
 import { IPositronModalDialogsService } from 'vs/workbench/services/positronModalDialogs/common/positronModalDialogs';
 import { ILabelService } from 'vs/platform/label/common/label';
+import { IPathService } from 'vs/workbench/services/path/common/pathService';
 
 /** The maximum number of recent executions to store. */
 const MaxRecentExecutions = 10;
@@ -163,6 +164,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@ILabelService private readonly _labelService: ILabelService,
+		@IPathService private readonly _pathService: IPathService,
 	) {
 		super();
 
@@ -856,6 +858,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 								this._logService,
 								this._notificationService,
 								this._labelService,
+								this._pathService,
 								plot,
 								this.savePlotAs,
 								suggestedPath

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProject.ts
@@ -85,6 +85,7 @@ export enum NewProjectTask {
  */
 export interface NewProjectConfiguration {
 	readonly folderScheme: string;
+	readonly folderAuthority: string;
 	readonly runtimeMetadata: ILanguageRuntimeMetadata | undefined;
 	readonly projectType: string;
 	readonly projectFolder: string;

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -16,7 +16,7 @@ import { Barrier } from 'vs/base/common/async';
 import { ILanguageRuntimeMetadata } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IFileService } from 'vs/platform/files/common/files';
 import { VSBuffer } from 'vs/base/common/buffer';
-import { joinPath } from 'vs/base/common/resources';
+import { joinPath, relativePath } from 'vs/base/common/resources';
 import { DOT_IGNORE_JUPYTER, DOT_IGNORE_PYTHON, DOT_IGNORE_R } from 'vs/workbench/services/positronNewProject/common/positronNewProjectTemplates';
 import { URI } from 'vs/base/common/uri';
 import { INotificationService } from 'vs/platform/notification/common/notification';
@@ -635,8 +635,13 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 		}
 		const currentFolderPath =
 			this._contextService.getWorkspace().folders[0]?.uri;
-		return this._newProjectConfig.projectFolder === currentFolderPath.path
-			&& this._newProjectConfig.folderScheme === currentFolderPath.scheme;
+		const newProjectFolder = URI.from({
+			scheme: this._newProjectConfig.folderScheme,
+			path: this._newProjectConfig.projectFolder
+		});
+		const currentWindowIsNewProject = relativePath(currentFolderPath, newProjectFolder) === '';
+		this._logService.debug(`[New project startup] Current window is new project: ${currentWindowIsNewProject}`);
+		return currentWindowIsNewProject;
 	}
 
 	async initNewProject() {

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -637,6 +637,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 			this._contextService.getWorkspace().folders[0]?.uri;
 		const newProjectFolder = URI.from({
 			scheme: this._newProjectConfig.folderScheme,
+			authority: this._newProjectConfig.folderAuthority,
 			path: this._newProjectConfig.projectFolder
 		});
 		const currentWindowIsNewProject = relativePath(currentFolderPath, newProjectFolder) === '';

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -119,7 +119,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 		this._register(
 			this.onDidChangePendingInitTasks((tasks) => {
 				this._logService.debug(
-					`[New project startup] Pending tasks changed to: ${tasks}`
+					`[New project startup] Pending tasks changed to: ${JSON.stringify(tasks)}`
 				);
 				// If there are no pending init tasks, it's time for runtime startup
 				if (tasks.size === 0) {
@@ -140,7 +140,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 		this._register(
 			this.onDidChangePostInitTasks((tasks) => {
 				this._logService.debug(
-					`[New project startup] Post-init tasks changed to: ${tasks}`
+					`[New project startup] Post-init tasks changed to: ${JSON.stringify(tasks)}`
 				);
 				// If there are no post-init tasks, the new project startup is complete
 				if (tasks.size === 0) {
@@ -328,7 +328,13 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	 * Relies on extension vscode.git
 	 */
 	private async _runGitInit() {
-		const projectRoot = URI.from({ scheme: this._newProjectConfig?.folderScheme ?? Schemas.file, path: this._newProjectConfig?.projectFolder });
+		if (!this._newProjectConfig) {
+			return;
+		}
+		const projectRoot = URI.from({
+			scheme: this._newProjectConfig?.folderScheme ?? Schemas.file,
+			path: this._newProjectConfig?.projectFolder
+		});
 
 		// true to skip the folder prompt
 		await this._commandService.executeCommand('git.init', true)
@@ -336,13 +342,13 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 				const errorMessage = localize('positronNewProjectService.gitInitError', 'Error initializing git repository {0}', error);
 				this._notificationService.error(errorMessage);
 			});
-		await this._fileService.createFile(joinPath(projectRoot, 'README.md'), VSBuffer.fromString(`# ${this._newProjectConfig?.projectName}`))
+		await this._fileService.createFile(joinPath(projectRoot, 'README.md'), VSBuffer.fromString(`# ${this._newProjectConfig.projectName}`))
 			.catch((error) => {
 				const errorMessage = localize('positronNewProjectService.readmeError', 'Error creating readme {0}', error);
 				this._notificationService.error(errorMessage);
 			});
 
-		switch (this._newProjectConfig?.projectType) {
+		switch (this._newProjectConfig.projectType) {
 			case NewProjectType.PythonProject:
 				await this._fileService.createFile(joinPath(projectRoot, '.gitignore'), VSBuffer.fromString(DOT_IGNORE_PYTHON))
 					.catch((error) => {
@@ -364,7 +370,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 			default:
 				this._logService.error(
 					'Cannot determine .gitignore content for unknown project type',
-					this._newProjectConfig?.projectType
+					this._newProjectConfig.projectType
 				);
 				break;
 		}
@@ -388,7 +394,9 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 					this._contextService.getWorkspace().folders[0];
 
 				if (!workspaceFolder) {
-					const message = this._failedPythonEnvMessage(`Could not determine workspace folder for ${this._newProjectConfig.projectFolder}.`);
+					const message = this._failedPythonEnvMessage(
+						`Could not determine workspace folder for ${this._newProjectConfig.projectFolder}.`
+					);
 					this._logService.error(message);
 					this._notificationService.warn(message);
 					this._removePendingInitTask(NewProjectTask.PythonEnvironment);
@@ -593,7 +601,7 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	}
 
 	/**
-	 *Returns the post initialization tasks that need to be performed for the new project.
+	 * Returns the post initialization tasks that need to be performed for the new project.
 	 * @returns Returns the post initialization tasks that need to be performed for the new project.
 	 */
 	private _getPostInitTasks(): Set<NewProjectTask> {
@@ -625,10 +633,10 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 		if (!this._newProjectConfig) {
 			return false;
 		}
-		const newProjectPath = this._newProjectConfig.projectFolder;
 		const currentFolderPath =
-			this._contextService.getWorkspace().folders[0]?.uri.fsPath;
-		return newProjectPath === currentFolderPath;
+			this._contextService.getWorkspace().folders[0]?.uri;
+		return this._newProjectConfig.projectFolder === currentFolderPath.path
+			&& this._newProjectConfig.folderScheme === currentFolderPath.scheme;
 	}
 
 	async initNewProject() {

--- a/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
+++ b/src/vs/workbench/services/positronNewProject/common/positronNewProjectService.ts
@@ -22,7 +22,6 @@ import { URI } from 'vs/base/common/uri';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { localize } from 'vs/nls';
 import { IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
-import { Schemas } from 'vs/base/common/network';
 
 /**
  * PositronNewProjectService class.
@@ -329,11 +328,14 @@ export class PositronNewProjectService extends Disposable implements IPositronNe
 	 */
 	private async _runGitInit() {
 		if (!this._newProjectConfig) {
+			this._logService.error(`[New project startup] git init - no new project configuration found`);
 			return;
 		}
+
 		const projectRoot = URI.from({
-			scheme: this._newProjectConfig?.folderScheme ?? Schemas.file,
-			path: this._newProjectConfig?.projectFolder
+			scheme: this._newProjectConfig.folderScheme,
+			authority: this._newProjectConfig.folderAuthority,
+			path: this._newProjectConfig.projectFolder
 		});
 
 		// true to skip the folder prompt


### PR DESCRIPTION
> [!NOTE]
> Opening this PR in place of https://github.com/posit-dev/positron/pull/5657 so we can target the prerelease/2024.11 branch, then cherry-pick into main.

- Addresses https://github.com/posit-dev/positron/issues/5616

### Implementation
- update the New Folder, New Folder from Git, Project Wizard and Save Plot modals with the file path fixes
- remove uses of `fsPath` -- the file system path seems to be formatted based on the client file system rather than the server file system
- leverage `IPathService` and `ILabelService` to manage paths -- these services are aware of the remote server platform
- create new path utils file `src/vs/workbench/browser/utils/path.ts` to convert to and from path strings and path URIs in a platform-aware way
- fix up folder checks in the new project initialization tasks
    - pass folder authority in addition to path and scheme for a more complete URI object

### QA Notes

#### Test areas
- New Folder modal
- New Folder from Git modal
- Project Wizard modal
    - Test with "Initialize project as Git repository" enabled and disabled
- Save Plot modal

For each modal, both the <kbd>Browse...</kbd> button method of selecting a parent directory and typing in a path should be tested.

I have tested on the following platforms:
- Mac: Desktop, Server Web, Workbench via Arc browser
- Windows: Desktop, Server Web, Workbench via Chrome/Edge browsers

I have not yet tested:
- Linux: Desktop, Server Web, Workbench via a browser
- Remote SSH from any client OS

Workbench via a browser on Windows should be fixed with this PR. All other platform configurations should not have regressed.

