### PR TITLE
Adding new 'big-gulp' script to package.json that creates an unmangled build in just a few minutes

### DIFF
--- a/build/gulpfile.compile.js
+++ b/build/gulpfile.compile.js
@@ -33,7 +33,7 @@ function makeCompileBuildTask(disableMangle) {
 
 // Full compile, including nls and inline sources in sourcemaps, mangling, minification, for build
 // --- Start Positron ---
-const compileBuildTask = task.define('compile-build', makeCompileBuildTask(process.argv.includes('--no-mangler')));
+const compileBuildTask = task.define('compile-build', makeCompileBuildTask(process.argv.includes('--disable-mangler')));
 // --- End Positron ---
 gulp.task(compileBuildTask);
 exports.compileBuildTask = compileBuildTask;

--- a/build/gulpfile.compile.js
+++ b/build/gulpfile.compile.js
@@ -32,7 +32,9 @@ function makeCompileBuildTask(disableMangle) {
 }
 
 // Full compile, including nls and inline sources in sourcemaps, mangling, minification, for build
-const compileBuildTask = task.define('compile-build', makeCompileBuildTask(false));
+// --- Start Positron ---
+const compileBuildTask = task.define('compile-build', makeCompileBuildTask(process.argv.includes('--no-mangler')));
+// --- End Positron ---
 gulp.task(compileBuildTask);
 exports.compileBuildTask = compileBuildTask;
 

--- a/build/gulpfile.compile.js
+++ b/build/gulpfile.compile.js
@@ -33,7 +33,7 @@ function makeCompileBuildTask(disableMangle) {
 
 // Full compile, including nls and inline sources in sourcemaps, mangling, minification, for build
 // --- Start Positron ---
-const compileBuildTask = task.define('compile-build', makeCompileBuildTask(process.argv.includes('--disable-mangler')));
+const compileBuildTask = task.define('compile-build', makeCompileBuildTask(process.env.DISABLE_MANGLE === 'true'));
 // --- End Positron ---
 gulp.task(compileBuildTask);
 exports.compileBuildTask = compileBuildTask;

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "extensions-ci-pr": "node --max-old-space-size=4095 ./node_modules/gulp/bin/gulp.js extensions-ci-pr",
     "perf": "node scripts/code-perf.js",
     "update-build-ts-version": "yarn add typescript@next && tsc -p ./build/tsconfig.build.json",
-    "fast-build": "node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js vscode --no-mangler"
+    "fast-build": "node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js vscode --disable-mangler"
   },
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "extensions-ci": "node --max-old-space-size=8095 ./node_modules/gulp/bin/gulp.js extensions-ci",
     "extensions-ci-pr": "node --max-old-space-size=4095 ./node_modules/gulp/bin/gulp.js extensions-ci-pr",
     "perf": "node scripts/code-perf.js",
-    "update-build-ts-version": "yarn add typescript@next && tsc -p ./build/tsconfig.build.json"
+    "update-build-ts-version": "yarn add typescript@next && tsc -p ./build/tsconfig.build.json",
+    "fast-build": "node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js vscode --no-mangler"
   },
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "kill-watch-build-toolsd": "deemon --kill yarn watch-build-tools",
     "precommit": "node build/hygiene.js",
     "gulp": "node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js",
+    "big-gulp": "DISABLE_MANGLE=true node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js",
     "electron": "node build/lib/electron",
     "7z": "7z",
     "update-grammars": "node build/npm/update-all-grammars.mjs",
@@ -78,8 +79,7 @@
     "extensions-ci": "node --max-old-space-size=8095 ./node_modules/gulp/bin/gulp.js extensions-ci",
     "extensions-ci-pr": "node --max-old-space-size=4095 ./node_modules/gulp/bin/gulp.js extensions-ci-pr",
     "perf": "node scripts/code-perf.js",
-    "update-build-ts-version": "yarn add typescript@next && tsc -p ./build/tsconfig.build.json",
-    "fast-build": "node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js vscode --disable-mangler"
+    "update-build-ts-version": "yarn add typescript@next && tsc -p ./build/tsconfig.build.json"
   },
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",


### PR DESCRIPTION
### Description

`yarn gulp vscode` (soon to be: `npm run gulp vscode`) takes upwards of 30-40 minutes to create a build. Almost all of this time is spent in the mangler (25 minutes in the following output from my M2 Max):

```
[~/Work/positron] git:(main) ✗ yarn gulp vscode
...
[14:30:07] Starting compile-src ...
[14:30:14] [mangler] Done collecting. Classes: 8411. Exported symbols: 10713
[14:30:15] [mangler] Done creating class replacements
[14:30:15] [mangler] Starting prepare rename edits
[14:30:15] Starting compilation...
[14:55:39] [mangler] Done preparing edits: 4528 files
[14:55:42] [mangler] Done: 5276.738kb saved, memory-usage:
...
[14:56:02] Finished 'vscode' after 29.73 min
```

This PR adds a new `big-gulp` script which can be used to create an unmangled build in just a few minutes, which can be a huge timesaver when you are debugging build issues on your development machine.

To run this script, use `yarn big-gulp` (soon to be: `npm run big-gulp`):

```
[~/Work/positron] git:(main) ✗ yarn big-gulp vscode
...
[12:44:11] Finished 'vscode' after 3.2 min
```

### QA Notes

None.