### PR TITLE
Improve UX when no runtimes found

### DIFF
--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -15,7 +15,7 @@ import { IExtensionService } from 'vs/workbench/services/extensions/common/exten
 import { ILanguageRuntimeExit, ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionLocation, LanguageRuntimeSessionMode, LanguageRuntimeStartupBehavior, RuntimeExitReason, RuntimeState, formatLanguageRuntimeMetadata } from 'vs/workbench/services/languageRuntime/common/languageRuntimeService';
 import { IRuntimeStartupService, RuntimeStartupPhase } from 'vs/workbench/services/runtimeStartup/common/runtimeStartupService';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService } from 'vs/workbench/services/runtimeSession/common/runtimeSessionService';
-import { Event } from 'vs/base/common/event';
+import { Emitter, Event } from 'vs/base/common/event';
 import { ISettableObservable, observableValue } from 'vs/base/common/observableInternal/base';
 import { ExtensionsRegistry } from 'vs/workbench/services/extensions/common/extensionsRegistry';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
@@ -91,6 +91,10 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 	private _shuttingDown = false;
 
 	onDidChangeRuntimeStartupPhase: Event<RuntimeStartupPhase>;
+
+	// The event emitter for the onDidCompleteDiscoveryPhase event.
+	onDidCompleteDiscoveryPhaseEmitter =
+		this._register(new Emitter<undefined>);
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -179,6 +183,16 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 							`An extension requested the runtime to be started immediately.`);
 					}
 				}
+			}
+		}));
+
+		// Add the onDidCompleteDiscoveryPhase event handler.
+		this._register(this.onDidCompleteDiscoveryPhase(() => {
+			if (this._languageRuntimeService.registeredRuntimes.length === 0) {
+				// if no runtimes were found, notify the user about the problem
+				this._notificationService.error(nls.localize('noRuntimesMessage',
+					"No runtimes found. Please see the [Get Started](https://positron.posit.co/start.html) \
+					page for instructions on how to add a runtime."));
 			}
 		}));
 
@@ -291,6 +305,9 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		}));
 	}
 
+	// An event that fires when the runtime discovery phase is completed.
+	readonly onDidCompleteDiscoveryPhase = this.onDidCompleteDiscoveryPhaseEmitter.event;
+
 	/**
 	 * The main entry point for the runtime startup service.
 	 */
@@ -335,6 +352,8 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 	 */
 	completeDiscovery(): void {
 		this._startupPhase.set(RuntimeStartupPhase.Complete, undefined);
+		// Fire the onDidCompleteDiscoveryPhase event.
+		this.onDidCompleteDiscoveryPhaseEmitter.fire(undefined);
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -384,7 +384,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 
 	/**
 	 * Activates all of the extensions that provides language runtimes, then
-	 * entires the discovery phase, in which each extension is asked to supply
+	 * enters the discovery phase, in which each extension is asked to supply
 	 * its language runtime metadata.
 	 */
 	private async discoverAllRuntimes() {

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -169,8 +169,8 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				// if no runtimes were found, notify the user about the problem
 				if (this._languageRuntimeService.registeredRuntimes.length === 0) {
 					this._notificationService.error(nls.localize('positron.runtimeStartupService.noRuntimesMessage',
-						"No runtimes found. Please see the [Get Started](https://positron.posit.co/start.html) \
-					page for instructions on how to add a runtime."));
+						"No interpreters found. Please see the [Get Started](https://positron.posit.co/start) \
+						documentation to learn how to prepare your Python and/or R environments to work with Positron."));
 				}
 
 				// If there are no affiliated runtimes, and no starting or running

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartupService.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartupService.ts
@@ -71,11 +71,6 @@ export interface IRuntimeStartupService {
 	onDidChangeRuntimeStartupPhase: Event<RuntimeStartupPhase>;
 
 	/**
-	 * Event for when the runtime discovery phase is completed.
-	 */
-	onDidCompleteDiscoveryPhase: Event<undefined>;
-
-	/**
 	 * The current startup phase.
 	 */
 	readonly startupPhase: RuntimeStartupPhase;

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartupService.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartupService.ts
@@ -71,6 +71,11 @@ export interface IRuntimeStartupService {
 	onDidChangeRuntimeStartupPhase: Event<RuntimeStartupPhase>;
 
 	/**
+	 * Event for when the runtime discovery phase is completed.
+	 */
+	onDidCompleteDiscoveryPhase: Event<undefined>;
+
+	/**
 	 * The current startup phase.
 	 */
 	readonly startupPhase: RuntimeStartupPhase;


### PR DESCRIPTION
### Description
Addresses #3468

This addresses a niche UX scenario: a user installs Positron before completing the [machine prerequisites](https://positron.posit.co/start.html#machine-prerequisites) i.e. there is no R or Python installed on the machine.

The solution is quite minimal since the overall runtime startup experience will be going through enhancements soon. A notification is displayed to the user letting them know that no runtimes were found. This notification is shown after the runtime discovery phase is complete.

<img width="1342" alt="Screenshot 2024-12-09 at 9 41 33 AM" src="https://github.com/user-attachments/assets/65e7f20d-4497-46fd-85e5-ef361f5809c7">

### QA Notes

In order to test this we'll need to install Positron in an environment that does not have R or Python installed. This should kick off a VS Code notification in the bottom right which lets a user know the problem and a link to the positron wiki for resolving the issue. 
