### PR TITLE
Add isPositron context key

### DIFF
--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -25,9 +25,9 @@ CONSTANT_VALUES.set('isEdge', isEdge);
 CONSTANT_VALUES.set('isFirefox', isFirefox);
 CONSTANT_VALUES.set('isChrome', isChrome);
 CONSTANT_VALUES.set('isSafari', isSafari);
-// --- START POSITRON ---
+// --- Start Positron ---
 CONSTANT_VALUES.set('isPositron', true);
-// --- END POSITRON ---
+// --- End Positron ---
 
 /** allow register constant context keys that are known only after startup; requires running `substituteConstants` on the context key - https://github.com/microsoft/vscode/issues/174218#issuecomment-1437972127 */
 export function setConstant(key: string, value: boolean) {

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -25,6 +25,9 @@ CONSTANT_VALUES.set('isEdge', isEdge);
 CONSTANT_VALUES.set('isFirefox', isFirefox);
 CONSTANT_VALUES.set('isChrome', isChrome);
 CONSTANT_VALUES.set('isSafari', isSafari);
+// --- START POSITRON ---
+CONSTANT_VALUES.set('isPositron', true);
+// --- END POSITRON ---
 
 /** allow register constant context keys that are known only after startup; requires running `substituteConstants` on the context key - https://github.com/microsoft/vscode/issues/174218#issuecomment-1437972127 */
 export function setConstant(key: string, value: boolean) {

--- a/src/vs/platform/contextkey/common/contextkeys.ts
+++ b/src/vs/platform/contextkey/common/contextkeys.ts
@@ -21,3 +21,7 @@ export const ProductQualityContext = new RawContextKey<string>('productQualityTy
 
 export const InputFocusedContextKey = 'inputFocus';
 export const InputFocusedContext = new RawContextKey<boolean>(InputFocusedContextKey, false, localize('inputFocus', "Whether keyboard focus is inside an input box"));
+
+// --- START POSITRON ---
+export const IsPositronContext = new RawContextKey<boolean>('isPositron', true, localize('isPositron', "Whether the application is Positron"));
+// --- END POSITRON ---

--- a/src/vs/platform/contextkey/common/contextkeys.ts
+++ b/src/vs/platform/contextkey/common/contextkeys.ts
@@ -22,6 +22,6 @@ export const ProductQualityContext = new RawContextKey<string>('productQualityTy
 export const InputFocusedContextKey = 'inputFocus';
 export const InputFocusedContext = new RawContextKey<boolean>(InputFocusedContextKey, false, localize('inputFocus', "Whether keyboard focus is inside an input box"));
 
-// --- START POSITRON ---
+// --- Start Positron ---
 export const IsPositronContext = new RawContextKey<boolean>('isPositron', true, localize('isPositron', "Whether the application is Positron"));
-// --- END POSITRON ---
+// --- End Positron ---

--- a/src/vs/platform/contextkey/test/common/contextkey.test.ts
+++ b/src/vs/platform/contextkey/test/common/contextkey.test.ts
@@ -377,9 +377,9 @@ suite('ContextKeyExpr', () => {
 		));
 	});
 
-	// --- START POSITRON ---
+	// --- Start Positron ---
 	test('Positron Context Key', () => {
 		assert.ok(ContextKeyExpr.has('isPositron').equals(ContextKeyExpr.true()));
 	});
-	// --- END POSITRON ---
+	// --- End Positron ---
 });

--- a/src/vs/platform/contextkey/test/common/contextkey.test.ts
+++ b/src/vs/platform/contextkey/test/common/contextkey.test.ts
@@ -376,4 +376,10 @@ suite('ContextKeyExpr', () => {
 			)!
 		));
 	});
+
+	// --- START POSITRON ---
+	test('Positron Context Key', () => {
+		assert.ok(ContextKeyExpr.has('isPositron').equals(ContextKeyExpr.true()));
+	});
+	// --- END POSITRON ---
 });

--- a/src/vs/workbench/browser/contextkeys.ts
+++ b/src/vs/workbench/browser/contextkeys.ts
@@ -36,6 +36,8 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 // eslint-disable-next-line no-duplicate-imports
 import { PositronTopActionBarVisibleContext } from 'vs/workbench/common/contextkeys';
 // eslint-disable-next-line no-duplicate-imports
+import { IsPositronContext } from 'vs/platform/contextkey/common/contextkeys';
+// eslint-disable-next-line no-duplicate-imports
 import { isTemporaryWorkspace } from 'vs/platform/workspace/common/workspace';
 // --- End Positron ---
 
@@ -116,6 +118,7 @@ export class WorkbenchContextKeysHandler extends Disposable {
 		this.virtualWorkspaceContext = VirtualWorkspaceContext.bindTo(this.contextKeyService);
 		// --- Start Positron ---
 		this.temporaryWorkspaceContext = TemporaryWorkspaceContext.bindTo(this.contextKeyService);
+		IsPositronContext.bindTo(this.contextKeyService);
 		// --- End Positron ---
 		this.updateWorkspaceContextKeys();
 


### PR DESCRIPTION
Address #5339 

Adds a `isPositron` context key that is `true`. This can be used with extensions like this:

```json
{
    "category": "Python",
    "command": "python.createEnvironment",
    "title": "%python.command.python.createEnvironment.title%",
    "enablement": "isPositron"
},
```

It can also be used internally with `IsPositronContext` or `ContextKeyExpr.has('isPositron')` if we had an existential crisis.

### QA Notes
Nothing uses this and the unit test is enough to know that the key is available.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
