### PR TITLE
E2E Test: Matplotlib notebook interact test

### DIFF
--- a/test/automation/src/positron/positronNotebooks.ts
+++ b/test/automation/src/positron/positronNotebooks.ts
@@ -94,4 +94,11 @@ export class PositronNotebooks {
 		await expect(markdownLocator).toBeVisible();
 		await expect(markdownLocator).toHaveText(expectedText);
 	}
+
+	async runAllCells(timeout: number = 30000) {
+		await this.code.driver.page.getByLabel('Run All').click();
+		const stopExecutionLocator = this.code.driver.page.locator('a').filter({ hasText: /Stop Execution|Interrupt/ });
+		await expect(stopExecutionLocator).toBeVisible();
+		await expect(stopExecutionLocator).not.toBeVisible({ timeout: timeout });
+	}
 }

--- a/test/e2e/features/notebook/notebook-large-python.test.ts
+++ b/test/e2e/features/notebook/notebook-large-python.test.ts
@@ -22,11 +22,7 @@ test.describe('Large Python Notebook', { tag: ['@notebook'] }, () => {
 		await app.workbench.positronQuickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'large_py_notebook', 'spotify.ipynb'));
 		await notebooks.selectInterpreter('Python Environments', process.env.POSITRON_PY_VER_SEL!);
 
-		await app.code.driver.page.getByLabel('Run All').click();
-
-		const stopExecutionLocator = app.code.driver.page.locator('a').filter({ hasText: /Stop Execution|Interrupt/ });
-		await expect(stopExecutionLocator).toBeVisible();
-		await expect(stopExecutionLocator).not.toBeVisible({ timeout: 120000 });
+		await notebooks.runAllCells(120000);
 
 		await app.workbench.quickaccess.runCommand('notebook.focusTop');
 		await app.code.driver.page.locator('span').filter({ hasText: 'import pandas as pd' }).locator('span').first().click();

--- a/test/e2e/features/plots/matplotlib-interact.test.ts
+++ b/test/e2e/features/plots/matplotlib-interact.test.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { test } from '../_test.setup';
+import { expect } from '@playwright/test';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Matplotlib Interact', { tag: ['@plots', '@notebook'] }, () => {
+
+	test('Python - Matplotlib Interact Test [C1067443]', {
+		tag: ['@pr', '@web', '@win'],
+	}, async function ({ app, python }) {
+
+		const notebooks = app.workbench.positronNotebooks;
+
+		await app.workbench.positronQuickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'matplotlib', 'interact.ipynb'));
+
+		await notebooks.selectInterpreter('Python Environments', process.env.POSITRON_PY_VER_SEL!);
+
+		await notebooks.runAllCells();
+
+		await app.workbench.quickaccess.runCommand('workbench.action.togglePanel');
+
+		const plotLocator = app.workbench.positronNotebooks.frameLocator.locator('.widget-output');
+
+		const plotImageLocator = plotLocator.locator('img');
+
+		const imgSrcBefore = await plotImageLocator.getAttribute('src');
+
+		const sliders = await app.workbench.positronNotebooks.frameLocator.locator('.slider-container .slider').all();
+
+		for (const slider of sliders) {
+			await slider.hover();
+			await slider.click();
+		}
+
+		const imgSrcAfter = await plotImageLocator.getAttribute('src');
+
+		expect(imgSrcBefore).not.toBe(imgSrcAfter);
+
+	});
+
+});


### PR DESCRIPTION
This test verifies that a previously seen regression does not return.  It uses [Matplotlib interact sample](https://github.com/posit-dev/qa-example-content/blob/main/workspaces/matplotlib/interact.ipynb) and adjusts the radius and linewidth, checking that the img src updates.  If the src doesn't update, that would mean that extra plots are drawing, which was the previous regression.

### QA Notes

All smoke tests should pass.
