### PR TITLE
Fix "view as scrollable element" not working

### DIFF
--- a/extensions/positron-notebook-controllers/src/notebookController.ts
+++ b/extensions/positron-notebook-controllers/src/notebookController.ts
@@ -9,8 +9,21 @@ import { JUPYTER_NOTEBOOK_TYPE } from './constants';
 import { log } from './extension';
 import { ResourceMap } from './map';
 
-/** The type of a Jupyter notebook cell output. */
+/**
+ * The type of a Jupyter notebook cell output.
+ *
+ * Used by the ipynb notebook serializer (extensions/ipynb/src/serializers.ts) to convert from
+ * VSCode notebook cell outputs to Jupyter notebook cell outputs.
+ *
+ * See: https://jupyter-client.readthedocs.io/en/latest/messaging.html
+ */
 enum NotebookCellOutputType {
+	/** An error occurred during an execution. */
+	Error = 'error',
+
+	/** Output from one of the standard streams (stdout or stderr). */
+	Stream = 'stream',
+
 	/** One of possibly many outputs related to an execution. */
 	DisplayData = 'display_data',
 
@@ -584,7 +597,9 @@ async function handleRuntimeMessageStream(
 	if (lastOutputItems && lastOutputItems.every(item => item.mime === cellOutputItem.mime)) {
 		await execution.appendOutputItems([cellOutputItem], lastOutput);
 	} else {
-		const cellOutput = new vscode.NotebookCellOutput([cellOutputItem]);
+		const cellOutput = new vscode.NotebookCellOutput(
+			[cellOutputItem], { outputType: NotebookCellOutputType.Stream },
+		);
 		await execution.appendOutput(cellOutput);
 	}
 }
@@ -605,6 +620,6 @@ async function handleRuntimeMessageError(
 			message: message.message,
 			stack: message.traceback.join('\n'),
 		})
-	]);
+	], { outputType: NotebookCellOutputType.Error });
 	await execution.appendOutput(cellOutput);
 }


### PR DESCRIPTION
Addresses #5603. The issue was due to cell output metadata being set to `undefined` by the Positron notebook controllers, causing the `scrollable` metadata to not be set here: https://github.com/posit-dev/positron/blob/54d791da6b5e015ff03a596a848c8893cf90d3bd/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts#L766-L769

We now set metadata and also set `outputType` since it also makes life easier for the ipynb serializer: https://github.com/posit-dev/positron/blob/3a8978af98c6b8b03a98916a9bf8b91ba7070df3/extensions/ipynb/src/serializers.ts#L182

### QA Notes

1. Run a Python notebook cell with the following code:

  ```python
    # code with error
  def divide_numbers(numbers):
      result = []
      for num in numbers:
          result.append(10 / num)
      return result
  
  numbers_to_divide = [2, 4, 0, 5, 7]
  
  try:
      divide_numbers(numbers_to_divide)
  except Exception as e:
      error_message = f"Error: {e}\n" * 50  # Repeat error message
      raise RuntimeError(error_message)
  ```
2. Click "View as scrollable element" - it should work.
3. Also try the "Notebook: Toggle scrollable element" command with the cell selected.