### PR TITLE
e2e-test: use enum for test tags

### DIFF
--- a/.github/workflows/e2e-test-release-run-ubuntu.yml
+++ b/.github/workflows/e2e-test-release-run-ubuntu.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       e2e_grep:
         required: false
-        description: "Grep filter to apply to the e2e tests: @pr, @win, etc."
+        description: "Grep filter to apply to the e2e tests: @critical, @win, etc."
         default: ""
         type: string
 

--- a/.github/workflows/positron-merge-to-branch.yml
+++ b/.github/workflows/positron-merge-to-branch.yml
@@ -9,14 +9,14 @@ on:
     inputs:
       e2e_grep:
         required: false
-        description: "Grep filter to apply to the e2e tests: @pr, @win, etc."
+        description: "Grep filter to apply to the e2e tests: @critical, @win, etc."
         default: ""
         type: string
   workflow_dispatch:
     inputs:
       e2e_grep:
         required: false
-        description: "Grep filter to apply to the e2e tests: @pr, @win, etc."
+        description: "Grep filter to apply to the e2e tests: @critical, @win, etc."
         default: ""
         type: string
 

--- a/.github/workflows/positron-pull-requests.yml
+++ b/.github/workflows/positron-pull-requests.yml
@@ -11,4 +11,4 @@ jobs:
     uses: ./.github/workflows/positron-merge-to-branch.yml
     secrets: inherit
     with:
-      e2e_grep: "@pr"
+      e2e_grep: "@critical"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -209,6 +209,6 @@ In order to get the "golden screenshots" used for plot comparison is CI, you wil
 
 ## Tests run on PRs
 
-If you think your test should be run when PRs are created, [tag the test with @pr](https://playwright.dev/docs/test-annotations#tag-tests). The existing @pr cases were selected to give good overall coverage while keeping the overall execution time down to ten minutes or less. If your new test functionality covers a part of the application that no other tests cover, it is probably a good idea to include it in the @pr set.
+If you think your test should be run when PRs are created, [tag the test with @critical](https://playwright.dev/docs/test-annotations#tag-tests). The existing @critical cases were selected to give good overall coverage while keeping the overall execution time down to ten minutes or less. If your new test functionality covers a part of the application that no other tests cover, it is probably a good idea to include it in the @critical set.
 
 <!-- End Positron -->

--- a/test/e2e/features/_test.setup.ts
+++ b/test/e2e/features/_test.setup.ts
@@ -7,7 +7,6 @@
 import * as playwright from '@playwright/test';
 const { test: base, expect: playwrightExpect } = playwright;
 
-
 // Node.js built-in modules
 import { join } from 'path';
 import * as os from 'os';

--- a/test/e2e/features/_test.setup.ts
+++ b/test/e2e/features/_test.setup.ts
@@ -7,6 +7,7 @@
 import * as playwright from '@playwright/test';
 const { test: base, expect: playwrightExpect } = playwright;
 
+
 // Node.js built-in modules
 import { join } from 'path';
 import * as os from 'os';
@@ -22,7 +23,7 @@ import { randomUUID } from 'crypto';
 import archiver from 'archiver';
 
 // Local imports
-import { createLogger, createApp } from '../helpers';
+import { createLogger, createApp, TestTags } from '../helpers';
 import { Application, Logger, PositronPythonFixtures, PositronRFixtures, PositronUserSettingsFixtures, UserSetting } from '../../automation';
 
 const TEMP_DIR = `temp-${randomUUID()}`;
@@ -298,6 +299,7 @@ test.afterAll(async function ({ logger }, testInfo) {
 });
 
 export { playwrightExpect as expect };
+export { TestTags as tags };
 
 async function moveAndOverwrite(sourcePath, destinationPath) {
 	try {

--- a/test/e2e/features/apps/python-apps.test.ts
+++ b/test/e2e/features/apps/python-apps.test.ts
@@ -3,14 +3,16 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 import { join } from 'path';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Python Applications', { tag: ['@pr', '@apps', '@viewer', '@editor'] }, () => {
+test.describe('Python Applications', {
+	tag: [tags.CRITICAL, tags.APPS, tags.VIEWER, tags.EDITOR]
+}, () => {
 	test.afterEach(async function ({ app }) {
 		await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
 
@@ -22,7 +24,7 @@ test.describe('Python Applications', { tag: ['@pr', '@apps', '@viewer', '@editor
 		await app.workbench.positronViewer.clearViewer();
 	});
 
-	test('Python - Verify Basic Dash App [C903305]', { tag: ['@win'] }, async function ({ app, python }) {
+	test('Python - Verify Basic Dash App [C903305]', { tag: [tags.WIN] }, async function ({ app, python }) {
 		const viewer = app.workbench.positronViewer;
 
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'python_apps', 'dash_example', 'dash_example.py'));
@@ -58,7 +60,7 @@ test.describe('Python Applications', { tag: ['@pr', '@apps', '@viewer', '@editor
 
 	// TODO: update for pop out to editor when issue resolved
 	test('Python - Verify Basic Gradio App [C903307]', {
-		tag: ['@win'],
+		tag: [tags.WIN],
 	}, async function ({ app, python }) {
 		const viewer = app.workbench.positronViewer;
 
@@ -71,7 +73,9 @@ test.describe('Python Applications', { tag: ['@pr', '@apps', '@viewer', '@editor
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleSidebarVisibility');
 	});
 
-	test('Python - Verify Basic Streamlit App [C903308]', { tag: ['@web', '@win'] }, async function ({ app, python }) {
+	test('Python - Verify Basic Streamlit App [C903308]', {
+		tag: [tags.WEB, tags.WIN]
+	}, async function ({ app, python }) {
 		const viewer = app.workbench.positronViewer;
 
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'python_apps', 'streamlit_example', 'streamlit_example.py'));
@@ -105,7 +109,7 @@ test.describe('Python Applications', { tag: ['@pr', '@apps', '@viewer', '@editor
 	});
 
 	test('Python - Verify Basic Flask App [C1013655]', {
-		tag: ['@web', '@win']
+		tag: [tags.WEB, tags.WIN]
 	}, async function ({ app, python, page }) {
 		const viewer = app.workbench.positronViewer;
 

--- a/test/e2e/features/apps/shiny.test.ts
+++ b/test/e2e/features/apps/shiny.test.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Shiny Application', { tag: ['@apps', '@viewer'] }, () => {
+test.describe('Shiny Application', { tag: [tags.APPS, tags.VIEWER] }, () => {
 	test.beforeAll(async function ({ app }) {
 		try {
 			await app.workbench.extensions.installExtension('posit.shiny', true);

--- a/test/e2e/features/connections/connections-db.test.ts
+++ b/test/e2e/features/connections/connections-db.test.ts
@@ -4,13 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('SQLite DB Connection', { tag: ['@web', '@win', '@pr', '@connections'] }, () => {
+test.describe('SQLite DB Connection', {
+	tag: [tags.WEB, tags.WIN, tags.CRITICAL, tags.CONNECTIONS]
+}, () => {
 	test.beforeAll(async function ({ userSettings }) {
 		await userSettings.set([['positron.connections.showConnectionPane', 'true']], true);
 	});

--- a/test/e2e/features/console/console-ansi.test.ts
+++ b/test/e2e/features/console/console-ansi.test.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Console ANSI styling', { tag: ['@pr', '@console'] }, () => {
+test.describe('Console ANSI styling', { tag: [tags.CRITICAL, tags.CONSOLE] }, () => {
 	test.beforeEach(async function ({ app }) {
 		await app.workbench.positronLayouts.enterLayout('fullSizedPanel');
 	});

--- a/test/e2e/features/console/console-autocomplete.test.ts
+++ b/test/e2e/features/console/console-autocomplete.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test } from '../_test.setup';
+import { test, tags } from '../_test.setup';
 import { fail } from 'assert';
 
 test.use({
@@ -11,7 +11,7 @@ test.use({
 });
 
 test.describe('Console Autocomplete', {
-	tag: ['@web', '@win', '@console']
+	tag: [tags.WEB, tags.WIN, tags.CONSOLE]
 }, () => {
 	test('Python - Verify Console Autocomplete [C947968]', async function ({ app, python }) {
 		await app.workbench.positronConsole.pasteCodeToConsole('import pandas as pd');

--- a/test/e2e/features/console/console-clipboard.test.ts
+++ b/test/e2e/features/console/console-clipboard.test.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as os from 'os';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 import { Application } from '../../../automation';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Console - Clipboard', { tag: ['@console'] }, () => {
+test.describe('Console - Clipboard', { tag: [tags.CONSOLE] }, () => {
 	test('Python - Copy from console & paste to console [C608100]', async function ({ app, python }) {
 		await testBody(app);
 	});

--- a/test/e2e/features/console/console-history.test.ts
+++ b/test/e2e/features/console/console-history.test.ts
@@ -3,14 +3,14 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Console History', {
-	tag: ['@web', '@win', '@console']
+	tag: [tags.WEB, tags.WIN, tags.CONSOLE]
 }, () => {
 	test.afterEach(async function ({ app }) {
 		app.workbench.positronConsole.sendKeyboardKey('Escape');

--- a/test/e2e/features/console/console-input.test.ts
+++ b/test/e2e/features/console/console-input.test.ts
@@ -3,14 +3,14 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Console Input', {
-	tag: ['@web', '@pr', '@win', '@console']
+	tag: [tags.WEB, tags.CRITICAL, tags.WIN, tags.CONSOLE]
 }, () => {
 
 	test.describe('Console Input - Python', () => {

--- a/test/e2e/features/console/console-output.test.ts
+++ b/test/e2e/features/console/console-output.test.ts
@@ -3,13 +3,13 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test } from '../_test.setup';
+import { test, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Console Output', { tag: ['@win', '@console'] }, () => {
+test.describe('Console Output', { tag: [tags.WIN, tags.CONSOLE] }, () => {
 	test('R - Console output in a loop with short pauses [C885225]', async function ({ app, r }) {
 		await app.workbench.positronConsole.pasteCodeToConsole(rCode);
 		await app.workbench.positronConsole.sendEnterKey();

--- a/test/e2e/features/console/console-python.test.ts
+++ b/test/e2e/features/console/console-python.test.ts
@@ -3,13 +3,13 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Console Pane: Python', { tag: ['@web', '@win', '@console'] }, () => {
+test.describe('Console Pane: Python', { tag: [tags.WEB, tags.WIN, tags.CONSOLE] }, () => {
 
 	test('Verify restart button inside the console [C377918]', async function ({ app, python }) {
 		await expect(async () => {

--- a/test/e2e/features/console/console-r.test.ts
+++ b/test/e2e/features/console/console-r.test.ts
@@ -3,14 +3,14 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Console Pane: R', {
-	tag: ['@web', '@win', '@console']
+	tag: [tags.WEB, tags.WIN, tags.CONSOLE]
 }, () => {
 	test.beforeAll(async function ({ app }) {
 		// Need to make console bigger to see all bar buttons

--- a/test/e2e/features/data-explorer/100x100-pandas.test.ts
+++ b/test/e2e/features/data-explorer/100x100-pandas.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test } from '../_test.setup';
+import { test, tags } from '../_test.setup';
 import { join } from 'path';
 import { parquetFilePath, testDataExplorer } from './helpers/100x100';
 
@@ -11,7 +11,9 @@ test.use({
 	suiteId: __filename
 });
 
-test('Data Explorer 100x100 - Python - Pandas [C557563]', { tag: ['@win', '@data-explorer'] }, async function ({ app, python }) {
+test('Data Explorer 100x100 - Python - Pandas [C557563]', {
+	tag: [tags.WIN, tags.DATA_EXPLORER]
+}, async function ({ app, python }) {
 	test.slow();
 
 	const dataFrameName = 'pandas100x100';

--- a/test/e2e/features/data-explorer/100x100-polars.test.ts
+++ b/test/e2e/features/data-explorer/100x100-polars.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test } from '../_test.setup';
+import { test, tags } from '../_test.setup';
 import { join } from 'path';
 import { parquetFilePath, testDataExplorer } from './helpers/100x100';
 
@@ -11,7 +11,9 @@ test.use({
 	suiteId: __filename
 });
 
-test('Data Explorer 100x100 - Python - Polars [C674520]', { tag: ['@win', '@data-explorer'] }, async function ({ app, python }) {
+test('Data Explorer 100x100 - Python - Polars [C674520]', {
+	tag: [tags.WIN, tags.DATA_EXPLORER]
+}, async function ({ app, python }) {
 	test.slow();
 
 	const dataFrameName = 'polars100x100';

--- a/test/e2e/features/data-explorer/100x100-r.test.ts
+++ b/test/e2e/features/data-explorer/100x100-r.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test } from '../_test.setup';
+import { test, tags } from '../_test.setup';
 import { join } from 'path';
 import { parquetFilePath, testDataExplorer } from './helpers/100x100';
 
@@ -11,7 +11,9 @@ test.use({
 	suiteId: __filename
 });
 
-test('Data Explorer 100x100 - R [C674521]', { tag: ['@win', '@data-explorer'] }, async function ({ app, r }) {
+test('Data Explorer 100x100 - R [C674521]', {
+	tag: [tags.WIN, tags.DATA_EXPLORER]
+}, async function ({ app, r }) {
 	test.slow();
 
 	// Test the data explorer.

--- a/test/e2e/features/data-explorer/data-explorer-headless.test.ts
+++ b/test/e2e/features/data-explorer/data-explorer-headless.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 import { Application, Logger } from '../../../automation';
 
 test.use({
@@ -12,7 +12,7 @@ test.use({
 });
 
 test.describe('Headless Data Explorer - Large Data Frame', {
-	tag: ['@web', '@data-explorer', '@duck-db']
+	tag: [tags.WEB, tags.DATA_EXPLORER, tags.DUCK_DB]
 }, () => {
 	// python fixture not actually needed but serves as a long wait so that we can be sure
 	// headless/duckdb open will work

--- a/test/e2e/features/data-explorer/data-explorer-python-pandas.test.ts
+++ b/test/e2e/features/data-explorer/data-explorer-python-pandas.test.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Data Explorer - Python Pandas', {
-	tag: ['@web', '@win', '@pr', '@data-explorer']
+	tag: [tags.WEB, tags.WIN, tags.CRITICAL, tags.DATA_EXPLORER]
 }, () => {
 	test('Python Pandas - Verifies basic data explorer functionality [C557556]', async function ({ app, python, logger }) {
 		// modified snippet from https://www.geeksforgeeks.org/python-pandas-dataframe/

--- a/test/e2e/features/data-explorer/data-explorer-python-polars.test.ts
+++ b/test/e2e/features/data-explorer/data-explorer-python-polars.test.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Data Explorer - Python Polars', {
-	tag: ['@win', '@web', '@pr', '@data-explorer']
+	tag: [tags.WIN, tags.WEB, tags.CRITICAL, tags.DATA_EXPLORER]
 }, () => {
 	test('Python Polars - Verifies basic data explorer functionality [C644538]', async function ({ app, python, logger }) {
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'polars-dataframe-py', 'polars_basic.py'));

--- a/test/e2e/features/data-explorer/data-explorer-r.test.ts
+++ b/test/e2e/features/data-explorer/data-explorer-r.test.ts
@@ -3,16 +3,16 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Data Explorer - R ', {
-	tag: ['@web', '@win', '@data-explorer']
+	tag: [tags.WEB, tags.WIN, tags.DATA_EXPLORER]
 }, () => {
-	test('R - Verifies basic data explorer functionality [C609620]', { tag: ['@pr'] }, async function ({ app, r, logger }) {
+	test('R - Verifies basic data explorer functionality [C609620]', { tag: [tags.CRITICAL] }, async function ({ app, r, logger }) {
 		// snippet from https://www.w3schools.com/r/r_data_frames.asp
 		const script = `Data_Frame <- data.frame (
 	Training = c("Strength", "Stamina", "Other"),
@@ -45,7 +45,7 @@ test.describe('Data Explorer - R ', {
 
 	});
 	test('R - Verifies basic data explorer column info functionality [C734265]', {
-		tag: ['@pr']
+		tag: [tags.CRITICAL]
 	}, async function ({ app, r }) {
 		await app.workbench.positronDataExplorer.expandSummary();
 

--- a/test/e2e/features/data-explorer/duckdb-sparklines.test.ts
+++ b/test/e2e/features/data-explorer/duckdb-sparklines.test.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Data Explorer - DuckDB Column Summary', {
-	tag: ['@web', '@win', '@pr', '@data-explorer', '@duck-db']
+	tag: [tags.WEB, tags.WIN, tags.CRITICAL, tags.DATA_EXPLORER, tags.DUCK_DB]
 }, () => {
 	// python fixture not actually needed but serves as a long wait so that we can be sure
 	// headless/duckdb open will work

--- a/test/e2e/features/data-explorer/large-data-frame.test.ts
+++ b/test/e2e/features/data-explorer/large-data-frame.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 const LAST_CELL_CONTENTS = '2013-09-30 08:00:00';
 const FILTER_PARAMS = ['distance', 'is equal to', '2586'];
@@ -15,7 +15,7 @@ test.use({
 });
 
 test.describe('Data Explorer - Large Data Frame', {
-	tag: ['@pr', '@web', '@win', '@data-explorer']
+	tag: [tags.CRITICAL, tags.WEB, tags.WIN, tags.DATA_EXPLORER]
 }, () => {
 	test.beforeEach(async function ({ app }) {
 		await app.workbench.positronLayouts.enterLayout('stacked');
@@ -58,7 +58,7 @@ test.describe('Data Explorer - Large Data Frame', {
 	});
 
 	test('R - Verifies data explorer functionality with large data frame [C557554]', {
-		tag: ['@web', '@pr']
+		tag: [tags.WEB, tags.CRITICAL]
 	}, async function ({ app, logger, r }) {
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'nyc-flights-data-r', 'flights-data-frame.r'));
 		await app.workbench.quickaccess.runCommand('r.sourceCurrentFile');

--- a/test/e2e/features/data-explorer/sparklines.test.ts
+++ b/test/e2e/features/data-explorer/sparklines.test.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Application } from '../../../automation';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Data Explorer - Sparklines', {
-	tag: ['@web', '@win', '@data-explorer']
+	tag: [tags.WEB, tags.WIN, tags.DATA_EXPLORER]
 }, () => {
 
 	test.beforeEach(async function ({ app }) {

--- a/test/e2e/features/data-explorer/very-large-data-frame.test.ts
+++ b/test/e2e/features/data-explorer/very-large-data-frame.test.ts
@@ -6,7 +6,7 @@
 import { fail } from 'assert';
 import { join } from 'path';
 import { downloadFileFromS3, S3FileDownloadOptions } from '../../../automation';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -19,7 +19,7 @@ const objectKey = "largeParquet.parquet";
 
 const githubActions = process.env.GITHUB_ACTIONS === "true";
 
-test.describe('Data Explorer - Very Large Data Frame', { tag: ['@win', '@data-explorer'] }, () => {
+test.describe('Data Explorer - Very Large Data Frame', { tag: [tags.WIN, tags.DATA_EXPLORER] }, () => {
 	test.beforeAll(async function ({ app }) {
 		if (githubActions) {
 			const localFilePath = join(app.workspacePathOrFolder, "data-files", objectKey);

--- a/test/e2e/features/data-explorer/xlsx-data-frame.test.ts
+++ b/test/e2e/features/data-explorer/xlsx-data-frame.test.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Data Explorer - XLSX', {
-	tag: ['@web', '@win', '@data-explorer']
+	tag: [tags.WEB, tags.WIN, tags.DATA_EXPLORER]
 }, () => {
 
 	test.afterEach(async function ({ app }) {

--- a/test/e2e/features/editor/fast-execution.test.ts
+++ b/test/e2e/features/editor/fast-execution.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -12,7 +12,7 @@ test.use({
 
 const FILENAME = 'fast-execution.r';
 
-test.describe('R Fast Execution', { tag: ['@web', '@editor'] }, () => {
+test.describe('R Fast Execution', { tag: [tags.WEB, tags.EDITOR] }, () => {
 	test('Verify fast execution is not out of order [C712539]', async function ({ app, r }) {
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'fast-statement-execution', FILENAME));
 

--- a/test/e2e/features/help/f1.test.ts
+++ b/test/e2e/features/help/f1.test.ts
@@ -4,15 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
 
-test.describe('F1 Help #web #win', {
-	tag: ['@web', '@win', '@help']
+test.describe('F1 Help', {
+	tag: [tags.WEB, tags.WIN, tags.HELP]
 }, () => {
 
 	test.afterEach(async function ({ app }) {

--- a/test/e2e/features/help/help.test.ts
+++ b/test/e2e/features/help/help.test.ts
@@ -3,13 +3,13 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Help', { tag: ['@help'] }, () => {
+test.describe('Help', { tag: [tags.HELP] }, () => {
 
 	test('Python - Verifies basic help functionality [C633814]', async function ({ app, python }) {
 		await app.workbench.positronConsole.executeCode('Python', `?load`, '>>>');

--- a/test/e2e/features/layouts/layouts.test.ts
+++ b/test/e2e/features/layouts/layouts.test.ts
@@ -3,13 +3,13 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Layouts', { tag: ['@web', '@layouts'] }, () => {
+test.describe('Layouts', { tag: [tags.WEB, tags.LAYOUTS] }, () => {
 
 	test.describe('Stacked Layout', () => {
 

--- a/test/e2e/features/new-project-wizard/new-project-python.test.ts
+++ b/test/e2e/features/new-project-wizard/new-project-python.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { PositronPythonFixtures, ProjectType, ProjectWizardNavigateAction } from '../../../automation';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -14,7 +14,7 @@ test.beforeEach(async function ({ app }) {
 	await app.workbench.positronConsole.waitForReadyOrNoInterpreter();
 });
 
-test.describe('Python - New Project Wizard', { tag: ['@new-project-wizard'] }, () => {
+test.describe('Python - New Project Wizard', { tag: [tags.NEW_PROJECT_WIZARD] }, () => {
 	const defaultProjectName = 'my-python-project';
 
 	test('Create a new Conda environment [C628628]', async function ({ app, page }) {
@@ -43,7 +43,7 @@ test.describe('Python - New Project Wizard', { tag: ['@new-project-wizard'] }, (
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 	});
 
-	test('Create a new Venv environment [C627912]', { tag: ['@pr'] }, async function ({ app, page }) {
+	test('Create a new Venv environment [C627912]', { tag: [tags.CRITICAL] }, async function ({ app, page }) {
 		// This is the default behavior for a new Python Project in the Project Wizard
 		const projSuffix = addRandomNumSuffix('_new_venv');
 		const pw = app.workbench.positronNewProjectWizard;
@@ -149,7 +149,7 @@ test.describe('Python - New Project Wizard', { tag: ['@new-project-wizard'] }, (
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 	});
 
-	test('Default Python Project with git init [C674522]', { tag: ['@pr', '@win'] }, async function ({ app, page }) {
+	test('Default Python Project with git init [C674522]', { tag: [tags.CRITICAL, tags.WIN] }, async function ({ app, page }) {
 		const projSuffix = addRandomNumSuffix('_gitInit');
 		const pw = app.workbench.positronNewProjectWizard;
 		await pw.startNewProject(ProjectType.PYTHON_PROJECT);

--- a/test/e2e/features/new-project-wizard/new-project-r-jupyter.test.ts
+++ b/test/e2e/features/new-project-wizard/new-project-r-jupyter.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ProjectType, ProjectWizardNavigateAction } from '../../../automation';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -15,12 +15,12 @@ test.beforeEach(async function ({ app }) {
 	await app.workbench.positronLayouts.enterLayout("stacked");
 });
 
-test.describe('R - New Project Wizard', { tag: ['@new-project-wizard'] }, () => {
+test.describe('R - New Project Wizard', { tag: [tags.NEW_PROJECT_WIZARD] }, () => {
 	test.describe.configure({ mode: 'serial' });
 
 	const defaultProjectName = 'my-r-project';
 
-	test('R - Project Defaults [C627913]', { tag: ['@pr', '@win'] }, async function ({ app }) {
+	test('R - Project Defaults [C627913]', { tag: [tags.CRITICAL, tags.WIN] }, async function ({ app }) {
 		const projSuffix = addRandomNumSuffix('_defaults');
 		const pw = app.workbench.positronNewProjectWizard;
 		await pw.startNewProject(ProjectType.R_PROJECT);
@@ -138,7 +138,7 @@ test.describe('R - New Project Wizard', { tag: ['@new-project-wizard'] }, () => 
 test.describe('Jupyter - New Project Wizard', () => {
 	const defaultProjectName = 'my-jupyter-notebook';
 
-	test('Jupyter Project Defaults [C629352]', { tag: ['@pr'] }, async function ({ app }) {
+	test('Jupyter Project Defaults [C629352]', { tag: [tags.CRITICAL] }, async function ({ app }) {
 		const projSuffix = addRandomNumSuffix('_defaults');
 		const pw = app.workbench.positronNewProjectWizard;
 		await pw.startNewProject(ProjectType.JUPYTER_NOTEBOOK);

--- a/test/e2e/features/notebook/notebook-create.test.ts
+++ b/test/e2e/features/notebook/notebook-create.test.ts
@@ -3,13 +3,15 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test } from '../_test.setup';
+import { test, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Notebooks', { tag: ['@pr', '@web', '@win', '@notebook'] }, () => {
+test.describe('Notebooks', {
+	tag: [tags.CRITICAL, tags.WEB, tags.WIN, tags.NOTEBOOK]
+}, () => {
 	test.describe('Python Notebooks', () => {
 		test.beforeEach(async function ({ app, python }) {
 			await app.workbench.positronLayouts.enterLayout('notebook');

--- a/test/e2e/features/notebook/notebook-large-python.test.ts
+++ b/test/e2e/features/notebook/notebook-large-python.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename,
@@ -12,7 +12,9 @@ test.use({
 });
 
 // Note that this test is too heavy to pass on web and windows
-test.describe('Large Python Notebook', { tag: ['@notebook'] }, () => {
+test.describe('Large Python Notebook', {
+	tag: [tags.NOTEBOOK]
+}, () => {
 
 	test('Python - Large notebook execution [C983592]', async function ({ app, python }) {
 		test.setTimeout(480_000); // huge timeout because this is a heavy test

--- a/test/e2e/features/outline/outline.test.ts
+++ b/test/e2e/features/outline/outline.test.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test } from '../_test.setup';
+import { test, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Outline #web #win', {
-	tag: ['@web', '@win', '@outline']
+	tag: [tags.WEB, tags.WIN, tags.OUTLINE]
 }, () => {
 
 	test('Python - Verify Outline Contents [C956870]', async function ({ app, python }) {

--- a/test/e2e/features/output/console-ouput-log.test.ts
+++ b/test/e2e/features/output/console-ouput-log.test.ts
@@ -3,13 +3,13 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test } from '../_test.setup';
+import { test, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Console Output Log', { tag: ['@web', '@output', '@console'] }, () => {
+test.describe('Console Output Log', { tag: [tags.WEB, tags.OUTPUT, tags.CONSOLE] }, () => {
 	test.beforeEach(async function ({ app }) {
 		await app.workbench.positronLayouts.enterLayout('stacked');
 	});

--- a/test/e2e/features/plots/plots.test.ts
+++ b/test/e2e/features/plots/plots.test.ts
@@ -4,18 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'path';
+import { test, expect, tags } from '../_test.setup';
 const compareImages = require('resemblejs/compareImages');
 import { ComparisonOptions } from 'resemblejs';
 import * as fs from 'fs';
 import { fail } from 'assert';
-import { test, expect } from '../_test.setup';
 import { Application } from '../../../automation';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Plots', { tag: ['@plots', '@editor'] }, () => {
+test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 	// Some tests are not tagged @win because they woould require a new master image.
 	test.describe('Python Plots', () => {
 
@@ -40,7 +40,7 @@ test.describe('Plots', { tag: ['@plots', '@editor'] }, () => {
 		});
 
 		test('Python - Verifies basic plot functionality - Dynamic Plot [C608114]', {
-			tag: ['@pr', '@web']
+			tag: [tags.CRITICAL, tags.WEB]
 		}, async function ({ app, logger, headless }) {
 			// modified snippet from https://www.geeksforgeeks.org/python-pandas-dataframe/
 			logger.log('Sending code to console');
@@ -86,7 +86,7 @@ test.describe('Plots', { tag: ['@plots', '@editor'] }, () => {
 			await app.workbench.positronPlots.waitForNoPlots();
 		});
 
-		test('Python - Verifies basic plot functionality - Static Plot [C654401]', { tag: ['@pr', '@web'] }, async function ({ app, logger }) {
+		test('Python - Verifies basic plot functionality - Static Plot [C654401]', { tag: [tags.CRITICAL, tags.WEB] }, async function ({ app, logger }) {
 			logger.log('Sending code to console');
 			await app.workbench.positronConsole.executeCode('Python', pythonStaticPlot, '>>>');
 			await app.workbench.positronPlots.waitForCurrentStaticPlot();
@@ -114,7 +114,7 @@ test.describe('Plots', { tag: ['@plots', '@editor'] }, () => {
 
 		});
 
-		test('Python - Verifies the plots pane action bar - Plot actions [C656297]', { tag: ['@web', '@win'] }, async function ({ app }) {
+		test('Python - Verifies the plots pane action bar - Plot actions [C656297]', { tag: [tags.WEB, tags.WIN] }, async function ({ app }) {
 			const plots = app.workbench.positronPlots;
 
 			// default plot pane state for action bar
@@ -161,7 +161,7 @@ test.describe('Plots', { tag: ['@plots', '@editor'] }, () => {
 			await expect(plots.plotSizeButton).not.toBeDisabled();
 		});
 
-		test('Python - Verifies saving a Python plot [C557005]', { tag: ['@win'] }, async function ({ app, logger }) {
+		test('Python - Verifies saving a Python plot [C557005]', { tag: [tags.WIN] }, async function ({ app, logger }) {
 			logger.log('Sending code to console');
 			await app.workbench.positronConsole.executeCode('Python', savePlot, '>>>');
 			await app.workbench.positronPlots.waitForCurrentPlot();
@@ -172,23 +172,23 @@ test.describe('Plots', { tag: ['@plots', '@editor'] }, () => {
 			await app.workbench.positronExplorer.waitForProjectFileToAppear('Python-scatter.jpeg');
 		});
 
-		test('Python - Verifies bqplot Python widget [C720869]', { tag: ['@web', '@win'] }, async function ({ app }) {
+		test('Python - Verifies bqplot Python widget [C720869]', { tag: [tags.WEB, tags.WIN] }, async function ({ app }) {
 			await runScriptAndValidatePlot(app, bgplot, '.svg-figure');
 		});
 
-		test('Python - Verifies ipydatagrid Python widget [C720870]', { tag: ['@web', '@win'] }, async function ({ app }) {
+		test('Python - Verifies ipydatagrid Python widget [C720870]', { tag: [tags.WEB, tags.WIN] }, async function ({ app }) {
 			await runScriptAndValidatePlot(app, ipydatagrid, 'canvas:nth-child(1)');
 		});
 
-		test('Python - Verifies ipyleaflet Python widget [C720871]', { tag: ['@web', '@win'] }, async function ({ app }) {
+		test('Python - Verifies ipyleaflet Python widget [C720871]', { tag: [tags.WEB, tags.WIN] }, async function ({ app }) {
 			await runScriptAndValidatePlot(app, ipyleaflet, '.leaflet-container');
 		});
 
-		test('Python - Verifies hvplot can load with plotly extension [C766660]', { tag: ['@web', '@win'] }, async function ({ app }) {
+		test('Python - Verifies hvplot can load with plotly extension [C766660]', { tag: [tags.WEB, tags.WIN] }, async function ({ app }) {
 			await runScriptAndValidatePlot(app, plotly, '.plotly');
 		});
 
-		test('Python - Verifies ipytree Python widget [C720872]', { tag: ['@web', '@win'] }, async function ({ app }) {
+		test('Python - Verifies ipytree Python widget [C720872]', { tag: [tags.WEB, tags.WIN] }, async function ({ app }) {
 			await runScriptAndValidatePlot(app, ipytree, '.jstree-container-ul');
 
 			// fullauxbar layout needed for some smaller windows
@@ -203,7 +203,7 @@ test.describe('Plots', { tag: ['@plots', '@editor'] }, () => {
 			await expect(treeNodes).toHaveCount(3);
 		});
 
-		test('Python - Verifies ipywidget.Output Python widget', { tag: ['@web', '@win'] }, async function ({ app }) {
+		test('Python - Verifies ipywidget.Output Python widget', { tag: [tags.WEB, tags.WIN] }, async function ({ app }) {
 			await app.workbench.positronConsole.pasteCodeToConsole(ipywidgetOutput);
 			await app.workbench.positronConsole.sendEnterKey();
 			await app.workbench.positronPlots.waitForWebviewPlot('.widget-output', 'attached');
@@ -220,7 +220,7 @@ test.describe('Plots', { tag: ['@plots', '@editor'] }, () => {
 			expect(lines).not.toContain('Hello, world!');
 		});
 
-		test('Python - Verifies bokeh Python widget [C730343]', { tag: ['@web', '@win'] }, async function ({ app }) {
+		test('Python - Verifies bokeh Python widget [C730343]', { tag: [tags.WEB, tags.WIN] }, async function ({ app }) {
 			await app.workbench.positronConsole.pasteCodeToConsole(bokeh);
 			await app.workbench.positronConsole.sendEnterKey();
 
@@ -278,7 +278,7 @@ test.describe('Plots', { tag: ['@plots', '@editor'] }, () => {
 			await app.workbench.positronPlots.waitForNoPlots();
 		});
 
-		test('R - Verifies basic plot functionality [C628633]', { tag: ['@pr', '@web'] }, async function ({ app, logger, headless }) {
+		test('R - Verifies basic plot functionality [C628633]', { tag: [tags.CRITICAL, tags.WEB] }, async function ({ app, logger, headless }) {
 			logger.log('Sending code to console');
 			await app.workbench.positronConsole.executeCode('R', rBasicPlot, '>');
 			await app.workbench.positronPlots.waitForCurrentPlot();
@@ -321,7 +321,7 @@ test.describe('Plots', { tag: ['@plots', '@editor'] }, () => {
 			await app.workbench.positronPlots.waitForNoPlots();
 		});
 
-		test('R - Verifies saving an R plot [C557006]', { tag: ['@win'] }, async function ({ app, logger }) {
+		test('R - Verifies saving an R plot [C557006]', { tag: [tags.WIN] }, async function ({ app, logger }) {
 			logger.log('Sending code to console');
 
 			await app.workbench.positronConsole.executeCode('R', rSavePlot, '>');
@@ -334,21 +334,21 @@ test.describe('Plots', { tag: ['@plots', '@editor'] }, () => {
 			await app.workbench.positronExplorer.waitForProjectFileToAppear('R-cars.svg');
 		});
 
-		test('R - Verifies rplot plot [C720873]', { tag: ['@web', '@win'] }, async function ({ app }) {
+		test('R - Verifies rplot plot [C720873]', { tag: [tags.WEB, tags.WIN] }, async function ({ app }) {
 			await app.workbench.positronConsole.pasteCodeToConsole(rplot);
 			await app.workbench.positronConsole.sendEnterKey();
 			await app.workbench.positronPlots.waitForCurrentPlot();
 		});
 
-		test('R - Verifies highcharter plot [C720874]', { tag: ['@web', '@win'] }, async function ({ app }) {
+		test('R - Verifies highcharter plot [C720874]', { tag: [tags.WEB, tags.WIN] }, async function ({ app }) {
 			await runScriptAndValidatePlot(app, highcharter, 'svg', app.web);
 		});
 
-		test('R - Verifies leaflet plot [C720875]', { tag: ['@web', '@win'] }, async function ({ app }) {
+		test('R - Verifies leaflet plot [C720875]', { tag: [tags.WEB, tags.WIN] }, async function ({ app }) {
 			await runScriptAndValidatePlot(app, leaflet, '.leaflet', app.web);
 		});
 
-		test('R - Verifies plotly plot [C720876]', { tag: ['@web', '@win'] }, async function ({ app }) {
+		test('R - Verifies plotly plot [C720876]', { tag: [tags.WEB, tags.WIN] }, async function ({ app }) {
 			await runScriptAndValidatePlot(app, rPlotly, '.plot-container', app.web);
 		});
 	});

--- a/test/e2e/features/quarto/quarto.test.ts
+++ b/test/e2e/features/quarto/quarto.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Application } from '../../../automation';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 const path = require('path');
 const fs = require('fs-extra');
 
@@ -14,7 +14,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Quarto', { tag: ['@web', '@quarto'] }, () => {
+test.describe('Quarto', { tag: [tags.WEB, tags.QUARTO] }, () => {
 	test.beforeAll(async function ({ app, browserName }) {
 		await app.workbench.quickaccess.openFile(path.join(app.workspacePathOrFolder, 'workspaces', 'quarto_basic', 'quarto_basic.qmd'));
 		isWeb = browserName === 'chromium';

--- a/test/e2e/features/r-markdown/r-markdown.test.ts
+++ b/test/e2e/features/r-markdown/r-markdown.test.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('R Markdown', { tag: ['@web', '@r-markdown'] }, () => {
+test.describe('R Markdown', { tag: [tags.WEB, tags.R_MARKDOWN] }, () => {
 	test('Render R Markdown [C680618]', async function ({ app, r }) {
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'basic-rmd-file', 'basicRmd.rmd'));
 

--- a/test/e2e/features/r-pkg-development/r-pkg-development.test.ts
+++ b/test/e2e/features/r-pkg-development/r-pkg-development.test.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path = require('path');
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('R Package Development', { tag: ['@web', '@r-pkg-development'] }, () => {
+test.describe('R Package Development', { tag: [tags.WEB, tags.R_PKG_DEVELOPMENT] }, () => {
 	test.beforeAll(async function ({ app, r, userSettings }) {
 		try {
 			// don't use native file picker

--- a/test/e2e/features/reticulate/reticulate.test.ts
+++ b/test/e2e/features/reticulate/reticulate.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -14,7 +14,7 @@ test.use({
 // to the installed python path
 
 test.describe('Reticulate', {
-	tag: ['@web', '@reticulate'],
+	tag: [tags.WEB, tags.RETICULATE],
 	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5226' }]
 }, () => {
 	test.beforeAll(async function ({ app, userSettings }) {

--- a/test/e2e/features/test-explorer/test-explorer.test.ts
+++ b/test/e2e/features/test-explorer/test-explorer.test.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path = require('path');
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Test Explorer', { tag: ['@test-explorer'] }, () => {
+test.describe('Test Explorer', { tag: [tags.TEST_EXPLORER] }, () => {
 	test.beforeAll(async function ({ app, r, userSettings }) {
 		try {
 			// don't use native file picker

--- a/test/e2e/features/top-action-bar/interpreter-dropdown.test.ts
+++ b/test/e2e/features/top-action-bar/interpreter-dropdown.test.ts
@@ -8,13 +8,13 @@ import {
 	PositronInterpreterDropdown,
 } from '../../../automation';
 
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe.skip('Interpreter Dropdown in Top Action Bar', { tag: ['@web', '@top-action-bar'] }, () => {
+test.describe.skip('Interpreter Dropdown in Top Action Bar', { tag: [tags.WEB, tags.TOP_ACTION_BAR] }, () => {
 	let interpreterDropdown: PositronInterpreterDropdown;
 	let positronConsole: PositronConsole;
 

--- a/test/e2e/features/top-action-bar/top-action-bar-save.test.ts
+++ b/test/e2e/features/top-action-bar/top-action-bar-save.test.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Top Action Bar - Save Actions', {
-	tag: ['@web', '@top-action-bar']
+	tag: [tags.WEB, tags.TOP_ACTION_BAR]
 }, () => {
 
 	test.beforeAll(async function ({ app, userSettings }) {

--- a/test/e2e/features/variables/variables-expanded.test.ts
+++ b/test/e2e/features/variables/variables-expanded.test.ts
@@ -3,13 +3,13 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Variables - Expanded View', { tag: ['@web', '@variables'] }, () => {
+test.describe('Variables - Expanded View', { tag: [tags.WEB, tags.VARIABLES] }, () => {
 	test.beforeEach(async function ({ app, python }) {
 		await app.workbench.positronConsole.executeCode('Python', script, '>>>');
 		await app.workbench.positronLayouts.enterLayout('fullSizedAuxBar');

--- a/test/e2e/features/variables/variables-notebook.test.ts
+++ b/test/e2e/features/variables/variables-notebook.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -14,7 +14,9 @@ test.afterEach(async function ({ app }) {
 	await app.workbench.positronLayouts.enterLayout('stacked');
 });
 
-test.describe('Variables Pane - Notebook', { tag: ['@pr', '@web', '@variables', '@notebook'] }, () => {
+test.describe('Variables Pane - Notebook', {
+	tag: [tags.CRITICAL, tags.WEB, tags.VARIABLES, tags.NOTEBOOK]
+}, () => {
 	test('Python - Verifies Variables pane basic function for notebook [C669188]', async function ({ app, python }) {
 		await app.workbench.positronNotebooks.createNewNotebook();
 

--- a/test/e2e/features/variables/variables-pane.test.ts
+++ b/test/e2e/features/variables/variables-pane.test.ts
@@ -3,13 +3,15 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Variables Pane', { tag: ['@web', '@win', '@pr', '@variables'] }, () => {
+test.describe('Variables Pane', {
+	tag: [tags.WEB, tags.WIN, tags.CRITICAL, tags.VARIABLES]
+}, () => {
 	test.beforeEach(async function ({ app }) {
 		await app.workbench.positronLayouts.enterLayout('stacked');
 	});

--- a/test/e2e/features/viewer/viewer.test.ts
+++ b/test/e2e/features/viewer/viewer.test.ts
@@ -3,13 +3,13 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test } from '../_test.setup';
+import { test, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Viewer', { tag: ['@viewer'] }, () => {
+test.describe('Viewer', { tag: [tags.VIEWER] }, () => {
 
 	test.afterEach(async function ({ app }) {
 		await app.workbench.positronViewer.clearViewer();
@@ -60,7 +60,6 @@ test.describe('Viewer', { tag: ['@viewer'] }, () => {
 	});
 
 	test('R - Verify Viewer functionality with reactable [C784930]', async function ({ app, logger, r }) {
-
 
 		logger.log('Sending code to console');
 		await app.workbench.positronConsole.executeCode('R', rReactableScript, '>');

--- a/test/e2e/features/welcome/welcome.test.ts
+++ b/test/e2e/features/welcome/welcome.test.ts
@@ -3,13 +3,13 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Welcome Page', { tag: ['@welcome'] }, () => {
+test.describe('Welcome Page', { tag: [tags.WELCOME] }, () => {
 	test.beforeEach(async function ({ app }) {
 		await app.workbench.quickaccess.runCommand('Help: Welcome');
 	});

--- a/test/e2e/helpers/index.ts
+++ b/test/e2e/helpers/index.ts
@@ -7,3 +7,4 @@ export { prepareTestEnv } from './test-setup';
 export { cloneTestRepo } from './utils';
 export { createApp } from './create-app';
 export { createLogger } from './logger';
+export { TestTags } from './test-tags';

--- a/test/e2e/helpers/test-tags.ts
+++ b/test/e2e/helpers/test-tags.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export enum TestTags {
+	APPS = '@apps',
+	CONNECTIONS = '@connections',
+	CONSOLE = '@console',
+	CRITICAL = '@critical',
+	DATA_EXPLORER = '@data-explorer',
+	DUCK_DB = '@duck-db',
+	HELP = '@help',
+	LAYOUTS = '@layouts',
+	VIEWER = '@viewer',
+	EDITOR = '@editor',
+	QUARTO = '@quarto',
+	NEW_PROJECT_WIZARD = '@new-project-wizard',
+	NOTEBOOK = '@notebook',
+	OUTLINE = '@outline',
+	OUTPUT = '@output',
+	PLOTS = '@plots',
+	R_MARKDOWN = '@r-markdown',
+	R_PKG_DEVELOPMENT = '@r-pkg-development',
+	RETICULATE = '@reticulate',
+	TEST_EXPLORER = '@test-explorer',
+	TOP_ACTION_BAR = '@top-action-bar',
+	VARIABLES = '@variables',
+	WEB = '@web',
+	WELCOME = '@welcome',
+	WIN = '@win'
+}


### PR DESCRIPTION
This PR updates test tags to use a centralized enum, enhancing consistency and accuracy in tests. Additionally, the `@pr` tag has been renamed to `@critical` to better reflect its purpose as a marker for tests essential to the product. All tests tagged as `@critical` will run on every PR.

### QA Notes

Ran full suite of tests: https://github.com/posit-dev/positron/actions/runs/12256783196
