### PR TITLE
Treat last line of selection more similar to the start line

### DIFF
--- a/src/vs/workbench/api/common/positron/extHostMethods.ts
+++ b/src/vs/workbench/api/common/positron/extHostMethods.ts
@@ -204,12 +204,16 @@ export class ExtHostMethods implements extHostProtocol.ExtHostMethodsShape {
 			const unicodePointsBeforeStart = Array.from(lineTextBeforeStart).length;
 
 			const text = editor.document.getText(selection);
-			const unicodePointsInSelection = Array.from(text).length;
+
+			const lineTextBeforeEnd = editor.document
+				.lineAt(selection.end.line)
+				.text.substring(0, selection.end.character);
+			const unicodePointsInSelectionEnd = Array.from(lineTextBeforeEnd).length;
 
 			return {
 				active: { line: selection.active.line, character: unicodePointsBeforeActive },
 				start: { line: selection.start.line, character: unicodePointsBeforeStart },
-				end: { line: selection.end.line, character: unicodePointsBeforeStart + unicodePointsInSelection },
+				end: { line: selection.end.line, character: unicodePointsInSelectionEnd },
 				text: text
 			};
 		});


### PR DESCRIPTION
Addresses #5682

That issue talks about the selection ending in a newline, but I think the more general statement of the problem/bug is that we're reporting an incorrect ending character for selections that start on one line and end on another.

### QA Notes

Here's some potentially tricky text, to make sure that we continue to account for multi-byte characters. Put this in an R file (or untitled file created with R: New R File). Make various selections (single or multiple) and check that the result of `rstudioapi::getActiveDocumentContext()` makes sense.

```
"nail 💅 care"
"crème brûlée"
"woman 🤷‍♀️ shrugging"
```

Make sure to check a selection that starts on one line and ends on another line. If you select a whole line with click-click-click, this selection will span the whole line and include the trailing newline, if there is one, resulting the selection ending on the first character of the next line (as in the example given by OP in #5682).

Note that 🤷‍♀️ is a ZWJ sequence (constructed from a combination of multiple emojis) and it is to be expected that it "counts" for 4 characters. If you inspect Positron's info on cursor position, you can verify we are being consistent. I'm talking about this circled readout for cursor position in lower right:

<img width="1045" alt="Screenshot 2024-12-10 at 10 32 02 PM" src="https://github.com/user-attachments/assets/e1235d62-ad76-4d70-94f7-1a68eb0acb31">


A few examples:

---

Selection = Entire first line, including its newline:

```
> rstudioapi::getActiveDocumentContext()$selection[[1]]
$range
Document Range:
- Start: [1, 1]
- End: [2, 1]

$text
[1] "\"nail 💅 care\"\n"
```

(Previously this would report `- End: [2, 15]`.)

---

Selection = Part of line 2, part of line 3:

```
> rstudioapi::getActiveDocumentContext()$selection[[1]]
$range
Document Range:
- Start: [2, 11]
- End: [3, 14]

$text
[1] "lée\"\n\"woman 🤷‍♀️ s"
```

(Previously this would report `- End: [3, 29]`.)
