### PR TITLE
E2E test: verify connections reconnect via dialog

### DIFF
--- a/test/automation/src/positron/positronConnections.ts
+++ b/test/automation/src/positron/positronConnections.ts
@@ -20,12 +20,14 @@ export class PositronConnections {
 	disconnectButton: Locator;
 	connectIcon: Locator;
 	connectionItems: Locator;
+	resumeConnectionButton: Locator;
 
 	constructor(private code: Code, private quickaccess: QuickAccess) {
 		this.deleteConnectionButton = code.driver.page.getByLabel('Delete Connection');
 		this.disconnectButton = code.driver.page.getByLabel('Disconnect');
 		this.connectIcon = code.driver.page.locator('.codicon-arrow-circle-right');
 		this.connectionItems = code.driver.page.locator('.connections-list-item');
+		this.resumeConnectionButton = code.driver.page.locator('.positron-modal-dialog-box').getByRole('button', { name: 'Resume Connection' });
 	}
 
 	async openConnectionsNodes(nodes: string[]) {

--- a/test/e2e/features/connections/connections-db.test.ts
+++ b/test/e2e/features/connections/connections-db.test.ts
@@ -14,7 +14,7 @@ test.describe('SQLite DB Connection', {
 	tag: [tags.WEB, tags.WIN, tags.CRITICAL, tags.CONNECTIONS]
 }, () => {
 	test.beforeAll(async function ({ userSettings }) {
-		await userSettings.set([['positron.connections.showConnectionPane', 'true']], true);
+		await userSettings.set([['positron.connections.showConnectionPane', 'true']]);
 	});
 
 	test.afterEach(async function ({ app }) {
@@ -42,6 +42,15 @@ test.describe('SQLite DB Connection', {
 			await app.workbench.positronConnections.openConnectionsNodes(['main']);
 			await app.workbench.positronConnections.assertConnectionNodes(['albums']);
 		});
+
+		await test.step('Disconnect, reconnect with dialog, & reverify', async () => {
+			await app.workbench.positronConnections.disconnectButton.click();
+			await app.workbench.positronConnections.connectIcon.click();
+			await app.workbench.positronConnections.resumeConnectionButton.click();
+
+			await app.workbench.positronConnections.openConnectionsNodes(['main']);
+			await app.workbench.positronConnections.assertConnectionNodes(['albums']);
+		});
 	});
 
 	test('R - SQLite DB Connection [C628637]', async function ({ app, r }) {
@@ -59,6 +68,16 @@ test.describe('SQLite DB Connection', {
 			await app.workbench.positronConnections.openConnectionsNodes(['SQLiteConnection', 'Default']);
 			await app.workbench.positronConnections.openConnectionsNodes(tables);
 		});
+
+		await test.step('Disconnect, reconnect with dialog, & reverify', async () => {
+			await app.workbench.positronConnections.disconnectButton.click();
+			await app.workbench.positronConnections.connectIcon.click();
+			await app.workbench.positronConnections.resumeConnectionButton.click();
+
+			await app.workbench.positronConnections.openConnectionsNodes(['SQLiteConnection', 'Default']);
+			await app.workbench.positronConnections.openConnectionsNodes(tables);
+		});
+
 	});
 
 	test('R - Connections are update after adding a database,[C663724]', async function ({ app, page, r }) {

--- a/test/e2e/features/connections/connections-db.test.ts
+++ b/test/e2e/features/connections/connections-db.test.ts
@@ -23,7 +23,9 @@ test.describe('SQLite DB Connection', {
 		await app.workbench.positronConnections.deleteConnection();
 	});
 
-	test('Python - SQLite DB Connection [C628636]', async function ({ app, python }) {
+	test.skip('Python - SQLite DB Connection [C628636]', {
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5692' }]
+	}, async function ({ app, python }) {
 		await test.step('Open a Python file and run it', async () => {
 			await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'chinook-db-py', 'chinook-sqlite.py'));
 			await app.workbench.quickaccess.runCommand('python.execInConsole');


### PR DESCRIPTION
Just a small addition of validation of the connections reconnect dialog usage.

### QA Notes

All smoke tests should pass.
