### PR TITLE
Editor Action Bar - Fix Preview in Quarto documents and Open in Viewer in HTML documents

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarActionButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarActionButton.tsx
@@ -12,15 +12,15 @@ import { useEffect, useRef, useState } from 'react'; // eslint-disable-line no-d
 
 // Other dependencies.
 import { IAction } from '../../../../base/common/actions.js';
-import { DisposableStore } from '../../../../base/common/lifecycle.js';
-import { useStateRef } from '../../../../base/browser/ui/react/useStateRef.js';
 import { MenuItemAction } from '../../../actions/common/actions.js';
-import { IModifierKeyStatus, ModifierKeyEmitter } from '../../../../base/browser/dom.js';
-import { IAccessibilityService } from '../../../accessibility/common/accessibility.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { actionTooltip, toMenuActionItem } from '../../common/helpers.js';
 import { useRegisterWithActionBar } from '../useRegisterWithActionBar.js';
 import { usePositronActionBarContext } from '../positronActionBarContext.js';
 import { ActionBarButton, ActionBarButtonProps } from './actionBarButton.js';
-import { actionTooltip, toMenuActionItem } from '../../common/helpers.js';
+import { useStateRef } from '../../../../base/browser/ui/react/useStateRef.js';
+import { IAccessibilityService } from '../../../accessibility/common/accessibility.js';
+import { IModifierKeyStatus, ModifierKeyEmitter } from '../../../../base/browser/dom.js';
 
 /**
  * Constants.
@@ -146,8 +146,13 @@ export const ActionBarActionButton = (props: ActionBarActionButtonProps) => {
 			disabled: !action.enabled,
 			onMouseEnter: () => setMouseInside(true),
 			onMouseLeave: () => setMouseInside(false),
-			onPressed: () =>
-				action.run()
+			onPressed: async () => {
+				try {
+					await action.run();
+				} catch (error) {
+					console.log(error);
+				}
+			}
 		};
 	})();
 

--- a/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
@@ -8,20 +8,20 @@ import * as React from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../nls.js';
+import { IEditorGroupView } from './editor.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { IAction, Separator, SubmenuAction } from '../../../../base/common/actions.js';
-import { IEditorGroupView } from './editor.js';
 import { actionTooltip } from '../../../../platform/positronActionBar/common/helpers.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
 import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { PositronActionBar } from '../../../../platform/positronActionBar/browser/positronActionBar.js';
-import { IMenu, IMenuService, MenuId, MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { ActionBarRegion } from '../../../../platform/positronActionBar/browser/components/actionBarRegion.js';
 import { ActionBarSeparator } from '../../../../platform/positronActionBar/browser/components/actionBarSeparator.js';
 import { ActionBarMenuButton } from '../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
 import { ActionBarActionButton } from '../../../../platform/positronActionBar/browser/components/actionBarActionButton.js';
 import { ActionBarCommandButton } from '../../../../platform/positronActionBar/browser/components/actionBarCommandButton.js';
+import { IMenu, IMenuActionOptions, IMenuService, MenuId, MenuItemAction } from '../../../../platform/actions/common/actions.js';
 
 // Constants.
 const PADDING_LEFT = 8;
@@ -185,7 +185,11 @@ export class EditorActionBarFactory extends Disposable {
 		const primaryActions: IAction[] = [];
 		const secondaryActions: IAction[] = [];
 		const submenuDescriptors = new Set<SubmenuDescriptor>();
-		for (const [group, actions] of this._editorTitleMenu.getActions()) {
+		const options = {
+			arg: this._editorGroup.activeEditor?.resource,
+			shouldForwardArgs: true
+		} satisfies IMenuActionOptions;
+		for (const [group, actions] of this._editorTitleMenu.getActions(options)) {
 			// Determine the target actions.
 			const targetActions = this.isPrimaryGroup(group) ? primaryActions : secondaryActions;
 


### PR DESCRIPTION
### Description

This PR addresses #5500.

For Quarto documents, the **Preview** Editor Action Bar button is now working:

https://github.com/user-attachments/assets/bf4b18f6-2323-4e91-bd9c-e82a180c7d2f

For HTML documents, the **Open in Viewer** Editor Action Bar button is now working:

https://github.com/user-attachments/assets/0c1d9f8c-c91e-4df6-bbde-8e8700779f28
