### PR TITLE
Cleanup stale github action references to download or upload artifact v3

### DIFF
--- a/extensions/positron-python/.github/actions/build-vsix/action.yml
+++ b/extensions/positron-python/.github/actions/build-vsix/action.yml
@@ -87,7 +87,7 @@ runs:
       shell: bash
 
     - name: Upload VSIX
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact_name }}
         path: ${{ inputs.vsix_name }}

--- a/extensions/positron-python/.github/actions/smoke-tests/action.yml
+++ b/extensions/positron-python/.github/actions/smoke-tests/action.yml
@@ -43,7 +43,7 @@ runs:
 
     # Bits from the VSIX are reused by smokeTest.ts to speed things up.
     - name: Download VSIX
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact_name }}
 


### PR DESCRIPTION
Even if we do not use these actions, moving them to v4 to avoid these showing up as false positives in searches.