### PR TITLE
allow for pop out viewer in editor tab and split editors

### DIFF
--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -48,7 +48,7 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 
 	private _onDidChangeActivePreviewWebview = new Emitter<string>;
 
-	private _editors: Map<string, { uri: URI; webview: PreviewWebview; title?: string }> = new Map();
+	private _editors: Map<string, { uri: URI; title?: string }> = new Map();
 
 	constructor(
 		@ICommandService private readonly _commandService: ICommandService,
@@ -515,7 +515,6 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		const previewId = `editorPreview.${uri.toString()}`;
 		this._editors.set(previewId, {
 			uri: uri,
-			webview: this.createPreviewUrl(previewId, undefined, uri),
 			title: title || uri.authority || uri.path
 		});
 
@@ -528,7 +527,9 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 	}
 
 	public editorWebview(editorId: string): PreviewWebview | undefined {
-		return this._editors.get(editorId)?.webview;
+		const uri = this._editors.get(editorId)?.uri;
+		if (!uri) { return undefined; }
+		return this.createPreviewUrl(editorId, undefined, uri);
 	}
 
 	public editorTitle(previewId: string): string | undefined {
@@ -536,7 +537,6 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 	}
 
 	public disposeEditor(previewId: string): void {
-		this._editors.get(previewId)?.webview.dispose();
 		// Remove the preview
 		this._editors.delete(previewId);
 	}

--- a/src/vs/workbench/contrib/positronPreviewEditor/browser/positronPreviewEditor.tsx
+++ b/src/vs/workbench/contrib/positronPreviewEditor/browser/positronPreviewEditor.tsx
@@ -111,16 +111,6 @@ export class PositronPreviewEditor
 			storageService
 		);
 		this._container = DOM.$('.positron-preview-editor-container');
-
-		this._register(this.onVisibilityChanged(visible => {
-			if (!visible) {
-				this._onSaveScrollPositionEmitter.fire();
-			} else {
-				this._onRestoreScrollPositionEmitter.fire();
-			}
-			this._onVisibilityChangedEmitter.fire(visible);
-		}
-		));
 	}
 
 	private renderContainer(previewId: string): void {
@@ -184,12 +174,9 @@ export class PositronPreviewEditor
 		// Dispose the PositronReactRenderer.
 		this.disposeReactRenderer();
 
-		// // If there is an identifier, clear it.
-		if (this._identifier) {
-			// Clear the focused Positron data explorer.
-			//this._positronPreviewService.editorWebview(this._identifier)?.dispose();
-
-			// Clear the identifier.
+		// If there is an identifier, clear it.
+		if (this._identifier && this._preview) {
+			this._preview.dispose();
 			this._identifier = undefined;
 		}
 
@@ -222,7 +209,6 @@ export class PositronPreviewEditor
 	override dispose(): void {
 		this.disposeReactRenderer();
 
-		// if there is a preview, dispose it.
 		if (this._preview) {
 			this._preview.dispose();
 		}

--- a/src/vs/workbench/contrib/positronPreviewEditor/browser/positronPreviewEditor.tsx
+++ b/src/vs/workbench/contrib/positronPreviewEditor/browser/positronPreviewEditor.tsx
@@ -23,6 +23,7 @@ import { PositronPreviewEditorInput } from 'vs/workbench/contrib/positronPreview
 import { IEditorGroup } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IPositronPreviewService } from 'vs/workbench/contrib/positronPreview/browser/positronPreview';
 import { EditorPreviewContainer } from 'vs/workbench/contrib/positronPreviewEditor/browser/editorPreviewContainer';
+import { PreviewWebview } from 'vs/workbench/contrib/positronPreview/browser/previewWebview';
 
 export interface IPositronPreviewEditorOptions extends IEditorOptions {
 	get identifier(): string | undefined;
@@ -58,6 +59,8 @@ export class PositronPreviewEditor
 	);
 
 	private readonly _onFocusedEmitter = this._register(new Emitter<void>());
+
+	private _preview: PreviewWebview | undefined;
 
 	get identifier(): string | undefined {
 		return this._identifier;
@@ -108,22 +111,33 @@ export class PositronPreviewEditor
 			storageService
 		);
 		this._container = DOM.$('.positron-preview-editor-container');
+
+		this._register(this.onVisibilityChanged(visible => {
+			if (!visible) {
+				this._onSaveScrollPositionEmitter.fire();
+			} else {
+				this._onRestoreScrollPositionEmitter.fire();
+			}
+			this._onVisibilityChangedEmitter.fire(visible);
+		}
+		));
 	}
 
 	private renderContainer(previewId: string): void {
 		if (!this._positronReactRenderer) {
 			this._positronReactRenderer = new PositronReactRenderer(this._container);
 		}
+		this._preview = this._positronPreviewService.editorWebview(previewId);
 
 		this._positronReactRenderer.render(
 			<PositronPreviewContextProvider
 				positronPreviewService={this._positronPreviewService}
 			>
 				<EditorPreviewContainer
-					preview={this._positronPreviewService.editorWebview(previewId)}
+					preview={this._preview}
 					width={this._width}
 					height={this._height}
-					visible={this.containerVisible}
+					visible={this._visible}
 				/>
 			</PositronPreviewContextProvider>
 		);
@@ -154,14 +168,6 @@ export class PositronPreviewEditor
 		this.onSizeChanged((event: ISize) => {
 			this._height = event.height;
 			this._width = event.width;
-
-			if (this._positronReactRenderer && this._identifier) {
-				this.renderContainer(this._identifier);
-			}
-		});
-
-		this.onVisibilityChanged((visible: boolean) => {
-			this._visible = visible;
 
 			if (this._positronReactRenderer && this._identifier) {
 				this.renderContainer(this._identifier);
@@ -215,6 +221,12 @@ export class PositronPreviewEditor
 
 	override dispose(): void {
 		this.disposeReactRenderer();
+
+		// if there is a preview, dispose it.
+		if (this._preview) {
+			this._preview.dispose();
+		}
+
 		super.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/positronPreviewEditor/browser/positronPreviewEditor.tsx
+++ b/src/vs/workbench/contrib/positronPreviewEditor/browser/positronPreviewEditor.tsx
@@ -144,31 +144,51 @@ export class PositronPreviewEditor
 		context: IEditorOpenContext,
 		token: CancellationToken
 	): Promise<void> {
-		const previewId = input._previewId;
+		this._identifier = input._previewId;
 
-		if (!previewId) { throw Error; }
+		if (!this._identifier) { return; }
 
-		this.renderContainer(previewId);
+		this.renderContainer(this._identifier);
 
 		// redraw if the editor is resized
 		this.onSizeChanged((event: ISize) => {
 			this._height = event.height;
 			this._width = event.width;
 
-			if (this._positronReactRenderer) {
-				this.renderContainer(previewId);
+			if (this._positronReactRenderer && this._identifier) {
+				this.renderContainer(this._identifier);
 			}
 		});
 
 		this.onVisibilityChanged((visible: boolean) => {
 			this._visible = visible;
 
-			if (this._positronReactRenderer) {
-				this.renderContainer(previewId);
+			if (this._positronReactRenderer && this._identifier) {
+				this.renderContainer(this._identifier);
 			}
 		});
 
 		await super.setInput(input, options, context, token);
+	}
+
+	/**
+	 * Clears the input.
+	 */
+	override clearInput(): void {
+		// Dispose the PositronReactRenderer.
+		this.disposeReactRenderer();
+
+		// // If there is an identifier, clear it.
+		if (this._identifier) {
+			// Clear the focused Positron data explorer.
+			//this._positronPreviewService.editorWebview(this._identifier)?.dispose();
+
+			// Clear the identifier.
+			this._identifier = undefined;
+		}
+
+		// Call the base class's method.
+		super.clearInput();
 	}
 
 	/**


### PR DESCRIPTION
part of #5500 


You should now be able to pop out (needed to handle `clearInput()` correctly)

![Screenshot 2024-12-10 at 4 55 38 PM](https://github.com/user-attachments/assets/cf45c5f8-5c64-4ab0-a2d9-c2a98dcb25f5)

and use split editors (needed to have editor create/handle webviews and not share them per url)!

![Screenshot 2024-12-10 at 4 56 16 PM](https://github.com/user-attachments/assets/1c3f87ce-6c83-4fb9-86ac-760fecba21d2)
