### PR TITLE
Remove extra `.` in strings for `openInEditor` command

### DIFF
--- a/src/vs/workbench/contrib/positronPreview/browser/components/htmlActionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/htmlActionBars.tsx
@@ -19,7 +19,7 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 const reload = localize('positron.preview.html.reload', "Reload the content");
 const clear = localize('positron.preview.html.clear', "Clear the content");
 const openInBrowser = localize('positron.preview.html.openInBrowser', "Open the content in the default browser");
-const openInEditor = localize('positron.preview.html.openInEditor', "Open the content in an editor tab.");
+const openInEditor = localize('positron.preview.html.openInEditor', "Open the content in an editor tab");
 
 /**
  * HtmlActionBarsProps interface.

--- a/src/vs/workbench/contrib/positronPreview/browser/components/urlActionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/urlActionBars.tsx
@@ -36,7 +36,7 @@ const reload = localize('positron.preview.reload', "Reload the current URL");
 const clear = localize('positron.preview.clear', "Clear the current URL");
 const openInBrowser = localize('positron.preview.openInBrowser', "Open the current URL in the default browser");
 const currentUrl = localize('positron.preview.currentUrl', "The current URL");
-const openInEditor = localize('positron.preview.html.openInEditor', "Open the content in an editor tab.");
+const openInEditor = localize('positron.preview.html.openInEditor', "Open the content in an editor tab");
 
 /**
  * UrlActionBars component.


### PR DESCRIPTION
These strings should not have `.` at the end.

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
