### PR TITLE
ci: fix typo in calling script for latest-release yml

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,11 @@ main branch by either pulling or rebasing.
   describe them here.
 -->
 
+### Tests to Run
+
+<!-- See `test/e2e/helpers/test-tags.ts` for a complete list of available tags. -->
+`@:critical`
+
 ### QA Notes
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,10 +16,6 @@ main branch by either pulling or rebasing.
   describe them here.
 -->
 
-### Tests to Run
-<!-- See `test/e2e/helpers/test-tags.ts` for a complete list of available tags. -->
-`@:critical`
-
 ### QA Notes
 
 <!--

--- a/.github/workflows/test-e2e-release.yml
+++ b/.github/workflows/test-e2e-release.yml
@@ -84,7 +84,7 @@ jobs:
         if: ${{ !cancelled() }}
 
       - name: Transform to Playwright Tags $PW_TAGS
-        run: bash scripts/pr-tags-transform "e2e-electron" "${{ inputs.grep }}"
+        run: bash scripts/pr-tags-transform.sh "e2e-electron" "${{ inputs.grep }}"
         shell: bash
 
       - name: Run Tests (Electron)


### PR DESCRIPTION
Just fixing a typo. And testing the tagging feature.

@:help