### PR TITLE
Fix location of the positron variables contribution import

### DIFF
--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -300,9 +300,9 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 			});
 
 		if (existingInstance) {
-			// Clean up the old session ID mapping
-			this._positronVariablesInstancesBySessionId.deleteAndDispose(existingInstance.session.sessionId);
-
+			// Clean up the old session ID mapping. Don't dispose of the instance because it's
+			// managed by other parts of the system.
+			this._positronVariablesInstancesBySessionId.deleteAndLeak(existingInstance.session.sessionId);
 			// Update the map of Positron variables instances by session ID.
 			this._positronVariablesInstancesBySessionId.set(
 				session.sessionId,

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -53,6 +53,8 @@ import 'vs/workbench/browser/parts/statusbar/statusbarPart';
 
 // --- Start Positron ---
 import 'vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarPart';
+// Positron Variables
+import 'vs/workbench/services/positronVariables/common/positronVariables.contribution';
 // --- End Positron ---
 
 //#endregion

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -181,8 +181,6 @@ import 'vs/workbench/contrib/encryption/electron-sandbox/encryption.contribution
 
 // --- Start Positron ---
 import 'vs/workbench/contrib/positronPreview/electron-sandbox/positronPreview.contribution';
-// Positron Variables
-import 'vs/workbench/services/positronVariables/common/positronVariables.contribution';
 // --- End Positron ---
 
 //#endregion


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

I mistakenly added the import that forces the variables contribution to be loaded in a desktop specific script rather than the more appropriate common one. This fixes that. 
