### PR TITLE
ci: add hidden red alert in PR comment

### DIFF
--- a/scripts/pr-e2e-comment.sh
+++ b/scripts/pr-e2e-comment.sh
@@ -40,8 +40,11 @@ COMMENT_ID=$(echo "$COMMENTS" | jq -r ".[] | select(.body | contains(\"$COMMENT_
 # Format the tags with individual backticks
 FORMATTED_TAGS=$(echo "$TAGS" | sed 's/,/` `/g' | sed 's/^/`/' | sed 's/$/`/')
 
+# Add the "🚨 RED ALERT!" note
+RED_ALERT_NOTE="<!-- \n🚨 RED ALERT! ✋ Rule breaker detected! Tags don’t go here—they belong above ^ in the PR description using this proper format: \`@:tag\`. Changing them here is a no-go (trust us, we’ve tried). Confused? Check out the link below before the sirens get louder!\n-->"
+
 # Build the new comment body with proper newlines
-NEW_COMMENT=$(printf "${COMMENT_MARKER}\n\n**E2E Tests** 🚀 &nbsp;<sup>[?](https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags)</sup>\nThis PR will run tests tagged with: %s" "$FORMATTED_TAGS")
+NEW_COMMENT=$(printf "${COMMENT_MARKER}\n${RED_ALERT_NOTE}\n\n**E2E Tests** 🚀 &nbsp;<sup>[?](https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags)</sup>\nThis PR will run tests tagged with: %s" "$FORMATTED_TAGS")
 
 if [ -n "$COMMENT_ID" ]; then
   # Update the existing comment


### PR DESCRIPTION
Just added a hidden comment in the "PR comments" to prevent people from editing them there. 

If someone tries to edit comment below, they should be guided to the right place:
<img width="888" alt="Screenshot 2024-12-12 at 9 41 18 AM" src="https://github.com/user-attachments/assets/54231a0f-8038-42b0-a65a-5e9a44224435" />
