### PR TITLE
Fix problem where we were over eager with disposing variables instances 

### DIFF
--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -300,9 +300,9 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 			});
 
 		if (existingInstance) {
-			// Clean up the old session ID mapping
-			this._positronVariablesInstancesBySessionId.deleteAndDispose(existingInstance.session.sessionId);
-
+			// Clean up the old session ID mapping. Don't dispose of the instance because it's
+			// managed by other parts of the system.
+			this._positronVariablesInstancesBySessionId.deleteAndLeak(existingInstance.session.sessionId);
 			// Update the map of Positron variables instances by session ID.
 			this._positronVariablesInstancesBySessionId.set(
 				session.sessionId,


### PR DESCRIPTION
Tried to fix leaks by disposing a variables instance instead of just removing a reference to it. Caused wonky data explorer bug. 

### QA Notes
 Steps to reproduce previously broken behavior
 
- run `Data_Frame <- mtcars`
- double click `Data_Frame` in variables and make sure it opens
- open a new editor
- again double click `Data_Frame` in variables and make sure it opens in original editor, not a new one. 