### PR TITLE
E2E Tests: Various new data explorer adjacent tests

### DIFF
--- a/test/automation/src/positron/positronVariables.ts
+++ b/test/automation/src/positron/positronVariables.ts
@@ -140,9 +140,9 @@ export class PositronVariables {
 
 	async selectVariablesGroup(name: string) {
 		await this.code.driver.page.locator(VARIABLES_GROUP_SELECTOR).click();
-		await this.code.driver.page.locator('a.action-menu-item', { hasText: name }).isVisible();
+		await this.code.driver.page.locator('a.action-menu-item', { hasText: name }).first().isVisible();
 		await this.code.wait(500);
-		await this.code.driver.page.locator('a.action-menu-item', { hasText: name }).click();
+		await this.code.driver.page.locator('a.action-menu-item', { hasText: name }).first().click();
 	}
 
 	async clickDatabaseIconForVariableRow(rowName: string) {


### PR DESCRIPTION
Various new data explorer adjacent tests:
* Python version of "make sure same instance of data explorer opens on reuse"
* Python and R - check spaces in data frames in data explorer
* getting variable details for large data frame shouldn't cause issues

Also, skip a test where we are awaiting a bug fix
Also, add some missing test tags

@:data-explorer 
@:variables

### QA Notes

All smoke tests should pass
