### PR TITLE
E2E Test: modify duckdb tests to leverage retries

### DIFF
--- a/test/e2e/features/data-explorer/data-explorer-headless.test.ts
+++ b/test/e2e/features/data-explorer/data-explorer-headless.test.ts
@@ -14,9 +14,7 @@ test.use({
 test.describe('Headless Data Explorer - Large Data Frame', {
 	tag: [tags.WEB, tags.DATA_EXPLORER, tags.DUCK_DB, tags.WIN]
 }, () => {
-	// python fixture not actually needed but serves as a long wait so that we can be sure
-	// headless/duckdb open will work
-	test.beforeEach(async function ({ app, python }) {
+	test.beforeEach(async function ({ app }) {
 		await app.workbench.positronLayouts.enterLayout('stacked');
 	});
 

--- a/test/e2e/features/data-explorer/duckdb-sparklines.test.ts
+++ b/test/e2e/features/data-explorer/duckdb-sparklines.test.ts
@@ -13,9 +13,7 @@ test.use({
 test.describe('Data Explorer - DuckDB Column Summary', {
 	tag: [tags.WEB, tags.WIN, tags.CRITICAL, tags.DATA_EXPLORER, tags.DUCK_DB]
 }, () => {
-	// python fixture not actually needed but serves as a long wait so that we can be sure
-	// headless/duckdb open will work
-	test('Verifies basic duckdb column summary functionality [C1053635]', async function ({ app, python }) {
+	test('Verifies basic duckdb column summary functionality [C1053635]', async function ({ app }) {
 
 		await app.workbench.positronQuickaccess.openDataFile(join(app.workspacePathOrFolder, 'data-files', '100x100', '100x100.parquet'));
 


### PR DESCRIPTION
Removing some "sleeps" that were in place before https://github.com/posit-dev/positron/issues/5655 was implemented

### QA Notes

All smoke tests should pass
