### PR TITLE
Fix `onWillStartSession` firing twice

### DIFF
--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -107,6 +107,9 @@ export enum SessionAttachMode {
 	/** The console is attaching to a restarting session */
 	Restarting = 'restarting',
 
+	/** The console is switching to a different session */
+	Switching = 'switching',
+
 	/** The console is attaching to a session that is being reconnected */
 	Reconnecting = 'reconnecting',
 

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -37,7 +37,7 @@ import { ActivityItemInput, ActivityItemInputState } from './classes/activityIte
 import { ActivityItemErrorStream, ActivityItemOutputStream } from './classes/activityItemStream.js';
 import { ILanguageRuntimeCodeExecutedEvent, IPositronConsoleInstance, IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID, PositronConsoleState, SessionAttachMode } from './interfaces/positronConsoleService.js';
 import { ILanguageRuntimeExit, ILanguageRuntimeMessage, ILanguageRuntimeMessageOutput, ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeOutputKind, RuntimeState, formatLanguageRuntimeMetadata, formatLanguageRuntimeSession } from '../../languageRuntime/common/languageRuntimeService.js';
-import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../runtimeSession/common/runtimeSessionService.js';
+import { ILanguageRuntimeSession, IRuntimeSessionService, RuntimeStartMode } from '../../runtimeSession/common/runtimeSessionService.js';
 import { UiFrontendEvent } from '../../languageRuntime/common/positronUiComm.js';
 import { IRuntimeStartupService } from '../../runtimeStartup/common/runtimeStartupService.js';
 
@@ -215,7 +215,18 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 				return;
 			}
 
-			const attachMode = e.isNew ? SessionAttachMode.Starting : SessionAttachMode.Reconnecting;
+			let attachMode: SessionAttachMode;
+			if (e.startMode === RuntimeStartMode.Starting) {
+				attachMode = SessionAttachMode.Starting;
+			} else if (e.startMode === RuntimeStartMode.Restarting) {
+				attachMode = SessionAttachMode.Restarting;
+			} else if (e.startMode === RuntimeStartMode.Reconnecting) {
+				attachMode = SessionAttachMode.Reconnecting;
+			} else if (e.startMode === RuntimeStartMode.Switching) {
+				attachMode = SessionAttachMode.Switching;
+			} else {
+				throw new Error(`Unexpected runtime start mode: ${e.startMode}`);
+			}
 
 			// If there is already a Positron console instance for the runtime,
 			// just reattach
@@ -237,8 +248,7 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 				this._positronConsoleInstancesBySessionId.set(e.session.sessionId, positronConsoleInstance);
 			} else {
 				// New runtime with a new language, so start a new Positron console instance.
-				this.startPositronConsoleInstance(e.session,
-					e.isNew ? SessionAttachMode.Starting : SessionAttachMode.Reconnecting);
+				this.startPositronConsoleInstance(e.session, attachMode);
 			}
 		}));
 
@@ -1226,6 +1236,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 								// tense of the attach mode.
 								switch (runtimeItem.attachMode) {
 									case SessionAttachMode.Starting:
+									case SessionAttachMode.Switching:
 										msg = localize('positronConsole.started', "{0} started.", this._session.metadata.sessionName);
 										break;
 									case SessionAttachMode.Restarting:
@@ -1281,42 +1292,33 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * @param attachMode A value which indicates the attachment mode.
 	 */
 	private emitStartRuntimeItems(attachMode: SessionAttachMode) {
-		// Set the state and add the appropriate runtime item to indicate whether the Positron
-		// console instance is is starting or is reconnected.
-		if (attachMode === SessionAttachMode.Starting ||
-			attachMode === SessionAttachMode.Reconnecting) {
-			let switchingRuntime = false;
-			for (let i = 0; i < this._runtimeItems.length; i++) {
-				if (this._runtimeItems[i] instanceof RuntimeItemExited) {
-					const runtimeItem = this._runtimeItems[i] as RuntimeItemExited;
-					switchingRuntime =
-						runtimeItem.reason === RuntimeExitReason.SwitchRuntime ||
-						runtimeItem.reason === RuntimeExitReason.ExtensionHost;
-				}
-			}
-			const restart = this._state === PositronConsoleState.Exited && !switchingRuntime;
+		// Set the state and add the appropriate runtime item indicating the session attach mode.
+		if (attachMode === SessionAttachMode.Restarting ||
+			// Consider starting from an exited state a restart.
+			(attachMode === SessionAttachMode.Starting && this._state === PositronConsoleState.Exited)) {
 			this.setState(PositronConsoleState.Starting);
-			if (restart) {
-				this.addRuntimeItem(new RuntimeItemStarting(
-					generateUuid(),
-					localize('positronConsole.starting.restart', "{0} restarting.", this._session.metadata.sessionName),
-					SessionAttachMode.Restarting));
-			} else if (attachMode === SessionAttachMode.Starting) {
-				this.addRuntimeItem(new RuntimeItemStarting(
-					generateUuid(),
-					localize('positronConsole.starting.start', "{0} starting.", this._session.metadata.sessionName),
-					attachMode));
-			} else if (attachMode === SessionAttachMode.Reconnecting) {
-				this.addRuntimeItem(new RuntimeItemStarting(
-					generateUuid(),
-					localize('positronConsole.starting.reconnect', "{0} reconnecting.", this._session.metadata.sessionName),
-					attachMode));
-			}
-		} else {
+			this.addRuntimeItem(new RuntimeItemStarting(
+				generateUuid(),
+				localize('positronConsole.starting.restart', "{0} restarting.", this._session.metadata.sessionName),
+				SessionAttachMode.Restarting));
+		} else if (attachMode === SessionAttachMode.Starting ||
+			attachMode === SessionAttachMode.Switching) {
+			this.setState(PositronConsoleState.Starting);
+			this.addRuntimeItem(new RuntimeItemStarting(
+				generateUuid(),
+				localize('positronConsole.starting.start', "{0} starting.", this._session.metadata.sessionName),
+				attachMode));
+		} else if (attachMode === SessionAttachMode.Reconnecting) {
+			this.setState(PositronConsoleState.Starting);
+			this.addRuntimeItem(new RuntimeItemStarting(
+				generateUuid(),
+				localize('positronConsole.starting.reconnect', "{0} reconnecting.", this._session.metadata.sessionName),
+				attachMode));
+		} else if (attachMode === SessionAttachMode.Connected) {
 			this.setState(PositronConsoleState.Ready);
 			this.addRuntimeItem(new RuntimeItemReconnected(
 				generateUuid(),
-				`${this._session.metadata.sessionName} reconnected.`
+				localize('positronConsole.starting.reconnected', "{0} reconnected.", this._session.metadata.sessionName),
 			));
 		}
 	}

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -23,11 +23,28 @@ export interface ILanguageRuntimeGlobalEvent {
 }
 
 /**
+ * The mode in which a runtime session is starting.
+ */
+export enum RuntimeStartMode {
+	/** A new runtime is starting. */
+	Starting = 'starting',
+
+	/** An existing runtime is restarting. */
+	Restarting = 'restarting',
+
+	/** An existing runtime is reconnecting. */
+	Reconnecting = 'reconnecting',
+
+	/** The previous runtime is being switched to a new runtime. */
+	Switching = 'switching',
+}
+
+/**
  * Event that fires when a runtime session is about to start.
  */
 export interface IRuntimeSessionWillStartEvent {
-	/** Whether this is a new session or an existing session (a reconnect) */
-	isNew: boolean;
+	/** The mode in which the session is starting. */
+	startMode: RuntimeStartMode;
 
 	/** The session about to start */
 	session: ILanguageRuntimeSession;

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -14,7 +14,7 @@ import { TestConfigurationService } from '../../../../../platform/configuration/
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { IWorkspaceTrustManagementService } from '../../../../../platform/workspace/common/workspaceTrust.js';
 import { formatLanguageRuntimeMetadata, formatLanguageRuntimeSession, ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionMode, RuntimeExitReason, RuntimeState } from '../../../languageRuntime/common/languageRuntimeService.js';
-import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService, IRuntimeSessionWillStartEvent, RuntimeClientType } from '../../common/runtimeSessionService.js';
+import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService, IRuntimeSessionWillStartEvent, RuntimeClientType, RuntimeStartMode } from '../../common/runtimeSessionService.js';
 import { TestLanguageRuntimeSession, waitForRuntimeState } from './testLanguageRuntimeSession.js';
 import { createRuntimeServices, createTestLanguageRuntimeMetadata, startTestLanguageRuntimeSession } from './testRuntimeSessionService.js';
 import { TestRuntimeSessionManager } from '../../../../test/common/positronWorkbenchTestServices.js';
@@ -278,18 +278,11 @@ suite('Positron - RuntimeSessionService', () => {
 				assertSingleSessionIsStarting(session);
 			});
 
-			// TODO: Should onWillStartSession only fire once?
-			//       It currently fires twice. Before the session is started and when the session
-			//       enters the ready state.
 			test(`${action} ${mode} fires onWillStartSession`, async () => {
 				let error: Error | undefined;
 				const target = sinon.spy(({ session }: IRuntimeSessionWillStartEvent) => {
 					try {
-						if (target.callCount > 1) {
-							return;
-						}
 						assert.strictEqual(session.getRuntimeState(), RuntimeState.Uninitialized);
-
 						assertSingleSessionWillStart(mode);
 					} catch (e) {
 						error = e;
@@ -298,10 +291,16 @@ suite('Positron - RuntimeSessionService', () => {
 				disposables.add(runtimeSessionService.onWillStartSession(target));
 				const session = await start();
 
-				sinon.assert.calledTwice(target);
-				// When restoring a session, the first event is fired with isNew: false.
-				sinon.assert.calledWith(target.getCall(0), { isNew: action !== 'restore', session });
-				sinon.assert.calledWith(target.getCall(1), { isNew: true, session });
+				let startMode: RuntimeStartMode;
+				if (action === 'restore') {
+					startMode = RuntimeStartMode.Reconnecting;
+				} else if (action === 'select') {
+					startMode = RuntimeStartMode.Switching;
+				} else {
+					startMode = RuntimeStartMode.Starting;
+				}
+				sinon.assert.calledOnceWithExactly(target, { startMode, session });
+
 				assert.ifError(error);
 			});
 
@@ -754,6 +753,9 @@ suite('Positron - RuntimeSessionService', () => {
 					session.setRuntimeState(state);
 				}
 
+				const willStartSession = sinon.spy();
+				disposables.add(runtimeSessionService.onWillStartSession(willStartSession));
+
 				await restartSession(session.sessionId);
 
 				assert.strictEqual(session.getRuntimeState(), RuntimeState.Restarting);
@@ -761,6 +763,11 @@ suite('Positron - RuntimeSessionService', () => {
 
 				await waitForRuntimeState(session, RuntimeState.Ready);
 				assertSingleSessionIsReady(session);
+
+				sinon.assert.calledOnceWithExactly(willStartSession, {
+					session,
+					startMode: RuntimeStartMode.Restarting,
+				});
 			});
 		}
 
@@ -772,9 +779,12 @@ suite('Positron - RuntimeSessionService', () => {
 				await session.shutdown(RuntimeExitReason.Shutdown);
 				await waitForRuntimeState(session, RuntimeState.Exited);
 
+				const willStartSession = sinon.spy();
+				disposables.add(runtimeSessionService.onWillStartSession(willStartSession));
+
 				await restartSession(session.sessionId);
 
-				// The existing sessino should remain exited.
+				// The existing session should remain exited.
 				assert.strictEqual(session.getRuntimeState(), RuntimeState.Exited);
 
 				// A new session should be starting.
@@ -786,6 +796,12 @@ suite('Positron - RuntimeSessionService', () => {
 				}
 				assert.ok(newSession);
 				disposables.add(newSession);
+
+				sinon.assert.calledOnceWithExactly(willStartSession, {
+					session: newSession,
+					// Since we restarted from an exited state, the start mode is 'starting'.
+					startMode: RuntimeStartMode.Starting,
+				});
 
 				assert.strictEqual(newSession.getRuntimeState(), RuntimeState.Starting);
 				assert.strictEqual(newSession.metadata.sessionName, session.metadata.sessionName);

--- a/test/e2e/areas/data-explorer/data-explorer-r.test.ts
+++ b/test/e2e/areas/data-explorer/data-explorer-r.test.ts
@@ -76,7 +76,7 @@ test.describe('Data Explorer - R ', {
 
 	});
 
-	test.skip('R - Open Data Explorer for the second time brings focus back [C701143]', {
+	test('R - Open Data Explorer for the second time brings focus back [C701143]', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5714' }]
 	}, async function ({ app, r }) {
 		// Regression test for https://github.com/posit-dev/positron/issues/4197


### PR DESCRIPTION
Also replaced `isNew` with a more descriptive enum, `RuntimeStartMode`, and refactored the positron console service to use it. Addresses #5714.

### QA Notes

Should address #5714.

For the refactor to the console service, the console should:

1. Display `starting`/`started` when starting a runtime for the first time or switching runtimes.
2. Display `restarting`/`restarted` when restarting the active runtime, or manually shutting it down and starting it again.
3. Display `reconnecting`/`reconnected` when refreshing the window.