### PR TITLE
Fix missing Interrupt button (render children of ActionBarButton)

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -125,6 +125,7 @@ export const ActionBarButton = forwardRef<
 				onPressed={props.onPressed}
 			>
 				<ActionBarButtonFace />
+				{props.children}
 			</Button>
 		);
 	} else {


### PR DESCRIPTION
This fixes an issue in which the Interrupt/Stop button disappeared from the Console. The problem appears to be that the `ActionBarButton` does not render its child elements when it has no dropdown indicator. The fix is to render them beneath the button face in this situation.

Addresses https://github.com/posit-dev/positron/issues/5724.

### QA Notes

This is only one line of code, but could affect any button in the UI.