### PR TITLE
Change open in editor tab to menu button

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
@@ -7,7 +7,7 @@
 import './actionBarMenuButton.css';
 
 // React.
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 // Other dependencies.
 import { IAction } from '../../../../base/common/actions.js';
@@ -36,6 +36,11 @@ interface ActionBarMenuButtonProps {
 
 /**
  * ActionBarCommandButton component.
+ *
+ * Actions can be set as checked. If `enabled-split` is set then a default action is allowed to run
+ * when the button is clicked. The default action is the first action that is checked or the first
+ * action if none are checked.
+ *
  * @param props An ActionBarMenuButtonProps that contains the component properties.
  * @returns The rendered component.
  */
@@ -45,6 +50,10 @@ export const ActionBarMenuButton = (props: ActionBarMenuButtonProps) => {
 
 	// Reference hooks.
 	const buttonRef = useRef<HTMLButtonElement>(undefined!);
+
+	// State hooks.
+	const [actions, setActions] = useState<readonly IAction[]>([]);
+	const [defaultAction, setDefaultAction] = useState<IAction | undefined>(undefined);
 
 	// Manage the aria-haspopup and aria-expanded attributes.
 	useEffect(() => {
@@ -60,6 +69,20 @@ export const ActionBarMenuButton = (props: ActionBarMenuButtonProps) => {
 		}
 	}, [positronActionBarContext.menuShowing]);
 
+	const getMenuActions = React.useCallback(async () => {
+		const actions = await props.actions();
+		const defaultAction = actions.find(action => action.checked);
+
+		setDefaultAction(defaultAction);
+		setActions(actions);
+
+		return actions;
+	}, [props]);
+
+	useEffect(() => {
+		getMenuActions();
+	}, [getMenuActions]);
+
 	// Participate in roving tabindex.
 	useRegisterWithActionBar([buttonRef]);
 
@@ -69,7 +92,6 @@ export const ActionBarMenuButton = (props: ActionBarMenuButtonProps) => {
 	 */
 	const showMenu = async () => {
 		// Get the actions. If there are no actions, return.
-		const actions = await props.actions();
 		if (!actions.length) {
 			return;
 		}
@@ -111,11 +133,8 @@ export const ActionBarMenuButton = (props: ActionBarMenuButtonProps) => {
 				if (props.dropdownIndicator !== 'enabled-split') {
 					await showMenu();
 				} else {
-					// Get the actions and run the first action.
-					const actions = await props.actions();
-					if (actions.length) {
-						actions[0].run();
-					}
+					// Run the preferred action.
+					defaultAction ? defaultAction.run() : actions[0].run();
 				}
 			}}
 			onDropdownPressed={async () => await showMenu()}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -182,6 +182,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						{enableEditorPlot ?
 							<OpenInEditorMenuButton
 								tooltip={localize('positron-editor-plot-popout', "Open in editor tab")}
+								ariaLabel={localize('positron-editor-plot-popout', "Open in editor tab")}
 								defaultGroup={positronPlotsContext.positronPlotsService.getPreferredEditorGroup()}
 								commandService={positronPlotsContext.commandService}
 							/>

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -34,6 +34,7 @@ import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { HtmlPlotClient } from '../htmlPlotClient.js';
 import { POSITRON_EDITOR_PLOTS, positronPlotsEditorEnabled } from '../../../positronPlotsEditor/browser/positronPlotsEditor.contribution.js';
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
+import { OpenInEditorMenuButton } from './openInEditorMenuButton.js';
 
 // Constants.
 const kPaddingLeft = 14;
@@ -179,16 +180,11 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 							: null
 						}
 						{enableEditorPlot ?
-							<ActionBarButton
-								iconId='go-to-file'
-								align='right'
-								tooltip={localize('positron-open-plot-editor', "Open plot in editor")}
-								ariaLabel={localize('positron-open-plot-editor', "Open plot in editor")}
-								onPressed={() => {
-									if (hasPlots) {
-										positronPlotsContext.positronPlotsService.openEditor();
-									}
-								}} />
+							<OpenInEditorMenuButton
+								tooltip={localize('positron-editor-plot-popout', "Open in editor tab")}
+								defaultGroup={positronPlotsContext.positronPlotsService.getPreferredEditorGroup()}
+								commandService={positronPlotsContext.commandService}
+							/>
 							: null
 						}
 					</ActionBarRegion>

--- a/src/vs/workbench/contrib/positronPlots/browser/components/openInEditorMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/openInEditorMenuButton.tsx
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import React, { useState, useCallback, useEffect } from 'react';
+
+import { IAction } from '../../../../../base/common/actions.js';
+import { localize } from '../../../../../nls.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
+import { AUX_WINDOW_GROUP_TYPE, ACTIVE_GROUP_TYPE, SIDE_GROUP_TYPE, AUX_WINDOW_GROUP, ACTIVE_GROUP, SIDE_GROUP } from '../../../../services/editor/common/editorService.js';
+import { PlotsEditorAction } from '../positronPlotsActions.js';
+
+interface OpenInEditorMenuButtonProps {
+	tooltip: string;
+	defaultGroup: number;
+	commandService: ICommandService;
+}
+
+interface OpenInEditorCommand {
+	editorTarget: AUX_WINDOW_GROUP_TYPE | ACTIVE_GROUP_TYPE | SIDE_GROUP_TYPE;
+	label: string;
+}
+
+// create an array of action ids with labels
+const openInEditorCommands: Array<OpenInEditorCommand> = [
+	{
+		'editorTarget': AUX_WINDOW_GROUP,
+		'label': localize('positron-editor-new-window', 'Open in new window')
+	},
+	{
+		'editorTarget': ACTIVE_GROUP,
+		'label': localize('positron-editor-new-tab', 'Open in editor tab')
+	},
+	{
+		'editorTarget': SIDE_GROUP,
+		'label': localize('positron-editor-new-tab-right', 'Open in editor tab to the right')
+	},
+];
+
+/**
+ * OpenInEditorMenuButton component.
+ *
+ * Creates a menu button that allows the user to open a plot in a new editor tab. Choosing a menu
+ * action will update the default action. The default action is preserved by the plots service when
+ * opening the editor tab succeeds.
+ *
+ * @param props An OpenInEditorMenuButtonProps that contains the component properties.
+ * @returns
+ */
+export const OpenInEditorMenuButton = (props: OpenInEditorMenuButtonProps) => {
+	const [defaultAction, setDefaultEditorAction] = useState<number>(props.defaultGroup);
+	const [actions, setActions] = useState<readonly IAction[]>([]);
+
+	const openEditorPlotHandler = useCallback((groupType: number) => {
+		// props.plotsService.openEditor(groupType);
+		props.commandService.executeCommand(PlotsEditorAction.ID, groupType);
+		setDefaultEditorAction(groupType);
+	}, [props.commandService]);
+
+	useEffect(() => {
+		const actions = openInEditorCommands.map((command) => {
+			return {
+				id: PlotsEditorAction.ID,
+				label: command.label,
+				tooltip: '',
+				class: undefined,
+				checked: defaultAction === command.editorTarget,
+				enabled: true,
+				run: () => openEditorPlotHandler(command.editorTarget)
+			};
+		});
+		setActions(actions);
+	}, [defaultAction]);
+
+
+	return (
+		<ActionBarMenuButton
+			iconId='go-to-file'
+			tooltip={localize('positron-editor-plot-popout', "Open in editor tab")}
+			actions={() => actions}
+			dropdownIndicator='enabled-split' />
+	);
+};

--- a/src/vs/workbench/contrib/positronPlots/browser/components/openInEditorMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/openInEditorMenuButton.tsx
@@ -14,6 +14,7 @@ import { PlotsEditorAction } from '../positronPlotsActions.js';
 
 interface OpenInEditorMenuButtonProps {
 	tooltip: string;
+	ariaLabel: string;
 	defaultGroup: number;
 	commandService: ICommandService;
 }
@@ -35,7 +36,7 @@ const openInEditorCommands: Array<OpenInEditorCommand> = [
 	},
 	{
 		'editorTarget': SIDE_GROUP,
-		'label': localize('positron-editor-new-tab-right', 'Open in editor tab to the right')
+		'label': localize('positron-editor-new-tab-right', 'Open in editor tab to the Side')
 	},
 ];
 
@@ -78,7 +79,8 @@ export const OpenInEditorMenuButton = (props: OpenInEditorMenuButtonProps) => {
 	return (
 		<ActionBarMenuButton
 			iconId='go-to-file'
-			tooltip={localize('positron-editor-plot-popout', "Open in editor tab")}
+			tooltip={props.tooltip}
+			ariaLabel={props.ariaLabel}
 			actions={() => actions}
 			dropdownIndicator='enabled-split' />
 	);

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -352,10 +352,10 @@ export class PlotsEditorAction extends Action2 {
 	 *
 	 * @param accessor The service accessor.
 	 */
-	async run(accessor: ServicesAccessor) {
+	async run(accessor: ServicesAccessor, groupType?: number) {
 		const plotsService = accessor.get(IPositronPlotsService);
 		if (plotsService.selectedPlotId) {
-			plotsService.openEditor();
+			plotsService.openEditor(groupType);
 		} else {
 			accessor.get(INotificationService).info(localize('positronPlots.noPlotSelected', 'No plot selected.'));
 		}

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -178,8 +178,16 @@ export interface IPositronPlotsService {
 
 	/**
 	 * Opens the currently selected plot in an editor.
+	 *
+	 * @param groupType Specify where the editor tab will be opened. Defaults to the preferred
+	 *   editor group.
 	 */
-	openEditor(): Promise<void>;
+	openEditor(groupType?: number): Promise<void>;
+
+	/**
+	 * Gets the preferred editor group for opening the plot in an editor tab.
+	 */
+	getPreferredEditorGroup(): number;
 
 	/**
 	 * Gets the plot client that is connected to an editor for the specified id.


### PR DESCRIPTION
Address #5446 

Adds changing the default action on the `ActionBarMenuButton` to the checked action. Refactors plots service to use a new editor's group target and store the last used option.

There are now three options when opening a plot in an editor tab:
1. New window (default)
2. New editor in active editor group
3. In the editor group to the right of the active group (creates a new one if necessary)

https://github.com/user-attachments/assets/4253f72c-7107-4cfd-b5cf-27407a8f915a

@:plots

### QA Notes
