### PR TITLE
E2E tests: remove waitAndClick from positron test code

### DIFF
--- a/test/automation/src/positron/positronBaseElement.ts
+++ b/test/automation/src/positron/positronBaseElement.ts
@@ -18,7 +18,7 @@ export class PositronBaseElement {
 	}
 
 	async click(): Promise<void> {
-		await this.code.waitAndClick(this.myselector);
+		await this.code.driver.page.locator(this.myselector).click();
 	}
 
 	async isNotVisible(retryCount: number = 200): Promise<void> {

--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -231,7 +231,7 @@ export class PositronConsole {
 	}
 
 	async maximizeConsole() {
-		await this.code.waitAndClick(MAXIMIZE_CONSOLE);
+		await this.code.driver.page.locator(MAXIMIZE_CONSOLE).click();
 	}
 
 	async pasteCodeToConsole(code: string) {

--- a/test/automation/src/positron/positronDataExplorer.ts
+++ b/test/automation/src/positron/positronDataExplorer.ts
@@ -93,15 +93,15 @@ export class PositronDataExplorer {
 	}
 
 	async closeDataExplorer() {
-		await this.code.waitAndClick(CLOSE_DATA_EXPLORER);
+		await this.code.driver.page.locator(CLOSE_DATA_EXPLORER).first().click();
 	}
 
 	async clickLowerRightCorner() {
-		await this.code.waitAndClick(SCROLLBAR_LOWER_RIGHT_CORNER);
+		await this.code.driver.page.locator(SCROLLBAR_LOWER_RIGHT_CORNER).click();
 	}
 
 	async clickUpperLeftCorner() {
-		await this.code.waitAndClick(DATA_GRID_TOP_LEFT);
+		await this.code.driver.page.locator(DATA_GRID_TOP_LEFT).click();
 	}
 
 	/*
@@ -109,15 +109,15 @@ export class PositronDataExplorer {
 	 */
 	async addFilter(columnName: string, functionText: string, filterValue: string) {
 
-		await this.code.waitAndClick(ADD_FILTER_BUTTON);
+		await this.code.driver.page.locator(ADD_FILTER_BUTTON).click();
 
 		// worakaround for column being set incorrectly
 		await expect(async () => {
 			try {
-				await this.code.waitAndClick(COLUMN_SELECTOR);
+				await this.code.driver.page.locator(COLUMN_SELECTOR).click();
 				const columnText = `${columnName}\n`;
 				await this.code.waitForSetValue(COLUMN_INPUT, columnText);
-				await this.code.waitAndClick(COLUMN_SELECTOR_CELL);
+				await this.code.driver.page.locator(COLUMN_SELECTOR_CELL).click();
 				const checkValue = (await this.code.waitForElement(COLUMN_SELECTOR)).textContent;
 				expect(checkValue).toBe(columnName);
 			} catch (e) {
@@ -127,7 +127,7 @@ export class PositronDataExplorer {
 		}).toPass({ timeout: 30000 });
 
 
-		await this.code.waitAndClick(FUNCTION_SELECTOR);
+		await this.code.driver.page.locator(FUNCTION_SELECTOR).click();
 
 		// note that base Microsoft funtionality does not work with "has text" type selection
 		const equalTo = this.code.driver.getLocator(`${OVERLAY_BUTTON} div:has-text("${functionText}")`);
@@ -136,7 +136,7 @@ export class PositronDataExplorer {
 		const filterValueText = `${filterValue}\n`;
 		await this.code.waitForSetValue(FILTER_SELECTOR, filterValueText);
 
-		await this.code.waitAndClick(APPLY_FILTER);
+		await this.code.driver.page.locator(APPLY_FILTER).click();
 	}
 
 	async getDataExplorerStatusBar() {
@@ -145,7 +145,7 @@ export class PositronDataExplorer {
 
 	async selectColumnMenuItem(columnIndex: number, menuItem: string) {
 
-		await this.code.waitAndClick(`.data-grid-column-header:nth-child(${columnIndex}) .sort-button`);
+		await this.code.driver.page.locator(`.data-grid-column-header:nth-child(${columnIndex}) .sort-button`).click();
 
 		await this.code.driver.getLocator(`.positron-modal-overlay div.title:has-text("${menuItem}")`).click();
 

--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -110,8 +110,13 @@ export class PositronNewProjectWizard {
 class ProjectWizardProjectTypeStep {
 	constructor(private code: Code) { }
 
+	cssEscape(value: string): string {
+		return value.replace(/[\s!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g, '\\$&');
+	}
+
 	async selectProjectType(projectType: ProjectType) {
-		await this.code.waitAndClick(`input[id="${projectType}"]`);
+		const locator = this.code.driver.page.locator('label').filter({hasText: projectType});
+		await locator.click({ force: true });
 	}
 }
 

--- a/test/automation/src/positron/positronPopups.ts
+++ b/test/automation/src/positron/positronPopups.ts
@@ -38,7 +38,7 @@ export class PositronPopups {
 			this.code.logger.log('Checking for modal dialog box');
 			// fail fast if the modal is not present
 			await this.code.waitForElement(POSITRON_MODAL_DIALOG_BOX, undefined, 50);
-			await this.code.waitAndClick(POSITRON_MODAL_DIALOG_BOX_OK);
+			await this.code.driver.page.locator(POSITRON_MODAL_DIALOG_BOX_OK).click();
 			this.code.logger.log('Installing ipykernel');
 			await this.waitForToastToAppear();
 			await this.waitForToastToDisappear();
@@ -68,11 +68,11 @@ export class PositronPopups {
 			);
 			if (install) {
 				this.code.logger.log('Installing Renv');
-				await this.code.waitAndClick(POSITRON_MODAL_DIALOG_BOX_OK);
+				await this.code.driver.page.locator(POSITRON_MODAL_DIALOG_BOX_OK).click();
 				this.code.logger.log('Installed Renv');
 			} else {
 				this.code.logger.log('Skipping Renv installation');
-				await this.code.waitAndClick(POSITRON_MODAL_DIALOG_BOX_CANCEL);
+				await this.code.driver.page.locator(POSITRON_MODAL_DIALOG_BOX_CANCEL).click();
 			}
 		} catch {
 			this.code.logger.log('Did not find install Renv modal dialog box');

--- a/test/automation/src/positron/positronSideBar.ts
+++ b/test/automation/src/positron/positronSideBar.ts
@@ -17,6 +17,6 @@ export class PositronSideBar {
 
 	async closeSecondarySideBar() {
 		this.code.logger.log('Hiding secondary side bar');
-		await this.code.waitAndClick(HIDE_SECONDARY_SIDE_BAR);
+		await this.code.driver.page.locator(HIDE_SECONDARY_SIDE_BAR).click();
 	}
 }

--- a/test/automation/src/positron/positronTestExplorer.ts
+++ b/test/automation/src/positron/positronTestExplorer.ts
@@ -9,7 +9,7 @@ import { PositronExplorer } from './positronExplorer';
 const TEST_RESULT_ITEM = '.monaco-list-row[aria-level="2"] .test-peek-item';
 const NAME = '.name';
 const COMPUTED_STATE = '.computed-state';
-const TEST_EXPLORER_ICON = '.codicon-test-view-icon';
+const TEST_EXPLORER_ICON = '.composite-bar .codicon-test-view-icon';
 const RUN_ALL = '.codicon-testing-run-all-icon';
 
 /*
@@ -52,7 +52,7 @@ export class PositronTestExplorer extends PositronExplorer {
 	 * @returns Promise<void>
 	 */
 	async clickTestExplorerIcon(): Promise<void> {
-		await this.code.waitAndClick(TEST_EXPLORER_ICON);
+		await this.code.driver.page.locator(TEST_EXPLORER_ICON).click();
 	}
 
 	/**
@@ -68,6 +68,6 @@ export class PositronTestExplorer extends PositronExplorer {
 	 * @returns Promise<void>
 	 */
 	async runAllTests(): Promise<void> {
-		await this.code.waitAndClick(RUN_ALL);
+		await this.code.driver.page.getByLabel('Testing actions').getByLabel('Run Tests').click();
 	}
 }

--- a/test/automation/src/positron/positronTestExplorer.ts
+++ b/test/automation/src/positron/positronTestExplorer.ts
@@ -10,7 +10,6 @@ const TEST_RESULT_ITEM = '.monaco-list-row[aria-level="2"] .test-peek-item';
 const NAME = '.name';
 const COMPUTED_STATE = '.computed-state';
 const TEST_EXPLORER_ICON = '.composite-bar .codicon-test-view-icon';
-const RUN_ALL = '.codicon-testing-run-all-icon';
 
 /*
  *  Reuseable Positron test explorer functionality for tests to leverage.


### PR DESCRIPTION
Cleaning up the positron code base by removing dependencies on the old Microsoft automation code.

This PR removes waitAndClick from our code

### QA Notes

All smoke tests should pass.
