### PR TITLE
ci: remove `trigger` job from test-full-suite

### DIFF
--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -42,19 +42,6 @@ on:
               - never
 
 jobs:
-  trigger:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Echo Input Details
-        run: |
-          echo "Workflow Inputs:"
-          echo "- E2E Electron (Linux): ${{ inputs.run_e2e_linux }}"
-          echo "- E2E Electron (Windows): ${{ inputs.run_e2e_windows }}"
-          echo "- E2E Chromium (Linux): ${{ inputs.run_e2e_browser }}"
-          echo "- Unit Tests: ${{ inputs.run_unit_tests }}"
-          echo "- Integration Tests: ${{ inputs.run_integration_tests }}"
-          echo "- Slack Notification On: ${{ inputs.notify_on }}"
-
   e2e-electron:
     name: e2e
     if: ${{ github.event_name == 'schedule' || inputs.run_e2e_linux  }}

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -95,10 +95,6 @@
       "filename": "build/secrets/.secrets.baseline"
     },
     {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
-    },
-    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -143,7 +139,7 @@
         "filename": ".github/workflows/test-full-suite.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 62,
+        "line_number": 49,
         "is_secret": false
       }
     ],
@@ -1944,5 +1940,5 @@
       }
     ]
   },
-  "generated_at": "2024-12-14T14:27:48Z"
+  "generated_at": "2024-12-16T16:39:50Z"
 }


### PR DESCRIPTION
I previously added the `trigger` jog to log the inputs from a manual dispatch, but I didn't realize it would end up in the slack notifications. So opting to remove instead to keep notifications strictly to test results.