### PR TITLE
ci: extend test-e2e-release timeout

### DIFF
--- a/.github/workflows/test-e2e-release.yml
+++ b/.github/workflows/test-e2e-release.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   e2e-electron:
     runs-on: ubuntu-latest-8x
-    timeout-minutes: 45
+    timeout-minutes: 80
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Allowing more time for test-e2e-release to run
