### PR TITLE
E2E tests: console interrupt tests

### DIFF
--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -282,4 +282,8 @@ export class PositronConsole {
 	async clickConsoleTab() {
 		await this.code.driver.page.locator('.basepanel').getByRole('tab', { name: 'Console', exact: true }).locator('a').click();
 	}
+
+	async interruptExecution() {
+		await this.code.driver.page.getByLabel('Interrupt execution').click();
+	}
 }

--- a/test/e2e/features/console/console-python.test.ts
+++ b/test/e2e/features/console/console-python.test.ts
@@ -42,4 +42,16 @@ test.describe('Console Pane: Python', { tag: [tags.WEB, tags.WIN, tags.CONSOLE] 
 		await app.workbench.positronConsole.waitForReady('>>>');
 		await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
 	});
+
+	test('Verify cancel button on console bar [C...]', {
+	}, async function ({ app, python }) {
+
+		await app.workbench.positronConsole.pasteCodeToConsole('import time; time.sleep(10)');
+		await app.workbench.positronConsole.sendEnterKey();
+
+		await app.workbench.positronConsole.interruptExecution();
+
+		await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('KeyboardInterrupt')));
+
+	});
 });

--- a/test/e2e/features/console/console-r.test.ts
+++ b/test/e2e/features/console/console-r.test.ts
@@ -36,5 +36,16 @@ test.describe('Console Pane: R', {
 			await app.workbench.positronConsole.waitForConsoleContents((contents) => contents.some((line) => line.includes('restarted')));
 		}).toPass();
 	});
+
+	test('Verify cancel button on console bar [C...]', {
+	}, async function ({ app, r }) {
+
+		await app.workbench.positronConsole.pasteCodeToConsole('Sys.sleep(10)');
+		await app.workbench.positronConsole.sendEnterKey();
+
+		await app.workbench.positronConsole.interruptExecution();
+
+		// nothing appears in console after interrupting execution
+	});
 });
 


### PR DESCRIPTION
Just adding a little interrupt test for R and Python after we noticed a missed regression

### QA Notes

All smoke tests should pass
