### PR TITLE
Fix plots views not triggering resize observer

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.css
@@ -85,6 +85,7 @@
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;
+	overflow: hidden;
 }
 
 .plot-thumbnail {


### PR DESCRIPTION
Address #3383 

Sets the parent element style to hide overflow. This triggers the size of the plot element to what is visible.

@:plots

### QA Notes
See the issue for a video on how to reproduce. Positioning the Plots view at the bottom of the window makes it easier to reproduce.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
