### PR TITLE
e2e-test: add quick-input POM

### DIFF
--- a/test/automation/src/positron/positronQuickInput.ts
+++ b/test/automation/src/positron/positronQuickInput.ts
@@ -32,8 +32,9 @@ export class PositronQuickInput {
 	}
 
 	async waitForQuickInputElementText(): Promise<string> {
-		await expect(this.code.driver.page.locator(PositronQuickInput.QUICK_INPUT_ENTRY_LABEL_SPAN)).not.toHaveText('');
-		return await this.code.driver.page.locator(PositronQuickInput.QUICK_INPUT_ENTRY_LABEL_SPAN).textContent() || '';
+		const quickInput = this.code.driver.page.locator(PositronQuickInput.QUICK_INPUT_ENTRY_LABEL_SPAN);
+		await expect(quickInput).not.toHaveText('');
+		return await quickInput.textContent() || '';
 	}
 
 	async closeQuickInput(): Promise<void> {
@@ -57,9 +58,9 @@ export class PositronQuickInput {
 	async selectQuickInputElement(index: number, keepOpen?: boolean): Promise<void> {
 		await this.waitForQuickInputOpened();
 		for (let from = 0; from < index; from++) {
-			await this.code.driver.page.keyboard.press('down');
+			await this.code.driver.page.keyboard.press('Down');
 		}
-		await this.code.driver.page.keyboard.press('enter');
+		await this.code.driver.page.keyboard.press('Enter');
 		if (!keepOpen) {
 			await this.waitForQuickInputClosed();
 		}

--- a/test/automation/src/positron/positronQuickInput.ts
+++ b/test/automation/src/positron/positronQuickInput.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from '@playwright/test';
+import { Code } from '../code';
+
+export class PositronQuickInput {
+
+	private static QUICK_INPUT = '.quick-input-widget';
+	private static QUICK_INPUT_INPUT = `${PositronQuickInput.QUICK_INPUT} .quick-input-box input`;
+	private static QUICK_INPUT_ROW = `${PositronQuickInput.QUICK_INPUT} .quick-input-list .monaco-list-row`;
+	private static QUICK_INPUT_FOCUSED_ELEMENT = `${PositronQuickInput.QUICK_INPUT_ROW}.focused .monaco-highlighted-label`;
+	// Note: this only grabs the label and not the description or detail
+	private static QUICK_INPUT_ENTRY_LABEL = `${this.QUICK_INPUT_ROW} .quick-input-list-row > .monaco-icon-label .label-name`;
+	private static QUICK_INPUT_ENTRY_LABEL_SPAN = `${this.QUICK_INPUT_ROW} .monaco-highlighted-label`;
+	private static QUICKINPUT_OK_BUTTON = '.quick-input-widget .quick-input-action a:has-text("OK")';
+
+	constructor(private code: Code) { }
+
+	async waitForQuickInputOpened(): Promise<void> {
+		await expect(this.code.driver.page.locator(PositronQuickInput.QUICK_INPUT_INPUT)).toBeVisible();
+	}
+
+	async type(value: string): Promise<void> {
+		await this.code.driver.page.locator(PositronQuickInput.QUICK_INPUT_INPUT).fill(value);
+	}
+
+	async waitForQuickInputElementFocused(): Promise<void> {
+		await expect(this.code.driver.page.locator(PositronQuickInput.QUICK_INPUT_FOCUSED_ELEMENT)).toBeFocused();
+	}
+
+	async waitForQuickInputElementText(): Promise<string> {
+		await expect(this.code.driver.page.locator(PositronQuickInput.QUICK_INPUT_ENTRY_LABEL_SPAN)).not.toHaveText('');
+		return await this.code.driver.page.locator(PositronQuickInput.QUICK_INPUT_ENTRY_LABEL_SPAN).textContent() || '';
+	}
+
+	async closeQuickInput(): Promise<void> {
+		await this.code.driver.page.keyboard.press('Escape');
+		await this.waitForQuickInputClosed();
+	}
+
+	async waitForQuickInputElements(accept: (names: string[]) => boolean): Promise<void> {
+		const locator = this.code.driver.page.locator(PositronQuickInput.QUICK_INPUT_ENTRY_LABEL);
+
+		await expect(async () => {
+			const names = await locator.allTextContents();
+			return accept(names);
+		}).toPass();
+	}
+
+	async waitForQuickInputClosed(): Promise<void> {
+		await expect(this.code.driver.page.locator(PositronQuickInput.QUICK_INPUT_INPUT)).not.toBeVisible();
+	}
+
+	async selectQuickInputElement(index: number, keepOpen?: boolean): Promise<void> {
+		await this.waitForQuickInputOpened();
+		for (let from = 0; from < index; from++) {
+			await this.code.driver.page.keyboard.press('down');
+		}
+		await this.code.driver.page.keyboard.press('enter');
+		if (!keepOpen) {
+			await this.waitForQuickInputClosed();
+		}
+	}
+
+	async selectQuickInputElementContaining(text: string): Promise<void> {
+		await this.code.driver.page.locator(`${PositronQuickInput.QUICK_INPUT_ROW}[aria-label*="${text}"]`).first().click({ timeout: 10000 });
+	}
+
+	async clickOkOnQuickInput(): Promise<void> {
+		await this.code.driver.page.locator(PositronQuickInput.QUICKINPUT_OK_BUTTON).click();
+	}
+}

--- a/test/automation/src/workbench.ts
+++ b/test/automation/src/workbench.ts
@@ -47,6 +47,7 @@ import { PositronTestExplorer } from './positron/positronTestExplorer';
 import { PositronQuickAccess } from './positron/positronQuickaccess';
 import { PositronOutline } from './positron/positronOutline';
 import { PositronClipboard } from './positron/positronClipboard';
+import { PositronQuickInput } from './positron/positronQuickInput';
 // --- End Positron ---
 
 export interface Commands {
@@ -98,6 +99,7 @@ export class Workbench {
 	readonly positronQuickaccess: PositronQuickAccess;
 	readonly positronOutline: PositronOutline;
 	readonly positronClipboard: PositronClipboard;
+	readonly positronQuickInput: PositronQuickInput;
 	// --- End Positron ---
 
 	constructor(code: Code) {
@@ -144,6 +146,7 @@ export class Workbench {
 		this.positronQuickaccess = new PositronQuickAccess(this.quickinput, this.quickaccess);
 		this.positronOutline = new PositronOutline(code, this.quickaccess);
 		this.positronClipboard = new PositronClipboard(code);
+		this.positronQuickInput = new PositronQuickInput(code);
 		// --- End Positron ---
 	}
 }

--- a/test/e2e/areas/quarto/quarto.test.ts
+++ b/test/e2e/areas/quarto/quarto.test.ts
@@ -57,7 +57,7 @@ test.describe('Quarto', { tag: [tags.WEB, tags.QUARTO] }, () => {
 const renderQuartoDocument = async (app: Application, fileExtension: string) => {
 	await test.step(`render quarto document`, async () => {
 		await app.workbench.quickaccess.runCommand('quarto.render.document', { keepOpen: true });
-		await app.workbench.quickinput.selectQuickInputElementContaining(fileExtension);
+		await app.workbench.positronQuickInput.selectQuickInputElementContaining(fileExtension);
 	});
 };
 

--- a/test/e2e/areas/r-pkg-development/r-pkg-development.test.ts
+++ b/test/e2e/areas/r-pkg-development/r-pkg-development.test.ts
@@ -31,9 +31,9 @@ test.describe('R Package Development', { tag: [tags.WEB, tags.R_PKG_DEVELOPMENT]
 			// Navigate to https://github.com/posit-dev/qa-example-content/tree/main/workspaces/r_testing
 			// This is an R package embedded in qa-example-content
 			await app.workbench.quickaccess.runCommand('workbench.action.files.openFolder', { keepOpen: true });
-			await app.workbench.quickinput.waitForQuickInputOpened();
-			await app.workbench.quickinput.type(path.join(app.workspacePathOrFolder, 'workspaces', 'r_testing'));
-			await app.workbench.quickinput.clickOkOnQuickInput();
+			await app.workbench.positronQuickInput.waitForQuickInputOpened();
+			await app.workbench.positronQuickInput.type(path.join(app.workspacePathOrFolder, 'workspaces', 'r_testing'));
+			await app.workbench.positronQuickInput.clickOkOnQuickInput();
 
 			// Wait for the console to be ready
 			await app.workbench.positronConsole.waitForReady('>', 45000);

--- a/test/e2e/areas/test-explorer/test-explorer.test.ts
+++ b/test/e2e/areas/test-explorer/test-explorer.test.ts
@@ -33,10 +33,10 @@ test.describe('Test Explorer', { tag: [tags.TEST_EXPLORER] }, () => {
 			// Navigate to https://github.com/posit-dev/qa-example-content/tree/main/workspaces/r_testing
 			// This is an R package embedded in qa-example-content
 			await app.workbench.quickaccess.runCommand('workbench.action.files.openFolder', { keepOpen: true });
-			await app.workbench.quickinput.waitForQuickInputOpened();
-			await app.workbench.quickinput.type(path.join(app.workspacePathOrFolder, 'workspaces', 'r_testing'));
+			await app.workbench.positronQuickInput.waitForQuickInputOpened();
+			await app.workbench.positronQuickInput.type(path.join(app.workspacePathOrFolder, 'workspaces', 'r_testing'));
 			// Had to add a positron class, because Microsoft did not have this:
-			await app.workbench.quickinput.clickOkOnQuickInput();
+			await app.workbench.positronQuickInput.clickOkOnQuickInput();
 
 			// Wait for the console to be ready
 			await app.workbench.positronConsole.waitForReady('>', 10000);

--- a/test/e2e/areas/welcome/welcome.test.ts
+++ b/test/e2e/areas/welcome/welcome.test.ts
@@ -72,7 +72,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME] }, () => {
 
 			await app.workbench.positronWelcome.newFileButton.click();
 
-			await app.workbench.quickinput.selectQuickInputElementContaining('Python File');
+			await app.workbench.positronQuickInput.selectQuickInputElementContaining('Python File');
 
 			await expect(app.workbench.editors.activeEditor.locator(app.workbench.editors.editorIcon)).toHaveClass(/python-lang-file-icon/);
 
@@ -111,7 +111,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME] }, () => {
 		test('Create a new R file from the Welcome page [C684755]', async function ({ app, r }) {
 			await app.workbench.positronWelcome.newFileButton.click();
 
-			await app.workbench.quickinput.selectQuickInputElementContaining('R File');
+			await app.workbench.positronQuickInput.selectQuickInputElementContaining('R File');
 
 			await expect(app.workbench.editors.activeEditor.locator(app.workbench.editors.editorIcon)).toHaveClass(/r-lang-file-icon/);
 		});


### PR DESCRIPTION
* Copied over original `QuickInput` POM and refactored to `PositronQuickInput` leveraging the Playwright API.
* Updated existing logic in tests to use `PositronQuickInput` instead.

### QA Notes

Ran all linux tests: https://github.com/posit-dev/positron/actions/runs/12373090485