### PR TITLE
python/ci: adjust CI testing for python 3.8

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -114,7 +114,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # Run the tests on the oldest and most recent versions of Python.
-        python: ['3.8', '3.12']
+        python: ['3.8', '3.13-dev']
 
     steps:
       - name: Checkout
@@ -149,8 +149,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: 'ubuntu-latest'
-            python: '3.8'
           - os: 'macos-latest'
             python: '3.9'
           - os: 'windows-latest'
@@ -159,6 +157,8 @@ jobs:
             python: '3.11'
           - os: 'ubuntu-latest'
             python: '3.12'
+          - os: 'ubuntu-latest'
+            python: '3.13-dev'
 
     steps:
       - name: Checkout

--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -114,7 +114,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # Run the tests on the oldest and most recent versions of Python.
-        python: ['3.8', '3.13']
+        python: ['3.8', '3.12']
 
     steps:
       - name: Checkout
@@ -157,8 +157,9 @@ jobs:
             python: '3.11'
           - os: 'ubuntu-latest'
             python: '3.12'
-          - os: 'ubuntu-latest'
-            python: '3.13'
+          # add in 3.13 when ibis-framework[duckdb] supports it
+          # - os: 'ubuntu-latest'
+          #   python: '3.13'
 
     steps:
       - name: Checkout

--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -114,7 +114,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # Run the tests on the oldest and most recent versions of Python.
-        python: ['3.8', '3.13-dev']
+        python: ['3.8', '3.13']
 
     steps:
       - name: Checkout
@@ -158,7 +158,7 @@ jobs:
           - os: 'ubuntu-latest'
             python: '3.12'
           - os: 'ubuntu-latest'
-            python: '3.13-dev'
+            python: '3.13'
 
     steps:
       - name: Checkout

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -44,7 +44,7 @@ jobs:
           - os: 'ubuntu-latest'
             python: '3.12'
           - os: 'ubuntu-latest'
-            python: '3.13-dev'
+            python: '3.13'
 
     steps:
       - name: Checkout
@@ -97,7 +97,7 @@ jobs:
           - os: 'ubuntu-latest'
             python: '3.12'
           - os: 'ubuntu-latest'
-            python: '3.13-dev'
+            python: '3.13'
 
     steps:
       - name: Checkout

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -43,8 +43,10 @@ jobs:
             python: '3.11'
           - os: 'ubuntu-latest'
             python: '3.12'
-          - os: 'ubuntu-latest'
-            python: '3.13'
+          # add in 3.13 when ibis-framework[duckdb] supports it
+          # - os: 'ubuntu-latest'
+          #   python: '3.13'
+
 
     steps:
       - name: Checkout
@@ -96,8 +98,10 @@ jobs:
             python: '3.11'
           - os: 'ubuntu-latest'
             python: '3.12'
-          - os: 'ubuntu-latest'
-            python: '3.13'
+          # add in 3.13 when ibis-framework[duckdb] supports it
+          # - os: 'ubuntu-latest'
+          #   python: '3.13'
+
 
     steps:
       - name: Checkout

--- a/.github/workflows/positron-python-nightly.yml
+++ b/.github/workflows/positron-python-nightly.yml
@@ -43,6 +43,8 @@ jobs:
             python: '3.11'
           - os: 'ubuntu-latest'
             python: '3.12'
+          - os: 'ubuntu-latest'
+            python: '3.13-dev'
 
     steps:
       - name: Checkout
@@ -94,6 +96,8 @@ jobs:
             python: '3.11'
           - os: 'ubuntu-latest'
             python: '3.12'
+          - os: 'ubuntu-latest'
+            python: '3.13-dev'
 
     steps:
       - name: Checkout

--- a/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
@@ -18,7 +18,7 @@ pandas==2.0.3; python_version < '3.9'
 plotly==5.24.1
 polars==1.7.1
 polars[timezone]==1.7.1; python_version < '3.9' or sys_platform == 'win32'
-pyarrow==17.0.0
+pyarrow==18.1.0
 pytest==8.0.2
 pytest-asyncio==0.23.8
 pytest-mock==3.14.0

--- a/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
@@ -13,7 +13,7 @@ matplotlib==3.7.4; python_version < '3.9'
 numpy==2.1.1; python_version >= '3.10'
 numpy==1.24.4; python_version < '3.9'
 numpy==2.0.2; python_version == '3.9'
-pandas==2.2.2; python_version >= '3.9'
+pandas==2.2.3; python_version >= '3.9'
 pandas==2.0.3; python_version < '3.9'
 plotly==5.24.1
 polars==1.7.1

--- a/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
@@ -22,7 +22,7 @@ pyarrow==17.0.0
 pytest==8.0.2
 pytest-asyncio==0.23.8
 pytest-mock==3.14.0
-torch==2.4.1; python_version >= '3.10'
+torch==2.5.1; python_version >= '3.10'
 torch==2.1.2; python_version < '3.10'
-SQLAlchemy==2.0.34
+SQLAlchemy==2.0.36
 

--- a/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/positron/pinned-test-requirements.txt
@@ -13,16 +13,16 @@ matplotlib==3.7.4; python_version < '3.9'
 numpy==2.1.1; python_version >= '3.10'
 numpy==1.24.4; python_version < '3.9'
 numpy==2.0.2; python_version == '3.9'
-pandas==2.2.3; python_version >= '3.9'
+pandas==2.2.2; python_version >= '3.9'
 pandas==2.0.3; python_version < '3.9'
 plotly==5.24.1
 polars==1.7.1
 polars[timezone]==1.7.1; python_version < '3.9' or sys_platform == 'win32'
-pyarrow==18.1.0
+pyarrow==17.0.0
 pytest==8.0.2
 pytest-asyncio==0.23.8
 pytest-mock==3.14.0
-torch==2.5.1; python_version >= '3.10'
+torch==2.4.1; python_version >= '3.10'
 torch==2.1.2; python_version < '3.10'
-SQLAlchemy==2.0.36
+SQLAlchemy==2.0.34
 

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/inspectors.py
@@ -738,7 +738,7 @@ class TorchTensorInspector(_BaseArrayInspector["torch.Tensor"]):
             "edgeitems": ARRAY_EDGEITEMS,
             "linewidth": print_width,
         }
-        options_obj = torch._tensor_str.PRINT_OPTS
+        options_obj = torch._tensor_str.PRINT_OPTS  # type: ignore[reportGeneralTypeIssues]
         original_options = {k: getattr(options_obj, k) for k in new_options}
 
         torch.set_printoptions(**new_options)

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_ui.py
@@ -110,8 +110,7 @@ def test_set_console_width(ui_comm: DummyComm) -> None:
     assert np.get_printoptions()["linewidth"] == width
     assert pd.get_option("display.width") is None
     assert pl.Config.state()["POLARS_TABLE_WIDTH"] == str(width)
-    if torch is not None:  # temporary workaround for Python 3.12
-        assert torch._tensor_str.PRINT_OPTS.linewidth == width
+    assert torch._tensor_str.PRINT_OPTS.linewidth == width  # type: ignore[reportGeneralTypeIssues]
 
 
 def test_open_editor(ui_service: UiService, ui_comm: DummyComm) -> None:


### PR DESCRIPTION
addresses #5136
~addresses #5137~ NOTE: due to `ibis-framework[duckdb]` not being available for 3.13, we will not be able to test at this time

- Slightly adjust cadence of Python 3.8 from every commit in a PR to nightly for ipykernel Positron tests (keep as-is for upstream tests, which only run on earliest and latest versions)
- Add in testing for Python 3.13 

This closely follows the strategy of upstream, which [tests on 3.8-3.13](https://github.com/microsoft/vscode-python/blob/d50b7cca88f7f81cef22516ef557b9aae5e9219e/.github/workflows/pr-check.yml#L150).

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

should pass CI