### PR TITLE
Execute selected code in console

### DIFF
--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -680,10 +680,6 @@ export function registerLanguageRuntimeActions() {
 				title: nls.localize2('positron.command.executeSelectedCode', "Execute Selected Code in Console"),
 				f1: true,
 				category,
-				keybinding: {
-					weight: KeybindingWeight.WorkbenchContrib,
-					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter
-				}
 			});
 		}
 


### PR DESCRIPTION
Based on #5747.

Adds a new action that can be used to execute selected code. Basically a wrapper for the existing `workbench.action.executeCode.console` action but that gets the code and language from the active editor and its selection. 


https://github.com/user-attachments/assets/1b288832-edb1-452c-af7d-9a975f8d727b


## QA Notes

This is a pretty thin wrapper around the existing action so I didn't add any tests. However you should be able to execute code that you have selected in a python or r file and it should go to the console. Aka basically the same as running `cmd + enter`. 