### PR TITLE
disable extension validation in Positron

### DIFF
--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
@@ -348,6 +348,13 @@ export class ExtensionManagementService extends AbstractExtensionManagementServi
 			const value = this.configurationService.getValue('extensions.verifySignature');
 			verifySignature = isBoolean(value) ? value : true;
 		}
+
+		// --- Start Positron ---
+		// Disable signature verification for Positron; we don't ship the
+		// `vsce-sign` tool used to validate signatues.
+		verifySignature = false;
+		// --- End Positron ---
+
 		const { location, verificationStatus } = await this.extensionsDownloader.download(extension, operation, verifySignature, clientTargetPlatform);
 
 		if (verificationStatus !== ExtensionSignatureVerificationCode.Success && verifySignature && this.environmentService.isBuilt && !isLinux) {

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -258,7 +258,11 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				description: localize('extensions.verifySignature', "When enabled, extensions are verified to be signed before getting installed."),
 				default: true,
 				scope: ConfigurationScope.APPLICATION,
-				included: isNative && !isLinux
+				// --- Start Positron ---
+				// Do not include this setting in Positron; it is not
+				// supported.
+				included: isNative && !isLinux && false
+				// --- End Positron ---
 			}
 		}
 	});


### PR DESCRIPTION
This change causes Positron to skip extension validation. Extension validation isn't a new feature from upstream, but it is a feature that was formerly not very aggressive. In this change from upstream 1.94 (which we picked up with the 1.93 -> 1.95 upstream merge), VS Code started blocking installation when signature verification fails.

https://github.com/microsoft/vscode/commit/2991008c4fd8ba016ed5d25765f816f126cba525

This change also added a new option, `extensions.verifySignature`, which controls the new behavior. The fix is to effectively hide this option and never perform signature verification.

In early drafts of this change I considered just defaulting the setting to `false`, but it turns out that Positron is missing an essential binary needed to perform signature verification (`@vscode/vsce-sign`), so we cannot verify signatures. Verification is also restricted to Windows and macOS platforms, even in upstream VS Code. 

This fix is a stopgap to get installation back online quickly. In the long term, we should consider investigating what work is needed to perform signature verification. While Positron does not bundle a copy of the vsce-sign tool, the tool is distributed on npm (note however that it is closed source and under a Microsoft license). https://www.npmjs.com/package/@vscode/vsce-sign

Addresses https://github.com/posit-dev/positron/issues/5758.

### QA Notes

Installing from local VSIX files as well as OpenVSX should work smoothly.