### PR TITLE
Bump ark to v0.1.159

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -686,7 +686,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.158"
+      "ark": "0.1.159"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
For:

[PR 655](https://github.com/posit-dev/ark/pull/655): Limits the number of bins for histograms to avoid crashes, addressing [issue 5744](https://github.com/posit-dev/positron/issues/5744).
[PR 654](https://github.com/posit-dev/ark/pull/654): Adds more logging for Help proxy errors, addressing [issue 3543](https://github.com/posit-dev/positron/issues/3543).
[PR 646](https://github.com/posit-dev/ark/pull/646): Refactors FormattedVector for faster formatting of S3 objects, improving performance when expanding large data.frames, related to [comment](https://github.com/posit-dev/positron/issues/3628#issuecomment-2498863196).