### PR TITLE
ci: prevent concurrency

### DIFF
--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -41,6 +41,10 @@ on:
               - always
               - never
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e-electron:
     name: e2e

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -6,6 +6,10 @@ on:
       - main
       - 'prerelease/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e-electron:
     name: e2e

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -7,6 +7,10 @@ on:
       - main
       - 'prerelease/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-tags:
     runs-on: ubuntu-latest

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -143,7 +143,7 @@
         "filename": ".github/workflows/test-full-suite.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 49,
+        "line_number": 53,
         "is_secret": false
       }
     ],
@@ -153,7 +153,7 @@
         "filename": ".github/workflows/test-merge.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 22,
         "is_secret": false
       }
     ],
@@ -163,7 +163,7 @@
         "filename": ".github/workflows/test-pull-request.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 39,
         "is_secret": false
       }
     ],
@@ -1944,5 +1944,5 @@
       }
     ]
   },
-  "generated_at": "2024-12-16T22:03:58Z"
+  "generated_at": "2024-12-18T16:07:04Z"
 }


### PR DESCRIPTION
This PR addresses duplicate workflow runs in CI for our main workflows by configuring them to automatically cancel any in-progress workflows triggered by the same PR, branch, or tag when a new workflow starts.

### QA Notes

Confirmed behavior works by manually triggering the same workflow 2x. The first one was auto-cancelled.
