### PR TITLE
Add saving to plots in editor tabs

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -29,7 +29,7 @@ import { ZoomPlotMenuButton } from './zoomPlotMenuButton.js';
 import { PlotClientInstance } from '../../../../services/languageRuntime/common/languageRuntimePlotClient.js';
 import { StaticPlotClient } from '../../../../services/positronPlots/common/staticPlotClient.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
-import { CopyPlotTarget, PlotsClearAction, PlotsCopyAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsSaveAction } from '../positronPlotsActions.js';
+import { PlotActionTarget, PlotsClearAction, PlotsCopyAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsSaveAction } from '../positronPlotsActions.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { HtmlPlotClient } from '../htmlPlotClient.js';
 import { POSITRON_EDITOR_PLOTS, positronPlotsEditorEnabled } from '../../../positronPlotsEditor/browser/positronPlotsEditor.contribution.js';
@@ -131,11 +131,11 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		props.zoomHandler(zoomLevel);
 	};
 	const savePlotHandler = () => {
-		props.commandService.executeCommand(PlotsSaveAction.ID);
+		props.commandService.executeCommand(PlotsSaveAction.ID, PlotActionTarget.VIEW);
 	};
 
 	const copyPlotHandler = () => {
-		props.commandService.executeCommand(PlotsCopyAction.ID, CopyPlotTarget.VIEW);
+		props.commandService.executeCommand(PlotsCopyAction.ID, PlotActionTarget.VIEW);
 	};
 
 	const popoutPlotHandler = () => {

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -18,7 +18,7 @@ import { IPositronPlotsService, POSITRON_PLOTS_VIEW_ID } from '../../../services
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from '../../../common/contributions.js';
 import { Extensions as ViewContainerExtensions, IViewsRegistry } from '../../../common/views.js';
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
-import { PlotsActiveEditorCopyAction, PlotsClearAction, PlotsCopyAction, PlotsEditorAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsRefreshAction, PlotsSaveAction } from './positronPlotsActions.js';
+import { PlotsActiveEditorCopyAction, PlotsActiveEditorSaveAction, PlotsClearAction, PlotsCopyAction, PlotsEditorAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsRefreshAction, PlotsSaveAction } from './positronPlotsActions.js';
 import { POSITRON_SESSION_CONTAINER } from '../../positronSession/browser/positronSessionContainer.js';
 
 // Register the Positron plots service.
@@ -71,6 +71,7 @@ class PositronPlotsContribution extends Disposable implements IWorkbenchContribu
 		registerAction2(PlotsPopoutAction);
 		registerAction2(PlotsEditorAction);
 		registerAction2(PlotsActiveEditorCopyAction);
+		registerAction2(PlotsActiveEditorSaveAction);
 	}
 }
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -47,7 +47,7 @@ abstract class AbstractPlotsAction extends Action2 {
 	 * @param notificationService the notification service
 	 */
 	abstract executeQuickPick(quickPick: IQuickPickItem, plotsService: IPositronPlotsService,
-		editorService: IEditorService, notificationService: INotificationService): Promise<void>;
+		editorService: IEditorService, notificationService: INotificationService): void;
 
 	/**
 	 * Executes the action on the target.
@@ -58,7 +58,7 @@ abstract class AbstractPlotsAction extends Action2 {
 	 * @param notificationService the notification service
 	 */
 	abstract executeTargetAction(target: PlotActionTarget, plotsService: IPositronPlotsService,
-		editorService: IEditorService, notificationService: INotificationService): Promise<void>;
+		editorService: IEditorService, notificationService: INotificationService): void;
 
 	async run(accessor: ServicesAccessor, target?: PlotActionTarget): Promise<void> {
 		const plotsService = accessor.get(IPositronPlotsService);
@@ -198,7 +198,7 @@ export class PlotsSaveAction extends AbstractPlotsAction {
 	}
 
 	override executeTargetAction(target: PlotActionTarget, plotsService: IPositronPlotsService,
-		editorService: IEditorService, notificationService: INotificationService): Promise<void> {
+		editorService: IEditorService, notificationService: INotificationService) {
 		if (target === PlotActionTarget.VIEW) {
 			plotsService.saveViewPlot();
 		} else if (target === PlotActionTarget.ACTIVE_EDITOR) {
@@ -207,7 +207,7 @@ export class PlotsSaveAction extends AbstractPlotsAction {
 				try {
 					if (!plotId) {
 						notificationService.error(localize('positronPlotsServicePlotNotFound', 'Plot {0} was not found', plotId));
-						return Promise.resolve();
+						return;
 					}
 					plotsService.saveEditorPlot(plotId);
 				} catch (error) {
@@ -217,23 +217,20 @@ export class PlotsSaveAction extends AbstractPlotsAction {
 		} else {
 			notificationService.info(localize('positronPlots.noPlotSelected', 'No plot selected.'));
 		}
-
-		return Promise.resolve();
 	}
 
 	override executeQuickPick(quickPick: IQuickPickItem, plotsService: IPositronPlotsService,
-		editorService: IEditorService, notificationService: INotificationService): Promise<void> {
+		editorService: IEditorService, notificationService: INotificationService) {
 		if (quickPick.id === PlotActionTarget.VIEW) {
 			plotsService.saveViewPlot();
 		} else {
 			const plotId = quickPick.id;
 			if (!plotId) {
 				notificationService.error(localize('positronPlotsServicePlotNotFound', 'Plot {0} was not found', plotId));
-				return Promise.resolve();
+				return;
 			}
 			plotsService.saveEditorPlot(plotId);
 		}
-		return Promise.resolve();
 	}
 }
 
@@ -263,7 +260,7 @@ export class PlotsCopyAction extends AbstractPlotsAction {
 		}
 	}
 
-	private copyEditorPlotToClipboard(plotsService: IPositronPlotsService, notificationService: INotificationService, editorService: IEditorService, plotId: string) {
+	private copyEditorPlotToClipboard(plotsService: IPositronPlotsService, notificationService: INotificationService, plotId: string) {
 		plotsService.copyEditorPlotToClipboard(plotId)
 			.then(() => {
 				notificationService.info(localize('positronPlots.plotCopied', 'Plot copied to clipboard.'));
@@ -274,32 +271,28 @@ export class PlotsCopyAction extends AbstractPlotsAction {
 	}
 
 	override executeQuickPick(selectedItem: IQuickPickItem, plotsService: IPositronPlotsService,
-		editorService: IEditorService, notificationService: INotificationService): Promise<void> {
+		editorService: IEditorService, notificationService: INotificationService) {
 		if (selectedItem?.id) {
 			if (selectedItem.id === PlotActionTarget.VIEW) {
 				this.copyViewPlotToClipboard(plotsService, notificationService);
 			} else {
-				this.copyEditorPlotToClipboard(plotsService, notificationService, editorService, selectedItem.id);
+				this.copyEditorPlotToClipboard(plotsService, notificationService, selectedItem.id);
 			}
 		}
-
-		return Promise.resolve();
 	}
 
 	override executeTargetAction(target: PlotActionTarget, plotsService: IPositronPlotsService,
-		editorService: IEditorService, notificationService: INotificationService): Promise<void> {
+		editorService: IEditorService, notificationService: INotificationService) {
 		if (target === PlotActionTarget.VIEW) {
 			this.copyViewPlotToClipboard(plotsService, notificationService);
 		} else if (target === PlotActionTarget.ACTIVE_EDITOR) {
 			const plotId = this.getActiveEditorPlotId(editorService);
 			if (plotId) {
-				this.copyEditorPlotToClipboard(plotsService, notificationService, editorService, plotId);
+				this.copyEditorPlotToClipboard(plotsService, notificationService, plotId);
 			} else {
 				notificationService.info(localize('positronPlots.noPlotSelected', 'No plot selected.'));
 			}
 		}
-
-		return Promise.resolve();
 	}
 }
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -833,46 +833,57 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		this._onDidReplacePlots.fire(this._plots);
 	}
 
-	savePlot(): void {
+	saveViewPlot(): void {
 		if (this._selectedPlotId) {
 			const plot = this._plots.find(plot => plot.id === this._selectedPlotId);
-			this._fileDialogService.defaultFilePath()
-				.then(defaultPath => {
-					const suggestedPath = defaultPath;
-					if (plot) {
-						let uri = '';
-
-						if (plot instanceof StaticPlotClient) {
-							// if it's a static plot, save the image to disk
-							uri = plot.uri;
-							this.showSavePlotDialog(uri);
-						} else if (plot instanceof PlotClientInstance) {
-							// if it's a dynamic plot, present options dialog
-							showSavePlotModalDialog(
-								this._selectedSizingPolicy,
-								this._layoutService,
-								this._keybindingService,
-								this._modalDialogService,
-								this._fileService,
-								this._fileDialogService,
-								this._logService,
-								this._notificationService,
-								this._labelService,
-								this._pathService,
-								plot,
-								this.savePlotAs,
-								suggestedPath
-							);
-						} else {
-							// if it's a webview plot, do nothing
-							return;
-						}
-					}
-				})
-				.catch((error) => {
-					throw new Error(`Error saving plot: ${error.message}`);
-				});
+			this.savePlot(plot);
 		}
+	}
+
+	saveEditorPlot(plotId: string): void {
+		const plot = this._editorPlots.get(plotId);
+		this.savePlot(plot);
+	}
+
+	private savePlot(plotClient?: IPositronPlotClient) {
+		if (!plotClient) {
+			this._notificationService.error(localize('positronPlots.noPlotSelected', 'No plot selected.'));
+			return;
+		}
+		this._fileDialogService.defaultFilePath()
+			.then(defaultPath => {
+				const suggestedPath = defaultPath;
+				if (plotClient) {
+					if (plotClient instanceof StaticPlotClient) {
+						// if it's a static plot, save the image to disk
+						const uri = plotClient.uri;
+						this.showSavePlotDialog(uri);
+					} else if (plotClient instanceof PlotClientInstance) {
+						// if it's a dynamic plot, present options dialog
+						showSavePlotModalDialog(
+							this._selectedSizingPolicy,
+							this._layoutService,
+							this._keybindingService,
+							this._modalDialogService,
+							this._fileService,
+							this._fileDialogService,
+							this._logService,
+							this._notificationService,
+							this._labelService,
+							this._pathService,
+							plotClient,
+							this.savePlotAs,
+							suggestedPath
+						);
+					} else {
+						// if it's a webview plot, do nothing
+						return;
+					}
+				}
+			})
+			.catch((error) => {
+				throw new Error(`Error saving plot: ${error.message}`);
+			});
 	}
 
 	private savePlotAs = (options: SavePlotOptions) => {

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -172,9 +172,16 @@ export interface IPositronPlotsService {
 	openPlotInNewWindow(): void;
 
 	/**
-	 * Saves the plot.
+	 * Saves the plot from the Plots View.
 	 */
-	savePlot(): void;
+	saveViewPlot(): void;
+
+	/**
+	 * Saves the plot from the editor tab.
+	 *
+	 * @param plotId The id of the plot to save.
+	 */
+	saveEditorPlot(plotId: string): void;
 
 	/**
 	 * Opens the currently selected plot in an editor.


### PR DESCRIPTION
Address #4361 

Refactors the command and action to work with editor tabs or the Plots view. Presents a quick pick when using the command palette if there is more than one plot across the plots view and editor tabs.

This introduces an abstract plot action so that other commands can also have the quick pick functionality with the command palette.


https://github.com/user-attachments/assets/b7308301-9d02-4873-a789-c4c2a78865b8



@:plots

### QA Notes
A new button will be available in the editor action bar for saving the editor tab plot.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
