### PR TITLE
Write content of kernel messages when at Debug level

### DIFF
--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -171,7 +171,6 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 
 		this._kernelChannel = positron.window.createRawLogOutputChannel(
 			`${runtimeMetadata.runtimeName}: Kernel`);
-
 		this._kernelChannel.appendLine(`** Begin kernel log for session ${metadata.sessionName} (${metadata.sessionId}) at ${new Date().toLocaleString()} **`);
 	}
 
@@ -1275,7 +1274,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		const msg = data as JupyterMessage;
 
 		// Log the message
-		this.log(`<<< RECV [${msg.channel}]: ${JSON.stringify(msg.content)}`, vscode.LogLevel.Debug);
+		this.log(`<<< RECV ${msg.header.msg_type} [${msg.channel}]: ${JSON.stringify(msg.content)}`, vscode.LogLevel.Debug);
 
 		// Check to see if the message is a reply to a request; if it is,
 		// resolve the associated promise and remove it from the pending

--- a/extensions/positron-supervisor/src/jupyter/JupyterCommand.ts
+++ b/extensions/positron-supervisor/src/jupyter/JupyterCommand.ts
@@ -89,7 +89,7 @@ export abstract class JupyterCommand<T> {
 			buffers: []
 		};
 		const text = JSON.stringify(payload);
-		socket.channel.debug(`>>> SEND [${this.channel}]: ${JSON.stringify(this.commandPayload)}`);
+		socket.channel.debug(`>>> SEND ${this.commandType} [${this.channel}]: ${JSON.stringify(this.commandPayload)}`);
 		socket.ws.send(text);
 	}
 }

--- a/extensions/positron-supervisor/src/jupyter/JupyterCommand.ts
+++ b/extensions/positron-supervisor/src/jupyter/JupyterCommand.ts
@@ -89,6 +89,7 @@ export abstract class JupyterCommand<T> {
 			buffers: []
 		};
 		const text = JSON.stringify(payload);
+		socket.channel.debug(`>>> SEND [${this.channel}]: ${JSON.stringify(this.commandPayload)}`);
 		socket.ws.send(text);
 	}
 }

--- a/extensions/positron-supervisor/src/ws/SocketSession.ts
+++ b/extensions/positron-supervisor/src/ws/SocketSession.ts
@@ -19,10 +19,12 @@ export class SocketSession implements vscode.Disposable {
 	 *
 	 * @param uri The WebSocket URI to connect to
 	 * @param sessionId The session ID to use
+	 * @param outputChannel The output channel to write trace messages to
 	 */
 	constructor(
 		public readonly uri: string,
-		public readonly sessionId: string
+		public readonly sessionId: string,
+		public readonly channel: vscode.LogOutputChannel
 	) {
 		// Create a new WebSocket client
 		this.ws = new WebSocket(uri);


### PR DESCRIPTION
This change improves debug logs for kernels run under the supervisor. Prior to the change, it was difficult to see the contents of individual messages, because it turns out that VS Code's Log Output Channels [use the global log level and can't be configured otherwise](https://github.com/microsoft/vscode/issues/170450) -- even though some message contents were written at the _Trace_ level, there's no way to see them without setting the entire IDE to the _Trace_ level, which isn't fun.

The change adds message content logging at the Debug level, and improves some formatting. For example here's a snippet of output logs for the kernel info request:

```
2024-12-18 10:27:32.319 [debug] <<< RECV [kernel]: {"kind":"kernel","status":{"status":"busy","reason":"kernel_info_request"}}
2024-12-18 10:27:32.319 [debug] State: ready => busy (kernel_info_request)
2024-12-18 10:27:32.319 [debug] <<< RECV status [iopub]: {"execution_state":"busy"}
2024-12-18 10:27:32.319 [debug] <<< RECV kernel_info_reply [shell]: {"banner":"\nR version 4.3.3 (2024-02-29) -- \"Angel Food Cake\"\nCopyright (C) 2024 The R Foundation for Statistical Computing\nPlatform: aarch64-apple-darwin20 (64-bit)\n\nR is free software and comes with ABSOLUTELY NO WARRANTY.\nYou are welcome to redistribute it under certain conditions.\nType 'license()' or 'licence()' for distribution details.\n\n  
```

### QA Notes

There should be no impact on functionality, but the _Console_ logs will become chattier. 
