### PR TITLE
ci: allow concurrency on merge to main

### DIFF
--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -6,10 +6,6 @@ on:
       - main
       - 'prerelease/**'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   e2e-electron:
     name: e2e

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -153,7 +153,7 @@
         "filename": ".github/workflows/test-merge.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 18,
         "is_secret": false
       }
     ],
@@ -1944,5 +1944,5 @@
       }
     ]
   },
-  "generated_at": "2024-12-18T16:07:04Z"
+  "generated_at": "2024-12-18T19:29:32Z"
 }


### PR DESCRIPTION
Let's keep concurrency on merges to main so we can be alerted if a particular commit triggered a failure, etc.

