### PR TITLE
Test: retry setup-build-env

### DIFF
--- a/.github/workflows/test-e2e-linux.yml
+++ b/.github/workflows/test-e2e-linux.yml
@@ -85,8 +85,22 @@ jobs:
       - name: Cache node_modules, build, extensions, and remote
         uses: ./.github/actions/cache-multi-paths
 
-      - name: Setup Build and Compile
+      - name: Attempt 1 - Setup Build and Compile
         uses: ./.github/actions/setup-build-env
+        continue-on-error: true
+
+      - name: Attempt 2 - Setup Build and Compile
+        if: ${{ failure() }}
+        uses: ./.github/actions/setup-build-env
+        continue-on-error: true
+
+      - name: Attempt 3 - Setup Build and Compile
+        if: ${{ failure() }}
+        uses: ./.github/actions/setup-build-env
+
+      - name: Fail if Retries Exhausted
+        if: ${{ failure() }}
+        run: exit 1
 
       - name: Install Positron License
         uses: ./.github/actions/install-license

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -29,8 +29,22 @@ jobs:
       - name: Cache node_modules, build, extensions, and remote
         uses: ./.github/actions/cache-multi-paths
 
-      - name: Setup Build and Compile
+      - name: Attempt 1 - Setup Build and Compile
         uses: ./.github/actions/setup-build-env
+        continue-on-error: true
+
+      - name: Attempt 2 - Setup Build and Compile
+        if: ${{ failure() }}
+        uses: ./.github/actions/setup-build-env
+        continue-on-error: true
+
+      - name: Attempt 3 - Setup Build and Compile
+        if: ${{ failure() }}
+        uses: ./.github/actions/setup-build-env
+
+      - name: Fail if Retries Exhausted
+        if: ${{ failure() }}
+        run: exit 1
 
       - name: Install Positron License
         uses: ./.github/actions/install-license

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -29,8 +29,22 @@ jobs:
       - name: Cache node_modules, build, extensions, and remote
         uses: ./.github/actions/cache-multi-paths
 
-      - name: Setup Build and Compile
+      - name: Attempt 1 - Setup Build and Compile
         uses: ./.github/actions/setup-build-env
+        continue-on-error: true
+
+      - name: Attempt 2 - Setup Build and Compile
+        if: ${{ failure() }}
+        uses: ./.github/actions/setup-build-env
+        continue-on-error: true
+
+      - name: Attempt 3 - Setup Build and Compile
+        if: ${{ failure() }}
+        uses: ./.github/actions/setup-build-env
+
+      - name: Fail if Retries Exhausted
+        if: ${{ failure() }}
+        run: exit 1
 
       - name: Install Positron License
         uses: ./.github/actions/install-license


### PR DESCRIPTION
Add two retries to setup-build-env to get around node-gyp errors that occur periodically

### QA Notes

Tests should pass.  Process should be more stable
