### PR TITLE
Add Editor Actions Left / Center / Right menus and EditorActionBarFac…

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -74,6 +74,11 @@ export class MenuId {
 	static readonly EditorContextCopy = new MenuId('EditorContextCopy');
 	static readonly EditorContextPeek = new MenuId('EditorContextPeek');
 	static readonly EditorContextShare = new MenuId('EditorContextShare');
+	// --- Start Positron ---
+	static readonly EditorActionsLeft = new MenuId('EditorActionsLeft');
+	static readonly EditorActionsCenter = new MenuId('EditorActionsCenter');
+	static readonly EditorActionsRight = new MenuId('EditorActionsRight');
+	// --- End Positron ---
 	static readonly EditorTitle = new MenuId('EditorTitle');
 	static readonly EditorTitleRun = new MenuId('EditorTitleRun');
 	static readonly EditorTitleContext = new MenuId('EditorTitleContext');

--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -64,6 +64,21 @@ const apiMenus: IAPIMenu[] = [
 		supportsSubmenus: false
 	},
 	{
+		key: 'editor/actions/left',
+		id: MenuId.EditorActionsLeft,
+		description: localize('menus.editorActionsLeft', "The editor actions left menu")
+	},
+	{
+		key: 'editor/actions/center',
+		id: MenuId.EditorActionsCenter,
+		description: localize('menus.editorActionsCenter', "The editor actions center menu")
+	},
+	{
+		key: 'editor/actions/right',
+		id: MenuId.EditorActionsRight,
+		description: localize('menus.editorActionsRight', "The editor actions right menu")
+	},
+	{
 		key: 'editor/title',
 		id: MenuId.EditorTitle,
 		description: localize('menus.editorTitle', "The editor title menu")

--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -63,6 +63,7 @@ const apiMenus: IAPIMenu[] = [
 		description: localize('menus.touchBar', "The touch bar (macOS only)"),
 		supportsSubmenus: false
 	},
+	// --- Start Positron ---
 	{
 		key: 'editor/actions/left',
 		id: MenuId.EditorActionsLeft,
@@ -78,6 +79,7 @@ const apiMenus: IAPIMenu[] = [
 		id: MenuId.EditorActionsRight,
 		description: localize('menus.editorActionsRight', "The editor actions right menu")
 	},
+	// --- End Positron ---
 	{
 		key: 'editor/title',
 		id: MenuId.EditorTitle,


### PR DESCRIPTION
### Description

This PR adds the `EditorActionsLeft` (`editor/actions/left`), `EditorActionsCenter` (`editor/actions/center`), and `EditorActionsRight` (`editor/actions/right`) menus which are used to create Editor Action Bar actions.

### QA Notes

There's nothing new to test yet in this PR. Soon, we will be adding Data Explorer and Quarto actions to the Editor Action Bar.