### PR TITLE
Switch to overlay webviews for notebooks

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/NotebookVisibilityContext.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/NotebookVisibilityContext.tsx
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// React.
+import React, { PropsWithChildren, createContext, useContext } from 'react';
+
+// Other dependencies.
+import { ISettableObservable } from '../../../../base/common/observableInternal/base.js';
+
+/**
+ * Create the notebook visibility context.
+ */
+const NotebookVisibilityContext = createContext<ISettableObservable<boolean>>(undefined!);
+
+/**
+ * Provider component for notebook visibility state
+ */
+export const NotebookVisibilityProvider = ({
+	isVisible,
+	children
+}: PropsWithChildren<{ isVisible: ISettableObservable<boolean> }>) => {
+	return (
+		<NotebookVisibilityContext.Provider value={isVisible}>
+			{children}
+		</NotebookVisibilityContext.Provider>
+	);
+};
+
+/**
+ * Hook to access the notebook visibility state
+ * @returns The current visibility state as a boolean
+ */
+export const useNotebookVisibility = () => {
+	return useContext(NotebookVisibilityContext)
+};

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -32,7 +32,9 @@ export function PositronNotebookComponent() {
 	const fontStyles = useFontStyles();
 	const containerRef = React.useRef<HTMLDivElement>(null);
 
-	useScrollContainerEvents(containerRef);
+	React.useEffect(() => {
+		notebookInstance.setCellsContainer(containerRef.current);
+	}, [notebookInstance]);
 
 	return (
 		<div className='positron-notebook' style={{ ...fontStyles }}>
@@ -63,53 +65,6 @@ function useFontStyles(): React.CSSProperties {
 		'--vscode-positronNotebook-text-output-font-family': family,
 		'--vscode-positronNotebook-text-output-font-size': `${fontInfo.fontSize}px`,
 	} as React.CSSProperties;
-}
-
-/**
- * Hook to manage scroll and DOM mutation events for the notebook cells container
- */
-function useScrollContainerEvents(
-	containerRef: React.RefObject<HTMLDivElement>,
-) {
-	const notebookInstance = useNotebookInstance();
-
-	React.useEffect(() => {
-		const container = containerRef.current;
-		if (!container) {
-			return;
-		}
-
-		// Fire initial scroll event after a small delay to ensure layout has settled
-		const initialScrollTimeout = setTimeout(() => {
-			notebookInstance.fireOnDidScrollCellsContainer();
-		}, 50);
-
-		// Set up scroll listener
-		const scrollListener = DOM.addDisposableListener(container, 'scroll', () => {
-			notebookInstance.fireOnDidScrollCellsContainer();
-		});
-
-		// Set up mutation observer to watch for DOM changes
-		const observer = new MutationObserver(() => {
-			// Small delay to let the DOM changes settle
-			setTimeout(() => {
-				notebookInstance.fireOnDidScrollCellsContainer();
-			}, 0);
-		});
-
-		observer.observe(container, {
-			childList: true,
-			subtree: true,
-			attributes: true,
-			attributeFilter: ['style', 'class']
-		});
-
-		return () => {
-			clearTimeout(initialScrollTimeout);
-			scrollListener.dispose();
-			observer.disconnect();
-		};
-	}, [notebookInstance]);
 }
 
 function NotebookCell({ cell }: {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -48,6 +48,7 @@ import { NotebookInstanceProvider } from './NotebookInstanceProvider.js';
 import { PositronNotebookComponent } from './PositronNotebookComponent.js';
 import { ServicesProvider } from './ServicesProvider.js';
 import { IEditorGroup, IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { PositronNotebookEditorInput } from './PositronNotebookEditorInput.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWebviewService } from '../../webview/browser/webview.js';
@@ -125,6 +126,7 @@ export class PositronNotebookEditor extends EditorPane {
 		@ICommandService private readonly _commandService: ICommandService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@INotificationService private readonly _notificationService: INotificationService,
+		@IEditorService private readonly _editorService: IEditorService,
 	) {
 		// Call the base class's constructor.
 		super(
@@ -475,7 +477,8 @@ export class PositronNotebookEditor extends EditorPane {
 						openerService: this._openerService,
 						notificationService: this._notificationService,
 						sizeObservable: this._size,
-						scopedContextKeyProviderCallback: container => scopedContextKeyService.createScoped(container)
+						scopedContextKeyProviderCallback: container => scopedContextKeyService.createScoped(container),
+						editorService: this._editorService
 					}}>
 						<PositronNotebookComponent />
 					</ServicesProvider>

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -49,6 +49,7 @@ import { PositronNotebookComponent } from './PositronNotebookComponent.js';
 import { ServicesProvider } from './ServicesProvider.js';
 import { IEditorGroup, IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
 import { PositronNotebookEditorInput } from './PositronNotebookEditorInput.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWebviewService } from '../../webview/browser/webview.js';
@@ -127,6 +128,7 @@ export class PositronNotebookEditor extends EditorPane {
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IEditorService private readonly _editorService: IEditorService,
+		@IWorkbenchLayoutService private readonly _layoutService: IWorkbenchLayoutService,
 	) {
 		// Call the base class's constructor.
 		super(
@@ -478,7 +480,8 @@ export class PositronNotebookEditor extends EditorPane {
 						notificationService: this._notificationService,
 						sizeObservable: this._size,
 						scopedContextKeyProviderCallback: container => scopedContextKeyService.createScoped(container),
-						editorService: this._editorService
+						editorService: this._editorService,
+						layoutService: this._layoutService
 					}}>
 						<PositronNotebookComponent />
 					</ServicesProvider>

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter } from '../../../../base/common/event.js';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { ISettableObservable, observableValue } from '../../../../base/common/observableInternal/base.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
@@ -110,6 +110,16 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	private _container: HTMLElement | undefined = undefined;
 
 	/**
+	 * The DOM element that contains the cells for the notebook.
+	 */
+	private _cellsContainer: HTMLElement | undefined = undefined;
+
+	/**
+	 * Disposables for the current cells container event listeners
+	 */
+	private readonly _cellsContainerListeners = this._register(new DisposableStore());
+
+	/**
 	 * Callback to clear the keyboard navigation listeners. Set when listeners are attached.
 	 */
 	private _clearKeyboardNavigation: (() => void) | undefined = undefined;
@@ -172,6 +182,59 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Unique identifier for the notebook instance. Currently just the notebook URI as a string.
 	 */
 	private _id: string;
+
+	/**
+	 * The DOM element that contains the cells for the notebook.
+	 */
+	get cellsContainer(): HTMLElement | undefined {
+		return this._cellsContainer;
+	}
+
+	/**
+	 * Sets the DOM element that contains the cells for the notebook.
+	 * @param container The container element to set, or undefined to clear
+	 */
+	setCellsContainer(container: HTMLElement | undefined | null): void {
+		// Clean up any existing listeners
+		this._cellsContainerListeners.clear();
+
+		if (!container) { return; }
+
+		this._cellsContainer = container;
+
+		// Fire initial scroll event after a small delay to ensure layout has settled
+		const initialScrollTimeout = setTimeout(() => {
+			this._onDidScrollCellsContainer.fire();
+		}, 50);
+
+		// Set up scroll listener
+		const scrollListener = DOM.addDisposableListener(container, 'scroll', () => {
+			this._onDidScrollCellsContainer.fire();
+		});
+
+		// Set up mutation observer to watch for DOM changes
+		const observer = new MutationObserver(() => {
+			// Small delay to let the DOM changes settle
+			setTimeout(() => {
+				this._onDidScrollCellsContainer.fire();
+			}, 0);
+		});
+
+		observer.observe(container, {
+			childList: true,
+			subtree: true,
+			attributes: true,
+			attributeFilter: ['style', 'class']
+		});
+
+		// Add all the disposables to our store
+		this._cellsContainerListeners.add(toDisposable(() => clearTimeout(initialScrollTimeout)));
+		this._cellsContainerListeners.add(scrollListener);
+		this._cellsContainerListeners.add(toDisposable(() => observer.disconnect()));
+
+		// Fire initial scroll event
+		this._onDidScrollCellsContainer.fire();
+	}
 
 	/**
 	 * User facing cells wrapped in an observerable for the UI to react to changes
@@ -495,14 +558,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 		this._setupKeyboardNavigation(container);
 		this._logService.info(this.id, 'attachView');
-	}
-
-	/**
-	 * Manually fires the scroll event for the cells container.
-	 * This can be called from React components after the container is mounted.
-	 */
-	fireOnDidScrollCellsContainer(): void {
-		this._onDidScrollCellsContainer.fire();
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -159,6 +159,12 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	private readonly _onDidChangeContent = this._register(new Emitter<void>());
 	readonly onDidChangeContent = this._onDidChangeContent.event;
 
+	/**
+	 * Event emitter for when the cells container is scrolled
+	 */
+	private readonly _onDidScrollCellsContainer = this._register(new Emitter<void>());
+	readonly onDidScrollCellsContainer = this._onDidScrollCellsContainer.event;
+
 	// =============================================================================================
 	// #region Public Properties
 
@@ -489,6 +495,14 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 		this._setupKeyboardNavigation(container);
 		this._logService.info(this.id, 'attachView');
+	}
+
+	/**
+	 * Manually fires the scroll event for the cells container.
+	 * This can be called from React components after the container is mounted.
+	 */
+	fireOnDidScrollCellsContainer(): void {
+		this._onDidScrollCellsContainer.fire();
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/ServicesProvider.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ServicesProvider.tsx
@@ -18,6 +18,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
 import { IPositronNotebookOutputWebviewService } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
 import { IWebviewService } from '../../webview/browser/webview.js';
 import { IPositronWebviewPreloadService } from '../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
@@ -88,6 +89,11 @@ interface ServiceBundle {
 	 * Service for managing active editors and editor state
 	 */
 	editorService: IEditorService;
+
+	/**
+	 * Service for managing workbench layout and panel positions
+	 */
+	layoutService: IWorkbenchLayoutService;
 
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/ServicesProvider.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ServicesProvider.tsx
@@ -17,6 +17,7 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IPositronNotebookOutputWebviewService } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
 import { IWebviewService } from '../../webview/browser/webview.js';
 import { IPositronWebviewPreloadService } from '../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
@@ -83,6 +84,11 @@ interface ServiceBundle {
 	 */
 	scopedContextKeyProviderCallback: (container: HTMLElement) => IScopedContextKeyService;
 
+	/**
+	 * Service for managing active editors and editor state
+	 */
+	editorService: IEditorService;
+
 }
 
 /**
@@ -110,5 +116,3 @@ export function useServices() {
 	}
 	return serviceBundle;
 }
-
-

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/PreloadMessageOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/PreloadMessageOutput.tsx
@@ -42,7 +42,7 @@ export function PreloadMessageOutput({ preloadMessageResult }: PreloadMessageOut
 }
 
 function DisplayedPreloadMessage({ webview }: DisplayedPreloadMessageProps) {
-	const { containerRef, isLoading, error } = useWebviewMount(webview);
+	const { containerRef, clipContainerRef, isLoading, error } = useWebviewMount(webview);
 
 	if (error) {
 		return <div>{error.message}</div>;
@@ -51,7 +51,13 @@ function DisplayedPreloadMessage({ webview }: DisplayedPreloadMessageProps) {
 	return (
 		<>
 			{isLoading && <div>{MESSAGES.LOADING}</div>}
-			<div ref={containerRef} />
+			<div
+				ref={clipContainerRef}
+				className='positron-webview-output-clip-container'
+				style={{ position: 'relative' }}
+			>
+				<div style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} ref={containerRef} />
+			</div>
 		</>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/PreloadMessageOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/PreloadMessageOutput.tsx
@@ -42,7 +42,7 @@ export function PreloadMessageOutput({ preloadMessageResult }: PreloadMessageOut
 }
 
 function DisplayedPreloadMessage({ webview }: DisplayedPreloadMessageProps) {
-	const { containerRef, clipContainerRef, isLoading, error } = useWebviewMount(webview);
+	const { containerRef, isLoading, error } = useWebviewMount(webview);
 
 	if (error) {
 		return <div>{error.message}</div>;
@@ -51,13 +51,7 @@ function DisplayedPreloadMessage({ webview }: DisplayedPreloadMessageProps) {
 	return (
 		<>
 			{isLoading && <div>{MESSAGES.LOADING}</div>}
-			<div
-				ref={clipContainerRef}
-				className='positron-webview-output-clip-container'
-				style={{ position: 'relative' }}
-			>
-				<div style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }} ref={containerRef} />
-			</div>
+			<div ref={containerRef} />
 		</>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
@@ -132,17 +132,16 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
 				// Listen for all editor and layout changes that might affect the webview
 				const handleLayoutChange = () => updateWebviewLayout(false);
 				editorChangeDisposable = Event.any(
-					editorService.onDidActiveEditorChange,
-					editorService.onDidVisibleEditorsChange, // Catches editor group changes
-					layoutService.onDidLayoutMainContainer, // Listen for main container layout changes
-					layoutService.onDidLayoutContainer, // Listen for any container layout changes
-					layoutService.onDidLayoutActiveContainer, // Listen for active container layout changes
-					layoutService.onDidChangePartVisibility,
-					layoutService.onDidChangeZenMode,
-					layoutService.onDidChangeWindowMaximized,
-					layoutService.onDidChangePanelAlignment,
-					layoutService.onDidChangePanelPosition,
-					layoutService.onDidChangeMainEditorCenteredLayout // Listen for main editor centered layout changes
+					editorService.onDidActiveEditorChange,          // Active editor switched
+					editorService.onDidVisibleEditorsChange,        // Editor groups/layout changed
+					layoutService.onDidLayoutMainContainer,         // Main container resized/moved
+					layoutService.onDidLayoutContainer,             // Any container resized/moved
+					layoutService.onDidLayoutActiveContainer,       // Active container resized/moved
+					layoutService.onDidChangePartVisibility,        // UI part shown/hidden
+					layoutService.onDidChangeWindowMaximized,       // Window maximized/restored
+					layoutService.onDidChangePanelAlignment,        // Panel alignment changed
+					layoutService.onDidChangePanelPosition,         // Panel position changed
+					layoutService.onDidChangeMainEditorCenteredLayout // Editor centered mode toggled
 				)(handleLayoutChange);
 
 				// Create and setup resize observer for layout changes

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
@@ -10,7 +10,6 @@ import { isHTMLOutputWebviewMessage } from '../../../../positronWebviewPreloads/
 import { useNotebookInstance } from '../../NotebookInstanceProvider.js';
 import { IOverlayWebview } from '../../../../webview/browser/webview.js';
 import { toDisposable } from '../../../../../../base/common/lifecycle.js';
-import { assertIsOverlayPositronWebview } from '../../../../positronOutputWebview/browser/notebookOutputWebviewServiceImpl.js';
 
 
 export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
@@ -45,7 +44,6 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
 				}
 
 				setIsLoading(false);
-				assertIsOverlayPositronWebview(resolvedWebview);
 				webviewElement = resolvedWebview.webview;
 
 				webviewElement.claim(

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
@@ -132,6 +132,9 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
 				return;
 			}
 			try {
+				// We're using the base ref here because it's a constant reference and thus
+				// will avoid unnecessary mismatches for claiming and releasing the webview
+				// across multiple renders.
 				webviewElement.claim(containerRef, getWindow(containerRef.current), undefined);
 			} catch (err) {
 				setError(new WebviewMountError('Failed to claim webview', err instanceof Error ? err : undefined));

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
@@ -134,11 +134,15 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
 				editorChangeDisposable = Event.any(
 					editorService.onDidActiveEditorChange,
 					editorService.onDidVisibleEditorsChange, // Catches editor group changes
+					layoutService.onDidLayoutMainContainer, // Listen for main container layout changes
+					layoutService.onDidLayoutContainer, // Listen for any container layout changes
+					layoutService.onDidLayoutActiveContainer, // Listen for active container layout changes
 					layoutService.onDidChangePartVisibility,
 					layoutService.onDidChangeZenMode,
 					layoutService.onDidChangeWindowMaximized,
 					layoutService.onDidChangePanelAlignment,
-					layoutService.onDidChangePanelPosition
+					layoutService.onDidChangePanelPosition,
+					layoutService.onDidChangeMainEditorCenteredLayout // Listen for main editor centered layout changes
 				)(handleLayoutChange);
 
 				// Create and setup resize observer for layout changes

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
@@ -17,7 +17,6 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
 	const [isLoading, setIsLoading] = React.useState(true);
 	const [error, setError] = React.useState<Error | null>(null);
 	const containerRef = React.useRef<HTMLDivElement>(null);
-	const clipContainerRef = React.useRef<HTMLDivElement>(null);
 	const notebookInstance = useNotebookInstance();
 
 	React.useEffect(() => {
@@ -32,7 +31,7 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
 			webviewElement.layoutWebviewOverElement(
 				containerRef.current,
 				undefined,
-				clipContainerRef.current || undefined
+				notebookInstance.cellsContainer
 			);
 		}
 
@@ -73,10 +72,7 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
 						// empty outputs that are 150px tall
 						boundedHeight = 0;
 					}
-					if (clipContainerRef.current) {
-						console.log("ClipContainerRef", clipContainerRef.current);
-						clipContainerRef.current.style.height = `${boundedHeight}px`;
-					}
+					containerRef.current.style.height = `${boundedHeight}px`;
 				});
 
 				return scrollDisposable;
@@ -96,5 +92,5 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
 		};
 	}, [webview, notebookInstance]);
 
-	return { containerRef, clipContainerRef, isLoading, error };
+	return { containerRef, isLoading, error };
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
@@ -4,11 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from 'react';
-import { getWindow } from '../../../../../../base/browser/dom.js';
+import { Dimension, getWindow } from '../../../../../../base/browser/dom.js';
 import { INotebookOutputWebview } from '../../../../positronOutputWebview/browser/notebookOutputWebviewService.js';
-import { IWebviewElement } from '../../../../webview/browser/webview.js';
-import { assertIsStandardPositronWebview } from '../../../../positronOutputWebview/browser/notebookOutputWebviewServiceImpl.js';
 import { isHTMLOutputWebviewMessage } from '../../../../positronWebviewPreloads/browser/notebookOutputUtils.js';
+import { useNotebookInstance } from '../../NotebookInstanceProvider.js';
+import { IOverlayWebview } from '../../../../webview/browser/webview.js';
+import { toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { assertIsOverlayPositronWebview } from '../../../../positronOutputWebview/browser/notebookOutputWebviewServiceImpl.js';
 
 
 export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebview.ts
@@ -16,15 +16,14 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { FromWebviewMessage, IClickedDataUrlMessage } from '../../notebook/browser/view/renderers/webviewMessages.js';
 import { IScopedRendererMessaging } from '../../notebook/common/notebookRendererMessagingService.js';
-import { INotebookOutputWebview, WebviewType } from './notebookOutputWebviewService.js';
-import { IOverlayWebview, IWebviewElement } from '../../webview/browser/webview.js';
+import { INotebookOutputWebview } from './notebookOutputWebviewService.js';
+import { IOverlayWebview } from '../../webview/browser/webview.js';
 import { INotebookLoggingService } from '../../notebook/common/notebookLoggingService.js';
 
 interface NotebookOutputWebviewOptions {
 	readonly id: string;
 	readonly sessionId: string;
-	readonly webview: IOverlayWebview | IWebviewElement;
-	webviewType: WebviewType;
+	readonly webview: IOverlayWebview;
 	rendererMessaging?: IScopedRendererMessaging;
 }
 
@@ -40,8 +39,7 @@ export class NotebookOutputWebview extends Disposable implements INotebookOutput
 
 	readonly id: string;
 	readonly sessionId: string;
-	readonly webview: IOverlayWebview | IWebviewElement;
-	readonly webviewType: WebviewType;
+	readonly webview: IOverlayWebview;
 
 	/**
 	 * Fired when the webviewPreloads script is loaded.
@@ -68,7 +66,6 @@ export class NotebookOutputWebview extends Disposable implements INotebookOutput
 			sessionId,
 			webview,
 			rendererMessaging,
-			webviewType
 		}: NotebookOutputWebviewOptions,
 		@IFileDialogService private _fileDialogService: IFileDialogService,
 		@IFileService private _fileService: IFileService,
@@ -85,7 +82,6 @@ export class NotebookOutputWebview extends Disposable implements INotebookOutput
 		this.id = id;
 		this.sessionId = sessionId;
 		this.webview = webview;
-		this.webviewType = webviewType;
 
 		if (rendererMessaging) {
 			this._register(rendererMessaging);

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
-import { IOverlayWebview, IWebviewElement } from '../../webview/browser/webview.js';
+import { IOverlayWebview } from '../../webview/browser/webview.js';
 import { ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageWebOutput } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Event } from '../../../../base/common/event.js';
@@ -24,28 +24,10 @@ export interface INotebookOutputWebview extends IDisposable {
 	sessionId: string;
 
 	/** The webview containing the output's content */
-	webview: IOverlayWebview | IWebviewElement;
-
-	/** The type of webview, used for later type assertions */
-	webviewType: WebviewType;
+	webview: IOverlayWebview;
 
 	/** Fired when the content completes rendering */
 	onDidRender: Event<void>;
-}
-
-export interface INotebookOutputOverlayWebview extends INotebookOutputWebview {
-	webview: IOverlayWebview;
-	webviewType: WebviewType.Overlay;
-}
-
-export interface INotebookOutputStandardWebview extends INotebookOutputWebview {
-	webview: IWebviewElement;
-	webviewType: WebviewType.Standard;
-}
-
-export enum WebviewType {
-	Overlay = 'overlay',
-	Standard = 'standard'
 }
 
 export interface IPositronNotebookOutputWebviewService {
@@ -71,7 +53,6 @@ export interface IPositronNotebookOutputWebviewService {
 			runtime: ILanguageRuntimeSession;
 			output: ILanguageRuntimeMessageOutput;
 			viewType?: string;
-			webviewType: WebviewType;
 		}
 	): Promise<INotebookOutputWebview | undefined>;
 
@@ -94,7 +75,6 @@ export interface IPositronNotebookOutputWebviewService {
 			preReqMessages: ILanguageRuntimeMessageWebOutput[];
 			displayMessage: ILanguageRuntimeMessageWebOutput;
 			viewType?: string;
-			webviewType: WebviewType;
 		}): Promise<INotebookOutputWebview | undefined>;
 
 	/**
@@ -111,7 +91,6 @@ export interface IPositronNotebookOutputWebviewService {
 		id: string;
 		html: string;
 		runtimeOrSessionId: ILanguageRuntimeSession | string;
-		webviewType: WebviewType;
 	}): Promise<INotebookOutputWebview>;
 }
 

--- a/src/vs/workbench/contrib/positronPlots/browser/notebookMultiMessagePlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/notebookMultiMessagePlotClient.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
-import { INotebookOutputWebview, IPositronNotebookOutputWebviewService, WebviewType } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
-import { assertIsOverlayPositronWebview } from '../../positronOutputWebview/browser/notebookOutputWebviewServiceImpl.js';
+import { INotebookOutputWebview, IPositronNotebookOutputWebviewService } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
 import { WebviewPlotClient } from './webviewPlotClient.js';
 import { ILanguageRuntimeMessageWebOutput } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
@@ -56,13 +55,11 @@ export class NotebookMultiMessagePlotClient extends WebviewPlotClient {
 			runtimeId: this._session.sessionId,
 			preReqMessages: this._preReqMessages,
 			displayMessage: this._displayMessage,
-			viewType: 'jupyter-notebook',
-			webviewType: WebviewType.Overlay
+			viewType: 'jupyter-notebook'
 		});
 		if (!output) {
 			throw new Error('Failed to create notebook output webview');
 		}
-		assertIsOverlayPositronWebview(output);
 		this._output.value = output;
 
 		// Wait for the webview to finish rendering. When it does, nudge the

--- a/src/vs/workbench/contrib/positronPlots/browser/notebookOutputPlotClient.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/notebookOutputPlotClient.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
-import { INotebookOutputWebview, IPositronNotebookOutputWebviewService, WebviewType } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
-import { assertIsOverlayPositronWebview } from '../../positronOutputWebview/browser/notebookOutputWebviewServiceImpl.js';
+import { INotebookOutputWebview, IPositronNotebookOutputWebviewService } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
 import { WebviewPlotClient } from './webviewPlotClient.js';
 import { ILanguageRuntimeMessageOutput } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
@@ -53,14 +52,12 @@ export class NotebookOutputPlotClient extends WebviewPlotClient {
 			id: this.id,
 			runtime: this._session,
 			output: this._message,
-			viewType: 'jupyter-notebook',
-			webviewType: WebviewType.Overlay,
+			viewType: 'jupyter-notebook'
 		});
 		if (!output) {
 			throw new Error('Failed to create notebook output webview');
 		}
 
-		assertIsOverlayPositronWebview(output);
 		this._output.value = output;
 		// Wait for the webview to finish rendering. When it does, nudge the
 		// timer that renders the thumbnail.

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -13,7 +13,7 @@ import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { POSITRON_PREVIEW_HTML_VIEW_TYPE, POSITRON_PREVIEW_URL_VIEW_TYPE, POSITRON_PREVIEW_VIEW_ID } from './positronPreviewSevice.js';
 import { ILanguageRuntimeMessageOutput, LanguageRuntimeSessionMode, RuntimeOutputKind } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
-import { IPositronNotebookOutputWebviewService, WebviewType } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
+import { IPositronNotebookOutputWebviewService } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
 import { URI } from '../../../../base/common/uri.js';
 import { PreviewUrl } from './previewUrl.js';
 import { ShowHtmlFileEvent, ShowUrlEvent, UiFrontendEvent } from '../../../services/languageRuntime/common/positronUiComm.js';
@@ -28,7 +28,6 @@ import { basename } from '../../../../base/common/path.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { Schemas } from '../../../../base/common/network.js';
-import { assertIsOverlayPositronWebview } from '../../positronOutputWebview/browser/notebookOutputWebviewServiceImpl.js';
 
 /**
  * Positron preview service; keeps track of the set of active previews and
@@ -404,11 +403,9 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 					this._notebookOutputWebviewService.createNotebookOutputWebview({
 						id: e.id,
 						runtime: session,
-						output: e,
-						webviewType: WebviewType.Overlay
+						output: e
 					});
 				if (webview) {
-					assertIsOverlayPositronWebview(webview);
 					const overlay = this.createOverlayWebview(webview.webview);
 					const preview = new PreviewWebview(
 						'notebookRenderer',

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -9,7 +9,7 @@ import { ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageWebOutput, Langua
 import { IPositronWebviewPreloadService, NotebookPreloadOutputResults } from '../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
-import { IPositronNotebookOutputWebviewService, WebviewType, INotebookOutputWebview } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
+import { IPositronNotebookOutputWebviewService, INotebookOutputWebview } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
 import { NotebookMultiMessagePlotClient } from '../../positronPlots/browser/notebookMultiMessagePlotClient.js';
 import { UiFrontendEvent } from '../../../services/languageRuntime/common/positronUiComm.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
@@ -240,8 +240,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 			html: buildWebviewHTML({
 				content: htmlOutput.data.toString(),
 				script: webviewMessageCodeString,
-			}),
-			webviewType: WebviewType.Standard
+			})
 		});
 
 		return notebookWebview;
@@ -268,8 +267,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 			runtimeId: instance.id,
 			preReqMessages: storedMessages,
 			displayMessage: displayMessage,
-			viewType: 'jupyter-notebook',
-			webviewType: WebviewType.Overlay
+			viewType: 'jupyter-notebook'
 		});
 
 		// Assert that we have a webview

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -269,7 +269,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 			preReqMessages: storedMessages,
 			displayMessage: displayMessage,
 			viewType: 'jupyter-notebook',
-			webviewType: WebviewType.Standard
+			webviewType: WebviewType.Overlay
 		});
 
 		// Assert that we have a webview

--- a/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -57,6 +57,18 @@ export interface IPositronNotebookInstance {
 	readonly connectedToEditor: boolean;
 
 	/**
+	 * The DOM element that contains the cells for the notebook.
+	 * This is set when the cells container is mounted in the React component.
+	 */
+	readonly cellsContainer: HTMLElement | undefined;
+
+	/**
+	 * Sets the DOM element that contains the cells for the notebook.
+	 * @param container The container element to set, or undefined to clear
+	 */
+	setCellsContainer(container: HTMLElement | undefined): void;
+
+	/**
 	 * Observable array of cells that make up the notebook. Changes to this array
 	 * will trigger UI updates in connected views.
 	 */

--- a/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/services/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -8,7 +8,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { CellKind, IPositronNotebookCell } from './IPositronNotebookCell.js';
 import { SelectionStateMachine } from './selectionMachine.js';
 import { ILanguageRuntimeSession } from '../../runtimeSession/common/runtimeSessionService.js';
-
+import { Event } from '../../../../base/common/event.js';
 /**
  * Represents the possible states of a notebook's kernel connection
  */
@@ -85,6 +85,11 @@ export interface IPositronNotebookInstance {
 	 * Used to prevent operations on destroyed instances.
 	 */
 	isDisposed: boolean;
+
+	/**
+	 * Event that fires when the cells container is scrolled
+	 */
+	readonly onDidScrollCellsContainer: Event<void>;
 
 	// ===== Methods =====
 	/**


### PR DESCRIPTION
Addresses #5491 

This PR changes how we render html output in notebooks 2.0 by switching to overlay webviews instead of standard ones. 
The reason for this switch was that there is no way to preserve the content of the webview across visibility changes with standard webviews. This means we would have to fully re-render every output every time the user switched to the notebook view. 

One benefit of this switch is we were able to remove all the logic surrounding different webview types being returned from the various webview services, simplifying the API a good bit. 


### QA Notes

- Dynamic plots like hvplot should still show up as expected. 
- You should be able to navigate away from the notebook and back and the plot should reappear in the same state it was in. 
- Plots should never spill out of the notebook containment. (e.g. be visible when the notebook isnt. This is an annoying problem with overlay webviews that we've had to deal with before in the plots pane etc..)
