### PR TITLE
e2e-test: replace `getLocator` with `page.locator`

### DIFF
--- a/test/automation/src/positron/positronConsole.ts
+++ b/test/automation/src/positron/positronConsole.ts
@@ -34,7 +34,7 @@ export class PositronConsole {
 	suggestionList: Locator;
 
 	get emptyConsole() {
-		return this.code.driver.getLocator(EMPTY_CONSOLE).getByText('There is no interpreter running');
+		return this.code.driver.page.locator(EMPTY_CONSOLE).getByText('There is no interpreter running');
 	}
 
 	constructor(private code: Code, private quickaccess: PositronQuickAccess, private quickinput: PositronQuickInput) {

--- a/test/automation/src/positron/positronDataExplorer.ts
+++ b/test/automation/src/positron/positronDataExplorer.ts
@@ -143,7 +143,7 @@ export class PositronDataExplorer {
 
 		await this.code.driver.page.locator(`.data-grid-column-header:nth-child(${columnIndex}) .sort-button`).click();
 
-		await this.code.driver.getLocator(`.positron-modal-overlay div.title:has-text("${menuItem}")`).click();
+		await this.code.driver.page.locator(`.positron-modal-overlay div.title:has-text("${menuItem}")`).click();
 
 	}
 

--- a/test/automation/src/positron/positronExplorer.ts
+++ b/test/automation/src/positron/positronExplorer.ts
@@ -26,7 +26,7 @@ export class PositronExplorer {
 	 * @returns Promise<string[]> Array of strings representing the top-level project files/directories in the explorer.
 	 */
 	async getExplorerProjectFiles(locator: string = POSITRON_EXPLORER_PROJECT_FILES): Promise<string[]> {
-		const explorerProjectFiles = this.code.driver.getLocator(locator);
+		const explorerProjectFiles = this.code.driver.page.locator(locator);
 		const filesList = await explorerProjectFiles.all();
 		const fileNames = filesList.map(async file => {
 			const fileText = await file.textContent();

--- a/test/automation/src/positron/positronHelp.ts
+++ b/test/automation/src/positron/positronHelp.ts
@@ -18,8 +18,8 @@ const AUX_BAR = '.part.auxiliarybar';
  *  Reuseable Positron Help functionality for tests to leverage.
  */
 export class PositronHelp {
-  
-  private auxilaryBar = this.code.driver.getLocator(AUX_BAR);
+
+	private auxilaryBar = this.code.driver.page.locator(AUX_BAR);
 
 	constructor(private code: Code) { }
 

--- a/test/automation/src/positron/positronInterpreterDropdown.ts
+++ b/test/automation/src/positron/positronInterpreterDropdown.ts
@@ -15,10 +15,10 @@ const INTERPRETER_ACTIONS_SELECTOR = `.interpreter-actions .action-button`;
  *  Reuseable Positron interpreter selection functionality for tests to leverage.
  */
 export class PositronInterpreterDropdown {
-	private interpreterGroups = this.code.driver.getLocator(
+	private interpreterGroups = this.code.driver.page.locator(
 		'.positron-modal-popup .interpreter-groups'
 	);
-	private interpreterDropdown = this.code.driver.getLocator(
+	private interpreterDropdown = this.code.driver.page.locator(
 		'.top-action-bar-interpreters-manager .left'
 	);
 
@@ -398,7 +398,7 @@ export class PositronInterpreterDropdown {
 	async getSelectedInterpreterInfo(): Promise<InterpreterInfo | undefined> {
 		// Get the label for the selected interpreter, e.g. Python 3.10.4 (Pyenv)
 		const selectedInterpreterLabel = await this.code.driver
-			.getLocator('.top-action-bar-interpreters-manager')
+			.page.locator('.top-action-bar-interpreters-manager')
 			.getAttribute('aria-label');
 		if (!selectedInterpreterLabel) {
 			throw new Error('There is no selected interpreter');

--- a/test/automation/src/positron/positronLayouts.ts
+++ b/test/automation/src/positron/positronLayouts.ts
@@ -38,7 +38,7 @@ export class PositronLayouts {
 	/**
 	 * Locator for the entire IDE. This is the "body" of the root page.
 	 */
-	fullApp = this.code.driver.getLocator(FULL_APP);
+	fullApp = this.code.driver.page.locator(FULL_APP);
 
 	/**
 	 * Button in upper right of IDE for customizing layout.
@@ -48,7 +48,7 @@ export class PositronLayouts {
 	/**
 	 * Locator for the panel part of the IDE.
 	 */
-	panel = this.code.driver.getLocator(PANEL);
+	panel = this.code.driver.page.locator(PANEL);
 
 	/**
 	 * Locator for the tabs in the panel used to navigate to different views.
@@ -70,7 +70,7 @@ export class PositronLayouts {
 	/**
 	 * Locator for the auxiliary bar part of the IDE.
 	 */
-	auxBar = this.code.driver.getLocator(AUX_BAR);
+	auxBar = this.code.driver.page.locator(AUX_BAR);
 
 	/**
 	 * Locator for the tabs in the auxiliary bar used to navigate to different views.
@@ -80,7 +80,7 @@ export class PositronLayouts {
 	/**
 	 * Locator for the sidebar part of the IDE.
 	 */
-	sidebar = this.code.driver.getLocator(SIDEBAR);
+	sidebar = this.code.driver.page.locator(SIDEBAR);
 
 	constructor(private code: Code, private workbench: Workbench) { }
 

--- a/test/automation/src/positron/positronNewProjectWizard.ts
+++ b/test/automation/src/positron/positronNewProjectWizard.ts
@@ -48,10 +48,10 @@ export class PositronNewProjectWizard {
 	pythonConfigurationStep: ProjectWizardPythonConfigurationStep;
 	currentOrNewWindowSelectionModal: CurrentOrNewWindowSelectionModal;
 
-	private backButton = this.code.driver.getLocator('div.left-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]');
-	private cancelButton = this.code.driver.getLocator('div.right-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]');
-	private nextButton = this.code.driver.getLocator(PROJECT_WIZARD_DEFAULT_BUTTON).getByText('Next');
-	private createButton = this.code.driver.getLocator(PROJECT_WIZARD_DEFAULT_BUTTON).getByText('Create');
+	private backButton = this.code.driver.page.locator('div.left-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]');
+	private cancelButton = this.code.driver.page.locator('div.right-actions > button.positron-button.button.action-bar-button[tabindex="0"][role="button"]');
+	private nextButton = this.code.driver.page.locator(PROJECT_WIZARD_DEFAULT_BUTTON).getByText('Next');
+	private createButton = this.code.driver.page.locator(PROJECT_WIZARD_DEFAULT_BUTTON).getByText('Create');
 
 	constructor(private code: Code, private quickaccess: PositronQuickAccess) {
 		this.projectTypeStep = new ProjectWizardProjectTypeStep(this.code);
@@ -121,10 +121,10 @@ class ProjectWizardProjectTypeStep {
 }
 
 class ProjectWizardProjectNameLocationStep {
-	projectNameInput = this.code.driver.getLocator(
+	projectNameInput = this.code.driver.page.locator(
 		'div[id="wizard-sub-step-project-name"] .wizard-sub-step-input input.text-input'
 	);
-	projectOptionCheckboxes = this.code.driver.getLocator(
+	projectOptionCheckboxes = this.code.driver.page.locator(
 		'div[id="wizard-sub-step-misc-proj-options"] div.checkbox'
 	);
 	gitInitCheckbox = this.projectOptionCheckboxes.getByText(
@@ -140,7 +140,7 @@ class ProjectWizardProjectNameLocationStep {
 }
 
 class ProjectWizardRConfigurationStep {
-	renvCheckbox = this.code.driver.getLocator(
+	renvCheckbox = this.code.driver.page.locator(
 		'div.renv-configuration > div.checkbox'
 	);
 
@@ -148,16 +148,16 @@ class ProjectWizardRConfigurationStep {
 }
 
 class ProjectWizardPythonConfigurationStep {
-	existingEnvRadioButton = this.code.driver.getLocator(
+	existingEnvRadioButton = this.code.driver.page.locator(
 		'div[id="wizard-step-set-up-python-environment"] div[id="wizard-sub-step-pythonenvironment-howtosetupenv"] .radio-button-input[id="existingEnvironment"]'
 	);
-	envProviderDropdown = this.code.driver.getLocator(
+	envProviderDropdown = this.code.driver.page.locator(
 		'div[id="wizard-sub-step-python-environment"] .wizard-sub-step-input button.drop-down-list-box'
 	);
-	interpreterFeedback = this.code.driver.getLocator(
+	interpreterFeedback = this.code.driver.page.locator(
 		'div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-feedback .wizard-formatted-text'
 	);
-	interpreterDropdown = this.code.driver.getLocator(
+	interpreterDropdown = this.code.driver.page.locator(
 		'div[id="wizard-sub-step-python-interpreter"] .wizard-sub-step-input button.drop-down-list-box'
 	);
 
@@ -189,7 +189,7 @@ class ProjectWizardPythonConfigurationStep {
 		try {
 			const preselected =
 				(await this.code.driver
-					.getLocator(
+					.page.locator(
 						`${PROJECT_WIZARD_PRESELECTED_DROPDOWN_ITEM} div.dropdown-entry-title`
 					)
 					.getByText(provider)
@@ -212,7 +212,7 @@ class ProjectWizardPythonConfigurationStep {
 		try {
 			await this.code.waitForElement(PROJECT_WIZARD_DROPDOWN_POPUP_ITEMS);
 			await this.code.driver
-				.getLocator(
+				.page.locator(
 					`${PROJECT_WIZARD_DROPDOWN_POPUP_ITEMS} div.dropdown-entry-title`
 				)
 				.getByText(provider)
@@ -237,7 +237,7 @@ class ProjectWizardPythonConfigurationStep {
 		try {
 			const preselected =
 				(await this.code.driver
-					.getLocator(
+					.page.locator(
 						`${PROJECT_WIZARD_PRESELECTED_DROPDOWN_ITEM} div.dropdown-entry-subtitle`
 					)
 					.getByText(interpreterPath)
@@ -268,7 +268,7 @@ class ProjectWizardPythonConfigurationStep {
 		// Get all the dropdown entry subtitles and build a comma-separated string of them for
 		// logging purposes.
 		const dropdownEntrySubtitleLocators = await this.code.driver
-			.getLocator(
+			.page.locator(
 				`${PROJECT_WIZARD_DROPDOWN_POPUP_ITEMS} div.dropdown-entry-subtitle`
 			).all();
 		const dropdownEntrySubtitles = dropdownEntrySubtitleLocators.map
@@ -277,7 +277,7 @@ class ProjectWizardPythonConfigurationStep {
 
 		// Find the dropdown item with the interpreterPath.
 		const dropdownItem = this.code.driver
-			.getLocator(`${PROJECT_WIZARD_DROPDOWN_POPUP_ITEMS} div.dropdown-entry-subtitle`)
+			.page.locator(`${PROJECT_WIZARD_DROPDOWN_POPUP_ITEMS} div.dropdown-entry-subtitle`)
 			.getByText(interpreterPath);
 
 		// There should be one dropdown item with the interpreterPath.
@@ -296,7 +296,7 @@ class ProjectWizardPythonConfigurationStep {
 
 class CurrentOrNewWindowSelectionModal {
 	currentWindowButton = this.code.driver
-		.getLocator(
+		.page.locator(
 			'button.positron-button.button.action-bar-button[tabindex="0"][role="button"]'
 		)
 		.getByText('Current Window');

--- a/test/automation/src/positron/positronPlots.ts
+++ b/test/automation/src/positron/positronPlots.ts
@@ -93,7 +93,7 @@ export class PositronPlots {
 	}
 
 	async getCurrentStaticPlotAsBuffer(): Promise<Buffer> {
-		return this.code.driver.getLocator(CURRENT_STATIC_PLOT).screenshot();
+		return this.code.driver.page.locator(CURRENT_STATIC_PLOT).screenshot();
 	}
 
 	async copyCurrentPlotToClipboard() {

--- a/test/automation/src/positron/positronPopups.ts
+++ b/test/automation/src/positron/positronPopups.ts
@@ -19,7 +19,7 @@ const NOTIFICATION_TOAST = '.notification-toast';
  */
 export class PositronPopups {
 
-	toastLocator = this.code.driver.getLocator(NOTIFICATION_TOAST);
+	toastLocator = this.code.driver.page.locator(NOTIFICATION_TOAST);
 
 	constructor(private code: Code) { }
 
@@ -133,7 +133,7 @@ export class PositronPopups {
 	 * @param label The label of the option to select.
 	 */
 	async clickOnModalDialogPopupOption(label: string | RegExp) {
-		const el = this.code.driver.getLocator(POSITRON_MODAL_DIALOG_POPUP_OPTION).getByText(label);
+		const el = this.code.driver.page.locator(POSITRON_MODAL_DIALOG_POPUP_OPTION).getByText(label);
 		await el.click();
 	}
 

--- a/test/automation/src/positron/positronTestExplorer.ts
+++ b/test/automation/src/positron/positronTestExplorer.ts
@@ -21,7 +21,7 @@ export class PositronTestExplorer extends PositronExplorer {
 	 * @returns Promise<object> Array of case names with fail/pass statuses.
 	 */
 	async getTestResults(): Promise<object> {
-		const cases = this.code.driver.getLocator(TEST_RESULT_ITEM);
+		const cases = this.code.driver.page.locator(TEST_RESULT_ITEM);
 		const caseList = await cases.all();
 		const caseStatuses = caseList.map(async aCase => {
 

--- a/test/automation/src/positron/positronVariables.ts
+++ b/test/automation/src/positron/positronVariables.ts
@@ -52,7 +52,7 @@ export class PositronVariables {
 	}
 
 	async waitForVariableRow(variableName: string): Promise<Locator> {
-		const desiredRow = this.code.driver.getLocator(`${VARIABLES_NAME_COLUMN} .name-value:text("${variableName}")`);
+		const desiredRow = this.code.driver.page.locator(`${VARIABLES_NAME_COLUMN} .name-value:text("${variableName}")`);
 		await desiredRow.waitFor({ state: 'attached' });
 		return desiredRow;
 	}

--- a/test/automation/src/positron/positronWelcome.ts
+++ b/test/automation/src/positron/positronWelcome.ts
@@ -20,19 +20,19 @@ const LINK_ROLE = 'link';
 
 export class PositronWelcome {
 
-	logo = this.code.driver.getLocator(LOGO);
-	title = this.code.driver.getLocator(TITLE);
-	footer = this.code.driver.getLocator(FOOTER);
-	startSection = this.code.driver.getLocator(START_SECTION);
+	logo = this.code.driver.page.locator(LOGO);
+	title = this.code.driver.page.locator(TITLE);
+	footer = this.code.driver.page.locator(FOOTER);
+	startSection = this.code.driver.page.locator(START_SECTION);
 	startTitle = this.startSection.getByRole(HEADING_ROLE);
 	startButtons = this.startSection.getByRole(BUTTON_ROLE);
-	helpSection = this.code.driver.getLocator(HELP_TITLE);
+	helpSection = this.code.driver.page.locator(HELP_TITLE);
 	helpTitle = this.helpSection.getByRole(HEADING_ROLE);
 	helpLinks = this.helpSection.getByRole(LINK_ROLE);
-	openSection = this.code.driver.getLocator(OPEN_SECTION);
+	openSection = this.code.driver.page.locator(OPEN_SECTION);
 	openTitle = this.openSection.getByRole(HEADING_ROLE);
 	openButtons = this.openSection.getByRole(BUTTON_ROLE);
-	recentSection = this.code.driver.getLocator(RECENT_SECTION);
+	recentSection = this.code.driver.page.locator(RECENT_SECTION);
 	recentTitle = this.recentSection.getByRole(HEADING_ROLE);
 	newNotebookButton = this.startButtons.getByText('New Notebook');
 	newFileButton = this.startButtons.getByText('New File');

--- a/test/e2e/areas/data-explorer/data-explorer-headless.test.ts
+++ b/test/e2e/areas/data-explorer/data-explorer-headless.test.ts
@@ -38,7 +38,7 @@ async function testBody(app: Application, logger: Logger, fileName: string) {
 
 	logger.log('Opening data grid');
 	await expect(async () => {
-		expect(await app.code.driver.getLocator(`.label-name:has-text("Data: ${fileName}")`).innerText() === `Data: ${fileName}`);
+		expect(await app.code.driver.page.locator(`.label-name:has-text("Data: ${fileName}")`).innerText() === `Data: ${fileName}`);
 	}).toPass();
 
 	await app.workbench.positronSideBar.closeSecondarySideBar();

--- a/test/e2e/areas/data-explorer/data-explorer-python-pandas.test.ts
+++ b/test/e2e/areas/data-explorer/data-explorer-python-pandas.test.ts
@@ -27,7 +27,7 @@ df = pd.DataFrame(data)`;
 		logger.log('Opening data grid');
 		await expect(async () => {
 			await app.workbench.positronVariables.doubleClickVariableRow('df');
-			await app.code.driver.getLocator('.label-name:has-text("Data: df")').innerText();
+			await app.code.driver.page.locator('.label-name:has-text("Data: df")').innerText();
 		}).toPass();
 
 		await app.workbench.positronSideBar.closeSecondarySideBar();
@@ -67,7 +67,7 @@ df2 = pd.DataFrame(data)`;
 		logger.log('Opening data grid');
 		await expect(async () => {
 			await app.workbench.positronVariables.doubleClickVariableRow('df2');
-			await app.code.driver.getLocator('.label-name:has-text("Data: df2")').innerText();
+			await app.code.driver.page.locator('.label-name:has-text("Data: df2")').innerText();
 		}).toPass();
 
 		// Need to make sure the data explorer is visible test.beforeAll we can interact with it
@@ -140,7 +140,7 @@ df2 = pd.DataFrame(data)`;
 
 		await expect(async () => {
 			await app.workbench.positronVariables.doubleClickVariableRow('df');
-			await app.code.driver.getLocator('.label-name:has-text("Data: df")').innerText();
+			await app.code.driver.page.locator('.label-name:has-text("Data: df")').innerText();
 		}).toPass({ timeout: 50000 });
 
 		await app.workbench.positronLayouts.enterLayout('notebook');
@@ -150,20 +150,20 @@ df2 = pd.DataFrame(data)`;
 			expect(tableData.length).toBe(11);
 		}).toPass({ timeout: 60000 });
 
-		await app.code.driver.getLocator('.tabs .label-name:has-text("pandas-update-dataframe.ipynb")').click();
+		await app.code.driver.page.locator('.tabs .label-name:has-text("pandas-update-dataframe.ipynb")').click();
 		await app.workbench.notebook.focusNextCell();
 		await app.workbench.notebook.executeActiveCell();
-		await app.code.driver.getLocator('.label-name:has-text("Data: df")').click();
+		await app.code.driver.page.locator('.label-name:has-text("Data: df")').click();
 
 		await expect(async () => {
 			const tableData = await app.workbench.positronDataExplorer.getDataExplorerTableData();
 			expect(tableData.length).toBe(12);
 		}).toPass({ timeout: 60000 });
 
-		await app.code.driver.getLocator('.tabs .label-name:has-text("pandas-update-dataframe.ipynb")').click();
+		await app.code.driver.page.locator('.tabs .label-name:has-text("pandas-update-dataframe.ipynb")').click();
 		await app.workbench.notebook.focusNextCell();
 		await app.workbench.notebook.executeActiveCell();
-		await app.code.driver.getLocator('.label-name:has-text("Data: df")').click();
+		await app.code.driver.page.locator('.label-name:has-text("Data: df")').click();
 		await app.workbench.positronDataExplorer.selectColumnMenuItem(1, 'Sort Descending');
 
 		await expect(async () => {
@@ -186,7 +186,7 @@ Data_Frame = data('mtcars')`;
 
 		await expect(async () => {
 			await app.workbench.positronVariables.doubleClickVariableRow('Data_Frame');
-			await app.code.driver.getLocator('.label-name:has-text("Data: Data_Frame")').innerText();
+			await app.code.driver.page.locator('.label-name:has-text("Data: Data_Frame")').innerText();
 		}).toPass();
 
 		// Now move focus out of the the data explorer pane
@@ -195,7 +195,7 @@ Data_Frame = data('mtcars')`;
 		await app.workbench.positronVariables.doubleClickVariableRow('Data_Frame');
 
 		await expect(async () => {
-			await app.code.driver.getLocator('.label-name:has-text("Data: Data_Frame")').innerText();
+			await app.code.driver.page.locator('.label-name:has-text("Data: Data_Frame")').innerText();
 		}).toPass();
 
 		await app.workbench.positronDataExplorer.closeDataExplorer();
@@ -210,7 +210,7 @@ df = pd.DataFrame({'x': ["a ", "a", "   ", ""]})`;
 
 		await expect(async () => {
 			await app.workbench.positronVariables.doubleClickVariableRow('df');
-			await app.code.driver.getLocator('.label-name:has-text("Data: df")').innerText();
+			await app.code.driver.page.locator('.label-name:has-text("Data: df")').innerText();
 		}).toPass();
 
 		await expect(async () => {

--- a/test/e2e/areas/data-explorer/data-explorer-python-polars.test.ts
+++ b/test/e2e/areas/data-explorer/data-explorer-python-polars.test.ts
@@ -20,7 +20,7 @@ test.describe('Data Explorer - Python Polars', {
 		logger.log('Opening data grid');
 		await expect(async () => {
 			await app.workbench.positronVariables.doubleClickVariableRow('df');
-			await app.code.driver.getLocator('.label-name:has-text("Data: df")').innerText();
+			await app.code.driver.page.locator('.label-name:has-text("Data: df")').innerText();
 		}).toPass();
 
 		await app.workbench.positronDataExplorer.maximizeDataExplorer(true);

--- a/test/e2e/areas/data-explorer/data-explorer-r.test.ts
+++ b/test/e2e/areas/data-explorer/data-explorer-r.test.ts
@@ -27,7 +27,7 @@ test.describe('Data Explorer - R ', {
 		logger.log('Opening data grid');
 		await expect(async () => {
 			await app.workbench.positronVariables.doubleClickVariableRow('Data_Frame');
-			await app.code.driver.getLocator('.label-name:has-text("Data: Data_Frame")').innerText();
+			await app.code.driver.page.locator('.label-name:has-text("Data: Data_Frame")').innerText();
 		}).toPass();
 
 		await app.workbench.positronDataExplorer.maximizeDataExplorer(true);
@@ -87,7 +87,7 @@ test.describe('Data Explorer - R ', {
 
 		await expect(async () => {
 			await app.workbench.positronVariables.doubleClickVariableRow('Data_Frame');
-			await app.code.driver.getLocator('.label-name:has-text("Data: Data_Frame")').innerText();
+			await app.code.driver.page.locator('.label-name:has-text("Data: Data_Frame")').innerText();
 		}).toPass();
 
 		// Now move focus out of the the data explorer pane
@@ -96,7 +96,7 @@ test.describe('Data Explorer - R ', {
 		await app.workbench.positronVariables.doubleClickVariableRow('Data_Frame');
 
 		await expect(async () => {
-			await app.code.driver.getLocator('.label-name:has-text("Data: Data_Frame")').innerText();
+			await app.code.driver.page.locator('.label-name:has-text("Data: Data_Frame")').innerText();
 		}).toPass();
 
 		await app.workbench.positronDataExplorer.closeDataExplorer();
@@ -109,7 +109,7 @@ test.describe('Data Explorer - R ', {
 
 		await expect(async () => {
 			await app.workbench.positronVariables.doubleClickVariableRow('df');
-			await app.code.driver.getLocator('.label-name:has-text("Data: df")').innerText();
+			await app.code.driver.page.locator('.label-name:has-text("Data: df")').innerText();
 		}).toPass();
 
 		await expect(async () => {

--- a/test/e2e/areas/data-explorer/helpers/100x100.ts
+++ b/test/e2e/areas/data-explorer/helpers/100x100.ts
@@ -28,7 +28,7 @@ export const testDataExplorer = async (
 	// Open the data frame.
 	await expect(async () => {
 		await app.workbench.positronVariables.doubleClickVariableRow(dataFrameName);
-		await app.code.driver.getLocator(`.label-name:has-text("Data: ${dataFrameName}")`).innerText();
+		await app.code.driver.page.locator(`.label-name:has-text("Data: ${dataFrameName}")`).innerText();
 	}).toPass();
 
 	// Maximize the data explorer.

--- a/test/e2e/areas/data-explorer/large-data-frame.test.ts
+++ b/test/e2e/areas/data-explorer/large-data-frame.test.ts
@@ -32,7 +32,7 @@ test.describe('Data Explorer - Large Data Frame', {
 		logger.log('Opening data grid');
 		await expect(async () => {
 			await app.workbench.positronVariables.doubleClickVariableRow('df');
-			expect(await app.code.driver.getLocator('.label-name:has-text("Data: df")').innerText() === 'Data: df');
+			expect(await app.code.driver.page.locator('.label-name:has-text("Data: df")').innerText() === 'Data: df');
 		}).toPass();
 
 		await app.workbench.positronSideBar.closeSecondarySideBar();
@@ -66,7 +66,7 @@ test.describe('Data Explorer - Large Data Frame', {
 		logger.log('Opening data grid');
 		await expect(async () => {
 			await app.workbench.positronVariables.doubleClickVariableRow('df2');
-			expect(await app.code.driver.getLocator('.label-name:has-text("Data: df2")').innerText() === 'Data: df2');
+			expect(await app.code.driver.page.locator('.label-name:has-text("Data: df2")').innerText() === 'Data: df2');
 		}).toPass();
 
 		await app.workbench.positronSideBar.closeSecondarySideBar();

--- a/test/e2e/areas/data-explorer/sparklines.test.ts
+++ b/test/e2e/areas/data-explorer/sparklines.test.ts
@@ -40,7 +40,7 @@ async function openDataExplorerColumnProfile(app: Application, variableName: str
 
 	await expect(async () => {
 		await app.workbench.positronVariables.doubleClickVariableRow(variableName);
-		await app.code.driver.getLocator(`.label-name:has-text("Data: ${variableName}")`).innerText();
+		await app.code.driver.page.locator(`.label-name:has-text("Data: ${variableName}")`).innerText();
 	}).toPass();
 
 	await app.workbench.positronQuickaccess.runCommand('workbench.action.toggleSidebarVisibility');
@@ -52,7 +52,7 @@ async function openDataExplorerColumnProfile(app: Application, variableName: str
 async function verifyGraphBarHeights(app: Application) {
 	// Get all graph graph bars/rectangles
 	await expect(async () => {
-		const rects = app.code.driver.getLocator('rect.count');
+		const rects = app.code.driver.page.locator('rect.count');
 
 		// Iterate over each rect and verify the height
 		const expectedHeights = ['50', '40', '30', '20', '10'];

--- a/test/e2e/areas/data-explorer/very-large-data-frame.test.ts
+++ b/test/e2e/areas/data-explorer/very-large-data-frame.test.ts
@@ -49,7 +49,7 @@ test.describe('Data Explorer - Very Large Data Frame', { tag: [tags.WIN, tags.DA
 				logger.log('Opening data grid');
 				await expect(async () => {
 					await app.workbench.positronVariables.doubleClickVariableRow('df');
-					await app.code.driver.getLocator('.label-name:has-text("Data: df")').innerText();
+					await app.code.driver.page.locator('.label-name:has-text("Data: df")').innerText();
 				}).toPass();
 
 				await app.workbench.positronSideBar.closeSecondarySideBar();
@@ -74,7 +74,7 @@ test.describe('Data Explorer - Very Large Data Frame', { tag: [tags.WIN, tags.DA
 				logger.log('Opening data grid');
 				await expect(async () => {
 					await app.workbench.positronVariables.doubleClickVariableRow('df_large');
-					await app.code.driver.getLocator('.label-name:has-text("Data: df_large")').innerText();
+					await app.code.driver.page.locator('.label-name:has-text("Data: df_large")').innerText();
 				}).toPass();
 
 				await app.workbench.positronSideBar.closeSecondarySideBar();
@@ -103,7 +103,7 @@ test.describe('Data Explorer - Very Large Data Frame', { tag: [tags.WIN, tags.DA
 				logger.log('Opening data grid');
 				await expect(async () => {
 					await app.workbench.positronVariables.doubleClickVariableRow('df2');
-					await app.code.driver.getLocator('.label-name:has-text("Data: df2")').innerText();
+					await app.code.driver.page.locator('.label-name:has-text("Data: df2")').innerText();
 				}).toPass();
 
 				await app.workbench.positronSideBar.closeSecondarySideBar();
@@ -129,7 +129,7 @@ test.describe('Data Explorer - Very Large Data Frame', { tag: [tags.WIN, tags.DA
 				logger.log('Opening data grid');
 				await expect(async () => {
 					await app.workbench.positronVariables.doubleClickVariableRow('df3_large');
-					await app.code.driver.getLocator('.label-name:has-text("Data: df3_large")').innerText();
+					await app.code.driver.page.locator('.label-name:has-text("Data: df3_large")').innerText();
 				}).toPass();
 
 				await app.workbench.positronSideBar.closeSecondarySideBar();

--- a/test/e2e/areas/data-explorer/xlsx-data-frame.test.ts
+++ b/test/e2e/areas/data-explorer/xlsx-data-frame.test.ts
@@ -26,7 +26,7 @@ test.describe('Data Explorer - XLSX', {
 		logger.log('Opening data grid');
 		await expect(async () => {
 			await app.workbench.positronVariables.doubleClickVariableRow('df');
-			await app.code.driver.getLocator('.label-name:has-text("Data: df")').innerText();
+			await app.code.driver.page.locator('.label-name:has-text("Data: df")').innerText();
 		}).toPass();
 
 		await app.workbench.positronSideBar.closeSecondarySideBar();
@@ -43,7 +43,7 @@ test.describe('Data Explorer - XLSX', {
 		logger.log('Opening data grid');
 		await expect(async () => {
 			await app.workbench.positronVariables.doubleClickVariableRow('df2');
-			await app.code.driver.getLocator('.label-name:has-text("Data: df2")').innerText();
+			await app.code.driver.page.locator('.label-name:has-text("Data: df2")').innerText();
 		}).toPass();
 
 		await app.workbench.positronSideBar.closeSecondarySideBar();

--- a/test/e2e/areas/welcome/welcome.test.ts
+++ b/test/e2e/areas/welcome/welcome.test.ts
@@ -103,7 +103,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME] }, () => {
 			await expect(app.workbench.editors.editorPart).not.toBeVisible();
 
 			// console is the active view in the bottom panel
-			await expect(app.workbench.positronLayouts.panelViewsTab.and(app.code.driver.getLocator('.checked'))).toHaveText('Console');
+			await expect(app.workbench.positronLayouts.panelViewsTab.and(app.code.driver.page.locator('.checked'))).toHaveText('Console');
 		});
 	});
 
@@ -127,7 +127,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME] }, () => {
 			await expect(app.workbench.editors.editorPart).not.toBeVisible();
 
 			// console is the active view in the bottom panel
-			await expect(app.workbench.positronLayouts.panelViewsTab.and(app.code.driver.getLocator('.checked'))).toHaveText('Console');
+			await expect(app.workbench.positronLayouts.panelViewsTab.and(app.code.driver.page.locator('.checked'))).toHaveText('Console');
 		});
 
 		test('Create a new R notebook from the Welcome page [C684757]', async function ({ app, r }) {


### PR DESCRIPTION
Just like the title says, replacing all instances of `getLocator()` with `page.locator()`
Note: Only made these replacements in `test/automation/src/positron` and `test/e2e`

### QA Notes

Do I spend the resources running the full suite?
