### PR TITLE
Attempt to re-establish session connection after unexpected disconnect

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -83,6 +83,13 @@
         "category": "%command.positron.supervisor.category%",
         "title": "%command.showKernelSupervisorLog.title%",
         "shortTitle": "%command.showKernelSupervisorLog.title%"
+      },
+      {
+        "command": "positron.supervisor.reconnectSession",
+        "category": "%command.positron.supervisor.category%",
+        "title": "%command.reconnectSession.title%",
+        "shortTitle": "%command.reconnectSession.title%",
+        "enablement": "isDevelopment"
       }
     ]
   },

--- a/extensions/positron-supervisor/package.nls.json
+++ b/extensions/positron-supervisor/package.nls.json
@@ -13,5 +13,6 @@
 	"configuration.attachOnStartup.description": "Run <f5> before starting up Jupyter kernel (when supported)",
 	"configuration.sleepOnStartup.description": "Sleep for n seconds before starting up Jupyter kernel (when supported)",
 	"command.positron.supervisor.category": "Kernel Supervisor",
-	"command.showKernelSupervisorLog.title": "Show the Kernel Supervisor Log"
+	"command.showKernelSupervisorLog.title": "Show the Kernel Supervisor Log",
+	"command.reconnectSession.title": "Reconnect the current session"
 }

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -502,7 +502,7 @@ export class KCApi implements KallichoreAdapterApi {
 					} catch (err) {
 						// The session could not be reconnected; mark it as
 						// offline and explain to the user what happened.
-						session.markOffline('Lost connection to the session WebSocket event stream');
+						session.markOffline('Lost connection to the session WebSocket event stream and could not restore it: ' + err);
 						vscode.window.showErrorMessage(vscode.l10n.t('Unable to re-establish connection to {0}: {1}', session.metadata.sessionName, err));
 					}
 				}
@@ -520,8 +520,9 @@ export class KCApi implements KallichoreAdapterApi {
 	 * handle the case where the server process is running but it's become
 	 * unresponsive.
 	 *
-	 * @returns A promise that resolves when the server has been confirmed to be
-	 * running or has been restarted. Resolves with `true` if the server did in fact exit, `false` otherwise.
+	 * @returns A promise that resolves when the server has been confirmed to
+	 * be running or has been restarted. Resolves with `true` if the server did
+	 * in fact exit, `false` otherwise.
 	 */
 	private async testServerExited(): Promise<boolean> {
 		// If we're currently starting, it doesn't make sense to test the

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -216,7 +216,7 @@ export class KCApi implements KallichoreAdapterApi {
 
 		// Start the server in a new terminal
 		this._log.appendLine(`Starting Kallichore server ${shellPath} on port ${port}`);
-		const terminal = vscode.window.createTerminal(<vscode.TerminalOptions>{
+		const terminal = vscode.window.createTerminal({
 			name: 'Kallichore',
 			shellPath: wrapperPath,
 			shellArgs: [
@@ -231,7 +231,7 @@ export class KCApi implements KallichoreAdapterApi {
 			message: `*** Kallichore Server (${shellPath}) ***`,
 			hideFromUser: !showTerminal,
 			isTransient: false
-		});
+		} satisfies vscode.TerminalOptions);
 
 		// Flag to track if the terminal exited before the start barrier opened
 		let exited = false;

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -571,8 +571,8 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			type === positron.RuntimeClientType.IPyWidgetControl) {
 
 			const msg: JupyterCommOpen = {
-				target_name: type,  // eslint-disable-line
-				comm_id: id,  // eslint-disable-line
+				target_name: type,
+				comm_id: id,
 				data: params
 			};
 			const commOpen = new CommOpenCommand(msg, metadata);

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -1165,6 +1165,15 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		this.onExited(exitCode);
 	}
 
+	/**
+	 * Marks the kernel as offline.
+	 *
+	 * @param reason The reason for the kernel going offline
+	 */
+	markOffline(reason: string) {
+		this.onStateChange(positron.RuntimeState.Offline, reason);
+	}
+
 	private onExited(exitCode: number) {
 		if (this._restarting) {
 			// If we're restarting, wait for the kernel to start up again

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -1045,6 +1045,13 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 	}
 
 	/**
+	 * Disconnect the session
+	 */
+	public disconnect() {
+		this._socket?.ws.close();
+	}
+
+	/**
 	 * Main entry point for handling messages delivered over the websocket from
 	 * the Kallichore server.
 	 *


### PR DESCRIPTION
This change adds resiliency to the WebSocket connections that Positron uses to send and receive kernel messages. We were already detecting unexpected connection drops and using them to recover from server crashes. However, we've seen a few reports in the wild of these connection drops happening even when everything else is healthy. 

The improvement here is as follows:

- If the session appears to be running, and the server is also running, we try to reestablish the connection. If we can, it is seamlessly resumed. Because messages that aren't delivered are queued on the supervisor side, we shouldn't miss any.
- If the connection cannot be re-established, the user is shown a message and the session is marked offline. This prevents the session from looking inexplicably frozen.

To help test this change without leaving Positron running for a day or more, I've added a development-only reconnect command that disconnects the socket for the active console session and lets the reconnect logic kick in to bring it back online. 

Addresses https://github.com/posit-dev/positron/issues/5788. 

### QA Notes

If you can't reproduce the original issue, you can use a development build and this command.

<img width="616" alt="image" src="https://github.com/user-attachments/assets/a135a664-d5a4-4ca9-8f5f-464491f15393" />

Since reconnect is meant to be seamless, check that the session can still run code after reconnecting, and check the logs to ensure that the reconnect sequence happened as expected. You should see something like this:

```
Session 'R 4.3.3' disconnected while in state 'idle'. This is unexpected; checking server status.
Kallichore server PID 75482 is still running
The server is still running; attempting to reconnect to session r-e6137faa
Successfully restored connection to  r-e6137faa
```