### PR TITLE
Make output channel names consistent

### DIFF
--- a/extensions/positron-code-cells/src/logging.ts
+++ b/extensions/positron-code-cells/src/logging.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 
 let channel: vscode.OutputChannel | undefined;
 export function initializeLogging() {
-	channel = vscode.window.createOutputChannel('Positron Code Cells');
+	channel = vscode.window.createOutputChannel('Code Cells');
 }
 
 export function trace(message: string) {

--- a/extensions/positron-notebook-controllers/src/extension.ts
+++ b/extensions/positron-notebook-controllers/src/extension.ts
@@ -12,7 +12,7 @@ import { JUPYTER_NOTEBOOK_TYPE } from './constants';
 import { registerExecutionInfoStatusBar } from './statusBar';
 import { getNotebookSession, isActiveNotebookEditorUri } from './utils';
 
-export const log = vscode.window.createOutputChannel('Positron Notebook Controllers', { log: true });
+export const log = vscode.window.createOutputChannel('Notebook Controllers', { log: true });
 
 const _onDidSetHasRunningNotebookSessionContext = new vscode.EventEmitter<boolean>();
 

--- a/extensions/positron-proxy/src/extension.ts
+++ b/extensions/positron-proxy/src/extension.ts
@@ -15,7 +15,7 @@ export type ProxyServerStyles = { readonly [key: string]: string | number };
 /**
  * Positron Proxy log output channel.
  */
-export const log = vscode.window.createOutputChannel('Positron Proxy', { log: true });
+export const log = vscode.window.createOutputChannel('HTML Proxy Server', { log: true });
 
 /**
  * Activates the extension.

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -266,7 +266,7 @@ export namespace InterpreterQuickPickList {
 
 export namespace OutputChannelNames {
     export const languageServer = l10n.t('Python Language Server');
-    export const python = l10n.t('Python');
+    export const python = l10n.t('Python Language Pack');
     export const pythonTest = l10n.t('Python Test Log');
 }
 

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -266,7 +266,9 @@ export namespace InterpreterQuickPickList {
 
 export namespace OutputChannelNames {
     export const languageServer = l10n.t('Python Language Server');
+    // --- Start Positron ---
     export const python = l10n.t('Python Language Pack');
+    // --- End Positron ---
     export const pythonTest = l10n.t('Python Test Log');
 }
 

--- a/extensions/positron-python/src/client/positron/lspOutputChannelManager.ts
+++ b/extensions/positron-python/src/client/positron/lspOutputChannelManager.ts
@@ -47,7 +47,9 @@ export class PythonLspOutputChannelManager {
         let out = this._channels.get(key);
 
         if (!out) {
-            const name = `${sessionName}: ${LSP_OUTPUT_CHANNEL_DESCRIPTOR} (${sessionMode.charAt(0).toUpperCase() + sessionMode.slice(1)})`;
+            const name = `${sessionName}: ${LSP_OUTPUT_CHANNEL_DESCRIPTOR} (${
+                sessionMode.charAt(0).toUpperCase() + sessionMode.slice(1)
+            })`;
             out = vscode.window.createOutputChannel(name);
             this._channels.set(key, out);
         }

--- a/extensions/positron-python/src/client/positron/lspOutputChannelManager.ts
+++ b/extensions/positron-python/src/client/positron/lspOutputChannelManager.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 
-const LSP_OUTPUT_CHANNEL_PREFIX = 'Positron Language Server: ';
+const LSP_OUTPUT_CHANNEL_DESCRIPTOR = 'Language Server';
 
 /**
  * Manages all the Python LSP output channels
@@ -47,7 +47,7 @@ export class PythonLspOutputChannelManager {
         let out = this._channels.get(key);
 
         if (!out) {
-            const name = `${LSP_OUTPUT_CHANNEL_PREFIX}${sessionName} (${sessionMode})`;
+            const name = `${sessionName}: ${LSP_OUTPUT_CHANNEL_DESCRIPTOR} (${sessionMode.charAt(0).toUpperCase() + sessionMode.slice(1)})`;
             out = vscode.window.createOutputChannel(name);
             this._channels.set(key, out);
         }

--- a/extensions/positron-r/src/extension.ts
+++ b/extensions/positron-r/src/extension.ts
@@ -14,7 +14,7 @@ import { setupTestExplorer, refreshTestExplorer } from './testing/testing';
 import { RRuntimeManager } from './runtime-manager';
 import { registerUriHandler } from './uri-handler';
 
-export const LOGGER = vscode.window.createOutputChannel('Positron R Extension', { log: true });
+export const LOGGER = vscode.window.createOutputChannel('R Language Pack', { log: true });
 
 export function activate(context: vscode.ExtensionContext) {
 	const onDidChangeLogLevel = (logLevel: vscode.LogLevel) => {

--- a/extensions/positron-r/src/lsp-output-channel-manager.ts
+++ b/extensions/positron-r/src/lsp-output-channel-manager.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 
-const LSP_OUTPUT_CHANNEL_PREFIX = 'Positron Language Server: ';
+const LSP_OUTPUT_CHANNEL_DESCRIPTOR = 'Language Server';
 
 /**
  * Manages all the R LSP output channels
@@ -47,7 +47,7 @@ export class RLspOutputChannelManager {
 		let out = this._channels.get(key);
 
 		if (!out) {
-			const name = `${LSP_OUTPUT_CHANNEL_PREFIX}${sessionName} (${sessionMode})`;
+			const name = `${sessionName}: ${LSP_OUTPUT_CHANNEL_DESCRIPTOR} (${sessionMode.charAt(0).toUpperCase() + sessionMode.slice(1)})`;
 			out = vscode.window.createOutputChannel(name);
 			this._channels.set(key, out);
 		}

--- a/extensions/positron-run-app/src/extension.ts
+++ b/extensions/positron-run-app/src/extension.ts
@@ -8,7 +8,7 @@ import { PositronRunAppApiImpl } from './api';
 import { registerDebugAdapterTrackerFactory } from './debugAdapterTrackerFactory';
 import { PositronRunApp } from './positron-run-app';
 
-export const log = vscode.window.createOutputChannel('Positron Run App', { log: true });
+export const log = vscode.window.createOutputChannel('App Launcher', { log: true });
 
 export enum Config {
 	ShellIntegrationEnabled = 'terminal.integrated.shellIntegration.enabled',

--- a/extensions/positron-supervisor/src/extension.ts
+++ b/extensions/positron-supervisor/src/extension.ts
@@ -13,7 +13,7 @@ import { KCApi } from './KallichoreAdapterApi';
 export let API_INSTANCE: KCApi;
 
 export function activate(context: vscode.ExtensionContext): KallichoreAdapterApi {
-	const log = positron.window.createRawLogOutputChannel('Positron Kernel Supervisor');
+	const log = positron.window.createRawLogOutputChannel('Kernel Supervisor');
 	log.appendLine('Positron Kernel Supervisor activated');
 
 	// Create the singleton instance of the Kallichore API wrapper


### PR DESCRIPTION
### Description
Addresses #1707

@:output

We've received feedback that the output channel list is confusing and not easy to parse. A lot of the channel names are prefixed with "Positron" which is redundant. The formatting of the names for the language channels is not consistent and adds friction to the UX when scanning the list.

The proposed change here does some tidying 🧹 of the names to improve the UX:
* The "Positron" prefix has been removed
* The language specific channel names have a consistent formatting which groups them together in the select
* Updates ambiguous output channel names

### Screenshots

<img width="1610" alt="Screenshot 2024-12-19 at 10 20 58 AM" src="https://github.com/user-attachments/assets/4ddad90c-62c6-4044-bf51-f977436ea8cc" />

<img width="1610" alt="Screenshot 2024-12-19 at 10 25 38 AM" src="https://github.com/user-attachments/assets/fee1ccde-e90d-4162-800e-baca2a95ae41" />
