### PR TITLE
e2e-test: add test cov for 'open changes' in editor action bar

### DIFF
--- a/test/e2e/areas/action-bar/editor-action-bar.test.ts
+++ b/test/e2e/areas/action-bar/editor-action-bar.test.ts
@@ -13,7 +13,7 @@ test.use({
 });
 
 test.describe('Editor Action Bar', {
-	tag: [tags.WEB, tags.ACTION_BAR, tags.EDITOR]
+	tag: [tags.WEB, tags.EDITOR_ACTION_BAR, tags.EDITOR]
 }, () => {
 	test.beforeAll(async function ({ userSettings }) {
 		await userSettings.set([['editor.actionBar.enabled', 'true']], false);
@@ -54,7 +54,6 @@ test.describe('Editor Action Bar', {
 		annotation: [{ type: 'info', description: 'electron test unable to interact with dropdown native menu' }],
 	}, async function ({ app, page }) {
 		await openNotebook(app, 'workspaces/large_r_notebook/spotify.ipynb');
-
 		await verifySplitEditor(page, 'spotify.ipynb');
 
 		if (app.web) {

--- a/test/e2e/areas/action-bar/editor-action-bar.test.ts
+++ b/test/e2e/areas/action-bar/editor-action-bar.test.ts
@@ -3,10 +3,11 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Page } from '@playwright/test';
 import { test, expect, tags } from '../_test.setup';
-import path = require('path');
 import { Application } from '../../../automation';
+import { Page } from '@playwright/test';
+import path = require('path');
+
 
 test.use({
 	suiteId: __filename
@@ -15,6 +16,7 @@ test.use({
 test.describe('Editor Action Bar', {
 	tag: [tags.WEB, tags.EDITOR_ACTION_BAR, tags.EDITOR]
 }, () => {
+
 	test.beforeAll(async function ({ userSettings }) {
 		await userSettings.set([['editor.actionBar.enabled', 'true']], false);
 	});

--- a/test/e2e/helpers/test-tags.ts
+++ b/test/e2e/helpers/test-tags.ts
@@ -13,7 +13,7 @@
  * which are not currently configured to run in PR workflows.
  */
 export enum TestTags {
-	ACTION_BAR = '@action-bar',
+	EDITOR_ACTION_BAR = '@editor-action-bar',
 	APPS = '@apps',
 	CONNECTIONS = '@connections',
 	CONSOLE = '@console',


### PR DESCRIPTION
Enhanced test coverage for the editor action bar, specifically verifying that ‘Open Changes’ functions as expected for `.qmd` files. Additionally, refined test readability for better clarity and maintainability.

### QA Notes
Tagged the test to run in this PR. If it passes, we are good. 🙌 

@:editor-action-bar