### PR TITLE
e2e-test: editor action test - use mouse down

### DIFF
--- a/test/e2e/areas/action-bar/editor-action-bar.test.ts
+++ b/test/e2e/areas/action-bar/editor-action-bar.test.ts
@@ -56,12 +56,13 @@ test.describe('Editor Action Bar', {
 		annotation: [{ type: 'info', description: 'electron test unable to interact with dropdown native menu' }],
 	}, async function ({ app, page }) {
 		await openNotebook(app, 'workspaces/large_r_notebook/spotify.ipynb');
+
 		await verifySplitEditor(page, 'spotify.ipynb');
 
-		if (app.web) {
-			await verifyToggleLineNumbers(page);
-			await verifyToggleBreadcrumb(page);
-		}
+		// if (app.web) {
+		// 	await verifyToggleLineNumbers(page);
+		// 	await verifyToggleBreadcrumb(page);
+		// }
 	});
 });
 
@@ -116,9 +117,10 @@ async function clickCustomizeNotebookMenuItem(page, menuItem: string) {
 	await dropdownButton.evaluate((button) => (button as HTMLElement).click());
 
 	const toggleMenuItem = page.getByRole(role, { name: menuItem });
-	await toggleMenuItem.hover();
-	await page.waitForTimeout(500);
-	await toggleMenuItem.click();
+	// await toggleMenuItem.hover();
+	// await page.waitForTimeout(500);
+	await toggleMenuItem.evaluate((el) => el.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true })));
+	// await toggleMenuItem.click();
 }
 
 async function verifyLineNumbersVisibility(page, isVisible: boolean) {

--- a/test/e2e/areas/action-bar/editor-action-bar.test.ts
+++ b/test/e2e/areas/action-bar/editor-action-bar.test.ts
@@ -57,12 +57,12 @@ test.describe('Editor Action Bar', {
 	}, async function ({ app, page }) {
 		await openNotebook(app, 'workspaces/large_r_notebook/spotify.ipynb');
 
-		await verifySplitEditor(page, 'spotify.ipynb');
+		if (app.web) {
+			await verifyToggleLineNumbers(page);
+			await verifyToggleBreadcrumb(page);
+		}
 
-		// if (app.web) {
-		// 	await verifyToggleLineNumbers(page);
-		// 	await verifyToggleBreadcrumb(page);
-		// }
+		await verifySplitEditor(page, 'spotify.ipynb');
 	});
 });
 
@@ -114,13 +114,14 @@ async function verifyOpenInNewWindow(page, expectedText: string) {
 async function clickCustomizeNotebookMenuItem(page, menuItem: string) {
 	const role = menuItem.includes('Line Numbers') ? 'menuitemcheckbox' : 'menuitem';
 	const dropdownButton = page.getByLabel('Customize Notebook...').nth(1);
-	await dropdownButton.evaluate((button) => (button as HTMLElement).click());
+	await dropdownButton.evaluate((button) => {
+		(button as HTMLElement).dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+	});
 
 	const toggleMenuItem = page.getByRole(role, { name: menuItem });
-	// await toggleMenuItem.hover();
-	// await page.waitForTimeout(500);
-	await toggleMenuItem.evaluate((el) => el.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true })));
-	// await toggleMenuItem.click();
+	await toggleMenuItem.hover();
+	await page.waitForTimeout(500);
+	await toggleMenuItem.click();
 }
 
 async function verifyLineNumbersVisibility(page, isVisible: boolean) {


### PR DESCRIPTION
Per the changes in https://github.com/posit-dev/positron/pull/5834, needed to adjust test to use mouse down in order to be able to click the menu.

### QA Notes

This particular test only runs on `browser` so now triggering here, but confirmed it works locally.