### PR TITLE
E2E test: extensions POM for playwright; enable shiny tests for web

### DIFF
--- a/test/automation/src/index.ts
+++ b/test/automation/src/index.ts
@@ -54,5 +54,6 @@ export * from './positron/utils/positronAWSUtils';
 export * from './positron/positronQuickaccess';
 export * from './positron/positronOutline';
 export * from './positron/positronClipboard';
+export * from './positron/positronExtensions';
 // --- End Positron ---
 export { getDevElectronPath, getBuildElectronPath, getBuildVersion } from './electron';

--- a/test/automation/src/positron/fixtures/positronRFixtures.ts
+++ b/test/automation/src/positron/fixtures/positronRFixtures.ts
@@ -32,7 +32,7 @@ export class PositronRFixtures {
 			await this.app.workbench.positronConsole.selectInterpreter(InterpreterType.R, desiredR, skipReadinessCheck);
 			await this.app.workbench.positronConsole.waitForReady('>', 40000);
 		} catch (e) {
-			this.app.code.driver.takeScreenshot('startRInterpreter');
+			await this.app.code.driver.takeScreenshot('startRInterpreter');
 			throw e;
 		}
 

--- a/test/automation/src/positron/positronExtensions.ts
+++ b/test/automation/src/positron/positronExtensions.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from '@playwright/test';
+import { Code } from '../code';
+import { PositronQuickAccess } from './positronQuickaccess';
+
+export class PositronExtensions {
+
+	constructor(private code: Code, private quickaccess: PositronQuickAccess) { }
+
+	async searchForExtension(id: string): Promise<void> {
+		await this.quickaccess.runCommand('Extensions: Focus on Extensions View', { exactLabelMatch: true });
+		await this.code.driver.page.locator('div.extensions-viewlet[id="workbench.view.extensions"] .monaco-editor textarea').fill(`@id:${id}`);
+		await expect(this.code.driver.page.locator(`div.part.sidebar div.composite.title h2`)).toHaveText('Extensions: Marketplace');
+
+		let retrials = 1;
+		while (retrials++ < 10) {
+			try {
+				const locator = this.code.driver.page.locator(`div.extensions-viewlet[id="workbench.view.extensions"] .monaco-list-row[data-extension-id="${id}"]`);
+				await expect(locator).toBeVisible();
+				return;
+			} catch (error) {
+				this.code.logger.log(`Extension '${id}' is not found. Retrying count: ${retrials}`);
+				await this.quickaccess.runCommand('workbench.extensions.action.refreshExtension');
+			}
+		}
+		throw new Error(`Extension ${id} is not found`);
+	}
+
+	async closeExtension(title: string): Promise<any> {
+		try {
+			await this.code.driver.page.locator(`.tabs-container div.tab[aria-label="Extension: ${title}, preview"] div.tab-actions a.action-label.codicon.codicon-close`).click();
+		} catch (e) {
+			this.code.logger.log(`Extension '${title}' not opened as preview. Trying without 'preview'.`);
+			await this.code.driver.page.locator(`.tabs-container div.tab[aria-label="Extension: ${title}"] div.tab-actions a.action-label.codicon.codicon-close`).click();
+		}
+	}
+
+	async installExtension(id: string, waitUntilEnabled: boolean): Promise<void> {
+		await this.searchForExtension(id);
+		const locator = this.code.driver.page.locator(`div.extensions-viewlet[id="workbench.view.extensions"] .monaco-list-row[data-extension-id="${id}"] .extension-list-item .monaco-action-bar .action-item:not(.disabled) .extension-action.install`).first();
+		await expect(locator).toBeVisible();
+		await locator.click();
+		await expect(this.code.driver.page.locator(`.extension-editor .monaco-action-bar .action-item:not(.disabled) .extension-action.uninstall`).first()).toBeVisible();
+		if (waitUntilEnabled) {
+			await expect(this.code.driver.page.locator(`.extension-editor .monaco-action-bar .action-item:not(.disabled) a[aria-label="Disable this extension"]`)).toBeVisible();
+		}
+	}
+
+
+}

--- a/test/automation/src/workbench.ts
+++ b/test/automation/src/workbench.ts
@@ -48,6 +48,7 @@ import { PositronQuickAccess } from './positron/positronQuickaccess';
 import { PositronOutline } from './positron/positronOutline';
 import { PositronClipboard } from './positron/positronClipboard';
 import { PositronQuickInput } from './positron/positronQuickInput';
+import { PositronExtensions } from './positron/positronExtensions';
 // --- End Positron ---
 
 export interface Commands {
@@ -100,6 +101,7 @@ export class Workbench {
 	readonly positronOutline: PositronOutline;
 	readonly positronClipboard: PositronClipboard;
 	readonly positronQuickInput: PositronQuickInput;
+	readonly positronExtensions: PositronExtensions;
 	// --- End Positron ---
 
 	constructor(code: Code) {
@@ -147,6 +149,7 @@ export class Workbench {
 		this.positronTestExplorer = new PositronTestExplorer(code);
 		this.positronOutline = new PositronOutline(code, this.positronQuickaccess);
 		this.positronClipboard = new PositronClipboard(code);
+		this.positronExtensions = new PositronExtensions(code, this.positronQuickaccess);
 		// --- End Positron ---
 	}
 }

--- a/test/e2e/areas/apps/shiny.test.ts
+++ b/test/e2e/areas/apps/shiny.test.ts
@@ -10,13 +10,13 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Shiny Application', { tag: [tags.APPS, tags.VIEWER, tags.WIN] }, () => {
+test.describe('Shiny Application', { tag: [tags.APPS, tags.VIEWER, tags.WIN, tags.WEB] }, () => {
 	test.beforeAll(async function ({ app }) {
 		try {
-			await app.workbench.extensions.installExtension('posit.shiny', true);
-			await app.workbench.extensions.closeExtension('Shiny');
+			await app.workbench.positronExtensions.installExtension('posit.shiny', true);
+			await app.workbench.positronExtensions.closeExtension('Shiny');
 		} catch (e) {
-			app.code.driver.takeScreenshot('shinySetup');
+			await app.code.driver.takeScreenshot('shinySetup');
 			throw e;
 		}
 	});
@@ -29,7 +29,10 @@ test.describe('Shiny Application', { tag: [tags.APPS, tags.VIEWER, tags.WIN] }, 
 	test('Python - Verify Basic Shiny App [C699099]', async function ({ app, python }) {
 		await app.workbench.positronQuickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'shiny-py-example', 'app.py'));
 		await app.workbench.positronQuickaccess.runCommand('shiny.python.runApp');
-		const headerLocator = app.workbench.positronViewer.getViewerLocator('h1');
+		const headerLocator = app.web
+			? app.workbench.positronViewer.viewerFrame.frameLocator('iframe').locator('h1')
+			: app.workbench.positronViewer.getViewerLocator('h1');
+
 		await expect(async () => {
 			await expect(headerLocator).toHaveText('Restaurant tipping', { timeout: 20000 });
 		}).toPass({ timeout: 60000 });
@@ -40,7 +43,9 @@ test.describe('Shiny Application', { tag: [tags.APPS, tags.VIEWER, tags.WIN] }, 
 runExample("01_hello")`;
 		await app.workbench.positronConsole.pasteCodeToConsole(code);
 		await app.workbench.positronConsole.sendEnterKey();
-		const headerLocator = app.workbench.positronViewer.getViewerLocator('h1');
+		const headerLocator = app.web
+			? app.workbench.positronViewer.viewerFrame.frameLocator('iframe').locator('h1')
+			: app.workbench.positronViewer.getViewerLocator('h1');
 		await expect(async () => {
 			await expect(headerLocator).toHaveText('Hello Shiny!', { timeout: 20000 });
 		}).toPass({ timeout: 60000 });

--- a/test/e2e/areas/r-pkg-development/r-pkg-development.test.ts
+++ b/test/e2e/areas/r-pkg-development/r-pkg-development.test.ts
@@ -19,7 +19,7 @@ test.describe('R Package Development', { tag: [tags.WEB, tags.R_PKG_DEVELOPMENT]
 			await app.workbench.positronConsole.barClearButton.click();
 			await app.workbench.positronQuickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 		} catch (e) {
-			app.code.driver.takeScreenshot('rPackageSetup');
+			await app.code.driver.takeScreenshot('rPackageSetup');
 			throw e;
 		}
 	});

--- a/test/e2e/areas/reticulate/reticulate.test.ts
+++ b/test/e2e/areas/reticulate/reticulate.test.ts
@@ -27,7 +27,7 @@ test.describe('Reticulate', {
 			]);
 
 		} catch (e) {
-			app.code.driver.takeScreenshot('reticulateSetup');
+			await app.code.driver.takeScreenshot('reticulateSetup');
 			throw e;
 		}
 	});

--- a/test/e2e/areas/test-explorer/test-explorer.test.ts
+++ b/test/e2e/areas/test-explorer/test-explorer.test.ts
@@ -23,7 +23,7 @@ test.describe('Test Explorer', { tag: [tags.TEST_EXPLORER] }, () => {
 			await app.workbench.positronConsole.barClearButton.click();
 			await app.workbench.positronQuickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 		} catch (e) {
-			app.code.driver.takeScreenshot('testExplorerSetup');
+			await app.code.driver.takeScreenshot('testExplorerSetup');
 			throw e;
 		}
 	});


### PR DESCRIPTION
Migrated the functions we are using from MS POM to a playwright only positron version.

Enabled the shiny tests for web.

Fixed some missing awaits on screenshot calls.

### QA Notes

All tests should pass.
