### PR TITLE
Configure cli file hyperlinks for R package dev tasks

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -273,12 +273,6 @@
             "default": [],
             "description": "%r.configuration.extraArguments.description%"
           },
-          "positron.r.taskHyperlinks": {
-            "scope": "window",
-            "type": "boolean",
-            "default": false,
-            "description": "%r.configuration.taskHyperlinks.description%"
-          },
           "positron.r.defaultRepositories": {
             "scope": "window",
             "type": "string",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -59,7 +59,6 @@
 	"r.configuration.pipe.native.description": "Native pipe available in R >= 4.1",
 	"r.configuration.pipe.magrittr.description": "Pipe operator from the magrittr package, re-exported by many other packages",
 	"r.configuration.diagnostics.enable.description": "Enable R diagnostics globally",
-	"r.configuration.taskHyperlinks.description": "Turn on experimental support for hyperlinks in package development tasks",
 	"r.configuration.defaultRepositories.description": "The default repositories to use for R package installation, if no repository is otherwise specified in R startup scripts (restart Positron to apply).\n\nThe default repositories will be set as the `repos` option in R.",
 	"r.configuration.defaultRepositories.auto.description": "Automatically choose a default repository, or use a repos.conf file if it exists.",
 	"r.configuration.defaultRepositories.rstudio.description": "Use the RStudio CRAN mirror (cran.rstudio.com)",

--- a/extensions/positron-r/src/uri-handler.ts
+++ b/extensions/positron-r/src/uri-handler.ts
@@ -73,7 +73,7 @@ export async function prepCliEnvVars(session?: RSession): Promise<EnvVar> {
 	}
 
 	const taskHyperlinks = taskHyperlinksEnabled();
-	const cliPkg = await session.packageVersion('cli', '3.6.3.9001');
+	const cliPkg = await session.packageVersion('cli', '3.6.3.9002');
 	const cliSupportsHyperlinks = cliPkg?.compatible ?? false;
 
 	if (!taskHyperlinks || !cliSupportsHyperlinks) {
@@ -84,6 +84,7 @@ export async function prepCliEnvVars(session?: RSession): Promise<EnvVar> {
 	return {
 		/* eslint-disable @typescript-eslint/naming-convention */
 		R_CLI_HYPERLINKS: 'TRUE',
+		R_CLI_HYPERLINK_FILE_URL_FORMAT: 'positron://file{path}:{line}:{column}',
 		// TODO: I'd like to request POSIX compliant hyperlinks in the future, but currently
 		// cli's tests implicitly assume the default and there are more important changes to
 		// propose in cli, such as tweaks to file hyperlinks. Leave this alone for now.

--- a/extensions/positron-r/src/uri-handler.ts
+++ b/extensions/positron-r/src/uri-handler.ts
@@ -5,24 +5,11 @@
 
 import * as vscode from 'vscode';
 
-import { LOGGER } from './extension';
 import { RSessionManager } from './session-manager';
 import { EnvVar, RSession } from './session';
 
 export async function registerUriHandler() {
 	vscode.window.registerUriHandler({ handleUri });
-}
-
-// Temporary feature flag to finesse the fact that cli hyperlinks are either all ON or all OFF.
-// cli 3.6.3.9001 gained support for configuring the URL format of run/help/vignette hyperlinks.
-// But file hyperlinks are not yet configurable and will delegate to operating system.
-// If the user still has RStudio as the app associated with .R files, it will open in RStudio.
-// Flag will be removed once cli can be configured to emit positron://file/... hyperlinks.
-function taskHyperlinksEnabled(): boolean {
-	const extConfig = vscode.workspace.getConfiguration('positron.r');
-	const taskHyperlinksEnabled = extConfig.get<boolean>('taskHyperlinks');
-
-	return taskHyperlinksEnabled === true;
 }
 
 // Example of a URI we expect to handle:
@@ -72,11 +59,10 @@ export async function prepCliEnvVars(session?: RSession): Promise<EnvVar> {
 		return {};
 	}
 
-	const taskHyperlinks = taskHyperlinksEnabled();
 	const cliPkg = await session.packageVersion('cli', '3.6.3.9002');
 	const cliSupportsHyperlinks = cliPkg?.compatible ?? false;
 
-	if (!taskHyperlinks || !cliSupportsHyperlinks) {
+	if (!cliSupportsHyperlinks) {
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		return { R_CLI_HYPERLINKS: 'FALSE' };
 	}

--- a/extensions/positron-r/src/uri-handler.ts
+++ b/extensions/positron-r/src/uri-handler.ts
@@ -72,8 +72,7 @@ export async function prepCliEnvVars(session?: RSession): Promise<EnvVar> {
 		R_CLI_HYPERLINKS: 'TRUE',
 		R_CLI_HYPERLINK_FILE_URL_FORMAT: 'positron://file{path}:{line}:{column}',
 		// TODO: I'd like to request POSIX compliant hyperlinks in the future, but currently
-		// cli's tests implicitly assume the default and there are more important changes to
-		// propose in cli, such as tweaks to file hyperlinks. Leave this alone for now.
+		// cli's tests implicitly assume the default. Doesn't seem worth the fuss at this time.
 		// R_CLI_HYPERLINK_MODE: "posix",
 		R_CLI_HYPERLINK_RUN: 'TRUE',
 		R_CLI_HYPERLINK_RUN_URL_FORMAT: 'positron://positron.positron-r/cli?command=x-r-run:{code}',


### PR DESCRIPTION
Addresses #5409

*Needed to wait for https://github.com/r-lib/cli/pull/744, which is now merged*

`@:r-pkg-development`

### QA Notes

Pre-requisite: You need to install a very recent version of the cli package. At the time I write this, this means a dev version of cli, although I think we'll get a release out fairly soon. In the meantime, a good way to install is:

```r
pak::pak("r-lib/cli")
```

Make sure the cli version is >= 3.6.3.9002:

``` r
packageVersion("cli")
#> [1] '3.6.3.9002'
```

There won't be any obvious error in the presence of an older cli version, but the new functionality just won't activate.

Then you need to run tests on a package with one or more failing tests, in order to be able to click on the filepath when test failure is reported. This should take you directly to the relevant test location.

I have made a toy package that could be obtained via [`usethis::create_from_github("jennybc/clilinks")`](https://github.com/jennybc/clilinks). It has a couple of snapshot tests that will always fail 😄 because they attempt to snapshot a random number. But really any package with a failing test will do.

* Install dev cli: `pak::pak("r-lib/cli")`
* Identify a package with a failing test and open it in Positron, perhaps via: `usethis::create_from_github("jennybc/clilinks")`
* Use our gesture for running package tests: Ctrl/Cmd + Shift + T or select *R: Test R Package* from the command palette.
* Click on a file hyperlink for a failing test:
  - Note this requires Ctrl/Cmd click! This is a VS Code convention, not specific to us.
  - Note that you might have to click twice. This is a bug (or 2 bugs?) for which fixes are making their way through the system (https://github.com/microsoft/vscode/issues/230010). Again, not us.
  - You might need to grant permission to open the file hyperlink. I think I have long since checked some box always permitting this for local files. This is a VS Code feature.
<img width="652" alt="file-hyperlink" src="https://github.com/user-attachments/assets/3c1c7a11-e545-4ae8-8891-991d3e22c032" />

---

Note that this PR removes the feature flag introduced in #5231, since now all hyperlinks work (if the cli version is recent enough). If you configured `positron://settings/positron.r.taskHyperlinks` in the interim, that setting can be removed and, indeed, no longer exists.
