### PR TITLE
Add Reticulate support to the kernel supervisor

### DIFF
--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -491,15 +491,15 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         }
         const kernel = this.kernelSpec
             ? // We have a kernel spec, so we're creating a new session
-            await this.adapterApi.createSession(
-                this.runtimeMetadata,
-                this.metadata,
-                this.kernelSpec,
-                this.dynState,
-                createJupyterKernelExtra(),
-            )
+              await this.adapterApi.createSession(
+                  this.runtimeMetadata,
+                  this.metadata,
+                  this.kernelSpec,
+                  this.dynState,
+                  createJupyterKernelExtra(),
+              )
             : // We don't have a kernel spec, so we're restoring a session
-            await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
+              await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
 
         kernel.onDidChangeRuntimeState((state) => {
             this._stateEmitter.fire(state);
@@ -622,10 +622,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             const regex = /^(\w*Error|Exception)\b/m;
             const errortext = regex.test(logFileContent)
                 ? vscode.l10n.t(
-                    '{0} exited unexpectedly with error: {1}',
-                    kernel.runtimeMetadata.runtimeName,
-                    logFileContent,
-                )
+                      '{0} exited unexpectedly with error: {1}',
+                      kernel.runtimeMetadata.runtimeName,
+                      logFileContent,
+                  )
                 : Console.consoleExitGeneric;
 
             const res = await showErrorMessage(errortext, vscode.l10n.t('Open Logs'));

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -468,7 +468,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
 
     private async createKernel(): Promise<JupyterLanguageRuntimeSession> {
         const config = vscode.workspace.getConfiguration('kernelSupervisor');
-        if (config.get<boolean>('enable', true) && this.runtimeMetadata.runtimeId !== 'reticulate') {
+        if (config.get<boolean>('enable', true)) {
             // Use the Positron kernel supervisor if enabled
             const ext = vscode.extensions.getExtension('positron.positron-supervisor');
             if (!ext) {
@@ -491,15 +491,15 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         }
         const kernel = this.kernelSpec
             ? // We have a kernel spec, so we're creating a new session
-              await this.adapterApi.createSession(
-                  this.runtimeMetadata,
-                  this.metadata,
-                  this.kernelSpec,
-                  this.dynState,
-                  createJupyterKernelExtra(),
-              )
+            await this.adapterApi.createSession(
+                this.runtimeMetadata,
+                this.metadata,
+                this.kernelSpec,
+                this.dynState,
+                createJupyterKernelExtra(),
+            )
             : // We don't have a kernel spec, so we're restoring a session
-              await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
+            await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
 
         kernel.onDidChangeRuntimeState((state) => {
             this._stateEmitter.fire(state);
@@ -622,10 +622,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             const regex = /^(\w*Error|Exception)\b/m;
             const errortext = regex.test(logFileContent)
                 ? vscode.l10n.t(
-                      '{0} exited unexpectedly with error: {1}',
-                      kernel.runtimeMetadata.runtimeName,
-                      logFileContent,
-                  )
+                    '{0} exited unexpectedly with error: {1}',
+                    kernel.runtimeMetadata.runtimeName,
+                    logFileContent,
+                )
                 : Console.consoleExitGeneric;
 
             const res = await showErrorMessage(errortext, vscode.l10n.t('Open Logs'));

--- a/extensions/positron-reticulate/src/async.ts
+++ b/extensions/positron-reticulate/src/async.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * PromiseHandles is a class that represents a promise that can be resolved or
+ * rejected externally.
+ */
+export class PromiseHandles<T> {
+	resolve!: (value: T | Promise<T>) => void;
+
+	reject!: (error: unknown) => void;
+
+	promise: Promise<T>;
+
+	constructor() {
+		this.promise = new Promise((resolve, reject) => {
+			this.resolve = resolve;
+			this.reject = reject;
+		});
+	}
+}
+
+/**
+ * A barrier that is initially closed and then becomes opened permanently.
+ * Ported from VS Code's async.ts.
+ */
+
+export class Barrier {
+	private _isOpen: boolean;
+	private _promise: Promise<boolean>;
+	private _completePromise!: (v: boolean) => void;
+
+	constructor() {
+		this._isOpen = false;
+		this._promise = new Promise<boolean>((c, _e) => {
+			this._completePromise = c;
+		});
+	}
+
+	isOpen(): boolean {
+		return this._isOpen;
+	}
+
+	open(): void {
+		this._isOpen = true;
+		this._completePromise(true);
+	}
+
+	wait(): Promise<boolean> {
+		return this._promise;
+	}
+}
+
+/**
+ * Wraps a promise in a timeout that rejects the promise if it does not resolve
+ * within the given time.
+ *
+ * @param promise The promise to wrap
+ * @param timeout The timeout interval in milliseconds
+ * @param message The error message to use if the promise times out
+ *
+ * @returns The wrapped promise
+ */
+export function withTimeout<T>(promise: Promise<T>,
+	timeout: number,
+	message: string): Promise<T> {
+	return Promise.race([
+		promise,
+		new Promise<T>((_, reject) => setTimeout(() => reject(new Error(message)), timeout))
+	]);
+}
+

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -410,8 +410,8 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 
 	// A function that starts a kernel and then connects to it.
 	async startKernel(session: JupyterSession, kernel: JupyterKernel) {
-		kernel.log('Starting the reticulate session!');
-		this.progress.report({ increment: 10, message: 'Starting the reticulate session in R' });
+		kernel.log('Starting the Reticulate session!');
+		this.progress.report({ increment: 10, message: 'Starting the Reticulate session in R' });
 
 		// Store a reference to the kernel, so the session can log, reconnect, etc.
 		this.kernel = kernel;
@@ -440,7 +440,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 			logLevel as string
 		) as string;
 
-		this.progress.report({ increment: 10, message: 'Connecting to the reticulate session' });
+		this.progress.report({ increment: 10, message: 'Connecting to the Reticulate session' });
 
 		// An empty result means that the initialization went fine.
 		if (init_err !== '') {

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -437,6 +437,13 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 			kernelSpec
 		);
 
+		// Open the start barrier once the session is ready.
+		this.pythonSession.onDidChangeRuntimeState((state) => {
+			if (state === positron.RuntimeState.Ready || state === positron.RuntimeState.Idle) {
+				this.started.open();
+			}
+		});
+
 		this.onDidReceiveRuntimeMessage = this.pythonSession.onDidReceiveRuntimeMessage;
 		this.onDidChangeRuntimeState = this.pythonSession.onDidChangeRuntimeState;
 		this.onDidEndSession = this.pythonSession.onDidEndSession;
@@ -647,7 +654,7 @@ async function getRSession_(progress: vscode.Progress<{ message?: string; increm
 
 	if (session) {
 		// Get foreground session will return a runtime session even if it has
-		// already exitted. We check that it's still there before proceeding.
+		// already exited. We check that it's still there before proceeding.
 		// TODO: it would be nice to have an API to check for the session state.
 		try {
 			await session.callMethod?.('is_installed', 'reticulate', '1.39');

--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -90,6 +90,12 @@
         "title": "%command.reconnectSession.title%",
         "shortTitle": "%command.reconnectSession.title%",
         "enablement": "isDevelopment"
+      },
+      {
+        "command": "positron.supervisor.restartSupervisor",
+        "category": "%command.positron.supervisor.category%",
+        "title": "%command.restartSupervisor.title%",
+        "shortTitle": "%command.restartSupervisor.title%"
       }
     ]
   },

--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -115,7 +115,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.24"
+      "kallichore": "0.1.26"
     }
   },
   "dependencies": {

--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -115,7 +115,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.22"
+      "kallichore": "0.1.24"
     }
   },
   "dependencies": {

--- a/extensions/positron-supervisor/package.nls.json
+++ b/extensions/positron-supervisor/package.nls.json
@@ -14,5 +14,6 @@
 	"configuration.sleepOnStartup.description": "Sleep for n seconds before starting up Jupyter kernel (when supported)",
 	"command.positron.supervisor.category": "Kernel Supervisor",
 	"command.showKernelSupervisorLog.title": "Show the Kernel Supervisor Log",
-	"command.reconnectSession.title": "Reconnect the current session"
+	"command.reconnectSession.title": "Reconnect the current session",
+	"command.restartSupervisor.title": "Restart the kernel supervisor"
 }

--- a/extensions/positron-supervisor/package.nls.json
+++ b/extensions/positron-supervisor/package.nls.json
@@ -14,6 +14,6 @@
 	"configuration.sleepOnStartup.description": "Sleep for n seconds before starting up Jupyter kernel (when supported)",
 	"command.positron.supervisor.category": "Kernel Supervisor",
 	"command.showKernelSupervisorLog.title": "Show the Kernel Supervisor Log",
-	"command.reconnectSession.title": "Reconnect the current session",
-	"command.restartSupervisor.title": "Restart the kernel supervisor"
+	"command.reconnectSession.title": "Reconnect the Current Session",
+	"command.restartSupervisor.title": "Restart the Kernel Supervisor"
 }

--- a/extensions/positron-supervisor/src/AdoptedSession.ts
+++ b/extensions/positron-supervisor/src/AdoptedSession.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as positron from 'positron';
+import { JupyterKernel, JupyterSession } from './jupyter-adapter';
+import { KallichoreSession } from './KallichoreSession';
+import { KernelInfoReply } from './jupyter/KernelInfoRequest';
+import { KallichoreAdapterApi } from './positron-supervisor';
+import { ConnectionInfo, DefaultApi } from './kcclient/api';
+
+export class AdoptedSession implements JupyterKernel {
+	private _runtimeInfo: KernelInfoReply | undefined;
+
+	constructor(
+		private readonly _session: KallichoreSession,
+		private readonly _api: DefaultApi
+	) {
+
+	}
+
+	async connectToSession(session: JupyterSession): Promise<void> {
+		// Read the connection information from the session
+		const connectionFile = session.state.connectionFile;
+		const connectionInfo = JSON.parse(connectionFile) as ConnectionInfo;
+
+		// Adopt the session using the connection information
+		this._api.adoptSession(session.state.sessionId, connectionInfo);
+	}
+
+	get runtimeInfo(): KernelInfoReply | undefined {
+		return this._runtimeInfo;
+	}
+
+	log(msg: string): void {
+		this._session.log(msg);
+	}
+}

--- a/extensions/positron-supervisor/src/AdoptedSession.ts
+++ b/extensions/positron-supervisor/src/AdoptedSession.ts
@@ -24,10 +24,10 @@ export class AdoptedSession implements JupyterKernel {
 	async connectToSession(session: JupyterSession): Promise<void> {
 		const connectionFile = session.state.connectionFile;
 		// Read the contents of the file from disk
-		const connectionInfo = fs.readFileSync(connectionFile, 'utf-8');
+		const connectionInfo = JSON.parse(fs.readFileSync(connectionFile, 'utf-8')) as ConnectionInfo;
 
 		// Adopt the session using the connection information
-		this._api.adoptSession(session.state.sessionId, connectionInfo);
+		this._runtimeInfo = (await this._api.adoptSession(session.state.sessionId, connectionInfo)).body;
 	}
 
 	get runtimeInfo(): KernelInfoReply | undefined {

--- a/extensions/positron-supervisor/src/AdoptedSession.ts
+++ b/extensions/positron-supervisor/src/AdoptedSession.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as positron from 'positron';
+import * as fs from 'fs';
 import { JupyterKernel, JupyterSession } from './jupyter-adapter';
 import { KallichoreSession } from './KallichoreSession';
 import { KernelInfoReply } from './jupyter/KernelInfoRequest';
@@ -21,9 +22,9 @@ export class AdoptedSession implements JupyterKernel {
 	}
 
 	async connectToSession(session: JupyterSession): Promise<void> {
-		// Read the connection information from the session
 		const connectionFile = session.state.connectionFile;
-		const connectionInfo = JSON.parse(connectionFile) as ConnectionInfo;
+		// Read the contents of the file from disk
+		const connectionInfo = fs.readFileSync(connectionFile, 'utf-8');
 
 		// Adopt the session using the connection information
 		this._api.adoptSession(session.state.sessionId, connectionInfo);

--- a/extensions/positron-supervisor/src/AdoptedSession.ts
+++ b/extensions/positron-supervisor/src/AdoptedSession.ts
@@ -20,20 +20,16 @@ export class AdoptedSession implements JupyterKernel {
 
 	constructor(
 		private readonly _session: KallichoreSession,
+		private readonly _connectionInfo: ConnectionInfo,
 		private readonly _api: DefaultApi
 	) {
 
 	}
 
 	async connectToSession(session: JupyterSession): Promise<void> {
-		const connectionFile = session.state.connectionFile;
-
-		// Read the contents of the file from disk
-		const connectionInfo = JSON.parse(fs.readFileSync(connectionFile, 'utf-8')) as ConnectionInfo;
-
 		// Adopt the session using the connection information
 		try {
-			this._runtimeInfo = (await this._api.adoptSession(session.state.sessionId, connectionInfo)).body;
+			this._runtimeInfo = (await this._api.adoptSession(session.state.sessionId, this._connectionInfo)).body;
 		} catch (err) {
 			const message = err instanceof HttpError ? summarizeHttpError(err) : err.message;
 			throw new Error(`Failed to adopt session: ${message}`);

--- a/extensions/positron-supervisor/src/AdoptedSession.ts
+++ b/extensions/positron-supervisor/src/AdoptedSession.ts
@@ -3,21 +3,33 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as positron from 'positron';
-import * as fs from 'fs';
 import { JupyterKernel, JupyterSession } from './jupyter-adapter';
 import { KallichoreSession } from './KallichoreSession';
 import { KernelInfoReply } from './jupyter/KernelInfoRequest';
-import { KallichoreAdapterApi } from './positron-supervisor';
 import { ConnectionInfo, DefaultApi, HttpError } from './kcclient/api';
 import { summarizeHttpError } from './util';
 import { Barrier } from './async';
 
+/**
+ * Represents a Jupyter kernel that has been adopted by a supervisor. These
+ * sessions are typically started outside the control of the supervisor, and
+ * then adopted by the supervisor once started.
+ *
+ * Currently, only Reticulate kernels use this mechanism.
+ */
 export class AdoptedSession implements JupyterKernel {
 	private _runtimeInfo: KernelInfoReply | undefined;
 
+	/// Whether the session is connected (or the connection has failed)
 	public connected = new Barrier();
 
+	/**
+	 * Create a new adopted session.
+	 *
+	 * @param _session The Kallichore session
+	 * @param _connectionInfo The connection information for the adopted session
+	 * @param _api The Kallichore API instance
+	 */
 	constructor(
 		private readonly _session: KallichoreSession,
 		private readonly _connectionInfo: ConnectionInfo,
@@ -26,22 +38,38 @@ export class AdoptedSession implements JupyterKernel {
 
 	}
 
+	/**
+	 * Connect to (adopt) the given session.
+	 *
+	 * @param session The session to connect to
+	 */
 	async connectToSession(session: JupyterSession): Promise<void> {
-		// Adopt the session using the connection information
 		try {
+			// Adopt the session via the API, using the connection information
 			this._runtimeInfo = (await this._api.adoptSession(session.state.sessionId, this._connectionInfo)).body;
 		} catch (err) {
 			const message = err instanceof HttpError ? summarizeHttpError(err) : err.message;
 			throw new Error(`Failed to adopt session: ${message}`);
 		} finally {
+			// Open the connected barrier to indicate we've finished connecting
+			// (or failed to)
 			this.connected.open();
 		}
 	}
 
+	/**
+	 * Get the runtime information for the kernel. We know this information
+	 * only if the session is connected.
+	 */
 	get runtimeInfo(): KernelInfoReply | undefined {
 		return this._runtimeInfo;
 	}
 
+	/**
+	 * Log a message to the session's output log.
+	 *
+	 * @param msg The message to log
+	 */
 	log(msg: string): void {
 		this._session.log(msg);
 	}

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -15,7 +15,7 @@ import { JupyterKernelExtra, JupyterKernelSpec, JupyterLanguageRuntimeSession } 
 import { KallichoreSession } from './KallichoreSession';
 import { Barrier, PromiseHandles, withTimeout } from './async';
 import { LogStreamer } from './LogStreamer';
-import { createUniqueId, summarizeHttpError } from './util';
+import { createUniqueId, summarizeError, summarizeHttpError } from './util';
 
 const KALLICHORE_STATE_KEY = 'positron-supervisor.v1';
 
@@ -793,7 +793,6 @@ export class KCApi implements KallichoreAdapterApi {
 			return this.ensureStarted();
 		}
 
-		// Clear the log output
 		this._log.appendLine('Restarting Kallichore server');
 
 		// Clean up all the sessions and mark them as exited
@@ -813,7 +812,7 @@ export class KCApi implements KallichoreAdapterApi {
 		} catch (err) {
 			// We can start a new server even if we failed to shut down the old
 			// one, so just log this error
-			const message = err instanceof HttpError ? summarizeHttpError(err) : err;
+			const message = summarizeError(err);
 			this._log.appendLine(`Failed to shut down Kallichore server: ${message}`);
 		}
 

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -75,6 +75,13 @@ export class KCApi implements KallichoreAdapterApi {
 	private _disposables: vscode.Disposable[] = [];
 
 	/**
+	 * The terminal hosting the server, if we know it. We only know the
+	 * terminal if it has been started in this session; reconnecting to an
+	 * existing server doesn't give us the terminal.
+	 */
+	private _terminal: vscode.Terminal | undefined;
+
+	/**
 	 * Create a new Kallichore API object.
 	 *
 	 * @param _context The extension context
@@ -96,6 +103,10 @@ export class KCApi implements KallichoreAdapterApi {
 
 		_context.subscriptions.push(vscode.commands.registerCommand('positron.supervisor.reconnectSession', () => {
 			this.reconnectActiveSession();
+		}));
+
+		_context.subscriptions.push(vscode.commands.registerCommand('positron.supervisor.restartSupervisor', () => {
+			this.restartSupervisor();
 		}));
 	}
 
@@ -770,5 +781,58 @@ export class KCApi implements KallichoreAdapterApi {
 		// trigger a reconnect.
 		kallichoreSession.log('Disconnecting by user request', vscode.LogLevel.Info);
 		kallichoreSession.disconnect();
+	}
+
+	/**
+	 * Restarts the supervisor, ending all sessions.
+	 */
+	private async restartSupervisor(): Promise<void> {
+
+		// If we never started the supervisor, just start it
+		if (!this._started.isOpen()) {
+			return this.ensureStarted();
+		}
+
+		// Clear the log output
+		this._log.appendLine('Restarting Kallichore server');
+
+		// Clean up all the sessions and mark them as exited
+		this._sessions.forEach(session => {
+			session.markExited(0, positron.RuntimeExitReason.Shutdown);
+			session.dispose();
+		});
+		this._sessions.length = 0;
+
+		// Clear the workspace state so we don't try to reconnect to the old
+		// server
+		this._context.workspaceState.update(KALLICHORE_STATE_KEY, undefined);
+
+		// Shut down the server itself
+		try {
+			await this._api.shutdownServer();
+		} catch (err) {
+			// We can start a new server even if we failed to shut down the old
+			// one, so just log this error
+			const message = err instanceof HttpError ? summarizeHttpError(err) : err;
+			this._log.appendLine(`Failed to shut down Kallichore server: ${message}`);
+		}
+
+		// If we know the terminal, kill it
+		if (this._terminal) {
+			this._terminal.dispose();
+			this._terminal = undefined;
+		}
+
+		// Reset the start barrier
+		this._started = new Barrier();
+
+		// Start the new server
+		try {
+			await this.ensureStarted();
+			vscode.window.showInformationMessage(vscode.l10n.t('Kernel supervisor successfully restarted'));
+		} catch (err) {
+			const message = err instanceof HttpError ? summarizeHttpError(err) : err;
+			vscode.window.showErrorMessage(vscode.l10n.t('Failed to restart kernel supervisor: {0}', err));
+		}
 	}
 }

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -744,10 +744,13 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		};
 
 		// Create the "kernel"
-		const kernel = new AdoptedSession(this);
+		const kernel = new AdoptedSession(this, this._api);
 
 		// Start the kernel and wait for it to be ready
 		await this._kernelSpec!.startKernel!(session, kernel);
+
+		// Mark the session as ready
+		this.markReady('kernel adoption complete');
 
 		// Return the runtime info from the adopted session
 		const info = kernel.runtimeInfo;

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -749,6 +749,9 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		// Start the kernel and wait for it to be ready
 		await this._kernelSpec!.startKernel!(session, kernel);
 
+		// Connect to the session's websocket
+		await withTimeout(this.connect(), 2000, `Start failed: timed out connecting to adopted session ${this.metadata.sessionId}`);
+
 		// Mark the session as ready
 		this.markReady('kernel adoption complete');
 

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -747,7 +747,10 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		const kernel = new AdoptedSession(this, this._api);
 
 		// Start the kernel and wait for it to be ready
-		await this._kernelSpec!.startKernel!(session, kernel);
+		await kernelSpec.startKernel!(session, kernel);
+
+		// Wait for session adoption to finish
+		await kernel.connected.wait();
 
 		// Connect to the session's websocket
 		await withTimeout(this.connect(), 2000, `Start failed: timed out connecting to adopted session ${this.metadata.sessionId}`);

--- a/extensions/positron-supervisor/src/kcclient/.openapi-generator/FILES
+++ b/extensions/positron-supervisor/src/kcclient/.openapi-generator/FILES
@@ -4,7 +4,6 @@ api/apis.ts
 api/defaultApi.ts
 git_push.sh
 model/activeSession.ts
-model/adoptedSession.ts
 model/connectionInfo.ts
 model/executionQueue.ts
 model/interruptMode.ts

--- a/extensions/positron-supervisor/src/kcclient/api/defaultApi.ts
+++ b/extensions/positron-supervisor/src/kcclient/api/defaultApi.ts
@@ -16,7 +16,7 @@ import http from 'http';
 
 /* tslint:disable:no-unused-locals */
 import { ActiveSession } from '../model/activeSession';
-import { AdoptedSession } from '../model/adoptedSession';
+import { ConnectionInfo } from '../model/connectionInfo';
 import { ModelError } from '../model/modelError';
 import { NewSession } from '../model/newSession';
 import { NewSession200Response } from '../model/newSession200Response';
@@ -102,10 +102,12 @@ export class DefaultApi {
     /**
      * 
      * @summary Adopt an existing session
-     * @param adoptedSession 
+     * @param sessionId 
+     * @param connectionInfo 
      */
-    public async adoptSession (adoptedSession: AdoptedSession, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body: NewSession200Response;  }> {
-        const localVarPath = this.basePath + '/sessions/adopt';
+    public async adoptSession (sessionId: string, connectionInfo: ConnectionInfo, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body: any;  }> {
+        const localVarPath = this.basePath + '/sessions/{session_id}/adopt'
+            .replace('{' + 'session_id' + '}', encodeURIComponent(String(sessionId)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this._defaultHeaders);
         const produces = ['application/json'];
@@ -117,9 +119,14 @@ export class DefaultApi {
         }
         let localVarFormParams: any = {};
 
-        // verify required parameter 'adoptedSession' is not null or undefined
-        if (adoptedSession === null || adoptedSession === undefined) {
-            throw new Error('Required parameter adoptedSession was null or undefined when calling adoptSession.');
+        // verify required parameter 'sessionId' is not null or undefined
+        if (sessionId === null || sessionId === undefined) {
+            throw new Error('Required parameter sessionId was null or undefined when calling adoptSession.');
+        }
+
+        // verify required parameter 'connectionInfo' is not null or undefined
+        if (connectionInfo === null || connectionInfo === undefined) {
+            throw new Error('Required parameter connectionInfo was null or undefined when calling adoptSession.');
         }
 
         (<any>Object).assign(localVarHeaderParams, options.headers);
@@ -133,7 +140,7 @@ export class DefaultApi {
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
-            body: ObjectSerializer.serialize(adoptedSession, "AdoptedSession")
+            body: ObjectSerializer.serialize(connectionInfo, "ConnectionInfo")
         };
 
         let authenticationPromise = Promise.resolve();
@@ -152,13 +159,13 @@ export class DefaultApi {
                     localVarRequestOptions.form = localVarFormParams;
                 }
             }
-            return new Promise<{ response: http.IncomingMessage; body: NewSession200Response;  }>((resolve, reject) => {
+            return new Promise<{ response: http.IncomingMessage; body: any;  }>((resolve, reject) => {
                 localVarRequest(localVarRequestOptions, (error, response, body) => {
                     if (error) {
                         reject(error);
                     } else {
                         if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                            body = ObjectSerializer.deserialize(body, "NewSession200Response");
+                            body = ObjectSerializer.deserialize(body, "any");
                             resolve({ response: response, body: body });
                         } else {
                             reject(new HttpError(response, body, response.statusCode));
@@ -227,6 +234,75 @@ export class DefaultApi {
                         reject(error);
                     } else {
                         if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
+                            resolve({ response: response, body: body });
+                        } else {
+                            reject(new HttpError(response, body, response.statusCode));
+                        }
+                    }
+                });
+            });
+        });
+    }
+    /**
+     * 
+     * @summary Get Jupyter connection information for the session
+     * @param sessionId 
+     */
+    public async connectionInfo (sessionId: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; body: ConnectionInfo;  }> {
+        const localVarPath = this.basePath + '/sessions/{session_id}/connection_info'
+            .replace('{' + 'session_id' + '}', encodeURIComponent(String(sessionId)));
+        let localVarQueryParameters: any = {};
+        let localVarHeaderParams: any = (<any>Object).assign({}, this._defaultHeaders);
+        const produces = ['application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
+        let localVarFormParams: any = {};
+
+        // verify required parameter 'sessionId' is not null or undefined
+        if (sessionId === null || sessionId === undefined) {
+            throw new Error('Required parameter sessionId was null or undefined when calling connectionInfo.');
+        }
+
+        (<any>Object).assign(localVarHeaderParams, options.headers);
+
+        let localVarUseFormData = false;
+
+        let localVarRequestOptions: localVarRequest.Options = {
+            method: 'GET',
+            qs: localVarQueryParameters,
+            headers: localVarHeaderParams,
+            uri: localVarPath,
+            useQuerystring: this._useQuerystring,
+            json: true,
+        };
+
+        let authenticationPromise = Promise.resolve();
+        authenticationPromise = authenticationPromise.then(() => this.authentications.default.applyToRequest(localVarRequestOptions));
+
+        let interceptorPromise = authenticationPromise;
+        for (const interceptor of this.interceptors) {
+            interceptorPromise = interceptorPromise.then(() => interceptor(localVarRequestOptions));
+        }
+
+        return interceptorPromise.then(() => {
+            if (Object.keys(localVarFormParams).length) {
+                if (localVarUseFormData) {
+                    (<any>localVarRequestOptions).formData = localVarFormParams;
+                } else {
+                    localVarRequestOptions.form = localVarFormParams;
+                }
+            }
+            return new Promise<{ response: http.IncomingMessage; body: ConnectionInfo;  }>((resolve, reject) => {
+                localVarRequest(localVarRequestOptions, (error, response, body) => {
+                    if (error) {
+                        reject(error);
+                    } else {
+                        if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
+                            body = ObjectSerializer.deserialize(body, "ConnectionInfo");
                             resolve({ response: response, body: body });
                         } else {
                             reject(new HttpError(response, body, response.statusCode));

--- a/extensions/positron-supervisor/src/kcclient/model/models.ts
+++ b/extensions/positron-supervisor/src/kcclient/model/models.ts
@@ -1,7 +1,6 @@
 import localVarRequest from 'request';
 
 export * from './activeSession';
-export * from './adoptedSession';
 export * from './connectionInfo';
 export * from './executionQueue';
 export * from './interruptMode';
@@ -27,7 +26,6 @@ export type RequestFile = string | Buffer | fs.ReadStream | RequestDetailedFile;
 
 
 import { ActiveSession } from './activeSession';
-import { AdoptedSession } from './adoptedSession';
 import { ConnectionInfo } from './connectionInfo';
 import { ExecutionQueue } from './executionQueue';
 import { InterruptMode } from './interruptMode';
@@ -58,7 +56,6 @@ let enumsMap: {[index: string]: any} = {
 
 let typeMap: {[index: string]: any} = {
     "ActiveSession": ActiveSession,
-    "AdoptedSession": AdoptedSession,
     "ConnectionInfo": ConnectionInfo,
     "ExecutionQueue": ExecutionQueue,
     "ModelError": ModelError,

--- a/extensions/positron-supervisor/src/util.ts
+++ b/extensions/positron-supervisor/src/util.ts
@@ -16,6 +16,28 @@ export function createUniqueId(): string {
 }
 
 /**
+ * Summarizes an error into a human-readable string. Used for serializing
+ * errors reported across the Positron API boundary.
+ *
+ * @param err An error to summarize.
+ * @returns A human-readable string summarizing the error.
+ */
+export function summarizeError(err: any): string {
+	if (err instanceof HttpError) {
+		// HTTP errors are common and should be summarized
+		return summarizeHttpError(err);
+	} else if (err instanceof Error) {
+		// Other errors should be summarized as their message
+		return err.message;
+	} else if (typeof err === 'string') {
+		// Strings are returned as-is
+		return err;
+	}
+	// For anything else, return the JSON representation
+	return JSON.stringify(err);
+}
+
+/**
  * Summarizes an HTTP error into a human-readable string. Used for serializing
  * structured errors reported up to Positron where only a string can be
  * displayed.


### PR DESCRIPTION
This change makes it possible to use Reticulate sessions with the kernel supervisor.

<img width="885" alt="image" src="https://github.com/user-attachments/assets/493a7c36-6d49-498f-86f1-886d4255d4e2" />

The supervisor has a new `adopt` endpoint that allows it to connect to a session that is already running somewhere else. Now, when you start a Reticulate session, the following things happen:

- An R session is started, if necessary.
- A Reticulate session is started inside the R session.
- The Python kernel is started inside the Reticulate session.
- The supervisor "adopts" the Python kernel, connecting to its ZeroMQ sockets and proxying messages as it does for other kernels.

In addition to adding the orchestration to use the supervisor, there are a couple of other small changes in this PR:

- There is a new _Restart the Kernel Supervisor_ command, which shuts down the supervisor process and all sessions, regardless of what state they're in. This is mostly intended as a debugging tool, and it was added in order to make it possible to pick up e.g. debug log level changes without restarting Positron, but could also be helpful as a last resort if things get stuck. 
- The progress shown when starting a Reticulate session is now much more chatty; it appears as soon as you try to start the session and shows more information along the way. 

Progress towards #4579; this enables the use of Reticulate on Posit Workbench, and is the last major piece of functionality that required the Jupyter Adapter. 

(Note that the main body of this change lives in the supervisor itself; this is just the front end / UI bits.)

### QA Notes

There's a _lot_ of orchestration involved already in starting Reticulate and this makes it even more complicated. The highest risk areas are around lifecycle management: shutting down, restarting, reconnecting, etc.

There is a known issue in which if you have an exited R session in your Console and try to start a Reticulate session, it never happens. I didn't try to fix that in this PR. 