### PR TITLE
fix fastapi app path to module conversion on Windows

### DIFF
--- a/extensions/positron-python/src/client/positron/webAppCommands.ts
+++ b/extensions/positron-python/src/client/positron/webAppCommands.ts
@@ -313,8 +313,7 @@ function pathToModule(p: string): string {
     }
 
     // Otherwise, convert the path to a Python module format.
-    const parts = relativeDir.split(path.sep);
-
+    const parts = relativeDir.split(/[/\\]/);
     return parts.concat(mod).join('.');
 }
 

--- a/test/e2e/tests/apps/python-apps.test.ts
+++ b/test/e2e/tests/apps/python-apps.test.ts
@@ -39,7 +39,9 @@ test.describe('Python Applications', {
 		});
 	});
 
-	test('Python - Verify Basic FastAPI App [C903306]', async function ({ app, python }) {
+	test('Python - Verify Basic FastAPI App [C903306]', {
+		tag: [tags.WIN]
+	}, async function ({ app, python }) {
 		const viewer = app.workbench.viewer;
 
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'python_apps', 'fastapi_example', 'fastapi_example.py'));


### PR DESCRIPTION
<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

### Summary

- addresses https://github.com/posit-dev/positron/issues/5312
- re-enables `Python - Verify Basic FastAPI App [C903306]` on Windows

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixes bug in file path to module import path conversion in the Python Extension, which was preventing FastAPI apps from running on Windows when using the App Launcher (#5312)

### QA Notes

Running [fastapi_example.py](https://github.com/posit-dev/qa-example-content/blob/main/workspaces/python_apps/fastapi_example/fastapi_example.py) with the App Launcher should now work on Windows.

#### PR Testing

@:apps

Windows Test Results 🎉 

- test run: https://github.com/posit-dev/positron/actions/runs/12486724958/job/34847131287

<img width="987" alt="image" src="https://github.com/user-attachments/assets/ddb9c59a-509c-496e-a7f0-eb961a4359b8" />
