### PR TITLE
Turn on New Project tests after Issue fixed

### DIFF
--- a/test/e2e/areas/new-project-wizard/new-project-python.test.ts
+++ b/test/e2e/areas/new-project-wizard/new-project-python.test.ts
@@ -99,9 +99,8 @@ test.describe('Python - New Project Wizard', { tag: [tags.NEW_PROJECT_WIZARD] },
 		await expect(app.workbench.positronConsole.activeConsole.getByText('>>>')).toBeVisible({ timeout: 90000 });
 	});
 
-	test.skip('With ipykernel not already installed [C609617]', {
+	test('With ipykernel not already installed [C609617]', {
 		tag: [tags.WIN],
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5730' }],
 	}, async function ({ app, page }) {
 		const projSuffix = addRandomNumSuffix('_noIpykernel');
 		const pw = app.workbench.positronNewProjectWizard;

--- a/test/e2e/areas/new-project-wizard/new-project-r-jupyter.test.ts
+++ b/test/e2e/areas/new-project-wizard/new-project-r-jupyter.test.ts
@@ -93,7 +93,7 @@ test.describe('R - New Project Wizard', { tag: [tags.NEW_PROJECT_WIZARD] }, () =
 			expect(projectFiles).toContain('renv');
 			expect(projectFiles).toContain('.Rprofile');
 			expect(projectFiles).toContain('renv.lock');
-		}).toPass({ timeout: 50000 });
+		}).toPass({ timeout: 100000 });
 		// Verify that renv output in the console confirms no issues occurred
 		await app.workbench.positronConsole.waitForConsoleContents('renv activated');
 	});


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Issue #5730 is now fixed, so turning back on the tests.  Also had to increase timeout for a new .renv project starting.
 
### QA Notes
@:new-project-wizard

Test pass in CI

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
