### PR TITLE
Don't refresh variables on every console execution

### DIFF
--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -372,13 +372,20 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 
 		const { sessionId } = session;
 
+		// No-op if this is already the active instance. Setting the active
+		// instance below triggers a refresh, so avoid it if if the instance is
+		// already active.
+		if (this._activePositronVariablesInstance?.session.sessionId === sessionId) {
+			return;
+		}
+
 		const positronVariablesInstance = this._positronVariablesInstancesBySessionId.get(
 			sessionId
 		);
 
 		if (positronVariablesInstance) {
 			this._setActivePositronVariablesInstance(positronVariablesInstance);
-			return
+			return;
 		}
 
 		this._logService.error(`Cannot show Variables: ${formatLanguageRuntimeSession(session)} became active, but a Variables instance for it is not running.`);


### PR DESCRIPTION
This change addresses an issue in which invoking long-running commands causes variables RPC errors to appear. 

The underlying issue is that currently every code execution in the Console is triggering a full refresh of the Variables pane (introduced in https://github.com/posit-dev/positron/pull/5583). So when code is executed, we're asking for a refreshed Variables pane immediately afterwards, but the RPC doesn't go through right away because code is executing. If the code takes a while to execute, the RPC eventually times out.

The fix is to avoid refreshing the Variables pane if it's already showing the correct session. 

There are other changes that would improve this, such as having the Variables pane queue refresh requests until the kernel is idle, or auditing refresh triggers so they run when code _finishes_ executing. This change is intended to be the minimal one that fixes the problem.

Addresses https://github.com/posit-dev/positron/issues/5813 and https://github.com/posit-dev/positron/issues/5806.

### QA Notes

Make sure the behavior described in https://github.com/posit-dev/positron/pull/5583 still works, too.