### PR TITLE
Bump version to 2025.02.0

### DIFF
--- a/product.json
+++ b/product.json
@@ -1,7 +1,7 @@
 {
 	"nameShort": "Positron",
 	"nameLong": "Positron",
-	"positronVersion": "2025.01.0",
+	"positronVersion": "2025.02.0",
 	"positronBuildNumber": 0,
 	"applicationName": "positron",
 	"dataFolderName": ".positron",

--- a/versions/2025.02.0.commit
+++ b/versions/2025.02.0.commit
@@ -1,0 +1,1 @@
+925e4287fbfb45acd1e2a4ef8ae8979e3ee906cc

--- a/versions/create-anchor.cjs
+++ b/versions/create-anchor.cjs
@@ -23,13 +23,11 @@ const version = product.positronVersion;
 const anchorPath = path.resolve(__dirname, version + '.commit');
 if (fs.existsSync(anchorPath)) {
 	console.log(`Anchor file ${anchorPath} already exists for version ${version}.`);
-	return 0;
+} else {
+	// Create the anchor file with the commit hash at the head of the current branch
+	const commit = child_process.execSync('git rev-parse HEAD').toString().trim();
+	fs.writeFileSync(anchorPath, commit);
+
+	// Tell the user what we did
+	console.log(`Created anchor file ${anchorPath} for version ${version} at commit ${commit}.`);
 }
-
-// Create the anchor file with the commit hash at the head of the current branch
-const commit = child_process.execSync('git rev-parse HEAD').toString().trim();
-fs.writeFileSync(anchorPath, commit);
-
-// Tell the user what we did
-console.log(`Created anchor file ${anchorPath} for version ${version} at commit ${commit}.`);
-


### PR DESCRIPTION
Bumps the version to 2025.02. 

Also makes `create-anchor` a `.cjs` rather than a `.js` since it is not an ESM and all scripts are now considered ESM unless otherwise indicated, post-1.95 merge. 