### PR TITLE
Auto update notification

### DIFF
--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -95,10 +95,6 @@
       "filename": "build/secrets/.secrets.baseline"
     },
     {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
-    },
-    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -599,7 +595,7 @@
         "filename": "product.json",
         "hashed_secret": "829eaa1d03499ac3be472b80e2d7a7b7df709fca",
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 45,
         "is_secret": false
       },
       {
@@ -607,7 +603,7 @@
         "filename": "product.json",
         "hashed_secret": "6dddc5671d5ed146759f817632cbb0c2d278fdd0",
         "is_verified": false,
-        "line_number": 59,
+        "line_number": 61,
         "is_secret": false
       },
       {
@@ -615,7 +611,7 @@
         "filename": "product.json",
         "hashed_secret": "98f6b0e364fc315e344dd24ce8ccd59b9a827ccd",
         "is_verified": false,
-        "line_number": 75,
+        "line_number": 77,
         "is_secret": false
       },
       {
@@ -623,7 +619,7 @@
         "filename": "product.json",
         "hashed_secret": "aa5db2e10c46111cbb98fa5d5bf0f7a51937dbfe",
         "is_verified": false,
-        "line_number": 229,
+        "line_number": 231,
         "is_secret": false
       }
     ],

--- a/product.json
+++ b/product.json
@@ -36,6 +36,8 @@
 	"nodejsRepository": "https://nodejs.org",
 	"urlProtocol": "positron",
 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/out/vs/workbench/contrib/webview/browser/pre/",
+	"updateUrl": "https://cdn.posit.co/positron",
+	"downloadUrl": "https://github.com/posit-dev/positron/releases",
 	"builtInExtensions": [
 		{
 			"name": "ms-vscode.js-debug-companion",

--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -9,7 +9,7 @@ import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurati
 import { Registry } from '../../registry/common/platform.js';
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
-// --- START POSITRON ---
+// --- Start Positron ---
 configurationRegistry.registerConfiguration({
 	id: 'update',
 	order: 15,
@@ -65,5 +65,5 @@ configurationRegistry.registerConfiguration({
 			included: false
 		}
 	}
-	// --- END POSITRON ---
+	// --- End Positron ---
 });

--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -9,6 +9,7 @@ import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurati
 import { Registry } from '../../registry/common/platform.js';
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+// --- START POSITRON ---
 configurationRegistry.registerConfiguration({
 	id: 'update',
 	order: 15,
@@ -20,7 +21,7 @@ configurationRegistry.registerConfiguration({
 			enum: ['none', 'manual', 'start', 'default'],
 			default: 'default',
 			scope: ConfigurationScope.APPLICATION,
-			description: localize('updateMode', "Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service."),
+			description: localize('updateMode', "Configure whether you receive automatic updates. Requires a restart after change to take effect."),
 			tags: ['usesOnlineServices'],
 			enumDescriptions: [
 				localize('none', "Disable updates."),
@@ -30,14 +31,21 @@ configurationRegistry.registerConfiguration({
 			],
 			policy: {
 				name: 'UpdateMode',
-				minimumVersion: '1.67',
+				minimumVersion: '2025.1.0',
 			}
+		},
+		'update.autoUpdateExperimental': {
+			type: 'boolean',
+			default: false,
+			scope: ConfigurationScope.APPLICATION,
+			description: localize('experimentalAutoUpdate', "CAUTION: Enable automatic update checking. Requires a restart after change to take effect."),
+			tags: ['usesOnlineServices'],
 		},
 		'update.channel': {
 			type: 'string',
 			default: 'default',
 			scope: ConfigurationScope.APPLICATION,
-			description: localize('updateMode', "Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service."),
+			description: localize('updateMode', "Configure whether you receive automatic updates. Requires a restart after change to take effect."),
 			deprecationMessage: localize('deprecated', "This setting is deprecated, please use '{0}' instead.", 'update.mode')
 		},
 		'update.enableWindowsBackgroundUpdates': {
@@ -50,10 +58,12 @@ configurationRegistry.registerConfiguration({
 		},
 		'update.showReleaseNotes': {
 			type: 'boolean',
-			default: true,
+			default: false,
 			scope: ConfigurationScope.APPLICATION,
-			description: localize('showReleaseNotes', "Show Release Notes after an update. The Release Notes are fetched from a Microsoft online service."),
-			tags: ['usesOnlineServices']
+			description: localize('showReleaseNotes', "Show Release Notes after an update."),
+			tags: ['usesOnlineServices'],
+			included: false
 		}
 	}
+	// --- END POSITRON ---
 });

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -225,8 +225,8 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		await this.doDownloadUpdate(this.state);
 	}
 
+	// --- Start Positron ---
 	protected async doDownloadUpdate(state: AvailableForDownload): Promise<void> {
-		// --- Start Positron ---
 		if (this.productService.downloadUrl && this.productService.downloadUrl.length > 0) {
 			// Use the download URL if available as we don't currently detect the package type that was
 			// installed and the website download page is more useful than the tarball generally.
@@ -286,8 +286,8 @@ export abstract class AbstractUpdateService implements IUpdateService {
 			return false;
 		}
 
+		// --- Start Positron ---
 		try {
-			// --- Start Positron ---
 			return this.requestService.request({ url: this.url }, CancellationToken.None)
 				.then<IUpdate | null>(asJson)
 				.then(update => {
@@ -296,12 +296,12 @@ export abstract class AbstractUpdateService implements IUpdateService {
 					}
 					return Promise.resolve(hasUpdate(update, this.productService.positronVersion));
 				});
-			// --- End Positron ---
 		} catch (error) {
 			this.logService.error('update#isLatestVersion(): failed to check for updates');
 			this.logService.error(error);
 			return undefined;
 		}
+		// --- End Positron ---
 	}
 
 	async _applySpecificUpdate(packagePath: string): Promise<void> {
@@ -316,8 +316,9 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		// noop
 	}
 
-	protected abstract doCheckForUpdates(context: any): void;
 	// --- Start Positron ---
+	// This isn't actually used for Positron updates but is kept to make future merges from upstream easier
+	protected abstract doCheckForUpdates(context: any): void;
 	protected abstract buildUpdateFeedUrl(channel: string): string | undefined;
 	protected updateAvailable(context: IUpdate): void {
 		this.setState(State.AvailableForDownload(context));

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -14,7 +14,7 @@ import { IProductService } from '../../product/common/productService.js';
 import { IRequestService } from '../../request/common/request.js';
 import { AvailableForDownload, DisablementReason, IUpdateService, State, StateType, UpdateType } from '../common/update.js';
 
-//--- START POSITRON
+//--- Start Positron ---
 // eslint-disable-next-line no-duplicate-imports
 import { asJson } from '../../request/common/request.js';
 // eslint-disable-next-line no-duplicate-imports
@@ -31,7 +31,7 @@ export const enum UpdateChannel {
 
 export function createUpdateURL(platform: string, channel: string, productService: IProductService): string {
 	return `${productService.updateUrl}/${channel}/${platform}`;
-	//--- END POSITRON
+	//--- End Positron ---
 }
 
 export type UpdateNotAvailableClassification = {
@@ -52,10 +52,10 @@ export abstract class AbstractUpdateService implements IUpdateService {
 
 	protected url: string | undefined;
 
-	// --- START POSITRON ---
+	// --- Start Positron ---
 	// enable the service to download and apply updates automatically
 	protected enableAutoUpdate: boolean;
-	// --- END POSITRON ---
+	// --- End Positron ---
 
 	private _state: State = State.Uninitialized;
 
@@ -78,7 +78,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		@IEnvironmentMainService private readonly environmentMainService: IEnvironmentMainService,
 		@IRequestService protected requestService: IRequestService,
 		@ILogService protected logService: ILogService,
-		// --- START POSITRON ---
+		// --- Start Positron ---
 		@IProductService protected readonly productService: IProductService,
 		@INativeHostMainService protected readonly nativeHostMainService: INativeHostMainService
 	) {
@@ -222,7 +222,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 
 		this.setState(State.Idle(this.getUpdateType()));
 	}
-	// --- END POSITRON ---
+	// --- End Positron ---
 
 	async applyUpdate(): Promise<void> {
 		this.logService.trace('update#applyUpdate, state = ', this.state.type);
@@ -272,7 +272,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		}
 
 		try {
-			// --- START POSITRON
+			// --- Start Positron ---
 			return this.requestService.request({ url: this.url }, CancellationToken.None)
 				.then<IUpdate | null>(asJson)
 				.then(update => {
@@ -281,7 +281,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 					}
 					return Promise.resolve(hasUpdate(update, this.productService.positronVersion));
 				});
-			// --- END POSITRON
+			// --- End Positron ---
 		} catch (error) {
 			this.logService.error('update#isLatestVersion(): failed to check for updates');
 			this.logService.error(error);
@@ -301,10 +301,10 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		// noop
 	}
 
-	// --- START POSITRON ---
+	// --- Start Positron ---
 	protected abstract buildUpdateFeedUrl(channel: string): string | undefined;
 	protected updateAvailable(context: IUpdate): void {
 		this.setState(State.AvailableForDownload(context));
 	}
-	// --- END POSITRON ---
+	// --- End Positron ---
 }

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -215,7 +215,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		if (this.productService.downloadUrl && this.productService.downloadUrl.length > 0) {
 			// Use the download URL if available as we don't currently detect the package type that was
 			// installed and the website download page is more useful than the tarball generally.
-			this.nativeHostMainService.openExternal(undefined, `${this.productService.downloadUrl}/tag/${state.update.version}`);
+			this.nativeHostMainService.openExternal(undefined, this.productService.downloadUrl);
 		} else if (state.update.url) {
 			this.nativeHostMainService.openExternal(undefined, state.update.url);
 		}

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -163,6 +163,8 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	}
 
 	// --- Start Positron ---
+	// This is essentially the update 'channel' (aka insiders, stable, etc.). VS Code sets it through the
+	// product.json. Positron will have it configurable for now.
 	// @ts-ignore
 	private getProductQuality(updateMode: string): string | undefined {
 		return updateMode === 'none' ? undefined : this.productService.quality;

--- a/src/vs/platform/update/electron-main/positronVersion.ts
+++ b/src/vs/platform/update/electron-main/positronVersion.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/platform/update/electron-main/positronVersion.ts
+++ b/src/vs/platform/update/electron-main/positronVersion.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IUpdate } from '../common/update.js';
+
+
+const POSITRON_VERSION_REGEX = /^\d{4}\.\d{2}\.\d+(-\d+)?$/;
+
+/**
+ * A Positron version in the format of YYYY.MM.patch-build
+ *
+ * The month is zero-padded and the build number is optional.
+ */
+export interface IPositronVersion {
+	year: number;
+	month: number;
+	patch: number;
+	build?: number;
+}
+
+/**
+ * Parses a calendar version from YYYY.MM.patch-build into IPositronVersion
+ *
+ * @param version - The version string to parse.
+ */
+export function parse(version: string): IPositronVersion {
+	if (!POSITRON_VERSION_REGEX.test(version)) {
+		throw new Error('Version format must be YYYY.MM.patch-build');
+	}
+	const [year, month, patchBuild] = version.split('.');
+	const [patch, build] = patchBuild.split('-').map(Number);
+
+	return { year: Number(year), month: Number(month), patch, build };
+}
+
+/**
+ * Checks if a version is valid. Each part of the version must be a number.
+ *
+ * @param version - The version string to check.
+ */
+export function valid(version: string): boolean {
+	return POSITRON_VERSION_REGEX.test(version);
+}
+
+/**
+ * Compares two versions of Positron. If either version does not have a build number, it is equal
+ * given the other parts are equal.
+ *
+ * @param v1 - The first version to compare.
+ * @param v2 - The second version to compare.
+ * @returns negative if v1 is less than v2, 0 if they are equal, and positive if v1 is greater than v2.
+ */
+export function compare(v1: string, v2: string): number {
+	const p1 = parse(v1);
+	const p2 = parse(v2);
+
+	if (p1.year !== p2.year) {
+		return p1.year - p2.year;
+	}
+
+	if (p1.month !== p2.month) {
+		return p1.month - p2.month;
+	}
+
+	if (p1.patch !== p2.patch) {
+		return p1.patch - p2.patch;
+	}
+
+	if (p1.build === undefined || p2.build === undefined) {
+		return 0;
+	}
+
+	return (p1.build || 0) - (p2.build || 0);
+}
+
+/**
+ * Checks if an update is newer than the current version.
+ *
+ * @param update - The update to check.
+ * @param currentVersion - The current version to compare against.
+ * @returns true if the update is newer, false otherwise.
+ */
+export function hasUpdate(update: IUpdate, currentVersion: string): boolean {
+	const latestVersion = update.version;
+
+	if (!valid(latestVersion)) {
+		throw new Error(`Invalid version format ${latestVersion}`);
+	}
+
+	if (!valid(currentVersion)) {
+		throw new Error(`Invalid version format ${currentVersion}`);
+	}
+
+	return compare(latestVersion, currentVersion) >= 1;
+}

--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -80,7 +80,7 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 		this.setState(State.Idle(UpdateType.Archive, message));
 	}
 
-	//--- START POSITRON
+	//--- Start Positron ---
 	protected buildUpdateFeedUrl(channel: string): string | undefined {
 		const platform = 'mac/universal';
 		const url = createUpdateURL(platform, channel, this.productService) + '/releases.json';
@@ -111,7 +111,7 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 			electron.autoUpdater.checkForUpdates();
 		}
 	}
-	//--- END POSITRON
+	//--- End Positron ---
 
 	private onUpdateAvailable(): void {
 		if (this.state.type !== StateType.CheckingForUpdates) {

--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -94,6 +94,12 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 		return url;
 	}
 
+	// Unused for Positron
+	protected doCheckForUpdates(context: any): void {
+		this.setState(State.CheckingForUpdates(context));
+		electron.autoUpdater.checkForUpdates();
+	}
+
 	/**
 	 * Manually check for updates and call Electron to install the update if an update is available.
 	 */

--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -82,7 +82,7 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 
 	//--- START POSITRON
 	protected buildUpdateFeedUrl(channel: string): string | undefined {
-		const platform = `mac/universal`;
+		const platform = 'mac/universal';
 		const url = createUpdateURL(platform, channel, this.productService) + '/releases.json';
 		try {
 			electron.autoUpdater.setFeedURL({ url: url });

--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -93,6 +93,7 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 		}
 		return url;
 	}
+	// --- End Positron ---
 
 	// Unused for Positron
 	protected doCheckForUpdates(context: any): void {
@@ -100,6 +101,7 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 		electron.autoUpdater.checkForUpdates();
 	}
 
+	// --- Start Positron ---
 	/**
 	 * Manually check for updates and call Electron to install the update if an update is available.
 	 */

--- a/src/vs/platform/update/electron-main/updateService.linux.ts
+++ b/src/vs/platform/update/electron-main/updateService.linux.ts
@@ -17,6 +17,7 @@ import { AbstractUpdateService, createUpdateURL, UpdateNotAvailableClassificatio
 
 export class LinuxUpdateService extends AbstractUpdateService {
 
+	// --- Start Positron ---
 	constructor(
 		@ILifecycleMainService lifecycleMainService: ILifecycleMainService,
 		@IConfigurationService configurationService: IConfigurationService,
@@ -24,11 +25,12 @@ export class LinuxUpdateService extends AbstractUpdateService {
 		@IEnvironmentMainService environmentMainService: IEnvironmentMainService,
 		@IRequestService requestService: IRequestService,
 		@ILogService logService: ILogService,
-		@INativeHostMainService private readonly nativeHostMainService: INativeHostMainService,
+		@INativeHostMainService nativeHostMainService: INativeHostMainService,
 		@IProductService productService: IProductService
 	) {
-		super(lifecycleMainService, configurationService, environmentMainService, requestService, logService, productService);
+		super(lifecycleMainService, configurationService, environmentMainService, requestService, logService, productService, nativeHostMainService);
 	}
+	// --- End Positron ---
 
 	protected buildUpdateFeedUrl(quality: string): string {
 		return createUpdateURL(`linux-${process.arch}`, quality, this.productService);

--- a/src/vs/platform/update/electron-main/updateService.linux.ts
+++ b/src/vs/platform/update/electron-main/updateService.linux.ts
@@ -41,6 +41,7 @@ export class LinuxUpdateService extends AbstractUpdateService {
 	}
 	// --- End Positron ---
 
+	// Unused for Positron
 	protected doCheckForUpdates(context: any): void {
 		if (!this.url) {
 			return;

--- a/src/vs/platform/update/electron-main/updateService.linux.ts
+++ b/src/vs/platform/update/electron-main/updateService.linux.ts
@@ -30,11 +30,16 @@ export class LinuxUpdateService extends AbstractUpdateService {
 	) {
 		super(lifecycleMainService, configurationService, environmentMainService, requestService, logService, productService, nativeHostMainService);
 	}
-	// --- End Positron ---
 
-	protected buildUpdateFeedUrl(quality: string): string {
-		return createUpdateURL(`linux-${process.arch}`, quality, this.productService);
+	protected buildUpdateFeedUrl(channel: string): string {
+		const arch = process.arch === 'x64' ? 'x86_64' : 'arm64';
+		const platform = `deb/${arch}`;
+		const baseUrl = createUpdateURL(platform, channel, this.productService);
+
+		// TODO: properly determine deb or rpm
+		return `${baseUrl}/releases.json`;
 	}
+	// --- End Positron ---
 
 	protected doCheckForUpdates(context: any): void {
 		if (!this.url) {

--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -99,7 +99,7 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 		await super.initialize();
 	}
 
-	// --- START POSITRON ---
+	// --- Start Positron ---
 	protected buildUpdateFeedUrl(channel: string): string | undefined {
 		const platform = `win/${process.arch === 'x64' ? 'x86_64' : 'arm64'}`;
 		const prefix = getUpdateType() === UpdateType.Setup ? 'system-' : 'user-';
@@ -151,7 +151,7 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 			});
 		});
 	}
-	// --- END POSITRON ---
+	// --- End Positron ---
 
 	private async getUpdatePackagePath(version: string): Promise<string> {
 		const cachePath = await this.cachePath;

--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -103,8 +103,10 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 	protected buildUpdateFeedUrl(channel: string): string | undefined {
 		const platform = `win/${process.arch === 'x64' ? 'x86_64' : 'arm64'}`;
 		const prefix = getUpdateType() === UpdateType.Setup ? 'system-' : 'user-';
+		const baseUrl = createUpdateURL(platform, channel, this.productService);
 
-		const url = createUpdateURL(platform, channel, this.productService) + `/${prefix}releases.json`;
+		// TODO: properly determine if this is a user or system install
+		const url = `${baseUrl}/${prefix}releases.json`;
 
 		return url;
 	}

--- a/src/vs/platform/update/test/electron-main/positronVersions.test.ts
+++ b/src/vs/platform/update/test/electron-main/positronVersions.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/platform/update/test/electron-main/positronVersions.test.ts
+++ b/src/vs/platform/update/test/electron-main/positronVersions.test.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { IUpdate } from '../../common/update.js';
+import * as positronVersion from '../../electron-main/positronVersion.js';
+
+suite('Positron Version', function () {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('UpdateService - compare update with build number to version without build number', () => {
+		const update: IUpdate = { version: '2024.11.0-111' };
+		assert.strictEqual(positronVersion.hasUpdate(update, '2024.11.0'), false, 'same version');
+		assert.strictEqual(positronVersion.hasUpdate(update, '2024.09.0'), true, 'update is newer');
+		assert.strictEqual(positronVersion.hasUpdate(update, '2024.12.0'), false, 'update is older');
+
+		const updateNoBuild: IUpdate = { version: '2024.11.0' };
+		assert.strictEqual(positronVersion.hasUpdate(updateNoBuild, '2024.11.0-111'), false, 'same version');
+		assert.strictEqual(positronVersion.hasUpdate(updateNoBuild, '2024.09.0-111'), true, 'update is newer');
+		assert.strictEqual(positronVersion.hasUpdate(updateNoBuild, '2024.12.0-111'), false, 'update is older');
+	});
+
+	test('UpdateService - compare year version', () => {
+		const update: IUpdate = { version: '2024.12.0-111' };
+		assert.strictEqual(positronVersion.hasUpdate(update, '2024.12.0-111'), false, 'same version');
+		assert.strictEqual(positronVersion.hasUpdate(update, '2023.12.0-111'), true, 'update is newer');
+		assert.strictEqual(positronVersion.hasUpdate(update, '2025.12.0-111'), false, 'update is older');
+	});
+
+	test('UpdateService - compare month version', () => {
+		const update: IUpdate = { version: '2024.05.0-111' };
+		assert.strictEqual(positronVersion.hasUpdate(update, '2024.05.0-111'), false, 'same version');
+		assert.strictEqual(positronVersion.hasUpdate(update, '2024.02.0-111'), true, 'update is newer');
+		assert.strictEqual(positronVersion.hasUpdate(update, '2024.12.0-111'), false, 'update is older');
+	});
+
+	test('UpdateService - compare patch version', () => {
+		const update: IUpdate = { version: '2024.11.10-18' };
+		assert.strictEqual(positronVersion.hasUpdate(update, '2024.11.10-18'), false, 'same version');
+		assert.strictEqual(positronVersion.hasUpdate(update, '2024.11.0-18'), true, 'update is newer');
+		assert.strictEqual(positronVersion.hasUpdate(update, '2024.11.12-18'), false, 'update is older');
+	});
+
+	test('UpdateService - compare build number', () => {
+		const update: IUpdate = { version: '2024.11.1-18' };
+		assert.strictEqual(positronVersion.hasUpdate(update, '2024.11.1-18'), false, 'same version');
+		assert.strictEqual(positronVersion.hasUpdate(update, '2024.11.1-10'), true, 'update is newer');
+		assert.strictEqual(positronVersion.hasUpdate(update, '2024.11.1-20'), false, 'update is older');
+	});
+
+});


### PR DESCRIPTION
Address https://github.com/posit-dev/positron/issues/1837

Checks the releases JSON and determines if there is an update available. This can be manually invoked from the cog menu at the bottom of the left sidebar or Positron will do so once per hour.

The Output view shows debug messages in the Main output. It will show the update URL (points to the platform's release JSON) at startup. Update checks are logged here as well. If the update URL is unavailable, a toast notification displays the error with more details in the Output view.

There didn't seem to be a calendar versioning package that supported build numbers and zero-padding so that's why there's a Positron version utility. It seems important to know that `2024.12.0-1` is older than `2024.12.0-2` if we want to be able to test updating private releases.

There are two environment variables for internal use:

* `POSITRON_UPDATE_CHANNEL` - The default is `prereleases` but can be set to `dailies` or `staging` for releases that haven't been published to Positron's releases page on GitHub. `dailies` isn't auto-publishing at the moment and `staging` has a 1-day expiry.
* `POSITRON_AUTO_UPDATE` - Setting to `1` will automatically download the update and notify the user when it is ready to restart to complete the install. This is for testing and needs a certified build (at least on Mac).

This will check is functional for all platforms with the following caveats:

* Windows needs a bit of cleanup with the install type. It's going to use the `system` release info. I think differentiating the system and user installers via a key/value in `product.json` would work.
* Linux checks the `deb` release info. It could use the same solution as Windows to differentiate the install type. Despite no auto-update support, it might be useful to know.
* All platforms link to Positron's releases page on GitHub.

![image](https://github.com/user-attachments/assets/5bf255ce-2a8d-45a6-b6f7-fb6d80b9b46c)
Manual check when there are no updates available

![image](https://github.com/user-attachments/assets/e5b29c84-257f-423b-ab82-306e6f15f9a7)
Update is available as indicated by the bottom of the left sidebar

The cog menu will change the check update action to download the update. This download action opens Positron's releases page in the user's browser.

### QA Notes
Positron Builds can run the action to push a staging release if we want to run an internal test. This is experimental as the generated release info may be stale (rerunning doesn't automatically update the hosted file) or expired (file is auto-deleted after one day).

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
