### PR TITLE
Readdress 5737 fixing the actual cause

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -150,6 +150,11 @@ export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProp
 	 * @param e A MouseEvent<HTMLDivElement> that describes a user interaction with the mouse.
 	 */
 	const mouseDownHandler = (e: MouseEvent<HTMLButtonElement>) => {
+		// Consume the event. This addresses https://github.com/posit-dev/positron/issues/5737 and
+		// was borrowed from ActionViewItem.
+		e.preventDefault();
+		e.stopPropagation();
+
 		// If the mouse trigger is mouse down, handle the event.
 		if (props.mouseTrigger === MouseTrigger.MouseDown) {
 			sendOnPressed(e);

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -11,7 +11,7 @@ import React, { useRef, PropsWithChildren, useImperativeHandle, forwardRef } fro
 
 // Other dependencies.
 import { usePositronActionBarContext } from '../positronActionBarContext.js';
-import { Button } from '../../../../base/browser/ui/positronComponents/button/button.js';
+import { Button, MouseTrigger } from '../../../../base/browser/ui/positronComponents/button/button.js';
 import { optionalBoolean, optionalValue, positronClassNames } from '../../../../base/common/positronUtilities.js';
 
 /**
@@ -30,6 +30,7 @@ export interface ActionBarButtonProps {
 	readonly ariaLabel?: string;
 	readonly dropdownAriaLabel?: string;
 	readonly dropdownIndicator?: 'disabled' | 'enabled' | 'enabled-split';
+	readonly mouseTrigger?: MouseTrigger;
 	readonly onMouseEnter?: () => void;
 	readonly onMouseLeave?: () => void;
 	readonly onPressed?: () => void;
@@ -120,6 +121,7 @@ export const ActionBarButton = forwardRef<
 				ariaLabel={ariaLabel}
 				tooltip={props.tooltip}
 				disabled={props.disabled}
+				mouseTrigger={props.mouseTrigger}
 				onMouseEnter={props.onMouseEnter}
 				onMouseLeave={props.onMouseLeave}
 				onPressed={props.onPressed}
@@ -141,6 +143,7 @@ export const ActionBarButton = forwardRef<
 					ariaLabel={ariaLabel}
 					tooltip={props.tooltip}
 					disabled={props.disabled}
+					mouseTrigger={props.mouseTrigger}
 					onMouseEnter={props.onMouseEnter}
 					onMouseLeave={props.onMouseLeave}
 					onPressed={props.onPressed}
@@ -153,6 +156,7 @@ export const ActionBarButton = forwardRef<
 					className='action-bar-button-drop-down-button'
 					ariaLabel={props.dropdownAriaLabel}
 					tooltip={props.dropdownTooltip}
+					mouseTrigger={MouseTrigger.MouseDown}
 					onPressed={props.onDropdownPressed}
 				>
 					<div className='action-bar-button-drop-down-arrow codicon codicon-positron-drop-down-arrow' />

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -11,7 +11,7 @@ import React, { useRef, PropsWithChildren, useImperativeHandle, forwardRef } fro
 
 // Other dependencies.
 import { usePositronActionBarContext } from '../positronActionBarContext.js';
-import { Button, MouseTrigger } from '../../../../base/browser/ui/positronComponents/button/button.js';
+import { Button } from '../../../../base/browser/ui/positronComponents/button/button.js';
 import { optionalBoolean, optionalValue, positronClassNames } from '../../../../base/common/positronUtilities.js';
 
 /**
@@ -120,7 +120,6 @@ export const ActionBarButton = forwardRef<
 				ariaLabel={ariaLabel}
 				tooltip={props.tooltip}
 				disabled={props.disabled}
-				mouseTrigger={MouseTrigger.MouseDown}
 				onMouseEnter={props.onMouseEnter}
 				onMouseLeave={props.onMouseLeave}
 				onPressed={props.onPressed}
@@ -142,7 +141,6 @@ export const ActionBarButton = forwardRef<
 					ariaLabel={ariaLabel}
 					tooltip={props.tooltip}
 					disabled={props.disabled}
-					mouseTrigger={MouseTrigger.MouseDown}
 					onMouseEnter={props.onMouseEnter}
 					onMouseLeave={props.onMouseLeave}
 					onPressed={props.onPressed}
@@ -155,7 +153,6 @@ export const ActionBarButton = forwardRef<
 					className='action-bar-button-drop-down-button'
 					ariaLabel={props.dropdownAriaLabel}
 					tooltip={props.dropdownTooltip}
-					mouseTrigger={MouseTrigger.MouseDown}
 					onPressed={props.onDropdownPressed}
 				>
 					<div className='action-bar-button-drop-down-arrow codicon codicon-positron-drop-down-arrow' />

--- a/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
@@ -16,6 +16,7 @@ import { AnchorAlignment, AnchorAxisAlignment } from '../../../../base/browser/u
 import { ActionBarButton } from './actionBarButton.js';
 import { useRegisterWithActionBar } from '../useRegisterWithActionBar.js';
 import { usePositronActionBarContext } from '../positronActionBarContext.js';
+import { MouseTrigger } from '../../../../base/browser/ui/positronComponents/button/button.js';
 
 /**
  * ActionBarMenuButtonProps interface.
@@ -129,6 +130,7 @@ export const ActionBarMenuButton = (props: ActionBarMenuButtonProps) => {
 			ref={buttonRef}
 			{...props}
 			dropdownIndicator={props.dropdownIndicator ?? 'enabled'}
+			mouseTrigger={MouseTrigger.MouseDown}
 			onPressed={async () => {
 				if (props.dropdownIndicator !== 'enabled-split') {
 					await showMenu();

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -554,6 +554,15 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 				target = (e as GestureEvent).initialTarget as HTMLElement;
 			}
 
+			// --- Start Positron ---
+			// Do not focus the editor if the event is for a Positron action bar. This addresses
+			// https://github.com/posit-dev/positron/issues/5737 and was borrowed from the code
+			// below.
+			if (findParentWithClass(target, 'positron-action-bar', this.titleContainer)) {
+				return;
+			}
+			// --- End Positron ---
+
 			if (findParentWithClass(target, 'monaco-action-bar', this.titleContainer) ||
 				findParentWithClass(target, 'monaco-breadcrumb-item', this.titleContainer)
 			) {


### PR DESCRIPTION
### Description

This PR readdresses https://github.com/posit-dev/positron/issues/5737 by fixing the actual cause of the issue. With this PR, mouse down events _do not steal focus_ when they occur inside a Positron action bar. This workaround was borrowed from code in `handleTitleClickOrTouch` that does the same thing for Monaco action bars.

@:editor-action-bar

### QA Notes

None.