### PR TITLE
Data Explorer: Support opening gzipped csv files with DuckDB by decompressing in memory in NodeJS

### DIFF
--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.ts
@@ -17,6 +17,7 @@ import { PositronDataExplorerEditor } from './positronDataExplorerEditor.js';
 import { PositronDataExplorerEditorInput } from './positronDataExplorerEditorInput.js';
 import { registerPositronDataExplorerActions } from './positronDataExplorerActions.js';
 import { extname } from '../../../../base/common/resources.js';
+import { posix } from '../../../../base/common/path.js';
 import { IPositronDataExplorerService } from '../../../services/positronDataExplorer/browser/interfaces/positronDataExplorerService.js';
 import { PositronDataExplorerUri } from '../../../services/positronDataExplorer/common/positronDataExplorerUri.js';
 
@@ -76,7 +77,7 @@ class PositronDataExplorerContribution extends Disposable {
 			}
 		));
 
-		const DUCKDB_SUPPORTED_EXTENSIONS = ['parquet', 'parq', 'csv', 'tsv'];
+		const DUCKDB_SUPPORTED_EXTENSIONS = ['parquet', 'parq', 'csv', 'tsv', 'gz'];
 
 		this._register(editorResolverService.registerEditor(
 			`*.{${DUCKDB_SUPPORTED_EXTENSIONS.join(',')}}`,
@@ -84,7 +85,12 @@ class PositronDataExplorerContribution extends Disposable {
 			{
 				singlePerResource: true,
 				canSupportResource: resource => {
-					return DUCKDB_SUPPORTED_EXTENSIONS.includes(extname(resource).substring(1));
+					let fileExt = extname(resource).substring(1);
+					if (fileExt === 'gz') {
+						// Strip the .gz and get the actual extension
+						fileExt = posix.extname(resource.path.slice(0, -3)).substring(1);
+					}
+					return DUCKDB_SUPPORTED_EXTENSIONS.includes(fileExt);
 				}
 			},
 			{


### PR DESCRIPTION
Addresses #5332. This works around duckdb-wasm's limitation that it cannot read directly from gzipped CSV/TSV files by unzipping in memory and registering as a virtual file. This is okay for small files but for very large gzipped files will feel a bit slow and use a bunch of memory (we will have to tackle that problem via #5889).

### Release Notes

#### New Features

- Support opening gzipped CSV/TSV files in the data explorer with .gz extension from the file explorer pane (#5332). 

#### Bug Fixes

- N/A

e2e: @:data-explorer