### PR TITLE
Add strip def to rpm spec template

### DIFF
--- a/resources/linux/rpm/positron.spec.template
+++ b/resources/linux/rpm/positron.spec.template
@@ -19,6 +19,7 @@ Positron is an extensible, polyglot tool for writing code and exploring data in 
 # Don't generate build_id links to prevent conflicts when installing multiple
 # versions of VS Code alongside each other (e.g. `code` and `code-insiders`)
 %define _build_id_links none
+%define __strip @@STRIP@@
 
 %install
 # Destination directories


### PR DESCRIPTION
This change makes it possible to use a custom strip binary for Positron RPM builds. The upstream copy of the template already has this line (so this is just updating ours to match it).

https://github.com/posit-dev/positron/blob/be85387931ff23fc51a080a28998adeea64f59be/resources/linux/rpm/code.spec.template#L19-L22

This change is in service of the larger effort to make arm64 builds of Positron possible.