### PR TITLE
Remove hard jupyter adapter dependency from Reticulate

### DIFF
--- a/extensions/positron-reticulate/package.json
+++ b/extensions/positron-reticulate/package.json
@@ -36,8 +36,7 @@
   },
   "extensionDependencies": [
     "ms-python.python",
-    "positron.positron-r",
-    "positron.jupyter-adapter"
+    "positron.positron-r"
   ],
   "devDependencies": {
     "@types/glob": "^7.2.0",


### PR DESCRIPTION
Removes the hard dependency on Jupyter Adapter from Reticulate. It _is_ still possible to use Jupyter Adapter with Reticulate; this just prevents the Reticulate extension from failing to load if Jupyter Adapter does.

Addresses #5917. 

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Basic test to make sure that Reticulate still boots is sufficient to validate.