### PR TITLE
Format with ruff 0.9.0

### DIFF
--- a/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/connections.py
@@ -530,7 +530,7 @@ class SQLite3Connection(Connection):
         self.host = self._find_path(conn)
         self.type = "SQLite"
         self.code = (
-            "import sqlite3\n" f'conn = sqlite3.connect("{self.host}")\n' "%connection_show conn\n"
+            f'import sqlite3\nconn = sqlite3.connect("{self.host}")\n%connection_show conn\n'
         )
 
     def _find_path(self, conn: sqlite3.Connection):

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/pydoc.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/pydoc.py
@@ -756,7 +756,7 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
         # Add the module's __version__ to the heading
         if len(version) > 0:
             pkg_version = self.escape(version)
-            text = f'<div class="package-version">{"v"+pkg_version}</div>'
+            text = f'<div class="package-version">{"v" + pkg_version}</div>'
             return text
         else:
             return ""

--- a/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/positron/positron_ipykernel/tests/test_inspectors.py
@@ -88,9 +88,9 @@ def verify_inspector(
                 assert inspector.equals(copied)
 
                 # Mutate the copied object, and check that the original object was not mutated.
-                assert (
-                    mutate is not None
-                ), "mutate function must be provided to test mutable objects"
+                assert mutate is not None, (
+                    "mutate function must be provided to test mutable objects"
+                )
                 mutate(copied)
                 assert not inspector.equals(copied)
             else:

--- a/extensions/positron-python/python_files/tests/unittestadapter/test_discovery.py
+++ b/extensions/positron-python/python_files/tests/unittestadapter/test_discovery.py
@@ -314,9 +314,9 @@ def test_simple_django_collect():
     if actual_list is not None:
         actual_item = actual_list.pop(0)
         assert all(item in actual_item for item in ("status", "cwd"))
-        assert (
-            actual_item.get("status") == "success"
-        ), f"Status is not 'success', error is: {actual_item.get('error')}"
+        assert actual_item.get("status") == "success", (
+            f"Status is not 'success', error is: {actual_item.get('error')}"
+        )
         assert actual_item.get("cwd") == os.fspath(data_path)
         assert len(actual_item["tests"]["children"]) == 1
         assert actual_item["tests"]["children"][0]["children"][0]["id_"] == os.fsdecode(


### PR DESCRIPTION
CI is failing due to a new ruff version ([example](https://github.com/posit-dev/positron/actions/runs/12693090155/job/35379904139)). The changes seem good though.