### PR TITLE
e2e-test: editor-action-bar split-editor flake

### DIFF
--- a/test/e2e/tests/action-bar/editor-action-bar.test.ts
+++ b/test/e2e/tests/action-bar/editor-action-bar.test.ts
@@ -96,10 +96,14 @@ async function verifySplitEditor(page, tabName: string) {
 		await page.getByRole('tab', { name: tabName }).getByLabel('Close').first().click();
 
 		// Split editor down
-		await page.keyboard.down('Alt');
-		await page.getByLabel('Split Editor Down').nth(1).click();
-		await page.keyboard.up('Alt');
-		await expect(page.getByRole('tab', { name: tabName })).toHaveCount(2);
+		// Sometimes in CI the click doesn't register, wrapping these actions to reduce flake
+		await expect(async () => {
+			await page.keyboard.down('Alt');
+			await page.getByLabel('Split Editor Down').nth(1).click();
+			await page.keyboard.up('Alt');
+			await expect(page.getByRole('tab', { name: tabName })).toHaveCount(2);
+		}).toPass({ timeout: 10000 });
+
 	});
 }
 

--- a/test/e2e/tests/action-bar/editor-action-bar.test.ts
+++ b/test/e2e/tests/action-bar/editor-action-bar.test.ts
@@ -86,8 +86,11 @@ async function openNotebook(app: Application, filePath: string) {
 async function verifySplitEditor(page, tabName: string) {
 	await test.step(`verify "split editor" opens another tab`, async () => {
 		// Split editor right
-		await page.getByLabel('Split Editor Right', { exact: true }).click();
-		await expect(page.getByRole('tab', { name: tabName })).toHaveCount(2);
+		// Sometimes in CI the click doesn't register, wrapping these actions to reduce flake
+		await expect(async () => {
+			await page.getByLabel('Split Editor Right', { exact: true }).click();
+			await expect(page.getByRole('tab', { name: tabName })).toHaveCount(2);
+		}).toPass({ timeout: 10000 });
 
 		// Close one tab
 		await page.getByRole('tab', { name: tabName }).getByLabel('Close').first().click();


### PR DESCRIPTION
### Summary
Made a small adjustment to retry clicking the ‘Split Editor’ button, as I noticed occasional test flakiness in this step.

### QA Notes
@:editor-action-bar
