### PR TITLE
comment out Positron Web configs from launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -341,33 +341,36 @@
 				"order": 3
 			}
 		},
-		{
-			"type": "chrome",
-			"request": "launch",
-			"outFiles": [],
-			"perScriptSourcemaps": "yes",
-			"name": "Positron Web (Chrome)",
-			"url": "http://localhost:8080",
-			"preLaunchTask": "Run code web",
-			"presentation": {
-				"group": "0_vscode",
-				"order": 3
-			}
-		},
-		{
-			"type": "msedge",
-			"request": "launch",
-			"outFiles": [],
-			"perScriptSourcemaps": "yes",
-			"name": "Positron Web (Edge)",
-			"url": "http://localhost:8080",
-			"pauseForSourceMap": false,
-			"preLaunchTask": "Run code web",
-			"presentation": {
-				"group": "0_vscode",
-				"order": 3
-			}
-		},
+		// --- Start Positron ---
+		// Remove `Positron Web` confiigurations since we don't use them.
+		// {
+		// 	"type": "chrome",
+		// 	"request": "launch",
+		// 	"outFiles": [],
+		// 	"perScriptSourcemaps": "yes",
+		// 	"name": "Positron Web (Chrome)",
+		// 	"url": "http://localhost:8080",
+		// 	"preLaunchTask": "Run code web",
+		// 	"presentation": {
+		// 		"group": "0_vscode",
+		// 		"order": 3
+		// 	}
+		// },
+		// {
+		// 	"type": "msedge",
+		// 	"request": "launch",
+		// 	"outFiles": [],
+		// 	"perScriptSourcemaps": "yes",
+		// 	"name": "Positron Web (Edge)",
+		// 	"url": "http://localhost:8080",
+		// 	"pauseForSourceMap": false,
+		// 	"preLaunchTask": "Run code web",
+		// 	"presentation": {
+		// 		"group": "0_vscode",
+		// 		"order": 3
+		// 	}
+		// },
+		// --- End Positron ---
 		{
 			"type": "node",
 			"request": "launch",


### PR DESCRIPTION
### Summary

Commented out the launch.json configs for Positron Web (Chrome) and Positron Web (Edge), which we don't use as much as the Positron Server (Web, [BROWSER]) configs. The Positron Web configurations can be confused with the Positron Server Web configurations, so removing them alleviates moments of 🤨🤔🧐🤷.

Commenting these configurations out removes them from the RUN AND DEBUG configurations dropdown. I commented them out instead of removing them altogether, just in case a dev wants to uncomment and run the Web configurations for some reason.

#### Before

<img width="406" alt="image" src="https://github.com/user-attachments/assets/637464b2-460e-4009-9948-a8891d82b1d5" />

#### After

<img width="406" alt="image" src="https://github.com/user-attachments/assets/13dbd251-7f3f-457f-8d3c-3b70dfa01602" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

Positron Web (Chrome) and Positron Web (Edge) should no longer show in the RUN AND DEBUG configurations dropdown.