### PR TITLE
Add windows and browser job to PR workflow

### DIFF
--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -69,6 +69,10 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Transform to Playwright tags $PW_TAGS
+        run: bash scripts/pr-tags-transform.sh "e2e-windows" "${{ inputs.grep }}"
+        shell: bash
+
       - name: Install System Level Python
         uses: actions/setup-python@v5
         with:
@@ -136,10 +140,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
-
-      - name: Transform to Playwright tags $PW_TAGS
-        run: bash scripts/pr-tags-transform.sh "e2e-windows" "${{ inputs.grep }}"
-        shell: bash
 
       - name: Send Results to GH Summary
         uses: ./.github/actions/gen-report-dir

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -146,6 +146,7 @@ jobs:
         if: ${{ !cancelled() }}
 
       - name: Run Tests on Windows (Electron)
+        shell: bash
         env:
           POSITRON_PY_VER_SEL: 3.10.10
           POSITRON_R_VER_SEL: 4.4.0

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tags: ${{ steps.pr-tags.outputs.tags }}
+      win_tag_found: ${{ steps.pr-tags.outputs.win_tag_found }}
     steps:
       - uses: actions/checkout@v4
 
@@ -39,6 +40,7 @@ jobs:
     secrets: inherit
 
   e2e-windows-electron:
+    if: ${{ needs.pr-tags.outputs.win_tag_found == 'true' }}
     name: e2e
     uses: ./.github/workflows/test-e2e-windows.yml
     needs: pr-tags
@@ -58,6 +60,3 @@ jobs:
     name: test
     uses: ./.github/workflows/test-integration.yml
     secrets: inherit
-
-
-

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -61,6 +61,7 @@ jobs:
     with:
       grep: ${{ needs.pr-tags.outputs.tags }}
       display_name: "browser (linux)"
+      project: "e2e-browser"
       currents_tags: "pull-request,browser/linux,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
     secrets: inherit

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -17,6 +17,8 @@ jobs:
     outputs:
       tags: ${{ steps.pr-tags.outputs.tags }}
       win_tag_found: ${{ steps.pr-tags.outputs.win_tag_found }}
+      web_tag_found: ${{ steps.pr-tags.outputs.web_tag_found }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -42,6 +44,18 @@ jobs:
   e2e-windows-electron:
     needs: pr-tags
     if: ${{ needs.pr-tags.outputs.win_tag_found == 'true' }}
+    name: e2e
+    uses: ./.github/workflows/test-e2e-windows.yml
+    with:
+      grep: ${{ needs.pr-tags.outputs.tags }}
+      display_name: "electron (windows)"
+      currents_tags: "pull-request,electron/windows,${{ needs.pr-tags.outputs.tags }}"
+      report_testrail: false
+    secrets: inherit
+
+  e2e-linux-web:
+    needs: pr-tags
+    if: ${{ needs.pr-tags.outputs.web_tag_found == 'true' }}
     name: e2e
     uses: ./.github/workflows/test-e2e-windows.yml
     with:

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -40,10 +40,10 @@ jobs:
     secrets: inherit
 
   e2e-windows-electron:
+    needs: pr-tags
     if: ${{ needs.pr-tags.outputs.win_tag_found == 'true' }}
     name: e2e
     uses: ./.github/workflows/test-e2e-windows.yml
-    needs: pr-tags
     with:
       grep: ${{ needs.pr-tags.outputs.tags }}
       display_name: "electron (windows)"

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -53,15 +53,15 @@ jobs:
       report_testrail: false
     secrets: inherit
 
-  e2e-linux-web:
+  e2e-linux-browser:
     needs: pr-tags
     if: ${{ needs.pr-tags.outputs.web_tag_found == 'true' }}
     name: e2e
-    uses: ./.github/workflows/test-e2e-windows.yml
+    uses: ./.github/workflows/test-e2e-linux.yml
     with:
       grep: ${{ needs.pr-tags.outputs.tags }}
-      display_name: "electron (windows)"
-      currents_tags: "pull-request,electron/windows,${{ needs.pr-tags.outputs.tags }}"
+      display_name: "browser (linux)"
+      currents_tags: "pull-request,browser/linux,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
     secrets: inherit
 

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -27,7 +27,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
-  e2e-electron:
+  e2e-linux-electron:
     name: e2e
     uses: ./.github/workflows/test-e2e-linux.yml
     needs: pr-tags
@@ -35,6 +35,17 @@ jobs:
       grep: ${{ needs.pr-tags.outputs.tags }}
       display_name: "electron (linux)"
       currents_tags: "pull-request,electron/linux,${{ needs.pr-tags.outputs.tags }}"
+      report_testrail: false
+    secrets: inherit
+
+  e2e-windows-electron:
+    name: e2e
+    uses: ./.github/workflows/test-e2e-windows.yml
+    needs: pr-tags
+    with:
+      grep: ${{ needs.pr-tags.outputs.tags }}
+      display_name: "electron (windows)"
+      currents_tags: "pull-request,electron/windows,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
     secrets: inherit
 

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -163,7 +163,7 @@
         "filename": ".github\\workflows\\test-pull-request.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 40,
+        "line_number": 42,
         "is_secret": false
       }
     ],
@@ -1918,5 +1918,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-10T21:36:45Z"
+  "generated_at": "2025-01-10T22:58:49Z"
 }

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -137,230 +137,230 @@
     }
   ],
   "results": {
-    ".github/workflows/test-full-suite.yml": [
+    ".github\\workflows\\test-full-suite.yml": [
       {
         "type": "Secret Keyword",
-        "filename": ".github/workflows/test-full-suite.yml",
+        "filename": ".github\\workflows\\test-full-suite.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
         "line_number": 53,
         "is_secret": false
       }
     ],
-    ".github/workflows/test-merge.yml": [
+    ".github\\workflows\\test-merge.yml": [
       {
         "type": "Secret Keyword",
-        "filename": ".github/workflows/test-merge.yml",
+        "filename": ".github\\workflows\\test-merge.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
         "line_number": 18,
         "is_secret": false
       }
     ],
-    ".github/workflows/test-pull-request.yml": [
+    ".github\\workflows\\test-pull-request.yml": [
       {
         "type": "Secret Keyword",
-        "filename": ".github/workflows/test-pull-request.yml",
+        "filename": ".github\\workflows\\test-pull-request.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 40,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/alpine/product-build-alpine.yml": [
+    "build\\azure-pipelines\\alpine\\product-build-alpine.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/alpine/product-build-alpine.yml",
+        "filename": "build\\azure-pipelines\\alpine\\product-build-alpine.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
         "line_number": 23,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/cli/cli-darwin-sign.yml": [
+    "build\\azure-pipelines\\cli\\cli-darwin-sign.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/cli/cli-darwin-sign.yml",
+        "filename": "build\\azure-pipelines\\cli\\cli-darwin-sign.yml",
         "hashed_secret": "70519fad4f6f57675a71ca41a152d4acb087bd21",
         "is_verified": false,
         "line_number": 12,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/cli/cli-win32-sign.yml": [
+    "build\\azure-pipelines\\cli\\cli-win32-sign.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/cli/cli-win32-sign.yml",
+        "filename": "build\\azure-pipelines\\cli\\cli-win32-sign.yml",
         "hashed_secret": "70519fad4f6f57675a71ca41a152d4acb087bd21",
         "is_verified": false,
         "line_number": 12,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/darwin/product-build-darwin-sign.yml": [
+    "build\\azure-pipelines\\darwin\\product-build-darwin-sign.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/darwin/product-build-darwin-sign.yml",
+        "filename": "build\\azure-pipelines\\darwin\\product-build-darwin-sign.yml",
         "hashed_secret": "70519fad4f6f57675a71ca41a152d4acb087bd21",
         "is_verified": false,
         "line_number": 21,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/darwin/product-build-darwin-universal.yml": [
+    "build\\azure-pipelines\\darwin\\product-build-darwin-universal.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/darwin/product-build-darwin-universal.yml",
+        "filename": "build\\azure-pipelines\\darwin\\product-build-darwin-universal.yml",
         "hashed_secret": "d8368fc8fec27a14a70083cc2cd6d959085086a9",
         "is_verified": false,
         "line_number": 15,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/darwin/product-build-darwin.yml": [
+    "build\\azure-pipelines\\darwin\\product-build-darwin.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/darwin/product-build-darwin.yml",
+        "filename": "build\\azure-pipelines\\darwin\\product-build-darwin.yml",
         "hashed_secret": "d8368fc8fec27a14a70083cc2cd6d959085086a9",
         "is_verified": false,
         "line_number": 33,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/distro/download-distro.yml": [
+    "build\\azure-pipelines\\distro\\download-distro.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/distro/download-distro.yml",
+        "filename": "build\\azure-pipelines\\distro\\download-distro.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
         "line_number": 7,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/linux/product-build-linux-legacy-server.yml": [
+    "build\\azure-pipelines\\linux\\product-build-linux-legacy-server.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/linux/product-build-linux-legacy-server.yml",
+        "filename": "build\\azure-pipelines\\linux\\product-build-linux-legacy-server.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
         "line_number": 23,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/linux/product-build-linux.yml": [
+    "build\\azure-pipelines\\linux\\product-build-linux.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/linux/product-build-linux.yml",
+        "filename": "build\\azure-pipelines\\linux\\product-build-linux.yml",
         "hashed_secret": "256e334e9cc8b59bb08501110e1c729c9b2edec4",
         "is_verified": false,
         "line_number": 35,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/product-compile.yml": [
+    "build\\azure-pipelines\\product-compile.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/product-compile.yml",
+        "filename": "build\\azure-pipelines\\product-compile.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
         "line_number": 20,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/product-publish.yml": [
+    "build\\azure-pipelines\\product-publish.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/product-publish.yml",
+        "filename": "build\\azure-pipelines\\product-publish.yml",
         "hashed_secret": "76f5d6eed49e94461f8e5f88ad74dc253578d3ac",
         "is_verified": false,
         "line_number": 16,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/web/product-build-web.yml": [
+    "build\\azure-pipelines\\web\\product-build-web.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/web/product-build-web.yml",
+        "filename": "build\\azure-pipelines\\web\\product-build-web.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
         "line_number": 15,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/win32/product-build-win32.yml": [
+    "build\\azure-pipelines\\win32\\product-build-win32.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/win32/product-build-win32.yml",
+        "filename": "build\\azure-pipelines\\win32\\product-build-win32.yml",
         "hashed_secret": "256e334e9cc8b59bb08501110e1c729c9b2edec4",
         "is_verified": false,
         "line_number": 40,
         "is_secret": false
       }
     ],
-    "build/azure-pipelines/win32/sdl-scan-win32.yml": [
+    "build\\azure-pipelines\\win32\\sdl-scan-win32.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "build/azure-pipelines/win32/sdl-scan-win32.yml",
+        "filename": "build\\azure-pipelines\\win32\\sdl-scan-win32.yml",
         "hashed_secret": "6bca595fb7e6690f8bacc9e0c1e056cd60e4b7cb",
         "is_verified": false,
         "line_number": 26,
         "is_secret": false
       }
     ],
-    "build/lib/stylelint/vscode-known-variables.json": [
+    "build\\lib\\stylelint\\vscode-known-variables.json": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "build/lib/stylelint/vscode-known-variables.json",
+        "filename": "build\\lib\\stylelint\\vscode-known-variables.json",
         "hashed_secret": "bebac042cf8ae1cf5954a7f233759a1373a1bd5b",
         "is_verified": false,
         "line_number": 737,
         "is_secret": false
       }
     ],
-    "build/secrets/README.md": [
+    "build\\secrets\\README.md": [
       {
         "type": "Secret Keyword",
-        "filename": "build/secrets/README.md",
+        "filename": "build\\secrets\\README.md",
         "hashed_secret": "7585d1f7ceb90fd0b1ab42d0a6ca39fcf55065c7",
         "is_verified": false,
         "line_number": 25,
         "is_secret": false
       }
     ],
-    "cli/Cargo.toml": [
+    "cli\\Cargo.toml": [
       {
         "type": "Hex High Entropy String",
-        "filename": "cli/Cargo.toml",
+        "filename": "cli\\Cargo.toml",
         "hashed_secret": "c9f4c5531397166586187c7c9fac98fc1f5624e6",
         "is_verified": false,
         "line_number": 37,
         "is_secret": false
       }
     ],
-    "cli/src/auth.rs": [
+    "cli\\src\\auth.rs": [
       {
         "type": "Hex High Entropy String",
-        "filename": "cli/src/auth.rs",
+        "filename": "cli\\src\\auth.rs",
         "hashed_secret": "b1ca527b736010b3f3125ce314832b9d92311cb2",
         "is_verified": false,
         "line_number": 72,
         "is_secret": false
       }
     ],
-    "cli/src/desktop/version_manager.rs": [
+    "cli\\src\\desktop\\version_manager.rs": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "cli/src/desktop/version_manager.rs",
+        "filename": "cli\\src\\desktop\\version_manager.rs",
         "hashed_secret": "4f29d0426d3ecc42e70ac2127ee3d7fd9d23f5c7",
         "is_verified": false,
         "line_number": 329,
         "is_secret": false
       }
     ],
-    "cli/src/tunnels/socket_signal.rs": [
+    "cli\\src\\tunnels\\socket_signal.rs": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "cli/src/tunnels/socket_signal.rs",
+        "filename": "cli\\src\\tunnels\\socket_signal.rs",
         "hashed_secret": "9d594c96ec4c8eb6d9ec54efd05ceca6052a8259",
         "is_verified": false,
         "line_number": 353,
@@ -368,7 +368,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "cli/src/tunnels/socket_signal.rs",
+        "filename": "cli\\src\\tunnels\\socket_signal.rs",
         "hashed_secret": "ede64ff4b2c5d298f40c0639b8dffeb241596cca",
         "is_verified": false,
         "line_number": 354,
@@ -376,27 +376,27 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "cli/src/tunnels/socket_signal.rs",
+        "filename": "cli\\src\\tunnels\\socket_signal.rs",
         "hashed_secret": "8758646166da378eb67718f0780b967bd1b0d5d2",
         "is_verified": false,
         "line_number": 355,
         "is_secret": false
       }
     ],
-    "extensions/cpp/syntaxes/platform.tmLanguage.json": [
+    "extensions\\cpp\\syntaxes\\platform.tmLanguage.json": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "extensions/cpp/syntaxes/platform.tmLanguage.json",
+        "filename": "extensions\\cpp\\syntaxes\\platform.tmLanguage.json",
         "hashed_secret": "f4f4522002ae0895566ebbc726b9ebc6064b5003",
         "is_verified": false,
         "line_number": 213,
         "is_secret": false
       }
     ],
-    "extensions/git/src/test/git.test.ts": [
+    "extensions\\git\\src\\test\\git.test.ts": [
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "3100a15f2a0660239142c51a09a9860091a57eb6",
         "is_verified": false,
         "line_number": 284,
@@ -404,7 +404,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "b3820b8646425e7ce86d52a14f0545675f5a0fb8",
         "is_verified": false,
         "line_number": 286,
@@ -412,7 +412,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "1bba808164c2bd2606270fd338b1bcfcbfb9972c",
         "is_verified": false,
         "line_number": 310,
@@ -420,7 +420,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "0026ab5726869f2f8d8d2b1e8c4ab07e66f75a98",
         "is_verified": false,
         "line_number": 463,
@@ -428,7 +428,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "15b70898ca2a438c30384441f139b460590fbe8a",
         "is_verified": false,
         "line_number": 465,
@@ -436,7 +436,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "4f4330cffae54a0d08fb33b66c533b2ee961accb",
         "is_verified": false,
         "line_number": 546,
@@ -444,7 +444,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "a3da0860baf4244389064b16f6788dafcf030d1f",
         "is_verified": false,
         "line_number": 547,
@@ -452,7 +452,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "30140192774a074079e5307bf65630ac4308a503",
         "is_verified": false,
         "line_number": 548,
@@ -460,7 +460,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "f339565b20b0740f51b54166570867fbcf37da8b",
         "is_verified": false,
         "line_number": 549,
@@ -468,7 +468,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "26bbee0ec44b5cb456171b8032b8494002b536d1",
         "is_verified": false,
         "line_number": 550,
@@ -476,7 +476,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "8cc5973678f7bed6507ba5440f0f7c132626affe",
         "is_verified": false,
         "line_number": 551,
@@ -484,7 +484,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "eafa4b025ed67291f5076bb171668e801c36b20e",
         "is_verified": false,
         "line_number": 552,
@@ -492,7 +492,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "2a0c0db2b79ee31c56309a893c2360be13f79f28",
         "is_verified": false,
         "line_number": 553,
@@ -500,7 +500,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "832e7e6717a35ffb092345019499f9c9c1db2eef",
         "is_verified": false,
         "line_number": 555,
@@ -508,7 +508,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "9b93e1d1a6c8e61ec6243d19841b85e081edc956",
         "is_verified": false,
         "line_number": 556,
@@ -516,67 +516,67 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/git/src/test/git.test.ts",
+        "filename": "extensions\\git\\src\\test\\git.test.ts",
         "hashed_secret": "1d744d5f622cf01c4cb6d97dae876e634dc9b065",
         "is_verified": false,
         "line_number": 578,
         "is_secret": false
       }
     ],
-    "extensions/github-authentication/src/config.ts": [
+    "extensions\\github-authentication\\src\\config.ts": [
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/github-authentication/src/config.ts",
+        "filename": "extensions\\github-authentication\\src\\config.ts",
         "hashed_secret": "b1ca527b736010b3f3125ce314832b9d92311cb2",
         "is_verified": false,
         "line_number": 16,
         "is_secret": false
       }
     ],
-    "extensions/github-authentication/src/test/flows.test.ts": [
+    "extensions\\github-authentication\\src\\test\\flows.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "extensions/github-authentication/src/test/flows.test.ts",
+        "filename": "extensions\\github-authentication\\src\\test\\flows.test.ts",
         "hashed_secret": "3da541559918a808c2402bba5012f6c60b27661c",
         "is_verified": false,
         "line_number": 21,
         "is_secret": false
       }
     ],
-    "extensions/ipynb/src/notebookImagePaste.ts": [
+    "extensions\\ipynb\\src\\notebookImagePaste.ts": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "extensions/ipynb/src/notebookImagePaste.ts",
+        "filename": "extensions\\ipynb\\src\\notebookImagePaste.ts",
         "hashed_secret": "e582429052cdb908833560f6f7582d232de37c4d",
         "is_verified": false,
         "line_number": 213,
         "is_secret": false
       }
     ],
-    "extensions/npm/src/features/bowerJSONContribution.ts": [
+    "extensions\\npm\\src\\features\\bowerJSONContribution.ts": [
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/npm/src/features/bowerJSONContribution.ts",
+        "filename": "extensions\\npm\\src\\features\\bowerJSONContribution.ts",
         "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
         "is_verified": false,
         "line_number": 16,
         "is_secret": false
       }
     ],
-    "extensions/positron-python/python_files/Notebooks intro.ipynb": [
+    "extensions\\positron-python\\python_files\\Notebooks intro.ipynb": [
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/positron-python/python_files/Notebooks intro.ipynb",
+        "filename": "extensions\\positron-python\\python_files\\Notebooks intro.ipynb",
         "hashed_secret": "c2e045c525442c9c56408ece0a534e0d48b30edd",
         "is_verified": false,
         "line_number": 142,
         "is_secret": false
       }
     ],
-    "extensions/vscode-api-tests/testWorkspace/test.ipynb": [
+    "extensions\\vscode-api-tests\\testWorkspace\\test.ipynb": [
       {
         "type": "Hex High Entropy String",
-        "filename": "extensions/vscode-api-tests/testWorkspace/test.ipynb",
+        "filename": "extensions\\vscode-api-tests\\testWorkspace\\test.ipynb",
         "hashed_secret": "536dce5e06e6a83a5ba6163a3859935316485e8e",
         "is_verified": false,
         "line_number": 32,
@@ -627,76 +627,60 @@
         "is_secret": false
       }
     ],
-    "scripts/playground-server.ts": [
+    "scripts\\playground-server.ts": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "scripts/playground-server.ts",
+        "filename": "scripts\\playground-server.ts",
         "hashed_secret": "1d278d3c888d1a2fa7eed622bfc02927ce4049af",
         "is_verified": false,
         "line_number": 821,
         "is_secret": false
       }
     ],
-    "src/bootstrap-window.ts": [
+    "src\\bootstrap-window.ts": [
       {
         "type": "Hex High Entropy String",
-        "filename": "src/bootstrap-window.ts",
+        "filename": "src\\bootstrap-window.ts",
         "hashed_secret": "b6cb3f02e20180320687f4905a9c795d72e0ad3a",
         "is_verified": false,
         "line_number": 222,
         "is_secret": false
       }
     ],
-    "src/vs/base/common/buffer.ts": [
+    "src\\vs\\base\\common\\buffer.ts": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/base/common/buffer.ts",
+        "filename": "src\\vs\\base\\common\\buffer.ts",
         "hashed_secret": "e582429052cdb908833560f6f7582d232de37c4d",
         "is_verified": false,
         "line_number": 405,
         "is_secret": false
       }
     ],
-    "src/vs/base/common/extpath.ts": [
+    "src\\vs\\base\\common\\extpath.ts": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/base/common/extpath.ts",
+        "filename": "src\\vs\\base\\common\\extpath.ts",
         "hashed_secret": "3ce1fc6461a712abb4ae6a9eafd66264cc3b3b18",
         "is_verified": false,
         "line_number": 389,
         "is_secret": false
       }
     ],
-    "src/vs/base/test/browser/hash.test.ts": [
+    "src\\vs\\base\\test\\common\\filters.perf.data.js": [
       {
-        "type": "Hex High Entropy String",
-        "filename": "src/vs/base/test/browser/hash.test.ts",
-        "hashed_secret": "66b60e6a2bcec249f7467e10476123722475d77f",
+        "type": "Base64 High Entropy String",
+        "filename": "src\\vs\\base\\test\\common\\filters.perf.data.js",
+        "hashed_secret": "548078cdc06251a11960d9f2e85846ebe4ab12c5",
         "is_verified": false,
-        "line_number": 90,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/vs/base/test/browser/hash.test.ts",
-        "hashed_secret": "80b90c522083cd51a34e3f10ded8ff5f8a9897ad",
-        "is_verified": false,
-        "line_number": 98,
-        "is_secret": false
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/vs/base/test/browser/hash.test.ts",
-        "hashed_secret": "9cf5caf6c36f5cccde8c73fad8894c958f4983da",
-        "is_verified": false,
-        "line_number": 102,
+        "line_number": 6,
         "is_secret": false
       }
     ],
-    "src/vs/base/test/common/uri.test.ts": [
+    "src\\vs\\base\\test\\common\\uri.test.ts": [
       {
         "type": "Basic Auth Credentials",
-        "filename": "src/vs/base/test/common/uri.test.ts",
+        "filename": "src\\vs\\base\\test\\common\\uri.test.ts",
         "hashed_secret": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
         "is_verified": false,
         "line_number": 346,
@@ -704,7 +688,7 @@
       },
       {
         "type": "Basic Auth Credentials",
-        "filename": "src/vs/base/test/common/uri.test.ts",
+        "filename": "src\\vs\\base\\test\\common\\uri.test.ts",
         "hashed_secret": "114838b44bb42c2832324bac6d42b6b693e15f60",
         "is_verified": false,
         "line_number": 352,
@@ -712,27 +696,27 @@
       },
       {
         "type": "Basic Auth Credentials",
-        "filename": "src/vs/base/test/common/uri.test.ts",
+        "filename": "src\\vs\\base\\test\\common\\uri.test.ts",
         "hashed_secret": "dde57062d0392ed551b4f21bb937d6f7f199a594",
         "is_verified": false,
         "line_number": 358,
         "is_secret": false
       }
     ],
-    "src/vs/base/test/node/crypto.test.ts": [
+    "src\\vs\\base\\test\\node\\crypto.test.ts": [
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/base/test/node/crypto.test.ts",
+        "filename": "src\\vs\\base\\test\\node\\crypto.test.ts",
         "hashed_secret": "9010fe091ace30090c9db33165cf7e7ee08c0cfb",
         "is_verified": false,
         "line_number": 34,
         "is_secret": false
       }
     ],
-    "src/vs/editor/browser/viewParts/minimap/minimapPreBaked.ts": [
+    "src\\vs\\editor\\browser\\viewParts\\minimap\\minimapPreBaked.ts": [
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/editor/browser/viewParts/minimap/minimapPreBaked.ts",
+        "filename": "src\\vs\\editor\\browser\\viewParts\\minimap\\minimapPreBaked.ts",
         "hashed_secret": "be2768cb6754de2aa14a7eb7fb67e5db0abd8890",
         "is_verified": false,
         "line_number": 55,
@@ -740,27 +724,27 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/editor/browser/viewParts/minimap/minimapPreBaked.ts",
+        "filename": "src\\vs\\editor\\browser\\viewParts\\minimap\\minimapPreBaked.ts",
         "hashed_secret": "7a15525cc2aa0af7747d53b65242a277dc582026",
         "is_verified": false,
         "line_number": 60,
         "is_secret": false
       }
     ],
-    "src/vs/editor/contrib/suggest/test/browser/suggestController.test.ts": [
+    "src\\vs\\editor\\contrib\\suggest\\test\\browser\\suggestController.test.ts": [
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/editor/contrib/suggest/test/browser/suggestController.test.ts",
+        "filename": "src\\vs\\editor\\contrib\\suggest\\test\\browser\\suggestController.test.ts",
         "hashed_secret": "e4e7bced229a170690fb933633e903876e75ee07",
         "is_verified": false,
         "line_number": 651,
         "is_secret": false
       }
     ],
-    "src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts": [
+    "src\\vs\\editor\\test\\common\\model\\pieceTreeTextBuffer\\pieceTreeTextBuffer.test.ts": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts",
+        "filename": "src\\vs\\editor\\test\\common\\model\\pieceTreeTextBuffer\\pieceTreeTextBuffer.test.ts",
         "hashed_secret": "2fbed46209c70d10fc62ec9c23e4a5b4969c4838",
         "is_verified": false,
         "line_number": 19,
@@ -768,7 +752,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts",
+        "filename": "src\\vs\\editor\\test\\common\\model\\pieceTreeTextBuffer\\pieceTreeTextBuffer.test.ts",
         "hashed_secret": "4f8be53e6119f97cd67d38d5ce03aba6dae2316d",
         "is_verified": false,
         "line_number": 1827,
@@ -776,27 +760,27 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts",
+        "filename": "src\\vs\\editor\\test\\common\\model\\pieceTreeTextBuffer\\pieceTreeTextBuffer.test.ts",
         "hashed_secret": "d84852bb1ee5e4a94dc72a90db9de265b7f18138",
         "is_verified": false,
         "line_number": 1832,
         "is_secret": false
       }
     ],
-    "src/vs/platform/backup/test/electron-main/backupMainService.test.ts": [
+    "src\\vs\\platform\\backup\\test\\electron-main\\backupMainService.test.ts": [
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/platform/backup/test/electron-main/backupMainService.test.ts",
+        "filename": "src\\vs\\platform\\backup\\test\\electron-main\\backupMainService.test.ts",
         "hashed_secret": "df85aee71ccafa1974bb0fab73f86de85f89eb52",
         "is_verified": false,
         "line_number": 595,
         "is_secret": false
       }
     ],
-    "src/vs/platform/checksum/test/node/checksumService.test.ts": [
+    "src\\vs\\platform\\checksum\\test\\node\\checksumService.test.ts": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/platform/checksum/test/node/checksumService.test.ts",
+        "filename": "src\\vs\\platform\\checksum\\test\\node\\checksumService.test.ts",
         "hashed_secret": "4a211cacf9cf46abb61d97cd30f8927f8ff68949",
         "is_verified": false,
         "line_number": 38,
@@ -804,17 +788,17 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/platform/checksum/test/node/checksumService.test.ts",
+        "filename": "src\\vs\\platform\\checksum\\test\\node\\checksumService.test.ts",
         "hashed_secret": "8b3419d93a3815bab365c9148edef39d80e7c8de",
         "is_verified": false,
         "line_number": 38,
         "is_secret": false
       }
     ],
-    "src/vs/platform/encryption/common/encryptionService.ts": [
+    "src\\vs\\platform\\encryption\\common\\encryptionService.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/vs/platform/encryption/common/encryptionService.ts",
+        "filename": "src\\vs\\platform\\encryption\\common\\encryptionService.ts",
         "hashed_secret": "2164a98794e6e6f7a8c1862ca735183450643ab8",
         "is_verified": false,
         "line_number": 34,
@@ -822,27 +806,27 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/vs/platform/encryption/common/encryptionService.ts",
+        "filename": "src\\vs\\platform\\encryption\\common\\encryptionService.ts",
         "hashed_secret": "27941be9e491ea754419893f64b724450376db52",
         "is_verified": false,
         "line_number": 45,
         "is_secret": false
       }
     ],
-    "src/vs/platform/extensionManagement/test/common/configRemotes.test.ts": [
+    "src\\vs\\platform\\extensionManagement\\test\\common\\configRemotes.test.ts": [
       {
         "type": "Basic Auth Credentials",
-        "filename": "src/vs/platform/extensionManagement/test/common/configRemotes.test.ts",
+        "filename": "src\\vs\\platform\\extensionManagement\\test\\common\\configRemotes.test.ts",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
         "line_number": 29,
         "is_secret": false
       }
     ],
-    "src/vs/platform/native/electron-main/auth.ts": [
+    "src\\vs\\platform\\native\\electron-main\\auth.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/vs/platform/native/electron-main/auth.ts",
+        "filename": "src\\vs\\platform\\native\\electron-main\\auth.ts",
         "hashed_secret": "1552ab4cda3b3f85ebbe13ab82fddd1071a00904",
         "is_verified": false,
         "line_number": 43,
@@ -850,47 +834,47 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/vs/platform/native/electron-main/auth.ts",
+        "filename": "src\\vs\\platform\\native\\electron-main\\auth.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
         "line_number": 218,
         "is_secret": false
       }
     ],
-    "src/vs/platform/telemetry/node/telemetryUtils.ts": [
+    "src\\vs\\platform\\telemetry\\node\\telemetryUtils.ts": [
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/platform/telemetry/node/telemetryUtils.ts",
+        "filename": "src\\vs\\platform\\telemetry\\node\\telemetryUtils.ts",
         "hashed_secret": "def4e2deaa6e984c6eaa63b1f8ed02574aaa4bda",
         "is_verified": false,
         "line_number": 17,
         "is_secret": false
       }
     ],
-    "src/vs/platform/telemetry/test/browser/1dsAppender.test.ts": [
+    "src\\vs\\platform\\telemetry\\test\\browser\\1dsAppender.test.ts": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/platform/telemetry/test/browser/1dsAppender.test.ts",
+        "filename": "src\\vs\\platform\\telemetry\\test\\browser\\1dsAppender.test.ts",
         "hashed_secret": "da43a8ebe3e071eb9f612ac529369068983ed590",
         "is_verified": false,
         "line_number": 70,
         "is_secret": false
       }
     ],
-    "src/vs/platform/windows/test/electron-main/windowsStateHandler.test.ts": [
+    "src\\vs\\platform\\windows\\test\\electron-main\\windowsStateHandler.test.ts": [
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/platform/windows/test/electron-main/windowsStateHandler.test.ts",
+        "filename": "src\\vs\\platform\\windows\\test\\electron-main\\windowsStateHandler.test.ts",
         "hashed_secret": "81902f90c165b5b742afc5a3be5180bb20fd6fa9",
         "is_verified": false,
         "line_number": 125,
         "is_secret": false
       }
     ],
-    "src/vs/platform/workspaces/test/electron-main/workspaces.test.ts": [
+    "src\\vs\\platform\\workspaces\\test\\electron-main\\workspaces.test.ts": [
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/platform/workspaces/test/electron-main/workspaces.test.ts",
+        "filename": "src\\vs\\platform\\workspaces\\test\\electron-main\\workspaces.test.ts",
         "hashed_secret": "80186838ad46c9ff7e226d081a5289b4b6dc9a3c",
         "is_verified": false,
         "line_number": 52,
@@ -898,7 +882,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/platform/workspaces/test/electron-main/workspaces.test.ts",
+        "filename": "src\\vs\\platform\\workspaces\\test\\electron-main\\workspaces.test.ts",
         "hashed_secret": "db8ab9b302acd24863d9f8b173ce760e876452c7",
         "is_verified": false,
         "line_number": 52,
@@ -906,7 +890,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/platform/workspaces/test/electron-main/workspaces.test.ts",
+        "filename": "src\\vs\\platform\\workspaces\\test\\electron-main\\workspaces.test.ts",
         "hashed_secret": "2d7b6bcb2710e7af54714bf26aa6df65d7d96bc9",
         "is_verified": false,
         "line_number": 60,
@@ -914,7 +898,7 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/platform/workspaces/test/electron-main/workspaces.test.ts",
+        "filename": "src\\vs\\platform\\workspaces\\test\\electron-main\\workspaces.test.ts",
         "hashed_secret": "fc8e06e896a2fca7d730591b367221b493df4677",
         "is_verified": false,
         "line_number": 60,
@@ -922,27 +906,27 @@
       },
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/platform/workspaces/test/electron-main/workspaces.test.ts",
+        "filename": "src\\vs\\platform\\workspaces\\test\\electron-main\\workspaces.test.ts",
         "hashed_secret": "11f36d26f88c98fc21501757dcaf1d189054b459",
         "is_verified": false,
         "line_number": 63,
         "is_secret": false
       }
     ],
-    "src/vs/platform/workspaces/test/electron-main/workspacesHistoryStorage.test.ts": [
+    "src\\vs\\platform\\workspaces\\test\\electron-main\\workspacesHistoryStorage.test.ts": [
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/platform/workspaces/test/electron-main/workspacesHistoryStorage.test.ts",
+        "filename": "src\\vs\\platform\\workspaces\\test\\electron-main\\workspacesHistoryStorage.test.ts",
         "hashed_secret": "81902f90c165b5b742afc5a3be5180bb20fd6fa9",
         "is_verified": false,
         "line_number": 120,
         "is_secret": false
       }
     ],
-    "src/vs/server/node/webClientServer.ts": [
+    "src\\vs\\server\\node\\webClientServer.ts": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/server/node/webClientServer.ts",
+        "filename": "src\\vs\\server\\node\\webClientServer.ts",
         "hashed_secret": "66e26ed510af41f1d322d1ebda4389302f4a03c7",
         "is_verified": false,
         "line_number": 453,
@@ -950,37 +934,37 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/server/node/webClientServer.ts",
+        "filename": "src\\vs\\server\\node\\webClientServer.ts",
         "hashed_secret": "93f2efffc36c6e096cdb21d6aadb7087dc0d7478",
         "is_verified": false,
         "line_number": 459,
         "is_secret": false
       }
     ],
-    "src/vs/workbench/api/test/browser/extHostTelemetry.test.ts": [
+    "src\\vs\\workbench\\api\\test\\browser\\extHostTelemetry.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/vs/workbench/api/test/browser/extHostTelemetry.test.ts",
+        "filename": "src\\vs\\workbench\\api\\test\\browser\\extHostTelemetry.test.ts",
         "hashed_secret": "7fe54a7b420126077bba3453c0f9d31430735c5e",
         "is_verified": false,
         "line_number": 256,
         "is_secret": false
       }
     ],
-    "src/vs/workbench/contrib/tags/test/node/workspaceTags.test.ts": [
+    "src\\vs\\workbench\\contrib\\tags\\test\\node\\workspaceTags.test.ts": [
       {
         "type": "Basic Auth Credentials",
-        "filename": "src/vs/workbench/contrib/tags/test/node/workspaceTags.test.ts",
+        "filename": "src\\vs\\workbench\\contrib\\tags\\test\\node\\workspaceTags.test.ts",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
         "line_number": 26,
         "is_secret": false
       }
     ],
-    "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts": [
+    "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "1095670d54a482a0e7b837495d1c631a33c656b3",
         "is_verified": false,
         "line_number": 3074,
@@ -988,7 +972,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "323c865df45801dd70a4859b1bd2a4f1d84971a6",
         "is_verified": false,
         "line_number": 3077,
@@ -996,7 +980,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "a585c1879792a1044ff41a979a255c7cc37dd4d4",
         "is_verified": false,
         "line_number": 3581,
@@ -1004,7 +988,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "4db99d2c269f599db70f64eaa92f890c270d1e6f",
         "is_verified": false,
         "line_number": 13646,
@@ -1012,7 +996,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "a6e67f06ed3560135bcfc7f81f1318bf9c7c32c7",
         "is_verified": false,
         "line_number": 13649,
@@ -1020,7 +1004,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "bf9ce539662b804d5e7c5f6ecf22e19468738604",
         "is_verified": false,
         "line_number": 13652,
@@ -1028,7 +1012,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "10e8ca604280c2932a91ea168197456d534a8a70",
         "is_verified": false,
         "line_number": 13655,
@@ -1036,7 +1020,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "6128fb9ecc1cd3ba8be7dfef6a80a7cfd32d7c61",
         "is_verified": false,
         "line_number": 13946,
@@ -1044,7 +1028,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "5dacc7c710c7a385c0dfd0eb5f8581ba85f5808c",
         "is_verified": false,
         "line_number": 13949,
@@ -1052,7 +1036,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "325418ca5710f545ff46ec8bc55d67d3b7280db9",
         "is_verified": false,
         "line_number": 13952,
@@ -1060,7 +1044,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "0becfcb7053e8dd092ec35428cb0737eb57e3b27",
         "is_verified": false,
         "line_number": 13955,
@@ -1068,7 +1052,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "0d836b6dc1f0f0e7f59e0820b197ba1fe706a96e",
         "is_verified": false,
         "line_number": 20240,
@@ -1076,7 +1060,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "7e59e1baa4844a8b758e8cc226d9bac3f44c2351",
         "is_verified": false,
         "line_number": 20243,
@@ -1084,7 +1068,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "d1303c3c0a00945e71a82cb6bb93abc06607ed1c",
         "is_verified": false,
         "line_number": 20246,
@@ -1092,7 +1076,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "994848e33dd55bff0b533477059e3facaaa439b2",
         "is_verified": false,
         "line_number": 20249,
@@ -1100,7 +1084,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "7d1fd53cd95b1fb28bcb5fe35c0856da71867546",
         "is_verified": false,
         "line_number": 20252,
@@ -1108,7 +1092,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "7139b3ae092aeb34c557e53e17471318240f781b",
         "is_verified": false,
         "line_number": 20255,
@@ -1116,7 +1100,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "2a6ff8e940126f10cb9097d1d5475130a92b7de8",
         "is_verified": false,
         "line_number": 20258,
@@ -1124,7 +1108,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "9ed276a1d4dcda9fc6d8e23ba545841a5c97d2a7",
         "is_verified": false,
         "line_number": 20261,
@@ -1132,7 +1116,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "1a8f2a4eb01e5368556f73d468e3ca72d7eacca3",
         "is_verified": false,
         "line_number": 20276,
@@ -1140,7 +1124,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "6ba39b95161303719b599f9b78e804c2a91d962d",
         "is_verified": false,
         "line_number": 20279,
@@ -1148,7 +1132,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "43af06bb8ca1fb2f7f132dcdefacdf592e6f341c",
         "is_verified": false,
         "line_number": 20282,
@@ -1156,7 +1140,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "b7ef38da15b915e6fcd8aeff052b78c2459cc7bf",
         "is_verified": false,
         "line_number": 20285,
@@ -1164,7 +1148,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "282f73128703322f3effe04575c2cc8c5a39fd45",
         "is_verified": false,
         "line_number": 20288,
@@ -1172,7 +1156,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "913b3de82b50d8f39de30a356bd26b4f53584f27",
         "is_verified": false,
         "line_number": 20291,
@@ -1180,7 +1164,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "a69b91e2139e5d8db1cc5ff769192205a51b0a66",
         "is_verified": false,
         "line_number": 20312,
@@ -1188,7 +1172,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "0e961a107f07be863ec58369607394db8201e369",
         "is_verified": false,
         "line_number": 20315,
@@ -1196,7 +1180,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "733776b9c58fe0d1273433dc0047eafb8af4c1e2",
         "is_verified": false,
         "line_number": 20615,
@@ -1204,7 +1188,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "467854dc626b3a18a1896fea044af1d09396e099",
         "is_verified": false,
         "line_number": 22739,
@@ -1212,7 +1196,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "312fcf8d0f94fb3488dfa915c30df08ee0d8cd16",
         "is_verified": false,
         "line_number": 22751,
@@ -1220,7 +1204,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "4711c04cd8eeadb151fc6da61ffd07f10f054495",
         "is_verified": false,
         "line_number": 22787,
@@ -1228,7 +1212,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "3afd002804ccc317621882c5f706f930263def07",
         "is_verified": false,
         "line_number": 22793,
@@ -1236,7 +1220,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "15b4b3e2ddeb2834b488e83d3097c422c6b2cc38",
         "is_verified": false,
         "line_number": 23066,
@@ -1244,7 +1228,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "ed62e0922293e2cce730deb5056aeed493620223",
         "is_verified": false,
         "line_number": 23372,
@@ -1252,7 +1236,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "d9727884f702ebe77a51c4ac3b6069704781650d",
         "is_verified": false,
         "line_number": 23378,
@@ -1260,7 +1244,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "6cfd5afa3476406661913cdea16149121ea4c3a7",
         "is_verified": false,
         "line_number": 23480,
@@ -1268,7 +1252,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "280adb57d87c6597e1741ea13e7c49c2e6d0fcb8",
         "is_verified": false,
         "line_number": 23600,
@@ -1276,7 +1260,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "6fa77ec4cf658821f0c36c3aa80ccc028d3ac749",
         "is_verified": false,
         "line_number": 23678,
@@ -1284,7 +1268,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "fa64e25255b2b3578ffd6f43ab69c9588a68afaf",
         "is_verified": false,
         "line_number": 23912,
@@ -1292,7 +1276,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "97d0bae3c59d61b547d97519f5e08c21a63dda2d",
         "is_verified": false,
         "line_number": 23915,
@@ -1300,7 +1284,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "e6c0dc8257aff85294f594c48a7de35c42270b51",
         "is_verified": false,
         "line_number": 23918,
@@ -1308,7 +1292,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "81a542a448df4b15bdc70d6b9953b3c5df0601c5",
         "is_verified": false,
         "line_number": 23921,
@@ -1316,7 +1300,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "1e3c14249938bbbb121a3c30f0473ef8becc98dc",
         "is_verified": false,
         "line_number": 24038,
@@ -1324,7 +1308,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "a2d49cff24b1a581898c20a4976fccb0e9558de8",
         "is_verified": false,
         "line_number": 24041,
@@ -1332,7 +1316,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "056d0598d668ed6bf3a1329248fee07fcc549ff3",
         "is_verified": false,
         "line_number": 24044,
@@ -1340,7 +1324,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "5e3b44d8a1248b3e47c943f01d3d373c9ea5d924",
         "is_verified": false,
         "line_number": 24047,
@@ -1348,7 +1332,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "040514c7a033ad93358f0b27e5bca3d0c90f20f1",
         "is_verified": false,
         "line_number": 24053,
@@ -1356,7 +1340,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "9698017ed814b94f4f1f616e49998cdd0bfba95b",
         "is_verified": false,
         "line_number": 24530,
@@ -1364,7 +1348,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "363b1a8efc0843157698acb704951b476d306743",
         "is_verified": false,
         "line_number": 24533,
@@ -1372,7 +1356,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "858e73f543f82ced50f1efcb1d303c00b89a7588",
         "is_verified": false,
         "line_number": 24539,
@@ -1380,7 +1364,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "601652b7a9ab6540f320fd614e303adf8c0e530a",
         "is_verified": false,
         "line_number": 25112,
@@ -1388,7 +1372,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "407ffb83492d35df8720157dde57e62f3033dacb",
         "is_verified": false,
         "line_number": 25346,
@@ -1396,7 +1380,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "ed95a6399b4a80e206e47e0711f2816d55cc13e6",
         "is_verified": false,
         "line_number": 25412,
@@ -1404,7 +1388,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "7601a6619614acfe6011dc86b7546189b01c87da",
         "is_verified": false,
         "line_number": 25415,
@@ -1412,7 +1396,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "64954401f16fe127094fe0f5f03e6bc8c54d689b",
         "is_verified": false,
         "line_number": 25490,
@@ -1420,7 +1404,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "1f13dbddb68708633f741e4325734332a1ea6e2c",
         "is_verified": false,
         "line_number": 25493,
@@ -1428,7 +1412,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "cd7b79311edb297131df0456828d4cbfb3e6b484",
         "is_verified": false,
         "line_number": 25535,
@@ -1436,7 +1420,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "405462389da7de9d172560261eb56dfd1afa9375",
         "is_verified": false,
         "line_number": 25556,
@@ -1444,7 +1428,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "83bbdf929f4c8dbf944d9c74e1e41bbde62aadda",
         "is_verified": false,
         "line_number": 25559,
@@ -1452,7 +1436,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "7a6c4611ba018c5e58339ec6b3beee0e740fef1b",
         "is_verified": false,
         "line_number": 25631,
@@ -1460,7 +1444,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "78f2ae3fa824593b797d336ed81f448dbca2ebdb",
         "is_verified": false,
         "line_number": 25733,
@@ -1468,7 +1452,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "482546d2d3b74d145f0e0593afe0c7ab2f9501c9",
         "is_verified": false,
         "line_number": 26144,
@@ -1476,7 +1460,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "838cfd0715f241baddcfecc1c352301d42bf5133",
         "is_verified": false,
         "line_number": 26186,
@@ -1484,7 +1468,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "79a228c5532e8c8bd19b3ab7887436083ba56c24",
         "is_verified": false,
         "line_number": 26294,
@@ -1492,7 +1476,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "3b257240683df2185dbf870cb4d2f641c2a75661",
         "is_verified": false,
         "line_number": 26318,
@@ -1500,7 +1484,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "9eccf131008cc6a66fc9936fcafba98da12b1034",
         "is_verified": false,
         "line_number": 26324,
@@ -1508,7 +1492,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "82a53eb15f89017e01fbd797057e9862eca21e62",
         "is_verified": false,
         "line_number": 26336,
@@ -1516,7 +1500,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "3b3155c88325519dc24f43256e30c0cc010a7b6f",
         "is_verified": false,
         "line_number": 26390,
@@ -1524,7 +1508,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "c9c3e05ec55a52ca817450841a4de85b0af103f8",
         "is_verified": false,
         "line_number": 26408,
@@ -1532,7 +1516,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "07a4a7f4ddcc1a7574aac68667673ebbc3d4bcc1",
         "is_verified": false,
         "line_number": 26414,
@@ -1540,7 +1524,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "86ff1bb47d1f062eadc9f57e9d0fb3ee9f5a76b6",
         "is_verified": false,
         "line_number": 26420,
@@ -1548,7 +1532,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "172ebbed136242dacf2623aa78e8a964a30cd3b6",
         "is_verified": false,
         "line_number": 26426,
@@ -1556,7 +1540,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "4c678f28a0e1e4aa5f0b65221ffaa5a832a01746",
         "is_verified": false,
         "line_number": 26432,
@@ -1564,7 +1548,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "c945c6538c5e5ae96bc6ea967fe79e75d9d87b5d",
         "is_verified": false,
         "line_number": 26438,
@@ -1572,7 +1556,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "b5b6709fb1054aa7e92824e2cc97ffc2d0e9169e",
         "is_verified": false,
         "line_number": 26444,
@@ -1580,7 +1564,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "6acd886fc41143d1c40521415a6375280dbd2c69",
         "is_verified": false,
         "line_number": 26789,
@@ -1588,7 +1572,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "d8c3afc68675cc6ca64b9de3a3fe922e75274fb3",
         "is_verified": false,
         "line_number": 26813,
@@ -1596,7 +1580,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "540c8a54b100062483ad05cacb5441fa94c2e0cf",
         "is_verified": false,
         "line_number": 26828,
@@ -1604,7 +1588,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "3d3ad01aab5c11320eaeeafc37c42522dbe93749",
         "is_verified": false,
         "line_number": 26831,
@@ -1612,7 +1596,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "d074160dee117b47bb95a1a658e07ff0a32334fd",
         "is_verified": false,
         "line_number": 26834,
@@ -1620,7 +1604,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "7fbab0fe7563982d0b865231f31ddee5a2d1a9be",
         "is_verified": false,
         "line_number": 26837,
@@ -1628,7 +1612,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "f0cbb10de4030ebe8890b97179fa428475045375",
         "is_verified": false,
         "line_number": 26879,
@@ -1636,7 +1620,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "e1b5e2771cf0668df3123159ae58fcba0555d199",
         "is_verified": false,
         "line_number": 26885,
@@ -1644,7 +1628,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "f3544e7251a65cad1417efc688d3aa264738a2ed",
         "is_verified": false,
         "line_number": 27731,
@@ -1652,7 +1636,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "1965ecad81522b99d719f205018abf6055c52c82",
         "is_verified": false,
         "line_number": 27764,
@@ -1660,7 +1644,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "19760c4d8c4dfe31c1aa9a17c836a1d06f64d9f0",
         "is_verified": false,
         "line_number": 27914,
@@ -1668,7 +1652,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "21bb0a47fc9aac09eec75374388690d8d7bfcab9",
         "is_verified": false,
         "line_number": 27917,
@@ -1676,7 +1660,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "1af31706740ee12ddfe99123c8bc1cfa80c8402a",
         "is_verified": false,
         "line_number": 28040,
@@ -1684,7 +1668,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "22b624071f09ba16af6851d6acb06f39052c9ddf",
         "is_verified": false,
         "line_number": 28142,
@@ -1692,7 +1676,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "894b1258407128e151f0aa965178c67376d97ef0",
         "is_verified": false,
         "line_number": 28145,
@@ -1700,7 +1684,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "70a6f97cc3ff842d4e78155d7ea0142c61f29517",
         "is_verified": false,
         "line_number": 28247,
@@ -1708,7 +1692,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "5aedfdbaff52e36d0c12b65ff6c58dff7199d83c",
         "is_verified": false,
         "line_number": 28808,
@@ -1716,7 +1700,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "9b0fa57d5cd0e6c8cfed234f4c66cc83b730c417",
         "is_verified": false,
         "line_number": 28811,
@@ -1724,7 +1708,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "e075e5cd1ed8c4f04b2a1f5f60316adf533da3cf",
         "is_verified": false,
         "line_number": 28814,
@@ -1732,7 +1716,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "d96d70bfc1f075e66870d79d4c6c89cad07ea837",
         "is_verified": false,
         "line_number": 28817,
@@ -1740,7 +1724,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "2af1bfa4d75d40e9378140c02ef817fbaca25867",
         "is_verified": false,
         "line_number": 31979,
@@ -1748,7 +1732,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "396a7e8c88918b91c234a69a90665bcdfb427d9a",
         "is_verified": false,
         "line_number": 32771,
@@ -1756,7 +1740,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "929316f0330d4e2697cc9d46e09544d9a97fb822",
         "is_verified": false,
         "line_number": 35057,
@@ -1764,7 +1748,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "4ab1f4e77420967d1b6d2ca93c64e23fc7e2b897",
         "is_verified": false,
         "line_number": 35063,
@@ -1772,7 +1756,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "8a0868ebaa3efc482fcc6aa5bd37b69074153cca",
         "is_verified": false,
         "line_number": 35087,
@@ -1780,7 +1764,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "cb9d2061a8358a6afa918ff9d5ed61f45f693ab9",
         "is_verified": false,
         "line_number": 35240,
@@ -1788,7 +1772,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "5bc12fe46e396a421f0710f0f5d1a412d6d184d1",
         "is_verified": false,
         "line_number": 35243,
@@ -1796,7 +1780,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "78b37ecbbb05229abf6e291ca96a90cbe783f8a8",
         "is_verified": false,
         "line_number": 36026,
@@ -1804,7 +1788,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "1ba83bbf068a3386569ab310b0b67ca72b5feaa7",
         "is_verified": false,
         "line_number": 36029,
@@ -1812,7 +1796,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "38e2c4ac1a5f6516db6f56e59a5470df019e97e6",
         "is_verified": false,
         "line_number": 41660,
@@ -1820,7 +1804,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "835889eaf31f2e6b8037b26e4b7b16417b0b76d0",
         "is_verified": false,
         "line_number": 41663,
@@ -1828,7 +1812,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "fd8e61f5fe203cda32be8d55a8f27e8c8d998ad8",
         "is_verified": false,
         "line_number": 41669,
@@ -1836,7 +1820,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "a9591116d2140cb9486b0663d28ab1c38f99c34f",
         "is_verified": false,
         "line_number": 41813,
@@ -1844,7 +1828,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "8384ecb1b5977812a434b10f290985fd5d69cab9",
         "is_verified": false,
         "line_number": 41819,
@@ -1852,7 +1836,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "6f0bef3c78fffbd70d9c9cb8e6210425d39687bf",
         "is_verified": false,
         "line_number": 48059,
@@ -1860,7 +1844,7 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "fb943ab04cf008ad965b009e69df769f15d0aa04",
         "is_verified": false,
         "line_number": 48119,
@@ -1868,47 +1852,47 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/terminalContrib/suggest/test/browser/testRawPwshCompletions.ts",
+        "filename": "src\\vs\\workbench\\contrib\\terminalContrib\\suggest\\test\\browser\\testRawPwshCompletions.ts",
         "hashed_secret": "845ad00f44983f3dfb12f62465e5c2c15466d5c8",
         "is_verified": false,
         "line_number": 49073,
         "is_secret": false
       }
     ],
-    "src/vs/workbench/contrib/webview/browser/pre/index.html": [
+    "src\\vs\\workbench\\contrib\\webview\\browser\\pre\\index.html": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/contrib/webview/browser/pre/index.html",
+        "filename": "src\\vs\\workbench\\contrib\\webview\\browser\\pre\\index.html",
         "hashed_secret": "18e28cb104e16a9281ba04f02b3d657de3110053",
         "is_verified": false,
         "line_number": 9,
         "is_secret": false
       }
     ],
-    "src/vs/workbench/services/environment/browser/environmentService.ts": [
+    "src\\vs\\workbench\\services\\environment\\browser\\environmentService.ts": [
       {
         "type": "Hex High Entropy String",
-        "filename": "src/vs/workbench/services/environment/browser/environmentService.ts",
+        "filename": "src\\vs\\workbench\\services\\environment\\browser\\environmentService.ts",
         "hashed_secret": "3a8f125da17a2c187d430daf0045e0fdfa707bdd",
         "is_verified": false,
         "line_number": 276,
         "is_secret": false
       }
     ],
-    "src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html": [
+    "src\\vs\\workbench\\services\\extensions\\worker\\webWorkerExtensionHostIframe.html": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html",
+        "filename": "src\\vs\\workbench\\services\\extensions\\worker\\webWorkerExtensionHostIframe.html",
         "hashed_secret": "76e4a11f0ba2f563c70f196469eb86bc12172ae4",
         "is_verified": false,
         "line_number": 8,
         "is_secret": false
       }
     ],
-    "src/vs/workbench/test/browser/webview.test.ts": [
+    "src\\vs\\workbench\\test\\browser\\webview.test.ts": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/test/browser/webview.test.ts",
+        "filename": "src\\vs\\workbench\\test\\browser\\webview.test.ts",
         "hashed_secret": "bd86be67e83058d60b6ae73f8264b0e0f4a53faf",
         "is_verified": false,
         "line_number": 14,
@@ -1916,17 +1900,17 @@
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/vs/workbench/test/browser/webview.test.ts",
+        "filename": "src\\vs\\workbench\\test\\browser\\webview.test.ts",
         "hashed_secret": "2cb6f8318e394386a6a2b875eca55c07e2af7045",
         "is_verified": false,
         "line_number": 19,
         "is_secret": false
       }
     ],
-    "test/integration/browser/src/index.ts": [
+    "test\\integration\\browser\\src\\index.ts": [
       {
         "type": "Hex High Entropy String",
-        "filename": "test/integration/browser/src/index.ts",
+        "filename": "test\\integration\\browser\\src\\index.ts",
         "hashed_secret": "3a8f125da17a2c187d430daf0045e0fdfa707bdd",
         "is_verified": false,
         "line_number": 134,
@@ -1934,5 +1918,5 @@
       }
     ]
   },
-  "generated_at": "2024-12-18T19:29:32Z"
+  "generated_at": "2025-01-10T21:36:45Z"
 }

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -37,13 +37,11 @@ if echo "$PR_BODY" | grep -q "@:all"; then
   TAGS="" # Set to an empty string to indicate all tests should run
 else
   if echo "$PR_BODY" | grep -q "@:win"; then
-    echo "Found @:win tag in PR body. Setting to run windows tests."
-    # PR_BODY=$(echo "$PR_BODY" | sed 's/@:win//g')
-    # Set a variable to indicate @:win was found
+    echo "Found win tag in PR body. Setting to run windows tests."
     echo "win_tag_found=true" >> "$GITHUB_OUTPUT"
   fi
   if echo "$PR_BODY" | grep -q "@:web"; then
-    echo "Found @:web tag in PR body. Setting to run web tests."
+    echo "Found web tag in PR body. Setting to run web tests."
     echo "web_tag_found=true" >> "$GITHUB_OUTPUT"
   fi
   # Parse tags starting with '@:' and convert to '@'

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -54,19 +54,6 @@ else
 		fi
 	fi
 fi
-else
-  # Parse tags starting with '@:' and convert to '@'
-  TAGS=$(echo "$PR_BODY" | grep -o "@:[a-zA-Z0-9_-]*" | sed 's/@://g' | sed 's/^/@/' | tr '\n' ',' | sed 's/,$//')
-
-  # Always add @critical if not already included
-  if [[ ! "$TAGS" =~ "@critical" ]]; then
-    if [[ -n "$TAGS" ]]; then
-      TAGS="@critical,$TAGS"
-    else
-      TAGS="@critical"
-    fi
-  fi
-fi
 
 # Output the tags
 echo "Extracted Tags: $TAGS"

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -37,8 +37,8 @@ if echo "$PR_BODY" | grep -q "@:all"; then
   TAGS="" # Set to an empty string to indicate all tests should run
 else
   if echo "$PR_BODY" | grep -q "@:win"; then
-    echo "Found @:win tag in PR body. Removing it from tags."
-    PR_BODY=$(echo "$PR_BODY" | sed 's/@:win//g')
+    echo "Found @:win tag in PR body. Setting to run windows tests."
+    # PR_BODY=$(echo "$PR_BODY" | sed 's/@:win//g')
     # Set a variable to indicate @:win was found
     echo "win_tag_found=true" >> "$GITHUB_OUTPUT"
   fi

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -40,7 +40,7 @@ else
     echo "Found @:win tag in PR body. Removing it from tags."
     PR_BODY=$(echo "$PR_BODY" | sed 's/@:win//g')
     # Set a variable to indicate @:win was found
-    echo "win_tag_found=true" >> "$GITHUB_ENV"
+    echo "win_tag_found=true" >> "$GITHUB_OUTPUT"
   fi
 
   # Parse tags starting with '@:' and convert to '@'

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -33,26 +33,27 @@ echo "Parsing tags from PR body..."
 
 # Check if @:all is present in the PR body
 if echo "$PR_BODY" | grep -q "@:all"; then
-	echo "Found @:all tag in PR body. Setting tags to run all tests."
-	TAGS="" # Set to an empty string to indicate all tests should run
-elif echo "$PR_BODY" | grep -q "@:win"; then
-	echo "Found @:win tag in PR body. Removing it from tags."
-	PR_BODY=$(echo "$PR_BODY" | sed 's/@:win//g')
-	TAGS=$(echo "$PR_BODY" | grep -o "@:[a-zA-Z0-9_-]*" | sed 's/@://g' | sed 's/^/@/' | tr '\n' ',' | sed 's/,$//')
-	# Set a variable to indicate @:win was found
-	echo "win_tag_found=true" >> "$GITHUB_ENV"
+  echo "Found @:all tag in PR body. Setting tags to run all tests."
+  TAGS="" # Set to an empty string to indicate all tests should run
 else
-	# Parse tags starting with '@:' and convert to '@'
-	TAGS=$(echo "$PR_BODY" | grep -o "@:[a-zA-Z0-9_-]*" | sed 's/@://g' | sed 's/^/@/' | tr '\n' ',' | sed 's/,$//')
+  if echo "$PR_BODY" | grep -q "@:win"; then
+    echo "Found @:win tag in PR body. Removing it from tags."
+    PR_BODY=$(echo "$PR_BODY" | sed 's/@:win//g')
+    # Set a variable to indicate @:win was found
+    echo "win_tag_found=true" >> "$GITHUB_ENV"
+  fi
 
-	# Always add @critical if not already included
-	if [[ ! "$TAGS" =~ "@critical" ]]; then
-		if [[ -n "$TAGS" ]]; then
-			TAGS="@critical,$TAGS"
-		else
-			TAGS="@critical"
-		fi
-	fi
+  # Parse tags starting with '@:' and convert to '@'
+  TAGS=$(echo "$PR_BODY" | grep -o "@:[a-zA-Z0-9_-]*" | sed 's/@://g' | sed 's/^/@/' | tr '\n' ',' | sed 's/,$//')
+
+  # Always add @critical if not already included
+  if [[ ! "$TAGS" =~ "@critical" ]]; then
+    if [[ -n "$TAGS" ]]; then
+      TAGS="@critical,$TAGS"
+    else
+      TAGS="@critical"
+    fi
+  fi
 fi
 
 # Output the tags

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -42,7 +42,10 @@ else
     # Set a variable to indicate @:win was found
     echo "win_tag_found=true" >> "$GITHUB_OUTPUT"
   fi
-
+  if echo "$PR_BODY" | grep -q "@:web"; then
+    echo "Found @:web tag in PR body. Setting to run web tests."
+    echo "web_tag_found=true" >> "$GITHUB_OUTPUT"
+  fi
   # Parse tags starting with '@:' and convert to '@'
   TAGS=$(echo "$PR_BODY" | grep -o "@:[a-zA-Z0-9_-]*" | sed 's/@://g' | sed 's/^/@/' | tr '\n' ',' | sed 's/,$//')
 

--- a/scripts/pr-tags-transform.sh
+++ b/scripts/pr-tags-transform.sh
@@ -20,12 +20,28 @@ OUTPUT=""
 if [[ "$PROJECT" == "e2e-windows" ]]; then
   # Remove @win from the tags
   TAGS=$(echo "$TAGS" | tr ',' '\n' | grep -v "@win" | sort -u | tr '\n' ',' | sed 's/,$//')
+	# If @web is present, remove it
+	if echo "$TAGS" | grep -q "@web"; then
+    TAGS=$(echo "$TAGS" | tr ',' '\n' | grep -v "@web" | sort -u | tr '\n' ',' | sed 's/,$//')
+  fi
 elif [[ "$PROJECT" == "e2e-browser" ]]; then
   # Remove @web from the tags
   TAGS=$(echo "$TAGS" | tr ',' '\n' | grep -v "@web" | sort -u | tr '\n' ',' | sed 's/,$//')
+	# If @win is present, remove it
+	if echo "$TAGS" | grep -q "@win"; then
+    TAGS=$(echo "$TAGS" | tr ',' '\n' | grep -v "@win" | sort -u | tr '\n' ',' | sed 's/,$//')
+  fi
 else
   # Deduplicate for other projects
   TAGS=$(echo "$TAGS" | tr ',' '\n' | sort -u | tr '\n' ',' | sed 's/,$//')
+	# If @web is present, remove it
+	if echo "$TAGS" | grep -q "@web"; then
+    TAGS=$(echo "$TAGS" | tr ',' '\n' | grep -v "@web" | sort -u | tr '\n' ',' | sed 's/,$//')
+  fi
+	# If @win is present, remove it
+	if echo "$TAGS" | grep -q "@win"; then
+    TAGS=$(echo "$TAGS" | tr ',' '\n' | grep -v "@win" | sort -u | tr '\n' ',' | sed 's/,$//')
+  fi
 fi
 
 # Determine prefix based on PROJECT

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -202,6 +202,10 @@ To add a test tag:
 
 From that point, all E2E tests linked to the specified tag(s) will run during the test job. For a full list of available tags, see this [file](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts).
 
+To include Windows testing:
+
+By default, only Linuxe e2e test will run.  You can optionally add `@:win` to your PR description and this will run test on windows as well. As of now, windows tests do take longer to run, so the overall PR test job will take longer to complete.
+
 Note: You can update the tags in the PR description at any time. The PR comment will confirm the parsed tags, and the test job will use the tags present in the PR description at the time of execution.
 
 ## Running Tests in Github Actions

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -202,7 +202,7 @@ To add a test tag:
 
 From that point, all E2E tests linked to the specified tag(s) will run during the test job. For a full list of available tags, see this [file](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts).
 
-To include Windows and Web Browser testing:
+To include Windows and Web Browser testing: 
 
 By default, only Linuxe e2e test will run.  You can optionally add `@:win` to your PR description and this will run test on windows as well. As of now, windows tests do take longer to run, so the overall PR test job will take longer to complete. You can also ass `@:web` to run the browser tests.
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -202,9 +202,9 @@ To add a test tag:
 
 From that point, all E2E tests linked to the specified tag(s) will run during the test job. For a full list of available tags, see this [file](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts).
 
-To include Windows testing: 
+To include Windows and Web Browser testing:
 
-By default, only Linuxe e2e test will run.  You can optionally add `@:win` to your PR description and this will run test on windows as well. As of now, windows tests do take longer to run, so the overall PR test job will take longer to complete.
+By default, only Linuxe e2e test will run.  You can optionally add `@:win` to your PR description and this will run test on windows as well. As of now, windows tests do take longer to run, so the overall PR test job will take longer to complete. You can also ass `@:web` to run the browser tests.
 
 Note: You can update the tags in the PR description at any time. The PR comment will confirm the parsed tags, and the test job will use the tags present in the PR description at the time of execution.
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -202,7 +202,7 @@ To add a test tag:
 
 From that point, all E2E tests linked to the specified tag(s) will run during the test job. For a full list of available tags, see this [file](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts).
 
-To include Windows testing:
+To include Windows testing: 
 
 By default, only Linuxe e2e test will run.  You can optionally add `@:win` to your PR description and this will run test on windows as well. As of now, windows tests do take longer to run, so the overall PR test job will take longer to complete.
 

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -9,12 +9,10 @@
  * Each tag corresponds to a specific feature, functionality, or area of the application. Use them
  * thoughtfully to ensure your tests align with the intended scope.
  *
- * Add `@:win` tag to enable the tests to run on windows as well. The default will only run
- * Linux electron e2e tests.
+ * Add `@:win` tag to enable the tests to run on windows. Add the `@:web` tag to enable a web run.
+ * The default will only run Linux electron e2e tests.
  *
- * Avoid using `@:web` tag, as this is reserved for web platform-specific tests,
- * which is not currently configured to run in PR workflows.
- */
+*/
 export enum TestTags {
 	EDITOR_ACTION_BAR = '@editor-action-bar',
 	APPS = '@apps',

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -9,8 +9,11 @@
  * Each tag corresponds to a specific feature, functionality, or area of the application. Use them
  * thoughtfully to ensure your tests align with the intended scope.
  *
- * Avoid using `@:web` and `@:win` tags, as these are reserved for web and Windows platform-specific tests,
- * which are not currently configured to run in PR workflows.
+ * Add `@:win` tag to enable the tests to run on windows as well. The default will only run
+ * Linux electron e2e tests.
+ *
+ * Avoid using `@:web` tag, as this is reserved for web platform-specific tests,
+ * which is not currently configured to run in PR workflows.
  */
 export enum TestTags {
 	EDITOR_ACTION_BAR = '@editor-action-bar',


### PR DESCRIPTION
Addresses #5935 and #5955
This adds windows and web tests to the PR workflow.  They are by default turned off, but can be added with the `win` and `web` tags.  
    
### QA Notes
I tested with and without the win and web tags. It also works in conjunction with other tags.

@:win @:web
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
