### PR TITLE
check file extension is `.html` before injecting HTML scripts

### DIFF
--- a/extensions/positron-proxy/src/htmlProxy.ts
+++ b/extensions/positron-proxy/src/htmlProxy.ts
@@ -94,8 +94,11 @@ export class HtmlProxyServer implements Disposable {
 				const filePath = path.join(targetPath, req.path);
 				if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
 					let content = fs.readFileSync(filePath, 'utf8');
-					// If there is an HTML configuration, use it to rewrite the content.
-					if (htmlConfig) {
+					const isHtmlFile = path.extname(filePath).toLowerCase() === '.html';
+
+					// If the file is an HTML file and we have an HTML configuration, inject the
+					// preview resources into the HTML content.
+					if (isHtmlFile && htmlConfig) {
 						content = injectPreviewResources(content, htmlConfig);
 					}
 					res.send(content);

--- a/extensions/positron-proxy/src/htmlProxy.ts
+++ b/extensions/positron-proxy/src/htmlProxy.ts
@@ -94,7 +94,8 @@ export class HtmlProxyServer implements Disposable {
 				const filePath = path.join(targetPath, req.path);
 				if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
 					let content = fs.readFileSync(filePath, 'utf8');
-					const isHtmlFile = path.extname(filePath).toLowerCase() === '.html';
+					const fileExt = path.extname(filePath).toLowerCase();
+					const isHtmlFile = ['.html', '.htm'].includes(fileExt);
 
 					// If the file is an HTML file and we have an HTML configuration, inject the
 					// preview resources into the HTML content.


### PR DESCRIPTION
## Summary

- follow-up to #5766
- part of addressing #4276

Thank you @testlabauto for noticing the test failures in main!

Plots were failing to display for the highcharter and plotly R examples, and errors would be seen in the dev tools console:

![image](https://github.com/user-attachments/assets/266c121b-4593-4795-996d-700e1e1ad417)

@:plots

### Implementation

- check that the file is an HTML file before injecting the HTML scripts
- the `Uncaught SyntaxError: Unexpected token '<'` error was occurring because we were injecting HTML into javascript files (oops!)

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

The [highcharter](https://github.com/posit-dev/qa-example-content/blob/main/workspaces/r-plots/highcharter-example.r) and [plotly](https://github.com/posit-dev/qa-example-content/blob/main/workspaces/r-plots/plotly-example.r) R examples should work in Positron Server Web.