### PR TITLE
ci: skip closed

### DIFF
--- a/.github/workflows/pr-e2e-comment.yml
+++ b/.github/workflows/pr-e2e-comment.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   e2e-tags:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.state != 'closed' }} # Skip job if PR is closed
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Updated workflow to not run `pr-comment` on closed PRs as it will just fail.
I ran into this when I edited the test of my PR description after I just merged it: https://github.com/posit-dev/positron/actions/runs/12756278764/job/35554074467

### QA Notes

n/a