### PR TITLE
ci: add link to tags in pr comment

### DIFF
--- a/scripts/pr-e2e-comment.sh
+++ b/scripts/pr-e2e-comment.sh
@@ -44,7 +44,7 @@ FORMATTED_TAGS=$(echo "$TAGS" | sed 's/,/` `/g' | sed 's/^/`/' | sed 's/$/`/')
 RED_ALERT_NOTE="<!-- \n🚨 RED ALERT! ✋ Rule breaker detected! Tags don’t go here—they belong above ^ in the PR description using this proper format: \`@:tag\`. Changing them here is a no-go (trust us, we’ve tried). Confused? Check out the link below before the sirens get louder!\n-->"
 
 # Build the new comment body with proper newlines
-NEW_COMMENT=$(printf "${COMMENT_MARKER}\n${RED_ALERT_NOTE}\n\n**E2E Tests** 🚀 &nbsp;<sup>[?](https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags)</sup>\nThis PR will run tests tagged with: %s" "$FORMATTED_TAGS")
+NEW_COMMENT=$(printf "${COMMENT_MARKER}\n${RED_ALERT_NOTE}\n\n**E2E Tests** 🚀 This PR will run tests tagged with: %s\n\n<sup>[readme](https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags)</sup>&nbsp;&nbsp;<sup>[valid tags](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts)</sup>" "$FORMATTED_TAGS")
 
 if [ -n "$COMMENT_ID" ]; then
   # Update the existing comment

--- a/scripts/pr-e2e-comment.sh
+++ b/scripts/pr-e2e-comment.sh
@@ -41,7 +41,7 @@ COMMENT_ID=$(echo "$COMMENTS" | jq -r ".[] | select(.body | contains(\"$COMMENT_
 FORMATTED_TAGS=$(echo "$TAGS" | sed 's/,/` `/g' | sed 's/^/`/' | sed 's/$/`/')
 
 # Add the "🚨 RED ALERT!" note
-RED_ALERT_NOTE="<!-- \n🚨 RED ALERT! ✋ Rule breaker detected! Tags don’t go here—they belong above ^ in the PR description using this proper format: \`@:tag\`. Changing them here is a no-go (trust us, we’ve tried). Confused? Check out the link below before the sirens get louder!\n-->"
+RED_ALERT_NOTE="<!-- \n🚨 RED ALERT! ✋ Rule breaker detected! Tags don’t go here, they belong above ^ in the PR description using this proper format: \`@:tag\`. Changing them here won't do anything (trust us, we’ve tried). Confused? Check out the README hyperlink.\n-->"
 
 # Build the new comment body with proper newlines
 NEW_COMMENT=$(printf "${COMMENT_MARKER}\n${RED_ALERT_NOTE}\n\n**E2E Tests** 🚀\nThis PR will run tests tagged with: %s\n\n<sup>[readme](https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags)</sup>&nbsp;&nbsp;<sup>[valid tags](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts)</sup>" "$FORMATTED_TAGS")

--- a/scripts/pr-e2e-comment.sh
+++ b/scripts/pr-e2e-comment.sh
@@ -44,7 +44,7 @@ FORMATTED_TAGS=$(echo "$TAGS" | sed 's/,/` `/g' | sed 's/^/`/' | sed 's/$/`/')
 RED_ALERT_NOTE="<!-- \n🚨 RED ALERT! ✋ Rule breaker detected! Tags don’t go here—they belong above ^ in the PR description using this proper format: \`@:tag\`. Changing them here is a no-go (trust us, we’ve tried). Confused? Check out the link below before the sirens get louder!\n-->"
 
 # Build the new comment body with proper newlines
-NEW_COMMENT=$(printf "${COMMENT_MARKER}\n${RED_ALERT_NOTE}\n\n**E2E Tests** 🚀 This PR will run tests tagged with: %s\n\n<sup>[readme](https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags)</sup>&nbsp;&nbsp;<sup>[valid tags](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts)</sup>" "$FORMATTED_TAGS")
+NEW_COMMENT=$(printf "${COMMENT_MARKER}\n${RED_ALERT_NOTE}\n\n**E2E Tests** 🚀\nThis PR will run tests tagged with: %s\n\n<sup>[readme](https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags)</sup>&nbsp;&nbsp;<sup>[valid tags](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts)</sup>" "$FORMATTED_TAGS")
 
 if [ -n "$COMMENT_ID" ]; then
   # Update the existing comment

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -202,7 +202,7 @@ To add a test tag:
 
 From that point, all E2E tests linked to the specified tag(s) will run during the test job. For a full list of available tags, see this [file](https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts).
 
-To include Windows and Web Browser testing: 
+To include Windows and Web Browser testing:
 
 By default, only Linuxe e2e test will run.  You can optionally add `@:win` to your PR description and this will run test on windows as well. As of now, windows tests do take longer to run, so the overall PR test job will take longer to complete. You can also ass `@:web` to run the browser tests.
 

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -12,6 +12,9 @@
  * Add `@:win` tag to enable the tests to run on windows. Add the `@:web` tag to enable a web run.
  * The default will only run Linux electron e2e tests.
  *
+ * DON'T FORGET TO ADD THE COLON `:` AFTER THE `@` SYMBOL when tagging tests in a PR description.
+ *   -> Correct:   `@:tag`
+ *   -> Incorrect: `@tag`
 */
 export enum TestTags {
 	EDITOR_ACTION_BAR = '@editor-action-bar',


### PR DESCRIPTION
### Summary

Updating the e2e test PR comment to include a hyperlink to the test tags for convenience.

### QA Notes

See the comment on this PR to see how it now appears.


