### PR TITLE
e2e-test: update test tags to use colons

### DIFF
--- a/scripts/pr-e2e-comment.sh
+++ b/scripts/pr-e2e-comment.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 # Script to update or create a PR comment with E2E test tags
-# Usage: ./update_pr_comment.sh "<comment_marker>" "<tags>"
-# Example: ./update_pr_comment.sh "<!-- PR Tags -->" "@critical,@quarto"
+# Usage: bash ./scripts/pr-e2e-comment.sh "<comment_marker>" "<tags>"
+# Example: bash ./scripts/pr-e2e-comment.sh "<!-- PR Tags -->" "@:critical,@:quarto"
 
 set -e
 
 # Arguments
 COMMENT_MARKER="$1"  # e.g., "<!-- PR Tags -->"
-TAGS="$2"            # e.g., "@critical,@quarto"
+TAGS="$2"            # e.g., "@:critical,@:quarto"
 
 # Ensure required arguments are provided
 if [ -z "$COMMENT_MARKER" ] || [ -z "$TAGS" ]; then

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -44,15 +44,13 @@ else
     echo "Found web tag in PR body. Setting to run web tests."
     echo "web_tag_found=true" >> "$GITHUB_OUTPUT"
   fi
-  # Parse tags starting with '@:' and convert to '@'
-  TAGS=$(echo "$PR_BODY" | grep -o "@:[a-zA-Z0-9_-]*" | sed 's/@://g' | sed 's/^/@/' | tr '\n' ',' | sed 's/,$//')
 
   # Always add @critical if not already included
-  if [[ ! "$TAGS" =~ "@critical" ]]; then
+  if [[ ! "$TAGS" =~ "@:critical" ]]; then
     if [[ -n "$TAGS" ]]; then
-      TAGS="@critical,$TAGS"
+      TAGS="@:critical,$TAGS"
     else
-      TAGS="@critical"
+      TAGS="@:critical"
     fi
   fi
 fi

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -46,8 +46,7 @@ else
   fi
 
   # Parse tags starting with '@:'
-  TAGS=$(echo "$PR_BODY" | grep -o "@:[a-zA-Z0-9_-]*" | sed 's/^/@/' | tr '\n' ',' | sed 's/,$//')
-  echo $TAGS
+  TAGS=$(echo "$PR_BODY" | grep -o "@:[a-zA-Z0-9_-]*" | tr '\n' ',' | sed 's/,$//')
 
   # Always add @:critical if not already included
   if [[ ! "$TAGS" =~ "@:critical" ]]; then

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -45,7 +45,10 @@ else
     echo "web_tag_found=true" >> "$GITHUB_OUTPUT"
   fi
 
-  # Always add @critical if not already included
+# Parse tags starting with '@:'
+  TAGS=$(echo "$PR_BODY" | grep -o "@:[a-zA-Z0-9_-]*" | sed 's/^/@/' | tr '\n' ',' | sed 's/,$//')
+
+  # Always add @:critical if not already included
   if [[ ! "$TAGS" =~ "@:critical" ]]; then
     if [[ -n "$TAGS" ]]; then
       TAGS="@:critical,$TAGS"

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -45,8 +45,9 @@ else
     echo "web_tag_found=true" >> "$GITHUB_OUTPUT"
   fi
 
-# Parse tags starting with '@:'
+  # Parse tags starting with '@:'
   TAGS=$(echo "$PR_BODY" | grep -o "@:[a-zA-Z0-9_-]*" | sed 's/^/@/' | tr '\n' ',' | sed 's/,$//')
+  echo $TAGS
 
   # Always add @:critical if not already included
   if [[ ! "$TAGS" =~ "@:critical" ]]; then

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -192,7 +192,7 @@ For R, add any package requirements to the "imports" section of the `DESCRIPTION
 
 When you create a pull request, the test runner automatically scans the PR description for test tags to determine which E2E tests to run.
 
-- **Always-on Tests:** Tests tagged with `@critical` always run, and you can’t opt out of them.
+- **Always-on Tests:** Tests tagged with `@:critical` always run, and you can’t opt out of them.
 - **Custom Tags:** If your changes affect a specific feature, you can include additional tags in the PR description to trigger relevant tests.
 
 To add a test tag:
@@ -204,7 +204,7 @@ From that point, all E2E tests linked to the specified tag(s) will run during th
 
 To include Windows and Web Browser testing:
 
-By default, only Linuxe e2e test will run.  You can optionally add `@:win` to your PR description and this will run test on windows as well. As of now, windows tests do take longer to run, so the overall PR test job will take longer to complete. You can also ass `@:web` to run the browser tests.
+By default, only Linux e2e test will run.  You can optionally add `@:win` to your PR description and this will run test on windows as well. As of now, windows tests do take longer to run, so the overall PR test job will take longer to complete. You can also ass `@:web` to run the browser tests.
 
 Note: You can update the tags in the PR description at any time. The PR comment will confirm the parsed tags, and the test job will use the tags present in the PR description at the time of execution.
 
@@ -224,4 +224,4 @@ In order to get the "golden screenshots" used for plot comparison is CI, you wil
 
 ## Tests run on PRs
 
-If you think your test should be run when PRs are created, [tag the test with @critical](https://playwright.dev/docs/test-annotations#tag-tests). The existing @critical cases were selected to give good overall coverage while keeping the overall execution time down to ten minutes or less. If your new test functionality covers a part of the application that no other tests cover, it is probably a good idea to include it in the @critical set.
+If you think your test should be run when PRs are created, [tag the test with @:critical](https://playwright.dev/docs/test-annotations#tag-tests). The existing @:critical cases were selected to give good overall coverage while keeping the overall execution time down to ten minutes or less. If your new test functionality covers a part of the application that no other tests cover, it is probably a good idea to include it in the @:critical set.

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -18,7 +18,6 @@
 
 export enum TestTags {
 
-<<<<<<< HEAD
 	// feature tags
 	EDITOR_ACTION_BAR = '@::editor-action-bar',
 	APPS = '@:apps',
@@ -50,39 +49,6 @@ export enum TestTags {
 	// platform tags
 	WEB = '@:web',
 	WIN = '@:win'
-=======
-	// features and functionality
-	EDITOR_ACTION_BAR = '@editor-action-bar',
-	APPS = '@apps',
-	CONNECTIONS = '@connections',
-	CONSOLE = '@console',
-	CRITICAL = '@critical',
-	DATA_EXPLORER = '@data-explorer',
-	DUCK_DB = '@duck-db',
-	HELP = '@help',
-	HTML = '@html',
-	INTERPRETER = '@interpreter',
-	LAYOUTS = '@layouts',
-	VIEWER = '@viewer',
-	EDITOR = '@editor',
-	QUARTO = '@quarto',
-	NEW_PROJECT_WIZARD = '@new-project-wizard',
-	NOTEBOOKS = '@notebooks',
-	OUTLINE = '@outline',
-	OUTPUT = '@output',
-	PLOTS = '@plots',
-	R_MARKDOWN = '@r-markdown',
-	R_PKG_DEVELOPMENT = '@r-pkg-development',
-	RETICULATE = '@reticulate',
-	TEST_EXPLORER = '@test-explorer',
-	TOP_ACTION_BAR = '@top-action-bar',
-	VARIABLES = '@variables',
-	WELCOME = '@welcome',
-
-	// platform
-	WEB = '@web',
-	WIN = '@win'
->>>>>>> main
 }
 
 

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -6,43 +6,56 @@
 /**
  * Use the tags listed below to selectively run e2e tests against your PR.
  *
- * Each tag corresponds to a specific feature, functionality, or area of the application. Use them
+ * Feature tags:
+ * Each tag corresponds to a specific feature, functionality of the application. Use them
  * thoughtfully to ensure your tests align with the intended scope.
  *
+ * Platform tags:
+ * By default PRs will only run e2e tests against Linux / Electron.
  * Add `@:win` tag to enable the tests to run on windows. Add the `@:web` tag to enable a web run.
- * The default will only run Linux electron e2e tests.
  *
- * DON'T FORGET TO ADD THE COLON `:` AFTER THE `@` SYMBOL when tagging tests in a PR description.
- *   -> Correct:   `@:tag`
- *   -> Incorrect: `@tag`
 */
+
 export enum TestTags {
-	EDITOR_ACTION_BAR = '@editor-action-bar',
-	APPS = '@apps',
-	CONNECTIONS = '@connections',
-	CONSOLE = '@console',
-	CRITICAL = '@critical',
-	DATA_EXPLORER = '@data-explorer',
-	DUCK_DB = '@duck-db',
-	HELP = '@help',
-	HTML = '@html',
-	INTERPRETER = '@interpreter',
-	LAYOUTS = '@layouts',
-	VIEWER = '@viewer',
-	EDITOR = '@editor',
-	QUARTO = '@quarto',
-	NEW_PROJECT_WIZARD = '@new-project-wizard',
-	NOTEBOOK = '@notebook',
-	OUTLINE = '@outline',
-	OUTPUT = '@output',
-	PLOTS = '@plots',
-	R_MARKDOWN = '@r-markdown',
-	R_PKG_DEVELOPMENT = '@r-pkg-development',
-	RETICULATE = '@reticulate',
-	TEST_EXPLORER = '@test-explorer',
-	TOP_ACTION_BAR = '@top-action-bar',
-	VARIABLES = '@variables',
-	WEB = '@web',
-	WELCOME = '@welcome',
-	WIN = '@win'
+
+	// feature tags
+	EDITOR_ACTION_BAR = '@::editor-action-bar',
+	APPS = '@:apps',
+	CONNECTIONS = '@:connections',
+	CONSOLE = '@:console',
+	CRITICAL = '@:critical',
+	DATA_EXPLORER = '@:data-explorer',
+	DUCK_DB = '@:duck-db',
+	HELP = '@:help',
+	HTML = '@:html',
+	INTERPRETER = '@:interpreter',
+	LAYOUTS = '@:layouts',
+	VIEWER = '@:viewer',
+	EDITOR = '@:editor',
+	QUARTO = '@:quarto',
+	NEW_PROJECT_WIZARD = '@:new-project-wizard',
+	NOTEBOOK = '@:notebook',
+	OUTLINE = '@:outline',
+	OUTPUT = '@:output',
+	PLOTS = '@:plots',
+	R_MARKDOWN = '@:r-markdown',
+	R_PKG_DEVELOPMENT = '@:r-pkg-development',
+	RETICULATE = '@:reticulate',
+	TEST_EXPLORER = '@:test-explorer',
+	TOP_ACTION_BAR = '@:top-action-bar',
+	VARIABLES = '@:variables',
+	WELCOME = '@:welcome',
+
+	// platform tags
+	WEB = '@:web',
+	WIN = '@:win'
 }
+
+
+type TestTagValue = `@:${string}`;
+
+function validateTags(tags: Record<string, TestTagValue>): void {
+	// This enforces that all tags conform to the @: pattern
+}
+
+validateTags(TestTags);

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -34,7 +34,7 @@ export enum TestTags {
 	EDITOR = '@:editor',
 	QUARTO = '@:quarto',
 	NEW_PROJECT_WIZARD = '@:new-project-wizard',
-	NOTEBOOK = '@:notebook',
+	NOTEBOOKS = '@:notebooks',
 	OUTLINE = '@:outline',
 	OUTPUT = '@:output',
 	PLOTS = '@:plots',
@@ -46,7 +46,7 @@ export enum TestTags {
 	VARIABLES = '@:variables',
 	WELCOME = '@:welcome',
 
-	// platform tags
+	// platform  tags
 	WEB = '@:web',
 	WIN = '@:win'
 }

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -17,7 +17,6 @@
 */
 
 export enum TestTags {
-
 	// feature tags
 	EDITOR_ACTION_BAR = '@:editor-action-bar',
 	APPS = '@:apps',

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -19,7 +19,7 @@
 export enum TestTags {
 
 	// feature tags
-	EDITOR_ACTION_BAR = '@::editor-action-bar',
+	EDITOR_ACTION_BAR = '@:editor-action-bar',
 	APPS = '@:apps',
 	CONNECTIONS = '@:connections',
 	CONSOLE = '@:console',


### PR DESCRIPTION
### Summary
Previously, our test tags used the format `@tag`. However, this caused conflicts in PRs, such as GitHub tagging users, etc. To resolve this, we switched to using the `@:tag` format for tagging tests in PRs. Whether or not to include the colon has been a source of confusion for people. Therefore, this PR updates the enum for test tags to include `:`, ensuring a unified format for both test usage and PR triggers. This change avoids conflicts and maintains consistency across test references and execution triggers.

### QA Notes
Confirmed tags are properly being handled across these scripts:
* `scripts/pr-tags-parse.sh`
* `scripts/pr-tags-transform.sh`
* `scripts/pr-e2e-comment.sh`

Confirmed PR comment reflects tag(s) correctly below on this PR.

@:interpreter