### PR TITLE
For testing purposes, add Data Explorer Clear Column Sorting action to Editor Actions (EditorTitle menu)

### DIFF
--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerActions.ts
@@ -609,6 +609,11 @@ class PositronDataExplorerClearColumnSortingAction extends Action2 {
 					id: MenuId.EditorActionsLeft,
 					when: POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR,
 				},
+				{
+					id: MenuId.EditorTitle,
+					group: 'navigation',
+					when: POSITRON_DATA_EXPLORER_IS_ACTIVE_EDITOR,
+				}
 			]
 		});
 	}


### PR DESCRIPTION
### Description

As part of https://github.com/posit-dev/positron/issues/2085, https://github.com/posit-dev/positron/issues/5361 has been addressed. This means that the Data Explorer action bar has been removed and its actions (Clear Column Sorting and Summary Layout) have been moved to the Editor Action Bar.

At the moment, the user can decide whether to use Editor Actions or the Editor Action Bar. When the user decides to use Editor Actions, this PR adds the Clear Column Sorting action in the `EditorTitle` menu so that the feature can be accessed in end-to-end tests.

Here's how Clear Column Sorting looks in Editor Actions:

![image](https://github.com/user-attachments/assets/235b1f2c-79b7-4137-af6c-b13b6efe7735)

And here's how Clear Column Sorting looks on the Editor Action Bar:

![image](https://github.com/user-attachments/assets/970edc54-9d53-4def-9bdd-44efc197b3b0)

### QA Notes

Tests:
@:editor-action-bar
@:data-explorer

Note that when the Clear Column Sorting action appears in Editor Actions, its title is not displayed because that would take up too much room.
