### PR TITLE
Compare build numbers

### DIFF
--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -198,11 +198,11 @@ export abstract class AbstractUpdateService implements IUpdateService {
 					return Promise.resolve(null);
 				}
 
-				if (hasUpdate(update, this.productService.positronVersion)) {
+				if (hasUpdate(update, `${this.productService.positronVersion}-${this.productService.positronBuildNumber}`)) {
 					this.logService.info(`update#checkForUpdates, ${update.version} is available`);
 					this.updateAvailable(update);
 				} else {
-					this.logService.info(`update#checkForUpdates, ${this.productService.positronVersion} is the latest version`);
+					this.logService.info(`update#checkForUpdates, ${this.productService.positronVersion}-${this.productService.positronBuildNumber} is the latest version`);
 					this.setState(State.Idle(this.getUpdateType()));
 				}
 				return Promise.resolve(update);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Address #1837 

Adds the build number into the version comparison. For example, 2025.02.0-48 can update to 2025.02.0-59.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes
Fixes build comparison to allow updating between builds within the same release version.
- N/A


### QA Notes
2025.02.0-48 introduced update notifications but it won't show one until 2025.03.0 or greater is available. This change will make it easier to test updating with daily builds.
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
