### PR TITLE
Add 'checked' state to `ActionBarButton` and use that state in `ActionBarActionButton`

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarActionButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarActionButton.tsx
@@ -148,6 +148,7 @@ export const ActionBarActionButton = (props: ActionBarActionButtonProps) => {
 					action.label :
 					undefined :
 				undefined,
+			checked: action.checked,
 			disabled: !action.enabled,
 			onMouseEnter: () => setMouseInside(true),
 			onMouseLeave: () => setMouseInside(false),

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
@@ -18,6 +18,7 @@
 	height: 28px;
 	border: none;
 	display: flex;
+	margin: 0 1px;
 	cursor: pointer;
 	overflow: visible;
 	border-radius: 6px;

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.css
@@ -27,6 +27,10 @@
 	color: var(--positronActionBar-foreground);
 }
 
+.action-bar-button.checked {
+	background: var(--positronActionBar-hoverBackground);
+}
+
 .action-bar-button:hover {
 	background: var(--positronActionBar-hoverBackground);
 }

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -26,6 +26,7 @@ export interface ActionBarButtonProps {
 	readonly align?: 'left' | 'right';
 	readonly tooltip?: string | (() => string | undefined);
 	readonly dropdownTooltip?: string | (() => string | undefined);
+	readonly checked?: boolean;
 	readonly disabled?: boolean;
 	readonly ariaLabel?: string;
 	readonly dropdownAriaLabel?: string;
@@ -116,7 +117,8 @@ export const ActionBarButton = forwardRef<
 				hoverManager={context.hoverManager}
 				className={positronClassNames(
 					'action-bar-button',
-					{ 'fade-in': optionalBoolean(props.fadeIn) }
+					{ 'fade-in': optionalBoolean(props.fadeIn) },
+					{ 'checked': optionalBoolean(props.checked) }
 				)}
 				ariaLabel={ariaLabel}
 				tooltip={props.tooltip}
@@ -134,7 +136,8 @@ export const ActionBarButton = forwardRef<
 		return (
 			<div className={positronClassNames(
 				'action-bar-button',
-				{ 'fade-in': optionalBoolean(props.fadeIn) }
+				{ 'fade-in': optionalBoolean(props.fadeIn) },
+				{ 'checked': optionalBoolean(props.checked) }
 			)}>
 				<Button
 					ref={buttonRef}


### PR DESCRIPTION
### Description

This PR addresses https://github.com/posit-dev/positron/issues/5501.

### Release Notes

None

#### New Features

`ActionBarButton` now has a checked state. When it is supplied and it is true, an `ActionBarButton` will display a background that indicates that the button is checked:

![image](https://github.com/user-attachments/assets/c8030fb9-4721-42aa-a1cb-733673c909d5)

The `ActionBarActionButton` component sets its `ActionBarButton` component's checked state from its `action`'s checked state.

Another screen shot:

<img width="1701" alt="image" src="https://github.com/user-attachments/assets/5c0e2e7f-5855-4948-ba93-f55cc6b4f79b" />

#### Bug Fixes

#5501

### QA Notes

Tests:
@:editor-action-bar
@:data-explorer