### PR TITLE
Fix boot on Windows for 1.96 release builds

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -149,22 +149,14 @@ const bundleVSCodeTask = task.define('bundle-vscode', task.series(
 				],
 				resources: vscodeResources,
 				fileContentMapper: filePath => {
-					// --- Start Positron ---
-					// We have modified these `endsWith` statements to use
-					// `path.join` instead of hardcoded `/` path separators;
-					// without this change, no content would be prepended on
-					// Windows. (Presumably, the upstream build process is
-					// running on a Unix-like system or the path separators are
-					// being normalized somewhere else.)
 					if (
-						filePath.endsWith(path.join('vs', 'code', 'electron-sandbox', 'workbench', 'workbench.js')) ||
-						filePath.endsWith(path.join('vs', 'code', 'electron-sandbox', 'processExplorer', 'processExplorer.js'))) {
+						filePath.endsWith('vs/code/electron-sandbox/workbench/workbench.js') ||
+						filePath.endsWith('vs/code/electron-sandbox/processExplorer/processExplorer.js')) {
 						return async (content) => {
 							const bootstrapWindowContent = await fs.promises.readFile(path.join(root, 'out-build', 'bootstrap-window.js'), 'utf-8');
 							return `${bootstrapWindowContent}\n${content}`; // prepend bootstrap-window.js content to entry points that are Electron windows
 						};
 					}
-					// --- End Positron ---
 					return undefined;
 				},
 				skipTSBoilerplateRemoval: entryPoint =>


### PR DESCRIPTION
This change addresses an app boot failure on Windows, which was due to (surprise) path separators.

Positron recently added a patch to work around an issue in which the file content mapper that concatenates startup scripts was being passed Windows-style path separators instead of Unix-style path separators.

It appears that in 1.96 this patch isn't necessary any more as the arguments to this function are once again arriving Unix-normalized, so the fix here is just to wholly revert our patch so that this behavior matches upstream.