### PR TITLE
use correct reh/reh-web package.json in bundle

### DIFF
--- a/build/gulpfile.reh.js
+++ b/build/gulpfile.reh.js
@@ -342,7 +342,8 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
 		// --- Start Positron ---
 		// Note: The remote/reh-web/package.json is generated/updated in build/npm/postinstall.js
 		const packageJsonBase = type === 'reh-web' ? 'remote/reh-web' : 'remote';
-		const packageJsonStream = gulp.src(['remote/package.json'], { base: packageJsonBase })
+		const packageJsonStream = gulp.src([`${packageJsonBase}/package.json`], { base: packageJsonBase })
+			// --- End Positron ---
 			.pipe(json({ name, version, dependencies: undefined, optionalDependencies: undefined, type: 'module' }))
 			.pipe(es.through(function (file) {
 				packageJsonContents = file.contents.toString();


### PR DESCRIPTION
This change addresses an issue in which Positron Server doesn't start due to an error like this one:

```
(node:11206) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/home/ubuntu/vscode-reh-web-linux-x64/out/server-main.js:26
export function __extends(d, b) {
^^^^^^

SyntaxError: Unexpected token 'export'
    at wrapSafe (node:internal/modules/cjs/loader:1378:20)
    at Module._compile 
```

The problem was caused by an incompletely merged line in the initial 1.95 merge, which caused a cascade of silent failures that led to `package.json` being omitted from the `reh-web` bundle, which led to the above failure since `package.json` was responsible for setting `"type": "module"` as noted above. The fix is just to update the line to match what it was before the merge:

https://github.com/posit-dev/positron/blob/fa567b23598d7f91eab1f2aa182ae8b1e8b50099/build/gulpfile.reh.js#L378-L383

Addresses, coincidentally, https://github.com/posit-dev/positron/issues/5775, which is where this error was first spotted.

After the change, it ought to be possible to run `./positron-server` without error. E.g.:

```
./positron-server --version
Positron: 2025.01.1 build 4
Positron SHA: 9f520e6e796d266fcd603d601ae904e2abae8f9f
Code OSS: 1.96.0
Arch: arm64
```