### PR TITLE
Fix word wrap behavior in console pane

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.css
@@ -52,6 +52,7 @@
 
 .console-core .console-instance .console-instance-container {
 	cursor: text;
+	word-wrap: break-word;
 }
 
 .console-core .console-instance:focus {

--- a/test/e2e/tests/console/console-output.test.ts
+++ b/test/e2e/tests/console/console-output.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, tags } from '../_test.setup';
+import { test, tags, expect } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -15,6 +15,16 @@ test.describe('Console Output', { tag: [tags.WIN, tags.CONSOLE, tags.WEB] }, () 
 		await app.workbench.console.sendEnterKey();
 		await app.workbench.console.waitForConsoleContents('Why do programmers prefer dark mode');
 		await app.workbench.console.waitForConsoleContents('Because light attracts bugs!');
+	});
+
+	test('Long console output wraps appropriately', async function ({ app, page, python }) {
+		await app.workbench.console.waitForReady('>>>');
+		await app.workbench.console.pasteCodeToConsole(pyCode);
+		await app.workbench.console.sendEnterKey();
+		await app.workbench.console.waitForReady('>>>');
+
+		const el = page.locator('.console-instance');
+		await expect(await el.evaluate((el) => el.scrollWidth)).toBeLessThanOrEqual(await el.evaluate((el) => el.clientWidth));
 	});
 });
 
@@ -38,3 +48,5 @@ const rCode = `tokens <- c(
 		cat(token)
 		Sys.sleep(0.01)
 	}`;
+
+const pyCode = `"Blah" * 300`;


### PR DESCRIPTION
Addresses #5580 

Updated console stylesheet to enable wrapping mid-word (i.e., not waiting for a natural breakpoint). Overflowing lines now wrap as soon as they reach the edge of a console, preventing the horizontal scrollbar from becoming active. 

New behavior in Python console:
<img width="704" alt="Screenshot 2025-01-17 at 10 38 40 AM" src="https://github.com/user-attachments/assets/5004526b-891e-4ac0-8f62-b2961377b9de" />

New behavior in R console:
<img width="705" alt="Screenshot 2025-01-17 at 10 38 09 AM" src="https://github.com/user-attachments/assets/11cd1a5a-7910-4612-aa08-cea6bfdeca3e" />

See issue above for prior behavior. 

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed bug in console pane to allow proper line wrapping behavior


### QA Notes
Adds e2e test to check this case is working properly.
@:console

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
