### PR TITLE
Increase margin for help pane test

### DIFF
--- a/test/e2e/tests/help/help.test.ts
+++ b/test/e2e/tests/help/help.test.ts
@@ -83,7 +83,7 @@ test.describe('Help', { tag: [tags.HELP, tags.WEB] }, () => {
 		// Reopen the panel
 		await helpPanelHeaderLocator.click();
 
-		if (helpPanelHeightAfter < 100) {
+		if (helpPanelHeightAfter < 125) {
 			// When the panel is small enough, it will pop back to the full size.
 			// This can happen if the window used for testing is too small.
 			// In this case we want to end the test early because the behavior wont be as


### PR DESCRIPTION
This change attempts to fix a test failure observed in the help pane tests, such as this one.

https://github.com/posit-dev/positron/actions/runs/12815040926

From debugging, it appears that the help pane is working correctly, but (as noted in the test comments) if you resize it to be very small and then collapse and expand it, it opens at a more reasonable size. The threshold at which it does this is around 100. 

<img width="574" alt="image" src="https://github.com/user-attachments/assets/ca50c089-0b6b-464f-a3a0-a6e883735cb3" />

The test window is near this breakpoint, such that the pane is small enough that the code wants to reopen it at full size, but the test expects it to reopen at its size before collapse.

The fix is to increase the margin around the breakpoint.