### PR TITLE
Fixup help resize test

### DIFF
--- a/test/e2e/tests/help/help.test.ts
+++ b/test/e2e/tests/help/help.test.ts
@@ -37,7 +37,7 @@ test.describe('Help', { tag: [tags.HELP, tags.WEB] }, () => {
 
 	});
 
-	test('Verifies help panel can be opened when empty and also can be resized smaller and remember resize height [C640934]', async function ({ app, logger }) {
+	test('Verifies help panel can be opened when empty and also can be resized smaller and remember resize height [C640934]', { tag: [tags.WIN] }, async function ({ app, logger }) {
 		// Not running on windows as the size calculation is off for the resolution in CI
 		const help = app.workbench.help;
 		const helpContainerLocator = help.getHelpContainer();
@@ -83,7 +83,7 @@ test.describe('Help', { tag: [tags.HELP, tags.WEB] }, () => {
 		// Reopen the panel
 		await helpPanelHeaderLocator.click();
 
-		if (helpPanelHeightAfter < 100) {
+		if (helpPanelHeightAfter <= 100) {
 			// When the panel is small enough, it will pop back to the full size.
 			// This can happen if the window used for testing is too small.
 			// In this case we want to end the test early because the behavior wont be as


### PR DESCRIPTION
This fixes up failure we are seeing in Linux for the help resize test

* Changed escape hatch to be >= as it was right at 100
* Added win tag as it works on windows now


### QA Notes
@:help @:win

Help tests should now pass
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
