### PR TITLE
Plot editor tab sizing policies

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotInstance.tsx
@@ -78,7 +78,7 @@ export const DynamicPlotInstance = (props: DynamicPlotInstanceProps) => {
 
 				// Wait for the plot to render.
 				const result =
-					await props.plotClient.render(plotSize, ratio);
+					await props.plotClient.renderWithSizingPolicy(plotSize, ratio);
 
 				// Update the URI to the URI of the new plot.
 				setUri(result.uri);
@@ -94,7 +94,7 @@ export const DynamicPlotInstance = (props: DynamicPlotInstanceProps) => {
 		};
 
 		// Render using the current sizing policy.
-		render(plotsContext.positronPlotsService.selectedSizingPolicy);
+		render(props.plotClient.sizingPolicy);
 
 		// When the plot is rendered, update the URI.
 		disposables.add(props.plotClient.onDidCompleteRender((result) => {
@@ -102,7 +102,7 @@ export const DynamicPlotInstance = (props: DynamicPlotInstanceProps) => {
 		}));
 
 		// Re-render if the sizing policy changes.
-		disposables.add(plotsContext.positronPlotsService.onDidChangeSizingPolicy((policy) => {
+		disposables.add(props.plotClient.onDidChangeSizingPolicy((policy) => {
 			render(policy);
 		}));
 

--- a/src/vs/workbench/contrib/positronPlots/browser/components/openInEditorMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/openInEditorMenuButton.tsx
@@ -55,7 +55,6 @@ export const OpenInEditorMenuButton = (props: OpenInEditorMenuButtonProps) => {
 	const [actions, setActions] = useState<readonly IAction[]>([]);
 
 	const openEditorPlotHandler = useCallback((groupType: number) => {
-		// props.plotsService.openEditor(groupType);
 		props.commandService.executeCommand(PlotsEditorAction.ID, groupType);
 		setDefaultEditorAction(groupType);
 	}, [props.commandService]);

--- a/src/vs/workbench/contrib/positronPlots/browser/components/sizingPolicyMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/sizingPolicyMenuButton.tsx
@@ -162,6 +162,7 @@ export const SizingPolicyMenuButton = (props: SizingPolicyMenuButtonProps) => {
 							} else {
 								// The user entered a valid size; set the custom policy.
 								props.plotsService.setCustomPlotSize(result.size);
+								props.plotClient.sizingPolicy = new PlotSizingPolicyCustom(result.size);
 							}
 						}
 					}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/sizingPolicyMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/sizingPolicyMenuButton.tsx
@@ -43,7 +43,7 @@ export const SizingPolicyMenuButton = (props: SizingPolicyMenuButtonProps) => {
 
 	// State.
 	const [activePolicyLabel, setActivePolicyLabel] =
-		React.useState(props.plotsService.selectedSizingPolicy.getName(props.plotClient));
+		React.useState(props.plotClient.sizingPolicy.getName(props.plotClient));
 
 	React.useEffect(() => {
 		const disposables = new DisposableStore();
@@ -76,7 +76,7 @@ export const SizingPolicyMenuButton = (props: SizingPolicyMenuButtonProps) => {
 		let policyDisposables = attachPolicy(props.plotsService.selectedSizingPolicy);
 
 		// Update the active policy label when the selected policy changes.
-		disposables.add(props.plotsService.onDidChangeSizingPolicy(policy => {
+		disposables.add(props.plotClient.onDidChangeSizingPolicy(policy => {
 			policyDisposables.dispose();
 			policyDisposables = attachPolicy(policy);
 		}));
@@ -106,7 +106,7 @@ export const SizingPolicyMenuButton = (props: SizingPolicyMenuButtonProps) => {
 					enabled,
 					checked: policy.id === selectedPolicy.id,
 					run: () => {
-						props.plotsService.selectSizingPolicy(policy.id);
+						props.plotClient.sizingPolicy = policy;
 					}
 				});
 			}
@@ -125,7 +125,7 @@ export const SizingPolicyMenuButton = (props: SizingPolicyMenuButtonProps) => {
 				enabled: true,
 				checked: customPolicy.id === selectedPolicy.id,
 				run: () => {
-					props.plotsService.selectSizingPolicy(customPolicy.id);
+					props.plotClient.sizingPolicy = customPolicy;
 				}
 			});
 		}

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -273,7 +273,7 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 			}
 			size = { height: height.value, width: width.value };
 		}
-		return props.plotClient.render(size, dpi.value / BASE_DPI, format, true);
+		return props.plotClient.renderWithSizingPolicy(size, dpi.value / BASE_DPI, format, true);
 	};
 
 	const previewButton = () => {

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -18,7 +18,7 @@ import { IPositronPlotsService, POSITRON_PLOTS_VIEW_ID } from '../../../services
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from '../../../common/contributions.js';
 import { Extensions as ViewContainerExtensions, IViewsRegistry } from '../../../common/views.js';
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
-import { PlotsActiveEditorCopyAction, PlotsActiveEditorSaveAction, PlotsClearAction, PlotsCopyAction, PlotsEditorAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsRefreshAction, PlotsSaveAction } from './positronPlotsActions.js';
+import { PlotsActiveEditorCopyAction, PlotsActiveEditorSaveAction, PlotsClearAction, PlotsCopyAction, PlotsEditorAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsRefreshAction, PlotsSaveAction, PlotsSizingPolicyAction } from './positronPlotsActions.js';
 import { POSITRON_SESSION_CONTAINER } from '../../positronSession/browser/positronSessionContainer.js';
 
 // Register the Positron plots service.
@@ -72,6 +72,7 @@ class PositronPlotsContribution extends Disposable implements IWorkbenchContribu
 		registerAction2(PlotsEditorAction);
 		registerAction2(PlotsActiveEditorCopyAction);
 		registerAction2(PlotsActiveEditorSaveAction);
+		registerAction2(PlotsSizingPolicyAction);
 	}
 }
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -14,7 +14,7 @@ import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextke
 import { IsDevelopmentContext } from '../../../../platform/contextkey/common/contextkeys.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
-import { IQuickInputService, IQuickPick, IQuickPickDidAcceptEvent, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { IQuickInputService, IQuickPick, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { PLOT_IS_ACTIVE_EDITOR, POSITRON_EDITOR_PLOTS } from '../../positronPlotsEditor/browser/positronPlotsEditor.contribution.js';
 import { PositronPlotsEditorInput } from '../../positronPlotsEditor/browser/positronPlotsEditorInput.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
@@ -543,7 +543,6 @@ export class PlotsSizingPolicyAction extends AbstractPlotsAction {
 		}
 
 		const isView = plotId === PlotActionTarget.VIEW;
-		const sizingItems = this.createSizingItems(plotsService, isView ? undefined : plotId);
 
 		if (isView) {
 			this.executeTargetAction(PlotActionTarget.VIEW, plotsService, editorService, notificationService);

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -418,7 +418,7 @@ export class PlotsEditorAction extends Action2 {
 	async run(accessor: ServicesAccessor, groupType?: number) {
 		const plotsService = accessor.get(IPositronPlotsService);
 		if (plotsService.selectedPlotId) {
-			plotsService.openEditor(groupType);
+			plotsService.openEditor(plotsService.selectedPlotId, groupType);
 		} else {
 			accessor.get(INotificationService).info(localize('positronPlots.noPlotSelected', 'No plot selected.'));
 		}

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -20,6 +20,7 @@ import { PositronPlotsEditorInput } from '../../positronPlotsEditor/browser/posi
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IPositronPlotsService } from '../../../services/positronPlots/common/positronPlots.js';
 import { PlotClientInstance } from '../../../services/languageRuntime/common/languageRuntimePlotClient.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
 
 export enum PlotActionTarget {
 	VIEW = 'view',
@@ -560,6 +561,8 @@ export class PlotsSizingPolicyAction extends AbstractPlotsAction {
 				id: policy.id,
 				label: policy.getName(plotClient),
 				ariaLabel: policy.getName(plotClient),
+				iconClass: plotClient.sizingPolicy.id === policy.id ? ThemeIcon.asClassName(Codicon.positronCheckMark)
+					: ThemeIcon.asClassName(Codicon.blank),
 			});
 		});
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -152,8 +152,7 @@ abstract class AbstractPlotsAction extends Action2 {
 					id: PlotActionTarget.VIEW,
 					label: localize('positronPlots.copyPlotsView', 'From Plots View'),
 					ariaLabel: localize('positronPlots.copyPlotsView', 'From Plots View'),
-				}
-				);
+				});
 			}
 		}
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -92,9 +92,6 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	/** The list of sizing policies. */
 	private readonly _sizingPolicies: IPositronPlotSizingPolicy[] = [];
 
-	/** The emitter for the onDidChangeSizingPolicy event */
-	private readonly _onDidChangeSizingPolicy = new Emitter<IPositronPlotSizingPolicy>();
-
 	/** The emitter for the onDidChangeHistoryPolicy event */
 	private readonly _onDidChangeHistoryPolicy = new Emitter<HistoryPolicy>();
 
@@ -398,7 +395,6 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		const selectedPlot = this._plots.find((plot) => this.selectedPlotId === plot.id);
 		if (selectedPlot instanceof PlotClientInstance) {
 			selectedPlot.sizingPolicy = policy;
-			// selectedPlot.metadata.sizing_policy = { id: policy.id };
 		}
 	}
 
@@ -434,7 +430,6 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		this._sizingPolicies.push(policy);
 		this._selectedSizingPolicy = policy;
 		this._customSizingPolicy = policy;
-		this._onDidChangeSizingPolicy.fire(policy);
 	}
 
 	/**
@@ -455,7 +450,6 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 			// sizing policy.
 			if (currentPolicy) {
 				this._selectedSizingPolicy = new PlotSizingPolicyAuto();
-				this._onDidChangeSizingPolicy.fire(this._selectedSizingPolicy);
 			}
 		}
 	}
@@ -776,7 +770,6 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	onDidSelectPlot: Event<string> = this._onDidSelectPlot.event;
 	onDidRemovePlot: Event<string> = this._onDidRemovePlot.event;
 	onDidReplacePlots: Event<IPositronPlotClient[]> = this._onDidReplacePlots.event;
-	onDidChangeSizingPolicy: Event<IPositronPlotSizingPolicy> = this._onDidChangeSizingPolicy.event;
 	onDidChangeHistoryPolicy: Event<HistoryPolicy> = this._onDidChangeHistoryPolicy.event;
 
 	// Gets the individual plot instances.

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -663,8 +663,6 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		if (storedMetadata) {
 			try {
 				const metadata = JSON.parse(storedMetadata) as IPositronPlotMetadata;
-				this._plotCommProxies.get(metadata.id);
-				// TODO: check if proxy exists and create one if it does not
 				const plot = this.createRuntimePlotClient(commProxy, metadata, PlotClientLocation.Editor);
 				this._editorPlots.set(plotId, plot);
 
@@ -1145,8 +1143,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	}
 
 	public async openEditor(plotId: string, groupType?: number): Promise<void> {
-		plotId = plotId ?? this.selectedPlotId;
-		const plotClient = this._plots.find(plot => plot.id === this.selectedPlotId);
+		const plotClient = this._editorPlots.get(plotId) ?? this._plots.find(plot => plot.id === this.selectedPlotId);
 
 		if (!plotId) {
 			throw new Error('Cannot open plot in editor: plot not found');

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -405,6 +405,20 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		}
 	}
 
+	setEditorSizingPolicy(plotId: string, policyId: string): void {
+		const plot = this._editorPlots.get(plotId);
+		if (plot instanceof PlotClientInstance) {
+			const policy = this._sizingPolicies.find(policy => policy.id === policyId);
+			if (policy) {
+				plot.sizingPolicy = policy;
+			} else {
+				this._notificationService.error(localize('positronPlots.sizing.invalidSizingPolicy', 'Invalid sizing policy: {0}', policyId));
+			}
+		} else {
+			this._notificationService.error(localize('positronPlots.sizing.invalidPlotType', 'Cannot set size for this plot type'));
+		}
+	}
+
 	/**
 	 * Sets a custom plot size and applies it as a custom sizing policy.
 	 *

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -208,14 +208,6 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		// When the storage service is about to save state, store the current history policy
 		// and storage policy in the workspace storage.
 		this._register(this._storageService.onWillSaveState(() => {
-			this._plots.forEach((plot) => {
-				this.storePlotMetadata(plot.metadata);
-			});
-
-			this._editorPlots.forEach((plot) => {
-				this.storePlotMetadata(plot.metadata);
-			});
-
 			this._storageService.store(
 				HistoryPolicyStorageKey,
 				this._selectedHistoryPolicy,

--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
@@ -164,7 +164,6 @@ export class PositronPlotsEditor extends EditorPane implements IPositronPlotsEdi
 		context: IEditorOpenContext,
 		token: CancellationToken
 	): Promise<void> {
-		this._plotClient?.dispose();
 		this._plotClient = this._positronPlotsService.getEditorInstance(input.resource.path);
 		if (!this._plotClient) {
 			throw new Error('Plot client not found');

--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditorInput.ts
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditorInput.ts
@@ -23,7 +23,7 @@ export class PositronPlotsEditorInput extends EditorInput {
 	override dispose(): void {
 		const plotClient = this._positronPlotsService.getEditorInstance(this.resource.path);
 		if (plotClient) {
-			this._positronPlotsService.unregisterPlotClient(plotClient);
+			this._positronPlotsService.removeEditorPlot(plotClient.id);
 		}
 		super.dispose();
 	}

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -7,8 +7,9 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Event, Emitter } from '../../../../base/common/event.js';
 import { IPositronPlotClient } from '../../positronPlots/common/positronPlots.js';
 import { IntrinsicSize, RenderFormat } from './positronPlotComm.js';
-import { IPlotSize } from '../../positronPlots/common/sizingPolicy.js';
+import { IPlotSize, IPositronPlotSizingPolicy } from '../../positronPlots/common/sizingPolicy.js';
 import { DeferredRender, IRenderedPlot, PositronPlotCommProxy, RenderRequest } from './positronPlotCommProxy.js';
+import { PlotSizingPolicyCustom } from '../../positronPlots/common/sizingPolicyCustom.js';
 
 export enum PlotClientLocation {
 	/** The plot is in the editor */
@@ -53,6 +54,12 @@ export interface IPositronPlotMetadata {
 
 	/** The ID of the runtime session that created the plot */
 	session_id: string;
+
+	/** The sizing policy for the plot. This may not be present with older metadata. */
+	sizing_policy?: {
+		id: string;
+		size?: IPlotSize;
+	};
 }
 
 /**
@@ -131,6 +138,12 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 	private readonly _didSetIntrinsicSizeEmitter = new Emitter<IntrinsicSize | undefined>();
 
 	/**
+	 * Event that fires when the sizing policy is changed.
+	 */
+	onDidChangeSizingPolicy: Event<IPositronPlotSizingPolicy>;
+	private readonly _sizingPolicyEmitter = new Emitter<IPositronPlotSizingPolicy>;
+
+	/**
 	 * Creates a new plot client instance.
 	 *
 	 * @param _commProxy The proxy than handles comm requests
@@ -138,6 +151,7 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 	 */
 	constructor(
 		private readonly _commProxy: PositronPlotCommProxy,
+		private _sizingPolicy: IPositronPlotSizingPolicy,
 		public readonly metadata: IPositronPlotMetadata) {
 		super();
 
@@ -166,6 +180,9 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 		// Connect the intrinsic size emitter event
 		this.onDidSetIntrinsicSize = this._didSetIntrinsicSizeEmitter.event;
 
+		// Connect the sizing policy emitter event
+		this.onDidChangeSizingPolicy = this._sizingPolicyEmitter.event;
+
 		// Listen to our own state changes
 		this._register(this.onDidChangeState((state) => {
 			this._state = state;
@@ -190,6 +207,23 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 	 */
 	public getIntrinsicSize(): Promise<IntrinsicSize | undefined> {
 		return this._commProxy.getIntrinsicSize();
+	}
+
+	get sizingPolicy() {
+		return this._sizingPolicy;
+	}
+
+	set sizingPolicy(newSizingPolicy: IPositronPlotSizingPolicy) {
+		this._sizingPolicy = newSizingPolicy;
+		this._commProxy.metadata.sizing_policy = {
+			id: newSizingPolicy.id,
+			size: newSizingPolicy instanceof PlotSizingPolicyCustom ? newSizingPolicy.size : undefined
+		};
+		this._sizingPolicyEmitter.fire(newSizingPolicy);
+	}
+
+	public renderWithSizingPolicy(size: IPlotSize | undefined, pixel_ratio: number, format = RenderFormat.Png, preview = false): Promise<IRenderedPlot> {
+		return this.render(size ? this._sizingPolicy.getPlotSize(size) : size, pixel_ratio, format, preview);
 	}
 
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -412,4 +412,9 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 		this.scheduleRender(req, 0);
 		return req.promise;
 	}
+
+	override dispose(): void {
+		this._closeEmitter.fire();
+		super.dispose();
+	}
 }

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -60,6 +60,9 @@ export interface IPositronPlotMetadata {
 		id: string;
 		size?: IPlotSize;
 	};
+
+	/** The plot's location for display. */
+	location?: PlotClientLocation;
 }
 
 /**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -218,7 +218,7 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 
 	set sizingPolicy(newSizingPolicy: IPositronPlotSizingPolicy) {
 		this._sizingPolicy = newSizingPolicy;
-		this._commProxy.metadata.sizing_policy = {
+		this.metadata.sizing_policy = {
 			id: newSizingPolicy.id,
 			size: newSizingPolicy instanceof PlotSizingPolicyCustom ? newSizingPolicy.size : undefined
 		};

--- a/src/vs/workbench/services/languageRuntime/common/positronPlotCommProxy.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotCommProxy.ts
@@ -7,7 +7,6 @@ import { Disposable } from '../../../../base/common/lifecycle.js';
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { Event, Emitter } from '../../../../base/common/event.js';
 import { IRuntimeClientInstance, RuntimeClientState } from './languageRuntimeClientInstance.js';
-import { IPositronPlotMetadata } from './languageRuntimePlotClient.js';
 import { IntrinsicSize, PositronPlotComm, RenderFormat } from './positronPlotComm.js';
 import { IPlotSize } from '../../positronPlots/common/sizingPolicy.js';
 
@@ -150,8 +149,7 @@ export class PositronPlotCommProxy extends Disposable {
 	private readonly _didSetIntrinsicSizeEmitter = new Emitter<IntrinsicSize | undefined>();
 
 	constructor(
-		client: IRuntimeClientInstance<any, any>,
-		public readonly metadata: IPositronPlotMetadata) {
+		client: IRuntimeClientInstance<any, any>) {
 		super();
 
 		this._comm = new PositronPlotComm(client, { render: { timeout: 30000 }, get_intrinsic_size: { timeout: 30000 } });

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -200,9 +200,10 @@ export interface IPositronPlotsService {
 	 *
 	 * @param plotId The id of the plot to open in an editor tab.
 	 * @param groupType Specify where the editor tab will be opened. Defaults to the preferred
+	 * @param metadata The metadata for the plot. Uses the existing plot client if not provided.
 	 *   editor group.
 	 */
-	openEditor(plotId: string, groupType?: number): Promise<void>;
+	openEditor(plotId: string, groupType?: number, metadata?: IPositronPlotMetadata): Promise<void>;
 
 	/**
 	 * Gets the preferred editor group for opening the plot in an editor tab.

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -62,11 +62,6 @@ export interface IPositronPlotsService {
 	readonly historyPolicy: HistoryPolicy;
 
 	/**
-	 * Notifies subscribers when the sizing policy has changed.
-	 */
-	readonly onDidChangeSizingPolicy: Event<IPositronPlotSizingPolicy>;
-
-	/**
 	 * Notifies subscribers when the history policy has changed.
 	 */
 	readonly onDidChangeHistoryPolicy: Event<HistoryPolicy>;

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -144,6 +144,11 @@ export interface IPositronPlotsService {
 	selectSizingPolicy(id: string): void;
 
 	/**
+	 * Sets the sizing policy for the plot.
+	 */
+	setEditorSizingPolicy(plotId: string, policyId: string): void;
+
+	/**
 	 * Sets a custom plot size (and selects the custom sizing policy)
 	 */
 	setCustomPlotSize(size: IPlotSize): void;

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -184,12 +184,13 @@ export interface IPositronPlotsService {
 	saveEditorPlot(plotId: string): void;
 
 	/**
-	 * Opens the currently selected plot in an editor.
+	 * Opens the given plot in an editor.
 	 *
+	 * @param plotId The id of the plot to open in an editor tab.
 	 * @param groupType Specify where the editor tab will be opened. Defaults to the preferred
 	 *   editor group.
 	 */
-	openEditor(groupType?: number): Promise<void>;
+	openEditor(plotId: string, groupType?: number): Promise<void>;
 
 	/**
 	 * Gets the preferred editor group for opening the plot in an editor tab.

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -122,6 +122,13 @@ export interface IPositronPlotsService {
 	removePlot(id: string): void;
 
 	/**
+	 * Remove an editor plot.
+	 *
+	 * @param id The ID of the plot to remove.
+	 */
+	removeEditorPlot(id: string): void;
+
+	/**
 	 * Removes the selected plot.
 	 */
 	removeSelectedPlot(): void;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes
Addresses #5522 and #4358

Each plot client has their own metadata that now includes the sizing policy. Each plot can, whether it is in an editor tab or the view, independently set a sizing policy that will be restored on reload.

Adds an action that can switch between sizing policies for the selected plot. The action only shows the options that would be available from the sizing policy menu button in the Plots view. A custom sizing policy can only be set if there already is one set in the Plots view. It cannot be altered from the action.

Restored editors might not restore to the same editor group if there are multiple. I can follow up with adding that to the plot metadata so it can be restored to the same location. The editor order may also not be the same but I think we can live with that.

Finally, it also needs another update later to add the action to the editor toolbar but that will need more work to allow a menu style button.

https://github.com/user-attachments/assets/d68cc152-87d5-4c5d-901f-ea285f0fd0d0



<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features
* Plots in editor tabs are restored when the window is reloaded.
* Plots in editor tabs can change their sizing policy independently of the Plots view. This is invoked via the Command Palette under `Change Plot Sizing Policy`

#### Bug Fixes

- N/A


### QA Notes
This is still hidden behind an experimental setting.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
