### PR TITLE
Add `onEnterRules` for regular old comments in R

### DIFF
--- a/extensions/positron-r/language-configuration/r-language-configuration.json
+++ b/extensions/positron-r/language-configuration/r-language-configuration.json
@@ -56,6 +56,7 @@
 		},
 
 		// Regular comments.
+		// This must come *after* the Roxygen and Plumber rules in this file.
 		{
 			"beforeText": "^\\s*#.*",
 			"afterText": ".+$",

--- a/extensions/positron-r/language-configuration/r-language-configuration.json
+++ b/extensions/positron-r/language-configuration/r-language-configuration.json
@@ -57,7 +57,8 @@
 
 		// Regular comments.
 		{
-			"beforeText": "^\\s*#",
+			"beforeText": "^\\s*#.*",
+			"afterText": ".+$",
 			"action": { "indent": "none", "appendText": "# " }
 		},
 

--- a/extensions/positron-r/language-configuration/r-language-configuration.json
+++ b/extensions/positron-r/language-configuration/r-language-configuration.json
@@ -55,6 +55,12 @@
 			"action": { "indent": "none", "appendText": "#* " }
 		},
 
+		// Regular comments.
+		{
+			"beforeText": "^\\s*#",
+			"action": { "indent": "none", "appendText": "# " }
+		},
+
 		// A line ending with an operator, preceded by a blank line.
 		{
 			"previousLineText": "^\\s*(?:#|$)",


### PR DESCRIPTION
Addresses #5974

The order in this JSON file is important; if you put the regular comment rule _before_ the ones for plumber and roxygen, it takes precedence and we lose the special behavior for plumber and roxygen. It has to go _after_.

We have continuation behavior for Python already here:

https://github.com/posit-dev/positron/blob/c200f27a3b8a608de408ac37ea191ecc96c47e2c/extensions/positron-python/src/client/language/languageConfiguration.ts#L25-L33

It is slightly different than what we've chosen for R; it will continue in the middle of a comment but not at the end. We inherit this behavior from upstream, while the R behavior was chosen to be more like RStudio. It's a little weird that the behavior is different but maybe appropriate, for the two language communities?

EDIT: we are making the continuation for `#` consistent with this Python behavior. This doesn't totally get R users the RStudio behavior they have been used to; we don't have consensus that it's good behavior to make available as a default.

### Release Notes

#### New Features

- Added continuation for regular comments for R, for new lines in the middle of a comment

#### Bug Fixes

- N/A


### QA Notes

The comment continuation for roxygen (`#'`) and plumber (`#*`) should continue to work in `.R` files in R Quarto cells, and now we will additionally continue regular old comments (`#`) in the same spots. The continuation for `#` is different than the other styles of comments; it will continue in the middle of a comment but _not_ when adding a new line at the end of a line. 