### PR TITLE
 add missing esm modules and help.html to reh-web

### DIFF
--- a/build/gulpfile.reh.js
+++ b/build/gulpfile.reh.js
@@ -392,7 +392,9 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
 			].map(resource => gulp.src(resource, { base: '.' }).pipe(rename(resource)));
 		}
 
-		const all = es.merge(
+		// --- Start Positron ---
+		let all = es.merge(
+			// --- End Positron ---
 			packageJsonStream,
 			productJsonStream,
 			license,
@@ -401,6 +403,14 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
 			node,
 			...web
 		);
+
+		// --- Start Positron ---
+		if (type === 'reh-web') {
+			// External modules (React, etc.)
+			const moduleSources = gulp.src('src/esm-package-dependencies/**').pipe(rename(function (p) { p.dirname = path.join('out', 'esm-package-dependencies', p.dirname) }));
+			all = es.merge(all, moduleSources);
+		}
+		// --- End Positron ---
 
 		let result = all
 			.pipe(util.skipDirectories())

--- a/build/gulpfile.vscode.web.js
+++ b/build/gulpfile.vscode.web.js
@@ -40,6 +40,10 @@ const positronVersion = (quality && quality !== 'stable') ? `${product.positronV
 // --- End Positron ---
 
 const vscodeWebResourceIncludes = [
+	// --- Start Positron ---
+	// Positron Help
+	'out-build/vs/workbench/contrib/positronHelp/browser/resources/help.html',
+	// --- End Positron ---
 
 	// NLS
 	'out-build/nls.messages.js',


### PR DESCRIPTION
- addresses https://github.com/rstudio/rstudio-pro/issues/7306
- adds help.html and external ESM modules to the reh-web build

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix issue preventing Positron from loading in Posit Workbench

### QA Notes

These files should no longer be missing, so Positron should now load in Workbench.
<img width="236" alt="image" src="https://github.com/user-attachments/assets/2142d440-58cb-4149-86fa-81b19b9da138" />

I also noticed that help.html was missing, which was preventing the Help Pane from working. Opening Help for R and Python from a Console should now work:

R Console
```r
?iris
```

Python Console
```python
?print
```