### PR TITLE
Add a command to focus the Variables view

### DIFF
--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariables.contribution.ts
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariables.contribution.ts
@@ -5,7 +5,7 @@
 
 import * as nls from '../../../../nls.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { KeyMod, KeyCode } from '../../../../base/common/keyCodes.js';
+import { KeyMod, KeyCode, KeyChord } from '../../../../base/common/keyCodes.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { PositronVariablesFocused } from '../../../common/contextkeys.js';
@@ -44,6 +44,12 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyH,
 				},
 				order: 1,
+			},
+			focusCommand: {
+				id: 'positronVariables.focus',
+				keybindings: {
+					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyV),
+				}
 			}
 		}
 	],


### PR DESCRIPTION
Adds a custom focus command to focus the Variables view; addresses https://github.com/posit-dev/positron/issues/6050. 

### Release Notes

#### New Features

- Add keybinding <kbd>Cmd</kbd> <kbd>K</kbd>, <kbd>V</kbd> for keyboard access to open/focus Variables view. https://github.com/posit-dev/positron/issues/6050

#### Bug Fixes

- N/A


### QA Notes

N/A