### PR TITLE
add windows and browser workflows to merge

### DIFF
--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -1,10 +1,9 @@
 name: "Test: Merge to branch"
 
 on:
-  push:
+  pull_request:
     branches:
       - main
-      - 'prerelease/**'
 
 jobs:
   e2e-electron:

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -17,6 +17,27 @@ jobs:
       currents_tags: "merge,electron/linux"
     secrets: inherit
 
+  e2e-windows-electron:
+    name: e2e
+    uses: ./.github/workflows/test-e2e-windows.yml
+    with:
+      grep: ""
+      display_name: "electron (windows)"
+      currents_tags: "merge,electron/windows"
+      report_testrail: false
+    secrets: inherit
+
+  e2e-linux-browser:
+    name: e2e
+    uses: ./.github/workflows/test-e2e-linux.yml
+    with:
+      grep: ""
+      display_name: "browser (linux)"
+      project: "e2e-browser"
+      currents_tags: "merge,browser/linux"
+      report_testrail: false
+    secrets: inherit
+
   unit-tests:
     name: test
     uses: ./.github/workflows/test-unit.yml

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -1,9 +1,10 @@
 name: "Test: Merge to branch"
 
 on:
-  pull_request:
+  push:
     branches:
       - main
+      - 'prerelease/**'
 
 jobs:
   e2e-electron:

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -49,7 +49,7 @@ jobs:
 
   slack-notify:
     if: failure()
-    needs: [unit-tests, integration-tests, e2e-electron]
+    needs: [unit-tests, integration-tests, e2e-electron, e2e-windows-electron, e2e-linux-browser]
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack Notification


### PR DESCRIPTION
### Intent

Adds windows and browser tests to the merge-to-branch workflow. This is will allow complete feedback on changes merged. 


### QA Notes

I briefly changed it to run on PRs. See run https://github.com/posit-dev/positron/actions/runs/12894706848

I won't merge until that completes 
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
