### PR TITLE
Store pending code in the code editor to address #5012

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -702,8 +702,8 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 		disposableStore.add(codeEditorWidget);
 		setCodeEditorWidget(codeEditorWidget);
 
-		// Provide a reference to the console instance.
-		props.positronConsoleInstance.inputTextEditor = codeEditorWidget;
+		// Provide a reference to the code editor.
+		props.positronConsoleInstance.codeEditor = codeEditorWidget;
 
 		// Attach the text model.
 		codeEditorWidget.setModel(positronConsoleContext.modelService.createModel(

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpActions.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpActions.ts
@@ -56,12 +56,9 @@ export class ShowHelpAtCursor extends Action2 {
 		// Look up the active editor
 		let editor = editorService.activeTextEditorControl as IEditor;
 
-		// Prefer the active console instance if it's focused
-		const inputEditor = consoleService.activeInputTextEditor;
-		if (inputEditor) {
-			if (inputEditor.hasTextFocus()) {
-				editor = inputEditor;
-			}
+		// Prefer the active code editor, if it exists and it's focused.
+		if (consoleService.activeCodeEditor?.hasTextFocus()) {
+			editor = consoleService.activeCodeEditor;
 		}
 
 		// If we didn't find an editor, we can't show help here. This should be

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../../../base/common/event.js';
-import { IEditor } from '../../../../../editor/common/editorCommon.js';
+import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { RuntimeItem } from '../classes/runtimeItem.js';
 import { ILanguageRuntimeSession } from '../../../runtimeSession/common/runtimeSessionService.js';
@@ -53,10 +53,10 @@ export interface IPositronConsoleService {
 	readonly activePositronConsoleInstance?: IPositronConsoleInstance;
 
 	/**
-	 * Gets the text editor (mini editor used to enter code at the REPL) for the
-	 * active Positron console instance.
+	 * Gets the active code editor (CodeEditorWidget used to enter code) for the active Positron
+	 * console instance.
 	 */
-	readonly activeInputTextEditor: IEditor | undefined;
+	readonly activeCodeEditor: ICodeEditor | undefined;
 
 	/**
 	 * The onDidStartPositronConsoleInstance event.
@@ -279,9 +279,9 @@ export interface IPositronConsoleInstance {
 	getWidthInChars(): number;
 
 	/**
-	 * Returns the active text editor widget for the console, if it exists.
+	 * Returns the active code editor for the console, if it exists.
 	 */
-	inputTextEditor: IEditor | undefined;
+	codeEditor: ICodeEditor | undefined;
 
 	/**
 	 * Toggles trace.


### PR DESCRIPTION
### Description

This PR addresses #5012 by storing pending code in the `CodeEditorWidget`. Prior to this PR, pending code was stored in the `PositronConsoleInstance` and was pushed to the `CodeEditorWidget` via the `onDidSetPendingCode` event. This resulted in stale pending code being executed if a user edited or deleted the pending code through the `CodeEditorWidget`.

Tests:
@:console
@:help

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #5012

### QA Notes

- [x] Test the #5012 scenario.
- [x] Enter some code into the console. Test that executing code from a source file using ⌘-Enter results in that code being appended to the code you just entered and that it gets executed, if it's a complete code fragment, or that it gets updated, if not.