### PR TITLE
Adds shared snippet for Positron overlay markers

### DIFF
--- a/.vscode/shared.code-snippets
+++ b/.vscode/shared.code-snippets
@@ -49,5 +49,15 @@
 			"private readonly _onDid$1 = new Emitter<$2>();",
 			"readonly onDid$1: Event<$2> = this._onDid$1.event;"
 		],
+	},
+	"Positron Markers": {
+		"scope": "javascript,typescript",
+		"prefix": "// --- Start Positron ---",
+		"description": "Add Positron overlay markers",
+		"body": [
+			"// --- Start Positron ---",
+			"$0",
+			"// --- End Positron ---"
+		]
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

This adds a shared VSCode snippet in the `.vscode/` directory to allow users to insert a Positron overlay marker.   
It is triggered by typing any prefix of `// --- Start Positron ---` within Typescript or Javascript files.

<img width="787" alt="Screenshot 2025-01-21 at 4 13 43 PM" src="https://github.com/user-attachments/assets/3bd14ce8-b4a3-419c-bbcc-dfc8c19471b2" />

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Adds VSCode snippet to add overlay markers

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
