### PR TITLE
Fix typo range bug in getRandomIntInclusive

### DIFF
--- a/src/vs/workbench/test/common/layoutManager.test.ts
+++ b/src/vs/workbench/test/common/layoutManager.test.ts
@@ -677,9 +677,9 @@ suite('LayoutManager', () => {
 	 * Gets a random integer in the inclusive range.
 	 */
 	const getRandomIntInclusive = (min: number, max: number) => {
-		const minCeiled = Math.ceil(min);
-		const maxFloored = Math.floor(max);
-		return Math.floor(Math.random() * (maxFloored - minCeiled + 1) + minCeiled);
+		min = Math.ceil(min);
+		max = Math.floor(max);
+		return Math.floor(Math.random() * (max - min + 1)) + min;
 	};
 
 	// Ensure that all disposables are cleaned up.


### PR DESCRIPTION
### Description

This PR fixes a bug in `getRandomIntInclusive` which I suspect was causing intermittent failures in `LayoutManager` tests (e.g. https://github.com/posit-dev/positron/actions/runs/12892792167/job/35947790688).

Tests:
@:data-explorer

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

I suspect this was the cause of the intermittent failures in `LayoutManager` tests.