### PR TITLE
Fix Positron Web boot: only send a heartbeat in Workbench sessions

### DIFF
--- a/src/vs/server/node/pwbHeartbeat.ts
+++ b/src/vs/server/node/pwbHeartbeat.ts
@@ -1,6 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
 import { createDecorator } from '../../../vs/platform/instantiation/common/instantiation.js';
 import { registerSingleton } from '../../../vs/platform/instantiation/common/extensions.js';
-import { SyncDescriptor } from '../../../vs/platform/instantiation/common/descriptors';
+import { SyncDescriptor } from '../../../vs/platform/instantiation/common/descriptors.js';
 import * as constants from './pwbConstants.js';
 
 export const IPwbHeartbeatService = createDecorator<IPwbHeartbeatService>('pwbHeartbeatService');

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -50,7 +50,7 @@ import { MandatoryServerConnectionToken } from './serverConnectionToken.js';
 // --- End Positron ---
 
 // --- Start PWB: Server proxy support ---
-import { kProxyRegex } from './pwbConstants.js';
+import { kProxyRegex, kSessionUrl } from './pwbConstants.js';
 import { IPwbHeartbeatService } from './pwbHeartbeat.js';
 // --- End PWB ---
 
@@ -852,11 +852,14 @@ export async function createServer(address: string | net.AddressInfo | null, arg
 		// -- End PWB: SSL support
 
 		// -- Start PWB: Heartbeat
-		instantiationService.invokeFunction(async (accessor) => {
-			const pwbHeartbeatService = accessor.get(IPwbHeartbeatService);
+		// Inside a Posit Workbench session, send an initial heartbeat.
+		if (kSessionUrl) {
+			instantiationService.invokeFunction(async (accessor) => {
+				const pwbHeartbeatService = accessor.get(IPwbHeartbeatService);
 
-			pwbHeartbeatService.sendInitialHeartbeat();
-		});
+				pwbHeartbeatService.sendInitialHeartbeat();
+			});
+		}
 		// -- End PWB: Heartbeat
 	}
 


### PR DESCRIPTION
This change addresses an issue in which -- on the prerelease branch specifically -- Positron web doesn't boot outside Workbench; the fix is to skip the initial heartbeat when Positron is running outside of Workbench (determined by checking the `RS_SESSION_URL` environment variable to see if we're in a Workbench session). 

