### PR TITLE
Update kernel supervisor version for Ubuntu 22 compatibility

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -141,7 +141,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.27"
+      "kallichore": "0.1.28"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6023 by updating to a new version of the kernel supervisor that is compatible with Ubuntu 22. 

### Release Notes

#### New Features

- Support for Ubuntu 22 on Linux arm64 platforms (https://github.com/posit-dev/positron/issues/6023)

#### Bug Fixes

- N/A


### QA Notes

This change affects only arm64 release of Positron; x86_64 releases were already Ubuntu 22 compatible. 
