### PR TITLE
e2e-test: fix data-explorer flakes

### DIFF
--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -254,4 +254,8 @@ export class DataExplorer {
 	async expandSummary(): Promise<void> {
 		await this.workbench.quickaccess.runCommand('workbench.action.positronDataExplorer.expandSummary');
 	}
+
+	async verifyTab(tabName: string): Promise<void> {
+		await expect(this.code.driver.page.getByRole('tab', { name: tabName })).toBeVisible();
+	}
 }

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -174,6 +174,13 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 		});
 	},
 
+	// ex: await executeCode('Python', 'print("Hello, world!")');
+	executeCode: async ({ app }, use) => {
+		await use(async (language: 'Python' | 'R', code: string) => {
+			await app.workbench.console.executeCode(language, code);
+		});
+	},
+
 	// ex: await userSettings.set([['editor.actionBar.enabled', 'true']], false);
 	userSettings: [async ({ app }, use) => {
 		const userSettings = new UserSettingsFixtures(app);
@@ -369,6 +376,7 @@ interface TestFixtures {
 	openFile: (filePath: string) => Promise<void>;
 	openDataFile: (filePath: string) => Promise<void>;
 	runCommand: (command: string) => Promise<void>;
+	executeCode: (language: 'Python' | 'R', code: string) => Promise<void>;
 }
 
 interface WorkerFixtures {

--- a/test/e2e/tests/data-explorer/data-explorer-r.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-r.test.ts
@@ -12,7 +12,7 @@ test.use({
 test.describe('Data Explorer - R ', {
 	tag: [tags.WEB, tags.WIN, tags.DATA_EXPLORER]
 }, () => {
-	test('R - Verifies basic data explorer functionality [C609620]', { tag: [tags.CRITICAL] }, async function ({ app, r, page, executeCode }) {
+	test('R - Verifies basic data explorer functionality [C609620]', { tag: [tags.CRITICAL] }, async function ({ app, r, executeCode }) {
 		// snippet from https://www.w3schools.com/r/r_data_frames.asp
 		await executeCode('R', `Data_Frame <- data.frame (
 	Training = c("Strength", "Stamina", "Other"),
@@ -22,8 +22,7 @@ test.describe('Data Explorer - R ', {
 )`);
 
 		await app.workbench.variables.doubleClickVariableRow('Data_Frame');
-		await expect(page.getByRole('tab', { name: 'Data: Data_Frame' })).toBeVisible();
-
+		await app.workbench.dataExplorer.verifyTab('Data: Data_Frame');
 		await app.workbench.dataExplorer.maximizeDataExplorer(true);
 
 		await expect(async () => {
@@ -70,30 +69,30 @@ test.describe('Data Explorer - R ', {
 
 	test('R - Open Data Explorer for the second time brings focus back [C701143]', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5714' }]
-	}, async function ({ app, r, page, runCommand, executeCode }) {
+	}, async function ({ app, r, runCommand, executeCode }) {
 		// Regression test for https://github.com/posit-dev/positron/issues/4197
 		// and https://github.com/posit-dev/positron/issues/5714
 		await executeCode('R', `Data_Frame <- mtcars`);
 		await runCommand('workbench.panel.positronVariables.focus');
 
 		await app.workbench.variables.doubleClickVariableRow('Data_Frame');
-		await expect(page.getByRole('tab', { name: 'Data: Data_Frame' })).toBeVisible();
+		await app.workbench.dataExplorer.verifyTab('Data: Data_Frame');
 
 		// Now move focus out of the the data explorer pane
 		await app.workbench.editors.newUntitledFile();
 		await runCommand('workbench.panel.positronVariables.focus');
 		await app.workbench.variables.doubleClickVariableRow('Data_Frame');
-		await expect(page.getByRole('tab', { name: 'Data: Data_Frame' })).toBeVisible();
+		await app.workbench.dataExplorer.verifyTab('Data: Data_Frame');
 
 		await app.workbench.dataExplorer.closeDataExplorer();
 		await runCommand('workbench.panel.positronVariables.focus');
 	});
 
-	test('R - Check blank spaces in data explorer [C1078834]', async function ({ app, r, page, executeCode }) {
+	test('R - Check blank spaces in data explorer [C1078834]', async function ({ app, r, executeCode }) {
 		await executeCode('R', `df = data.frame(x = c("a ", "a", "   ", ""))`);
 
 		await app.workbench.variables.doubleClickVariableRow('df');
-		await expect(page.getByRole('tab', { name: 'Data: df' })).toBeVisible();
+		await app.workbench.dataExplorer.verifyTab('Data: df');
 
 		await expect(async () => {
 			const tableData = await app.workbench.dataExplorer.getDataExplorerTableData();


### PR DESCRIPTION
### Summary
* Improved the way we are asserting that the tab is visible.
* Added fixture `executeCommand`

### QA Notes
* Tagged test to run in this PR.
* Ran test 10x locally
<img width="734" alt="Screenshot 2025-01-22 at 3 47 07 PM" src="https://github.com/user-attachments/assets/d5cbfe7a-0cb8-449c-9e22-0cbb82c2e01d" />


@:data-explorer
