### PR TITLE
Don't veto shutdown in web mode

### DIFF
--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -321,6 +321,11 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				// storage, but it is possible that this workspace will be
 				// re-opened without an interleaving quit (e.g. if multiple
 				// Positron windows are open).
+				//
+				// We don't do this in web mode because async shutdown
+				// operations aren't supported on the web, and if used will
+				// trigger a browser warning when the user attempts to navigate
+				// away.
 				if (!isWeb) {
 					e.veto(this.clearWorkspaceSessions(), 'positron.runtimeStartup.clearWorkspaceSessions');
 				}

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -23,6 +23,7 @@ import { IWorkspaceTrustManagementService } from '../../../../platform/workspace
 import { URI } from '../../../../base/common/uri.js';
 import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 import { IPositronNewProjectService } from '../../positronNewProject/common/positronNewProject.js';
+import { isWeb } from '../../../../base/common/platform.js';
 
 interface ILanguageRuntimeProviderMetadata {
 	languageId: string;
@@ -320,7 +321,9 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				// storage, but it is possible that this workspace will be
 				// re-opened without an interleaving quit (e.g. if multiple
 				// Positron windows are open).
-				e.veto(this.clearWorkspaceSessions(), 'positron.runtimeStartup.clearWorkspaceSessions');
+				if (!isWeb) {
+					e.veto(this.clearWorkspaceSessions(), 'positron.runtimeStartup.clearWorkspaceSessions');
+				}
 			}
 		}));
 	}


### PR DESCRIPTION
This change fixes an issue in which Positron prompts to save changes whenever you try to navigate away from the page in web mode.

It turns out that in web mode (specifically), async shutdown operations aren't supported, and trying to use them results in this behavior. The fix is simply to not clear the session list in web mode, which should be fine as the reason we need to do this has to do with multiple Electron windows. 

Addresses https://github.com/posit-dev/positron/issues/6062. 

### QA Notes

As noted in the issue it's very easy to hit this, so should be easy to verify as well!