### PR TITLE
Don't veto shutdown in web mode (2025.01 backport of https://github.com/posit-dev/positron/pull/6091) 

### DIFF
--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -26,6 +26,7 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { URI } from '../../../../base/common/uri.js';
 import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 import { IPositronNewProjectService } from '../../positronNewProject/common/positronNewProject.js';
+import { isWeb } from '../../../../base/common/platform.js';
 
 interface ILanguageRuntimeProviderMetadata {
 	languageId: string;
@@ -306,7 +307,9 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				// storage, but it is possible that this workspace will be
 				// re-opened without an interleaving quit (e.g. if multiple
 				// Positron windows are open).
-				e.veto(this.clearWorkspaceSessions(), 'positron.runtimeStartup.clearWorkspaceSessions');
+				if (!isWeb) {
+					e.veto(this.clearWorkspaceSessions(), 'positron.runtimeStartup.clearWorkspaceSessions');
+				}
 			}
 		}));
 	}

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -307,6 +307,11 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				// storage, but it is possible that this workspace will be
 				// re-opened without an interleaving quit (e.g. if multiple
 				// Positron windows are open).
+				//
+				// We don't do this in web mode because async shutdown
+				// operations aren't supported on the web, and if used will
+				// trigger a browser warning when the user attempts to navigate
+				// away.
 				if (!isWeb) {
 					e.veto(this.clearWorkspaceSessions(), 'positron.runtimeStartup.clearWorkspaceSessions');
 				}


### PR DESCRIPTION
This PR is a backport of https://github.com/posit-dev/positron/pull/6091 to the 2025.01 release branch; see that PR for notes.