### PR TITLE
E2E test: flaky test fix dismissing toasts before plot screenshots

### DIFF
--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -47,6 +47,8 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await app.workbench.console.executeCode('Python', pythonDynamicPlot);
 			await app.workbench.plots.waitForCurrentPlot();
 
+			await app.workbench.popups.closeAllToasts();
+
 			const buffer = await app.workbench.plots.getCurrentPlotAsBuffer();
 			await compareImages({
 				app,
@@ -85,6 +87,8 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			logger.log('Sending code to console');
 			await app.workbench.console.executeCode('Python', pythonStaticPlot);
 			await app.workbench.plots.waitForCurrentStaticPlot();
+
+			await app.workbench.popups.closeAllToasts();
 
 			const buffer = await app.workbench.plots.getCurrentStaticPlotAsBuffer();
 			await compareImages({
@@ -294,6 +298,8 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			logger.log('Sending code to console');
 			await app.workbench.console.executeCode('R', rBasicPlot);
 			await app.workbench.plots.waitForCurrentPlot();
+
+			await app.workbench.popups.closeAllToasts();
 
 			const buffer = await app.workbench.plots.getCurrentPlotAsBuffer();
 			await compareImages({


### PR DESCRIPTION
Dismissing toasts before taking plot snapshots as toast will appear in snapshot and break evaluation.

### QA Notes

All plots tests pass without flakes

@:plots @:web @:win
