### PR TITLE
create multi-root workspace for `positron` and `positron-python` extension

### DIFF
--- a/positron.code-workspace
+++ b/positron.code-workspace
@@ -1,0 +1,10 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "./extensions/positron-python"
+		}
+	]
+}


### PR DESCRIPTION
Adds a multiroot workspace config file to resolve Positron Python formatting conflicts. This will respect the different formatters from `positron` and `positron-python` within a single workspace, so we no longer will have to work in multiple windows!

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Addresses #5838 by respecting formatting in both `positron` and `positron-python` workspaces


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

N/A, an opt-in dev experience