### PR TITLE
In development, disable caching of resources so that every resource is reloaded when the window is reloaded

### DIFF
--- a/src/vs/platform/protocol/electron-main/protocolMainService.ts
+++ b/src/vs/platform/protocol/electron-main/protocolMainService.ts
@@ -104,6 +104,14 @@ export class ProtocolMainService extends Disposable implements IProtocolMainServ
 			}
 		}
 
+		// --- Start Positron ---
+		// In development, disable caching of resources so that every resource is reloaded when the
+		// window is reloaded.
+		if (!this.environmentService.isBuilt) {
+			headers = { ...headers, 'Cache-Control': 'no-store' };
+		}
+		// --- End Positron ---
+
 		// first check by validRoots
 		if (this.validRoots.findSubstr(path)) {
 			return callback({ path, headers });

--- a/src/vs/workbench/test/common/layoutManager.test.ts
+++ b/src/vs/workbench/test/common/layoutManager.test.ts
@@ -54,7 +54,7 @@ suite('LayoutManager', () => {
 		verifyDefaultSizedEntries(1, 1_000);
 		verifyDefaultSizedEntries(19, 1_000);
 		verifyDefaultSizedEntries(127, 20_000);
-		// verifyDefaultSizedEntries(23, 500_000);
+		verifyDefaultSizedEntries(23, 500_000);
 	});
 
 	/**
@@ -63,7 +63,7 @@ suite('LayoutManager', () => {
 	test('Default-Sized Entries With Overrides', () => {
 		verifyDefaultSizedEntriesWithOverrides(127, 253, 20_000, 500);
 		verifyDefaultSizedEntriesWithOverrides(200, 18, 50_000, 1_000);
-		// verifyDefaultSizedEntriesWithOverrides(187, 392, 50_000_000, 10_000);
+		verifyDefaultSizedEntriesWithOverrides(187, 392, 50_000_000, 10_000);
 	});
 
 	/**
@@ -75,7 +75,7 @@ suite('LayoutManager', () => {
 		verifyFixedSizedPredefinedEntries(1, 1_000);
 		verifyFixedSizedPredefinedEntries(19, 1_000);
 		verifyFixedSizedPredefinedEntries(127, 20_000);
-		// verifyFixedSizedPredefinedEntries(23, 500_000);
+		verifyFixedSizedPredefinedEntries(23, 500_000);
 	});
 
 	/**

--- a/src/vs/workbench/test/common/layoutManager.test.ts
+++ b/src/vs/workbench/test/common/layoutManager.test.ts
@@ -54,7 +54,7 @@ suite('LayoutManager', () => {
 		verifyDefaultSizedEntries(1, 1_000);
 		verifyDefaultSizedEntries(19, 1_000);
 		verifyDefaultSizedEntries(127, 20_000);
-		verifyDefaultSizedEntries(23, 500_000);
+		// verifyDefaultSizedEntries(23, 500_000);
 	});
 
 	/**
@@ -63,7 +63,7 @@ suite('LayoutManager', () => {
 	test('Default-Sized Entries With Overrides', () => {
 		verifyDefaultSizedEntriesWithOverrides(127, 253, 20_000, 500);
 		verifyDefaultSizedEntriesWithOverrides(200, 18, 50_000, 1_000);
-		verifyDefaultSizedEntriesWithOverrides(187, 392, 50_000_000, 10_000);
+		// verifyDefaultSizedEntriesWithOverrides(187, 392, 50_000_000, 10_000);
 	});
 
 	/**
@@ -75,7 +75,7 @@ suite('LayoutManager', () => {
 		verifyFixedSizedPredefinedEntries(1, 1_000);
 		verifyFixedSizedPredefinedEntries(19, 1_000);
 		verifyFixedSizedPredefinedEntries(127, 20_000);
-		verifyFixedSizedPredefinedEntries(23, 500_000);
+		// verifyFixedSizedPredefinedEntries(23, 500_000);
 	});
 
 	/**


### PR DESCRIPTION
### Description

In development, this PR disables caching of resources so that every resource is reloaded when the window is reloaded.

Prior to this PR, developers had to use **Developer Tools -> Network -> Disable cache** to accomplish this:

<img width="1525" alt="image" src="https://github.com/user-attachments/assets/6ac0b9d1-3a4c-4afd-812b-bc0e35212f17" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

- N/A