### PR TITLE
E2E Test: skip plot comparison for R until 5954 is resolved

### DIFF
--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -299,6 +299,10 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await app.workbench.console.executeCode('R', rBasicPlot);
 			await app.workbench.plots.waitForCurrentPlot();
 
+			// https://github.com/posit-dev/positron/issues/5954
+			// when the "Error rendering plot to `Auto' Size: RPC timeout... " message appears
+			// this comparison fails
+			/*
 			await app.workbench.popups.closeAllToasts();
 
 			const buffer = await app.workbench.plots.getCurrentPlotAsBuffer();
@@ -309,6 +313,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 				masterScreenshotName: `autos-${process.platform}`,
 				testInfo
 			});
+			*/
 
 			if (!headless) {
 				await app.workbench.plots.copyCurrentPlotToClipboard();

--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -293,7 +293,8 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 		});
 
 		test('R - Verifies basic plot functionality', {
-			tag: [tags.CRITICAL, tags.WEB, tags.WIN]
+			tag: [tags.CRITICAL, tags.WEB, tags.WIN],
+			annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5954 (see comment)' }]
 		}, async function ({ app, logger, headless, logsPath }, testInfo) {
 			logger.log('Sending code to console');
 			await app.workbench.console.executeCode('R', rBasicPlot);


### PR DESCRIPTION
Skipping test portion until 5954 is resolved

### QA Notes

Should be no difference aside from less flakes
