### PR TITLE
Mark problematic overrides as protected override

### DIFF
--- a/src/vs/workbench/browser/panecomposite.ts
+++ b/src/vs/workbench/browser/panecomposite.ts
@@ -150,7 +150,7 @@ export abstract class PaneComposite extends Composite implements IPaneComposite 
 	}
 
 	// --- Start Positron ---
-	override saveState(): void {
+	protected override saveState(): void {
 		super.saveState();
 	}
 	// --- End Positron ---

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -627,7 +627,7 @@ export class PlotsSizingPolicyAction extends AbstractPlotsAction {
 		return items;
 	}
 
-	override plotActionFilter(plotClient: IPositronPlotClient): boolean {
+	protected override plotActionFilter(plotClient: IPositronPlotClient): boolean {
 		return plotClient instanceof PlotClientInstance;
 	}
 }


### PR DESCRIPTION
### Description

This PR fixes mangler errors that were caused by public overrides of protected methods. (See https://github.com/posit-dev/positron-builds/actions/runs/12936772450/job/36083119595).

```
> code-oss-dev@1.96.0 gulp
> node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js vscode-darwin-arm64

[[20](https://github.com/posit-dev/positron-builds/actions/runs/12936772450/job/36083119595#step:11:21):11:27] Using gulpfile ~/actions-runner/_work/positron-builds/positron-builds/positron/gulpfile.js
[20:11:27] Starting 'vscode-darwin-arm64'...
[20:11:27] Starting clean-out-build ...
[20:11:27] Finished clean-out-build after 5 ms
[20:11:27] Starting build-date-file ...
[20:11:27] Finished build-date-file after 3 ms
[20:11:27] Starting compile-api-proposal-names ...
[20:11:27] Starting compilation api-proposal-names...
[20:11:27] Finished compilation api-proposal-names with 0 errors after 141 ms
[20:11:27] Finished compile-api-proposal-names after 161 ms
[20:11:27] Starting compile-src ...
[20:11:40] [mangler] Done collecting. Classes: 8559. Exported symbols: 10929
[20:11:41] [mangler] WARN: 'saveState' from /Users/ec2-user/actions-runner/_work/positron-builds/positron-builds/positron/src/vs/workbench/common/component.ts:51 became PUBLIC because of: /Users/ec2-user/actions-runner/_work/positron-builds/positron-builds/positron/src/vs/workbench/browser/panecomposite.ts:153
[20:11:41] [mangler] WARN: 'plotActionFilter' from /Users/ec2-user/actions-runner/_work/positron-builds/positron-builds/positron/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts:1[21](https://github.com/posit-dev/positron-builds/actions/runs/12936772450/job/36083119595#step:11:22) became PUBLIC because of: /Users/ec2-user/actions-runner/_work/positron-builds/positron-builds/positron/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts:630
[20:11:41] [mangler] ERROR: Protected fields have been made PUBLIC. This hurts minification and is therefore not allowed. Review the WARN messages further above
[20:11:41] Starting compilation...
[20:11:41] 'vscode-darwin-arm64' errored after 14 s
[20:11:41] Error: Protected fields have been made PUBLIC. This hurts minification and is therefore not allowed. Review the WARN messages further above
    at Mangler.computeNewFileContents (/Users/ec2-user/actions-runner/_work/positron-builds/positron-builds/positron/build/lib/mangle/index.js:468:19)
    at task (/Users/ec2-user/actions-runner/_work/positron-builds/positron-builds/positron/build/lib/compilation.js:120:56)
    at /Users/ec2-user/actions-runner/_work/positron-builds/positron-builds/positron/build/lib/task.js:47:28
    at new Promise (<anonymous>)
    at _doExecute (/Users/ec2-user/actions-runner/_work/positron-builds/positron-builds/positron/build/lib/task.js:36:12)
    at _execute (/Users/ec2-user/actions-runner/_work/positron-builds/positron-builds/positron/build/lib/task.js:[27](https://github.com/posit-dev/positron-builds/actions/runs/12936772450/job/36083119595#step:11:28):11)
    at result (/Users/ec2-user/actions-runner/_work/positron-builds/positron-builds/positron/build/lib/task.js:66:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async _execute (/Users/ec2-user/actions-runner/_work/positron-builds/positron-builds/positron/build/lib/task.js:27:5)
    at async result (/Users/ec2-user/actions-runner/_work/positron-builds/positron-builds/positron/build/lib/task.js:66:13)
Error: Process completed with exit code 1.
```

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

- N/A