### PR TITLE
e2e-test: add terminal and console contents to e2e logs

### DIFF
--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -107,11 +107,10 @@ export class Console {
 	}
 
 	async logConsoleContents() {
-		this.code.logger.log('------------------');
-		this.code.logger.log('Console contents:');
-		this.code.logger.log('------------------');
+		this.code.logger.log('---- START: Console Contents ----');
 		const contents = await this.code.driver.page.locator(CONSOLE_LINES).allTextContents();
 		contents.forEach(line => this.code.logger.log(line));
+		this.code.logger.log('---- END: Console Contents ----');
 	}
 
 	async typeToConsole(text: string, delay = 30, pressEnter = false) {

--- a/test/e2e/pages/terminal.ts
+++ b/test/e2e/pages/terminal.ts
@@ -72,8 +72,8 @@ export class Terminal {
 	}
 
 	async logTerminalContents() {
-		const locator = this.code.driver.page.locator('.xterm-rows > div');
-		const plainText = (await locator.evaluateAll((rows) =>
+		const terminalRows = this.code.driver.page.locator('.xterm-rows > div');
+		const terminalContents = (await terminalRows.evaluateAll((rows) =>
 			rows.map((row) => {
 				const spans = row.querySelectorAll('span');
 				return Array.from(spans)
@@ -84,7 +84,7 @@ export class Terminal {
 			.join('\n');
 
 		this.code.logger.log('---- START: Terminal Contents ----');
-		this.code.logger.log(plainText);
+		this.code.logger.log(terminalContents);
 		this.code.logger.log('---- END: Terminal Contents ----');
 	}
 }

--- a/test/e2e/pages/terminal.ts
+++ b/test/e2e/pages/terminal.ts
@@ -70,4 +70,23 @@ export class Terminal {
 			}
 		}, text);
 	}
+
+	async logTerminalContents() {
+		const plainText = await this.code.driver.page.evaluate(() => {
+			const rows = document.querySelectorAll('.xterm-rows > div');
+			return Array.from(rows)
+				.map((row) => {
+					const spans = row.querySelectorAll('span');
+					return Array.from(spans)
+						.map((span) => span.textContent?.trim() || '')
+						.join(' '); // Join spans within a row with a space
+				})
+				.filter((line) => line && line.length > 0) // Remove empty lines
+				.join('\n'); // Join rows with newlines
+		});
+
+		this.code.logger.log('---- START: Terminal Contents ----');
+		this.code.logger.log(plainText);
+		this.code.logger.log('---- END: Terminal Contents ----');
+	}
 }

--- a/test/e2e/pages/terminal.ts
+++ b/test/e2e/pages/terminal.ts
@@ -78,10 +78,10 @@ export class Terminal {
 				const spans = row.querySelectorAll('span');
 				return Array.from(spans)
 					.map((span) => span.textContent?.trim() || '')
-					.join(' '); // Join spans within a row with a space
+					.join(' ');
 			})
-		)).filter((line) => line && line.length > 0) // Remove empty lines
-			.join('\n'); // Join rows with newlines
+		)).filter((line) => line && line.length > 0)
+			.join('\n');
 
 		this.code.logger.log('---- START: Terminal Contents ----');
 		this.code.logger.log(plainText);

--- a/test/e2e/pages/terminal.ts
+++ b/test/e2e/pages/terminal.ts
@@ -72,18 +72,16 @@ export class Terminal {
 	}
 
 	async logTerminalContents() {
-		const plainText = await this.code.driver.page.evaluate(() => {
-			const rows = document.querySelectorAll('.xterm-rows > div');
-			return Array.from(rows)
-				.map((row) => {
-					const spans = row.querySelectorAll('span');
-					return Array.from(spans)
-						.map((span) => span.textContent?.trim() || '')
-						.join(' '); // Join spans within a row with a space
-				})
-				.filter((line) => line && line.length > 0) // Remove empty lines
-				.join('\n'); // Join rows with newlines
-		});
+		const locator = this.code.driver.page.locator('.xterm-rows > div');
+		const plainText = (await locator.evaluateAll((rows) =>
+			rows.map((row) => {
+				const spans = row.querySelectorAll('span');
+				return Array.from(spans)
+					.map((span) => span.textContent?.trim() || '')
+					.join(' '); // Join spans within a row with a space
+			})
+		)).filter((line) => line && line.length > 0) // Remove empty lines
+			.join('\n'); // Join rows with newlines
 
 		this.code.logger.log('---- START: Terminal Contents ----');
 		this.code.logger.log(plainText);

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -293,7 +293,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 		await use(app.code.driver.page);
 	},
 
-	autoTestFixture: [async ({ logger, suiteId }, use, testInfo) => {
+	autoTestFixture: [async ({ logger, suiteId, app }, use, testInfo) => {
 		if (!suiteId) { throw new Error('suiteId is required'); }
 
 		logger.log('');
@@ -305,6 +305,9 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 		const failed = testInfo.status !== testInfo.expectedStatus;
 		const testTitle = testInfo.title;
 		const endLog = failed ? `>>> !!! FAILURE !!! Test end: '${testTitle}' !!! FAILURE !!! <<<` : `>>> Test end: '${testTitle}' <<<`;
+
+		await app.workbench.console.logConsoleContents();
+		await app.workbench.terminal.logTerminalContents();
 
 		logger.log('');
 		logger.log(endLog);

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -302,12 +302,12 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 
 		await use();
 
+		await app.workbench.console.logConsoleContents();
+		await app.workbench.terminal.logTerminalContents();
+
 		const failed = testInfo.status !== testInfo.expectedStatus;
 		const testTitle = testInfo.title;
 		const endLog = failed ? `>>> !!! FAILURE !!! Test end: '${testTitle}' !!! FAILURE !!! <<<` : `>>> Test end: '${testTitle}' <<<`;
-
-		await app.workbench.console.logConsoleContents();
-		await app.workbench.terminal.logTerminalContents();
 
 		logger.log('');
 		logger.log(endLog);


### PR DESCRIPTION
### Summary
* Added method to log Terminal Contents to `e2e-test-runner.log`.
* Configured the auto test fixture to always logs Terminal and Console contents after each test.

### QA Notes

* Reviewed output of `e2e-test-runner.log` to confirm contents appear as expected.
