### PR TITLE
Add aria label to open plot in editor dropdown

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/openInEditorMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/openInEditorMenuButton.tsx
@@ -81,6 +81,9 @@ export const OpenInEditorMenuButton = (props: OpenInEditorMenuButtonProps) => {
 			tooltip={props.tooltip}
 			ariaLabel={props.ariaLabel}
 			actions={() => actions}
-			dropdownIndicator='enabled-split' />
+			dropdownIndicator='enabled-split'
+			dropdownAriaLabel={localize('positron-editor-open-in-editor-dropdown', 'Select where to open plot')}
+			dropdownTooltip={localize('positron-editor-open-in-editor-dropdown', 'Select where to open plot')}
+		/>
 	);
 };


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #5894 Add `aria-label` to the dropdown element for the open plot in editor action


### QA Notes
The dropdown button should have an `aria-label` describing the element. The button is still behind a feature flag.

![image](https://github.com/user-attachments/assets/77ab6a77-beee-4aa6-a5de-a44b18f7948b)

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
