### PR TITLE
Fix final step of Windows auto-update

### DIFF
--- a/build/win32/positron.iss
+++ b/build/win32/positron.iss
@@ -1519,7 +1519,8 @@ begin
 
       StopTunnelServiceIfNeeded();
 
-      Exec(ExpandConstant('{app}\tools\inno_updater.exe'), ExpandConstant('"{app}\{#ExeBasename}.exe" ' + BoolToStr(LockFileExists())), '', SW_SHOW, ewWaitUntilTerminated, UpdateResultCode);
+      // inno_updater requires 3 arguments (exe of current installation, lock file status, and a string for the log)
+      Exec(ExpandConstant('{app}\tools\inno_updater.exe'), ExpandConstant('"{app}\{#ExeBasename}.exe" ' + BoolToStr(LockFileExists()) + ' "Updating Positron..."'), '', SW_SHOW, ewWaitUntilTerminated, UpdateResultCode);
     end;
 
     if ShouldRestartTunnelService then


### PR DESCRIPTION

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

I've got a wiki update to describe the entire update process that is WIP: https://github.com/posit-dev/positron-wiki/tree/auto-updates

It describes the steps of the auto-update in detail for Windows that explains what the installer does to update Positron.

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

Add missing argument to inno_updater execution. It expects 3 arguments (exe path of existing installation, lock file status, and a string for the log). See https://github.com/microsoft/inno-updater/blob/3fc01e98dadd9b41fb8073f769fe0756a6f94cf9/src/main.rs#L546 (note that it does check for 4 but the first arg is `inno_updater.exe`)

Without the last argument, `inno_updater.exe` exits without replacing the existing install with the updated one.

#### New Features

- N/A

#### Bug Fixes

- #5540 Fix auto-update on Windows


### QA Notes
This change is required so that the auto-update will complete successfully. Otherwise, the old installation will remain with the updated one located in the `<existing Positron path>\_\` directory.
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
