### PR TITLE
e2e-test: use hot keys to focus variables in tests

### DIFF
--- a/test/e2e/pages/variables.ts
+++ b/test/e2e/pages/variables.ts
@@ -57,6 +57,10 @@ export class Variables {
 		return variables;
 	}
 
+	async focusVariablesView() {
+		await this.code.driver.page.keyboard.press(process.platform === 'darwin' ? 'Meta+K+V' : 'Control+K+V');
+	}
+
 	async waitForVariableRow(variableName: string): Promise<Locator> {
 		const desiredRow = this.code.driver.page.locator(VARIABLES_NAME_COLUMN).filter({ hasText: variableName });
 		await expect(desiredRow).toBeVisible();

--- a/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
@@ -193,7 +193,7 @@ Data_Frame = pd.DataFrame({
 	"carb": [4, 4, 1, 1, 2]
 })`;
 		await app.workbench.console.executeCode('Python', script);
-		await app.workbench.quickaccess.runCommand('workbench.panel.positronVariables.focus');
+		await app.workbench.variables.focusVariablesView();
 
 		await expect(async () => {
 			await app.workbench.variables.doubleClickVariableRow('Data_Frame');
@@ -202,7 +202,7 @@ Data_Frame = pd.DataFrame({
 
 		// Now move focus out of the the data explorer pane
 		await app.workbench.editors.newUntitledFile();
-		await app.workbench.quickaccess.runCommand('workbench.panel.positronVariables.focus');
+		await app.workbench.variables.focusVariablesView();
 		await app.workbench.variables.doubleClickVariableRow('Data_Frame');
 
 		await expect(async () => {
@@ -210,7 +210,7 @@ Data_Frame = pd.DataFrame({
 		}).toPass();
 
 		await app.workbench.dataExplorer.closeDataExplorer();
-		await app.workbench.quickaccess.runCommand('workbench.panel.positronVariables.focus');
+		await app.workbench.variables.focusVariablesView();
 	});
 
 	test('Python - Check blank spaces in data explorer', async function ({ app, python }) {

--- a/test/e2e/tests/data-explorer/data-explorer-r.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-r.test.ts
@@ -12,7 +12,7 @@ test.use({
 
 test.beforeEach(async function ({ app, runCommand }) {
 	await app.workbench.layouts.enterLayout('stacked');
-	await runCommand('workbench.panel.positronVariables.focus');
+	await app.workbench.variables.focusVariablesView();
 });
 
 test.afterEach(async function ({ runCommand }) {
@@ -49,7 +49,7 @@ test.describe('Data Explorer - R ', {
 	}, async function ({ app, r, runCommand, executeCode }) {
 		// Execute code to generate data frames
 		await executeCode('R', `Data_Frame <- mtcars`);
-		await runCommand('workbench.panel.positronVariables.focus');
+		await app.workbench.variables.focusVariablesView();
 
 		// Open Data Explorer
 		await app.workbench.variables.doubleClickVariableRow('Data_Frame');
@@ -57,7 +57,7 @@ test.describe('Data Explorer - R ', {
 
 		// Now move focus out of the the data explorer pane
 		await app.workbench.editors.newUntitledFile();
-		await runCommand('workbench.panel.positronVariables.focus');
+		await app.workbench.variables.focusVariablesView();
 		await app.workbench.dataExplorer.verifyTab('Data: Data_Frame', { isVisible: true, isSelected: false });
 		await app.workbench.variables.doubleClickVariableRow('Data_Frame');
 		await app.workbench.dataExplorer.verifyTab('Data: Data_Frame', { isVisible: true, isSelected: true });

--- a/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
+++ b/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
@@ -3,19 +3,22 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { join } from 'path';
 import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
+test.afterEach(async function ({ runCommand }) {
+	runCommand('workbench.action.closeAllEditors');
+});
+
 test.describe('Data Explorer - DuckDB Column Summary', {
 	tag: [tags.WEB, tags.WIN, tags.CRITICAL, tags.DATA_EXPLORER, tags.DUCK_DB]
 }, () => {
-	test('Verifies basic duckdb column summary functionality', async function ({ app }) {
+	test('Verifies basic duckdb column summary functionality', async function ({ app, openDataFile }) {
 
-		await app.workbench.quickaccess.openDataFile(join(app.workspacePathOrFolder, 'data-files', '100x100', '100x100.parquet'));
+		await openDataFile('data-files/100x100/100x100.parquet');
 
 		await app.workbench.layouts.enterLayout('notebook');
 
@@ -107,12 +110,5 @@ test.describe('Data Explorer - DuckDB Column Summary', {
 				'0.0',
 			]);
 		});
-
-		await app.workbench.layouts.enterLayout('stacked');
-		await app.workbench.sideBar.closeSecondarySideBar();
-
-		await app.workbench.dataExplorer.closeDataExplorer();
-		await app.workbench.variables.toggleVariablesView();
-
 	});
 });


### PR DESCRIPTION
### Summary
Updating tests to use hot keys to focus variables review instead of quick access because it's quicker and likely more reliable... and ensures they work as expected.

### QA Notes

@:data-explorer @:win @:web
