### PR TITLE
e2e-test: address editor-action-bar click flakes

### DIFF
--- a/test/e2e/pages/editorActionBar.ts
+++ b/test/e2e/pages/editorActionBar.ts
@@ -28,11 +28,13 @@ export class EditorActionBar {
 	async clickSplitEditorButton(direction: 'down' | 'right') {
 		if (direction === 'down') {
 			await this.page.keyboard.down('Alt');
-			await this.splitEditorDownButton.click({ force: true }); // need force to avoid flakes
+			await this.splitEditorDownButton.hover();
+			await this.splitEditorDownButton.click();
 			await this.page.keyboard.up('Alt');
 		}
 		else {
-			await this.splitEditorRightButton.click({ force: true }); // need force to avoid flakes
+			await this.splitEditorRightButton.hover();
+			await this.splitEditorRightButton.click();
 		}
 	}
 
@@ -114,7 +116,11 @@ export class EditorActionBar {
 			await test.step(`Verify "open new window" contains: ${text}`, async () => {
 				const [newPage] = await Promise.all([
 					this.page.context().waitForEvent('page'),
-					this.page.getByLabel('Move into new window').first().click({ force: true }), // need force to avoid flakes
+					(async () => {
+						const button = this.page.getByLabel('Move into new window').first();
+						await button.hover();
+						await button.click();
+					})()
 				]);
 				await newPage.waitForLoadState('load');
 				exact

--- a/test/e2e/pages/editorActionBar.ts
+++ b/test/e2e/pages/editorActionBar.ts
@@ -28,11 +28,11 @@ export class EditorActionBar {
 	async clickSplitEditorButton(direction: 'down' | 'right') {
 		if (direction === 'down') {
 			await this.page.keyboard.down('Alt');
-			await this.page.getByLabel('Split Editor Down').click();
+			await this.splitEditorDownButton.click({ force: true }); // need force to avoid flakes
 			await this.page.keyboard.up('Alt');
 		}
 		else {
-			await this.splitEditorRightButton.click();
+			await this.splitEditorRightButton.click({ force: true }); // need force to avoid flakes
 		}
 	}
 
@@ -114,7 +114,7 @@ export class EditorActionBar {
 			await test.step(`Verify "open new window" contains: ${text}`, async () => {
 				const [newPage] = await Promise.all([
 					this.page.context().waitForEvent('page'),
-					this.page.getByLabel('Move into new window').first().click(),
+					this.page.getByLabel('Move into new window').first().click({ force: true }), // need force to avoid flakes
 				]);
 				await newPage.waitForLoadState('load');
 				exact

--- a/test/e2e/tests/editor-action-bar/document-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/document-files.test.ts
@@ -88,6 +88,7 @@ async function verifyOpenInNewWindow(app: Application, text: string) {
 }
 
 async function verifyOpenViewerRendersHtml(app: Application, title: string) {
+	await editorActionBar.openInViewerButton.hover();
 	await editorActionBar.openInViewerButton.click();
 	await editorActionBar.verifyOpenViewerRendersHtml(app.web, title);
 }


### PR DESCRIPTION
### Summary
This PR addresses flakiness issues with certain buttons in the editor action bar that occasionally fail to register clicks. Upon reviewing traces, it was observed that the hover state wasn’t consistently behaving as expected. By explicitly adding a hover action before clicking, the issue appears to be resolved. 🤞 

### QA Notes

@:editor-action-bar