### PR TITLE
Speculative fix for AggregateError at startup

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -141,7 +141,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.28"
+      "kallichore": "0.1.29"
     }
   },
   "dependencies": {

--- a/extensions/positron-supervisor/src/util.ts
+++ b/extensions/positron-supervisor/src/util.ts
@@ -26,6 +26,10 @@ export function summarizeError(err: any): string {
 	if (err instanceof HttpError) {
 		// HTTP errors are common and should be summarized
 		return summarizeHttpError(err);
+	} else if (err.errors) {
+		// If we have multiple errors (as in the case of an AggregateError),
+		// summarize each one
+		return err.errors.map(summarizeError).join('\n\n');
 	} else if (err instanceof Error) {
 		// Other errors should be summarized as their message
 		return err.message;

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -580,6 +580,20 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 					// We have an error message and details; use both
 					this._startupFailureEmitter.fire(err satisfies ILanguageRuntimeStartupFailure);
 					reject(err.message);
+				} else if (err.message && err.errors) {
+					// There are multiple errors (AggregateError)
+					this._startupFailureEmitter.fire({
+						message: err.message,
+						details: err.errors.join('\n\n')
+					} satisfies ILanguageRuntimeStartupFailure);
+					reject(err.message);
+				} else if (err.name && err.message) {
+					// We have a name and a message.
+					this._startupFailureEmitter.fire({
+						message: err.name,
+						details: err.message
+					} satisfies ILanguageRuntimeStartupFailure);
+					reject(err.message);
 				} else if (err.message) {
 					// We only have a message.
 					this._startupFailureEmitter.fire({

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -584,7 +584,7 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 					// There are multiple errors (AggregateError)
 					this._startupFailureEmitter.fire({
 						message: err.message,
-						details: err.errors.join('\n\n')
+						details: err.errors.map((e: any) => e.toString()).join('\n\n')
 					} satisfies ILanguageRuntimeStartupFailure);
 					reject(err.message);
 				} else if (err.name && err.message) {


### PR DESCRIPTION
This change is a speculative fix for an error that has been observed when starting R sessions. 

The problem (based on analysis of the logs) results from the new logic the supervisor has to clean itself up if it is left idle for too long, an improvement added to help support #4996. What appears to be happening is that in some cases, the supervisor is performing an idle check the instant it starts up, then determining itself to be idle (which of course it _is_), then exiting.

There are two changes here:

- First, use a new build of the supervisor that ensures that the first idle check doesn't happen prematurely (0.28 => 0.29)
- Second, the "AggregateError" message is not very helpful, so added logic to help unpack AggregateErrors when summarizing errors thrown across the API boundary. 

Addresses https://github.com/posit-dev/positron/issues/6129.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Speculative fix for occasional `AggregateError` seen when starting a new console (#6129). 


### QA Notes

Unfortunately we don't have a repro for this. 