### PR TITLE
E2E test: references checks

### DIFF
--- a/test/e2e/infra/index.ts
+++ b/test/e2e/infra/index.ts
@@ -37,6 +37,7 @@ export * from '../pages/editors';
 export * from '../pages/settings';
 export * from '../pages/debug';
 export * from '../pages/problems';
+export * from '../pages/references';
 
 // fixtures
 export * from './fixtures/userSettings';

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -39,6 +39,8 @@ export enum TestTags {
 	OUTLINE = '@:outline',
 	OUTPUT = '@:output',
 	PLOTS = '@:plots',
+	PROBLEMS = '@:problems',
+	REFERENCES = '@:references',
 	R_MARKDOWN = '@:r-markdown',
 	R_PKG_DEVELOPMENT = '@:r-pkg-development',
 	RETICULATE = '@:reticulate',
@@ -46,7 +48,6 @@ export enum TestTags {
 	TOP_ACTION_BAR = '@:top-action-bar',
 	VARIABLES = '@:variables',
 	WELCOME = '@:welcome',
-	PROBLEMS = '@:problems',
 
 	// platform  tags
 	WEB = '@:web',

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -34,6 +34,7 @@ import { Settings } from '../pages/settings';
 import { Debug } from '../pages/debug';
 import { EditorActionBar } from '../pages/editorActionBar';
 import { Problems } from '../pages/problems';
+import { References } from '../pages/references';
 
 export interface Commands {
 	runCommand(command: string, options?: { exactLabelMatch?: boolean }): Promise<any>;
@@ -71,6 +72,7 @@ export class Workbench {
 	readonly debug: Debug;
 	readonly editorActionBar: EditorActionBar;
 	readonly problems: Problems;
+	readonly references: References
 
 	constructor(code: Code) {
 
@@ -105,6 +107,7 @@ export class Workbench {
 		this.debug = new Debug(code);
 		this.editorActionBar = new EditorActionBar(code.driver.page, this.viewer, this.quickaccess);
 		this.problems = new Problems(code, this.quickaccess);
+		this.references = new References(code);
 	}
 }
 

--- a/test/e2e/pages/references.ts
+++ b/test/e2e/pages/references.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { expect } from '@playwright/test';
+import { Code } from '../infra/code';
+
+/*
+ *  Reuseable Positron references functionality for tests to leverage.
+ */
+export class References {
+
+	private static readonly REFERENCES_WIDGET = '.monaco-editor .zone-widget .zone-widget-container.peekview-widget.reference-zone-widget.results-loaded';
+	private static readonly REFERENCES_TITLE_COUNT = `${References.REFERENCES_WIDGET} .head .peekview-title .meta`;
+	private static readonly REFERENCES = `${References.REFERENCES_WIDGET} .body .ref-tree.inline .monaco-list-row .highlight`;
+	private static readonly REFERENCES_TITLE_FILE_NAME = `${References.REFERENCES_WIDGET} .head .peekview-title .filename`;
+	private static readonly REFERENCE_FILES = `${References.REFERENCES_WIDGET} .reference-file .label-name`;
+
+	constructor(private code: Code) { }
+
+	async waitUntilOpen(): Promise<void> {
+		await expect(this.code.driver.page.locator(References.REFERENCES_WIDGET)).toBeVisible();
+	}
+
+	async waitForReferencesCountInTitle(count: number): Promise<void> {
+
+		await expect(async () => {
+			const text = await this.code.driver.page.locator(References.REFERENCES_TITLE_COUNT).textContent();
+			const matches = text ? text.match(/\d+/) : null;
+			return matches ? parseInt(matches[0]) === count : false;
+		}).toPass({ timeout: 20000 });
+	}
+
+	async waitForReferencesCount(count: number): Promise<void> {
+		await expect(async () => {
+			const references = await this.code.driver.page.locator(References.REFERENCES).all();
+
+			expect(references.length).toBe(count);
+		}).toPass({ timeout: 20000 });
+
+	}
+
+	async waitForFile(file: string): Promise<void> {
+		const titles = await this.code.driver.page.locator(References.REFERENCES_TITLE_FILE_NAME).all();
+
+		for (const title of titles) {
+			const text = await title.textContent();
+			expect(text).toContain(file);
+		}
+	}
+
+	async waitForReferenceFiles(files: string[]): Promise<void> {
+		await expect(async () => {
+			const fileNames = await this.code.driver.page.locator(References.REFERENCE_FILES).all();
+
+			for (const fileNameLocator of fileNames) {
+				const fileName = await fileNameLocator.textContent();
+				expect(files).toContain(fileName);
+			}
+		}).toPass({ timeout: 20000 });
+	}
+
+	async close(): Promise<void> {
+		// Sometimes someone else eats up the `Escape` key
+		let count = 0;
+		while (true) {
+			await this.code.driver.page.keyboard.press('Escape');
+
+			try {
+				expect((await this.code.driver.page.locator(References.REFERENCES_WIDGET).all()).length).toBe(0);
+				return;
+			} catch (err) {
+				if (++count > 5) {
+					throw err;
+				} else {
+					await this.code.wait(1000);
+				}
+			}
+		}
+	}
+}

--- a/test/e2e/tests/references/references.test.ts
+++ b/test/e2e/tests/references/references.test.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Application } from '../../infra';
+import { test, tags } from '../_test.setup';
+import { join } from 'path';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('References', {
+	tag: [tags.REFERENCES, tags.WEB, tags.WIN]
+}, () => {
+
+	test.afterEach(async ({ app }) => {
+
+		await app.workbench.references.close();
+		await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
+
+	});
+
+	test('Python - Verify References Functionality', { tag: [tags.WIN, tags.WEB, tags.REFERENCES] }, async function ({ app, python, openFile }) {
+
+		const helper = 'helper.py';
+		await test.step('Open helper file and select function name', async () => {
+			await openFile(join('workspaces', 'references_tests', 'python', helper));
+
+			await app.workbench.editor.clickOnTerm(helper, 'add', 1, true);
+
+		});
+
+		await sharedSteps(app, helper);
+
+		await test.step('Verify reference files', async () => {
+			await app.workbench.references.waitForReferenceFiles(['main.py', 'another_script.py', helper]);
+		});
+
+	});
+
+
+	test('R - Verify References Functionality', { tag: [tags.WIN, tags.WEB, tags.REFERENCES] }, async function ({ app, r, openFile }) {
+
+		const helper = 'helper.R';
+		await test.step('Open helper file and select function name', async () => {
+			await openFile(join('workspaces', 'references_tests', 'r', helper));
+
+			await app.workbench.editor.clickOnTerm(helper, 'add', 1, true);
+
+		});
+
+		await sharedSteps(app, helper);
+
+		await test.step('Verify reference files', async () => {
+			await app.workbench.references.waitForReferenceFiles(['main.R', 'another_script.R', helper]);
+		});
+	});
+
+});
+
+async function sharedSteps(app: Application, helper: string) {
+	await test.step('Open references view', async () => {
+		await app.code.driver.page.keyboard.press('F12');
+
+		await app.workbench.references.waitUntilOpen();
+	});
+
+	await test.step('Verify title references count', async () => {
+		await app.workbench.sideBar.closeSecondarySideBar();
+
+		await app.workbench.references.waitForReferencesCountInTitle(4);
+
+		await app.workbench.layouts.enterLayout('stacked');
+	});
+
+	await test.step('Verify references count', async () => {
+		await app.workbench.references.waitForReferencesCount(1);
+	});
+
+	await test.step('Verify references file', async () => {
+		await app.workbench.references.waitForFile(helper);
+	});
+
+}


### PR DESCRIPTION
References tests for R and Python.

In both the R and Python cases, a helper script simply performs addition.  Two other files (main and another_script) use the addition function.  Reference checks are performed on the add function.

### QA Notes

All tests should pass.

@:references @:web @:win
