### PR TITLE
Fix reconnection after going offline for supervisor-managed terminals

### DIFF
--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -1260,7 +1260,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		}
 		if (this._runtimeState === positron.RuntimeState.Offline &&
 			newState !== positron.RuntimeState.Exited &&
-			newState === positron.RuntimeState.Offline) {
+			newState !== positron.RuntimeState.Offline) {
 			// The kernel was offline but is back online; open the connected
 			// barrier
 			this.log(`The kernel is back online.`, vscode.LogLevel.Info);


### PR DESCRIPTION
This change fixes an issue in which reconnection doesn't fully work for sessions managed by the supervisor. 

The issue appears to just be a typo made when porting from the soon-to-be-extinct Jupyter Adapter, with the result that the connection barrier (which holds operations until the kernel is back online) is not opened even though the supervisor correctly detects that the kernel is back online. 

Addresses https://github.com/posit-dev/positron/issues/6126


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix issue causing Console to become unresponsive after an interpreter goes offline and then back online (#6126)

### QA Notes

The easiest way to repro this on macOS is to use `Sys.getpid()` in R and then `lldb -p PID` to take the kernel offline. Type "c" at the LLDB prompt to bring it back online; more notes in Davis's writeup.