### PR TITLE
Remove black formatting (and other unneeded Python config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ product.overrides.json
 /blob-report/
 /playwright/.cache/
 /test-logs/
+.venv
 # --- End Positron ---

--- a/extensions/positron-python/.vscode/settings.json
+++ b/extensions/positron-python/.vscode/settings.json
@@ -74,7 +74,7 @@
     "python.testing.pytestArgs": [
         "python_files/tests",
          // --- Start Positron ---
-         "python_files/posit/positron"
+         "python_files/posit/positron/tests"
          // --- End Positron ---
     ],
     "python.testing.unittestEnabled": false,

--- a/extensions/positron-python/python_files/.vscode/settings.json
+++ b/extensions/positron-python/python_files/.vscode/settings.json
@@ -3,15 +3,8 @@
         "**/__pycache__/**": true,
         "**/**/*.pyc": true
     },
-    "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter",
-        "editor.formatOnSave": true,
-        "editor.rulers": [100],
-    },
-    "python.testing.pytestArgs": [
-        "tests",
-        "posit/positron/tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
+    // --- Start Positron ---
+    // We use Ruff, which is already configured in the positron-python workspace.
+    // "python.formatting.provider": "black"
+    // --- End Positron ---
 }


### PR DESCRIPTION
Addresses #3576. Since we now share a workspace file, which uses `positron-python` as one of the roots, and doesn't use `python_files` at all, I've updated the `python_files` settings to match upstream ([source](https://github.com/microsoft/vscode-python/blob/main/python_files/.vscode/settings.json)) with one changed line.

I also added `.venv` to `.gitignore` since it's a common workflow (which I happen to use atm).

### QA Notes

Editing files in `python_files` should continue to format and sort imports using Ruff, and discover and run tests as before.