### PR TITLE
e2e-test: editor action bar use hover and click for all

### DIFF
--- a/test/e2e/pages/editorActionBar.ts
+++ b/test/e2e/pages/editorActionBar.ts
@@ -23,7 +23,7 @@ export class EditorActionBar {
 	 * @param button - Name of the button to click in the editor action bar.
 	 */
 	async clickButton(
-		button: 'Split Editor Right' | 'Split Editor Down' | 'Preview' | 'Open Changes' | 'Open in Viewer'
+		button: 'Split Editor Right' | 'Split Editor Down' | 'Preview' | 'Open Changes' | 'Open in Viewer' | 'Move into new window'
 	): Promise<void> {
 		const buttonLocator = this.page.getByLabel(button, { exact: true });
 
@@ -118,11 +118,7 @@ export class EditorActionBar {
 			await test.step(`Verify "open new window" contains: ${text}`, async () => {
 				const [newPage] = await Promise.all([
 					this.page.context().waitForEvent('page'),
-					(async () => {
-						const button = this.page.getByLabel('Move into new window').first();
-						await button.hover();
-						await button.click();
-					})()
+					this.clickButton('Move into new window')
 				]);
 				await newPage.waitForLoadState('load');
 				exact

--- a/test/e2e/pages/editorActionBar.ts
+++ b/test/e2e/pages/editorActionBar.ts
@@ -10,31 +10,33 @@ import { QuickAccess } from './quickaccess';
 
 export class EditorActionBar {
 
-	previewButton = this.page.getByLabel('Preview', { exact: true });
-	openChangesButton = this.page.getByLabel('Open Changes');
-	splitEditorRightButton = this.page.getByLabel('Split Editor Right', { exact: true });
-	splitEditorDownButton = this.page.getByLabel('Split Editor Down', { exact: true });
-	openInViewerButton = this.page.getByLabel('Open in Viewer');
-
 	constructor(private page: Page, private viewer: Viewer, private quickaccess: QuickAccess) {
 	}
 
 	// --- Actions ---
 
 	/**
-	 * Action: Click the "Split Editor" button. Handles pressing the 'Alt' key for 'down' direction.
-	 * @param direction 'down' or 'right'
+	 * Action: Click a specified button in the editor action bar.
+	 * Note: Adds hover before click to prevent test flakes in CI.
+	 * Special handling is included for the "Split Editor Down" action (requires holding Alt key).
+	 *
+	 * @param button - Name of the button to click in the editor action bar.
 	 */
-	async clickSplitEditorButton(direction: 'down' | 'right') {
-		if (direction === 'down') {
+	async clickButton(
+		button: 'Split Editor Right' | 'Split Editor Down' | 'Preview' | 'Open Changes' | 'Open in Viewer'
+	): Promise<void> {
+		const buttonLocator = this.page.getByLabel(button, { exact: true });
+
+		if (button === 'Split Editor Down') {
+			// Special case: "Split Editor Down" requires holding Alt key
 			await this.page.keyboard.down('Alt');
-			await this.splitEditorDownButton.hover();
-			await this.splitEditorDownButton.click();
+			await buttonLocator.hover();
+			await buttonLocator.click();
 			await this.page.keyboard.up('Alt');
-		}
-		else {
-			await this.splitEditorRightButton.hover();
-			await this.splitEditorRightButton.click();
+		} else {
+			// General case: Hover and click the button
+			await buttonLocator.hover();
+			await buttonLocator.click();
 		}
 	}
 

--- a/test/e2e/tests/editor-action-bar/data-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/data-files.test.ts
@@ -74,10 +74,10 @@ test.describe('Editor Action Bar: Data Files', {
 			await editorActionBar.selectSummaryOn(app.web, 'Right');
 			await editorActionBar.verifySummaryPosition('Right');
 
-			await editorActionBar.clickSplitEditorButton('right');
+			await editorActionBar.clickButton('Split Editor Right');
 			await editorActionBar.verifySplitEditor('right', testCase.tabName);
 
-			await editorActionBar.clickSplitEditorButton('down');
+			await editorActionBar.clickButton('Split Editor Down');
 			await editorActionBar.verifySplitEditor('down', testCase.tabName);
 
 			await editorActionBar.verifyOpenInNewWindow(app.web, testCase.tabName);

--- a/test/e2e/tests/editor-action-bar/document-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/document-files.test.ts
@@ -71,15 +71,15 @@ test.describe('Editor Action Bar: Document Files', {
 // Helper functions
 
 async function verifyPreviewRendersHtml(heading: string) {
-	await editorActionBar.previewButton.click();
+	await editorActionBar.clickButton('Preview');
 	await editorActionBar.verifyPreviewRendersHtml(heading);
 }
 
 async function verifySplitEditor(tabName: string) {
-	await editorActionBar.clickSplitEditorButton('right');
+	await editorActionBar.clickButton('Split Editor Right');
 	await editorActionBar.verifySplitEditor('right', tabName);
 
-	await editorActionBar.clickSplitEditorButton('down');
+	await editorActionBar.clickButton('Split Editor Down');
 	await editorActionBar.verifySplitEditor('down', tabName);
 }
 
@@ -88,8 +88,7 @@ async function verifyOpenInNewWindow(app: Application, text: string) {
 }
 
 async function verifyOpenViewerRendersHtml(app: Application, title: string) {
-	await editorActionBar.openInViewerButton.hover();
-	await editorActionBar.openInViewerButton.click();
+	await editorActionBar.clickButton('Open in Viewer');
 	await editorActionBar.verifyOpenViewerRendersHtml(app.web, title);
 }
 
@@ -105,7 +104,7 @@ async function verifyOpenChanges(page: Page) {
 		await bindPlatformHotkey(page, 'S');
 
 		// click open changes & verify
-		await page.getByLabel('Open Changes').click();
+		await editorActionBar.clickButton('Open Changes');
 		await expect(page.getByLabel('Revert Block')).toBeVisible();
 		await expect(page.getByLabel('Stage Block')).toBeVisible();
 		await page.getByRole('tab', { name: 'quarto_basic.qmd (Working' }).getByLabel('Close').click();


### PR DESCRIPTION
### Summary
Refactored the Editor Action Bar POM to include an abstract `clickButton` method. This ensures all interactions with the Editor Action Bar consistently use a hover action before clicking, improving reliability and reducing flakiness in tests.

### QA Notes

@:editor-action-bar