### PR TITLE
Fix some language server features not working in the console and in Jupyter notebooks e.g. hover and signature help

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -150,10 +150,6 @@ class PositronInspector(Generic[T]):
 
         return type_name
 
-    # TODO: Rename to get_hover?
-    def get_docstring(self) -> str:
-        return self.value.__doc__ or ""
-
     def get_kind(self) -> str:
         return _get_kind(self.value)
 
@@ -842,10 +838,6 @@ class BaseColumnInspector(_BaseMapInspector[Column], ABC):
 
         return (display_value, True)
 
-    def get_docstring(self) -> str:
-        # Return a preview of the column.
-        return str(self.value)
-
     def get_size(self) -> int:
         dtype = self.value.dtype
 
@@ -968,10 +960,6 @@ class BaseTableInspector(_BaseMapInspector[Table], Generic[Table, Column], ABC):
         type_name = type(self.value).__name__
         shape = self.value.shape
         return f"{type_name} [{shape[0]}x{shape[1]}]"
-
-    def get_docstring(self) -> str:
-        # Return a preview of the table.
-        return str(self.value)
 
     def get_kind(self) -> str:
         return "table"

--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -150,6 +150,10 @@ class PositronInspector(Generic[T]):
 
         return type_name
 
+    # TODO: Rename to get_hover?
+    def get_docstring(self) -> str:
+        return self.value.__doc__ or ""
+
     def get_kind(self) -> str:
         return _get_kind(self.value)
 
@@ -838,6 +842,10 @@ class BaseColumnInspector(_BaseMapInspector[Column], ABC):
 
         return (display_value, True)
 
+    def get_docstring(self) -> str:
+        # Return a preview of the column.
+        return str(self.value)
+
     def get_size(self) -> int:
         dtype = self.value.dtype
 
@@ -960,6 +968,10 @@ class BaseTableInspector(_BaseMapInspector[Table], Generic[Table, Column], ABC):
         type_name = type(self.value).__name__
         shape = self.value.shape
         return f"{type_name} [{shape[0]}x{shape[1]}]"
+
+    def get_docstring(self) -> str:
+        # Return a preview of the table.
+        return str(self.value)
 
     def get_kind(self) -> str:
         return "table"

--- a/extensions/positron-python/python_files/posit/positron/jedi.py
+++ b/extensions/positron-python/python_files/posit/positron/jedi.py
@@ -10,7 +10,7 @@ from typing import Any, Tuple
 
 from ._vendor.jedi import cache, debug, settings
 from ._vendor.jedi.api import Interpreter
-from ._vendor.jedi.api.classes import Completion
+from ._vendor.jedi.api.classes import BaseName, Completion
 from ._vendor.jedi.api.completion import (
     Completion as CompletionAPI,
 )
@@ -342,7 +342,7 @@ def _is_allowed_getitem_type(obj: Any) -> bool:
     )
 
 
-def get_python_object(completion: Completion) -> Tuple[Any, bool]:
+def get_python_object(completion: BaseName) -> Tuple[Any, bool]:
     """
     Get the Python object corresponding to a completion.
 

--- a/extensions/positron-python/python_files/posit/positron/jedi.py
+++ b/extensions/positron-python/python_files/posit/positron/jedi.py
@@ -56,6 +56,7 @@ else:
 settings.cache_directory = _cache_directory.expanduser()
 
 
+# Store the original versions of Jedi functions/methods that we patch.
 _original_interpreter_complete = Interpreter.complete
 _original_interpreter_help = Interpreter.help
 _original_interpreter_goto = Interpreter.goto
@@ -70,6 +71,7 @@ def _interpreter_complete(
     *,
     fuzzy: bool = False,
 ) -> List["PositronCompletion"]:
+    # Wrap original completions in `PositronCompletion`.
     return [
         PositronCompletion(name)
         for name in _original_interpreter_complete(self, line, column, fuzzy=fuzzy)
@@ -79,6 +81,7 @@ def _interpreter_complete(
 def _interpreter_help(
     self: Interpreter, line: Optional[int] = None, column: Optional[int] = None
 ) -> List["PositronName"]:
+    # Wrap original help items in `PositronName`.
     return [PositronName(name) for name in _original_interpreter_help(self, line, column)]
 
 
@@ -92,6 +95,7 @@ def _interpreter_goto(
     only_stubs: bool = False,
     prefer_stubs: bool = False,
 ) -> List["PositronName"]:
+    # Wrap original goto items in `PositronName`.
     return [
         PositronName(name)
         for name in _original_interpreter_goto(
@@ -107,6 +111,7 @@ def _interpreter_goto(
 
 
 def _mixed_name_infer(self: MixedName) -> ValueSet:
+    # Wrap values of known data science types.
     return ValueSet(_wrap_value(value) for value in _original_mixed_name_infer(self))
 
 
@@ -140,34 +145,40 @@ def _is_polars_dataframe(value: Union[MixedObject, Value]) -> bool:
 
 
 class SafeDictLikeMixedObjectWrapper(ValueWrapper):
+    """
+    A `ValueWrapper` of a `MixedObject` that always allows getitem access.
+
+    This should only be used for known types with safe getitem implementations.
+    """
+
     _wrapped_value: MixedObject
     compiled_value: CompiledValue
 
     def __init__(self, wrapped_value: MixedObject) -> None:
         super().__init__(wrapped_value)
 
+        # Enable dict completion for this object.
         self.array_type = "dict"
 
     def py__simple_getitem__(self, index) -> ValueSet:
-        # Remove safety checks.
+        # Get the item without any safety checks.
         return self.compiled_value.py__simple_getitem__(index)
 
 
 class PolarsDataFrameMixedObjectWrapper(SafeDictLikeMixedObjectWrapper):
     def get_key_values(self):
+        # Polars dataframes don't have `.keys()`, instead iterate through `.columns`.
         for columns in self._wrapped_value.py__getattribute__("columns"):
             columns: CompiledValue
             for values in columns.py__iter__():
                 values: LazyKnownValue
-                for value in values.infer():
-                    value: CompiledValue
-                    yield value
+                yield from values.infer()
 
 
 def _mixed_tree_name_infer(self: MixedTreeName) -> ValueSet:
-    # First try to use the namespace, then fall back to static analysis.
-    # This is the reverse of `MixedTreeName.infer`.
-    # See: TODO: Link issue here.
+    # First search the user's namespace, then fall back to static analysis.
+    # This is the reverse of the original implementation.
+    # See: https://github.com/posit-dev/positron/issues/601.
     for compiled_value in self.parent_context.mixed_values:
         for f in compiled_value.get_filters():
             values = ValueSet.from_sets(n.infer() for n in f.get(self.string_name))
@@ -181,23 +192,27 @@ class PositronName(Name):
     """
     Wraps a `jedi.api.classes.BaseName` to customize LSP responses.
 
-    `jedi_language_server` acesses name's properties to generate `lsprotocol` types. We override
-    these properties to enhance LSP responses. This is usually via a `PositronInspector` on the
-    underlying object referenced by the wrapped name.
+    `jedi_language_server` accesses a name's properties to generate `lsprotocol` types which are
+    sent to the client. We override these properties to customize LSP responses.
     """
 
     def __init__(self, name: BaseName) -> None:
         super().__init__(name._inference_state, name._name)  # noqa: SLF001
 
+        # Store the original name.
         self._wrapped_name = name
 
     @cached_property
     def _inspector(self) -> Optional[PositronInspector]:
         """A `PositronInspector` for the object referenced by this name, if available."""
         name = self._wrapped_name._name  # noqa: SLF001
+        # Does the wrapped name reference an actual object?
         if isinstance(name, (CompiledName, MixedName)):
+            # Infer the object.
             value = name.infer_compiled_value()
+            # Can we access the underlying object itself?
             if isinstance(value, CompiledValue):
+                # Get an inspector for the object.
                 obj = value.access_handle.access._obj  # noqa: SLF001
                 return get_inspector(obj)
         return None
@@ -205,7 +220,6 @@ class PositronName(Name):
     @property
     def full_name(self):  # type: ignore
         if self._inspector:
-            # TODO: Move to inspector get_full_name method?
             return get_qualname(self._inspector.value)
         return super().full_name
 
@@ -218,7 +232,6 @@ class PositronName(Name):
     @property
     def module_path(self):
         if self._inspector:
-            # TODO: Move to inspector method?
             fname = oinspect.find_file(self._inspector.value)
             if fname is not None:
                 return Path(fname)
@@ -226,20 +239,28 @@ class PositronName(Name):
 
     def docstring(self, raw=False, fast=True):  # noqa: ARG002, FBT002
         if self._inspector:
-            return self._inspector.get_docstring()
+            if isinstance(self._inspector, (BaseColumnInspector, BaseTableInspector)):
+                # Return a preview of the column/table.
+                return str(self._inspector.value)
+
+            # Return the value's docstring.
+            return self._inspector.value.__doc__ or ""
+
         return super().docstring(raw=raw)
 
     def get_signatures(self):
-        # TODO: Move to inspector get_signatures method?
         if isinstance(self._inspector, (BaseColumnInspector, BaseTableInspector)):
             return []
         return super().get_signatures()
 
 
 class PositronCompletion(PositronName):
+    """Wraps a `jedi.api.classes.Completion` to customize LSP responses."""
+
     def __init__(self, completion: Completion) -> None:
         super().__init__(completion)
 
+        # Store the original completion.
         self._wrapped_completion = completion
 
     @property
@@ -248,7 +269,7 @@ class PositronCompletion(PositronName):
 
 
 class DictKeyName(CompiledName):
-    """A dictionary key with support for inferring its value."""
+    """A dictionary key which can infer its own value."""
 
     def __init__(
         self,
@@ -285,7 +306,8 @@ class DictKeyName(CompiledName):
         return None
 
 
-# Adapted from jedi.api.strings._completions_for_dicts.
+# Adapted from `jedi.api.strings._completions_for_dicts` to use a `DictKeyName`,
+# which shows a preview of tables/columns in the hover text.
 def _completions_for_dicts(
     inference_state: InferenceState,
     dicts: Iterable[CompiledValue],
@@ -313,7 +335,7 @@ def _completions_for_dicts(
 
 
 def apply_jedi_patches():
-    # Apply our patches to Jedi.
+    """Apply Positron patches to Jedi."""
     Interpreter.complete = _interpreter_complete
     Interpreter.help = _interpreter_help
     Interpreter.goto = _interpreter_goto

--- a/extensions/positron-python/python_files/posit/positron/jedi.py
+++ b/extensions/positron-python/python_files/posit/positron/jedi.py
@@ -8,12 +8,12 @@ import pathlib
 import platform
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Optional, Tuple
+from typing import Optional
 
 from IPython.core import oinspect
 
 from ._vendor.jedi import cache, debug, settings
-from ._vendor.jedi.api import Interpreter
+from ._vendor.jedi.api import Interpreter, strings
 from ._vendor.jedi.api.classes import BaseName, Completion, Name
 
 # Rename to avoid conflict with classes.Completion
@@ -33,29 +33,21 @@ from ._vendor.jedi.api.interpreter import (
     MixedParserTreeFilter,
     MixedTreeName,
 )
-from ._vendor.jedi.api.strings import get_quote_ending
 from ._vendor.jedi.cache import memoize_method
-from ._vendor.jedi.file_io import KnownContentFileIO
-from ._vendor.jedi.inference import InferenceState
 from ._vendor.jedi.inference.base_value import HasNoContext, Value, ValueSet, ValueWrapper
-from ._vendor.jedi.inference.compiled import ExactValue, create_from_access_path
-from ._vendor.jedi.inference.compiled.access import create_access_path
+from ._vendor.jedi.inference.compiled import ExactValue
 from ._vendor.jedi.inference.compiled.mixed import MixedName, MixedObject, MixedObjectFilter
 from ._vendor.jedi.inference.compiled.value import CompiledName, CompiledValue
-from ._vendor.jedi.inference.context import ModuleContext, ValueContext
+from ._vendor.jedi.inference.context import ValueContext
 from ._vendor.jedi.inference.filters import MergedFilter
-from ._vendor.jedi.inference.helpers import infer_call_of_leaf
-from ._vendor.jedi.inference.value import ModuleValue
-from ._vendor.jedi.parser_utils import cut_value_at_position
 from ._vendor.jedi.plugins import plugin_manager
-from ._vendor.parso.python.tree import Name as TreeName
 from .inspectors import (
     BaseColumnInspector,
     BaseTableInspector,
     PositronInspector,
     get_inspector,
 )
-from .utils import get_qualname, safe_isinstance
+from .utils import get_qualname
 
 #
 # We adapt code from the MIT-licensed jedi static analysis library to provide enhanced completions
@@ -65,14 +57,8 @@ from .utils import get_qualname, safe_isinstance
 # https://github.com/davidhalter/jedi
 #
 
-_sentinel = object()
-
 
 class PositronMixedTreeName(MixedTreeName):
-    def __init__(self, *args, **kwargs):
-        print("PositronMixedTreeName.__init__")  # , args, kwargs)
-        super().__init__(*args, **kwargs)
-
     def infer(self):
         # First try to use the namespace, then fall back to static analysis.
         # This is the reverse of MixedTreeName.
@@ -82,7 +68,6 @@ class PositronMixedTreeName(MixedTreeName):
         provided was already executed. In that case if something is not properly
         inferred, it should still infer from the variables it already knows.
         """
-        print("PositronMixedTreeName.infer", self.string_name)
         for compiled_value in self.parent_context.mixed_values:
             for f in compiled_value.get_filters():
                 values = ValueSet.from_sets(n.infer() for n in f.get(self.string_name))
@@ -95,29 +80,10 @@ class PositronMixedTreeName(MixedTreeName):
 class PositronMixedParserTreeFilter(MixedParserTreeFilter):
     name_class = PositronMixedTreeName
 
-    def __init__(self, *args, **kwargs):
-        print("PositronMixedParserTreeFilter.__init__")  # , args, kwargs)
-        super().__init__(*args, **kwargs)
-
-    def _filter(self, names):
-        result = super()._filter(names)
-        print("PositronMixedParserTreeFilter._filter", names, result)
-        return result
-
 
 class PositronMixedName(MixedName):
-    # TODO: infer() eventually calls down to execute(). Can we somehow use this for pandas dataframe completions
-    #       from a namespace?
     def infer(self):
-        result = super().infer()
-        print(
-            "PositronMixedName.infer",
-            self.string_name,
-            result,
-            [(value.get_root_context().py__name__(), value.py__name__()) for value in iter(result)],
-        )
         return ValueSet(
-            # TODO: value? tree instance?
             PandasDataFrameMixedObjectWrapper(value)
             if _is_pandas_dataframe(value)
             else SeriesMixedObjectWrapper(value)
@@ -125,40 +91,31 @@ class PositronMixedName(MixedName):
             else PolarsDataFrameMixedObjectWrapper(value)
             if _is_polars_dataframe(value)
             else value
-            for value in result
+            for value in super().infer()
         )
 
 
 class PandasDataFrameMixedObjectWrapper(ValueWrapper):
-    def __init__(self, wrapped_value):
-        print("DataFrameMixedObjectWrapper.__init__", wrapped_value)
-        super().__init__(wrapped_value)
-
     @property
     def array_type(self) -> str:
         return "dict"
 
-    # def get_key_values(self):
-    #     result = self._wrapped_value.get_key_values()
-    #     breakpoint()
-    #     return result
+    def py__simple_getitem__(self, index):
+        # Remove safety checks.
+        return self.compiled_value.py__simple_getitem__(index)
 
 
 class SeriesMixedObjectWrapper(ValueWrapper):
-    def __init__(self, wrapped_value):
-        print("SeriesMixedObjectWrapper.__init__", wrapped_value)
-        super().__init__(wrapped_value)
-
     @property
     def array_type(self) -> str:
         return "dict"
 
+    def py__simple_getitem__(self, index):
+        # Remove safety checks.
+        return self.compiled_value.py__simple_getitem__(index)
+
 
 class PolarsDataFrameMixedObjectWrapper(ValueWrapper):
-    def __init__(self, wrapped_value):
-        print("DataFrameMixedObjectWrapper.__init__", wrapped_value)
-        super().__init__(wrapped_value)
-
     @property
     def array_type(self) -> str:
         return "dict"
@@ -166,11 +123,15 @@ class PolarsDataFrameMixedObjectWrapper(ValueWrapper):
     def get_key_values(self):
         for columns in self._wrapped_value.py__getattribute__("columns"):
             # columns: CompiledValue[List[str]]
-            for seq_value in columns.py__iter__():
-                # seq_value: LazyKnownValue[CompiledValue[str]]
-                for value in seq_value.infer():
+            for values in columns.py__iter__():
+                # values: LazyKnownValue[CompiledValue[str]]
+                for value in values.infer():
                     # value: CompiledValue[str]
                     yield value
+
+    def py__simple_getitem__(self, index):
+        # Remove safety checks.
+        return self.compiled_value.py__simple_getitem__(index)
 
 
 class PositronMixedObjectFilter(MixedObjectFilter):
@@ -182,23 +143,13 @@ class PositronMixedObjectFilter(MixedObjectFilter):
 
 
 class PositronMixedObject(MixedObject):
-    # def get_filters(self, *args, **kwargs):
-    #     result = super().get_filters(*args, **kwargs)
-    #     print("PositronMixedObject.get_filters", self, list(iter(result)))
-    #     return result
-
     def get_filters(self, *args, **kwargs):
         yield PositronMixedObjectFilter(
             self.inference_state, self.compiled_value, self._wrapped_value
         )
 
 
-class NamespaceObject:
-    def __init__(self, dct):
-        self.__dict__ = dct
-
-
-class PositronMixedModuleContext(ModuleContext):
+class PositronMixedModuleContext(MixedModuleContext):
     """
     Special MixedModuleContext.
 
@@ -215,38 +166,16 @@ class PositronMixedModuleContext(ModuleContext):
     Completing the line `x['` should return `a` and not `b`.
     """
 
-    # TODO: May not need to override this if we subclass MixedModuleContext and just override _get_mixed_object,
-    #       unless we need to override NamespaceObject for some reason.
-    def __init__(self, tree_module_value, namespaces):
-        super().__init__(tree_module_value)
-        self.mixed_values = [
-            self._get_mixed_object(
-                create_from_access_path(
-                    self.inference_state,
-                    create_access_path(self.inference_state, NamespaceObject(n)),
-                )
-            )
-            for n in namespaces
-        ]
-
     def _get_mixed_object(self, compiled_value):
         return PositronMixedObject(compiled_value=compiled_value, tree_value=self._value)
 
+    # TODO: We could patch MixedParserTreeFilter.name_class instead?
     def get_filters(self, until_position=None, origin_scope=None):
-        # TODO: Could we yield from super and wrap MixedParserTreeFilter results?
-        # filters = super().get_filters(until_position, origin_scope)
-
-        # # Store the first filter – which corresponds to static analysis of the source code.
-        # merged_filter = next(filters)
-
-        # # Yield the remaining filters – which correspond to the user's namespaces.
-        # yield from filters
-
-        # # Finally, yield the first filter.
-        # yield merged_filter
         yield MergedFilter(
             PositronMixedParserTreeFilter(
-                parent_context=self, until_position=until_position, origin_scope=origin_scope
+                parent_context=self,
+                until_position=until_position,
+                origin_scope=origin_scope,
             ),
             self.get_global_filter(),
         )
@@ -341,22 +270,6 @@ class PositronInterpreter(Interpreter):
     @validate_line_column
     def complete(self, line=None, column=None, *, fuzzy=False):
         return [PositronCompletion(name) for name in super().complete(line, column, fuzzy=fuzzy)]
-        self._inference_state.reset_recursion_limitations()
-        with debug.increase_indent_cm("complete"):
-            # --- Start Positron ---
-            # Use our custom completion class.
-            completion = PositronCompletionAPI(
-                # --- End Positron ---
-                self._inference_state,
-                self._get_module_context(),
-                self._code_lines,
-                (line, column),
-                self.get_signatures,
-                fuzzy=fuzzy,
-            )
-            # --- Start Positron ---
-            return [PositronCompletion(name) for name in completion.complete()]
-            # --- End Positron ---
 
     @validate_line_column
     def help(self, line=None, column=None):
@@ -386,237 +299,6 @@ class PositronInterpreter(Interpreter):
         ]
 
 
-class PositronCompletionAPI(CompletionAPI):
-    # As is from jedi.api.completion.Completion, copied here to use our `complete_dict`.
-    def complete(self):
-        leaf = self._module_node.get_leaf_for_position(
-            self._original_position, include_prefixes=True
-        )
-        string, start_leaf, quote = _extract_string_while_in_string(leaf, self._original_position)
-
-        prefixed_completions = complete_dict(
-            self._module_context,
-            self._code_lines,
-            start_leaf or leaf,
-            self._original_position,
-            None if string is None else quote + string,  # type: ignore
-            fuzzy=self._fuzzy,
-        )
-
-        if string is not None and not prefixed_completions:
-            prefixed_completions = list(
-                complete_file_name(
-                    self._inference_state,
-                    self._module_context,
-                    start_leaf,
-                    quote,
-                    string,
-                    self._like_name,
-                    self._signatures_callback,
-                    self._code_lines,
-                    self._original_position,
-                    self._fuzzy,
-                )
-            )
-        if string is not None:
-            if not prefixed_completions and "\n" in string:
-                # Complete only multi line strings
-                prefixed_completions = self._complete_in_string(start_leaf, string)
-            return prefixed_completions
-
-        cached_name, completion_names = self._complete_python(leaf)
-
-        imported_names = []
-        if leaf.parent is not None and leaf.parent.type in ["import_as_names", "dotted_as_names"]:
-            imported_names.extend(extract_imported_names(leaf.parent))  # type: ignore  # noqa: F821
-
-        completions = list(
-            filter_names(
-                self._inference_state,
-                completion_names,
-                self.stack,
-                self._like_name,
-                self._fuzzy,
-                imported_names,
-                cached_name=cached_name,
-            )
-        )
-
-        return (
-            # Removing duplicates mostly to remove False/True/None duplicates.
-            _remove_duplicates(prefixed_completions, completions)
-            + sorted(
-                completions,
-                key=lambda x: (
-                    not x.name.startswith(self._like_name),
-                    x.name.startswith("__"),
-                    x.name.startswith("_"),
-                    x.name.lower(),
-                ),
-            )
-        )
-
-
-class DictKeyName(CompiledName):
-    """A dictionary key with support for inferring its value."""
-
-    def __init__(self, inference_state, parent_value, key):
-        self._inference_state = inference_state
-
-        try:
-            self.parent_context = parent_value.as_context()
-        except HasNoContext:
-            # If we're completing a dict literal, e.g. `{'a': 0}['`, then parent_value is a
-            # DictLiteralValue which does not override `as_context()`.
-            # Manually create the context instead.
-            self.parent_context = ValueContext(parent_value)
-
-        self._parent_value = parent_value
-        self._key = key
-        self.string_name = str(key)
-
-        # NOTE(seem): IIUC is_descriptor is used to return the api_type() 'instance' without an
-        # execution. If so, it should be safe to always set it to false, but I may have misread
-        # the jedi code.
-        self.is_descriptor = False
-
-    @memoize_method
-    def infer_compiled_value(self) -> CompiledValue:
-        parent = self._parent_value
-
-        # We actually want to override MixedObject.py__simple_getitem__ to include objects from
-        # popular data science libraries as allowed getitem types. However, it's simpler to special
-        # case here instead of vendoring all instantiations of MixedObject.
-        # START: MixedObject.py__simple_getitem__
-        if isinstance(parent, MixedObject):
-            python_object = parent.compiled_value.access_handle.access._obj  # noqa: SLF001
-            if _is_allowed_getitem_type(python_object):
-                values = parent.compiled_value.py__simple_getitem__(self._key)
-            else:
-                values = parent._wrapped_value.py__simple_getitem__(self._key)  # noqa: SLF001
-        # END: MixedObject.py__simple_getitem__
-        else:
-            values = parent.py__simple_getitem__(self._key)
-
-        values = list(values)
-
-        if len(values) != 1:
-            raise ValueError(f"Expected exactly one value, got {len(values)}")
-        value = values[0]
-
-        # This may return an ExactValue which wraps a CompiledValue e.g. when completing a dict
-        # literal like: `{"a": 0}['`.
-        # For some reason, ExactValue().get_signatures() returns an empty list, but
-        # ExactValue()._compiled_value.get_signatures() returns the correct signatures,
-        # so we return the wrapped compiled value instead.
-        if isinstance(value, ExactValue):
-            return value._compiled_value  # noqa: SLF001
-
-        return value
-
-
-# As is from jedi.api.completion.Completion, copied here to use our `_completions_for_dicts`.
-def complete_dict(module_context, code_lines, leaf, position, string, fuzzy):
-    bracket_leaf = leaf
-    if bracket_leaf != "[":
-        bracket_leaf = leaf.get_previous_leaf()
-
-    cut_end_quote = ""
-    if string:
-        cut_end_quote = get_quote_ending(string, code_lines, position, invert_result=True)
-
-    if bracket_leaf == "[":
-        if string is None and leaf is not bracket_leaf:
-            string = cut_value_at_position(leaf, position)
-
-        context = module_context.create_context(bracket_leaf)
-
-        before_node = before_bracket_leaf = bracket_leaf.get_previous_leaf()  # type: ignore
-        if before_node in (")", "]", "}"):
-            before_node = before_node.parent
-        if before_node.type in ("atom", "trailer", "name"):
-            values = infer_call_of_leaf(context, before_bracket_leaf)
-            return list(
-                _completions_for_dicts(
-                    module_context.inference_state,
-                    values,
-                    "" if string is None else string,
-                    cut_end_quote,
-                    fuzzy=fuzzy,
-                )
-            )
-    return []
-
-
-# Adapted from jedi.api.strings._completions_for_dicts.
-def _completions_for_dicts(inference_state, dicts, literal_string, _cut_end_quote, fuzzy):
-    # --- Start Positron ---
-    # Since we've modified _get_python_keys to return Names, sort by yielded value's string_name
-    # instead of the yielded value itself.
-    for name in sorted(_get_python_keys(inference_state, dicts), key=lambda x: repr(x.string_name)):
-        # --- End Positron ---
-        yield Completion(
-            inference_state,
-            name,
-            stack=None,
-            like_name_length=len(literal_string),
-            is_fuzzy=fuzzy,
-        )
-
-
-# Adapted from jedi.api.strings._get_python_keys.
-def _get_python_keys(inference_state, dicts):
-    for dct in dicts:
-        # --- Start Positron ---
-        # Handle dict-like objects from popular data science libraries.
-        try:
-            obj = dct.compiled_value.access_handle.access._obj  # noqa: SLF001
-        except AttributeError:
-            pass
-        else:
-            if _is_allowed_getitem_type(obj) and hasattr(obj, "columns"):
-                for key in obj.columns:
-                    yield DictKeyName(inference_state, dct, key)
-                return
-
-        # --- End Positron ---
-        if dct.array_type == "dict":
-            for key in dct.get_key_values():
-                dict_key = key.get_safe_value(default=_sentinel)
-                if dict_key is not _sentinel:
-                    # --- Start Positron ---
-                    # Return a DictKeyName instead of a string.
-                    yield DictKeyName(inference_state, dct, dict_key)
-                    # --- End Positron ---
-
-
-def _is_allowed_getitem_type(obj: Any) -> bool:
-    """Answer to 'Can we safely call `obj.__getitem__`?'."""
-    # Only trust builtin types and types from popular data science libraries.
-    # We specifically compare type(obj) instead of using isinstance because we don't want to trust
-    # subclasses of builtin types.
-    return (
-        type(obj) in (str, list, tuple, bytes, bytearray, dict)
-        or safe_isinstance(obj, "pandas", "DataFrame")
-        or safe_isinstance(obj, "polars", "DataFrame")
-    )
-
-
-def get_python_object(completion: BaseName) -> Tuple[Any, bool]:
-    """
-    Get the Python object corresponding to a completion.
-
-    And a boolean indicating whether an object was found.
-    """
-    name = completion._name  # noqa: SLF001
-    if isinstance(name, (CompiledName, MixedName)):
-        value = name.infer_compiled_value()
-        if isinstance(value, CompiledValue):
-            obj = value.access_handle.access._obj  # noqa: SLF001
-            return obj, True
-    return None, False
-
-
 def _is_pandas_dataframe(value: Value) -> bool:
     return (
         value.get_root_context().py__name__() == "pandas.core.frame"
@@ -638,19 +320,13 @@ def _is_polars_dataframe(value: Value) -> bool:
     )
 
 
-# def _is_polars_series(value: Value) -> bool:
-#     return (
-#         value.get_root_context().py__name__() == "polars.core.frame"
-#         and value.py__name__() == "DataFrame"
-#     )
-
-
 # TODO: Continue trying to refactor our completion customizations to a plugin.
 #       Could even ask Jedi author if we can add a plugin point for this.
 class JediPandas:
     def execute(self, callback):
         # TODO: Can this be more specifically TreeValue?
         def wrapper(value: Value, arguments):
+            print("execute start")
             result = callback(value, arguments)
             obj_name = value.name.string_name
             print(
@@ -662,86 +338,147 @@ class JediPandas:
                 arguments,
                 result,
             )
-            if _is_pandas_dataframe(value):
-                return ValueSet(DataFrameTreeInstanceWrapper(r) for r in result)
+            # if _is_pandas_dataframe(value):
+            #     return ValueSet(DataFrameTreeInstanceWrapper(r) for r in result)
             return result
 
         return wrapper
 
-    def tree_name_to_values(self, func):
-        # TODO: Is this always a ModuleContext?
-        def wrapper(
-            inference_state: InferenceState, context: ModuleContext, tree_name: TreeName
-        ) -> ValueSet:
-            result = func(inference_state, context, tree_name)
-            print("tree_name_to_values", tree_name, result, tree_name.value)
-            # if tree_name.value in ["NDFrame", "PandasObject"]:
-            return ValueSet(DataFrameWrapper(r) for r in result)
-            # print("tree_name_to_values", context, tree_name, type(tree_name))
-            # print("tree_name_to_values", type(inference_state), type(context), type(tree_name))
-            # if tree_name.value in _FILTER_LIKE_METHODS:
-            #     # Here we try to overwrite stuff like User.objects.filter. We need
-            #     # this to make sure that keyword param completion works on these
-            #     # kind of methods.
-            #     for v in result:
-            #         if v.get_qualified_names() == ('_BaseQuerySet', tree_name.value) \
-            #                 and v.parent_context.is_module() \
-            #                 and v.parent_context.py__name__() == 'django.db.models.query':
-            #             qs = context.get_value()
-            #             generics = qs.get_generics()
-            #             if len(generics) >= 1:
-            #                 return ValueSet(QuerySetMethodWrapper(v, model)
-            #                                 for model in generics[0])
+    # def tree_name_to_values(self, func):
+    #     # TODO: Is this always a ModuleContext?
+    #     def wrapper(
+    #         inference_state: InferenceState, context: ModuleContext, tree_name: TreeName
+    #     ) -> ValueSet:
+    #         result = func(inference_state, context, tree_name)
+    #         # print("tree_name_to_values", tree_name, result, tree_name.value)
+    #         # if tree_name.value in ["NDFrame", "PandasObject"]:
+    #         return ValueSet(DataFrameWrapper(r) for r in result)
+    #         # print("tree_name_to_values", context, tree_name, type(tree_name))
+    #         # print("tree_name_to_values", type(inference_state), type(context), type(tree_name))
+    #         # if tree_name.value in _FILTER_LIKE_METHODS:
+    #         #     # Here we try to overwrite stuff like User.objects.filter. We need
+    #         #     # this to make sure that keyword param completion works on these
+    #         #     # kind of methods.
+    #         #     for v in result:
+    #         #         if v.get_qualified_names() == ('_BaseQuerySet', tree_name.value) \
+    #         #                 and v.parent_context.is_module() \
+    #         #                 and v.parent_context.py__name__() == 'django.db.models.query':
+    #         #             qs = context.get_value()
+    #         #             generics = qs.get_generics()
+    #         #             if len(generics) >= 1:
+    #         #                 return ValueSet(QuerySetMethodWrapper(v, model)
+    #         #                                 for model in generics[0])
 
-            # elif tree_name.value == 'BaseManager' and context.is_module() \
-            #         and context.py__name__() == 'django.db.models.manager':
-            #     return ValueSet(ManagerWrapper(r) for r in result)
+    #         # elif tree_name.value == 'BaseManager' and context.is_module() \
+    #         #         and context.py__name__() == 'django.db.models.manager':
+    #         #     return ValueSet(ManagerWrapper(r) for r in result)
 
-            # elif tree_name.value == 'Field' and context.is_module() \
-            #         and context.py__name__() == 'django.db.models.fields':
-            #     return ValueSet(FieldWrapper(r) for r in result)
-            return result
+    #         # elif tree_name.value == 'Field' and context.is_module() \
+    #         #         and context.py__name__() == 'django.db.models.fields':
+    #         #     return ValueSet(FieldWrapper(r) for r in result)
+    #         return result
 
-        return wrapper
-
-
-class DataFrameWrapper(ValueWrapper):
-    def __getattr__(self, name):
-        print(f"DataFrameWrapper.{name}", self._wrapped_value)
-        return super().__getattr__(name)
-
-    def get_filters(self, origin_scope=None):
-        result = self._wrapped_value.get_filters(origin_scope=origin_scope)
-        # values = [list(result.values()) for result in iter(result)]
-        # print("get_filters", list(iter(result)), self._wrapped_value)
-        # print("get_filters", origin_scope, values)
-        return result
-
-    def py__call__(self, arguments):
-        # print("py__call__", arguments)
-        return self._wrapped_value.py__call__(arguments)
-
-    def py__getitem__(self, index_value_set, contextualized_node):
-        # print("py__getitem__", index_value_set, contextualized_node)
-        return ValueSet(
-            # GenericManagerWrapper(generic)
-            generic
-            for generic in self._wrapped_value.py__getitem__(index_value_set, contextualized_node)
-        )
+    #     return wrapper
 
 
-class DataFrameTreeInstanceWrapper(ValueWrapper):
-    def __init__(self, *args, **kwargs):
-        print("DataFrameTreeInstanceWrapper.__init__")
-        super().__init__(*args, **kwargs)
+# class DataFrameWrapper(ValueWrapper):
+#     def __getattr__(self, name):
+#         print(f"DataFrameWrapper.{name}", self._wrapped_value)
+#         return super().__getattr__(name)
 
-    def __getattr__(self, name):
-        print(f"DataFrameTreeInstanceWrapper.{name}", self._wrapped_value)
-        return super().__getattr__(name)
+#     def get_filters(self, origin_scope=None):
+#         result = self._wrapped_value.get_filters(origin_scope=origin_scope)
+#         # values = [list(result.values()) for result in iter(result)]
+#         # print("get_filters", list(iter(result)), self._wrapped_value)
+#         # print("get_filters", origin_scope, values)
+#         return result
 
-    @property
-    def array_type(self):
-        return "dict"
+#     def py__call__(self, arguments):
+#         # print("py__call__", arguments)
+#         return self._wrapped_value.py__call__(arguments)
+
+#     def py__getitem__(self, index_value_set, contextualized_node):
+#         # print("py__getitem__", index_value_set, contextualized_node)
+#         return ValueSet(
+#             # GenericManagerWrapper(generic)
+#             generic
+#             for generic in self._wrapped_value.py__getitem__(index_value_set, contextualized_node)
+#         )
+
+
+# class DataFrameTreeInstanceWrapper(ValueWrapper):
+#     def __init__(self, *args, **kwargs):
+#         print("DataFrameTreeInstanceWrapper.__init__")
+#         super().__init__(*args, **kwargs)
+
+#     def __getattr__(self, name):
+#         print(f"DataFrameTreeInstanceWrapper.{name}", self._wrapped_value)
+#         return super().__getattr__(name)
+
+#     @property
+#     def array_type(self):
+#         return "dict"
 
 
 plugin_manager.register(JediPandas())
+
+
+_original_completions_for_dicts = strings._completions_for_dicts
+
+
+class DictKeyName(CompiledName):
+    """
+    A dictionary key with support for inferring its value.
+    """
+
+    def __init__(self, inference_state, parent_value, name, is_descriptor, key):
+        self._inference_state = inference_state
+        try:
+            self.parent_context = parent_value.as_context()
+        except HasNoContext:
+            # If we're completing a dict literal, e.g. `{'a': 0}['`, then parent_value is a
+            # DictLiteralValue which does not override `as_context()`.
+            # Manually create the context instead.
+            self.parent_context = ValueContext(parent_value)
+        self._parent_value = parent_value
+        self.string_name = name
+        self.is_descriptor = is_descriptor
+        self._key = key
+
+    @memoize_method
+    def infer_compiled_value(self):
+        for value in self._parent_value.py__simple_getitem__(self._key):
+            # This may return an ExactValue which wraps a CompiledValue e.g. when completing a dict
+            # literal like: `{"a": 0}['`.
+            # For some reason, ExactValue().get_signatures() returns an empty list, but
+            # ExactValue()._compiled_value.get_signatures() returns the correct signatures,
+            # so we return the wrapped compiled value instead.
+            if isinstance(value, ExactValue):
+                return value._compiled_value
+            return value
+
+
+def _completions_for_dicts(inference_state, dicts, literal_string, cut_end_quote, fuzzy):
+    for dct in dicts:
+        if dct.array_type == "dict":
+            for key in dct.get_key_values():
+                dict_key = key.get_safe_value(default=strings._sentinel)
+                if dict_key is not strings._sentinel:
+                    dict_key_str = strings._create_repr_string(literal_string, dict_key)
+                    if dict_key_str.startswith(literal_string):
+                        string_name = dict_key_str[: -len(cut_end_quote) or None]
+                        name = DictKeyName(inference_state, dct, string_name, False, dict_key)
+                        yield Completion(
+                            inference_state,
+                            name,
+                            stack=None,
+                            like_name_length=len(literal_string),
+                            is_fuzzy=fuzzy,
+                        )
+
+    return _original_completions_for_dicts(
+        inference_state, dicts, literal_string, cut_end_quote, fuzzy
+    )
+
+
+strings._completions_for_dicts = _completions_for_dicts

--- a/extensions/positron-python/python_files/posit/positron/jedi.py
+++ b/extensions/positron-python/python_files/posit/positron/jedi.py
@@ -58,41 +58,111 @@ from .utils import get_qualname
 #
 
 
-class PositronMixedTreeName(MixedTreeName):
-    def infer(self):
-        # First try to use the namespace, then fall back to static analysis.
-        # This is the reverse of MixedTreeName.
-        # See: TODO: Link issue here.
-        """
-        In IPython notebook it is typical that some parts of the code that is
-        provided was already executed. In that case if something is not properly
-        inferred, it should still infer from the variables it already knows.
-        """
-        for compiled_value in self.parent_context.mixed_values:
-            for f in compiled_value.get_filters():
-                values = ValueSet.from_sets(n.infer() for n in f.get(self.string_name))
-                if values:
-                    return values
+class PositronInterpreter(Interpreter):
+    """
+    A `jedi.Interpreter` that provides enhanced completions for data science users.
+    """
 
-        return super().infer()
+    @cache.memoize_method
+    def _get_module_context(self):
+        return PositronMixedModuleContext(
+            super()._get_module_context()._value,
+            self.namespaces,
+        )
+
+    def complete(self, line=None, column=None, *, fuzzy=False):
+        return [PositronCompletion(name) for name in super().complete(line, column, fuzzy=fuzzy)]
+
+    def help(self, line=None, column=None):
+        return [PositronName(name) for name in super().help(line, column)]
+
+    def goto(
+        self,
+        line=None,
+        column=None,
+        *,
+        follow_imports=False,
+        follow_builtin_imports=False,
+        only_stubs=False,
+        prefer_stubs=False,
+    ):
+        return [
+            PositronName(name)
+            for name in super().goto(
+                line,
+                column,
+                follow_imports=follow_imports,
+                follow_builtin_imports=follow_builtin_imports,
+                only_stubs=only_stubs,
+                prefer_stubs=prefer_stubs,
+            )
+        ]
 
 
-class PositronMixedParserTreeFilter(MixedParserTreeFilter):
-    name_class = PositronMixedTreeName
+class PositronMixedModuleContext(MixedModuleContext):
+    def _get_mixed_object(self, compiled_value):
+        return PositronMixedObject(compiled_value=compiled_value, tree_value=self._value)
+
+    def get_filters(self, until_position=None, origin_scope=None):
+        yield MergedFilter(
+            PositronMixedParserTreeFilter(
+                parent_context=self, until_position=until_position, origin_scope=origin_scope
+            ),
+            self.get_global_filter(),
+        )
+
+        for mixed_object in self.mixed_values:
+            yield from mixed_object.get_filters(until_position, origin_scope)
+
+
+class PositronMixedObject(MixedObject):
+    def get_filters(self, *args, **kwargs):
+        yield PositronMixedObjectFilter(
+            self.inference_state, self.compiled_value, self._wrapped_value
+        )
+
+
+class PositronMixedObjectFilter(MixedObjectFilter):
+    def _create_name(self, *args, **kwargs):
+        return PositronMixedName(
+            super()._create_name(*args, **kwargs),
+            self._tree_value,
+        )
 
 
 class PositronMixedName(MixedName):
     def infer(self):
-        return ValueSet(
-            PandasDataFrameMixedObjectWrapper(value)
-            if _is_pandas_dataframe(value)
-            else SeriesMixedObjectWrapper(value)
-            if _is_pandas_series(value)
-            else PolarsDataFrameMixedObjectWrapper(value)
-            if _is_polars_dataframe(value)
-            else value
-            for value in super().infer()
-        )
+        return ValueSet(self._wrap_value(value) for value in super().infer())
+
+    def _wrap_value(self, value: Value):
+        if _is_pandas_dataframe(value):
+            return PandasDataFrameMixedObjectWrapper(value)
+        if _is_pandas_series(value):
+            return SeriesMixedObjectWrapper(value)
+        if _is_polars_dataframe(value):
+            return PolarsDataFrameMixedObjectWrapper(value)
+        return value
+
+
+def _is_pandas_dataframe(value: Value) -> bool:
+    return (
+        value.get_root_context().py__name__() == "pandas.core.frame"
+        and value.py__name__() == "DataFrame"
+    )
+
+
+def _is_pandas_series(value: Value) -> bool:
+    return (
+        value.get_root_context().py__name__() == "pandas.core.series"
+        and value.py__name__() == "Series"
+    )
+
+
+def _is_polars_dataframe(value: Value) -> bool:
+    return (
+        value.get_root_context().py__name__() == "polars.dataframe.frame"
+        and value.py__name__() == "DataFrame"
+    )
 
 
 class PandasDataFrameMixedObjectWrapper(ValueWrapper):
@@ -134,54 +204,27 @@ class PolarsDataFrameMixedObjectWrapper(ValueWrapper):
         return self.compiled_value.py__simple_getitem__(index)
 
 
-class PositronMixedObjectFilter(MixedObjectFilter):
-    def _create_name(self, *args, **kwargs):
-        return PositronMixedName(
-            super()._create_name(*args, **kwargs),
-            self._tree_value,
-        )
+class PositronMixedTreeName(MixedTreeName):
+    def infer(self):
+        # First try to use the namespace, then fall back to static analysis.
+        # This is the reverse of MixedTreeName.
+        # See: TODO: Link issue here.
+        """
+        In IPython notebook it is typical that some parts of the code that is
+        provided was already executed. In that case if something is not properly
+        inferred, it should still infer from the variables it already knows.
+        """
+        for compiled_value in self.parent_context.mixed_values:
+            for f in compiled_value.get_filters():
+                values = ValueSet.from_sets(n.infer() for n in f.get(self.string_name))
+                if values:
+                    return values
+
+        return super().infer()
 
 
-class PositronMixedObject(MixedObject):
-    def get_filters(self, *args, **kwargs):
-        yield PositronMixedObjectFilter(
-            self.inference_state, self.compiled_value, self._wrapped_value
-        )
-
-
-class PositronMixedModuleContext(MixedModuleContext):
-    """
-    Special MixedModuleContext.
-
-    A `jedi.api.interpreter.MixedModuleContext` that prefers values from the user's namespace over
-    static analysis.
-
-    For example, given the namespace: `{"x": {"a": 0}}`, and the code:
-
-    ```
-    x = {"b": 0}
-    x['
-    ```
-
-    Completing the line `x['` should return `a` and not `b`.
-    """
-
-    def _get_mixed_object(self, compiled_value):
-        return PositronMixedObject(compiled_value=compiled_value, tree_value=self._value)
-
-    # TODO: We could patch MixedParserTreeFilter.name_class instead?
-    def get_filters(self, until_position=None, origin_scope=None):
-        yield MergedFilter(
-            PositronMixedParserTreeFilter(
-                parent_context=self,
-                until_position=until_position,
-                origin_scope=origin_scope,
-            ),
-            self.get_global_filter(),
-        )
-
-        for mixed_object in self.mixed_values:
-            yield from mixed_object.get_filters(until_position, origin_scope)
+class PositronMixedParserTreeFilter(MixedParserTreeFilter):
+    name_class = PositronMixedTreeName
 
 
 class PositronName(Name):
@@ -254,173 +297,6 @@ class PositronCompletion(PositronName):
     @property
     def complete(self):
         return self._wrapped_completion.complete
-
-
-class PositronInterpreter(Interpreter):
-    """A `jedi.Interpreter` that provides enhanced completions for data science users."""
-
-    @cache.memoize_method
-    def _get_module_context(self):
-        # Use our custom module context class.
-        return PositronMixedModuleContext(
-            super()._get_module_context()._value,
-            self.namespaces,
-        )
-
-    @validate_line_column
-    def complete(self, line=None, column=None, *, fuzzy=False):
-        return [PositronCompletion(name) for name in super().complete(line, column, fuzzy=fuzzy)]
-
-    @validate_line_column
-    def help(self, line=None, column=None):
-        return [PositronName(name) for name in super().help(line, column)]
-
-    @validate_line_column
-    def goto(
-        self,
-        line=None,
-        column=None,
-        *,
-        follow_imports=False,
-        follow_builtin_imports=False,
-        only_stubs=False,
-        prefer_stubs=False,
-    ):
-        return [
-            PositronName(name)
-            for name in super().goto(
-                line,
-                column,
-                follow_imports=follow_imports,
-                follow_builtin_imports=follow_builtin_imports,
-                only_stubs=only_stubs,
-                prefer_stubs=prefer_stubs,
-            )
-        ]
-
-
-def _is_pandas_dataframe(value: Value) -> bool:
-    return (
-        value.get_root_context().py__name__() == "pandas.core.frame"
-        and value.py__name__() == "DataFrame"
-    )
-
-
-def _is_pandas_series(value: Value) -> bool:
-    return (
-        value.get_root_context().py__name__() == "pandas.core.series"
-        and value.py__name__() == "Series"
-    )
-
-
-def _is_polars_dataframe(value: Value) -> bool:
-    return (
-        value.get_root_context().py__name__() == "polars.dataframe.frame"
-        and value.py__name__() == "DataFrame"
-    )
-
-
-# TODO: Continue trying to refactor our completion customizations to a plugin.
-#       Could even ask Jedi author if we can add a plugin point for this.
-class JediPandas:
-    def execute(self, callback):
-        # TODO: Can this be more specifically TreeValue?
-        def wrapper(value: Value, arguments):
-            print("execute start")
-            result = callback(value, arguments)
-            obj_name = value.name.string_name
-            print(
-                "execute",
-                obj_name,
-                value.parent_context.py__name__(),
-                value.py__name__(),
-                value,
-                arguments,
-                result,
-            )
-            # if _is_pandas_dataframe(value):
-            #     return ValueSet(DataFrameTreeInstanceWrapper(r) for r in result)
-            return result
-
-        return wrapper
-
-    # def tree_name_to_values(self, func):
-    #     # TODO: Is this always a ModuleContext?
-    #     def wrapper(
-    #         inference_state: InferenceState, context: ModuleContext, tree_name: TreeName
-    #     ) -> ValueSet:
-    #         result = func(inference_state, context, tree_name)
-    #         # print("tree_name_to_values", tree_name, result, tree_name.value)
-    #         # if tree_name.value in ["NDFrame", "PandasObject"]:
-    #         return ValueSet(DataFrameWrapper(r) for r in result)
-    #         # print("tree_name_to_values", context, tree_name, type(tree_name))
-    #         # print("tree_name_to_values", type(inference_state), type(context), type(tree_name))
-    #         # if tree_name.value in _FILTER_LIKE_METHODS:
-    #         #     # Here we try to overwrite stuff like User.objects.filter. We need
-    #         #     # this to make sure that keyword param completion works on these
-    #         #     # kind of methods.
-    #         #     for v in result:
-    #         #         if v.get_qualified_names() == ('_BaseQuerySet', tree_name.value) \
-    #         #                 and v.parent_context.is_module() \
-    #         #                 and v.parent_context.py__name__() == 'django.db.models.query':
-    #         #             qs = context.get_value()
-    #         #             generics = qs.get_generics()
-    #         #             if len(generics) >= 1:
-    #         #                 return ValueSet(QuerySetMethodWrapper(v, model)
-    #         #                                 for model in generics[0])
-
-    #         # elif tree_name.value == 'BaseManager' and context.is_module() \
-    #         #         and context.py__name__() == 'django.db.models.manager':
-    #         #     return ValueSet(ManagerWrapper(r) for r in result)
-
-    #         # elif tree_name.value == 'Field' and context.is_module() \
-    #         #         and context.py__name__() == 'django.db.models.fields':
-    #         #     return ValueSet(FieldWrapper(r) for r in result)
-    #         return result
-
-    #     return wrapper
-
-
-# class DataFrameWrapper(ValueWrapper):
-#     def __getattr__(self, name):
-#         print(f"DataFrameWrapper.{name}", self._wrapped_value)
-#         return super().__getattr__(name)
-
-#     def get_filters(self, origin_scope=None):
-#         result = self._wrapped_value.get_filters(origin_scope=origin_scope)
-#         # values = [list(result.values()) for result in iter(result)]
-#         # print("get_filters", list(iter(result)), self._wrapped_value)
-#         # print("get_filters", origin_scope, values)
-#         return result
-
-#     def py__call__(self, arguments):
-#         # print("py__call__", arguments)
-#         return self._wrapped_value.py__call__(arguments)
-
-#     def py__getitem__(self, index_value_set, contextualized_node):
-#         # print("py__getitem__", index_value_set, contextualized_node)
-#         return ValueSet(
-#             # GenericManagerWrapper(generic)
-#             generic
-#             for generic in self._wrapped_value.py__getitem__(index_value_set, contextualized_node)
-#         )
-
-
-# class DataFrameTreeInstanceWrapper(ValueWrapper):
-#     def __init__(self, *args, **kwargs):
-#         print("DataFrameTreeInstanceWrapper.__init__")
-#         super().__init__(*args, **kwargs)
-
-#     def __getattr__(self, name):
-#         print(f"DataFrameTreeInstanceWrapper.{name}", self._wrapped_value)
-#         return super().__getattr__(name)
-
-#     @property
-#     def array_type(self):
-#         return "dict"
-
-
-plugin_manager.register(JediPandas())
 
 
 _original_completions_for_dicts = strings._completions_for_dicts

--- a/extensions/positron-python/python_files/posit/positron/jedi.py
+++ b/extensions/positron-python/python_files/posit/positron/jedi.py
@@ -234,7 +234,7 @@ class PositronName(Name):
         return None
 
     @property
-    def full_name(self) -> str:  # type: ignore
+    def full_name(self) -> Optional[str]:
         if self._inspector:
             return get_qualname(self._inspector.value)
         return super().full_name

--- a/extensions/positron-python/python_files/posit/positron/jedi.py
+++ b/extensions/positron-python/python_files/posit/positron/jedi.py
@@ -8,7 +8,7 @@ import pathlib
 import platform
 from functools import cached_property
 from pathlib import Path
-from typing import Optional
+from typing import Any, Iterable, List, Optional
 
 from IPython.core import oinspect
 
@@ -34,13 +34,13 @@ from ._vendor.jedi.api.interpreter import (
     MixedTreeName,
 )
 from ._vendor.jedi.cache import memoize_method
-from ._vendor.jedi.inference.base_value import HasNoContext, Value, ValueSet, ValueWrapper
+from ._vendor.jedi.inference import InferenceState
+from ._vendor.jedi.inference.base_value import HasNoContext, ValueSet, ValueWrapper
 from ._vendor.jedi.inference.compiled import ExactValue
-from ._vendor.jedi.inference.compiled.mixed import MixedName, MixedObject, MixedObjectFilter
+from ._vendor.jedi.inference.compiled.mixed import MixedName, MixedObject
 from ._vendor.jedi.inference.compiled.value import CompiledName, CompiledValue
 from ._vendor.jedi.inference.context import ValueContext
-from ._vendor.jedi.inference.filters import MergedFilter
-from ._vendor.jedi.plugins import plugin_manager
+from ._vendor.jedi.inference.lazy_value import LazyKnownValue
 from .inspectors import (
     BaseColumnInspector,
     BaseTableInspector,
@@ -58,124 +58,115 @@ from .utils import get_qualname
 #
 
 
-class PositronInterpreter(Interpreter):
-    """
-    A `jedi.Interpreter` that provides enhanced completions for data science users.
-    """
-
-    def complete(self, line=None, column=None, *, fuzzy=False):
-        return [PositronCompletion(name) for name in super().complete(line, column, fuzzy=fuzzy)]
-
-    def help(self, line=None, column=None):
-        return [PositronName(name) for name in super().help(line, column)]
-
-    def goto(
-        self,
-        line=None,
-        column=None,
-        *,
-        follow_imports=False,
-        follow_builtin_imports=False,
-        only_stubs=False,
-        prefer_stubs=False,
-    ):
-        return [
-            PositronName(name)
-            for name in super().goto(
-                line,
-                column,
-                follow_imports=follow_imports,
-                follow_builtin_imports=follow_builtin_imports,
-                only_stubs=only_stubs,
-                prefer_stubs=prefer_stubs,
-            )
-        ]
+_original_Interpreter_complete = Interpreter.complete
+_original_Interpreter_help = Interpreter.help
+_original_Interpreter_goto = Interpreter.goto
+_original_mixed_name_infer = MixedName.infer
+_original_mixed_tree_name_infer = MixedTreeName.infer
 
 
-original_mixed_name_infer = MixedName.infer
+def _Interpreter_complete(
+    self: Interpreter,
+    line: Optional[int] = None,
+    column: Optional[int] = None,
+    *,
+    fuzzy: bool = False,
+) -> List["PositronCompletion"]:
+    return [
+        PositronCompletion(name)
+        for name in _original_Interpreter_complete(self, line, column, fuzzy=fuzzy)
+    ]
 
 
-def _mixed_name_infer(self):
-    return ValueSet(_wrap_value(value) for value in original_mixed_name_infer(self))
+def _Interpreter_help(
+    self: Interpreter, line: Optional[int] = None, column: Optional[int] = None
+) -> List["PositronName"]:
+    return [PositronName(name) for name in _original_Interpreter_help(self, line, column)]
 
 
-MixedName.infer = _mixed_name_infer
+def _Interpreter_goto(
+    self: Interpreter,
+    line: Optional[int] = None,
+    column: Optional[int] = None,
+    *,
+    follow_imports: bool = False,
+    follow_builtin_imports: bool = False,
+    only_stubs: bool = False,
+    prefer_stubs: bool = False,
+) -> List["PositronName"]:
+    return [
+        PositronName(name)
+        for name in _original_Interpreter_goto(
+            self,
+            line,
+            column,
+            follow_imports=follow_imports,
+            follow_builtin_imports=follow_builtin_imports,
+            only_stubs=only_stubs,
+            prefer_stubs=prefer_stubs,
+        )
+    ]
 
 
-def _wrap_value(value: Value):
-    if _is_pandas_dataframe(value):
-        return PandasDataFrameMixedObjectWrapper(value)
-    if _is_pandas_series(value):
-        return SeriesMixedObjectWrapper(value)
+def _MixedName_infer(self: MixedName) -> ValueSet:
+    return ValueSet(_wrap_value(value) for value in _original_mixed_name_infer(self))
+
+
+def _wrap_value(value: MixedObject):
+    if _is_pandas_dataframe(value) or _is_pandas_series(value):
+        return SafeDictLikeMixedObjectWrapper(value)
     if _is_polars_dataframe(value):
         return PolarsDataFrameMixedObjectWrapper(value)
     return value
 
 
-def _is_pandas_dataframe(value: Value) -> bool:
+def _is_pandas_dataframe(value: MixedObject) -> bool:
     return (
         value.get_root_context().py__name__() == "pandas.core.frame"
         and value.py__name__() == "DataFrame"
     )
 
 
-def _is_pandas_series(value: Value) -> bool:
+def _is_pandas_series(value: MixedObject) -> bool:
     return (
         value.get_root_context().py__name__() == "pandas.core.series"
         and value.py__name__() == "Series"
     )
 
 
-def _is_polars_dataframe(value: Value) -> bool:
+def _is_polars_dataframe(value: MixedObject) -> bool:
     return (
         value.get_root_context().py__name__() == "polars.dataframe.frame"
         and value.py__name__() == "DataFrame"
     )
 
 
-class PandasDataFrameMixedObjectWrapper(ValueWrapper):
-    @property
-    def array_type(self) -> str:
-        return "dict"
+class SafeDictLikeMixedObjectWrapper(ValueWrapper):
+    _wrapped_value: MixedObject
+    compiled_value: CompiledValue
 
-    def py__simple_getitem__(self, index):
+    def __init__(self, wrapped_value: MixedObject) -> None:
+        super().__init__(wrapped_value)
+
+        self.array_type = "dict"
+
+    def py__simple_getitem__(self, index) -> ValueSet:
         # Remove safety checks.
         return self.compiled_value.py__simple_getitem__(index)
 
 
-class SeriesMixedObjectWrapper(ValueWrapper):
-    @property
-    def array_type(self) -> str:
-        return "dict"
-
-    def py__simple_getitem__(self, index):
-        # Remove safety checks.
-        return self.compiled_value.py__simple_getitem__(index)
-
-
-class PolarsDataFrameMixedObjectWrapper(ValueWrapper):
-    @property
-    def array_type(self) -> str:
-        return "dict"
-
+class PolarsDataFrameMixedObjectWrapper(SafeDictLikeMixedObjectWrapper):
     def get_key_values(self):
         for columns in self._wrapped_value.py__getattribute__("columns"):
-            # columns: CompiledValue[List[str]]
+            columns: CompiledValue
             for values in columns.py__iter__():
-                # values: LazyKnownValue[CompiledValue[str]]
+                values: LazyKnownValue
                 for value in values.infer():
-                    # value: CompiledValue[str]
+                    value: CompiledValue
                     yield value
 
-    def py__simple_getitem__(self, index):
-        # Remove safety checks.
-        return self.compiled_value.py__simple_getitem__(index)
 
-
-original_mixed_tree_name_infer = MixedTreeName.infer
-
-
-def _mixed_tree_name_infer(self: MixedTreeName):
+def _MixedTreeName_infer(self: MixedTreeName) -> ValueSet:
     # First try to use the namespace, then fall back to static analysis.
     # This is the reverse of MixedTreeName.
     # See: TODO: Link issue here.
@@ -190,10 +181,7 @@ def _mixed_tree_name_infer(self: MixedTreeName):
             if values:
                 return values
 
-    return original_mixed_tree_name_infer(self)
-
-
-MixedTreeName.infer = _mixed_tree_name_infer
+    return _original_mixed_tree_name_infer(self)
 
 
 class PositronName(Name):
@@ -268,15 +256,19 @@ class PositronCompletion(PositronName):
         return self._wrapped_completion.complete
 
 
-_original_completions_for_dicts = strings._completions_for_dicts
-
-
 class DictKeyName(CompiledName):
     """
     A dictionary key with support for inferring its value.
     """
 
-    def __init__(self, inference_state, parent_value, name, is_descriptor, key):
+    def __init__(
+        self,
+        inference_state: InferenceState,
+        parent_value: CompiledValue,
+        name: str,
+        is_descriptor: bool,
+        key: Any,
+    ):
         self._inference_state = inference_state
         try:
             self.parent_context = parent_value.as_context()
@@ -291,7 +283,7 @@ class DictKeyName(CompiledName):
         self._key = key
 
     @memoize_method
-    def infer_compiled_value(self):
+    def infer_compiled_value(self) -> Optional[CompiledValue]:
         for value in self._parent_value.py__simple_getitem__(self._key):
             # This may return an ExactValue which wraps a CompiledValue e.g. when completing a dict
             # literal like: `{"a": 0}['`.
@@ -303,27 +295,38 @@ class DictKeyName(CompiledName):
             return value
 
 
-def _completions_for_dicts(inference_state, dicts, literal_string, cut_end_quote, fuzzy):
+# Adapted from jedi.api.strings._completions_for_dicts.
+def _completions_for_dicts(
+    inference_state: InferenceState,
+    dicts: Iterable[CompiledValue],
+    literal_string: str,
+    cut_end_quote: str,
+    fuzzy: bool,
+) -> Iterable[Completion]:
     for dct in dicts:
         if dct.array_type == "dict":
             for key in dct.get_key_values():
-                dict_key = key.get_safe_value(default=strings._sentinel)
-                if dict_key is not strings._sentinel:
-                    dict_key_str = strings._create_repr_string(literal_string, dict_key)
-                    if dict_key_str.startswith(literal_string):
-                        string_name = dict_key_str[: -len(cut_end_quote) or None]
-                        name = DictKeyName(inference_state, dct, string_name, False, dict_key)
-                        yield Completion(
-                            inference_state,
-                            name,
-                            stack=None,
-                            like_name_length=len(literal_string),
-                            is_fuzzy=fuzzy,
-                        )
-
-    return _original_completions_for_dicts(
-        inference_state, dicts, literal_string, cut_end_quote, fuzzy
-    )
+                if key:
+                    dict_key = key.get_safe_value(default=strings._sentinel)
+                    if dict_key is not strings._sentinel:
+                        dict_key_str = strings._create_repr_string(literal_string, dict_key)
+                        if dict_key_str.startswith(literal_string):
+                            string_name = dict_key_str[: -len(cut_end_quote) or None]
+                            name = DictKeyName(inference_state, dct, string_name, False, dict_key)
+                            yield Completion(
+                                inference_state,
+                                name,
+                                stack=None,
+                                like_name_length=len(literal_string),
+                                is_fuzzy=fuzzy,
+                            )
 
 
-strings._completions_for_dicts = _completions_for_dicts
+def apply_jedi_patches():
+    # Apply our patches to Jedi.
+    Interpreter.complete = _Interpreter_complete
+    Interpreter.help = _Interpreter_help
+    Interpreter.goto = _Interpreter_goto
+    MixedName.infer = _MixedName_infer
+    MixedTreeName.infer = _MixedTreeName_infer
+    strings._completions_for_dicts = _completions_for_dicts

--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -120,11 +120,10 @@ apply_jedi_patches()
 def script(project: Optional[Project], document: TextDocument) -> Script:
     # Get the server object from the caller's scope.
     frame = inspect.currentframe()
-    if frame is not None:
-        if frame.f_back is not None:
-            server = frame.f_back.f_locals.get("server")
-            if isinstance(server, PositronJediLanguageServer):
-                return _interpreter(project, document, server.shell)
+    if frame is not None and frame.f_back is not None:
+        server = frame.f_back.f_locals.get("server")
+        if isinstance(server, PositronJediLanguageServer):
+            return _interpreter(project, document, server.shell)
     raise AssertionError("Could not find server object in the caller's scope")
 
 
@@ -456,7 +455,7 @@ def positron_completion(
                 # jedi_utils.lsp_completion_item uses completion.name which isn't available when
                 # accessing the most recent completions dict (in positron_completion_item_resolve),
                 # and which may differ from the label.
-                jedi_utils._MOST_RECENT_COMPLETIONS[jedi_completion_item.label] = cast(
+                jedi_utils._MOST_RECENT_COMPLETIONS[jedi_completion_item.label] = cast(  # noqa: SLF001
                     Completion, completion
                 )
 

--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -653,7 +653,18 @@ def positron_hover(
 def positron_references(
     server: PositronJediLanguageServer, params: TextDocumentPositionParams
 ) -> Optional[List[Location]]:
-    return references(server, params)
+    document = server.workspace.get_text_document(params.text_document.uri)
+    # TODO: Don't use an Interpreter until we debug the corresponding test on Python <= 3.9.
+    #       Not missing out on much since references don't use namespace information anyway.
+    jedi_script = Script(code=document.source, path=document.path, project=server.project)
+    jedi_lines = jedi_utils.line_column(params.position)
+    names = jedi_script.get_references(*jedi_lines)
+    locations = [
+        location
+        for location in (jedi_utils.lsp_location(name) for name in names)
+        if location is not None
+    ]
+    return locations if locations else None
 
 
 @POSITRON.feature(TEXT_DOCUMENT_DOCUMENT_SYMBOL)

--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -31,7 +31,6 @@ from ._vendor.jedi_language_server.server import (
     document_symbol,
     highlight,
     hover,
-    references,
     rename,
     signature_help,
     type_definition,

--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -97,7 +97,7 @@ from ._vendor.pygls.feature_manager import has_ls_param_or_annotation
 from ._vendor.pygls.protocol import lsp_method
 from ._vendor.pygls.workspace.text_document import TextDocument
 from .help_comm import ShowHelpTopicParams
-from .jedi import PositronInterpreter
+from .jedi import apply_jedi_patches
 from .utils import debounce
 
 if TYPE_CHECKING:
@@ -113,6 +113,8 @@ _SHELL_PREFIX = "!"
 _HELP_PREFIX_OR_SUFFIX = "?"
 _HELP_TOPIC = "positron/textDocument/helpTopic"
 _VSCODE_NOTEBOOK_CELL_SCHEME = "vscode-notebook-cell"
+
+apply_jedi_patches()
 
 
 def script(project: Optional[Project], document: TextDocument) -> Script:
@@ -840,4 +842,4 @@ def _interpreter(
     if shell is not None:
         namespaces.append(shell.user_ns)
 
-    return PositronInterpreter(document.source, namespaces, path=document.path, project=project)
+    return Interpreter(document.source, namespaces, path=document.path, project=project)

--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -450,6 +450,14 @@ def positron_completion(
                     sort_append_text=completion.name,
                 )
 
+                # Set the most recent completion using the label.
+                # jedi_utils.lsp_completion_item uses completion.name which isn't available when
+                # accessing the most recent completions dict (in positron_completion_item_resolve),
+                # and which may differ from the label.
+                jedi_utils._MOST_RECENT_COMPLETIONS[jedi_completion_item.label] = cast(
+                    Completion, completion
+                )
+
                 # If Jedi knows how to complete the expression, use its suggestion.
                 if completion.complete is not None:
                     # Using the text_edit attribute (instead of insert_text used in

--- a/extensions/positron-python/python_files/posit/positron/tests/lsp_data/func.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/lsp_data/func.py
@@ -1,0 +1,8 @@
+#
+# Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+#
+
+
+def func(x=1, y=1):
+    "A function with parameters."

--- a/extensions/positron-python/python_files/posit/positron/tests/lsp_data/type.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/lsp_data/type.py
@@ -1,0 +1,8 @@
+#
+# Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+#
+
+
+class Type:
+    pass

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -45,7 +45,6 @@ from positron._vendor.lsprotocol.types import (
     TextDocumentPositionParams,
     TextEdit,
 )
-from positron._vendor.pygls.uris import from_fs_path
 from positron._vendor.pygls.workspace.text_document import TextDocument
 from positron.help_comm import ShowHelpTopicParams
 from positron.positron_jedilsp import (
@@ -80,10 +79,12 @@ if TYPE_CHECKING:
     from threading import Timer
 
 
-LSP_DATA_DIR = Path(__file__).parent / "lsp_data"
-TEST_DOCUMENT_PATH = Path("foo.py")
-# Use `from_fs_path` to ensure the same URI format as used by the server.
-TEST_DOCUMENT_URI = from_fs_path(str(TEST_DOCUMENT_PATH))
+# NOTE: We have to construct paths via __file__ so that the casing matches Jedi-produced paths
+#       on Windows.
+DIR = Path(__file__).parent
+LSP_DATA_DIR = DIR / "lsp_data"
+TEST_DOCUMENT_PATH = DIR / "foo.py"
+TEST_DOCUMENT_URI = TEST_DOCUMENT_PATH.as_uri()
 
 
 @pytest.fixture(autouse=True)

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -4,7 +4,6 @@
 #
 
 import os
-import sys
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
@@ -13,6 +12,7 @@ from unittest.mock import Mock, patch
 import pandas as pd
 import polars as pl
 import pytest
+from python_files.posit.positron._vendor.pygls.uris import from_fs_path
 
 from positron._vendor import cattrs
 from positron._vendor.jedi_language_server import jedi_utils
@@ -81,8 +81,9 @@ if TYPE_CHECKING:
 
 
 LSP_DATA_DIR = Path(__file__).parent / "lsp_data"
-TEST_DOCUMENT_PATH = Path("foo.py").absolute()
-TEST_DOCUMENT_URI = TEST_DOCUMENT_PATH.as_uri()
+TEST_DOCUMENT_PATH = Path("foo.py")
+# Use `from_fs_path` to ensure the same URI format as used by the server.
+TEST_DOCUMENT_URI = from_fs_path(str(TEST_DOCUMENT_PATH))
 
 
 @pytest.fixture(autouse=True)
@@ -474,7 +475,7 @@ def test_positron_completion_item_resolve(
             "1 +",
             [
                 (
-                    "SyntaxError: invalid syntax (TEST_DOCUMENT_URI, line 1)"
+                    f"SyntaxError: invalid syntax ({TEST_DOCUMENT_URI}, line 1)"
                     if os.name == "nt"
                     else "SyntaxError: invalid syntax (foo.py, line 1)"
                 )

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -233,13 +233,6 @@ def _completions(
             marks=pytest.mark.skip(reason="Completing integer dict keys not supported"),
         ),
         pytest.param(
-            'x["',
-            {"x": pd.DataFrame({"a": []})},
-            None,
-            ['a"'],
-            id="pandas_dataframe_string_dict_key",
-        ),
-        pytest.param(
             'x["', {"x": pd.Series({"a": 0})}, None, ['a"'], id="pandas_series_string_dict_key"
         ),
         pytest.param(

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -211,19 +211,39 @@ def _completions(
     ("source", "namespace", "expected_labels"),
     [
         # Dict key mapping to a property.
-        ('x["', {"x": {"a": _object_with_property.prop}}, ["a"]),
+        pytest.param(
+            'x["', {"x": {"a": _object_with_property.prop}}, ['a"'], id="dict_key_to_property"
+        ),
+        pytest.param(
+            'x = {"a": 0}\nx["',
+            {},
+            ['a"'],
+            id="source_dict_key_to_int",
+        ),
         # When completions match a variable defined in the source _and_ a variable in the user's namespace,
         # prefer the namespace variable.
-        ('x = {"a": 0}\nx["', {"x": {"b": 0}}, ["b"]),
+        pytest.param(
+            'x = {"a": 0}\nx["', {"x": {"b": 0}}, ['b"'], id="prefer_namespace_over_source"
+        ),
         # Dict key mapping to an int.
-        ('x["', {"x": {"a": 0}}, ["a"]),
+        pytest.param('x["', {"x": {"a": 0}}, ['a"'], id="dict_key_to_int"),
         # Dict literal key mapping to an int.
-        ('{"a": 0}["', {}, ["a"]),
+        pytest.param('{"a": 0}["', {}, ['a"'], id="dict_literal_key_to_int"),
         # Pandas dataframe - dict key access.
-        ('x["', {"x": pd.DataFrame({"a": []})}, ["a"]),  # string column name
-        ('x["', {"x": pd.DataFrame({0: []})}, ["0"]),  # integer column name
+        pytest.param(
+            'x["', {"x": pd.DataFrame({"a": []})}, ['a"'], id="pandas_dataframe_string_dict_key"
+        ),  # string column name
+        pytest.param(
+            'x["', {"x": pd.Series({"a": 0})}, ['a"'], id="pandas_series_string_dict_key"
+        ),  # string column name
+        # TODO: This test was actually incorrect behavior. x["0"] won't work, x[0] is necessary.
+        #       We could look into completion x[ but not going to prioritize this.
+        # pytest.param(
+        #     'x["', {"x": pd.DataFrame({0: []})}, ['0"'], id="pandas_dataframe_int_dict_key"
+        # ),  # integer column name
         # Polars dataframe - dict key access.
-        ('x["', {"x": pl.DataFrame({"a": []})}, ["a"]),
+        pytest.param('x["', {"x": pl.DataFrame({"a": []})}, ['a"'], id="polars_dataframe_dict_key"),
+        # Polars series only have a "range" integer index so no need to complete those.
     ],
 )
 def test_positron_completion_exact(

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -79,9 +79,8 @@ if TYPE_CHECKING:
     from threading import Timer
 
 
-# NOTE: We have to construct paths via __file__ so that the casing matches Jedi-produced paths
-#       on Windows.
-DIR = Path(__file__).parent
+# Normalize casing to match Jedi-produced paths on Windows.
+DIR = Path(os.path.normcase(__file__)).parent
 LSP_DATA_DIR = DIR / "lsp_data"
 TEST_DOCUMENT_PATH = DIR / "foo.py"
 TEST_DOCUMENT_URI = TEST_DOCUMENT_PATH.as_uri()

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -56,6 +56,7 @@ from positron.positron_jedilsp import (
     PositronJediLanguageServer,
     PositronJediLanguageServerProtocol,
     _clear_diagnostics_debounced,
+    _MagicType,
     _publish_diagnostics,
     _publish_diagnostics_debounced,
     positron_code_action,
@@ -138,6 +139,10 @@ def create_server(
     # Mock the shell, since we only really care about the user's namespace.
     server.shell = Mock()
     server.shell.user_ns = {} if namespace is None else namespace
+    server.shell.magics_manager.lsmagic.return_value = {
+        _MagicType.cell: {},
+        _MagicType.line: {},
+    }
 
     return server
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -30,7 +30,6 @@ from positron._vendor.lsprotocol.types import (
     Location,
     MarkupContent,
     MarkupKind,
-    OptionalVersionedTextDocumentIdentifier,
     ParameterInformation,
     Position,
     Range,
@@ -45,7 +44,6 @@ from positron._vendor.lsprotocol.types import (
     TextDocumentItem,
     TextDocumentPositionParams,
     TextEdit,
-    WorkspaceEdit,
 )
 from positron._vendor.pygls.workspace.text_document import TextDocument
 from positron.help_comm import ShowHelpTopicParams
@@ -77,15 +75,13 @@ from positron.utils import get_qualname
 from .lsp_data.func import func
 from .lsp_data.type import Type
 
+if TYPE_CHECKING:
+    from threading import Timer
+
+
 LSP_DATA_DIR = Path(__file__).parent / "lsp_data"
 TEST_DOCUMENT_PATH = Path("foo.py").absolute()
 TEST_DOCUMENT_URI = TEST_DOCUMENT_PATH.as_uri()
-
-if TYPE_CHECKING:
-    from threading import Timer
-
-if TYPE_CHECKING:
-    from threading import Timer
 
 
 @pytest.fixture(autouse=True)
@@ -939,29 +935,3 @@ def test_positron_rename(
     text_document_edit = workspace_edit.document_changes[0]
     assert isinstance(text_document_edit, TextDocumentEdit)
     assert text_document_edit.edits == expected_text_edits
-
-
-# @pytest.mark.parametrize(
-#     ("source", "namespace", "expected_code_actions"),
-#     [
-#         ("x = 1\nx", {}, []),
-#         ("def foo():\n    pass\nfoo()", {}, []),
-#     ],
-# )
-# def test_positron_code_action(
-#     source: str, namespace: Dict[str, Any], expected_code_actions: List[CodeAction]
-# ) -> None:
-#     server = create_server(namespace)
-#     text_document = create_text_document(server, TEST_DOCUMENT_URI, source)
-
-#     params = CodeActionParams(
-#         text_document=TextDocumentIdentifier(text_document.uri),
-#         range=Range(start=Position(1, 0), end=Position(1, 1)),
-#         context=CodeActionContext(
-#             diagnostics=[],
-#         ),
-#     )
-
-#     code_actions = positron_code_action(server, params)
-
-#     assert code_actions == expected_code_actions

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -12,7 +12,6 @@ from unittest.mock import Mock, patch
 import pandas as pd
 import polars as pl
 import pytest
-from python_files.posit.positron._vendor.pygls.uris import from_fs_path
 
 from positron._vendor import cattrs
 from positron._vendor.jedi_language_server import jedi_utils
@@ -46,6 +45,7 @@ from positron._vendor.lsprotocol.types import (
     TextDocumentPositionParams,
     TextEdit,
 )
+from positron._vendor.pygls.uris import from_fs_path
 from positron._vendor.pygls.workspace.text_document import TextDocument
 from positron.help_comm import ShowHelpTopicParams
 from positron.positron_jedilsp import (

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -17,17 +17,11 @@ from positron._vendor import cattrs
 from positron._vendor.jedi_language_server import jedi_utils
 from positron._vendor.lsprotocol.types import (
     ClientCapabilities,
-    CodeAction,
-    CodeActionContext,
-    CodeActionParams,
     CompletionClientCapabilities,
     CompletionClientCapabilitiesCompletionItemType,
     CompletionItem,
     CompletionParams,
     DidCloseTextDocumentParams,
-    DocumentHighlight,
-    DocumentSymbol,
-    DocumentSymbolParams,
     Hover,
     InitializeParams,
     Location,
@@ -36,20 +30,16 @@ from positron._vendor.lsprotocol.types import (
     ParameterInformation,
     Position,
     Range,
-    RenameParams,
     SignatureHelp,
     SignatureInformation,
-    SymbolKind,
     TextDocumentClientCapabilities,
     TextDocumentIdentifier,
     TextDocumentItem,
     TextDocumentPositionParams,
     TextEdit,
-    WorkspaceEdit,
 )
 from positron._vendor.pygls.workspace.text_document import TextDocument
 from positron.help_comm import ShowHelpTopicParams
-from positron.jedi import PositronCompletion, PositronInterpreter, PositronName
 from positron.positron_jedilsp import (
     HelpTopicParams,
     PositronInitializationOptions,
@@ -59,18 +49,13 @@ from positron.positron_jedilsp import (
     _MagicType,
     _publish_diagnostics,
     _publish_diagnostics_debounced,
-    positron_code_action,
     positron_completion,
     positron_completion_item_resolve,
     positron_declaration,
     positron_definition,
     positron_did_close_diagnostics,
-    positron_document_symbol,
     positron_help_topic_request,
-    positron_highlight,
     positron_hover,
-    positron_references,
-    positron_rename,
     positron_signature_help,
     positron_type_definition,
 )

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -254,7 +254,10 @@ def test_positron_completion_exact(
     server = create_server(namespace)
     text_document = create_text_document(server, TEST_DOCUMENT_URI, source)
     completions = _completions(server, text_document)
-    completion_labels = [completion.label for completion in completions]
+    completion_labels = [
+        completion.text_edit.new_text if completion.text_edit else completion.insert_text
+        for completion in completions
+    ]
     assert completion_labels == expected_labels
 
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -822,13 +822,6 @@ def test_positron_hover(source: str, namespace: Dict[str, Any], expected_fullnam
                 Location(TEST_DOCUMENT_URI, Range(Position(0, 0), Position(0, 4))),
             ],
             id="from_namespace",
-            marks=pytest.mark.skipif(
-                sys.version_info <= (3, 9),
-                reason=(
-                    "Fails due to a missing Parso cache entry. "
-                    "Probably not worth debugging at this point."
-                ),
-            ),
         ),
     ],
 )

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -261,6 +261,21 @@ def test_positron_completion_exact(
     assert completion_labels == expected_labels
 
 
+def test_parameter_completions_appear_first() -> None:
+    server = create_server()
+    text_document = create_text_document(
+        server,
+        TEST_DOCUMENT_URI,
+        """\
+def f(x): pass
+f(""",
+    )
+    completions = sorted(_completions(server, text_document), key=lambda c: c.sort_text or c.label)
+    completion_labels = [completion.label for completion in completions]
+    assert "x=" in completion_labels
+    assert completion_labels[0] == "x="
+
+
 @pytest.mark.parametrize(
     ("source", "namespace", "expected_label"),
     [

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -215,7 +215,6 @@ def _completions(
 @pytest.mark.parametrize(
     ("source", "namespace", "expected_labels"),
     [
-        # Dict key mapping to a property.
         pytest.param(
             'x["', {"x": {"a": _object_with_property.prop}}, ['a"'], id="dict_key_to_property"
         ),
@@ -230,25 +229,30 @@ def _completions(
         pytest.param(
             'x = {"a": 0}\nx["', {"x": {"b": 0}}, ['b"'], id="prefer_namespace_over_source"
         ),
-        # Dict key mapping to an int.
         pytest.param('x["', {"x": {"a": 0}}, ['a"'], id="dict_key_to_int"),
-        # Dict literal key mapping to an int.
         pytest.param('{"a": 0}["', {}, ['a"'], id="dict_literal_key_to_int"),
-        # Pandas dataframe - dict key access.
         pytest.param(
             'x["', {"x": pd.DataFrame({"a": []})}, ['a"'], id="pandas_dataframe_string_dict_key"
-        ),  # string column name
+        ),
         pytest.param(
-            'x["', {"x": pd.Series({"a": 0})}, ['a"'], id="pandas_series_string_dict_key"
-        ),  # string column name
-        # TODO: This test was actually incorrect behavior. x["0"] won't work, x[0] is necessary.
-        #       We could look into completion x[ but not going to prioritize this.
-        # pytest.param(
-        #     'x["', {"x": pd.DataFrame({0: []})}, ['0"'], id="pandas_dataframe_int_dict_key"
-        # ),  # integer column name
-        # Polars dataframe - dict key access.
+            "x[",
+            {"x": pd.DataFrame({0: []})},
+            ["0"],
+            id="pandas_dataframe_int_dict_key",
+            marks=pytest.mark.skip(reason="Completing integer dict keys not supported"),
+        ),
+        pytest.param(
+            'x["', {"x": pd.DataFrame({"a": []})}, ['a"'], id="pandas_dataframe_string_dict_key"
+        ),
+        pytest.param('x["', {"x": pd.Series({"a": 0})}, ['a"'], id="pandas_series_string_dict_key"),
         pytest.param('x["', {"x": pl.DataFrame({"a": []})}, ['a"'], id="polars_dataframe_dict_key"),
-        # Polars series only have a "range" integer index so no need to complete those.
+        pytest.param(
+            "x[",
+            {"x": pl.Series([0])},
+            ["0"],
+            id="polars_series_dict_key",
+            marks=pytest.mark.skip(reason="Completing integer dict keys not supported"),
+        ),
     ],
 )
 def test_positron_completion_exact(
@@ -362,7 +366,6 @@ _pl_df = pl.DataFrame({"a": [0]})
 @pytest.mark.parametrize(
     ("source", "namespace", "expected_detail", "expected_documentation"),
     [
-        # Dict key mapping to a property.
         pytest.param(
             'x["',
             {"x": {"a": _object_with_property.prop}},
@@ -370,7 +373,6 @@ _pl_df = pl.DataFrame({"a": [0]})
             jedi_utils.convert_docstring(cast(str, str.__doc__), MarkupKind.Markdown),
             id="dict_key_to_property",
         ),
-        # Dict key mapping to an int.
         pytest.param(
             'x["',
             {"x": {"a": 0}},
@@ -378,7 +380,6 @@ _pl_df = pl.DataFrame({"a": [0]})
             jedi_utils.convert_docstring(cast(str, int.__doc__), MarkupKind.Markdown),
             id="dict_key_to_int",
         ),
-        # Integer, to sanity check for a basic value.
         pytest.param(
             "x",
             {"x": 0},
@@ -386,7 +387,6 @@ _pl_df = pl.DataFrame({"a": [0]})
             jedi_utils.convert_docstring(cast(str, int.__doc__), MarkupKind.Markdown),
             id="int",
         ),
-        # Dict literal key mapping to an int.
         pytest.param(
             '{"a": 0}["',
             {},
@@ -394,7 +394,6 @@ _pl_df = pl.DataFrame({"a": [0]})
             jedi_utils.convert_docstring(cast(str, int.__doc__), MarkupKind.Markdown),
             id="dict_literal_key_to_int",
         ),
-        # Pandas dataframe.
         pytest.param(
             "x",
             {"x": _pd_df},
@@ -402,7 +401,6 @@ _pl_df = pl.DataFrame({"a": [0]})
             f"```text\n{str(_pd_df).strip()}\n```",
             id="pandas_dataframe",
         ),
-        # Pandas dataframe column - dict key access.
         pytest.param(
             'x["',
             {"x": _pd_df},
@@ -410,7 +408,6 @@ _pl_df = pl.DataFrame({"a": [0]})
             f"```text\n{str(_pd_df['a']).strip()}\n```",
             id="pandas_dataframe_dict_key",
         ),
-        # Pandas series.
         pytest.param(
             "x",
             {"x": _pd_df["a"]},
@@ -418,7 +415,6 @@ _pl_df = pl.DataFrame({"a": [0]})
             f"```text\n{str(_pd_df['a']).strip()}\n```",
             id="pandas_series",
         ),
-        # Polars dataframe.
         pytest.param(
             "x",
             {"x": _pl_df},
@@ -426,7 +422,6 @@ _pl_df = pl.DataFrame({"a": [0]})
             f"```text\n{str(_pl_df).strip()}\n```",
             id="polars_dataframe",
         ),
-        # Polars dataframe column - dict key access.
         pytest.param(
             'x["',
             {"x": _pl_df},
@@ -434,7 +429,6 @@ _pl_df = pl.DataFrame({"a": [0]})
             f"```text\n{str(_pl_df['a']).strip()}\n```",
             id="polars_dataframe_dict_key",
         ),
-        # Polars series.
         pytest.param(
             "x",
             {"x": _pl_df["a"]},

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -4,6 +4,7 @@
 #
 
 import os
+import sys
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
@@ -798,12 +799,8 @@ def test_positron_hover(source: str, namespace: Dict[str, Any], expected_fullnam
             "x = 1\nx",
             {},
             [
-                Location(
-                    uri=TEST_DOCUMENT_URI, range=Range(start=Position(0, 0), end=Position(0, 1))
-                ),
-                Location(
-                    uri=TEST_DOCUMENT_URI, range=Range(start=Position(1, 0), end=Position(1, 1))
-                ),
+                Location(TEST_DOCUMENT_URI, Range(Position(0, 0), Position(0, 1))),
+                Location(TEST_DOCUMENT_URI, Range(Position(1, 0), Position(1, 1))),
             ],
             id="assignment",
         ),
@@ -811,12 +808,8 @@ def test_positron_hover(source: str, namespace: Dict[str, Any], expected_fullnam
             "def foo():\n    pass\nfoo",
             {},
             [
-                Location(
-                    uri=TEST_DOCUMENT_URI, range=Range(start=Position(0, 4), end=Position(0, 7))
-                ),
-                Location(
-                    uri=TEST_DOCUMENT_URI, range=Range(start=Position(2, 0), end=Position(2, 3))
-                ),
+                Location(TEST_DOCUMENT_URI, Range(Position(0, 4), Position(0, 7))),
+                Location(TEST_DOCUMENT_URI, Range(Position(2, 0), Position(2, 3))),
             ],
             id="function_definition",
         ),
@@ -826,11 +819,16 @@ def test_positron_hover(source: str, namespace: Dict[str, Any], expected_fullnam
             [
                 # TODO: Ideally, this would include `func`'s definition, but seems to be a
                 #       limitation of Jedi.
-                Location(
-                    uri=TEST_DOCUMENT_URI, range=Range(start=Position(0, 0), end=Position(0, 4))
-                ),
+                Location(TEST_DOCUMENT_URI, Range(Position(0, 0), Position(0, 4))),
             ],
             id="from_namespace",
+            marks=pytest.mark.skipif(
+                sys.version_info <= (3, 9),
+                reason=(
+                    "Fails due to a missing Parso cache entry. "
+                    "Probably not worth debugging at this point."
+                ),
+            ),
         ),
     ],
 )


### PR DESCRIPTION
The main goal of this PR is to address #5739. Along the way, I decided to refactor how we customize Jedi. I've moved away from subclassing to just patching things. Since Jedi wasn't really designed to be customized at this level, patching lets us copy/paste _a lot_ less of their code, which I think is more robust moving forward, and it's more succinct. Since we're patching a _vendored_ version of Jedi, we also don't run the risk of messing with a user's own independent usage of Jedi.

I also added a bunch of tests for different LSP features. I think it's worth having those since we might still want to run a variation of them even if we eventually move away from Jedi.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix some language server features not working in the console and in Jupyter notebooks e.g. hover and signature help (#5739). This also fixes language server features for custom Pandas DataFrame accessors (#5077).

### QA Notes

The linked issues have great repros. They should work in both notebooks and the console when you define an object in one execution, then trigger the LSP in another.