### PR TITLE
Remove plot in editor tab flag

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -7,7 +7,7 @@
 import './actionBars.css';
 
 // React.
-import React, { PropsWithChildren, useEffect } from 'react';
+import React, { PropsWithChildren } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
@@ -15,7 +15,7 @@ import { ICommandService } from '../../../../../platform/commands/common/command
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
-import { IConfigurationChangeEvent, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { PositronActionBar } from '../../../../../platform/positronActionBar/browser/positronActionBar.js';
 import { IWorkbenchLayoutService } from '../../../../services/layout/browser/layoutService.js';
 import { ActionBarRegion } from '../../../../../platform/positronActionBar/browser/components/actionBarRegion.js';
@@ -32,7 +32,6 @@ import { INotificationService } from '../../../../../platform/notification/commo
 import { PlotActionTarget, PlotsClearAction, PlotsCopyAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsSaveAction } from '../positronPlotsActions.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { HtmlPlotClient } from '../htmlPlotClient.js';
-import { POSITRON_EDITOR_PLOTS, positronPlotsEditorEnabled } from '../../../positronPlotsEditor/browser/positronPlotsEditor.contribution.js';
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { OpenInEditorMenuButton } from './openInEditorMenuButton.js';
 
@@ -66,7 +65,6 @@ export interface ActionBarsProps {
 export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	// Hooks.
 	const positronPlotsContext = usePositronPlotsContext();
-	const [useEditorPlots, setUseEditorPlots] = React.useState<boolean>(positronPlotsEditorEnabled(props.configurationService));
 
 	// Do we have any plots?
 	const noPlots = positronPlotsContext.positronPlotInstances.length === 0;
@@ -94,18 +92,9 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	const enablePopoutPlot = hasPlots &&
 		selectedPlot instanceof HtmlPlotClient;
 
-	const enableEditorPlot = hasPlots && useEditorPlots
+	const enableEditorPlot = hasPlots
 		&& (selectedPlot instanceof PlotClientInstance
 			|| selectedPlot instanceof StaticPlotClient);
-
-	useEffect(() => {
-		const disposable = props.configurationService.onDidChangeConfiguration((event: IConfigurationChangeEvent) => {
-			if (event.affectedKeys.has(POSITRON_EDITOR_PLOTS)) {
-				setUseEditorPlots(positronPlotsEditorEnabled(props.configurationService));
-			}
-		});
-		return () => disposable.dispose();
-	}, [props.configurationService]);
 
 	// Clear all the plots from the service.
 	const clearAllPlotsHandler = () => {

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsActions.ts
@@ -455,11 +455,11 @@ export class PlotsActiveEditorCopyAction extends Action2 {
 			category,
 			f1: false, // do not show in the command palette
 			icon: Codicon.copy,
-			precondition: ContextKeyExpr.and(ContextKeyExpr.equals(`config.${POSITRON_EDITOR_PLOTS}`, true), PLOT_IS_ACTIVE_EDITOR),
+			precondition: PLOT_IS_ACTIVE_EDITOR,
 			menu: [
 				{
 					id: MenuId.EditorTitle,
-					when: ContextKeyExpr.and(ContextKeyExpr.equals(`config.${POSITRON_EDITOR_PLOTS}`, true), PLOT_IS_ACTIVE_EDITOR),
+					when: PLOT_IS_ACTIVE_EDITOR,
 					group: 'navigation',
 					order: 2,
 				}
@@ -492,11 +492,11 @@ export class PlotsActiveEditorSaveAction extends Action2 {
 			category,
 			f1: false, // do not show in the command palette
 			icon: Codicon.positronSave,
-			precondition: ContextKeyExpr.and(ContextKeyExpr.equals(`config.${POSITRON_EDITOR_PLOTS}`, true), PLOT_IS_ACTIVE_EDITOR),
+			precondition: PLOT_IS_ACTIVE_EDITOR,
 			menu: [
 				{
 					id: MenuId.EditorTitle,
-					when: ContextKeyExpr.and(ContextKeyExpr.equals(`config.${POSITRON_EDITOR_PLOTS}`, true), PLOT_IS_ACTIVE_EDITOR),
+					when: PLOT_IS_ACTIVE_EDITOR,
 					group: 'navigation',
 					order: 1,
 				}

--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.contribution.ts
@@ -6,14 +6,11 @@
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { localize } from '../../../../nls.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from '../../../browser/editor.js';
-import { applicationConfigurationNodeBase } from '../../../common/configuration.js';
 import { registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 import { EditorExtensions } from '../../../common/editor.js';
 import { PositronPlotsEditor } from './positronPlotsEditor.js';
@@ -78,23 +75,5 @@ registerWorkbenchContribution2(
 	PositronPlotsEditorContribution,
 	WorkbenchPhase.AfterRestored
 );
-
-const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
-configurationRegistry.registerConfiguration({
-	...applicationConfigurationNodeBase,
-	properties: {
-		[POSITRON_EDITOR_PLOTS]: {
-			scope: ConfigurationScope.APPLICATION,
-			type: 'boolean',
-			default: false,
-			tags: ['experimental'],
-			description: localize('workbench.positronPlotsEditor.description', 'When enabled, plots can be opened in an editor tab.')
-		}
-	}
-});
-
-export function positronPlotsEditorEnabled(configurationService: IConfigurationService) {
-	return Boolean(configurationService.getValue(POSITRON_EDITOR_PLOTS));
-}
 
 export const PLOT_IS_ACTIVE_EDITOR = ContextKeyExpr.equals('activeEditor', PositronPlotsEditorInput.EditorID);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

@:plots


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #6146 Lifts the experimental flag on viewing plots in an editor tab. This feature introduces an action menu button in the Plots view to open a plot for viewing in an editor. The default action opens the plot in a new window. The menu options allow opening the plot in the same window either in the existing editor group or to the side of the existing group. Selecting an alternate location sets it as the default action. This is setting is remembered for the project. Plots in an editor tab are rendered separately from the Plots view so they can have their own sizing policy.

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
