### PR TITLE
E2E test: add alternate Python and R versions

### DIFF
--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -1,5 +1,10 @@
 name: "Setup Python"
-description: "Install Python dependencies."
+description: "Install Python dependencies and alternate version."
+inputs:
+  alternate_version:
+    description: "The alternate version of Python to install (e.g., 3.13.0)"
+    required: true
+    default: "3.13.0"
 runs:
   using: "composite"
   steps:
@@ -7,12 +12,17 @@ runs:
       shell: bash
       run: |
         curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt
-        python -m pip install ipykernel trcli
+        python3 -m pip install --upgrade pip
+        python3 -m pip install -r requirements.txt
+        python3 -m pip install ipykernel trcli
 
     - name: Verify Python Version
       shell: bash
       run: |
-        python3 --version
+        python --version
         which python
+
+    - name: Install alternate Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "${{ inputs.alternate_version }}"

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Verify Python Version
       shell: bash
       run: |
-        python --version
+        python3 --version
         which python
 
     - name: Install alternate Python

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -14,7 +14,7 @@ runs:
         curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
         python3 -m pip install --upgrade pip
         python3 -m pip install -r requirements.txt
-        python3 -m pip install ipykernel trcli
+        python3 -m pip install ipykernel
 
     - name: Verify Python Version
       shell: bash
@@ -51,6 +51,17 @@ runs:
         PYTHON_ALTERNATE_VERSION="${{ inputs.alternate_version }}"
         echo "Installing Python version $PYTHON_ALTERNATE_VERSION using pyenv..."
         pyenv install -s "$PYTHON_ALTERNATE_VERSION"
-
-        # Verify installation (but don't set it as default)
+        
         pyenv versions
+
+        pyenv global "$PYTHON_ALTERNATE_VERSION"
+        python --version
+        python -m pip install --upgrade pip
+        python -m pip install ipykernel
+
+        # Undo the change and reset to system Python
+        echo "Resetting pyenv to system Python..."
+        pyenv global --unset || pyenv global system
+
+        # Verify that Python is reset
+        python --version

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -22,7 +22,31 @@ runs:
         python3 --version
         which python
 
-    - name: Install alternate Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "${{ inputs.alternate_version }}"
+    - name: Install pyenv
+      shell: bash
+      run: |
+        echo "Installing pyenv..."
+        curl https://pyenv.run | bash
+
+        # Add pyenv to PATH in bashrc (for later steps and tests)
+        echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> ~/.bashrc
+        echo 'eval "$(pyenv init --path)"' >> ~/.bashrc
+        echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc
+
+        # Apply changes for the current session
+        export PATH="$HOME/.pyenv/bin:$PATH"
+        eval "$(pyenv init --path)"
+        eval "$(pyenv virtualenv-init -)"
+
+        # Verify installation
+        pyenv --version
+
+    - name: Install Alternate Python Version
+      shell: bash
+      run: |
+        PYTHON_ALTERNATE_VERSION="${{ inputs.alternate_version }}"
+        echo "Installing Python version $PYTHON_ALTERNATE_VERSION using pyenv..."
+        pyenv install -s "$PYTHON_ALTERNATE_VERSION"
+
+        # Verify installation (but don't set it as default)
+        pyenv versions

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -61,7 +61,7 @@ runs:
 
         # Undo the change and reset to system Python
         echo "Resetting pyenv to system Python..."
-        pyenv global --unset || pyenv global system
+        pyenv global system
 
         # Verify that Python is reset
         python --version

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -44,6 +44,10 @@ runs:
     - name: Install Alternate Python Version
       shell: bash
       run: |
+        export PATH="$HOME/.pyenv/bin:$PATH"
+        eval "$(pyenv init --path)"
+        eval "$(pyenv virtualenv-init -)"
+
         PYTHON_ALTERNATE_VERSION="${{ inputs.alternate_version }}"
         echo "Installing Python version $PYTHON_ALTERNATE_VERSION using pyenv..."
         pyenv install -s "$PYTHON_ALTERNATE_VERSION"

--- a/.github/actions/install-r/action.yml
+++ b/.github/actions/install-r/action.yml
@@ -1,18 +1,21 @@
 name: "Setup Rig, R, and R Packages"
-description: "Install a specified R version using rig, with an option to install additional R packages."
+description: "Install a specified R version using Rig, with an option to install additional R packages."
 inputs:
   version:
     description: "The R version to install (e.g., 4.4.0)"
     required: false
     default: "4.4.0"
+  alternate_version:
+    description: "The alternate R version to install (e.g., 4.4.2)"
+    required: false
+    default: "4.4.2"
 runs:
   using: "composite"
   steps:
     - name: Install Rig and R
       shell: bash
-      env:
-        R_VERSION: "${{ inputs.version }}"
       run: |
+        R_VERSION="${{ inputs.version }}"
         echo "Installing R version $R_VERSION using Rig..."
         curl -Ls https://github.com/r-lib/rig/releases/download/latest/rig-linux-"$(arch)"-latest.tar.gz | sudo tar xz -C /usr/local
         rig add "$R_VERSION"
@@ -44,3 +47,10 @@ runs:
         curl -s https://raw.githubusercontent.com/posit-dev/qa-example-content/main/DESCRIPTION --output DESCRIPTION
         Rscript -e "if (!requireNamespace('pak', quietly = TRUE)) install.packages('pak', repos = 'https://cran.rstudio.com')"
         Rscript -e "options(pak.install_binary = TRUE); pak::local_install_dev_deps(ask = FALSE)"
+
+    - name: Install alternate R version
+      shell: bash
+      run: |
+        R_ALTERNATE_VERSION="${{ inputs.alternate_version }}"
+        echo "Installing R version $R_ALTERNATE_VERSION using Rig..."
+        rig add "$R_ALTERNATE_VERSION"

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -44,8 +44,11 @@ runs:
 
     - name: Setup Python
       uses: ./.github/actions/install-python
+      with:
+        alternate_version: "3.13.0"
 
     - name: Setup R
       uses: ./.github/actions/install-r
       with:
         version: "4.4.0"
+        alternate_version: "4.4.2"

--- a/.github/workflows/test-e2e-linux.yml
+++ b/.github/workflows/test-e2e-linux.yml
@@ -135,6 +135,8 @@ jobs:
         env:
           POSITRON_PY_VER_SEL: 3.12.3
           POSITRON_R_VER_SEL: 4.4.0
+          POSITRON_PY_ALT_VER_SEL: 3.13.0
+          POSITRON_R_ALT_VER_SEL: 4.4.2
           CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
           CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}

--- a/.github/workflows/test-e2e-release.yml
+++ b/.github/workflows/test-e2e-release.yml
@@ -104,6 +104,8 @@ jobs:
         env:
           POSITRON_PY_VER_SEL: 3.12.3
           POSITRON_R_VER_SEL: 4.4.0
+          POSITRON_PY_ALT_VER_SEL: 3.13.0
+          POSITRON_R_ALT_VER_SEL: 4.4.2
           CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
           CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}

--- a/test/e2e/infra/fixtures/interpreter.ts
+++ b/test/e2e/infra/fixtures/interpreter.ts
@@ -82,7 +82,8 @@ export class Interpreter {
 				await selectedPrimaryInterpreter.click();
 			} else {
 				primaryInterpreterByType.getByRole('button', { name: '' }).click();
-				await secondaryInterpreterOption.click();
+				// first() here is a workaround because we are detecting the same interpreter twice
+				await secondaryInterpreterOption.first().click();
 			}
 
 			if (waitForReady) {

--- a/test/e2e/pages/scm.ts
+++ b/test/e2e/pages/scm.ts
@@ -29,15 +29,16 @@ export class SCM {
 	}
 
 	async waitForChange(name: string, type: string): Promise<void> {
-		await expect(async () => {
 
-			await this.layout.enterLayout('fullSizedSidebar');
+		await this.layout.enterLayout('fullSizedSidebar');
+
+		await expect(async () => {
 
 			const scmResources = await this.code.driver.page.locator(SCM_RESOURCE).all();
 
 			const resources: { name: string; type: string }[] = [];
 			for (const resource of scmResources) {
-				const text = await resource.locator('.label-name').textContent();
+				const text = await resource.locator('.label-name').textContent({ timeout: 5000 });
 				const tooltip = await resource.getAttribute('data-tooltip') || '';
 
 				if (text !== null) {
@@ -53,9 +54,9 @@ export class SCM {
 				expect.arrayContaining([{ name, type }])
 			);
 
-			await this.layout.enterLayout('stacked');
+		}).toPass({ timeout: 30000 });
 
-		}).toPass({ timeout: 60000 });
+		await this.layout.enterLayout('stacked');
 	}
 
 	async openChange(name: string): Promise<void> {
@@ -64,6 +65,7 @@ export class SCM {
 
 	async stage(name: string): Promise<void> {
 		await this.code.driver.page.locator(SCM_RESOURCE_ACTION_CLICK(name, 'Stage Changes')).click();
+		// this means a staged change:
 		await this.waitForChange(name, 'Index Modified');
 	}
 

--- a/test/e2e/pages/scm.ts
+++ b/test/e2e/pages/scm.ts
@@ -13,6 +13,7 @@ import { Layouts } from './layouts';
 
 const VIEWLET = 'div[id="workbench.view.scm"]';
 const SCM_INPUT_TEXTAREA = `${VIEWLET} .scm-editor textarea`;
+const SCM_RESOURCE = `${VIEWLET} .monaco-list-row .resource`;
 const SCM_RESOURCE_CLICK = (name: string) => `${VIEWLET} .monaco-list-row .resource .monaco-icon-label[aria-label*="${name}"] .label-name`;
 const SCM_RESOURCE_ACTION_CLICK = (name: string, actionName: string) => `.monaco-list-row .resource .monaco-icon-label[aria-label*="${name}"] .actions .action-label[aria-label="${actionName}"]`;
 const COMMIT_COMMAND = `div[id="workbench.parts.sidebar"] .actions-container a.action-label[aria-label="Commit"]`;
@@ -28,17 +29,33 @@ export class SCM {
 	}
 
 	async waitForChange(name: string, type: string): Promise<void> {
+		await expect(async () => {
 
-		await this.layout.enterLayout('fullSizedSidebar');
+			await this.layout.enterLayout('fullSizedSidebar');
 
-		const tooltip = type === 'Staged' ? 'Index Modified' : 'Modified';
-		const locator = this.code.driver.page
-			.getByLabel('Source Control Management')
-			.locator(`[data-tooltip="${tooltip}"] .file-icon`)
-			.filter({ hasText: name });
+			const scmResources = await this.code.driver.page.locator(SCM_RESOURCE).all();
 
-		await expect(locator).toBeVisible();
-		await this.layout.enterLayout('stacked');
+			const resources: { name: string; type: string }[] = [];
+			for (const resource of scmResources) {
+				const text = await resource.locator('.label-name').textContent();
+				const tooltip = await resource.getAttribute('data-tooltip') || '';
+
+				if (text !== null) {
+					resources.push({ name: text.trim(), type: tooltip.trim() });
+				}
+			}
+
+			// debug
+			resources.forEach(resource => this.code.logger.log(`Name: ${resource.name}, Type: ${resource.type}`));
+
+			// Check if at least one resource matches both name and type
+			expect(resources).toEqual(
+				expect.arrayContaining([{ name, type }])
+			);
+
+			await this.layout.enterLayout('stacked');
+
+		}).toPass({ timeout: 20000 });
 	}
 
 	async openChange(name: string): Promise<void> {

--- a/test/e2e/pages/scm.ts
+++ b/test/e2e/pages/scm.ts
@@ -13,7 +13,6 @@ import { Layouts } from './layouts';
 
 const VIEWLET = 'div[id="workbench.view.scm"]';
 const SCM_INPUT_TEXTAREA = `${VIEWLET} .scm-editor textarea`;
-const SCM_RESOURCE = `${VIEWLET} .monaco-list-row .resource`;
 const SCM_RESOURCE_CLICK = (name: string) => `${VIEWLET} .monaco-list-row .resource .monaco-icon-label[aria-label*="${name}"] .label-name`;
 const SCM_RESOURCE_ACTION_CLICK = (name: string, actionName: string) => `.monaco-list-row .resource .monaco-icon-label[aria-label*="${name}"] .actions .action-label[aria-label="${actionName}"]`;
 const COMMIT_COMMAND = `div[id="workbench.parts.sidebar"] .actions-container a.action-label[aria-label="Commit"]`;
@@ -32,29 +31,12 @@ export class SCM {
 
 		await this.layout.enterLayout('fullSizedSidebar');
 
-		await expect(async () => {
+		const tooltip = type === 'Staged' ? 'Index Modified' : 'Modified';
+		const locator = this.code.driver.page
+			.getByLabel('Source Control Management')
+			.locator(`[data-tooltip="${tooltip}"] .file-icon`);
 
-			const scmResources = await this.code.driver.page.locator(SCM_RESOURCE).all();
-
-			const resources: { name: string; type: string }[] = [];
-			for (const resource of scmResources) {
-				const text = await resource.locator('.label-name').textContent({ timeout: 5000 });
-				const tooltip = await resource.getAttribute('data-tooltip') || '';
-
-				if (text !== null) {
-					resources.push({ name: text.trim(), type: tooltip.trim() });
-				}
-			}
-
-			// debug
-			resources.forEach(resource => this.code.logger.log(`Name: ${resource.name}, Type: ${resource.type}`));
-
-			// Check if at least one resource matches both name and type
-			expect(resources).toEqual(
-				expect.arrayContaining([{ name, type }])
-			);
-
-		}).toPass({ timeout: 30000 });
+		await expect(locator).toContainText(name);
 
 		await this.layout.enterLayout('stacked');
 	}
@@ -65,8 +47,7 @@ export class SCM {
 
 	async stage(name: string): Promise<void> {
 		await this.code.driver.page.locator(SCM_RESOURCE_ACTION_CLICK(name, 'Stage Changes')).click();
-		// this means a staged change:
-		await this.waitForChange(name, 'Index Modified');
+		await this.waitForChange(name, 'Staged');
 	}
 
 	async commit(message: string): Promise<void> {

--- a/test/e2e/pages/scm.ts
+++ b/test/e2e/pages/scm.ts
@@ -64,7 +64,7 @@ export class SCM {
 
 	async stage(name: string): Promise<void> {
 		await this.code.driver.page.locator(SCM_RESOURCE_ACTION_CLICK(name, 'Stage Changes')).click();
-		await this.waitForChange(name, 'Staged');
+		await this.waitForChange(name, 'Index Modified');
 	}
 
 	async commit(message: string): Promise<void> {

--- a/test/e2e/pages/scm.ts
+++ b/test/e2e/pages/scm.ts
@@ -55,7 +55,7 @@ export class SCM {
 
 			await this.layout.enterLayout('stacked');
 
-		}).toPass({ timeout: 20000 });
+		}).toPass({ timeout: 60000 });
 	}
 
 	async openChange(name: string): Promise<void> {

--- a/test/e2e/pages/scm.ts
+++ b/test/e2e/pages/scm.ts
@@ -34,10 +34,10 @@ export class SCM {
 		const tooltip = type === 'Staged' ? 'Index Modified' : 'Modified';
 		const locator = this.code.driver.page
 			.getByLabel('Source Control Management')
-			.locator(`[data-tooltip="${tooltip}"] .file-icon`);
+			.locator(`[data-tooltip="${tooltip}"] .file-icon`)
+			.filter({ hasText: name });
 
-		await expect(locator).toContainText(name);
-
+		await expect(locator).toBeVisible();
 		await this.layout.enterLayout('stacked');
 	}
 

--- a/test/e2e/tests/console/console-python.test.ts
+++ b/test/e2e/tests/console/console-python.test.ts
@@ -3,7 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { fail } from 'assert';
 import { test, expect, tags } from '../_test.setup';
+import { InterpreterType } from '../../infra';
 
 test.use({
 	suiteId: __filename
@@ -49,5 +51,39 @@ test.describe('Console Pane: Python', { tag: [tags.WEB, tags.WIN, tags.CONSOLE] 
 
 		await app.workbench.console.interruptExecution();
 
+	});
+
+	test('Verify multiple versions', async function ({ app, python }) {
+
+		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+
+		const primaryPython = process.env.POSITRON_PY_VER_SEL;
+
+		if (primaryPython) {
+
+			await app.workbench.console.barClearButton.click();
+
+			await app.workbench.console.pasteCodeToConsole('import platform; print(platform.python_version())');
+			await app.workbench.console.sendEnterKey();
+
+			await app.workbench.console.waitForConsoleContents(primaryPython);
+		} else {
+			fail('Primary Python version not set');
+		}
+
+		const secondaryPython = process.env.POSITRON_PY_ALT_VER_SEL;
+
+		if (secondaryPython) {
+
+			await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, `${secondaryPython} (Pyenv)`, true);
+
+			await app.workbench.console.barClearButton.click();
+
+			await app.workbench.console.pasteCodeToConsole(`import platform; print(platform.python_version())`);
+			await app.workbench.console.sendEnterKey();
+			await app.workbench.console.waitForConsoleContents(secondaryPython);
+		} else {
+			fail('Secondary Python version not set');
+		}
 	});
 });

--- a/test/e2e/tests/console/console-python.test.ts
+++ b/test/e2e/tests/console/console-python.test.ts
@@ -11,9 +11,11 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Console Pane: Python', { tag: [tags.WEB, tags.WIN, tags.CONSOLE] }, () => {
+test.describe('Console Pane: Python', { tag: [tags.WEB, tags.CONSOLE] }, () => {
 
-	test('Verify restart button inside the console', async function ({ app, python }) {
+	test('Verify restart button inside the console', {
+		tag: [tags.WIN]
+	}, async function ({ app, python }) {
 		await expect(async () => {
 			await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 			await app.workbench.console.barClearButton.click();
@@ -30,6 +32,7 @@ test.describe('Console Pane: Python', { tag: [tags.WEB, tags.WIN, tags.CONSOLE] 
 	});
 
 	test('Verify restart button on console bar', {
+		tag: [tags.WIN]
 	}, async function ({ app, python }) {
 		// Need to make console bigger to see all bar buttons
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
@@ -44,6 +47,7 @@ test.describe('Console Pane: Python', { tag: [tags.WEB, tags.WIN, tags.CONSOLE] 
 	});
 
 	test('Verify cancel button on console bar', {
+		tag: [tags.WIN]
 	}, async function ({ app, python }) {
 
 		await app.workbench.console.pasteCodeToConsole('import time; time.sleep(10)');
@@ -53,6 +57,7 @@ test.describe('Console Pane: Python', { tag: [tags.WEB, tags.WIN, tags.CONSOLE] 
 
 	});
 
+	// not enabled for WIN yet; need to add additional versions
 	test('Verify multiple versions', async function ({ app, python }) {
 
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');

--- a/test/e2e/tests/console/console-r.test.ts
+++ b/test/e2e/tests/console/console-r.test.ts
@@ -12,14 +12,16 @@ test.use({
 });
 
 test.describe('Console Pane: R', {
-	tag: [tags.WEB, tags.WIN, tags.CONSOLE]
+	tag: [tags.WEB, tags.CONSOLE]
 }, () => {
 	test.beforeAll(async function ({ app }) {
 		// Need to make console bigger to see all bar buttons
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 	});
 
-	test('Verify restart button inside the console', async function ({ app, r }) {
+	test('Verify restart button inside the console', {
+		tag: [tags.WIN]
+	}, async function ({ app, r }) {
 		await expect(async () => {
 			await app.workbench.console.barClearButton.click();
 			await app.workbench.console.barPowerButton.click();
@@ -29,7 +31,9 @@ test.describe('Console Pane: R', {
 		}).toPass();
 	});
 
-	test('Verify restart button on console bar', async function ({ app, r }) {
+	test('Verify restart button on console bar', {
+		tag: [tags.WIN]
+	}, async function ({ app, r }) {
 		await expect(async () => {
 			await app.workbench.console.barClearButton.click();
 			await app.workbench.console.barRestartButton.click();
@@ -38,6 +42,7 @@ test.describe('Console Pane: R', {
 	});
 
 	test('Verify cancel button on console bar', {
+		tag: [tags.WIN]
 	}, async function ({ app, r }) {
 
 		await app.workbench.console.pasteCodeToConsole('Sys.sleep(10)');
@@ -48,6 +53,7 @@ test.describe('Console Pane: R', {
 		// nothing appears in console after interrupting execution
 	});
 
+	// not enabled for WIN yet; need to add additional versions
 	test('Verify multiple versions', async function ({ app, r }) {
 
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');

--- a/test/e2e/tests/console/console-r.test.ts
+++ b/test/e2e/tests/console/console-r.test.ts
@@ -3,7 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { fail } from 'assert';
 import { test, expect, tags } from '../_test.setup';
+import { InterpreterType } from '../../infra';
 
 test.use({
 	suiteId: __filename
@@ -44,6 +46,40 @@ test.describe('Console Pane: R', {
 		await app.workbench.console.interruptExecution();
 
 		// nothing appears in console after interrupting execution
+	});
+
+	test('Verify multiple versions', async function ({ app, r }) {
+
+		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+
+		const primaryR = process.env.POSITRON_R_VER_SEL;
+
+		if (primaryR) {
+
+			await app.workbench.console.barClearButton.click();
+
+			await app.workbench.console.pasteCodeToConsole('R.version.string');
+			await app.workbench.console.sendEnterKey();
+
+			await app.workbench.console.waitForConsoleContents(primaryR);
+		} else {
+			fail('Primary R version not set');
+		}
+
+		const secondaryR = process.env.POSITRON_R_ALT_VER_SEL;
+
+		if (secondaryR) {
+
+			await app.workbench.interpreter.selectInterpreter(InterpreterType.R, secondaryR, true);
+
+			await app.workbench.console.barClearButton.click();
+
+			await app.workbench.console.pasteCodeToConsole(`R.version.string`);
+			await app.workbench.console.sendEnterKey();
+			await app.workbench.console.waitForConsoleContents(secondaryR);
+		} else {
+			fail('Secondary R version not set');
+		}
 	});
 });
 


### PR DESCRIPTION
Adding alternate R and Python versions in preparation for multi console tests.  One simple R and Python test was added to ensure the installations were successful.

Local setup:
* pyenv install 3.13.0 # Must be a pyenv environment (My OSX has a 3.13.0 global env)
* install ipykernel to 3.13.0
* rig add 4.4.2

Local env vars:
* export POSITRON_PY_ALT_VER_SEL='3.13.0'
* export POSITRON_R_ALT_VER_SEL='4.4.2'

### QA Notes

All tests should pass.
@:scm @:web @:console @:win