### PR TITLE
Display active runtime metadata in console pane

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -25,6 +25,8 @@ import { PositronConsoleState } from '../../../../services/positronConsole/brows
 import { RuntimeExitReason, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, RuntimeStartMode } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { ConsoleInstanceMenuButton } from './consoleInstanceMenuButton.js';
+import { multipleConsoleSessionsFeatureEnabled } from '../../../../services/runtimeSession/common/positronMultipleConsoleSessionsFeatureFlag.js';
+import { ConsoleInstanceInfoButton } from './consoleInstanceInfoButton.js';
 
 /**
  * Constants.
@@ -101,6 +103,7 @@ export const ActionBar = (props: ActionBarProps) => {
 
 	// Constants.
 	const showDeveloperUI = IsDevelopmentContext.getValue(positronConsoleContext.contextKeyService);
+	const multiSessionsEnabled = multipleConsoleSessionsFeatureEnabled(positronConsoleContext.configurationService);
 
 	// State hooks.
 	const [activePositronConsoleInstance, setActivePositronConsoleInstance] =
@@ -382,6 +385,7 @@ export const ActionBar = (props: ActionBarProps) => {
 							ariaLabel={positronRestartConsole}
 							onPressed={restartConsoleHandler}
 						/>
+						{multiSessionsEnabled && <ConsoleInstanceInfoButton />}
 						<ActionBarSeparator />
 						{showDeveloperUI &&
 							<ActionBarButton

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.css
@@ -8,7 +8,7 @@
 }
 
 .console-instance-info .top-separator {
-	border-top: 1px solid var(--vscode-positronModalDialog-separator);
+	border-top: 1px solid var(--vscode-editorHoverWidget-border);
 }
 
 .console-instance-info .actions {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.css
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.console-instance-info {
+	padding: 4px;
+	display: flex;
+	flex-direction: column;
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.css
@@ -3,8 +3,30 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.console-instance-info {
-	padding: 4px;
-	display: flex;
-	flex-direction: column;
+.positron-modal-popup-children:has(.console-instance-info) {
+	background: var(--vscode-editorHoverWidget-background);
+}
+
+.console-instance-info .top-separator {
+	border-top: 1px solid var(--vscode-positronModalDialog-separator);
+}
+
+.console-instance-info .actions {
+	background-color: var(--vscode-editorHoverWidget-statusBarBackground);
+	padding-bottom: 4px;
+}
+
+.console-instance-info .content .line {
+	margin: 8px 0px;
+	overflow-wrap: break-word;
+	padding: 0px 8px;
+}
+
+.console-instance-info .actions .link {
+	color: var(--vscode-textLink-foreground);
+	cursor: pointer;
+	font-size: 12px;
+	line-height: 22px;
+	padding: 0px 8px;
+	text-decoration: underline;
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.css
@@ -17,9 +17,9 @@
 }
 
 .console-instance-info .content .line {
-	margin: 8px 0px;
+	margin: 8px 0;
 	overflow-wrap: break-word;
-	padding: 0px 8px;
+	padding: 0 8px;
 }
 
 .console-instance-info .actions .link {
@@ -27,6 +27,6 @@
 	cursor: pointer;
 	font-size: 12px;
 	line-height: 22px;
-	padding: 0px 8px;
+	padding: 0 8px;
 	text-decoration: underline;
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -20,8 +20,8 @@ import { PositronButton } from '../../../../../base/browser/ui/positronComponent
 import { ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 
-const positronConsoleInfo = localize('positronConsoleInfo', "Console information");
-const showKernelOutputChannel = localize('positron.showKernelOutputChannel', "Show Kernel Output Channel");
+const positronConsoleInfo = localize('positron.console.info.label', "Console information");
+const showKernelOutputChannel = localize('positron.console.info.showKernelOutputChannel', "Show Kernel Output Channel");
 
 export const ConsoleInstanceInfoButton = () => {
 	// Hooks.
@@ -106,12 +106,26 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 				<div className='content'>
 					<p className='line'>{props.session?.metadata.sessionName}</p>
 					<div className='top-separator'>
-						<p className='line'>Session ID: {props.session?.sessionId}</p>
-						<p className='line'>State: {sessionState}</p>
+						<p className='line'>
+							{(() => localize(
+								'positron.console.info.sessionId', 'Session ID: {0}',
+								props.session.sessionId
+							))()}
+						</p>
+						<p className='line'>{(() => localize(
+							'positron.console.info.state', 'State: {0}',
+							sessionState))()}
+						</p>
 					</div>
 					<div className='top-separator'>
-						<p className='line'>Path: {props.session?.runtimeMetadata.runtimePath}</p>
-						<p className='line'>Source: {props.session?.runtimeMetadata.runtimeSource}</p>
+						<p className='line'>{(() => localize(
+							'positron.console.info.runtimePath', 'Path: {0}',
+							props.session.runtimeMetadata.runtimePath))()}
+						</p>
+						<p className='line'>{(() => localize(
+							'positron.console.info.runtimeSource', 'Source: {0}',
+							props.session.runtimeMetadata.runtimeSource))()}
+						</p>
 					</div>
 				</div>
 				<div className='top-separator actions'>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -81,7 +81,7 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 			setSessionState(state);
 		}));
 		return () => disposableStore.dispose();
-	});
+	}, []);
 
 	const showKernelOutputChannelClickHandler = () => {
 		props.session.showOutput();

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -72,7 +72,7 @@ interface ConsoleInstanceInfoModalPopupProps {
 }
 
 const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps) => {
-	const [sessionState, setSessionState] = useState(props.session?.getRuntimeState());
+	const [sessionState, setSessionState] = useState(props.session.getRuntimeState());
 
 	// Main useEffect hook.
 	useEffect(() => {
@@ -84,11 +84,7 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 	});
 
 	const showKernelOutputChannelClickHandler = () => {
-		props.session?.showOutput();
-	}
-
-	if (!props.session) {
-		return null;
+		props.session.showOutput();
 	}
 
 	// Render.
@@ -104,7 +100,7 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 		>
 			<div className='console-instance-info'>
 				<div className='content'>
-					<p className='line'>{props.session?.metadata.sessionName}</p>
+					<p className='line'>{props.session.metadata.sessionName}</p>
 					<div className='top-separator'>
 						<p className='line'>
 							{(() => localize(

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -104,14 +104,14 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 		>
 			<div className='console-instance-info'>
 				<div className='content'>
-					<div className='line'>{props.session?.metadata.sessionName}</div>
+					<p className='line'>{props.session?.metadata.sessionName}</p>
 					<div className='top-separator'>
-						<div className='line'>Session ID: {props.session?.sessionId}</div>
-						<div className='line'>State: {sessionState}</div>
+						<p className='line'>Session ID: {props.session?.sessionId}</p>
+						<p className='line'>State: {sessionState}</p>
 					</div>
 					<div className='top-separator'>
-						<div className='line'>Path: {props.session?.runtimeMetadata.runtimePath}</div>
-						<div className='line'>Source: {props.session?.runtimeMetadata.runtimeSource}</div>
+						<p className='line'>Path: {props.session?.runtimeMetadata.runtimePath}</p>
+						<p className='line'>Source: {props.session?.runtimeMetadata.runtimeSource}</p>
 					</div>
 				</div>
 				<div className='top-separator actions'>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// React.
+import React from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../nls.js';
+import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
+
+const positronConsoleInfo = localize('positronConsoleInfo', "Console information");
+
+export const ConsoleInstanceInfoButton = () => {
+	return (
+		<ActionBarButton
+			iconId='info'
+			align='right'
+			tooltip={positronConsoleInfo}
+			ariaLabel={positronConsoleInfo}
+		/>
+	)
+};

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -3,6 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// CSS.
+import './consoleInstanceInfoButton.css';
+
 // React.
 import React, { useRef } from 'react';
 
@@ -13,8 +16,11 @@ import { PositronModalPopup } from '../../../../browser/positronComponents/posit
 import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
 import { PositronModalReactRenderer } from '../../../../browser/positronModalReactRenderer/positronModalReactRenderer.js';
 import { usePositronConsoleContext } from '../positronConsoleContext.js';
+import { PositronButton } from '../../../../../base/browser/ui/positronComponents/button/positronButton.js';
+import { ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 
 const positronConsoleInfo = localize('positronConsoleInfo', "Console information");
+const showKernelOutputChannel = localize('positron.showKernelOutputChannel', "Show Kernel Output Channel");
 
 export const ConsoleInstanceInfoButton = () => {
 	// Hooks.
@@ -36,6 +42,7 @@ export const ConsoleInstanceInfoButton = () => {
 			<ConsoleInstanceInfoModalPopup
 				anchorElement={ref.current}
 				renderer={renderer}
+				session={positronConsoleContext.activePositronConsoleInstance?.session}
 			/>
 		);
 	}
@@ -55,22 +62,26 @@ export const ConsoleInstanceInfoButton = () => {
 
 interface ConsoleInstanceInfoModalPopupProps {
 	anchorElement: HTMLElement;
-	renderer: PositronModalReactRenderer
+	renderer: PositronModalReactRenderer;
+	session: ILanguageRuntimeSession | undefined;
 }
 
 const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps) => {
-	// Hooks.
-	const positronConsoleContext = usePositronConsoleContext();
+	const session = props.session;
 
-	// Constants
-	const activeConsoleInstance = positronConsoleContext.positronConsoleService.activePositronConsoleInstance;
-	const session = activeConsoleInstance?.session;
+	const showKernelOutputChannelClickHandler = () => {
+		session?.showOutput();
+	}
+
+	if (!session) {
+		return null;
+	}
 
 	// Render.
 	return (
 		<PositronModalPopup
 			anchorElement={props.anchorElement}
-			height={200}
+			height='min-content'
 			keyboardNavigationStyle='menu'
 			renderer={props.renderer}
 			popupAlignment='auto'
@@ -78,11 +89,21 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 			width={400}
 		>
 			<div className='console-instance-info'>
-				<p>Name: {session?.metadata.sessionName}</p>
-				<p>ID: {session?.sessionId}</p>
-				<p>State: {session?.getRuntimeState()}</p>
-				<p>Path: {session?.runtimeMetadata.runtimePath}</p>
-				<p>Source: {session?.runtimeMetadata.runtimeSource}</p>
+				<div className='content'>
+					<div className='line'>{session?.metadata.sessionName}</div>
+					<div className='top-separator'>
+						<div className='line'>Session ID: {session?.sessionId}</div>
+					</div>
+					<div className='top-separator'>
+						<div className='line'>Path: {session?.runtimeMetadata.runtimePath}</div>
+						<div className='line'>Source: {session?.runtimeMetadata.runtimeSource}</div>
+					</div>
+				</div>
+				<div className='top-separator actions'>
+					<PositronButton className='link' onPressed={showKernelOutputChannelClickHandler}>
+						{showKernelOutputChannel}
+					</PositronButton>
+				</div>
 			</div>
 		</PositronModalPopup>
 	)

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -72,7 +72,7 @@ interface ConsoleInstanceInfoModalPopupProps {
 }
 
 const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps) => {
-	const [sessionState, setSessionState] = useState(props.session.getRuntimeState());
+	const [sessionState, setSessionState] = useState(() => props.session.getRuntimeState());
 
 	// Main useEffect hook.
 	useEffect(() => {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -4,21 +4,86 @@
  *--------------------------------------------------------------------------------------------*/
 
 // React.
-import React from 'react';
+import React, { useRef } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
+import * as DOM from '../../../../../base/browser/dom.js';
+import { PositronModalPopup } from '../../../../browser/positronComponents/positronModalPopup/positronModalPopup.js'
 import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
+import { PositronModalReactRenderer } from '../../../../browser/positronModalReactRenderer/positronModalReactRenderer.js';
+import { usePositronConsoleContext } from '../positronConsoleContext.js';
 
 const positronConsoleInfo = localize('positronConsoleInfo', "Console information");
 
 export const ConsoleInstanceInfoButton = () => {
+	// Hooks.
+	const positronConsoleContext = usePositronConsoleContext();
+
+	// Reference hooks.
+	const ref = useRef<HTMLButtonElement>(undefined!);
+
+	const handlePressed = () => {
+		// Create the renderer.
+		const renderer = new PositronModalReactRenderer({
+			keybindingService: positronConsoleContext.keybindingService,
+			layoutService: positronConsoleContext.workbenchLayoutService,
+			container: positronConsoleContext.workbenchLayoutService.getContainer(DOM.getWindow(ref.current)),
+			parent: ref.current
+		});
+
+		renderer.render(
+			<ConsoleInstanceInfoModalPopup
+				anchorElement={ref.current}
+				renderer={renderer}
+			/>
+		);
+	}
+
+	// Render.
 	return (
 		<ActionBarButton
 			iconId='info'
 			align='right'
 			tooltip={positronConsoleInfo}
 			ariaLabel={positronConsoleInfo}
+			onPressed={handlePressed}
+			ref={ref}
 		/>
+	)
+};
+
+interface ConsoleInstanceInfoModalPopupProps {
+	anchorElement: HTMLElement;
+	renderer: PositronModalReactRenderer
+}
+
+const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps) => {
+	// Hooks.
+	const positronConsoleContext = usePositronConsoleContext();
+
+	// Constants
+	const activeConsoleInstance = positronConsoleContext.positronConsoleService.activePositronConsoleInstance;
+	const session = activeConsoleInstance?.session;
+
+	// Render.
+	return (
+		<PositronModalPopup
+			anchorElement={props.anchorElement}
+			height={200}
+			keyboardNavigationStyle='menu'
+			renderer={props.renderer}
+			popupAlignment='auto'
+			popupPosition='auto'
+			width={400}
+		>
+			<div className='console-instance-info'>
+				<p>Name: {session?.metadata.sessionName}</p>
+				<p>ID: {session?.sessionId}</p>
+				<p>State: {session?.getRuntimeState()}</p>
+				<p>Path: {session?.runtimeMetadata.runtimePath}</p>
+				<p>Source: {session?.runtimeMetadata.runtimeSource}</p>
+			</div>
+		</PositronModalPopup>
 	)
 };

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeSession.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeSession.tsx
@@ -34,7 +34,7 @@ interface RuntimeSessionProps {
  */
 export const RuntimeSession = (props: RuntimeSessionProps) => {
 
-	const [sessionState, setSessionState] = useState(props.session.getRuntimeState());
+	const [sessionState, setSessionState] = useState(() => props.session.getRuntimeState());
 	const [expanded, setExpanded] = useState(false);
 
 	// Main useEffect hook.
@@ -44,7 +44,7 @@ export const RuntimeSession = (props: RuntimeSessionProps) => {
 			setSessionState(state);
 		}));
 		return () => disposableStore.dispose();
-	});
+	}, []);
 
 	// Render.
 	return (

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeSessionCard.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeSessionCard.tsx
@@ -30,7 +30,7 @@ interface runtimeSessionCardProps {
  */
 export const RuntimeSessionCard = (props: runtimeSessionCardProps) => {
 
-	const [sessionState, setSessionState] = useState(props.session.getRuntimeState());
+	const [sessionState, setSessionState] = useState(() => props.session.getRuntimeState());
 
 	const shutdownSession = () => {
 		props.session.shutdown(RuntimeExitReason.Shutdown);
@@ -59,7 +59,7 @@ export const RuntimeSessionCard = (props: runtimeSessionCardProps) => {
 			setSessionState(state);
 		}));
 		return () => disposableStore.dispose();
-	});
+	}, []);
 
 	return (
 		<tr>

--- a/src/vs/workbench/services/runtimeSession/common/positronMultipleConsoleSessionsFeatureFlag.ts
+++ b/src/vs/workbench/services/runtimeSession/common/positronMultipleConsoleSessionsFeatureFlag.ts
@@ -5,11 +5,7 @@
 
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import {
-	ConfigurationScope,
-	Extensions,
-	IConfigurationRegistry,
-} from '../../../../platform/configuration/common/configurationRegistry.js';
+import { ConfigurationScope, Extensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { positronConfigurationNodeBase } from '../../languageRuntime/common/languageRuntime.js';
 

--- a/src/vs/workbench/services/runtimeSession/common/positronMultipleConsoleSessionsFeatureFlag.ts
+++ b/src/vs/workbench/services/runtimeSession/common/positronMultipleConsoleSessionsFeatureFlag.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import {
+	ConfigurationScope,
+	Extensions,
+	IConfigurationRegistry,
+} from '../../../../platform/configuration/common/configurationRegistry.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { positronConfigurationNodeBase } from '../../languageRuntime/common/languageRuntime.js';
+
+// Key for the multiple sessions setting
+export const USE_POSITRON_MULTIPLE_CONSOLE_SESSIONS_CONFIG_KEY =
+	'positron.multipleConsoleSessions';
+
+/**
+ * Retrieves the value of the configuration setting that determines whether to enable
+ * multiple sessions feature.
+ * @param configurationService The configuration service
+ * @returns Whether to enablet the multiple sessions feature
+ */
+export function multipleConsoleSessionsFeatureEnabled(
+	configurationService: IConfigurationService
+) {
+	return Boolean(
+		configurationService.getValue(USE_POSITRON_MULTIPLE_CONSOLE_SESSIONS_CONFIG_KEY)
+	);
+}
+
+// Register the configuration setting
+const configurationRegistry = Registry.as<IConfigurationRegistry>(
+	Extensions.Configuration
+);
+configurationRegistry.registerConfiguration({
+	...positronConfigurationNodeBase,
+	scope: ConfigurationScope.MACHINE_OVERRIDABLE,
+	properties: {
+		[USE_POSITRON_MULTIPLE_CONSOLE_SESSIONS_CONFIG_KEY]: {
+			type: 'boolean',
+			default: false,
+			markdownDescription: localize(
+				'positron.enableMultipleConsoleSessionsFeature',
+				'**CAUTION**: Enable experimental Positron multiple console sessions features which may result in unexpected behaviour. Please restart Positron if you change this option.'
+			),
+		},
+	},
+});


### PR DESCRIPTION
Addresses #5999 

Adds a new feature flag called `positron.multipleConsoleSessions`. When the feature flag is on users can now view details for an active session by clicking on the new info icon button that lives in the console pane action bar. A modal popup will render, containing the details of the session, such as name, state, id, interpreter path, and environment management tool.

The popup provides a link to the session logs in the output pane. When clicked, the user is taken to the output pane and shown the kernel channel for their interpreter.

This is a first pass for the info panel - additional information may be added based off feedback! Follow up work to add additional links to other channels is covered in #6149.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
- [ ] Verify the info button is only shown when the feature flag is on and there is an active session for the console instance
  - Note: An issue has been noted where the popup is not rendered if the console pane height is smaller than the height of the popup (#3061)
- [ ] Verify the session status shown in the popup updates in real time

### Screenshots

**Feature Flag**
<img width="1272" alt="Screenshot 2025-01-29 at 2 19 30 PM" src="https://github.com/user-attachments/assets/84154034-f7a7-4696-b016-61c4aa3c9370" />

**Popup**
<img width="1330" alt="Screenshot 2025-01-29 at 4 38 16 PM" src="https://github.com/user-attachments/assets/fc819ef6-ad75-4e59-9217-47b97c965b41" />

**Real-Time Session State Updates**

https://github.com/user-attachments/assets/16b0b81f-7b48-43d0-9f54-047e6e2af4be

