### PR TITLE
e2e Testing: Add README for editor action bar 

### DIFF
--- a/test/e2e/tests/editor-action-bar/README.md
+++ b/test/e2e/tests/editor-action-bar/README.md
@@ -1,0 +1,8 @@
+# Editor Action Bar Testing
+This group of tests cover the use of the action bar feature on the editor tab(s)
+
+## Manual Tests
+- Verify HTML file can be opened directly in a browser from action bar button. See [Issue 6047](https://github.com/posit-dev/positron/issues/6047)
+  - Open HTML file, then click "Open in Browser" button on action bar. Verify it opens.
+
+## Additional Setup Notes

--- a/test/e2e/tests/editor-action-bar/README.md
+++ b/test/e2e/tests/editor-action-bar/README.md
@@ -4,5 +4,6 @@ This group of tests cover the use of the action bar feature on the editor tab(s)
 ## Manual Tests
 - Verify HTML file can be opened directly in a browser from action bar button. See [Issue 6047](https://github.com/posit-dev/positron/issues/6047)
   - Open HTML file, then click "Open in Browser" button on action bar. Verify it opens.
+  - _This can't be automated as it opens a browser window._
 
 ## Additional Setup Notes


### PR DESCRIPTION
Added README for editor-action-bar tests to log manual tests that can't be automated.