### PR TITLE
e2e-test: console python test, add an extra enter key

### DIFF
--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -219,9 +219,13 @@ export class Console {
 		await this.code.driver.page.locator(MAXIMIZE_CONSOLE).click();
 	}
 
-	async pasteCodeToConsole(code: string) {
+	async pasteCodeToConsole(code: string, sendEnterKey = false) {
 		const consoleInput = this.activeConsole.locator(CONSOLE_INPUT);
 		await this.pasteInMonaco(consoleInput!, code);
+
+		if (sendEnterKey) {
+			await this.sendEnterKey();
+		}
 	}
 
 	async pasteInMonaco(

--- a/test/e2e/tests/console/console-python.test.ts
+++ b/test/e2e/tests/console/console-python.test.ts
@@ -68,7 +68,7 @@ test.describe('Console Pane: Python', { tag: [tags.WEB, tags.CONSOLE] }, () => {
 
 			await app.workbench.console.barClearButton.click();
 
-			await app.workbench.console.pasteCodeToConsole('import platform; print(platform.python_version())');
+			await app.workbench.console.pasteCodeToConsole('import platform; print(platform.python_version())', true);
 			await app.workbench.console.sendEnterKey();
 
 			await app.workbench.console.waitForConsoleContents(primaryPython);
@@ -84,7 +84,7 @@ test.describe('Console Pane: Python', { tag: [tags.WEB, tags.CONSOLE] }, () => {
 
 			await app.workbench.console.barClearButton.click();
 
-			await app.workbench.console.pasteCodeToConsole(`import platform; print(platform.python_version())`);
+			await app.workbench.console.pasteCodeToConsole(`import platform; print(platform.python_version())`, true);
 			await app.workbench.console.sendEnterKey();
 			await app.workbench.console.waitForConsoleContents(secondaryPython);
 		} else {

--- a/test/e2e/tests/console/console-r.test.ts
+++ b/test/e2e/tests/console/console-r.test.ts
@@ -64,7 +64,7 @@ test.describe('Console Pane: R', {
 
 			await app.workbench.console.barClearButton.click();
 
-			await app.workbench.console.pasteCodeToConsole('R.version.string');
+			await app.workbench.console.pasteCodeToConsole('R.version.string', true);
 			await app.workbench.console.sendEnterKey();
 
 			await app.workbench.console.waitForConsoleContents(primaryR);
@@ -80,7 +80,7 @@ test.describe('Console Pane: R', {
 
 			await app.workbench.console.barClearButton.click();
 
-			await app.workbench.console.pasteCodeToConsole(`R.version.string`);
+			await app.workbench.console.pasteCodeToConsole(`R.version.string`, true);
 			await app.workbench.console.sendEnterKey();
 			await app.workbench.console.waitForConsoleContents(secondaryR);
 		} else {


### PR DESCRIPTION
### Summary
The console displays a + prompt instead of executing the command, indicating it is expecting more input because the previous command was incomplete. We don't know why this is happening, but maybe sending another Enter key will kick it in gear.

### QA Notes

@:console
