### PR TITLE
Add language syntax highlighting to the Console `ActivityInput` component

### DIFF
--- a/src/vs/code/electron-sandbox/workbench/workbench-dev.html
+++ b/src/vs/code/electron-sandbox/workbench/workbench-dev.html
@@ -65,6 +65,7 @@
 					stickyScrollViewLayer
 					tokenizeToString
 					notebookChatEditController
+					positronConsole
 				;
 		"/>
 	</head>

--- a/src/vs/code/electron-sandbox/workbench/workbench.html
+++ b/src/vs/code/electron-sandbox/workbench/workbench.html
@@ -64,27 +64,31 @@
 					stickyScrollViewLayer
 					tokenizeToString
 					notebookChatEditController
+					positronConsole
 				;
-		"/>
+		"
+		/>
 
-        <script type="importmap" nonce="84405825-c9a7-4d5e-beac-4e5aaf0329f3">
-            {
-                "imports": {
-                    "he": "../../../../esm-package-dependencies/he.js",
-                    "react": "../../../../esm-package-dependencies/react.js",
-                    "react-dom": "../../../../esm-package-dependencies/react-dom.js",
-                    "react-dom/client": "../../../../esm-package-dependencies/client.js",
-                    "react-window": "../../../../esm-package-dependencies/react-window.js"
-                }
-            }
-        </script>
+		<script type="importmap" nonce="84405825-c9a7-4d5e-beac-4e5aaf0329f3">
+			{
+				"imports": {
+					"he": "../../../../esm-package-dependencies/he.js",
+					"react": "../../../../esm-package-dependencies/react.js",
+					"react-dom": "../../../../esm-package-dependencies/react-dom.js",
+					"react-dom/client": "../../../../esm-package-dependencies/client.js",
+					"react-window": "../../../../esm-package-dependencies/react-window.js"
+				}
+			}
+		</script>
 
 		<!-- Workbench CSS -->
-		<link rel="stylesheet" href="../../../workbench/workbench.desktop.main.css">
+		<link
+			rel="stylesheet"
+			href="../../../workbench/workbench.desktop.main.css"
+		/>
 	</head>
 
-	<body aria-label="">
-	</body>
+	<body aria-label=""></body>
 
 	<!-- Startup (do not modify order of script tags!) -->
 	<script src="./workbench.js" type="module"></script>

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1568,15 +1568,6 @@ export const POSITRON_DROP_DOWN_SEPARATOR_BACKGROUND = registerColor('positronDr
 	hcLight: menuBorder
 }, localize('positronDropDownListBox.separatorBackground', "Positron drop down list box separator background color."));
 
-
-
-
-
-
-
-
-
-
 // < --- Positron Console --- >
 
 // Positron console background color.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -7,20 +7,94 @@
 import './activityInput.css';
 
 // React.
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 // Other dependencies.
+import { ttPolicy } from '../positronConsole.js';
+import { usePositronConsoleContext } from '../positronConsoleContext.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { FontInfo } from '../../../../../editor/common/config/fontInfo.js';
-import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
-import { ActivityItemInput, ActivityItemInputState } from '../../../../services/positronConsole/browser/classes/activityItemInput.js';
-import { usePositronConsoleContext } from '../positronConsoleContext.js';
+import { LineTokens } from '../../../../../editor/common/tokens/lineTokens.js';
+import { ViewLineRenderingData } from '../../../../../editor/common/viewModel.js';
 import { OutputRun } from '../../../../browser/positronAnsiRenderer/outputRun.js';
+import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+import { RenderLineInput, renderViewLine2 } from '../../../../../editor/common/viewLayout/viewLineRenderer.js';
+import { ILanguageIdCodec, ITokenizationSupport, TokenizationRegistry } from '../../../../../editor/common/languages.js';
+import { IPositronConsoleInstance } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService';
+import { ActivityItemInput, ActivityItemInputState } from '../../../../services/positronConsole/browser/classes/activityItemInput.js';
+
+/**
+ * Colorizes code output lines.
+ * @param codeOutputLines The code output lines to colorize.
+ * @param tokenizationSupport The tokenization support.
+ * @param languageIdCodec The language ID codec.
+ * @returns The colorized code output lines.
+ */
+const colorizeCodeOutoutLines = (
+	codeOutputLines: string[],
+	tokenizationSupport: ITokenizationSupport,
+	languageIdCodec: ILanguageIdCodec
+) => {
+	// The colorized output lines.
+	const colorizedOutputLines: TrustedHTML[] = [];
+
+	// If the trusted type policy is not available, return.
+	if (!ttPolicy) {
+		return colorizedOutputLines;
+	}
+
+	// Set the initial state.
+	let state = tokenizationSupport.getInitialState();
+
+	// Iterate over the code output lines and colorize them.
+	codeOutputLines.forEach(codeOutputLine => {
+		// Create the render line input.
+		const tokenizeResult = tokenizationSupport.tokenizeEncoded(codeOutputLine, true, state);
+		LineTokens.convertToEndOffset(tokenizeResult.tokens, codeOutputLine.length);
+		const lineTokens = new LineTokens(tokenizeResult.tokens, codeOutputLine, languageIdCodec);
+		const isBasicASCII = ViewLineRenderingData.isBasicASCII(codeOutputLine, /* check for basic ASCII */true);
+		const containsRTL = ViewLineRenderingData.containsRTL(codeOutputLine, isBasicASCII, /* check for RTL */true);
+		const renderLineInput = new RenderLineInput(
+			false,
+			true,
+			codeOutputLine,
+			false,
+			isBasicASCII,
+			containsRTL,
+			0,
+			lineTokens.inflate(),
+			[],
+			0,
+			0,
+			0,
+			0,
+			0,
+			-1,
+			'none',
+			false,
+			false,
+			null
+		);
+
+		// Render the render line input.
+		const renderLineOutput = renderViewLine2(renderLineInput);
+
+		// Create and push the colorized output line.
+		colorizedOutputLines.push(ttPolicy!.createHTML(renderLineOutput.html));
+
+		// Update the state for the next code output line.
+		state = tokenizeResult.endState;
+	});
+
+	// Return the colorized output lines.
+	return colorizedOutputLines;
+};
 
 // ActivityInputProps interface.
 export interface ActivityInputProps {
 	fontInfo: FontInfo;
 	activityItemInput: ActivityItemInput;
+	positronConsoleInstance: IPositronConsoleInstance;
 }
 
 /**
@@ -29,14 +103,15 @@ export interface ActivityInputProps {
  * @returns The rendered component.
  */
 export const ActivityInput = (props: ActivityInputProps) => {
-	// Hooks.
+	// Context hooks.
+	const positronConsoleContext = usePositronConsoleContext();
+
+	// State hooks.
 	const [state, setState] = useState(props.activityItemInput.state);
+	const [colorizedOutputLines, setColorizedOutputLines] = useState<TrustedHTML[]>([]);
 
-	// Get services from the context.
-	const { openerService, notificationService } = usePositronConsoleContext();
-
-	// Main useEffect.
-	React.useEffect(() => {
+	// Main useEffect for event handlers.
+	useEffect(() => {
 		// Create the disposable store for cleanup.
 		const disposableStore = new DisposableStore();
 
@@ -48,6 +123,62 @@ export const ActivityInput = (props: ActivityInputProps) => {
 		// Return the cleanup function that will dispose of the disposables.
 		return () => disposableStore.dispose();
 	}, [props.activityItemInput]);
+
+	// Colorize the lines useEffect.
+	useEffect(() => {
+		/**
+		 * Colorizes the lines.
+		 */
+		const colorizeLines = async () => {
+			// If there isn't an attached runtime, clear the colorized lines and return.
+			if (!props.positronConsoleInstance.attachedRuntimeSession) {
+				setColorizedOutputLines([]);
+				return;
+			}
+
+			// Get the tokenization support. This appears to be an async operation, but in practice,
+			// it is synchronous because the tokenization support is cached.
+			const tokenizationSupport = await TokenizationRegistry.getOrCreate(
+				props.positronConsoleInstance.attachedRuntimeSession.runtimeMetadata.languageId
+			);
+
+			// If there isn't tokenization support, clear the colorized lines and return.
+			if (!tokenizationSupport) {
+				setColorizedOutputLines([]);
+				return;
+			}
+
+			// Built the code output lines to colorize.
+			const codeOutputLines: string[] = [];
+			for (let i = 0; i < props.activityItemInput.codeOutputLines.length; i++) {
+				// Get the output runs for the code output line.
+				const outputRuns = props.activityItemInput.codeOutputLines[i].outputRuns;
+
+				// If there are no output runs, add an empty code output line. If there is only one
+				// output run and it has no format, add the output run text as the code output line.
+				// Otherwise, clear the colorized lines and return because the output line already
+				// has formatting for some reason.
+				if (outputRuns.length === 0) {
+					codeOutputLines.push('');
+				} if (outputRuns.length === 1 && outputRuns[0].format === undefined) {
+					codeOutputLines.push(outputRuns[0].text);
+				} else {
+					setColorizedOutputLines([]);
+					return;
+				}
+			}
+
+			// Colorize the output lines.
+			setColorizedOutputLines(colorizeCodeOutoutLines(
+				codeOutputLines,
+				tokenizationSupport,
+				positronConsoleContext.languageService.languageIdCodec
+			));
+		};
+
+		// Colorize the lines.
+		colorizeLines();
+	}, [positronConsoleContext.languageService.languageIdCodec, props.activityItemInput.codeOutputLines, props.positronConsoleInstance.attachedRuntimeSession]);
 
 	// Calculate the prompt length.
 	const promptLength = Math.max(
@@ -65,28 +196,58 @@ export const ActivityInput = (props: ActivityInputProps) => {
 		{ 'cancelled': state === ActivityItemInputState.Cancelled }
 	);
 
-	// Render.
-	return (
-		<div className={classNames}>
-			{state === ActivityItemInputState.Executing && <div className='progress-bar' />}
-			{props.activityItemInput.codeOutputLines.map((outputLine, index) =>
-				<div key={outputLine.id}>
-					<span className='prompt' style={{ width: promptWidth }}>
-						{(index === 0 ?
-							props.activityItemInput.inputPrompt :
-							props.activityItemInput.continuationPrompt) + ' '
-						}
-					</span>
-					{outputLine.outputRuns.map(outputRun =>
-						<OutputRun
-							key={outputRun.id}
-							outputRun={outputRun}
-							notificationService={notificationService}
-							openerService={openerService}
+	/**
+	 * Prompt component.
+	 * @param index The prompt index.
+	 * @returns The rendered component.
+	 */
+	const Prompt = ({ index }: { index: number }) => {
+		return (
+			<span className='prompt' style={{ width: promptWidth }}>
+				{(index === 0 ?
+					props.activityItemInput.inputPrompt :
+					props.activityItemInput.continuationPrompt) + ' '
+				}
+			</span>
+		);
+	}
+
+	// Render lines.
+	if (colorizedOutputLines.length) {
+		// Render colorized lines.
+		return (
+			<div className={classNames}>
+				{state === ActivityItemInputState.Executing && <div className='progress-bar' />}
+				{colorizedOutputLines.map((outputLine, index) =>
+					<div key={`outputLine-${index}`}>
+						<Prompt index={index} />
+						<span
+							key={`colorizedOutputLine-${index}`}
+							dangerouslySetInnerHTML={{ __html: outputLine }}
 						/>
-					)}
-				</div>
-			)}
-		</div>
-	);
+					</div>
+				)}
+			</div>
+		);
+	} else {
+		// Render non-colorized lines.
+		return (
+			<div className={classNames}>
+				{state === ActivityItemInputState.Executing && <div className='progress-bar' />}
+				{props.activityItemInput.codeOutputLines.map((outputLine, index) =>
+					<div key={outputLine.id}>
+						<Prompt index={index} />
+						{outputLine.outputRuns.map(outputRun =>
+							<OutputRun
+								key={outputRun.id}
+								outputRun={outputRun}
+								notificationService={positronConsoleContext.notificationService}
+								openerService={positronConsoleContext.openerService}
+							/>
+						)}
+					</div>
+				)}
+			</div>
+		);
+	}
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
@@ -160,7 +160,7 @@ export const ActivityInput = (props: ActivityInputProps) => {
 				// has formatting for some reason.
 				if (outputRuns.length === 0) {
 					codeOutputLines.push('');
-				} if (outputRuns.length === 1 && outputRuns[0].format === undefined) {
+				} else if (outputRuns.length === 1 && outputRuns[0].format === undefined) {
 					codeOutputLines.push(outputRuns[0].text);
 				} else {
 					setColorizedOutputLines([]);

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeActivity.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeActivity.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -47,7 +47,7 @@ export const RuntimeActivity = (props: RuntimeActivityProps) => {
 		<div className='runtime-activity'>
 			{props.runtimeItemActivity.activityItems.map(activityItem => {
 				if (activityItem instanceof ActivityItemInput) {
-					return <ActivityInput key={activityItem.id} fontInfo={props.fontInfo} activityItemInput={activityItem} />;
+					return <ActivityInput key={activityItem.id} fontInfo={props.fontInfo} activityItemInput={activityItem} positronConsoleInstance={props.positronConsoleInstance} />;
 				} else if (activityItem instanceof ActivityItemOutputStream) {
 					return <ActivityOutputStream key={activityItem.id} activityItemOutputStream={activityItem} />;
 				} else if (activityItem instanceof ActivityItemErrorStream) {

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -10,11 +10,15 @@ import './positronConsole.css';
 import React, { PropsWithChildren, useEffect, useState } from 'react';
 
 // Other dependencies.
-import { DisposableStore } from '../../../../base/common/lifecycle.js';
-import { IReactComponentContainer } from '../../../../base/browser/positronReactRenderer.js';
 import { ConsoleCore } from './components/consoleCore.js';
 import { PositronConsoleServices } from './positronConsoleState.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { PositronConsoleContextProvider } from './positronConsoleContext.js';
+import { createTrustedTypesPolicy } from '../../../../base/browser/trustedTypes.js';
+import { IReactComponentContainer } from '../../../../base/browser/positronReactRenderer.js';
+
+// Create the trusted types policy.
+export const ttPolicy = createTrustedTypesPolicy('positronConsole', { createHTML: value => value });
 
 /**
  * PositronConsoleProps interface.

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.tsx
@@ -50,7 +50,7 @@ export const PositronConsole = (props: PropsWithChildren<PositronConsoleProps>) 
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.reactComponentContainer]);
 
 	// Render.
 	return (

--- a/test/e2e/tests/console/console-clipboard.test.ts
+++ b/test/e2e/tests/console/console-clipboard.test.ts
@@ -62,7 +62,7 @@ async function executeCopyAndPaste(console: Console, page: any, testLine: string
 		await console.waitForConsoleExecution();
 
 		// Ensure the test line is in the console's output
-		await console.waitForConsoleContents(testLine);
+		await console.waitForConsoleContents(testLine, { expectedCount: 2 });
 
 		// Clear the console
 		await console.barClearButton.click();
@@ -80,6 +80,6 @@ async function verifyClipboardPaste(console: any, testLine: string) {
 		await console.waitForConsoleExecution();
 
 		// Ensure the console contains the test line after execution
-		await console.waitForConsoleContents(testLine);
+		await console.waitForConsoleContents(testLine, { expectedCount: 2 });
 	});
 }

--- a/test/e2e/tests/console/console-history.test.ts
+++ b/test/e2e/tests/console/console-history.test.ts
@@ -52,7 +52,7 @@ async function enterLines(app: Application, lines: string[]) {
 		for (const line of lines) {
 			await app.workbench.console.typeToConsole(line);
 			await app.workbench.console.sendEnterKey();
-			await app.workbench.console.waitForConsoleContents(line);
+			await app.workbench.console.waitForConsoleContents(line, { expectedCount: 2 });
 		}
 	});
 }


### PR DESCRIPTION
### Description

This PR adds language syntax highlighting to the Console `ActivityInput` component.

<img width="1386" alt="image" src="https://github.com/user-attachments/assets/195a8629-adb6-47a7-a4cb-66fcbd2a7505" />

It feels like, along with this work, we need to do something to the ActivityInput component to differentiate code that was executed from code that is being edited in the CodeEditorWidget. Something like changing the background color:

<img width="1488" alt="image" src="https://github.com/user-attachments/assets/ff3bcbfd-7aa2-410e-b660-4f42077c00fe" />

Tests:
@:console

### Release Notes

#### New Features

- #243

#### Bug Fixes

- N/A

### QA Notes

- N/A