### PR TITLE
e2e-test: console flake - verify no red box before hitting enter

### DIFF
--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -224,6 +224,7 @@ export class Console {
 		await this.pasteInMonaco(consoleInput!, code);
 
 		if (sendEnterKey) {
+			await expect(this.code.driver.page.getByLabel('Interrupt execution')).not.toBeVisible();
 			await this.sendEnterKey();
 		}
 	}

--- a/test/e2e/tests/console/console-python.test.ts
+++ b/test/e2e/tests/console/console-python.test.ts
@@ -68,9 +68,7 @@ test.describe('Console Pane: Python', { tag: [tags.WEB, tags.CONSOLE] }, () => {
 
 			await app.workbench.console.barClearButton.click();
 
-			await app.workbench.console.pasteCodeToConsole('import platform; print(platform.python_version())');
-			await app.code.driver.page.waitForTimeout(1000);
-			await app.workbench.console.sendEnterKey();
+			await app.workbench.console.pasteCodeToConsole('import platform; print(platform.python_version())', true);
 
 			await app.workbench.console.waitForConsoleContents(primaryPython);
 		} else {
@@ -85,9 +83,7 @@ test.describe('Console Pane: Python', { tag: [tags.WEB, tags.CONSOLE] }, () => {
 
 			await app.workbench.console.barClearButton.click();
 
-			await app.workbench.console.pasteCodeToConsole(`import platform; print(platform.python_version())`);
-			await app.code.driver.page.waitForTimeout(1000);
-			await app.workbench.console.sendEnterKey();
+			await app.workbench.console.pasteCodeToConsole(`import platform; print(platform.python_version())`, true);
 			await app.workbench.console.waitForConsoleContents(secondaryPython);
 		} else {
 			fail('Secondary Python version not set');

--- a/test/e2e/tests/console/console-python.test.ts
+++ b/test/e2e/tests/console/console-python.test.ts
@@ -65,11 +65,8 @@ test.describe('Console Pane: Python', { tag: [tags.WEB, tags.CONSOLE] }, () => {
 		const primaryPython = process.env.POSITRON_PY_VER_SEL;
 
 		if (primaryPython) {
-
 			await app.workbench.console.barClearButton.click();
-
 			await app.workbench.console.pasteCodeToConsole('import platform; print(platform.python_version())', true);
-
 			await app.workbench.console.waitForConsoleContents(primaryPython);
 		} else {
 			fail('Primary Python version not set');
@@ -78,11 +75,8 @@ test.describe('Console Pane: Python', { tag: [tags.WEB, tags.CONSOLE] }, () => {
 		const secondaryPython = process.env.POSITRON_PY_ALT_VER_SEL;
 
 		if (secondaryPython) {
-
 			await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, `${secondaryPython} (Pyenv)`, true);
-
 			await app.workbench.console.barClearButton.click();
-
 			await app.workbench.console.pasteCodeToConsole(`import platform; print(platform.python_version())`, true);
 			await app.workbench.console.waitForConsoleContents(secondaryPython);
 		} else {

--- a/test/e2e/tests/console/console-r.test.ts
+++ b/test/e2e/tests/console/console-r.test.ts
@@ -61,12 +61,8 @@ test.describe('Console Pane: R', {
 		const primaryR = process.env.POSITRON_R_VER_SEL;
 
 		if (primaryR) {
-
 			await app.workbench.console.barClearButton.click();
-
 			await app.workbench.console.pasteCodeToConsole('R.version.string', true);
-			await app.workbench.console.sendEnterKey();
-
 			await app.workbench.console.waitForConsoleContents(primaryR);
 		} else {
 			fail('Primary R version not set');
@@ -75,11 +71,8 @@ test.describe('Console Pane: R', {
 		const secondaryR = process.env.POSITRON_R_ALT_VER_SEL;
 
 		if (secondaryR) {
-
 			await app.workbench.interpreter.selectInterpreter(InterpreterType.R, secondaryR, true);
-
 			await app.workbench.console.barClearButton.click();
-
 			await app.workbench.console.pasteCodeToConsole(`R.version.string`, true);
 			await app.workbench.console.waitForConsoleContents(secondaryR);
 		} else {

--- a/test/e2e/tests/console/console-r.test.ts
+++ b/test/e2e/tests/console/console-r.test.ts
@@ -64,8 +64,7 @@ test.describe('Console Pane: R', {
 
 			await app.workbench.console.barClearButton.click();
 
-			await app.workbench.console.pasteCodeToConsole('R.version.string');
-			await app.code.driver.page.waitForTimeout(1000);
+			await app.workbench.console.pasteCodeToConsole('R.version.string', true);
 			await app.workbench.console.sendEnterKey();
 
 			await app.workbench.console.waitForConsoleContents(primaryR);
@@ -81,9 +80,7 @@ test.describe('Console Pane: R', {
 
 			await app.workbench.console.barClearButton.click();
 
-			await app.workbench.console.pasteCodeToConsole(`R.version.string`);
-			await app.code.driver.page.waitForTimeout(1000);
-			await app.workbench.console.sendEnterKey();
+			await app.workbench.console.pasteCodeToConsole(`R.version.string`, true);
 			await app.workbench.console.waitForConsoleContents(secondaryR);
 		} else {
 			fail('Secondary R version not set');


### PR DESCRIPTION
### Summary
Trying to fix the console flakes. I think it's due to the fact that the "red box" is running and we send `Enter` key at this time. Adjusted test to wait for it to disappear before sending `Enter`.

### QA Notes

@:console
