### PR TITLE
ci: cancel e2e test run if 10 failures identified

### DIFF
--- a/.github/workflows/test-e2e-linux.yml
+++ b/.github/workflows/test-e2e-linux.yml
@@ -143,7 +143,7 @@ jobs:
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/linux' }}
         run: |
-          DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 --grep "${{ env.PW_TAGS }}" --repeat-each ${{ inputs.repeat_each }}
+          DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 --grep "${{ env.PW_TAGS }}" --repeat-each ${{ inputs.repeat_each }} --pwc-cancel-after-failures 10
 
       - name: Upload Playwright Report to S3
         if: ${{ success() || failure() }}

--- a/.github/workflows/test-e2e-linux.yml
+++ b/.github/workflows/test-e2e-linux.yml
@@ -143,7 +143,7 @@ jobs:
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/linux' }}
         run: |
-          DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 --grep "${{ env.PW_TAGS }}" --repeat-each ${{ inputs.repeat_each }} --pwc-cancel-after-failures 10
+          DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 --grep "${{ env.PW_TAGS }}" --repeat-each ${{ inputs.repeat_each }} --max-failures 10
 
       - name: Upload Playwright Report to S3
         if: ${{ success() || failure() }}

--- a/.github/workflows/test-e2e-release.yml
+++ b/.github/workflows/test-e2e-release.yml
@@ -114,7 +114,7 @@ jobs:
         id: electron-e2e-tests
         run: |
           export DISPLAY=:10
-          BUILD=/usr/share/positron npx playwright test --project e2e-electron --workers 2 --grep "${{ env.PW_TAGS }}" --pwc-cancel-after-failures 10
+          BUILD=/usr/share/positron npx playwright test --project e2e-electron --workers 2 --grep "${{ env.PW_TAGS }}" --max-failures 10
 
       - name: Upload Playwright Report to S3
         if: ${{ !cancelled() }}

--- a/.github/workflows/test-e2e-release.yml
+++ b/.github/workflows/test-e2e-release.yml
@@ -114,7 +114,7 @@ jobs:
         id: electron-e2e-tests
         run: |
           export DISPLAY=:10
-          BUILD=/usr/share/positron npx playwright test --project e2e-electron --workers 2 --grep "${{ env.PW_TAGS }}"
+          BUILD=/usr/share/positron npx playwright test --project e2e-electron --workers 2 --grep "${{ env.PW_TAGS }}" --pwc-cancel-after-failures 10
 
       - name: Upload Playwright Report to S3
         if: ${{ !cancelled() }}

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -157,7 +157,7 @@ jobs:
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/win'}}
         if: ${{ !cancelled() }}
-        run: npx playwright test --project "e2e-windows" --grep "${{ env.PW_TAGS }}" --workers 2 --repeat-each ${{ inputs.repeat_each }} --pwc-cancel-after-failures 10
+        run: npx playwright test --project "e2e-windows" --grep "${{ env.PW_TAGS }}" --workers 2 --repeat-each ${{ inputs.repeat_each }} --max-failures 10
 
       - name: Upload Playwright Report to S3
         if: ${{ success() || failure() }}

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -157,7 +157,7 @@ jobs:
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/win'}}
         if: ${{ !cancelled() }}
-        run: npx playwright test --project "e2e-windows" --grep "${{ env.PW_TAGS }}" --workers 2 --repeat-each ${{ inputs.repeat_each }}
+        run: npx playwright test --project "e2e-windows" --grep "${{ env.PW_TAGS }}" --workers 2 --repeat-each ${{ inputs.repeat_each }} --pwc-cancel-after-failures 10
 
       - name: Upload Playwright Report to S3
         if: ${{ success() || failure() }}


### PR DESCRIPTION
### Summary
We ran into the situation of mostly all windows tests failing due to Ark bump, but the report didn't output because the tests timed out (due to extensive retrying of every test). 

### QA Notes

@:win
