### PR TITLE
Enable update checks and allow auto-updates

### DIFF
--- a/product.json
+++ b/product.json
@@ -37,7 +37,7 @@
 	"urlProtocol": "positron",
 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/out/vs/workbench/contrib/webview/browser/pre/",
 	"updateUrl": "https://cdn.posit.co/positron",
-	"downloadUrl": "https://github.com/posit-dev/positron/releases",
+	"downloadUrl": "https://positron.posit.co/download.html",
 	"builtInExtensions": [
 		{
 			"name": "ms-vscode.js-debug-companion",
@@ -245,7 +245,8 @@
 	},
 	"linkProtectionTrustedDomains": [
 		"https://open-vsx.org",
-		"https://github.com/posit-dev/positron"
+		"https://github.com/posit-dev/positron",
+		"https://positron.posit.co"
 	],
 	"extensionsEnabledWithApiProposalVersion": [
 		"GitHub.copilot-chat"

--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isWeb, isWindows } from '../../../base/common/platform.js';
+import { isMacintosh, isWeb, isWindows } from '../../../base/common/platform.js';
 import { localize } from '../../../nls.js';
 import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../configuration/common/configurationRegistry.js';
 import { Registry } from '../../registry/common/platform.js';
@@ -31,7 +31,7 @@ configurationRegistry.registerConfiguration({
 			],
 			policy: {
 				name: 'UpdateMode',
-				minimumVersion: '2025.1.0',
+				minimumVersion: '2025.02.0',
 			}
 		},
 		'update.autoUpdate': {
@@ -40,6 +40,7 @@ configurationRegistry.registerConfiguration({
 			scope: ConfigurationScope.APPLICATION,
 			description: localize('autoUpdateEnable', "Enable automatic updates. Requires a restart after change to take effect."),
 			tags: ['usesOnlineServices'],
+			included: (isWindows || isMacintosh) && !isWeb
 		},
 		'update.channel': {
 			type: 'string',

--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -34,11 +34,11 @@ configurationRegistry.registerConfiguration({
 				minimumVersion: '2025.1.0',
 			}
 		},
-		'update.autoUpdateExperimental': {
+		'update.autoUpdate': {
 			type: 'boolean',
 			default: false,
 			scope: ConfigurationScope.APPLICATION,
-			description: localize('experimentalAutoUpdate', "CAUTION: Enable automatic update checking. Requires a restart after change to take effect."),
+			description: localize('autoUpdateEnable', "Enable automatic updates. Requires a restart after change to take effect."),
 			tags: ['usesOnlineServices'],
 		},
 		'update.channel': {

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -54,7 +54,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 
 	// --- Start Positron ---
 	// enable the service to download and apply updates automatically
-	protected enableAutoUpdate: boolean;
+	protected enableAutoUpdate = false;
 	// --- End Positron ---
 
 	private _state: State = State.Uninitialized;
@@ -83,10 +83,6 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		@INativeHostMainService protected readonly nativeHostMainService: INativeHostMainService
 		// --- End Positron ---
 	) {
-		// --- Start Positron ---
-		this.enableAutoUpdate = process.env.POSITRON_AUTO_UPDATE === '1';
-		// --- End Positron ---
-
 		lifecycleMainService.when(LifecycleMainPhase.AfterWindowOpen)
 			.finally(() => this.initialize());
 	}
@@ -99,16 +95,9 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	protected async initialize(): Promise<void> {
 		// --- Start Positron ---
 		const updateChannel = process.env.POSITRON_UPDATE_CHANNEL ?? UpdateChannel.Prereleases;
-		const autoUpdateFlag = this.configurationService.getValue<boolean>('update.autoUpdateExperimental');
+		this.enableAutoUpdate = this.configurationService.getValue<boolean>('update.autoUpdate');
 
-		if (!this.environmentMainService.isBuilt && !autoUpdateFlag) {
-			this.setState(State.Disabled(DisablementReason.NotBuilt));
-			return; // updates are never enabled when running out of sources
-		} else if (!this.environmentMainService.isBuilt && updateChannel && autoUpdateFlag) {
-			this.logService.warn('update#ctor - updates enabled in dev environment; attempted update installs will fail');
-		}
-
-		if (this.environmentMainService.disableUpdates || !autoUpdateFlag) {
+		if (this.environmentMainService.disableUpdates) {
 			this.setState(State.Disabled(DisablementReason.DisabledByEnvironment));
 			this.logService.info('update#ctor - updates are disabled by the environment');
 			return;
@@ -130,6 +119,11 @@ export abstract class AbstractUpdateService implements IUpdateService {
 
 		this.url = this.buildUpdateFeedUrl(updateChannel);
 		this.logService.debug('update#ctor - update URL is', this.url);
+
+		if (!this.environmentMainService.isBuilt) {
+			this.setState(State.Disabled(DisablementReason.NotBuilt));
+			return; // updates are never enabled when running out of sources
+		}
 		// --- End Positron ---
 		if (!this.url) {
 			this.setState(State.Disabled(DisablementReason.InvalidConfiguration));

--- a/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts
+++ b/src/vs/workbench/contrib/relauncher/browser/relauncher.contribution.ts
@@ -24,7 +24,9 @@ import { IUserDataSyncEnablementService, IUserDataSyncService, SyncStatus } from
 import { IUserDataSyncWorkbenchService } from '../../../services/userDataSync/common/userDataSync.js';
 
 interface IConfiguration extends IWindowsConfiguration {
-	update?: { mode?: string };
+	// --- Start Positron ---
+	update?: { mode?: string; autoUpdate?: boolean };
+	// --- End Positron ---
 	debug?: { console?: { wordWrap?: boolean } };
 	editor?: { accessibilitySupport?: 'on' | 'off' | 'auto' };
 	security?: { workspace?: { trust?: { enabled?: boolean } }; restrictUNCAccess?: boolean };
@@ -48,7 +50,10 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 		'workbench.enableExperiments',
 		'_extensionsGallery.enablePPE',
 		'security.restrictUNCAccess',
-		'accessibility.verbosity.debug'
+		// --- Start Positron ---
+		'accessibility.verbosity.debug',
+		'update.autoUpdate',
+		// --- End Positron ---
 	];
 
 	private readonly titleBarStyle = new ChangeObserver<TitlebarStyle>('string');
@@ -63,6 +68,9 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 	private readonly enablePPEExtensionsGallery = new ChangeObserver('boolean');
 	private readonly restrictUNCAccess = new ChangeObserver('boolean');
 	private readonly accessibilityVerbosityDebug = new ChangeObserver('boolean');
+	// --- Start Positron ---
+	private readonly autoUpdate = new ChangeObserver('boolean');
+	// --- End Positron ---
 
 	constructor(
 		@IHostService private readonly hostService: IHostService,
@@ -124,6 +132,10 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 
 			// Update mode
 			processChanged(this.updateMode.handleChange(config.update?.mode));
+
+			// --- Start Positron ---
+			processChanged(this.autoUpdate.handleChange(config.update?.autoUpdate));
+			// --- End Positron ---
 
 			// On linux turning on accessibility support will also pass this flag to the chrome renderer, thus a restart is required
 			if (isLinux && typeof config.editor?.accessibilitySupport === 'string' && config.editor.accessibilitySupport !== this.accessibilitySupport) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes
Address #1837 

Enables update checking by default. The update service will respect the update mode setting. When an update is discovered, an action is available for the user to download the update.

![image](https://github.com/user-attachments/assets/9781303c-0949-41a3-9c98-6d96defa33fa)

An auto-update option is shown for Mac and Windows users that is off by default. Turning on auto-updates will check the pre-releases for a new version. This will update Positron in the background.

If auto-update is enabled in dev, it disables updates. The check has been moved later in the initialization so that the logs can show the preferences were set. Disabling auto-update will allow update checks for testing.

When auto-updates off, the download update action links to the file update instead of the Positron site. This ensures the correct update is downloaded in case there is a lag with updating the website download links. The Positron website has also been added to the trusted links.

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #1837 Update checking is enabled by default. There are preferences for setting when updates are checked or to turn it off. A preference for auto-updates has been added to Mac and Windows that is disabled by default. Turning it on allows Positron to immediately download the update.

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
