### PR TITLE
E2E test: remove defunct feature flag

### DIFF
--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -16,12 +16,7 @@ test.use({
 });
 
 test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
-	// Some tests are not tagged @:win because they would require a new master image.
 	test.describe('Python Plots', () => {
-
-		test.beforeAll(async function ({ userSettings }) {
-			await userSettings.set([['application.experimental.positronPlotsInEditorTab', 'true']]);
-		});
 
 		test.beforeEach(async function ({ app, interpreter }) {
 			// Set the viewport to a size that ensures all the plots view actions are visible


### PR DESCRIPTION
Remove feature flag for plots in editor since its no longer used.

### QA Notes

@:plots
