### PR TITLE
Fix ESLint errors

### DIFF
--- a/src/vs/base/browser/ui/ExternalLink/ExternalLink.tsx
+++ b/src/vs/base/browser/ui/ExternalLink/ExternalLink.tsx
@@ -22,7 +22,6 @@ interface ExternalLinkProps extends React.ComponentPropsWithoutRef<'a'> {
  * @returns The rendered link component that opens in the opener service.
  */
 export function ExternalLink(props: ExternalLinkProps) {
-	// eslint-disable-next-line react/prop-types
 	const { href, openerService, ...otherProps } = props;
 
 	return <a

--- a/src/vs/platform/positronActionBar/browser/components/actionBarActionButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarActionButton.tsx
@@ -8,7 +8,7 @@ import './actionBarActionButton.css';
 
 // React.
 import * as React from 'react';
-import { useEffect, useRef, useState } from 'react'; // eslint-disable-line no-duplicate-imports
+import { useEffect, useRef, useState } from 'react';
 
 // Other dependencies.
 import { IAction } from '../../../../base/common/actions.js';

--- a/src/vs/platform/positronActionBar/browser/components/actionBarActionButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarActionButton.tsx
@@ -7,8 +7,7 @@
 import './actionBarActionButton.css';
 
 // React.
-import * as React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 // Other dependencies.
 import { IAction } from '../../../../base/common/actions.js';

--- a/src/vs/platform/positronActionBar/browser/useRegisterWithActionBar.tsx
+++ b/src/vs/platform/positronActionBar/browser/useRegisterWithActionBar.tsx
@@ -27,5 +27,5 @@ export const useRegisterWithActionBar = (refs: MutableRefObject<HTMLElement>[]) 
 		return () => {
 			refs.forEach(ref => focusableComponents.delete(ref.current));
 		};
-	}, []);
+	}, [focusableComponents, refs]);
 };

--- a/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
@@ -178,7 +178,7 @@ export class EditorActionBarFactory extends Disposable {
 
 		// Build the right action bar elements from the editor actions right menu and the editor
 		// title menu.
-		let rightActionBarElements = [
+		const rightActionBarElements = [
 			// Build the right action bar elements from the editor actions right menu.
 			...this.buildActionBarElements(
 				processedActions,

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterActions.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterActions.tsx
@@ -67,7 +67,7 @@ export const InterpreterActions = (props: PropsWithChildren<InterpreterActionsPr
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.runtime.runtimeId, props.runtimeSessionService, session]);
 
 	// Interrupt the session, if we have one.
 	const interrupt = () => {

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterGroup.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterGroup.tsx
@@ -7,7 +7,7 @@
 import './interpreterGroup.css';
 
 // React.
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 // Other dependencies.
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
@@ -38,7 +38,7 @@ export const InterpreterGroup = (props: InterpreterGroupProps) => {
 	 * Determines whether an alternate runtime is alive.
 	 * @returns A value which indicates whether an alternate runtime is alive.
 	 */
-	const isAlternateRuntimeAlive = () => {
+	const isAlternateRuntimeAlive = useCallback(() => {
 		// Get the active sessions.
 		const activeSessions = props.runtimeSessionService.activeSessions;
 
@@ -66,7 +66,7 @@ export const InterpreterGroup = (props: InterpreterGroupProps) => {
 
 		// An alternate runtime is not alive.
 		return false;
-	};
+	}, [props.interpreterGroup.alternateRuntimes, props.runtimeSessionService.activeSessions]);
 
 	// State hooks.
 	const [alternateRuntimeAlive, setAlternateRuntimeAlive] = useState(isAlternateRuntimeAlive());
@@ -91,7 +91,7 @@ export const InterpreterGroup = (props: InterpreterGroupProps) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [isAlternateRuntimeAlive, props.runtimeSessionService]);
 
 	// Render.
 	return (

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterGroups.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterGroups.tsx
@@ -108,7 +108,7 @@ export const InterpreterGroups = (props: InterpreterGroupsProps) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.languageRuntimeService, props.runtimeAffiliationService]);
 
 	// Render.
 	return (

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/primaryInterpreter.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/primaryInterpreter.tsx
@@ -69,7 +69,7 @@ export const PrimaryInterpreter = (props: PrimaryInterpreterProps) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.runtime.runtimeId, props.runtimeSessionService, session]);
 
 	// Render.
 	return (

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/secondaryInterpreter.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/secondaryInterpreter.tsx
@@ -65,7 +65,7 @@ export const SecondaryInterpreter = (props: SecondaryInterpreterProps) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.runtime.runtimeId, props.runtimeSessionService, session]);
 
 	// Render.
 	return (

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarState.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarState.tsx
@@ -45,7 +45,7 @@ export const usePositronTopActionBarState = (services: PositronTopActionBarServi
 
 		// Return the clean up for our event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [services.workspaceContextService]);
 
 	// Return the Positron top action bar state.
 	return {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -81,7 +81,7 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 			setSessionState(state);
 		}));
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.session]);
 
 	const showKernelOutputChannelClickHandler = () => {
 		props.session.showOutput();

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceMenuButton.tsx
@@ -52,7 +52,7 @@ export const ConsoleInstanceMenuButton = (props: ConsoleInstanceMenuButtonProps)
 			setActiveRuntimeLabel(labelForSession(e?.session));
 		}));
 		return () => disposables.dispose();
-	}, [positronConsoleContext.activePositronConsoleInstance]);
+	}, [positronConsoleContext.activePositronConsoleInstance, positronConsoleContext.positronConsoleService]);
 
 	// Builds the actions.
 	const actions = () => {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/historyBrowserPopup.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/historyBrowserPopup.tsx
@@ -73,7 +73,7 @@ export const HistoryBrowserPopup = (props: HistoryBrowserPopupProps) => {
 		return () => {
 			DOM.getActiveWindow().removeEventListener('click', clickHandler);
 		};
-	}, [props.selectedIndex]);
+	}, [props]);
 
 	const noMatch = nls.localize('positronConsoleHistoryMatchesEmpty', "No matching history items");
 

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
@@ -89,7 +89,7 @@ export const usePositronConsoleState = (services: PositronConsoleServices): Posi
 
 		// Return the clean up for our event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [services.positronConsoleService]);
 
 	// Return the Positron console state.
 	return {

--- a/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
@@ -118,7 +118,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.positronHelpService, props.reactComponentContainer]);
 
 	// useEffect for currentHelpEntry.
 	useEffect(() => {

--- a/src/vs/workbench/contrib/positronNotebook/browser/utilityComponents/ActionButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/utilityComponents/ActionButton.tsx
@@ -17,7 +17,6 @@ import { Button } from '../../../../../base/browser/ui/positronComponents/button
  * @param props The props for the button
  * @return A button with `action` and `action-button` classes added to it.
  */
-// eslint-disable-next-line react/prop-types
 export function ActionButton({ className, ...props }: React.ComponentProps<typeof Button>) {
 	return <Button className={`action action-button ${className}`} {...props} />;
 }

--- a/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotThumbnail.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotThumbnail.tsx
@@ -39,7 +39,7 @@ export const DynamicPlotThumbnail = (props: DynamicPlotThumbnailProps) => {
 		props.plotClient.onDidCompleteRender((result) => {
 			setUri(result.uri);
 		});
-	});
+	}, [props.plotClient]);
 
 	// If the plot is not yet rendered yet (no URI), show a placeholder;
 	// otherwise, show the rendered plot.

--- a/src/vs/workbench/contrib/positronPlots/browser/components/openInEditorMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/openInEditorMenuButton.tsx
@@ -72,7 +72,7 @@ export const OpenInEditorMenuButton = (props: OpenInEditorMenuButtonProps) => {
 			};
 		});
 		setActions(actions);
-	}, [defaultAction]);
+	}, [defaultAction, openEditorPlotHandler]);
 
 
 	return (

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.tsx
@@ -7,7 +7,7 @@
 import './positronPlots.css';
 
 // React.
-import React, { PropsWithChildren, useEffect, useState } from 'react';
+import React, { PropsWithChildren, useCallback, useEffect, useState } from 'react';
 
 // Other dependencies.
 import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
@@ -42,7 +42,7 @@ export interface PositronPlotsProps extends PositronPlotsServices {
 export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 
 	// Compute the history visibility based on the history policy.
-	const computeHistoryVisibility = (policy: HistoryPolicy) => {
+	const computeHistoryVisibility = useCallback((policy: HistoryPolicy) => {
 		switch (policy) {
 			case HistoryPolicy.AlwaysVisible:
 				return true;
@@ -63,7 +63,7 @@ export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 				// Show the history.
 				return true;
 		}
-	};
+	}, [props.positronPlotsService.positronPlotInstances.length, props.reactComponentContainer.height, props.reactComponentContainer.width]);
 
 	const zoomHandler = (zoom: number) => {
 		setZoom(zoom);

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeClient.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeClient.tsx
@@ -58,7 +58,7 @@ export const RuntimeClient = (props: runtimeClientProps) => {
 		return () => {
 			disposableStore.dispose();
 		};
-	}, []);
+	}, [props.client.clientState, props.client.messageCounter]);
 
 	return <tr className='runtime-client'>
 		<td>

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeClientList.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeClientList.tsx
@@ -42,7 +42,7 @@ export const RuntimeClientList = (props: runtimeClientListProps) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [clients, props.session]);
 
 	return <div className='runtime-client-list'>
 		<table>

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeSession.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeSession.tsx
@@ -44,7 +44,7 @@ export const RuntimeSession = (props: RuntimeSessionProps) => {
 			setSessionState(state);
 		}));
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.session]);
 
 	// Render.
 	return (

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeSessionCard.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeSessionCard.tsx
@@ -59,7 +59,7 @@ export const RuntimeSessionCard = (props: runtimeSessionCardProps) => {
 			setSessionState(state);
 		}));
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.session]);
 
 	return (
 		<tr>

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessions.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessions.tsx
@@ -51,7 +51,7 @@ export const PositronSessions = (props: PropsWithChildren<PositronSessionsProps>
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.reactComponentContainer]);
 
 	// Render.
 	return (

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstanceMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstanceMenuButton.tsx
@@ -46,7 +46,7 @@ export const VariablesInstanceMenuButton = () => {
 			setActiveRuntimeLabel(labelForRuntime(e?.session));
 		}));
 		return () => disposables.dispose();
-	}, [positronVariablesContext.activePositronVariablesInstance]);
+	}, [positronVariablesContext.activePositronVariablesInstance, positronVariablesContext.positronVariablesService]);
 
 	// Builds the actions.
 	const actions = () => {

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariables.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariables.tsx
@@ -63,7 +63,7 @@ export const PositronVariables = (props: PropsWithChildren<PositronVariablesProp
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.reactComponentContainer]);
 
 	// Render.
 	return (


### PR DESCRIPTION
As part of merging 1.96 from upstream, ESLint was switched to use a flat config which we did not have setup. As a result, React linting from `eslint-plugin-react` and `eslint-plugin-react-hooks` were no longer configured for Positron. This problem was addressed in #6172.

During the time period between merging 1.96 from upstream and #6172 being merged into main, we had uncaught React linting errors get pushed to main.

This PR aims to resolve the ESLint errors for all `*.tsx` files.

To only see ESLint errors the following command can be run : `npx eslint **/*.tsx --quiet`

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
