### PR TITLE
e2e Test: Change reference test to use shift+F12

### DIFF
--- a/test/e2e/tests/references/references.test.ts
+++ b/test/e2e/tests/references/references.test.ts
@@ -23,7 +23,9 @@ test.describe('References', {
 
 	});
 
-	test('Python - Verify References Functionality', async function ({ app, python, openFile }) {
+	test('Python - Verify References Functionality', {
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6211' }]
+	}, async function ({ app, python, openFile }) {
 		const helper = 'helper.py';
 
 		await openFile(join('workspaces', 'references_tests', 'python', helper));

--- a/test/e2e/tests/references/references.test.ts
+++ b/test/e2e/tests/references/references.test.ts
@@ -57,7 +57,7 @@ async function openAndCommonValidations(app: Application, helper: string) {
 		await app.workbench.editor.clickOnTerm(helper, 'add', 1, true);
 
 		await test.step('Open references view', async () => {
-			await app.code.driver.page.keyboard.press('F12');
+			await app.code.driver.page.keyboard.press('Shift+F12');
 
 			await app.workbench.references.waitUntilOpen();
 		});


### PR DESCRIPTION
Due to #6211 needed to switch to using shift+F12

### QA Notes
@:references @:win
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
