### PR TITLE
exclude PET from create universal app

### DIFF
--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -47,6 +47,8 @@ const stashPatterns = [
     '**/ark', // Compiled R kernel and LSP
     // Exclusions from Kallichore Jupyter supervisor
     '**/kcserver', // Compiled Jupyter supervisor
+    // Exclusions for Python Environment Tools
+    '**/python-env-tools/pet',
     // Exclusions from Quarto
     '**/quarto/bin/tools/**',
     // Exclusions from Node Addon API

--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -50,6 +50,8 @@ const stashPatterns = [
 	'**/ark',                   // Compiled R kernel and LSP
 	// Exclusions from Kallichore Jupyter supervisor
 	'**/kcserver',              // Compiled Jupyter supervisor
+	// Exclusions for Python Environment Tools
+	'**/python-env-tools/pet',
 	// Exclusions from Quarto
 	'**/quarto/bin/tools/**',
 	// Exclusions from Node Addon API


### PR DESCRIPTION
Should fix the issue where the build is mad about PET having one build x64 and arm64, since we create a [universal build beforehand](https://github.com/posit-dev/positron-pet-builds/blob/a95fbb4764b271013f7639c211fea4912dcb6cb5/.github/workflows/release.yml#L301-L318)

```
Detected file "Contents/Resources/app/extensions/positron-python/python-env-tools/pet" that's the same in both x64 and arm64 builds and not covered by the x64ArchFiles rule: "*/kerberos.node"
```