### PR TITLE
Add send to active Terminal keybinding for shellscripts

### DIFF
--- a/extensions/shellscript/package.json
+++ b/extensions/shellscript/package.json
@@ -13,6 +13,14 @@
   },
   "categories": ["Programming Languages"],
   "contributes": {
+    "keybindings": [
+      {
+        "command": "workbench.action.terminal.runSelectedText",
+        "key": "ctrl+enter",
+        "mac": "cmd+enter",
+        "when": "editorTextFocus && editorLangId == shellscript"
+      }
+    ],
     "languages": [
       {
         "id": "shellscript",


### PR DESCRIPTION
Addresses #5251

Add keybinding Ctrl+Enter (Cmd+Enter on Mac) to send the currently selected text to the active Terminal for editor files of language id 'shellscript'.

### Release Notes

#### New Features

- Add Ctrl+Enter keybinding to send the selected text to the active Terminal in shellscripts

#### Bug Fixes

- N/A


### QA Notes

Similar to other language ids, documents considered "shellscripts" by the built in shellscript extensions should now allow the selected text (or current line, if no selection) to be sent to the active Terminal. File extensions and names considered shellscripts by the extension are outlined in the extension's [package.json](https://github.com/posit-dev/positron/blob/main/extensions/shellscript/package.json#L29)