### PR TITLE
Fix R Package Development test failures

### DIFF
--- a/test/e2e/tests/r-pkg-development/r-pkg-development.test.ts
+++ b/test/e2e/tests/r-pkg-development/r-pkg-development.test.ts
@@ -65,11 +65,11 @@ test.describe('R Package Development', { tag: [tags.WEB, tags.R_PKG_DEVELOPMENT]
 			// await app.workbench.terminal.waitForTerminalText('✔ Installed testfun 0.0.0.9000');
 
 			await app.workbench.console.waitForConsoleContents('restarted', { timeout: 30000 });
-			await app.workbench.console.waitForConsoleContents('library(testfun)', { timeout: 30000 });
+			await app.workbench.console.waitForConsoleContents('library(testfun)', { expectedCount: 2, timeout: 30000 });
 
 			await app.workbench.console.pasteCodeToConsole('(.packages())');
 			await app.workbench.console.sendEnterKey();
-			await app.workbench.console.waitForConsoleContents('"testfun"');
+			await app.workbench.console.waitForConsoleContents('"testfun"', { expectedCount: 1 });
 		});
 	});
 });


### PR DESCRIPTION
This PR fixes a couple of test failures in the R Package Development tests. 

Tests:
@:r-pkg-development

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

We need to revisit `app.workbench.console.waitForConsoleContents` and update it to deal with syntax highlighting.