### PR TITLE
e2e-test: add env var to indicate PW tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,8 @@ import { CustomTestOptions } from './test/e2e/tests/_test.setup';
 import type { GitHubActionOptions } from '@midleman/github-actions-reporter';
 import { currentsReporter } from '@currents/playwright';
 
+process.env.PW_TEST = 'true';
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ import { CustomTestOptions } from './test/e2e/tests/_test.setup';
 import type { GitHubActionOptions } from '@midleman/github-actions-reporter';
 import { currentsReporter } from '@currents/playwright';
 
-process.env.PW_TEST = 'true';
+process.env.PW_TEST = '1';
 
 /**
  * See https://playwright.dev/docs/test-configuration.


### PR DESCRIPTION
### Summary

Adding `process.env.PW_TEST` to indicate whether Playwright tests are running. This variable is automatically set to "1" when Playwright executes tests, allowing conditional logic in the test environment.


### QA Notes

No functional changes to the tests or application behavior. This is an internal enhancement to make environment detection more explicit.
