### PR TITLE
Apply an automatic dark theme to plots in dark themes

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.css
@@ -1,8 +1,18 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 .positron-plots-container .action-bars {
 	height: min-content;
+}
+
+.vs-dark .positron-plots-container .codicon-color-mode {
+	rotate: 180deg;
+	transition: 0.2s ease;
+}
+
+.positron-plots-container .codicon-color-mode {
+	rotate: 0deg;
+	transition: 0.2s ease;
 }

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -89,6 +89,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	const enableCopyPlot = hasPlots &&
 		(selectedPlot instanceof StaticPlotClient
 			|| selectedPlot instanceof PlotClientInstance);
+	const enableDarkFilter = enableCopyPlot;
 
 	const enablePopoutPlot = hasPlots &&
 		selectedPlot instanceof HtmlPlotClient;
@@ -180,7 +181,9 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						}
 					</ActionBarRegion>
 					<ActionBarRegion location='right'>
-						<DarkFilterMenuButton plotsService={positronPlotsContext.positronPlotsService} />
+						{enableDarkFilter &&
+							<DarkFilterMenuButton plotsService={positronPlotsContext.positronPlotsService} />
+						}
 						<HistoryPolicyMenuButton plotsService={positronPlotsContext.positronPlotsService} />
 						<ActionBarSeparator />
 						<ActionBarButton iconId='clear-all' align='right' disabled={noPlots} tooltip={localize('positronClearAllPlots', "Clear all plots")}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -34,6 +34,7 @@ import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { HtmlPlotClient } from '../htmlPlotClient.js';
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { OpenInEditorMenuButton } from './openInEditorMenuButton.js';
+import { DarkFilterMenuButton } from './darkFilterMenuButton.js';
 
 // Constants.
 const kPaddingLeft = 14;
@@ -179,6 +180,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						}
 					</ActionBarRegion>
 					<ActionBarRegion location='right'>
+						<DarkFilterMenuButton plotsService={positronPlotsContext.positronPlotsService} />
 						<HistoryPolicyMenuButton plotsService={positronPlotsContext.positronPlotsService} />
 						<ActionBarSeparator />
 						<ActionBarButton iconId='clear-all' align='right' disabled={noPlots} tooltip={localize('positronClearAllPlots', "Clear all plots")}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -35,6 +35,7 @@ import { HtmlPlotClient } from '../htmlPlotClient.js';
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
 import { OpenInEditorMenuButton } from './openInEditorMenuButton.js';
 import { DarkFilterMenuButton } from './darkFilterMenuButton.js';
+import { IPreferencesService } from '../../../../services/preferences/common/preferences.js';
 
 // Constants.
 const kPaddingLeft = 14;
@@ -54,6 +55,7 @@ export interface ActionBarsProps {
 	readonly keybindingService: IKeybindingService;
 	readonly layoutService: IWorkbenchLayoutService;
 	readonly notificationService: INotificationService;
+	readonly preferencesService: IPreferencesService;
 	readonly zoomHandler: (zoomLevel: number) => void;
 	readonly zoomLevel: number;
 }
@@ -182,7 +184,9 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 					</ActionBarRegion>
 					<ActionBarRegion location='right'>
 						{enableDarkFilter &&
-							<DarkFilterMenuButton plotsService={positronPlotsContext.positronPlotsService} />
+							<DarkFilterMenuButton
+								plotsService={positronPlotsContext.positronPlotsService}
+								preferencesService={positronPlotsContext.preferencesService} />
 						}
 						<HistoryPolicyMenuButton plotsService={positronPlotsContext.positronPlotsService} />
 						<ActionBarSeparator />

--- a/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
@@ -12,9 +12,12 @@ import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/b
 import { DarkFilter, IPositronPlotsService } from '../../../../services/positronPlots/common/positronPlots.js';
 import * as nls from '../../../../../nls.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { IPreferencesService } from '../../../../services/preferences/common/preferences.js';
+import { localize } from '../../../../../nls.js';
 
 interface DarkFilterMenuButtonProps {
 	readonly plotsService: IPositronPlotsService;
+	readonly preferencesService: IPreferencesService;
 }
 
 // Labels for the menu.
@@ -88,6 +91,20 @@ export const DarkFilterMenuButton = (props: DarkFilterMenuButtonProps) => {
 			});
 		});
 
+		// Add an action to open the settings.
+		actions.push({
+			id: 'open-settings',
+			label: localize('positron.openDarkFilterSettings', "Change Default..."),
+			tooltip: '',
+			class: undefined,
+			enabled: true,
+			run: async () => {
+				await props.preferencesService.openUserSettings({
+					jsonEditor: false,
+					query: 'positron.plots.darkFilter'
+				});
+			}
+		});
 		return actions;
 	};
 

--- a/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
@@ -4,13 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 // React.
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 // Other dependencies.
 import { IAction } from '../../../../../base/common/actions.js';
 import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
 import { DarkFilter, IPositronPlotsService } from '../../../../services/positronPlots/common/positronPlots.js';
 import * as nls from '../../../../../nls.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 
 interface DarkFilterMenuButtonProps {
 	readonly plotsService: IPositronPlotsService;
@@ -29,6 +30,21 @@ const darkFilterTooltip = nls.localize('positronDarkFilterTooltip', "Set whether
  * @returns The rendered component.
  */
 export const DarkFilterMenuButton = (props: DarkFilterMenuButtonProps) => {
+
+	const [darkFilterMode, setDarkFilterMode] = useState(props.plotsService.darkFilterMode);
+
+	useEffect(() => {
+		// Create the disposable store for cleanup.
+		const disposableStore = new DisposableStore();
+
+		// Add the event handler for dark filter mode changes.
+		disposableStore.add(props.plotsService.onDidChangeDarkFilterMode(mode => {
+			setDarkFilterMode(mode);
+		}));
+
+		// Return the cleanup function that will dispose of the event handlers.
+		return () => disposableStore.dispose();
+	}, [props.plotsService]);
 
 	const labelForDarkFilter = (policy: DarkFilter): string => {
 		switch (policy) {
@@ -54,7 +70,7 @@ export const DarkFilterMenuButton = (props: DarkFilterMenuButtonProps) => {
 				tooltip: '',
 				class: undefined,
 				enabled: true,
-				checked: props.plotsService.darkFilterMode === mode,
+				checked: darkFilterMode === mode,
 				run: () => {
 					props.plotsService.setDarkFilterMode(mode);
 				}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
@@ -57,6 +57,17 @@ export const DarkFilterMenuButton = (props: DarkFilterMenuButtonProps) => {
 		}
 	};
 
+	const iconForDarkFilter = (policy: DarkFilter): string => {
+		switch (policy) {
+			case DarkFilter.On:
+				return 'circle-large-filled';
+			case DarkFilter.Off:
+				return 'circle-large';
+			case DarkFilter.Auto:
+				return 'color-mode';
+		}
+	}
+
 	// Builds the actions.
 	const actions = () => {
 		const modes = [DarkFilter.On,
@@ -82,7 +93,7 @@ export const DarkFilterMenuButton = (props: DarkFilterMenuButtonProps) => {
 
 	return (
 		<ActionBarMenuButton
-			iconId='light-bulb'
+			iconId={iconForDarkFilter(darkFilterMode)}
 			tooltip={darkFilterTooltip}
 			ariaLabel={darkFilterTooltip}
 			align='right'

--- a/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// React.
+import React from 'react';
+
+// Other dependencies.
+import { IAction } from '../../../../../base/common/actions.js';
+import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
+import { DarkFilter, IPositronPlotsService } from '../../../../services/positronPlots/common/positronPlots.js';
+import * as nls from '../../../../../nls.js';
+
+interface DarkFilterMenuButtonProps {
+	readonly plotsService: IPositronPlotsService;
+}
+
+// Labels for the menu.
+const darkFilterLabel = nls.localize('positron.darkFilter', "Dark Filter");
+const darkFilterNoneLabel = nls.localize('positron.darkFilterNone', "No Filter");
+const darkFilterFollowThemeLabel = nls.localize('positron.darkFilterFollowTheme', "Follow Theme");
+
+const darkFilterTooltip = nls.localize('positronDarkFilterTooltip', "Set whether a dark filter is applied to plots.");
+
+/**
+ * DarkFilterMenuButton component.
+ * @param props A DarkFilterMenuButtonProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const DarkFilterMenuButton = (props: DarkFilterMenuButtonProps) => {
+
+	const labelForDarkFilter = (policy: DarkFilter): string => {
+		switch (policy) {
+			case DarkFilter.On:
+				return darkFilterLabel;
+			case DarkFilter.Off:
+				return darkFilterNoneLabel;
+			case DarkFilter.Auto:
+				return darkFilterFollowThemeLabel;
+		}
+	};
+
+	// Builds the actions.
+	const actions = () => {
+		const modes = [DarkFilter.On,
+		DarkFilter.Off,
+		DarkFilter.Auto];
+		const actions: IAction[] = [];
+		modes.map(mode => {
+			actions.push({
+				id: mode,
+				label: labelForDarkFilter(mode),
+				tooltip: '',
+				class: undefined,
+				enabled: true,
+				checked: props.plotsService.darkFilterMode === mode,
+				run: () => {
+					props.plotsService.setDarkFilterMode(mode);
+				}
+			});
+		});
+
+		return actions;
+	};
+
+	return (
+		<ActionBarMenuButton
+			iconId='light-bulb'
+			tooltip={darkFilterTooltip}
+			ariaLabel={darkFilterTooltip}
+			align='right'
+			actions={actions}
+		/>
+	);
+};

--- a/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
@@ -94,7 +94,7 @@ export const DarkFilterMenuButton = (props: DarkFilterMenuButtonProps) => {
 		// Add an action to open the settings.
 		actions.push({
 			id: 'open-settings',
-			label: localize('positron.openDarkFilterSettings', "Change Default..."),
+			label: localize('positron.openDarkFilterSettings', "Change Default in Settings..."),
 			tooltip: '',
 			class: undefined,
 			enabled: true,

--- a/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotThumbnail.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotThumbnail.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -47,7 +47,7 @@ export const DynamicPlotThumbnail = (props: DynamicPlotThumbnailProps) => {
 	// Consider: we probably want a more explicit loading state; as written we
 	// will show the old URI until the new one is ready.
 	if (uri) {
-		return <img src={uri} alt={'Plot ' + props.plotClient.id} />;
+		return <img className='plot' src={uri} alt={'Plot ' + props.plotClient.id} />;
 	} else {
 		return <PlaceholderThumbnail />;
 	}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/panZoomImage.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/panZoomImage.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -77,7 +77,8 @@ export const PanZoomImage = (props: PanZoomImageProps) => {
 
 	return (
 		<Scrollable width={props.width} height={props.height} scrollableWidth={scrollableWidth} scrollableHeight={scrollableHeight} mousePan={true}>
-			<img src={props.imageUri}
+			<img className='plot'
+				src={props.imageUri}
 				alt={props.description}
 				draggable={false}
 				ref={imageRef}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.css
@@ -7,9 +7,9 @@
  * Enable the dark filter when it is set to be on (always enabled) or when it
  * is set to auto and we're in a dark theme (vs-dark).
  */
-.dark-filter-on .selected-plot img,
-.dark-filter-on .plot-thumbnail img,
-.vs-dark .dark-filter-auto .selected-plot img,
-.vs-dark .dark-filter-auto .plot-thumbnail img {
+.dark-filter-on .selected-plot img.plot,
+.dark-filter-on .plot-thumbnail img.plot,
+.vs-dark .dark-filter-auto .selected-plot img.plot,
+.vs-dark .dark-filter-auto .plot-thumbnail img.plot {
 	filter: invert(1) hue-rotate(180deg);
 }

--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.css
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.vs-dark .selected-plot img {
+	filter: invert(1) hue-rotate(180deg);
+}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.css
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.css
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.vs-dark .selected-plot img {
+.vs-dark .selected-plot img,
+.vs-dark .plot-thumbnail img {
 	filter: invert(1) hue-rotate(180deg);
 }

--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
@@ -20,7 +20,7 @@ import { WebviewPlotThumbnail } from './webviewPlotThumbnail.js';
 import { usePositronPlotsContext } from '../positronPlotsContext.js';
 import { WebviewPlotClient } from '../webviewPlotClient.js';
 import { PlotClientInstance } from '../../../../services/languageRuntime/common/languageRuntimePlotClient.js';
-import { IPositronPlotClient } from '../../../../services/positronPlots/common/positronPlots.js';
+import { DarkFilter, IPositronPlotClient } from '../../../../services/positronPlots/common/positronPlots.js';
 import { StaticPlotClient } from '../../../../services/positronPlots/common/staticPlotClient.js';
 
 /**
@@ -33,6 +33,7 @@ interface PlotContainerProps {
 	y: number;
 	visible: boolean;
 	showHistory: boolean;
+	darkFilterMode: DarkFilter;
 	zoom: number;
 }
 
@@ -161,7 +162,7 @@ export const PlotsContainer = (props: PlotContainerProps) => {
 	// If there are no plot instances, show a placeholder; otherwise, show the
 	// most recently generated plot.
 	return (
-		<div className={'plots-container ' + historyEdge}>
+		<div className={'plots-container dark-filter-' + props.darkFilterMode + ' ' + historyEdge}>
 			<div className='selected-plot'>
 				{positronPlotsContext.positronPlotInstances.length === 0 &&
 					<div className='plot-placeholder'></div>}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
@@ -1,7 +1,10 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './plotsContainer.css';
 
 // React.
 import React, { useEffect } from 'react';

--- a/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotThumbnail.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotThumbnail.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -23,5 +23,5 @@ interface StaticPlotThumbnailProps {
  * @returns The rendered component.
  */
 export const StaticPlotThumbnail = (props: StaticPlotThumbnailProps) => {
-	return <img src={props.plotClient.uri} alt={'Plot ' + props.plotClient.id} />;
+	return <img className='plot' src={props.plotClient.uri} alt={'Plot ' + props.plotClient.id} />;
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -20,6 +20,8 @@ import { Extensions as ViewContainerExtensions, IViewsRegistry } from '../../../
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { PlotsActiveEditorCopyAction, PlotsActiveEditorSaveAction, PlotsClearAction, PlotsCopyAction, PlotsEditorAction, PlotsNextAction, PlotsPopoutAction, PlotsPreviousAction, PlotsRefreshAction, PlotsSaveAction, PlotsSizingPolicyAction } from './positronPlotsActions.js';
 import { POSITRON_SESSION_CONTAINER } from '../../positronSession/browser/positronSessionContainer.js';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { localize } from '../../../../nls.js';
 
 // Register the Positron plots service.
 registerSingleton(IPositronPlotsService, PositronPlotsService, InstantiationType.Delayed);
@@ -75,6 +77,28 @@ class PositronPlotsContribution extends Disposable implements IWorkbenchContribu
 		registerAction2(PlotsSizingPolicyAction);
 	}
 }
+
+// Register the configuration setting
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
+	.registerConfiguration({
+		properties: {
+			'positron.plots.darkFilter': {
+				type: 'string',
+				default: 'auto',
+				enum: [
+					'on',
+					'off',
+					'auto'
+				],
+				enumDescriptions: [
+					localize('positron.plots.darkFilterOn', 'Always apply the dark filter'),
+					localize('positron.plots.darkFilterOff', 'Never apply the dark filter'),
+					localize('positron.plots.darkFilterAuto', 'Apply the dark filter when Positron is using a dark theme')
+				],
+				description: localize('positron.plots.darkFilterSetting', "Use a color filter to make light plots appear dark."),
+			}
+		}
+	});
 
 Registry.
 	as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.contribution.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.tsx
@@ -20,6 +20,7 @@ import { ActionBars } from './components/actionBars.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { PositronPlotsViewPane } from './positronPlotsView.js';
 import { ZoomLevel } from './components/zoomPlotMenuButton.js';
+import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
 
 /**
  * PositronPlotsProps interface.
@@ -30,6 +31,7 @@ export interface PositronPlotsProps extends PositronPlotsServices {
 	readonly reactComponentContainer: PositronPlotsViewPane;
 	readonly positronPlotsService: IPositronPlotsService;
 	readonly notificationService: INotificationService;
+	readonly preferencesService: IPreferencesService;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.tsx
@@ -75,6 +75,7 @@ export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 	const [visible, setVisible] = useState(props.reactComponentContainer.containerVisible);
 	const [showHistory, setShowHistory] = useState(computeHistoryVisibility(
 		props.positronPlotsService.historyPolicy));
+	const [darkFilterMode, setDarkFilterMode] = useState(props.positronPlotsService.darkFilterMode);
 	const [zoom, setZoom] = useState(ZoomLevel.Fit);
 
 	// Add IReactComponentContainer event handlers.
@@ -117,9 +118,14 @@ export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 			setShowHistory(computeHistoryVisibility(policy));
 		}));
 
+		// Add the event handler for dark filter mode changes.
+		disposableStore.add(props.positronPlotsService.onDidChangeDarkFilterMode(mode => {
+			setDarkFilterMode(mode);
+		}));
+
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [computeHistoryVisibility, props.positronPlotsService, props.reactComponentContainer]);
 
 	// Render.
 	return (
@@ -127,6 +133,7 @@ export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 			<ActionBars {...props} zoomHandler={zoomHandler} zoomLevel={zoom} />
 			<PlotsContainer
 				showHistory={showHistory}
+				darkFilterMode={darkFilterMode}
 				visible={visible}
 				width={width}
 				height={height - 34}

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsState.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsState.tsx
@@ -100,7 +100,7 @@ export const usePositronPlotsState = (services: PositronPlotsServices): Positron
 
 		// Return the clean up for our event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [services.positronPlotsService]);
 
 	return { ...services, positronPlotInstances, selectedInstanceId, selectedInstanceIndex };
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsState.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsState.tsx
@@ -10,6 +10,7 @@ import { PositronActionBarServices } from '../../../../platform/positronActionBa
 import { PlotClientInstance } from '../../../services/languageRuntime/common/languageRuntimePlotClient.js';
 import { ILanguageRuntimeService } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IPositronPlotClient, IPositronPlotsService } from '../../../services/positronPlots/common/positronPlots.js';
+import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
 
 /**
  * PositronPlotsServices interface. Defines the set of services that are required by the Positron plots.
@@ -18,6 +19,7 @@ export interface PositronPlotsServices extends PositronActionBarServices {
 	readonly languageRuntimeService: ILanguageRuntimeService;
 	readonly positronPlotsService: IPositronPlotsService;
 	readonly notificationService: INotificationService;
+	readonly preferencesService: IPreferencesService;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsView.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsView.tsx
@@ -32,6 +32,7 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { PositronViewPane } from '../../../browser/positronViewPane/positronViewPane.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
+import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
 
 /**
  * PositronPlotsViewPane class.
@@ -155,6 +156,7 @@ export class PositronPlotsViewPane extends PositronViewPane implements IReactCom
 	 * @param notificationService The notification service.
 	 * @param openerService The opener service.
 	 * @param positronPlotsService The oositron plots service.
+	 * @param preferencesService The preferences service.
 	 * @param telemetryService The telemetry service.
 	 * @param themeService The theme service.
 	 * @param viewDescriptorService The view descriptor service.
@@ -175,6 +177,7 @@ export class PositronPlotsViewPane extends PositronViewPane implements IReactCom
 		@INotificationService private readonly notificationService: INotificationService,
 		@IOpenerService openerService: IOpenerService,
 		@IPositronPlotsService private readonly positronPlotsService: IPositronPlotsService,
+		@IPreferencesService private readonly preferencesService: IPreferencesService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IThemeService themeService: IThemeService,
 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
@@ -254,6 +257,7 @@ export class PositronPlotsViewPane extends PositronViewPane implements IReactCom
 				layoutService={this.layoutService}
 				positronPlotsService={this.positronPlotsService}
 				notificationService={this.notificationService}
+				preferencesService={this.preferencesService}
 				reactComponentContainer={this} />
 		);
 	}

--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/editorPlotsContainer.css
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/editorPlotsContainer.css
@@ -7,9 +7,7 @@
  * Enable the dark filter when it is set to be on (always enabled) or when it
  * is set to auto and we're in a dark theme (vs-dark).
  */
-.dark-filter-on .selected-plot img,
-.dark-filter-on .plot-thumbnail img,
-.vs-dark .dark-filter-auto .selected-plot img,
-.vs-dark .dark-filter-auto .plot-thumbnail img {
+.positron-plots-editor-container .dark-filter-on img,
+.vs-dark .positron-plots-editor-container .dark-filter-auto img {
 	filter: invert(1) hue-rotate(180deg);
 }

--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/editorPlotsContainer.tsx
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/editorPlotsContainer.tsx
@@ -1,26 +1,35 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// CSS.
+import './editorPlotsContainer.css';
+
 // React.
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 // Other dependencies.
 import { DynamicPlotInstance } from '../../positronPlots/browser/components/dynamicPlotInstance.js';
 import { StaticPlotInstance } from '../../positronPlots/browser/components/staticPlotInstance.js';
 import { ZoomLevel } from '../../positronPlots/browser/components/zoomPlotMenuButton.js';
 import { PlotClientInstance } from '../../../services/languageRuntime/common/languageRuntimePlotClient.js';
-import { IPositronPlotClient } from '../../../services/positronPlots/common/positronPlots.js';
+import { IPositronPlotClient, IPositronPlotsService } from '../../../services/positronPlots/common/positronPlots.js';
 import { StaticPlotClient } from '../../../services/positronPlots/common/staticPlotClient.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
 
 interface EditorPlotsContainerProps {
 	plotClient: IPositronPlotClient;
+	positronPlotsService: IPositronPlotsService,
 	height: number;
 	width: number;
 }
 
 export const EditorPlotsContainer = (props: EditorPlotsContainerProps) => {
+
+
+	const [darkFilterMode, setDarkFilterMode] = useState(props.positronPlotsService.darkFilterMode);
+
 	const render = () => {
 		if (props.plotClient instanceof PlotClientInstance) {
 			return <DynamicPlotInstance
@@ -40,8 +49,21 @@ export const EditorPlotsContainer = (props: EditorPlotsContainerProps) => {
 		return null;
 	};
 
+	useEffect(() => {
+		// Create the disposable store for cleanup.
+		const disposableStore = new DisposableStore();
+
+		// Add the event handler for dark filter mode changes.
+		disposableStore.add(props.positronPlotsService.onDidChangeDarkFilterMode(mode => {
+			setDarkFilterMode(mode);
+		}));
+
+		// Return the cleanup function that will dispose of the event handlers.
+		return () => disposableStore.dispose();
+	}, [props.positronPlotsService]);
+
 	return (
-		<div style={
+		<div className={'dark-filter-' + darkFilterMode} style={
 			{
 				width: props.width,
 				height: props.height

--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
@@ -31,6 +31,7 @@ import { PositronPlotsEditorInput } from './positronPlotsEditorInput.js';
 import { IEditorGroup } from '../../../services/editor/common/editorGroupsService.js';
 import { ILanguageRuntimeService } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IPositronPlotClient, IPositronPlotsService } from '../../../services/positronPlots/common/positronPlots.js';
+import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
 
 export interface IPositronPlotsEditorOptions extends IEditorOptions {
 }
@@ -100,6 +101,7 @@ export class PositronPlotsEditor extends EditorPane implements IPositronPlotsEdi
 		@IPositronPlotsService private readonly _positronPlotsService: IPositronPlotsService,
 		@ILanguageRuntimeService private readonly _languageRuntimeService: ILanguageRuntimeService,
 		@INotificationService private readonly _notificationService: INotificationService,
+		@IPreferencesService private readonly _preferencesService: IPreferencesService,
 		@ICommandService private readonly _commandService: ICommandService,
 		@IHoverService private readonly _hoverService: IHoverService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
@@ -139,6 +141,7 @@ export class PositronPlotsEditor extends EditorPane implements IPositronPlotsEdi
 				languageRuntimeService={this._languageRuntimeService}
 				positronPlotsService={this._positronPlotsService}
 				notificationService={this._notificationService}
+				preferencesService={this._preferencesService}
 			>
 				<EditorPlotsContainer
 					width={this._width}

--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
@@ -143,6 +143,7 @@ export class PositronPlotsEditor extends EditorPane implements IPositronPlotsEdi
 				<EditorPlotsContainer
 					width={this._width}
 					height={this._height}
+					positronPlotsService={this._positronPlotsService}
 					plotClient={plotClient}
 				/>
 			</PositronPlotsContextProvider>

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -28,6 +28,20 @@ export enum HistoryPolicy {
 	AlwaysVisible = 'always',
 	Automatic = 'auto',
 	NeverVisible = 'never'
+}
+
+/**
+ * The possible dark filter modes.
+ */
+export enum DarkFilter {
+	/** The dark filter is always on. */
+	On = 'on',
+
+	/** The dark filter is always off (i.e. plots are always shown in their given colors */
+	Off = 'off',
+
+	/** The dark filter follows the current theme (i.e. it's on in dark themes and off in light themes) */
+	Auto = 'auto'
 }
 
 /**
@@ -65,6 +79,16 @@ export interface IPositronPlotsService {
 	 * Notifies subscribers when the history policy has changed.
 	 */
 	readonly onDidChangeHistoryPolicy: Event<HistoryPolicy>;
+
+	/**
+	 * Gets the current dark filter mode.
+	 */
+	readonly darkFilterMode: DarkFilter;
+
+	/**
+	 * Notifies subscribers when the dark filter mode has changed.
+	 */
+	readonly onDidChangeDarkFilterMode: Event<DarkFilter>;
 
 	/**
 	 * Notifies subscribers when a new Positron plot instance is created.
@@ -157,6 +181,11 @@ export interface IPositronPlotsService {
 	 * Selects a history policy.
 	 */
 	selectHistoryPolicy(policy: HistoryPolicy): void;
+
+	/**
+	 * Sets a new dark filter mode.
+	 */
+	setDarkFilterMode(mode: DarkFilter): void;
 
 	/**
 	 * Copies the current plot from the Plots View to the clipboard.


### PR DESCRIPTION
Quick little airplane feature to make plots in Positron's Plots pane (and editors) automatically turn dark in dark themes. It's intended for exploratory data analysis, wherein you're not preparing plots for publication but just using them as a visualization tool.

https://github.com/user-attachments/assets/19d49c58-2c26-411a-b0c4-8c440b17d2cf

Because I expect that this feature will be somewhat polarizing, it is controlled by a explicit configuration setting rather than an implicitly saved preference. You can turn it off at user level, workspace level, etc. in Settings.

<img width="473" alt="image" src="https://github.com/user-attachments/assets/cc8b1775-0537-49ae-a36d-192321321570" />

Addresses https://github.com/posit-dev/positron/issues/6255.

### Release Notes


#### New Features

- Optionally apply a color filter to plots in dark mode for automatic theming (#6255)

#### Bug Fixes

- N/A

### QA Notes

It is possible to change the dark filter mode right on the Plots pane by clicking the color mode drop down. Note however that this only changes it temporarily! If you want the change to stick (across reloads, etc.) you need to do that in Settings. Changing the value in Settings should cause the UI to react appropriately.

I briefly considered having the dropdown update the setting for you but there's really too much guessing there (did you mean to turn it off for all projects? just this one? etc.)

Test tags: `@:plots`