### PR TITLE
Fixes issue in Data Explorer where summary state is not retained

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -50,7 +50,7 @@ export const DataExplorer = () => {
 	const [layout, setLayout] = useState(context.instance.layout);
 	const [columnsWidth, setColumnsWidth] = useState(0);
 	const [animateColumnsWidth, setAnimateColumnsWidth] = useState(false);
-	const [columnsCollapsed, setColumnsCollapsed] = useState(false);
+	const [columnsCollapsed, setColumnsCollapsed] = useState(context.instance.isSummaryCollapsed);
 
 	// Dynamic column width layout.
 	useLayoutEffect(() => {

--- a/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/interfaces/positronDataExplorerInstance.ts
@@ -30,6 +30,11 @@ export interface IPositronDataExplorerInstance extends IDisposable {
 	layout: PositronDataExplorerLayout;
 
 	/**
+	 * Gets or sets a value which indicates whether the summary is collapsed.
+	 */
+	isSummaryCollapsed: boolean;
+
+	/**
 	 * Gets or sets the columns width percent.
 	 */
 	columnsWidthPercent: number;

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -51,6 +51,11 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	private _layout = PositronDataExplorerLayout.SummaryOnLeft;
 
 	/**
+	 * Gets or sets a value which indicates whether the summary is collapsed.
+	 */
+	private _isSummaryCollapsed = false;
+
+	/**
 	 * Gets or sets the columns width percent.
 	 */
 	private _columnsWidthPercent = 0.25;
@@ -228,6 +233,13 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	}
 
 	/**
+	 * Gets a value which indicates whether the summary is collapsed.
+	 */
+	get isSummaryCollapsed() {
+		return this._isSummaryCollapsed;
+	}
+
+	/**
 	 * Gets the columns width percent.
 	 */
 	get columnsWidthPercent() {
@@ -274,6 +286,7 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	 * Collapses the summary.
 	 */
 	collapseSummary(): void {
+		this._isSummaryCollapsed = true;
 		this._onDidCollapseSummaryEmitter.fire();
 	}
 
@@ -281,6 +294,7 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	 * Expands the summary.
 	 */
 	expandSummary(): void {
+		this._isSummaryCollapsed = false;
 		this._onDidExpandSummaryEmitter.fire();
 	}
 


### PR DESCRIPTION
Moves Data Explorer summary state (expanded/collapsed) into the D.E. context to preserve.

Addresses #4979 

https://github.com/user-attachments/assets/ed554fed-f17f-4802-82cd-9302ba7f397b


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- When switching tabs, Data Explorer summary remains expanded or collapsed upon return


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

e2e: @:data-explorer
