### PR TITLE
add `/opt/python` to environment search directories

### DIFF
--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonFinder.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonFinder.ts
@@ -382,7 +382,9 @@ class NativePythonFinderImpl extends DisposableBase implements NativePythonFinde
         const options: ConfigurationOptions = {
             workspaceDirectories: getWorkspaceFolderPaths(),
             // We do not want to mix this with `search_paths`
-            environmentDirectories: getCustomVirtualEnvDirs(),
+            // --- Start Positron ---
+            environmentDirectories: getEnvironmentDirs(),
+            // --- End Positron ---
             condaExecutable: getPythonSettingAndUntildify<string>(CONDAPATH_SETTING_KEY),
             poetryExecutable: getPythonSettingAndUntildify<string>('poetryPath'),
             cacheDirectory: this.cacheDirectory?.fsPath,
@@ -436,6 +438,35 @@ function getCustomVirtualEnvDirs(): string[] {
     }
     return Array.from(new Set(venvDirs));
 }
+
+// --- Start Positron ---
+/**
+ * Gets the list of directories to search for Python environments.
+ * @returns List of directories to search for Python environments.
+ */
+function getEnvironmentDirs(): string[] {
+    const venvDirs = getCustomVirtualEnvDirs();
+    const additionalDirs = getAdditionalEnvDirs();
+    const uniqueEnvDirs = new Set([...venvDirs, ...additionalDirs]);
+    return Array.from(uniqueEnvDirs);
+}
+
+/**
+ * Gets the list of additional directories to add to environment directories.
+ * @returns List of directories to add to environment directories.
+ */
+function getAdditionalEnvDirs(): string[] {
+    const additionalDirs: string[] = [];
+    if (!isWindows()) {
+        // /opt/python is a recommended Python installation location on Posit Workbench.
+        // see: https://docs.posit.co/ide/server-pro/python/installing_python.html
+        additionalDirs.push('/opt/python');
+    }
+    // TODO: add user-specified additional directories to include in discovery
+    // see: https://github.com/posit-dev/positron/issues/3574
+    return additionalDirs;
+}
+// --- End Positron ---
 
 function getPythonSettingAndUntildify<T>(name: string, scope?: Uri): T | undefined {
     const value = getConfiguration('python', scope).get<T>(name);


### PR DESCRIPTION
### Summary
- Addresses #6254
- adds `/opt/python` as a python installation search directory when not running on a Windows machine
- adds the ability to specify additional directories to include in discovery via `getAdditionalEnvDirs()` function
    - user-specified "include" dirs will be added to the function, as part of #3574

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Positron now searches `/opt/python` for Python installations (#6254)

#### Bug Fixes

- N/A


### QA Notes

See #6254 for notes. `/opt/python` installations of Python should now be picked up by Positron without adding `/opt/python` to the `PATH` on UNIX-alike machines.
