### PR TITLE
Active runtime metadata not shown when console is too small

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.css
@@ -23,11 +23,11 @@
 }
 
 .positron-modal-popup-container .positron-modal-popup.shadow-top {
-	box-shadow: 0px -4px 10px 0 rgba(0, 0, 0, 0.1);
+	box-shadow: 0 -4px 10px 0 rgba(0, 0, 0, 0.1);
 }
 
 .positron-modal-popup-container .positron-modal-popup.shadow-bottom {
-	box-shadow: 0px 4px 10px 0 rgba(0, 0, 0, 0.1);
+	box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1);
 }
 
 .positron-modal-popup-container .positron-modal-popup .positron-modal-popup-children {

--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -132,7 +132,12 @@ export interface PositronModalPopupProps {
  * @returns The rendered component.
  */
 export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupProps>) => {
-	// Setup the anchor layout.
+	// Reference hooks.
+	const popupContainerRef = useRef<HTMLDivElement>(undefined!);
+	const popupRef = useRef<HTMLDivElement>(undefined!);
+	const popupChildrenRef = useRef<HTMLDivElement>(undefined!);
+
+	// State hooks.
 	const [anchorLayout] = useState(() => {
 		if (props.anchorPoint) {
 			return new AnchorLayout(props.anchorPoint.clientX, props.anchorPoint.clientY, 0, 0);
@@ -146,13 +151,6 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 			);
 		}
 	});
-
-	// Reference hooks.
-	const popupContainerRef = useRef<HTMLDivElement>(undefined!);
-	const popupRef = useRef<HTMLDivElement>(undefined!);
-	const popupChildrenRef = useRef<HTMLDivElement>(undefined!);
-
-	// State hooks.
 	const [popupLayout, setPopupLayout] = useState<PopupLayout>(() => {
 		// Initially, position the popup off screen.
 		const newPopupLayout = new PopupLayout();
@@ -224,7 +222,7 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 		 * Positions the popup at the top of the anchor element.
 		 */
 		const positionTop = () => {
-			popupLayout.bottom = -(anchorLayout.anchorY - 1);
+			popupLayout.bottom = documentHeight - (anchorLayout.anchorY - 1);
 			popupLayout.maxHeight = anchorLayout.anchorY - LAYOUT_MARGIN;
 		};
 
@@ -247,9 +245,9 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 				LAYOUT_MARGIN;
 
 			// Try to position the popup fully at the bottom or fully at the top. If this this
-			// isn't possible, try to position the popup with scrolling at the bottom or at the
-			// top. If this isn't posssible, fallback to positioning the popup at the top of its
-			// container.
+			// isn't possible, try to position the popup with scrolling at the bottom or with
+			// scrolling at the top. If this isn't posssible, fallback to positioning the popup at
+			// the top of its container.
 			if (idealBottom < documentHeight - 1) {
 				positionBottom();
 			} else if (childrenHeight < anchorLayout.anchorY - 1) {

--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -447,12 +447,6 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 		return () => disposableStore.dispose();
 	}, [anchorLayout.anchorY, popupLayout, props]);
 
-	// Create the class names.
-	const classNames = positronClassNames(
-		'positron-modal-popup',
-		props.popupPosition === 'top' ? 'shadow-top' : 'shadow-bottom'
-	);
-
 	// Render.
 	return (
 		<div
@@ -463,7 +457,10 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 		>
 			<div
 				ref={popupRef}
-				className={classNames}
+				className={positronClassNames(
+					'positron-modal-popup',
+					popupLayout.top === 'auto' ? 'shadow-top' : 'shadow-bottom'
+				)}
 				style={{
 					...popupLayout,
 					width: props.width,
@@ -471,9 +468,9 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 					height: props.height,
 					minHeight: props.minHeight ?? 'auto'
 				}}
-				onWheel={(e) => {
-					// window.ts#registerListeners() discards the wheel event to prevent back/forward gestures
-					// send it to the div so it is not lost
+				onWheel={e => {
+					// window.ts#registerListeners() discards wheel events to prevent back / forward
+					// gestures. Send wheel events to the div so they are not lost.
 					e.currentTarget.scrollBy(e.deltaX, e.deltaY);
 					e.preventDefault();
 				}}

--- a/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.tsx
+++ b/src/vs/workbench/browser/positronModalReactRenderer/positronModalReactRenderer.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -283,16 +283,18 @@ export class PositronModalReactRenderer extends Disposable {
 		 * @param e A KeyboardEvent that describes a user interaction with the keyboard.
 		 */
 		const keydownHandler = (e: KeyboardEvent) => {
+			// Convert the KeyboardEvent into a StandardKeyboardEvent.
 			const event = new StandardKeyboardEvent(e);
 
-			// Soft dispatch the key event so we can determine whether it is bound to a command.
+			// Soft dispatch the keyboard event so we can determine whether it is bound to a
+			// command.
 			const resolutionResult = renderer._options.keybindingService.softDispatch(
 				event,
 				renderer._options.layoutService.activeContainer
 			);
 
-			// If a keybinding to a command was found, stop it from being processed if it is not one of
-			// the allowable commands.
+			// If a keybinding to a command was found, stop it from being processed if it is not one
+			// of the allowable commands.
 			if (resolutionResult.kind === ResultKind.KbFound && resolutionResult.commandId) {
 				if (ALLOWABLE_COMMANDS.indexOf(resolutionResult.commandId) === -1) {
 					DOM.EventHelper.stop(event, true);

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -81,7 +81,7 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 			setSessionState(state);
 		}));
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.session]);
 
 	const showKernelOutputChannelClickHandler = () => {
 		props.session.showOutput();
@@ -90,13 +90,13 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 	// Render.
 	return (
 		<PositronModalPopup
-			anchorElement={props.anchorElement}
-			height='min-content'
-			keyboardNavigationStyle='menu'
 			renderer={props.renderer}
+			anchorElement={props.anchorElement}
 			popupAlignment='auto'
 			popupPosition='auto'
 			width={400}
+			height='min-content'
+			keyboardNavigationStyle='menu'
 		>
 			<div className='console-instance-info'>
 				<div className='content'>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -90,13 +90,13 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 	// Render.
 	return (
 		<PositronModalPopup
-			renderer={props.renderer}
 			anchorElement={props.anchorElement}
-			popupPosition='auto'
-			popupAlignment='auto'
-			width={400}
 			height='min-content'
 			keyboardNavigationStyle='menu'
+			popupAlignment='auto'
+			popupPosition='auto'
+			renderer={props.renderer}
+			width={400}
 		>
 			<div className='console-instance-info'>
 				<div className='content'>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -92,8 +92,8 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 		<PositronModalPopup
 			renderer={props.renderer}
 			anchorElement={props.anchorElement}
-			popupAlignment='auto'
 			popupPosition='auto'
+			popupAlignment='auto'
 			width={400}
 			height='min-content'
 			keyboardNavigationStyle='menu'


### PR DESCRIPTION
### Description

This PR addresses https://github.com/posit-dev/positron/issues/6259 by fixing a layout bug in the `PositronModalPopup` component.

Prior to this PR, the `ConsoleInstanceInfoModalPopup` would display properly when there was room for it to be positioned below the Console action bar:

![image](https://github.com/user-attachments/assets/d9363bb5-164a-40ad-9314-b53f57a661b4)

But, when there wasn't room for it to be positioned below the Console action bar, nothing was displayed:

https://github.com/user-attachments/assets/b64e8d9b-0165-4d8c-bceb-ae085d62f130

With this PR, the `ConsoleInstanceInfoModalPopup` component will display below or above the Console action bar, as the situation demands:

Below:
<img width="1573" alt="image" src="https://github.com/user-attachments/assets/1fc3cebe-02d3-47a2-b9b4-3b214314c7cb" />

Above:
<img width="1573" alt="image" src="https://github.com/user-attachments/assets/41ad4fb3-33ff-46af-97da-5021c5990079" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #6259 

### QA Notes

- N/A