### PR TITLE
search additional R installation directories on Linux and Mac

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -83,11 +83,8 @@ export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRun
 	updateBinaries(moreBinaries);
 
 	// Optional, user-specified root directories or binaries
-	const userHqBinaries = discoverHQBinaries(userRHeadquarters());
-	updateBinaries(userHqBinaries);
-
-	const userMoreBinaries = discoverAdHocBinaries(userRBinaries());
-	updateBinaries(userMoreBinaries);
+	const userBinaries = discoverUserSpecifiedBinaries();
+	updateBinaries(userBinaries);
 
 	// Directories relevant to Posit Workbench. Not relevant on Windows.
 	if (os.platform() !== 'win32') {
@@ -530,6 +527,18 @@ function discoverAdHocBinaries(paths: string[]): RBinary[] {
 		.filter(b => fs.existsSync(b))
 		.map(b => fs.realpathSync(b))
 		.map(b => ({ path: b, reasons: [ReasonDiscovered.adHoc] }));
+}
+
+/**
+ * Discovers optional, user-specified root directories or binaries.
+ * @returns R binaries that the user has specified.
+ */
+function discoverUserSpecifiedBinaries(): RBinary[] {
+	const userHqBinaries = discoverHQBinaries(userRHeadquarters());
+	const userMoreBinaries = discoverAdHocBinaries(userRBinaries());
+	const userBinaries = userHqBinaries.concat(userMoreBinaries);
+	// Return the binaries, overwriting the ReasonDiscovered with ReasonDiscovered.user
+	return userBinaries.map(b => ({ path: b.path, reasons: [ReasonDiscovered.user] }));
 }
 
 /**

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -86,7 +86,9 @@ export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRun
 	const userBinaries = discoverUserSpecifiedBinaries();
 	updateBinaries(userBinaries);
 
-	// Directories relevant to Posit Workbench. Not relevant on Windows.
+	// Directories to check for R binaries on Linux and macOS. These locations are also searched by
+	// RStudio on POSIX platforms.
+	// See https://github.com/rstudio/rstudio/blob/bb8cbf17bb415467f87d6e415f9e3777fa46e583/src/cpp/core/r_util/RVersionsPosix.cpp#L121-L147
 	if (os.platform() !== 'win32') {
 		const pwbBinaries = discoverPWBBinaries();
 		updateBinaries(pwbBinaries);

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -86,12 +86,12 @@ export async function* rRuntimeDiscoverer(): AsyncGenerator<positron.LanguageRun
 	const userBinaries = discoverUserSpecifiedBinaries();
 	updateBinaries(userBinaries);
 
-	// Directories to check for R binaries on Linux and macOS. These locations are also searched by
-	// RStudio on POSIX platforms.
+	// Search locations for R binaries that are conventional on servers. These locations are also
+	// searched by RStudio/Posit Workbench on POSIX platforms, such as Linux and macOS.
 	// See https://github.com/rstudio/rstudio/blob/bb8cbf17bb415467f87d6e415f9e3777fa46e583/src/cpp/core/r_util/RVersionsPosix.cpp#L121-L147
 	if (os.platform() !== 'win32') {
-		const pwbBinaries = discoverPWBBinaries();
-		updateBinaries(pwbBinaries);
+		const serverBinaries = discoverServerBinaries();
+		updateBinaries(serverBinaries);
 	}
 
 	// (Try to) promote each RBinary to a proper RInstallation
@@ -544,12 +544,13 @@ function discoverUserSpecifiedBinaries(): RBinary[] {
 }
 
 /**
- * Discovers R binaries that are relevant to Posit Workbench.
+ * Discovers R binaries that are installed in conventional locations on servers, such as Posit
+ * Workbench.
  * Paths are from: https://docs.posit.co/ide/server-pro/r/using_multiple_versions_of_r.html
- * @returns R binaries that are relevant to Posit Workbench.
+ * @returns R binaries that are installed in conventional locations on servers.
  */
-function discoverPWBBinaries(): RBinary[] {
-	const pwbBinaries = discoverHQBinaries([
+function discoverServerBinaries(): RBinary[] {
+	const serverBinaries = discoverHQBinaries([
 		'/usr/lib/R',
 		'/usr/lib64/R',
 		'/usr/local/lib/R',
@@ -559,8 +560,8 @@ function discoverPWBBinaries(): RBinary[] {
 		// '/opt/R', // Already checked for in rHeadquarters
 		'/opt/local/R'
 	]);
-	// Return the binaries, overwriting the ReasonDiscovered with ReasonDiscovered.pwb
-	return pwbBinaries.map(b => ({ path: b.path, reasons: [ReasonDiscovered.pwb] }));
+	// Return the binaries, overwriting the ReasonDiscovered with ReasonDiscovered.server
+	return serverBinaries.map(b => ({ path: b.path, reasons: [ReasonDiscovered.server] }));
 }
 
 // R discovery helpers

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -538,19 +538,16 @@ function discoverAdHocBinaries(paths: string[]): RBinary[] {
  * @returns R binaries that are relevant to Posit Workbench.
  */
 function discoverPWBBinaries(): RBinary[] {
-	const rBinaries = discoverAdHocBinaries([
+	const pwbBinaries = discoverHQBinaries([
 		'/usr/lib/R',
 		'/usr/lib64/R',
 		'/usr/local/lib/R',
 		'/usr/local/lib64/R',
 		'/opt/local/lib/R',
 		'/opt/local/lib64/R',
-	]);
-	const hqBinaries = discoverHQBinaries([
 		// '/opt/R', // Already checked for in rHeadquarters
 		'/opt/local/R'
 	]);
-	const pwbBinaries = [...rBinaries, ...hqBinaries];
 	// Return the binaries, overwriting the ReasonDiscovered with ReasonDiscovered.pwb
 	return pwbBinaries.map(b => ({ path: b.path, reasons: [ReasonDiscovered.pwb] }));
 }

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -44,7 +44,7 @@ export enum ReasonDiscovered {
 	/* eslint-enable @typescript-eslint/naming-convention */
 	adHoc = "adHoc",
 	user = "user",
-	pwb = "Posit Workbench"
+	server = "server"
 }
 
 /**
@@ -71,8 +71,8 @@ export function friendlyReason(reason: ReasonDiscovered | ReasonRejected | null)
 				return 'Found in a conventional location for symlinked R binaries';
 			case ReasonDiscovered.user:
 				return 'User-specified location';
-			case ReasonDiscovered.pwb:
-				return 'Found in a directory supported by Posit Workbench';
+			case ReasonDiscovered.server:
+				return 'Found in a conventional location for R binaries installed on a server';
 		}
 	} else if (Object.values(ReasonRejected).includes(reason as ReasonRejected)) {
 		switch (reason) {

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -44,9 +44,6 @@ export enum ReasonDiscovered {
 	/* eslint-enable @typescript-eslint/naming-convention */
 	adHoc = "adHoc",
 	user = "user",
-	/**
-	 * The binary was found in a directory supported by Posit Workbench.
-	 */
 	pwb = "Posit Workbench"
 }
 

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -43,7 +43,11 @@ export enum ReasonDiscovered {
 	HQ = "HQ",
 	/* eslint-enable @typescript-eslint/naming-convention */
 	adHoc = "adHoc",
-	user = "user"
+	user = "user",
+	/**
+	 * The binary was found in a directory supported by Posit Workbench.
+	 */
+	pwb = "Posit Workbench"
 }
 
 /**
@@ -70,6 +74,8 @@ export function friendlyReason(reason: ReasonDiscovered | ReasonRejected | null)
 				return 'Found in a conventional location for symlinked R binaries';
 			case ReasonDiscovered.user:
 				return 'User-specified location';
+			case ReasonDiscovered.pwb:
+				return 'Found in a directory supported by Posit Workbench';
 		}
 	} else if (Object.values(ReasonRejected).includes(reason as ReasonRejected)) {
 		switch (reason) {


### PR DESCRIPTION
### Summary
- addresses #6257
- adds support for the following locations based on Workbench's [recommended installation directories](https://docs.posit.co/ide/server-pro/r/installing_r.html#recommended-installation-directories):
    ```sh
    /usr/lib/R
    /usr/lib64/R
    /usr/local/lib/R
    /usr/local/lib64/R
    /opt/local/lib/R
    /opt/local/lib64/R
    /opt/R/* # This is already supported by Positron's R extension
    /opt/local/R/*
    ```
    - R installations in a subdirectory `/bin/R` within the above directories will now be found on Linux and Mac
    - Discovered installations are tagged with `ReasonDiscovered.server
- applies `ReasonDiscovered.user` to user-specified R installations -- this reason was not being applied previously

#### Preview

##### Interpreter Dropdown
<img width="377" alt="image" src="https://github.com/user-attachments/assets/f117507f-ed93-4ecb-bbf0-3f5cc40377dd" />

##### Command Palette `R: Select Interpreter`
<img width="608" alt="image" src="https://github.com/user-attachments/assets/b5bac332-6086-4bca-8f23-84b238a63874" />

##### R Language Pack Output

```js
2025-02-18 10:33:26.286 [info] Candidate R binary at /opt/local/R/4.3-arm64/Resources/bin/R
2025-02-18 10:33:26.286 [info] R installation discovered: {
  "usable": true,
  "supported": true,
  "reasonDiscovered": [
    "Found in a conventional location for R binaries installed on a server"
  ],
  "reasonRejected": null,
  "binpath": "/opt/local/R/4.3-arm64/Resources/bin/R",
  "homepath": "/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources",
  "semVersion": {
    "options": {},
    "loose": false,
    "includePrerelease": false,
    "raw": "4.3.3",
    "major": 4,
    "minor": 3,
    "patch": 3,
    "prerelease": [],
    "build": [],
    "version": "4.3.3"
  },
  "version": "4.3.3",
  "arch": "arm64",
  "current": false,
  "orthogonal": true
}
```

### Release Notes

#### New Features

- Positron now searches Workbench's recommended R installation directories during interpreter discovery (#6257)

#### Bug Fixes

- User-specified R binaries now show "User-specified location" as reason discovered in R Language Pack output

### QA Notes

See #6257 for testing notes. R installations in the paths listed above should now be searched during R discovery and the R Language Pack Output for the interpreters should have:

```json
  "reasonDiscovered": [
    "Found in a conventional location for R binaries installed on a server"
  ],
```

In addition, binaries specified by the user via the options described in https://positron.posit.co/r-installations.html#customizing-r-discovery should now be labeled with `ReasonDiscovered.user`. To verify this, open the R Language Pack output and confirm that the user-specified installation is found in the output and contains the following:

```json
"reasonDiscovered": [
    "User-specified location"
],
```