### PR TITLE
Bump to ark v0.1.164

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -683,7 +683,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.163"
+      "ark": "0.1.164"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
For:

* https://github.com/posit-dev/ark/pull/680

### Release Notes

#### New Features

- R completions in specific contexts (such as with the `?` help operator or inside `debug()`) no longer add trailing parentheses to functions (#1818, #2338).

#### Bug Fixes

- N/A

### QA Notes

In the R Console:

* Request help for a function, such `enc2native()`, using the `?` operator. Literally, type `?enc2` and allow the completions to pop-up. Accept the completion for `enc2native`. There should be no trailing parentheses. You should complete to `?enc2native` and not `?enc2native()`.
* Apply the `str()` or `args()` function to a function, while accepting a completion for that function. Let's use the `new.env()` function as an example. Start typing `args(new.)` and allow the completions to pop-up. Accept the completion for `new.env`. There should be no trailing parenthese. You should complete to `args(new.env)`, which works and reveals the arguments, not to `args(new.env())`, which just returns `NULL`.

``` r
# GOOD, what you should see
args(new.env)
#> function (hash = TRUE, parent = parent.frame(), size = 29L) 
#> NULL

# BAD, what you should NOT see
args(new.env())
#> NULL
```

<sup>Created on 2025-02-10 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

