### PR TITLE
Render <!DOCTYPE> html to the Viewer pane

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -817,10 +817,12 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 		if (mimeTypes.includes('text/html')) {
 			// Check to see if there are any tags that look like they belong in
 			// a standalone HTML document.
-			if (/<(script|html|body|iframe)/.test(message.data['text/html'])) {
+			const htmlContent = message.data['text/html'];
+			if (/<(script|html|body|iframe|!DOCTYPE)/.test(htmlContent)) {
 				// This looks like standalone HTML.
-				if (message.data['text/html'].includes('<table')) {
-					// Tabular data? Probably best in the Viewer pane.
+				if (htmlContent.includes('<table') ||
+					htmlContent.includes('<!DOCTYPE')) {
+					// Tabular data or document? Probably best in the Viewer pane.
 					return RuntimeOutputKind.ViewerWidget;
 				} else {
 					// Guess that anything else is a plot.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1545,7 +1545,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					if (htmlContent.indexOf('<script') >= 0 ||
 						htmlContent.indexOf('<body') >= 0 ||
 						htmlContent.indexOf('<html') >= 0 ||
-						htmlContent.indexOf('<iframe') >= 0) {
+						htmlContent.indexOf('<iframe') >= 0 ||
+						htmlContent.indexOf('<!doctype') >= 0) {
 						// We only want to render HTML fragments for now; if it has
 						// scripts or looks like it is a self-contained document,
 						// hard pass. In the future, we'll need to render those in a


### PR DESCRIPTION
This change addresses an issue in which HTML that contains a `<!DOCTYPE>` tag but _not_ an `<html>` tag will break the Console. 

The underlying problem is that the naive HTML parser tries to create a React element for the `!DOCTYPE` tag, which creates an exception that causes the whole console component to fail to render.

There are three layers of protection added in this fix:

- First, HTML returned by runtimes is inspected for `!DOCTYPE` tags. If any are found, the HTML is rendered in the Viewer pane (where it can be rendered safely in an iframe) instead of in the console.
- Second, the HTML renderer now safely skips any `!TAGNAME` tags.
- Third, some exception handling in the HTML renderer helps guard against exceptions taking down the whole Console. 

This is probably not the last issue we'll have around the heuristic way we try to render HTML returned from kernels, which is homespun and has a hard time with these kinds of edge cases. 

Addresses https://github.com/posit-dev/positron/issues/6258. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix issue causing some Polars query plans to break the Console when printed (#6258)


### QA Notes

Note that this issue is easiest to reproduce in a browser-based environment. Printing these objects should now result in the query plan to show up in the Viewer, like this:

<img width="454" alt="image" src="https://github.com/user-attachments/assets/c32d8d6e-6e7b-4439-a22f-a37dd905207f" />

Test tags: `@:console`