### PR TITLE
Fix issues around comm and session lifecycles

### DIFF
--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -632,8 +632,14 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 	}
 
 	removeClient(id: string): void {
-		const commOpen = new CommCloseCommand(id);
-		this.sendCommand(commOpen);
+		// Ignore this if the session is already exited; an exited session has
+		// no clients
+		if (this._runtimeState === positron.RuntimeState.Exited) {
+			this.log(`Ignoring request to close comm ${id}; kernel has already exited`, vscode.LogLevel.Debug);
+			return;
+		}
+		const commClose = new CommCloseCommand(id);
+		this.sendCommand(commClose);
 	}
 
 	/**

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -9,7 +9,7 @@ import * as extHostProtocol from './extHost.positron.protocol.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 import { Disposable, LanguageRuntimeMessageType } from '../extHostTypes.js';
-import { RuntimeClientType } from './extHostTypes.positron.js';
+import { RuntimeClientState, RuntimeClientType } from './extHostTypes.positron.js';
 import { ExtHostRuntimeClientInstance } from './extHostClientInstance.js';
 import { ExtensionIdentifier, IExtensionDescription } from '../../../../platform/extensions/common/extensions.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -887,6 +887,9 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		// Dispose the client instance when the runtime exits
 		this._runtimeSessions[handle].onDidChangeRuntimeState(state => {
 			if (state === RuntimeState.Exited) {
+				// Mark the client instance as already closed so disposal
+				// doesn't try to close it
+				clientInstance.setClientState(RuntimeClientState.Closed);
 				clientInstance.dispose();
 			}
 		});


### PR DESCRIPTION
This change addresses a few problems found by @DavisVaughan around session and comm lifecycles. Specifically:

- Comms were trying to close themselves on disposal even after the kernel has exited, leading to some errors logged since  the close requests could not be delivered to the kernel.
- Runtime sessions dispose methods were never being called. This is an artifact from a time when runtime sessions could be started again after fully exiting. Now, "restarting" an exited runtime actually starts a new session. The `dispose()` method is implemented in the language pack and does things like clean up log streamers/file handles/sockets/etc. 

Addresses https://github.com/posit-dev/positron/issues/2908
Addresses https://github.com/posit-dev/positron/issues/3964

While these changes are important for code quality and hygiene, aside from addressing some leaks, there ought to be no observable difference in behavior.

## QA Notes

Since one of these issues results in errors being logged, it should be pretty easy to verify. For the other, the main risk here is that the runtime is going to get prematurely disposed -- once it's disposed we no longer get events, logs, anything (it's inert). So no heavy verification needed, but good to check start/stop/start cycles and make sure we're getting good behavior, events, and appropriate logs.