### PR TITLE
Add react/jsx-sort-props ESLint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -160,7 +160,7 @@ export default tseslint.config(
 			// to find bugs.
 			'react-hooks/exhaustive-deps': 'error',
 			'react/jsx-sort-props': [
-				2,
+				'error',
 				{
 					'callbacksLast': true,
 					'reservedFirst': true,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -159,6 +159,14 @@ export default tseslint.config(
 			// Make react-hooks/exhaustive-deps an error. Bad dependencies leads invariably to hard
 			// to find bugs.
 			'react-hooks/exhaustive-deps': 'error',
+			'react/jsx-sort-props': [
+				2,
+				{
+					'callbacksLast': true,
+					'reservedFirst': true,
+					'shorthandFirst': true
+				}
+			]
 		},
 	},
 	// --- End Positron ---


### PR DESCRIPTION
### Description

This PR enables the `react/jsx-sort-props` ESLint rule with the following configuration:

```
'react/jsx-sort-props': [
	'error',
	{
		'callbacksLast': true,
		'reservedFirst': true,
		'shorthandFirst': true
	}
]
```

Properties that are out of order are highlighted:

<img width="458" alt="image" src="https://github.com/user-attachments/assets/834f93c4-459a-4535-967d-9164e9aac5ab" />

And you can then use ⌘. to fix the error:

Before:
<img width="536" alt="image" src="https://github.com/user-attachments/assets/348e699f-c363-4ae7-b56a-9301f05a3ba1" />

After:
<img width="441" alt="image" src="https://github.com/user-attachments/assets/9ef5f813-59c0-4331-8c57-2ae096f9a3c2" />


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

- N/A