### PR TITLE
Connections: Support for custom icons

### DIFF
--- a/src/vs/workbench/contrib/positronConnections/browser/components/listConnections.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/listConnections.css
@@ -49,6 +49,7 @@
 .connections-list-container .col-icon {
 	flex-shrink: 0;
 	height: 100%;
+	width: 26px;
 }
 
 .connections-list-container .col-name {
@@ -65,6 +66,15 @@
 
 .connections-list-item .col-status.disabled {
 	color: var(--vscode-positronSideActionBar-disabledForeground);
+}
+
+.connections-list-item .col-icon {
+	width: 26px;
+}
+
+.connections-list-item .col-icon > img {
+	width: 26px;
+	height: 26px;
 }
 
 .connections-list-container .col-language {

--- a/src/vs/workbench/contrib/positronConnections/browser/components/listConnections.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/listConnections.tsx
@@ -70,7 +70,7 @@ export const ListConnections = (props: React.PropsWithChildren<ListConnnectionsP
 
 	const ItemEntry = (props: { index: number; style: CSSProperties }) => {
 		const itemProps = instances[props.index];
-		const { language_id, name } = itemProps.metadata;
+		const { language_id, name, icon } = itemProps.metadata;
 
 		return (
 			<div
@@ -81,7 +81,9 @@ export const ListConnections = (props: React.PropsWithChildren<ListConnnectionsP
 				)}
 				onMouseDown={() => setSelectedInstanceId(itemProps.id)}
 			>
-				<div className='col-icon' style={{ width: `${26}px` }}></div>
+				<div className='col-icon' style={{ width: `${26}px` }}>
+					{icon ? <img src={icon} style={{ width: '26px', height: '26px' }}></img> : <></>}
+				</div>
 				<div className='col-name'>{name}</div>
 				<div className='col-language'>
 					{language_id ? languageIdToName(language_id) : ''}

--- a/src/vs/workbench/contrib/positronConnections/browser/components/listConnections.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/listConnections.tsx
@@ -81,8 +81,8 @@ export const ListConnections = (props: React.PropsWithChildren<ListConnnectionsP
 				)}
 				onMouseDown={() => setSelectedInstanceId(itemProps.id)}
 			>
-				<div className='col-icon' style={{ width: `${26}px` }}>
-					{icon ? <img src={icon} style={{ width: '26px', height: '26px' }}></img> : <></>}
+				<div className='col-icon'>
+					{icon ? <img src={icon}></img> : <></>}
 				</div>
 				<div className='col-name'>{name}</div>
 				<div className='col-language'>
@@ -136,7 +136,7 @@ export const ListConnections = (props: React.PropsWithChildren<ListConnnectionsP
 			</ActionBar>
 			<div className='connections-list-container'>
 				<div className='connections-list-header' style={{ height: `${TABLE_HEADER_HEIGHT}px` }}>
-					<div className='col-icon' style={{ width: `${26}px` }}></div>
+					<div className='col-icon'></div>
 					<VerticalSplitter />
 					<div className='col-name'>
 						{localize('positron.listConnections.connection', 'Connection')}

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
@@ -104,6 +104,7 @@
 	flex-grow: 0;
 	flex-shrink: 0;
 	width: 26px;
+	height: 26px;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
@@ -14,6 +14,7 @@
 	cursor: pointer;
 	align-items: center;
 	height: 26px;
+	scrollbar-gutter: stable;
 }
 
 .connections-details {
@@ -88,6 +89,7 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	width: calc(100% - 2px);
+	scrollbar-gutter: stable;
 }
 
 .connections-instance-details .connection-name {

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.css
@@ -111,3 +111,7 @@
 	align-items: center;
 	justify-content: center;
 }
+
+.connections-items-list {
+	scrollbar-gutter: stable;
+}

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -126,11 +126,13 @@ export const SchemaNavigation = (props: React.PropsWithChildren<SchemaNavigation
 				<div className={'connections-instance-details'} style={{ height: DETAILS_BAR_HEIGHT }}>
 					<div className='connection-name'>{name}</div>
 					<div className='connection-language'>{languageIdToName(language_id)}</div>
-					<div className={'connection-icon'}>
-						{
-							icon || <div className='codicon codicon-positron-database-connection'></div>
-						}
-					</div>
+					{
+						icon ?
+							<img className='connection-icon' src={icon}></img> :
+							<div className='connection-icon'>
+								<div className='codicon codicon-positron-database-connection'></div>
+							</div>
+					}
 				</div>
 				<List
 					itemCount={entries.length}

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -179,16 +179,9 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 		props.onToggleExpand(props.item.id);
 	};
 
-	const icon = (() => {
-
-		if (props.item.icon) {
-			return props.item.icon;
-		}
-
-		if (props.item.kind) {
-			// TODO: we'll probably want backends to implement the casting to a set of known
-			// types or provide their own icon.
-			switch (props.item.kind) {
+	const iconClass = (kind?: string) => {
+		if (kind) {
+			switch (kind) {
 				case 'table':
 					return 'positron-table-connection';
 				case 'view':
@@ -214,8 +207,26 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 					}
 			}
 		}
-		// If kind is not known, then no icon is dplsayed by default.
+
 		return '';
+	}
+
+	const icon = (() => {
+		// icon is a base64 encoded png
+		if (props.item.icon) {
+			return <img
+				src={props.item.icon}
+			>
+			</img>;
+		}
+
+		return <div
+			className={positronClassNames(
+				'codicon',
+				`codicon-${iconClass(props.item.kind)}`,
+			)}
+		>
+		</div>
 	})();
 
 	const rowMouseDownHandler = (e: MouseEvent<HTMLElement>) => {
@@ -270,17 +281,13 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 				{props.item.error && <span className='connections-error codicon codicon-error' title={props.item.error}></span>}
 			</div>
 			<div
-				className='connections-icon'
+				className={positronClassNames(
+					'connections-icon',
+					{ 'disabled': props.item.preview === undefined }
+				)}
 				onClick={() => props.item.preview?.()}
 			>
-				<div
-					className={positronClassNames(
-						'codicon',
-						`codicon-${icon}`,
-						{ 'disabled': props.item.preview === undefined }
-					)}
-				>
-				</div>
+				{icon}
 			</div>
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -181,7 +181,7 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 
 	const iconClass = (kind?: string) => {
 		if (kind) {
-			switch (kind) {
+			switch (kind.toLowerCase()) {
 				case 'table':
 					return 'positron-table-connection';
 				case 'view':
@@ -193,11 +193,13 @@ const PositronConnectionsItem = (props: React.PropsWithChildren<PositronConnecti
 				case 'catalog':
 					return 'positron-catalog-connection';
 				case 'field':
-					switch (props.item.dtype) {
+					switch (props.item.dtype?.toLowerCase()) {
 						case 'character':
+						case 'string':
 							return 'positron-data-type-string';
 						case 'integer':
 						case 'numeric':
+						case 'float':
 							return 'positron-data-type-number';
 						case 'boolean':
 						case 'bool':

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -139,10 +139,10 @@ export const SchemaNavigation = (props: React.PropsWithChildren<SchemaNavigation
 					itemSize={26}
 					/* size if the actionbar and the secondary side bar combined) */
 					height={height - ACTION_BAR_HEIGHT - DETAILS_BAR_HEIGHT}
+					className='connections-items-list'
 					width={'100%'}
 					itemKey={index => entries[index].id}
 					innerRef={innerRef}
-					style={{ scrollbarGutter: 'stable' }}
 				>
 					{ItemEntry}
 				</List>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -139,9 +139,10 @@ export const SchemaNavigation = (props: React.PropsWithChildren<SchemaNavigation
 					itemSize={26}
 					/* size if the actionbar and the secondary side bar combined) */
 					height={height - ACTION_BAR_HEIGHT - DETAILS_BAR_HEIGHT}
-					width={'calc(100% - 2px)'}
+					width={'100%'}
 					itemKey={index => entries[index].id}
 					innerRef={innerRef}
+					style={{ scrollbarGutter: 'stable' }}
 				>
 					{ItemEntry}
 				</List>


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6187

Add support for custom icons in the new connections pane.
The [connections contract](https://rstudio.github.io/rstudio-extensions/connections-contract.html#examples) allows connections to provide a custom icon, which should be a full path to a squared png file.

![CleanShot 2025-02-11 at 11 11 06@2x](https://github.com/user-attachments/assets/3008cd0a-5a20-4355-be1a-afa95afe6c73)

This PR adds support for those icons in a few different places:

![CleanShot 2025-02-11 at 11 12 34@2x](https://github.com/user-attachments/assets/9f874353-d8a8-4247-8b9b-cbae7f3bbb4f)

![CleanShot 2025-02-11 at 11 12 44@2x](https://github.com/user-attachments/assets/749d673f-7b65-4df7-986d-bf02e227a456)

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Support for custom icons in the connections pane (https://github.com/posit-dev/positron/issues/6187)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

Not many packages support custom icons. I think the easiest setup is to use [`bigrquery`](https://bigrquery.r-dbi.org):

```
library(DBI)

con <- dbConnect(
  bigrquery::bigquery(),
  project = "publicdata",
  dataset = "samples",
  billing = "gcp-project-id"
)
```

Where billing is a GCP project id.

HEre's another snippet that might be useful for reproducing:

```
install.packages("FactoMineR")
remotes::install_github("ColinFay/fryingpane")

library(fryingpane)
cook("FactoMineR")
```

@:connections