### PR TITLE
python variables pane: don't hide `_` if it was changed by the user

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/conftest.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 

--- a/extensions/positron-python/python_files/posit/positron/tests/conftest.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/conftest.py
@@ -75,7 +75,7 @@ def _prepare_shell(shell: PositronShell) -> None:
     #       manually add them to user_ns_hidden to replicate running in Positron.
     shell.user_ns_hidden.update(
         {
-            k: None
+            k: ""
             for k in [
                 "__name__",
                 "__doc__",
@@ -134,6 +134,8 @@ def shell(kernel) -> Iterable[PositronShell]:
     new_user_ns_keys = set(shell.user_ns.keys()) - user_ns_keys
     for key in new_user_ns_keys:
         del shell.user_ns[key]
+    if "_" in shell.user_ns:
+        del shell.user_ns["_"]
 
 
 @pytest.fixture

--- a/extensions/positron-python/python_files/posit/positron/tests/test_variables.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_variables.py
@@ -368,7 +368,7 @@ async def test_clear(
     assert "x" not in shell.user_ns
     assert "y" not in shell.user_ns
 
-    # ...except hidden variables, because %reset doesn't touch those
+    # ...except hidden variables, because %reset -s doesn't touch those
     assert "_" in shell.user_ns
 
 

--- a/test/e2e/tests/variables/variables-pane.test.ts
+++ b/test/e2e/tests/variables/variables-pane.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/test/e2e/tests/variables/variables-pane.test.ts
+++ b/test/e2e/tests/variables/variables-pane.test.ts
@@ -24,6 +24,7 @@ test.describe('Variables Pane', {
 		await executeCode('x=1');
 		await executeCode('y=10');
 		await executeCode('z=100');
+		await executeCode('_=1000');
 
 		logger.log('Entered lines in console defining variables');
 		await app.workbench.console.logConsoleContents();
@@ -33,6 +34,7 @@ test.describe('Variables Pane', {
 		expect(variablesMap.get('x')).toStrictEqual({ value: '1', type: 'int' });
 		expect(variablesMap.get('y')).toStrictEqual({ value: '10', type: 'int' });
 		expect(variablesMap.get('z')).toStrictEqual({ value: '100', type: 'int' });
+		expect(variablesMap.get('_')).toStrictEqual({ value: '1000', type: 'int' });
 
 	});
 
@@ -78,5 +80,3 @@ test.describe('Variables Pane', {
 		expect((await groupList).length).toBe(1);
 	});
 });
-
-


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Addresses #3366. This PR changes the Variables pane behavior in the Python extension so that it no longer hides the `_` variable if it was explicitly changed by the user.

An example: type `_ = 1` into the console. Before this change, `_` wouldn't show up. Now it does.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Allowed `_` to show up in the Python Variables pane if defined by the user. (#3366)


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

Try messing around with the `_` variable; it should work like other variables in the Variables pane. Examples:
```py
_ = 1
_ = 2
_ = [1] * 1000
del _
from ibis import _
```
(the last one requires `pip install ibis-framework`)

@:console @:variables