### PR TITLE
Remove `git credential` workflow and allow download w/o PAT

### DIFF
--- a/extensions/positron-python/scripts/install-pet.ts
+++ b/extensions/positron-python/scripts/install-pet.ts
@@ -104,11 +104,10 @@ async function executeCommand(command: string, stdin?: string): Promise<{ stdout
  * Downloads the specified version of Python Environment Tool and replaces the local directory.
  *
  * @param version The version of Python Environment Tool to download.
- * @param githubPat A Github Personal Access Token with the appropriate rights
+ * @param githubPat An optional Github Personal Access Token with the appropriate rights
  *  to download the release.
- * @param gitCredential Whether the PAT originated from the `git credential` command.
  */
-async function downloadAndReplacePet(version: string, githubPat: string, gitCredential: boolean): Promise<void> {
+async function downloadAndReplacePet(version: string, githubPat: string | undefined): Promise<void> {
     try {
         const headers: Record<string, string> = {
             Accept: 'application/vnd.github.v3.raw', // eslint-disable-line
@@ -127,59 +126,6 @@ async function downloadAndReplacePet(version: string, githubPat: string, gitCred
         };
 
         const response = (await httpsGetAsync(requestOptions as any)) as any;
-
-        // Special handling for PATs originating from `git credential`.
-        if (gitCredential && response.statusCode === 200) {
-            // If the PAT hasn't been approved yet, do so now. This stores the credential in
-            // the system credential store (or whatever `git credential` uses on the system).
-            // Without this step, the user will be prompted for a username and password the
-            // next time they try to download PET.
-            const { stdout, stderr } = await executeCommand(
-                'git credential approve',
-                `protocol=https\n` +
-                    `host=github.com\n` +
-                    `path=/repos/posit-dev/positron-pet-builds/releases\n` +
-                    `username=\n` +
-                    `password=${githubPat}\n`,
-            );
-            console.log(stdout);
-            if (stderr) {
-                console.warn(
-                    `Unable to approve PAT. You may be prompted for a username and ` +
-                        `password the next time you download Python Environment Tools.`,
-                );
-                console.error(stderr);
-            }
-        } else if (gitCredential && response.statusCode > 400 && response.statusCode < 500) {
-            // This handles the case wherein we got an invalid PAT from `git credential`. In this
-            // case we need to clean up the PAT from the credential store, so that we don't
-            // continue to use it.
-            const { stdout, stderr } = await executeCommand(
-                'git credential reject',
-                `protocol=https\n` +
-                    `host=github.com\n` +
-                    `path=/repos/posit-dev/positron-pet-builds/releases\n` +
-                    `username=\n` +
-                    `password=${githubPat}\n`,
-            );
-            console.log(stdout);
-            if (stderr) {
-                console.error(stderr);
-                throw new Error(
-                    `The stored PAT returned by 'git credential' is invalid, but\n` +
-                        `could not be removed. Please manually remove the PAT from 'git credential'\n` +
-                        `for the host 'github.com'`,
-                );
-            }
-            throw new Error(
-                `The PAT returned by 'git credential' is invalid. Python Environment Tool cannot be\n` +
-                    `downloaded.\n\n` +
-                    `Check to be sure that your Personal Access Token:\n` +
-                    '- Has the `repo` scope\n' +
-                    '- Is not expired\n' +
-                    '- Has been authorized for the "posit-dev" organization on Github (Configure SSO)\n',
-            );
-        }
 
         let responseBody = '';
 
@@ -300,13 +246,13 @@ async function main() {
         return;
     }
 
-    // We need a Github Personal Access Token (PAT) to download PET. Because this is sensitive
-    // information, there are a lot of ways to set it. We try the following in order:
+    // We can optionally use a Github Personal Access Token (PAT) to download
+    // PET. Because this is sensitive information, there are a lot of ways to
+    // set it. We try the following in order:
 
     // (1) The GITHUB_PAT environment variable.
     // (2) The POSITRON_GITHUB_PAT environment variable.
     // (3) The git config setting 'credential.https://api.github.com.token'.
-    // (4) The git credential store.
 
     // (1) Get the GITHUB_PAT from the environment.
     let githubPat = process.env.GITHUB_PAT;
@@ -331,50 +277,11 @@ async function main() {
                 console.log(`Using Github PAT from git config setting 'credential.https://api.github.com.token'.`);
             }
         } catch (error) {
-            // We don't care if this fails; we'll try `git credential` next.
+            // We don't care if this fails; we'll try without a PAT.
         }
     }
 
-    // (4) If no GITHUB_PAT is set, try to get it from git credential.
-    if (!githubPat) {
-        // Explain to the user what's about to happen.
-        console.log(
-            `Attempting to retrieve a Github Personal Access Token from git in order\n` +
-                `to download Python Environment Tool ${packageJsonVersion}. If you are prompted for a username and\n` +
-                `password, enter your Github username and a Personal Access Token with the\n` +
-                `'repo' scope. You can read about how to create a Personal Access Token here: \n` +
-                `\n` +
-                `https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens\n` +
-                `\n` +
-                `If you don't want to set up a Personal Access Token now, just press Enter twice to set \n` +
-                `a blank value for the password. Python Environment Tool will not be downloaded, but you will still be\n` +
-                `able to run Positron with Python support.\n` +
-                `\n` +
-                `You can set a PAT later by running yarn again and supplying the PAT at this prompt,\n` +
-                `or by running 'git config credential.https://api.github.com.token YOUR_GITHUB_PAT'\n`,
-        );
-        const { stdout } = await executeCommand(
-            'git credential fill',
-            `protocol=https\n host=github.com\n path=/repos/posit-dev/pet/releases\n`,
-        );
-
-        gitCredential = true;
-        // Extract the `password = ` line from the output.
-        const passwordLine = stdout.split('\n').find((line: string) => line.startsWith('password='));
-        if (passwordLine) {
-            [, githubPat] = passwordLine.split('=');
-            console.log(`Using Github PAT returned from 'git credential'.`);
-        }
-    }
-
-    if (!githubPat) {
-        throw new Error(
-            `No Github PAT was found. Unable to download PET ${packageJsonVersion}.\n` +
-                `You can still run Positron with Python Support.`,
-        );
-    }
-
-    await downloadAndReplacePet(packageJsonVersion, githubPat, gitCredential);
+    await downloadAndReplacePet(packageJsonVersion, githubPat);
 }
 
 main().catch((error) => {

--- a/extensions/positron-python/scripts/install-pet.ts
+++ b/extensions/positron-python/scripts/install-pet.ts
@@ -256,7 +256,6 @@ async function main() {
 
     // (1) Get the GITHUB_PAT from the environment.
     let githubPat = process.env.GITHUB_PAT;
-    let gitCredential = false;
     if (githubPat) {
         console.log('Using Github PAT from environment variable GITHUB_PAT.');
     } else {

--- a/extensions/positron-r/scripts/install-kernel.ts
+++ b/extensions/positron-r/scripts/install-kernel.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -88,13 +88,11 @@ async function executeCommand(command: string, stdin?: string):
  * Downloads the specified version of Ark and replaces the local binary.
  *
  * @param version The version of Ark to download.
- * @param githubPat A Github Personal Access Token with the appropriate rights
+ * @param githubPat An optional Github Personal Access Token with the appropriate rights
  *  to download the release.
- * @param gitCredential Whether the PAT originated from the `git credential` command.
  */
 async function downloadAndReplaceArk(version: string,
-	githubPat: string,
-	gitCredential: boolean): Promise<void> {
+	githubPat: string | undefined): Promise<void> {
 
 	try {
 		const headers: Record<string, string> = {
@@ -114,51 +112,6 @@ async function downloadAndReplaceArk(version: string,
 		};
 
 		const response = await httpsGetAsync(requestOptions as any) as any;
-
-		// Special handling for PATs originating from `git credential`.
-		if (gitCredential && response.statusCode === 200) {
-			// If the PAT hasn't been approved yet, do so now. This stores the credential in
-			// the system credential store (or whatever `git credential` uses on the system).
-			// Without this step, the user will be prompted for a username and password the
-			// next time they try to download Ark.
-			const { stdout, stderr } =
-				await executeCommand('git credential approve',
-					`protocol=https\n` +
-					`host=github.com\n` +
-					`path=/repos/posit-dev/ark/releases\n` +
-					`username=\n` +
-					`password=${githubPat}\n`);
-			console.log(stdout);
-			if (stderr) {
-				console.warn(`Unable to approve PAT. You may be prompted for a username and ` +
-					`password the next time you download Ark.`);
-				console.error(stderr);
-			}
-		} else if (gitCredential && response.statusCode > 400 && response.statusCode < 500) {
-			// This handles the case wherein we got an invalid PAT from `git credential`. In this
-			// case we need to clean up the PAT from the credential store, so that we don't
-			// continue to use it.
-			const { stdout, stderr } =
-				await executeCommand('git credential reject',
-					`protocol=https\n` +
-					`host=github.com\n` +
-					`path=/repos/posit-dev/ark/releases\n` +
-					`username=\n` +
-					`password=${githubPat}\n`);
-			console.log(stdout);
-			if (stderr) {
-				console.error(stderr);
-				throw new Error(`The stored PAT returned by 'git credential' is invalid, but\n` +
-					`could not be removed. Please manually remove the PAT from 'git credential'\n` +
-					`for the host 'github.com'`);
-			}
-			throw new Error(`The PAT returned by 'git credential' is invalid. Ark cannot be\n` +
-				`downloaded.\n\n` +
-				`Check to be sure that your Personal Access Token:\n` +
-				'- Has the `repo` scope\n' +
-				'- Is not expired\n' +
-				'- Has been authorized for the "posit-dev" organization on Github (Configure SSO)\n');
-		}
 
 		let responseBody = '';
 
@@ -290,17 +243,16 @@ async function main() {
 		return;
 	}
 
-	// We need a Github Personal Access Token (PAT) to download Ark. Because this is sensitive
-	// information, there are a lot of ways to set it. We try the following in order:
+	// We can optionally use a Github Personal Access Token (PAT) to download
+	// Ark. Because this is sensitive information, there are a lot of ways to
+	// set it. We try the following in order:
 
 	// (1) The GITHUB_PAT environment variable.
 	// (2) The POSITRON_GITHUB_PAT environment variable.
 	// (3) The git config setting 'credential.https://api.github.com.token'.
-	// (4) The git credential store.
 
 	// (1) Get the GITHUB_PAT from the environment.
 	let githubPat = process.env.GITHUB_PAT;
-	let gitCredential = false;
 	if (githubPat) {
 		console.log('Using Github PAT from environment variable GITHUB_PAT.');
 	} else {
@@ -323,48 +275,11 @@ async function main() {
 					`'credential.https://api.github.com.token'.`);
 			}
 		} catch (error) {
-			// We don't care if this fails; we'll try `git credential` next.
+			// We don't care if this fails; we'll without a PAT.
 		}
 	}
 
-	// (4) If no GITHUB_PAT is set, try to get it from git credential.
-	if (!githubPat) {
-		// Explain to the user what's about to happen.
-		console.log(`Attempting to retrieve a Github Personal Access Token from git in order\n` +
-			`to download Ark ${packageJsonVersion}. If you are prompted for a username and\n` +
-			`password, enter your Github username and a Personal Access Token with the\n` +
-			`'repo' scope. You can read about how to create a Personal Access Token here: \n` +
-			`\n` +
-			`https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens\n` +
-			`\n` +
-			`If you don't want to set up a Personal Access Token now, just press Enter twice to set \n` +
-			`a blank value for the password. Ark will not be downloaded, but you will still be\n` +
-			`able to run Positron without R support.\n` +
-			`\n` +
-			`You can set a PAT later by running yarn again and supplying the PAT at this prompt,\n` +
-			`or by running 'git config credential.https://api.github.com.token YOUR_GITHUB_PAT'\n`);
-		const { stdout, stderr } =
-			await executeCommand('git credential fill',
-				`protocol=https\n` +
-				`host=github.com\n` +
-				`path=/repos/posit-dev/ark/releases\n`);
-
-		gitCredential = true;
-		// Extract the `password = ` line from the output.
-		const passwordLine = stdout.split('\n').find(
-			(line: string) => line.startsWith('password='));
-		if (passwordLine) {
-			githubPat = passwordLine.split('=')[1];
-			console.log(`Using Github PAT returned from 'git credential'.`);
-		}
-	}
-
-	if (!githubPat) {
-		throw new Error(`No Github PAT was found. Unable to download Ark ${packageJsonVersion}.\n` +
-			`You can still run Positron without R support.`);
-	}
-
-	await downloadAndReplaceArk(packageJsonVersion, githubPat, gitCredential);
+	await downloadAndReplaceArk(packageJsonVersion, githubPat);
 }
 
 main().catch((error) => {

--- a/extensions/positron-supervisor/scripts/install-kallichore-server.ts
+++ b/extensions/positron-supervisor/scripts/install-kallichore-server.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -99,18 +99,16 @@ async function executeCommand(command: string, stdin?: string):
  * Downloads the specified version of Kallichore and replaces the local binary.
  *
  * @param version The version of Kallichore to download.
- * @param githubPat A Github Personal Access Token with the appropriate rights
+ * @param githubPat An optional Github Personal Access Token with the appropriate rights
  *  to download the release.
- * @param gitCredential Whether the PAT originated from the `git credential` command.
  */
 async function downloadAndReplaceKallichore(version: string,
-	githubPat: string,
-	gitCredential: boolean): Promise<void> {
+	githubPat: string | undefined): Promise<void> {
 
 	try {
 		const headers: Record<string, string> = {
-			'Accept': 'application/vnd.github.v3.raw', // eslint-disable-line
-			'User-Agent': 'positron-kallichore-downloader' // eslint-disable-line
+			'Accept': 'application/vnd.github.v3.raw',
+			'User-Agent': 'positron-kallichore-downloader'
 		};
 		// If we have a githubPat, set it for better rate limiting.
 		if (githubPat) {
@@ -125,51 +123,6 @@ async function downloadAndReplaceKallichore(version: string,
 		};
 
 		const response = await httpsGetAsync(requestOptions as any) as any;
-
-		// Special handling for PATs originating from `git credential`.
-		if (gitCredential && response.statusCode === 200) {
-			// If the PAT hasn't been approved yet, do so now. This stores the credential in
-			// the system credential store (or whatever `git credential` uses on the system).
-			// Without this step, the user will be prompted for a username and password the
-			// next time they try to download Kallichore.
-			const { stdout, stderr } =
-				await executeCommand('git credential approve',
-					`protocol=https\n` +
-					`host=github.com\n` +
-					`path=/repos/posit-dev/kallichore-builds/releases\n` +
-					`username=\n` +
-					`password=${githubPat}\n`);
-			console.log(stdout);
-			if (stderr) {
-				console.warn(`Unable to approve PAT. You may be prompted for a username and ` +
-					`password the next time you download Kallichore.`);
-				console.error(stderr);
-			}
-		} else if (gitCredential && response.statusCode > 400 && response.statusCode < 500) {
-			// This handles the case wherein we got an invalid PAT from `git credential`. In this
-			// case we need to clean up the PAT from the credential store, so that we don't
-			// continue to use it.
-			const { stdout, stderr } =
-				await executeCommand('git credential reject',
-					`protocol=https\n` +
-					`host=github.com\n` +
-					`path=/repos/posit-dev/kallichore-builds/releases\n` +
-					`username=\n` +
-					`password=${githubPat}\n`);
-			console.log(stdout);
-			if (stderr) {
-				console.error(stderr);
-				throw new Error(`The stored PAT returned by 'git credential' is invalid, but\n` +
-					`could not be removed. Please manually remove the PAT from 'git credential'\n` +
-					`for the host 'github.com'`);
-			}
-			throw new Error(`The PAT returned by 'git credential' is invalid. Kallichore cannot be\n` +
-				`downloaded.\n\n` +
-				`Check to be sure that your Personal Access Token:\n` +
-				'- Has the `repo` scope\n' +
-				'- Is not expired\n' +
-				'- Has been authorized for the "posit-dev" organization on Github (Configure SSO)\n');
-		}
 
 		let responseBody = '';
 
@@ -302,17 +255,16 @@ async function main() {
 		return;
 	}
 
-	// We need a Github Personal Access Token (PAT) to download Kallichore. Because this is sensitive
-	// information, there are a lot of ways to set it. We try the following in order:
+	// We can optionally use a Github Personal Access Token (PAT) to download
+	// Kallichore. Because this is sensitive information, there are a lot of
+	// ways to set it. We try the following in order:
 
 	// (1) The GITHUB_PAT environment variable.
 	// (2) The POSITRON_GITHUB_PAT environment variable.
 	// (3) The git config setting 'credential.https://api.github.com.token'.
-	// (4) The git credential store.
 
 	// (1) Get the GITHUB_PAT from the environment.
 	let githubPat = process.env.GITHUB_PAT;
-	let gitCredential = false;
 	if (githubPat) {
 		console.log('Using Github PAT from environment variable GITHUB_PAT.');
 	} else {
@@ -337,49 +289,11 @@ async function main() {
 				console.error(stderr);
 			}
 		} catch (error) {
-			// We don't care if this fails; we'll try `git credential` next.
+			// We don't care if this fails; we'll try without a PAT.
 		}
 	}
 
-	// (4) If no GITHUB_PAT is set, try to get it from git credential.
-	if (!githubPat) {
-		// Explain to the user what's about to happen.
-		console.log(`Attempting to retrieve a Github Personal Access Token from git in order\n` +
-			`to download Kallichore ${packageJsonVersion}. If you are prompted for a username and\n` +
-			`password, enter your Github username and a Personal Access Token with the\n` +
-			`'repo' scope. You can read about how to create a Personal Access Token here: \n` +
-			`\n` +
-			`https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens\n` +
-			`\n` +
-			`If you don't want to set up a Personal Access Token now, just press Enter twice to set \n` +
-			`a blank value for the password. Kallichore will not be downloaded. \n` +
-			`\n` +
-			`You can set a PAT later by running yarn again and supplying the PAT at this prompt,\n` +
-			`or by running 'git config credential.https://api.github.com.token YOUR_GITHUB_PAT'\n`);
-		const { stdout, stderr } =
-			await executeCommand('git credential fill',
-				`protocol=https\n` +
-				`host=github.com\n` +
-				`path=/repos/posit-dev/kallichore-builds/releases\n`);
-
-		gitCredential = true;
-		// Extract the `password = ` line from the output.
-		const passwordLine = stdout.split('\n').find(
-			(line: string) => line.startsWith('password='));
-		if (passwordLine) {
-			githubPat = passwordLine.split('=')[1];
-			console.log(`Using Github PAT returned from 'git credential'.`);
-		} else {
-			console.error(stderr);
-		}
-	}
-
-	if (!githubPat) {
-		console.log(`No Github PAT was found. Unable to download Kallichore ${packageJsonVersion}.`);
-		return;
-	}
-
-	await downloadAndReplaceKallichore(packageJsonVersion, githubPat, gitCredential);
+	await downloadAndReplaceKallichore(packageJsonVersion, githubPat);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
This changes makes it possible to build Positron without specifying a Github Personal Access Token by allowing the scripts that install Ark, PET, and Kallichore to run without credentials.

It also removes the `git credential` workflow since it is not possible to use it non-interactively; if you want to supply a token, it's now necessary to do so via an environment variable or Git configuration value.

Addresses https://github.com/posit-dev/positron/issues/6083