### PR TITLE
Fix React ESLint errors

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -165,24 +165,24 @@ export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProp
 	return (
 		<button
 			ref={buttonRef}
+			aria-disabled={props.disabled ? 'true' : undefined}
+			aria-label={props.ariaLabel}
 			className={positronClassNames(
 				'positron-button',
 				props.className,
 				{ 'disabled': props.disabled }
 			)}
-			style={props.style}
-			tabIndex={props.tabIndex ?? 0}
 			disabled={props.disabled}
 			role='button'
-			aria-label={props.ariaLabel}
-			aria-disabled={props.disabled ? 'true' : undefined}
-			onFocus={props.onFocus}
+			style={props.style}
+			tabIndex={props.tabIndex ?? 0}
 			onBlur={props.onBlur}
-			onKeyDown={keyDownHandler}
 			onClick={clickHandler}
+			onFocus={props.onFocus}
+			onKeyDown={keyDownHandler}
+			onMouseDown={mouseDownHandler}
 			onMouseEnter={mouseEnterHandler}
 			onMouseLeave={mouseLeaveHandler}
-			onMouseDown={mouseDownHandler}
 		>
 			{props.children}
 		</button>

--- a/src/vs/base/browser/ui/positronComponents/button/positronButton.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/positronButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -106,16 +106,16 @@ export const PositronButton = forwardRef<HTMLDivElement, PropsWithChildren<Props
 	return (
 		<div
 			ref={ref}
+			aria-disabled={props.disabled ? 'true' : undefined}
+			aria-label={props.ariaLabel}
 			className={positronClassNames(
 				props.className,
 				{ 'disabled': props.disabled }
 			)}
-			tabIndex={0}
 			role='button'
-			aria-label={props.ariaLabel}
-			aria-disabled={props.disabled ? 'true' : undefined}
-			onKeyDown={keyDownHandler}
+			tabIndex={0}
 			onClick={clickHandler}
+			onKeyDown={keyDownHandler}
 			onMouseDown={mouseDownHandler}
 		>
 			{props.children}

--- a/src/vs/base/browser/ui/positronComponents/scrollable/Scrollable.tsx
+++ b/src/vs/base/browser/ui/positronComponents/scrollable/Scrollable.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -111,7 +111,7 @@ export const Scrollable = (props: PropsWithChildren<ScrollableProps>) => {
 	};
 
 	return (
-		<div className={positronClassNames('scrollable', { 'grab': !grabbing, 'grabbing': grabbing })} ref={scrollableRef} onMouseMoveCapture={panImage} onMouseDown={updateCursor} onMouseUp={updateCursor}>
+		<div ref={scrollableRef} className={positronClassNames('scrollable', { 'grab': !grabbing, 'grabbing': grabbing })} onMouseDown={updateCursor} onMouseMoveCapture={panImage} onMouseUp={updateCursor}>
 			{props.children}
 		</div >
 	);

--- a/src/vs/base/browser/ui/positronComponents/splitters/verticalSplitter.tsx
+++ b/src/vs/base/browser/ui/positronComponents/splitters/verticalSplitter.tsx
@@ -385,9 +385,9 @@ export const VerticalSplitter = ({
 					left: collapsible ? -1 : -(sashWidth / 2),
 					width: collapsible ? sashWidth + 2 : sashWidth
 				}}
+				onPointerDown={sashPointerDownHandler}
 				onPointerEnter={sashPointerEnterHandler}
 				onPointerLeave={sashPointerLeaveHandler}
-				onPointerDown={sashPointerDownHandler}
 			>
 				{showSash && (hovering || resizing) &&
 					<div
@@ -406,12 +406,12 @@ export const VerticalSplitter = ({
 				<Button
 					ref={expandCollapseButtonRef}
 					className='expand-collapse-button'
+					mouseTrigger={MouseTrigger.MouseDown}
 					style={{
 						top: EXPAND_COLLAPSE_BUTTON_TOP,
 						width: EXPAND_COLLAPSE_BUTTON_SIZE,
 						height: EXPAND_COLLAPSE_BUTTON_SIZE
 					}}
-					mouseTrigger={MouseTrigger.MouseDown}
 					onPressed={expandCollapseButtonPressedHandler}
 				>
 					<div

--- a/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -77,7 +77,7 @@ export const ActionBarButton = forwardRef<
 	 */
 	const ActionBarButtonFace = () => {
 		return (
-			<div className='action-bar-button-face' aria-hidden='true'>
+			<div aria-hidden='true' className='action-bar-button-face'>
 				{props.iconId && (
 					<div
 						className={positronClassNames(
@@ -114,16 +114,16 @@ export const ActionBarButton = forwardRef<
 		return (
 			<Button
 				ref={buttonRef}
-				hoverManager={context.hoverManager}
+				ariaLabel={ariaLabel}
 				className={positronClassNames(
 					'action-bar-button',
 					{ 'fade-in': optionalBoolean(props.fadeIn) },
 					{ 'checked': optionalBoolean(props.checked) }
 				)}
-				ariaLabel={ariaLabel}
-				tooltip={props.tooltip}
 				disabled={props.disabled}
+				hoverManager={context.hoverManager}
 				mouseTrigger={props.mouseTrigger}
+				tooltip={props.tooltip}
 				onMouseEnter={props.onMouseEnter}
 				onMouseLeave={props.onMouseLeave}
 				onPressed={props.onPressed}
@@ -141,12 +141,12 @@ export const ActionBarButton = forwardRef<
 			)}>
 				<Button
 					ref={buttonRef}
-					hoverManager={context.hoverManager}
-					className='action-bar-button-action-button'
 					ariaLabel={ariaLabel}
-					tooltip={props.tooltip}
+					className='action-bar-button-action-button'
 					disabled={props.disabled}
+					hoverManager={context.hoverManager}
 					mouseTrigger={props.mouseTrigger}
+					tooltip={props.tooltip}
 					onMouseEnter={props.onMouseEnter}
 					onMouseLeave={props.onMouseLeave}
 					onPressed={props.onPressed}
@@ -155,11 +155,11 @@ export const ActionBarButton = forwardRef<
 				</Button>
 				<Button
 					ref={dropdownButtonRef}
-					hoverManager={context.hoverManager}
-					className='action-bar-button-drop-down-button'
 					ariaLabel={props.dropdownAriaLabel}
-					tooltip={props.dropdownTooltip}
+					className='action-bar-button-drop-down-button'
+					hoverManager={context.hoverManager}
 					mouseTrigger={MouseTrigger.MouseDown}
+					tooltip={props.dropdownTooltip}
 					onPressed={props.onDropdownPressed}
 				>
 					<div className='action-bar-button-drop-down-arrow codicon codicon-positron-drop-down-arrow' />

--- a/src/vs/platform/positronActionBar/browser/components/actionBarCommandButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarCommandButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -88,8 +88,8 @@ export const ActionBarCommandButton = (props: ActionBarCommandButtonProps) => {
 		<ActionBarButton
 			ref={buttonRef}
 			{...props}
-			tooltip={tooltip}
 			disabled={props.disabled || commandDisabled}
+			tooltip={tooltip}
 			onPressed={() =>
 				positronActionBarContext.commandService.executeCommand(props.commandId)
 			}

--- a/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -54,13 +54,13 @@ export const ActionBarFilter = (props: ActionBarFilterProps) => {
 			<div className={positronClassNames('action-bar-filter-input', { 'focused': focused })}>
 				<input
 					ref={inputRef}
-					type='text'
 					className='text-input'
 					placeholder={(() => localize('positronFilterPlacehold', "filter"))()}
+					type='text'
 					value={filterText}
-					onFocus={() => setFocused(true)}
 					onBlur={() => setFocused(false)}
-					onChange={changeHandler} />
+					onChange={changeHandler}
+					onFocus={() => setFocused(true)} />
 				{filterText !== '' && (
 					<button className='clear-button'>
 						<div className={'codicon codicon-positron-search-cancel'} onClick={buttonClearClickHandler} />

--- a/src/vs/platform/positronActionBar/browser/components/actionBarFind.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFind.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -56,21 +56,21 @@ export const ActionBarFind = (props: ActionBarFindProps) => {
 			<div className={positronClassNames('action-bar-find-input', { 'focused': focused })}>
 				<input
 					ref={inputRef}
-					type='text'
 					className='text-input'
 					placeholder={(() => localize('positronFindPlacehold', "find"))()}
+					type='text'
 					value={findText}
-					onFocus={() => setFocused(true)}
 					onBlur={() => setFocused(false)}
-					onChange={changeHandler} />
+					onChange={changeHandler}
+					onFocus={() => setFocused(true)} />
 				{findText !== '' && (
 					<button className='clear-button'>
 						<div className={'codicon codicon-positron-search-cancel'} onClick={buttonClearClickHandler} />
 					</button>
 				)}
 			</div>
-			<ActionBarButton iconId='chevron-up' align='right' tooltip={(() => localize('positronFindPrevious', "Find previous"))()} disabled={!props.findResults} onPressed={() => props.onFindPrevious!()} />
-			<ActionBarButton iconId='chevron-down' align='right' tooltip={(() => localize('positronFindNext', "Find next"))()} disabled={!props.findResults} onPressed={() => props.onFindNext!()} />
+			<ActionBarButton align='right' disabled={!props.findResults} iconId='chevron-up' tooltip={(() => localize('positronFindPrevious', "Find previous"))()} onPressed={() => props.onFindPrevious!()} />
+			<ActionBarButton align='right' disabled={!props.findResults} iconId='chevron-down' tooltip={(() => localize('positronFindNext', "Find next"))()} onPressed={() => props.onFindNext!()} />
 		</div>
 	);
 };

--- a/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -131,6 +131,7 @@ export const ActionBarMenuButton = (props: ActionBarMenuButtonProps) => {
 			{...props}
 			dropdownIndicator={props.dropdownIndicator ?? 'enabled'}
 			mouseTrigger={MouseTrigger.MouseDown}
+			onDropdownPressed={async () => await showMenu()}
 			onPressed={async () => {
 				if (props.dropdownIndicator !== 'enabled-split') {
 					await showMenu();
@@ -139,7 +140,6 @@ export const ActionBarMenuButton = (props: ActionBarMenuButtonProps) => {
 					defaultAction ? defaultAction.run() : actions[0].run();
 				}
 			}}
-			onDropdownPressed={async () => await showMenu()}
 		/>
 	);
 };

--- a/src/vs/platform/positronActionBar/browser/components/actionBarSearch.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarSearch.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -52,12 +52,12 @@ export const ActionBarSearch = (props: ActionBarSearchProps) => {
 			</button>
 			<input
 				ref={inputRef}
-				type='text'
 				className='text-input'
 				placeholder={props.placeholder}
-				onFocus={() => setFocused(true)}
+				type='text'
 				onBlur={() => setFocused(false)}
-				onChange={(e) => setSearchText(e.target.value)} />
+				onChange={(e) => setSearchText(e.target.value)}
+				onFocus={() => setFocused(true)} />
 			<button className='action-bar-search-button' onClick={cancelButtonClickHandler}>
 				<div className={positronClassNames('action-bar-search-button-icon', 'codicon', 'codicon-positron-search-cancel', { 'disabled': searchText === '' })} />
 			</button>

--- a/src/vs/platform/positronActionBar/browser/components/actionBarSeparator.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarSeparator.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -27,11 +27,11 @@ export const ActionBarSeparator = (props: ActionBarSeparatorProps) => {
 	// Render.
 	return (
 		<div
+			aria-hidden='true'
 			className={positronClassNames(
 				'action-bar-separator',
 				{ 'fade-in': optionalBoolean(props.fadeIn) }
-			)}
-			aria-hidden='true' >
+			)} >
 			<div className='action-bar-separator-icon codicon codicon-positron-separator' />
 		</div>
 	);

--- a/src/vs/platform/positronActionBar/browser/positronActionBar.tsx
+++ b/src/vs/platform/positronActionBar/browser/positronActionBar.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -127,12 +127,12 @@ export const PositronActionBar = (props: PropsWithChildren<PositronActionBarProp
 	return (
 		<div
 			className={classNames}
-			onKeyDown={props.nestedActionBar ? undefined : keyDownHandler}
 			style={{
 				gap: optionalValue(props.gap, 0),
 				paddingLeft: optionalValue(props.paddingLeft, 0),
 				paddingRight: optionalValue(props.paddingRight, 0)
-			}}>
+			}}
+			onKeyDown={props.nestedActionBar ? undefined : keyDownHandler}>
 			{props.children}
 		</div>
 	);

--- a/src/vs/platform/positronActionBar/browser/useRegisterWithActionBar.tsx
+++ b/src/vs/platform/positronActionBar/browser/useRegisterWithActionBar.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -27,5 +27,5 @@ export const useRegisterWithActionBar = (refs: MutableRefObject<HTMLElement>[]) 
 		return () => {
 			refs.forEach(ref => focusableComponents.delete(ref.current));
 		};
-	}, []);
+	}, [focusableComponents, refs]);
 };

--- a/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -105,9 +105,9 @@ export class EditorActionBarControl extends Disposable {
 				configurationService={this._configurationService}
 				contextKeyService={this._contextKeyService}
 				contextMenuService={this._contextMenuService}
+				editorActionBarFactory={editorActionBarFactory}
 				hoverService={this._hoverService}
 				keybindingService={this._keybindingService}
-				editorActionBarFactory={editorActionBarFactory}
 			/>
 		);
 	}

--- a/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -178,7 +178,7 @@ export class EditorActionBarFactory extends Disposable {
 
 		// Build the right action bar elements from the editor actions right menu and the editor
 		// title menu.
-		let rightActionBarElements = [
+		const rightActionBarElements = [
 			// Build the right action bar elements from the editor actions right menu.
 			...this.buildActionBarElements(
 				processedActions,
@@ -198,22 +198,22 @@ export class EditorActionBarFactory extends Disposable {
 			rightActionBarElements.length - 1,
 			0,
 			<ActionBarCommandButton
+				ariaLabel={positronMoveIntoNewWindowAriaLabel}
+				commandId='workbench.action.moveEditorToNewWindow'
 				disabled={auxiliaryWindow}
 				iconId='positron-open-in-new-window'
 				tooltip={positronMoveIntoNewWindowTooltip}
-				ariaLabel={positronMoveIntoNewWindowAriaLabel}
-				commandId='workbench.action.moveEditorToNewWindow'
 			/>
 		);
 
 		// Return the action bar.
 		return (
 			<PositronActionBar
-				size='small'
-				borderTop={false}
 				borderBottom={true}
+				borderTop={false}
 				paddingLeft={PADDING_LEFT}
 				paddingRight={PADDING_RIGHT}
+				size='small'
 			>
 				{leftActionBarElements.length > 0 &&
 					<ActionBarRegion location='left'>
@@ -360,17 +360,17 @@ export class EditorActionBarFactory extends Disposable {
 					// Push the action bar menu button.
 					elements.push(
 						<ActionBarMenuButton
-							iconId={iconId}
-							ariaLabel={action.label ?? action.tooltip}
+							actions={() => action.actions}
 							align='left'
+							ariaLabel={action.label ?? action.tooltip}
+							dropdownIndicator='disabled'
+							iconId={iconId}
 							tooltip={actionTooltip(
 								this._contextKeyService,
 								this._keybindingService,
 								action,
 								false
 							)}
-							dropdownIndicator='disabled'
-							actions={() => action.actions}
 						/>
 					);
 				} else {
@@ -386,25 +386,25 @@ export class EditorActionBarFactory extends Disposable {
 						// Push the action bar menu button.
 						elements.push(
 							<ActionBarMenuButton
-								iconId={iconId}
-								text={iconId ? undefined : firstAction.label}
+								actions={() => action.actions}
+								align='left'
 								ariaLabel={firstAction.label ?? firstAction.tooltip}
 								dropdownAriaLabel={action.label ?? action.tooltip}
-								align='left'
-								tooltip={actionTooltip(
-									this._contextKeyService,
-									this._keybindingService,
-									firstAction,
-									false
-								)}
+								dropdownIndicator='enabled-split'
 								dropdownTooltip={actionTooltip(
 									this._contextKeyService,
 									this._keybindingService,
 									action,
 									false
 								)}
-								dropdownIndicator='enabled-split'
-								actions={() => action.actions}
+								iconId={iconId}
+								text={iconId ? undefined : firstAction.label}
+								tooltip={actionTooltip(
+									this._contextKeyService,
+									this._keybindingService,
+									firstAction,
+									false
+								)}
 							/>
 						);
 					}
@@ -417,12 +417,12 @@ export class EditorActionBarFactory extends Disposable {
 		if (secondaryActions.length) {
 			elements.push(
 				<ActionBarMenuButton
-					iconId='toolbar-more'
-					ariaLabel={positronMoreActionsAriaLabel}
-					align='left'
-					tooltip={positronMoreActionsTooltip}
-					dropdownIndicator='disabled'
 					actions={() => secondaryActions}
+					align='left'
+					ariaLabel={positronMoreActionsAriaLabel}
+					dropdownIndicator='disabled'
+					iconId='toolbar-more'
+					tooltip={positronMoreActionsTooltip}
 				/>
 			);
 		}

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCommandCenter.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCommandCenter.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -63,16 +63,16 @@ export const TopActionBarCommandCenter = () => {
 	return (
 		<div className='top-action-bar-command-center' onClick={(e) => clickHandler(e)}>
 			<div className='left'>
-				<div className='codicon codicon-positron-search' aria-hidden='true' />
+				<div aria-hidden='true' className='codicon codicon-positron-search' />
 			</div>
 			<div className='center'>
-				<button className='search' ref={searchRef} onClick={(e) => clickHandler(e)}>
+				<button ref={searchRef} className='search' onClick={(e) => clickHandler(e)}>
 					<div className='action-bar-button-text'>Search</div>
 				</button>
 			</div>
 			<div className='right'>
-				<button className='drop-down' ref={dropdownRef} onClick={(e) => dropDownClickHandler(e)} aria-label={positronShowQuickAccess} >
-					<div className='icon codicon codicon-chevron-down' aria-hidden='true' />
+				<button ref={dropdownRef} aria-label={positronShowQuickAccess} className='drop-down' onClick={(e) => dropDownClickHandler(e)} >
+					<div aria-hidden='true' className='icon codicon codicon-chevron-down' />
 				</button>
 			</div>
 		</div>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCustomFolderMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarCustomFolderMenu.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -55,9 +55,9 @@ export const TopActionBarCustonFolderMenu = () => {
 		renderer.render(
 			<CustomFolderModalPopup
 				{...context}
-				renderer={renderer}
-				recentlyOpened={recentlyOpened}
 				anchorElement={ref.current}
+				recentlyOpened={recentlyOpened}
+				renderer={renderer}
 			/>
 		);
 	};
@@ -85,14 +85,14 @@ export const TopActionBarCustonFolderMenu = () => {
 	return (
 		<div
 			ref={ref}
+			aria-haspopup='menu'
+			aria-label={positronFolderMenu}
 			className='top-action-bar-custom-folder-menu'
 			role='button'
 			tabIndex={0}
-			onKeyDown={keyDownHandler}
 			onClick={clickHandler}
-			aria-label={positronFolderMenu}
-			aria-haspopup='menu'>
-			<div className='left' aria-hidden='true'>
+			onKeyDown={keyDownHandler}>
+			<div aria-hidden='true' className='left'>
 				<div className='label'>
 					<div className={'action-bar-button-icon codicon codicon-folder'} />
 					{context.workspaceFolder &&
@@ -102,7 +102,7 @@ export const TopActionBarCustonFolderMenu = () => {
 					}
 				</div>
 			</div>
-			<div className='right' aria-hidden='true'>
+			<div aria-hidden='true' className='right'>
 				<div className='chevron codicon codicon-chevron-down' />
 			</div>
 		</div>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarInterpretersManager.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarInterpretersManager.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -58,8 +58,8 @@ export const TopActionBarInterpretersManager = (props: TopActionBarInterpretersM
 			<InterpretersManagerModalPopup
 				{...context}
 				{...props}
-				renderer={renderer}
 				anchorElement={ref.current}
+				renderer={renderer}
 			/>
 		);
 	}, [context, props]);
@@ -118,14 +118,14 @@ export const TopActionBarInterpretersManager = (props: TopActionBarInterpretersM
 	return (
 		<div
 			ref={ref}
+			aria-haspopup='menu'
+			aria-label={label}
 			className='top-action-bar-interpreters-manager'
 			role='button'
 			tabIndex={0}
-			onKeyDown={keyDownHandler}
-			onClick={clickHandler}
-			aria-haspopup='menu' aria-label={label}
+			onClick={clickHandler} onKeyDown={keyDownHandler}
 		>
-			<div className='left' aria-hidden='true'>
+			<div aria-hidden='true' className='left'>
 				{!activeSession ?
 					<div className='label'>{label}</div> :
 					<div className='label'>
@@ -134,7 +134,7 @@ export const TopActionBarInterpretersManager = (props: TopActionBarInterpretersM
 					</div>
 				}
 			</div>
-			<div className='right' aria-hidden='true'>
+			<div aria-hidden='true' className='right'>
 				<div className='chevron codicon codicon-chevron-down' />
 			</div>
 		</div>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarNewMenu.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -58,9 +58,9 @@ export const TopActionBarNewMenu = () => {
 	// compontent
 	return (
 		<ActionBarMenuButton
+			actions={actions}
 			iconId='positron-new'
 			text={positronNew}
-			actions={actions}
 			tooltip={positronNewFileFolder}
 		/>
 	);

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarOpenMenu.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarOpenMenu.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -95,10 +95,10 @@ export const TopActionBarOpenMenu = () => {
 	// Render.
 	return (
 		<ActionBarMenuButton
+			actions={actions}
+			iconFontSize={18}
 			iconId='folder-opened'
 			text={positronOpen}
-			iconFontSize={18}
-			actions={actions}
 			tooltip={positronOpenFileFolder}
 		/>
 	);

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -126,8 +126,8 @@ export const CustomFolderMenuItems = (props: CustomFolderMenuItemsProps) => {
 					return (
 						<CustomFolderRecentlyUsedMenuItem
 							key={index}
-							label={label}
 							enabled={true}
+							label={label}
 							onOpen={e => {
 								props.onMenuItemSelected();
 								props.hostService.openWindow([openable], {

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderModalPopup.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderModalPopup.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -46,14 +46,14 @@ export const CustomFolderModalPopup = (props: CustomFolderModalPopupProps) => {
 	// Render.
 	return (
 		<PositronModalPopup
-			renderer={props.renderer}
 			anchorElement={props.anchorElement}
-			popupPosition='bottom'
-			popupAlignment='right'
-			width={'max-content'}
-			minWidth={275}
 			height={'min-content'}
 			keyboardNavigationStyle='menu'
+			minWidth={275}
+			popupAlignment='right'
+			popupPosition='bottom'
+			renderer={props.renderer}
+			width={'max-content'}
 		>
 			<CustomFolderMenuItems
 				commandService={props.commandService}

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterActions.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterActions.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -67,7 +67,7 @@ export const InterpreterActions = (props: PropsWithChildren<InterpreterActionsPr
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.runtime.runtimeId, props.runtimeSessionService, session]);
 
 	// Interrupt the session, if we have one.
 	const interrupt = () => {
@@ -109,8 +109,8 @@ export const InterpreterActions = (props: PropsWithChildren<InterpreterActionsPr
 				>
 					<span
 						className='codicon codicon-positron-interrupt-runtime'
-						title={(() => localize('positronInterruptInterpreter', "Interrupt the interpreter"))()}
 						style={{ color: 'red' }}
+						title={(() => localize('positronInterruptInterpreter', "Interrupt the interpreter"))()}
 					/>
 				</PositronButton>
 			}

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterGroup.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterGroup.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -7,7 +7,7 @@
 import './interpreterGroup.css';
 
 // React.
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 // Other dependencies.
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
@@ -38,7 +38,7 @@ export const InterpreterGroup = (props: InterpreterGroupProps) => {
 	 * Determines whether an alternate runtime is alive.
 	 * @returns A value which indicates whether an alternate runtime is alive.
 	 */
-	const isAlternateRuntimeAlive = () => {
+	const isAlternateRuntimeAlive = useCallback(() => {
 		// Get the active sessions.
 		const activeSessions = props.runtimeSessionService.activeSessions;
 
@@ -66,7 +66,7 @@ export const InterpreterGroup = (props: InterpreterGroupProps) => {
 
 		// An alternate runtime is not alive.
 		return false;
-	};
+	}, [props.interpreterGroup.alternateRuntimes, props.runtimeSessionService.activeSessions]);
 
 	// State hooks.
 	const [alternateRuntimeAlive, setAlternateRuntimeAlive] = useState(isAlternateRuntimeAlive());
@@ -91,19 +91,19 @@ export const InterpreterGroup = (props: InterpreterGroupProps) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [isAlternateRuntimeAlive, props.runtimeSessionService]);
 
 	// Render.
 	return (
 		<div className='interpreter-group'>
 			<PrimaryInterpreter
-				languageRuntimeService={props.languageRuntimeService}
-				runtimeSessionService={props.runtimeSessionService}
-				runtime={props.interpreterGroup.primaryRuntime}
 				enableShowAllVersions={props.interpreterGroup.alternateRuntimes.length > 0}
+				languageRuntimeService={props.languageRuntimeService}
+				runtime={props.interpreterGroup.primaryRuntime}
+				runtimeSessionService={props.runtimeSessionService}
+				onActivate={async () => await props.onActivateRuntime(props.interpreterGroup.primaryRuntime)}
 				onShowAllVersions={() => setShowAllVersions(!showAllVersions)}
 				onStart={async () => await props.onStartRuntime(props.interpreterGroup.primaryRuntime)}
-				onActivate={async () => await props.onActivateRuntime(props.interpreterGroup.primaryRuntime)}
 			/>
 			{(alternateRuntimeAlive || showAllVersions) &&
 				<div className='secondary-interpreters' onWheel={(e) => {
@@ -116,10 +116,10 @@ export const InterpreterGroup = (props: InterpreterGroupProps) => {
 						<SecondaryInterpreter
 							key={runtime.runtimeId}
 							languageRuntimeService={props.languageRuntimeService}
-							runtimeSessionService={props.runtimeSessionService}
 							runtime={runtime}
-							onStart={async () => await props.onStartRuntime(runtime)}
+							runtimeSessionService={props.runtimeSessionService}
 							onActivate={async () => await props.onActivateRuntime(runtime)}
+							onStart={async () => await props.onStartRuntime(runtime)}
 						/>
 					)}
 				</div>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterGroups.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpreterGroups.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -108,7 +108,7 @@ export const InterpreterGroups = (props: InterpreterGroupsProps) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.languageRuntimeService, props.runtimeAffiliationService]);
 
 	// Render.
 	return (
@@ -116,11 +116,11 @@ export const InterpreterGroups = (props: InterpreterGroupsProps) => {
 			{interpreterGroups.map((interpreterGroup, index, runningRuntimes) => (
 				<InterpreterGroup
 					key={interpreterGroup.primaryRuntime.runtimeId}
+					interpreterGroup={interpreterGroup}
 					languageRuntimeService={props.languageRuntimeService}
 					runtimeSessionService={props.runtimeSessionService}
-					interpreterGroup={interpreterGroup}
-					onStartRuntime={props.onStartRuntime}
 					onActivateRuntime={props.onActivateRuntime}
+					onStartRuntime={props.onStartRuntime}
 				/>
 			))}
 		</div>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpretersManagerModalPopup.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/interpretersManagerModalPopup.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -43,19 +43,18 @@ export const InterpretersManagerModalPopup = (props: InterpretersManagerModalPop
 	// Render.
 	return (
 		<PositronModalPopup
-			renderer={props.renderer}
 			anchorElement={props.anchorElement}
-			popupPosition='bottom'
-			popupAlignment='right'
-			width={375}
 			height={'min-content'}
 			keyboardNavigationStyle='menu'
+			popupAlignment='right'
+			popupPosition='bottom'
+			renderer={props.renderer}
+			width={375}
 		>
 			<InterpreterGroups
 				languageRuntimeService={props.languageRuntimeService}
 				runtimeAffiliationService={props.runtimeStartupService}
 				runtimeSessionService={props.runtimeSessionService}
-				onStartRuntime={props.onStartRuntime}
 				onActivateRuntime={async (runtime) => {
 					// Activate the runtime.
 					await props.onActivateRuntime(runtime);
@@ -63,6 +62,7 @@ export const InterpretersManagerModalPopup = (props: InterpretersManagerModalPop
 					// Dismiss the popup.
 					props.renderer.dispose();
 				}}
+				onStartRuntime={props.onStartRuntime}
 			/>
 		</PositronModalPopup>
 	);

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/primaryInterpreter.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/primaryInterpreter.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -69,7 +69,7 @@ export const PrimaryInterpreter = (props: PrimaryInterpreterProps) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.runtime.runtimeId, props.runtimeSessionService, session]);
 
 	// Render.
 	return (
@@ -87,10 +87,10 @@ export const PrimaryInterpreter = (props: PrimaryInterpreterProps) => {
 				</div>
 			</div>
 			<InterpreterActions
-				runtime={props.runtime}
-				onStart={props.onStart}
 				languageRuntimeService={props.languageRuntimeService}
-				runtimeSessionService={props.runtimeSessionService}>
+				runtime={props.runtime}
+				runtimeSessionService={props.runtimeSessionService}
+				onStart={props.onStart}>
 				{props.enableShowAllVersions &&
 					<PositronButton className='action-button' onPressed={props.onShowAllVersions}>
 						<span

--- a/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/secondaryInterpreter.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/interpretersManagerModalPopup/secondaryInterpreter.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -65,7 +65,7 @@ export const SecondaryInterpreter = (props: SecondaryInterpreterProps) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.runtime.runtimeId, props.runtimeSessionService, session]);
 
 	// Render.
 	return (
@@ -86,8 +86,8 @@ export const SecondaryInterpreter = (props: SecondaryInterpreterProps) => {
 			</div>
 			<InterpreterActions
 				languageRuntimeService={props.languageRuntimeService}
-				runtimeSessionService={props.runtimeSessionService}
 				runtime={props.runtime}
+				runtimeSessionService={props.runtimeSessionService}
 				onStart={props.onStart} />
 		</PositronButton>
 	);

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -150,10 +150,10 @@ export const PositronTopActionBar = (props: PositronTopActionBarProps) => {
 			<PositronActionBarContextProvider {...props}>
 
 				<PositronActionBar
-					size='large'
 					borderBottom={true}
 					paddingLeft={kHorizontalPadding}
 					paddingRight={kHorizontalPadding}
+					size='large'
 				>
 					<ActionBarRegion location='left'>
 						<TopActionBarNewMenu />
@@ -161,32 +161,32 @@ export const PositronTopActionBar = (props: PositronTopActionBarProps) => {
 						<TopActionBarOpenMenu />
 						<ActionBarSeparator />
 						<ActionBarCommandButton
-							iconId='positron-save'
-							commandId={SAVE}
 							ariaLabel={CommandCenter.title(SAVE)}
+							commandId={SAVE}
+							iconId='positron-save'
 						/>
 						<ActionBarCommandButton
-							iconId='positron-save-all'
-							commandId={SAVE_ALL}
 							ariaLabel={CommandCenter.title(SAVE_ALL)}
+							commandId={SAVE_ALL}
+							iconId='positron-save-all'
 						/>
 					</ActionBarRegion>
 
 					{showCenterUI && (
 						<ActionBarRegion location='center'>
 
-							<PositronActionBar size='large' nestedActionBar={true}>
+							<PositronActionBar nestedActionBar={true} size='large'>
 								{showFullCenterUI && (
-									<ActionBarRegion width={60} location='left' justify='right'>
+									<ActionBarRegion justify='right' location='left' width={60}>
 										<ActionBarCommandButton
-											iconId='chevron-left'
-											commandId={NAV_BACK}
 											ariaLabel={CommandCenter.title(NAV_BACK)}
+											commandId={NAV_BACK}
+											iconId='chevron-left'
 										/>
 										<ActionBarCommandButton
-											iconId='chevron-right'
-											commandId={NAV_FORWARD}
 											ariaLabel={CommandCenter.title(NAV_FORWARD)}
+											commandId={NAV_FORWARD}
+											iconId='chevron-right'
 										/>
 									</ActionBarRegion>
 								)}
@@ -194,7 +194,7 @@ export const PositronTopActionBar = (props: PositronTopActionBarProps) => {
 									<TopActionBarCommandCenter />
 								</ActionBarRegion>
 								{showFullCenterUI && (
-									<ActionBarRegion width={60} location='right' justify='left' />
+									<ActionBarRegion justify='left' location='right' width={60} />
 								)}
 							</PositronActionBar>
 
@@ -203,8 +203,8 @@ export const PositronTopActionBar = (props: PositronTopActionBarProps) => {
 
 					<ActionBarRegion location='right'>
 						<TopActionBarInterpretersManager
-							onStartRuntime={startRuntimeHandler}
 							onActivateRuntime={activateRuntimeHandler}
+							onStartRuntime={startRuntimeHandler}
 						/>
 						{showCenterUI && (
 							<TopActionBarCustonFolderMenu />

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarPart.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarPart.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -154,8 +154,8 @@ export class PositronTopActionBarPart extends Part implements IPositronTopAction
 				positronTopActionBarContainer={this}
 				positronTopActionBarService={this}
 				quickInputService={this.quickInputService}
-				runtimeStartupService={this.runtimeStartupService}
 				runtimeSessionService={this.runtimeSessionService}
+				runtimeStartupService={this.runtimeStartupService}
 				workspaceContextService={this.workspaceContextService}
 				workspacesService={this.workspacesService}
 			/>

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarState.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBarState.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -45,7 +45,7 @@ export const usePositronTopActionBarState = (services: PositronTopActionBarServi
 
 		// Return the clean up for our event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [services.workspaceContextService]);
 
 	// Return the Positron top action bar state.
 	return {

--- a/src/vs/workbench/browser/positronAnsiRenderer/outputLine.tsx
+++ b/src/vs/workbench/browser/positronAnsiRenderer/outputLine.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -37,9 +37,9 @@ export const OutputLine = (props: OutputLineProps) => {
 				props.outputLine.outputRuns.map(outputRun =>
 					<OutputRun
 						key={outputRun.id}
-						outputRun={outputRun}
-						openerService={props.openerService}
 						notificationService={props.notificationService}
+						openerService={props.openerService}
+						outputRun={outputRun}
 					/>
 				)
 			}

--- a/src/vs/workbench/browser/positronAnsiRenderer/outputLines.tsx
+++ b/src/vs/workbench/browser/positronAnsiRenderer/outputLines.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -34,9 +34,9 @@ export const OutputLines = (props: OutputLinesProps) => {
 			{props.outputLines.map(outputLine =>
 				<OutputLine
 					key={outputLine.id}
-					outputLine={outputLine}
-					openerService={props.openerService}
 					notificationService={props.notificationService}
+					openerService={props.openerService}
+					outputLine={outputLine}
 				/>
 			)}
 		</>

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -89,16 +89,16 @@ export const showCustomContextMenu = async ({
 	// Show the context menu popup.
 	renderer.render(
 		<CustomContextMenuModalPopup
-			commandService={commandService}
-			keybindingService={keybindingService}
-			renderer={renderer}
 			anchorElement={anchorElement}
 			anchorPoint={anchorPoint}
-			popupPosition={popupPosition}
-			popupAlignment={popupAlignment}
-			width={width}
-			minWidth={minWidth}
+			commandService={commandService}
 			entries={entries}
+			keybindingService={keybindingService}
+			minWidth={minWidth}
+			popupAlignment={popupAlignment}
+			popupPosition={popupPosition}
+			renderer={renderer}
+			width={width}
 		/>
 	);
 };
@@ -215,15 +215,15 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 	// Render.
 	return (
 		<PositronModalPopup
-			renderer={props.renderer}
 			anchorElement={props.anchorElement}
 			anchorPoint={props.anchorPoint}
-			popupPosition={props.popupPosition}
-			popupAlignment={props.popupAlignment}
-			width={props.width}
-			minWidth={props.minWidth}
 			height={'min-content'}
 			keyboardNavigationStyle='menu'
+			minWidth={props.minWidth}
+			popupAlignment={props.popupAlignment}
+			popupPosition={props.popupPosition}
+			renderer={props.renderer}
+			width={props.width}
 		>
 			<div className='custom-context-menu-items'>
 				{props.entries.map((entry, index) => {

--- a/src/vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBox.tsx
+++ b/src/vs/workbench/browser/positronComponents/dropDownListBox/dropDownListBox.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -113,8 +113,8 @@ export const DropDownListBox = <T extends NonNullable<any>, V,>(props: DropDownL
 	return (
 		<Button
 			ref={ref}
-			disabled={props.disabled}
 			className={positronClassNames('drop-down-list-box', props.className)}
+			disabled={props.disabled}
 			onPressed={() => {
 				// Create the renderer.
 				const renderer = new PositronModalReactRenderer({
@@ -130,10 +130,10 @@ export const DropDownListBox = <T extends NonNullable<any>, V,>(props: DropDownL
 				// Show the drop down list box modal popup.
 				renderer.render(
 					<DropDownListBoxModalPopup<T, V>
-						renderer={renderer}
 						anchorElement={ref.current}
-						entries={props.entries}
 						createItem={props.createItem}
+						entries={props.entries}
+						renderer={renderer}
 						onItemHighlighted={dropDownListBoxItem =>
 							setHighlightedDropDownListBoxItem(dropDownListBoxItem)
 						}
@@ -148,7 +148,7 @@ export const DropDownListBox = <T extends NonNullable<any>, V,>(props: DropDownL
 			<div className='title'>
 				<Title />
 			</div>
-			<div className='chevron' aria-hidden='true'>
+			<div aria-hidden='true' className='chevron'>
 				<div className='codicon codicon-chevron-down' />
 			</div>
 		</Button>
@@ -176,14 +176,14 @@ const DropDownListBoxModalPopup = <T, V,>(props: DropDownListBoxModalPopupProps<
 	// Render.
 	return (
 		<PositronModalPopup
-			renderer={props.renderer}
 			anchorElement={props.anchorElement}
-			popupPosition='auto'
-			popupAlignment='left'
-			width={props.anchorElement.offsetWidth}
-			minWidth={props.anchorElement.offsetWidth}
 			height={'min-content'}
 			keyboardNavigationStyle='menu'
+			minWidth={props.anchorElement.offsetWidth}
+			popupAlignment='left'
+			popupPosition='auto'
+			renderer={props.renderer}
+			width={props.anchorElement.offsetWidth}
 		>
 			<div className='drop-down-list-box-items'>
 				{props.entries.map((entry, index) => {

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/checkbox.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/checkbox.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -39,7 +39,7 @@ export const Checkbox = ({ label, initialChecked, onChanged }: CheckboxProps) =>
 	// Render.
 	return (
 		<div className='checkbox'>
-			<button ref={buttonRef} id={id} className='checkbox-button' aria-checked='false' tabIndex={0} role='checkbox' onClick={clickHandler}>
+			<button ref={buttonRef} aria-checked='false' className='checkbox-button' id={id} role='checkbox' tabIndex={0} onClick={clickHandler}>
 				{checked && <div className='check-indicator codicon codicon-check' />}
 			</button>
 			<label htmlFor={id}>{label}</label>

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/labeledFolderInput.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/labeledFolderInput.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -66,7 +66,7 @@ export const LabeledFolderInput = ({ skipValidation = false, ...props }: Labeled
 			<label>
 				{props.label}
 				<div className='folder-input'>
-					<input className='text-input' readOnly={props.readOnlyInput} placeholder={props.placeholder} type='text' value={props.value} onChange={props.onChange} maxLength={255} />
+					<input className='text-input' maxLength={255} placeholder={props.placeholder} readOnly={props.readOnlyInput} type='text' value={props.value} onChange={props.onChange} />
 					<Button className='browse-button' onPressed={props.onBrowse}>
 						{localize('positronFolderInputBrowse', 'Browse...')}
 					</Button>

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/labeledTextInput.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/labeledTextInput.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -52,16 +52,16 @@ export const LabeledTextInput = forwardRef<HTMLInputElement, LabeledTextInputPro
 			<label className='label'>
 				<span className='label-text'>{props.label}</span>
 				<input
-					className={positronClassNames('text-input', { 'error': props.error })}
 					ref={ref}
+					autoFocus={props.autoFocus}
+					className={positronClassNames('text-input', { 'error': props.error })}
+					disabled={props.disabled}
+					max={props.max}
+					maxLength={props.maxLength}
+					min={props.min}
 					type={props.type}
 					value={props.value}
-					autoFocus={props.autoFocus}
 					onChange={props.onChange}
-					max={props.max}
-					min={props.min}
-					maxLength={props.maxLength}
-					disabled={props.disabled}
 				/>
 				{errorMsg ? <span className='error error-msg'>{errorMsg}</span> : null}
 			</label>

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelActionBar.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelActionBar.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -52,7 +52,7 @@ export const OKCancelActionBar = (props: OKCancelActionBarProps) => {
 	return (
 		<div className='ok-cancel-action-bar top-separator'>
 			{preActions}
-			<PlatformNativeDialogActionBar secondaryButton={cancelButton} primaryButton={okButton} />
+			<PlatformNativeDialogActionBar primaryButton={okButton} secondaryButton={cancelButton} />
 		</div>
 	);
 };

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelBackNextActionBar.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelBackNextActionBar.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -40,15 +40,15 @@ interface ActionBarButtonConfig {
  */
 export const OKCancelBackNextActionBar = ({ okButtonConfig, cancelButtonConfig, backButtonConfig, nextButtonConfig }: OKCancelBackNextActionBarProps) => {
 	const cancelButton = (cancelButtonConfig ?
-		<Button className='action-bar-button' onPressed={cancelButtonConfig.onClick} disabled={cancelButtonConfig.disable ?? false}>
+		<Button className='action-bar-button' disabled={cancelButtonConfig.disable ?? false} onPressed={cancelButtonConfig.onClick}>
 			{cancelButtonConfig.title ?? localize('positronCancel', "Cancel")}
 		</Button> : null);
 	const okButton = (okButtonConfig ?
-		<Button className='action-bar-button default' onPressed={okButtonConfig.onClick} disabled={okButtonConfig.disable ?? false}>
+		<Button className='action-bar-button default' disabled={okButtonConfig.disable ?? false} onPressed={okButtonConfig.onClick}>
 			{okButtonConfig.title ?? localize('positronOK', "OK")}
 		</Button> : null);
 	const nextButton = (nextButtonConfig ?
-		<Button className='action-bar-button default' onPressed={nextButtonConfig.onClick} disabled={nextButtonConfig.disable ?? false}>
+		<Button className='action-bar-button default' disabled={nextButtonConfig.disable ?? false} onPressed={nextButtonConfig.onClick}>
 			{nextButtonConfig.title ?? localize('positronNext', "Next")}
 		</Button> : null);
 
@@ -57,7 +57,7 @@ export const OKCancelBackNextActionBar = ({ okButtonConfig, cancelButtonConfig, 
 		<div className='ok-cancel-back-action-bar top-separator'>
 			<div className='left-actions'>
 				{backButtonConfig ?
-					<Button className='action-bar-button' onPressed={backButtonConfig.onClick} disabled={backButtonConfig.disable ?? false}>
+					<Button className='action-bar-button' disabled={backButtonConfig.disable ?? false} onPressed={backButtonConfig.onClick}>
 						{backButtonConfig.title ?? localize('positronBack', "Back")}
 					</Button> : null
 				}

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/radioButton.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/radioButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -47,13 +47,13 @@ export const RadioButton = (props: RadioButtonProps) => {
 	return (
 		<div className='radio-button'>
 			<input
+				checked={props.selected}
 				className='radio-button-input'
-				type='radio'
-				tabIndex={props.selected ? 0 : -1}
 				id={props.identifier}
 				name={props.groupName}
+				tabIndex={props.selected ? 0 : -1}
+				type='radio'
 				value={props.identifier}
-				checked={props.selected}
 				onClick={props.onSelected}
 			/>
 			<label htmlFor={props.identifier}>{props.title}</label>

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/radioGroup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/radioGroup.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -43,19 +43,19 @@ export const RadioGroup = (props: PropsWithChildren<RadioGroupProps>) => {
 	// Render.
 	return (
 		<div
+			aria-describedby={props.describedBy}
+			aria-labelledby={props.labelledBy}
 			className='radio-group'
 			role='radiogroup'
-			aria-labelledby={props.labelledBy}
-			aria-describedby={props.describedBy}
 		>
 			{props.entries.map((entry, index) => {
 				return (
 					<RadioButton
 						key={index}
-						identifier={entry.options.identifier}
-						title={entry.options.title}
 						groupName={props.name}
+						identifier={entry.options.identifier}
 						selected={entry.options.identifier === currentSelection}
+						title={entry.options.title}
 						onSelected={() => onSelectionChanged(entry.options.identifier)}
 					/>
 				);

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/confirmDeleteModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/confirmDeleteModalDialog.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -62,7 +62,7 @@ export const ConfirmDeleteModalDialog = (props: PropsWithChildren<ConfirmDeleteM
 				<div className='left-actions'>
 				</div>
 				<div className='right-actions'>
-					<PlatformNativeDialogActionBar secondaryButton={cancelButton} primaryButton={deleteButton} />
+					<PlatformNativeDialogActionBar primaryButton={deleteButton} secondaryButton={cancelButton} />
 				</div>
 			</div>
 		</PositronModalDialog>

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -294,7 +294,7 @@ export const PositronModalDialog = (props: PropsWithChildren<PositronModalDialog
 	return (
 		<div ref={dialogContainerRef} className='positron-modal-dialog-container' role='dialog'>
 			<div ref={dialogBoxRef} className='positron-modal-dialog-box' style={{ left: dialogBoxState.left, top: dialogBoxState.top, width: props.width, height: props.height }}>
-				<DraggableTitleBar {...props} onStartDrag={startDragHandler} onDrag={dragHandler} onStopDrag={stopDragHandler} />
+				<DraggableTitleBar {...props} onDrag={dragHandler} onStartDrag={startDragHandler} onStopDrag={stopDragHandler} />
 				{props.children}
 			</div>
 		</div>

--- a/src/vs/workbench/browser/positronDataExplorer/components/actionBar/actionBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/actionBar/actionBar.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -60,17 +60,17 @@ export const ActionBar = () => {
 		<PositronActionBarContextProvider {...context}>
 			<div ref={ref} className='action-bar'>
 				<PositronActionBar
-					size='small'
 					borderBottom={true}
 					paddingLeft={kPaddingLeft}
 					paddingRight={kPaddingRight}
+					size='small'
 				>
 					<ActionBarRegion location='left'>
 						<ActionBarButton
+							ariaLabel={clearSortButtonDescription}
 							iconId='positron-clear-sorting'
 							text={clearSortButtonTitle}
 							tooltip={clearSortButtonDescription}
-							ariaLabel={clearSortButtonDescription}
 							onPressed={async () =>
 								await context.instance.tableDataDataGridInstance.
 									clearColumnSortKeys()
@@ -80,10 +80,10 @@ export const ActionBar = () => {
 					<ActionBarRegion location='right'>
 						<LayoutMenuButton />
 						<ActionBarButton
+							ariaLabel={moveIntoNewWindowButtonDescription}
 							disabled={moveIntoNewWindowDisabled}
 							iconId='positron-open-in-new-window'
 							tooltip={moveIntoNewWindowButtonDescription}
-							ariaLabel={moveIntoNewWindowButtonDescription}
 							onPressed={() =>
 								context.commandService.executeCommand(
 									'workbench.action.moveEditorToNewWindow'

--- a/src/vs/workbench/browser/positronDataExplorer/components/actionBar/components/layoutMenuButton.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/actionBar/components/layoutMenuButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -111,11 +111,11 @@ export const LayoutMenuButton = () => {
 	// Render.
 	return (
 		<ActionBarMenuButton
+			actions={actions}
+			ariaLabel={layoutButtonDescription}
 			iconId={selectIconId(currentLayout)}
 			text={layoutButtonTitle}
 			tooltip={layoutButtonDescription}
-			ariaLabel={layoutButtonDescription}
-			actions={actions}
 		/>
 	);
 };

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerClosed/positronDataExplorerClosed.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerClosed/positronDataExplorerClosed.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -73,8 +73,9 @@ export const PositronDataExplorerClosed = (
 				<div className='error-message'>
 					{errorMessage}
 				</div>
-				<Button className='close-button'
+				<Button
 					ariaLabel={closeDataExplorer}
+					className='close-button'
 					onPressed={props.onClose}
 				>
 					{closeDataExplorer}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -752,27 +752,18 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 	// Render.
 	return (
 		<PositronModalPopup
-			renderer={props.renderer}
 			anchorElement={props.anchorElement}
-			popupPosition='auto'
-			popupAlignment='auto'
-			width={275}
 			height={'min-content'}
 			keyboardNavigationStyle='dialog'
+			popupAlignment='auto'
+			popupPosition='auto'
+			renderer={props.renderer}
+			width={275}
 			onAccept={applyRowFilter}
 		>
 			<div className='add-edit-row-filter-modal-popup-body'>
 				{supportsConditions && !props.isFirstFilter &&
 					<DropDownListBox
-						onSelectionChanged={dropDownListBoxItem => {
-							setSelectedCondition(dropDownListBoxItem.options.identifier);
-						}}
-						keybindingService={props.renderer.keybindingService}
-						layoutService={props.renderer.layoutService}
-						title={(() => localize(
-							'positron.addEditRowFilter.selectCombiningOperator',
-							"Select Combining Operator"
-						))()}
 						entries={[
 							new DropDownListBoxItem({
 								identifier: RowFilterCondition.And,
@@ -791,19 +782,28 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 								value: RowFilterCondition.Or
 							})
 						]}
+						keybindingService={props.renderer.keybindingService}
+						layoutService={props.renderer.layoutService}
 						selectedIdentifier={selectedCondtion}
+						title={(() => localize(
+							'positron.addEditRowFilter.selectCombiningOperator',
+							"Select Combining Operator"
+						))()}
+						onSelectionChanged={dropDownListBoxItem => {
+							setSelectedCondition(dropDownListBoxItem.options.identifier);
+						}}
 					/>
 				}
 				<DropDownColumnSelector
 					configurationService={props.configurationService}
+					dataExplorerClientInstance={props.dataExplorerClientInstance}
 					keybindingService={props.renderer.keybindingService}
 					layoutService={props.renderer.layoutService}
-					dataExplorerClientInstance={props.dataExplorerClientInstance}
+					selectedColumnSchema={selectedColumnSchema}
 					title={(() => localize(
 						'positron.addEditRowFilter.selectColumn',
 						"Select Column"
 					))()}
-					selectedColumnSchema={selectedColumnSchema}
 					onSelectedColumnSchemaChanged={columnSchema => {
 						// Set the selected column schema.
 						setSelectedColumnSchema(columnSchema);
@@ -817,14 +817,14 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 				/>
 				<DropDownListBox
 					disabled={selectedColumnSchema === undefined}
+					entries={conditionEntries()}
 					keybindingService={props.renderer.keybindingService}
 					layoutService={props.renderer.layoutService}
+					selectedIdentifier={selectedFilterType}
 					title={(() => localize(
 						'positron.addEditRowFilter.selectCondition',
 						"Select Condition"
 					))()}
-					entries={conditionEntries()}
-					selectedIdentifier={selectedFilterType}
 					onSelectionChanged={dropDownListBoxItem => {
 						const prevSelected = selectedFilterType;
 						const nextSelected = dropDownListBoxItem.options.identifier;

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSearch.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSearch.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -66,17 +66,17 @@ export const ColumnSearch = (props: ColumnSearchProps) => {
 			<div className={positronClassNames('column-search-input', { 'focused': focused })}>
 				<input
 					ref={inputRef}
-					type='text'
 					className='text-input'
 					placeholder={(() => localize('positron.searchPlacehold', "search"))()}
+					type='text'
 					value={searchText}
-					onKeyDown={handleOnKeyDown}
-					onFocus={() => setFocused(true)}
 					onBlur={() => setFocused(false)}
 					onChange={e => {
 						setSearchText(e.target.value);
 						props.onSearchTextChanged(e.target.value);
 					}}
+					onFocus={() => setFocused(true)}
+					onKeyDown={handleOnKeyDown}
 				/>
 				{searchText !== '' && (
 					<button className='clear-button'>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorDataGridInstance.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -242,9 +242,9 @@ export class ColumnSelectorDataGridInstance extends DataGridInstance {
 		// Return the cell.
 		return (
 			<ColumnSelectorCell
-				instance={this}
-				columnSchema={columnSchema}
 				columnIndex={rowIndex}
+				columnSchema={columnSchema}
+				instance={this}
 				onPressed={() => this._onDidSelectColumnEmitter.fire(columnSchema)}
 			/>
 		);

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSelectorModalPopup.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -73,31 +73,31 @@ export const ColumnSelectorModalPopup = (props: ColumnSelectorModalPopupProps) =
 	// Render.
 	return (
 		<PositronModalPopup
-			renderer={props.renderer}
 			anchorElement={props.anchorElement}
-			popupPosition='auto'
-			popupAlignment='auto'
-			width={props.anchorElement.offsetWidth}
-			height={'min-content'}
 			focusableElementSelectors='input[type="text"],div[id=column-positron-data-grid]'
+			height={'min-content'}
 			keyboardNavigationStyle='dialog'
+			popupAlignment='auto'
+			popupPosition='auto'
+			renderer={props.renderer}
+			width={props.anchorElement.offsetWidth}
 		>
 			<div className='column-selector' >
 				<div className='column-selector-search'>
 					<ColumnSearch
-						initialSearchText={props.searchInput}
 						focus={props.focusInput}
-						onSearchTextChanged={async searchText => {
-							await props.columnSelectorDataGridInstance.setSearchText(
-								searchText !== '' ? searchText : undefined
-							);
+						initialSearchText={props.searchInput}
+						onConfirmSearch={() => {
+							props.columnSelectorDataGridInstance.selectItem(props.columnSelectorDataGridInstance.cursorColumnIndex);
 						}}
 						onNavigateOut={() => {
 							positronDataGridRef.current.focus();
 							props.columnSelectorDataGridInstance.showCursor();
 						}}
-						onConfirmSearch={() => {
-							props.columnSelectorDataGridInstance.selectItem(props.columnSelectorDataGridInstance.cursorColumnIndex);
+						onSearchTextChanged={async searchText => {
+							await props.columnSelectorDataGridInstance.setSearchText(
+								searchText !== '' ? searchText : undefined
+							);
 						}}
 					/>
 				</div>
@@ -106,11 +106,11 @@ export const ColumnSelectorModalPopup = (props: ColumnSelectorModalPopupProps) =
 					onKeyDown={onKeyDown}
 				>
 					<PositronDataGrid
-						configurationService={props.configurationService}
-						layoutService={props.renderer.layoutService}
 						ref={positronDataGridRef}
+						configurationService={props.configurationService}
 						id='column-positron-data-grid'
 						instance={props.columnSelectorDataGridInstance}
+						layoutService={props.renderer.layoutService}
 					/>
 				</div>
 			</div>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/dropDownColumnSelector.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/dropDownColumnSelector.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -80,10 +80,10 @@ export const DropDownColumnSelector = (props: DropDownColumnSelectorProps) => {
 			// Inform the user that the column selector data grid instance could not be created.
 			renderer.render(
 				<OKModalDialog
-					renderer={renderer}
-					width={400}
 					height={195}
+					renderer={renderer}
 					title={title}
+					width={400}
 					onAccept={async () => {
 						renderer.dispose();
 					}}
@@ -109,11 +109,11 @@ export const DropDownColumnSelector = (props: DropDownColumnSelectorProps) => {
 			// Show the drop down list box modal popup.
 			renderer.render(
 				<ColumnSelectorModalPopup
-					configurationService={props.configurationService}
-					renderer={renderer}
-					columnSelectorDataGridInstance={columnSelectorDataGridInstance}
 					anchorElement={ref.current}
+					columnSelectorDataGridInstance={columnSelectorDataGridInstance}
+					configurationService={props.configurationService}
 					focusInput={focusInput}
+					renderer={renderer}
 					onItemSelected={columnSchema => {
 						renderer.dispose();
 						setSelectedColumnSchema(columnSchema);
@@ -157,7 +157,7 @@ export const DropDownColumnSelector = (props: DropDownColumnSelectorProps) => {
 					</div>
 				)
 			}
-			<div className='chevron' aria-hidden='true'>
+			<div aria-hidden='true' className='chevron'>
 				<div className='codicon codicon-chevron-down' />
 			</div>
 		</Button>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/rowFilterParameter.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/rowFilterParameter.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -51,16 +51,16 @@ export const RowFilterParameter = forwardRef<HTMLInputElement, RowFilterParamete
 			>
 				<input
 					ref={inputRef}
-					type='text'
 					className='text-input'
 					placeholder={props.placeholder}
+					type='text'
 					value={text}
-					onFocus={() => setFocused(true)}
 					onBlur={() => setFocused(false)}
 					onChange={e => {
 						setText(e.target.value);
 						props.onTextChanged(e.target.value);
 					}}
+					onFocus={() => setFocused(true)}
 				/>
 			</div>
 		</div>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -320,11 +320,11 @@ export const DataExplorer = () => {
 			<div ref={leftColumnRef} className='left-column'>
 				<PositronDataGrid
 					configurationService={context.configurationService}
-					layoutService={context.layoutService}
 					instance={layout === PositronDataExplorerLayout.SummaryOnLeft ?
 						context.instance.tableSchemaDataGridInstance :
 						context.instance.tableDataDataGridInstance
 					}
+					layoutService={context.layoutService}
 				/>
 			</div>
 			{layout === PositronDataExplorerLayout.SummaryOnLeft && columnsCollapsed &&
@@ -332,16 +332,16 @@ export const DataExplorer = () => {
 			}
 			<div ref={splitterRef} className='splitter'>
 				<VerticalSplitter
+					collapsible={true}
 					configurationService={context.configurationService}
 					invert={layout === PositronDataExplorerLayout.SummaryOnRight}
-					collapsible={true}
 					showSash={true}
 					onBeginResize={beginResizeHandler}
-					onResize={resizeHandler}
 					onCollapsedChanged={collapsed => {
 						setAnimateColumnsWidth(!context.accessibilityService.isMotionReduced());
 						setColumnsCollapsed(collapsed);
 					}}
+					onResize={resizeHandler}
 				/>
 			</div>
 			{layout === PositronDataExplorerLayout.SummaryOnRight && columnsCollapsed &&
@@ -350,11 +350,11 @@ export const DataExplorer = () => {
 			<div ref={rightColumnRef} className='right-column'>
 				<PositronDataGrid
 					configurationService={context.configurationService}
-					layoutService={context.layoutService}
 					instance={layout === PositronDataExplorerLayout.SummaryOnLeft ?
 						context.instance.tableDataDataGridInstance :
 						context.instance.tableSchemaDataGridInstance
 					}
+					layoutService={context.layoutService}
 				/>
 			</div>
 		</div >

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -80,10 +80,10 @@ export const RowFilterBar = () => {
 			// Inform the user that another filter cannot be added.
 			renderer.render(
 				<OKModalDialog
+					height={150}
 					renderer={renderer}
 					title={(() => localize('positron.dataExplorer.filtering.addFilter', "Add Filter"))()}
 					width={350}
-					height={150}
 					onAccept={() => renderer.dispose()}
 					onCancel={() => renderer.dispose()}
 				>
@@ -128,13 +128,13 @@ export const RowFilterBar = () => {
 			// Show the add /edit row filter modal popup.
 			renderer.render(
 				<AddEditRowFilterModalPopup
+					anchorElement={anchorElement}
 					configurationService={context.configurationService}
 					dataExplorerClientInstance={context.instance.dataExplorerClientInstance}
-					renderer={renderer}
-					anchorElement={anchorElement}
-					isFirstFilter={isFirstFilter}
-					schema={schema}
 					editRowFilter={editRowFilterDescriptor}
+					isFirstFilter={isFirstFilter}
+					renderer={renderer}
+					schema={schema}
 					onApplyRowFilter={applyRowFilterHandler}
 				/>
 			);
@@ -258,8 +258,8 @@ export const RowFilterBar = () => {
 		<div ref={ref} className='row-filter-bar'>
 			<Button
 				ref={rowFilterButtonRef}
-				className='row-filter-button'
 				ariaLabel={(() => localize('positron.dataExplorer.filtering', "Filtering"))()}
+				className='row-filter-button'
 				onPressed={filterButtonPressedHandler}
 			>
 				<div className='codicon codicon-positron-row-filter' />
@@ -268,14 +268,15 @@ export const RowFilterBar = () => {
 			<div className='filter-entries'>
 				{!rowFiltersHidden && rowFilterDescriptors.map((rowFilter, index) =>
 					<RowFilterWidget
+						key={index}
 						ref={ref => {
 							if (ref) {
 								rowFilterWidgetRefs.current[index] = ref;
 							}
 						}}
-						key={index}
-						rowFilter={rowFilter}
 						booleanOperator={index === 0 ? undefined : rowFilter.props.condition}
+						rowFilter={rowFilter}
+						onClear={async () => await clearRowFilter(rowFilter.identifier)}
 						onEdit={() => {
 							if (rowFilterWidgetRefs.current[index]) {
 								addRowFilterHandler(
@@ -285,13 +286,12 @@ export const RowFilterBar = () => {
 									rowFilter
 								);
 							}
-						}}
-						onClear={async () => await clearRowFilter(rowFilter.identifier)} />
+						}} />
 				)}
 				<Button
 					ref={addFilterButtonRef}
-					className='add-row-filter-button'
 					ariaLabel={(() => localize('positron.dataExplorer.addFilter', "Add Filter"))()}
+					className='add-row-filter-button'
 					disabled={!canFilter}
 					onPressed={() => addRowFilterHandler(
 						addFilterButtonRef.current,

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBarActivityIndicator.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/statusBarActivityIndicator.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -99,7 +99,7 @@ export const StatusBarActivityIndicator = () => {
 	// Render.
 	return (
 		<div className='status-bar-indicator'>
-			<div className={`icon ${statusClassName}`} title={statusText} aria-label={statusText} />
+			<div aria-label={statusText} className={`icon ${statusClassName}`} title={statusText} />
 		</div>
 	);
 };

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -163,8 +163,8 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 				<Button
 					ref={sortingButtonRef}
 					className='sort-button'
-					tabIndex={-1}
 					mouseTrigger={MouseTrigger.MouseDown}
+					tabIndex={-1}
 					onPressed={dropdownPressed}
 				>
 					<div className='codicon codicon-positron-vertical-ellipsis' style={{ fontSize: 18 }} />

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeaders.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeaders.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -30,6 +30,9 @@ interface DataGridColumnHeadersProps {
  */
 export const DataGridColumnHeaders = (props: DataGridColumnHeadersProps) => {
 	// Context hooks.
+	// FALSE POSITIVE: The ESLint rule of hooks is incorrectly flagging this line as a violation of
+	// the rules of hooks. https://github.com/facebook/react/issues/31687
+	// eslint-disable-next-line react-hooks/rules-of-hooks
 	const context = usePositronDataGridContext();
 
 	// Create the data grid column headers.

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeaders.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeaders.tsx
@@ -31,7 +31,7 @@ interface DataGridColumnHeadersProps {
 export const DataGridColumnHeaders = (props: DataGridColumnHeadersProps) => {
 	// Context hooks.
 	// FALSE POSITIVE: The ESLint rule of hooks is incorrectly flagging this line as a violation of
-	// the rules of hooks. https://github.com/facebook/react/issues/31687
+	// the rules of hooks. See: https://github.com/facebook/react/issues/31687
 	// eslint-disable-next-line react-hooks/rules-of-hooks
 	const context = usePositronDataGridContext();
 

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRow.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRow.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -29,6 +29,9 @@ interface DataGridRowProps {
  */
 export const DataGridRow = (props: DataGridRowProps) => {
 	// Context hooks.
+	// FALSE POSITIVE: The ESLint rule of hooks is incorrectly flagging this line as a violation of
+	// the rules of hooks. https://github.com/facebook/react/issues/31687
+	// eslint-disable-next-line react-hooks/rules-of-hooks
 	const context = usePositronDataGridContext();
 
 	// Create the data grid column headers.
@@ -41,8 +44,8 @@ export const DataGridRow = (props: DataGridRowProps) => {
 			<DataGridRowCell
 				key={`row-cell-${props.rowIndex}-${columnDescriptor.columnIndex}`}
 				columnIndex={columnDescriptor.columnIndex}
-				rowIndex={props.rowIndex}
 				left={columnDescriptor.left - context.instance.horizontalScrollOffset}
+				rowIndex={props.rowIndex}
 			/>
 		);
 	}

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRow.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRow.tsx
@@ -30,7 +30,7 @@ interface DataGridRowProps {
 export const DataGridRow = (props: DataGridRowProps) => {
 	// Context hooks.
 	// FALSE POSITIVE: The ESLint rule of hooks is incorrectly flagging this line as a violation of
-	// the rules of hooks. https://github.com/facebook/react/issues/31687
+	// the rules of hooks. See: https://github.com/facebook/react/issues/31687
 	// eslint-disable-next-line react-hooks/rules-of-hooks
 	const context = usePositronDataGridContext();
 

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -162,8 +162,8 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 				</>
 			}
 			<div
-				id={`data-grid-row-cell-content-${props.columnIndex}-${props.rowIndex}`}
 				className='content'
+				id={`data-grid-row-cell-content-${props.columnIndex}-${props.rowIndex}`}
 				style={{
 					paddingLeft: context.instance.horizontalCellPadding,
 					paddingRight: context.instance.horizontalCellPadding

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeaders.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeaders.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -27,6 +27,9 @@ interface DataGridRowHeadersProps {
  */
 export const DataGridRowHeaders = (props: DataGridRowHeadersProps) => {
 	// Context hooks.
+	// FALSE POSITIVE: The ESLint rule of hooks is incorrectly flagging this line as a violation of
+	// the rules of hooks. https://github.com/facebook/react/issues/31687
+	// eslint-disable-next-line react-hooks/rules-of-hooks
 	const context = usePositronDataGridContext();
 
 	// Create the data grid rows headers.

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeaders.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeaders.tsx
@@ -28,7 +28,7 @@ interface DataGridRowHeadersProps {
 export const DataGridRowHeaders = (props: DataGridRowHeadersProps) => {
 	// Context hooks.
 	// FALSE POSITIVE: The ESLint rule of hooks is incorrectly flagging this line as a violation of
-	// the rules of hooks. https://github.com/facebook/react/issues/31687
+	// the rules of hooks. See: https://github.com/facebook/react/issues/31687
 	// eslint-disable-next-line react-hooks/rules-of-hooks
 	const context = usePositronDataGridContext();
 

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -1,7 +1,11 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
+
+// FALSE POSITIVE: The ESLint rule of hooks is incorrectly flagging numerous lines in this file as a
+// violation of the rules of hooks. https://github.com/facebook/react/issues/31687
+/* eslint-disable react-hooks/rules-of-hooks */
 
 // CSS.
 import './dataGridWaffle.css';
@@ -496,9 +500,9 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 		dataGridRows.push(
 			<DataGridRow
 				key={`row-${rowLayoutEntry.rowIndex}`}
-				width={width}
-				top={rowLayoutEntry.top - context.instance.verticalScrollOffset}
 				rowIndex={rowLayoutEntry.rowIndex}
+				top={rowLayoutEntry.top - context.instance.verticalScrollOffset}
+				width={width}
 			/>
 		);
 	}
@@ -507,12 +511,12 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 	return (
 		<div
 			ref={dataGridWaffleRef}
-			tabIndex={0}
 			className='data-grid-waffle'
-			onKeyDown={keyDownHandler}
-			onWheel={wheelHandler}
+			tabIndex={0}
 			onBlur={() => context.instance.setFocused(false)}
 			onFocus={() => context.instance.setFocused(true)}
+			onKeyDown={keyDownHandler}
+			onWheel={wheelHandler}
 		>
 			{context.instance.columnHeaders && context.instance.rowHeaders &&
 				<DataGridCornerTopLeft
@@ -523,8 +527,8 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 			}
 			{context.instance.columnHeaders &&
 				<DataGridColumnHeaders
-					width={width - context.instance.rowHeadersWidth}
 					height={context.instance.columnHeadersHeight}
+					width={width - context.instance.rowHeadersWidth}
 				/>
 			}
 			{context.instance.rowHeaders &&
@@ -534,18 +538,18 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 			}
 			{context.instance.horizontalScrollbar &&
 				<DataGridScrollbar
-					containerWidth={width}
-					containerHeight={height}
-					orientation='horizontal'
 					bothScrollbarsVisible={
 						context.instance.horizontalScrollbar && context.instance.verticalScrollbar
 					}
-					scrollbarThickness={context.instance.scrollbarThickness}
-					scrollSize={context.instance.scrollWidth}
+					containerHeight={height}
+					containerWidth={width}
 					layoutSize={context.instance.layoutWidth}
+					maximumScrollOffset={() => context.instance.maximumHorizontalScrollOffset}
+					orientation='horizontal'
 					pageSize={context.instance.pageWidth}
 					scrollOffset={context.instance.horizontalScrollOffset}
-					maximumScrollOffset={() => context.instance.maximumHorizontalScrollOffset}
+					scrollSize={context.instance.scrollWidth}
+					scrollbarThickness={context.instance.scrollbarThickness}
 					onDidChangeScrollOffset={async scrollOffset => {
 						await context.instance.setHorizontalScrollOffset(scrollOffset);
 					}}
@@ -553,18 +557,18 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 			}
 			{context.instance.verticalScrollbar &&
 				<DataGridScrollbar
-					containerWidth={width}
-					containerHeight={height}
-					orientation='vertical'
 					bothScrollbarsVisible={
 						context.instance.horizontalScrollbar && context.instance.verticalScrollbar
 					}
-					scrollbarThickness={context.instance.scrollbarThickness}
-					scrollSize={context.instance.scrollHeight}
+					containerHeight={height}
+					containerWidth={width}
 					layoutSize={context.instance.layoutHeight}
+					maximumScrollOffset={() => context.instance.maximumVerticalScrollOffset}
+					orientation='vertical'
 					pageSize={context.instance.pageHeight}
 					scrollOffset={context.instance.verticalScrollOffset}
-					maximumScrollOffset={() => context.instance.maximumVerticalScrollOffset}
+					scrollSize={context.instance.scrollHeight}
+					scrollbarThickness={context.instance.scrollbarThickness}
 					onDidChangeScrollOffset={async scrollOffset => {
 						await context.instance.setVerticalScrollOffset(scrollOffset);
 					}}

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // FALSE POSITIVE: The ESLint rule of hooks is incorrectly flagging numerous lines in this file as a
-// violation of the rules of hooks. https://github.com/facebook/react/issues/31687
+// violation of the rules of hooks. See: https://github.com/facebook/react/issues/31687
 /* eslint-disable react-hooks/rules-of-hooks */
 
 // CSS.

--- a/src/vs/workbench/browser/positronDataGrid/positronDataGrid.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/positronDataGrid.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -30,7 +30,7 @@ export const PositronDataGrid = forwardRef<HTMLDivElement, PositronDataGridProps
 	// Render.
 	return (
 		<PositronDataGridContextProvider {...props}>
-			<div id={props.id} className='data-grid'>
+			<div className='data-grid' id={props.id}>
 				<DataGridWaffle ref={ref} />
 			</div>
 		</PositronDataGridContextProvider>

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -56,11 +56,6 @@ export const showNewFolderFromGitModalDialog = async (
 	// Show the new folder from git modal dialog.
 	renderer.render(
 		<NewFolderFromGitModalDialog
-			fileDialogService={fileDialogService}
-			labelService={labelService}
-			pathService={pathService}
-			renderer={renderer}
-			parentFolder={await fileDialogService.defaultFolderPath()}
 			createFolder={async result => {
 				if (result.repo) {
 					// temporarily set openAfterClone to facilitate result.newWindow then set it
@@ -88,6 +83,11 @@ export const showNewFolderFromGitModalDialog = async (
 					}
 				}
 			}}
+			fileDialogService={fileDialogService}
+			labelService={labelService}
+			parentFolder={await fileDialogService.defaultFolderPath()}
+			pathService={pathService}
+			renderer={renderer}
 		/>
 	);
 };
@@ -171,14 +171,14 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 	// Render.
 	return (
 		<OKCancelModalDialog
-			renderer={props.renderer}
-			width={400}
+			catchErrors
 			height={300}
+			renderer={props.renderer}
 			title={(() => localize(
 				'positronNewFolderFromGitModalDialogTitle',
 				"New Folder from Git"
 			))()}
-			catchErrors
+			width={400}
 			onAccept={async () => {
 				if (isInputEmpty(result.repo)) {
 					throw new Error(localize('positron.gitRepoNotProvided', "A git repository URL was not provided."));
@@ -191,12 +191,12 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 			<VerticalStack>
 				<LabeledTextInput
 					ref={folderNameRef}
-					value={result.repo}
+					autoFocus
 					label={(() => localize(
 						'positron.GitRepositoryURL',
 						"Git repository URL"
 					))()}
-					autoFocus
+					value={result.repo}
 					onChange={e => setResult({ ...result, repo: e.target.value })}
 				/>
 				<LabeledFolderInput

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderModalDialog.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -56,11 +56,6 @@ export const showNewFolderModalDialog = async (
 	// Show the new folder modal dialog.
 	renderer.render(
 		<NewFolderModalDialog
-			fileDialogService={fileDialogService}
-			labelService={labelService}
-			pathService={pathService}
-			renderer={renderer}
-			parentFolder={await fileDialogService.defaultFolderPath()}
 			createFolder={async result => {
 				// Create the folder path.
 				const folderURI = URI.joinPath(result.parentFolder, result.folder);
@@ -80,6 +75,11 @@ export const showNewFolderModalDialog = async (
 					}
 				);
 			}}
+			fileDialogService={fileDialogService}
+			labelService={labelService}
+			parentFolder={await fileDialogService.defaultFolderPath()}
+			pathService={pathService}
+			renderer={renderer}
 		/>
 	);
 };
@@ -163,11 +163,11 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 	// Render.
 	return (
 		<OKCancelModalDialog
-			renderer={props.renderer}
-			width={400}
-			height={300}
-			title={(() => localize('positronNewFolderModalDialogTitle', "New Folder"))()}
 			catchErrors
+			height={300}
+			renderer={props.renderer}
+			title={(() => localize('positronNewFolderModalDialogTitle', "New Folder"))()}
+			width={400}
 			onAccept={async () => {
 				if (isInputEmpty(result.folder)) {
 					throw new Error(localize('positron.folderNameNotProvided', "A folder name was not provided."));
@@ -179,11 +179,11 @@ const NewFolderModalDialog = (props: NewFolderModalDialogProps) => {
 			<VerticalStack>
 				<LabeledTextInput
 					ref={folderNameRef}
-					label={(() => localize('positron.folderName', "Folder name"))()}
 					autoFocus
+					label={(() => localize('positron.folderName', "Folder name"))()}
+					validator={(x: string | number) => checkIfPathValid(x, { parentPath: result.parentFolder.path })}
 					value={result.folder}
 					onChange={e => setResult({ ...result, folder: e.target.value })}
-					validator={(x: string | number) => checkIfPathValid(x, { parentPath: result.parentFolder.path })}
 				/>
 				<LabeledFolderInput
 					label={(() => localize(

--- a/src/vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/chooseNewProjectWindowModalDialog.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -38,9 +38,6 @@ export const showChooseNewProjectWindowModalDialog = (
 	// Show the choose new project window modal dialog.
 	renderer.render(
 		<ChooseNewProjectWindowModalDialog
-			renderer={renderer}
-			projectName={projectName}
-			openInNewWindow={openInNewWindow}
 			chooseNewProjectWindowAction={async (openInNewWindow: boolean) => {
 				// Open the project in the selected window.
 				await commandService.executeCommand(
@@ -52,6 +49,9 @@ export const showChooseNewProjectWindowModalDialog = (
 					}
 				);
 			}}
+			openInNewWindow={openInNewWindow}
+			projectName={projectName}
+			renderer={renderer}
 		/>
 	);
 };
@@ -102,14 +102,14 @@ const ChooseNewProjectWindowModalDialog = (props: ChooseNewProjectWindowModalDia
 	// Render.
 	return (
 		<PositronModalDialog
-			renderer={props.renderer}
-			width={320}
 			height={180}
+			renderer={props.renderer}
 			title={(() =>
 				localize(
 					'positron.chooseNewProjectWindowModalDialog.title',
 					'Create New Project'
 				))()}
+			width={320}
 		>
 			<div className='choose-new-project-window-modal-dialog'>
 				<VerticalStack>

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/logos/logoJupyter.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/logos/logoJupyter.tsx
@@ -1,7 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
+
+/* eslint-disable react/jsx-sort-props */
 
 // CSS.
 import './projectTypeLogo.css';

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/logos/logoPython.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/logos/logoPython.tsx
@@ -1,7 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
+
+/* eslint-disable react/jsx-sort-props */
 
 // CSS.
 import './projectTypeLogo.css';

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/logos/logoR.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/logos/logoR.tsx
@@ -1,7 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
+
+/* eslint-disable react/jsx-sort-props */
 
 // CSS.
 import './projectTypeLogo.css';

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/projectType.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/projectType.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -65,16 +65,16 @@ export const ProjectType = (props: ProjectTypeProps) => {
 			</div>
 			<input
 				ref={inputRef}
+				autoFocus={projectType && props.activeTabIndex}
+				checked={props.selected}
 				className='project-type-input'
-				type='radio'
-				tabIndex={props.activeTabIndex ? 0 : -1}
 				id={props.identifier}
 				name={props.groupName}
-				value={props.identifier}
-				checked={props.selected}
+				tabIndex={props.activeTabIndex ? 0 : -1}
+				type='radio'
 				// Set the autofocus to the selected project type when the user navigates back to
 				// the project type step.
-				autoFocus={projectType && props.activeTabIndex}
+				value={props.identifier}
 			/>
 			<label htmlFor={props.identifier}>{props.identifier}</label>
 		</div>

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/projectTypeGroup.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/projectTypeGroup.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -47,19 +47,19 @@ export const ProjectTypeGroup = (props: PropsWithChildren<ProjectTypeProps>) => 
 	// Render.
 	return (
 		<div
+			aria-describedby={props.describedBy}
+			aria-labelledby={props.labelledBy}
 			className='project-type-group'
 			role='radiogroup'
-			aria-labelledby={props.labelledBy}
-			aria-describedby={props.describedBy}
 		>
 			{projectTypes.map((projectType, index) => {
 				return (
 					<ProjectType
 						key={index}
-						identifier={projectType}
-						groupName={props.name}
-						selected={projectType === currentSelection}
 						activeTabIndex={projectType === activeIndexId}
+						groupName={props.name}
+						identifier={projectType}
+						selected={projectType === currentSelection}
 						onSelected={() => onSelectionChanged(projectType)}
 					/>
 				);

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/interpreterEntry.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/interpreterEntry.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -27,9 +27,9 @@ export const InterpreterEntry = ({ interpreterInfo }: InterpreterEntryProps) => 
 	return (
 		<DropdownEntry
 			codicon={interpreterInfo.preferred ? 'codicon-star-full' : undefined}
-			title={`${interpreterInfo.languageName} ${interpreterInfo.languageVersion}`}
-			subtitle={`${interpreterInfo.runtimePath}`}
 			group={interpreterInfo.runtimeSource}
+			subtitle={`${interpreterInfo.runtimePath}`}
+			title={`${interpreterInfo.languageName} ${interpreterInfo.languageVersion}`}
 		/>
 	);
 };

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectNameLocationStep.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -165,11 +165,7 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 	// Render.
 	return (
 		<PositronWizardStep
-			title={(() =>
-				localize(
-					'projectNameLocationStep.title',
-					"Set project name and location"
-				))()}
+			backButtonConfig={{ onClick: props.back }}
 			cancelButtonConfig={{ onClick: props.cancel }}
 			nextButtonConfig={{
 				onClick: nextStep,
@@ -181,14 +177,13 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 					(projectNameFeedback &&
 						projectNameFeedback.type === WizardFormattedTextType.Error),
 			}}
-			backButtonConfig={{ onClick: props.back }}
+			title={(() =>
+				localize(
+					'projectNameLocationStep.title',
+					"Set project name and location"
+				))()}
 		>
 			<PositronWizardSubStep
-				title={(() =>
-					localize(
-						'projectNameLocationSubStep.projectName.label',
-						"Project Name"
-					))()}
 				feedback={
 					projectNameFeedback ? (
 						<WizardFormattedText type={projectNameFeedback.type}>
@@ -200,33 +195,33 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 						</WizardFormattedText>
 						: undefined
 				}
+				title={(() =>
+					localize(
+						'projectNameLocationSubStep.projectName.label',
+						"Project Name"
+					))()}
 			>
 				<LabeledTextInput
+					autoFocus
+					error={
+						(projectNameFeedback &&
+							projectNameFeedback.type === WizardFormattedTextType.Error) ||
+						Boolean(nameValidationErrorMsg)
+					}
 					label={(() =>
 						localize(
 							'projectNameLocationSubStep.projectName.description',
 							"Enter a name for your new {0}",
 							context.projectType
 						))()}
-					autoFocus
-					value={projectName}
-					onChange={(e) => onChangeProjectName(e.target.value)}
-					type='text'
 					// Don't let the user create a project with a location that is too long.
 					maxLength={maxProjectPathLength}
-					error={
-						(projectNameFeedback &&
-							projectNameFeedback.type === WizardFormattedTextType.Error) ||
-						Boolean(nameValidationErrorMsg)
-					}
+					type='text'
+					value={projectName}
+					onChange={(e) => onChangeProjectName(e.target.value)}
 				/>
 			</PositronWizardSubStep>
 			<PositronWizardSubStep
-				title={(() =>
-					localize(
-						'projectNameLocationSubStep.parentDirectory.label',
-						"Parent Directory"
-					))()}
 				feedback={
 					parentPathErrorMsg ?
 						<WizardFormattedText type={WizardFormattedTextType.Error}>
@@ -247,8 +242,15 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 							/>
 						</WizardFormattedText>
 				}
+				title={(() =>
+					localize(
+						'projectNameLocationSubStep.parentDirectory.label',
+						"Parent Directory"
+					))()}
 			>
 				<LabeledFolderInput
+					skipValidation
+					error={Boolean(parentPathErrorMsg)}
 					label={(() =>
 						localize(
 							'projectNameLocationSubStep.parentDirectory.description',
@@ -256,8 +258,6 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 						))()}
 					value={parentFolder}
 					onBrowse={browseHandler}
-					error={Boolean(parentPathErrorMsg)}
-					skipValidation
 					onChange={(e) => onChangeParentFolder(e.target.value)}
 				/>
 			</PositronWizardSubStep>
@@ -266,13 +266,13 @@ export const ProjectNameLocationStep = (props: PropsWithChildren<NewProjectWizar
 			>
 				{/* TODO: display a warning/message if the user doesn't have git set up */}
 				<Checkbox
+					initialChecked={context.initGitRepo}
 					label={(() =>
 						localize(
 							'projectNameLocationSubStep.initGitRepo.label',
 							"Initialize project as Git repository"
 						))()}
 					onChanged={(checked) => context.initGitRepo = checked}
-					initialChecked={context.initGitRepo}
 				/>
 			</PositronWizardSubStep>
 		</PositronWizardStep>

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectTypeStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/projectTypeStep.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -94,9 +94,9 @@ export const ProjectTypeStep = (props: PropsWithChildren<NewProjectWizardStepPro
 					))()}
 			</div>
 			<ProjectTypeGroup
-				name='projectType'
-				labelledBy='project-type-selection-step-title'
 				describedBy='project-type-selection-step-description'
+				labelledBy='project-type-selection-step-title'
+				name='projectType'
 				selectedProjectId={selectedProjectType}
 				onSelectionChanged={(projectType) =>
 					setSelectedProjectType(projectType)

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/pythonEnvironmentStep.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -146,7 +146,6 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 								"The environment will be created at: "
 							))()}
 						<PathDisplay
-							pathService={context.services.pathService}
 							maxLength={65}
 							pathComponents={
 								locationForNewEnv(
@@ -155,6 +154,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 									envProviderNameForId(envProviderId, envProviders!)
 								)
 							}
+							pathService={context.services.pathService}
 						/>
 
 					</WizardFormattedText>
@@ -367,10 +367,6 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 	// Render.
 	return (
 		<PositronWizardStep
-			title={(() => localize(
-				'pythonEnvironmentStep.title',
-				"Set up Python environment"
-			))()}
 			backButtonConfig={{ onClick: props.back }}
 			cancelButtonConfig={{ onClick: props.cancel }}
 			okButtonConfig={{
@@ -381,6 +377,10 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 				))(),
 				disable: disableCreateButton()
 			}}
+			title={(() => localize(
+				'pythonEnvironmentStep.title',
+				"Set up Python environment"
+			))()}
 		>
 			{/* New or existing Python environment selection */}
 			<PositronWizardSubStep
@@ -391,10 +391,10 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 				titleId='pythonEnvironment-howToSetUpEnv'
 			>
 				<RadioGroup
-					name='envSetup'
-					labelledBy='pythonEnvironment-howToSetUpEnv'
 					entries={envSetupRadioButtons}
 					initialSelectionId={envSetupType}
+					labelledBy='pythonEnvironment-howToSetUpEnv'
+					name='envSetup'
 					onSelectionChanged={
 						identifier => onEnvSetupTypeSelected(identifier)
 					}
@@ -403,10 +403,6 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 			{/* If New Environment, show dropdown for Python environment providers */}
 			{envSetupType === EnvironmentSetupType.NewEnvironment ?
 				<PositronWizardSubStep
-					title={(() => localize(
-						'pythonEnvironmentSubStep.label',
-						"Python Environment"
-					))()}
 					description={
 						<WizardFormattedText type={WizardFormattedTextType.Info}>
 							{(() => localize(
@@ -421,20 +417,24 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 						</WizardFormattedText>
 					}
 					feedback={envProviderStepFeedback()}
+					title={(() => localize(
+						'pythonEnvironmentSubStep.label',
+						"Python Environment"
+					))()}
 				>
 					<DropDownListBox
-						keybindingService={keybindingService}
-						layoutService={layoutService}
-						disabled={!envProvidersAvailable()}
-						title={envProviderDropdownTitle()}
-						entries={envProviderDropdownEntries()}
-						selectedIdentifier={envProviderId}
 						createItem={(item) => (
 							<DropdownEntry
-								title={item.options.value.name}
 								subtitle={item.options.value.description}
+								title={item.options.value.name}
 							/>
 						)}
+						disabled={!envProvidersAvailable()}
+						entries={envProviderDropdownEntries()}
+						keybindingService={keybindingService}
+						layoutService={layoutService}
+						selectedIdentifier={envProviderId}
+						title={envProviderDropdownTitle()}
 						onSelectionChanged={(item) =>
 							onEnvProviderSelected(item.options.identifier)
 						}
@@ -443,30 +443,30 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewProjectWizardS
 			}
 			{/* Show the Python interpreter dropdown */}
 			<PositronWizardSubStep
-				title={(() =>
-					localize(
-						'pythonInterpreterSubStep.title',
-						"Python Interpreter"
-					))()}
 				description={(() =>
 					localize(
 						'pythonInterpreterSubStep.description',
 						"Select a Python installation for your project."
 					))()}
 				feedback={interpreterStepFeedback()}
+				title={(() =>
+					localize(
+						'pythonInterpreterSubStep.title',
+						"Python Interpreter"
+					))()}
 			>
 				<DropDownListBox
-					keybindingService={keybindingService}
-					layoutService={layoutService}
-					disabled={!interpretersAvailable()}
-					title={interpreterDropdownTitle()}
-					entries={interpreterDropdownEntries()}
-					selectedIdentifier={selectedInterpreterId()}
 					createItem={(item) => (
 						<InterpreterEntry
 							interpreterInfo={item.options.value}
 						/>
 					)}
+					disabled={!interpretersAvailable()}
+					entries={interpreterDropdownEntries()}
+					keybindingService={keybindingService}
+					layoutService={layoutService}
+					selectedIdentifier={selectedInterpreterId()}
+					title={interpreterDropdownTitle()}
 					onSelectionChanged={(item) =>
 						onInterpreterSelected(item.options.identifier)
 					}

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/steps/rConfigurationStep.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -109,10 +109,6 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 	// Render.
 	return (
 		<PositronWizardStep
-			title={(() => localize(
-				'rConfigurationStep.title',
-				"Set up project configuration"
-			))()}
 			backButtonConfig={{ onClick: props.back }}
 			cancelButtonConfig={{ onClick: props.cancel }}
 			okButtonConfig={{
@@ -123,13 +119,12 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 				))(),
 				disable: !selectedInterpreter
 			}}
+			title={(() => localize(
+				'rConfigurationStep.title',
+				"Set up project configuration"
+			))()}
 		>
 			<PositronWizardSubStep
-				title={(() =>
-					localize(
-						'rConfigurationStep.versionSubStep.title',
-						'R Version'
-					))()}
 				description={(() =>
 					localize(
 						'rConfigurationStep.versionSubStep.description',
@@ -149,12 +144,19 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 						</WizardFormattedText>
 					) : undefined
 				}
+				title={(() =>
+					localize(
+						'rConfigurationStep.versionSubStep.title',
+						'R Version'
+					))()}
 			>
 				<DropDownListBox
-					keybindingService={keybindingService}
-					layoutService={layoutService}
+					createItem={(item) => (
+						<InterpreterEntry
+							interpreterInfo={item.options.value}
+						/>
+					)}
 					disabled={!interpretersAvailable()}
-					title={interpreterDropdownTitle()}
 					entries={
 						interpretersAvailable()
 							? interpretersToDropdownItems(
@@ -163,12 +165,10 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 							)
 							: []
 					}
+					keybindingService={keybindingService}
+					layoutService={layoutService}
 					selectedIdentifier={selectedInterpreter?.runtimeId}
-					createItem={(item) => (
-						<InterpreterEntry
-							interpreterInfo={item.options.value}
-						/>
-					)}
+					title={interpreterDropdownTitle()}
 					onSelectionChanged={(item) =>
 						onInterpreterSelected(item.options.identifier)
 					}
@@ -183,18 +183,18 @@ export const RConfigurationStep = (props: PropsWithChildren<NewProjectWizardStep
 			>
 				<div className='renv-configuration'>
 					<Checkbox
+						initialChecked={context.useRenv}
 						label={(() =>
 							localize(
 								'rConfigurationStep.additionalConfigSubStep.useRenv.label',
 								"Use `renv` to create a reproducible environment"
 							))()}
 						onChanged={(checked) => (context.useRenv = checked)}
-						initialChecked={context.useRenv}
 					/>
 					<ExternalLink
 						className='renv-docs-external-link'
-						openerService={openerService}
 						href='https://rstudio.github.io/renv/articles/renv.html'
+						openerService={openerService}
 						title='https://rstudio.github.io/renv/articles/renv.html'
 					>
 						<div className='codicon codicon-link-external' />

--- a/src/vs/workbench/browser/positronNewProjectWizard/components/wizardStep.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/components/wizardStep.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -38,10 +38,10 @@ export const PositronWizardStep = (props: PropsWithChildren<PositronWizardStepPr
 			<div className='wizard-step-title'>{props.title}</div>
 			<VerticalStack>{props.children}</VerticalStack>
 			<OKCancelBackNextActionBar
-				okButtonConfig={props.okButtonConfig}
-				cancelButtonConfig={props.cancelButtonConfig}
 				backButtonConfig={props.backButtonConfig}
+				cancelButtonConfig={props.cancelButtonConfig}
 				nextButtonConfig={props.nextButtonConfig}
+				okButtonConfig={props.okButtonConfig}
 			/>
 		</div>
 	);

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectModalDialog.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -62,6 +62,8 @@ export const showNewProjectModalDialog = async (
 	// Show the new project modal dialog.
 	renderer.render(
 		<NewProjectWizardContextProvider
+			initialStep={NewProjectWizardStep.ProjectTypeSelection}
+			parentFolder={await fileDialogService.defaultFolderPath()}
 			services={{
 				commandService,
 				configurationService,
@@ -77,11 +79,8 @@ export const showNewProjectModalDialog = async (
 				runtimeSessionService,
 				runtimeStartupService,
 			}}
-			parentFolder={await fileDialogService.defaultFolderPath()}
-			initialStep={NewProjectWizardStep.ProjectTypeSelection}
 		>
 			<NewProjectModalDialog
-				renderer={renderer}
 				createProject={async result => {
 					// Create the new project folder if it doesn't already exist.
 					const folder = URI.joinPath(result.parentFolder, result.projectName);
@@ -162,6 +161,7 @@ export const showNewProjectModalDialog = async (
 						result.openInNewWindow
 					);
 				}}
+				renderer={renderer}
 			/>
 		</NewProjectWizardContextProvider>
 	);
@@ -197,12 +197,12 @@ const NewProjectModalDialog = (props: NewProjectModalDialogProps) => {
 	// Render.
 	return (
 		<PositronModalDialog
-			renderer={props.renderer}
-			width={700} height={520}
-			title={(() => localize('positronNewProjectWizard.title', "Create New Project"))()}
+			height={520}
+			renderer={props.renderer} title={(() => localize('positronNewProjectWizard.title', "Create New Project"))()}
+			width={700}
 			onCancel={cancelHandler}
 		>
-			<NewProjectWizardStepContainer cancel={cancelHandler} accept={acceptHandler} />
+			<NewProjectWizardStepContainer accept={acceptHandler} cancel={cancelHandler} />
 		</PositronModalDialog>
 	);
 };

--- a/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardStepContainer.tsx
+++ b/src/vs/workbench/browser/positronNewProjectWizard/newProjectWizardStepContainer.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -30,6 +30,6 @@ export const NewProjectWizardStepContainer = (props: PropsWithChildren<NewProjec
 	};
 
 	return (
-		<WizardStep next={nextHandler} back={backHandler} cancel={props.cancel} accept={props.accept} />
+		<WizardStep accept={props.accept} back={backHandler} cancel={props.cancel} next={nextHandler} />
 	);
 };

--- a/src/vs/workbench/contrib/positronConnections/browser/components/listConnections.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/listConnections.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -74,11 +74,11 @@ export const ListConnections = (props: React.PropsWithChildren<ListConnnectionsP
 
 		return (
 			<div
-				style={props.style}
 				className={positronClassNames(
 					'connections-list-item',
 					{ 'selected': itemProps.id === selectedInstanceId }
 				)}
+				style={props.style}
 				onMouseDown={() => setSelectedInstanceId(itemProps.id)}
 			>
 				<div className='col-icon'>
@@ -153,12 +153,12 @@ export const ListConnections = (props: React.PropsWithChildren<ListConnnectionsP
 					<div className='col-action' style={{ width: `${26}px` }}></div>
 				</div>
 				<List
-					itemCount={instances.length}
-					itemSize={26}
 					height={height - ACTION_BAR_HEIGHT - TABLE_HEADER_HEIGHT}
-					width={'calc(100% - 2px)'}
-					itemKey={index => instances[index].id}
 					innerRef={innerRef}
+					itemCount={instances.length}
+					itemKey={index => instances[index].id}
+					itemSize={26}
+					width={'calc(100% - 2px)'}
 				>
 					{ItemEntry}
 				</List>
@@ -191,11 +191,11 @@ const ActionBar = (props: React.PropsWithChildren<ActionBarProps>) => {
 		<div style={{ height: ACTION_BAR_HEIGHT }}>
 			<PositronActionBarContextProvider {...props}>
 				<PositronActionBar
-					size='small'
-					borderTop={true}
 					borderBottom={true}
+					borderTop={true}
 					paddingLeft={ACTION_BAR_PADDING_LEFT}
 					paddingRight={ACTION_BAR_PADDING_RIGHT}
+					size='small'
 				>
 					<ActionBarRegion location='left'>
 						<ActionBarButton
@@ -210,9 +210,9 @@ const ActionBar = (props: React.PropsWithChildren<ActionBarProps>) => {
 					<ActionBarRegion location='right'>
 						<ActionBarButton
 							align='right'
+							disabled={props.onDeleteConnection === undefined}
 							iconId='close'
 							text={localize('positron.listConnections.deleteConnection', 'Delete Connection')}
-							disabled={props.onDeleteConnection === undefined}
 							onPressed={props.onDeleteConnection}
 						/>
 					</ActionBarRegion>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -61,10 +61,10 @@ const NewConnectionModalDialog = (props: PropsWithChildren<NewConnectionModalDia
 	};
 
 	return <PositronModalDialog
+		height={NEW_CONNECTION_MODAL_DIALOG_HEIGHT}
 		renderer={props.renderer}
 		title={(() => localize('positron.newConnectionModalDialog.title', "Create New Connection"))()}
 		width={NEW_CONNECTION_MODAL_DIALOG_WIDTH}
-		height={NEW_CONNECTION_MODAL_DIALOG_HEIGHT}
 		onCancel={cancelHandler}
 	>
 		<div className='connections-new-connection-modal'>
@@ -72,17 +72,17 @@ const NewConnectionModalDialog = (props: PropsWithChildren<NewConnectionModalDia
 				{
 					selectedDriver ?
 						<CreateConnection
-							services={props.services}
 							renderer={props.renderer}
-							onCancel={cancelHandler}
-							onBack={backHandler}
-							selectedDriver={selectedDriver} /> :
-						<ListDrivers
+							selectedDriver={selectedDriver}
 							services={props.services}
+							onBack={backHandler}
+							onCancel={cancelHandler} /> :
+						<ListDrivers
+							languageId={languageId}
+							services={props.services}
+							setLanguageId={setLanguageId}
 							onCancel={cancelHandler}
 							onSelection={(driver) => setSelectedDriver(driver)}
-							languageId={languageId}
-							setLanguageId={setLanguageId}
 						/>}
 			</ContentArea>
 		</div>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -106,13 +106,13 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 		<div className='create-connection-code-editor'>
 			<SimpleCodeEditor
 				ref={editorRef}
-				services={props.services}
-				language={languageId}
+				code={code}
 				editorOptions={{
 					readOnly: true,
 					cursorBlinking: 'solid'
 				}}
-				code={code}
+				language={languageId}
+				services={props.services}
 			>
 			</SimpleCodeEditor>
 		</div>
@@ -183,8 +183,8 @@ const FormElement = (props: PropsWithChildren<FormElementProps>) => {
 			return <div className='labeled-input'>
 				<LabeledTextInput
 					label={label}
-					value={defaultValue}
 					type='text'
+					value={defaultValue}
 					onChange={(e) => props.onChange(e.target.value)}
 				></LabeledTextInput>
 			</div>;
@@ -194,10 +194,10 @@ const FormElement = (props: PropsWithChildren<FormElementProps>) => {
 				{
 					options && options.length > 0 ?
 						<RadioGroup
-							name={label}
-							labelledBy={label}
 							entries={options.map(option => ({ options: option }))}
 							initialSelectionId={options[0].identifier}
+							labelledBy={label}
+							name={label}
 							onSelectionChanged={(option) => props.onChange(option)}
 						/>
 						: <p>
@@ -210,8 +210,8 @@ const FormElement = (props: PropsWithChildren<FormElementProps>) => {
 			return <div className='labeled-input'>
 				<LabeledTextInput
 					label={label}
-					value={defaultValue}
 					type='text'
+					value={defaultValue}
 					onChange={(e) => props.onChange(e.target.value)}
 				></LabeledTextInput>
 			</div>;

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -51,15 +51,6 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 		</div>
 		<div className='select-language'>
 			<DropDownListBox
-				keybindingService={props.services.keybindingService}
-				layoutService={props.services.layoutService}
-				title={(() => localize('positron.newConnectionModalDialog.listDrivers.selectLanguage', "Select a language"))()}
-				entries={getRegisteredLanguages(props.services).map((item) => {
-					return new DropDownListBoxItem({
-						identifier: item.languageId,
-						value: item
-					});
-				})}
 				createItem={(item) => {
 					const value = item.options.value;
 
@@ -70,8 +61,17 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 						</div>
 					</div>;
 				}}
-				onSelectionChanged={(item) => onLanguageChangeHandler(item.options.identifier)}
+				entries={getRegisteredLanguages(props.services).map((item) => {
+					return new DropDownListBoxItem({
+						identifier: item.languageId,
+						value: item
+					});
+				})}
+				keybindingService={props.services.keybindingService}
+				layoutService={props.services.layoutService}
 				selectedIdentifier={languageId}
+				title={(() => localize('positron.newConnectionModalDialog.listDrivers.selectLanguage', "Select a language"))()}
+				onSelectionChanged={(item) => onLanguageChangeHandler(item.options.identifier)}
 			>
 			</DropDownListBox>
 		</div>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/resumeConnectionModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/resumeConnectionModalDialog.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -36,9 +36,9 @@ export const showResumeConnectionModalDialog = (
 
 	renderer.render(
 		<ResumeConnectionModalDialog
+			activeInstaceId={activeInstanceId}
 			renderer={renderer}
 			services={services}
-			activeInstaceId={activeInstanceId}
 			setActiveInstanceId={setActiveInstanceId}
 		/>
 	);
@@ -128,11 +128,11 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 	return (
 		<div className='connections-resume-connection-modal'>
 			<PositronModalDialog
-				width={RESUME_CONNECTION_MODAL_DIALOG_WIDTH}
 				height={RESUME_CONNECTION_MODAL_DIALOG_HEIGHT}
-				title={(() => localize('positron.resumeConnectionModalDialog.title', "Resume Connection"))()}
-				onCancel={cancelHandler}
 				renderer={props.renderer}
+				title={(() => localize('positron.resumeConnectionModalDialog.title', "Resume Connection"))()}
+				width={RESUME_CONNECTION_MODAL_DIALOG_WIDTH}
+				onCancel={cancelHandler}
 			>
 				<ContentArea>
 					<div className='content'>
@@ -140,22 +140,22 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 						<div className='code'>
 							<SimpleCodeEditor
 								ref={editorRef}
-								services={services}
 								code={code}
-								language={language_id}
 								editorOptions={{
 									readOnly: true,
 									domReadOnly: true,
 									cursorBlinking: 'solid',
 								}}
+								language={language_id}
+								services={services}
 							></SimpleCodeEditor>
 						</div>
 						<div className='buttons'>
 							<div className='top'>
 								<PositronButton
 									className='button action-bar-button'
-									onPressed={editHandler}
 									disabled={!code}
+									onPressed={editHandler}
 								>
 									{(() => localize('positron.resumeConnectionModalDialog.edit', "Edit"))()}
 								</PositronButton>
@@ -163,8 +163,8 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 							<div className='bottom'>
 								<PositronButton
 									className='button action-bar-button'
-									onPressed={copyHandler}
 									disabled={!code}
+									onPressed={copyHandler}
 								>
 									{(() => localize('positron.resumeConnectionModalDialog.copy', "Copy"))()}
 								</PositronButton>
@@ -179,8 +179,8 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 						<div className='footer'>
 							<PositronButton
 								className='button action-bar-button default'
-								onPressed={resumeHandler}
 								disabled={!activeInstance.connect}
+								onPressed={resumeHandler}
 							>
 								{(() => localize('positron.resumeConnectionModalDialog.resume', "Resume Connection"))()}
 							</PositronButton>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigation.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -83,9 +83,9 @@ export const SchemaNavigation = (props: React.PropsWithChildren<SchemaNavigation
 			<div className='positron-connections-schema-navigation'>
 				<ActionBar
 					{...context}
+					onBack={() => props.setActiveInstanceId(undefined)}
 					onDisconnect={() => { }}
 					onRefresh={() => { }}
-					onBack={() => props.setActiveInstanceId(undefined)}
 				>
 				</ActionBar>
 			</div>
@@ -103,9 +103,9 @@ export const SchemaNavigation = (props: React.PropsWithChildren<SchemaNavigation
 			<PositronConnectionsItem
 				item={itemProps}
 				selected={itemProps.id === selectedId}
+				style={props.style}
 				onSelected={() => setSelectedId(itemProps.id)}
-				onToggleExpand={toggleExpandHandler}
-				style={props.style}>
+				onToggleExpand={toggleExpandHandler}>
 			</PositronConnectionsItem>
 		);
 	};
@@ -117,9 +117,9 @@ export const SchemaNavigation = (props: React.PropsWithChildren<SchemaNavigation
 		<div className='positron-connections-schema-navigation'>
 			<ActionBar
 				{...context}
+				onBack={() => props.setActiveInstanceId(undefined)}
 				onDisconnect={() => activeInstance.disconnect?.()}
 				onRefresh={() => activeInstance.refresh?.()}
-				onBack={() => props.setActiveInstanceId(undefined)}
 			>
 			</ActionBar>
 			<div className='connections-items-container'>
@@ -135,14 +135,13 @@ export const SchemaNavigation = (props: React.PropsWithChildren<SchemaNavigation
 					}
 				</div>
 				<List
-					itemCount={entries.length}
-					itemSize={26}
-					/* size if the actionbar and the secondary side bar combined) */
 					height={height - ACTION_BAR_HEIGHT - DETAILS_BAR_HEIGHT}
-					className='connections-items-list'
-					width={'100%'}
-					itemKey={index => entries[index].id}
 					innerRef={innerRef}
+					itemCount={entries.length}
+					itemKey={index => entries[index].id}
+					itemSize={26}
+					width={'calc(100% - 2px)'}
+				/* size if the actionbar and the secondary side bar combined) */
 				>
 					{ItemEntry}
 				</List>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigationActionBar.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigationActionBar.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -50,11 +50,11 @@ export const ActionBar = (props: React.PropsWithChildren<ConnectionActionBarProp
 		<div style={{ height: ACTION_BAR_HEIGHT }}>
 			<PositronActionBarContextProvider {...props}>
 				<PositronActionBar
-					size='small'
-					borderTop={true}
 					borderBottom={true}
+					borderTop={true}
 					paddingLeft={ACTION_BAR_PADDING_LEFT}
 					paddingRight={ACTION_BAR_PADDING_RIGHT}
+					size='small'
 				>
 					<ActionBarRegion location='left'>
 						<ActionBarButton

--- a/src/vs/workbench/contrib/positronConnections/browser/components/simpleCodeEditor.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/simpleCodeEditor.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -88,7 +88,7 @@ export const SimpleCodeEditor = forwardRef<
 			services.modelService,
 		]);
 
-	return <div style={{ height: '100%' }} ref={editorContainerRef}></div>;
+	return <div ref={editorContainerRef} style={{ height: '100%' }}></div>;
 });
 
 SimpleCodeEditor.displayName = 'SimpleCodeEditor';

--- a/src/vs/workbench/contrib/positronConnections/browser/positronConnectionsView.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/positronConnectionsView.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -140,21 +140,21 @@ export class PositronConnectionsView
 		this.positronReactRenderer.render(
 			<PositronConnections
 				accessibilityService={this.accessibilityService}
-				configurationService={this.configurationService}
+				clipboardService={this.clipboardService}
 				commandService={this.commandService}
+				configurationService={this.configurationService}
+				connectionsService={this.connectionsService}
 				contextKeyService={this.contextKeyService}
 				contextMenuService={this.contextMenuService}
-				hoverService={this.hoverService}
-				keybindingService={this.keybindingService}
-				connectionsService={this.connectionsService}
-				layoutService={this.layoutService}
-				reactComponentContainer={this}
-				clipboardService={this.clipboardService}
-				notificationService={this.notificationService}
 				editorService={this.editorService}
+				hoverService={this.hoverService}
 				instantiationService={this.instantiationService}
-				modelService={this.modelService}
+				keybindingService={this.keybindingService}
 				languageRuntimeService={this.languageRuntimeService}
+				layoutService={this.layoutService}
+				modelService={this.modelService}
+				notificationService={this.notificationService}
+				reactComponentContainer={this}
 				runtimeAffiliationService={this.runtimeStartupService}
 				runtimeSessionService={this.runtimeSessionService}
 			/>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -325,21 +325,21 @@ export const ActionBar = (props: ActionBarProps) => {
 		<PositronActionBarContextProvider {...positronConsoleContext}>
 			<div className='action-bar'>
 				<PositronActionBar
-					size='small'
-					borderTop={true}
 					borderBottom={true}
+					borderTop={true}
 					paddingLeft={kPaddingLeft}
 					paddingRight={kPaddingRight}
+					size='small'
 				>
 					<ActionBarRegion location='left'>
 						<ConsoleInstanceMenuButton {...props} />
 						<div className='action-bar-separator' />
 						{directoryLabel &&
-							<div className='directory-label'
-								aria-label={(() => localize(
-									'directoryLabel',
-									"Current Working Directory"
-								))()}
+							<div aria-label={(() => localize(
+								'directoryLabel',
+								"Current Working Directory"
+							))()}
+								className='directory-label'
 							>
 								<span className='codicon codicon-folder' role='presentation'></span>
 								<span className='label' title={directoryLabel}>{directoryLabel}</span>
@@ -350,11 +350,11 @@ export const ActionBar = (props: ActionBarProps) => {
 						<div className='state-label'>{stateLabel}</div>
 						{interruptible &&
 							<ActionBarButton
-								fadeIn={true}
-								disabled={interrupting}
 								align='right'
-								tooltip={positronInterruptExecution}
 								ariaLabel={positronInterruptExecution}
+								disabled={interrupting}
+								fadeIn={true}
+								tooltip={positronInterruptExecution}
 								onPressed={interruptHandler}
 							>
 								<div className={
@@ -370,45 +370,45 @@ export const ActionBar = (props: ActionBarProps) => {
 							<ActionBarSeparator fadeIn={true} />
 						}
 						<ActionBarButton
-							iconId='positron-power-button-thin'
 							align='right'
-							disabled={!(canShutdown || canStart)}
-							tooltip={canStart ? positronStartConsole : positronShutdownConsole}
 							ariaLabel={canStart ? positronStartConsole : positronShutdownConsole}
+							disabled={!(canShutdown || canStart)}
+							iconId='positron-power-button-thin'
+							tooltip={canStart ? positronStartConsole : positronShutdownConsole}
 							onPressed={powerCycleConsoleHandler}
 						/>
 						<ActionBarButton
-							iconId='positron-restart-runtime-thin'
 							align='right'
-							disabled={!canShutdown}
-							tooltip={positronRestartConsole}
 							ariaLabel={positronRestartConsole}
+							disabled={!canShutdown}
+							iconId='positron-restart-runtime-thin'
+							tooltip={positronRestartConsole}
 							onPressed={restartConsoleHandler}
 						/>
 						{multiSessionsEnabled && <ConsoleInstanceInfoButton />}
 						<ActionBarSeparator />
 						{showDeveloperUI &&
 							<ActionBarButton
-								iconId='wand'
 								align='right'
-								tooltip={positronToggleTrace}
 								ariaLabel={positronToggleTrace}
+								iconId='wand'
+								tooltip={positronToggleTrace}
 								onPressed={toggleTraceHandler}
 							/>
 						}
 						<ActionBarButton
-							iconId='word-wrap'
 							align='right'
-							tooltip={positronToggleWordWrap}
 							ariaLabel={positronToggleWordWrap}
+							iconId='word-wrap'
+							tooltip={positronToggleWordWrap}
 							onPressed={toggleWordWrapHandler}
 						/>
 						<ActionBarSeparator />
 						<ActionBarButton
-							iconId='clear-all'
 							align='right'
-							tooltip={positronClearConsole}
 							ariaLabel={positronClearConsole}
+							iconId='clear-all'
+							tooltip={positronClearConsole}
 							onPressed={clearConsoleHandler}
 						/>
 					</ActionBarRegion>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
@@ -222,8 +222,8 @@ export const ActivityInput = (props: ActivityInputProps) => {
 					<div key={`outputLine-${index}`}>
 						<Prompt index={index} />
 						<span
-							key={`colorizedOutputLine-${index}`}
 							dangerouslySetInnerHTML={{ __html: outputLine }}
+							key={`colorizedOutputLine-${index}`}
 						/>
 					</div>
 				)}
@@ -240,9 +240,9 @@ export const ActivityInput = (props: ActivityInputProps) => {
 						{outputLine.outputRuns.map(outputRun =>
 							<OutputRun
 								key={outputRun.id}
-								outputRun={outputRun}
 								notificationService={positronConsoleContext.notificationService}
 								openerService={positronConsoleContext.openerService}
+								outputRun={outputRun}
 							/>
 						)}
 					</div>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityOutputPlot.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -38,8 +38,8 @@ export const ActivityOutputPlot = (props: ActivityOutputPlotProps) => {
 		<>
 			<OutputLines outputLines={props.activityItemOutputPlot.outputLines} />
 			<a className='activity-output-plot'
-				onClick={handleClick}
-				title={linkTitle}>
+				title={linkTitle}
+				onClick={handleClick}>
 				<img src={props.activityItemOutputPlot.plotUri} />
 				<span className='inspect codicon codicon-positron-search' />
 			</a>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -215,9 +215,9 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 					outputLine.outputRuns.map(outputRun =>
 						<OutputRun
 							key={outputRun.id}
-							outputRun={outputRun}
-							openerService={openerService}
 							notificationService={notificationService}
+							openerService={openerService}
+							outputRun={outputRun}
 						/>
 					)
 				)}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.tsx
@@ -67,10 +67,10 @@ export const ConsoleCore = (props: ConsoleCoreProps) => {
 					<ConsoleInstance
 						key={positronConsoleInstance.session.runtimeMetadata.languageId}
 						active={positronConsoleInstance === positronConsoleContext.activePositronConsoleInstance}
-						width={props.width}
 						height={adjustedHeight}
 						positronConsoleInstance={positronConsoleInstance}
 						reactComponentContainer={props.reactComponentContainer}
+						width={props.width}
 					/>
 				)}
 			</div>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -990,11 +990,11 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			{historyBrowserActive &&
 				<HistoryBrowserPopup
 					bottomPx={historyBrowserBottomPx}
-					leftPx={historyBrowserLeftPx}
 					items={historyItems}
+					leftPx={historyBrowserLeftPx}
 					selectedIndex={historyBrowserSelectedIndex}
-					onSelected={acceptHistoryMatch}
-					onDismissed={disengageHistoryBrowser} />
+					onDismissed={disengageHistoryBrowser}
+					onSelected={acceptHistoryMatch} />
 			}
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -615,19 +615,19 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			onClick={clickHandler}
 			onKeyDown={keyDownHandler}
 			onMouseDown={mouseDownHandler}
-			onWheel={wheelHandler}
-			onScroll={scrollHandler}>
+			onScroll={scrollHandler}
+			onWheel={wheelHandler}>
 			<div
 				ref={consoleInstanceContainerRef}
 				className='console-instance-container'
 				onWheel={scrollOverrideHandler}
 			>
 				<ConsoleInstanceItems
-					positronConsoleInstance={props.positronConsoleInstance}
-					editorFontInfo={editorFontInfo}
-					trace={trace}
-					runtimeAttached={runtimeAttached}
 					consoleInputWidth={consoleInputWidth}
+					editorFontInfo={editorFontInfo}
+					positronConsoleInstance={props.positronConsoleInstance}
+					runtimeAttached={runtimeAttached}
+					trace={trace}
 					onSelectAll={() => selectAllRuntimeItems()}
 				/>
 			</div>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -55,12 +55,12 @@ export const ConsoleInstanceInfoButton = () => {
 	// Render.
 	return (
 		<ActionBarButton
-			iconId='info'
-			align='right'
-			tooltip={positronConsoleInfo}
-			ariaLabel={positronConsoleInfo}
-			onPressed={handlePressed}
 			ref={ref}
+			align='right'
+			ariaLabel={positronConsoleInfo}
+			iconId='info'
+			tooltip={positronConsoleInfo}
+			onPressed={handlePressed}
 		/>
 	)
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceItems.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceItems.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -73,7 +73,7 @@ export class ConsoleInstanceItems extends Component<ConsoleInstanceItemsProps> {
 				<div className='top-spacer' />
 				{this.props.positronConsoleInstance.runtimeItems.map(runtimeItem => {
 					if (runtimeItem instanceof RuntimeItemActivity) {
-						return <RuntimeActivity key={runtimeItem.id} fontInfo={this.props.editorFontInfo} runtimeItemActivity={runtimeItem} positronConsoleInstance={this.props.positronConsoleInstance} />;
+						return <RuntimeActivity key={runtimeItem.id} fontInfo={this.props.editorFontInfo} positronConsoleInstance={this.props.positronConsoleInstance} runtimeItemActivity={runtimeItem} />;
 					} else if (runtimeItem instanceof RuntimeItemPendingInput) {
 						return <RuntimePendingInput key={runtimeItem.id} fontInfo={this.props.editorFontInfo} runtimeItemPendingInput={runtimeItem} />;
 					} else if (runtimeItem instanceof RuntimeItemStartup) {
@@ -95,7 +95,7 @@ export class ConsoleInstanceItems extends Component<ConsoleInstanceItemsProps> {
 						}
 						return <RuntimeExited key={runtimeItem.id} runtimeItemExited={runtimeItem} />;
 					} else if (runtimeItem instanceof RuntimeItemRestartButton) {
-						return <RuntimeRestartButton key={runtimeItem.id} runtimeItemRestartButton={runtimeItem} positronConsoleInstance={this.props.positronConsoleInstance} />;
+						return <RuntimeRestartButton key={runtimeItem.id} positronConsoleInstance={this.props.positronConsoleInstance} runtimeItemRestartButton={runtimeItem} />;
 					} else if (runtimeItem instanceof RuntimeItemStartupFailure) {
 						return <RuntimeStartupFailure key={runtimeItem.id} runtimeItemStartupFailure={runtimeItem} />;
 					} else if (runtimeItem instanceof RuntimeItemTrace) {
@@ -118,13 +118,13 @@ export class ConsoleInstanceItems extends Component<ConsoleInstanceItemsProps> {
 
 				<ConsoleInput
 					hidden={this.props.positronConsoleInstance.promptActive || !this.props.runtimeAttached}
-					width={this.props.consoleInputWidth}
 					positronConsoleInstance={this.props.positronConsoleInstance}
-					onSelectAll={this.props.onSelectAll}
+					width={this.props.consoleInputWidth}
 					onCodeExecuted={() =>
 						// Update the component to eliminate flickering.
 						flushSync(() => this.forceUpdate()
 						)}
+					onSelectAll={this.props.onSelectAll}
 				/>
 			</>
 		);

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceMenuButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -52,7 +52,7 @@ export const ConsoleInstanceMenuButton = (props: ConsoleInstanceMenuButtonProps)
 			setActiveRuntimeLabel(labelForSession(e?.session));
 		}));
 		return () => disposables.dispose();
-	}, [positronConsoleContext.activePositronConsoleInstance]);
+	}, [positronConsoleContext.activePositronConsoleInstance, positronConsoleContext.positronConsoleService]);
 
 	// Builds the actions.
 	const actions = () => {
@@ -82,8 +82,8 @@ export const ConsoleInstanceMenuButton = (props: ConsoleInstanceMenuButtonProps)
 	// Render.
 	return (
 		<ActionBarMenuButton
-			text={activeRuntimeLabel}
 			actions={actions}
+			text={activeRuntimeLabel}
 		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/components/historyBrowserPopup.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/historyBrowserPopup.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -73,11 +73,11 @@ export const HistoryBrowserPopup = (props: HistoryBrowserPopupProps) => {
 		return () => {
 			DOM.getActiveWindow().removeEventListener('click', clickHandler);
 		};
-	}, [props.selectedIndex]);
+	}, [props, props.selectedIndex]);
 
 	const noMatch = nls.localize('positronConsoleHistoryMatchesEmpty', "No matching history items");
 
-	return <div className='suggest-widget history-browser-popup' ref={popupRef}
+	return <div ref={popupRef} className='suggest-widget history-browser-popup'
 		style={{ bottom: props.bottomPx, left: props.leftPx }}>
 		{props.items.length === 0 && <div className='no-results'>{noMatch}</div>}
 		{props.items.length > 0 &&

--- a/src/vs/workbench/contrib/positronConsole/browser/components/outputLines.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/outputLines.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -28,7 +28,7 @@ export const OutputLines = (props: OutputLinesProps) => {
 
 	return <OutputLinesOriginal
 		{...props}
-		openerService={openerService}
 		notificationService={notificationService}
+		openerService={openerService}
 	/>;
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/components/outputRunWithLinks.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/outputRunWithLinks.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -64,10 +64,10 @@ export const OutputRunWithLinks = (props: OutputRunWithLinksProps) => {
 			// Add the hyperlink.
 			parts.push(
 				<a
+					key={match}
+					className='output-run-hyperlink'
 					href='#'
 					onClick={clickHandler.bind(null, match)}
-					className='output-run-hyperlink'
-					key={match}
 				>
 					{match}
 				</a>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeActivity.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeActivity.tsx
@@ -47,7 +47,7 @@ export const RuntimeActivity = (props: RuntimeActivityProps) => {
 		<div className='runtime-activity'>
 			{props.runtimeItemActivity.activityItems.map(activityItem => {
 				if (activityItem instanceof ActivityItemInput) {
-					return <ActivityInput key={activityItem.id} fontInfo={props.fontInfo} activityItemInput={activityItem} positronConsoleInstance={props.positronConsoleInstance} />;
+					return <ActivityInput key={activityItem.id} activityItemInput={activityItem} fontInfo={props.fontInfo} positronConsoleInstance={props.positronConsoleInstance} />;
 				} else if (activityItem instanceof ActivityItemOutputStream) {
 					return <ActivityOutputStream key={activityItem.id} activityItemOutputStream={activityItem} />;
 				} else if (activityItem instanceof ActivityItemErrorStream) {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimePendingInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimePendingInput.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -47,9 +47,9 @@ export const RuntimePendingInput = (props: RuntimePendingInputProps) => {
 					{outputLine.outputRuns.map(outputRun =>
 						<OutputRun
 							key={outputRun.id}
-							outputRun={outputRun}
-							openerService={openerService}
 							notificationService={notificationService}
+							openerService={openerService}
+							outputRun={outputRun}
 						/>
 					)}
 				</div>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/startupStatus.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/startupStatus.tsx
@@ -93,7 +93,7 @@ export const StartupStatus = () => {
 	// Render.
 	return (
 		<div className='startup-status'>
-			<div className='progress' ref={progressRef}></div>
+			<div ref={progressRef} className='progress'></div>
 			{runtimeStartupEvent &&
 				<RuntimeStartupProgress evt={runtimeStartupEvent} />
 			}

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsole.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsole.tsx
@@ -56,7 +56,7 @@ export const PositronConsole = (props: PropsWithChildren<PositronConsoleProps>) 
 	return (
 		<PositronConsoleContextProvider {...props}>
 			<div className='positron-console'>
-				<ConsoleCore {...props} width={width} height={height} />
+				<ConsoleCore {...props} height={height} width={width} />
 			</div>
 		</PositronConsoleContextProvider>
 	);

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleState.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -89,7 +89,7 @@ export const usePositronConsoleState = (services: PositronConsoleServices): Posi
 
 		// Return the clean up for our event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [services.positronConsoleService]);
 
 	// Return the Positron console state.
 	return {

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -290,8 +290,6 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 				instantiationService={this.instantiationService}
 				keybindingService={this.keybindingService}
 				languageRuntimeService={this.languageRuntimeService}
-				runtimeSessionService={this.runtimeSessionService}
-				runtimeStartupService={this.runtimeStartupService}
 				languageService={this.languageService}
 				logService={this.logService}
 				modelService={this.modelService}
@@ -299,9 +297,11 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 				openerService={this.openerService}
 				positronConsoleService={this.positronConsoleService}
 				positronPlotsService={this.positronPlotsService}
+				reactComponentContainer={this}
+				runtimeSessionService={this.runtimeSessionService}
+				runtimeStartupService={this.runtimeStartupService}
 				viewsService={this.viewsService}
 				workbenchLayoutService={this.workbenchLayoutService}
-				reactComponentContainer={this}
 			/>
 		);
 

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -380,9 +380,9 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 						contextKeyService={this._contextKeyService}
 						contextMenuService={this._contextMenuService}
 						hoverService={this._hoverService}
+						instance={positronDataExplorerInstance}
 						keybindingService={this._keybindingService}
 						layoutService={this._layoutService}
-						instance={positronDataExplorerInstance}
 						onClose={() => this._group.closeEditor(this.input)}
 					/>
 				);

--- a/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
+++ b/src/vs/workbench/contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.tsx
@@ -512,6 +512,6 @@ export class PositronDataExplorerEditor extends EditorPane implements IPositronD
 }
 
 const PLAINTEXT_EXTS = [
-	".csv",
-	".tsv"
+	'.csv',
+	'.tsv'
 ]

--- a/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -118,7 +118,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.positronHelpService, props.reactComponentContainer]);
 
 	// useEffect for currentHelpEntry.
 	useEffect(() => {
@@ -145,33 +145,33 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		<div className='action-bars'>
 			<PositronActionBarContextProvider {...props}>
 				<PositronActionBar
-					size='small'
 					borderBottom={true}
 					paddingLeft={kPaddingLeft}
 					paddingRight={kPaddingRight}
+					size='small'
 				>
 					<ActionBarButton
+						ariaLabel={tooltipPreviousTopic}
 						disabled={!canNavigateBackward}
 						iconId='positron-left-arrow'
 						tooltip={tooltipPreviousTopic}
-						ariaLabel={tooltipPreviousTopic}
 						onPressed={() => props.positronHelpService.navigateBackward()}
 					/>
 					<ActionBarButton
+						ariaLabel={tooltipNextTopic}
 						disabled={!canNavigateForward}
 						iconId='positron-right-arrow'
 						tooltip={tooltipNextTopic}
-						ariaLabel={tooltipNextTopic}
 						onPressed={() => props.positronHelpService.navigateForward()}
 					/>
 
 					<ActionBarSeparator />
 
 					<ActionBarButton
-						iconId='positron-home'
-						tooltip={tooltipShowPositronHelp}
 						ariaLabel={tooltipShowPositronHelp}
 						disabled={true}
+						iconId='positron-home'
+						tooltip={tooltipShowPositronHelp}
 						onPressed={() => props.onHome()}
 					/>
 
@@ -183,28 +183,28 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 
 				</PositronActionBar>
 				<PositronActionBar
-					size='small'
-					gap={kSecondaryActionBarGap}
 					borderBottom={true}
+					gap={kSecondaryActionBarGap}
 					paddingLeft={kPaddingLeft}
 					paddingRight={kPaddingRight}
+					size='small'
 				>
 					<ActionBarRegion location='left'>
 						{currentHelpTitle &&
 							<ActionBarMenuButton
+								actions={helpHistoryActions}
 								text={currentHelpTitle}
 								tooltip={tooltipHelpHistory}
-								actions={helpHistoryActions}
 							/>
 						}
 					</ActionBarRegion>
 					<ActionBarRegion location='right'>
 						<ActionBarButton
+							align='right'
+							ariaLabel={tooltipShowPositronHelp}
+							disabled={currentHelpEntry === undefined}
 							iconId='positron-search'
 							tooltip={tooltipShowPositronHelp}
-							ariaLabel={tooltipShowPositronHelp}
-							align='right'
-							disabled={currentHelpEntry === undefined}
 							onPressed={() => currentHelpEntry?.showFind()}
 						/>
 					</ActionBarRegion>

--- a/src/vs/workbench/contrib/positronModalDialogs/browser/positronModalDialogs.tsx
+++ b/src/vs/workbench/contrib/positronModalDialogs/browser/positronModalDialogs.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -61,12 +61,12 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 		// Show the confirmation modal dialog.
 		renderer.render(
 			<OKCancelModalDialog
-				renderer={renderer}
-				width={400}
-				height={195}
-				title={options.title}
-				okButtonTitle={options.okButtonTitle}
 				cancelButtonTitle={options.cancelButtonTitle}
+				height={195}
+				okButtonTitle={options.okButtonTitle}
+				renderer={renderer}
+				title={options.title}
+				width={400}
 				onAccept={async () => {
 					renderer.dispose();
 					await options.action();
@@ -117,7 +117,7 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 		};
 
 		renderer.render(
-			<PositronModalDialog renderer={renderer} title={title} width={400} height={200} onCancel={cancelHandler}>
+			<PositronModalDialog height={200} renderer={renderer} title={title} width={400} onCancel={cancelHandler}>
 				<ContentArea>
 					{renderHtml(
 						message,
@@ -129,8 +129,8 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 					)}
 				</ContentArea>
 				<OKCancelActionBar
-					okButtonTitle={okButtonTitle}
 					cancelButtonTitle={cancelButtonTitle}
+					okButtonTitle={okButtonTitle}
 					onAccept={acceptHandler}
 					onCancel={cancelHandler} />
 			</PositronModalDialog>
@@ -184,10 +184,10 @@ export class PositronModalDialogs implements IPositronModalDialogsService {
 
 		renderer.render(
 			<PositronModalDialog
+				height={200}
 				renderer={renderer}
 				title={title}
 				width={400}
-				height={200}
 				onCancel={cancelHandler}
 			>
 				<ContentArea>

--- a/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -20,8 +20,8 @@ export function AddCellButtons({ index }: { index: number }) {
 	const notebookInstance = useNotebookInstance();
 
 	return <div className='positron-add-cell-buttons'>
-		<AddCodeCellButton notebookInstance={notebookInstance} index={index} bordered />
-		<AddMarkdownCellButton notebookInstance={notebookInstance} index={index} bordered />
+		<AddCodeCellButton bordered index={index} notebookInstance={notebookInstance} />
+		<AddMarkdownCellButton bordered index={index} notebookInstance={notebookInstance} />
 	</div>;
 }
 
@@ -31,11 +31,11 @@ export function AddCodeCellButton({ notebookInstance, index, bordered }: { noteb
 	const label = localize('newCodeCellshort', 'Code');
 	const fullLabel = localize('newCodeCellLong', 'New Code Cell');
 	return <IconedButton
-		codicon='code'
-		label={label}
-		fullLabel={fullLabel}
-		onClick={() => notebookInstance.addCell(CellKind.Code, index)}
 		bordered={bordered}
+		codicon='code'
+		fullLabel={fullLabel}
+		label={label}
+		onClick={() => notebookInstance.addCell(CellKind.Code, index)}
 	/>;
 
 }
@@ -46,11 +46,11 @@ export function AddMarkdownCellButton({ notebookInstance, index, bordered }: { n
 	const label = localize('newMarkdownCellShort', 'Markdown');
 	const fullLabel = localize('newMarkdownCellLong', 'New Markdown Cell');
 	return <IconedButton
-		codicon='markdown'
-		label={label}
-		fullLabel={fullLabel}
-		onClick={() => notebookInstance.addCell(CellKind.Markup, index)}
 		bordered={bordered}
+		codicon='markdown'
+		fullLabel={fullLabel}
+		label={label}
+		onClick={() => notebookInstance.addCell(CellKind.Markup, index)}
 	/>;
 
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/KernelStatusBadge.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/KernelStatusBadge.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -24,8 +24,8 @@ export function KernelStatusBadge() {
 	const services = useServices();
 
 	return <ActionButton
-		onPressed={() => services.commandService.executeCommand(SELECT_KERNEL_ID_POSITRON, { forceDropdown: true })}
 		className='positron-notebook-kernel-status-badge'
+		onPressed={() => services.commandService.executeCommand(SELECT_KERNEL_ID_POSITRON, { forceDropdown: true })}
 	>
 		<div>
 			Kernel

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -39,7 +39,7 @@ export function PositronNotebookComponent() {
 	return (
 		<div className='positron-notebook' style={{ ...fontStyles }}>
 			<PositronNotebookHeader notebookInstance={notebookInstance} />
-			<div className='positron-notebook-cells-container' ref={containerRef}>
+			<div ref={containerRef} className='positron-notebook-cells-container'>
 				{notebookCells?.length ? notebookCells?.map((cell, index) => <>
 					<NotebookCell key={cell.handleId} cell={cell as PositronNotebookCellGeneral} />
 					<AddCellButtons index={index + 1} />

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookHeader.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookHeader.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -20,17 +20,17 @@ export function PositronNotebookHeader({ notebookInstance }: { notebookInstance:
 	return <div className='positron-notebook-header'>
 		<IconedButton
 			codicon='notebook-execute-all'
-			label={(() => localize('runAllCellsShort', 'Run All'))()}
 			fullLabel={(() => localize('runAllCellsLong', 'Run All Cells'))()}
+			label={(() => localize('runAllCellsShort', 'Run All'))()}
 			onClick={() => { notebookInstance.runAllCells(); }} />
 		<IconedButton
 			codicon='positron-clean'
-			label={(() => localize('clearAllCellOutputsShort', 'Clear Outputs'))()}
 			fullLabel={(() => localize('clearAllCellOutputsLong', 'Clear All Cell Outputs'))()}
+			label={(() => localize('clearAllCellOutputsShort', 'Clear Outputs'))()}
 			onClick={() => { notebookInstance.clearAllCellOutputs(); }} />
 		<div style={{ marginLeft: 'auto' }}></div>
-		<AddCodeCellButton notebookInstance={notebookInstance} index={0} />
-		<AddMarkdownCellButton notebookInstance={notebookInstance} index={0} />
+		<AddCodeCellButton index={0} notebookInstance={notebookInstance} />
+		<AddMarkdownCellButton index={0} notebookInstance={notebookInstance} />
 		<HeaderDivider />
 		<KernelStatusBadge />
 	</div>;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -31,8 +31,8 @@ import { PositronNotebookCellGeneral } from '../PositronNotebookCells/PositronNo
 export function CellEditorMonacoWidget({ cell }: { cell: PositronNotebookCellGeneral }) {
 	const { editorPartRef } = useCellEditorWidget(cell);
 	return <div
-		className='positron-cell-editor-monaco-widget'
 		ref={editorPartRef}
+		className='positron-cell-editor-monaco-widget'
 	/>;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -94,18 +94,18 @@ export function CellTextOutput({ content, type }: ParsedTextOutput) {
 	return <>
 		<div ref={containerRef} className={`notebook-${type} positron-notebook-text-output long-output-${truncation.mode}`}>
 			<OutputLines
-				outputLines={ANSIOutput.processOutput(truncation.content)}
-				openerService={openerService}
 				notificationService={notificationService}
+				openerService={openerService}
+				outputLines={ANSIOutput.processOutput(truncation.content)}
 			/>
 			{
 				truncation.mode === 'truncate'
 					? <>
-						<TruncationMessage truncationResult={truncation} commandService={commandService} />
+						<TruncationMessage commandService={commandService} truncationResult={truncation} />
 						<OutputLines
-							outputLines={ANSIOutput.processOutput(truncation.contentAfter)}
-							openerService={openerService}
 							notificationService={notificationService}
+							openerService={openerService}
+							outputLines={ANSIOutput.processOutput(truncation.contentAfter)}
 						/>
 					</>
 					: null
@@ -113,7 +113,7 @@ export function CellTextOutput({ content, type }: ParsedTextOutput) {
 		</div>
 		{
 			truncation.mode === 'scroll'
-				? <TruncationMessage truncationResult={truncation} commandService={commandService} />
+				? <TruncationMessage commandService={commandService} truncationResult={truncation} />
 				: null
 		}
 	</>;
@@ -134,8 +134,8 @@ const TruncationMessage = ({ truncationResult, commandService }: { truncationRes
 	return <i className='notebook-output-truncation-message'>
 		{msg + ' '}
 		<a
-			href=''
 			aria-label='notebook output settings'
+			href=''
 			onClick={openSettings}
 		>Change behavior.</a>
 	</i>;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeferredImage.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeferredImage.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -108,8 +108,8 @@ export function DeferredImage({ src = 'no-source', ...props }: React.ComponentPr
 	switch (results.status) {
 		case 'pending':
 			return <div
-				className='positron-notebooks-deferred-img-placeholder'
 				aria-label={(() => localize('deferredImageLoading', 'Loading image...'))()}
+				className='positron-notebooks-deferred-img-placeholder'
 				role='img'
 				{...props}
 			></div>;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -31,9 +31,9 @@ export function NotebookCellWrapper({ cell, children }: { cell: IPositronNoteboo
 	}, [cell, cellRef]);
 
 	return <div
+		ref={cellRef}
 		className={`positron-notebook-cell positron-notebook-${cell.kind === CellKind.Code ? 'code' : 'markdown'}-cell ${selectionStatus}`}
 		data-is-running={executionStatus === 'running'}
-		ref={cellRef}
 		tabIndex={0}
 		onClick={(e) => {
 			const clickTarget = e.nativeEvent.target as HTMLElement;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -87,7 +87,7 @@ function CellOutput(output: NotebookCellOutputs) {
 				{localize('cellExecutionKeyboardInterupt', 'Cell execution stopped due to keyboard interupt.')}
 			</div>;
 		case 'image':
-			return <img src={parsed.dataUrl} alt='output image' />;
+			return <img alt='output image' src={parsed.dataUrl} />;
 		case 'unknown':
 			return <div className='unknown-mime-type'>
 				{localize('cellExecutionUnknownMimeType', 'Can\'t handle mime types "{0}" yet', outputs.map(o => o.mime).join(','))}

--- a/src/vs/workbench/contrib/positronNotebook/browser/utilityComponents/IconedButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/utilityComponents/IconedButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -21,8 +21,8 @@ import { ActionButton } from './ActionButton.js';
  */
 export function IconedButton({ codicon, label, fullLabel = label, onClick, bordered = false }: { codicon: string; label: string; fullLabel?: string; onClick: () => void; bordered?: boolean }) {
 	return <ActionButton
-		className={`positron-iconed-button ${bordered ? 'bordered' : ''}`}
 		ariaLabel={fullLabel}
+		className={`positron-iconed-button ${bordered ? 'bordered' : ''}`}
 		onPressed={onClick}
 	>
 		<div className={`button-icon codicon codicon-${codicon}`} />

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -140,17 +140,17 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	return (
 		<PositronActionBarContextProvider {...props}>
 			<div className='action-bars'>
-				<PositronActionBar size='small' borderTop={true} borderBottom={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
+				<PositronActionBar borderBottom={true} borderTop={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight} size='small'>
 					<ActionBarRegion location='left'>
-						<ActionBarButton iconId='positron-left-arrow' disabled={disableLeft} tooltip={localize('positronShowPreviousPlot', "Show previous plot")}
-							ariaLabel={localize('positronShowPreviousPlot', "Show previous plot")} onPressed={showPreviousPlotHandler} />
-						<ActionBarButton iconId='positron-right-arrow' disabled={disableRight} tooltip={localize('positronShowNextPlot', "Show next plot")}
-							ariaLabel={localize('positronShowNextPlot', "Show next plot")} onPressed={showNextPlotHandler} />
+						<ActionBarButton ariaLabel={localize('positronShowPreviousPlot', "Show previous plot")} disabled={disableLeft} iconId='positron-left-arrow'
+							tooltip={localize('positronShowPreviousPlot', "Show previous plot")} onPressed={showPreviousPlotHandler} />
+						<ActionBarButton ariaLabel={localize('positronShowNextPlot', "Show next plot")} disabled={disableRight} iconId='positron-right-arrow'
+							tooltip={localize('positronShowNextPlot', "Show next plot")} onPressed={showNextPlotHandler} />
 
 						{(enableSizingPolicy || enableSavingPlots || enableZoomPlot || enablePopoutPlot) ? <ActionBarSeparator /> : null}
-						{enableSavingPlots ? <ActionBarButton iconId='positron-save' tooltip={localize('positronSavePlot', "Save plot")}
-							ariaLabel={localize('positronSavePlot', "Save plot")} onPressed={savePlotHandler} /> : null}
-						{enableCopyPlot ? <ActionBarButton iconId='copy' disabled={!hasPlots} tooltip={localize('positron-copy-plot', "Copy plot to clipboard")} ariaLabel={localize('positron-copy-plot', "Copy plot to clipboard")}
+						{enableSavingPlots ? <ActionBarButton ariaLabel={localize('positronSavePlot', "Save plot")} iconId='positron-save'
+							tooltip={localize('positronSavePlot', "Save plot")} onPressed={savePlotHandler} /> : null}
+						{enableCopyPlot ? <ActionBarButton ariaLabel={localize('positron-copy-plot', "Copy plot to clipboard")} disabled={!hasPlots} iconId='copy' tooltip={localize('positron-copy-plot', "Copy plot to clipboard")}
 							onPressed={copyPlotHandler} /> : null}
 						{enableZoomPlot ? <ZoomPlotMenuButton actionHandler={zoomPlotHandler} zoomLevel={props.zoomLevel} /> : null}
 						{enableSizingPolicy ?
@@ -158,26 +158,26 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 								keybindingService={props.keybindingService}
 								layoutService={props.layoutService}
 								notificationService={positronPlotsContext.notificationService}
-								plotsService={positronPlotsContext.positronPlotsService}
 								plotClient={selectedPlot}
+								plotsService={positronPlotsContext.positronPlotsService}
 							/>
 							: null
 						}
 						{enablePopoutPlot ?
 							<ActionBarButton
-								iconId='positron-open-in-new-window'
 								align='right'
-								tooltip={localize('positron-popout-plot', "Open plot in new window")}
 								ariaLabel={localize('positron-popout-plot', "Open plot in new window")}
+								iconId='positron-open-in-new-window'
+								tooltip={localize('positron-popout-plot', "Open plot in new window")}
 								onPressed={popoutPlotHandler} />
 							: null
 						}
 						{enableEditorPlot ?
 							<OpenInEditorMenuButton
-								tooltip={localize('positron-editor-plot-popout', "Open in editor tab")}
 								ariaLabel={localize('positron-editor-plot-popout', "Open in editor tab")}
-								defaultGroup={positronPlotsContext.positronPlotsService.getPreferredEditorGroup()}
 								commandService={positronPlotsContext.commandService}
+								defaultGroup={positronPlotsContext.positronPlotsService.getPreferredEditorGroup()}
+								tooltip={localize('positron-editor-plot-popout', "Open in editor tab")}
 							/>
 							: null
 						}
@@ -190,8 +190,8 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 						}
 						<HistoryPolicyMenuButton plotsService={positronPlotsContext.positronPlotsService} />
 						<ActionBarSeparator />
-						<ActionBarButton iconId='clear-all' align='right' disabled={noPlots} tooltip={localize('positronClearAllPlots', "Clear all plots")}
-							ariaLabel={localize('positronClearAllPlots', "Clear all plots")} onPressed={clearAllPlotsHandler} />
+						<ActionBarButton align='right' ariaLabel={localize('positronClearAllPlots', "Clear all plots")} disabled={noPlots} iconId='clear-all'
+							tooltip={localize('positronClearAllPlots', "Clear all plots")} onPressed={clearAllPlotsHandler} />
 					</ActionBarRegion>
 				</PositronActionBar>
 			</div>

--- a/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/darkFilterMenuButton.tsx
@@ -110,11 +110,11 @@ export const DarkFilterMenuButton = (props: DarkFilterMenuButtonProps) => {
 
 	return (
 		<ActionBarMenuButton
+			actions={actions}
+			align='right'
+			ariaLabel={darkFilterTooltip}
 			iconId={iconForDarkFilter(darkFilterMode)}
 			tooltip={darkFilterTooltip}
-			ariaLabel={darkFilterTooltip}
-			align='right'
-			actions={actions}
 		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotInstance.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -168,13 +168,13 @@ export const DynamicPlotInstance = (props: DynamicPlotInstanceProps) => {
 	// Render method for the plot image.
 	const renderedImage = () => {
 		return <PanZoomImage
-			imageUri={uri}
 			description={props.plotClient.metadata.code ?
 				props.plotClient.metadata.code :
 				'Plot ' + props.plotClient.id}
-			zoom={props.zoom}
-			width={props.width}
 			height={props.height}
+			imageUri={uri}
+			width={props.width}
+			zoom={props.zoom}
 		/>;
 	};
 

--- a/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotThumbnail.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/dynamicPlotThumbnail.tsx
@@ -39,7 +39,7 @@ export const DynamicPlotThumbnail = (props: DynamicPlotThumbnailProps) => {
 		props.plotClient.onDidCompleteRender((result) => {
 			setUri(result.uri);
 		});
-	});
+	}, [props.plotClient]);
 
 	// If the plot is not yet rendered yet (no URI), show a placeholder;
 	// otherwise, show the rendered plot.
@@ -47,7 +47,7 @@ export const DynamicPlotThumbnail = (props: DynamicPlotThumbnailProps) => {
 	// Consider: we probably want a more explicit loading state; as written we
 	// will show the old URI until the new one is ready.
 	if (uri) {
-		return <img className='plot' src={uri} alt={'Plot ' + props.plotClient.id} />;
+		return <img alt={'Plot ' + props.plotClient.id} className='plot' src={uri} />;
 	} else {
 		return <PlaceholderThumbnail />;
 	}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/historyPolicyMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/historyPolicyMenuButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -65,11 +65,11 @@ export const HistoryPolicyMenuButton = (props: HistoryPolicyMenuButtonProps) => 
 
 	return (
 		<ActionBarMenuButton
+			actions={actions}
+			align='right'
+			ariaLabel={historyPolicyTooltip}
 			iconId='layout'
 			tooltip={historyPolicyTooltip}
-			ariaLabel={historyPolicyTooltip}
-			align='right'
-			actions={actions}
 		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/components/openInEditorMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/openInEditorMenuButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -72,18 +72,18 @@ export const OpenInEditorMenuButton = (props: OpenInEditorMenuButtonProps) => {
 			};
 		});
 		setActions(actions);
-	}, [defaultAction]);
+	}, [defaultAction, openEditorPlotHandler]);
 
 
 	return (
 		<ActionBarMenuButton
+			actions={() => actions}
+			ariaLabel={props.ariaLabel}
+			dropdownAriaLabel={localize('positron-editor-open-in-editor-dropdown', 'Select where to open plot')}
+			dropdownIndicator='enabled-split'
+			dropdownTooltip={localize('positron-editor-open-in-editor-dropdown', 'Select where to open plot')}
 			iconId='go-to-file'
 			tooltip={props.tooltip}
-			ariaLabel={props.ariaLabel}
-			actions={() => actions}
-			dropdownIndicator='enabled-split'
-			dropdownAriaLabel={localize('positron-editor-open-in-editor-dropdown', 'Select where to open plot')}
-			dropdownTooltip={localize('positron-editor-open-in-editor-dropdown', 'Select where to open plot')}
 		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/components/panZoomImage.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/panZoomImage.tsx
@@ -76,12 +76,12 @@ export const PanZoomImage = (props: PanZoomImageProps) => {
 	}, [naturalWidth, naturalHeight, props.width, props.height, props.zoom, props.imageUri]);
 
 	return (
-		<Scrollable width={props.width} height={props.height} scrollableWidth={scrollableWidth} scrollableHeight={scrollableHeight} mousePan={true}>
-			<img className='plot'
-				src={props.imageUri}
+		<Scrollable height={props.height} mousePan={true} scrollableHeight={scrollableHeight} scrollableWidth={scrollableWidth} width={props.width}>
+			<img ref={imageRef}
 				alt={props.description}
+				className='plot'
 				draggable={false}
-				ref={imageRef}
+				src={props.imageUri}
 				onLoad={(el) => {
 					// ensures the zoom level is applied correctly when switching images
 					setNaturalWidth(el.currentTarget.naturalWidth);

--- a/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/plotsContainer.tsx
@@ -96,10 +96,10 @@ export const PlotsContainer = (props: PlotContainerProps) => {
 		if (plotInstance instanceof PlotClientInstance) {
 			return <DynamicPlotInstance
 				key={plotInstance.id}
-				width={plotWidth}
 				height={plotHeight}
-				zoom={props.zoom}
-				plotClient={plotInstance} />;
+				plotClient={plotInstance}
+				width={plotWidth}
+				zoom={props.zoom} />;
 		} else if (plotInstance instanceof StaticPlotClient) {
 			return <StaticPlotInstance
 				key={plotInstance.id}
@@ -108,10 +108,10 @@ export const PlotsContainer = (props: PlotContainerProps) => {
 		} else if (plotInstance instanceof WebviewPlotClient) {
 			return <WebviewPlotInstance
 				key={plotInstance.id}
-				width={plotWidth}
 				height={plotHeight}
+				plotClient={plotInstance}
 				visible={props.visible}
-				plotClient={plotInstance} />;
+				width={plotWidth} />;
 		}
 		return null;
 	};
@@ -140,16 +140,16 @@ export const PlotsContainer = (props: PlotContainerProps) => {
 
 		return <PlotGalleryThumbnail
 			key={plotInstance.id}
-			selected={selected}
+			plotClient={plotInstance}
 			plotService={positronPlotsContext}
-			plotClient={plotInstance}>
+			selected={selected}>
 			{renderThumbnailImage()}
 		</PlotGalleryThumbnail>;
 	};
 
 	// Render the plot history gallery.
 	const renderHistory = () => {
-		return <div className='plot-history-scroller' ref={plotHistoryRef}>
+		return <div ref={plotHistoryRef} className='plot-history-scroller'>
 			<div className='plot-history'>
 				{positronPlotsContext.positronPlotInstances.map((plotInstance) => (
 					renderThumbnail(plotInstance,

--- a/src/vs/workbench/contrib/positronPlots/browser/components/sizingPolicyMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/sizingPolicyMenuButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -175,10 +175,10 @@ export const SizingPolicyMenuButton = (props: SizingPolicyMenuButtonProps) => {
 
 	return (
 		<ActionBarMenuButton
+			actions={actions}
 			iconId='symbol-ruler'
 			text={activePolicyLabel}
 			tooltip={sizingPolicyTooltip}
-			actions={actions}
 		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotInstance.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -53,13 +53,13 @@ export const StaticPlotInstance = (props: StaticPlotInstanceProps) => {
 	}, []);
 
 	return (
-		<div className='plot-instance static-plot-instance' ref={ref}>
+		<div ref={ref} className='plot-instance static-plot-instance'>
 			<PanZoomImage
-				imageUri={props.plotClient.uri}
 				description={props.plotClient.code ? props.plotClient.code : 'Plot ' + props.plotClient.id}
-				zoom={props.zoom}
-				width={width}
 				height={height}
+				imageUri={props.plotClient.uri}
+				width={width}
+				zoom={props.zoom}
 			/>
 		</div>);
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotThumbnail.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/staticPlotThumbnail.tsx
@@ -23,5 +23,5 @@ interface StaticPlotThumbnailProps {
  * @returns The rendered component.
  */
 export const StaticPlotThumbnail = (props: StaticPlotThumbnailProps) => {
-	return <img className='plot' src={props.plotClient.uri} alt={'Plot ' + props.plotClient.id} />;
+	return <img alt={'Plot ' + props.plotClient.id} className='plot' src={props.plotClient.uri} />;
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotInstance.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotInstance.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -70,7 +70,7 @@ export const WebviewPlotInstance = (props: WebviewPlotInstanceProps) => {
 	// The DOM we render is just a single div that the webview will be
 	// positioned over.
 	return (
-		<div style={style} className='plot-instance' ref={webviewRef}>
+		<div ref={webviewRef} className='plot-instance' style={style}>
 		</div>
 	);
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotThumbnail.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/webviewPlotThumbnail.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -48,7 +48,7 @@ export const WebviewPlotThumbnail = (props: WebviewPlotThumbnailProps) => {
 	// If the plot is not yet rendered yet (no URI), show a placeholder;
 	// otherwise, show the rendered thumbnail.
 	if (uri) {
-		return <img src={uri} alt={'Plot ' + props.plotClient.id} />;
+		return <img alt={'Plot ' + props.plotClient.id} src={uri} />;
 	} else {
 		return <PlaceholderThumbnail />;
 	}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/zoomPlotMenuButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -70,10 +70,10 @@ export const ZoomPlotMenuButton = (props: ZoomPlotMenuButtonProps) => {
 
 	return (
 		<ActionBarMenuButton
+			actions={actions}
 			iconId='positron-size-to-fit'
 			text={activeZoomLabel}
 			tooltip={zoomPlotTooltip}
-			actions={actions}
 		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -90,22 +90,22 @@ export const showSavePlotModalDialog = (
 
 	renderer.render(
 		<SavePlotModalDialog
-			layoutService={layoutService}
 			dialogService={modalDialogService}
-			fileService={fileService}
+			enableIntrinsicSize={selectedSizingPolicy instanceof PlotSizingPolicyIntrinsic}
 			fileDialogService={fileDialogService}
+			fileService={fileService}
 			keybindingService={keybindingService}
+			labelService={labelService}
+			layoutService={layoutService}
 			logService={logService}
 			notificationService={notificationService}
-			labelService={labelService}
 			pathService={pathService}
-			renderer={renderer}
-			enableIntrinsicSize={selectedSizingPolicy instanceof PlotSizingPolicyIntrinsic}
-			plotSize={plotClient.lastRender?.size}
-			plotIntrinsicSize={plotClient.intrinsicSize}
-			suggestedPath={suggestedPath}
-			savePlotCallback={savePlotCallback}
 			plotClient={plotClient}
+			plotIntrinsicSize={plotClient.intrinsicSize}
+			plotSize={plotClient.lastRender?.size}
+			renderer={renderer}
+			savePlotCallback={savePlotCallback}
+			suggestedPath={suggestedPath}
 		/>
 	);
 };
@@ -307,119 +307,119 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 
 	return (
 		<PositronModalDialog
-			width={SAVE_PLOT_MODAL_DIALOG_WIDTH}
 			height={SAVE_PLOT_MODAL_DIALOG_HEIGHT}
+			renderer={props.renderer}
 			title={(() => localize('positron.savePlotModalDialog.title', "Save Plot"))()}
-			onCancel={cancelHandler}
-			renderer={props.renderer}>
+			width={SAVE_PLOT_MODAL_DIALOG_WIDTH}
+			onCancel={cancelHandler}>
 			<ContentArea>
 				<div className='plot-preview-container'>
 					<div className='plot-preview-input'>
 						<div className='browse'>
 							<LabeledFolderInput
+								error={!directory.valid}
+								inputRef={inputRef}
 								label={(() => localize(
 									'positron.savePlotModalDialog.directory',
 									"Directory"
 								))()}
+								readOnlyInput={false}
 								value={pathUriToLabel(directory.value, props.labelService)}
+								onBrowse={browseHandler}
 								onChange={async e => updatePath(
 									await combineLabelWithPathUri(
 										e.target.value,
 										directory.value,
 										props.pathService
 									)
-								)}
-								onBrowse={browseHandler}
-								readOnlyInput={false}
-								error={!directory.valid}
-								inputRef={inputRef} />
+								)} />
 						</div>
 						<div className='file'>
 							<LabeledTextInput
+								error={!name.valid}
 								label={(() => localize(
 									'positron.savePlotModalDialog.name',
 									"Name"
 								))()}
 								value={name.value}
 								onChange={e => setName({ value: e.target.value, valid: !!e.target.value })}
-								error={!name.valid}
 							/>
 							<div>
 								<label>{(() => localize('positron.savePlotModalDialog.format', "Format"))()}
 									<DropDownListBox
-										title={(() => localize(
-											'positron.savePlotModalDialog.format',
-											"Format"
-										))()}
-										selectedIdentifier={format}
-										onSelectionChanged={(ext) => { setFormat(ext.options.identifier); }}
-										keybindingService={props.keybindingService}
-										layoutService={props.layoutService}
 										entries={[
 											new DropDownListBoxItem<RenderFormat, RenderFormat>({ identifier: RenderFormat.Png, title: RenderFormat.Png.toUpperCase(), value: RenderFormat.Png }),
 											new DropDownListBoxItem<RenderFormat, RenderFormat>({ identifier: RenderFormat.Jpeg, title: RenderFormat.Jpeg.toUpperCase(), value: RenderFormat.Jpeg }),
 											new DropDownListBoxItem<RenderFormat, RenderFormat>({ identifier: RenderFormat.Svg, title: RenderFormat.Svg.toUpperCase(), value: RenderFormat.Svg }),
 											new DropDownListBoxItem<RenderFormat, RenderFormat>({ identifier: RenderFormat.Pdf, title: RenderFormat.Pdf.toUpperCase(), value: RenderFormat.Pdf }),
 											new DropDownListBoxItem<RenderFormat, RenderFormat>({ identifier: RenderFormat.Tiff, title: RenderFormat.Tiff.toUpperCase(), value: RenderFormat.Tiff }),
-										]} />
+										]}
+										keybindingService={props.keybindingService}
+										layoutService={props.layoutService}
+										selectedIdentifier={format}
+										title={(() => localize(
+											'positron.savePlotModalDialog.format',
+											"Format"
+										))()}
+										onSelectionChanged={(ext) => { setFormat(ext.options.identifier); }} />
 								</label>
 							</div>
 						</div>
 						<div className='plot-input'>
 							{enableIntrinsicSize ? <>
 								<LabeledTextInput
+									disabled={true}
 									label={(() => localize(
 										'positron.savePlotModalDialog.width',
 										"Width"
 									))()}
 									type={'text'}
 									value={intrinsicWidth}
-									disabled={true}
 								/>
 								<LabeledTextInput
+									disabled={true}
 									label={(() => localize(
 										'positron.savePlotModalDialog.height',
 										"Height"
 									))()}
 									type={'text'}
 									value={intrinsicHeight}
-									disabled={true}
 								/>
 							</> : <>
 								<LabeledTextInput
+									error={!width.valid}
 									label={(() => localize(
 										'positron.savePlotModalDialog.width',
 										"Width"
 									))()}
-									value={width.value}
-									type={'number'}
-									onChange={e => updateWidth(e.target.value)}
 									min={1}
-									error={!width.valid}
+									type={'number'}
+									value={width.value}
+									onChange={e => updateWidth(e.target.value)}
 								/>
 								<LabeledTextInput
+									error={!height.valid}
 									label={(() => localize(
 										'positron.savePlotModalDialog.height',
 										"Height"
 									))()}
-									value={height.value}
-									type={'number'}
-									onChange={e => updateHeight(e.target.value)}
 									min={1}
-									error={!height.valid}
+									type={'number'}
+									value={height.value}
+									onChange={e => updateHeight(e.target.value)}
 								/>
 							</>}
 							{enableDPI && <LabeledTextInput
+								error={!dpi.valid}
 								label={(() => localize(
 									'positron.savePlotModalDialog.dpi',
 									"DPI"
 								))()}
-								value={dpi.value}
-								type={'number'}
-								onChange={e => updateDpi(e.target.value)}
-								min={1}
 								max={300}
-								error={!dpi.valid}
+								min={1}
+								type={'number'}
+								value={dpi.value}
+								onChange={e => updateDpi(e.target.value)}
 							/>}
 							<div className='error'>
 								<div>
@@ -450,11 +450,11 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 						</div>
 						<div className='use-intrinsic-size'>
 							{props.plotIntrinsicSize ? <Checkbox
+								initialChecked={enableIntrinsicSize}
 								label={(() => localize(
 									'positron.savePlotModalDialog.useIntrinsicSize',
 									"Use intrinsic size"
 								))()}
-								initialChecked={enableIntrinsicSize}
 								onChanged={checked => setEnableIntrinsicSize(checked)} /> : null}
 						</div>
 						<div className='preview-progress'>
@@ -462,7 +462,7 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 						</div>
 						<div className='plot-preview-image-container preview'>
 							{(uri &&
-								<img className='plot-preview' src={uri} alt={props.plotClient.metadata.code} />)
+								<img alt={props.plotClient.metadata.code} className='plot-preview' src={uri} />)
 							}
 						</div>
 					</div>
@@ -476,7 +476,7 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 					</PositronButton>
 				</div>
 				<div className='right'>
-					<PlatformNativeDialogActionBar secondaryButton={cancelButton} primaryButton={okButton} />
+					<PlatformNativeDialogActionBar primaryButton={okButton} secondaryButton={cancelButton} />
 				</div>
 			</div>
 

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/setPlotSizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/setPlotSizeModalDialog.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -51,8 +51,8 @@ export const showSetPlotSizeModalDialog = async (
 	// Show the set plot size modal dialog.
 	renderer.render(
 		<SetPlotSizeModalDialog
-			renderer={renderer}
 			customSize={customSize}
+			renderer={renderer}
 			setPlotSize={setPlotSize}
 		/>
 	);
@@ -122,30 +122,30 @@ const SetPlotSizeModalDialog = (props: SetPlotSizeModalDialogProps) => {
 	// Render.
 	return (
 		<PositronModalDialog
-			renderer={props.renderer}
-			width={350}
 			height={200}
+			renderer={props.renderer}
 			title={(() => localize('positronSetPlotSizeModalDialogTitle', "Custom Plot Size"))()}
+			width={350}
 			onCancel={cancelHandler}>
 			<ContentArea>
 				<table>
 					<tbody>
 						<tr>
 							<td>
-								<LabeledTextInput label={(() => localize(
-									'positronPlotWidth',
-									"Width"
-								))()}
-									value={width} autoFocus={true} min={100}
-									type='number' onChange={(el) => setWidth(el.target.valueAsNumber)} />
+								<LabeledTextInput autoFocus={true}
+									label={(() => localize(
+										'positronPlotWidth',
+										"Width"
+									))()} min={100} type='number'
+									value={width} onChange={(el) => setWidth(el.target.valueAsNumber)} />
 							</td>
 							<td>
 								<LabeledTextInput label={(() => localize(
 									'positronPlotHeight',
 									"Height"
 								))()}
-									value={height} min={100}
-									type='number' onChange={(el) => setHeight(el.target.valueAsNumber)} />
+									min={100} type='number'
+									value={height} onChange={(el) => setHeight(el.target.valueAsNumber)} />
 							</td>
 						</tr>
 					</tbody>
@@ -163,7 +163,7 @@ const SetPlotSizeModalDialog = (props: SetPlotSizeModalDialogProps) => {
 					</Button>
 				</div>
 				<div className='right'>
-					<PlatformNativeDialogActionBar secondaryButton={cancelButton} primaryButton={okButton} />
+					<PlatformNativeDialogActionBar primaryButton={okButton} secondaryButton={cancelButton} />
 				</div>
 			</div>
 		</PositronModalDialog>

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlots.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlots.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -7,7 +7,7 @@
 import './positronPlots.css';
 
 // React.
-import React, { PropsWithChildren, useEffect, useState } from 'react';
+import React, { PropsWithChildren, useCallback, useEffect, useState } from 'react';
 
 // Other dependencies.
 import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
@@ -42,7 +42,7 @@ export interface PositronPlotsProps extends PositronPlotsServices {
 export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 
 	// Compute the history visibility based on the history policy.
-	const computeHistoryVisibility = (policy: HistoryPolicy) => {
+	const computeHistoryVisibility = useCallback((policy: HistoryPolicy) => {
 		switch (policy) {
 			case HistoryPolicy.AlwaysVisible:
 				return true;
@@ -63,7 +63,7 @@ export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 				// Show the history.
 				return true;
 		}
-	};
+	}, [props.positronPlotsService.positronPlotInstances.length, props.reactComponentContainer.height, props.reactComponentContainer.width]);
 
 	const zoomHandler = (zoom: number) => {
 		setZoom(zoom);
@@ -134,11 +134,11 @@ export const PositronPlots = (props: PropsWithChildren<PositronPlotsProps>) => {
 		<PositronPlotsContextProvider {...props}>
 			<ActionBars {...props} zoomHandler={zoomHandler} zoomLevel={zoom} />
 			<PlotsContainer
-				showHistory={showHistory}
 				darkFilterMode={darkFilterMode}
+				height={height - 34}
+				showHistory={showHistory}
 				visible={visible}
 				width={width}
-				height={height - 34}
 				x={posX}
 				y={posY}
 				zoom={zoom} />

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsView.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsView.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -255,8 +255,8 @@ export class PositronPlotsViewPane extends PositronViewPane implements IReactCom
 				keybindingService={this.keybindingService}
 				languageRuntimeService={this.languageRuntimeService}
 				layoutService={this.layoutService}
-				positronPlotsService={this.positronPlotsService}
 				notificationService={this.notificationService}
+				positronPlotsService={this.positronPlotsService}
 				preferencesService={this.preferencesService}
 				reactComponentContainer={this} />
 		);

--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/editorPlotsContainer.tsx
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/editorPlotsContainer.tsx
@@ -35,8 +35,8 @@ export const EditorPlotsContainer = (props: EditorPlotsContainerProps) => {
 			return <DynamicPlotInstance
 				key={props.plotClient.id}
 				height={props.height}
-				width={props.width}
 				plotClient={props.plotClient}
+				width={props.width}
 				zoom={ZoomLevel.Fit} />;
 		}
 		if (props.plotClient instanceof StaticPlotClient) {

--- a/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
+++ b/src/vs/workbench/contrib/positronPlotsEditor/browser/positronPlotsEditor.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -139,15 +139,15 @@ export class PositronPlotsEditor extends EditorPane implements IPositronPlotsEdi
 				hoverService={this._hoverService}
 				keybindingService={this._keybindingService}
 				languageRuntimeService={this._languageRuntimeService}
-				positronPlotsService={this._positronPlotsService}
 				notificationService={this._notificationService}
+				positronPlotsService={this._positronPlotsService}
 				preferencesService={this._preferencesService}
 			>
 				<EditorPlotsContainer
-					width={this._width}
 					height={this._height}
-					positronPlotsService={this._positronPlotsService}
 					plotClient={plotClient}
+					positronPlotsService={this._positronPlotsService}
+					width={this._width}
 				/>
 			</PositronPlotsContextProvider>
 		);

--- a/src/vs/workbench/contrib/positronPreview/browser/components/htmlActionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/htmlActionBars.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -78,7 +78,7 @@ export const HtmlActionBars = (props: PropsWithChildren<HtmlActionBarsProps>) =>
 	return (
 		<PositronActionBarContextProvider {...props}>
 			<div className='action-bars preview-action-bar'>
-				<PositronActionBar size='small' borderTop={true} borderBottom={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
+				<PositronActionBar borderBottom={true} borderTop={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight} size='small'>
 					<ActionBarRegion location='left'>
 						<span className='codicon codicon-file'></span>
 					</ActionBarRegion>
@@ -87,30 +87,30 @@ export const HtmlActionBars = (props: PropsWithChildren<HtmlActionBarsProps>) =>
 					</ActionBarRegion>
 					<ActionBarRegion location='right'>
 						<ActionBarButton
-							iconId='positron-refresh'
 							align='right'
-							tooltip={reload}
 							ariaLabel={reload}
+							iconId='positron-refresh'
+							tooltip={reload}
 							onPressed={reloadHandler} />
 						<ActionBarButton
-							iconId='positron-open-in-new-window'
 							align='right'
-							tooltip={openInBrowser}
 							ariaLabel={openInBrowser}
+							iconId='positron-open-in-new-window'
+							tooltip={openInBrowser}
 							onPressed={openInBrowserHandler} />
 						<ActionBarSeparator />
 						<ActionBarButton
-							iconId='go-to-file'
 							align='right'
-							tooltip={openInEditor}
 							ariaLabel={openInEditor}
+							iconId='go-to-file'
+							tooltip={openInEditor}
 							onPressed={openInEditorHandler} />
 						<ActionBarSeparator />
 						<ActionBarButton
-							iconId='clear-all'
 							align='right'
-							tooltip={clear}
 							ariaLabel={clear}
+							iconId='clear-all'
+							tooltip={clear}
 							onPressed={clearHandler} />
 					</ActionBarRegion>
 				</PositronActionBar>

--- a/src/vs/workbench/contrib/positronPreview/browser/components/previewContainer.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/previewContainer.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -93,7 +93,7 @@ export const PreviewContainer = (props: PreviewContainerProps) => {
 	// The DOM we render is just a single div that the webview will be
 	// positioned over.
 	return (
-		<div className='preview-container' ref={webviewRef} style={style}>
+		<div ref={webviewRef} className='preview-container' style={style}>
 		</div>
 	);
 };

--- a/src/vs/workbench/contrib/positronPreview/browser/components/urlActionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/urlActionBars.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -163,56 +163,56 @@ export const UrlActionBars = (props: PropsWithChildren<UrlActionBarsProps>) => {
 	return (
 		<PositronActionBarContextProvider {...props}>
 			<div className='action-bars preview-action-bar'>
-				<PositronActionBar size='small' borderTop={true} borderBottom={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
+				<PositronActionBar borderBottom={true} borderTop={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight} size='small'>
 					<ActionBarRegion location='left'>
-						<ActionBarButton iconId='positron-left-arrow'
+						<ActionBarButton ariaLabel={navigateBack}
+							iconId='positron-left-arrow'
 							tooltip={navigateBack}
-							ariaLabel={navigateBack}
 							onPressed={navigateBackHandler} />
 						<ActionBarButton
+							ariaLabel={navigateForward}
 							iconId='positron-right-arrow'
 							tooltip={navigateForward}
-							ariaLabel={navigateForward}
 							onPressed={navigateForwardHandler} />
 					</ActionBarRegion>
 					<ActionBarRegion location='center'>
 						<form onSubmit={navigateToHandler}>
 							<input
-								className='text-input url-bar'
-								aria-label={currentUrl}
-								name={kUrlBarInputName}
-								type='text'
 								ref={urlInputRef}
-								defaultValue={props.preview.currentUri.toString()}>
+								aria-label={currentUrl}
+								className='text-input url-bar'
+								defaultValue={props.preview.currentUri.toString()}
+								name={kUrlBarInputName}
+								type='text'>
 							</input>
 						</form>
 					</ActionBarRegion>
 					<ActionBarRegion location='right'>
 						<ActionBarButton
-							iconId='positron-refresh'
 							align='right'
-							tooltip={reload}
 							ariaLabel={reload}
+							iconId='positron-refresh'
+							tooltip={reload}
 							onPressed={reloadHandler} />
 						<ActionBarButton
-							iconId='positron-open-in-new-window'
 							align='right'
-							tooltip={openInBrowser}
 							ariaLabel={openInBrowser}
+							iconId='positron-open-in-new-window'
+							tooltip={openInBrowser}
 							onPressed={openInBrowserHandler} />
 						<ActionBarSeparator />
 						<ActionBarButton
-							iconId='go-to-file'
 							align='right'
-							tooltip={openInEditor}
 							ariaLabel={openInEditor}
+							iconId='go-to-file'
+							tooltip={openInEditor}
 							onPressed={openInEditorHandler} />
 						<ActionBarSeparator />
 						<ActionBarButton
-							iconId='clear-all'
 							align='right'
-							tooltip={clear}
 							ariaLabel={clear}
+							iconId='clear-all'
+							tooltip={clear}
 							onPressed={clearHandler} />
 					</ActionBarRegion>
 				</PositronActionBar>

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreview.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreview.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -119,10 +119,10 @@ export const PositronPreview = (props: PropsWithChildren<PositronPreviewProps>) 
 				<HtmlActionBars key={activePreview.previewId} preview={activePreview} {...props} />
 			}
 			<PreviewContainer
+				height={height - (showToolbar ? 32 : 0)}
 				preview={activePreview}
 				visible={visible}
 				width={width}
-				height={height - (showToolbar ? 32 : 0)}
 				x={x}
 				y={y} />
 		</PositronPreviewContextProvider>

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewView.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -183,14 +183,14 @@ export class PositronPreviewViewPane extends PositronViewPane implements IReactC
 			<PositronPreview
 				accessibilityService={this.accessibilityService}
 				commandService={this.commandService}
-				layoutService={this.layoutService}
 				configurationService={this.configurationService}
 				contextKeyService={this.contextKeyService}
 				contextMenuService={this.contextMenuService}
 				hoverService={this.hoverService}
 				keybindingService={this.keybindingService}
-				openerService={this.openerService}
+				layoutService={this.layoutService}
 				notificationService={this.notificationService}
+				openerService={this.openerService}
 				positronPreviewService={this.positronPreviewService}
 				reactComponentContainer={this}
 				runtimeSessionService={this.runtimeSessionService} />

--- a/src/vs/workbench/contrib/positronPreviewEditor/browser/editorPreviewContainer.tsx
+++ b/src/vs/workbench/contrib/positronPreviewEditor/browser/editorPreviewContainer.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -56,7 +56,7 @@ export const EditorPreviewContainer = (props: EditorPreviewContainerProps) => {
 	// The DOM we render is just a single div that the webview will be
 	// positioned over.
 	return (
-		<div className='preview-container' ref={webviewRef} style={style}>
+		<div ref={webviewRef} className='preview-container' style={style}>
 		</div>
 	);
 };

--- a/src/vs/workbench/contrib/positronPreviewEditor/browser/positronPreviewEditor.tsx
+++ b/src/vs/workbench/contrib/positronPreviewEditor/browser/positronPreviewEditor.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -124,10 +124,10 @@ export class PositronPreviewEditor
 				positronPreviewService={this._positronPreviewService}
 			>
 				<EditorPreviewContainer
-					preview={this._preview}
-					width={this._width}
 					height={this._height}
+					preview={this._preview}
 					visible={this._visible}
+					width={this._width}
 				/>
 			</PositronPreviewContextProvider>
 		);

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/actionBars.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -56,7 +56,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	return (
 		<PositronActionBarContextProvider {...props}>
 			<div className='action-bars'>
-				<PositronActionBar size='small' borderTop={true} borderBottom={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight}>
+				<PositronActionBar borderBottom={true} borderTop={true} paddingLeft={kPaddingLeft} paddingRight={kPaddingRight} size='small'>
 					{positronSessionsContext.positronSessions.size} sessions
 				</PositronActionBar>
 			</div>

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeClient.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeClient.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -58,7 +58,7 @@ export const RuntimeClient = (props: runtimeClientProps) => {
 		return () => {
 			disposableStore.dispose();
 		};
-	}, []);
+	}, [props.client.clientState, props.client.messageCounter]);
 
 	return <tr className='runtime-client'>
 		<td>

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeClientList.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeClientList.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -42,7 +42,7 @@ export const RuntimeClientList = (props: runtimeClientListProps) => {
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [clients, props.session]);
 
 	return <div className='runtime-client-list'>
 		<table>

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeSession.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeSession.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -44,7 +44,7 @@ export const RuntimeSession = (props: RuntimeSessionProps) => {
 			setSessionState(state);
 		}));
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.session]);
 
 	// Render.
 	return (

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeSessionCard.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/runtimeSessionCard.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -59,7 +59,7 @@ export const RuntimeSessionCard = (props: runtimeSessionCardProps) => {
 			setSessionState(state);
 		}));
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.session]);
 
 	return (
 		<tr>

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/sessionsCore.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/components/sessionsCore.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -66,10 +66,10 @@ export const SessionsCore = (props: SessionsCoreProps) => {
 					{allSessions.map(session =>
 						<RuntimeSession
 							key={session.sessionId}
-							width={props.width}
 							height={adjustedHeight}
+							reactComponentContainer={props.reactComponentContainer}
 							session={session}
-							reactComponentContainer={props.reactComponentContainer} />
+							width={props.width} />
 					)}
 				</table>
 			</div>

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessions.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessions.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -51,13 +51,13 @@ export const PositronSessions = (props: PropsWithChildren<PositronSessionsProps>
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.reactComponentContainer]);
 
 	// Render.
 	return (
 		<PositronSessionsContextProvider {...props}>
 			<div className='positron-sessions'>
-				<SessionsCore {...props} width={_width} height={_height} />
+				<SessionsCore {...props} height={_height} width={_width} />
 			</div>
 		</PositronSessionsContextProvider>
 	);

--- a/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessionsView.tsx
+++ b/src/vs/workbench/contrib/positronRuntimeSessions/browser/positronRuntimeSessionsView.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -248,8 +248,8 @@ export class PositronRuntimeSessionsViewPane extends PositronViewPane implements
 				hoverService={this.hoverService}
 				keybindingService={this.keybindingService}
 				layoutService={this._layoutService}
-				runtimeSessionService={this._runtimeSessionService}
 				reactComponentContainer={this}
+				runtimeSessionService={this._runtimeSessionService}
 			/>
 		);
 	}

--- a/src/vs/workbench/contrib/positronVariables/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/actionBars.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -89,12 +89,12 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		// Show the delete all variables modal dialog.
 		renderer.render(
 			<DeleteAllVariablesModalDialog
-				renderer={renderer}
 				deleteAllVariablesAction={async deleteAllVariablesResult =>
 					positronVariablesContext.activePositronVariablesInstance?.requestClear(
 						deleteAllVariablesResult.includeHiddenObjects
 					)
 				}
+				renderer={renderer}
 			/>
 		);
 	};
@@ -117,11 +117,11 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		<PositronActionBarContextProvider {...props}>
 			<div className='action-bars'>
 				<PositronActionBar
-					size='small'
-					borderTop={true}
 					borderBottom={true}
+					borderTop={true}
 					paddingLeft={kPaddingLeft}
 					paddingRight={kPaddingRight}
+					size='small'
 				>
 					<ActionBarRegion location='left'>
 						<GroupingMenuButton />
@@ -131,35 +131,35 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 					<ActionBarRegion location='right'>
 						<ActionBarButton
 							align='right'
+							ariaLabel={positronRefreshObjects}
 							iconId='positron-refresh'
 							tooltip={positronRefreshObjects}
-							ariaLabel={positronRefreshObjects}
 							onPressed={refreshObjectsHandler}
 						/>
 						<ActionBarSeparator />
 						<ActionBarButton
 							align='right'
+							ariaLabel={positronDeleteAllObjects}
 							iconId='clear-all'
 							tooltip={positronDeleteAllObjects}
-							ariaLabel={positronDeleteAllObjects}
 							onPressed={deleteAllObjectsHandler}
 						/>
 					</ActionBarRegion>
 				</PositronActionBar>
 				<PositronActionBar
-					size='small'
 					borderBottom={true}
 					gap={kSecondaryActionBarGap}
 					paddingLeft={kPaddingLeft}
 					paddingRight={kPaddingRight}
+					size='small'
 				>
 					<ActionBarRegion location='left'>
 						<VariablesInstanceMenuButton />
 					</ActionBarRegion>
 					<ActionBarRegion location='right'>
 						<ActionBarFilter
-							width={150}
 							initialFilterText={filterText}
+							width={150}
 							onFilterTextChanged={filterText => setFilterText(filterText)} />
 					</ActionBarRegion>
 				</PositronActionBar>

--- a/src/vs/workbench/contrib/positronVariables/browser/components/groupingMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/groupingMenuButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -111,10 +111,10 @@ export const GroupingMenuButton = () => {
 	// Render.
 	return (
 		<ActionBarMenuButton
+			actions={actions}
+			ariaLabel={positronChangeHowVariablesAreGrouped}
 			iconId='positron-variables-grouping'
 			tooltip={positronChangeHowVariablesAreGrouped}
-			ariaLabel={positronChangeHowVariablesAreGrouped}
-			actions={actions}
 		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronVariables/browser/components/sortingMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/sortingMenuButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -132,10 +132,10 @@ export const SortingMenuButton = () => {
 	// Render.
 	return (
 		<ActionBarMenuButton
+			actions={actions}
+			ariaLabel={positronChangeHowVariablesAreSorted}
 			iconId='positron-variables-sorting'
 			tooltip={positronChangeHowVariablesAreSorted}
-			ariaLabel={positronChangeHowVariablesAreSorted}
-			actions={actions}
 		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableGroup.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableGroup.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -142,7 +142,7 @@ export const VariableGroup = (props: VariableGroupProps) => {
 
 	// Render.
 	return (
-		<div className={classNames} onMouseDown={rowMouseDownHandler} style={props.style}>
+		<div className={classNames} style={props.style} onMouseDown={rowMouseDownHandler}>
 			<div className='expand-collapse-area' onMouseDown={chevronMouseDownHandler} onMouseUp={chevronMouseUpHandler}>
 				{props.variableGroup.expanded ?
 					<div className={`expand-collapse-icon codicon codicon-chevron-down`} /> :

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -420,7 +420,7 @@ export const VariableItem = (props: VariableItemProps) => {
 
 	// Render.
 	return (
-		<div className={classNames} onDoubleClick={doubleClickHandler} onMouseDown={mouseDownHandler} style={props.style}>
+		<div className={classNames} style={props.style} onDoubleClick={doubleClickHandler} onMouseDown={mouseDownHandler}>
 			<div className='name-column' style={{ width: props.nameColumnWidth, minWidth: props.nameColumnWidth }}>
 				<div className='name-column-indenter' style={{ marginLeft: props.variableItem.indentLevel * 20 }}>
 					<div className='gutter'>

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableOverflow.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableOverflow.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -91,7 +91,7 @@ export const VariableOverflow = (props: VariableOverflowProps) => {
 
 	// Render.
 	return (
-		<div className={classNames} onMouseDown={mouseDownHandler} style={props.style}>
+		<div className={classNames} style={props.style} onMouseDown={mouseDownHandler}>
 			<div className='name-column' style={{ width: props.nameColumnWidth, minWidth: props.nameColumnWidth }}>
 				<div className='name-column-indenter' style={{ marginLeft: props.variableOverflow.indentLevel * 20 }}>
 					<div className='name-value'>

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesCore.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesCore.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -50,10 +50,10 @@ export const VariablesCore = (props: VariablesCoreProps) => {
 					<VariablesInstance
 						key={positronVariablesInstance.session.sessionId}
 						active={positronVariablesInstance === positronVariablesContext.activePositronVariablesInstance}
-						width={props.width}
 						height={adjustedHeight}
 						positronVariablesInstance={positronVariablesInstance}
-						reactComponentContainer={props.reactComponentContainer} />
+						reactComponentContainer={props.reactComponentContainer}
+						width={props.width} />
 				)}
 			</div>
 		</div>

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -474,50 +474,50 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 			return (
 				<VariableGroup
 					key={entry.id}
-					variableGroup={entry}
-					style={style}
 					focused={focused}
-					selected={selectedId === entry.id}
-					onSelected={() => selectedHandler(index)}
-					onDeselected={deselectedHandler}
-					onToggleExpandCollapse={() => toggleExpandCollapseHandler(index)}
 					positronVariablesInstance={props.positronVariablesInstance}
+					selected={selectedId === entry.id}
+					style={style}
+					variableGroup={entry}
+					onDeselected={deselectedHandler}
+					onSelected={() => selectedHandler(index)}
+					onToggleExpandCollapse={() => toggleExpandCollapseHandler(index)}
 				/>
 			);
 		} else if (isVariableItem(entry)) {
 			return (
 				<VariableItem
 					key={entry.id}
-					disabled={clientState === RuntimeClientState.Closed}
-					nameColumnWidth={nameColumnWidth}
 					detailsColumnWidth={detailsColumnWidth}
-					rightColumnVisible={rightColumnVisible}
-					variableItem={entry}
-					style={style}
+					disabled={clientState === RuntimeClientState.Closed}
 					focused={focused}
-					selected={selectedId === entry.id}
-					onSelected={() => selectedHandler(index)}
-					onDeselected={deselectedHandler}
-					onToggleExpandCollapse={() => toggleExpandCollapseHandler(index)}
-					onBeginResizeNameColumn={beginResizeNameColumnHandler}
-					onResizeNameColumn={resizeNameColumnHandler}
+					nameColumnWidth={nameColumnWidth}
 					positronVariablesInstance={props.positronVariablesInstance}
+					rightColumnVisible={rightColumnVisible}
+					selected={selectedId === entry.id}
+					style={style}
+					variableItem={entry}
+					onBeginResizeNameColumn={beginResizeNameColumnHandler}
+					onDeselected={deselectedHandler}
+					onResizeNameColumn={resizeNameColumnHandler}
+					onSelected={() => selectedHandler(index)}
+					onToggleExpandCollapse={() => toggleExpandCollapseHandler(index)}
 				/>
 			);
 		} else if (isVariableOverflow(entry)) {
 			return (
 				<VariableOverflow
 					key={entry.id}
-					nameColumnWidth={nameColumnWidth}
 					detailsColumnWidth={detailsColumnWidth}
-					variableOverflow={entry}
-					style={style}
 					focused={focused}
+					nameColumnWidth={nameColumnWidth}
 					selected={selectedId === entry.id}
-					onSelected={() => selectedHandler(index)}
-					onDeselected={deselectedHandler}
+					style={style}
+					variableOverflow={entry}
 					onBeginResizeNameColumn={beginResizeNameColumnHandler}
+					onDeselected={deselectedHandler}
 					onResizeNameColumn={resizeNameColumnHandler}
+					onSelected={() => selectedHandler(index)}
 				/>
 			);
 		} else {
@@ -533,24 +533,24 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 			className={'variables-instance state-' + clientState}
 			style={{ width: props.width, height: props.height, zIndex: props.active ? 1 : -1 }}
 			tabIndex={0}
-			onKeyDown={keyDownHandler}
-			onFocus={focusHandler}
 			onBlur={blurHandler}
+			onFocus={focusHandler}
+			onKeyDown={keyDownHandler}
 			onWheel={wheelHandler}
 		>
 			{!variableEntries.length ?
 				<VariablesEmpty initializing={initializing} /> :
 				<List
-					className='list'
 					ref={listRef}
+					className='list'
+					height={props.height}
 					innerRef={innerRef}
 					itemCount={variableEntries.length}
-					// Use a custom item key instead of index.
 					itemKey={index => variableEntries[index].id}
-					width={props.width}
-					height={props.height}
 					itemSize={LINE_HEIGHT}
 					overscanCount={10}
+					width={props.width}
+					// Use a custom item key instead of index.
 					onScroll={({ scrollOffset }) => {
 						// Save the scroll offset when we're active and scrolled.
 						if (props.active) {

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstanceMenuButton.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstanceMenuButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -46,7 +46,7 @@ export const VariablesInstanceMenuButton = () => {
 			setActiveRuntimeLabel(labelForRuntime(e?.session));
 		}));
 		return () => disposables.dispose();
-	}, [positronVariablesContext.activePositronVariablesInstance]);
+	}, [positronVariablesContext.activePositronVariablesInstance, positronVariablesContext.positronVariablesService]);
 
 	// Builds the actions.
 	const actions = () => {
@@ -82,8 +82,8 @@ export const VariablesInstanceMenuButton = () => {
 	// Render.
 	return (
 		<ActionBarMenuButton
-			text={activeRuntimeLabel}
 			actions={actions}
+			text={activeRuntimeLabel}
 		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronVariables/browser/modalDialogs/deleteAllVariablesModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/modalDialogs/deleteAllVariablesModalDialog.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -55,13 +55,13 @@ export const DeleteAllVariablesModalDialog = (props: DeleteAllVariablesModalDial
 
 	return (
 		<ConfirmDeleteModalDialog
-			renderer={props.renderer}
-			width={375}
 			height={175}
+			renderer={props.renderer}
 			title={(() => localize(
 				'positron.deleteAllVariablesModalDialogTitle',
 				"Delete All Variables"
 			))()}
+			width={375}
 			onCancel={cancelHandler}
 			onDeleteAction={acceptHandler}
 		>

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariables.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariables.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -63,13 +63,13 @@ export const PositronVariables = (props: PropsWithChildren<PositronVariablesProp
 
 		// Return the cleanup function that will dispose of the event handlers.
 		return () => disposableStore.dispose();
-	}, []);
+	}, [props.reactComponentContainer]);
 
 	// Render.
 	return (
 		<PositronVariablesContextProvider {...props}>
 			<div className='positron-variables'>
-				<VariablesCore width={width} height={height} {...props} />
+				<VariablesCore height={height} width={width} {...props} />
 			</div>
 		</PositronVariablesContextProvider>
 	);

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariablesView.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -279,14 +279,14 @@ export class PositronVariablesViewPane extends PositronViewPane implements IReac
 				contextKeyService={this.contextKeyService}
 				contextMenuService={this.contextMenuService}
 				dataExplorerService={this._dataExplorerService}
-				notificationService={this._notificationService}
 				hoverService={this.hoverService}
 				keybindingService={this.keybindingService}
-				runtimeSessionService={this._runtimeSessionService}
 				languageRuntimeService={this._languageRuntimeService}
 				layoutService={this._layoutService}
+				notificationService={this._notificationService}
 				positronVariablesService={this._positronVariablesService}
 				reactComponentContainer={this}
+				runtimeSessionService={this._runtimeSessionService}
 			/>
 		);
 	}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomeButton.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomeButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -28,11 +28,11 @@ export function WelcomeButtonInner(props: WelcomeButtonProps, ref?: React.Forwar
 	// Render.
 	return (
 		<ActionButton
-			className='positron-welcome-button'
 			ariaLabel={props.ariaLabel}
+			className='positron-welcome-button'
 			onPressed={props.onPressed}
 		>
-			<div className='button-container' ref={ref}>
+			<div ref={ref} className='button-container'>
 				<div className={`button-icon codicon codicon-${props.codicon}`} />
 				<div className='action-label'>
 					{props.label}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomeConsoleButton.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomeConsoleButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -58,18 +58,18 @@ export function WelcomeConsoleButton(props: WelcomeConsoleButtonProps) {
 		});
 		renderer.render(
 			<PositronModalPopup
-				renderer={renderer}
 				anchorElement={ref.current}
-				popupPosition='bottom'
-				popupAlignment='left'
-				width={375}
 				height={'min-content'}
 				keyboardNavigationStyle='menu'
+				popupAlignment='left'
+				popupPosition='bottom'
+				renderer={renderer}
+				width={375}
 			>
 				<InterpreterGroups
 					languageRuntimeService={props.languageRuntimeService}
-					runtimeSessionService={props.runtimeSessionService}
 					runtimeAffiliationService={props.runtimeStartupService}
+					runtimeSessionService={props.runtimeSessionService}
 					onActivateRuntime={activateRuntime}
 					onStartRuntime={async (runtime: ILanguageRuntimeMetadata) => {
 						startRuntime(runtime);
@@ -82,11 +82,11 @@ export function WelcomeConsoleButton(props: WelcomeConsoleButtonProps) {
 	// Render.
 	return (
 		<ActionButton
-			className='positron-welcome-button'
 			ariaLabel={(() => localize('positron.welcome.newConsoleDescription', "Create a new console"))()}
+			className='positron-welcome-button'
 			onPressed={showPopup}
 		>
-			<div className='button-container' ref={ref}>
+			<div ref={ref} className='button-container'>
 				<div className={`button-icon codicon codicon-positron-new-console`} />
 				<div className='action-label'>
 					{(() => localize('positron.welcome.newConsole', "New Console"))()}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomeMenuButton.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomeMenuButton.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -48,13 +48,13 @@ export function WelcomeMenuButton(props: WelcomeMenuButtonProps) {
 
 		renderer.render(
 			<PositronModalPopup
-				renderer={renderer}
 				anchorElement={ref.current}
-				popupPosition='bottom'
-				popupAlignment='left'
-				width={300}
 				height={'min-content'}
 				keyboardNavigationStyle='menu'
+				popupAlignment='left'
+				popupPosition='bottom'
+				renderer={renderer}
+				width={300}
 			>
 				<div className='welcome-page-start menu-button-container'>
 					{props.actions.map((action, index) => (
@@ -78,11 +78,11 @@ export function WelcomeMenuButton(props: WelcomeMenuButtonProps) {
 	// Render.
 	return (
 		<WelcomeButton
-			label={props.label}
-			codicon={props.codicon}
-			ariaLabel={props.ariaLabel}
-			onPressed={showPopup}
 			ref={ref}
+			ariaLabel={props.ariaLabel}
+			codicon={props.codicon}
+			label={props.label}
+			onPressed={showPopup}
 		/>
 	);
 }

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageLeft.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageLeft.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -36,12 +36,12 @@ export const PositronWelcomePageLeft = (props: PropsWithChildren<PositronWelcome
 	return (
 		<>
 			<PositronWelcomePageStart
-				keybindingService={props.keybindingService}
-				layoutService={props.layoutService}
 				commandService={props.commandService}
+				keybindingService={props.keybindingService}
+				languageRuntimeService={props.languageRuntimeService}
+				layoutService={props.layoutService}
 				runtimeSessionService={props.runtimesSessionService}
 				runtimeStartupService={props.runtimeStartupService}
-				languageRuntimeService={props.languageRuntimeService}
 			/>
 			<PositronWelcomePageHelp openerService={props.openerService} />
 		</>
@@ -61,13 +61,13 @@ export const createWelcomePageLeft = (
 	const renderer = new PositronReactRenderer(container);
 	renderer.render(
 		<PositronWelcomePageLeft
-			openerService={openerService}
-			keybindingService={keybindingService}
-			layoutService={layoutService}
 			commandService={commandService}
-			runtimesSessionService={runtimeSessionService}
-			runtimeStartupService={runtimeStartupService}
+			keybindingService={keybindingService}
 			languageRuntimeService={languageRuntimeService}
+			layoutService={layoutService}
+			openerService={openerService}
+			runtimeStartupService={runtimeStartupService}
+			runtimesSessionService={runtimeSessionService}
 		/>
 	);
 	return renderer;

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageStart.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageStart.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -41,9 +41,6 @@ export const PositronWelcomePageStart = (props: PropsWithChildren<PositronWelcom
 			<h2>Start</h2>
 			<div className='positron-welcome-page-start buttons'>
 				<WelcomeMenuButton
-					label={(() => localize('positron.welcome.newNotebook', "New Notebook"))()}
-					codicon='positron-new-notebook'
-					ariaLabel={(() => localize('positron.welcome.newNotebookDescription', "Create a Python or R Notebook"))()}
 					actions={[
 						{
 							renderIcon: () => <PythonLogo />,
@@ -60,27 +57,30 @@ export const PositronWelcomePageStart = (props: PropsWithChildren<PositronWelcom
 							tooltip: localize('positron.welcome.newRNotebookDescription', "Create a new R notebook"),
 						},
 					]}
+					ariaLabel={(() => localize('positron.welcome.newNotebookDescription', "Create a Python or R Notebook"))()}
+					codicon='positron-new-notebook'
 					keybindingService={props.keybindingService}
+					label={(() => localize('positron.welcome.newNotebook', "New Notebook"))()}
 					layoutService={props.layoutService}
 				/>
 				<WelcomeButton
-					label={(() => localize('positron.welcome.newFile', "New File"))()}
-					codicon='positron-new-file'
 					ariaLabel={(() => localize('positron.welcome.newFileDescription', "Create a new file"))()}
+					codicon='positron-new-file'
+					label={(() => localize('positron.welcome.newFile', "New File"))()}
 					onPressed={() => props.commandService.executeCommand('welcome.showNewFileEntries')}
 				/>
-				<WelcomeConsoleButton keybindingService={props.keybindingService}
-					layoutService={props.layoutService}
+				<WelcomeConsoleButton commandService={props.commandService}
+					keybindingService={props.keybindingService}
 					languageRuntimeService={props.languageRuntimeService}
+					layoutService={props.layoutService}
 					runtimeSessionService={props.runtimeSessionService}
 					runtimeStartupService={props.runtimeStartupService}
-					commandService={props.commandService}
 				/>
 
 				<WelcomeButton
-					label={(() => localize('positron.welcome.newProject', "New Project"))()}
-					codicon='positron-new-project'
 					ariaLabel={(() => localize('positron.welcome.newProjectDescription', "Create a new project"))()}
+					codicon='positron-new-project'
+					label={(() => localize('positron.welcome.newProject', "New Project"))()}
 					onPressed={() => props.commandService.executeCommand(PositronNewProjectAction.ID)}
 				/>
 			</div>

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileSparklines.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileSparklines.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -46,10 +46,10 @@ export const ColumnProfileSparklineHistogram = ({
 			}}
 		>
 			<VectorHistogram
-				graphWidth={GRAPH_WIDTH}
-				graphHeight={GRAPH_HEIGHT}
-				xAxisHeight={X_AXIS_HEIGHT}
 				columnHistogram={columnHistogram}
+				graphHeight={GRAPH_HEIGHT}
+				graphWidth={GRAPH_WIDTH}
+				xAxisHeight={X_AXIS_HEIGHT}
 			/>
 		</div >
 	);
@@ -80,10 +80,10 @@ export const ColumnProfileSparklineFrequencyTable = ({
 			}}
 		>
 			<VectorFrequencyTable
-				graphWidth={GRAPH_WIDTH}
-				graphHeight={GRAPH_HEIGHT}
-				xAxisHeight={X_AXIS_HEIGHT}
 				columnFrequencyTable={columnFrequencyTable}
+				graphHeight={GRAPH_HEIGHT}
+				graphWidth={GRAPH_WIDTH}
+				xAxisHeight={X_AXIS_HEIGHT}
 			/>
 		</div >
 	);

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -104,10 +104,10 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 						}}
 					>
 						<VectorHistogram
-							graphWidth={SPARKLINE_WIDTH}
-							graphHeight={SPARKLINE_HEIGHT}
-							xAxisHeight={SPARKLINE_X_AXIS_HEIGHT}
 							columnHistogram={columnHistogram}
+							graphHeight={SPARKLINE_HEIGHT}
+							graphWidth={SPARKLINE_WIDTH}
+							xAxisHeight={SPARKLINE_X_AXIS_HEIGHT}
 						/>
 					</div >
 				);
@@ -132,10 +132,10 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 						}}
 					>
 						<VectorFrequencyTable
-							graphWidth={SPARKLINE_WIDTH}
-							graphHeight={SPARKLINE_HEIGHT}
-							xAxisHeight={SPARKLINE_X_AXIS_HEIGHT}
 							columnFrequencyTable={columnFrequencyTable}
+							graphHeight={SPARKLINE_HEIGHT}
+							graphWidth={SPARKLINE_WIDTH}
+							xAxisHeight={SPARKLINE_X_AXIS_HEIGHT}
 						/>
 					</div >
 				);
@@ -189,42 +189,42 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 					</div>
 				}
 				<div className='graph-percent'>
-					<svg viewBox='0 0 52 14' shapeRendering='geometricPrecision'>
+					<svg shapeRendering='geometricPrecision' viewBox='0 0 52 14'>
 						<defs>
 							<clipPath id='clip-indicator'>
-								<rect x='1' y='1' width='50' height='12' rx='6' ry='6' />
+								<rect height='12' rx='6' ry='6' width='50' x='1' y='1' />
 							</clipPath>
 						</defs>
 						{graphNullPercent === undefined ?
 							<g>
 								<rect className='empty'
-									x='1'
-									y='1'
-									width='50'
 									height='12'
 									rx='6'
 									ry='6'
 									strokeWidth='1'
+									width='50'
+									x='1'
+									y='1'
 								/>
 							</g> :
 							<g>
 								<rect className='background'
-									x='1'
-									y='1'
-									width='50'
 									height='12'
 									rx='6'
 									ry='6'
 									strokeWidth='1'
-								/>
-								<rect className='indicator'
+									width='50'
 									x='1'
 									y='1'
-									width={50 * ((100 - graphNullPercent) / 100)}
+								/>
+								<rect className='indicator'
+									clipPath='url(#clip-indicator)'
 									height='12'
 									rx='6'
 									ry='6'
-									clipPath='url(#clip-indicator)'
+									width={50 * ((100 - graphNullPercent) / 100)}
+									x='1'
+									y='1'
 								/>
 							</g>
 						}
@@ -243,23 +243,23 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		switch (props.columnSchema.type_display) {
 			// Number.
 			case ColumnDisplayType.Number:
-				return <ColumnProfileNumber instance={props.instance} columnIndex={props.columnIndex} />;
+				return <ColumnProfileNumber columnIndex={props.columnIndex} instance={props.instance} />;
 
 			// Boolean.
 			case ColumnDisplayType.Boolean:
-				return <ColumnProfileBoolean instance={props.instance} columnIndex={props.columnIndex} />;
+				return <ColumnProfileBoolean columnIndex={props.columnIndex} instance={props.instance} />;
 
 			// String.
 			case ColumnDisplayType.String:
-				return <ColumnProfileString instance={props.instance} columnIndex={props.columnIndex} />;
+				return <ColumnProfileString columnIndex={props.columnIndex} instance={props.instance} />;
 
 			// Date.
 			case ColumnDisplayType.Date:
-				return <ColumnProfileDate instance={props.instance} columnIndex={props.columnIndex} />;
+				return <ColumnProfileDate columnIndex={props.columnIndex} instance={props.instance} />;
 
 			// Datetime.
 			case ColumnDisplayType.Datetime:
-				return <ColumnProfileDatetime instance={props.instance} columnIndex={props.columnIndex} />;
+				return <ColumnProfileDatetime columnIndex={props.columnIndex} instance={props.instance} />;
 
 			// Column display types that do not render a profile.
 			case ColumnDisplayType.Time:
@@ -397,6 +397,7 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 				<div
 					ref={dataTypeRef}
 					className={`data-type-icon codicon ${dataTypeIcon}`}
+					onMouseLeave={() => props.hoverService.hideHover()}
 					onMouseOver={() =>
 						props.hoverService.showHover({
 							content: `${props.columnSchema.type_name}`,
@@ -413,7 +414,6 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 							}
 						}, false)
 					}
-					onMouseLeave={() => props.hoverService.hideHover()}
 				/>
 				<div className='column-name'>
 					{renderedColumn}

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorFrequencyTable.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorFrequencyTable.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -80,10 +80,10 @@ export const VectorFrequencyTable = (props: VectorFrequencyTableProps) => {
 		return (
 			<rect
 				className='count other'
+				height={countHeight}
+				width={props.graphWidth - x}
 				x={x}
 				y={props.graphHeight - props.xAxisHeight - countHeight}
-				width={props.graphWidth - x}
-				height={countHeight}
 			/>
 		);
 	};
@@ -93,27 +93,27 @@ export const VectorFrequencyTable = (props: VectorFrequencyTableProps) => {
 	return (
 		<svg
 			className='vector-frequency-table'
-			viewBox={`0 0 ${props.graphWidth} ${props.graphHeight + props.xAxisHeight}`}
 			shapeRendering='crispEdges'
+			viewBox={`0 0 ${props.graphWidth} ${props.graphHeight + props.xAxisHeight}`}
 		>
 			<g>
 				<rect className='x-axis'
+					height={props.xAxisHeight}
+					width={props.graphWidth}
 					x={0}
 					y={props.graphHeight - props.xAxisHeight}
-					width={props.graphWidth}
-					height={props.xAxisHeight}
 				/>
 				{props.columnFrequencyTable.counts.map((count, countIndex) => {
 					const countHeight = Math.max(1, (count / maxCount) * props.graphHeight);
 					try {
 						return (
 							<rect
-								className='count'
 								key={`count-${countIndex}`}
+								className='count'
+								height={countHeight}
+								width={countWidth}
 								x={x}
 								y={props.graphHeight - props.xAxisHeight - countHeight}
-								width={countWidth}
-								height={countHeight}
 							/>
 						);
 					} finally {

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/vectorHistogram.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -59,26 +59,26 @@ export const VectorHistogram = (props: VectorHistogramProps) => {
 	return (
 		<svg
 			className='vector-histogram'
-			viewBox={`0 0 ${props.graphWidth} ${props.graphHeight + props.xAxisHeight}`}
 			shapeRendering='crispEdges'
+			viewBox={`0 0 ${props.graphWidth} ${props.graphHeight + props.xAxisHeight}`}
 		>
 			<g>
 				<rect className='x-axis'
+					height={props.xAxisHeight}
+					width={props.graphWidth}
 					x={0}
 					y={props.graphHeight - props.xAxisHeight}
-					width={props.graphWidth}
-					height={props.xAxisHeight}
 				/>
 				{props.columnHistogram.bin_counts.map((binCount, binCountIndex) => {
 					const binCountHeight = (binCount / maxBinCount) * props.graphHeight;
 					return (
 						<rect
-							className='bin-count'
 							key={`bin-count-${binCountIndex}`}
+							className='bin-count'
+							height={binCountHeight}
+							width={binWidth}
 							x={binCountIndex * binWidth}
 							y={props.graphHeight - props.xAxisHeight - binCountHeight}
-							width={binWidth}
-							height={binCountHeight}
 						/>
 					);
 				})}

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -222,10 +222,10 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 		// Return the ColumnSummaryCell.
 		return (
 			<ColumnSummaryCell
+				columnIndex={rowIndex}
+				columnSchema={columnSchema}
 				hoverService={this._hoverService}
 				instance={this}
-				columnSchema={columnSchema}
-				columnIndex={rowIndex}
 				onDoubleClick={() => this._onDidSelectColumnEmitter.fire(rowIndex)}
 			/>
 		);


### PR DESCRIPTION
### Description

This PR fixes React ESLint errors caused by the following rules:

```
react-hooks/rules-of-hooks
react-hooks/exhaustive-deps
react/jsx-sort-props
```

To verify that everything has been addressed, you can execute:

```
npx eslint **/*.tsx --quiet
```

Tests:
@:all @:web @:win

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

- N/A