### PR TITLE
add command `r.scriptPath` which returns the path to Rscript

### DIFF
--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -14,6 +14,7 @@ import { RSessionManager } from './session-manager';
 import { quickPickRuntime } from './runtime-quickpick';
 import { MINIMUM_RENV_VERSION, MINIMUM_R_VERSION } from './constants';
 import { RRuntimeManager } from './runtime-manager';
+import { RMetadataExtra } from './r-installation';
 
 export async function registerCommands(context: vscode.ExtensionContext, runtimeManager: RRuntimeManager) {
 
@@ -155,7 +156,7 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 			if (!session) {
 				throw new Error(`Cannot get Rscript path; no R session available`);
 			}
-			const scriptPath = session.runtimeMetadata.extraRuntimeData.scriptPath;
+			const scriptPath = (session.runtimeMetadata.extraRuntimeData as RMetadataExtra).scriptpath;
 			if (!scriptPath) {
 				throw new Error(`Cannot get Rscript path; no Rscript path available`);
 			}

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -150,6 +150,18 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 			await quickPickRuntime(runtimeManager);
 		}),
 
+		vscode.commands.registerCommand('r.rScriptPath', async () => {
+			const binPath = RSessionManager.instance.getLastBinpath();
+			if (!binPath) {
+				console.error('[r.rScriptPath] Could not determine RScript path as no R session is available.');
+				return;
+			}
+			// The RScript path is the same as the R binary path, but with the 'R' or 'R.exe'
+			// executable replaced with 'RScript' or 'RScript.exe'.
+			const rScriptPath = binPath.replace(/R(\.exe)?$/, 'RScript$1');
+			return rScriptPath;
+		}),
+
 		// Commands used to source the current file
 		vscode.commands.registerCommand('r.sourceCurrentFile', async () => {
 			sourceCurrentFile(false);

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -151,14 +151,14 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 		}),
 
 		vscode.commands.registerCommand('r.rScriptPath', async () => {
-			const binPath = RSessionManager.instance.getLastBinpath();
-			if (!binPath) {
-				console.error('[r.rScriptPath] Could not determine RScript path as no R session is available.');
-				return;
+			const session = RSessionManager.instance.getConsoleSession();
+			if (!session) {
+				throw new Error(`Cannot get RScript path; no R session available`);
 			}
-			// The RScript path is the same as the R binary path, but with the 'R' or 'R.exe'
-			// executable replaced with 'RScript' or 'RScript.exe'.
-			const rScriptPath = binPath.replace(/R(\.exe)?$/, 'RScript$1');
+			const rScriptPath = session.runtimeMetadata.extraRuntimeData.rScriptPath;
+			if (!rScriptPath) {
+				throw new Error(`Cannot get RScript path; no RScript path available`);
+			}
 			return rScriptPath;
 		}),
 

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -150,16 +150,16 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 			await quickPickRuntime(runtimeManager);
 		}),
 
-		vscode.commands.registerCommand('r.rScriptPath', async () => {
+		vscode.commands.registerCommand('r.scriptPath', async () => {
 			const session = RSessionManager.instance.getConsoleSession();
 			if (!session) {
-				throw new Error(`Cannot get RScript path; no R session available`);
+				throw new Error(`Cannot get Rscript path; no R session available`);
 			}
-			const rScriptPath = session.runtimeMetadata.extraRuntimeData.rScriptPath;
-			if (!rScriptPath) {
-				throw new Error(`Cannot get RScript path; no RScript path available`);
+			const scriptPath = session.runtimeMetadata.extraRuntimeData.scriptPath;
+			if (!scriptPath) {
+				throw new Error(`Cannot get Rscript path; no Rscript path available`);
 			}
-			return rScriptPath;
+			return scriptPath;
 		}),
 
 		// Commands used to source the current file

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -190,6 +190,11 @@ export async function makeMetadata(
 		path.join('~', rInst.binpath.substring(homedir.length)) :
 		rInst.binpath;
 
+	// Create the RScript path.
+	// The RScript path is the same as the R binary path, but with the 'R' or 'R.exe' executable
+	// replaced with 'RScript' or 'RScript.exe, respectively.
+	const rScriptPath = rInst.binpath.replace(/R(\.exe)?$/, 'RScript$1');
+
 	// Does the runtime path have 'homebrew' as a component? (we assume that
 	// it's a Homebrew installation if it does)
 	const isHomebrewInstallation = rInst.binpath.includes('/homebrew/');
@@ -216,11 +221,12 @@ export async function makeMetadata(
 	digest.update(rVersion);
 	const runtimeId = digest.digest('hex').substring(0, 32);
 
-	// Save the R home path and binary path as extra data.
+	// Save the R home path, binary path and RScript path as extra data.
 	// Also, whether this R installation is the "current" R version.
 	const extraRuntimeData: RMetadataExtra = {
 		homepath: rInst.homepath,
 		binpath: rInst.binpath,
+		rScriptPath: rScriptPath,
 		current: rInst.current,
 		reasonDiscovered: rInst.reasonDiscovered,
 	};

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -190,10 +190,10 @@ export async function makeMetadata(
 		path.join('~', rInst.binpath.substring(homedir.length)) :
 		rInst.binpath;
 
-	// Create the RScript path.
-	// The RScript path is the same as the R binary path, but with the 'R' or 'R.exe' executable
-	// replaced with 'RScript' or 'RScript.exe, respectively.
-	const rScriptPath = rInst.binpath.replace(/R(\.exe)?$/, 'RScript$1');
+	// Create the Rscript path.
+	// The Rscript path is the same as the R binary path, but with the 'R' or 'R.exe' executable
+	// replaced with 'Rscript' or 'Rscript.exe, respectively.
+	const scriptPath = rInst.binpath.replace(/R(\.exe)?$/, 'Rscript$1');
 
 	// Does the runtime path have 'homebrew' as a component? (we assume that
 	// it's a Homebrew installation if it does)
@@ -221,12 +221,12 @@ export async function makeMetadata(
 	digest.update(rVersion);
 	const runtimeId = digest.digest('hex').substring(0, 32);
 
-	// Save the R home path, binary path and RScript path as extra data.
+	// Save the R home path, binary path and Rscript path as extra data.
 	// Also, whether this R installation is the "current" R version.
 	const extraRuntimeData: RMetadataExtra = {
 		homepath: rInst.homepath,
 		binpath: rInst.binpath,
-		rScriptPath: rScriptPath,
+		scriptPath: scriptPath,
 		current: rInst.current,
 		reasonDiscovered: rInst.reasonDiscovered,
 	};

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -226,7 +226,7 @@ export async function makeMetadata(
 	const extraRuntimeData: RMetadataExtra = {
 		homepath: rInst.homepath,
 		binpath: rInst.binpath,
-		scriptPath: scriptPath,
+		scriptpath: scriptPath,
 		current: rInst.current,
 		reasonDiscovered: rInst.reasonDiscovered,
 	};

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -19,6 +19,9 @@ export interface RMetadataExtra {
 
 	/** R's binary path */
 	readonly binpath: string;
+
+	/** R's RScript path */
+	readonly rScriptPath: string;
 
 	/**
 	 * Is this known to be the current version of R?

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -21,7 +21,7 @@ export interface RMetadataExtra {
 	readonly binpath: string;
 
 	/** R's Rscript path */
-	readonly scriptPath: string;
+	readonly scriptpath: string;
 
 	/**
 	 * Is this known to be the current version of R?

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -20,8 +20,8 @@ export interface RMetadataExtra {
 	/** R's binary path */
 	readonly binpath: string;
 
-	/** R's RScript path */
-	readonly rScriptPath: string;
+	/** R's Rscript path */
+	readonly scriptPath: string;
 
 	/**
 	 * Is this known to be the current version of R?

--- a/extensions/positron-r/src/runtime-manager.ts
+++ b/extensions/positron-r/src/runtime-manager.ts
@@ -71,7 +71,7 @@ export class RRuntimeManager implements positron.LanguageRuntimeManager {
 		if (!metadataExtra.binpath) {
 			throw new Error('R metadata is missing bin path');
 		}
-		// metadataExtra.scriptPath may not exist yet and will be constructed via makeMetadata.
+		// metadataExtra.scriptpath may not exist yet and will be constructed via makeMetadata.
 
 		// Look for the current R binary. Note that this can return undefined,
 		// if there are no current/default R installations on the system. This

--- a/extensions/positron-r/src/runtime-manager.ts
+++ b/extensions/positron-r/src/runtime-manager.ts
@@ -71,7 +71,7 @@ export class RRuntimeManager implements positron.LanguageRuntimeManager {
 		if (!metadataExtra.binpath) {
 			throw new Error('R metadata is missing bin path');
 		}
-		// metadataExtra.rScriptPath may not exist yet and will be constructed via makeMetadata.
+		// metadataExtra.scriptPath may not exist yet and will be constructed via makeMetadata.
 
 		// Look for the current R binary. Note that this can return undefined,
 		// if there are no current/default R installations on the system. This

--- a/extensions/positron-r/src/runtime-manager.ts
+++ b/extensions/positron-r/src/runtime-manager.ts
@@ -71,6 +71,7 @@ export class RRuntimeManager implements positron.LanguageRuntimeManager {
 		if (!metadataExtra.binpath) {
 			throw new Error('R metadata is missing bin path');
 		}
+		// metadataExtra.rScriptPath may not exist yet and will be constructed via makeMetadata.
 
 		// Look for the current R binary. Note that this can return undefined,
 		// if there are no current/default R installations on the system. This


### PR DESCRIPTION
### Summary

- adds a new R extension command `r.scriptPath` which returns the Rscript path based on the last R bin path
- this is being introduced to provide a similar option to Python's `"command": "${command:python.interpreterPath} ${file}"` that can be used in tasks.json for tests

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@testlabauto could you please fill out this section on how to use the option in tasks.json? :D

Sure!  Here is a sample tasks.json using r.scriptPath

```
{
    "version": "2.0.0",
    "tasks": [
        {
            "label": "Run R File",
            "command": "${command:r.scriptPath} ${file}",
            "type": "shell",
            "group": {
                "kind": "build",
                "isDefault": true
            },
            "presentation": {
                "reveal": "always",
                "panel": "new",
                "focus": true
            }
        }
    ]
}
```
This will run the currently open file with the current Rscript.  You can test the fail condition by having no active R session.
