### PR TITLE
Rename `VerticalSplitterResizeParams ` `columnWidth` to `startingWidth`

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/splitters/verticalSplitter.tsx
+++ b/src/vs/base/browser/ui/positronComponents/splitters/verticalSplitter.tsx
@@ -59,7 +59,7 @@ type VerticalSplitterProps = VerticalSplitterBaseProps & VerticalSplitterCollaps
 export interface VerticalSplitterResizeParams {
 	readonly minimumWidth: number;
 	readonly maximumWidth: number;
-	readonly columnsWidth: number;
+	readonly startingWidth: number;
 }
 
 /**
@@ -275,7 +275,7 @@ export const VerticalSplitter = ({
 
 		// Setup the resize state.
 		const resizeParams = onBeginResize();
-		const startingWidth = collapsed ? sashWidth : resizeParams.columnsWidth;
+		const startingWidth = collapsed ? sashWidth : resizeParams.startingWidth;
 		const target = DOM.getWindow(e.currentTarget).document.body;
 		const clientX = e.clientX;
 		const styleSheet = createStyleSheet(target);

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -291,7 +291,7 @@ export const DataExplorer = () => {
 	const beginResizeHandler = (): VerticalSplitterResizeParams => ({
 		minimumWidth: MIN_COLUMN_WIDTH,
 		maximumWidth: Math.trunc(2 * width / 3),
-		columnsWidth
+		startingWidth: columnsWidth
 	});
 
 	/**

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -177,7 +177,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 					onBeginResize={() => ({
 						minimumWidth: context.instance.minimumColumnWidth,
 						maximumWidth: context.instance.maximumColumnWidth,
-						columnsWidth: context.instance.getColumnWidth(props.columnIndex)
+						startingWidth: context.instance.getColumnWidth(props.columnIndex)
 					})}
 					onResize={async columnWidth =>
 						await context.instance.setColumnWidth(props.columnIndex, columnWidth)

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridCornerTopLeft.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridCornerTopLeft.tsx
@@ -38,7 +38,7 @@ export const DataGridCornerTopLeft = (props: DataGridCornerTopLeftProps) => {
 				onBeginResize={() => ({
 					minimumWidth: 20,
 					maximumWidth: context.instance.maximumColumnWidth,
-					columnsWidth: context.instance.rowHeadersWidth
+					startingWidth: context.instance.rowHeadersWidth
 				})}
 				onResize={async width =>
 					await context.instance.setRowHeadersWidth(width)

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
@@ -177,7 +177,7 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 					onBeginResize={() => ({
 						minimumWidth: context.instance.minimumColumnWidth,
 						maximumWidth: context.instance.maximumColumnWidth,
-						columnsWidth: context.instance.getColumnWidth(props.columnIndex)
+						startingWidth: context.instance.getColumnWidth(props.columnIndex)
 					})}
 					onResize={async columnWidth =>
 						await context.instance.setColumnWidth(props.columnIndex, columnWidth)

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
@@ -118,7 +118,7 @@ export const DataGridRowHeader = (props: DataGridRowHeaderProps) => {
 				onBeginResize={() => ({
 					minimumWidth: context.instance.minimumColumnWidth,
 					maximumWidth: context.instance.maximumColumnWidth,
-					columnsWidth: context.instance.rowHeadersWidth
+					startingWidth: context.instance.rowHeadersWidth
 				})}
 				onResize={async width =>
 					await context.instance.setRowHeadersWidth(width)

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
@@ -370,7 +370,7 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 	const beginResizeNameColumnHandler = (): VerticalSplitterResizeParams => ({
 		minimumWidth: MINIMUM_NAME_COLUMN_WIDTH,
 		maximumWidth: Math.trunc(2 * props.width / 3),
-		columnsWidth: nameColumnWidth
+		startingWidth: nameColumnWidth
 	});
 
 	/**


### PR DESCRIPTION
### Description

This PR renames `VerticalSplitterResizeParams` `columnsWidth` to `startingWidth`. This was a missed refactoring that should have been done when the `VerticalSplitter` component was adapted for generalized use.

```
export interface VerticalSplitterResizeParams {
	readonly minimumWidth: number;
	readonly maximumWidth: number;
	readonly startingWidth: number; // Renamed!
}
```

Now, the `VerticalSplitterResizeParams` and `HorizontalSplitterResizeParams` match one another in this regard.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

- N/A
