### PR TITLE
Fix unsynchronized collapse state in Data Explorer

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/splitters/verticalSplitter.tsx
+++ b/src/vs/base/browser/ui/positronComponents/splitters/verticalSplitter.tsx
@@ -42,9 +42,11 @@ type VerticalSplitterBaseProps = | {
  */
 type VerticalSplitterCollapseProps = | {
 	readonly collapsible?: false;
+	readonly isCollapsed?: never;
 	readonly onCollapsedChanged?: never;
 } | {
 	readonly collapsible: true;
+	readonly isCollapsed: boolean;
 	readonly onCollapsedChanged: (collapsed: boolean) => void;
 };
 
@@ -134,6 +136,7 @@ export const VerticalSplitter = ({
 	invert,
 	showSash,
 	collapsible,
+	isCollapsed,
 	onCollapsedChanged,
 	onBeginResize,
 	onResize,
@@ -154,7 +157,7 @@ export const VerticalSplitter = ({
 	const [hovering, setHovering] = useState(false);
 	const [highlightExpandCollapse, setHighlightExpandCollapse] = useState(false);
 	const [hoveringDelayer, setHoveringDelayer] = useState<Delayer<void>>(undefined!);
-	const [collapsed, setCollapsed, collapsedRef] = useStateRef(false);
+	const [collapsed, setCollapsed, collapsedRef] = useStateRef(isCollapsed);
 	const [resizing, setResizing] = useState(false);
 
 	// Main useEffect.
@@ -188,6 +191,11 @@ export const VerticalSplitter = ({
 		// Return the cleanup function that will dispose of the disposables.
 		return () => disposableStore.dispose();
 	}, [collapsible, configurationService]);
+
+	// Collapsed useEffect.
+	useEffect(() => {
+		setCollapsed(isCollapsed);
+	}, [isCollapsed, setCollapsed]);
 
 	/**
 	 * Sash onPointerEnter handler.

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -335,6 +335,7 @@ export const DataExplorer = () => {
 					collapsible={true}
 					configurationService={context.configurationService}
 					invert={layout === PositronDataExplorerLayout.SummaryOnRight}
+					isCollapsed={columnsCollapsed}
 					showSash={true}
 					onBeginResize={beginResizeHandler}
 					onCollapsedChanged={collapsed => {


### PR DESCRIPTION
Fixes behavior omitted in PR #6260
Addresses #6318 

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Synchronizes VerticalSplitter state with column collapsed state in Data Explorer


### QA Notes

e2e: @:data-explorer
