### PR TITLE
e2e-test: add fixture to open folder

### DIFF
--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -143,6 +143,11 @@ export class Console {
 		await this.waitForConsoleContents('restarted', { timeout });
 	}
 
+	async waitForInterpretersToFinishLoading() {
+		// ensure interpreter(s) containing starting/discovering do not exist in DOM
+		await expect(this.code.driver.page.locator('text=/^Starting up|^Starting|^Preparing|^Discovering( \\w+)? interpreters|starting\\.$/i')).toHaveCount(0, { timeout: 50000 });
+	}
+
 	/**
 	 * Check if the console is ready with Python or R, or if no interpreter is running.
 	 * @throws An error if the console is not ready after the retry count.
@@ -150,8 +155,7 @@ export class Console {
 	async waitForReadyOrNoInterpreter() {
 		const page = this.code.driver.page;
 
-		// ensure interpreter(s) containing starting/discovering do not exist in DOM
-		await expect(page.locator('text=/^Starting up|^Starting|^Preparing|^Discovering( \\w+)? interpreters|starting\\.$/i')).toHaveCount(0, { timeout: 50000 });
+		await this.waitForInterpretersToFinishLoading();
 
 		// ensure we are on Console tab
 		await page.getByRole('tab', { name: 'Console', exact: true }).locator('a').click();

--- a/test/e2e/pages/quickInput.ts
+++ b/test/e2e/pages/quickInput.ts
@@ -82,23 +82,23 @@ export class QuickInput {
 		await this.code.driver.page.locator(QuickInput.QUICKINPUT_OK_BUTTON).click();
 	}
 
-	async arrowDownToSelectElementWithText(text: string): Promise<void> {
-		await test.step(`Arrow down to select "${text}"`, async () => {
+	async arrowDownToSelectOption(option: string): Promise<void> {
+		await test.step(`Arrow down to select "${option}"`, async () => {
 			const page = this.code.driver.page;
 			for (let i = 0; i < 50; i++) {
-				const element = page.getByRole('option', { name: text }).locator('a');
+				const quickInputOption = page.getByRole('option', { name: option }).locator('a');
 
-				if (await element.isVisible()) {
-					await element.click();
-					// await expect(page.getByLabel('input')).toHaveValue(new RegExp('/' + text + '/'));
-					await expect(element).not.toBeVisible();
+				if (await quickInputOption.isVisible()) {
+					await quickInputOption.click();
+					// this is important as it guarantees the dropdown has refreshed
+					await expect(quickInputOption).not.toBeVisible();
 					return;
 				}
 
 				await page.keyboard.press('ArrowDown');
 			}
 
-			throw new Error(`Element with text "${text}" not found`);
+			throw new Error(`Element with text "${option}" not found`);
 		});
 	}
 }

--- a/test/e2e/pages/quickInput.ts
+++ b/test/e2e/pages/quickInput.ts
@@ -3,8 +3,10 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
+import test, { expect, Locator } from '@playwright/test';
 import { Code } from '../infra/code';
+
+const QUICK_INPUT_LIST = '.quick-input-widget .quick-input-list';
 
 export class QuickInput {
 
@@ -14,8 +16,11 @@ export class QuickInput {
 	// Note: this only grabs the label and not the description or detail
 	private static QUICK_INPUT_ENTRY_LABEL = `${this.QUICK_INPUT_RESULT} .quick-input-list-row > .monaco-icon-label .label-name`;
 	private static QUICKINPUT_OK_BUTTON = '.quick-input-widget .quick-input-action a:has-text("OK")';
+	quickInputList: Locator;
 
-	constructor(private code: Code) { }
+	constructor(private code: Code) {
+		this.quickInputList = this.code.driver.page.locator(QUICK_INPUT_LIST);
+	}
 
 	async waitForQuickInputOpened({ timeout = 10000 }: { timeout?: number } = {}): Promise<void> {
 		await expect(this.code.driver.page.locator(QuickInput.QUICK_INPUT_INPUT)).toBeVisible({ timeout });
@@ -68,10 +73,32 @@ export class QuickInput {
 	}
 
 	async selectQuickInputElementContaining(text: string): Promise<void> {
-		await this.code.driver.page.locator(`${QuickInput.QUICK_INPUT_RESULT}[aria-label*="${text}"]`).first().click({ timeout: 10000 });
+		const element = `${QuickInput.QUICK_INPUT_RESULT}[aria-label*="${text}"]`;
+
+		await this.code.driver.page.locator(element).first().click({ force: true, timeout: 10000 });
 	}
 
-	async clickOkOnQuickInput(): Promise<void> {
+	async clickOkButton(): Promise<void> {
 		await this.code.driver.page.locator(QuickInput.QUICKINPUT_OK_BUTTON).click();
+	}
+
+	async arrowDownToSelectElementWithText(text: string): Promise<void> {
+		await test.step(`Arrow down to select "${text}"`, async () => {
+			const page = this.code.driver.page;
+			for (let i = 0; i < 50; i++) {
+				const element = page.getByRole('option', { name: text }).locator('a');
+
+				if (await element.isVisible()) {
+					await element.click();
+					// await expect(page.getByLabel('input')).toHaveValue(new RegExp('/' + text + '/'));
+					await expect(element).not.toBeVisible();
+					return;
+				}
+
+				await page.keyboard.press('ArrowDown');
+			}
+
+			throw new Error(`Element with text "${text}" not found`);
+		});
 	}
 }

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -158,11 +158,28 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 		});
 	},
 
-	// ex: await openDataFile(app, 'workspaces/large_r_notebook/spotify.ipynb');
+	// ex: await openDataFile('workspaces/large_r_notebook/spotify.ipynb');
 	openDataFile: async ({ app }, use) => {
 		await use(async (filePath: string) => {
 			await test.step(`Open data file: ${path.basename(filePath)}`, async () => {
 				await app.workbench.quickaccess.openDataFile(path.join(app.workspacePathOrFolder, filePath));
+			});
+		});
+	},
+
+	// ex: await openFolder(path.join('qa-example-content/workspaces/r_testing'));
+	openFolder: async ({ app }, use) => {
+		await use(async (folderPath: string) => {
+			await test.step(`Open folder: ${folderPath}`, async () => {
+				await app.workbench.quickaccess.runCommand('workbench.action.files.openFolder', { keepOpen: true });
+				await playwright.expect(app.workbench.quickInput.quickInputList.getByLabel('..', { exact: true }).locator('a')).toBeVisible();
+
+				const folderNames = folderPath.split('/');
+				for (const folderName of folderNames) {
+					await app.workbench.quickInput.arrowDownToSelectElementWithText(folderName);
+				}
+
+				await app.workbench.quickInput.clickOkButton();
 			});
 		});
 	},
@@ -386,6 +403,7 @@ interface TestFixtures {
 	devTools: void;
 	openFile: (filePath: string) => Promise<void>;
 	openDataFile: (filePath: string) => Promise<void>;
+	openFolder: (folderPath: string) => Promise<void>;
 	runCommand: (command: string) => Promise<void>;
 	executeCode: (language: 'Python' | 'R', code: string) => Promise<void>;
 }

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -176,7 +176,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 
 				const folderNames = folderPath.split('/');
 				for (const folderName of folderNames) {
-					await app.workbench.quickInput.arrowDownToSelectElementWithText(folderName);
+					await app.workbench.quickInput.arrowDownToSelectOption(folderName);
 				}
 
 				await app.workbench.quickInput.clickOkButton();

--- a/test/e2e/tests/r-pkg-development/r-pkg-development.test.ts
+++ b/test/e2e/tests/r-pkg-development/r-pkg-development.test.ts
@@ -24,18 +24,12 @@ test.describe('R Package Development', { tag: [tags.WEB, tags.R_PKG_DEVELOPMENT]
 		}
 	});
 
-	test('R Package Development Tasks', async function ({ app, logger }) {
+	test('R Package Development Tasks', async function ({ app, openFolder, logger }) {
 		test.slow();
 
 		await test.step('Open R Package', async () => {
-			// Navigate to https://github.com/posit-dev/qa-example-content/tree/main/workspaces/r_testing
-			// This is an R package embedded in qa-example-content
-			await app.workbench.quickaccess.runCommand('workbench.action.files.openFolder', { keepOpen: true });
-			await app.workbench.quickInput.waitForQuickInputOpened();
-			await app.workbench.quickInput.type(path.join(app.workspacePathOrFolder, 'workspaces', 'r_testing'));
-			await app.workbench.quickInput.clickOkOnQuickInput();
-
-			// Wait for the console to be ready
+			// Open an R package embedded in qa-example-content
+			await openFolder(path.join('qa-example-content/workspaces/r_testing'));
 			await app.workbench.console.waitForReadyAndStarted('>', 45000);
 		});
 

--- a/test/e2e/tests/r-pkg-development/r-pkg-development.test.ts
+++ b/test/e2e/tests/r-pkg-development/r-pkg-development.test.ts
@@ -27,11 +27,9 @@ test.describe('R Package Development', { tag: [tags.WEB, tags.R_PKG_DEVELOPMENT]
 	test('R - Verify can open, test, check, install, and restart package', async function ({ app, openFolder, logger }) {
 		test.slow();
 
-		await test.step('Open R Package', async () => {
-			// Open an R package embedded in qa-example-content
-			await openFolder(path.join('qa-example-content/workspaces/r_testing'));
-			await app.workbench.console.waitForReadyAndStarted('>', 45000);
-		});
+		// Open an R package embedded in qa-example-content
+		await openFolder(path.join('qa-example-content/workspaces/r_testing'));
+		await app.workbench.console.waitForReadyAndStarted('>', 45000);
 
 		await test.step('Test R Package', async () => {
 			logger.log('Test R Package');

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -31,7 +31,7 @@ test.describe('Test Explorer', { tag: [tags.TEST_EXPLORER, tags.WEB] }, () => {
 	test('R - Verify Basic Test Explorer Functionality', async function ({ app, openFolder }) {
 		// Open R package embedded in qa-example-content
 		await openFolder(path.join('qa-example-content/workspaces/r_testing'));
-		await app.workbench.console.waitForReadyAndStarted('>', 10000);
+		await app.workbench.console.waitForReadyAndStarted('>');
 
 		await app.workbench.testExplorer.clickTestExplorerIcon();
 		await app.workbench.testExplorer.verifyTestFilesExist(['test-mathstuff.R']);

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -31,9 +31,9 @@ test.describe('Test Explorer', { tag: [tags.TEST_EXPLORER, tags.WEB] }, () => {
 	test('R - Verify Basic Test Explorer Functionality', async function ({ app, openFolder }) {
 		// Open R package embedded in qa-example-content
 		await openFolder(path.join('qa-example-content/workspaces/r_testing'));
-		await app.workbench.console.waitForReadyAndStarted('>');
 
 		await app.workbench.testExplorer.clickTestExplorerIcon();
+		await app.workbench.console.waitForInterpretersToFinishLoading();
 		await app.workbench.testExplorer.verifyTestFilesExist(['test-mathstuff.R']);
 
 		await app.workbench.testExplorer.runAllTests();

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -28,14 +28,10 @@ test.describe('Test Explorer', { tag: [tags.TEST_EXPLORER, tags.WEB] }, () => {
 		}
 	});
 
-	test('R - Verify Basic Test Explorer Functionality', async function ({ app }) {
+	test('R - Verify Basic Test Explorer Functionality', async function ({ app, openFolder }) {
 		await expect(async () => {
-			// Navigate to https://github.com/posit-dev/qa-example-content/tree/main/workspaces/r_testing
-			// This is an R package embedded in qa-example-content
-			await app.workbench.quickaccess.runCommand('workbench.action.files.openFolder', { keepOpen: true });
-			await app.workbench.quickInput.waitForQuickInputOpened();
-			await app.workbench.quickInput.type(path.join(app.workspacePathOrFolder, 'workspaces', 'r_testing'));
-			await app.workbench.quickInput.clickOkOnQuickInput();
+			// Open R package embedded in qa-example-content
+			await openFolder(path.join('qa-example-content/workspaces/r_testing'));
 			await app.workbench.console.waitForReadyAndStarted('>', 10000);
 		}).toPass({ timeout: 50000 });
 

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -29,11 +29,9 @@ test.describe('Test Explorer', { tag: [tags.TEST_EXPLORER, tags.WEB] }, () => {
 	});
 
 	test('R - Verify Basic Test Explorer Functionality', async function ({ app, openFolder }) {
-		await expect(async () => {
-			// Open R package embedded in qa-example-content
-			await openFolder(path.join('qa-example-content/workspaces/r_testing'));
-			await app.workbench.console.waitForReadyAndStarted('>', 10000);
-		}).toPass({ timeout: 50000 });
+		// Open R package embedded in qa-example-content
+		await openFolder(path.join('qa-example-content/workspaces/r_testing'));
+		await app.workbench.console.waitForReadyAndStarted('>', 10000);
 
 		await app.workbench.testExplorer.clickTestExplorerIcon();
 		await app.workbench.testExplorer.verifyTestFilesExist(['test-mathstuff.R']);


### PR DESCRIPTION
### Summary
In the r-pkg-development test, there was an intermittent issue when opening a folder. I determined that this was due to a lag in files loading within the quick input dropdown.

To resolve this, I found the most reliable approach was to add each directory in the path individually, ensuring the correct folder is opened. I encapsulated this logic into a reusable fixture: `openFolder`.

### QA Notes

@:r-pkg-development @:test-explorer @:web