### PR TITLE
E2E test: add alternate interpreters for windows

### DIFF
--- a/.github/workflows/test-e2e-linux.yml
+++ b/.github/workflows/test-e2e-linux.yml
@@ -135,7 +135,7 @@ jobs:
         env:
           POSITRON_PY_VER_SEL: 3.12.3
           POSITRON_R_VER_SEL: 4.4.0
-          POSITRON_PY_ALT_VER_SEL: 3.13.0
+          POSITRON_PY_ALT_VER_SEL: "3.13.0 (Pyenv)"
           POSITRON_R_ALT_VER_SEL: 4.4.2
           CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
           CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/test-e2e-release.yml
+++ b/.github/workflows/test-e2e-release.yml
@@ -104,7 +104,7 @@ jobs:
         env:
           POSITRON_PY_VER_SEL: 3.12.3
           POSITRON_R_VER_SEL: 4.4.0
-          POSITRON_PY_ALT_VER_SEL: 3.13.0
+          POSITRON_PY_ALT_VER_SEL: "3.13.0 (Pyenv)"
           POSITRON_R_ALT_VER_SEL: 4.4.2
           CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
           CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -147,14 +147,17 @@ jobs:
       - name: Verify Installed Versions
         shell: bash
         run: |
-          echo "Python 3.10.10: $(python --version)"
+          echo "Python 3.10.10: $(py -3.10 --version)"
           echo "Python 3.13.0: $(py -3.13 --version)"
 
+          echo "Finding Installed R Versions..."
+          where Rscript || which Rscript  # This shows all installed Rscript locations
+
           echo "R 4.4.0:"
-          "C:/Program Files/R/R-4.4.0/bin/Rscript.exe" -e 'cat(R.version.string)'
+          "$(where Rscript | findstr 4.4.0)" -e 'cat(R.version.string)'
 
           echo "R 4.4.2:"
-          "C:/Program Files/R/R-4.4.2/bin/Rscript.exe" -e 'cat(R.version.string)'
+          "$(where Rscript | findstr 4.4.2)" -e 'cat(R.version.string)'
 
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2.0.2

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -78,9 +78,6 @@ jobs:
         with:
           python-version: "3.10.10"
 
-      - name: Cache node_modules, build, extensions, and remote
-        uses: ./.github/actions/cache-multi-paths
-
       - name: Install node dependencies
         env:
           npm_config_arch: x64
@@ -139,21 +136,17 @@ jobs:
           rig default 4.4.0
           rig ls
 
-
       - name: Install R packages for 4.4.0
         run: |
           curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/DESCRIPTION --output DESCRIPTION
           Rscript -e "install.packages('pak')"
           Rscript -e "pak::local_install_dev_deps(ask = FALSE)"
 
-
       # Install R 4.4.2 using rig
       - name: Install R 4.4.2
         run: |
           rig add 4.4.2
           rig ls
-
-
 
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2.0.2

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -144,6 +144,14 @@ jobs:
         with:
           r-version: "4.4.2"
 
+      - name: Verify Installed Versions
+        run: |
+          echo "Python 3.10.10: $(python --version)"
+          echo "Python 3.13.0: $(py -3.13 --version)"
+
+          echo "R 4.4.0: $("C:/Program Files/R/R-4.4.0/bin/Rscript.exe" -e 'cat(R.version.string)')"
+          echo "R 4.4.2: $("C:/Program Files/R/R-4.4.2/bin/Rscript.exe" -e 'cat(R.version.string)')"
+
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2.0.2
 

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -145,12 +145,16 @@ jobs:
           r-version: "4.4.2"
 
       - name: Verify Installed Versions
+        shell: bash
         run: |
           echo "Python 3.10.10: $(python --version)"
           echo "Python 3.13.0: $(py -3.13 --version)"
 
-          echo "R 4.4.0: $("C:/Program Files/R/R-4.4.0/bin/Rscript.exe" -e 'cat(R.version.string)')"
-          echo "R 4.4.2: $("C:/Program Files/R/R-4.4.2/bin/Rscript.exe" -e 'cat(R.version.string)')"
+          echo "R 4.4.0:"
+          "C:/Program Files/R/R-4.4.0/bin/Rscript.exe" -e 'cat(R.version.string)'
+
+          echo "R 4.4.2:"
+          "C:/Program Files/R/R-4.4.2/bin/Rscript.exe" -e 'cat(R.version.string)'
 
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2.0.2

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -139,10 +139,20 @@ jobs:
           Rscript -e "pak::local_install_dev_deps(ask = FALSE)"
 
       # Alternate R version
-      - name: Install R 4.4.2
-        uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: "4.4.2"
+      - name: Install rig
+        run: |
+          choco install rig
+
+      - name: Install R versions
+        run: |
+          rig add 4.4.2
+          rig default 4.4.2
+          rig ls
+
+      # Install ipykernel inside R 4.4.2
+      - name: Install ipykernel in R 4.4.2
+        run: |
+          rig exec 4.4.2 -- Rscript -e "install.packages('ipykernel')"
 
       - name: Verify Installed Versions
         shell: bash
@@ -150,29 +160,12 @@ jobs:
           echo "Python 3.10.10: $(py -3.10 --version)"
           echo "Python 3.13.0: $(py -3.13 --version)"
 
-          echo "Listing R Installations in C:/Program Files/R:"
-          dir "C:/Program Files/R"
 
-          echo "Finding Installed R Versions..."
-          where Rscript || which Rscript  # Print all detected Rscript locations
+          echo "Running R 4.4.0:"
+          Rscript -e 'cat(R.version.string)'
 
-          # Manually define the paths if known
-          R44_0="C:/Program Files/R/R-4.4.0/bin/Rscript.exe"
-          R44_2="C:/Program Files/R/R-4.4.2/bin/Rscript.exe"
-
-          echo "R 4.4.0:"
-          if [[ -f "$R44_0" ]]; then
-            "$R44_0" -e 'cat(R.version.string)'
-          else
-            echo "R 4.4.0 not found!"
-          fi
-
-          echo "R 4.4.2:"
-          if [[ -f "$R44_2" ]]; then
-            "$R44_2" -e 'cat(R.version.string)'
-          else
-            echo "R 4.4.2 not found!"
-          fi
+          echo "Running R 4.4.2:"
+          rig exec 4.4.2 -- Rscript -e 'cat(R.version.string)'
 
 
       - name: Setup Graphviz

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -114,6 +114,19 @@ jobs:
           python -m pip install -r requirements.txt
           python -m pip install ipykernel trcli
 
+      # Alternate python version
+      - name: Install Python 3.13.0
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13.0"
+
+      # Ensure Python 3.13.0 is used and only install ipykernel
+      - name: Install ipykernel for Python 3.13.0
+        run: |
+          python --version  # Verify it's 3.13.0
+          python -m pip install --upgrade pip
+          python -m pip install ipykernel
+
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:
@@ -124,6 +137,12 @@ jobs:
           curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/DESCRIPTION --output DESCRIPTION
           Rscript -e "install.packages('pak')"
           Rscript -e "pak::local_install_dev_deps(ask = FALSE)"
+
+      # Alternate R version
+      - name: Install R 4.4.2
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: "4.4.2"
 
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2.0.2
@@ -150,6 +169,8 @@ jobs:
         env:
           POSITRON_PY_VER_SEL: 3.10.10
           POSITRON_R_VER_SEL: 4.4.0
+          POSITRON_PY_ALT_VER_SEL: 3.13.0
+          POSITRON_R_ALT_VER_SEL: 4.4.2
           CURRENTS_PROJECT_ID: ZOs5z2
           CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
           CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -150,14 +150,30 @@ jobs:
           echo "Python 3.10.10: $(py -3.10 --version)"
           echo "Python 3.13.0: $(py -3.13 --version)"
 
+          echo "Listing R Installations in C:/Program Files/R:"
+          dir "C:/Program Files/R"
+
           echo "Finding Installed R Versions..."
-          where Rscript || which Rscript  # This shows all installed Rscript locations
+          where Rscript || which Rscript  # Print all detected Rscript locations
+
+          # Manually define the paths if known
+          R44_0="C:/Program Files/R/R-4.4.0/bin/Rscript.exe"
+          R44_2="C:/Program Files/R/R-4.4.2/bin/Rscript.exe"
 
           echo "R 4.4.0:"
-          "$(where Rscript | findstr 4.4.0)" -e 'cat(R.version.string)'
+          if [[ -f "$R44_0" ]]; then
+            "$R44_0" -e 'cat(R.version.string)'
+          else
+            echo "R 4.4.0 not found!"
+          fi
 
           echo "R 4.4.2:"
-          "$(where Rscript | findstr 4.4.2)" -e 'cat(R.version.string)'
+          if [[ -f "$R44_2" ]]; then
+            "$R44_2" -e 'cat(R.version.string)'
+          else
+            echo "R 4.4.2 not found!"
+          fi
+
 
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2.0.2

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -127,45 +127,32 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install ipykernel
 
-      - name: Set up R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: "4.4.0"
+      # Install rig (R Installation Manager)
+      - name: Install rig
+        run: |
+          choco install rig
 
-      - name: Install R packages
+      # Install R 4.4.0 using rig
+      - name: Install R 4.4.0
+        run: |
+          rig add 4.4.0
+          rig default 4.4.0
+          rig ls
+
+
+      - name: Install R packages for 4.4.0
         run: |
           curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/DESCRIPTION --output DESCRIPTION
           Rscript -e "install.packages('pak')"
           Rscript -e "pak::local_install_dev_deps(ask = FALSE)"
 
-      # Alternate R version
-      - name: Install rig
-        run: |
-          choco install rig
 
-      - name: Install R versions
+      # Install R 4.4.2 using rig
+      - name: Install R 4.4.2
         run: |
           rig add 4.4.2
-          rig default 4.4.2
           rig ls
 
-      # Install ipykernel inside R 4.4.2
-      - name: Install ipykernel in R 4.4.2
-        run: |
-          rig exec 4.4.2 -- Rscript -e "install.packages('ipykernel')"
-
-      - name: Verify Installed Versions
-        shell: bash
-        run: |
-          echo "Python 3.10.10: $(py -3.10 --version)"
-          echo "Python 3.13.0: $(py -3.13 --version)"
-
-
-          echo "Running R 4.4.0:"
-          Rscript -e 'cat(R.version.string)'
-
-          echo "Running R 4.4.2:"
-          rig exec 4.4.2 -- Rscript -e 'cat(R.version.string)'
 
 
       - name: Setup Graphviz

--- a/test/e2e/tests/console/console-python.test.ts
+++ b/test/e2e/tests/console/console-python.test.ts
@@ -57,8 +57,9 @@ test.describe('Console Pane: Python', { tag: [tags.WEB, tags.CONSOLE] }, () => {
 
 	});
 
-	// not enabled for WIN yet; need to add additional versions
-	test('Python - Verify can use multiple interpreter versions', async function ({ app, python }) {
+	test('Python - Verify can use multiple interpreter versions', {
+		tag: [tags.WIN]
+	}, async function ({ app, python }) {
 
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 

--- a/test/e2e/tests/console/console-python.test.ts
+++ b/test/e2e/tests/console/console-python.test.ts
@@ -76,10 +76,11 @@ test.describe('Console Pane: Python', { tag: [tags.WEB, tags.CONSOLE] }, () => {
 		const secondaryPython = process.env.POSITRON_PY_ALT_VER_SEL;
 
 		if (secondaryPython) {
-			await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, `${secondaryPython} (Pyenv)`, true);
+			await app.workbench.interpreter.selectInterpreter(InterpreterType.Python, secondaryPython, true);
 			await app.workbench.console.barClearButton.click();
 			await app.workbench.console.pasteCodeToConsole(`import platform; print(platform.python_version())`, true);
-			await app.workbench.console.waitForConsoleContents(secondaryPython);
+			// If POSITRON_PY_ALT_VER_SEL has " (Pyenv)" in it, remove it"
+			await app.workbench.console.waitForConsoleContents(secondaryPython.replace(' (Pyenv)', ''));
 		} else {
 			fail('Secondary Python version not set');
 		}

--- a/test/e2e/tests/console/console-r.test.ts
+++ b/test/e2e/tests/console/console-r.test.ts
@@ -51,8 +51,9 @@ test.describe('Console Pane: R', {
 		// nothing appears in console after interrupting execution
 	});
 
-	// not enabled for WIN yet; need to add additional versions
-	test('R - Verify can use multiple interpreter versions', async function ({ app, r }) {
+	test('R - Verify can use multiple interpreter versions', {
+		tag: [tags.WIN]
+	}, async function ({ app, r }) {
 
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 


### PR DESCRIPTION
Add additional R and Python interpreters to Windows workflow.

Enable tests that verify alternate installations.

### QA Notes

All tests should pass

@:console @:win