### PR TITLE
e2e-test: improve handling of open folder options

### DIFF
--- a/test/e2e/pages/quickInput.ts
+++ b/test/e2e/pages/quickInput.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import test, { expect, Locator } from '@playwright/test';
+import { expect, Locator } from '@playwright/test';
 import { Code } from '../infra/code';
 
 const QUICK_INPUT_LIST = '.quick-input-widget .quick-input-list';
@@ -17,9 +17,11 @@ export class QuickInput {
 	private static QUICK_INPUT_ENTRY_LABEL = `${this.QUICK_INPUT_RESULT} .quick-input-list-row > .monaco-icon-label .label-name`;
 	private static QUICKINPUT_OK_BUTTON = '.quick-input-widget .quick-input-action a:has-text("OK")';
 	quickInputList: Locator;
+	quickInput: Locator;
 
 	constructor(private code: Code) {
 		this.quickInputList = this.code.driver.page.locator(QUICK_INPUT_LIST);
+		this.quickInput = this.code.driver.page.locator(QuickInput.QUICK_INPUT_INPUT);
 	}
 
 	async waitForQuickInputOpened({ timeout = 10000 }: { timeout?: number } = {}): Promise<void> {
@@ -80,25 +82,5 @@ export class QuickInput {
 
 	async clickOkButton(): Promise<void> {
 		await this.code.driver.page.locator(QuickInput.QUICKINPUT_OK_BUTTON).click();
-	}
-
-	async arrowDownToSelectOption(option: string): Promise<void> {
-		await test.step(`Arrow down to select "${option}"`, async () => {
-			const page = this.code.driver.page;
-			for (let i = 0; i < 100; i++) {
-				const quickInputOption = page.getByRole('option', { name: option }).locator('a');
-
-				if (await quickInputOption.isVisible()) {
-					await quickInputOption.click();
-					// this is important as it guarantees the dropdown has refreshed
-					await expect(quickInputOption).not.toBeVisible();
-					return;
-				}
-
-				await page.keyboard.press('ArrowDown');
-			}
-
-			throw new Error(`Element with text "${option}" not found`);
-		});
 	}
 }

--- a/test/e2e/pages/quickInput.ts
+++ b/test/e2e/pages/quickInput.ts
@@ -85,7 +85,7 @@ export class QuickInput {
 	async arrowDownToSelectOption(option: string): Promise<void> {
 		await test.step(`Arrow down to select "${option}"`, async () => {
 			const page = this.code.driver.page;
-			for (let i = 0; i < 50; i++) {
+			for (let i = 0; i < 100; i++) {
 				const quickInputOption = page.getByRole('option', { name: option }).locator('a');
 
 				if (await quickInputOption.isVisible()) {

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -175,8 +175,11 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 				await playwright.expect(app.workbench.quickInput.quickInputList.getByLabel('..', { exact: true }).locator('a')).toBeVisible();
 
 				const folderNames = folderPath.split('/');
+
 				for (const folderName of folderNames) {
-					await app.workbench.quickInput.arrowDownToSelectOption(folderName);
+					await app.workbench.quickInput.quickInput.pressSequentially(folderName + '/');
+					const quickInputOption = app.code.driver.page.getByRole('option', { name: folderName }).locator('a');
+					await playwright.expect(quickInputOption).not.toBeVisible();
 				}
 
 				await app.workbench.quickInput.clickOkButton();


### PR DESCRIPTION
### Summary
So I previously just fixed this, but I didn't account for the fact that in CI full test suite runs specifically there are A LOT of temp dirs, therefore the max of 50 options (which I had set) is not enough. Rather than extending that, I opted to type each dir of the path sequentially and wait for list to load.

### QA Notes

[Running full suite](https://github.com/posit-dev/positron/actions/runs/13297607899) to confirm all is well.

@:r-pkg-development @:test-explorer
