### PR TITLE
Add support for older Linux versions to supervisor

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -136,7 +136,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.29"
+      "kallichore": "0.1.31"
     }
   },
   "dependencies": {


### PR DESCRIPTION
This change is a stepping stone on the way to full RHEL8 compatibility to Positron. It replaces the kernel supervisor with a new version that has no OpenSSL dependency and works with glibc versions all the way down to 2.26.

```
[jmcphers@hyperv-rocky8 scratch]$ ./kcserver --version
kcserver 0.1.31
[jmcphers@hyperv-rocky8 scratch]$ head /etc/os-release
NAME="Rocky Linux"
VERSION="8.10 (Green Obsidian)"
ID="rocky"
ID_LIKE="rhel centos fedora"
VERSION_ID="8.10"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Rocky Linux 8.10 (Green Obsidian)"
ANSI_COLOR="0;32"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:rocky:rocky:8:GA"
```

Note that additional work is required to get Positron _itself_ to work on RHEL8, but little point in doing that if you can't start kernels. 

Part of #3854; helps mitigate #5700.

