### PR TITLE
e2e-test: more resilient locator in test-explorer

### DIFF
--- a/test/e2e/pages/testExplorer.ts
+++ b/test/e2e/pages/testExplorer.ts
@@ -68,6 +68,6 @@ export class TestExplorer extends Explorer {
 	 * @returns Promise<void>
 	 */
 	async runAllTests(): Promise<void> {
-		await this.code.driver.page.getByLabel('Testing actions').getByLabel('Run Tests').click();
+		await this.code.driver.page.getByRole('toolbar').getByLabel('Run Tests').click();
 	}
 }


### PR DESCRIPTION
Picking a more reliable locator for test to prevent flakes.

### QA Notes

@:test-explorer