### PR TITLE
e2e-test: bump timeout to render html

### DIFF
--- a/test/e2e/pages/editorActionBar.ts
+++ b/test/e2e/pages/editorActionBar.ts
@@ -136,7 +136,7 @@ export class EditorActionBar {
 		await test.step('Verify "preview" renders html', async () => {
 			await this.page.getByLabel('Preview', { exact: true }).click();
 			const viewerFrame = this.viewer.getViewerFrame().frameLocator('iframe');
-			await expect(viewerFrame.getByRole('heading', { name: heading })).toBeVisible({ timeout: 30000 });
+			await expect(viewerFrame.getByRole('heading', { name: heading })).toBeVisible({ timeout: 60000 });
 		});
 	}
 


### PR DESCRIPTION
### Summary
Increased the wait time for rendering the HTML preview to prevent test timeouts. This change addresses a recent test flake that occurred due to the preview taking longer than expected to render.

### QA Notes

n/a
