### PR TITLE
python: update pip to latest version

### DIFF
--- a/extensions/positron-python/python_files/download_get_pip.py
+++ b/extensions/positron-python/python_files/download_get_pip.py
@@ -10,12 +10,7 @@ from packaging.version import parse as version_parser
 EXTENSION_ROOT = pathlib.Path(__file__).parent.parent
 GET_PIP_DEST = EXTENSION_ROOT / "python_files"
 PIP_PACKAGE = "pip"
-
-# --- Start Positron ---
-# Temporarily disable "latest" due to upstream break with pre-release version
-# PIP_VERSION = "latest"  # Can be "latest", or specific version "23.1.2"
-PIP_VERSION = "24.0"
-# --- End Positron ---
+PIP_VERSION = "latest"  # Can be "latest", or specific version "23.1.2"
 
 
 def _get_package_data():


### PR DESCRIPTION
Re-aligning with upstream: https://github.com/microsoft/vscode-python/blob/b4aa112990c7e25f1eb06fb5e2b85418f2f4c4fa/python_files/download_get_pip.py#L10C1-L13C72

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #3037 


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

should pass ci