### PR TITLE
Escape strings when generating the connection code

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -507,7 +507,7 @@ class SQLite3Connection(Connection):
         self.host = self._find_path(conn)
         self.type = "SQLite"
         self.code = (
-            f'import sqlite3\nconn = sqlite3.connect({repr(self.host)})\n%connection_show conn\n'
+            f"import sqlite3\nconn = sqlite3.connect({self.host!r})\n%connection_show conn\n"
         )
 
     def _find_path(self, conn: sqlite3.Connection):
@@ -626,7 +626,7 @@ class SQLAlchemyConnection(Connection):
         self.type = "SQLAlchemy"
         self.code = (
             "import sqlalchemy\n"
-            f"engine = sqlalchemy.create_engine({repr(self.host)})\n"
+            f"engine = sqlalchemy.create_engine({self.host!r})\n"
             "%connection_show engine\n"
         )
 

--- a/extensions/positron-python/python_files/posit/positron/connections.py
+++ b/extensions/positron-python/python_files/posit/positron/connections.py
@@ -507,7 +507,7 @@ class SQLite3Connection(Connection):
         self.host = self._find_path(conn)
         self.type = "SQLite"
         self.code = (
-            f'import sqlite3\nconn = sqlite3.connect("{self.host}")\n%connection_show conn\n'
+            f'import sqlite3\nconn = sqlite3.connect({repr(self.host)})\n%connection_show conn\n'
         )
 
     def _find_path(self, conn: sqlite3.Connection):
@@ -619,14 +619,14 @@ class SQLite3Connection(Connection):
 class SQLAlchemyConnection(Connection):
     """Support for SQLAlchemy connections to databases."""
 
-    def __init__(self, conn):
-        self.conn: sqlalchemy.Engine = conn
+    def __init__(self, conn: sqlalchemy.Engine):
+        self.conn = conn
         self.display_name = f"SQLAlchemy ({conn.name})"
         self.host = conn.url.render_as_string()
         self.type = "SQLAlchemy"
         self.code = (
             "import sqlalchemy\n"
-            f"engine = sqlalchemy.create_engine('{self.host}')\n"
+            f"engine = sqlalchemy.create_engine({repr(self.host)})\n"
             "%connection_show engine\n"
         )
 


### PR DESCRIPTION
Adresses https://github.com/posit-dev/positron/issues/5692

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed bug when reconnecting to a database connection for which the 'host' attribute contained values that should be escaped (https://github.com/posit-dev/positron/issues/5692)

### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

See https://github.com/posit-dev/positron/issues/5692 for a minimal reproducible example that should work now.

@:connections
