### PR TITLE
Add `ms-python.python` to extension compat list

### DIFF
--- a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
@@ -886,6 +886,7 @@ const kPositronDuplicativeExtensions = [
 	'mikhail-arkhipov.r',
 	'vscode.r',
 	'jeanp413.open-remote-ssh',
+	'ms-python.python',
 ];
 
 interface PositronExtensionCompatibilty {


### PR DESCRIPTION
Related to #6348 and #6267, but doesn't really close either one

None of us are sure how the MS Python extension could have even gotten installed in #6267. We take over the ID `ms-python.python` with our extension so Positron thinks you already have it installed, and we don't believe it can then show up in the marketplaces, etc. This PR is sort of speculative in that I am not sure it would have protected against #6267, but it will keep someone from installing anything with this ID from a marketplace or via `.vsix`.


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

No QA needed per se, but I have confirmed Positron can run, including activating and using functionality from our Python extension (which, to be extra clear, _does_ have this ID).
