### PR TITLE
Fix Variables for python types with unexpected __qualname__  behavior

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/test_utils.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_utils.py
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+#
+
+import pytest
+
+from positron.utils import get_qualname
+
+
+class BadGetAttrImpl:
+    def __getattr__(self, _attribute: str):
+        # Wrongly returns an instance of itself instead of raising an AttributeError
+        return BadGetAttrImpl()
+
+
+@pytest.mark.parametrize("value", [BadGetAttrImpl(), BadGetAttrImpl])
+def test_get_qualname_handles_bad_class(value) -> None:
+    """Test we can handle classes with bad __getattr__ implementations. See issue 6237."""
+    qualname = get_qualname(value)
+
+    # qualname should be a valid string and not raise any errors
+    assert isinstance(qualname, str), f"Expected string, got {type(qualname)}"
+    assert qualname == "positron.tests.test_utils.BadGetAttrImpl"

--- a/extensions/positron-python/python_files/posit/positron/utils.py
+++ b/extensions/positron-python/python_files/posit/positron/utils.py
@@ -73,7 +73,7 @@ def get_qualname(value: Any) -> str:
 
     # In the rare situation an object incorrectly handles __qualname__ by not returning
     # a str, we fall back to the name of the type
-    if type(qualname) is not str:
+    if not isinstance(qualname, str):
         qualname = getattr(type(value), "__name__", "object")
 
     # Tell the type checker that it's a string

--- a/extensions/positron-python/python_files/posit/positron/utils.py
+++ b/extensions/positron-python/python_files/posit/positron/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
@@ -69,6 +69,11 @@ def get_qualname(value: Any) -> str:
 
     if qualname is None:
         # Finally, try to return the generic type's name, otherwise report object
+        qualname = getattr(type(value), "__name__", "object")
+
+    # In the rare situation an object incorrectly handles __qualname__ by not returning
+    # a str, we fall back to the name of the type
+    if type(qualname) is not str:
         qualname = getattr(type(value), "__name__", "object")
 
     # Tell the type checker that it's a string


### PR DESCRIPTION
Addresses issue #6237

`dfply.base.Intention` has a bad implementation of `__getattr__` which impacts calls to built-in attributes such as `__qualname__`. Instead of returning a `str` it incorrectly returns a new instance of `Intention()`. This breaks our inspection logic and stopped Variables from working once objects of this type were encountered.

This change adds some simple defensive code to the utility used by our Inspectors that summarize variables.

Added a simple unit test to cover this case.


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Ensure Python objects with invalid `__qualname__` return values do not stop Variables inspection. Fixes #6237.


### QA Notes

Added a unit test to cover the general problem, but this fix covers the specific type mentioned in the customer issue.

```
from dfply import *
```
