### PR TITLE
E2E test: remove ipykernel from primary interpreters

### DIFF
--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -14,7 +14,6 @@ runs:
         curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
         python3 -m pip install --upgrade pip
         python3 -m pip install -r requirements.txt
-        python3 -m pip install ipykernel
 
     - name: Verify Python Version
       shell: bash
@@ -51,7 +50,7 @@ runs:
         PYTHON_ALTERNATE_VERSION="${{ inputs.alternate_version }}"
         echo "Installing Python version $PYTHON_ALTERNATE_VERSION using pyenv..."
         pyenv install -s "$PYTHON_ALTERNATE_VERSION"
-        
+
         pyenv versions
 
         pyenv global "$PYTHON_ALTERNATE_VERSION"

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -108,7 +108,7 @@ jobs:
           curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install ipykernel trcli
+          python -m pip install trcli
 
       # Alternate python version
       - name: Install Python 3.13.0

--- a/test/e2e/pages/newProjectWizard.ts
+++ b/test/e2e/pages/newProjectWizard.ts
@@ -151,12 +151,20 @@ export class NewProjectWizard {
 		}
 
 		// Open the dropdown and select the interpreter by path
-		await this.interpreterDropdown.click();
-		await this.dropDropdownOptions
-			.locator('div.dropdown-entry-subtitle')
-			.getByText(interpreterPath)
-			.first()
-			.click();
+		await expect(async () => {
+
+			try {
+				await this.interpreterDropdown.click();
+				await this.dropDropdownOptions
+					.locator('div.dropdown-entry-subtitle')
+					.getByText(interpreterPath)
+					.first()
+					.click({ timeout: 5000 });
+			} catch (error) {
+				await this.code.driver.page.keyboard.press('Escape');
+			}
+
+		}).toPass({ intervals: [1_000, 5_000, 10_000], timeout: 15000 });
 	}
 }
 

--- a/test/e2e/pages/newProjectWizard.ts
+++ b/test/e2e/pages/newProjectWizard.ts
@@ -162,6 +162,7 @@ export class NewProjectWizard {
 					.click({ timeout: 5000 });
 			} catch (error) {
 				await this.code.driver.page.keyboard.press('Escape');
+				throw error;
 			}
 
 		}).toPass({ intervals: [1_000, 5_000, 10_000], timeout: 15000 });

--- a/test/e2e/tests/new-project-wizard/new-project-python.test.ts
+++ b/test/e2e/tests/new-project-wizard/new-project-python.test.ts
@@ -13,35 +13,18 @@ test.use({
 // Not running conda test on windows because conda reeks havoc on selecting the correct python interpreter
 test.describe('Python - New Project Wizard', { tag: [tags.MODAL, tags.NEW_PROJECT_WIZARD] }, () => {
 
-	test('Existing env: ipykernel already installed', { tag: [tags.WIN], }, async function ({ app, python, packages }) {
+	test('Existing env: ipykernel already installed', { tag: [tags.WIN], }, async function ({ app, python }) {
 		const projectTitle = addRandomNumSuffix('ipykernel-installed');
 
-		await packages.manage('ipykernel', 'install');
 		await createNewProject(app, {
 			type: ProjectType.PYTHON_PROJECT,
 			title: projectTitle,
 			status: 'existing',
-			ipykernelFeedback: 'hide',
+			ipykernelFeedback: 'show', // change to 'hide' when https://github.com/posit-dev/positron/issues/6386 is fixed
 			interpreterPath: await getInterpreterPath(app),
 		});
 
 		await verifyProjectCreation(app, projectTitle);
-	});
-
-	test('Existing env: ipykernel not already installed', { tag: [tags.WIN] }, async function ({ app, python, packages }) {
-		const projectTitle = addRandomNumSuffix('no-ipykernel');
-
-		await packages.manage('ipykernel', 'uninstall');
-		await createNewProject(app, {
-			type: ProjectType.PYTHON_PROJECT,
-			title: projectTitle,
-			status: 'existing',
-			interpreterPath: await getInterpreterPath(app),
-			ipykernelFeedback: 'show'
-		});
-
-		await verifyProjectCreation(app, projectTitle);
-		await verifyIpykernelInstalled(app);
 	});
 
 	test('New env: Git initialized', { tag: [tags.CRITICAL, tags.WIN] }, async function ({ app }) {

--- a/test/e2e/tests/new-project-wizard/new-project-python.test.ts
+++ b/test/e2e/tests/new-project-wizard/new-project-python.test.ts
@@ -128,14 +128,6 @@ async function verifyGitStatus(app: Application) {
 	});
 }
 
-
-async function verifyIpykernelInstalled(app: Application) {
-	await test.step('Verify ipykernel is installed', async () => {
-		await app.workbench.console.typeToConsole('pip show ipykernel', 10, true);
-		await app.workbench.console.waitForConsoleContents('Name: ipykernel');
-	});
-}
-
 async function getInterpreterPath(app: Application): Promise<string> {
 	let interpreterPath: string | undefined;
 

--- a/test/e2e/tests/reticulate/reticulate.test.ts
+++ b/test/e2e/tests/reticulate/reticulate.test.ts
@@ -13,9 +13,10 @@ test.use({
 // RETICULATE_PYTHON
 // to the installed python path
 
+// Re-add WEB tag when https://github.com/posit-dev/positron/issues/6397 is fixed
 test.describe('Reticulate', {
-	tag: [tags.WEB, tags.RETICULATE],
-	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5226' }]
+	tag: [tags.RETICULATE],
+	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6397' }]
 }, () => {
 	test.beforeAll(async function ({ app, userSettings }) {
 		try {


### PR DESCRIPTION
Now that ipykernel is bundled, we should modify the tests to no longer install it for the "primary" interpreters which are the interpreters used for most of the tests.

### QA Notes

All tests should pass.

@:web @:win @:new-project-wizard @:reticulate

