### PR TITLE
Data Explorer: Implement copy-paste / export_data_selection RPC for DuckDB backend

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -678,6 +678,13 @@ function isNumeric(duckdbName: string) {
 }
 
 function formatDate(date: Date): string {
+	const year = date.getUTCFullYear();
+	const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+	const day = String(date.getUTCDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
+}
+
+function formatTimestamp(date: Date): string {
 	const year = date.getFullYear();
 	const month = String(date.getMonth() + 1).padStart(2, '0');
 	const day = String(date.getDate()).padStart(2, '0');
@@ -699,7 +706,9 @@ function formatDate(date: Date): string {
 // Function for converting Arrow JS values to strings (in exportDataSelection)
 function valueToString(value: any, column_type: string): string {
 	if (column_type === 'TIMESTAMP') {
-		value = new Date(value);
+		return formatTimestamp(new Date(value));
+	} else if (column_type === 'DATE') {
+		value = formatDate(new Date(value));
 	}
 
 	if (value === null || value === undefined) {

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -16,6 +16,7 @@ import {
 	DataExplorerBackendRequest,
 	DataExplorerResponse,
 	DataExplorerRpc,
+	ExportFormat,
 	FilterComparisonOp,
 	FormatOptions,
 	GetDataValuesParams,
@@ -209,8 +210,12 @@ suite('Positron DuckDB Extension Test Suite', () => {
 				},
 				set_sort_columns: { support_status: SupportStatus.Supported, },
 				export_data_selection: {
-					support_status: SupportStatus.Unsupported,
-					supported_formats: []
+					support_status: SupportStatus.Supported,
+					supported_formats: [
+						ExportFormat.Csv,
+						ExportFormat.Tsv,
+						ExportFormat.Html
+					]
 				}
 			}
 		} satisfies BackendState);

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -481,7 +481,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 			{
 				name: 'float_col',
 				type: 'DOUBLE',
-				values: ['1.1', '2.2', '3.3', 'NULL', '5.5']
+				values: ['1.1', '2.2', '3.3', 'NULL', '5.5E20']
 			},
 			{
 				name: 'date0',
@@ -548,6 +548,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 
 			// DOUBLE
 			{ row: 3, col: 2, expected: 'NULL' },
+			{ row: 4, col: 2, expected: '5.5e+20' },
 
 			// Date type
 			{ row: 0, col: 3, expected: '2023-10-20' },
@@ -631,7 +632,7 @@ suite('Positron DuckDB Extension Test Suite', () => {
 		const testColumnIndices = async (indices: number[], expected: string) => {
 			await testSelection(TableSelectionKind.ColumnIndices, { indices }, expected);
 		};
-		await testColumnIndices([0, 2], 'int_col,float_col\n1,1.1\n2,2.2\n3,3.3\n4,NULL\nNULL,5.5');
+		await testColumnIndices([0, 2], 'int_col,float_col\n1,1.1\n2,2.2\n3,3.3\n4,NULL\nNULL,5.5e+20');
 
 		// Test TSV format
 		await testSelection(TableSelectionKind.CellRange,

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -482,6 +482,28 @@ suite('Positron DuckDB Extension Test Suite', () => {
 				name: 'float_col',
 				type: 'DOUBLE',
 				values: ['1.1', '2.2', '3.3', '4.4', '5.5']
+			},
+			{
+				name: 'date0',
+				type: 'DATE',
+				values: ['\'2023-10-20\'', '\'2024-01-01\'', 'NULL', '\'2024-01-02\'', 'NULL']
+			},
+			{
+				name: 'timestamp0',
+				type: 'TIMESTAMP',
+				values: ['\'2023-10-20 15:30:00\'', '\'2024-01-01 08:00:00\'', 'NULL',
+					'\'2024-01-02 12:00:00\'', 'NULL']
+			},
+			{
+				name: 'timestamptz0',
+				type: 'TIMESTAMP WITH TIME ZONE',
+				values: ['\'2023-10-20 15:30:00+00\'', '\'2024-01-01 08:00:00-05\'', 'NULL',
+					'\'2024-01-02 12:00:00+01\'', 'NULL']
+			},
+			{
+				name: 'time0',
+				type: 'TIME',
+				values: ['\'13:30:00\'', '\'07:12:34.567\'', 'NULL', '\'12:00:00\'', 'NULL']
 			}
 		]);
 
@@ -513,10 +535,39 @@ suite('Positron DuckDB Extension Test Suite', () => {
 			);
 		};
 
-		await testSingleCell(0, 0, '1');
-		await testSingleCell(1, 0, '2');
-		await testSingleCell(2, 1, 'c');
-		await testSingleCell(3, 2, '4.4');
+
+		const cellTestCases = [
+			// Number and string types
+			{ row: 0, col: 0, expected: '1' },
+			{ row: 1, col: 0, expected: '2' },
+			{ row: 2, col: 1, expected: 'c' },
+			{ row: 3, col: 2, expected: '4.4' },
+
+			// Date type
+			{ row: 0, col: 3, expected: '2023-10-20' },
+			{ row: 1, col: 3, expected: '2024-01-01' },
+			{ row: 2, col: 3, expected: '' },
+
+			// Timestamp type
+			{ row: 0, col: 4, expected: '2023-10-20 15:30:00' },
+			{ row: 1, col: 4, expected: '2024-01-01 08:00:00' },
+			{ row: 2, col: 4, expected: '' },
+
+			// Timestamp with timezone type
+			{ row: 0, col: 5, expected: '2023-10-20 15:30:00+00' },
+			{ row: 1, col: 5, expected: '2024-01-01 08:00:00-05' },
+			{ row: 2, col: 5, expected: '' },
+
+			// Time type
+			{ row: 0, col: 6, expected: '13:30:00' },
+			{ row: 1, col: 6, expected: '07:12:34.567' },
+			{ row: 2, col: 6, expected: '' }
+		];
+
+		// Run all test cases
+		for (const { row, col, expected } of cellTestCases) {
+			await testSingleCell(row, col, expected);
+		}
 
 		const testCellRange = async (firstRow: number, lastRow: number, firstCol: number,
 			lastCol: number, expected: string) => {


### PR DESCRIPTION
Addresses #5157 by implementing the export_data_selection RPC. 
e2e: @:data-explorer

### Release Notes

#### New Features

- Copy-pasting when opening files in the data explorer from the file explorer (DuckDB backend) is now supported (#5157).

#### Bug Fixes

- N/A

### QA Notes

Test different modes of copy paste (single cell, rectangle, row range, column range, ctrl-click multiple rows or columns) into Google Sheets. 