### PR TITLE
Connections: Fix icon rendering on Windows

### DIFF
--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsInstance.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsInstance.ts
@@ -15,6 +15,9 @@ import { Severity } from '../../../../platform/notification/common/notification.
 import { IPositronConnectionsService } from '../common/interfaces/positronConnectionsService.js';
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { localize } from '../../../../nls.js';
+import { FileAccess } from '../../../../base/common/network.js';
+import { URI } from '../../../../base/common/uri.js';
+
 
 interface PathSchema extends ObjectSchema {
 	dtype?: string;
@@ -72,7 +75,7 @@ export class PositronConnectionsInstance extends BaseConnectionsInstance impleme
 			try {
 				// Failing to acquire the icon is fine
 				// We just log the error
-				object.metadata.icon = await object.getIcon();
+				object.metadata.icon = FileAccess.uriToBrowserUri(URI.file(await object.getIcon())).toString();
 			} catch (err: any) {
 				service.log(`Failed to get icon for ${object.id}: ${err.message}`);
 			}
@@ -461,7 +464,7 @@ class PositronConnectionItem implements IPositronConnectionItem {
 		if (icon === '') {
 			return undefined;
 		} else {
-			return icon;
+			return FileAccess.uriToBrowserUri(URI.file(icon)).toString();
 		}
 	}
 


### PR DESCRIPTION
This tries to fix an issue when rendering an icon on Windows. (It would probably also fail on the Web version)
When loading a local asset, we have to convert it into a browserURI using `FileAccess.uriToBrowserUri`, this wraps the URI with `vscode-file://vscode-file/C://` which seems to be sufficient for the file to be found when rendering.

Adresses https://github.com/posit-dev/positron/issues/6187#issuecomment-2660105009

Another alternative would be the backend to return base64 encoded png images, if this ends up still being problematic.


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

See https://github.com/posit-dev/positron/issues/6187#issuecomment-2660105009 for more info.