### PR TITLE
Switch editor action bar to "on" by default

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3180,7 +3180,7 @@ class EditorActionBar extends BaseEditorOption<EditorOption.actionBar, IEditorAc
 		 * Default options for the editor action bar.
 		 */
 		const defaults: EditorActionBarOptions = {
-			enabled: false,
+			enabled: true,
 		};
 
 		// Call the base class's constructor.

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -65,7 +65,10 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 					localize('workbench.editor.editorActionsLocation.hidden', "Editor actions are not shown."),
 				],
 				'markdownDescription': localize('editorActionsLocation', "Controls where the editor actions are shown."),
-				'default': 'default'
+				// --- Start Positron ---
+				'default': 'hidden'
+				// 'default': 'default'
+				// --- End Positron ---
 			},
 			'workbench.editor.alwaysShowEditorActions': {
 				'type': 'boolean',

--- a/test/e2e/tests/editor-action-bar/data-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/data-files.test.ts
@@ -41,9 +41,8 @@ test.describe('Editor Action Bar: Data Files', {
 	tag: [tags.WEB, tags.WIN, tags.EDITOR_ACTION_BAR, tags.DATA_EXPLORER]
 }, () => {
 
-	test.beforeAll(async function ({ app, userSettings }) {
+	test.beforeAll(async function ({ app }) {
 		editorActionBar = app.workbench.editorActionBar;
-		await userSettings.set([['editor.actionBar.enabled', 'true']], false);
 	});
 
 	test.afterEach(async function ({ runCommand }) {

--- a/test/e2e/tests/editor-action-bar/document-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/document-files.test.ts
@@ -18,9 +18,8 @@ test.describe('Editor Action Bar: Document Files', {
 	tag: [tags.WEB, tags.WIN, tags.EDITOR_ACTION_BAR, tags.EDITOR]
 }, () => {
 
-	test.beforeAll(async function ({ userSettings, app }) {
+	test.beforeAll(async function ({ app }) {
 		editorActionBar = app.workbench.editorActionBar;
-		await userSettings.set([['editor.actionBar.enabled', 'true']], false);
 	});
 
 	test.afterEach(async function ({ runCommand }) {


### PR DESCRIPTION
Addresses [#6317](https://github.com/posit-dev/positron/issues/6317)

@:editor-action-bar

### Release Notes

#### New Features

- New editor action bar is now enabled by default. You can switch this bar off by toggling the `editor.actionBar.enabled` setting (#6317).

#### Bug Fixes

- N/A


### QA Notes

After this change, we should see the editor action bar enabled by default, for example:

![editor-action-bar](https://github.com/user-attachments/assets/146febf9-a70c-4f28-bae8-eaad59056da8)
