### PR TITLE
Exclude ipykernel native libs for macOS universal release

### DIFF
--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -43,16 +43,13 @@ const stashPatterns = [
     '**/html.icns',
     // Exclusions from Python language pack (positron-python)
     '**/pydevd/**', // Cython pre-built binaries for Python debugging
+	'**/lib/ipykernel/**',      // Pre-built ipykernel dependencies
     // Exclusions from R language pack (positron-r)
     '**/ark', // Compiled R kernel and LSP
     // Exclusions from Kallichore Jupyter supervisor
     '**/kcserver', // Compiled Jupyter supervisor
     // Exclusions for Python Environment Tools
     '**/python-env-tools/pet',
-    // Exclusions from ipykernel .so files
-    '**/lib/ipykernel/**/*.so',
-    // Exclusions from ipykernel .dylib files
-    '**/lib/ipykernel/**/.dylibs/**',
     // Exclusions from Quarto
     '**/quarto/bin/tools/**',
     // Exclusions from Node Addon API

--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -43,6 +43,8 @@ const stashPatterns = [
     '**/html.icns',
     // Exclusions from Python language pack (positron-python)
     '**/pydevd/**', // Cython pre-built binaries for Python debugging
+    '**/lib/ipykernel/**', // Bundled IPyKernel dependencies
+    '**/lib/ipykernel/**/.dylibs/**', // Bundled IPyKernel dependency dylibs
     // Exclusions from R language pack (positron-r)
     '**/ark', // Compiled R kernel and LSP
     // Exclusions from Kallichore Jupyter supervisor

--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -49,6 +49,8 @@ const stashPatterns = [
     '**/kcserver', // Compiled Jupyter supervisor
     // Exclusions for Python Environment Tools
     '**/python-env-tools/pet',
+    // Exclusions from ipykernel
+    '**/lib/ipykernel/**/*.so',
     // Exclusions from Quarto
     '**/quarto/bin/tools/**',
     // Exclusions from Node Addon API

--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -43,7 +43,6 @@ const stashPatterns = [
     '**/html.icns',
     // Exclusions from Python language pack (positron-python)
     '**/pydevd/**', // Cython pre-built binaries for Python debugging
-	'**/lib/ipykernel/**',      // Pre-built ipykernel dependencies
     // Exclusions from R language pack (positron-r)
     '**/ark', // Compiled R kernel and LSP
     // Exclusions from Kallichore Jupyter supervisor

--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -52,7 +52,7 @@ const stashPatterns = [
     // Exclusions from ipykernel .so files
     '**/lib/ipykernel/**/*.so',
     // Exclusions from ipykernel .dylib files
-    '**/lib/ipykernel/**/*.dylib',
+    '**/lib/ipykernel/**/.dylibs/**',
     // Exclusions from Quarto
     '**/quarto/bin/tools/**',
     // Exclusions from Node Addon API

--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -49,8 +49,10 @@ const stashPatterns = [
     '**/kcserver', // Compiled Jupyter supervisor
     // Exclusions for Python Environment Tools
     '**/python-env-tools/pet',
-    // Exclusions from ipykernel
+    // Exclusions from ipykernel .so files
     '**/lib/ipykernel/**/*.so',
+    // Exclusions from ipykernel .dylib files
+    '**/lib/ipykernel/**/*.dylib',
     // Exclusions from Quarto
     '**/quarto/bin/tools/**',
     // Exclusions from Node Addon API

--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -46,16 +46,13 @@ const stashPatterns = [
 	'**/html.icns',
 	// Exclusions from Python language pack (positron-python)
 	'**/pydevd/**',             // Cython pre-built binaries for Python debugging
+	'**/lib/ipykernel/**',      // Pre-built ipykernel dependencies
 	// Exclusions from R language pack (positron-r)
 	'**/ark',                   // Compiled R kernel and LSP
 	// Exclusions from Kallichore Jupyter supervisor
 	'**/kcserver',              // Compiled Jupyter supervisor
 	// Exclusions for Python Environment Tools
 	'**/python-env-tools/pet',
-	// Exclusions from ipykernel .so files
-	'**/lib/ipykernel/**/*.so',
-	// Exclusions from ipykernel .dylib files
-	'**/lib/ipykernel/**/.dylibs/**',
 	// Exclusions from Quarto
 	'**/quarto/bin/tools/**',
 	// Exclusions from Node Addon API

--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -55,7 +55,7 @@ const stashPatterns = [
 	// Exclusions from ipykernel .so files
 	'**/lib/ipykernel/**/*.so',
 	// Exclusions from ipykernel .dylib files
-	'**/lib/ipykernel/**/*.dylib',
+	'**/lib/ipykernel/**/.dylibs/**',
 	// Exclusions from Quarto
 	'**/quarto/bin/tools/**',
 	// Exclusions from Node Addon API

--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -46,6 +46,8 @@ const stashPatterns = [
 	'**/html.icns',
 	// Exclusions from Python language pack (positron-python)
 	'**/pydevd/**',             // Cython pre-built binaries for Python debugging
+	'**/lib/ipykernel/**',      // Bundled IPyKernel dependencies
+	'**/lib/ipykernel/**/.dylibs/**',  // Bundled IPyKernel dependency dylibs
 	// Exclusions from R language pack (positron-r)
 	'**/ark',                   // Compiled R kernel and LSP
 	// Exclusions from Kallichore Jupyter supervisor

--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -52,6 +52,8 @@ const stashPatterns = [
 	'**/kcserver',              // Compiled Jupyter supervisor
 	// Exclusions for Python Environment Tools
 	'**/python-env-tools/pet',
+	// Exclusions from ipykernel
+	'**/lib/ipykernel/**/*.so',
 	// Exclusions from Quarto
 	'**/quarto/bin/tools/**',
 	// Exclusions from Node Addon API

--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -46,7 +46,6 @@ const stashPatterns = [
 	'**/html.icns',
 	// Exclusions from Python language pack (positron-python)
 	'**/pydevd/**',             // Cython pre-built binaries for Python debugging
-	'**/lib/ipykernel/**',      // Pre-built ipykernel dependencies
 	// Exclusions from R language pack (positron-r)
 	'**/ark',                   // Compiled R kernel and LSP
 	// Exclusions from Kallichore Jupyter supervisor

--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -52,8 +52,10 @@ const stashPatterns = [
 	'**/kcserver',              // Compiled Jupyter supervisor
 	// Exclusions for Python Environment Tools
 	'**/python-env-tools/pet',
-	// Exclusions from ipykernel
+	// Exclusions from ipykernel .so files
 	'**/lib/ipykernel/**/*.so',
+	// Exclusions from ipykernel .dylib files
+	'**/lib/ipykernel/**/*.dylib',
 	// Exclusions from Quarto
 	'**/quarto/bin/tools/**',
 	// Exclusions from Node Addon API

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -569,12 +569,6 @@ BUILD_TARGETS.forEach(buildTarget => {
 	const platform = buildTarget.platform;
 	const arch = buildTarget.arch;
 	const opts = buildTarget.opts;
-	// --- Start Positron ---
-	// Store the target platform and arch. This is used by positron-python to bundle the correct
-	// ipykernel dependencies regardless of the Python interpreter used during the build.
-	process.env.POSITRON_BUILD_TARGET_PLATFORM = platform;
-	process.env.POSITRON_BUILD_TARGET_ARCH = arch;
-	// --- End Positron ---
 
 	const [vscode, vscodeMin] = ['', 'min'].map(minified => {
 		const sourceFolderName = `out-vscode${dashed(minified)}`;

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -569,6 +569,12 @@ BUILD_TARGETS.forEach(buildTarget => {
 	const platform = buildTarget.platform;
 	const arch = buildTarget.arch;
 	const opts = buildTarget.opts;
+	// --- Start Positron ---
+	// Store the target platform and arch. This is used by positron-python to bundle the correct
+	// ipykernel dependencies regardless of the Python interpreter used during the build.
+	process.env.POSITRON_BUILD_TARGET_PLATFORM = platform;
+	process.env.POSITRON_BUILD_TARGET_ARCH = arch;
+	// --- End Positron ---
 
 	const [vscode, vscodeMin] = ['', 'min'].map(minified => {
 		const sourceFolderName = `out-vscode${dashed(minified)}`;

--- a/extensions/positron-python/gulpfile.js
+++ b/extensions/positron-python/gulpfile.js
@@ -32,7 +32,7 @@ const isCI = process.env.TRAVIS === 'true' || process.env.TF_BUILD !== undefined
 
 // --- Start Positron ---
 const pythonCommand = locatePython();
-const arch = os.arch();
+const arch = process.env.POSITRON_PYTHON_ARCH || os.arch();
 if (arch !== 'x64' && arch !== 'arm64') {
     throw new Error(`Unsupported architecture: ${arch}`);
 }

--- a/extensions/positron-python/gulpfile.js
+++ b/extensions/positron-python/gulpfile.js
@@ -32,7 +32,7 @@ const isCI = process.env.TRAVIS === 'true' || process.env.TF_BUILD !== undefined
 
 // --- Start Positron ---
 const pythonCommand = locatePython();
-const arch = process.env.POSITRON_PYTHON_ARCH || os.arch();
+const arch = os.arch();
 if (arch !== 'x64' && arch !== 'arm64') {
     throw new Error(`Unsupported architecture: ${arch}`);
 }

--- a/extensions/positron-python/gulpfile.js
+++ b/extensions/positron-python/gulpfile.js
@@ -32,7 +32,6 @@ const isCI = process.env.TRAVIS === 'true' || process.env.TF_BUILD !== undefined
 
 // --- Start Positron ---
 const pythonCommand = locatePython();
-const pipPlatform = getPipPlatform();
 // --- End Positron ---
 
 gulp.task('compileCore', (done) => {
@@ -280,94 +279,52 @@ async function vendorPythonKernelRequirements() {
     await spawnAsync(pythonCommand, ['scripts/vendor.py']);
 }
 
-function getPipPlatform() {
-    const platform = process.env.POSITRON_BUILD_TARGET_PLATFORM;
-    const arch = process.env.POSITRON_BUILD_TARGET_ARCH;
-    if ((platform && !arch) || (!platform && arch)) {
-        throw new Error('Both POSITRON_BUILD_TARGET_PLATFORM and POSITRON_BUILD_TARGET_ARCH must be set or neither.');
-    }
-    if (!platform && !arch) {
-        // Don't manually specify a platform. Pip will use the current interpreter's.
-        return undefined;
-    }
-
-    // Unfortunately, pip doesn't simply accept a platform and architecture. Not sure the best way
-    // to determine the exact versions used below. These were determined via trial and error
-    // running the following locally:
-    //
-    //   python -m pip download --only-binary :all: --implementation cp --abi cp38 \
-    //     --python-version 3.8 --platform <platform> \
-    //     ipykernel==6.29.5
-    switch ([platform, arch]) {
-        case ['win32', 'x64']:
-            return 'win32';
-        case ['win32', 'arm64']:
-            return 'win_arm64';
-        case ['darwin', 'x64']:
-            return 'macosx_11_0_x86_64';
-        case ['darwin', 'arm64']:
-            return 'macosx_11_0_arm64';
-        case ['linux', 'x64']:
-            return 'manylinux2014_x86_64';
-        case ['linux', 'arm64']:
-            return 'manylinux2014_aarch64';
-        default:
-            return undefined;
-    }
-}
-
 async function installIPyKernelPurePythonRequirements() {
-    await pipInstall(
-        [
-            '--target',
-            './python_files/lib/ipykernel/py3',
-            '--implementation',
-            'py',
-            '--python-version',
-            '3.8',
-            '--abi',
-            'none',
-            '-r',
-            './python_files/ipykernel_requirements/py3-requirements.txt',
-        ].concat(pipPlatform ? ['--platform', pipPlatform] : []),
-    );
+    await pipInstall([
+        '--target',
+        './python_files/lib/ipykernel/py3',
+        '--implementation',
+        'py',
+        '--python-version',
+        '3.8',
+        '--abi',
+        'none',
+        '-r',
+        './python_files/ipykernel_requirements/py3-requirements.txt',
+    ]);
 }
 
 async function installIPyKernelCPythonVersionAgnosticRequirements() {
-    await pipInstall(
-        [
-            '--target',
-            './python_files/lib/ipykernel/cp3',
-            '--implementation',
-            'cp',
-            '--python-version',
-            '3.8',
-            '--abi',
-            'abi3',
-            '-r',
-            './python_files/ipykernel_requirements/cp3-requirements.txt',
-        ].concat(pipPlatform ? ['--platform', pipPlatform] : []),
-    );
+    await pipInstall([
+        '--target',
+        './python_files/lib/ipykernel/cp3',
+        '--implementation',
+        'cp',
+        '--python-version',
+        '3.8',
+        '--abi',
+        'abi3',
+        '-r',
+        './python_files/ipykernel_requirements/cp3-requirements.txt',
+    ]);
 }
 
 async function installIPyKernelCPythonVersionSpecificRequirements() {
     for (const pythonVersion of ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']) {
         const shortVersion = pythonVersion.replace('.', '');
         const abi = `cp${shortVersion}`;
-        await pipInstall(
-            [
-                '--target',
-                `./python_files/lib/ipykernel/${abi}`,
-                '--implementation',
-                'cp',
-                '--python-version',
-                pythonVersion,
-                '--abi',
-                abi,
-                '-r',
-                './python_files/ipykernel_requirements/cpx-requirements.txt',
-            ].concat(pipPlatform ? ['--platform', pipPlatform] : []),
-        );
+        await pipInstall([
+            '--target',
+            `./python_files/lib/ipykernel/${abi}`,
+            '--implementation',
+            'cp',
+            '--python-version',
+            pythonVersion,
+            '--abi',
+            abi,
+            '-r',
+            './python_files/ipykernel_requirements/cpx-requirements.txt',
+        ]);
     }
 }
 

--- a/extensions/positron-python/scripts/pip-compile-ipykernel.py
+++ b/extensions/positron-python/scripts/pip-compile-ipykernel.py
@@ -311,7 +311,7 @@ if __name__ == "__main__":
     main(
         requirement="ipykernel",
         python_versions=["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
-        output_dir=Path("./python_files/lib/ipykernel/"),
+        output_dir=Path("./python_files/ipykernel_requirements/"),
         max_rounds=10,
         cache_dir=CACHE_DIR,
     )

--- a/extensions/positron-python/src/client/positron/ipykernel.ts
+++ b/extensions/positron-python/src/client/positron/ipykernel.ts
@@ -3,12 +3,19 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as path from 'path';
 import * as vscode from 'vscode';
+import * as fs from '../common/platform/fs-paths';
 import { IServiceContainer } from '../ioc/types';
 import { PythonEnvironment } from '../pythonEnvironments/info';
 import { IWorkspaceService } from '../common/application/types';
 import { IPythonExecutionFactory } from '../common/process/types';
-import { traceVerbose } from '../logging';
+import { traceVerbose, traceWarn } from '../logging';
+import { EXTENSION_ROOT_DIR } from '../constants';
+
+export interface IPykernelBundle {
+    paths: string[] | undefined;
+}
 
 /**
  * Check if an interpreter should use the bundled ipykernel.
@@ -17,11 +24,11 @@ import { traceVerbose } from '../logging';
  * @param serviceContainer The service container to use for dependency injection.
  * @param resource The resource to scope setting to.
  */
-export async function shouldUseBundledIpykernel(
+export async function getIpykernelBundle(
     interpreter: PythonEnvironment,
     serviceContainer: IServiceContainer,
     resource?: vscode.Uri,
-): Promise<boolean> {
+): Promise<IPykernelBundle> {
     // Get the required services.
     const workspaceService = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
     const pythonExecutionFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
@@ -32,7 +39,7 @@ export async function shouldUseBundledIpykernel(
         .get<boolean>('useBundledIpykernel', true);
     if (!useBundledIpykernel) {
         traceVerbose('createPythonRuntime: ipykernel bundling is disabled');
-        return false;
+        return { paths: undefined };
     }
     traceVerbose('createPythonRuntime: ipykernel bundling is enabled, checking if interpreter is supported');
 
@@ -40,7 +47,7 @@ export async function shouldUseBundledIpykernel(
     // (defined in scripts/pip-compile-ipykernel.py).
     if (interpreter.version?.major !== 3 || ![8, 9, 10, 11, 12, 13].includes(interpreter.version?.minor)) {
         traceVerbose(`createPythonRuntime: ipykernel not bundled for interpreter version: ${interpreter.version?.raw}`);
-        return false;
+        return { paths: undefined };
     }
 
     // Get the interpreter implementation if it's not already available.
@@ -56,9 +63,27 @@ export async function shouldUseBundledIpykernel(
         traceVerbose(
             `createPythonRuntime: ipykernel not bundled for interpreter implementation: ${interpreter.implementation}`,
         );
-        return false;
+        return { paths: undefined };
     }
 
+    // Append the bundle paths (defined in gulpfile.js) to the PYTHONPATH environment variable.
     traceVerbose(`createPythonRuntime: ipykernel bundling is supported by interpreter: ${interpreter.path}`);
-    return true;
+    const cpxSpecifier = `cp${interpreter.version.major}${interpreter.version.minor}`;
+    const paths = [
+        path.join(EXTENSION_ROOT_DIR, 'python_files', 'lib', 'ipykernel', 'py3'),
+        path.join(EXTENSION_ROOT_DIR, 'python_files', 'lib', 'ipykernel', 'cp3'),
+        path.join(EXTENSION_ROOT_DIR, 'python_files', 'lib', 'ipykernel', cpxSpecifier),
+    ];
+
+    for (const path of paths) {
+        if (!(await fs.pathExists(path))) {
+            // This shouldn't happen. Did something go wrong during `npm install`?
+            traceWarn(
+                `createPythonRuntime: ipykernel not bundled for interpreter implementation: ${interpreter.implementation}`,
+            );
+            return { paths: undefined };
+        }
+    }
+
+    return { paths };
 }

--- a/extensions/positron-python/src/client/positron/runtime.ts
+++ b/extensions/positron-python/src/client/positron/runtime.ts
@@ -18,11 +18,11 @@ import { IInstaller, Product, ProductInstallStatus } from '../common/types';
 import { IApplicationEnvironment, IWorkspaceService } from '../common/application/types';
 import { EXTENSION_ROOT_DIR, IPYKERNEL_VERSION, PYTHON_LANGUAGE } from '../common/constants';
 import { EnvLocationHeuristic, getEnvLocationHeuristic } from '../interpreter/configuration/environmentTypeComparer';
-import { shouldUseBundledIpykernel } from './ipykernel';
+import { getIpykernelBundle, IPykernelBundle } from './ipykernel';
 
 export interface PythonRuntimeExtraData {
     pythonPath: string;
-    useBundledIpykernel?: boolean;
+    ipykernelBundle?: IPykernelBundle;
 }
 
 export async function createPythonRuntimeMetadata(
@@ -43,11 +43,11 @@ export async function createPythonRuntimeMetadata(
     traceInfo('createPythonRuntime: getting extension runtime settings');
 
     // Check if we should use the bundled ipykernel.
-    const useBundledIpykernel = await shouldUseBundledIpykernel(interpreter, serviceContainer, workspaceUri);
+    const ipykernelBundle = await getIpykernelBundle(interpreter, serviceContainer, workspaceUri);
 
     // Determine if a compatible version of ipykernel is available (either bundled or already installed).
     let hasCompatibleKernel: boolean;
-    if (useBundledIpykernel) {
+    if (ipykernelBundle.paths) {
         hasCompatibleKernel = true;
     } else {
         traceInfo('createPythonRuntime: checking if ipykernel is installed');
@@ -116,7 +116,7 @@ export async function createPythonRuntimeMetadata(
     // runtime session.
     const extraRuntimeData: PythonRuntimeExtraData = {
         pythonPath: interpreter.path,
-        useBundledIpykernel,
+        ipykernelBundle,
     };
 
     // Check the kernel supervisor's configuration; if it's  configured to

--- a/extensions/positron-python/src/client/positron/runtime.ts
+++ b/extensions/positron-python/src/client/positron/runtime.ts
@@ -47,16 +47,20 @@ export async function createPythonRuntimeMetadata(
 
     // Determine if a compatible version of ipykernel is available (either bundled or already installed).
     let hasCompatibleKernel: boolean;
-    if (ipykernelBundle.paths) {
-        hasCompatibleKernel = true;
-    } else {
-        traceInfo('createPythonRuntime: checking if ipykernel is installed');
+    if (ipykernelBundle.disabledReason) {
+        traceInfo(
+            `createPythonRuntime: ipykernel bundling is disabled, ` +
+                `reason: ${ipykernelBundle.disabledReason}. ` +
+                `Checking if ipykernel is installed`,
+        );
         const productInstallStatus = await installer.isProductVersionCompatible(
             Product.ipykernel,
             IPYKERNEL_VERSION,
             interpreter,
         );
         hasCompatibleKernel = productInstallStatus === ProductInstallStatus.Installed;
+    } else {
+        hasCompatibleKernel = true;
     }
 
     // Define the startup behavior; request immediate startup if this is the

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -71,9 +71,6 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
     /** The current state of the runtime */
     private _state: positron.RuntimeState = positron.RuntimeState.Uninitialized;
 
-    /** The service for managing application UI interactions */
-    // private _applicationShell: IApplicationShell;
-
     /** The service for installing Python packages */
     private _installer: IInstaller;
 
@@ -85,9 +82,6 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
 
     /** The service for managing environment variables */
     private _envVarsService: IEnvironmentVariablesService;
-
-    /** The service for executing Python code */
-    // private _pythonExecutionFactory: IPythonExecutionFactory;
 
     /**
      * Map of parent message IDs currently handled by IPyWidgets output widget comms,
@@ -137,12 +131,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             this.onStateChange(state);
         });
 
-        // this._applicationShell = serviceContainer.get<IApplicationShell>(IApplicationShell);
         this._installer = this.serviceContainer.get<IInstaller>(IInstaller);
         this._interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
         this._interpreterPathService = serviceContainer.get<IInterpreterPathService>(IInterpreterPathService);
         this._envVarsService = serviceContainer.get<IEnvironmentVariablesService>(IEnvironmentVariablesService);
-        // this._pythonExecutionFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
     }
 
     onDidReceiveRuntimeMessage: vscode.Event<positron.LanguageRuntimeMessage>;

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -271,6 +271,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         }
 
         if (!this._ipykernelBundle.paths) {
+            traceInfo(`Not using bundled ipykernel. Reason: ${this._ipykernelBundle.disabledReason}`);
             return false;
         }
 

--- a/extensions/positron-python/src/test/positron/session.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/session.unit.test.ts
@@ -7,6 +7,7 @@
 
 import * as assert from 'assert';
 import { interfaces } from 'inversify';
+import * as os from 'os';
 import * as path from 'path';
 // eslint-disable-next-line import/no-unresolved
 import * as positron from 'positron';
@@ -231,13 +232,14 @@ suite('Python Runtime Session', () => {
 
         // Ipykernel bundles should be added to the PYTHONPATH.
         sinon.assert.callCount(envVarsServiceSpy.appendPythonPath, 3);
+        const arch = os.arch();
         assert.deepStrictEqual(envVarsServiceSpy.appendPythonPath.args[0], [
             kernelSpec.env,
-            path.join(EXTENSION_ROOT_DIR, 'python_files', 'lib', 'ipykernel', 'cp38'),
+            path.join(EXTENSION_ROOT_DIR, 'python_files', 'lib', 'ipykernel', arch, 'cp38'),
         ]);
         assert.deepStrictEqual(envVarsServiceSpy.appendPythonPath.args[1], [
             kernelSpec.env,
-            path.join(EXTENSION_ROOT_DIR, 'python_files', 'lib', 'ipykernel', 'cp3'),
+            path.join(EXTENSION_ROOT_DIR, 'python_files', 'lib', 'ipykernel', arch, 'cp3'),
         ]);
         assert.deepStrictEqual(envVarsServiceSpy.appendPythonPath.args[2], [
             kernelSpec.env,
@@ -289,7 +291,7 @@ suite('Python Runtime Session', () => {
         sinon.assert.called(installerSpy.isProductVersionCompatible);
     });
 
-    test('Start: dont bundle ipykernel on error', async () => {
+    test('Start: dont bundle if bundle path does not exist', async () => {
         // Simulate the bundle paths not existing.
         sinon.stub(fs, 'pathExists').resolves(false);
 


### PR DESCRIPTION
Fixing macOS releases. 

Skipping comparing files from the bundled ipykernel while preparing macOS universal release.

To expedite fixing desktop macOS builds, it was decided to not try to bundle ipykernel for both arm64 AND x86 macOS. Wasim updated the PR so that we only bundle ipykernel for arm64 macOS for now. Intel x86 environments will need to continue install ipykernel on first use.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Windows, Linux and MacOS arm64 should have ipykernel available in Positron python sessions, where as macOS x86 will still need ipykernel to be installed on first use.