### PR TITLE
E2E tests: verify basic tasks functionality

### DIFF
--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -45,6 +45,7 @@ export enum TestTags {
 	R_PKG_DEVELOPMENT = '@:r-pkg-development',
 	RETICULATE = '@:reticulate',
 	SCM = '@:scm',
+	TASKS = '@:tasks',
 	TEST_EXPLORER = '@:test-explorer',
 	TOP_ACTION_BAR = '@:top-action-bar',
 	VARIABLES = '@:variables',

--- a/test/e2e/pages/terminal.ts
+++ b/test/e2e/pages/terminal.ts
@@ -39,26 +39,6 @@ export class Terminal {
 		return expectedCount ? matchingLines.allTextContents() : [];
 	}
 
-
-	/**
-	 * Verify: Wait for the terminal to contain the expected output.
-	 * Note: This leverages the clipboard to read the terminal text. This may be helpful if terminal renders canvas.
-	 * @param expectedOutput the expected output to be found in the terminal
-	 */
-	async waitForTerminalTextViaClipboard(expectedOutput: string) {
-		await this.code.driver.page.locator('#terminal').click();
-		await this.code.driver.context.grantPermissions(['clipboard-read', 'clipboard-write']);
-
-		await expect(async () => {
-			await this.code.driver.page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
-			await this.code.driver.page.keyboard.press(process.platform === 'darwin' ? 'Meta+C' : 'Control+C');
-
-			const clipboardText = await this.code.driver.page.evaluate(() => navigator.clipboard.readText());
-
-			return expect(clipboardText).toContain(expectedOutput);
-		}).toPass({ timeout: 15000 });
-	}
-
 	async waitForTerminalLines() {
 
 		await expect(async () => {

--- a/test/e2e/pages/terminal.ts
+++ b/test/e2e/pages/terminal.ts
@@ -39,6 +39,26 @@ export class Terminal {
 		return expectedCount ? matchingLines.allTextContents() : [];
 	}
 
+
+	/**
+	 * Verify: Wait for the terminal to contain the expected output.
+	 * Note: This leverages the clipboard to read the terminal text. This may be helpful if terminal renders canvas.
+	 * @param expectedOutput the expected output to be found in the terminal
+	 */
+	async waitForTerminalTextViaClipboard(expectedOutput: string) {
+		await this.code.driver.page.locator('#terminal').click();
+		await this.code.driver.context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+		await expect(async () => {
+			await this.code.driver.page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+			await this.code.driver.page.keyboard.press(process.platform === 'darwin' ? 'Meta+C' : 'Control+C');
+
+			const clipboardText = await this.code.driver.page.evaluate(() => navigator.clipboard.readText());
+
+			return expect(clipboardText).toContain(expectedOutput);
+		}).toPass({ timeout: 15000 });
+	}
+
 	async waitForTerminalLines() {
 
 		await expect(async () => {

--- a/test/e2e/tests/tasks/tasks.test.ts
+++ b/test/e2e/tests/tasks/tasks.test.ts
@@ -10,9 +10,8 @@ test.use({
 	suiteId: __filename
 });
 
-// WEB and WIN padd in CI but not locally
 test.describe('Tasks', {
-	tag: [tags.TASKS]
+	tag: [tags.TASKS, tags.WEB]
 }, () => {
 
 	test('Python: Verify Basic Tasks Functionality', async function ({ app, python, openFile }) {
@@ -25,8 +24,7 @@ test.describe('Tasks', {
 		await app.workbench.quickInput.selectQuickInputElementContaining('Run Python File');
 		await app.workbench.quickInput.waitForQuickInputClosed();
 
-		await app.workbench.terminal.waitForTerminalText('336776');
-
+		await app.workbench.terminal.waitForTerminalTextViaClipboard('336776');
 		await app.workbench.terminal.sendKeysToTerminal('Enter');
 	});
 
@@ -40,8 +38,7 @@ test.describe('Tasks', {
 		await app.workbench.quickInput.selectQuickInputElementContaining('Run R File');
 		await app.workbench.quickInput.waitForQuickInputClosed();
 
-		await app.workbench.terminal.waitForTerminalText('336776');
-
+		await app.workbench.terminal.waitForTerminalTextViaClipboard('336776');
 		await app.workbench.terminal.sendKeysToTerminal('Enter');
 	});
 });

--- a/test/e2e/tests/tasks/tasks.test.ts
+++ b/test/e2e/tests/tasks/tasks.test.ts
@@ -10,8 +10,9 @@ test.use({
 	suiteId: __filename
 });
 
+// WEB and WIN padd in CI but not locally
 test.describe('Tasks', {
-	tag: [tags.TASKS, tags.WEB, tags.WIN]
+	tag: [tags.TASKS]
 }, () => {
 
 	test('Python: Verify Basic Tasks Functionality', async function ({ app, python, openFile }) {

--- a/test/e2e/tests/tasks/tasks.test.ts
+++ b/test/e2e/tests/tasks/tasks.test.ts
@@ -11,7 +11,7 @@ test.use({
 });
 
 test.describe('Tasks', {
-	tag: [tags.TASKS, tags.WEB]
+	tag: [tags.TASKS]
 }, () => {
 
 	test('Python: Verify Basic Tasks Functionality', async function ({ app, python, openFile }) {
@@ -24,7 +24,7 @@ test.describe('Tasks', {
 		await app.workbench.quickInput.selectQuickInputElementContaining('Run Python File');
 		await app.workbench.quickInput.waitForQuickInputClosed();
 
-		await app.workbench.terminal.waitForTerminalTextViaClipboard('336776');
+		await app.workbench.terminal.waitForTerminalText('336776');
 		await app.workbench.terminal.sendKeysToTerminal('Enter');
 	});
 
@@ -38,7 +38,7 @@ test.describe('Tasks', {
 		await app.workbench.quickInput.selectQuickInputElementContaining('Run R File');
 		await app.workbench.quickInput.waitForQuickInputClosed();
 
-		await app.workbench.terminal.waitForTerminalTextViaClipboard('336776');
+		await app.workbench.terminal.waitForTerminalText('336776');;
 		await app.workbench.terminal.sendKeysToTerminal('Enter');
 	});
 });

--- a/test/e2e/tests/tasks/tasks.test.ts
+++ b/test/e2e/tests/tasks/tasks.test.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Tasks', {
+	tag: [tags.TASKS, tags.WEB, tags.WIN]
+}, () => {
+
+	test('Python: Verify Basic Tasks Functionality', async function ({ app, python, openFile }) {
+
+		await openFile(join('workspaces', 'nyc-flights-data-py', 'flights-data-frame.py'));
+
+		await app.code.driver.page.keyboard.press(process.platform === 'darwin' ? 'Meta+Shift+B' : 'Control+Shift+B');
+
+		await app.workbench.quickInput.waitForQuickInputOpened();
+		await app.workbench.quickInput.selectQuickInputElementContaining('Run Python File');
+		await app.workbench.quickInput.waitForQuickInputClosed();
+
+		await app.workbench.terminal.waitForTerminalText('336776');
+
+		await app.workbench.terminal.sendKeysToTerminal('Enter');
+	});
+
+	test('R: Verify Basic Tasks Functionality', async function ({ app, r, openFile }) {
+
+		await openFile(join('workspaces', 'nyc-flights-data-r', 'flights-data-frame.r'));
+
+		await app.code.driver.page.keyboard.press(process.platform === 'darwin' ? 'Meta+Shift+B' : 'Control+Shift+B');
+
+		await app.workbench.quickInput.waitForQuickInputOpened();
+		await app.workbench.quickInput.selectQuickInputElementContaining('Run R File');
+		await app.workbench.quickInput.waitForQuickInputClosed();
+
+		await app.workbench.terminal.waitForTerminalText('336776');
+
+		await app.workbench.terminal.sendKeysToTerminal('Enter');
+	});
+});


### PR DESCRIPTION
Verification of basic tasks functionality where the tasks.json is:

```
{
    // See https://go.microsoft.com/fwlink/?LinkId=733558
    // for the documentation about the tasks.json format
    "version": "2.0.0",
    "tasks": [
        {
            "label": "Run Python File",
            "command": "${command:python.interpreterPath} ${file}",
            "type": "shell",
            "group": {
                "kind": "build",
                "isDefault": true
            },
            "presentation": {
                "reveal": "always",
                "panel": "new",
                "focus": true
            }
        },
        {
            "label": "Run R File",
            "command": "${command:r.scriptPath} ${file}",
            "type": "shell",
            "group": {
                "kind": "build",
                "isDefault": true
            },
            "presentation": {
                "reveal": "always",
                "panel": "new",
                "focus": true
            }
        }
    ]
}
```

Thus, for R and Python, execution of the currently open file.

### QA Notes

All tests should pass.

@:tasks @:win @:web
