### PR TITLE
Language Reporting

### DIFF
--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -49,6 +49,14 @@ configurationRegistry.registerConfiguration({
 			description: localize('updateMode', "Configure whether you receive automatic updates. Requires a restart after change to take effect."),
 			deprecationMessage: localize('deprecated', "This setting is deprecated, please use '{0}' instead.", 'update.mode')
 		},
+		'update.languageReporting': {
+			type: 'boolean',
+			default: true,
+			scope: ConfigurationScope.APPLICATION,
+			description: localize('update.languageReporting', "Send the language sessions that are used to help improve Positron."),
+			tags: ['usesOnlineServices'],
+			included: !isWeb
+		},
 		'update.enableWindowsBackgroundUpdates': {
 			type: 'boolean',
 			default: true,

--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -49,11 +49,11 @@ configurationRegistry.registerConfiguration({
 			description: localize('updateMode', "Configure whether you receive automatic updates. Requires a restart after change to take effect."),
 			deprecationMessage: localize('deprecated', "This setting is deprecated, please use '{0}' instead.", 'update.mode')
 		},
-		'update.languageReporting': {
+		'update.primaryLanguageReporting': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.APPLICATION,
-			description: localize('update.languageReporting', "Send the language sessions that are used to help improve Positron."),
+			description: localize('update.primaryLanguageReporting', "Share the primary data science languages in use, such as Python and R, to help us improve Positron."),
 			tags: ['usesOnlineServices'],
 			included: !isWeb
 		},

--- a/src/vs/platform/update/common/update.ts
+++ b/src/vs/platform/update/common/update.ts
@@ -107,4 +107,8 @@ export interface IUpdateService {
 
 	isLatestVersion(): Promise<boolean | undefined>;
 	_applySpecificUpdate(packagePath: string): Promise<void>;
+
+	// --- Start Positron ---
+	updateActiveLanguages(languages: string[]): void;
+	// --- End Positron ---
 }

--- a/src/vs/platform/update/common/updateIpc.ts
+++ b/src/vs/platform/update/common/updateIpc.ts
@@ -29,6 +29,7 @@ export class UpdateChannel implements IServerChannel {
 			case '_getInitialState': return Promise.resolve(this.service.state);
 			case 'isLatestVersion': return this.service.isLatestVersion();
 			case '_applySpecificUpdate': return this.service._applySpecificUpdate(arg);
+			case 'updateActiveLanguages': return Promise.resolve(this.service.updateActiveLanguages(arg));
 		}
 
 		throw new Error(`Call not found: ${command}`);
@@ -82,4 +83,10 @@ export class UpdateChannelClient implements IUpdateService {
 	dispose(): void {
 		this.disposables.dispose();
 	}
+
+	// --- Start Positron ---
+	updateActiveLanguages(languages: string[]): void {
+		this.channel.call('updateActiveLanguages', languages);
+	}
+	// --- End Positron ---
 }

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -176,7 +176,8 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	private async scheduleCheckForUpdates(delay = 6 * 60 * 60 * 1000): Promise<void> {
 		return timeout(delay)
 			.then(() => {
-				const includeLanguages = this._activeLanguages.length > 0;
+				const includeLanguages = this.configurationService.getValue<boolean>('update.languageReporting');
+				this.logService.debug('update#scheduleCheckForUpdates, includeLanguages =', includeLanguages);
 				this.checkForUpdates(false, includeLanguages);
 			})
 			.then(() => {

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -53,6 +53,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	protected url: string | undefined;
 
 	// --- Start Positron ---
+	private _activeLanguages: string[];
 	// enable the service to download and apply updates automatically
 	protected enableAutoUpdate = false;
 	// --- End Positron ---
@@ -83,6 +84,10 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		@INativeHostMainService protected readonly nativeHostMainService: INativeHostMainService
 		// --- End Positron ---
 	) {
+		// --- Start Positron ---
+		this._activeLanguages = [];
+		// --- End Positron ---
+
 		lifecycleMainService.when(LifecycleMainPhase.AfterWindowOpen)
 			.finally(() => this.initialize());
 	}
@@ -179,6 +184,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	async checkForUpdates(explicit: boolean): Promise<void> {
 		this.logService.trace('update#checkForUpdates, state = ', this.state.type);
 
+		this.logService.debug('update#checkForUpdates, languages =', this._activeLanguages.join(', '));
 		if (this.state.type !== StateType.Idle) {
 			return;
 		}
@@ -320,6 +326,9 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	protected abstract buildUpdateFeedUrl(channel: string): string | undefined;
 	protected updateAvailable(context: IUpdate): void {
 		this.setState(State.AvailableForDownload(context));
+	}
+	updateActiveLanguages(languages: string[]): void {
+		this._activeLanguages = languages;
 	}
 	// --- End Positron ---
 }

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -176,9 +176,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	private async scheduleCheckForUpdates(delay = 6 * 60 * 60 * 1000): Promise<void> {
 		return timeout(delay)
 			.then(() => {
-				const includeLanguages = this.configurationService.getValue<boolean>('update.languageReporting');
-				this.logService.debug('update#scheduleCheckForUpdates, includeLanguages =', includeLanguages);
-				this.checkForUpdates(false, includeLanguages);
+				this.checkForUpdates(false);
 			})
 			.then(() => {
 				// Check again after 6 hours
@@ -188,7 +186,9 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	}
 
 	// --- Start Positron ---
-	async checkForUpdates(explicit: boolean, includeLanguages = false): Promise<void> {
+	async checkForUpdates(explicit: boolean): Promise<void> {
+		const includeLanguages = this.configurationService.getValue<boolean>('update.primaryLanguageReporting');
+		this.logService.debug('update#checkForUpdates, includeLanguages =', includeLanguages);
 		this.logService.trace('update#checkForUpdates, state = ', this.state.type);
 
 		this.logService.debug('update#checkForUpdates, languages =', this._activeLanguages.join(', '));

--- a/src/vs/platform/update/electron-main/updateService.snap.ts
+++ b/src/vs/platform/update/electron-main/updateService.snap.ts
@@ -135,6 +135,12 @@ abstract class AbstractUpdateService implements IUpdateService {
 	}
 
 	protected abstract doCheckForUpdates(context: any): void;
+
+	// --- Start Positron ---
+	updateActiveLanguages(languages: string[]): void {
+		// no-op
+	}
+	// --- End Positron ---
 }
 
 export class SnapUpdateService extends AbstractUpdateService {

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -106,7 +106,7 @@ class ExtHostLanguageRuntimeSessionAdapter implements ILanguageRuntimeSession {
 	private readonly _onDidCreateClientInstanceEmitter = new Emitter<ILanguageRuntimeClientCreatedEvent>();
 
 	private _currentState: RuntimeState = RuntimeState.Uninitialized;
-	private _lastUsed: number = Date.now();
+	private _lastUsed: number = 0;
 	private _clients: Map<string, ExtHostRuntimeClientInstance<any, any>> =
 		new Map<string, ExtHostRuntimeClientInstance<any, any>>();
 

--- a/src/vs/workbench/contrib/update/browser/update.contribution.ts
+++ b/src/vs/workbench/contrib/update/browser/update.contribution.ts
@@ -23,7 +23,10 @@ import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+
+// --- Start Positron ---
 import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+// --- End Positron ---
 
 const workbench = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
 

--- a/src/vs/workbench/contrib/update/browser/update.contribution.ts
+++ b/src/vs/workbench/contrib/update/browser/update.contribution.ts
@@ -23,6 +23,7 @@ import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { URI } from '../../../../base/common/uri.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 
 const workbench = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
 
@@ -193,6 +194,26 @@ class DownloadAction extends Action2 {
 		}
 	}
 }
+
+// --- Start Positron ---
+class DeveloperRefreshLanguageUsage extends Action2 {
+	constructor() {
+		super({
+			id: 'update.updateLanguageUsage',
+			title: localize2('updateLanguageUsage', 'Update Language Usage'),
+			category: Categories.Developer,
+			f1: true
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const runtimeSessionService = accessor.get(IRuntimeSessionService);
+		runtimeSessionService.updateActiveLanguages();
+	}
+}
+
+registerAction2(DeveloperRefreshLanguageUsage);
+// --- End Positron ---
 
 registerAction2(DownloadAction);
 registerAction2(CheckForUpdateAction);

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1671,13 +1671,17 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		return id;
 	}
 
-	private async scheduleUpdateActiveLanguages(delay = 60 * 60 * 1000): Promise<void> {
+	private async scheduleUpdateActiveLanguages(delay = 10 * 1000): Promise<void> {
 		return timeout(delay)
 			.then(() => {
 				const languages: string[] = [];
 				this._activeSessionsBySessionId.forEach(activeSession => {
-					// if lastUsed in the past 24 hours, include it
-					if (activeSession.session.lastUsed > Date.now() - 24 * 60 * 60 * 1000) {
+					// get the beginning of the day in UTC
+					const startUTC = new Date(Date.now()).setUTCHours(0, 0, 0, 0);
+					const lastUsed = activeSession.session.lastUsed;
+
+					// only update the active languages if the session was used today
+					if (lastUsed > startUTC) {
 						languages.push(activeSession.session.runtimeMetadata.languageId);
 					}
 				});

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1682,7 +1682,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	}
 
 	public updateActiveLanguages(): void {
-		const languages: string[] = [];
+		const languages = new Set<string>();
 		this._activeSessionsBySessionId.forEach(activeSession => {
 			// get the beginning of the day in UTC so that usage is the same 24-hour period across time zones
 			const startUTC = new Date(Date.now()).setUTCHours(0, 0, 0, 0);
@@ -1690,10 +1690,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 
 			// only update the active languages if the session was used today
 			if (lastUsed > startUTC && activeSession.session.getRuntimeState() !== RuntimeState.Exited) {
-				languages.push(activeSession.session.runtimeMetadata.languageId);
+				languages.add(activeSession.session.runtimeMetadata.languageId);
 			}
 		});
-		this._updateService.updateActiveLanguages(languages);
+		this._updateService.updateActiveLanguages([...languages]);
 	}
 
 }

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -443,6 +443,13 @@ export interface IRuntimeSessionService {
 	 * @returns A promise that resolves when the session has exited.
 	 */
 	shutdownNotebookSession(notebookUri: URI, exitReason: RuntimeExitReason, source: string): Promise<void>;
+
+	/**
+	 * Updates the active languages with the update service. This has to be pushed to the update
+	 * service since it is in the platform layer.z
+	 *
+	 */
+	updateActiveLanguages(): void;
 }
 
 export { RuntimeClientType };

--- a/src/vs/workbench/services/update/browser/updateService.ts
+++ b/src/vs/workbench/services/update/browser/updateService.ts
@@ -97,6 +97,12 @@ export class BrowserUpdateService extends Disposable implements IUpdateService {
 	async _applySpecificUpdate(packagePath: string): Promise<void> {
 		// noop
 	}
+
+	// --- Start Positron ---
+	updateActiveLanguages(languages: string[]): void {
+		// no-op
+	}
+	// --- End Positron ---
 }
 
 registerSingleton(IUpdateService, BrowserUpdateService, InstantiationType.Eager);


### PR DESCRIPTION
### Release Notes

Add query parameters to update check that show active language sessions that were used within a 24-hour period. An option has been added to disable this.

The update service holds which languages were used and now checks for updates every six hours instead of one. This is refreshed by the runtime session service on a one hour timer. Since the update service is at the platform layer, it cannot access the runtime session service so the data flows the other way on a schedule.

The initial language check happens 25 seconds after startup and then every six hours afterwards. The update service runs its initial check 30 seconds after startup so it will have recent usage (but likely that no usage occurs so soon after startup).

A developer action is also included to manually update the language usage for testing scenarios. It is accessible from the command palette.

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- #6388 Adds if a language session was used to the update check

#### Bug Fixes

- N/A


### QA Notes
The developer action to update the language usage may be useful in testing.

![image](https://github.com/user-attachments/assets/b5a3ee1d-ebfe-4ac7-8025-64cdc7f67827)

The Output view on the Main channel can show some debug info that may also help confirm what's happening with the language usage. Changing the log level to `Debug` will show these messages. If the language reporting is disabled, the logs will show that the update URL does not have the languages added.

The update language usage action can be used before manually initiating an update check.

![image](https://github.com/user-attachments/assets/2f70a370-d15b-4f93-b224-12bdd81eb27a)

Updating the language usage only includes runtime sessions that are not in the `Exited` state (ie. must be running). Once a runtime session has started _and_ code has run in the session, it will be added the next time the update language usage action is invoked.

If no languages have been used or no sessions have been started, the update URL will not include anything extra.

Also note that notebooks have their own session so it will contribute to this list.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
