### PR TITLE
Data Explorer: Compute summary statistics for pandas dtype=object columns having mixed types

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/connections_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/connections_comm.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 

--- a/extensions/positron-python/python_files/posit/positron/data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer.py
@@ -84,6 +84,7 @@ from .data_explorer_comm import (
     SummaryStatsDate,
     SummaryStatsDatetime,
     SummaryStatsNumber,
+    SummaryStatsOther,
     SummaryStatsString,
     SupportedFeatures,
     SupportStatus,
@@ -811,6 +812,13 @@ def _box_number_stats(min_val, max_val, mean_val, median_val, std_val):
     )
 
 
+def _box_other_stats(num_unique):
+    return ColumnSummaryStats(
+        type_display=ColumnDisplayType.Object,
+        other_stats=SummaryStatsOther(num_unique=int(num_unique)),
+    )
+
+
 def _box_string_stats(num_empty, num_unique):
     return ColumnSummaryStats(
         type_display=ColumnDisplayType.String,
@@ -1011,6 +1019,11 @@ def _pandas_summarize_string(col: pd.Series, _options: FormatOptions):
     num_empty = (col.str.len() == 0).sum()
     num_unique = col.nunique()
     return _box_string_stats(num_empty, num_unique)
+
+
+def _pandas_summarize_object(col: pd.Series, _options: FormatOptions):
+    num_unique = col.nunique()
+    return _box_other_stats(num_unique)
 
 
 def _pandas_summarize_boolean(col: pd.Series, _options: FormatOptions):
@@ -1328,8 +1341,8 @@ class PandasView(DataExplorerTableView):
             "complex64": "number",
             "complex128": "number",
             "complex256": "number",
-            "mixed-integer": "number",
-            "mixed-integer-float": "number",
+            "mixed-integer": "object",
+            "mixed-integer-float": "object",
             "mixed": "object",
             "decimal": "number",
             "complex": "number",
@@ -1688,6 +1701,7 @@ class PandasView(DataExplorerTableView):
             ColumnDisplayType.String: _pandas_summarize_string,
             ColumnDisplayType.Date: _pandas_summarize_date,
             ColumnDisplayType.Datetime: _pandas_summarize_datetime,
+            ColumnDisplayType.Object: _pandas_summarize_object,
         }
     )
 

--- a/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/data_explorer_comm.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
@@ -700,6 +700,11 @@ class ColumnSummaryStats(BaseModel):
         description="Statistics for a datetime data type",
     )
 
+    other_stats: Optional[SummaryStatsOther] = Field(
+        default=None,
+        description="Summary statistics for any other data types",
+    )
+
 
 class SummaryStatsNumber(BaseModel):
     """
@@ -743,6 +748,17 @@ class SummaryStatsBoolean(BaseModel):
 
     false_count: StrictInt = Field(
         description="The number of non-null false values",
+    )
+
+
+class SummaryStatsOther(BaseModel):
+    """
+    SummaryStatsOther in Schemas
+    """
+
+    num_unique: Optional[StrictInt] = Field(
+        default=None,
+        description="The number of unique values",
     )
 
 
@@ -1652,6 +1668,8 @@ ColumnSummaryStats.update_forward_refs()
 SummaryStatsNumber.update_forward_refs()
 
 SummaryStatsBoolean.update_forward_refs()
+
+SummaryStatsOther.update_forward_refs()
 
 SummaryStatsString.update_forward_refs()
 

--- a/extensions/positron-python/python_files/posit/positron/help_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/help_comm.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 

--- a/extensions/positron-python/python_files/posit/positron/plot_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/plot_comm.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_data_explorer.py
@@ -697,6 +697,8 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
             "datetime",
         ),
         ([None, MyData(5), MyData(-1), None, None], "mixed", "object"),
+        (["foo", 1, None, "str", False], "mixed-integer", "object"),
+        (np.array([1, 2, 3.5, None, 5], dtype=object), "mixed-integer-float", "object"),
         (
             np.array([1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, 5 + 5j], dtype="complex64"),
             "complex64",
@@ -771,7 +773,8 @@ def test_pandas_get_schema(dxf: DataExplorerFixture):
     dxf.register_table("full_schema", test_df)
     result = dxf.get_schema("full_schema", list(range(100)))
 
-    assert result == _wrap_json(ColumnSchema, full_schema)
+    for result_item, expected_item in zip(result, full_schema):
+        assert result_item == ColumnSchema(**expected_item).dict()
 
     # Test partial schema gets, boundschecking
     result = dxf.get_schema("full_schema", list(range(2, 100)))
@@ -2524,6 +2527,10 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             "f7": [1 + 1j, 2 + 2j, 3 + 3j, 4 + 4j, np.nan] * 20,  # complex,
             "f8": [np.nan, np.inf, -np.inf, 0, np.nan] * 20,  # with infinity
             "f9": [np.nan] * 100,
+            # mixed-integer
+            "f10": ["str", 1, 2, None, False] * 20,
+            # mixed-integer-float
+            "f11": np.array([1.5, 2, 2, None, 3.5] * 20, dtype=object),
         }
     )
 
@@ -2660,6 +2667,18 @@ def test_pandas_profile_summary_stats(dxf: DataExplorerFixture):
             "df1",
             9,
             {},
+        ),
+        # mixed-integer
+        (
+            "df1",
+            10,
+            {"num_unique": 4},
+        ),
+        # mixed-integer-float
+        (
+            "df1",
+            11,
+            {"num_unique": 3},
         ),
         (
             "df_mixed_tz1",

--- a/extensions/positron-python/python_files/posit/positron/ui_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/ui_comm.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 

--- a/extensions/positron-python/python_files/posit/positron/variables_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/variables_comm.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+# Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 

--- a/positron/comms/data_explorer-backend-openrpc.json
+++ b/positron/comms/data_explorer-backend-openrpc.json
@@ -37,19 +37,19 @@
 			"name": "get_schema",
 			"summary": "Request schema",
 			"description": "Request subset of column schemas for a table-like object",
-            "params": [
-                {
-                    "name": "column_indices",
-                    "description": "The column indices (relative to the filtered/selected columns) to fetch",
-                    "required": true,
-                    "schema": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
-                    }
-                }
-            ],
+			"params": [
+				{
+					"name": "column_indices",
+					"description": "The column indices (relative to the filtered/selected columns) to fetch",
+					"required": true,
+					"schema": {
+						"type": "array",
+						"items": {
+							"type": "integer"
+						}
+					}
+				}
+			],
 			"result": {
 				"schema": {
 					"$ref": "#/components/schemas/table_schema"
@@ -1014,6 +1014,10 @@
 					"datetime_stats": {
 						"description": "Statistics for a datetime data type",
 						"$ref": "#/components/schemas/summary_stats_datetime"
+					},
+					"other_stats": {
+						"description": "Summary statistics for any other data types",
+						"$ref": "#/components/schemas/summary_stats_other"
 					}
 				}
 			},
@@ -1057,6 +1061,16 @@
 					"false_count": {
 						"type": "integer",
 						"description": "The number of non-null false values"
+					}
+				}
+			},
+			"summary_stats_other": {
+				"type": "object",
+				"required": [],
+				"properties": {
+					"num_unique": {
+						"type": "integer",
+						"description": "The number of unique values"
 					}
 				}
 			},

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -433,7 +433,7 @@ function* createRustComm(name: string, frontend: any, backend: any): Generator<s
 	yield `// @generated
 
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) ${year} Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-${year} Posit Software, PBC. All rights reserved.
  *--------------------------------------------------------------------------------------------*/
 
 //
@@ -786,7 +786,7 @@ function* createPythonComm(name: string,
 	frontend: any,
 	backend: any): Generator<string> {
 	yield `#
-# Copyright (C) ${year} Posit Software, PBC. All rights reserved.
+# Copyright (C) 2024-${year} Posit Software, PBC. All rights reserved.
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
@@ -1159,7 +1159,7 @@ function* createTypescriptComm(name: string, frontend: any, backend: any): Gener
 	const metadata: CommMetadata = JSON.parse(
 		readFileSync(path.join(commsDir, `${name}.json`), { encoding: 'utf-8' }));
 	yield `/*---------------------------------------------------------------------------------------------
- *  Copyright (C) ${year} Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-${year} Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/services/languageRuntime/common/positronConnectionsComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronConnectionsComm.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronDataExplorerComm.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -559,6 +559,11 @@ export interface ColumnSummaryStats {
 	 */
 	datetime_stats?: SummaryStatsDatetime;
 
+	/**
+	 * Summary statistics for any other data types
+	 */
+	other_stats?: SummaryStatsOther;
+
 }
 
 /**
@@ -605,6 +610,17 @@ export interface SummaryStatsBoolean {
 	 * The number of non-null false values
 	 */
 	false_count: number;
+
+}
+
+/**
+ * SummaryStatsOther in Schemas
+ */
+export interface SummaryStatsOther {
+	/**
+	 * The number of unique values
+	 */
+	num_unique?: number;
 
 }
 

--- a/src/vs/workbench/services/languageRuntime/common/positronHelpComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronHelpComm.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotComm.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronVariablesComm.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileObject.css
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileObject.css
@@ -1,0 +1,4 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileObject.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnProfileObject.tsx
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './columnProfileObject.css';
+
+// React.
+import React from 'react';
+
+// Other dependencies.
+import { StatsValue } from './statsValue.js';
+import { positronMissing, positronUnique } from '../../common/constants.js';
+import { TableSummaryDataGridInstance } from '../tableSummaryDataGridInstance.js';
+import { ColumnProfileNullCountValue } from './columnProfileNullCountValue.js';
+
+/**
+ * Constants.
+ */
+export const COLUMN_PROFILE_OBJECT_LINE_COUNT = 3;
+
+/**
+ * ColumnProfileObjectProps interface.
+ */
+interface ColumnProfileObjectProps {
+	instance: TableSummaryDataGridInstance;
+	columnIndex: number;
+}
+
+/**
+ * ColumnProfileObject component.
+ * @param props A ColumnProfileObjectProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const ColumnProfileObject = (props: ColumnProfileObjectProps) => {
+	// Render.
+	const stats = props.instance.getColumnProfileSummaryStats(props.columnIndex)?.other_stats;
+	return (
+		<div className='column-profile-info'>
+			<div className='tabular-info'>
+				<div className='labels'>
+					<div className='label'>{positronMissing}</div>
+					<div className='label'>{positronUnique}</div>
+				</div>
+				<div className='values'>
+					<ColumnProfileNullCountValue {...props} />
+					<StatsValue stats={stats} value={stats?.num_unique} />
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/components/columnSummaryCell.tsx
@@ -17,6 +17,7 @@ import { usePositronDataGridContext } from '../../../../browser/positronDataGrid
 import { VectorHistogram } from './vectorHistogram.js';
 import { ColumnProfileDate } from './columnProfileDate.js';
 import { ColumnProfileNumber } from './columnProfileNumber.js';
+import { ColumnProfileObject } from './columnProfileObject.js';
 import { ColumnProfileString } from './columnProfileString.js';
 import { VectorFrequencyTable } from './vectorFrequencyTable.js';
 import { ColumnProfileBoolean } from './columnProfileBoolean.js';
@@ -261,9 +262,12 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 			case ColumnDisplayType.Datetime:
 				return <ColumnProfileDatetime columnIndex={props.columnIndex} instance={props.instance} />;
 
+			// Object (pandas columns of dtype=object that are not uniformly typed).
+			case ColumnDisplayType.Object:
+				return <ColumnProfileObject columnIndex={props.columnIndex} instance={props.instance} />;
+
 			// Column display types that do not render a profile.
 			case ColumnDisplayType.Time:
-			case ColumnDisplayType.Object:
 			case ColumnDisplayType.Array:
 			case ColumnDisplayType.Struct:
 			case ColumnDisplayType.Unknown:
@@ -338,11 +342,10 @@ export const ColumnSummaryCell = (props: ColumnSummaryCellProps) => {
 		case ColumnDisplayType.String:
 		case ColumnDisplayType.Date:
 		case ColumnDisplayType.Datetime:
+		case ColumnDisplayType.Object:
 			summaryStatsSupported = isSummaryStatsSupported();
 			break;
-
 		case ColumnDisplayType.Time:
-		case ColumnDisplayType.Object:
 		case ColumnDisplayType.Array:
 		case ColumnDisplayType.Struct:
 		case ColumnDisplayType.Unknown:

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -17,6 +17,7 @@ import { BackendState, ColumnDisplayType } from '../../languageRuntime/common/po
 import { DataExplorerClientInstance } from '../../languageRuntime/common/languageRuntimeDataExplorerClient.js';
 import { COLUMN_PROFILE_DATE_LINE_COUNT } from './components/columnProfileDate.js';
 import { COLUMN_PROFILE_NUMBER_LINE_COUNT } from './components/columnProfileNumber.js';
+import { COLUMN_PROFILE_OBJECT_LINE_COUNT } from './components/columnProfileObject.js';
 import { COLUMN_PROFILE_STRING_LINE_COUNT } from './components/columnProfileString.js';
 import { COLUMN_PROFILE_BOOLEAN_LINE_COUNT } from './components/columnProfileBoolean.js';
 import { COLUMN_PROFILE_DATE_TIME_LINE_COUNT } from './components/columnProfileDatetime.js';
@@ -427,9 +428,13 @@ export class TableSummaryDataGridInstance extends DataGridInstance {
 				return rowHeight(false, COLUMN_PROFILE_DATE_TIME_LINE_COUNT);
 			}
 
+			// Object.
+			case ColumnDisplayType.Object: {
+				return rowHeight(true, COLUMN_PROFILE_OBJECT_LINE_COUNT);
+			}
+
 			// Column display types that do not render a profile.
 			case ColumnDisplayType.Time:
-			case ColumnDisplayType.Object:
 			case ColumnDisplayType.Array:
 			case ColumnDisplayType.Struct:
 			case ColumnDisplayType.Unknown: {


### PR DESCRIPTION
Addresses #3401. Currently, only the number of nulls and number of unique values are own through an "other_stats" object that can capture statistics we want to pass outside of the other types we support in the summary pane. 

There is no sparkline for now, but we could experiment with a frequency table in follow up work. On account of there being no sparkline, there is a bunch of wasted space in the expanded profile:

![Screenshot From 2025-02-18 16-56-53](https://github.com/user-attachments/assets/e851493d-a7f4-4de0-9675-c2ec7c4807c9)

@:data-explorer

### Release Notes

#### New Features

- Show summary statistics in Data Explorer for pandas columns with mixed data types (#3401).

#### Bug Fixes

- N/A


### QA Notes

Here's an example data frame having data like this:

```
df = pd.DataFrame({'mixed': ['foo', 1, None, 'str', False],
                   'mixedf': np.array([1.5, 2, 2, None, 3.5], dtype=object),})
``