### PR TITLE
Don't uninstall bundled packages

### DIFF
--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -10,7 +10,6 @@
 import * as positron from 'positron';
 import * as vscode from 'vscode';
 import PQueue from 'p-queue';
-import path from 'path';
 import * as fs from '../common/platform/fs-paths';
 import { ProductNames } from '../common/installer/productNames';
 import { InstallOptions, ModuleInstallFlags } from '../common/installer/types';

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -185,7 +185,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         // A bundled package is being uninstalled.
         // Emit a messaging explaining why the uninstall is not allowed.
         const protectedPackagesStr = protectedPackages
-            .map(({ parent, name }) => `- ${name} (from ${parent})`)
+            .map(({ parent, name }) => vscode.l10n.t('- {0} (from {1})', name, parent))
             .join('\n');
         this._messageEmitter.fire({
             id: `${id}-0`,

--- a/extensions/positron-python/src/test/mocks/pst/index.ts
+++ b/extensions/positron-python/src/test/mocks/pst/index.ts
@@ -1,10 +1,49 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
+
+// Types copied from positron.d.ts for use in the positron-python unit test environment.
 
 export enum LanguageRuntimeSessionMode {
     Console = 'console',
     Notebook = 'notebook',
     Background = 'background',
+}
+
+export enum RuntimeCodeExecutionMode {
+    Interactive = 'interactive',
+    Transient = 'transient',
+    Silent = 'silent',
+}
+
+export enum RuntimeErrorBehavior {
+    Stop = 'stop',
+    Continue = 'continue',
+}
+
+export enum LanguageRuntimeMessageType {
+    ClearOutput = 'clear_output',
+    Output = 'output',
+    Result = 'result',
+    Stream = 'stream',
+    Input = 'input',
+    Error = 'error',
+    Prompt = 'prompt',
+    State = 'state',
+    Event = 'event',
+    CommOpen = 'comm_open',
+    CommData = 'comm_data',
+    CommClosed = 'comm_closed',
+    IPyWidget = 'ipywidget',
+}
+
+export enum LanguageRuntimeStreamName {
+    Stdout = 'stdout',
+    Stderr = 'stderr',
+}
+
+export enum RuntimeOnlineState {
+    Idle = 'idle',
+    Busy = 'busy',
 }

--- a/extensions/positron-python/src/test/positron/session.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/session.unit.test.ts
@@ -40,6 +40,7 @@ import { mock } from './utils';
 import { EXTENSION_ROOT_DIR } from '../../client/constants';
 
 suite('Python Runtime Session', () => {
+    let disposables: vscode.Disposable[];
     let applicationShell: IApplicationShell;
     let runtimeMetadata: positron.LanguageRuntimeMetadata;
     let installerSpy: sinon.SinonSpiedInstance<IInstaller>;
@@ -50,10 +51,13 @@ suite('Python Runtime Session', () => {
     let interpreter: PythonEnvironment;
     let serviceContainer: IServiceContainer;
     let kernelSpec: JupyterKernelSpec;
+    let kernel: JupyterLanguageRuntimeSession;
     let consoleSession: positron.LanguageRuntimeSession;
     let notebookSession: positron.LanguageRuntimeSession;
 
     setup(() => {
+        disposables = [];
+
         applicationShell = mock<IApplicationShell>({
             showErrorMessage: () => Promise.resolve(undefined),
         });
@@ -153,13 +157,12 @@ suite('Python Runtime Session', () => {
 
         kernelSpec = mock<JupyterKernelSpec>({ env: {} });
 
-        const kernel = mock<JupyterLanguageRuntimeSession>({
+        kernel = mock<JupyterLanguageRuntimeSession>({
+            execute: () => { },
             onDidChangeRuntimeState: () => ({ dispose() {} }),
             onDidReceiveRuntimeMessage: () => ({ dispose() {} }),
             onDidEndSession: () => ({ dispose() {} }),
-            start() {
-                return Promise.resolve({} as positron.LanguageRuntimeInfo);
-            },
+            start: () => Promise.resolve({} as positron.LanguageRuntimeInfo,
         });
 
         const adapterApi = mock<PositronSupervisorApi>({
@@ -199,6 +202,7 @@ suite('Python Runtime Session', () => {
     });
 
     teardown(() => {
+        disposables.forEach((disposable) => disposable.dispose());
         sinon.restore();
     });
 
@@ -303,5 +307,38 @@ suite('Python Runtime Session', () => {
 
         // Should try to use ipykernel from the environment.
         sinon.assert.called(installerSpy.isProductVersionCompatible);
+    });
+
+    test('Execute: dont uninstall bundled packages', async () => {
+        // Start a console session.
+        await consoleSession.start();
+
+        // Spy on the kernel execute method.
+        const executeSpy = sinon.spy(kernel, 'execute');
+
+        // Record emitted runtime messages.
+        const messages: positron.LanguageRuntimeMessage[] = [];
+        disposables.push(consoleSession.onDidReceiveRuntimeMessage(message => messages.push(message)));
+
+        // Execute a command that tries to uninstall a bundled package.
+        const id = 'execute-id';
+        consoleSession.execute(
+            'pip uninstall ipykernel',
+            id,
+            positron.RuntimeCodeExecutionMode.Interactive,
+            positron.RuntimeErrorBehavior.Stop,
+        );
+
+        // Should not execute the command.
+        sinon.assert.notCalled(executeSpy);
+
+        // Should display a message and end the execution (via state: idle).
+        assert.strictEqual(messages.length, 2);
+        assert.strictEqual(messages[0].type, positron.LanguageRuntimeMessageType.Stream);
+        const stream = messages[0] as positron.LanguageRuntimeStream;
+        assert.ok(stream.text.startsWith('Cannot uninstall'));
+        assert.strictEqual(messages[1].type, positron.LanguageRuntimeMessageType.State);
+        const state = messages[1] as positron.LanguageRuntimeState;
+        assert.strictEqual(state.state, positron.RuntimeOnlineState.Idle);
     });
 });

--- a/extensions/positron-python/src/test/positron/session.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/session.unit.test.ts
@@ -158,11 +158,11 @@ suite('Python Runtime Session', () => {
         kernelSpec = mock<JupyterKernelSpec>({ env: {} });
 
         kernel = mock<JupyterLanguageRuntimeSession>({
-            execute: () => { },
+            execute: () => {},
             onDidChangeRuntimeState: () => ({ dispose() {} }),
             onDidReceiveRuntimeMessage: () => ({ dispose() {} }),
             onDidEndSession: () => ({ dispose() {} }),
-            start: () => Promise.resolve({} as positron.LanguageRuntimeInfo,
+            start: () => Promise.resolve({} as positron.LanguageRuntimeInfo),
         });
 
         const adapterApi = mock<PositronSupervisorApi>({
@@ -318,7 +318,7 @@ suite('Python Runtime Session', () => {
 
         // Record emitted runtime messages.
         const messages: positron.LanguageRuntimeMessage[] = [];
-        disposables.push(consoleSession.onDidReceiveRuntimeMessage(message => messages.push(message)));
+        disposables.push(consoleSession.onDidReceiveRuntimeMessage((message) => messages.push(message)));
 
         // Execute a command that tries to uninstall a bundled package.
         const id = 'execute-id';

--- a/extensions/positron-python/src/test/vscode-mock.ts
+++ b/extensions/positron-python/src/test/vscode-mock.ts
@@ -170,4 +170,9 @@ mockedVSCode.LogLevel = vscodeMocks.LogLevel;
 mockedVSCode.TestRunProfileKind = vscodeMocks.TestRunProfileKind;
 // --- Start Positron ---
 mockedPositron.LanguageRuntimeSessionMode = positronMocks.LanguageRuntimeSessionMode;
+mockedPositron.RuntimeCodeExecutionMode = positronMocks.RuntimeCodeExecutionMode;
+mockedPositron.RuntimeErrorBehavior = positronMocks.RuntimeErrorBehavior;
+mockedPositron.LanguageRuntimeMessageType = positronMocks.LanguageRuntimeMessageType;
+mockedPositron.LanguageRuntimeStreamName = positronMocks.LanguageRuntimeStreamName;
+mockedPositron.RuntimeOnlineState = positronMocks.RuntimeOnlineState;
 // --- End Positron ---


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6385 where a user could uninstall a bundled package and break Positron's Python functionality.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Try to uninstall `ipykernel` (or any of the other bundled dependencies) from the console from different environment types.