### PR TITLE
Enable Multiple Console Sessions Feature Flag for Web

### DIFF
--- a/src/vs/workbench/services/runtimeSession/common/positronMultipleConsoleSessionsFeatureFlag.ts
+++ b/src/vs/workbench/services/runtimeSession/common/positronMultipleConsoleSessionsFeatureFlag.ts
@@ -5,7 +5,7 @@
 
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { ConfigurationScope, Extensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { Extensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { positronConfigurationNodeBase } from '../../languageRuntime/common/languageRuntime.js';
 
@@ -33,7 +33,6 @@ const configurationRegistry = Registry.as<IConfigurationRegistry>(
 );
 configurationRegistry.registerConfiguration({
 	...positronConfigurationNodeBase,
-	scope: ConfigurationScope.MACHINE_OVERRIDABLE,
 	properties: {
 		[USE_POSITRON_MULTIPLE_CONSOLE_SESSIONS_CONFIG_KEY]: {
 			type: 'boolean',

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -270,9 +270,15 @@ export class Console {
 	}
 
 	async clickConsoleTab() {
-		await this.code.driver.page.locator('.basepanel').getByRole('tab', { name: 'Console', exact: true }).locator('a').click();
-		// Move mouse to prevent tooltip hover
-		await this.code.driver.page.mouse.move(0, 0);
+		// sometimes the click doesn't seem to work, so adding a retry
+		await expect(async () => {
+			await this.code.driver.page.locator('.basepanel').getByRole('tab', { name: 'Console', exact: true }).locator('a').click();
+			// Move mouse to prevent tooltip hover
+			await this.code.driver.page.mouse.move(0, 0);
+			await expect(this.code.driver.page.getByRole('tab', { name: 'Console', exact: true })).toHaveClass('action-item checked');
+
+
+		}).toPass();
 	}
 
 	async interruptExecution() {
@@ -360,7 +366,8 @@ class Session {
 			// Todo: https://github.com/posit-dev/positron/issues/6389
 			// Todo: remove when menu closes on click as expected
 			await this.page.keyboard.press('Escape');
-			await this.page.keyboard.press(process.platform === 'darwin' ? 'Meta+ArrowUp' : 'Control+Home');
+			await expect(this.page.getByRole('tab', { name: 'Output' })).toHaveClass('action-item checked');
+			await this.page.keyboard.press(process.platform === 'darwin' ? 'Meta+ArrowUp' : 'Home');
 			await expect(this.page.getByText(`Begin kernel log for session ${data.language} ${data.version}`)).toBeVisible();
 
 			// Todo: https://github.com/posit-dev/positron/issues/6149
@@ -441,7 +448,7 @@ class Session {
 	async ensureStartedAndIdle(session: SessionDetails): Promise<void> {
 		await test.step(`Ensure ${session.language} ${session.version} session is started and idle`, async () => {
 			// Start Session if it does not exist
-			const sessionExists = await this.getSessionLocator(session).isVisible();
+			const sessionExists = await this.getSessionLocator(session).isVisible({ timeout: 30000 });
 			if (!sessionExists) {
 				await this.console.selectInterpreter(session.language === 'Python' ? InterpreterType.Python : InterpreterType.R, session.version);
 			}

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -276,8 +276,6 @@ export class Console {
 			// Move mouse to prevent tooltip hover
 			await this.code.driver.page.mouse.move(0, 0);
 			await expect(this.code.driver.page.getByRole('tab', { name: 'Console', exact: true })).toHaveClass('action-item checked');
-
-
 		}).toPass();
 	}
 

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -367,7 +367,7 @@ class Session {
 			// Todo: remove when menu closes on click as expected
 			await this.page.keyboard.press('Escape');
 			await expect(this.page.getByRole('tab', { name: 'Output' })).toHaveClass('action-item checked');
-			await this.page.keyboard.press(process.platform === 'darwin' ? 'Meta+ArrowUp' : 'Home');
+			await this.page.keyboard.press('Home');
 			await expect(this.page.getByText(`Begin kernel log for session ${data.language} ${data.version}`)).toBeVisible();
 
 			// Todo: https://github.com/posit-dev/positron/issues/6149

--- a/test/e2e/tests/console/console-sessions.test.ts
+++ b/test/e2e/tests/console/console-sessions.test.ts
@@ -20,7 +20,7 @@ test.use({
 });
 
 test.describe('Console: Sessions', {
-	tag: [tags.WIN, tags.CONSOLE, tags.SESSIONS]
+	tag: [tags.WIN, tags.WEB, tags.CONSOLE, tags.SESSIONS]
 }, () => {
 
 	test.beforeAll(async function ({ userSettings }) {


### PR DESCRIPTION
### Release Notes
Addresses #6401 

The configuration scope for `console.multipleConsoleSessions` was set to `MACHINE_OVERRIDABLE` which prevented enabling the feature flag as a user setting in the Web build of Positron. 

We do not require this scope so it has been removed and allows the feature flag to be enabled which unblcosk CI testing for this new feature!

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes
@:sessions @:web @:win

