### PR TITLE
E2E test: ensure mikhail-arkhipov.r cannot be installed

### DIFF
--- a/src/vs/workbench/services/dialogs/common/dialogService.ts
+++ b/src/vs/workbench/services/dialogs/common/dialogService.ts
@@ -33,7 +33,9 @@ export class DialogService extends Disposable implements IDialogService {
 			return true; // integration tests
 		}
 
-		return !!this.environmentService.enableSmokeTestDriver; // smoke tests
+		// --- Start Positron ---
+		return false;
+		// --- End Positron ---
 	}
 
 	async confirm(confirmation: IConfirmation): Promise<IConfirmationResult> {

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -26,6 +26,7 @@ export enum TestTags {
 	DEBUG = '@:debug',
 	DUCK_DB = '@:duck-db',
 	EDITOR_ACTION_BAR = '@:editor-action-bar',
+	EXTENSIONS = '@:extensions',
 	HELP = '@:help',
 	HTML = '@:html',
 	INTERPRETER = '@:interpreter',

--- a/test/e2e/pages/extensions.ts
+++ b/test/e2e/pages/extensions.ts
@@ -39,14 +39,16 @@ export class Extensions {
 		}
 	}
 
-	async installExtension(id: string, waitUntilEnabled: boolean): Promise<void> {
+	async installExtension(id: string, waitUntilEnabled: boolean, attemptInstallOnly: boolean = false): Promise<void> {
 		await this.searchForExtension(id);
 		const locator = this.code.driver.page.locator(`div.extensions-viewlet[id="workbench.view.extensions"] .monaco-list-row[data-extension-id="${id}"] .extension-list-item .monaco-action-bar .action-item:not(.disabled) .extension-action.install`).first();
 		await expect(locator).toBeVisible();
 		await locator.click();
-		await expect(this.code.driver.page.locator(`.extension-editor .monaco-action-bar .action-item:not(.disabled) .extension-action.uninstall`).first()).toBeVisible();
-		if (waitUntilEnabled) {
-			await expect(this.code.driver.page.locator(`.extension-editor .monaco-action-bar .action-item:not(.disabled) a[aria-label="Disable this extension"]`)).toBeVisible();
+		if (!attemptInstallOnly) {
+			await expect(this.code.driver.page.locator(`.extension-editor .monaco-action-bar .action-item:not(.disabled) .extension-action.uninstall`).first()).toBeVisible();
+			if (waitUntilEnabled) {
+				await expect(this.code.driver.page.locator(`.extension-editor .monaco-action-bar .action-item:not(.disabled) a[aria-label="Disable this extension"]`)).toBeVisible();
+			}
 		}
 	}
 

--- a/test/e2e/tests/extensions/blocked-installs.test.ts
+++ b/test/e2e/tests/extensions/blocked-installs.test.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from '@playwright/test';
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+
+test.describe('Extensions', {
+	tag: [tags.EXTENSIONS, tags.WEB],
+}, () => {
+
+	test('Verify block of R extension installation', {
+		tag: [tags.WEB_ONLY]
+	}, async function ({ app }) {
+
+		await app.workbench.extensions.installExtension('mikhail-arkhipov.r', false, true);
+
+		expect(app.code.driver.page.getByText('Cannot install the \'R Tools\' extension')).toBeVisible();
+
+	});
+});
+


### PR DESCRIPTION
Ensure mikhail-arkhipov.r cannot be installed as it conflicts with Positron.

### QA Notes

All tests pass

@:web @:extensions
