### PR TITLE
E2E test: don't allow blocked dialogs for extensions blocking test

### DIFF
--- a/src/vs/workbench/services/dialogs/common/dialogService.ts
+++ b/src/vs/workbench/services/dialogs/common/dialogService.ts
@@ -33,9 +33,7 @@ export class DialogService extends Disposable implements IDialogService {
 			return true; // integration tests
 		}
 
-		// --- Start Positron ---
-		return false;
-		// --- End Positron ---
+		return !!this.environmentService.enableSmokeTestDriver; // smoke tests
 	}
 
 	async confirm(confirmation: IConfirmation): Promise<IConfirmationResult> {

--- a/test/e2e/tests/extensions/blocked-installs.test.ts
+++ b/test/e2e/tests/extensions/blocked-installs.test.ts
@@ -21,7 +21,7 @@ test.describe('Extensions', {
 
 		await app.workbench.extensions.installExtension('mikhail-arkhipov.r', false, true);
 
-		expect(app.code.driver.page.getByText('Cannot install the \'R Tools\' extension')).toBeVisible();
+		await expect(app.code.driver.page.getByLabel('DialogService: refused to show dialog in tests. Contents: Cannot install the \'R Tools\' extension because it conflicts with Positron built-in features').first()).toBeVisible();
 
 	});
 });


### PR DESCRIPTION
It previously seemed feasible to allow blocked dialogs for the sake of testing, but that turned out to be a bad assumption because unexpected dialogs started popping up in tests.

This small fix restores the dialog blocking and changes the test that was relying on the blocked dialog. 

### QA Notes

@:extensions @:connections @:web @:win
