### PR TITLE
Fix bug where uninstalling a bundled Python package twice worked

### DIFF
--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -40,7 +40,7 @@ import { Console } from '../common/utils/localize';
 import { getIpykernelBundle, IPykernelBundle } from './ipykernel';
 
 /** Regex for commands to uninstall packages using supported Python package managers. */
-const _uninstallCommandRegex = /(pip|pipenv|conda).*uninstall|poetry.*remove/g;
+const _uninstallCommandRegex = /(pip|pipenv|conda).*uninstall|poetry.*remove/;
 
 /**
  * A Positron language runtime that wraps a Jupyter kernel and a Language Server


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/6385.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Running `pip uninstall ipykernel` any number of times should not work.