### PR TITLE
E2E test: disable currents reporting for PRs

### DIFF
--- a/.github/workflows/test-e2e-linux.yml
+++ b/.github/workflows/test-e2e-linux.yml
@@ -33,6 +33,11 @@ on:
         description: "Whether or not to report results to TestRail."
         default: false
         type: boolean
+      enable_currents_reporter:
+        required: false
+        description: "Whether or not to report results to Currents."
+        type: boolean
+        default: true
 
   workflow_dispatch:
     inputs:
@@ -142,6 +147,7 @@ jobs:
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/linux' }}
+          ENABLE_CURRENTS_REPORTER: ${{ inputs.enable_currents_reporter }}
         run: |
           if [ "${{ inputs.project }}" == "e2e-electron" ]; then
             DISPLAY=:10 npx playwright test --project ${{ inputs.project }} --workers 2 --grep "${{ env.PW_TAGS }}" --grep-invert @:web-only --repeat-each ${{ inputs.repeat_each }} --max-failures 10

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -23,10 +23,15 @@ on:
         default: ""
         type: string
       report_testrail:
-          required: false
-          description: "Whether or not to report results to TestRail."
-          default: false
-          type: boolean
+        required: false
+        description: "Whether or not to report results to TestRail."
+        default: false
+        type: boolean
+      enable_currents_reporter:
+        required: false
+        description: "Whether or not to report results to Currents."
+        type: boolean
+        default: true
 
   workflow_dispatch:
     inputs:
@@ -180,6 +185,7 @@ jobs:
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }} # only works on push events
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/win'}}
+          ENABLE_CURRENTS_REPORTER: ${{ inputs.enable_currents_reporter }}
         if: ${{ !cancelled() }}
         run: npx playwright test --project "e2e-windows" --grep "${{ env.PW_TAGS }}" --workers 2 --repeat-each ${{ inputs.repeat_each }} --max-failures 10
 

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -38,6 +38,7 @@ jobs:
       display_name: "electron (linux)"
       currents_tags: "pull-request,electron/linux,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
+      enable_currents_reporter: false
     secrets: inherit
 
   e2e-windows-electron:
@@ -50,6 +51,7 @@ jobs:
       display_name: "electron (windows)"
       currents_tags: "pull-request,electron/windows,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
+      enable_currents_reporter: false
     secrets: inherit
 
   e2e-linux-browser:
@@ -63,6 +65,7 @@ jobs:
       project: "e2e-browser"
       currents_tags: "pull-request,browser/linux,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
+      enable_currents_reporter: false
     secrets: inherit
 
   unit-tests:

--- a/build/secrets/.secrets.baseline
+++ b/build/secrets/.secrets.baseline
@@ -159,7 +159,7 @@
         "filename": ".github/workflows/test-pull-request.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 41,
+        "line_number": 42,
         "is_secret": false
       }
     ],
@@ -1940,5 +1940,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-27T19:50:17Z"
+  "generated_at": "2025-02-21T16:51:27Z"
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,12 +42,14 @@ export default defineConfig<CustomTestOptions>({
 			}],
 			['junit', { outputFile: 'test-results/junit.xml' }],
 			['list'], ['html'], ['blob'],
-			currentsReporter({
-				ciBuildId: process.env.CURRENTS_CI_BUILD_ID || Date.now().toString(),
-				recordKey: process.env.CURRENTS_RECORD_KEY || '',
-				projectId: 'ZOs5z2',
-				disableTitleTags: true,
-			}),
+			...(process.env.ENABLE_CURRENTS_REPORTER !== 'false'
+				? [currentsReporter({
+					ciBuildId: process.env.CURRENTS_CI_BUILD_ID || Date.now().toString(),
+					recordKey: process.env.CURRENTS_RECORD_KEY || '',
+					projectId: 'ZOs5z2',
+					disableTitleTags: true,
+				})]
+				: [])
 		]
 		: [
 			['list'],


### PR DESCRIPTION
Our usage of currents.dev has been trending too high for what we planned to pay (pricing is a function of tests reported).  Therefore, we are going to stop reporting to currents.dev for PR runs.

### QA Notes

PR runs should not be reported to currents.

@:web @:win
