### PR TITLE
e2e-test: add more session tests (output channels, busy when executing)

### DIFF
--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -441,6 +441,21 @@ class Session {
 	}
 
 	/**
+	 * Action: click Metadata menu button
+	 * @param menuItem the menu item to click on the metadata dialog
+	 */
+	async clickMetadataMenuItem(menuItem: 'Show Kernel Output Channel' | 'Show Console Output Channel' | 'Show LSP Output Channel') {
+		await this.console.clickConsoleTab();
+		await this.metadataButton.click();
+		await this.metadataDialog.getByText(menuItem).click();
+
+		await expect(this.page.getByRole('tab', { name: 'Output' })).toHaveClass('action-item checked');
+		// Todo: https://github.com/posit-dev/positron/issues/6389
+		// Todo: remove when menu closes on click as expected
+		await this.page.keyboard.press('Escape');
+	}
+
+	/**
 	 * Verify: Check the metadata of the session dialog
 	 * @param data the expected metadata to verify
 	 */
@@ -458,19 +473,19 @@ class Session {
 			await expect(this.metadataDialog.getByText(`State: ${data.state}`)).toBeVisible();
 			await expect(this.metadataDialog.getByText(/^Path: [\/~a-zA-Z0-9.]+/)).toBeVisible();
 			await expect(this.metadataDialog.getByText(/^Source: (Pyenv|System)$/)).toBeVisible();
+			await this.page.keyboard.press('Escape');
+
+			// Verify Language Console
+			await this.clickMetadataMenuItem('Show Console Output Channel');
+			await expect(this.page.getByRole('combobox')).toHaveValue(new RegExp(`^${data.language} ${data.version}.*: Console$`));
 
 			// Verify Output Channel
-			await this.page.getByRole('button', { name: 'Show Kernel Output Channel' }).click();
-			// Todo: https://github.com/posit-dev/positron/issues/6389
-			// Todo: remove when menu closes on click as expected
-			await this.page.keyboard.press('Escape');
-			await expect(this.page.getByRole('tab', { name: 'Output' })).toHaveClass('action-item checked');
-			await this.page.keyboard.press('Home');
-			await expect(this.page.getByText(`Begin kernel log for session ${data.language} ${data.version}`)).toBeVisible();
+			await this.clickMetadataMenuItem('Show Kernel Output Channel');
+			await expect(this.page.getByRole('combobox')).toHaveValue(new RegExp(`^${data.language} ${data.version}.*: Kernel$`));
 
-			// Todo: https://github.com/posit-dev/positron/issues/6149
-			// Todo: Verify Language Pack when implemented
-			// Todo: Verify Language Console when implemented
+			// Verify LSP Output Channel
+			await this.clickMetadataMenuItem('Show LSP Output Channel');
+			await expect(this.page.getByRole('combobox')).toHaveValue(/Language Server \(Console\)$/);
 
 			// Go back to console when done
 			await this.console.clickConsoleTab();

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -441,7 +441,7 @@ class Session {
 	}
 
 	/**
-	 * Action: click Metadata menu button
+	 * Action: Open the metadata dialog and select the desired menu item
 	 * @param menuItem the menu item to click on the metadata dialog
 	 */
 	async clickMetadataMenuItem(menuItem: 'Show Kernel Output Channel' | 'Show Console Output Channel' | 'Show LSP Output Channel') {

--- a/test/e2e/tests/console/console-sessions.test.ts
+++ b/test/e2e/tests/console/console-sessions.test.ts
@@ -94,8 +94,7 @@ test.describe('Console: Sessions', {
 
 	test('Validate metadata between sessions', {
 		annotation: [
-			{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6389' },
-			{ type: 'waiting on feature', description: 'https://github.com/posit-dev/positron/issues/6149' }]
+			{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6389' }]
 	}, async function ({ app }) {
 		const console = app.workbench.console;
 

--- a/test/e2e/tests/console/console-sessions.test.ts
+++ b/test/e2e/tests/console/console-sessions.test.ts
@@ -78,14 +78,14 @@ test.describe('Console: Sessions', {
 		await console.session.ensureStartedAndIdle(pythonSession);
 		await console.session.ensureStartedAndIdle(rSession);
 
-		// Execute code in Python session
+		// Verify Python session transitions to active when executing code
 		await console.session.select(pythonSession);
 		await console.typeToConsole('import time', true);
 		await console.typeToConsole('time.sleep(1)', true);
 		await console.session.checkStatus(pythonSession, 'active');
 		await console.session.checkStatus(pythonSession, 'idle');
 
-		// Execute code in R session
+		// Verify R session transitions to active when executing code
 		await console.session.select(rSession);
 		await console.typeToConsole('Sys.sleep(1)', true);
 		await console.session.checkStatus(rSession, 'active');

--- a/test/e2e/tests/console/console-sessions.test.ts
+++ b/test/e2e/tests/console/console-sessions.test.ts
@@ -71,6 +71,27 @@ test.describe('Console: Sessions', {
 		await console.session.checkStatus(pythonSession, 'disconnected');
 	});
 
+	test('Validate session state displays as active when executing code', async function ({ app }) {
+		const console = app.workbench.console;
+
+		// Ensure sessions exist and are idle
+		await console.session.ensureStartedAndIdle(pythonSession);
+		await console.session.ensureStartedAndIdle(rSession);
+
+		// Execute code in Python session
+		await console.session.select(pythonSession);
+		await console.typeToConsole('import time', true);
+		await console.typeToConsole('time.sleep(1)', true);
+		await console.session.checkStatus(pythonSession, 'active');
+		await console.session.checkStatus(pythonSession, 'idle');
+
+		// Execute code in R session
+		await console.session.select(rSession);
+		await console.typeToConsole('Sys.sleep(1)', true);
+		await console.session.checkStatus(rSession, 'active');
+		await console.session.checkStatus(pythonSession, 'idle');
+	});
+
 	test('Validate metadata between sessions', {
 		annotation: [
 			{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6389' },

--- a/test/e2e/tests/console/console-sessions.test.ts
+++ b/test/e2e/tests/console/console-sessions.test.ts
@@ -89,7 +89,7 @@ test.describe('Console: Sessions', {
 		await console.session.select(rSession);
 		await console.typeToConsole('Sys.sleep(1)', true);
 		await console.session.checkStatus(rSession, 'active');
-		await console.session.checkStatus(pythonSession, 'idle');
+		await console.session.checkStatus(rSession, 'idle');
 	});
 
 	test('Validate metadata between sessions', {


### PR DESCRIPTION
### Summary
Add test coverage for:
* New Output Channel links in Metadata menu
  * https://github.com/posit-dev/positron/issues/6149
  * https://github.com/posit-dev/positron/pull/6299
* Ensure session displays as active when running code
  * https://github.com/posit-dev/positron/issues/6160

### QA Notes

@:sessions