### PR TITLE
python: filter versions less than 3.8 from interpreter dropdown

### DIFF
--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -56,6 +56,8 @@ import { IPythonRuntimeManager } from '../../../../positron/manager';
 import { showErrorMessage } from '../../../../common/vscodeApis/windowApis';
 import { traceError } from '../../../../logging';
 import { shouldIncludeInterpreter } from '../../../../positron/interpreterSettings';
+// eslint-disable-next-line import/no-duplicates
+import { MINIMUM_PYTHON_VERSION } from '../../../../common/constants';
 // --- End Positron ---
 import { untildify } from '../../../../common/helpers';
 import { useEnvExtension } from '../../../../envExt/api.internal';
@@ -737,6 +739,14 @@ function getGroup(item: IInterpreterQuickPickItem, workspacePath?: string) {
  * @returns A new filter function that includes the original filter function and the additional filtering logic
  */
 function filterWrapper(filter: ((i: PythonEnvironment) => boolean) | undefined) {
-    return (i: PythonEnvironment) => (filter ? filter(i) : true) && shouldIncludeInterpreter(i.path);
+    return (i: PythonEnvironment) => {
+        const version = i.version?.major ?? 0;
+        return (
+            (filter ? filter(i) : true) &&
+            shouldIncludeInterpreter(i.path) &&
+            version >= MINIMUM_PYTHON_VERSION.major &&
+            (i.version?.minor ?? 0) >= MINIMUM_PYTHON_VERSION.minor
+        );
+    };
 }
 // --- End Positron ---

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -1,5 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+// --- Start Positron ---
+// Disable eslint rules for our import block below. This appears at the top of the file to stop
+// auto-formatting tools from reordering the imports.
+/* eslint-disable import/no-duplicates */
+// --- End Positron ---
 
 'use strict';
 
@@ -50,13 +55,11 @@ import { BaseInterpreterSelectorCommand } from './base';
 // --- Start Positron ---
 // eslint-disable-next-line import/order
 import * as fs from 'fs-extra';
-// eslint-disable-next-line import/no-duplicates
 import { CreateEnv } from '../../../../common/utils/localize';
 import { IPythonRuntimeManager } from '../../../../positron/manager';
 import { showErrorMessage } from '../../../../common/vscodeApis/windowApis';
 import { traceError } from '../../../../logging';
 import { shouldIncludeInterpreter } from '../../../../positron/interpreterSettings';
-// eslint-disable-next-line import/no-duplicates
 import { MINIMUM_PYTHON_VERSION } from '../../../../common/constants';
 import { isVersionSupported } from '../../../../positron/discoverer';
 // --- End Positron ---

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -58,6 +58,7 @@ import { traceError } from '../../../../logging';
 import { shouldIncludeInterpreter } from '../../../../positron/interpreterSettings';
 // eslint-disable-next-line import/no-duplicates
 import { MINIMUM_PYTHON_VERSION } from '../../../../common/constants';
+import { isVersionSupported } from '../../../../positron/discoverer';
 // --- End Positron ---
 import { untildify } from '../../../../common/helpers';
 import { useEnvExtension } from '../../../../envExt/api.internal';
@@ -742,7 +743,6 @@ function filterWrapper(filter: ((i: PythonEnvironment) => boolean) | undefined) 
     return (i: PythonEnvironment) =>
         (filter ? filter(i) : true) &&
         shouldIncludeInterpreter(i.path) &&
-        (i.version?.major ?? 0) >= MINIMUM_PYTHON_VERSION.major &&
-        (i.version?.minor ?? 0) >= MINIMUM_PYTHON_VERSION.minor;
+        isVersionSupported(i.version, MINIMUM_PYTHON_VERSION);
 }
 // --- End Positron ---

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -739,14 +739,10 @@ function getGroup(item: IInterpreterQuickPickItem, workspacePath?: string) {
  * @returns A new filter function that includes the original filter function and the additional filtering logic
  */
 function filterWrapper(filter: ((i: PythonEnvironment) => boolean) | undefined) {
-    return (i: PythonEnvironment) => {
-        const version = i.version?.major ?? 0;
-        return (
-            (filter ? filter(i) : true) &&
-            shouldIncludeInterpreter(i.path) &&
-            version >= MINIMUM_PYTHON_VERSION.major &&
-            (i.version?.minor ?? 0) >= MINIMUM_PYTHON_VERSION.minor
-        );
-    };
+    return (i: PythonEnvironment) =>
+        (filter ? filter(i) : true) &&
+        shouldIncludeInterpreter(i.path) &&
+        (i.version?.major ?? 0) >= MINIMUM_PYTHON_VERSION.major &&
+        (i.version?.minor ?? 0) >= MINIMUM_PYTHON_VERSION.minor;
 }
 // --- End Positron ---

--- a/extensions/positron-python/src/client/positron/discoverer.ts
+++ b/extensions/positron-python/src/client/positron/discoverer.ts
@@ -165,6 +165,9 @@ async function hasFiles(includes: string[]): Promise<boolean> {
  * Check if a version is supported (i.e. >= the minimum supported version).
  * Also returns true if the version could not be determined.
  */
-function isVersionSupported(version: PythonVersion | undefined, minimumSupportedVersion: PythonVersion): boolean {
+export function isVersionSupported(
+    version: PythonVersion | undefined,
+    minimumSupportedVersion: PythonVersion,
+): boolean {
     return !version || comparePythonVersionDescending(minimumSupportedVersion, version) >= 0;
 }


### PR DESCRIPTION
### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #3740 filters out unsupported (<3.8) Python versions from the `Python: Select Interpreter` dropdown


### QA Notes

1. create a Python interpreter <3.8 (if you are a pyenv user, you can do `pyenv install 3.6`)
2. go to `Python: Select Interpreter`
3. should not appear in dropdown