### PR TITLE
testing: allow manual runs of python ci

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -1,6 +1,7 @@
 name: 'Positron Python CI'
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Quality of life fix so we can trigger Python CI manually if we want 👾 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Allows Python CI to be run by manual trigger

#### Bug Fixes

- N/A


### QA Notes

N/A