### PR TITLE
e2e-test: verify session list order in quick pick vs console

### DIFF
--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -195,10 +195,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             name: positron.LanguageRuntimeStreamName.Stdout,
             text: vscode.l10n.t(
                 'Cannot uninstall the following packages:\n\n{0}\n\n' +
-                'These packages are bundled with Positron, ' +
-                "and removing them would break Positron's Python functionality.\n\n" +
-                'If you would like to uninstall these packages from the active environment, ' +
-                'please rerun `{1}` in a terminal.',
+                    'These packages are bundled with Positron, ' +
+                    "and removing them would break Positron's Python functionality.\n\n" +
+                    'If you would like to uninstall these packages from the active environment, ' +
+                    'please rerun `{1}` in a terminal.',
                 protectedPackagesStr,
                 code,
             ),
@@ -614,15 +614,15 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         this.adapterApi = ext?.exports as PositronSupervisorApi;
         const kernel = this.kernelSpec
             ? // We have a kernel spec, so we're creating a new session
-            await this.adapterApi.createSession(
-                this.runtimeMetadata,
-                this.metadata,
-                this.kernelSpec,
-                this.dynState,
-                createJupyterKernelExtra(),
-            )
+              await this.adapterApi.createSession(
+                  this.runtimeMetadata,
+                  this.metadata,
+                  this.kernelSpec,
+                  this.dynState,
+                  createJupyterKernelExtra(),
+              )
             : // We don't have a kernel spec, so we're restoring a session
-            await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
+              await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
 
         kernel.onDidChangeRuntimeState((state) => {
             this._stateEmitter.fire(state);
@@ -745,10 +745,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             const regex = /^(\w*Error|Exception)\b/m;
             const errortext = regex.test(logFileContent)
                 ? vscode.l10n.t(
-                    '{0} exited unexpectedly with error: {1}',
-                    kernel.runtimeMetadata.runtimeName,
-                    logFileContent,
-                )
+                      '{0} exited unexpectedly with error: {1}',
+                      kernel.runtimeMetadata.runtimeName,
+                      logFileContent,
+                  )
                 : Console.consoleExitGeneric;
 
             const res = await showErrorMessage(errortext, vscode.l10n.t('Open Logs'));

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -195,10 +195,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             name: positron.LanguageRuntimeStreamName.Stdout,
             text: vscode.l10n.t(
                 'Cannot uninstall the following packages:\n\n{0}\n\n' +
-                    'These packages are bundled with Positron, ' +
-                    "and removing them would break Positron's Python functionality.\n\n" +
-                    'If you would like to uninstall these packages from the active environment, ' +
-                    'please rerun `{1}` in a terminal.',
+                'These packages are bundled with Positron, ' +
+                "and removing them would break Positron's Python functionality.\n\n" +
+                'If you would like to uninstall these packages from the active environment, ' +
+                'please rerun `{1}` in a terminal.',
                 protectedPackagesStr,
                 code,
             ),
@@ -614,15 +614,15 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         this.adapterApi = ext?.exports as PositronSupervisorApi;
         const kernel = this.kernelSpec
             ? // We have a kernel spec, so we're creating a new session
-              await this.adapterApi.createSession(
-                  this.runtimeMetadata,
-                  this.metadata,
-                  this.kernelSpec,
-                  this.dynState,
-                  createJupyterKernelExtra(),
-              )
+            await this.adapterApi.createSession(
+                this.runtimeMetadata,
+                this.metadata,
+                this.kernelSpec,
+                this.dynState,
+                createJupyterKernelExtra(),
+            )
             : // We don't have a kernel spec, so we're restoring a session
-              await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
+            await this.adapterApi.restoreSession(this.runtimeMetadata, this.metadata);
 
         kernel.onDidChangeRuntimeState((state) => {
             this._stateEmitter.fire(state);
@@ -745,10 +745,10 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             const regex = /^(\w*Error|Exception)\b/m;
             const errortext = regex.test(logFileContent)
                 ? vscode.l10n.t(
-                      '{0} exited unexpectedly with error: {1}',
-                      kernel.runtimeMetadata.runtimeName,
-                      logFileContent,
-                  )
+                    '{0} exited unexpectedly with error: {1}',
+                    kernel.runtimeMetadata.runtimeName,
+                    logFileContent,
+                )
                 : Console.consoleExitGeneric;
 
             const res = await showErrorMessage(errortext, vscode.l10n.t('Open Logs'));

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -601,8 +601,8 @@ export function registerLanguageRuntimeActions() {
 		const runtimeSessionService = accessor.get(IRuntimeSessionService);
 		const commandService = accessor.get(ICommandService);
 
-		// Create quick pick items for active runtimes.
-		const sortedActiveSessions = [...runtimeSessionService.activeSessions].sort((a, b) => b.lastUsed - a.lastUsed);
+		// Create quick pick items for active runtimes sorted by creation time, oldest to newest.
+		const sortedActiveSessions = [...runtimeSessionService.activeSessions].sort((a, b) => a.metadata.createdTimestamp - b.metadata.createdTimestamp);
 
 		const activeRuntimeItems: IQuickPickItem[] = sortedActiveSessions.filter(
 			(session) => {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -119,25 +119,25 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 		>
 			<div className='console-instance-info'>
 				<div className='content'>
-					<p className='line'>{props.session.metadata.sessionName}</p>
+					<p className='line' data-testid='session-name'>{props.session.metadata.sessionName}</p>
 					<div className='top-separator'>
-						<p className='line'>
+						<p className='line' data-testid='session-id'>
 							{(() => localize(
 								'positron.console.info.sessionId', 'Session ID: {0}',
 								props.session.sessionId
 							))()}
 						</p>
-						<p className='line'>{(() => localize(
+						<p className='line' data-testid='session-state'>{(() => localize(
 							'positron.console.info.state', 'State: {0}',
 							sessionState))()}
 						</p>
 					</div>
 					<div className='top-separator'>
-						<p className='line'>{(() => localize(
+						<p className='line' data-testid='session-path'>{(() => localize(
 							'positron.console.info.runtimePath', 'Path: {0}',
 							props.session.runtimeMetadata.runtimePath))()}
 						</p>
-						<p className='line'>{(() => localize(
+						<p className='line' data-testid='session-source'>{(() => localize(
 							'positron.console.info.runtimeSource', 'Source: {0}',
 							props.session.runtimeMetadata.runtimeSource))()}
 						</p>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTabList.tsx
@@ -43,7 +43,7 @@ export const ConsoleTabList = (props: ConsoleTabListProps) => {
 		onChangeForegroundSession(sessionId);
 	};
 
-	// Sort console sessions by created time, so the most recent sessions are at the bottom
+	// Sort console sessions by created time, oldest to newest
 	const consoleInstances = Array.from(positronConsoleContext.positronConsoleInstances.values()).sort((a, b) => {
 		return a.session.metadata.createdTimestamp - b.session.metadata.createdTimestamp;
 	});

--- a/test/e2e/infra/fixtures/interpreter-new.ts
+++ b/test/e2e/infra/fixtures/interpreter-new.ts
@@ -54,6 +54,31 @@ export class InterpreterNew {
 	// --- Utils ---
 
 	/**
+	 * Util: Get active sessions from the session picker.
+	 * @returns The list of active sessions.
+	 */
+	async getActiveSessions(): Promise<QuickPickSessionInfo[]> {
+		await this.openSessionQuickPickMenu(false);
+		const allSessions = await this.code.driver.page.locator('.quick-input-list-rows').all();
+
+		// Get the text of all sessions
+		const activeSessions = await Promise.all(
+			allSessions.map(async element => {
+				const runtime = (await element.locator('.quick-input-list-row').nth(0).textContent())?.replace('Currently Selected', '');
+				const path = await element.locator('.quick-input-list-row').nth(1).textContent();
+				return { name: runtime?.trim() || '', path: path?.trim() || '' };
+			})
+		);
+
+		// Filter out the one with "New Session..."
+		const filteredSessions = activeSessions
+			.filter(session => !session.name.includes("New Session..."))
+
+		await this.closeSessionQuickPickMenu();
+		return filteredSessions;
+	}
+
+	/**
 	 * Util: Get the interpreter info for the currently selected interpreter in the dropdown.
 	 * @returns The interpreter info for the selected interpreter if found, otherwise undefined.
 	 */
@@ -130,3 +155,8 @@ export class InterpreterNew {
 		});
 	}
 }
+
+export type QuickPickSessionInfo = {
+	name: string;
+	path: string;
+};

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -3,12 +3,11 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-
 import test, { expect, Locator, Page } from '@playwright/test';
 import { Code } from '../infra/code';
 import { QuickAccess } from './quickaccess';
 import { QuickInput } from './quickInput';
-import { InterpreterNew } from '../infra';
+import { InterpreterNew, QuickPickSessionInfo } from '../infra';
 import { InterpreterType } from '../infra/fixtures/interpreter';
 
 const CONSOLE_INPUT = '.console-input';
@@ -391,6 +390,7 @@ class Session {
 	activeStatus: (session: Locator) => Locator;
 	idleStatus: (session: Locator) => Locator;
 	disconnectedStatus: (session: Locator) => Locator;
+	sessions: Locator;
 	metadataButton: Locator;
 	metadataDialog: Locator;
 
@@ -398,25 +398,30 @@ class Session {
 		this.activeStatus = (session: Locator) => session.locator('.codicon-positron-status-active');
 		this.idleStatus = (session: Locator) => session.locator('.codicon-positron-status-idle');
 		this.disconnectedStatus = (session: Locator) => session.locator('.codicon-positron-status-disconnected');
+		this.sessions = this.page.getByTestId(/console-tab/);
 		this.metadataButton = this.page.getByRole('button', { name: 'Console information' });
 		this.metadataDialog = this.page.getByRole('dialog');
 	}
 
 	/**
-	 * Helper: Get the locator for the session tab
-	 * @param session details of the session (language and version)
-	 * @returns locator for the session tab
+	 * Helper: Get the locator for the session tab.
+	 * @param session Either a session object (language and version) or a string representing the session name.
+	 * @returns The locator for the session tab.
 	 */
-	getSessionLocator(session: SessionDetails): Locator {
-		return this.page.getByRole('tab', { name: new RegExp(`${session.language} ${session.version}`) });
+	getSessionLocator(session: SessionName | string): Locator {
+		const sessionName = typeof session === 'string'
+			? session
+			: `${session.language} ${session.version}`;
+
+		return this.page.getByRole('tab', { name: new RegExp(sessionName) });
 	}
 
 	/**
 	 * Helper: Get the status of the session tab
-	 * @param session details of the session (language and version)
+	 * @param session Either a session object (language and version) or a string representing the session name.
 	 * @returns 'active', 'idle', 'disconnected', or 'unknown'
 	 */
-	private async getStatus(session: SessionDetails): Promise<'active' | 'idle' | 'disconnected' | 'unknown'> {
+	private async getStatus(session: SessionName | string): Promise<'active' | 'idle' | 'disconnected' | 'unknown'> {
 		const expectedSession = this.getSessionLocator(session);
 
 		if (await this.activeStatus(expectedSession).isVisible()) { return 'active'; }
@@ -427,11 +432,15 @@ class Session {
 
 	/**
 	 * Verify: Check the status of the session tab
-	 * @param session details of the session (language and version)
+	 * @param session Either a session object (language and version) or a string representing the session name.
 	 * @param expectedStatus status to check for ('active', 'idle', 'disconnected')
 	 */
-	async checkStatus(session: SessionDetails, expectedStatus: 'active' | 'idle' | 'disconnected') {
-		await test.step(`Verify ${session.language} ${session.version} session status: ${expectedStatus}`, async () => {
+	async checkStatus(session: SessionName | string, expectedStatus: 'active' | 'idle' | 'disconnected') {
+		const stepTitle = session instanceof Object
+			? `Verify ${session.language} ${session.version} session status: ${expectedStatus}`
+			: `Verify ${session} session status: ${expectedStatus}`;
+
+		await test.step(stepTitle, async () => {
 			const sessionLocator = this.getSessionLocator(session);
 			const statusClass = `.codicon-positron-status-${expectedStatus}`;
 
@@ -459,7 +468,7 @@ class Session {
 	 * Verify: Check the metadata of the session dialog
 	 * @param data the expected metadata to verify
 	 */
-	async checkMetadata(data: SessionDetails & { state: 'active' | 'idle' | 'disconnected' | 'exited' }) {
+	async checkMetadata(data: SessionName & { state: 'active' | 'idle' | 'disconnected' | 'exited' }) {
 		await test.step(`Verify ${data.language} ${data.version} metadata`, async () => {
 
 			// Click metadata button for desired session
@@ -493,11 +502,56 @@ class Session {
 	}
 
 	/**
+	 * Util: Get the session ID from the session name
+	 * @param sessionName the session name to get the ID for
+	 * @returns the session ID
+	 */
+	async getSessionId(sessionName: string): Promise<string> {
+		const testId = await this.getTestIdFromName(sessionName);
+		return testId.match(/-(\S+)$/)?.[1] || '';
+	}
+
+	/**
+	 * Util: Get the test ID from the session name
+	 * @param sessionName the session name to get the ID for
+	 * @returns the session ID
+	 */
+	async getTestIdFromName(sessionName: string): Promise<string> {
+		const session = this.getSessionLocator(sessionName);
+		const testId = await session.getAttribute('data-testid');
+		const match = testId?.match(/console-tab-(\S+)/);
+		return match ? match[1] : '';
+	}
+
+	/**
+	 * Util: Get the metadata of the session
+	 * @param sessionId the session ID to get metadata for
+	 * @returns the metadata of the session
+	 */
+	async getMetadata(sessionId: string): Promise<SessionMetaData> {
+		// select the session tab and open the metadata dialog
+		await this.page.getByTestId(`console-tab-${sessionId}`).click();
+		await this.metadataButton.click();
+
+		// get metadata
+		const name = (await this.metadataDialog.getByTestId('session-name').textContent() || '').trim();
+		const id = (await this.metadataDialog.getByTestId('session-id').textContent() || '').replace('Session ID: ', '');
+		const state = (await this.metadataDialog.getByTestId('session-state').textContent() || '').replace('State: ', '');
+		const path = (await this.metadataDialog.getByTestId('session-path').textContent() || '').replace('Path: ', '');
+		const source = (await this.metadataDialog.getByTestId('session-source').textContent() || '').replace('Source: ', '');
+
+		// temporary: close metadata dialog
+		await this.metadataButton.click({ force: true });
+
+		return { name, id, state, path, source };
+	}
+
+	/**
 	 * Action: Select session in tab list and start the session
 	 * @param session details of the session (language and version)
 	 * @param waitForIdle wait for the session to display as "idle" (ready)
 	 */
-	async start(session: SessionDetails, waitForIdle = true): Promise<void> {
+	async start(session: SessionName, waitForIdle = true): Promise<void> {
 		await test.step(`Start session: ${session.language} ${session.version}`, async () => {
 			const sessionLocator = this.getSessionLocator(session);
 			await sessionLocator.click();
@@ -514,7 +568,7 @@ class Session {
 	 * @param session details of the session (language and version)
 	 * @param waitForIdle wait for the session to display as "idle" (ready)
 	 */
-	async restart(session: SessionDetails, waitForIdle = true): Promise<void> {
+	async restart(session: SessionName, waitForIdle = true): Promise<void> {
 		await test.step(`Restart session: ${session.language} ${session.version}`, async () => {
 			const sessionLocator = this.getSessionLocator(session);
 			await sessionLocator.click();
@@ -531,7 +585,7 @@ class Session {
 	 * @param session details of the session (language and version)
 	 * @param waitForDisconnected wait for the session to display as disconnected
 	 */
-	async shutdown(session: SessionDetails, waitForDisconnected = true): Promise<void> {
+	async shutdown(session: SessionName, waitForDisconnected = true): Promise<void> {
 		await test.step(`Shutdown session: ${session.language} ${session.version}`, async () => {
 			const sessionLocator = this.getSessionLocator(session);
 			await sessionLocator.click();
@@ -547,7 +601,7 @@ class Session {
 	 * Action: Select the session
 	 * @param session details of the session (language and version)
 	 */
-	async select(session: SessionDetails): Promise<void> {
+	async select(session: SessionName): Promise<void> {
 		await test.step(`Select session: ${session.language} ${session.version}`, async () => {
 			const sessionLocator = this.getSessionLocator(session);
 			await sessionLocator.click();
@@ -558,7 +612,7 @@ class Session {
 	 * Helper: Ensure the session is started and idle (ready)
 	 * @param session details of the session (language and version)
 	 */
-	async ensureStartedAndIdle(session: SessionDetails): Promise<void> {
+	async ensureStartedAndIdle(session: SessionName): Promise<void> {
 		await test.step(`Ensure ${session.language} ${session.version} session is started and idle`, async () => {
 			// Start Session if it does not exist
 			const sessionExists = await this.getSessionLocator(session).isVisible({ timeout: 30000 });
@@ -573,9 +627,54 @@ class Session {
 			}
 		});
 	}
+
+	/**
+	 * Util: Get Active Sessions in the Console Session Tab List
+	 * Note: Sessions that are disconnected are filtered out
+	 */
+	async getActiveSessions(): Promise<QuickPickSessionInfo[]> {
+		const allSessions = await this.sessions.all();
+
+		const activeSessions = (
+			await Promise.all(
+				allSessions.map(async session => {
+					const isDisconnected = await session.locator('.codicon-positron-status-disconnected').isVisible();
+					if (isDisconnected) { return null; }
+
+					// Extract session ID from data-testid attribute
+					const testId = await session.getAttribute('data-testid');
+					const match = testId?.match(/console-tab-(\S+)/);
+					const sessionId = match ? match[1] : null;
+
+					return sessionId ? { sessionId, session } : null;
+				})
+			)
+		).filter(session => session !== null) as { sessionId: string; session: Locator }[];
+
+
+		const activeSessionInfo: QuickPickSessionInfo[] = [];
+
+		for (const session of activeSessions) {
+			const { name, path } = await this.getMetadata(session.sessionId);
+
+			activeSessionInfo.push({
+				name,
+				path,
+			});
+		}
+		return activeSessionInfo;
+	}
 }
 
-export type SessionDetails = {
+export type SessionName = {
 	language: 'Python' | 'R';
 	version: string; // e.g. '3.10.15'
+};
+
+export type SessionMetaData = {
+	name: string;
+	id: string;
+	state: string;
+	source: string;
+	path: string;
 };

--- a/test/e2e/pages/variables.ts
+++ b/test/e2e/pages/variables.ts
@@ -7,7 +7,7 @@
 import { Code } from '../infra/code';
 import * as os from 'os';
 import test, { expect, Locator } from '@playwright/test';
-import { SessionDetails } from '../infra';
+import { SessionName } from '../infra';
 
 interface FlatVariables {
 	value: string;
@@ -187,7 +187,7 @@ export class Variables {
 	 * @param language the language of the runtime: Python or R
 	 * @param version the version of the runtime: e.g. 3.10.15
 	 */
-	async selectRuntime(session: SessionDetails) {
+	async selectRuntime(session: SessionName) {
 		await test.step(`Select runtime: ${session.language} ${session.version}`, async () => {
 			await this.togglePane('show');
 			await this.code.driver.page.locator('[id="workbench.panel.positronSession"]').getByLabel(/^(?!Refresh objects$)(Python|R)/).click();
@@ -200,7 +200,7 @@ export class Variables {
 	 * @param language the language of the runtime: Python or R
 	 * @param version the version of the runtime: e.g. 3.10.15
 	 */
-	async checkRuntime(session: SessionDetails) {
+	async checkRuntime(session: SessionName) {
 		await test.step(`Verify runtime: ${session.language} ${session.version}`, async () => {
 			await this.togglePane('show');
 			await expect(this.code.driver.page.locator('[id="workbench.panel.positronSession"]').getByLabel(new RegExp(`${session.language}.*${session.version}`))).toBeVisible();

--- a/test/e2e/tests/console/console-sessions.test.ts
+++ b/test/e2e/tests/console/console-sessions.test.ts
@@ -158,7 +158,7 @@ test.describe('Console: Sessions', {
 
 	test('Validate active session list in console matches active session list in session picker', {
 		annotation: [
-			{ type: 'issue', description: 'sessions are not correctly sorted atm. see line 174' }
+			{ type: 'issue', description: 'sessions are not correctly sorted atm. see line 174.' }
 		]
 	}, async function ({ app }) {
 		const console = app.workbench.console;
@@ -171,7 +171,7 @@ test.describe('Console: Sessions', {
 		// Get active sessions and verify they match the session picker: order matters!
 		let activeSessionsFromConsole = await console.session.getActiveSessions();
 		let activeSessionsFromPicker = await interpreter.getActiveSessions();
-		// expect(activeSessionsFromConsole).toStrictEqual(activeSessionsFromPicker);
+		expect(activeSessionsFromConsole).toStrictEqual(activeSessionsFromPicker);
 
 		// Shutdown Python session and verify active sessions
 		await console.session.shutdown(pythonSession);
@@ -181,6 +181,18 @@ test.describe('Console: Sessions', {
 
 		// Shutdown R session and verify active sessions
 		await console.session.shutdown(rSession);
+		activeSessionsFromConsole = await console.session.getActiveSessions();
+		activeSessionsFromPicker = await interpreter.getActiveSessions();
+		expect(activeSessionsFromConsole).toStrictEqual(activeSessionsFromPicker);
+
+		// Start Python session (again) and verify active sessions
+		await console.session.start(pythonSession);
+		activeSessionsFromConsole = await console.session.getActiveSessions();
+		activeSessionsFromPicker = await interpreter.getActiveSessions();
+		expect(activeSessionsFromConsole).toStrictEqual(activeSessionsFromPicker);
+
+		// Restart Python session and verify active sessions
+		await console.session.restart(pythonSession);
 		activeSessionsFromConsole = await console.session.getActiveSessions();
 		activeSessionsFromPicker = await interpreter.getActiveSessions();
 		expect(activeSessionsFromConsole).toStrictEqual(activeSessionsFromPicker);

--- a/test/e2e/tests/top-action-bar/session-button.test.ts
+++ b/test/e2e/tests/top-action-bar/session-button.test.ts
@@ -3,23 +3,23 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { SessionDetails } from '../../infra';
+import { SessionName } from '../../infra';
 import { test, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-const pythonSession: SessionDetails = {
+const pythonSession: SessionName = {
 	language: 'Python',
 	version: process.env.POSITRON_PY_VER_SEL || ''
 };
-const rSession: SessionDetails = {
+const rSession: SessionName = {
 	language: 'R',
 	version: process.env.POSITRON_R_VER_SEL || ''
 };
 
-test.describe('Top Action Bar - Session Button', {
+test.describe('Top Action Bar: Session Button', {
 	tag: [tags.WEB, tags.CRITICAL, tags.WIN, tags.TOP_ACTION_BAR, tags.SESSIONS]
 }, () => {
 


### PR DESCRIPTION
### Summary
* Added first basic test to verify active session list is the same between quick pick and console.
   * ~Part of test is commented out bc it currently fails. (known issue)~
   * We can expand this to add more interesting scenarios, once we can have multiple sessions

### QA Notes

@:sessions