### PR TITLE
Fix problem which prematurely terminated ActivityItemStreams

### DIFF
--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemStream.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemStream.ts
@@ -110,7 +110,7 @@ export class ActivityItemStream {
 		this.processActivityItemStreams();
 
 		// Update the terminated flag.
-		this.terminated = this.ansiOutput.isBuffering;
+		this.terminated = !this.ansiOutput.isBuffering;
 
 		// If there is no remainder text, return undefined, indicating that there is no remainder
 		// ActivityItemStream to be processed.


### PR DESCRIPTION
### Description

This PR addresses #5819 by fixing a bug which prematurely terminated `ActivityItemStream`s while they were still buffering.

Before:

<img width="1861" alt="image" src="https://github.com/user-attachments/assets/63d6e09b-a030-4eb3-8066-b5d19bc25f85" />

After:

<img width="1861" alt="image" src="https://github.com/user-attachments/assets/b69428ff-6ee8-4104-a7c1-32ad085a2233" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #5819

### QA Notes

Tests:
@:console
