### PR TITLE
Remove unnecessary types/vscode (fix build issue)

### DIFF
--- a/extensions/positron-assistant/package-lock.json
+++ b/extensions/positron-assistant/package-lock.json
@@ -19,7 +19,6 @@
         "@openrouter/ai-sdk-provider": "^0.0.6",
         "@stylistic/eslint-plugin": "^2.9.0",
         "@types/node": "^20",
-        "@types/vscode": "^1.73.0",
         "ai": "^4.1.0",
         "eslint": "^9.13.0",
         "google-auth-library": "^9.15.1",
@@ -2099,11 +2098,6 @@
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/vscode": {
-      "version": "1.95.0",
       "dev": true,
       "license": "MIT"
     },

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -149,7 +149,6 @@
     "@openrouter/ai-sdk-provider": "^0.0.6",
     "@stylistic/eslint-plugin": "^2.9.0",
     "@types/node": "^20",
-    "@types/vscode": "^1.73.0",
     "ai": "^4.1.0",
     "eslint": "^9.13.0",
     "google-auth-library": "^9.15.1",

--- a/extensions/positron-assistant/tsconfig.json
+++ b/extensions/positron-assistant/tsconfig.json
@@ -17,7 +17,8 @@
 		"../../src/vscode-dts/vscode.proposed.mappedEditsProvider.d.ts",
 		"../../src/vscode-dts/vscode.proposed.defaultChat*.d.ts",
 		"../../src/vscode-dts/vscode.proposed.inlineCompletions*.d.ts",
+		"../../src/vscode-dts/vscode.d.ts",
 		"../../src/positron-dts/positron.d.ts",
 	],
-	"exclude": ["node_modules"]
+	"exclude": ["node_modules"],
 }


### PR DESCRIPTION
Addresses this build issue:

```
[17:44:35] Error: @types/vscode ^1.73.0 greater than engines.vscode ^1.65.0. Consider upgrade engines.vscode or use an older @types/vscode version
    at validateVSCodeTypesCompatibility (/Users/jmcphers/git/positron/build/node_modules/@vscode/vsce/out/validation.js:115:19)
    at validateManifest (/Users/jmcphers/git/positron/build/node_modules/@vscode/vsce/out/package.js:913:59)
    at async Promise.all (index 0)
    at async listFiles (/Users/jmcphers/git/positron/build/node_modules/@vscode/vsce/out/package.js:1333:22)
```

The fix is to remove `@types/vscode` from positron-assistant and get these types from Positron's internal copy instead.
