### PR TITLE
e2e-test: rename dropdown to button

### DIFF
--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -89,13 +89,13 @@ export class Console {
 	 * @param options - Configuration options for selecting the interpreter.
 	 * @param options.language the programming language interpreter to select.
 	 * @param options.version the specific version of the interpreter to select (e.g., "3.10.15").
-	 * @param options.triggerMode the method used to trigger the selection: button or quickaccess.
+	 * @param options.triggerMode the method used to trigger the selection: top-action-bar or quickaccess.
 	 * @param options.waitForReady whether to wait for the console to be ready after selecting the interpreter.
 	 */
 	async startSession(options: {
 		language: 'Python' | 'R';
 		version?: string;
-		triggerMode?: 'button' | 'quickaccess';
+		triggerMode?: 'top-action-bar' | 'quickaccess';
 		waitForReady?: boolean;
 	}): Promise<void> {
 

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -85,17 +85,17 @@ export class Console {
 	}
 
 	/**
-	 * Action: Start a session via the dropdown or quickaccess.
+	 * Action: Start a session via the top action bar button or quickaccess.
 	 * @param options - Configuration options for selecting the interpreter.
 	 * @param options.language the programming language interpreter to select.
 	 * @param options.version the specific version of the interpreter to select (e.g., "3.10.15").
-	 * @param options.triggerMode the method used to trigger the selection: dropdown or quickaccess.
+	 * @param options.triggerMode the method used to trigger the selection: button or quickaccess.
 	 * @param options.waitForReady whether to wait for the console to be ready after selecting the interpreter.
 	 */
 	async startSession(options: {
 		language: 'Python' | 'R';
 		version?: string;
-		triggerMode?: 'dropdown' | 'quickaccess';
+		triggerMode?: 'button' | 'quickaccess';
 		waitForReady?: boolean;
 	}): Promise<void> {
 

--- a/test/e2e/tests/top-action-bar/session-button.test.ts
+++ b/test/e2e/tests/top-action-bar/session-button.test.ts
@@ -28,13 +28,13 @@ test.describe('Top Action Bar: Session Button', {
 	});
 
 	test('Python - Verify session starts and displays as running', async function ({ app }) {
-		await app.workbench.console.startSession({ ...pythonSession, triggerMode: 'button' });
+		await app.workbench.console.startSession({ ...pythonSession, triggerMode: 'top-action-bar' });
 		await app.workbench.interpreterNew.verifySessionIsSelected(pythonSession);
 		await app.workbench.console.session.checkStatus(pythonSession, 'idle');
 	});
 
 	test('R - Verify session starts and displays as running', async function ({ app }) {
-		await app.workbench.console.startSession({ ...rSession, triggerMode: 'button' });
+		await app.workbench.console.startSession({ ...rSession, triggerMode: 'top-action-bar' });
 		await app.workbench.interpreterNew.verifySessionIsSelected(rSession);
 		await app.workbench.console.session.checkStatus(rSession, 'idle');
 	});

--- a/test/e2e/tests/top-action-bar/session-button.test.ts
+++ b/test/e2e/tests/top-action-bar/session-button.test.ts
@@ -28,13 +28,13 @@ test.describe('Top Action Bar: Session Button', {
 	});
 
 	test('Python - Verify session starts and displays as running', async function ({ app }) {
-		await app.workbench.console.startSession({ ...pythonSession, triggerMode: 'dropdown' });
+		await app.workbench.console.startSession({ ...pythonSession, triggerMode: 'button' });
 		await app.workbench.interpreterNew.verifySessionIsSelected(pythonSession);
 		await app.workbench.console.session.checkStatus(pythonSession, 'idle');
 	});
 
 	test('R - Verify session starts and displays as running', async function ({ app }) {
-		await app.workbench.console.startSession({ ...rSession, triggerMode: 'dropdown' });
+		await app.workbench.console.startSession({ ...rSession, triggerMode: 'button' });
 		await app.workbench.interpreterNew.verifySessionIsSelected(rSession);
 		await app.workbench.console.session.checkStatus(rSession, 'idle');
 	});


### PR DESCRIPTION
### Summary
Just fixing the incorrect terminology. There no longer is an interpreter drop down, it's a button now.

### QA Notes
@:sessions