### PR TITLE
QOL: make pytest more verbose in the Testing pane

### DIFF
--- a/extensions/positron-python/python_files/pyproject.toml
+++ b/extensions/positron-python/python_files/pyproject.toml
@@ -92,6 +92,6 @@ convention = "pep257"
 
 # --- Start Positron ---
 [tool.pytest.ini_options]
-# Enable colors in the VSCode Test Results pane.
-addopts = "--color=yes"
+# Enable colors and verbosity in the VSCode Test Results pane.
+addopts = "--color=yes -vv"
 # --- End Positron ---


### PR DESCRIPTION
A small quality of life improvement to help with running the positron-python tests in the Testing pane in the sidebar. This turns up the verbosity of pytest.