### PR TITLE
Update Quarto to 1.6.42 hotfix

### DIFF
--- a/build/lib/quarto.js
+++ b/build/lib/quarto.js
@@ -83,7 +83,7 @@ function getQuartoLinux(version) {
  */
 function getQuartoStream() {
     // quarto version
-    const version = '1.6.40';
+    const version = '1.6.42';
     fancyLog(`Synchronizing quarto ${version}...`);
     // Get the download/unpack stream for the current platform
     return process.platform === 'win32' ?

--- a/build/lib/quarto.ts
+++ b/build/lib/quarto.ts
@@ -89,7 +89,7 @@ function getQuartoLinux(version: string): Stream {
  */
 export function getQuartoStream(): Stream {
 	// quarto version
-	const version = '1.6.40';
+	const version = '1.6.42';
 
 	fancyLog(`Synchronizing quarto ${version}...`);
 


### PR DESCRIPTION
Quarto [addressed](https://github.com/quarto-dev/quarto-cli/commit/ffee8fddeadc27bc8aff021468ae98672df9bbf9) a regression with code completions for .qmd files and backported the fix to in the [1.6.42 release](https://github.com/quarto-dev/quarto-cli/releases/tag/v1.6.42).


### Release Notes

#### New Features

- Update Quarto to 1.6.42

#### Bug Fixes

- Updating Quarto to restore autocompletions in code blocks in .qmd files #6444


### QA Notes

A quick test is needed to confirm autocompletions are provided in a code block in a .qmd file
