### PR TITLE
Enables the new Positron Connections Pane by default

### DIFF
--- a/extensions/positron-connections/src/test/connection.test.ts
+++ b/extensions/positron-connections/src/test/connection.test.ts
@@ -17,6 +17,14 @@ suite('Connections pane works for R', () => {
 
 	test('Can list tables and fields from R connections', async () => {
 
+		const config = vscode.workspace.getConfiguration('positron');
+		// Old connections pane is enabled, when the new is enabled.
+		const enabled = !config.get<boolean>('connections', false);
+
+		if (!enabled) {
+			return;
+		}
+
 		// Waits until positron is ready to start a runtime
 		const info = await assert_or_timeout(async () => {
 			return await positron.runtime.getPreferredRuntime('r');

--- a/src/vs/workbench/services/positronConnections/browser/positronConnectionsFeatureFlag.ts
+++ b/src/vs/workbench/services/positronConnections/browser/positronConnectionsFeatureFlag.ts
@@ -33,10 +33,10 @@ configurationRegistry.registerConfiguration({
 	properties: {
 		[USE_POSITRON_CONNECTIONS_KEY]: {
 			type: 'boolean',
-			default: false,
+			default: true,
 			markdownDescription: localize(
 				'positron.enableConnectionsPane',
-				'**CAUTION**: Enable experimental Positron Connections Pane features which may result in unexpected behaviour. Please restart Positron if you change this option.'
+				'Enables the new Positron Connections Pane. Please restart Positron if you change this option.'
 			),
 		},
 	},


### PR DESCRIPTION
Addresses: https://github.com/posit-dev/positron/issues/6341

To be merged after https://github.com/posit-dev/positron/pull/6428
Makes the new UI for the connections pane enabled by default. Users can still use the old UI by desabling this option.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- The new UI for the Connections Pane is enabled by default. (https://github.com/posit-dev/positron/issues/6341)

#### Bug Fixes

- N/A


### QA Notes

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
