### PR TITLE
Bump ark to 0.1.167

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -683,7 +683,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.166"
+      "ark": "0.1.167"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
For https://github.com/posit-dev/ark/pull/720 and https://github.com/posit-dev/ark/pull/719
Addresses https://github.com/posit-dev/positron/issues/5050

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- The initial memory usage of the R backend (ark) has been reduced by 2/3.


### QA Notes

The `ark` processes created by Positron should now take about 110mb instead of 400ish.

Triggering completions in a script or in the console will cause the memory usage to spike. I just did it on mac with a release build and saw it go from 105mb to 185mb. Loading any additional packages and triggering completions will increase memory usage further.

If you add a breakpoint e.g. with `debug(identity)` or `debugonce(identity)`, memory usage shoots back up to what it was prior to these fixes.
