### PR TITLE
ci: replace linux with ubuntu in e2e workflows

### DIFF
--- a/.github/workflows/test-e2e-release.yml
+++ b/.github/workflows/test-e2e-release.yml
@@ -110,7 +110,7 @@ jobs:
           CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
           PWTEST_BLOB_DO_NOT_REMOVE: 1
-          CURRENTS_TAG: "release,electron/linux"
+          CURRENTS_TAG: "release,electron/ubuntu"
         id: electron-e2e-tests
         run: |
           export DISPLAY=:10

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -1,4 +1,4 @@
-name: "Test: E2E (Linux)"
+name: "Test: E2E (Ubuntu)"
 
 on:
   workflow_call:
@@ -26,7 +26,7 @@ on:
       currents_tags:
         required: false
         description: "The tags to use for Currents recording."
-        default: "@linux"
+        default: "@ubuntu"
         type: string
       report_testrail:
         required: false
@@ -146,7 +146,7 @@ jobs:
           CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
           PWTEST_BLOB_DO_NOT_REMOVE: 1
-          CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/linux' }}
+          CURRENTS_TAG: ${{ inputs.currents_tags || 'electron/ubuntu' }}
           ENABLE_CURRENTS_REPORTER: ${{ inputs.enable_currents_reporter }}
         run: |
           if [ "${{ inputs.project }}" == "e2e-electron" ]; then

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
       inputs:
         run_e2e_linux:
-          description: "E2E Tests / Electron (Linux)"
+          description: "E2E Tests / Electron (Ubuntu)"
           required: false
           default: true
           type: boolean
@@ -15,7 +15,7 @@ on:
           default: true
           type: boolean
         run_e2e_browser:
-          description: "E2E Tests / Chromium (Linux)"
+          description: "E2E Tests / Chromium (Ubuntu)"
           required: false
           default: true
           type: boolean
@@ -47,13 +47,13 @@ jobs:
   e2e-electron:
     name: e2e
     if: ${{ github.event_name == 'schedule' || inputs.run_e2e_linux  }}
-    uses: ./.github/workflows/test-e2e-linux.yml
+    uses: ./.github/workflows/test-e2e-ubuntu.yml
     secrets: inherit
     with:
       grep: ""
       project: "e2e-electron"
-      display_name: "electron (linux)"
-      currents_tags: ${{ github.event_name == 'schedule' && 'nightly,electron/linux' || 'electron/linux' }}
+      display_name: "electron (ubuntu)"
+      currents_tags: ${{ github.event_name == 'schedule' && 'nightly,electron/ubuntu' || 'electron/ubuntu' }}
       report_testrail: false
 
   e2e-windows:
@@ -70,13 +70,13 @@ jobs:
   e2e-browser:
     name: e2e
     if: ${{  github.event_name == 'schedule' || inputs.run_e2e_browser }}
-    uses: ./.github/workflows/test-e2e-linux.yml
+    uses: ./.github/workflows/test-e2e-ubuntu.yml
     secrets: inherit
     with:
       grep: ""
       project: "e2e-browser"
-      display_name: "browser (linux)"
-      currents_tags: ${{ github.event_name == 'schedule' && 'nightly,browser/linux' || 'browser/linux' }}
+      display_name: "browser (ubuntu)"
+      currents_tags: ${{ github.event_name == 'schedule' && 'nightly,browser/ubuntu' || 'browser/ubuntu' }}
       report_testrail: false
 
   unit-tests:

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -9,12 +9,12 @@ on:
 jobs:
   e2e-electron:
     name: e2e
-    uses: ./.github/workflows/test-e2e-linux.yml
+    uses: ./.github/workflows/test-e2e-ubuntu.yml
     with:
       grep: ""
       project: "e2e-electron"
-      display_name: "electron (linux)"
-      currents_tags: "merge,electron/linux"
+      display_name: "electron (ubuntu)"
+      currents_tags: "merge,electron/ubuntu"
     secrets: inherit
 
   e2e-windows-electron:
@@ -29,12 +29,12 @@ jobs:
 
   e2e-linux-browser:
     name: e2e
-    uses: ./.github/workflows/test-e2e-linux.yml
+    uses: ./.github/workflows/test-e2e-ubuntu.yml
     with:
       grep: ""
-      display_name: "browser (linux)"
+      display_name: "browser (ubuntu)"
       project: "e2e-browser"
-      currents_tags: "merge,browser/linux"
+      currents_tags: "merge,browser/ubuntu"
       report_testrail: false
     secrets: inherit
 

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -31,12 +31,12 @@ jobs:
 
   e2e-linux-electron:
     name: e2e
-    uses: ./.github/workflows/test-e2e-linux.yml
+    uses: ./.github/workflows/test-e2e-ubuntu.yml
     needs: pr-tags
     with:
       grep: ${{ needs.pr-tags.outputs.tags }}
-      display_name: "electron (linux)"
-      currents_tags: "pull-request,electron/linux,${{ needs.pr-tags.outputs.tags }}"
+      display_name: "electron (ubuntu)"
+      currents_tags: "pull-request,electron/ubuntu,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
       enable_currents_reporter: false
     secrets: inherit
@@ -58,12 +58,12 @@ jobs:
     needs: pr-tags
     if: ${{ needs.pr-tags.outputs.web_tag_found == 'true' }}
     name: e2e
-    uses: ./.github/workflows/test-e2e-linux.yml
+    uses: ./.github/workflows/test-e2e-ubuntu.yml
     with:
       grep: ${{ needs.pr-tags.outputs.tags }}
-      display_name: "browser (linux)"
+      display_name: "browser (ubuntu)"
       project: "e2e-browser"
-      currents_tags: "pull-request,browser/linux,${{ needs.pr-tags.outputs.tags }}"
+      currents_tags: "pull-request,browser/ubuntu,${{ needs.pr-tags.outputs.tags }}"
       report_testrail: false
       enable_currents_reporter: false
     secrets: inherit


### PR DESCRIPTION
### Summary
Updating to create consistent naming conventions across jobs/notifications.

See related PR: https://github.com/posit-dev/positron-builds/pull/251