### PR TITLE
Fix Python completions in Quarto

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -90,7 +90,6 @@ from ._vendor.lsprotocol.types import (
     SymbolInformation,
     TextDocumentIdentifier,
     TextDocumentPositionParams,
-    TextEdit,
     WorkspaceEdit,
     WorkspaceSymbolParams,
 )

--- a/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_jedilsp.py
@@ -78,6 +78,7 @@ from ._vendor.lsprotocol.types import (
     Hover,
     InitializeParams,
     InitializeResult,
+    InsertReplaceEdit,
     InsertTextFormat,
     Location,
     MessageType,
@@ -522,15 +523,24 @@ def positron_completion(
                 )
 
                 # If Jedi knows how to complete the expression, use its suggestion.
-                if completion.complete is not None:
+                new_text = completion.complete
+                if new_text is not None:
                     # Using the text_edit attribute (instead of insert_text used in
-                    # lsp_completion_item) notifies the client to use the text as is.
+                    # lsp_completion_item) notifies the client to use the text as is,
+                    # which is required to complete paths across `-` symbols,
+                    # since the client may treat them as word boundaries.
                     # See https://github.com/posit-dev/positron/issues/5193.
-                    jedi_completion_item.text_edit = TextEdit(
+                    #
+                    # Use InsertReplaceEdit instead of TextEdit since the latter ends up
+                    # setting the deprecated vscode.CompletionItem.textEdit property
+                    # in the client. Quarto also doesn't support the textEdit property.
+                    # See https://github.com/posit-dev/positron/issues/6444.
+                    jedi_completion_item.text_edit = InsertReplaceEdit(
+                        new_text=new_text,
                         # Use a range that starts and ends at the cursor position to insert
                         # text at the cursor.
-                        Range(params.position, params.position),
-                        completion.complete,
+                        insert=Range(params.position, params.position),
+                        replace=Range(params.position, params.position),
                     )
                 completion_items.append(jedi_completion_item)
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_jedilsp.py
@@ -32,6 +32,7 @@ from positron._vendor.lsprotocol.types import (
     Hover,
     HoverParams,
     InitializeParams,
+    InsertReplaceEdit,
     Location,
     MarkupContent,
     MarkupKind,
@@ -444,8 +445,11 @@ def assert_has_path_completion(
     assert len(completions) == 1
 
     expected_position = Position(0, character)
-    assert completions[0].text_edit == TextEdit(
-        Range(expected_position, expected_position), expected_completion
+    expected_range = Range(expected_position, expected_position)
+    assert completions[0].text_edit == InsertReplaceEdit(
+        new_text=expected_completion,
+        insert=expected_range,
+        replace=expected_range,
     )
 
 


### PR DESCRIPTION
Quarto converts ranges to/from the Python language server ([source](https://github.com/quarto-dev/quarto/blob/1375251f147d7f9417be8f41181c8b4e3b9f7e3a/apps/vscode/src/vdoc/vdoc-completion.ts#L35-L52)). The problem is that Quarto wasn't converting the `vscode.CompletionItem.textEdit` property if present, which we started using in https://github.com/posit-dev/positron/pull/6002.

Quarto may want to also fix on their side to support `textEdit`. I think the reason they don't is because it's deprecated, but other language servers may use it too.

I've made the fix (https://github.com/posit-dev/positron/pull/6471) on our side too since it is a deprecated property. Would've avoided using it to begin with, but there unfortunately wasn't any deprecation note in the Python completion type.

Addresses #6444.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed a regression where Python completions did not work in Quarto documents (https://github.com/posit-dev/positron/issues/6444).