### PR TITLE
Skip e2e reticulate test

### DIFF
--- a/test/e2e/tests/reticulate/reticulate.test.ts
+++ b/test/e2e/tests/reticulate/reticulate.test.ts
@@ -35,7 +35,7 @@ test.describe.skip('Reticulate', {
 	// will already be running
 	let sequential = false;
 
-	test.skip('R - Verify Basic Reticulate Functionality', async function ({ app, r, interpreter }) {
+	test('R - Verify Basic Reticulate Functionality', async function ({ app, r, interpreter }) {
 
 		await app.workbench.console.pasteCodeToConsole('reticulate::repl_python()');
 		await app.workbench.console.sendEnterKey();

--- a/test/e2e/tests/reticulate/reticulate.test.ts
+++ b/test/e2e/tests/reticulate/reticulate.test.ts
@@ -17,7 +17,7 @@ test.use({
 // Skipping until https://github.com/posit-dev/ark/pull/713 is merged
 test.describe.skip('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB],
-	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6397' }],
+	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6397' }]
 }, () => {
 	test.beforeAll(async function ({ app, userSettings }) {
 		try {

--- a/test/e2e/tests/reticulate/reticulate.test.ts
+++ b/test/e2e/tests/reticulate/reticulate.test.ts
@@ -34,7 +34,9 @@ test.describe('Reticulate', {
 	// will already be running
 	let sequential = false;
 
-	test('R - Verify Basic Reticulate Functionality', async function ({ app, r, interpreter }) {
+	test.skip('R - Verify Basic Reticulate Functionality', {
+		annotation: [{ type: 'issue', description: 'Need https://github.com/posit-dev/ark/pull/713' }]
+	}, async function ({ app, r, interpreter }) {
 
 		await app.workbench.console.pasteCodeToConsole('reticulate::repl_python()');
 		await app.workbench.console.sendEnterKey();

--- a/test/e2e/tests/reticulate/reticulate.test.ts
+++ b/test/e2e/tests/reticulate/reticulate.test.ts
@@ -14,9 +14,10 @@ test.use({
 // to the installed python path
 
 // Re-add WEB tag when https://github.com/posit-dev/positron/issues/6397 is fixed
-test.describe('Reticulate', {
+// Skipping until https://github.com/posit-dev/ark/pull/713 is merged
+test.describe.skip('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB],
-	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6397' }]
+	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6397' }],
 }, () => {
 	test.beforeAll(async function ({ app, userSettings }) {
 		try {
@@ -34,9 +35,7 @@ test.describe('Reticulate', {
 	// will already be running
 	let sequential = false;
 
-	test.skip('R - Verify Basic Reticulate Functionality', {
-		annotation: [{ type: 'issue', description: 'Need https://github.com/posit-dev/ark/pull/713' }]
-	}, async function ({ app, r, interpreter }) {
+	test.skip('R - Verify Basic Reticulate Functionality', async function ({ app, r, interpreter }) {
 
 		await app.workbench.console.pasteCodeToConsole('reticulate::repl_python()');
 		await app.workbench.console.sendEnterKey();


### PR DESCRIPTION
Until https://github.com/posit-dev/ark/pull/713  is merged, reticulate tests will fail.

Skipping until ARK with that fix is merged.

### QA Notes
@:reticulate
