### PR TITLE
Fire `onDidClose` event from `PositronDataExplorerInstance` when it is disposed

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -114,7 +114,7 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 
 	//#endregion Private Properties
 
-	//#region Constructor
+	//#region Constructor & Dispose
 
 	/**
 	 * Constructor.
@@ -199,7 +199,18 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 		}));
 	}
 
-	//#endregion Constructor
+	/**
+	 * Dispose method.
+	 */
+	public override dispose(): void {
+		// Fire the onDidClose event.
+		this._onDidCloseEmitter.fire();
+
+		// Call the base class's dispose method.
+		super.dispose();
+	}
+
+	//#endregion Constructor & Dispose
 
 	//#region IPositronDataExplorerInstance Implementation
 


### PR DESCRIPTION
### Description

This PR addresses #6480 by ensuring that the `onDidClose` event is fired when a `PositronDataExplorerInstance` is disposed. This puts the Data Explorer UI into the closed state.

Before:

![image](https://github.com/user-attachments/assets/13675fd3-b383-4165-aa5d-ad33e1c548fd)

After:

![image](https://github.com/user-attachments/assets/3638b078-4bbe-4a64-b9e1-6ba9eba192c9)

Tests:
@:data-explorer

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #6480

### QA Notes

None