### PR TITLE
E2E test: install CI python dependencies with uv

### DIFF
--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: |
         curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
-        uv pip install --break-system-packages -r requirements.txt
+        uv pip install --break-system-packages --system -r requirements.txt
 
     - name: Verify Python Version
       shell: bash

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: |
         curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
-        uv pip install -r requirements.txt
+        uv pip install --system -r requirements.txt
 
     - name: Verify Python Version
       shell: bash

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -12,16 +12,19 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install `uv`
-      shell: bash
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12.6'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
 
     - name: Install Python dependencies
       shell: bash
       run: |
         curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
-        uv pip install --break-system-packages --system -r requirements.txt -v
+        uv pip install --system -r requirements.txt -v
         echo "Checking installed packages..."
         python -m pip list
 

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -21,7 +21,9 @@ runs:
       shell: bash
       run: |
         curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
-        uv pip install --break-system-packages --system -r requirements.txt
+        uv pip install --break-system-packages --system -r requirements.txt -v
+        echo "Checking installed packages..."
+        python -m pip list
 
     - name: Verify Python Version
       shell: bash

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: |
         curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
-        uv pip install --system -r requirements.txt
+        uv pip install --break-system-packages -r requirements.txt
 
     - name: Verify Python Version
       shell: bash

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -24,7 +24,7 @@ runs:
       shell: bash
       run: |
         curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
-        uv pip install --system -r requirements.txt -v
+        uv pip install --system -r requirements.txt
         echo "Checking installed packages..."
         python -m pip list
 

--- a/.github/actions/install-python/action.yml
+++ b/.github/actions/install-python/action.yml
@@ -12,12 +12,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Install `uv`
+      shell: bash
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+
     - name: Install Python dependencies
       shell: bash
       run: |
         curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
-        python3 -m pip install --upgrade pip
-        python3 -m pip install -r requirements.txt
+        uv pip install -r requirements.txt
 
     - name: Verify Python Version
       shell: bash

--- a/.github/workflows/test-e2e-release.yml
+++ b/.github/workflows/test-e2e-release.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Run Tests (Electron)
         if: ${{ !cancelled() }}
         env:
-          POSITRON_PY_VER_SEL: 3.12.3
+          POSITRON_PY_VER_SEL: 3.12.6
           POSITRON_R_VER_SEL: 4.4.0
           POSITRON_PY_ALT_VER_SEL: "3.13.0 (Pyenv)"
           POSITRON_R_ALT_VER_SEL: 4.4.2

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Run Playwright Tests (Electron)
         env:
-          POSITRON_PY_VER_SEL: 3.12.3
+          POSITRON_PY_VER_SEL: 3.12.6
           POSITRON_R_VER_SEL: 4.4.0
           POSITRON_PY_ALT_VER_SEL: "3.13.0 (Pyenv)"
           POSITRON_R_ALT_VER_SEL: 4.4.2

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -382,7 +382,7 @@ export class Sessions {
 			await expect(this.metadataDialog.getByText(new RegExp(`Session ID: ${data.language.toLowerCase()}-[a-zA-Z0-9]+`))).toBeVisible();
 			await expect(this.metadataDialog.getByText(`State: ${data.state}`)).toBeVisible();
 			await expect(this.metadataDialog.getByText(/^Path: [\/~a-zA-Z0-9.]+/)).toBeVisible();
-			await expect(this.metadataDialog.getByText(/^Source: (Pyenv|System)$/)).toBeVisible();
+			await expect(this.metadataDialog.getByText(/^Source: (Pyenv|System|Global)$/)).toBeVisible();
 			await this.page.keyboard.press('Escape');
 
 			// Verify Language Console

--- a/test/e2e/pages/utils/packageManager.ts
+++ b/test/e2e/pages/utils/packageManager.ts
@@ -51,8 +51,8 @@ export class PackageManager {
 	private getCommand(language: 'R' | 'Python', packageName: PackageName, action: PackageAction): string {
 		if (language === 'Python') {
 			return action === 'install'
-				? `pip install ${packageName}`
-				: `pip uninstall -y ${packageName}`;
+				? `uv pip install ${packageName}`
+				: `uv pip uninstall -y ${packageName}`;
 		} else {
 			return action === 'install'
 				? `install.packages("${packageName}")`
@@ -69,10 +69,10 @@ export class PackageManager {
 		switch (packageName) {
 			case 'ipykernel':
 				return action === 'install'
-					? /Note: you may need to restart the kernel to use updated packages/
+					? /uv pip install completed successfully|Requirement already satisfied/
 					: /Successfully uninstalled ipykernel|Skipping ipykernel as it is not installed/;
 			default:
-				return action === 'install' ? /Installing/ : /Removing/;
+				return action === 'install' ? /Installing|Downloading|Fetched/ : /Removing|Uninstalling/;
 		}
 	}
 }


### PR DESCRIPTION
Converting to using uv instead of pip for python package installation pre test.

### QA Notes

All tests should pass

@:web @:sessions
