### PR TITLE
E2E test: fix scm test flake with layout changes

### DIFF
--- a/test/e2e/pages/scm.ts
+++ b/test/e2e/pages/scm.ts
@@ -41,7 +41,11 @@ export class SCM {
 	}
 
 	async openChange(name: string): Promise<void> {
-		await this.code.driver.page.locator(SCM_RESOURCE_CLICK(name)).last().click({ force: true });
+		await this.layout.enterLayout('fullSizedSidebar');
+
+		await this.code.driver.page.locator(SCM_RESOURCE_CLICK(name)).last().click();
+
+		await this.layout.enterLayout('stacked');
 	}
 
 	async stage(name: string): Promise<void> {

--- a/test/e2e/pages/scm.ts
+++ b/test/e2e/pages/scm.ts
@@ -41,7 +41,7 @@ export class SCM {
 	}
 
 	async openChange(name: string): Promise<void> {
-		await this.code.driver.page.locator(SCM_RESOURCE_CLICK(name)).last().click();
+		await this.code.driver.page.locator(SCM_RESOURCE_CLICK(name)).last().click({ force: true });
 	}
 
 	async stage(name: string): Promise<void> {


### PR DESCRIPTION
Seeing an occasional test flake that could be the result of click trying to happen when the view is partially obscured.

### QA Notes

@:win @:scm
