### PR TITLE
use posit cdn instead of github release asset for download url

### DIFF
--- a/extensions/positron-python/src/test/positron/testElectron.ts
+++ b/extensions/positron-python/src/test/positron/testElectron.ts
@@ -9,7 +9,6 @@ import { IncomingMessage } from 'http';
 import * as https from 'https';
 import * as os from 'os';
 import * as path from 'path';
-import { URL } from 'url';
 import { defaultCachePath } from '@vscode/test-electron/out/download';
 import { TestOptions } from '@vscode/test-electron/out/runTest';
 import { runTests as vscodeRunTests } from '@vscode/test-electron';
@@ -271,20 +270,20 @@ export async function downloadAndUnzipPositron(): Promise<{ version: string; exe
     }
 
     const fileName = `Positron-${version}${suffix}`;
-    const downloadUrl = URL.parse(`https://cdn.posit.co/positron/prereleases/mac/universal/${fileName}`);
-    if (!downloadUrl) {
-        throw new Error(`Failed to parse URL: ${downloadUrl}`);
+    const url = new URL(`https://cdn.posit.co/positron/prereleases/mac/universal/${fileName}`);
+    if (!url) {
+        throw new Error(`Failed to parse URL: ${url}`);
     }
 
-    console.log(`Downloading Positron for ${platform} from ${downloadUrl.href}`);
+    console.log(`Downloading Positron for ${platform} from ${url.href}`);
     // Reset the Accept header to download the asset.
     headers.Accept = 'application/octet-stream';
     const dlRequestOptions: https.RequestOptions = {
         headers,
         method: 'GET',
-        protocol: downloadUrl.protocol,
-        hostname: downloadUrl.hostname,
-        path: downloadUrl.pathname,
+        protocol: url.protocol,
+        hostname: url.hostname,
+        path: url.pathname,
     };
 
     let dlResponse = await httpsGetAsync(dlRequestOptions);

--- a/extensions/positron-python/src/test/positron/testElectron.ts
+++ b/extensions/positron-python/src/test/positron/testElectron.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -9,6 +9,7 @@ import { IncomingMessage } from 'http';
 import * as https from 'https';
 import * as os from 'os';
 import * as path from 'path';
+import { URL } from 'url';
 import { defaultCachePath } from '@vscode/test-electron/out/download';
 import { TestOptions } from '@vscode/test-electron/out/runTest';
 import { runTests as vscodeRunTests } from '@vscode/test-electron';
@@ -270,20 +271,20 @@ export async function downloadAndUnzipPositron(): Promise<{ version: string; exe
     }
 
     const fileName = `Positron-${version}${suffix}`;
-    const url = URL.parse(`https://cdn.posit.co/positron/prereleases/mac/universal/${fileName}`);
-    if (!url) {
-        throw new Error(`Failed to parse URL: ${url}`);
+    const downloadUrl = URL.parse(`https://cdn.posit.co/positron/prereleases/mac/universal/${fileName}`);
+    if (!downloadUrl) {
+        throw new Error(`Failed to parse URL: ${downloadUrl}`);
     }
 
-    console.log(`Downloading Positron for ${platform} from ${url.href}`);
+    console.log(`Downloading Positron for ${platform} from ${downloadUrl.href}`);
     // Reset the Accept header to download the asset.
     headers.Accept = 'application/octet-stream';
     const dlRequestOptions: https.RequestOptions = {
         headers,
         method: 'GET',
-        protocol: url.protocol,
-        hostname: url.hostname,
-        path: url.pathname,
+        protocol: downloadUrl.protocol,
+        hostname: downloadUrl.hostname,
+        path: downloadUrl.pathname,
     };
 
     let dlResponse = await httpsGetAsync(dlRequestOptions);

--- a/extensions/positron-python/src/test/positron/testElectron.ts
+++ b/extensions/positron-python/src/test/positron/testElectron.ts
@@ -18,6 +18,8 @@ const rmrf = require('rimraf');
 
 const COMPLETE_FILE_NAME = 'is-complete';
 
+const USER_AGENT = 'positron-python-tests';
+
 // Create a promisified version of https.get. We can't use the built-in promisify
 // because the callback doesn't follow the promise convention of (error, result).
 const httpsGetAsync = (opts: string | https.RequestOptions) =>
@@ -143,7 +145,7 @@ export async function downloadAndUnzipPositron(): Promise<{ version: string; exe
 
     const headers: Record<string, string> = {
         Accept: 'application/vnd.github.v3.raw', // eslint-disable-line
-        'User-Agent': 'positron-python-tests', // eslint-disable-line
+        'User-Agent': USER_AGENT, // eslint-disable-line
     };
     // If we have a githubPat, set it for better rate limiting.
     if (githubPat) {
@@ -281,10 +283,13 @@ export async function downloadAndUnzipPositron(): Promise<{ version: string; exe
     }
 
     console.log(`Downloading Positron for ${platform} from ${url.href}`);
-    // Reset the Accept header to download the asset.
-    headers.Accept = 'application/octet-stream';
+    // Use separate headers for downloading the Positron binary.
+    const dlHeaders: Record<string, string> = {
+        Accept: 'application/octet-stream',
+        'User-Agent': USER_AGENT,
+    };
     const dlRequestOptions: https.RequestOptions = {
-        headers,
+        headers: dlHeaders,
         method: 'GET',
         protocol: url.protocol,
         hostname: url.hostname,

--- a/extensions/positron-python/src/test/positron/testElectron.ts
+++ b/extensions/positron-python/src/test/positron/testElectron.ts
@@ -269,10 +269,15 @@ export async function downloadAndUnzipPositron(): Promise<{ version: string; exe
         }
     }
 
-    const fileName = `Positron-${version}${suffix}`;
-    const url = new URL(`https://cdn.posit.co/positron/prereleases/mac/universal/${fileName}`);
-    if (!url) {
-        throw new Error(`Failed to parse URL: ${url}`);
+    let fileName: string;
+    let url: URL | undefined;
+    switch (platform) {
+        case 'darwin':
+            fileName = `Positron-${version}${suffix}`;
+            url = new URL(`https://cdn.posit.co/positron/prereleases/mac/universal/${fileName}`);
+            break;
+        default:
+            throw new Error(`Unsupported platform: ${platform}`);
     }
 
     console.log(`Downloading Positron for ${platform} from ${url.href}`);


### PR DESCRIPTION
We no longer publish the release binaries as assets, but the `downloadAndUnzipPositron()` function still assumes that we do.

This PR updates the script to use the CDN url so we shouldn't see this error anymore when running Python extension MacOS tests:

```
Run GabrielBB/xvfb-action@v1.7
/Users/runner/hostedtoolcache/node/20.12.1/arm64/bin/npm run testDebugger

> python@2025.99.0-dev testDebugger
> node ./out/test/testBootstrap.js ./out/test/debuggerTest.js

Test server listening on port 49253
****************************************************************************************************
Start Debugger tests
Using Github PAT from environment variable POSITRON_GITHUB_PAT.
End Debugger tests (with errors) Error: No asset found with suffix .dmg for platform darwin
    at downloadAndUnzipPositron (/Users/runner/work/positron/positron/path with spaces/extensions/positron-python/out/test/positron/testElectron.js:197:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async runTests (/Users/runner/work/positron/positron/path with spaces/extensions/positron-python/out/test/positron/testElectron.js:269:63)
Exiting with test failures
Killing VSC
Error: The process '/Users/runner/hostedtoolcache/node/20.12.1/arm64/bin/npm' failed with exit code 1
```

### QA Notes

Python Mac OS tests should now pass locally and in CI.
