### PR TITLE
Add "conserve space" mode to the PositronActionBar and use that mode in the Console action bar

### DIFF
--- a/src/vs/platform/positronActionBar/browser/positronActionBarState.tsx
+++ b/src/vs/platform/positronActionBar/browser/positronActionBarState.tsx
@@ -55,6 +55,8 @@ export interface PositronActionBarState extends PositronActionBarServices {
 	menuShowing: boolean;
 	setMenuShowing(menuShowing: boolean): void;
 	focusableComponents: Set<HTMLElement>;
+	conserveSpace: boolean;
+	setConserveSpace(conserveSpace: boolean): void;
 }
 
 /**
@@ -66,6 +68,7 @@ export const usePositronActionBarState = (
 	services: PositronActionBarServices
 ): PositronActionBarState => {
 	const [menuShowing, setMenuShowing] = useState(false);
+	const [conserveSpace, setConserveSpace] = useState(false);
 	const [focusableComponents] = useState(new Set<HTMLElement>());
 	const [hoverManager, setHoverManager] = useState<IHoverManager>(undefined!);
 
@@ -152,6 +155,8 @@ export const usePositronActionBarState = (
 		hoverManager,
 		menuShowing,
 		setMenuShowing,
-		focusableComponents
+		focusableComponents,
+		conserveSpace,
+		setConserveSpace
 	};
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.css
@@ -16,7 +16,8 @@
 	font-size: 12px;
 	overflow: hidden;
 	display: flex;
-	max-width: 300px;
+	max-width: 200px;
+	align-items: center;
 }
 
 .positron-console .directory-label .codicon {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -7,7 +7,7 @@
 import './actionBar.css';
 
 // React.
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
@@ -20,7 +20,7 @@ import { ActionBarRegion } from '../../../../../platform/positronActionBar/brows
 import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
 import { ActionBarSeparator } from '../../../../../platform/positronActionBar/browser/components/actionBarSeparator.js';
 import { usePositronConsoleContext } from '../positronConsoleContext.js';
-import { PositronActionBarContextProvider } from '../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
+import { PositronActionBarContextProvider, usePositronActionBarContext } from '../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
 import { PositronConsoleState } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { RuntimeExitReason, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, RuntimeStartMode } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
@@ -60,6 +60,7 @@ const positronClearConsole = localize('positronClearConsole', "Clear console");
 const positronRestartConsole = localize('positronRestartConsole', "Restart console");
 const positronShutdownConsole = localize('positronShutdownConsole', "Shutdown console");
 const positronStartConsole = localize('positronStartConsole', "Start console");
+const positronCurrentWorkingDirectory = localize('positronCurrentWorkingDirectory', "Current Working Directory");
 
 /**
  * Provides a localized label for the given runtime state. Only the transient
@@ -325,6 +326,60 @@ export const ActionBar = (props: ActionBarProps) => {
 			'User-requested restart from console action bar');
 	};
 
+	/**
+	 * CurrentWorkingDirectoryProps interface.
+	 */
+	interface CurrentWorkingDirectoryProps {
+		readonly directoryLabel: string;
+	}
+
+	/**
+	 * The current working directory component.
+	 * @returns The rendered component.
+	 */
+	const CurrentWorkingDirectory = (props: CurrentWorkingDirectoryProps) => {
+		// Context hooks.
+		const context = usePositronActionBarContext();
+
+		// Reference hooks.
+		const ref = useRef<HTMLDivElement>(undefined!);
+
+		// State hooks.
+		const [mouseInside, setMouseInside] = useState(false);
+
+		// Hover useEffect.
+		useEffect(() => {
+			// If the mouse is inside, show the hover. This has the effect of showing the hover when
+			// mouseInside is set to true and updating the hover when the tooltip changes.
+			if (mouseInside) {
+				context.hoverManager.showHover(ref.current, props.directoryLabel);
+			}
+		}, [context.hoverManager, mouseInside, props.directoryLabel]);
+
+		// Render.
+		return (
+			<div
+				ref={ref}
+				aria-label={positronCurrentWorkingDirectory}
+				className='directory-label'
+				onMouseEnter={() => {
+					// Set the mouse inside state.
+					setMouseInside(true);
+				}}
+				onMouseLeave={() => {
+					// Clear the mouse inside state.
+					setMouseInside(false);
+
+					// Hide the hover.
+					context.hoverManager?.hideHover();
+				}}
+			>
+				<span className='codicon codicon-folder' role='presentation'></span>
+				<span className='label'>{!context.conserveSpace ? directoryLabel : '...'}</span>
+			</div>
+		);
+	};
+
 	// Render.
 	return (
 		<PositronActionBarContextProvider {...positronConsoleContext}>
@@ -336,38 +391,15 @@ export const ActionBar = (props: ActionBarProps) => {
 					paddingRight={kPaddingRight}
 					size='small'
 				>
-					{!multiSessionsEnabled &&
-						<ActionBarRegion location='left'>
-							<ConsoleInstanceMenuButton {...props} />
-							<div className='action-bar-separator' />
-							{directoryLabel &&
-								<div aria-label={(() => localize(
-									'directoryLabel',
-									"Current Working Directory"
-								))()}
-									className='directory-label'
-								>
-									<span className='codicon codicon-folder' role='presentation'></span>
-									<span className='label' title={directoryLabel}>{directoryLabel}</span>
-								</div>
-							}
-						</ActionBarRegion>
-					}
-					{multiSessionsEnabled &&
-						<div>
-							{directoryLabel &&
-								<div aria-label={(() => localize(
-									'directoryLabel',
-									"Current Working Directory"
-								))()}
-									className='directory-label'
-								>
-									<span className='codicon codicon-folder' role='presentation'></span>
-									<span className='label' title={directoryLabel}>{directoryLabel}</span>
-								</div>
-							}
-						</div>
-					}
+					<ActionBarRegion location='left'>
+						{!multiSessionsEnabled &&
+							<>
+								<ConsoleInstanceMenuButton {...props} />
+								<ActionBarSeparator />
+							</>
+						}
+						<CurrentWorkingDirectory directoryLabel={directoryLabel} />
+					</ActionBarRegion>
 					<ActionBarRegion location='right'>
 						<div className='state-label'>{stateLabel}</div>
 						{interruptible &&

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.css
@@ -20,6 +20,7 @@
 	margin: 8px 0;
 	overflow-wrap: break-word;
 	padding: 0 8px;
+	user-select: text;
 }
 
 .console-instance-info .actions .link {


### PR DESCRIPTION
### Description

This PR partially addresses #6199 by making several adjustments to the `PositronActionBar` component and the Console action bar so that the left and right regions do not exceed the width of the action bar in most cases.

#### What was wrong:

This screenshot shows the problem. Note that the actions on the right of the Console action bar are hidden:

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/aa9a5078-a7d8-4702-a2d8-4c02b8a1a101" />

#### What was changed:

1) The maximum width of the `CurrentWorkingDirectory` component in the Console action bar is now 200px. When the `CurrentWorkingDirectory` component exceeds this width, it's label is truncated.

![image](https://github.com/user-attachments/assets/af226471-1b5b-412f-ae11-cb365c5b4510)

2) A user can hover over the `CurrentWorkingDirectory` component to see the full directory name.

![image](https://github.com/user-attachments/assets/a5c56c35-0b0b-4e08-9c79-899e0ef6d5f9)

3) When the width of a `PositronActionBar` is less than 500px, it is placed into "conserve space" mode. The `CurrentWorkingDirectory` component uses the "conserve space" mode to turn off its label.

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/63f4c7ba-7817-48e2-8dd9-2b38161bf507" />

And again, the user can hover over the `CurrentWorkingDirectory` component to see the full directory name:

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/0fad701b-65c1-4264-89d1-67718f60b634" />

#### Notes

These changes are only meant to be a stopgap until we can make a more significant investment in the `PositronActionBar` component.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #6199


### QA Notes

Tests:
@:console

None