### PR TITLE
Add file metadata to Windows exe

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -527,24 +527,31 @@ function patchWin32DependenciesTask(cwd) {
 		const packageJson = JSON.parse(await fs.promises.readFile(path.join(cwd, 'resources', 'app', 'package.json'), 'utf8'));
 		const product = JSON.parse(await fs.promises.readFile(path.join(cwd, 'resources', 'app', 'product.json'), 'utf8'));
 		const baseVersion = packageJson.version.replace(/-.*$/, '');
+		// --- Start Positron ---
+		const executablePath = `${product.nameShort}.exe`;
+		const fileMetadata = {
+			'file-version': baseVersion,
+			'version-string': {
+				'CompanyName': 'Microsoft Corporation',
+				'FileDescription': product.nameLong,
+				'FileVersion': packageJson.version,
+				'InternalName': executablePath,
+				'LegalCopyright': 'Copyright (C) 2022 Microsoft. All rights reserved',
+				'OriginalFilename': executablePath,
+				'ProductName': product.nameLong,
+				'ProductVersion': packageJson.version,
+			}
+		};
+		fancyLog('rcedit: ' + executablePath);
+
+		await rcedit(path.join(cwd, executablePath), fileMetadata);
 
 		await Promise.all(deps.map(async dep => {
 			const basename = path.basename(dep);
-			// --- Start Positron ---
+			fancyLog('rcedit: ' + dep);
 			try {
-				await rcedit(path.join(cwd, dep), {
-					'file-version': baseVersion,
-					'version-string': {
-						'CompanyName': 'Microsoft Corporation',
-						'FileDescription': product.nameLong,
-						'FileVersion': packageJson.version,
-						'InternalName': basename,
-						'LegalCopyright': 'Copyright (C) 2022 Microsoft. All rights reserved',
-						'OriginalFilename': basename,
-						'ProductName': product.nameLong,
-						'ProductVersion': packageJson.version,
-					}
-				});
+				fileMetadata['version-string'].InternalName = basename;
+				await rcedit(path.join(cwd, dep), fileMetadata);
 			} catch (e) {
 				fancyLog('Skipping rcedit for ' + dep + ': ' + e);
 			}

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -536,7 +536,7 @@ function patchWin32DependenciesTask(cwd) {
 		await rcedit(path.join(cwd, executablePath), {
 			'file-version': product.positronVersion,
 			'version-string': {
-				'CompanyName': 'Posit',
+				'CompanyName': 'Posit Software, PBC',
 				'FileDescription': product.nameLong,
 				'FileVersion': product.positronVersion,
 				'InternalName': executablePath,


### PR DESCRIPTION
Address #3671 

The build only updates the exe's icon so the file metadata was the original Electron details. Windows Task Manager uses the file metadata to show the details. It probably uses the exe name until the metadata is read so that causes the brief moment of it showing Positron.

I've added some logging to the build to show which files have `rcedit` run on it to add the file metadata.

I've added what the logging looks like below. I don't think the failed rcedits are a problem since they're for non-Windows.

```
[14:47:53] rcedit: Positron.exe
[14:47:54] rcedit: resources/app/extensions/microsoft-authentication/dist/msal-node-runtime.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/darwin-arm64/node.napi.glibc.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/darwin-x64/node.napi.glibc.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/linux-arm/node.napi.glibc.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/linux-arm64/node.napi.glibc.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/linux-arm64/node.napi.musl.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/linux-x64/node.napi.glibc.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/linux-x64/node.napi.musl.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/win32-arm64/node.napi.glibc.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/win32-x64/node.napi.glibc.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromqold/prebuilds/darwin-x64/node.napi.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromqold/prebuilds/linux-arm/node.napi.glibc.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromqold/prebuilds/linux-arm64/node.napi.glibc.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromqold/prebuilds/linux-x64/node.napi.glibc.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromqold/prebuilds/linux-x64/node.napi.musl.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromqold/prebuilds/win32-ia32/node.napi.node
[14:47:54] rcedit: resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromqold/prebuilds/win32-x64/node.napi.node
[14:47:54] rcedit: resources/app/extensions/ms-vscode.js-debug/src/w32appcontainertokens-LVKSWXR7.node
[14:47:54] rcedit: resources/app/node_modules/@parcel/watcher/build/Release/watcher.node
[14:47:54] rcedit: resources/app/node_modules/@vscode/deviceid/build/Release/windows.node
[14:47:54] rcedit: resources/app/node_modules/@vscode/policy-watcher/build/Release/vscode-policy-watcher.node
[14:47:54] rcedit: resources/app/node_modules/@vscode/spdlog/build/Release/spdlog.node
[14:47:54] rcedit: resources/app/node_modules/@vscode/sqlite3/build/Release/vscode-sqlite3.node
[14:47:54] rcedit: resources/app/node_modules/@vscode/windows-ca-certs/build/Release/crypt32.node
[14:47:54] rcedit: resources/app/node_modules/@vscode/windows-mutex/build/Release/CreateMutex.node
[14:47:54] rcedit: resources/app/node_modules/@vscode/windows-process-tree/build/Release/windows_process_tree.node
[14:47:54] rcedit: resources/app/node_modules/@vscode/windows-registry/build/Release/winregistry.node
[14:47:54] rcedit: resources/app/node_modules/kerberos/build/Release/kerberos.node
[14:47:54] rcedit: resources/app/node_modules/native-is-elevated/build/Release/iselevated.node
[14:47:54] rcedit: resources/app/node_modules/native-keymap/build/Release/keymapping.node
[14:47:54] rcedit: resources/app/node_modules/native-watchdog/build/Release/watchdog.node
[14:47:54] rcedit: resources/app/node_modules/node-pty/build/Release/conpty_console_list.node
[14:47:54] rcedit: resources/app/node_modules/node-pty/build/Release/conpty.node
[14:47:54] rcedit: resources/app/node_modules/node-pty/build/Release/pty.node
[14:47:54] rcedit: resources/app/node_modules/windows-foreground-love/build/Release/foreground_love.node
[14:47:54] Skipping rcedit for resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/linux-x64/node.napi.glibc.node: Error: rcedit.exe failed with exit code 1. Unable to load file: "D:\Users\tim.mok-windows\source\px64\resources\app\extensions\ms-toolsai.jupyter\dist\node_modules\zeromq\prebuilds\linux-x64\node.napi.glibc.node"
[14:47:54] Skipping rcedit for resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/linux-arm64/node.napi.glibc.node: Error: rcedit.exe failed with exit code 1. Unable to load file: "D:\Users\tim.mok-windows\source\px64\resources\app\extensions\ms-toolsai.jupyter\dist\node_modules\zeromq\prebuilds\linux-arm64\node.napi.glibc.node"
[14:47:54] Skipping rcedit for resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromqold/prebuilds/darwin-x64/node.napi.node: Error: rcedit.exe failed with exit code 1. Unable to load file: "D:\Users\tim.mok-windows\source\px64\resources\app\extensions\ms-toolsai.jupyter\dist\node_modules\zeromqold\prebuilds\darwin-x64\node.napi.node"
[14:47:54] Skipping rcedit for resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/darwin-x64/node.napi.glibc.node: Error: rcedit.exe failed with exit code 1. Unable to load file: "D:\Users\tim.mok-windows\source\px64\resources\app\extensions\ms-toolsai.jupyter\dist\node_modules\zeromq\prebuilds\darwin-x64\node.napi.glibc.node"
[14:47:54] Skipping rcedit for resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/linux-arm64/node.napi.musl.node: Error: rcedit.exe failed with exit code 1. Unable to load file: "D:\Users\tim.mok-windows\source\px64\resources\app\extensions\ms-toolsai.jupyter\dist\node_modules\zeromq\prebuilds\linux-arm64\node.napi.musl.node"
[14:47:54] Skipping rcedit for resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromqold/prebuilds/linux-x64/node.napi.glibc.node: Error: rcedit.exe failed with exit code 1. Unable to load file: "D:\Users\tim.mok-windows\source\px64\resources\app\extensions\ms-toolsai.jupyter\dist\node_modules\zeromqold\prebuilds\linux-x64\node.napi.glibc.node"
[14:47:54] Skipping rcedit for resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromqold/prebuilds/linux-arm64/node.napi.glibc.node: Error: rcedit.exe failed with exit code 1. Unable to load file: "D:\Users\tim.mok-windows\source\px64\resources\app\extensions\ms-toolsai.jupyter\dist\node_modules\zeromqold\prebuilds\linux-arm64\node.napi.glibc.node"
[14:47:54] Skipping rcedit for resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromqold/prebuilds/linux-arm/node.napi.glibc.node: Error: rcedit.exe failed with exit code 1. Unable to load file: "D:\Users\tim.mok-windows\source\px64\resources\app\extensions\ms-toolsai.jupyter\dist\node_modules\zeromqold\prebuilds\linux-arm\node.napi.glibc.node"
[14:47:54] Skipping rcedit for resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/linux-arm/node.napi.glibc.node: Error: rcedit.exe failed with exit code 1. Unable to load file: "D:\Users\tim.mok-windows\source\px64\resources\app\extensions\ms-toolsai.jupyter\dist\node_modules\zeromq\prebuilds\linux-arm\node.napi.glibc.node"
[14:47:54] Skipping rcedit for resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/linux-x64/node.napi.musl.node: Error: rcedit.exe failed with exit code 1. Unable to load file: "D:\Users\tim.mok-windows\source\px64\resources\app\extensions\ms-toolsai.jupyter\dist\node_modules\zeromq\prebuilds\linux-x64\node.napi.musl.node"
[14:47:54] Skipping rcedit for resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromq/prebuilds/darwin-arm64/node.napi.glibc.node: Error: rcedit.exe failed with exit code 1. Unable to load file: "D:\Users\tim.mok-windows\source\px64\resources\app\extensions\ms-toolsai.jupyter\dist\node_modules\zeromq\prebuilds\darwin-arm64\node.napi.glibc.node"
[14:47:54] Skipping rcedit for resources/app/extensions/ms-toolsai.jupyter/dist/node_modules/zeromqold/prebuilds/linux-x64/node.napi.musl.node: Error: rcedit.exe failed with exit code 1. Unable to load file: "D:\Users\tim.mok-windows\source\px64\resources\app\extensions\ms-toolsai.jupyter\dist\node_modules\zeromqold\prebuilds\linux-x64\node.napi.musl.node"
```

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes



#### New Features

- N/A

#### Bug Fixes

- #3671 Fix process name in Windows Task Manager


### QA Notes
The file's properties in the details tab should look like this:
![image](https://github.com/user-attachments/assets/80fcdebb-e9dc-497a-a369-61bdc41a1e79)


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
