### PR TITLE
Connections: Fix css for web/server mode

### DIFF
--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.css
@@ -71,7 +71,7 @@
 	padding: 2px;
 }
 
-.create-connection-inputs > .labeled-input label {
+.create-connection-inputs > .labeled-input label.label {
 	display: flex;
 	flex-direction: row;
 	align-items: center;

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
@@ -172,7 +172,15 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 const Form = (props: PropsWithChildren<{ inputs: Input[], onInputsChange: (inputs: Input[]) => void }>) => {
 	const { inputs, onInputsChange } = props;
 
-	return <form className='create-connection-inputs'>
+	// On web, there's a global window event handler that captures the wheel event and prevents it
+	// from being captured by the form div.
+	// We need to stop the event propagation so we can actually scroll the form.
+	// See https://github.com/posit-dev/positron/blob/58c02080130dc80e08fd319573e05a57073491aa/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts#L135
+	const handleWheel = (e: any) => {
+		e.stopPropagation();
+	};
+
+	return <form onWheel={handleWheel} className='create-connection-inputs'>
 		{
 			inputs.map((input) => {
 				return <FormElement key={input.id} input={input} onChange={(value) => {
@@ -209,7 +217,7 @@ const FormElement = (props: PropsWithChildren<FormElementProps>) => {
 				></LabeledTextInput>
 			</div>;
 		case 'option':
-			return <div className='labeled-input'><label>
+			return <div className='labeled-input'><label className='label'>
 				<span className='label-text'>{label}</span>
 				{
 					options && options.length > 0 ?

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModelDialog.css
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModelDialog.css
@@ -3,6 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.connections-new-connection-modal > .content-area {
+.positron-modal-dialog-box > .connections-new-connection-modal > .content-area {
 	bottom: 0px;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->

There's some slightly different CSS's that are used when using the Web mode. Those CSS declarations were taking larger importance than the ones we declared earlier. With this PR we make the css declarations more specific so they take precedence over the global css.

Adresses https://github.com/posit-dev/positron/issues/6495

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Verify the the connection modals are correcltly rendered on Web/Server mode.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
