### PR TITLE
python: identify uv environments

### DIFF
--- a/extensions/positron-python/src/client/api/types.ts
+++ b/extensions/positron-python/src/client/api/types.ts
@@ -268,6 +268,9 @@ export type KnownEnvironmentTools =
     | 'VirtualEnvWrapper'
     | 'Pyenv'
     | 'Hatch'
+    // --- Start Positron ---
+    | 'Uv'
+    // --- End Positron ---
     | 'Unknown';
 
 /**

--- a/extensions/positron-python/src/client/envExt/api.legacy.ts
+++ b/extensions/positron-python/src/client/envExt/api.legacy.ts
@@ -37,6 +37,11 @@ function toEnvironmentType(pythonEnv: PythonEnvironment): EnvironmentType {
     if (pythonEnv.envId.managerId.toLowerCase().endsWith('hatch')) {
         return EnvironmentType.Hatch;
     }
+    // --- Start Positron ---
+    if (pythonEnv.envId.managerId.toLowerCase().endsWith('uv')) {
+        return EnvironmentType.Uv;
+    }
+    // --- End Positron ---
     if (pythonEnv.envId.managerId.toLowerCase().endsWith('pixi')) {
         return EnvironmentType.Pixi;
     }
@@ -51,6 +56,9 @@ function toEnvironmentType(pythonEnv: PythonEnvironment): EnvironmentType {
 
 function getEnvType(kind: EnvironmentType): PythonEnvType | undefined {
     switch (kind) {
+        // --- Start Positron ---
+        // The only Positron change here is adding uv, but this fence can't be in the middle
+        case EnvironmentType.Uv:
         case EnvironmentType.Pipenv:
         case EnvironmentType.VirtualEnv:
         case EnvironmentType.Pyenv:
@@ -60,6 +68,7 @@ function getEnvType(kind: EnvironmentType): PythonEnvType | undefined {
         case EnvironmentType.Pixi:
         case EnvironmentType.VirtualEnvWrapper:
         case EnvironmentType.ActiveState:
+            // --- End Positron ---
             return PythonEnvType.Virtual;
 
         case EnvironmentType.Conda:

--- a/extensions/positron-python/src/client/envExt/envExtApi.ts
+++ b/extensions/positron-python/src/client/envExt/envExtApi.ts
@@ -59,6 +59,11 @@ function getKind(pythonEnv: PythonEnvironment): PythonEnvKind {
     if (pythonEnv.envId.managerId.toLowerCase().endsWith('hatch')) {
         return PythonEnvKind.Hatch;
     }
+    // --- Start Positron ---
+    if (pythonEnv.envId.managerId.toLowerCase().endsWith('uv')) {
+        return PythonEnvKind.Uv;
+    }
+    // --- End Positron ---
     if (pythonEnv.envId.managerId.toLowerCase().endsWith('activestate')) {
         return PythonEnvKind.ActiveState;
     }
@@ -100,6 +105,9 @@ function getLocation(pythonEnv: PythonEnvironment): string {
 
 function getEnvType(kind: PythonEnvKind): PythonEnvType | undefined {
     switch (kind) {
+        // --- Start Positron ---
+        // The only Positron change here is adding uv, but this fence can't be in the middle
+        case PythonEnvKind.Uv:
         case PythonEnvKind.Poetry:
         case PythonEnvKind.Pyenv:
         case PythonEnvKind.VirtualEnv:
@@ -110,6 +118,7 @@ function getEnvType(kind: PythonEnvKind): PythonEnvType | undefined {
         case PythonEnvKind.ActiveState:
         case PythonEnvKind.Hatch:
         case PythonEnvKind.Pixi:
+            // --- End Positron ---
             return PythonEnvType.Virtual;
 
         case PythonEnvKind.Conda:

--- a/extensions/positron-python/src/client/environmentApi.ts
+++ b/extensions/positron-python/src/client/environmentApi.ts
@@ -357,6 +357,10 @@ function convertKind(kind: PythonEnvKind): EnvironmentTools | undefined {
             return 'Conda';
         case PythonEnvKind.Pyenv:
             return 'Pyenv';
+        // --- Start Positron ---
+        case PythonEnvKind.Uv:
+            return 'Uv';
+        // --- End Positron ---
         default:
             return undefined;
     }

--- a/extensions/positron-python/src/client/interpreter/configuration/environmentTypeComparer.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/environmentTypeComparer.ts
@@ -316,6 +316,9 @@ function compareEnvironmentType(a: PythonEnvironment, b: PythonEnvironment): num
 function getPrioritizedEnvironmentType(): EnvironmentType[] {
     return [
         // Prioritize non-Conda environments.
+        // --- Start Positron ---
+        EnvironmentType.Uv,
+        // --- End Positron ---
         EnvironmentType.Poetry,
         EnvironmentType.Pipenv,
         EnvironmentType.VirtualEnvWrapper,

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -93,6 +93,9 @@ export namespace EnvGroups {
     export const Poetry = 'Poetry';
     export const Hatch = 'Hatch';
     export const Pixi = 'Pixi';
+    // --- Start Positron ---
+    export const Uv = 'Uv';
+    // --- End Positron ---
     export const VirtualEnvWrapper = 'VirtualEnvWrapper';
     export const ActiveState = 'ActiveState';
     export const Recommended = Common.recommended;

--- a/extensions/positron-python/src/client/pythonEnvironments/base/info/envKind.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/info/envKind.ts
@@ -13,6 +13,9 @@ export function getKindDisplayName(kind: PythonEnvKind): string {
         // Note that Unknown is excluded here.
         [PythonEnvKind.System, 'system'],
         [PythonEnvKind.MicrosoftStore, 'Microsoft Store'],
+        // --- Start Positron ---
+        [PythonEnvKind.Uv, 'uv'],
+        // --- End Positron ---
         [PythonEnvKind.Pyenv, 'pyenv'],
         [PythonEnvKind.Poetry, 'Poetry'],
         [PythonEnvKind.Hatch, 'Hatch'],
@@ -64,6 +67,9 @@ export function getPrioritizedEnvKinds(): PythonEnvKind[] {
         PythonEnvKind.Pixi, // Placed here since Pixi environments are essentially Conda envs
         PythonEnvKind.Conda,
         PythonEnvKind.MicrosoftStore,
+        // --- Start Positron ---
+        PythonEnvKind.Uv, // Placed here since uv environments are essentially venvs
+        // --- End Positron ---
         PythonEnvKind.Pipenv,
         PythonEnvKind.Poetry,
         PythonEnvKind.Hatch,

--- a/extensions/positron-python/src/client/pythonEnvironments/base/info/index.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/info/index.ts
@@ -27,6 +27,9 @@ export enum PythonEnvKind {
     Pipenv = 'virt-pipenv',
     Conda = 'virt-conda',
     OtherVirtual = 'virt-other',
+    // --- Start Positron ---
+    Uv = 'uv',
+    // --- End Positron ---
 }
 
 export enum PythonEnvType {
@@ -53,6 +56,9 @@ export const virtualEnvKinds = [
     PythonEnvKind.VirtualEnvWrapper,
     PythonEnvKind.Conda,
     PythonEnvKind.VirtualEnv,
+    // --- Start Positron ---
+    PythonEnvKind.Uv,
+    // --- End Positron ---
 ];
 
 export const globallyInstalledEnvKinds = [

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonUtils.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonUtils.ts
@@ -14,6 +14,9 @@ export enum NativePythonEnvironmentKind {
     PyenvVirtualEnv = 'PyenvVirtualEnv',
     Pipenv = 'Pipenv',
     Poetry = 'Poetry',
+    // --- Start Positron ---
+    Uv = 'Uv',
+    // --- End Positron ---
     MacPythonOrg = 'MacPythonOrg',
     MacCommandLineTools = 'MacCommandLineTools',
     LinuxGlobal = 'LinuxGlobal',
@@ -33,6 +36,7 @@ const mapping = new Map<NativePythonEnvironmentKind, PythonEnvKind>([
     [NativePythonEnvironmentKind.PyenvVirtualEnv, PythonEnvKind.Pyenv],
     [NativePythonEnvironmentKind.Pipenv, PythonEnvKind.Pipenv],
     [NativePythonEnvironmentKind.Poetry, PythonEnvKind.Poetry],
+    [NativePythonEnvironmentKind.Uv, PythonEnvKind.Uv],
     [NativePythonEnvironmentKind.VirtualEnv, PythonEnvKind.VirtualEnv],
     [NativePythonEnvironmentKind.VirtualEnvWrapper, PythonEnvKind.VirtualEnvWrapper],
     [NativePythonEnvironmentKind.Venv, PythonEnvKind.Venv],

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/composite/envsCollectionService.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/composite/envsCollectionService.ts
@@ -289,6 +289,9 @@ export class EnvsCollectionService extends PythonEnvsWatcher<PythonEnvCollection
             const venvEnvs = envs.filter((e) => e.kind === PythonEnvKind.Venv).length;
             const virtualEnvEnvs = envs.filter((e) => e.kind === PythonEnvKind.VirtualEnv).length;
             const virtualEnvWrapperEnvs = envs.filter((e) => e.kind === PythonEnvKind.VirtualEnvWrapper).length;
+            // --- Start Positron ---
+            const uvEnvs = envs.filter((e) => e.kind === PythonEnvKind.Uv).length;
+            // --- End Positron ---
 
             // Intent is to capture time taken for discovery of all envs to complete the first time.
             sendTelemetryEvent(EventName.PYTHON_INTERPRETER_DISCOVERY, stopWatch.elapsedTime, {
@@ -310,6 +313,9 @@ export class EnvsCollectionService extends PythonEnvsWatcher<PythonEnvCollection
                 venvEnvs,
                 virtualEnvEnvs,
                 virtualEnvWrapperEnvs,
+                // --- Start Positron ---
+                uvEnvs,
+                // --- End Positron ---
             });
         }
         this.hasRefreshFinishedForQuery.set(query, true);

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/customVirtualEnvLocator.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/customVirtualEnvLocator.ts
@@ -16,6 +16,9 @@ import {
     isVirtualenvEnvironment,
     isVirtualenvwrapperEnvironment,
 } from '../../../common/environmentManagers/simplevirtualenvs';
+// --- Start Positron ---
+import { isUvEnvironment } from '../../../common/environmentManagers/uv';
+// --- End Positron ---
 import '../../../../common/extensions';
 import { asyncFilter } from '../../../../common/utils/arrayUtils';
 import { traceError, traceInfo, traceVerbose } from '../../../../logging';
@@ -56,6 +59,12 @@ async function getCustomVirtualEnvDirs(): Promise<string[]> {
  * @param interpreterPath: Absolute path to the interpreter paths.
  */
 async function getVirtualEnvKind(interpreterPath: string): Promise<PythonEnvKind> {
+    // --- Start Positron ---
+    if (await isUvEnvironment(interpreterPath)) {
+        return PythonEnvKind.Uv;
+    }
+    // --- End Positron ---
+
     if (await isPipenvEnvironment(interpreterPath)) {
         return PythonEnvKind.Pipenv;
     }

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/globalVirtualEnvronmentLocator.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/globalVirtualEnvronmentLocator.ts
@@ -17,6 +17,9 @@ import {
     isVirtualenvEnvironment,
     isVirtualenvwrapperEnvironment,
 } from '../../../common/environmentManagers/simplevirtualenvs';
+// --- Start Positron ---
+import { isUvEnvironment } from '../../../common/environmentManagers/uv';
+// --- End Positron ---
 import '../../../../common/extensions';
 import { asyncFilter } from '../../../../common/utils/arrayUtils';
 import { traceError, traceInfo, traceVerbose } from '../../../../logging';
@@ -79,6 +82,12 @@ async function getSearchLocation(env: BasicEnvInfo): Promise<Uri | undefined> {
  * @param interpreterPath: Absolute path to the interpreter paths.
  */
 async function getVirtualEnvKind(interpreterPath: string): Promise<PythonEnvKind> {
+    // --- Start Positron ---
+    if (await isUvEnvironment(interpreterPath)) {
+        return PythonEnvKind.Uv;
+    }
+    // --- End Positron ---
+
     if (await isPipenvEnvironment(interpreterPath)) {
         return PythonEnvKind.Pipenv;
     }

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/workspaceVirtualEnvLocator.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/lowLevel/workspaceVirtualEnvLocator.ts
@@ -7,6 +7,9 @@ import { findInterpretersInDir, looksLikeBasicVirtualPython } from '../../../com
 import { pathExists } from '../../../common/externalDependencies';
 import { isPipenvEnvironment } from '../../../common/environmentManagers/pipenv';
 import { isVenvEnvironment, isVirtualenvEnvironment } from '../../../common/environmentManagers/simplevirtualenvs';
+// --- Start Positron ---
+import { isUvEnvironment } from '../../../common/environmentManagers/uv';
+// --- End Positron ---
 import { PythonEnvKind } from '../../info';
 import { BasicEnvInfo, IPythonEnvsIterator } from '../../locator';
 import { FSWatcherKind, FSWatchingLocator } from './fsWatchingLocator';
@@ -33,6 +36,12 @@ function getWorkspaceVirtualEnvDirs(root: string): Promise<string[]> {
  * @param interpreterPath: Absolute path to the interpreter paths.
  */
 async function getVirtualEnvKind(interpreterPath: string): Promise<PythonEnvKind> {
+    // --- Start Positron ---
+    if (await isUvEnvironment(interpreterPath)) {
+        return PythonEnvKind.Uv;
+    }
+    // --- End Positron ---
+
     if (await isPipenvEnvironment(interpreterPath)) {
         return PythonEnvKind.Pipenv;
     }

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentIdentifier.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentIdentifier.ts
@@ -17,6 +17,9 @@ import {
 import { isMicrosoftStoreEnvironment } from './environmentManagers/microsoftStoreEnv';
 import { isActiveStateEnvironment } from './environmentManagers/activestate';
 import { isPixiEnvironment } from './environmentManagers/pixi';
+// --- Start Positron ---
+import { isUvEnvironment } from './environmentManagers/uv';
+// --- End Positron ---
 
 const notImplemented = () => Promise.resolve(false);
 
@@ -37,6 +40,9 @@ function getIdentifiers(): Map<PythonEnvKind, (path: string) => Promise<boolean>
     identifier.set(PythonEnvKind.VirtualEnvWrapper, isVirtualEnvWrapperEnvironment);
     identifier.set(PythonEnvKind.VirtualEnv, isVirtualEnvEnvironment);
     identifier.set(PythonEnvKind.ActiveState, isActiveStateEnvironment);
+    // --- Start Positron ---
+    identifier.set(PythonEnvKind.Uv, isUvEnvironment);
+    // --- End Positron ---
     identifier.set(PythonEnvKind.Unknown, defaultTrue);
     identifier.set(PythonEnvKind.OtherGlobal, isGloballyInstalledEnv);
     return identifier;

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/simplevirtualenvs.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/simplevirtualenvs.ts
@@ -11,7 +11,10 @@ import { comparePythonVersionSpecificity } from '../../base/info/env';
 import { parseBasicVersion, parseRelease, parseVersion } from '../../base/info/pythonVersion';
 import { isParentPath, pathExists, readFile } from '../externalDependencies';
 
-function getPyvenvConfigPathsFrom(interpreterPath: string): string[] {
+// --- Start Positron ---
+// Only change here is exporting it so uv.ts can use it
+export function getPyvenvConfigPathsFrom(interpreterPath: string): string[] {
+    // --- End Positron ---
     const pyvenvConfigFile = 'pyvenv.cfg';
 
     // Check if the pyvenv.cfg file is in the parent directory relative to the interpreter.

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import { cache } from '../../../common/utils/decorators';
+import { traceVerbose } from '../../../logging';
+import { exec, resolveSymbolicLink } from '../externalDependencies';
+import { isTestExecution } from '../../../common/constants';
+
+/** Wraps the "uv" utility, and exposes its functionality. */
+class UvUtils {
+    private static uvPromise: Promise<UvUtils | undefined>;
+
+    constructor(public readonly command: string) {}
+
+    public static async getUvUtils(): Promise<UvUtils | undefined> {
+        if (UvUtils.uvPromise === undefined || isTestExecution()) {
+            UvUtils.uvPromise = UvUtils.locate();
+        }
+        return UvUtils.uvPromise;
+    }
+
+    private static async locate(): Promise<UvUtils | undefined> {
+        const uvPath = 'uv';
+        traceVerbose(`Probing uv binary ${uvPath}`);
+        const uv = new UvUtils(uvPath);
+        const uvDir = await uv.getUvDir();
+        if (uvDir !== undefined) {
+            traceVerbose(`Found uv binary ${uvPath}`);
+            return uv;
+        }
+        traceVerbose(`No uv binary found`);
+        return undefined;
+    }
+
+    @cache(-1)
+    public async getUvDir(): Promise<string | undefined> {
+        try {
+            const result = await exec(this.command, ['python', 'dir'], { throwOnStdErr: true });
+            return result?.stdout.trim();
+        } catch (ex) {
+            traceVerbose(ex);
+            return undefined;
+        }
+    }
+}
+
+/**
+ * Checks if the given interpreter belongs to a uv-managed environment.
+ * @param interpreterPath Absolute path to the python interpreter.
+ * @returns {boolean} Returns true if the interpreter belongs to a uv environment.
+ */
+export async function isUvEnvironment(interpreterPath: string): Promise<boolean> {
+    const uvUtils = await UvUtils.getUvUtils();
+    if (!uvUtils) {
+        return false;
+    }
+
+    const uvDir = await uvUtils.getUvDir();
+    if (!uvDir) {
+        return false;
+    }
+
+    // Check if interpreter is directly in the uv directory
+    const normalizedInterpreterPath = path.normalize(interpreterPath);
+    const normalizedUvDir = path.normalize(uvDir);
+    if (normalizedInterpreterPath.startsWith(normalizedUvDir)) {
+        return true;
+    }
+
+    // Check if it's a symlink pointing to the uv directory
+    try {
+        const resolvedPath = await resolveSymbolicLink(interpreterPath);
+        if (
+            resolvedPath &&
+            resolvedPath !== interpreterPath &&
+            path.normalize(resolvedPath).startsWith(normalizedUvDir)
+        ) {
+            return true;
+        }
+    } catch (ex) {
+        // If we can't resolve the symlink, fall back to false
+        traceVerbose(ex);
+    }
+
+    return false;
+}

--- a/extensions/positron-python/src/client/pythonEnvironments/info/index.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/info/index.ts
@@ -21,6 +21,9 @@ export enum EnvironmentType {
     Poetry = 'Poetry',
     Hatch = 'Hatch',
     Pixi = 'Pixi',
+    // --- Start Positron ---
+    Uv = 'Uv',
+    // --- End Positron ---
     VirtualEnvWrapper = 'VirtualEnvWrapper',
     ActiveState = 'ActiveState',
     Global = 'Global',
@@ -29,7 +32,15 @@ export enum EnvironmentType {
 /**
  * These envs are only created for a specific workspace, which we're able to detect.
  */
-export const workspaceVirtualEnvTypes = [EnvironmentType.Poetry, EnvironmentType.Pipenv, EnvironmentType.Pixi];
+// --- Start Positron ---
+// Added uv
+export const workspaceVirtualEnvTypes = [
+    EnvironmentType.Poetry,
+    EnvironmentType.Pipenv,
+    EnvironmentType.Pixi,
+    EnvironmentType.Uv,
+];
+// --- End Positron ---
 
 export const virtualEnvTypes = [
     ...workspaceVirtualEnvTypes,
@@ -131,6 +142,11 @@ export function getEnvironmentTypeName(environmentType: EnvironmentType): string
         case EnvironmentType.Pixi: {
             return 'pixi';
         }
+        // --- Start Positron ---
+        case EnvironmentType.Uv: {
+            return 'uv';
+        }
+        // --- End Positron ---
         case EnvironmentType.VirtualEnvWrapper: {
             return 'virtualenvwrapper';
         }

--- a/extensions/positron-python/src/client/pythonEnvironments/legacyIOC.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/legacyIOC.ts
@@ -40,6 +40,9 @@ const convertedKinds = new Map(
         [PythonEnvKind.Poetry]: EnvironmentType.Poetry,
         [PythonEnvKind.Hatch]: EnvironmentType.Hatch,
         [PythonEnvKind.Pixi]: EnvironmentType.Pixi,
+        // --- Start Positron ---
+        [PythonEnvKind.Uv]: EnvironmentType.Uv,
+        // --- End Positron ---
         [PythonEnvKind.Venv]: EnvironmentType.Venv,
         [PythonEnvKind.VirtualEnvWrapper]: EnvironmentType.VirtualEnvWrapper,
         [PythonEnvKind.ActiveState]: EnvironmentType.ActiveState,

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -491,7 +491,7 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
         const native = await this.finder.resolve(envPath);
         if (native) {
             // --- Start Positron ---
-            if (native.executable && await isUvEnvironment(native.executable)) {
+            if (native.executable && (await isUvEnvironment(native.executable))) {
                 traceInfo(`Found uv environment: ${native.executable}`);
                 native.kind = NativePythonEnvironmentKind.Uv;
             }

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -94,6 +94,10 @@ function kindToShortString(kind: PythonEnvKind): string | undefined {
             return 'hatch';
         case PythonEnvKind.Pixi:
             return 'pixi';
+        // --- Start Positron ---
+        case PythonEnvKind.Uv:
+            return 'uv';
+        // --- End Positron ---
         case PythonEnvKind.System:
         case PythonEnvKind.Unknown:
         case PythonEnvKind.OtherGlobal:
@@ -132,6 +136,9 @@ function validEnv(nativeEnv: NativeEnvInfo): boolean {
 
 function getEnvType(kind: PythonEnvKind): PythonEnvType | undefined {
     switch (kind) {
+        // --- Start Positron ---
+        // The only Positron change here is adding uv, but this fence can't be in the middle
+        case PythonEnvKind.Uv:
         case PythonEnvKind.Poetry:
         case PythonEnvKind.Pyenv:
         case PythonEnvKind.VirtualEnv:
@@ -142,6 +149,7 @@ function getEnvType(kind: PythonEnvKind): PythonEnvType | undefined {
         case PythonEnvKind.ActiveState:
         case PythonEnvKind.Hatch:
         case PythonEnvKind.Pixi:
+            // --- End Positron ---
             return PythonEnvType.Virtual;
 
         case PythonEnvKind.Conda:

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -36,6 +36,10 @@ import {
 } from './base/locators/common/pythonWatcher';
 import { getWorkspaceFolders, onDidChangeWorkspaceFolders } from '../common/vscodeApis/workspaceApis';
 
+// --- Start Positron ---
+import { isUvEnvironment } from './common/environmentManagers/uv';
+// --- End Positron ---
+
 function makeExecutablePath(prefix?: string): string {
     if (!prefix) {
         return process.platform === 'win32' ? 'python.exe' : 'python';
@@ -486,6 +490,12 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
         }
         const native = await this.finder.resolve(envPath);
         if (native) {
+            // --- Start Positron ---
+            if (native.executable && await isUvEnvironment(native.executable)) {
+                traceInfo(`Found uv environment: ${native.executable}`);
+                native.kind = NativePythonEnvironmentKind.Uv;
+            }
+            // --- End Positron ---
             if (native.kind === NativePythonEnvironmentKind.Conda && this._condaEnvDirs.length === 0) {
                 this._condaEnvDirs = (await getCondaEnvDirs()) ?? [];
             }

--- a/extensions/positron-python/src/client/telemetry/index.ts
+++ b/extensions/positron-python/src/client/telemetry/index.ts
@@ -1430,6 +1430,9 @@ export interface IEventNamePropertyMapping {
          * Number of environments of a specific type
          */
         pyenvEnvs?: number;
+        // --- Start Positron ---
+        uvEnvs?: number;
+        // --- End Positron ---
         /**
          * Number of environments of a specific type
          */

--- a/extensions/positron-python/src/test/pythonEnvironments/base/info/envKind.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/base/info/envKind.unit.test.ts
@@ -15,6 +15,9 @@ const KIND_NAMES: [PythonEnvKind, string][] = [
     [PythonEnvKind.Poetry, 'poetry'],
     [PythonEnvKind.Hatch, 'hatch'],
     [PythonEnvKind.Pixi, 'pixi'],
+    // --- Start Positron ---
+    [PythonEnvKind.Uv, 'uv'],
+    // --- End Positron ---
     [PythonEnvKind.Custom, 'customGlobal'],
     [PythonEnvKind.OtherGlobal, 'otherGlobal'],
     [PythonEnvKind.Venv, 'venv'],

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as fileUtils from '../../../../client/pythonEnvironments/common/externalDependencies';
+import { isUvEnvironment } from '../../../../client/pythonEnvironments/common/environmentManagers/uv';
+import * as platformUtils from '../../../../client/common/utils/platform';
+import * as logging from '../../../../client/logging';
+
+suite('UV Environment Tests', () => {
+    let resolveSymbolicLinkStub: sinon.SinonStub;
+    let getOSTypeStub: sinon.SinonStub;
+    let getEnvironmentVariableStub: sinon.SinonStub;
+    let execStub: sinon.SinonStub;
+    let traceVerboseStub: sinon.SinonStub;
+
+    const customDir = '/custom/uv/python';
+    const exampleUvPython = `${customDir}/cpython-3.12`;
+
+    setup(() => {
+        resolveSymbolicLinkStub = sinon.stub(fileUtils, 'resolveSymbolicLink');
+        getOSTypeStub = sinon.stub(platformUtils, 'getOSType');
+        getEnvironmentVariableStub = sinon.stub(platformUtils, 'getEnvironmentVariable');
+        execStub = sinon.stub(fileUtils, 'exec');
+        traceVerboseStub = sinon.stub(logging, 'traceVerbose');
+
+        getOSTypeStub.returns(platformUtils.OSType.Linux);
+        execStub.resolves({ stdout: customDir });
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    suite('UV Command Execution', () => {
+        test('exec is called with correct arguments', async () => {
+            await isUvEnvironment(exampleUvPython);
+
+            assert.ok(execStub.calledWith('uv', ['python', 'dir'], { throwOnStdErr: true }));
+        });
+
+        test('getUvDir returns undefined when command fails', async () => {
+            execStub.rejects(new Error('Command failed'));
+
+            const result = await isUvEnvironment(exampleUvPython);
+
+            assert.strictEqual(result, false);
+            assert.ok(traceVerboseStub.calledWith(sinon.match.instanceOf(Error)));
+            assert.ok(traceVerboseStub.calledWith('No uv binary found'));
+        });
+
+        test('UvUtils.locate traces verbose logs on success', async () => {
+            await isUvEnvironment(exampleUvPython);
+
+            assert.ok(traceVerboseStub.calledWith('Probing uv binary uv'));
+            assert.ok(traceVerboseStub.calledWith('Found uv binary uv'));
+        });
+
+        test('UvUtils.locate traces verbose logs on failure', async () => {
+            execStub.rejects(new Error('Command failed'));
+
+            await isUvEnvironment(exampleUvPython);
+
+            assert.ok(traceVerboseStub.calledWith('Probing uv binary uv'));
+            assert.ok(traceVerboseStub.calledWith('No uv binary found'));
+        });
+    });
+
+    suite('UV directory detection', () => {
+        test('Works on Unix', async () => {
+            const result = await isUvEnvironment(exampleUvPython);
+            assert.strictEqual(result, true);
+        });
+
+        test('Works on Windows', async () => {
+            const appData = 'C:\\Users\\user\\AppData\\Roaming';
+            const uvDir = `${appData}\\uv\\data\\python`;
+            const interpreter = `${uvDir}\\env123\\Scripts\\python.exe`;
+            getOSTypeStub.returns(platformUtils.OSType.Windows);
+            getEnvironmentVariableStub
+                .withArgs('APPDATA')
+                .returns(appData)
+                .withArgs('UV_PYTHON_INSTALL_DIR')
+                .returns(undefined);
+            execStub.resolves({ stdout: uvDir });
+
+            const result = await isUvEnvironment(interpreter);
+            assert.strictEqual(result, true);
+        });
+
+        test('Works with a symlink to the python dir', async () => {
+            const interpreter = '/path/to/venv/bin/python';
+            resolveSymbolicLinkStub.withArgs(interpreter).resolves(exampleUvPython);
+
+            assert.ok(await isUvEnvironment(interpreter));
+        });
+
+        test('symlink resolution fails', async () => {
+            const interpreter = '/path/to/venv/bin/python';
+            resolveSymbolicLinkStub.withArgs(interpreter).rejects(new Error('Failed to resolve symlink'));
+            assert.strictEqual(await isUvEnvironment(interpreter), false);
+        });
+
+        test('symlink resolves but not to uv directory', async () => {
+            const interpreter = '/path/to/venv/bin/python';
+            const resolvedPath = '/path/to/other/venv/bin/python';
+            resolveSymbolicLinkStub.withArgs(interpreter).resolves(resolvedPath);
+            assert.strictEqual(await isUvEnvironment(interpreter), false);
+        });
+    });
+});


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->
Addresses https://github.com/posit-dev/positron/issues/6476.

<img width="596" alt="image" src="https://github.com/user-attachments/assets/c977cb08-a256-4329-9362-34e10f01409a" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Start to recognize `uv` environments (#6476)

#### Bug Fixes

- N/A


### QA Notes

I'd recommend clearing Positron state before testing this, since there's a lot of environment caching.

Set up `uv` on your system: https://docs.astral.sh/uv/getting-started/installation/

Try creating a venv or two and see how they look in the picker.
<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:interpreter @:extensions