### PR TITLE
Pre-release: Bump ark to v0.1.169

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -702,7 +702,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.168"
+      "ark": "0.1.169"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
v0.1.169 fixes a deadlock when starting reticulate sessions.
It would be great to get it included in 2025.03 release.

See: https://github.com/posit-dev/ark/pull/728