### PR TITLE
Add variables instance stop event

### DIFF
--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariablesState.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariablesState.tsx
@@ -61,12 +61,17 @@ export const usePositronVariablesState = (services: PositronVariablesServices): 
 
 		// Add the onDidStartPositronVariablesInstance event handler.
 		disposableStore.add(services.positronVariablesService.onDidStartPositronVariablesInstance(positronVariablesInstance => {
-			setPositronVariablesInstances(positronVariablesInstances => [...positronVariablesInstances, positronVariablesInstance]);
+			if ((positronVariablesInstances.find(i => i.session.sessionId === positronVariablesInstance.session.sessionId)) === undefined) {
+				// if this instance is already known, it's a restart so activate it
+				// activating through the service ensures all listeners are notified
+				services.positronVariablesService.setActivePositronVariablesSession(positronVariablesInstance.session.sessionId);
+			}
+			setPositronVariablesInstances(services.positronVariablesService.positronVariablesInstances);
 		}));
 
 		// Add the onDidStopPositronVariablesInstance event handler.
-		disposableStore.add(services.positronVariablesService.onDidStopPositronVariablesInstance(positronVariablesInstance => {
-			setPositronVariablesInstances(positronVariablesInstances => positronVariablesInstances.filter(i => i !== positronVariablesInstance));
+		disposableStore.add(services.positronVariablesService.onDidStopPositronVariablesInstance(_positronVariablesInstance => {
+			setPositronVariablesInstances(services.positronVariablesService.positronVariablesInstances);
 		}));
 
 		// Add the onDidChangeActivePositronVariablesInstance event handler.

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariablesState.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariablesState.tsx
@@ -64,6 +64,11 @@ export const usePositronVariablesState = (services: PositronVariablesServices): 
 			setPositronVariablesInstances(positronVariablesInstances => [...positronVariablesInstances, positronVariablesInstance]);
 		}));
 
+		// Add the onDidStopPositronVariablesInstance event handler.
+		disposableStore.add(services.positronVariablesService.onDidStopPositronVariablesInstance(positronVariablesInstance => {
+			setPositronVariablesInstances(positronVariablesInstances => positronVariablesInstances.filter(i => i !== positronVariablesInstance));
+		}));
+
 		// Add the onDidChangeActivePositronVariablesInstance event handler.
 		disposableStore.add(services.positronVariablesService.onDidChangeActivePositronVariablesInstance(positronVariablesInstance => {
 			setActivePositronVariablesInstance(positronVariablesInstance);

--- a/src/vs/workbench/services/positronVariables/common/interfaces/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/interfaces/positronVariablesService.ts
@@ -35,6 +35,11 @@ export interface IPositronVariablesService {
 	readonly onDidStartPositronVariablesInstance: Event<IPositronVariablesInstance>;
 
 	/**
+	 * The onDidStopPositronVariablesInstance event.
+	 */
+	readonly onDidStopPositronVariablesInstance: Event<IPositronVariablesInstance>;
+
+	/**
 	 * The onDidChangeActivePositronVariablesInstance event.
 	 */
 	readonly onDidChangeActivePositronVariablesInstance: Event<IPositronVariablesInstance | undefined>;

--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -47,6 +47,12 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 		this._register(new Emitter<IPositronVariablesInstance>);
 
 	/**
+	 * The onDidStopPositronVariablesInstance event emitter.
+	 */
+	private readonly _onDidStopPositronVariablesInstanceEmitter =
+		this._register(new Emitter<IPositronVariablesInstance>());
+
+	/**
 	 * The onDidChangeActivePositronVariablesInstance event emitter.
 	 */
 	private readonly _onDidChangeActivePositronVariablesInstanceEmitter =
@@ -141,6 +147,10 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 	readonly onDidStartPositronVariablesInstance =
 		this._onDidStartPositronVariablesInstanceEmitter.event;
 
+	// An event that is fired when a REPL instance is stopped.
+	readonly onDidStopPositronVariablesInstance =
+		this._onDidStopPositronVariablesInstanceEmitter.event;
+
 	// An event that is fired when the active REPL instance changes.
 	readonly onDidChangeActivePositronVariablesInstance =
 		this._onDidChangeActivePositronVariablesInstanceEmitter.event;
@@ -197,9 +207,9 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 				this._setActivePositronVariablesInstance(undefined);
 			}
 
-
 			// Dispose the instance and remove it from our map
 			this._positronVariablesInstancesBySessionId.deleteAndDispose(sessionId);
+			this._onDidStopPositronVariablesInstanceEmitter.fire(instance);
 		}
 	}
 

--- a/test/e2e/tests/variables/variables-pane.test.ts
+++ b/test/e2e/tests/variables/variables-pane.test.ts
@@ -38,7 +38,7 @@ test.describe('Variables Pane', {
 
 	});
 
-	test.skip('Python - Verify only 1 entry per environment', {
+	test('Python - Verify only 1 entry per environment', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5887' }],
 	}, async function ({ app, logger, python }) {
 		await app.workbench.console.barClearButton.click();
@@ -69,7 +69,7 @@ test.describe('Variables Pane', {
 	});
 
 
-	test.skip('R - Verify only 1 entry per environment', {
+	test('R - Verify only 1 entry per environment', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/5887' }],
 	}, async function ({ app, logger, r }) {
 		await app.workbench.console.barClearButton.click();


### PR DESCRIPTION
Address #5887 and #3504 

This adds a stop event for sessions so that the view can remove it from the list. Restarting or stopping sessions will clear it from the Variables view.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #5887 #3504 Update the Variables view when a session is stopped


### QA Notes
There may be a delay of a second or two in updating the list while the event is propagated. 

@:variables