### PR TITLE
Add data explorer summary settings for default collapse state and layout position

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -23,7 +23,7 @@ import { TableSummaryDataGridInstance } from './tableSummaryDataGridInstance.js'
 import { PositronDataExplorerLayout } from './interfaces/positronDataExplorerService.js';
 import { IPositronDataExplorerInstance } from './interfaces/positronDataExplorerInstance.js';
 import { ClipboardCell, ClipboardCellRange, ClipboardColumnIndexes, ClipboardColumnRange, ClipboardRowIndexes, ClipboardRowRange } from '../../../browser/positronDataGrid/classes/dataGridInstance.js';
-import { DataExplorerSummaryCollapseEnabled } from "../common/positronDataExplorerSummary.js";
+import { DataExplorerSummaryCollapseEnabled, DefaultDataExplorerSummaryLayout } from '../common/positronDataExplorerSummary.js';
 
 /**
  * Constants.
@@ -49,7 +49,7 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	/**
 	 * Gets or sets the layout.
 	 */
-	private _layout = PositronDataExplorerLayout.SummaryOnLeft;
+	private _layout = DefaultDataExplorerSummaryLayout(this._configurationService);
 
 	/**
 	 * Gets or sets a value which indicates whether the summary is collapsed.

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -23,7 +23,7 @@ import { TableSummaryDataGridInstance } from './tableSummaryDataGridInstance.js'
 import { PositronDataExplorerLayout } from './interfaces/positronDataExplorerService.js';
 import { IPositronDataExplorerInstance } from './interfaces/positronDataExplorerInstance.js';
 import { ClipboardCell, ClipboardCellRange, ClipboardColumnIndexes, ClipboardColumnRange, ClipboardRowIndexes, ClipboardRowRange } from '../../../browser/positronDataGrid/classes/dataGridInstance.js';
-import { DataExplorerSummaryCollapseEnabled, DefaultDataExplorerSummaryLayout } from '../common/positronDataExplorerSummary.js';
+import { DataExplorerSummaryCollapseEnabled, DefaultDataExplorerSummaryLayout } from './positronDataExplorerSummary.js';
 
 /**
  * Constants.

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerInstance.ts
@@ -23,6 +23,7 @@ import { TableSummaryDataGridInstance } from './tableSummaryDataGridInstance.js'
 import { PositronDataExplorerLayout } from './interfaces/positronDataExplorerService.js';
 import { IPositronDataExplorerInstance } from './interfaces/positronDataExplorerInstance.js';
 import { ClipboardCell, ClipboardCellRange, ClipboardColumnIndexes, ClipboardColumnRange, ClipboardRowIndexes, ClipboardRowRange } from '../../../browser/positronDataGrid/classes/dataGridInstance.js';
+import { DataExplorerSummaryCollapseEnabled } from "../common/positronDataExplorerSummary.js";
 
 /**
  * Constants.
@@ -53,7 +54,7 @@ export class PositronDataExplorerInstance extends Disposable implements IPositro
 	/**
 	 * Gets or sets a value which indicates whether the summary is collapsed.
 	 */
-	private _isSummaryCollapsed = false;
+	private _isSummaryCollapsed = DataExplorerSummaryCollapseEnabled(this._configurationService);
 
 	/**
 	 * Gets or sets the columns width percent.

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerSummary.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerSummary.ts
@@ -15,7 +15,7 @@ import { positronConfigurationNodeBase } from '../../languageRuntime/common/lang
 import { PositronDataExplorerLayout } from './interfaces/positronDataExplorerService.js';
 
 // Key for the configuration setting
-export const USE_POSITRON_DATA_EXPLORER_SUMMARY_COLLAPSE_KEY =
+export const USE_POSITRON_DATA_EXPLORER_SUMMARY_COLLAPSED_KEY =
 	'positron.dataExplorerSummaryCollapsed';
 export const USE_POSITRON_DATA_EXPLORER_SUMMARY_LAYOUT_KEY =
 	'positron.dataExplorerSummaryLayout';
@@ -24,7 +24,7 @@ export function DataExplorerSummaryCollapseEnabled(
 	configurationService: IConfigurationService
 ) {
 	return Boolean(
-		configurationService.getValue(USE_POSITRON_DATA_EXPLORER_SUMMARY_COLLAPSE_KEY)
+		configurationService.getValue(USE_POSITRON_DATA_EXPLORER_SUMMARY_COLLAPSED_KEY)
 	);
 }
 
@@ -48,7 +48,7 @@ configurationRegistry.registerConfiguration({ // for summary collapse
 	...positronConfigurationNodeBase,
 	scope: ConfigurationScope.MACHINE_OVERRIDABLE,
 	properties: {
-		[USE_POSITRON_DATA_EXPLORER_SUMMARY_COLLAPSE_KEY]: {
+		[USE_POSITRON_DATA_EXPLORER_SUMMARY_COLLAPSED_KEY]: {
 			type: 'boolean',
 			default: false,
 			markdownDescription: localize(

--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerSummary.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerSummary.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { positronConfigurationNodeBase } from '../../languageRuntime/common/languageRuntime.js';
-import { PositronDataExplorerLayout } from '../browser/interfaces/positronDataExplorerService.js';
+import { PositronDataExplorerLayout } from './interfaces/positronDataExplorerService.js';
 
 // Key for the configuration setting
 export const USE_POSITRON_DATA_EXPLORER_SUMMARY_COLLAPSE_KEY =

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerSummary.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerSummary.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import {
+	ConfigurationScope,
+	Extensions,
+	IConfigurationRegistry,
+} from '../../../../platform/configuration/common/configurationRegistry.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { positronConfigurationNodeBase } from '../../languageRuntime/common/languageRuntime.js';
+
+// Key for the configuration setting
+export const USE_POSITRON_DATA_EXPLORER_SUMMARY_COLLAPSE_KEY =
+	'positron.dataExplorerSummaryCollapse';
+
+/**
+ * Retrieves the value of the configuration setting that determines whether to enable
+ * experimental features in the Positron Data Explorer.
+ *
+ * @param configurationService The configuration service
+ * @returns Whether to enable experimental Positron Data Explorer features
+ */
+export function DataExplorerSummaryCollapseEnabled(
+	configurationService: IConfigurationService
+) {
+	return Boolean(
+		configurationService.getValue(USE_POSITRON_DATA_EXPLORER_SUMMARY_COLLAPSE_KEY)
+	);
+}
+
+// Register the configuration setting
+const configurationRegistry = Registry.as<IConfigurationRegistry>(
+	Extensions.Configuration
+);
+configurationRegistry.registerConfiguration({
+	...positronConfigurationNodeBase,
+	scope: ConfigurationScope.MACHINE_OVERRIDABLE,
+	properties: {
+		[USE_POSITRON_DATA_EXPLORER_SUMMARY_COLLAPSE_KEY]: {
+			type: 'boolean',
+			default: false,
+			markdownDescription: localize(
+				'positron.enablePositronDataExplorerSummaryCollapse',
+				'Collapse Data Explorer Summary Panel by default.'
+			),
+		},
+	},
+});

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerSummary.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerSummary.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -16,17 +16,10 @@ import { PositronDataExplorerLayout } from '../browser/interfaces/positronDataEx
 
 // Key for the configuration setting
 export const USE_POSITRON_DATA_EXPLORER_SUMMARY_COLLAPSE_KEY =
-	'positron.dataExplorerSummaryCollapse';
+	'positron.dataExplorerSummaryCollapsed';
 export const USE_POSITRON_DATA_EXPLORER_SUMMARY_LAYOUT_KEY =
 	'positron.dataExplorerSummaryLayout';
 
-/**
- * Retrieves the value of the configuration setting that determines whether to enable
- * experimental features in the Positron Data Explorer.
- *
- * @param configurationService The configuration service
- * @returns Whether to enable experimental Positron Data Explorer features
- */
 export function DataExplorerSummaryCollapseEnabled(
 	configurationService: IConfigurationService
 ) {
@@ -40,7 +33,7 @@ export function DefaultDataExplorerSummaryLayout(
 ) {
 	if (String(
 		configurationService.getValue(USE_POSITRON_DATA_EXPLORER_SUMMARY_LAYOUT_KEY)
-	) === 'Left') {
+	) === 'left') {
 		return PositronDataExplorerLayout.SummaryOnLeft;
 	} else {
 		return PositronDataExplorerLayout.SummaryOnRight;
@@ -71,8 +64,8 @@ configurationRegistry.registerConfiguration({ // for summary layout
 	properties: {
 		[USE_POSITRON_DATA_EXPLORER_SUMMARY_LAYOUT_KEY]: {
 			type: 'string',
-			default: 'Left', // Default value (can be "left" or "right")
-			enum: ['Left', 'Right'], // Define possible values
+			default: 'left', // Default value (can be "left" or "right")
+			enum: ['left', 'right'], // Define possible values
 			markdownDescription: localize(
 				'positron.dataExplorerSummaryLayout',
 				'Select the position of the Data Explorer Summary Panel (left or right).'

--- a/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerSummary.ts
+++ b/src/vs/workbench/services/positronDataExplorer/common/positronDataExplorerSummary.ts
@@ -12,10 +12,13 @@ import {
 } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { positronConfigurationNodeBase } from '../../languageRuntime/common/languageRuntime.js';
+import { PositronDataExplorerLayout } from '../browser/interfaces/positronDataExplorerService.js';
 
 // Key for the configuration setting
 export const USE_POSITRON_DATA_EXPLORER_SUMMARY_COLLAPSE_KEY =
 	'positron.dataExplorerSummaryCollapse';
+export const USE_POSITRON_DATA_EXPLORER_SUMMARY_LAYOUT_KEY =
+	'positron.dataExplorerSummaryLayout';
 
 /**
  * Retrieves the value of the configuration setting that determines whether to enable
@@ -32,11 +35,23 @@ export function DataExplorerSummaryCollapseEnabled(
 	);
 }
 
+export function DefaultDataExplorerSummaryLayout(
+	configurationService: IConfigurationService
+) {
+	if (String(
+		configurationService.getValue(USE_POSITRON_DATA_EXPLORER_SUMMARY_LAYOUT_KEY)
+	) === 'Left') {
+		return PositronDataExplorerLayout.SummaryOnLeft;
+	} else {
+		return PositronDataExplorerLayout.SummaryOnRight;
+	}
+}
+
 // Register the configuration setting
 const configurationRegistry = Registry.as<IConfigurationRegistry>(
 	Extensions.Configuration
 );
-configurationRegistry.registerConfiguration({
+configurationRegistry.registerConfiguration({ // for summary collapse
 	...positronConfigurationNodeBase,
 	scope: ConfigurationScope.MACHINE_OVERRIDABLE,
 	properties: {
@@ -46,6 +61,21 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: localize(
 				'positron.enablePositronDataExplorerSummaryCollapse',
 				'Collapse Data Explorer Summary Panel by default.'
+			),
+		},
+	},
+});
+configurationRegistry.registerConfiguration({ // for summary layout
+	...positronConfigurationNodeBase,
+	scope: ConfigurationScope.MACHINE_OVERRIDABLE,
+	properties: {
+		[USE_POSITRON_DATA_EXPLORER_SUMMARY_LAYOUT_KEY]: {
+			type: 'string',
+			default: 'Left', // Default value (can be "left" or "right")
+			enum: ['Left', 'Right'], // Define possible values
+			markdownDescription: localize(
+				'positron.dataExplorerSummaryLayout',
+				'Select the position of the Data Explorer Summary Panel (left or right).'
 			),
 		},
 	},


### PR DESCRIPTION
### Release Notes

#### New Features

-  Add a new setting entry for collapsing data summary by default (Fixes #5435 requested by me)
-  Add a new setting entry for data summary on Right by default

https://github.com/user-attachments/assets/78901cf8-8ca9-44d1-a574-9e2ff53566c1

#### Bug Fixes

- N/A


### QA Notes

- N/A
