### PR TITLE
Fix retention for data summary collapses triggered by splitter button and resizing

### DIFF
--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -340,7 +340,6 @@ export const DataExplorer = () => {
 					onBeginResize={beginResizeHandler}
 					onCollapsedChanged={collapsed => {
 						setAnimateColumnsWidth(!context.accessibilityService.isMotionReduced());
-						setColumnsCollapsed(collapsed);
 						if (collapsed) {
 							context.instance.collapseSummary();
 						} else {

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/dataExplorer.tsx
@@ -341,6 +341,11 @@ export const DataExplorer = () => {
 					onCollapsedChanged={collapsed => {
 						setAnimateColumnsWidth(!context.accessibilityService.isMotionReduced());
 						setColumnsCollapsed(collapsed);
+						if (collapsed) {
+							context.instance.collapseSummary();
+						} else {
+							context.instance.expandSummary();
+						}
 					}}
 					onResize={resizeHandler}
 				/>


### PR DESCRIPTION
### Release Notes

#### New Features

- N/A

#### Bug Fixes

- The closures of the data summary panel by pressing the button/dragging are retained the same way as the command. (Fix #6485 )

After this fix, it is also safe to close #5572 .

https://github.com/user-attachments/assets/e4d55ee1-16a3-4831-b3a2-95052db8abf7



### QA Notes

- NA
