### PR TITLE
block interpreters from Positron dropdown

### DIFF
--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -124,7 +124,8 @@ export class PythonRuntimeManager implements IPythonRuntimeManager {
         if (!isVersionSupported(pythonVersion, MINIMUM_PYTHON_VERSION)) {
             traceInfo(`Not registering runtime ${extraData.pythonPath} as it is not a supported version.`);
             return;
-        } // Check if the interpreter should be included in the list of registered runtimes
+        }
+
         if (shouldIncludeInterpreter(extraData.pythonPath)) {
             // Save the runtime for later use
             this.registeredPythonRuntimes.set(extraData.pythonPath, runtime);

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -21,11 +21,13 @@ import { traceError, traceInfo } from '../logging';
 import { IConfigurationService, IDisposable } from '../common/types';
 import { PythonRuntimeSession } from './session';
 import { createPythonRuntimeMetadata, PythonRuntimeExtraData } from './runtime';
-import { EXTENSION_ROOT_DIR } from '../common/constants';
+import { EXTENSION_ROOT_DIR, MINIMUM_PYTHON_VERSION } from '../common/constants';
 import { JupyterKernelSpec } from '../positron-supervisor.d';
 import { IEnvironmentVariablesProvider } from '../common/variables/types';
 import { checkAndInstallPython } from './extension';
-import { shouldIncludeInterpreter } from './interpreterSettings';
+import { shouldIncludeInterpreter, isVersionSupported } from './interpreterSettings';
+import { parseVersion, toSemverLikeVersion } from '../pythonEnvironments/base/info/pythonVersion';
+import { PythonVersion } from '../pythonEnvironments/info/pythonVersion';
 
 export const IPythonRuntimeManager = Symbol('IPythonRuntimeManager');
 
@@ -116,7 +118,13 @@ export class PythonRuntimeManager implements IPythonRuntimeManager {
      */
     public registerLanguageRuntime(runtime: positron.LanguageRuntimeMetadata): void {
         const extraData = runtime.extraRuntimeData as PythonRuntimeExtraData;
+        const pythonVersion: PythonVersion = toSemverLikeVersion(parseVersion(runtime.languageVersion));
+
         // Check if the interpreter should be included in the list of registered runtimes
+        if (!isVersionSupported(pythonVersion, MINIMUM_PYTHON_VERSION)) {
+            traceInfo(`Not registering runtime ${extraData.pythonPath} as it is not a supported version.`);
+            return;
+        } // Check if the interpreter should be included in the list of registered runtimes
         if (shouldIncludeInterpreter(extraData.pythonPath)) {
             // Save the runtime for later use
             this.registeredPythonRuntimes.set(extraData.pythonPath, runtime);

--- a/extensions/positron-python/src/client/pythonEnvironments/base/info/pythonVersion.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/info/pythonVersion.ts
@@ -233,7 +233,10 @@ function compareVersionRelease(left: PythonVersion, right: PythonVersion): [numb
  * Convert Python version to semver like version object.
  *
  * Remarks: primarily used to convert to old type of environment info.
- * @deprecated
+ * // --- Start Positron ---
+ *  This is used in environment discovery.
+ *  Upstream has deprecated, but do not remove.
+ * // --- End Positron ---
  */
 export function toSemverLikeVersion(
     version: PythonVersion,

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -15,6 +15,7 @@ import * as fs from '../../client/common/platform/fs-paths';
 import * as runtime from '../../client/positron/runtime';
 import * as session from '../../client/positron/session';
 import * as workspaceApis from '../../client/common/vscodeApis/workspaceApis';
+import * as interpreterSettings from '../../client/positron/interpreterSettings';
 import { IEnvironmentVariablesProvider } from '../../client/common/variables/types';
 import { IConfigurationService, IDisposable } from '../../client/common/types';
 import { IServiceContainer } from '../../client/ioc/types';
@@ -36,6 +37,7 @@ suite('Python runtime manager', () => {
     let workspaceConfig: TypeMoq.IMock<WorkspaceConfiguration>;
 
     let getConfigurationStub: sinon.SinonStub;
+    let isVersionSupportedStub: sinon.SinonStub;
 
     let pythonRuntimeManager: PythonRuntimeManager;
     let disposables: IDisposable[];
@@ -67,6 +69,9 @@ suite('Python runtime manager', () => {
             }
             return undefined;
         });
+
+        isVersionSupportedStub = sinon.stub(interpreterSettings, 'isVersionSupported');
+        isVersionSupportedStub.returns(true);
 
         pythonRuntimeManager = new PythonRuntimeManager(serviceContainer.object, interpreterService.object);
         disposables = [];


### PR DESCRIPTION
Should block <3.8 interpreters from being registered when found. It seems to fix everything for me locally, I think this is the only place where old interpreters could sneak by.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #3740 


### QA Notes

1. Create a Python interpreter <3.8 (if you are a pyenv user, you can do pyenv install 3.6)
2. Fo to `Python: Select Interpreter`, should not appear in dropdown
3. Go to Positron interpreter selector, should not appear here either 
