### PR TITLE
Add find keyboard binding for help view

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelp.contribution.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelp.contribution.ts
@@ -14,8 +14,8 @@ import { SyncDescriptor } from '../../../../platform/instantiation/common/descri
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ViewPaneContainer } from '../../../browser/parts/views/viewPaneContainer.js';
 import { PositronHelpView } from './positronHelpView.js';
-import { POSITRON_HELP_VIEW_ID } from './positronHelpService.js';
-import { POSITRON_HELP_COPY } from './positronHelpIdentifiers.js';
+import { IPositronHelpService, POSITRON_HELP_VIEW_ID } from './positronHelpService.js';
+import { POSITRON_HELP_COPY, POSITRON_HELP_FIND } from './positronHelpIdentifiers.js';
 import { ICommandAndKeybindingRule, KeybindingWeight, KeybindingsRegistry } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
 import { ViewContainer, IViewContainersRegistry, ViewContainerLocation, Extensions as ViewContainerExtensions, IViewsRegistry } from '../../../common/views.js';
@@ -77,7 +77,15 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	handler: accessor => { }
 } satisfies ICommandAndKeybindingRule);
 
-
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: POSITRON_HELP_FIND,
+	weight: KeybindingWeight.WorkbenchContrib,
+	primary: KeyMod.CtrlCmd | KeyCode.KeyF,
+	when: PositronHelpFocused,
+	handler: accessor => {
+		accessor.get(IPositronHelpService).find();
+	}
+} satisfies ICommandAndKeybindingRule);
 
 class PositronHelpContribution extends Disposable implements IWorkbenchContribution {
 

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpIdentifiers.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpIdentifiers.ts
@@ -5,3 +5,4 @@
 
 // Identifiers.
 export const POSITRON_HELP_COPY = 'positron.help.copy';
+export const POSITRON_HELP_FIND = 'positron.help.find';

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -115,6 +115,11 @@ export interface IPositronHelpService {
 	 * Navigates forward.
 	 */
 	navigateForward(): void;
+
+	/**
+	 * Show the find widget.
+	 */
+	find(): void;
 }
 
 /**
@@ -382,6 +387,13 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 		if (this._helpEntryIndex < this._helpEntries.length - 1) {
 			this._onDidChangeCurrentHelpEntryEmitter.fire(this._helpEntries[++this._helpEntryIndex]);
 		}
+	}
+
+	/**
+	 * Show the find widget.
+	 */
+	find() {
+		this.currentHelpEntry.showFind();
 	}
 
 	//#endregion IPositronHelpService


### PR DESCRIPTION
Address #2653 

Adds to the help service a focus listener on the help overlay so that it can update the help view focus context key. A keybinding action that is enabled based on the context key shows the find widget.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Link to any GitHub issues but avoid "magic" keywords that will
  automatically close the issue. If there are any details about your
  approach that are unintuitive or you want to draw attention to, please
  describe them here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #2653 Add keybinding action for the find widget in the Help view


### QA Notes
The copy action and the context menu in the Help view also depend or changes the Help view focus status.

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
