### PR TITLE
ci: add prelaunch to ci for e2e tests (#6522)

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -43,7 +43,7 @@ runs:
 
     - name: Compile and Download
       shell: bash
-      run: npm exec -- npm-run-all --max_old_space_size=4095 -lp compile "electron x64" playwright-install download-builtin-extensions
+      run: npm exec -- npm-run-all --max_old_space_size=4095 -lp compile "electron x64" playwright-install
 
     # Although not directly part of the build environment, this configuration is essential for running unit, integration, and e2e tests.
     - name: Configure xvfb Service
@@ -53,3 +53,7 @@ runs:
         sudo chmod +x /etc/init.d/xvfb
         sudo update-rc.d xvfb defaults
         sudo service xvfb start
+
+    # Downloads Builtin Extensions (needed for integration & e2e testing)
+    - shell: bash
+      run: npm run prelaunch

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -102,7 +102,11 @@ jobs:
           npm --prefix test/e2e ci
 
       - name: Compile and Download
-        run: npm exec -- npm-run-all --max-old-space-size=4095 -lp compile "electron x64" playwright-install download-builtin-extensions
+        run: npm exec -- npm-run-all --max-old-space-size=4095 -lp compile "electron x64" playwright-install
+
+      # Downloads Builtin Extensions (needed for integration & e2e testing)
+      - shell: bash
+        run: npm run prelaunch
 
       - name: Compile E2E Tests
         run: |

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "e2e-failed": "npx playwright test --last-failed",
     "e2e-summary": "python test/e2e/create-test-summary.py test/e2e/tests",
     "e2e-ui": "PW_UI_MODE=true npx playwright test --ui",
+    "prelaunch": "node build/lib/preLaunch.js",
     "download-builtin-extensions": "node build/lib/builtInExtensions.js",
     "download-builtin-extensions-cg": "node build/lib/builtInExtensionsCG.js",
     "download-quarto": "node build/lib/quarto.js",


### PR DESCRIPTION
Porting over the fixes to add prelaunch to CI tests.

### QA Notes

@:quarto @:web @:win
