### PR TITLE
Update bootstrapped extensions

### DIFF
--- a/product.json
+++ b/product.json
@@ -116,7 +116,7 @@
 	"bootstrapExtensions": [
 		{
 			"name": "ms-python.black-formatter",
-			"version": "2024.2.0",
+			"version": "2024.6.0",
 			"repo": "https://github.com/microsoft/vscode-black-formatter",
 			"metadata": {
 				"id": "859e640c-c157-47da-8699-9080b81c8371",
@@ -177,7 +177,7 @@
 
 		{
 			"name": "ms-toolsai.jupyter",
-			"version": "2024.8.1",
+			"version": "2025.1.0",
 			"repo": "https://github.com/Microsoft/vscode-jupyter",
 			"metadata": {
 				"id": "6c2f1801-1e7f-45b2-9b5c-7782f1e076e8",
@@ -192,7 +192,7 @@
 		},
 		{
 			"name": "ms-pyright.pyright",
-			"version": "1.1.379",
+			"version": "1.1.395",
 			"repo": "https://github.com/Microsoft/pyright",
 			"metadata": {
 				"id": "593fe6a5-513e-4cb3-abfb-5b9f5fe39802",
@@ -207,7 +207,7 @@
 		},
 		{
 			"name": "ms-python.debugpy",
-			"version": "2024.8.0",
+			"version": "2025.0.1",
 			"repo": "https://github.com/microsoft/vscode-python-debugger",
 			"metadata": {
 				"id": "4bd5d2c9-9d65-401a-b0b2-7498d9f17615",


### PR DESCRIPTION
Update `product.json` to provide the most recent release of each bootstrapped extension we're providing. Otherwise, when users have AutoUpdate enabled, at first launch, Positron will do two back-to-back installs.
This was causing issues with our automation that required skipping the Problems tests in https://github.com/posit-dev/positron/pull/6537


### QA Notes

@:problems