### PR TITLE
run python ci tests on prerelease branches and pin ipython to <=8.31.0

### DIFF
--- a/.github/workflows/positron-python-ci.yml
+++ b/.github/workflows/positron-python-ci.yml
@@ -5,12 +5,14 @@ on:
   push:
     branches:
       - main
+      - 'prerelease/**'
     paths:
       - '.github/workflows/positron-python-ci.yml'
       - 'extensions/positron-python/**'
   pull_request:
     branches:
       - main
+      - 'prerelease/**'
     paths:
       - '.github/workflows/positron-python-ci.yml'
       - 'extensions/positron-python/**'

--- a/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
@@ -9,7 +9,7 @@ hvplot==0.11.2 ; python_version >= '3.9'
 hvplot==0.8.0 ; python_version < '3.9'
 ibis-framework[duckdb]==10.0.0; python_version >= '3.10'
 ipykernel==6.29.5
-ipython==8.31.0
+ipython<=8.31.0
 ipywidgets==8.1.5
 lightning==2.3.2
 matplotlib==3.7.4; python_version < '3.9'

--- a/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
+++ b/extensions/positron-python/python_files/posit/pinned-test-requirements.txt
@@ -9,6 +9,7 @@ hvplot==0.11.2 ; python_version >= '3.9'
 hvplot==0.8.0 ; python_version < '3.9'
 ibis-framework[duckdb]==10.0.0; python_version >= '3.10'
 ipykernel==6.29.5
+ipython==8.31.0
 ipywidgets==8.1.5
 lightning==2.3.2
 matplotlib==3.7.4; python_version < '3.9'

--- a/extensions/positron-python/src/test/positron/testElectron.ts
+++ b/extensions/positron-python/src/test/positron/testElectron.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 


### PR DESCRIPTION
### Summary
- Python CI tests will now run on prerelease branch PRs starting from `prerelease/2025.03`
- Python CI tests will run when commits are pushed to prerelease branches
- pins ipython to <=8.31.0 to avoid a test failure occurring in the Python IPyKernel tests on this branch and on the main branch
    ```
    FAILED python_files/posit/positron/tests/test_positron_ipkernel.py::test_console_traceback - AttributeError: 'AutoFormattedTB' object has no attribute 'Colors'
    ```
- pulls in https://github.com/posit-dev/positron/pull/6496 to fix up python CI tests on mac

NOTE: This change will need to go into main as well!