### PR TITLE
create the bootstrap .version file in the extensions directory rather than the application directory

### DIFF
--- a/src/vs/platform/extensionManagement/node/positronBootstrapExtensionsInitializer.ts
+++ b/src/vs/platform/extensionManagement/node/positronBootstrapExtensionsInitializer.ts
@@ -15,7 +15,6 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { Disposable } from '../../../base/common/lifecycle.js';
 
 export class PositronBootstrapExtensionsInitializer extends Disposable {
-	private readonly storageFilePath: string;
 
 	constructor(
 		@INativeEnvironmentService private readonly environmentService: INativeEnvironmentService,
@@ -26,19 +25,19 @@ export class PositronBootstrapExtensionsInitializer extends Disposable {
 	) {
 		super();
 
-		this.storageFilePath = join(this.getVSIXPath().fsPath, '.version');
+		const storageFilePath = join(this.environmentService.extensionsPath, '.version');
 		const currentVersion = this.productService.positronVersion;
 
-		const lastKnownVersion = existsSync(this.storageFilePath) ? readFileSync(this.storageFilePath, 'utf8').trim() : '';
+		const lastKnownVersion = existsSync(storageFilePath) ? readFileSync(storageFilePath, 'utf8').trim() : '';
 
 		if (lastKnownVersion !== currentVersion) {
 			this.logService.info('First launch after first install, upgrade, or downgrade. Installing bootstrapped extensions');
 			this.installVSIXOnStartup()
 				.then(() => {
 					try {
-						writeFileSync(this.storageFilePath, currentVersion);
+						writeFileSync(storageFilePath, currentVersion);
 					} catch (error) {
-						this.logService.error('Error writing bootstrapped extension storage file', this.storageFilePath, getErrorMessage(error));
+						this.logService.error('Error writing bootstrapped extension storage file', storageFilePath, getErrorMessage(error));
 					}
 				})
 				.catch(error => {


### PR DESCRIPTION
@midleman and @testlabauto reported that their tests relying on extensions were failing locally. This is because the bootstrapped extension feature was saving `.version` to the application folder rather than the user's extension folder, causing the bootstrapped extensions to only be installed for the first user that launched the application. Because the tests use a temporary user data directory per run, the extensions would not be installed on subsequent runs.

This would've prevented extensions from being installed for multiple users on Workbench as well. 

We now create, look for, and update `.version` in the user's extension directory rather that the application directory. 

In the implementation, `storageFilePath` was unnecessarily being declared as a class member so I fixed that as well. 