### PR TITLE
Merging prerelease/2025.03 to main

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -43,7 +43,7 @@ runs:
 
     - name: Compile and Download
       shell: bash
-      run: npm exec -- npm-run-all --max_old_space_size=4095 -lp compile "electron x64" playwright-install download-builtin-extensions
+      run: npm exec -- npm-run-all --max_old_space_size=4095 -lp compile "electron x64" playwright-install
 
     # Although not directly part of the build environment, this configuration is essential for running unit, integration, and e2e tests.
     - name: Configure xvfb Service
@@ -53,3 +53,7 @@ runs:
         sudo chmod +x /etc/init.d/xvfb
         sudo update-rc.d xvfb defaults
         sudo service xvfb start
+
+    # Downloads Builtin Extensions (needed for integration & e2e testing)
+    - shell: bash
+      run: npm run prelaunch

--- a/.github/workflows/test-e2e-windows.yml
+++ b/.github/workflows/test-e2e-windows.yml
@@ -102,7 +102,11 @@ jobs:
           npm --prefix test/e2e ci
 
       - name: Compile and Download
-        run: npm exec -- npm-run-all --max-old-space-size=4095 -lp compile "electron x64" playwright-install download-builtin-extensions
+        run: npm exec -- npm-run-all --max-old-space-size=4095 -lp compile "electron x64" playwright-install
+
+      # Downloads Builtin Extensions (needed for integration & e2e testing)
+      - shell: bash
+        run: npm run prelaunch
 
       - name: Compile E2E Tests
         run: |

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -702,7 +702,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.168"
+      "ark": "0.1.169"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "e2e-failed": "npx playwright test --last-failed",
     "e2e-summary": "python test/e2e/create-test-summary.py test/e2e/tests",
     "e2e-ui": "PW_UI_MODE=true npx playwright test --ui",
+    "prelaunch": "node build/lib/preLaunch.js",
     "download-builtin-extensions": "node build/lib/builtInExtensions.js",
     "download-builtin-extensions-cg": "node build/lib/builtInExtensionsCG.js",
     "download-quarto": "node build/lib/quarto.js",

--- a/product.json
+++ b/product.json
@@ -116,7 +116,7 @@
 	"bootstrapExtensions": [
 		{
 			"name": "ms-python.black-formatter",
-			"version": "2024.2.0",
+			"version": "2024.6.0",
 			"repo": "https://github.com/microsoft/vscode-black-formatter",
 			"metadata": {
 				"id": "859e640c-c157-47da-8699-9080b81c8371",
@@ -177,7 +177,7 @@
 
 		{
 			"name": "ms-toolsai.jupyter",
-			"version": "2024.8.1",
+			"version": "2025.1.0",
 			"repo": "https://github.com/Microsoft/vscode-jupyter",
 			"metadata": {
 				"id": "6c2f1801-1e7f-45b2-9b5c-7782f1e076e8",
@@ -192,7 +192,7 @@
 		},
 		{
 			"name": "ms-pyright.pyright",
-			"version": "1.1.379",
+			"version": "1.1.395",
 			"repo": "https://github.com/Microsoft/pyright",
 			"metadata": {
 				"id": "593fe6a5-513e-4cb3-abfb-5b9f5fe39802",
@@ -207,7 +207,7 @@
 		},
 		{
 			"name": "ms-python.debugpy",
-			"version": "2024.8.0",
+			"version": "2025.0.1",
 			"repo": "https://github.com/microsoft/vscode-python-debugger",
 			"metadata": {
 				"id": "4bd5d2c9-9d65-401a-b0b2-7498d9f17615",

--- a/src/vs/platform/extensionManagement/node/positronBootstrapExtensionsInitializer.ts
+++ b/src/vs/platform/extensionManagement/node/positronBootstrapExtensionsInitializer.ts
@@ -15,7 +15,6 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { Disposable } from '../../../base/common/lifecycle.js';
 
 export class PositronBootstrapExtensionsInitializer extends Disposable {
-	private readonly storageFilePath: string;
 
 	constructor(
 		@INativeEnvironmentService private readonly environmentService: INativeEnvironmentService,
@@ -26,19 +25,19 @@ export class PositronBootstrapExtensionsInitializer extends Disposable {
 	) {
 		super();
 
-		this.storageFilePath = join(this.getVSIXPath().fsPath, '.version');
+		const storageFilePath = join(this.environmentService.extensionsPath, '.version');
 		const currentVersion = this.productService.positronVersion;
 
-		const lastKnownVersion = existsSync(this.storageFilePath) ? readFileSync(this.storageFilePath, 'utf8').trim() : '';
+		const lastKnownVersion = existsSync(storageFilePath) ? readFileSync(storageFilePath, 'utf8').trim() : '';
 
 		if (lastKnownVersion !== currentVersion) {
 			this.logService.info('First launch after first install, upgrade, or downgrade. Installing bootstrapped extensions');
 			this.installVSIXOnStartup()
 				.then(() => {
 					try {
-						writeFileSync(this.storageFilePath, currentVersion);
+						writeFileSync(storageFilePath, currentVersion);
 					} catch (error) {
-						this.logService.error('Error writing bootstrapped extension storage file', this.storageFilePath, getErrorMessage(error));
+						this.logService.error('Error writing bootstrapped extension storage file', storageFilePath, getErrorMessage(error));
 					}
 				})
 				.catch(error => {


### PR DESCRIPTION
Capturing any work done on the prerelease/2025.03 branch to main.

Ignoring the ark bump as main had since moved to v0.1.170.

It looked like QA's changes were duplicated to main already on https://github.com/posit-dev/positron/pull/6522, so it ended up being a no-op, but probably best to merge the history rather than re-do on main in future.