### PR TITLE
Omit Shiny from bootstrapped extensions

### DIFF
--- a/build/lib/bootstrapExtensions.js
+++ b/build/lib/bootstrapExtensions.js
@@ -114,13 +114,6 @@ function getBootstrapExtensions() {
     for (const extension of [...bootstrapExtensions]) {
         const controlState = control[extension.name] || 'marketplace';
         control[extension.name] = controlState;
-        // Discard extensions intended for the web. The 'type' field isn't a
-        // formal part of the extension definition but a custom field we use to
-        // filter out web-only extensions (i.e. Posit Workbench)
-        // @ts-ignore
-        if (extension.type === 'reh-web') {
-            continue;
-        }
         streams.push(syncExtension(extension, controlState));
     }
     writeControlFile(control, controlFilePath);

--- a/build/lib/bootstrapExtensions.ts
+++ b/build/lib/bootstrapExtensions.ts
@@ -141,14 +141,6 @@ export function getBootstrapExtensions(): Promise<void> {
 		const controlState = control[extension.name] || 'marketplace';
 		control[extension.name] = controlState;
 
-		// Discard extensions intended for the web. The 'type' field isn't a
-		// formal part of the extension definition but a custom field we use to
-		// filter out web-only extensions (i.e. Posit Workbench)
-		// @ts-ignore
-		if (extension.type === 'reh-web') {
-			continue;
-		}
-
 		streams.push(syncExtension(extension, controlState));
 	}
 

--- a/product.json
+++ b/product.json
@@ -234,18 +234,6 @@
 			"publisherDisplayName": "Posit Software, PBC"
 		},
 		{
-			"name": "posit.shiny",
-			"version": "1.1.2",
-			"repo": "http://github.com/posit-dev/shiny-vscode",
-			"type": "reh-web",
-			"metadata": {
-				"id": "f1b3b3b4-3b3b-4b3b-8b3b-3b3b3b3b3b3b",
-				"publisherId": "090804ff-7eb2-4fbd-bb61-583e34f2b070",
-				"displayName": "Shiny",
-				"multiPlatformServiceUrl": "https://open-vsx.org/api"
-			}
-		},
-		{
 			"name": "quarto.quarto",
 			"version": "1.118.0",
 			"repo": "https://github.com/quarto-dev/quarto/tree/main/apps/vscode",


### PR DESCRIPTION
The Shiny extension 1.1.2 is missing a macOS binary, which is causing builds to fail when we try to bundle it.

```
[VSCode-darwin-universal/Positron.app/Contents/Resources/app/extensions/bootstrap/posit.shiny-1.1.2.vsix]
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of VSCode-darwin-universal/Positron.app/Contents/Resources/app/extensions/bootstrap/posit.shiny-1.1.2.vsix or
        VSCode-darwin-universal/Positron.app/Contents/Resources/app/extensions/bootstrap/posit.shiny-1.1.2.vsix.zip, and cannot find VSCode-darwin-universal/Positron.app/Contents/Resources/app/extensions/bootstrap/posit.shiny-1.1.2.vsix.ZIP, period.
```

We shouldn't even be trying to bundle the Shiny extension for MacOS; it is happening because the mechanism for selecting extensions for inclusion in Workbench vs. Desktop needs to be reworked (this change also removes the existing mechanism). 

The fix here is just to remove the extension from the set of bootstrapped extensions. I'll open a separate issue to add it back for Workbench.