### PR TITLE
downgrade to 2024.11.0 because we still on 1.96.0 based Code OSS

### DIFF
--- a/product.json
+++ b/product.json
@@ -177,7 +177,7 @@
 
 		{
 			"name": "ms-toolsai.jupyter",
-			"version": "2025.1.0",
+			"version": "2024.11.0",
 			"repo": "https://github.com/Microsoft/vscode-jupyter",
 			"metadata": {
 				"id": "6c2f1801-1e7f-45b2-9b5c-7782f1e076e8",


### PR DESCRIPTION
Pulling in https://github.com/posit-dev/positron/pull/6559/commits/9abab809606c60e138c6354dee9c2660af20fe52 from https://github.com/posit-dev/positron/pull/6559