### PR TITLE
Update remote ssh to use cdn hosted artifacts

### DIFF
--- a/extensions/open-remote-ssh/package.json
+++ b/extensions/open-remote-ssh/package.json
@@ -75,9 +75,9 @@
         },
         "remoteSSH.serverDownloadUrlTemplate": {
           "type": "string",
-          "description": "The URL from where the Positron server will be downloaded. You can use the following variables and they will be replaced dynamically:\n- ${quality}: Positron server quality, e.g. stable or insiders\n- ${version}: Positron server version, e.g. 2024.10.0-123\n- ${commit}: Positron server release commit\n- ${arch}: Positron server arch, e.g. x64, armhf, arm64",
+          "description": "The URL from where the Positron server will be downloaded. You can use the following variables and they will be replaced dynamically:\n- ${quality}: Positron server quality, e.g. stable or insiders\n- ${version}: Positron server version, e.g. 2024.10.0-123\n- ${commit}: Positron server release commit\n- ${arch}: Positron server arch, e.g. x64, armhf, arm64\n- ${arch-long}: Positron server arch in long format, e.g. x86_64, arm64",
           "scope": "application",
-          "default": "https://github.com/posit-dev/positron/releases/download/${version}/positron-reh-${os}-${arch}-${version}.tar.gz"
+          "default": "https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz"
         },
         "remoteSSH.remotePlatform": {
           "type": "object",

--- a/extensions/open-remote-ssh/src/serverSetup.ts
+++ b/extensions/open-remote-ssh/src/serverSetup.ts
@@ -40,7 +40,7 @@ const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://cdn.posit.co/positron/dailies/reh
 export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTemplate: string | undefined, extensionIds: string[], envVariables: string[], platform: string | undefined, useSocketPath: boolean, logger: Log): Promise<ServerInstallResult> {
     let shell = 'powershell';
 
-    // detect plaform and shell for windows
+	// detect platform and shell for windows
     if (!platform || platform === 'windows') {
         const result = await conn.exec('uname -s');
 
@@ -394,7 +394,7 @@ if [[ -f $SERVER_LOGFILE ]]; then
     done
 
     if [[ -z $LISTENING_ON ]]; then
-        echo "Error server did not start sucessfully"
+        echo "Error server did not start successfully"
         print_install_results_and_exit 1
     fi
 else

--- a/extensions/open-remote-ssh/src/serverSetup.ts
+++ b/extensions/open-remote-ssh/src/serverSetup.ts
@@ -4,203 +4,203 @@ import { getVSCodeServerConfig } from './serverConfig';
 import SSHConnection from './ssh/sshConnection';
 
 export interface ServerInstallOptions {
-    id: string;
-    quality: string;
-    commit: string;
-    version: string;
-    release?: string; // vscodium specific
-    extensionIds: string[];
-    envVariables: string[];
-    useSocketPath: boolean;
-    serverApplicationName: string;
-    serverDataFolderName: string;
-    serverDownloadUrlTemplate: string;
+	id: string;
+	quality: string;
+	commit: string;
+	version: string;
+	release?: string; // vscodium specific
+	extensionIds: string[];
+	envVariables: string[];
+	useSocketPath: boolean;
+	serverApplicationName: string;
+	serverDataFolderName: string;
+	serverDownloadUrlTemplate: string;
 }
 
 export interface ServerInstallResult {
-    exitCode: number;
-    listeningOn: number | string;
-    connectionToken: string;
-    logFile: string;
-    osReleaseId: string;
-    arch: string;
-    platform: string;
-    tmpDir: string;
-    [key: string]: any;
+	exitCode: number;
+	listeningOn: number | string;
+	connectionToken: string;
+	logFile: string;
+	osReleaseId: string;
+	arch: string;
+	platform: string;
+	tmpDir: string;
+	[key: string]: any;
 }
 
 export class ServerInstallError extends Error {
-    constructor(message: string) {
-        super(message);
-    }
+	constructor(message: string) {
+		super(message);
+	}
 }
 
 const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz';
 
 export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTemplate: string | undefined, extensionIds: string[], envVariables: string[], platform: string | undefined, useSocketPath: boolean, logger: Log): Promise<ServerInstallResult> {
-    let shell = 'powershell';
+	let shell = 'powershell';
 
 	// detect platform and shell for windows
-    if (!platform || platform === 'windows') {
-        const result = await conn.exec('uname -s');
+	if (!platform || platform === 'windows') {
+		const result = await conn.exec('uname -s');
 
-        if (result.stdout) {
-            if (result.stdout.includes('windows32')) {
-                platform = 'windows';
-            } else if (result.stdout.includes('MINGW64')) {
-                platform = 'windows';
-                shell = 'bash';
-            }
-        } else if (result.stderr) {
-            if (result.stderr.includes('FullyQualifiedErrorId : CommandNotFoundException')) {
-                platform = 'windows';
-            }
+		if (result.stdout) {
+			if (result.stdout.includes('windows32')) {
+				platform = 'windows';
+			} else if (result.stdout.includes('MINGW64')) {
+				platform = 'windows';
+				shell = 'bash';
+			}
+		} else if (result.stderr) {
+			if (result.stderr.includes('FullyQualifiedErrorId : CommandNotFoundException')) {
+				platform = 'windows';
+			}
 
-            if (result.stderr.includes('is not recognized as an internal or external command')) {
-                platform = 'windows';
-                shell = 'cmd';
-            }
-        }
+			if (result.stderr.includes('is not recognized as an internal or external command')) {
+				platform = 'windows';
+				shell = 'cmd';
+			}
+		}
 
-        if (platform) {
-            logger.trace(`Detected platform: ${platform}, ${shell}`);
-        }
-    }
+		if (platform) {
+			logger.trace(`Detected platform: ${platform}, ${shell}`);
+		}
+	}
 
-    const scriptId = crypto.randomBytes(12).toString('hex');
+	const scriptId = crypto.randomBytes(12).toString('hex');
 
-    const vscodeServerConfig = await getVSCodeServerConfig();
-    const installOptions: ServerInstallOptions = {
-        id: scriptId,
-        version: vscodeServerConfig.version,
-        commit: vscodeServerConfig.commit,
-        quality: vscodeServerConfig.quality,
-        release: vscodeServerConfig.release,
-        extensionIds,
-        envVariables,
-        useSocketPath,
-        serverApplicationName: vscodeServerConfig.serverApplicationName,
-        serverDataFolderName: vscodeServerConfig.serverDataFolderName,
-        serverDownloadUrlTemplate: serverDownloadUrlTemplate ?? vscodeServerConfig.serverDownloadUrlTemplate ?? DEFAULT_DOWNLOAD_URL_TEMPLATE,
-    };
+	const vscodeServerConfig = await getVSCodeServerConfig();
+	const installOptions: ServerInstallOptions = {
+		id: scriptId,
+		version: vscodeServerConfig.version,
+		commit: vscodeServerConfig.commit,
+		quality: vscodeServerConfig.quality,
+		release: vscodeServerConfig.release,
+		extensionIds,
+		envVariables,
+		useSocketPath,
+		serverApplicationName: vscodeServerConfig.serverApplicationName,
+		serverDataFolderName: vscodeServerConfig.serverDataFolderName,
+		serverDownloadUrlTemplate: serverDownloadUrlTemplate ?? vscodeServerConfig.serverDownloadUrlTemplate ?? DEFAULT_DOWNLOAD_URL_TEMPLATE,
+	};
 
-    let commandOutput: { stdout: string; stderr: string };
-    if (platform === 'windows') {
-        const installServerScript = generatePowerShellInstallScript(installOptions);
+	let commandOutput: { stdout: string; stderr: string };
+	if (platform === 'windows') {
+		const installServerScript = generatePowerShellInstallScript(installOptions);
 
-        logger.trace('Server install command:', installServerScript);
+		logger.trace('Server install command:', installServerScript);
 
-        const installDir = `$HOME\\${vscodeServerConfig.serverDataFolderName}\\install`;
-        const installScript = `${installDir}\\${vscodeServerConfig.commit}.ps1`;
-        const endRegex = new RegExp(`${scriptId}: end`);
-        // investigate if it's possible to use `-EncodedCommand` flag
-        // https://devblogs.microsoft.com/powershell/invoking-powershell-with-complex-expressions-using-scriptblocks/
-        let command = '';
-        if (shell === 'powershell') {
-            command = `md -Force ${installDir}; echo @'\n${installServerScript}\n'@ | Set-Content ${installScript}; powershell -ExecutionPolicy ByPass -File "${installScript}"`;
-        } else if (shell === 'bash') {
-            command = `mkdir -p ${installDir.replace(/\\/g, '/')} && echo '\n${installServerScript.replace(/'/g, '\'"\'"\'')}\n' > ${installScript.replace(/\\/g, '/')} && powershell -ExecutionPolicy ByPass -File "${installScript}"`;
-        } else if (shell === 'cmd') {
-            const script = installServerScript.trim()
-                // remove comments
-                .replace(/^#.*$/gm, '')
-                // remove empty lines
-                .replace(/\n{2,}/gm, '\n')
-                // remove leading spaces
-                .replace(/^\s*/gm, '')
-                // escape double quotes (from powershell/cmd)
-                .replace(/"/g, '"""')
-                // escape single quotes (from cmd)
-                .replace(/'/g, `''`)
-                // escape redirect (from cmd)
-                .replace(/>/g, `^>`)
-                // escape new lines (from powershell/cmd)
-                .replace(/\n/g, '\'`n\'');
+		const installDir = `$HOME\\${vscodeServerConfig.serverDataFolderName}\\install`;
+		const installScript = `${installDir}\\${vscodeServerConfig.commit}.ps1`;
+		const endRegex = new RegExp(`${scriptId}: end`);
+		// investigate if it's possible to use `-EncodedCommand` flag
+		// https://devblogs.microsoft.com/powershell/invoking-powershell-with-complex-expressions-using-scriptblocks/
+		let command = '';
+		if (shell === 'powershell') {
+			command = `md -Force ${installDir}; echo @'\n${installServerScript}\n'@ | Set-Content ${installScript}; powershell -ExecutionPolicy ByPass -File "${installScript}"`;
+		} else if (shell === 'bash') {
+			command = `mkdir -p ${installDir.replace(/\\/g, '/')} && echo '\n${installServerScript.replace(/'/g, '\'"\'"\'')}\n' > ${installScript.replace(/\\/g, '/')} && powershell -ExecutionPolicy ByPass -File "${installScript}"`;
+		} else if (shell === 'cmd') {
+			const script = installServerScript.trim()
+				// remove comments
+				.replace(/^#.*$/gm, '')
+				// remove empty lines
+				.replace(/\n{2,}/gm, '\n')
+				// remove leading spaces
+				.replace(/^\s*/gm, '')
+				// escape double quotes (from powershell/cmd)
+				.replace(/"/g, '"""')
+				// escape single quotes (from cmd)
+				.replace(/'/g, `''`)
+				// escape redirect (from cmd)
+				.replace(/>/g, `^>`)
+				// escape new lines (from powershell/cmd)
+				.replace(/\n/g, '\'`n\'');
 
-            command = `powershell "md -Force ${installDir}" && powershell "echo '${script}'" > ${installScript.replace('$HOME', '%USERPROFILE%')} && powershell -ExecutionPolicy ByPass -File "${installScript.replace('$HOME', '%USERPROFILE%')}"`;
+			command = `powershell "md -Force ${installDir}" && powershell "echo '${script}'" > ${installScript.replace('$HOME', '%USERPROFILE%')} && powershell -ExecutionPolicy ByPass -File "${installScript.replace('$HOME', '%USERPROFILE%')}"`;
 
-            logger.trace('Command length (8191 max):', command.length);
+			logger.trace('Command length (8191 max):', command.length);
 
-            if (command.length > 8191) {
-                throw new ServerInstallError(`Command line too long`);
-            }
-        } else {
-            throw new ServerInstallError(`Not supported shell: ${shell}`);
-        }
+			if (command.length > 8191) {
+				throw new ServerInstallError(`Command line too long`);
+			}
+		} else {
+			throw new ServerInstallError(`Not supported shell: ${shell}`);
+		}
 
-        commandOutput = await conn.execPartial(command, (stdout: string) => endRegex.test(stdout));
-    } else {
-        const installServerScript = generateBashInstallScript(installOptions);
+		commandOutput = await conn.execPartial(command, (stdout: string) => endRegex.test(stdout));
+	} else {
+		const installServerScript = generateBashInstallScript(installOptions);
 
-        logger.trace('Server install command:', installServerScript);
-        // Fish shell does not support heredoc so let's workaround it using -c option,
-        // also replace single quotes (') within the script with ('\'') as there's no quoting within single quotes, see https://unix.stackexchange.com/a/24676
-        commandOutput = await conn.exec(`bash -c '${installServerScript.replace(/'/g, `'\\''`)}'`);
-    }
+		logger.trace('Server install command:', installServerScript);
+		// Fish shell does not support heredoc so let's workaround it using -c option,
+		// also replace single quotes (') within the script with ('\'') as there's no quoting within single quotes, see https://unix.stackexchange.com/a/24676
+		commandOutput = await conn.exec(`bash -c '${installServerScript.replace(/'/g, `'\\''`)}'`);
+	}
 
-    if (commandOutput.stderr) {
-        logger.trace('Server install command stderr:', commandOutput.stderr);
-    }
-    logger.trace('Server install command stdout:', commandOutput.stdout);
+	if (commandOutput.stderr) {
+		logger.trace('Server install command stderr:', commandOutput.stderr);
+	}
+	logger.trace('Server install command stdout:', commandOutput.stdout);
 
-    const resultMap = parseServerInstallOutput(commandOutput.stdout, scriptId);
-    if (!resultMap) {
-        throw new ServerInstallError(`Failed parsing install script output`);
-    }
+	const resultMap = parseServerInstallOutput(commandOutput.stdout, scriptId);
+	if (!resultMap) {
+		throw new ServerInstallError(`Failed parsing install script output`);
+	}
 
-    const exitCode = parseInt(resultMap.exitCode, 10);
-    if (exitCode !== 0) {
-        throw new ServerInstallError(`Couldn't install vscode server on remote server, install script returned non-zero exit status`);
-    }
+	const exitCode = parseInt(resultMap.exitCode, 10);
+	if (exitCode !== 0) {
+		throw new ServerInstallError(`Couldn't install vscode server on remote server, install script returned non-zero exit status`);
+	}
 
-    const listeningOn = resultMap.listeningOn.match(/^\d+$/)
-        ? parseInt(resultMap.listeningOn, 10)
-        : resultMap.listeningOn;
+	const listeningOn = resultMap.listeningOn.match(/^\d+$/)
+		? parseInt(resultMap.listeningOn, 10)
+		: resultMap.listeningOn;
 
-    const remoteEnvVars = Object.fromEntries(Object.entries(resultMap).filter(([key,]) => envVariables.includes(key)));
+	const remoteEnvVars = Object.fromEntries(Object.entries(resultMap).filter(([key,]) => envVariables.includes(key)));
 
-    return {
-        exitCode,
-        listeningOn,
-        connectionToken: resultMap.connectionToken,
-        logFile: resultMap.logFile,
-        osReleaseId: resultMap.osReleaseId,
-        arch: resultMap.arch,
-        platform: resultMap.platform,
-        tmpDir: resultMap.tmpDir,
-        ...remoteEnvVars
-    };
+	return {
+		exitCode,
+		listeningOn,
+		connectionToken: resultMap.connectionToken,
+		logFile: resultMap.logFile,
+		osReleaseId: resultMap.osReleaseId,
+		arch: resultMap.arch,
+		platform: resultMap.platform,
+		tmpDir: resultMap.tmpDir,
+		...remoteEnvVars
+	};
 }
 
 function parseServerInstallOutput(str: string, scriptId: string): { [k: string]: string } | undefined {
-    const startResultStr = `${scriptId}: start`;
-    const endResultStr = `${scriptId}: end`;
+	const startResultStr = `${scriptId}: start`;
+	const endResultStr = `${scriptId}: end`;
 
-    const startResultIdx = str.indexOf(startResultStr);
-    if (startResultIdx < 0) {
-        return undefined;
-    }
+	const startResultIdx = str.indexOf(startResultStr);
+	if (startResultIdx < 0) {
+		return undefined;
+	}
 
-    const endResultIdx = str.indexOf(endResultStr, startResultIdx + startResultStr.length);
-    if (endResultIdx < 0) {
-        return undefined;
-    }
+	const endResultIdx = str.indexOf(endResultStr, startResultIdx + startResultStr.length);
+	if (endResultIdx < 0) {
+		return undefined;
+	}
 
-    const installResult = str.substring(startResultIdx + startResultStr.length, endResultIdx);
+	const installResult = str.substring(startResultIdx + startResultStr.length, endResultIdx);
 
-    const resultMap: { [k: string]: string } = {};
-    const resultArr = installResult.split(/\r?\n/);
-    for (const line of resultArr) {
-        const [key, value] = line.split('==');
-        resultMap[key] = value;
-    }
+	const resultMap: { [k: string]: string } = {};
+	const resultArr = installResult.split(/\r?\n/);
+	for (const line of resultArr) {
+		const [key, value] = line.split('==');
+		resultMap[key] = value;
+	}
 
-    return resultMap;
+	return resultMap;
 }
 
 function generateBashInstallScript({ id, quality, version, commit, release, extensionIds, envVariables, useSocketPath, serverApplicationName, serverDataFolderName, serverDownloadUrlTemplate }: ServerInstallOptions) {
-    const extensions = extensionIds.map(id => '--install-extension ' + id).join(' ');
-    return `
+	const extensions = extensionIds.map(id => '--install-extension ' + id).join(' ');
+	return `
 # Server installation script
 
 TMP_DIR="\${XDG_RUNTIME_DIR:-"/tmp"}"
@@ -270,18 +270,23 @@ ARCH="$(uname -m)"
 case $ARCH in
     x86_64 | amd64)
         SERVER_ARCH="x64"
+		ARCH_LONG="x86_64"
         ;;
     armv7l | armv8l)
         SERVER_ARCH="armhf"
+		ARCH_LONG="armhf"
         ;;
     arm64 | aarch64)
         SERVER_ARCH="arm64"
+		ARCH_LONG="arm64"
         ;;
     ppc64le)
         SERVER_ARCH="ppc64le"
+		ARCH_LONG="ppc64le"
         ;;
     riscv64)
         SERVER_ARCH="riscv64"
+		ARCH_LONG="riscv64"
         ;;
     *)
         echo "Error architecture not supported: $ARCH"
@@ -307,7 +312,7 @@ if [[ ! -d $SERVER_DIR ]]; then
     fi
 fi
 
-SERVER_DOWNLOAD_URL="$(echo "${serverDownloadUrlTemplate.replace(/\$\{/g, '\\${')}" | sed "s/\\\${quality}/$DISTRO_QUALITY/g" | sed "s/\\\${version}/$DISTRO_VERSION/g" | sed "s/\\\${commit}/$DISTRO_COMMIT/g" | sed "s/\\\${os}/$PLATFORM/g" | sed "s/\\\${arch}/$SERVER_ARCH/g" | sed "s/\\\${release}/$DISTRO_VSCODIUM_RELEASE/g")"
+SERVER_DOWNLOAD_URL="$(echo "${serverDownloadUrlTemplate.replace(/\$\{/g, '\\${')}" | sed "s/\\\${quality}/$DISTRO_QUALITY/g" | sed "s/\\\${version}/$DISTRO_VERSION/g" | sed "s/\\\${commit}/$DISTRO_COMMIT/g" | sed "s/\\\${os}/$PLATFORM/g" | sed "s/\\\${arch}/$SERVER_ARCH/g" | sed "s/\\\${arch-long}/$ARCH_LONG/g" | sed "s/\\\${release}/$DISTRO_VSCODIUM_RELEASE/g")"
 
 # Check if server script is already installed
 if [[ ! -f $SERVER_SCRIPT ]]; then
@@ -408,16 +413,16 @@ print_install_results_and_exit 0
 }
 
 function generatePowerShellInstallScript({ id, quality, version, commit, release, extensionIds, envVariables, useSocketPath, serverApplicationName, serverDataFolderName, serverDownloadUrlTemplate }: ServerInstallOptions) {
-    const extensions = extensionIds.map(id => '--install-extension ' + id).join(' ');
-    const downloadUrl = serverDownloadUrlTemplate
-        .replace(/\$\{quality\}/g, quality)
-        .replace(/\$\{version\}/g, version)
-        .replace(/\$\{commit\}/g, commit)
-        .replace(/\$\{os\}/g, 'win32')
-        .replace(/\$\{arch\}/g, 'x64')
-        .replace(/\$\{release\}/g, release ?? '');
+	const extensions = extensionIds.map(id => '--install-extension ' + id).join(' ');
+	const downloadUrl = serverDownloadUrlTemplate
+		.replace(/\$\{quality\}/g, quality)
+		.replace(/\$\{version\}/g, version)
+		.replace(/\$\{commit\}/g, commit)
+		.replace(/\$\{os\}/g, 'win32')
+		.replace(/\$\{arch\}/g, 'x64')
+		.replace(/\$\{release\}/g, release ?? '');
 
-    return `
+	return `
 # Server installation script
 
 $TMP_DIR="$env:TEMP\\$([System.IO.Path]::GetRandomFileName())"

--- a/extensions/open-remote-ssh/src/serverSetup.ts
+++ b/extensions/open-remote-ssh/src/serverSetup.ts
@@ -35,7 +35,7 @@ export class ServerInstallError extends Error {
     }
 }
 
-const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://github.com/posit-dev/positron/releases/download/${version}/positron-reh-${os}-${arch}-${version}.tar.gz';
+const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz';
 
 export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTemplate: string | undefined, extensionIds: string[], envVariables: string[], platform: string | undefined, useSocketPath: boolean, logger: Log): Promise<ServerInstallResult> {
     let shell = 'powershell';

--- a/extensions/open-remote-ssh/src/serverSetup.ts
+++ b/extensions/open-remote-ssh/src/serverSetup.ts
@@ -4,203 +4,203 @@ import { getVSCodeServerConfig } from './serverConfig';
 import SSHConnection from './ssh/sshConnection';
 
 export interface ServerInstallOptions {
-	id: string;
-	quality: string;
-	commit: string;
-	version: string;
-	release?: string; // vscodium specific
-	extensionIds: string[];
-	envVariables: string[];
-	useSocketPath: boolean;
-	serverApplicationName: string;
-	serverDataFolderName: string;
-	serverDownloadUrlTemplate: string;
+    id: string;
+    quality: string;
+    commit: string;
+    version: string;
+    release?: string; // vscodium specific
+    extensionIds: string[];
+    envVariables: string[];
+    useSocketPath: boolean;
+    serverApplicationName: string;
+    serverDataFolderName: string;
+    serverDownloadUrlTemplate: string;
 }
 
 export interface ServerInstallResult {
-	exitCode: number;
-	listeningOn: number | string;
-	connectionToken: string;
-	logFile: string;
-	osReleaseId: string;
-	arch: string;
-	platform: string;
-	tmpDir: string;
-	[key: string]: any;
+    exitCode: number;
+    listeningOn: number | string;
+    connectionToken: string;
+    logFile: string;
+    osReleaseId: string;
+    arch: string;
+    platform: string;
+    tmpDir: string;
+    [key: string]: any;
 }
 
 export class ServerInstallError extends Error {
-	constructor(message: string) {
-		super(message);
-	}
+    constructor(message: string) {
+        super(message);
+    }
 }
 
 const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz';
 
 export async function installCodeServer(conn: SSHConnection, serverDownloadUrlTemplate: string | undefined, extensionIds: string[], envVariables: string[], platform: string | undefined, useSocketPath: boolean, logger: Log): Promise<ServerInstallResult> {
-	let shell = 'powershell';
+    let shell = 'powershell';
 
-	// detect platform and shell for windows
-	if (!platform || platform === 'windows') {
-		const result = await conn.exec('uname -s');
+    // detect plaform and shell for windows
+    if (!platform || platform === 'windows') {
+        const result = await conn.exec('uname -s');
 
-		if (result.stdout) {
-			if (result.stdout.includes('windows32')) {
-				platform = 'windows';
-			} else if (result.stdout.includes('MINGW64')) {
-				platform = 'windows';
-				shell = 'bash';
-			}
-		} else if (result.stderr) {
-			if (result.stderr.includes('FullyQualifiedErrorId : CommandNotFoundException')) {
-				platform = 'windows';
-			}
+        if (result.stdout) {
+            if (result.stdout.includes('windows32')) {
+                platform = 'windows';
+            } else if (result.stdout.includes('MINGW64')) {
+                platform = 'windows';
+                shell = 'bash';
+            }
+        } else if (result.stderr) {
+            if (result.stderr.includes('FullyQualifiedErrorId : CommandNotFoundException')) {
+                platform = 'windows';
+            }
 
-			if (result.stderr.includes('is not recognized as an internal or external command')) {
-				platform = 'windows';
-				shell = 'cmd';
-			}
-		}
+            if (result.stderr.includes('is not recognized as an internal or external command')) {
+                platform = 'windows';
+                shell = 'cmd';
+            }
+        }
 
-		if (platform) {
-			logger.trace(`Detected platform: ${platform}, ${shell}`);
-		}
-	}
+        if (platform) {
+            logger.trace(`Detected platform: ${platform}, ${shell}`);
+        }
+    }
 
-	const scriptId = crypto.randomBytes(12).toString('hex');
+    const scriptId = crypto.randomBytes(12).toString('hex');
 
-	const vscodeServerConfig = await getVSCodeServerConfig();
-	const installOptions: ServerInstallOptions = {
-		id: scriptId,
-		version: vscodeServerConfig.version,
-		commit: vscodeServerConfig.commit,
-		quality: vscodeServerConfig.quality,
-		release: vscodeServerConfig.release,
-		extensionIds,
-		envVariables,
-		useSocketPath,
-		serverApplicationName: vscodeServerConfig.serverApplicationName,
-		serverDataFolderName: vscodeServerConfig.serverDataFolderName,
-		serverDownloadUrlTemplate: serverDownloadUrlTemplate ?? vscodeServerConfig.serverDownloadUrlTemplate ?? DEFAULT_DOWNLOAD_URL_TEMPLATE,
-	};
+    const vscodeServerConfig = await getVSCodeServerConfig();
+    const installOptions: ServerInstallOptions = {
+        id: scriptId,
+        version: vscodeServerConfig.version,
+        commit: vscodeServerConfig.commit,
+        quality: vscodeServerConfig.quality,
+        release: vscodeServerConfig.release,
+        extensionIds,
+        envVariables,
+        useSocketPath,
+        serverApplicationName: vscodeServerConfig.serverApplicationName,
+        serverDataFolderName: vscodeServerConfig.serverDataFolderName,
+        serverDownloadUrlTemplate: serverDownloadUrlTemplate ?? vscodeServerConfig.serverDownloadUrlTemplate ?? DEFAULT_DOWNLOAD_URL_TEMPLATE,
+    };
 
-	let commandOutput: { stdout: string; stderr: string };
-	if (platform === 'windows') {
-		const installServerScript = generatePowerShellInstallScript(installOptions);
+    let commandOutput: { stdout: string; stderr: string };
+    if (platform === 'windows') {
+        const installServerScript = generatePowerShellInstallScript(installOptions);
 
-		logger.trace('Server install command:', installServerScript);
+        logger.trace('Server install command:', installServerScript);
 
-		const installDir = `$HOME\\${vscodeServerConfig.serverDataFolderName}\\install`;
-		const installScript = `${installDir}\\${vscodeServerConfig.commit}.ps1`;
-		const endRegex = new RegExp(`${scriptId}: end`);
-		// investigate if it's possible to use `-EncodedCommand` flag
-		// https://devblogs.microsoft.com/powershell/invoking-powershell-with-complex-expressions-using-scriptblocks/
-		let command = '';
-		if (shell === 'powershell') {
-			command = `md -Force ${installDir}; echo @'\n${installServerScript}\n'@ | Set-Content ${installScript}; powershell -ExecutionPolicy ByPass -File "${installScript}"`;
-		} else if (shell === 'bash') {
-			command = `mkdir -p ${installDir.replace(/\\/g, '/')} && echo '\n${installServerScript.replace(/'/g, '\'"\'"\'')}\n' > ${installScript.replace(/\\/g, '/')} && powershell -ExecutionPolicy ByPass -File "${installScript}"`;
-		} else if (shell === 'cmd') {
-			const script = installServerScript.trim()
-				// remove comments
-				.replace(/^#.*$/gm, '')
-				// remove empty lines
-				.replace(/\n{2,}/gm, '\n')
-				// remove leading spaces
-				.replace(/^\s*/gm, '')
-				// escape double quotes (from powershell/cmd)
-				.replace(/"/g, '"""')
-				// escape single quotes (from cmd)
-				.replace(/'/g, `''`)
-				// escape redirect (from cmd)
-				.replace(/>/g, `^>`)
-				// escape new lines (from powershell/cmd)
-				.replace(/\n/g, '\'`n\'');
+        const installDir = `$HOME\\${vscodeServerConfig.serverDataFolderName}\\install`;
+        const installScript = `${installDir}\\${vscodeServerConfig.commit}.ps1`;
+        const endRegex = new RegExp(`${scriptId}: end`);
+        // investigate if it's possible to use `-EncodedCommand` flag
+        // https://devblogs.microsoft.com/powershell/invoking-powershell-with-complex-expressions-using-scriptblocks/
+        let command = '';
+        if (shell === 'powershell') {
+            command = `md -Force ${installDir}; echo @'\n${installServerScript}\n'@ | Set-Content ${installScript}; powershell -ExecutionPolicy ByPass -File "${installScript}"`;
+        } else if (shell === 'bash') {
+            command = `mkdir -p ${installDir.replace(/\\/g, '/')} && echo '\n${installServerScript.replace(/'/g, '\'"\'"\'')}\n' > ${installScript.replace(/\\/g, '/')} && powershell -ExecutionPolicy ByPass -File "${installScript}"`;
+        } else if (shell === 'cmd') {
+            const script = installServerScript.trim()
+                // remove comments
+                .replace(/^#.*$/gm, '')
+                // remove empty lines
+                .replace(/\n{2,}/gm, '\n')
+                // remove leading spaces
+                .replace(/^\s*/gm, '')
+                // escape double quotes (from powershell/cmd)
+                .replace(/"/g, '"""')
+                // escape single quotes (from cmd)
+                .replace(/'/g, `''`)
+                // escape redirect (from cmd)
+                .replace(/>/g, `^>`)
+                // escape new lines (from powershell/cmd)
+                .replace(/\n/g, '\'`n\'');
 
-			command = `powershell "md -Force ${installDir}" && powershell "echo '${script}'" > ${installScript.replace('$HOME', '%USERPROFILE%')} && powershell -ExecutionPolicy ByPass -File "${installScript.replace('$HOME', '%USERPROFILE%')}"`;
+            command = `powershell "md -Force ${installDir}" && powershell "echo '${script}'" > ${installScript.replace('$HOME', '%USERPROFILE%')} && powershell -ExecutionPolicy ByPass -File "${installScript.replace('$HOME', '%USERPROFILE%')}"`;
 
-			logger.trace('Command length (8191 max):', command.length);
+            logger.trace('Command length (8191 max):', command.length);
 
-			if (command.length > 8191) {
-				throw new ServerInstallError(`Command line too long`);
-			}
-		} else {
-			throw new ServerInstallError(`Not supported shell: ${shell}`);
-		}
+            if (command.length > 8191) {
+                throw new ServerInstallError(`Command line too long`);
+            }
+        } else {
+            throw new ServerInstallError(`Not supported shell: ${shell}`);
+        }
 
-		commandOutput = await conn.execPartial(command, (stdout: string) => endRegex.test(stdout));
-	} else {
-		const installServerScript = generateBashInstallScript(installOptions);
+        commandOutput = await conn.execPartial(command, (stdout: string) => endRegex.test(stdout));
+    } else {
+        const installServerScript = generateBashInstallScript(installOptions);
 
-		logger.trace('Server install command:', installServerScript);
-		// Fish shell does not support heredoc so let's workaround it using -c option,
-		// also replace single quotes (') within the script with ('\'') as there's no quoting within single quotes, see https://unix.stackexchange.com/a/24676
-		commandOutput = await conn.exec(`bash -c '${installServerScript.replace(/'/g, `'\\''`)}'`);
-	}
+        logger.trace('Server install command:', installServerScript);
+        // Fish shell does not support heredoc so let's workaround it using -c option,
+        // also replace single quotes (') within the script with ('\'') as there's no quoting within single quotes, see https://unix.stackexchange.com/a/24676
+        commandOutput = await conn.exec(`bash -c '${installServerScript.replace(/'/g, `'\\''`)}'`);
+    }
 
-	if (commandOutput.stderr) {
-		logger.trace('Server install command stderr:', commandOutput.stderr);
-	}
-	logger.trace('Server install command stdout:', commandOutput.stdout);
+    if (commandOutput.stderr) {
+        logger.trace('Server install command stderr:', commandOutput.stderr);
+    }
+    logger.trace('Server install command stdout:', commandOutput.stdout);
 
-	const resultMap = parseServerInstallOutput(commandOutput.stdout, scriptId);
-	if (!resultMap) {
-		throw new ServerInstallError(`Failed parsing install script output`);
-	}
+    const resultMap = parseServerInstallOutput(commandOutput.stdout, scriptId);
+    if (!resultMap) {
+        throw new ServerInstallError(`Failed parsing install script output`);
+    }
 
-	const exitCode = parseInt(resultMap.exitCode, 10);
-	if (exitCode !== 0) {
-		throw new ServerInstallError(`Couldn't install vscode server on remote server, install script returned non-zero exit status`);
-	}
+    const exitCode = parseInt(resultMap.exitCode, 10);
+    if (exitCode !== 0) {
+        throw new ServerInstallError(`Couldn't install vscode server on remote server, install script returned non-zero exit status`);
+    }
 
-	const listeningOn = resultMap.listeningOn.match(/^\d+$/)
-		? parseInt(resultMap.listeningOn, 10)
-		: resultMap.listeningOn;
+    const listeningOn = resultMap.listeningOn.match(/^\d+$/)
+        ? parseInt(resultMap.listeningOn, 10)
+        : resultMap.listeningOn;
 
-	const remoteEnvVars = Object.fromEntries(Object.entries(resultMap).filter(([key,]) => envVariables.includes(key)));
+    const remoteEnvVars = Object.fromEntries(Object.entries(resultMap).filter(([key,]) => envVariables.includes(key)));
 
-	return {
-		exitCode,
-		listeningOn,
-		connectionToken: resultMap.connectionToken,
-		logFile: resultMap.logFile,
-		osReleaseId: resultMap.osReleaseId,
-		arch: resultMap.arch,
-		platform: resultMap.platform,
-		tmpDir: resultMap.tmpDir,
-		...remoteEnvVars
-	};
+    return {
+        exitCode,
+        listeningOn,
+        connectionToken: resultMap.connectionToken,
+        logFile: resultMap.logFile,
+        osReleaseId: resultMap.osReleaseId,
+        arch: resultMap.arch,
+        platform: resultMap.platform,
+        tmpDir: resultMap.tmpDir,
+        ...remoteEnvVars
+    };
 }
 
 function parseServerInstallOutput(str: string, scriptId: string): { [k: string]: string } | undefined {
-	const startResultStr = `${scriptId}: start`;
-	const endResultStr = `${scriptId}: end`;
+    const startResultStr = `${scriptId}: start`;
+    const endResultStr = `${scriptId}: end`;
 
-	const startResultIdx = str.indexOf(startResultStr);
-	if (startResultIdx < 0) {
-		return undefined;
-	}
+    const startResultIdx = str.indexOf(startResultStr);
+    if (startResultIdx < 0) {
+        return undefined;
+    }
 
-	const endResultIdx = str.indexOf(endResultStr, startResultIdx + startResultStr.length);
-	if (endResultIdx < 0) {
-		return undefined;
-	}
+    const endResultIdx = str.indexOf(endResultStr, startResultIdx + startResultStr.length);
+    if (endResultIdx < 0) {
+        return undefined;
+    }
 
-	const installResult = str.substring(startResultIdx + startResultStr.length, endResultIdx);
+    const installResult = str.substring(startResultIdx + startResultStr.length, endResultIdx);
 
-	const resultMap: { [k: string]: string } = {};
-	const resultArr = installResult.split(/\r?\n/);
-	for (const line of resultArr) {
-		const [key, value] = line.split('==');
-		resultMap[key] = value;
-	}
+    const resultMap: { [k: string]: string } = {};
+    const resultArr = installResult.split(/\r?\n/);
+    for (const line of resultArr) {
+        const [key, value] = line.split('==');
+        resultMap[key] = value;
+    }
 
-	return resultMap;
+    return resultMap;
 }
 
 function generateBashInstallScript({ id, quality, version, commit, release, extensionIds, envVariables, useSocketPath, serverApplicationName, serverDataFolderName, serverDownloadUrlTemplate }: ServerInstallOptions) {
-	const extensions = extensionIds.map(id => '--install-extension ' + id).join(' ');
-	return `
+    const extensions = extensionIds.map(id => '--install-extension ' + id).join(' ');
+    return `
 # Server installation script
 
 TMP_DIR="\${XDG_RUNTIME_DIR:-"/tmp"}"
@@ -270,23 +270,23 @@ ARCH="$(uname -m)"
 case $ARCH in
     x86_64 | amd64)
         SERVER_ARCH="x64"
-		ARCH_LONG="x86_64"
+        ARCH_LONG="x86_64"
         ;;
     armv7l | armv8l)
         SERVER_ARCH="armhf"
-		ARCH_LONG="armhf"
+        ARCH_LONG="armhf"
         ;;
     arm64 | aarch64)
         SERVER_ARCH="arm64"
-		ARCH_LONG="arm64"
+        ARCH_LONG="arm64"
         ;;
     ppc64le)
         SERVER_ARCH="ppc64le"
-		ARCH_LONG="ppc64le"
+        ARCH_LONG="ppc64le"
         ;;
     riscv64)
         SERVER_ARCH="riscv64"
-		ARCH_LONG="riscv64"
+        ARCH_LONG="riscv64"
         ;;
     *)
         echo "Error architecture not supported: $ARCH"
@@ -399,7 +399,7 @@ if [[ -f $SERVER_LOGFILE ]]; then
     done
 
     if [[ -z $LISTENING_ON ]]; then
-        echo "Error server did not start successfully"
+        echo "Error server did not start sucessfully"
         print_install_results_and_exit 1
     fi
 else
@@ -413,16 +413,17 @@ print_install_results_and_exit 0
 }
 
 function generatePowerShellInstallScript({ id, quality, version, commit, release, extensionIds, envVariables, useSocketPath, serverApplicationName, serverDataFolderName, serverDownloadUrlTemplate }: ServerInstallOptions) {
-	const extensions = extensionIds.map(id => '--install-extension ' + id).join(' ');
-	const downloadUrl = serverDownloadUrlTemplate
-		.replace(/\$\{quality\}/g, quality)
-		.replace(/\$\{version\}/g, version)
-		.replace(/\$\{commit\}/g, commit)
-		.replace(/\$\{os\}/g, 'win32')
-		.replace(/\$\{arch\}/g, 'x64')
-		.replace(/\$\{release\}/g, release ?? '');
+    const extensions = extensionIds.map(id => '--install-extension ' + id).join(' ');
+    const downloadUrl = serverDownloadUrlTemplate
+        .replace(/\$\{quality\}/g, quality)
+        .replace(/\$\{version\}/g, version)
+        .replace(/\$\{commit\}/g, commit)
+        .replace(/\$\{os\}/g, 'win32')
+        .replace(/\$\{arch\}/g, 'x64')
+        .replace(/\$\{arch-long}/g, 'x86_64')
+        .replace(/\$\{release\}/g, release ?? '');
 
-	return `
+    return `
 # Server installation script
 
 $TMP_DIR="$env:TEMP\\$([System.IO.Path]::GetRandomFileName())"

--- a/product.json
+++ b/product.json
@@ -263,7 +263,9 @@
 		"https://github.com/posit-dev/positron",
 		"https://positron.posit.co"
 	],
-	"extensionsEnabledWithApiProposalVersion": ["GitHub.copilot-chat"],
+	"extensionsEnabledWithApiProposalVersion": [
+		"GitHub.copilot-chat"
+	],
 	"extensionEnabledApiProposals": {
 		"ms-vscode.vscode-selfhost-test-provider": [
 			"testObserver",
@@ -293,7 +295,9 @@
 			"workspaceTrust",
 			"tunnels"
 		],
-		"ms-toolsai.vscode-ai-remote": ["resolvers"],
+		"ms-toolsai.vscode-ai-remote": [
+			"resolvers"
+		],
 		"ms-python.python": [
 			"contribEditorContentMenu",
 			"quickPickSortByLabel",
@@ -305,7 +309,9 @@
 			"contribIssueReporter",
 			"terminalShellIntegration"
 		],
-		"ms-dotnettools.dotnet-interactive-vscode": ["notebookMessaging"],
+		"ms-dotnettools.dotnet-interactive-vscode": [
+			"notebookMessaging"
+		],
 		"GitHub.codespaces": [
 			"contribEditSessions",
 			"contribMenuBarHome",
@@ -357,7 +363,11 @@
 			"contribViewsRemote",
 			"telemetry"
 		],
-		"ms-vscode.remote-server": ["resolvers", "tunnels", "contribViewsWelcome"],
+		"ms-vscode.remote-server": [
+			"resolvers",
+			"tunnels",
+			"contribViewsWelcome"
+		],
 		"ms-vscode.remote-explorer": [
 			"contribRemoteHelp",
 			"contribViewsRemote",
@@ -379,8 +389,12 @@
 			"workspaceTrust",
 			"tunnels"
 		],
-		"ms-vscode.lsif-browser": ["documentFiltersExclusive"],
-		"ms-vscode.vscode-speech": ["speech"],
+		"ms-vscode.lsif-browser": [
+			"documentFiltersExclusive"
+		],
+		"ms-vscode.vscode-speech": [
+			"speech"
+		],
 		"GitHub.vscode-pull-request-github": [
 			"activeComment",
 			"codiconDecoration",
@@ -405,8 +419,13 @@
 			"tokenInformation",
 			"treeViewMarkdownMessage"
 		],
-		"GitHub.copilot": ["authGetSessions", "inlineCompletionsAdditions"],
-		"GitHub.copilot-nightly": ["inlineCompletionsAdditions"],
+		"GitHub.copilot": [
+			"authGetSessions",
+			"inlineCompletionsAdditions"
+		],
+		"GitHub.copilot-nightly": [
+			"inlineCompletionsAdditions"
+		],
 		"GitHub.copilot-chat": [
 			"interactive",
 			"terminalDataWriteEvent",
@@ -455,15 +474,21 @@
 			"textSearchProvider",
 			"timeline"
 		],
-		"ms-python.gather": ["notebookCellExecutionState"],
-		"ms-python.vscode-pylance": ["notebookCellExecutionState"],
+		"ms-python.gather": [
+			"notebookCellExecutionState"
+		],
+		"ms-python.vscode-pylance": [
+			"notebookCellExecutionState"
+		],
 		"ms-python.debugpy": [
 			"contribIssueReporter",
 			"contribViewsWelcome",
 			"debugVisualization",
 			"portsAttributes"
 		],
-		"ms-toolsai.jupyter-renderers": ["contribNotebookStaticPreloads"],
+		"ms-toolsai.jupyter-renderers": [
+			"contribNotebookStaticPreloads"
+		],
 		"ms-toolsai.jupyter": [
 			"notebookDeprecated",
 			"notebookMessaging",
@@ -480,21 +505,39 @@
 			"notebookCellExecution",
 			"notebookVariableProvider"
 		],
-		"dbaeumer.vscode-eslint": ["notebookCellExecutionState"],
-		"ms-vscode.azure-sphere-tools-ui": ["tunnels"],
-		"ms-azuretools.vscode-azureappservice": ["terminalDataWriteEvent"],
-		"ms-azuretools.vscode-azureresourcegroups": ["authGetSessions"],
+		"dbaeumer.vscode-eslint": [
+			"notebookCellExecutionState"
+		],
+		"ms-vscode.azure-sphere-tools-ui": [
+			"tunnels"
+		],
+		"ms-azuretools.vscode-azureappservice": [
+			"terminalDataWriteEvent"
+		],
+		"ms-azuretools.vscode-azureresourcegroups": [
+			"authGetSessions"
+		],
 		"ms-azuretools.vscode-azure-github-copilot": [
 			"chatParticipantAdditions",
 			"embeddings",
 			"languageModelSystem",
 			"lmTools"
 		],
-		"ms-vscode.anycode": ["extensionsAny"],
-		"ms-vscode.cpptools": ["terminalDataWriteEvent"],
-		"redhat.java": ["documentPaste"],
-		"ms-dotnettools.csdevkit": ["inlineCompletionsAdditions"],
-		"ms-dotnettools.vscodeintellicode-csharp": ["inlineCompletionsAdditions"],
+		"ms-vscode.anycode": [
+			"extensionsAny"
+		],
+		"ms-vscode.cpptools": [
+			"terminalDataWriteEvent"
+		],
+		"redhat.java": [
+			"documentPaste"
+		],
+		"ms-dotnettools.csdevkit": [
+			"inlineCompletionsAdditions"
+		],
+		"ms-dotnettools.vscodeintellicode-csharp": [
+			"inlineCompletionsAdditions"
+		],
 		"microsoft-IsvExpTools.powerplatform-vscode": [
 			"fileSearchProvider",
 			"textSearchProvider"

--- a/product.json
+++ b/product.json
@@ -14,7 +14,7 @@
 	"serverLicensePrompt": "",
 	"serverApplicationName": "positron-server",
 	"serverDataFolderName": ".positron-server",
-	"serverDownloadUrlTemplate": "https://github.com/posit-dev/positron/releases/download/${version}/positron-reh-${os}-${arch}-${version}.tar.gz",
+	"serverDownloadUrlTemplate": "https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz",
 	"tunnelApplicationName": "positron-tunnel",
 	"win32DirName": "Positron",
 	"win32NameVersion": "Positron",
@@ -263,9 +263,7 @@
 		"https://github.com/posit-dev/positron",
 		"https://positron.posit.co"
 	],
-	"extensionsEnabledWithApiProposalVersion": [
-		"GitHub.copilot-chat"
-	],
+	"extensionsEnabledWithApiProposalVersion": ["GitHub.copilot-chat"],
 	"extensionEnabledApiProposals": {
 		"ms-vscode.vscode-selfhost-test-provider": [
 			"testObserver",
@@ -295,9 +293,7 @@
 			"workspaceTrust",
 			"tunnels"
 		],
-		"ms-toolsai.vscode-ai-remote": [
-			"resolvers"
-		],
+		"ms-toolsai.vscode-ai-remote": ["resolvers"],
 		"ms-python.python": [
 			"contribEditorContentMenu",
 			"quickPickSortByLabel",
@@ -309,9 +305,7 @@
 			"contribIssueReporter",
 			"terminalShellIntegration"
 		],
-		"ms-dotnettools.dotnet-interactive-vscode": [
-			"notebookMessaging"
-		],
+		"ms-dotnettools.dotnet-interactive-vscode": ["notebookMessaging"],
 		"GitHub.codespaces": [
 			"contribEditSessions",
 			"contribMenuBarHome",
@@ -363,11 +357,7 @@
 			"contribViewsRemote",
 			"telemetry"
 		],
-		"ms-vscode.remote-server": [
-			"resolvers",
-			"tunnels",
-			"contribViewsWelcome"
-		],
+		"ms-vscode.remote-server": ["resolvers", "tunnels", "contribViewsWelcome"],
 		"ms-vscode.remote-explorer": [
 			"contribRemoteHelp",
 			"contribViewsRemote",
@@ -389,12 +379,8 @@
 			"workspaceTrust",
 			"tunnels"
 		],
-		"ms-vscode.lsif-browser": [
-			"documentFiltersExclusive"
-		],
-		"ms-vscode.vscode-speech": [
-			"speech"
-		],
+		"ms-vscode.lsif-browser": ["documentFiltersExclusive"],
+		"ms-vscode.vscode-speech": ["speech"],
 		"GitHub.vscode-pull-request-github": [
 			"activeComment",
 			"codiconDecoration",
@@ -419,13 +405,8 @@
 			"tokenInformation",
 			"treeViewMarkdownMessage"
 		],
-		"GitHub.copilot": [
-			"authGetSessions",
-			"inlineCompletionsAdditions"
-		],
-		"GitHub.copilot-nightly": [
-			"inlineCompletionsAdditions"
-		],
+		"GitHub.copilot": ["authGetSessions", "inlineCompletionsAdditions"],
+		"GitHub.copilot-nightly": ["inlineCompletionsAdditions"],
 		"GitHub.copilot-chat": [
 			"interactive",
 			"terminalDataWriteEvent",
@@ -474,21 +455,15 @@
 			"textSearchProvider",
 			"timeline"
 		],
-		"ms-python.gather": [
-			"notebookCellExecutionState"
-		],
-		"ms-python.vscode-pylance": [
-			"notebookCellExecutionState"
-		],
+		"ms-python.gather": ["notebookCellExecutionState"],
+		"ms-python.vscode-pylance": ["notebookCellExecutionState"],
 		"ms-python.debugpy": [
 			"contribIssueReporter",
 			"contribViewsWelcome",
 			"debugVisualization",
 			"portsAttributes"
 		],
-		"ms-toolsai.jupyter-renderers": [
-			"contribNotebookStaticPreloads"
-		],
+		"ms-toolsai.jupyter-renderers": ["contribNotebookStaticPreloads"],
 		"ms-toolsai.jupyter": [
 			"notebookDeprecated",
 			"notebookMessaging",
@@ -505,39 +480,21 @@
 			"notebookCellExecution",
 			"notebookVariableProvider"
 		],
-		"dbaeumer.vscode-eslint": [
-			"notebookCellExecutionState"
-		],
-		"ms-vscode.azure-sphere-tools-ui": [
-			"tunnels"
-		],
-		"ms-azuretools.vscode-azureappservice": [
-			"terminalDataWriteEvent"
-		],
-		"ms-azuretools.vscode-azureresourcegroups": [
-			"authGetSessions"
-		],
+		"dbaeumer.vscode-eslint": ["notebookCellExecutionState"],
+		"ms-vscode.azure-sphere-tools-ui": ["tunnels"],
+		"ms-azuretools.vscode-azureappservice": ["terminalDataWriteEvent"],
+		"ms-azuretools.vscode-azureresourcegroups": ["authGetSessions"],
 		"ms-azuretools.vscode-azure-github-copilot": [
 			"chatParticipantAdditions",
 			"embeddings",
 			"languageModelSystem",
 			"lmTools"
 		],
-		"ms-vscode.anycode": [
-			"extensionsAny"
-		],
-		"ms-vscode.cpptools": [
-			"terminalDataWriteEvent"
-		],
-		"redhat.java": [
-			"documentPaste"
-		],
-		"ms-dotnettools.csdevkit": [
-			"inlineCompletionsAdditions"
-		],
-		"ms-dotnettools.vscodeintellicode-csharp": [
-			"inlineCompletionsAdditions"
-		],
+		"ms-vscode.anycode": ["extensionsAny"],
+		"ms-vscode.cpptools": ["terminalDataWriteEvent"],
+		"redhat.java": ["documentPaste"],
+		"ms-dotnettools.csdevkit": ["inlineCompletionsAdditions"],
+		"ms-dotnettools.vscodeintellicode-csharp": ["inlineCompletionsAdditions"],
 		"microsoft-IsvExpTools.powerplatform-vscode": [
 			"fileSearchProvider",
 			"textSearchProvider"


### PR DESCRIPTION
### Release Notes

#### New Features

- With installers now hosted on cdn.posit.com, this PR updates the remote ssh template to point to the cdn and not github for release artifacts (Fixes #6498 ).

#### Bug Fixes

- N/A


### QA Notes

- NA